### PR TITLE
ci(submission): validate generated automation pull requests

### DIFF
--- a/.github/workflows/readme-refresh-pr.yml
+++ b/.github/workflows/readme-refresh-pr.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -51,6 +52,7 @@ jobs:
         run: node scripts/build-readme-refresh-body.mjs --output "$RUNNER_TEMP/readme-refresh-body.md"
 
       - name: Create README update PR
+        id: cpr
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           branch: automation/readme-refresh
@@ -62,3 +64,10 @@ jobs:
             automation
           add-paths: |
             README.md
+
+      - name: Trigger content validation for README PR
+        if: ${{ steps.cpr.outputs.pull-request-url != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATION_REF: automation/readme-refresh
+        run: gh workflow run content-validation.yml --ref "$VALIDATION_REF"

--- a/.github/workflows/submission-import-pr.yml
+++ b/.github/workflows/submission-import-pr.yml
@@ -6,6 +6,7 @@ on:
       - labeled
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -148,6 +149,13 @@ jobs:
 
             ## Notes
             - Closes #${{ steps.metadata.outputs.issue_number }} after merge.
+
+      - name: Trigger content validation for import PR
+        if: ${{ steps.cpr.outputs.pull-request-url != '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VALIDATION_REF: ${{ steps.metadata.outputs.branch }}
+        run: gh workflow run content-validation.yml --ref "$VALIDATION_REF"
 
       - name: Link PR on submission issue
         if: ${{ steps.cpr.outputs.pull-request-url != '' }}

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -61,6 +61,11 @@ describe("submission automation workflows", () => {
     expect(source).toContain("pnpm validate:content:strict");
     expect(source).toContain("peter-evans/create-pull-request@");
     expect(source).toContain("branch=automation/submission-");
+    expect(source).toContain("actions: write");
+    expect(source).toContain("Trigger content validation for import PR");
+    expect(source).toContain(
+      'gh workflow run content-validation.yml --ref "$VALIDATION_REF"',
+    );
     expect(source).toContain("pr_title=feat(content): add");
     expect(source).toContain("issue_author=");
     expect(source).toContain("issue_author_id=");
@@ -118,6 +123,11 @@ describe("submission automation workflows", () => {
     expect(source).toContain("Build README refresh body");
     expect(source).toContain(
       "body-path: ${{ runner.temp }}/readme-refresh-body.md",
+    );
+    expect(source).toContain("actions: write");
+    expect(source).toContain("Trigger content validation for README PR");
+    expect(source).toContain(
+      'gh workflow run content-validation.yml --ref "$VALIDATION_REF"',
     );
     expect(source).toContain(".github/workflows/readme-refresh-pr.yml");
     expect(source).not.toContain("body: |");


### PR DESCRIPTION
## Summary
- Makes generated submission-import and README-refresh PRs dispatch the required Content Validation workflow for their generated branches.

## What changed
- Grants `actions: write` to the two automation workflows that create PRs.
- Dispatches `content-validation.yml` after a submission import PR is opened or updated.
- Dispatches `content-validation.yml` after the README refresh PR is opened or updated.
- Adds workflow tests so the dispatch behavior does not regress.

## Why
- PRs created with the default `GITHUB_TOKEN` do not reliably trigger normal `pull_request` validation workflows, which leaves automation PRs blocked with missing required checks.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `actionlint`
- `trunk check --ci --all`
- `pnpm validate:clean`

## Notes
- Existing automation PRs still need a one-time manual Content Validation dispatch because they were created before this fix lands.
