### PR TITLE
ci(submissions): add stale queue hygiene

### DIFF
--- a/.github/workflows/submission-queue.yml
+++ b/.github/workflows/submission-queue.yml
@@ -66,16 +66,19 @@ jobs:
             "# Submission Queue",
             "",
             `- Import ready: ${queue.summary.importReady}`,
-            `- Needs changes: ${queue.summary.needsChanges}`,
+            `- Needs author input: ${queue.summary.needsAuthorInput}`,
+            `- Source needs verification: ${queue.summary.sourceNeedsVerification}`,
+            `- Stale reminder due: ${queue.summary.staleReminderDue}`,
+            `- Close eligible: ${queue.summary.closeEligible}`,
             `- Skipped: ${queue.summary.skipped}`,
             "",
-            "| Issue | Status | Category | Slug | Notes |",
-            "| --- | --- | --- | --- | --- |",
+            "| Issue | Status | Age | Category | Slug | Action | Notes |",
+            "| --- | --- | ---: | --- | --- | --- | --- |",
           ];
           for (const entry of queue.entries) {
             const issue = entry.url ? `[#${entry.number}](${entry.url})` : `#${entry.number}`;
             const notes = entry.errors.length ? entry.errors.join("<br>") : entry.importPath;
-            lines.push(`| ${issue} | ${entry.status} | ${entry.category || "-"} | ${entry.slug || "-"} | ${notes || "-"} |`);
+            lines.push(`| ${issue} | ${entry.status} | ${entry.ageDays ?? 0}d | ${entry.category || "-"} | ${entry.slug || "-"} | ${entry.actionDue || "-"} | ${notes || "-"} |`);
           }
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
           NODE

--- a/.github/workflows/submission-stale.yml
+++ b/.github/workflows/submission-stale.yml
@@ -1,0 +1,51 @@
+name: Submission Stale Manager
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: "Apply labels/comments/closures. Leave false for dry-run."
+        required: false
+        default: "false"
+  schedule:
+    - cron: "17 11 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  manage-stale-submissions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    concurrency:
+      group: submission-stale-manager
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Dry-run stale submission policy
+        if: github.event_name == 'workflow_dispatch' && inputs.apply != 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm submission:stale
+
+      - name: Apply stale submission policy
+        if: github.event_name == 'schedule' || inputs.apply == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm submission:stale -- --apply

--- a/.github/workflows/submission-stale.yml
+++ b/.github/workflows/submission-stale.yml
@@ -2,11 +2,6 @@ name: Submission Stale Manager
 
 on:
   workflow_dispatch:
-    inputs:
-      apply:
-        description: "Apply labels/comments/closures. Leave false for dry-run."
-        required: false
-        default: "false"
   schedule:
     - cron: "17 11 * * 1"
 
@@ -39,13 +34,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Dry-run stale submission policy
-        if: github.event_name == 'workflow_dispatch' && inputs.apply != 'true'
+        if: github.event_name == 'workflow_dispatch'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm submission:stale
 
       - name: Apply stale submission policy
-        if: github.event_name == 'schedule' || inputs.apply == 'true'
+        if: github.event_name == 'schedule'
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm submission:stale -- --apply

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ content issues.
 - Registry package: [packages/registry](packages/registry)
 - Read-only MCP server: [packages/mcp](packages/mcp)
 - Issue forms: [.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE)
+- Submission queue ops: [docs/submission-queue-ops.md](docs/submission-queue-ops.md)
 - Package trust model: [docs/package-security-policy.md](docs/package-security-policy.md)
 
 ---

--- a/apps/web/src/app/submissions/page.tsx
+++ b/apps/web/src/app/submissions/page.tsx
@@ -84,7 +84,11 @@ async function getSubmissionQueue() {
 
 function statusLabel(status: string) {
   if (status === "import_ready") return "Import ready";
-  if (status === "needs_changes") return "Needs changes";
+  if (status === "maintainer_review") return "Maintainer review";
+  if (status === "needs_author_input") return "Needs author input";
+  if (status === "source_needs_verification") return "Source verification";
+  if (status === "stale_reminder_due") return "Reminder due";
+  if (status === "close_eligible") return "Close eligible";
   return "Skipped";
 }
 
@@ -141,7 +145,8 @@ export default async function SubmissionsPage() {
       <section className="grid gap-4 md:grid-cols-3">
         {[
           ["Import ready", queue.summary.importReady],
-          ["Needs changes", queue.summary.needsChanges],
+          ["Needs author input", queue.summary.needsAuthorInput],
+          ["Source verification", queue.summary.sourceNeedsVerification],
           ["Tracked issues", queue.count],
         ].map(([label, value]) => (
           <div key={label} className="surface-panel p-5">
@@ -183,6 +188,7 @@ export default async function SubmissionsPage() {
                   </h2>
                   <p className="text-sm text-muted-foreground">
                     {entry.category || "unknown"} / {entry.slug || "no slug"}
+                    {entry.ageDays ? ` / ${entry.ageDays}d waiting` : ""}
                   </p>
                 </div>
                 {entry.importPath ? (
@@ -197,6 +203,11 @@ export default async function SubmissionsPage() {
                     <li key={issue}>{issue}</li>
                   ))}
                 </ul>
+              ) : null}
+              {entry.actionDue ? (
+                <p className="mt-4 text-sm leading-7 text-muted-foreground">
+                  Next action: {entry.actionDue.replaceAll("_", " ")}
+                </p>
               ) : null}
             </article>
           ))

--- a/docs/submission-queue-ops.md
+++ b/docs/submission-queue-ops.md
@@ -1,0 +1,54 @@
+# Submission Queue Operations
+
+HeyClaude content submissions stay issue-first and maintainer-reviewed. The
+queue automation helps maintainers see which submissions are ready, blocked, or
+stale; it does not publish content directly.
+
+## Labels
+
+- `content-submission`: canonical routing label for directory submissions.
+- `needs-review`: default state for newly-routed submissions.
+- `needs-author-input`: validation is blocked on missing or malformed fields.
+- `source-needs-verification`: the submitted source URL is missing, ambiguous,
+  unavailable, or otherwise needs maintainer review.
+- `stale-submission`: the issue has waited at least 7 days for author input.
+- `accepted` / `import-approved`: maintainer-reviewed approval labels that can
+  open an import PR.
+- `import-pr-open`: an import PR exists; stale automation must not close it.
+
+## Queue States
+
+- `import_ready`: schema-valid and ready for maintainer review/approval.
+- `maintainer_review`: protected by `accepted`, `import-approved`, or
+  `import-pr-open`.
+- `needs_author_input`: missing required fields or invalid submission data.
+- `source_needs_verification`: source/package URLs need review before import.
+- `stale_reminder_due`: invalid submission has been waiting 7+ days.
+- `close_eligible`: invalid submission has been waiting 14+ days and already
+  received the stale reminder label.
+- `skipped`: not a core submission category.
+
+## Automation
+
+- `Submission Queue` runs weekly and on demand. It writes a GitHub Actions
+  summary from `pnpm submission:queue`.
+- `Submission Stale Manager` runs weekly and on demand. Manual dispatch defaults
+  to dry-run. Scheduled runs and `apply=true` can add labels, upsert one reminder
+  comment, and close only eligible stale submissions.
+- Stale automation never imports content, creates PRs, or touches issues with
+  `accepted`, `import-approved`, or `import-pr-open`.
+
+## Maintainer Flow
+
+1. Review `/submissions` or the `Submission Queue` workflow summary.
+2. For `needs_author_input`, wait for the author to update the issue.
+3. For `source_needs_verification`, verify canonical source/package URLs before
+   approving.
+4. For `stale_reminder_due`, let the manager add `stale-submission` and post the
+   reminder.
+5. For `close_eligible`, close as not planned only after the stale reminder has
+   already been applied.
+6. Apply `accepted` or `import-approved` only after maintainer source review.
+
+Authors can reopen or resubmit closed stale submissions when the missing fields
+or source details are ready.

--- a/docs/submission-queue-ops.md
+++ b/docs/submission-queue-ops.md
@@ -33,8 +33,8 @@ stale; it does not publish content directly.
 - `Submission Queue` runs weekly and on demand. It writes a GitHub Actions
   summary from `pnpm submission:queue`.
 - `Submission Stale Manager` runs weekly and on demand. Manual dispatch defaults
-  to dry-run. Scheduled runs and `apply=true` can add labels, upsert one reminder
-  comment, and close only eligible stale submissions.
+  to dry-run and does not accept runtime inputs. Scheduled runs can add labels,
+  upsert one reminder comment, and close only eligible stale submissions.
 - Stale automation never imports content, creates PRs, or touches issues with
   `accepted`, `import-approved`, or `import-pr-open`.
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "validate:mcp-endpoint": "pnpm --filter @heyclaude/mcp validate:endpoint",
     "test:mcp": "vitest run tests/mcp-server.test.ts",
     "submission:queue": "node scripts/build-submission-queue.mjs",
+    "submission:stale": "node scripts/manage-stale-submissions.mjs",
     "test": "vitest run",
     "test:e2e": "node scripts/run-playwright.mjs",
     "test:seo-jsonld": "vitest run tests/seo-jsonld.test.ts",

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -455,7 +455,18 @@ export type SubmissionQueueEntry = {
   updatedAt: string;
   labels: string[];
   recommendedLabels: string[];
-  status: "import_ready" | "needs_changes" | "skipped";
+  status:
+    | "import_ready"
+    | "maintainer_review"
+    | "needs_author_input"
+    | "source_needs_verification"
+    | "stale_reminder_due"
+    | "close_eligible"
+    | "skipped";
+  staleState: "not_applicable" | "fresh" | "reminder_due" | "close_eligible";
+  ageDays: number;
+  sourceNeedsVerification: boolean;
+  actionDue: "" | "author_input" | "verify_source" | "remind" | "close";
   category: string;
   slug: string;
   name: string;
@@ -471,6 +482,11 @@ export type SubmissionQueue = {
   count: number;
   summary: {
     importReady: number;
+    maintainerReview: number;
+    needsAuthorInput: number;
+    sourceNeedsVerification: number;
+    staleReminderDue: number;
+    closeEligible: number;
     needsChanges: number;
     skipped: number;
   };
@@ -872,15 +888,46 @@ export function recommendedSubmissionLabels(
   issue: Record<string, unknown>,
   report?: SubmissionValidationReport,
 ): string[];
+export function hasProtectedSubmissionLabel(
+  issue?: Record<string, unknown>,
+): boolean;
+export function submissionSourceNeedsVerification(
+  report: SubmissionValidationReport,
+  issue?: Record<string, unknown>,
+): boolean;
+export function submissionAgeDays(
+  issue?: Record<string, unknown>,
+  options?: { now?: string },
+): number;
+export function submissionStaleState(
+  issue?: Record<string, unknown>,
+  report?: SubmissionValidationReport,
+  options?: { now?: string },
+): "not_applicable" | "fresh" | "reminder_due" | "close_eligible";
 export function submissionQueueStatus(
   report: SubmissionValidationReport,
+  issue?: Record<string, unknown>,
+  options?: { now?: string },
 ): string;
 export const SUBMISSION_BASE_LABELS: string[];
 export const COMMUNITY_CATEGORY_LABELS: Record<string, string>;
+export const SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL: string;
+export const SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL: string;
+export const SUBMISSION_STALE_LABEL: string;
+export const SUBMISSION_PROTECTED_REVIEW_LABELS: string[];
+export const SUBMISSION_STALE_LABEL_DEFINITIONS: Record<
+  string,
+  { color: string; description: string }
+>;
+export const SUBMISSION_STALE_POLICY: {
+  reminderDays: number;
+  closeDays: number;
+};
 export function submissionLabelsForCategory(category: string): string[];
 export function recommendedLabelsForCategory(category: string): string[];
 export function buildSubmissionQueue(
   issues: Array<Record<string, unknown>>,
+  options?: { now?: string },
 ): SubmissionQueue;
 export function validateSubmission(
   issue: Record<string, unknown>,

--- a/packages/registry/src/submission-labels.js
+++ b/packages/registry/src/submission-labels.js
@@ -1,4 +1,31 @@
 export const SUBMISSION_BASE_LABELS = ["content-submission", "needs-review"];
+export const SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL = "needs-author-input";
+export const SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL =
+  "source-needs-verification";
+export const SUBMISSION_STALE_LABEL = "stale-submission";
+export const SUBMISSION_PROTECTED_REVIEW_LABELS = [
+  "accepted",
+  "import-approved",
+  "import-pr-open",
+];
+
+export const SUBMISSION_STALE_LABEL_DEFINITIONS = {
+  [SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL]: {
+    color: "b60205",
+    description:
+      "Submission needs changes from the author before review can continue",
+  },
+  [SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL]: {
+    color: "d93f0b",
+    description:
+      "Submission source, package, or canonical URL needs maintainer verification",
+  },
+  [SUBMISSION_STALE_LABEL]: {
+    color: "cfd3d7",
+    description:
+      "Submission has been waiting on author input past the reminder window",
+  },
+};
 
 export const COMMUNITY_CATEGORY_LABELS = {
   agents: "community-agents",

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -1,6 +1,12 @@
 import categorySpec from "./category-spec.json" with { type: "json" };
 import { normalizeBrandDomain } from "./brand-assets.js";
-import { recommendedLabelsForCategory } from "./submission-labels.js";
+import {
+  recommendedLabelsForCategory,
+  SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL,
+  SUBMISSION_PROTECTED_REVIEW_LABELS,
+  SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL,
+  SUBMISSION_STALE_LABEL,
+} from "./submission-labels.js";
 import { buildSubmissionFieldModel } from "./submission-spec.js";
 
 export const CORE_CATEGORIES = categorySpec.categoryOrder;
@@ -13,6 +19,12 @@ export const CATEGORY_REQUIREMENTS = Object.fromEntries(
 );
 
 export const COMMON_REQUIRED_FIELDS = categorySpec.commonIssueRequiredFields;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export const SUBMISSION_STALE_POLICY = {
+  reminderDays: 7,
+  closeDays: 14,
+};
 
 export const HEADING_KEY_MAP = {
   name: "name",
@@ -574,20 +586,99 @@ export function recommendedSubmissionLabels(
     labels.add("content-submission");
     labels.add("needs-review");
   }
+  if (!report?.skipped && report && !report.ok) {
+    labels.add(SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL);
+  }
+  if (submissionSourceNeedsVerification(report, issue)) {
+    labels.add(SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL);
+  }
+  const staleState = submissionStaleState(issue, report);
+  if (staleState === "reminder_due" || staleState === "close_eligible") {
+    labels.add(SUBMISSION_STALE_LABEL);
+  }
   return [...labels].sort();
 }
 
-export function submissionQueueStatus(report) {
-  if (report?.skipped) return "skipped";
-  return report?.ok ? "import_ready" : "needs_changes";
+export function hasProtectedSubmissionLabel(issue = {}) {
+  const labels = new Set(issueLabels(issue));
+  return SUBMISSION_PROTECTED_REVIEW_LABELS.some((label) => labels.has(label));
 }
 
-export function buildSubmissionQueue(issues = []) {
+export function submissionSourceNeedsVerification(report, issue = {}) {
+  if (!report || report.skipped) return false;
+  const labels = new Set(issueLabels(issue));
+  if (labels.has(SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL)) return true;
+  if (
+    report.warnings?.some((warning) =>
+      String(warning).includes("No github_url/docs_url provided"),
+    )
+  ) {
+    return true;
+  }
+  return Boolean(
+    report.errors?.some((error) =>
+      /must be a valid https URL|affiliate\/referral URLs|local \/downloads hosting/.test(
+        String(error),
+      ),
+    ),
+  );
+}
+
+function parseTimestamp(value) {
+  const timestamp = Date.parse(String(value || ""));
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+export function submissionAgeDays(issue = {}, options = {}) {
+  const updatedAt = parseTimestamp(issue.updatedAt || issue.updated_at);
+  const createdAt = parseTimestamp(issue.createdAt || issue.created_at);
+  const reference = updatedAt || createdAt;
+  if (!reference) return 0;
+  const now = options.now ? parseTimestamp(options.now) : Date.now();
+  if (!Number.isFinite(now) || now <= reference) return 0;
+  return Math.floor((now - reference) / DAY_MS);
+}
+
+export function submissionStaleState(
+  issue = {},
+  report = validateSubmission(issue),
+  options = {},
+) {
+  if (report?.skipped || hasProtectedSubmissionLabel(issue)) {
+    return "not_applicable";
+  }
+  if (report?.ok) return "not_applicable";
+
+  const ageDays = submissionAgeDays(issue, options);
+  if (ageDays >= SUBMISSION_STALE_POLICY.closeDays) {
+    return "close_eligible";
+  }
+  if (ageDays >= SUBMISSION_STALE_POLICY.reminderDays) {
+    return "reminder_due";
+  }
+  return "fresh";
+}
+
+export function submissionQueueStatus(report, issue = {}, options = {}) {
+  if (report?.skipped) return "skipped";
+  if (hasProtectedSubmissionLabel(issue)) return "maintainer_review";
+  const staleState = submissionStaleState(issue, report, options);
+  if (staleState === "close_eligible") return "close_eligible";
+  if (staleState === "reminder_due") return "stale_reminder_due";
+  if (!report?.ok) return "needs_author_input";
+  if (submissionSourceNeedsVerification(report, issue)) {
+    return "source_needs_verification";
+  }
+  return "import_ready";
+}
+
+export function buildSubmissionQueue(issues = [], options = {}) {
   const entries = issues
     .filter(looksLikeSubmissionIssue)
     .map((issue) => {
       const report = validateSubmission(issue);
-      const status = submissionQueueStatus(report);
+      const status = submissionQueueStatus(report, issue, options);
+      const staleState = submissionStaleState(issue, report, options);
       return {
         number: issue.number ?? null,
         title: String(issue.title || ""),
@@ -600,6 +691,22 @@ export function buildSubmissionQueue(issues = []) {
         labels: issueLabels(issue),
         recommendedLabels: recommendedSubmissionLabels(issue, report),
         status,
+        staleState,
+        ageDays: submissionAgeDays(issue, options),
+        sourceNeedsVerification: submissionSourceNeedsVerification(
+          report,
+          issue,
+        ),
+        actionDue:
+          status === "close_eligible"
+            ? "close"
+            : status === "stale_reminder_due"
+              ? "remind"
+              : status === "needs_author_input"
+                ? "author_input"
+                : status === "source_needs_verification"
+                  ? "verify_source"
+                  : "",
         category: report.category || "",
         slug: report.fields?.slug || "",
         name: report.fields?.name || "",
@@ -614,8 +721,12 @@ export function buildSubmissionQueue(issues = []) {
     .sort((left, right) => {
       const statusOrder = {
         import_ready: 0,
-        needs_changes: 1,
-        skipped: 2,
+        maintainer_review: 1,
+        close_eligible: 2,
+        stale_reminder_due: 3,
+        needs_author_input: 4,
+        source_needs_verification: 5,
+        skipped: 6,
       };
       return (
         (statusOrder[left.status] ?? 99) - (statusOrder[right.status] ?? 99) ||
@@ -632,8 +743,29 @@ export function buildSubmissionQueue(issues = []) {
     summary: {
       importReady: entries.filter((entry) => entry.status === "import_ready")
         .length,
-      needsChanges: entries.filter((entry) => entry.status === "needs_changes")
-        .length,
+      maintainerReview: entries.filter(
+        (entry) => entry.status === "maintainer_review",
+      ).length,
+      needsAuthorInput: entries.filter(
+        (entry) => entry.status === "needs_author_input",
+      ).length,
+      sourceNeedsVerification: entries.filter(
+        (entry) => entry.sourceNeedsVerification,
+      ).length,
+      staleReminderDue: entries.filter(
+        (entry) => entry.status === "stale_reminder_due",
+      ).length,
+      closeEligible: entries.filter(
+        (entry) => entry.status === "close_eligible",
+      ).length,
+      needsChanges: entries.filter((entry) =>
+        [
+          "needs_author_input",
+          "source_needs_verification",
+          "stale_reminder_due",
+          "close_eligible",
+        ].includes(entry.status),
+      ).length,
       skipped: entries.filter((entry) => entry.status === "skipped").length,
     },
     entries,

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,12 @@
       "matchDepNames": ["node"],
       "allowedVersions": "24.x",
       "automerge": false
+    },
+    {
+      "description": "Keep package engines as compatibility ranges; setup-node pins CI/runtime versions separately",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "enabled": false
     }
   ]
 }

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -182,6 +182,7 @@ content issues.
 - Registry package: [packages/registry](packages/registry)
 - Read-only MCP server: [packages/mcp](packages/mcp)
 - Issue forms: [.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE)
+- Submission queue ops: [docs/submission-queue-ops.md](docs/submission-queue-ops.md)
 - Package trust model: [docs/package-security-policy.md](docs/package-security-policy.md)
 
 ---

--- a/scripts/manage-stale-submissions.mjs
+++ b/scripts/manage-stale-submissions.mjs
@@ -1,0 +1,297 @@
+import {
+  buildSubmissionQueue,
+  issueLabels,
+  looksLikeSubmissionIssue,
+  validateSubmission,
+} from "@heyclaude/registry/submission";
+import {
+  SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL,
+  SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL,
+  SUBMISSION_STALE_LABEL,
+  SUBMISSION_STALE_LABEL_DEFINITIONS,
+} from "@heyclaude/registry/submission-labels";
+
+const apiBaseUrl = "https://api.github.com";
+const marker = "<!-- heyclaude-stale-submission -->";
+const managedLabels = new Set([
+  SUBMISSION_NEEDS_AUTHOR_INPUT_LABEL,
+  SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL,
+  SUBMISSION_STALE_LABEL,
+]);
+
+function hasFlag(flag) {
+  return process.argv.includes(flag);
+}
+
+function argValue(flag) {
+  const idx = process.argv.indexOf(flag);
+  if (idx < 0) return "";
+  return process.argv[idx + 1] ?? "";
+}
+
+function repoParts() {
+  const raw = argValue("--repo") || process.env.GITHUB_REPOSITORY || "";
+  const [owner, repo] = raw.split("/");
+  if (!owner || !repo) {
+    throw new Error("Set GITHUB_REPOSITORY or pass --repo owner/name.");
+  }
+  return { owner, repo };
+}
+
+async function githubJson(path, options = {}) {
+  const token = process.env.GITHUB_TOKEN;
+  if (!token) throw new Error("GITHUB_TOKEN is required.");
+  const response = await fetch(`${apiBaseUrl}${path}`, {
+    ...options,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "user-agent": "heyclaude-submission-stale-manager",
+      "x-github-api-version": "2022-11-28",
+      ...(options.headers || {}),
+    },
+  });
+  if (response.status === 204) return null;
+  const text = await response.text();
+  const payload = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${options.method || "GET"} ${path} failed with ${response.status}: ${text}`,
+    );
+  }
+  return payload;
+}
+
+async function githubPaginate(path) {
+  const output = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const payload = await githubJson(
+      `${path}${separator}per_page=100&page=${page}`,
+    );
+    if (!Array.isArray(payload) || payload.length === 0) break;
+    output.push(...payload);
+    if (payload.length < 100) break;
+  }
+  return output;
+}
+
+async function ensureLabels(owner, repo) {
+  for (const [name, definition] of Object.entries(
+    SUBMISSION_STALE_LABEL_DEFINITIONS,
+  )) {
+    const path = `/repos/${owner}/${repo}/labels/${encodeURIComponent(name)}`;
+    try {
+      await githubJson(path, {
+        method: "PATCH",
+        body: JSON.stringify(definition),
+      });
+    } catch (error) {
+      if (!String(error.message).includes("404")) throw error;
+      await githubJson(`/repos/${owner}/${repo}/labels`, {
+        method: "POST",
+        body: JSON.stringify({ name, ...definition }),
+      });
+    }
+  }
+}
+
+async function addLabels(owner, repo, issueNumber, labels) {
+  if (!labels.length) return;
+  await githubJson(`/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+    method: "POST",
+    body: JSON.stringify({ labels }),
+  });
+}
+
+async function listComments(owner, repo, issueNumber) {
+  return githubPaginate(
+    `/repos/${owner}/${repo}/issues/${issueNumber}/comments`,
+  );
+}
+
+async function upsertReminder(owner, repo, issueNumber, body) {
+  const comments = await listComments(owner, repo, issueNumber);
+  const existing = comments.find((comment) => comment.body?.includes(marker));
+  if (existing) {
+    await githubJson(`/repos/${owner}/${repo}/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+    });
+    return;
+  }
+  await githubJson(`/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+  });
+}
+
+async function closeIssue(owner, repo, issueNumber) {
+  await githubJson(`/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    method: "PATCH",
+    body: JSON.stringify({
+      state: "closed",
+      state_reason: "not_planned",
+    }),
+  });
+}
+
+function reminderBody(entry) {
+  const lines = [
+    marker,
+    "Thanks for submitting this entry. The validation queue still needs author input before maintainers can review it for import.",
+    "",
+    "Please update the issue with the missing or corrected fields shown in the validation report. After you update the issue, the submission validator will rerun automatically.",
+  ];
+  if (entry.errors.length) {
+    lines.push("", "Current blockers:");
+    for (const error of entry.errors) lines.push(`- ${error}`);
+  }
+  lines.push(
+    "",
+    "If there is no update after the stale window, maintainers may close this issue as not planned. You can reopen or resubmit when the missing details are ready.",
+  );
+  return lines.join("\n");
+}
+
+function closeBody(entry) {
+  const lines = [
+    marker,
+    "Closing this submission as not planned because it has been waiting on author input past the stale window.",
+    "",
+    "This is not a rejection of the project. Please reopen this issue or submit a new one when the missing fields or source details are ready.",
+  ];
+  if (entry.errors.length) {
+    lines.push("", "Last known blockers:");
+    for (const error of entry.errors) lines.push(`- ${error}`);
+  }
+  return lines.join("\n");
+}
+
+function normalizeIssue(issue) {
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body || "",
+    url: issue.html_url,
+    updatedAt: issue.updated_at,
+    createdAt: issue.created_at,
+    author: issue.user?.login || "",
+    labels: issue.labels || [],
+  };
+}
+
+async function urlNeedsVerification(url) {
+  if (!url) return false;
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+    try {
+      let response = await fetch(url, {
+        method: "HEAD",
+        redirect: "follow",
+        signal: controller.signal,
+      });
+      if (response.status === 405 || response.status === 403) {
+        response = await fetch(url, {
+          method: "GET",
+          redirect: "follow",
+          signal: controller.signal,
+        });
+      }
+      return response.status === 404 || response.status === 410;
+    } finally {
+      clearTimeout(timeout);
+    }
+  } catch {
+    return false;
+  }
+}
+
+async function submissionSourceCheckLabels(issue) {
+  const report = validateSubmission(issue);
+  const urls = [
+    report.fields.github_url,
+    report.fields.docs_url,
+    report.fields.download_url,
+  ].filter(Boolean);
+  for (const url of urls) {
+    if (await urlNeedsVerification(url)) {
+      return [SUBMISSION_SOURCE_NEEDS_VERIFICATION_LABEL];
+    }
+  }
+  return [];
+}
+
+async function main() {
+  const apply = hasFlag("--apply");
+  const now = argValue("--now") || new Date().toISOString();
+  const { owner, repo } = repoParts();
+  const issues = (
+    await githubPaginate(`/repos/${owner}/${repo}/issues?state=open`)
+  )
+    .filter((issue) => !issue.pull_request)
+    .map(normalizeIssue)
+    .filter(looksLikeSubmissionIssue);
+  const queue = buildSubmissionQueue(issues, { now });
+  const issuesByNumber = new Map(issues.map((issue) => [issue.number, issue]));
+
+  if (apply) await ensureLabels(owner, repo);
+
+  const actions = [];
+  for (const entry of queue.entries) {
+    const existingLabels = new Set(entry.labels);
+    const sourceCheckLabels = entry.number
+      ? await submissionSourceCheckLabels(issuesByNumber.get(entry.number))
+      : [];
+    const labels = new Set([...entry.recommendedLabels, ...sourceCheckLabels]);
+    const nextLabels = [...labels].filter(
+      (label) => managedLabels.has(label) && !existingLabels.has(label),
+    );
+    const staleDue =
+      entry.status === "stale_reminder_due" ||
+      entry.status === "close_eligible";
+    const shouldRemind =
+      staleDue && !existingLabels.has(SUBMISSION_STALE_LABEL);
+    const shouldClose = staleDue && existingLabels.has(SUBMISSION_STALE_LABEL);
+
+    actions.push({
+      issue: entry.number,
+      status: entry.status,
+      labels: nextLabels,
+      remind: shouldRemind,
+      close: shouldClose,
+    });
+
+    if (!apply || !entry.number) continue;
+    await addLabels(owner, repo, entry.number, nextLabels);
+    if (shouldRemind) {
+      await upsertReminder(owner, repo, entry.number, reminderBody(entry));
+    }
+    if (shouldClose) {
+      await upsertReminder(owner, repo, entry.number, closeBody(entry));
+      await closeIssue(owner, repo, entry.number);
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        mode: apply ? "apply" : "dry-run",
+        now,
+        count: queue.count,
+        summary: queue.summary,
+        actions,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/manage-stale-submissions.mjs
+++ b/scripts/manage-stale-submissions.mjs
@@ -1,6 +1,5 @@
 import {
   buildSubmissionQueue,
-  issueLabels,
   looksLikeSubmissionIssue,
   validateSubmission,
 } from "@heyclaude/registry/submission";
@@ -10,6 +9,7 @@ import {
   SUBMISSION_STALE_LABEL,
   SUBMISSION_STALE_LABEL_DEFINITIONS,
 } from "@heyclaude/registry/submission-labels";
+import { pathToFileURL } from "node:url";
 
 const apiBaseUrl = "https://api.github.com";
 const marker = "<!-- heyclaude-stale-submission -->";
@@ -169,6 +169,29 @@ function closeBody(entry) {
   return lines.join("\n");
 }
 
+export function planStaleSubmissionAction(entry, sourceCheckLabels = []) {
+  const existingLabels = new Set(entry.labels);
+  const labels = new Set([...entry.recommendedLabels, ...sourceCheckLabels]);
+  const nextLabels = [...labels].filter(
+    (label) => managedLabels.has(label) && !existingLabels.has(label),
+  );
+  const shouldRemind =
+    (entry.status === "stale_reminder_due" ||
+      entry.status === "close_eligible") &&
+    !existingLabels.has(SUBMISSION_STALE_LABEL);
+  const shouldClose =
+    entry.status === "close_eligible" &&
+    existingLabels.has(SUBMISSION_STALE_LABEL);
+
+  return {
+    issue: entry.number,
+    status: entry.status,
+    labels: nextLabels,
+    remind: shouldRemind,
+    close: shouldClose,
+  };
+}
+
 function normalizeIssue(issue) {
   return {
     number: issue.number,
@@ -241,35 +264,18 @@ async function main() {
 
   const actions = [];
   for (const entry of queue.entries) {
-    const existingLabels = new Set(entry.labels);
     const sourceCheckLabels = entry.number
       ? await submissionSourceCheckLabels(issuesByNumber.get(entry.number))
       : [];
-    const labels = new Set([...entry.recommendedLabels, ...sourceCheckLabels]);
-    const nextLabels = [...labels].filter(
-      (label) => managedLabels.has(label) && !existingLabels.has(label),
-    );
-    const staleDue =
-      entry.status === "stale_reminder_due" ||
-      entry.status === "close_eligible";
-    const shouldRemind =
-      staleDue && !existingLabels.has(SUBMISSION_STALE_LABEL);
-    const shouldClose = staleDue && existingLabels.has(SUBMISSION_STALE_LABEL);
-
-    actions.push({
-      issue: entry.number,
-      status: entry.status,
-      labels: nextLabels,
-      remind: shouldRemind,
-      close: shouldClose,
-    });
+    const action = planStaleSubmissionAction(entry, sourceCheckLabels);
+    actions.push(action);
 
     if (!apply || !entry.number) continue;
-    await addLabels(owner, repo, entry.number, nextLabels);
-    if (shouldRemind) {
+    await addLabels(owner, repo, entry.number, action.labels);
+    if (action.remind) {
       await upsertReminder(owner, repo, entry.number, reminderBody(entry));
     }
-    if (shouldClose) {
+    if (action.close) {
       await upsertReminder(owner, repo, entry.number, closeBody(entry));
       await closeIssue(owner, repo, entry.number);
     }
@@ -291,7 +297,12 @@ async function main() {
   );
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -11,6 +11,8 @@ import {
   looksLikeSubmissionIssue,
   parseIssueFormBody,
   recommendedSubmissionLabels,
+  submissionQueueStatus,
+  submissionStaleState,
   validateSubmission,
 } from "@heyclaude/registry/submission";
 import { categorySpec } from "@heyclaude/registry";
@@ -395,6 +397,7 @@ claude mcp add prompt-to-asset -- npx -y prompt-to-asset`,
       "community-mcp",
       "content-submission",
       "needs-review",
+      "source-needs-verification",
     ]);
   });
 
@@ -410,6 +413,9 @@ mcp
 
 ### Public contact
 dev@example.com
+
+### GitHub URL
+https://github.com/example/contrastapi
 
 ### Description
 Security MCP.
@@ -442,12 +448,116 @@ Writing cleanup.
 
 ### Usage snippet
 npx unslop --help`);
-    const queue = buildSubmissionQueue([valid, invalid, { title: "Question" }]);
+    const queue = buildSubmissionQueue(
+      [valid, invalid, { title: "Question" }],
+      { now: "2026-04-30T00:00:00Z" },
+    );
     expect(queue.count).toBe(2);
     expect(queue.summary.importReady).toBe(1);
     expect(queue.summary.needsChanges).toBe(1);
     expect(queue.entries[0].status).toBe("import_ready");
     expect(queue.entries[0].importPath).toBe("content/mcp/contrastapi.mdx");
+    expect(queue.entries[1].status).toBe("needs_author_input");
+    expect(queue.entries[1].actionDue).toBe("author_input");
+  });
+
+  it("tracks stale author-input states without touching maintainer-approved issues", () => {
+    const invalidBody = `### Name
+Unslop
+
+### Slug
+unslop
+
+### Category
+skills
+
+### Public contact
+dev@example.com
+
+### Description
+Writing cleanup.
+
+### Card description
+Writing cleanup.
+
+### Usage snippet
+npx unslop --help`;
+    const fresh = issue(invalidBody, ["content-submission"]);
+    const reminderDue = {
+      ...issue(invalidBody, ["content-submission"]),
+      updatedAt: "2026-04-20T00:00:00Z",
+    };
+    const closeEligible = {
+      ...issue(invalidBody, ["content-submission", "stale-submission"]),
+      updatedAt: "2026-04-10T00:00:00Z",
+    };
+    const approved = {
+      ...issue(invalidBody, ["content-submission", "import-approved"]),
+      updatedAt: "2026-04-10T00:00:00Z",
+    };
+
+    const report = validateSubmission(fresh);
+    expect(report.ok).toBe(false);
+    expect(
+      submissionQueueStatus(report, fresh, { now: "2026-04-30T00:00:00Z" }),
+    ).toBe("needs_author_input");
+    expect(
+      submissionStaleState(reminderDue, validateSubmission(reminderDue), {
+        now: "2026-04-30T00:00:00Z",
+      }),
+    ).toBe("reminder_due");
+    expect(
+      submissionQueueStatus(validateSubmission(closeEligible), closeEligible, {
+        now: "2026-04-30T00:00:00Z",
+      }),
+    ).toBe("close_eligible");
+    expect(
+      submissionQueueStatus(validateSubmission(approved), approved, {
+        now: "2026-04-30T00:00:00Z",
+      }),
+    ).toBe("maintainer_review");
+  });
+
+  it("separates source verification from author-input failures", () => {
+    const sourceProblem = issue(
+      `### Name
+Source Review MCP
+
+### Slug
+source-review-mcp
+
+### Category
+mcp
+
+### Public contact
+dev@example.com
+
+### GitHub URL
+https://github.com/example/source-review-mcp
+
+### Description
+MCP server with a source that maintainers marked for verification.
+
+### Card description
+Source verification coverage.
+
+### Install command
+npx -y source-review-mcp
+
+### Usage snippet
+claude mcp add source-review-mcp -- npx -y source-review-mcp`,
+      ["content-submission", "source-needs-verification"],
+    );
+    const report = validateSubmission(sourceProblem);
+    expect(report.ok).toBe(true);
+    expect(
+      submissionQueueStatus(report, sourceProblem, {
+        now: "2026-04-30T00:00:00Z",
+      }),
+    ).toBe("source_needs_verification");
+    expect(recommendedSubmissionLabels(sourceProblem)).toContain(
+      "source-needs-verification",
+    );
   });
 
   it("rejects missing required category fields", () => {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -63,4 +63,44 @@ describe("submission automation workflows", () => {
     expect(source).toContain("Dry-run Resend template sync");
     expect(source).toContain("pnpm resend:sync-templates -- --dry-run");
   });
+
+  it("keeps stale submission automation review-only and label-scoped", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/submission-stale.yml"),
+      "utf8",
+    );
+
+    expect(source).toContain("Submission Stale Manager");
+    expect(source).toContain("issues: write");
+    expect(source).toContain("pnpm submission:stale");
+    expect(source).toContain("--apply");
+    expect(source).not.toContain("import-approved");
+    expect(source).not.toContain("scripts/import-submission-issue.mjs");
+    expect(source).not.toContain("peter-evans/create-pull-request");
+  });
+
+  it("prevents Renovate from pinning package engine ranges", () => {
+    const renovate = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "renovate.json"), "utf8"),
+    );
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
+    );
+
+    expect(packageJson.engines.node).toBe(">=20");
+    expect(renovate.packageRules).toContainEqual(
+      expect.objectContaining({
+        matchManagers: ["npm"],
+        matchDepTypes: ["engines"],
+        enabled: false,
+      }),
+    );
+    expect(renovate.packageRules).toContainEqual(
+      expect.objectContaining({
+        matchManagers: ["github-actions"],
+        matchDepNames: ["node"],
+        allowedVersions: "24.x",
+      }),
+    );
+  });
 });

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { planStaleSubmissionAction } from "../scripts/manage-stale-submissions.mjs";
 import { repoRoot } from "./helpers/registry-fixtures";
 
 describe("submission automation workflows", () => {
@@ -77,6 +78,58 @@ describe("submission automation workflows", () => {
     expect(source).not.toContain("import-approved");
     expect(source).not.toContain("scripts/import-submission-issue.mjs");
     expect(source).not.toContain("peter-evans/create-pull-request");
+  });
+
+  it("keeps stale reminders separate from close eligibility", () => {
+    const baseEntry = {
+      number: 296,
+      status: "stale_reminder_due",
+      labels: ["content-submission", "needs-author-input"],
+      recommendedLabels: [
+        "content-submission",
+        "needs-review",
+        "needs-author-input",
+        "stale-submission",
+      ],
+    };
+
+    expect(planStaleSubmissionAction(baseEntry)).toMatchObject({
+      issue: 296,
+      labels: ["stale-submission"],
+      remind: true,
+      close: false,
+    });
+    expect(
+      planStaleSubmissionAction({
+        ...baseEntry,
+        labels: [...baseEntry.labels, "stale-submission"],
+      }),
+    ).toMatchObject({
+      labels: [],
+      remind: false,
+      close: false,
+    });
+    expect(
+      planStaleSubmissionAction({
+        ...baseEntry,
+        status: "close_eligible",
+        labels: [...baseEntry.labels, "stale-submission"],
+      }),
+    ).toMatchObject({
+      labels: [],
+      remind: false,
+      close: true,
+    });
+    expect(
+      planStaleSubmissionAction({
+        ...baseEntry,
+        status: "close_eligible",
+      }),
+    ).toMatchObject({
+      labels: ["stale-submission"],
+      remind: true,
+      close: false,
+    });
   });
 
   it("prevents Renovate from pinning package engine ranges", () => {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -73,6 +73,9 @@ describe("submission automation workflows", () => {
 
     expect(source).toContain("Submission Stale Manager");
     expect(source).toContain("issues: write");
+    expect(source).toContain("workflow_dispatch:");
+    expect(source).not.toContain("inputs:");
+    expect(source).not.toContain("inputs.");
     expect(source).toContain("pnpm submission:stale");
     expect(source).toContain("--apply");
     expect(source).not.toContain("import-approved");


### PR DESCRIPTION
## Summary
- adds stale submission management for invalid content submissions
- expands submission queue status output for maintainer review
- prevents Renovate from pinning package engine ranges
- fixes stale closure behavior so reminder labels do not close issues before the close window
- documents maintainer queue/stale policy in `docs/submission-queue-ops.md`

## What changed
- adds `submission:stale` and weekly `Submission Stale Manager` workflow
- adds queue states for import-ready, needs-author-input, source-needs-verification, stale reminder due, close eligible, and protected review
- labels invalid submissions without touching accepted/import-approved/import-pr-open issues
- keeps stale automation review-only; it never imports or publishes content
- updates README with the submission queue ops runbook

## Validation
- `pnpm validate:issue-templates`
- `pnpm test:submission-intake`
- `pnpm test -- tests/submission-workflows.test.ts`
- `pnpm validate:readme`
- `pnpm validate:clean`

## Notes
- This PR does not import or publish content automatically.
- Release PR 1.0.0 should remain held until an intentional production cut.
