### PR TITLE
docs(mcp): polish npm package readme

### DIFF
--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @heyclaude/mcp Changelog
 
+## 0.1.1 - Package Page Polish
+
+- Add npm-facing package README branding, repository links, npm links, and
+  release provenance notes.
+- Keep published package behavior unchanged.
+
 ## 0.1.0 - Initial Public Package
 
 - Add remote-first stdio bridge for the public HeyClaude MCP endpoint.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,5 +1,19 @@
 # HeyClaude MCP Server
 
+<p align="center">
+  <a href="https://heyclau.de">
+    <img src="https://heyclau.de/heyclaude-wordmark.svg" alt="HeyClaude" width="300">
+  </a>
+</p>
+
+<p align="center">
+  <a href="https://heyclau.de">Website</a> •
+  <a href="https://github.com/JSONbored/claudepro-directory">GitHub</a> •
+  <a href="https://www.npmjs.com/package/@heyclaude/mcp">npm</a> •
+  <a href="https://heyclau.de/api/mcp">MCP endpoint</a> •
+  <a href="https://github.com/JSONbored/claudepro-directory/releases/tag/mcp-v0.1.1">v0.1.1 release</a>
+</p>
+
 Read-only Model Context Protocol server for the HeyClaude registry.
 
 It exposes the same public registry surface used by the website and Raycast:
@@ -117,6 +131,9 @@ checks the HTTP guards used by the remote route.
 MCP releases are package-scoped. Website/catalog changes do not create repo-wide
 semver releases. The initial public package version is `0.1.0`, and GitHub
 release tags use `mcp-vX.Y.Z`.
+
+The npm package artifact is hosted on npmjs.com. GitHub Releases track the
+matching package-scoped source tag and release notes, such as `mcp-v0.1.1`.
 
 Do not publish until the web branch has shipped, the production endpoint has
 been verified, and the package smoke test passes. The release checklist is:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heyclaude/mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "description": "Read-only MCP server for the HeyClaude registry.",
   "license": "MIT",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -76,6 +76,31 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(packageJson.exports).toHaveProperty("./submissions");
   });
 
+  it("keeps npm package README branding, links, and release convention current", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
+    ) as {
+      version: string;
+    };
+    const readme = fs.readFileSync(
+      path.join(repoRoot, "packages/mcp/README.md"),
+      "utf8",
+    );
+
+    expect(readme).toContain("https://heyclau.de/heyclaude-wordmark.svg");
+    expect(readme).toContain(
+      "https://github.com/JSONbored/claudepro-directory",
+    );
+    expect(readme).toContain("https://www.npmjs.com/package/@heyclaude/mcp");
+    expect(readme).toContain("https://heyclau.de/api/mcp");
+    expect(readme).toContain(
+      `https://github.com/JSONbored/claudepro-directory/releases/tag/mcp-v${packageJson.version}`,
+    );
+    expect(readme).toContain("`mcp-vX.Y.Z`");
+    expect(readme).toContain("npmjs.com");
+    expect(readme).toContain("GitHub Releases track");
+  });
+
   it("exposes only read-only registry and submission helper tools", () => {
     expect(TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual(
       READ_ONLY_TOOL_NAMES,


### PR DESCRIPTION
## Summary
- add npm-facing HeyClaude branding and links to the MCP package README
- document that npm hosts the package artifact while GitHub Releases track package-scoped tags
- bump the MCP package to 0.1.1 so the updated README can be published to npm

## What changed
- added the public HeyClaude wordmark, website, GitHub, npm, MCP endpoint, and release links to `packages/mcp/README.md`
- added README metadata coverage in the MCP package tests
- added a `0.1.1` changelog entry for package page polish

## Why
- npm renders the package README, not the repo root README, so the live npm page needs package-local branding and release links

## Validation
- `pnpm test:mcp`
- `MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package`
- `pnpm validate:clean`
- `pnpm --filter @heyclaude/mcp pack --dry-run --json`
- temp install of `@heyclaude/mcp@0.1.0` with `npm audit signatures`
- MCP stdio smoke using `npx -y @heyclaude/mcp`

## Notes
- `@heyclaude/mcp@0.1.1` should be published through the trusted publishing workflow after this lands on `main`.
- Local Codex and Claude Desktop configs were updated outside the repo to use `npx -y @heyclaude/mcp`.