### PR TITLE
fix(readme): center theme-aware wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-![HeyClaude](apps/web/public/heyclaude-wordmark.svg)
-
 <div align="center">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="apps/web/public/heyclaude-wordmark-dark.svg">
+  <img src="apps/web/public/heyclaude-wordmark.svg" alt="HeyClaude" width="300">
+</picture>
 
 # HeyClaude
 

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -98,9 +98,12 @@ const total = categoryOrder.reduce(
   0,
 );
 
-const readme = `![HeyClaude](apps/web/public/heyclaude-wordmark.svg)
+const readme = `<div align="center">
 
-<div align="center">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="apps/web/public/heyclaude-wordmark-dark.svg">
+  <img src="apps/web/public/heyclaude-wordmark.svg" alt="HeyClaude" width="300">
+</picture>
 
 # HeyClaude
 


### PR DESCRIPTION
## Summary
- center the README wordmark inside the header block
- use a theme-aware picture element so GitHub dark mode gets the light wordmark and light mode gets the standard wordmark
- regenerate README from the generator

## Validation
- pnpm validate:readme
- pnpm generate:readme -- --check
- trunk check README.md scripts/generate-readme.mjs
- git diff --check