### PR TITLE
fix(submission): preserve config snippets during import

### DIFF
--- a/.github/workflows/jobs-source-revalidation.yml
+++ b/.github/workflows/jobs-source-revalidation.yml
@@ -53,14 +53,25 @@ jobs:
             exit 1
           fi
           if [ -z "$ADMIN_API_TOKEN" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+              echo "::warning::Skipping scheduled jobs source revalidation because JOBS_ADMIN_API_TOKEN or ADMIN_API_TOKEN is not configured."
+              {
+                echo "skip=true"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
             echo "::error::Missing JOBS_ADMIN_API_TOKEN or ADMIN_API_TOKEN."
             exit 1
           fi
-          echo "mode=$mode" >> "$GITHUB_OUTPUT"
-          echo "base-url=$base_url" >> "$GITHUB_OUTPUT"
+          {
+            echo "skip=false"
+            echo "mode=$mode"
+            echo "base-url=$base_url"
+          } >> "$GITHUB_OUTPUT"
           echo "Running jobs source revalidation in $mode mode against $base_url"
 
       - name: Check job sources
+        if: steps.source-check.outputs.skip != 'true'
         env:
           SOURCE_BASE_URL: ${{ steps.source-check.outputs.base-url }}
           SOURCE_CHECK_MODE: ${{ steps.source-check.outputs.mode }}

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -89,6 +89,7 @@ export const HEADING_KEY_MAP = {
   usage: "usage_snippet",
   configuration: "config_snippet",
   config: "config_snippet",
+  "config-snippet": "config_snippet",
   trigger: "trigger",
   "config-snippet-optional": "config_snippet",
   "script-language-optional": "script_language",

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -757,6 +757,51 @@ Review build logs, identify the failing step, and summarize the likely fix.`),
     expect(report.fields.full_copyable_content).toContain("Review build logs");
   });
 
+  it("preserves MCP config snippet headings during import", () => {
+    const body = buildSubmissionIssueDraft({
+      name: "Config Snippet MCP",
+      slug: "config-snippet-mcp",
+      category: "mcp",
+      docs_url: "https://example.com/mcp",
+      description:
+        "Hosted MCP server submitted with a client configuration snippet.",
+      card_description: "Config snippet import coverage.",
+      install_command:
+        "claude mcp add --transport http config-snippet https://example.com/mcp",
+      usage_snippet: "claude mcp status config-snippet",
+      config_snippet: `\`\`\`json
+{
+  "mcpServers": {
+    "config-snippet": {
+      "type": "http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+\`\`\``,
+    }).body;
+
+    const report = validateSubmission(issue(body));
+    expect(report.ok).toBe(true);
+    expect(report.fields.config_snippet).toContain('"mcpServers"');
+
+    const output = importSubmissionDryRun({
+      number: 779,
+      html_url: "https://github.com/JSONbored/claudepro-directory/issues/779",
+      created_at: "2026-05-10T00:00:00Z",
+      user: {
+        login: "content-author",
+        html_url: "https://github.com/content-author",
+      },
+      body,
+      labels: [{ name: "content-submission" }, { name: "community-mcp" }],
+    });
+
+    expect(output).toContain("configSnippet: |-");
+    expect(output).toContain('"mcpServers"');
+    expect(output).toContain('"url": "https://example.com/mcp"');
+  });
+
   it("adds deterministic security/safety context to the maintainer queue", () => {
     const legal = issue(`### Name
 Spain Legal by Legal Fournier

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -363,5 +363,11 @@ diff --git a/README.md b/README.md
       "SOURCE_BASE_URL: ${{ steps.source-check.outputs.base-url }}",
     );
     expect(jobsSource).toContain('args=(--base-url "$SOURCE_BASE_URL"');
+    expect(jobsSource).toContain('echo "skip=true"');
+    expect(jobsSource).toContain('} >> "$GITHUB_OUTPUT"');
+    expect(jobsSource).toContain("Skipping scheduled jobs source revalidation");
+    expect(jobsSource).toContain(
+      "if: steps.source-check.outputs.skip != 'true'",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Fixes submission issue parsing so `### Config snippet` imports as `configSnippet`.
- Prevents scheduled jobs source revalidation from failing noisily when the admin token secret is not configured.

## What changed
- Added the canonical `config-snippet` heading alias to the submission parser.
- Added a regression test that validates issue parsing and import dry-run frontmatter output.
- Updated `Jobs Source Revalidation` so scheduled runs skip with a warning when `JOBS_ADMIN_API_TOKEN`/`ADMIN_API_TOKEN` is missing, while manual runs still fail loudly.
- Added workflow coverage for the scheduled skip behavior.

## Why
- Import PR automation for issues #324 and #325 failed because their valid `### Config snippet` sections were dropped during parsing, producing MDX without the recommended `configSnippet` field.
- The scheduled jobs source workflow was failing before doing useful work in repos/environments without the required admin token.

## Validation
- `pnpm test:submission-intake`
- `pnpm exec vitest run tests/submission-workflows.test.ts tests/job-source-check-script.test.ts`
- `pnpm validate:issue-templates`
- `pnpm validate:clean`
- `pnpm validate:content:strict`
- `pnpm validate:packages`
- `pnpm validate:raycast-feed`
- `pnpm test:registry-artifacts`
- `pnpm test:seo-jsonld`
- `actionlint`
- `trunk check --ci --all`
- `pnpm generate:readme && pnpm validate:readme`, then restored generated `README.md`
- `pnpm generate:readme && pnpm test`, then restored generated `README.md`
- Live dry-run import for issues #324 and #325 confirmed `configSnippet` is present.

## Notes
- This does not include generated README changes; the existing README refresh automation owns that PR.
- After this lands on `main`, #324 and #325 need the import workflow retriggered because the failed label events already ran on the old parser.
