### PR TITLE
fix(mcp): normalize npm package metadata

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -9,7 +9,7 @@
   "homepage": "https://heyclau.de",
   "repository": {
     "type": "git",
-    "url": "https://github.com/JSONbored/claudepro-directory.git",
+    "url": "git+https://github.com/JSONbored/claudepro-directory.git",
     "directory": "packages/mcp"
   },
   "bugs": {
@@ -62,7 +62,7 @@
     }
   },
   "bin": {
-    "heyclaude-mcp": "./src/cli.js"
+    "heyclaude-mcp": "src/cli.js"
   },
   "engines": {
     "node": ">=20"

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -50,7 +50,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     };
 
     expect(packageJson.private).not.toBe(true);
-    expect(packageJson.bin).toHaveProperty("heyclaude-mcp", "./src/cli.js");
+    expect(packageJson.bin).toHaveProperty("heyclaude-mcp", "src/cli.js");
     expect(packageJson.files).toContain("scripts/**/*.mjs");
     expect(packageJson.scripts).not.toHaveProperty("preinstall");
     expect(packageJson.scripts).not.toHaveProperty("install");


### PR DESCRIPTION
## Summary
- normalize the MCP package repository URL and CLI bin path to npm's publishable manifest shape
- update the package publishability test to assert the normalized bin path

## Why
- `npm publish --dry-run` auto-corrected the pre-existing manifest and would strip the CLI binary from the published package unless the bin path is normalized first

## Validation
- `pnpm test:mcp`
- `MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package`
- `npm publish --access public --provenance --dry-run`