### PR TITLE
fix(ci): rerun PR risk checks against current base

### DIFF
--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout base repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -35,6 +35,10 @@ describe("submission automation workflows", () => {
 
     expect(source).toContain("pull_request_target:");
     expect(source).toContain("Checkout base repository");
+    expect(source).toContain("ref: ${{ github.event.pull_request.base.ref }}");
+    expect(source).not.toContain(
+      "ref: ${{ github.event.pull_request.base.sha }}",
+    );
     expect(source).toContain("github.rest.repos.getContent");
     expect(source).toContain("pr.head.sha");
     expect(source).toContain("sourceType");


### PR DESCRIPTION
## Summary
- Fixes `Submission PR Risk Review` reruns on older open PRs after provenance workflow changes land on `main`.

## What changed
- Checkout the trusted base branch ref instead of the stale PR `base.sha`.
- Add workflow-test coverage so the PR risk workflow does not regress back to stale base-SHA checkout.

## Why
- #337 and #338 still have old base SHAs, so the rerun used the new workflow file but checked out an old base commit that did not contain `scripts/ci/fail-provenance-report.mjs`.
- The workflow reads PR content via the GitHub API as data, so using the current trusted base branch checkout is the correct behavior for `pull_request_target` maintenance reruns.

## Validation
- `CI=true pnpm install --frozen-lockfile`
- `pnpm vitest run tests/submission-workflows.test.ts`
- `pnpm test:submission-intake`
- `pnpm validate:clean`
- `actionlint .github/workflows/submission-pr-risk.yml`

## Notes
- After this merges, rerun #337 and #338 again by editing/synchronizing the PRs. The risk comments should then tag the original submitter and linked issue instead of `github-actions[bot]`.
