### PR TITLE
ci(security): restore codeql workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,99 @@
+name: Security
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "apps/**/*.cjs"
+      - "apps/**/*.js"
+      - "apps/**/*.jsx"
+      - "apps/**/*.mjs"
+      - "apps/**/*.ts"
+      - "apps/**/*.tsx"
+      - "emails/**/*.ts"
+      - "emails/**/*.tsx"
+      - "integrations/**/*.cjs"
+      - "integrations/**/*.js"
+      - "integrations/**/*.jsx"
+      - "integrations/**/*.mjs"
+      - "integrations/**/*.ts"
+      - "integrations/**/*.tsx"
+      - "packages/**/*.cjs"
+      - "packages/**/*.js"
+      - "packages/**/*.jsx"
+      - "packages/**/*.mjs"
+      - "packages/**/*.ts"
+      - "packages/**/*.tsx"
+      - "scripts/**/*.cjs"
+      - "scripts/**/*.js"
+      - "scripts/**/*.mjs"
+      - "scripts/**/*.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/**"
+      - "apps/**/*.cjs"
+      - "apps/**/*.js"
+      - "apps/**/*.jsx"
+      - "apps/**/*.mjs"
+      - "apps/**/*.ts"
+      - "apps/**/*.tsx"
+      - "emails/**/*.ts"
+      - "emails/**/*.tsx"
+      - "integrations/**/*.cjs"
+      - "integrations/**/*.js"
+      - "integrations/**/*.jsx"
+      - "integrations/**/*.mjs"
+      - "integrations/**/*.ts"
+      - "integrations/**/*.tsx"
+      - "packages/**/*.cjs"
+      - "packages/**/*.js"
+      - "packages/**/*.jsx"
+      - "packages/**/*.mjs"
+      - "packages/**/*.ts"
+      - "packages/**/*.tsx"
+      - "scripts/**/*.cjs"
+      - "scripts/**/*.js"
+      - "scripts/**/*.mjs"
+      - "scripts/**/*.ts"
+      - "package.json"
+      - "pnpm-lock.yaml"
+  schedule:
+    - cron: "37 10 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225
+        with:
+          languages: javascript-typescript, actions
+          build-mode: none
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225


### PR DESCRIPTION
## Summary
- restores `.github/workflows/security.yml` so the stale CodeQL advanced setup configuration has a workflow file again
- scans JavaScript/TypeScript plus GitHub Actions with CodeQL `security-extended` queries
- keeps permissions minimal and pins workflow actions to commit SHAs

## Why
GitHub code scanning reported that `.github/workflows/security.yml` no longer existed for the existing CodeQL configuration. Re-adding the workflow keeps the repository security setup explicit and reviewable.

## Validation
- `actionlint .github/workflows/security.yml`
- `trunk check --show-existing --fix .github/workflows/security.yml`
- `pnpm validate:clean`

## Notes
- I cleared ignored local build/temp output under `apps/web/.open-next` and `apps/web/.wrangler/tmp` so `pnpm validate:clean` checked the actual repo state cleanly.
- This PR does not change application code.