### PR TITLE
ci(submission): format generated import content

### DIFF
--- a/.github/workflows/submission-import-pr.yml
+++ b/.github/workflows/submission-import-pr.yml
@@ -74,6 +74,13 @@ jobs:
           node scripts/import-submission-issue.mjs \
             --issue-json .github/tmp/issue.json
 
+      - name: Format imported content
+        run: |
+          changed_mdx="$(git diff --name-only --diff-filter=ACM | grep -E '^content/.+\.mdx$' || true)"
+          if [ -n "$changed_mdx" ]; then
+            printf '%s\n' "$changed_mdx" | xargs pnpm exec prettier --write
+          fi
+
       - name: Build registry artifacts
         run: pnpm --filter web run prebuild
 

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -56,6 +56,8 @@ describe("submission automation workflows", () => {
       "contains(github.event.issue.labels.*.name, 'content-submission')",
     );
     expect(source).toContain("scripts/import-submission-issue.mjs");
+    expect(source).toContain("Format imported content");
+    expect(source).toContain("pnpm exec prettier --write");
     expect(source).toContain("pnpm --filter web run prebuild");
     expect(source).toContain("pnpm generate:readme");
     expect(source).toContain("pnpm validate:content:strict");


### PR DESCRIPTION
## Summary
- Formats imported MDX before generated submission import PRs are created.

## What changed
- Adds a `Format imported content` step after issue import and before artifact generation.
- Runs Prettier on changed `content/**/*.mdx` files.
- Adds workflow test coverage for the formatting step.

## Why
- Import PRs for #324 and #325 passed content validation but failed final Trunk formatting because generated MDX was not Prettier-normalized before PR creation.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `actionlint`
- `trunk check --ci --all`
- `pnpm validate:clean`

## Notes
- Existing generated import PRs still need their content files formatted once because they were created before this workflow fix lands.
