### PR TITLE
fix: resolve CSP violations and update Umami analytics configuration

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -134,7 +134,8 @@ const nextConfig = {
 
   experimental: {
     // React Compiler (automatic React optimization)
-    reactCompiler: true,
+    // Disabled: Causes eval() CSP violations in production with strict-dynamic
+    reactCompiler: false,
 
     // ✨ Turbopack Persistent Caching (requires next@canary - disabled for stable)
     // turbopackPersistentCaching: true,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import { connection } from 'next/server';
+import { connection, headers } from 'next/server';
 import { ThemeProvider } from 'next-themes';
 import './globals.css';
 import { Toaster } from 'sonner';
@@ -115,6 +115,11 @@ export default async function RootLayout({
   // Opt-out of static generation for every page so the CSP nonce can be applied
   await connection();
 
+  // Get CSP nonce for inline scripts
+  const headersList = await headers();
+  const cspHeader = headersList.get('content-security-policy');
+  const nonce = cspHeader?.match(/nonce-([a-zA-Z0-9+/=]+)/)?.[1];
+
   return (
     <html lang="en" suppressHydrationWarning className={`${inter.variable} font-sans`}>
       <head>
@@ -183,6 +188,7 @@ export default async function RootLayout({
           src="/scripts/service-worker-init.js"
           integrity="sha384-0tKKFTk8IlkGOHQjqC00b0Xn/MEUQcn73JljDRsW34lCFxSqKEUZwBNKSp9N/AM/"
           crossOrigin="anonymous"
+          nonce={nonce}
           defer
         />
       </body>

--- a/src/components/shared/umami-script.tsx
+++ b/src/components/shared/umami-script.tsx
@@ -28,7 +28,7 @@ export async function UmamiScript() {
       defer
       src="https://umami.claudepro.directory/script.js"
       data-website-id="b734c138-2949-4527-9160-7fe5d0e81121"
-      integrity="sha384-PFqUEdHVrSOSpICvHVdlcWE6pKB/vTQI0WLgkDWMdsDJDsIuRuK0hDO54xvpXSaT"
+      integrity="sha384-gW+82edTiLqRoEvPbT3xKDCYZ5M02YXbW4tA3gbojZWiiMYNJZb4YneJrS4ri3Rn"
       crossOrigin="anonymous"
       nonce={nonce}
     />


### PR DESCRIPTION
Fix Content Security Policy violations preventing Umami analytics and service worker from loading correctly in production.

## CSP Violations Fixed

### 1. Umami Analytics Script
- Updated SRI integrity hash to match current script content
- Old hash: sha384-PFqUEdHVrSOSpICvHVdlcWE6pKB/vTQI0WLgkDWMdsDJDsIuRuK0hDO54xvpXSaT
- New hash: sha384-gW+82edTiLqRoEvPbT3xKDCYZ5M02YXbW4tA3gbojZWiiMYNJZb4YneJrS4ri3Rn
- Hash mismatch was blocking script execution despite correct nonce

### 2. Service Worker Initialization Script
- Added nonce extraction in layout.tsx root component
- Applied nonce to service-worker-init.js script tag
- Fixes "inline script blocked" CSP violation

### 3. React Compiler eval() Violations
- Disabled React Compiler (reactCompiler: false)
- React Compiler generates code using eval() which violates strict CSP
- Removed 3 eval() CSP violations from Next.js chunks
- Trade-off: Lose automatic React optimizations to maintain security compliance

## Technical Details

With Nosecone's strict-dynamic CSP policy:
- All external scripts require nonces for execution (even with SRI)
- Inline scripts require nonces (service worker init)
- eval() is blocked unless explicitly allowed with 'unsafe-eval'
- React Compiler is incompatible with strict CSP in production

Files changed:
- src/components/shared/umami-script.tsx (SRI hash)
- src/app/layout.tsx (nonce extraction + service worker)
- next.config.mjs (React Compiler disabled)
