### PR TITLE
feat(submission): harden contributor risk analysis

### DIFF
--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -220,6 +220,13 @@ jobs:
               const login = normalizeGitHubLogin(value);
               return login ? `@${login}` : markdownCodeSpan(value);
             };
+            const uniquePush = (list, value) => {
+              const normalized = normalizeText(value);
+              if (normalized && !list.includes(normalized)) list.push(normalized);
+            };
+            const uniquePushMany = (list, values) => {
+              for (const value of values || []) uniquePush(list, value);
+            };
             const readFrontmatter = (content) => {
               const lines = String(content || "").split(/\r?\n/);
               if (lines[0]?.trim() !== "---") return {};
@@ -331,6 +338,8 @@ jobs:
               contentProvenance: [],
               effectiveContributor: null,
               contributorSource: "",
+              contributorAnalysis: baseContributorAnalysis(),
+              contributionAnalysis: baseContributionAnalysis(),
               pullRequestActor: null,
               riskTier: "low",
               reviewFlags: [],
@@ -342,35 +351,122 @@ jobs:
               humanReviewNotes: [],
               labelDefinitions: RISK_LABEL_DEFINITIONS
             });
+            const baseContributorAnalysis = (source = "") => ({
+              login: "",
+              rawLogin: "",
+              source,
+              profileUrl: "",
+              id: null,
+              accountType: "unknown",
+              resolutionStatus: "unresolved",
+              accountAgeDays: null,
+              publicRepos: null,
+              reviewSignals: [],
+              warnings: []
+            });
+            const contributorProfileUrl = (contributor = {}, login = "") => {
+              const url = normalizeText(contributor.html_url || contributor.htmlUrl);
+              if (url && sameGitHubLogin(url, login)) return url;
+              return login ? `https://github.com/${login}` : "";
+            };
             const contributorSummary = (contributor = {}) => {
-              const login = normalizeText(contributor.login || contributor.name);
+              const login = normalizeGitHubLogin(contributor.login);
               if (!login) return null;
               return {
                 login,
-                htmlUrl: normalizeText(contributor.html_url || contributor.url),
-                id: contributor.id ?? null
+                htmlUrl: contributorProfileUrl(contributor, login),
+                id: contributor.id ?? null,
+                accountType: normalizeText(contributor.type) || undefined,
+                createdAt: normalizeText(contributor.created_at || contributor.createdAt),
+                publicRepos: contributor.public_repos ?? contributor.publicRepos ?? null,
+                error: normalizeText(contributor.error)
               };
             };
-            const contributorSignals = (contributor = {}, report) => {
-              const login = normalizeText(contributor.login || contributor.name);
-              if (login) {
-                report.trustSignals.push(
-                  `Contributor analyzed: ${githubUserReference(login)}`
-                );
-              }
-              const createdAt = Date.parse(
-                contributor.created_at || contributor.createdAt
+            const contributorAnalysis = (contributor = {}, source = "", fallback = {}) => {
+              const profile = contributorSummary(contributor) || contributorSummary(fallback);
+              const analysis = baseContributorAnalysis(source);
+              const rawLogin = normalizeText(
+                contributor.login || fallback.login || contributor.name || fallback.name
               );
+              analysis.rawLogin = rawLogin;
+              if (!profile) {
+                analysis.reviewSignals.push("identity_unresolved");
+                analysis.warnings.push(
+                  rawLogin
+                    ? `Unresolved GitHub contributor login: ${rawLogin}`
+                    : "No GitHub contributor login was available"
+                );
+                return analysis;
+              }
+              analysis.login = profile.login;
+              analysis.profileUrl = profile.htmlUrl;
+              analysis.id = profile.id;
+              analysis.accountType =
+                profile.accountType || (profile.login.endsWith("[bot]") ? "Bot" : "User");
+              analysis.resolutionStatus = profile.error
+                ? "metadata_unavailable"
+                : "resolved";
+              if (profile.error) {
+                analysis.reviewSignals.push("profile_metadata_unavailable");
+                analysis.warnings.push(`GitHub profile metadata unavailable: ${profile.error}`);
+              }
+              if (analysis.accountType.toLowerCase() === "bot") {
+                analysis.reviewSignals.push("bot_account");
+              }
+              const createdAt = Date.parse(profile.createdAt);
               if (Number.isFinite(createdAt)) {
                 const ageDays = Math.floor((Date.now() - createdAt) / 86400000);
-                if (ageDays < 7) {
+                analysis.accountAgeDays = ageDays;
+                if (ageDays < 7) analysis.reviewSignals.push("new_account");
+                else if (ageDays < 30) analysis.reviewSignals.push("young_account");
+                else analysis.reviewSignals.push("established_account");
+              } else {
+                analysis.reviewSignals.push("account_age_unknown");
+              }
+              const hasPublicRepos =
+                profile.publicRepos !== null &&
+                profile.publicRepos !== undefined &&
+                profile.publicRepos !== "";
+              const publicRepos = Number(profile.publicRepos);
+              if (hasPublicRepos && Number.isFinite(publicRepos)) {
+                analysis.publicRepos = publicRepos;
+                if (publicRepos <= 0) analysis.reviewSignals.push("no_public_repositories");
+              } else {
+                analysis.reviewSignals.push("public_repository_count_unknown");
+              }
+              return analysis;
+            };
+            const applyContributorAnalysis = (
+              report,
+              contributor = {},
+              source = "",
+              fallback = {}
+            ) => {
+              const analysis = contributorAnalysis(contributor, source, fallback);
+              report.contributorAnalysis = analysis;
+              if (analysis.login) {
+                report.trustSignals.push(
+                  `Contributor analyzed: ${githubUserReference(analysis.login)}`
+                );
+              } else {
+                const raw = normalizeText(
+                  contributor.login || fallback.login || contributor.name
+                );
+                if (raw) {
+                  report.trustSignals.push(
+                    `Contributor identity unresolved: ${githubUserReference(raw)}`
+                  );
+                }
+              }
+              if (analysis.accountAgeDays !== null) {
+                if (analysis.accountAgeDays < 7) {
                   addFlag(
                     report,
                     "high",
                     "new_contributor_account",
                     "Contributor account is less than 7 days old"
                   );
-                } else if (ageDays < 30) {
+                } else if (analysis.accountAgeDays < 30) {
                   addFlag(
                     report,
                     "medium",
@@ -378,15 +474,80 @@ jobs:
                     "Contributor account is less than 30 days old"
                   );
                 } else {
-                  report.trustSignals.push(`Contributor account age: ${ageDays} days`);
+                  report.trustSignals.push(
+                    `Contributor account age: ${analysis.accountAgeDays} days`
+                  );
                 }
               }
-              const publicRepos = Number(
-                contributor.public_repos ?? contributor.publicRepos
-              );
-              if (Number.isFinite(publicRepos) && publicRepos > 0) {
-                report.trustSignals.push(`Contributor public repos: ${publicRepos}`);
+              if (Number.isFinite(analysis.publicRepos) && analysis.publicRepos > 0) {
+                report.trustSignals.push(`Contributor public repos: ${analysis.publicRepos}`);
               }
+            };
+            const CAPABILITY_BUCKET_BY_FLAG = {
+              embedded_secret: "unsafe_install_or_secret",
+              non_https_executable_source: "unsafe_install_or_secret",
+              unsafe_install_pipeline: "unsafe_install_or_secret",
+              malicious_data_theft_capability: "abuse_or_malware",
+              malware_or_abuse_surface: "abuse_or_malware",
+              prohibited_content: "abuse_or_malware",
+              requires_credentials: "credentials_or_auth",
+              financial_or_identity_sensitive: "financial_or_identity",
+              external_write_capability: "external_write",
+              local_or_personal_data_access: "local_or_personal_data",
+              destructive_actions: "destructive_actions",
+              downloadable_binary_or_installer: "binary_or_installer",
+              no_canonical_source: "source_review",
+              non_https_source_url: "source_review",
+              invalid_source_url: "source_review",
+              missing_pr_file_content: "content_review",
+              invalid_frontmatter: "content_review"
+            };
+            const baseContributionAnalysis = () => ({
+              schemaState: "not_checked",
+              sourceState: "unknown",
+              contentFiles: [],
+              sourceUrls: [],
+              githubSourceRepos: [],
+              capabilityRiskBuckets: [],
+              provenanceState: "not_applicable",
+              maintainerActionItems: []
+            });
+            const addContentFileAnalysis = (report, file = {}) => {
+              const existing = report.contributionAnalysis.contentFiles.find(
+                (entry) => entry.filename === file.filename
+              );
+              if (existing) Object.assign(existing, file);
+              else report.contributionAnalysis.contentFiles.push(file);
+            };
+            const addGithubSourceRepo = (report, repo) => {
+              const fullName = normalizeText(repo.fullName || repo.full_name || repo);
+              if (!fullName) return;
+              const existing = report.contributionAnalysis.githubSourceRepos.find(
+                (entry) => entry.fullName.toLowerCase() === fullName.toLowerCase()
+              );
+              const next = {
+                fullName,
+                url: normalizeText(repo.htmlUrl || repo.html_url),
+                defaultBranch: normalizeText(repo.defaultBranch || repo.default_branch),
+                visibility: normalizeText(repo.visibility),
+                archived: repo.archived === undefined ? undefined : Boolean(repo.archived),
+                disabled: repo.disabled === undefined ? undefined : Boolean(repo.disabled),
+                stargazersCount:
+                  repo.stargazersCount ?? repo.stargazers_count ?? repo.stars ?? null,
+                forksCount: repo.forksCount ?? repo.forks_count ?? null
+              };
+              if (existing) {
+                for (const [key, value] of Object.entries(next)) {
+                  if (value !== "" && value !== null && value !== undefined) {
+                    existing[key] = value;
+                  }
+                }
+              } else {
+                report.contributionAnalysis.githubSourceRepos.push(next);
+              }
+            };
+            const setMaintainerAction = (report, action) => {
+              uniquePush(report.contributionAnalysis.maintainerActionItems, action);
             };
             const addSourceSignals = (report, fields, text) => {
               const urls = [
@@ -402,6 +563,7 @@ jobs:
               report.sourceUrls = [
                 ...new Set([...(report.sourceUrls || []), ...uniqueUrls])
               ];
+              uniquePushMany(report.contributionAnalysis.sourceUrls, uniqueUrls);
               const sourceFields = [
                 fields.github_url,
                 fields.docs_url,
@@ -440,6 +602,7 @@ jobs:
               const githubSources = sourceFields.map(githubRepoFromUrl).filter(Boolean);
               if (githubSources.length) {
                 report.trustSignals.push(`GitHub source: ${githubSources.join(", ")}`);
+                for (const source of githubSources) addGithubSourceRepo(report, source);
               }
               const docsHost = hostname(fields.docs_url);
               if (docsHost) report.trustSignals.push(`Docs host: ${docsHost}`);
@@ -755,6 +918,72 @@ jobs:
               }
               return notes;
             };
+            const finalizeContributionAnalysis = (report) => {
+              const analysis = report.contributionAnalysis;
+              analysis.sourceState = report.reviewFlags.some(
+                (flag) => flag.id === "no_canonical_source"
+              )
+                ? "missing"
+                : report.reviewFlags.some((flag) =>
+                    ["non_https_source_url", "invalid_source_url"].includes(flag.id)
+                  )
+                  ? "needs_verification"
+                  : analysis.sourceUrls.length
+                    ? "provided"
+                    : "unknown";
+              analysis.provenanceState = report.provenanceStatus || "not_applicable";
+              for (const flag of report.reviewFlags) {
+                uniquePush(analysis.capabilityRiskBuckets, CAPABILITY_BUCKET_BY_FLAG[flag.id]);
+              }
+              if (report.classificationWarnings.length) {
+                uniquePush(analysis.capabilityRiskBuckets, "classification_review");
+              }
+              if (report.provenanceFindings.some((finding) => finding.blocking)) {
+                uniquePush(analysis.capabilityRiskBuckets, "provenance_review");
+              }
+              if (analysis.sourceState === "missing") {
+                setMaintainerAction(
+                  report,
+                  "Ask for a canonical source, docs, repository, or package URL."
+                );
+              } else if (analysis.sourceState === "needs_verification") {
+                setMaintainerAction(report, "Verify source URLs before import or merge.");
+              }
+              if (analysis.capabilityRiskBuckets.includes("credentials_or_auth")) {
+                setMaintainerAction(report, "Check credential scope and setup instructions.");
+              }
+              if (
+                analysis.capabilityRiskBuckets.some((bucket) =>
+                  ["external_write", "destructive_actions"].includes(bucket)
+                )
+              ) {
+                setMaintainerAction(
+                  report,
+                  "Confirm user-consent and permission boundaries before listing."
+                );
+              }
+              if (analysis.capabilityRiskBuckets.includes("local_or_personal_data")) {
+                setMaintainerAction(
+                  report,
+                  "Review local app, browser, workspace, or personal data access."
+                );
+              }
+              if (analysis.capabilityRiskBuckets.includes("binary_or_installer")) {
+                setMaintainerAction(report, "Verify binary or installer provenance.");
+              }
+              if (analysis.capabilityRiskBuckets.includes("classification_review")) {
+                setMaintainerAction(report, "Confirm this belongs in the submitted category.");
+              }
+              if (analysis.capabilityRiskBuckets.includes("provenance_review")) {
+                setMaintainerAction(report, "Resolve provenance blockers before merge.");
+              }
+              if (report.riskTier === "critical") {
+                setMaintainerAction(
+                  report,
+                  "Block import or merge until critical findings are resolved."
+                );
+              }
+            };
             const finalizeReport = (report) => {
               report.riskTier = tierFromFlags(report.reviewFlags);
               report.recommendedLabels = [RISK_LABEL_BY_TIER[report.riskTier]];
@@ -762,6 +991,7 @@ jobs:
                 report.riskTier === "critical"
                   ? "block_until_resolved"
                   : "maintainer_review";
+              finalizeContributionAnalysis(report);
               report.humanReviewNotes = riskNotes(report);
               report.labelDefinitions = RISK_LABEL_DEFINITIONS;
               return report;
@@ -904,7 +1134,7 @@ jobs:
                   const issueContributor = issuesByNumber.get(
                     provenance.submissionIssueNumber
                   )?.contributor;
-                  const issueLogin = normalizeText(issueContributor?.login);
+                  const issueLogin = normalizeGitHubLogin(issueContributor?.login);
                   if (!issueLogin) {
                     addProvenanceFinding(
                       report,
@@ -1058,13 +1288,6 @@ jobs:
               ) {
                 lines.push("", "### Provenance");
                 lines.push(`- Status: \`${report.provenanceStatus}\``);
-                if (report.effectiveContributor?.login) {
-                  lines.push(
-                    `- Contributor analyzed: ${githubUserReference(
-                      report.effectiveContributor.login
-                    )}`
-                  );
-                }
                 if (
                   report.pullRequestActor?.login &&
                   !sameGitHubLogin(
@@ -1077,9 +1300,6 @@ jobs:
                       report.pullRequestActor.login
                     )}`
                   );
-                }
-                if (report.contributorSource) {
-                  lines.push(`- Contributor source: \`${report.contributorSource}\``);
                 }
                 for (const provenance of report.contentProvenance || []) {
                   const parts = [];
@@ -1105,6 +1325,73 @@ jobs:
                   );
                 }
               }
+              const contributor = report.contributorAnalysis || baseContributorAnalysis();
+              if (
+                contributor.login ||
+                contributor.rawLogin ||
+                contributor.warnings?.length
+              ) {
+                lines.push("", "### Contributor");
+                const analyzed = contributor.login
+                  ? githubUserReference(contributor.login)
+                  : markdownCodeSpan(contributor.rawLogin);
+                if (analyzed) lines.push(`- Contributor analyzed: ${analyzed}`);
+                if (contributor.source) lines.push(`- Source: \`${contributor.source}\``);
+                lines.push(`- Resolution: \`${contributor.resolutionStatus}\``);
+                if (contributor.accountType) {
+                  lines.push(`- Account type: \`${contributor.accountType}\``);
+                }
+                if (contributor.profileUrl) {
+                  lines.push(`- Profile: ${markdownCodeSpan(contributor.profileUrl)}`);
+                }
+                if (contributor.accountAgeDays !== null) {
+                  lines.push(`- Account age: ${contributor.accountAgeDays} days`);
+                }
+                if (contributor.publicRepos !== null) {
+                  lines.push(`- Public repos: ${contributor.publicRepos}`);
+                }
+                if (contributor.reviewSignals?.length) {
+                  lines.push(
+                    `- Signals: ${contributor.reviewSignals
+                      .map((signal) => `\`${signal}\``)
+                      .join(", ")}`
+                  );
+                }
+                for (const warning of contributor.warnings || []) {
+                  lines.push(`- Warning: ${escapeMarkdownText(warning)}`);
+                }
+              }
+              const contribution = report.contributionAnalysis || baseContributionAnalysis();
+              lines.push("", "### Contribution");
+              lines.push(`- Schema: \`${contribution.schemaState}\``);
+              lines.push(`- Sources: \`${contribution.sourceState}\``);
+              if (contribution.contentFiles?.length) {
+                const listedFiles = contribution.contentFiles
+                  .slice(0, 8)
+                  .map((file) => markdownCodeSpan(file.filename))
+                  .join(", ");
+                lines.push(`- Content files: ${listedFiles}`);
+              }
+              if (contribution.sourceUrls?.length) {
+                lines.push(`- Source URLs: ${contribution.sourceUrls.length}`);
+              }
+              if (contribution.githubSourceRepos?.length) {
+                const repos = contribution.githubSourceRepos
+                  .slice(0, 8)
+                  .map((repo) => markdownCodeSpan(repo.fullName))
+                  .join(", ");
+                lines.push(`- GitHub sources: ${repos}`);
+              }
+              if (contribution.capabilityRiskBuckets?.length) {
+                lines.push(
+                  `- Capability buckets: ${contribution.capabilityRiskBuckets
+                    .map((bucket) => `\`${bucket}\``)
+                    .join(", ")}`
+                );
+              } else {
+                lines.push("- Capability buckets: none");
+              }
+              lines.push(`- Provenance: \`${contribution.provenanceState}\``);
               lines.push("", "### Review flags");
               if (report.reviewFlags.length) {
                 for (const flag of report.reviewFlags) {
@@ -1133,9 +1420,17 @@ jobs:
                   lines.push(`- ${escapeMarkdownText(signal)}`);
                 }
               }
-              if (report.humanReviewNotes.length) {
-                lines.push("", "### Maintainer notes");
-                for (const note of report.humanReviewNotes) {
+              const maintainerChecks = [
+                ...(contribution.maintainerActionItems || []),
+                ...(report.humanReviewNotes || [])
+              ].filter(
+                (item, index, list) =>
+                  normalizeText(item) &&
+                  list.findIndex((candidate) => candidate === item) === index
+              );
+              if (maintainerChecks.length) {
+                lines.push("", "### Maintainer checks");
+                for (const note of maintainerChecks) {
                   lines.push(`- ${escapeMarkdownText(note)}`);
                 }
               }
@@ -1310,10 +1605,45 @@ jobs:
               const fields = frontmatterFields(frontmatter, category);
               const provenance = frontmatterProvenance(frontmatter);
               entries.push({ filename: file.filename, fields, provenance });
+              addContentFileAnalysis(report, {
+                filename: file.filename,
+                status: normalizeText(file.status),
+                category,
+                slug: fields.slug,
+                sourceUrls: [
+                  fields.github_url,
+                  fields.docs_url,
+                  fields.download_url,
+                  fields.website_url
+                ].filter(Boolean),
+                githubSources: [
+                  fields.github_url,
+                  fields.docs_url,
+                  fields.download_url,
+                  fields.website_url
+                ]
+                  .map(githubRepoFromUrl)
+                  .filter(Boolean)
+              });
               report.trustSignals.push(`Content file: ${file.filename}`);
               addSourceSignals(report, fields, content);
               addContentRiskSignals(report, fields, content);
               addToolListingClassificationSignals(report, fields, content);
+            }
+            for (const sourceRepo of [...report.contributionAnalysis.githubSourceRepos]) {
+              const [owner, repoName] = sourceRepo.fullName.split("/");
+              if (!owner || !repoName) continue;
+              try {
+                const { data: repoData } = await github.rest.repos.get({
+                  owner,
+                  repo: repoName
+                });
+                addGithubSourceRepo(report, repoData);
+              } catch (error) {
+                core.warning(
+                  `Could not enrich GitHub source ${sourceRepo.fullName}: ${error.message}`
+                );
+              }
             }
             validatePrProvenance(
               report,
@@ -1322,9 +1652,11 @@ jobs:
               frontmatterContributors,
               submissionIssueContributors
             );
-            contributorSignals(
+            applyContributorAnalysis(
+              report,
               report.effectiveContributor || pullRequestActor || pr.user || {},
-              report
+              report.contributorSource,
+              pr.user || {}
             );
             finalizeReport(report);
             const markdownReport = formatRiskMarkdown(report);

--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -1105,8 +1105,14 @@ jobs:
                   contributorSource = "content_frontmatter";
                 }
               }
-              if (!effectiveContributor) {
+              if (
+                !effectiveContributor &&
+                contributorSource !== "submission_issue_author"
+              ) {
                 effectiveContributor = contributorSummary(pullRequestActor || {});
+                if (effectiveContributor) {
+                  contributorSource = "pull_request_actor";
+                }
               }
               report.effectiveContributor = effectiveContributor;
               report.contributorSource = contributorSource;
@@ -1270,6 +1276,45 @@ jobs:
                   report.trustSignals.push(`Submission issue: #${issueNumberValue}`);
                 }
               }
+            };
+            const contributorAnalysisTarget = (
+              report,
+              pullRequestActor,
+              prUser = {}
+            ) => {
+              if (report.effectiveContributor) {
+                return {
+                  contributor: report.effectiveContributor,
+                  source: report.contributorSource,
+                  fallback: prUser || {}
+                };
+              }
+              if (report.contributorSource === "submission_issue_author") {
+                return {
+                  contributor: {},
+                  source: report.contributorSource,
+                  fallback: {}
+                };
+              }
+              if (contributorSummary(pullRequestActor)) {
+                return {
+                  contributor: pullRequestActor,
+                  source: "pull_request_actor",
+                  fallback: prUser || {}
+                };
+              }
+              if (contributorSummary(prUser)) {
+                return {
+                  contributor: prUser,
+                  source: "pr_user",
+                  fallback: prUser || {}
+                };
+              }
+              return {
+                contributor: {},
+                source: report.contributorSource,
+                fallback: prUser || {}
+              };
             };
             const formatRiskMarkdown = (report) => {
               const lines = [
@@ -1652,11 +1697,23 @@ jobs:
               frontmatterContributors,
               submissionIssueContributors
             );
+            const analysisTarget = contributorAnalysisTarget(
+              report,
+              pullRequestActor,
+              pr.user || {}
+            );
+            const analysisContributor = contributorSummary(
+              analysisTarget.contributor
+            );
+            if (!report.effectiveContributor && analysisContributor) {
+              report.effectiveContributor = analysisContributor;
+              report.contributorSource = analysisTarget.source;
+            }
             applyContributorAnalysis(
               report,
-              report.effectiveContributor || pullRequestActor || pr.user || {},
-              report.contributorSource,
-              pr.user || {}
+              analysisTarget.contributor,
+              analysisTarget.source,
+              analysisTarget.fallback
             );
             finalizeReport(report);
             const markdownReport = formatRiskMarkdown(report);

--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -1282,31 +1282,42 @@ jobs:
               pullRequestActor,
               prUser = {}
             ) => {
-              if (report.effectiveContributor) {
-                return {
-                  contributor: report.effectiveContributor,
-                  source: report.contributorSource,
-                  fallback: prUser || {}
-                };
-              }
-              if (report.contributorSource === "submission_issue_author") {
+              if (
+                report.contributorSource === "submission_issue_author" &&
+                !report.effectiveContributor
+              ) {
                 return {
                   contributor: {},
                   source: report.contributorSource,
                   fallback: {}
                 };
               }
-              if (contributorSummary(pullRequestActor)) {
+              const candidates = [
+                [pullRequestActor, "pull_request_actor"],
+                [prUser, "pr_user"]
+              ];
+              for (const [contributor, source] of candidates) {
+                const summary = contributorSummary(contributor);
+                if (!summary) continue;
+                if (
+                  report.effectiveContributor &&
+                  !sameGitHubLogin(
+                    summary.login,
+                    report.effectiveContributor.login
+                  )
+                ) {
+                  continue;
+                }
                 return {
-                  contributor: pullRequestActor,
-                  source: "pull_request_actor",
+                  contributor,
+                  source,
                   fallback: prUser || {}
                 };
               }
-              if (contributorSummary(prUser)) {
+              if (report.effectiveContributor) {
                 return {
-                  contributor: prUser,
-                  source: "pr_user",
+                  contributor: report.effectiveContributor,
+                  source: report.contributorSource,
                   fallback: prUser || {}
                 };
               }
@@ -1705,7 +1716,14 @@ jobs:
             const analysisContributor = contributorSummary(
               analysisTarget.contributor
             );
-            if (!report.effectiveContributor && analysisContributor) {
+            if (
+              analysisContributor &&
+              (!report.effectiveContributor ||
+                sameGitHubLogin(
+                  analysisContributor.login,
+                  report.effectiveContributor.login
+                ))
+            ) {
               report.effectiveContributor = analysisContributor;
               report.contributorSource = analysisTarget.source;
             }

--- a/.github/workflows/submission-queue.yml
+++ b/.github/workflows/submission-queue.yml
@@ -72,17 +72,25 @@ jobs:
             `- Close eligible: ${queue.summary.closeEligible}`,
             `- Skipped: ${queue.summary.skipped}`,
             "",
-            "| Issue | Status | Security | Age | Category | Slug | Action | Notes |",
-            "| --- | --- | --- | ---: | --- | --- | --- | --- |",
+            "| Issue | Status | Security | Source | Contributor | Age | Category | Slug | Action | Notes |",
+            "| --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
           ];
+          const cell = (value) => String(value || "-").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
           for (const entry of queue.entries) {
             const issue = entry.url ? `[#${entry.number}](${entry.url})` : `#${entry.number}`;
-            const notes = entry.errors.length ? entry.errors.join("<br>") : entry.importPath;
+            const notes = entry.maintainerActions?.length
+              ? entry.maintainerActions.slice(0, 3).join("<br>")
+              : entry.errors.length
+                ? entry.errors.join("<br>")
+                : entry.importPath;
             const riskTier = entry.riskTier || "-";
-            const risk = entry.riskFlags?.length
+            const risk = entry.riskSummary || (entry.riskFlags?.length
               ? `${riskTier} (${entry.riskFlags.join(", ")})`
-              : riskTier;
-            lines.push(`| ${issue} | ${entry.status} | ${risk} | ${entry.ageDays ?? 0}d | ${entry.category || "-"} | ${entry.slug || "-"} | ${entry.actionDue || "-"} | ${notes || "-"} |`);
+              : riskTier);
+            const contributor = entry.contributorReview?.length
+              ? entry.contributorReview.join(", ")
+              : "-";
+            lines.push(`| ${issue} | ${cell(entry.status)} | ${cell(risk)} | ${cell(entry.sourceState)} | ${cell(contributor)} | ${entry.ageDays ?? 0}d | ${cell(entry.category)} | ${cell(entry.slug)} | ${cell(entry.actionDue)} | ${cell(notes)} |`);
           }
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
           NODE

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -540,6 +540,10 @@ export type SubmissionRiskContributor = {
   login: string;
   htmlUrl?: string;
   id?: number | string | null;
+  accountType?: string;
+  createdAt?: string;
+  publicRepos?: number | string | null;
+  error?: string;
 };
 
 export type SubmissionContentProvenance = {
@@ -552,6 +556,47 @@ export type SubmissionContentProvenance = {
   importPrUrl?: string;
 };
 
+export type SubmissionContributorAnalysis = {
+  login: string;
+  rawLogin: string;
+  source: string;
+  profileUrl: string;
+  id: number | string | null;
+  accountType: string;
+  resolutionStatus: "resolved" | "metadata_unavailable" | "unresolved";
+  accountAgeDays: number | null;
+  publicRepos: number | null;
+  reviewSignals: string[];
+  warnings: string[];
+};
+
+export type SubmissionContributionAnalysis = {
+  schemaState: "not_checked" | "skipped" | "passed" | "failed";
+  sourceState: "unknown" | "missing" | "needs_verification" | "provided";
+  contentFiles: Array<{
+    filename: string;
+    status?: string;
+    category?: string;
+    slug?: string;
+    sourceUrls?: string[];
+    githubSources?: string[];
+  }>;
+  sourceUrls: string[];
+  githubSourceRepos: Array<{
+    fullName: string;
+    url?: string;
+    defaultBranch?: string;
+    visibility?: string;
+    archived?: boolean;
+    disabled?: boolean;
+    stargazersCount?: number | string | null;
+    forksCount?: number | string | null;
+  }>;
+  capabilityRiskBuckets: string[];
+  provenanceState: "not_applicable" | "passed" | "failed";
+  maintainerActionItems: string[];
+};
+
 export type SubmissionRiskReport = {
   schemaVersion: number;
   kind: "submission-risk";
@@ -562,6 +607,8 @@ export type SubmissionRiskReport = {
   contentProvenance: SubmissionContentProvenance[];
   effectiveContributor: SubmissionRiskContributor | null;
   contributorSource: string;
+  contributorAnalysis: SubmissionContributorAnalysis;
+  contributionAnalysis: SubmissionContributionAnalysis;
   pullRequestActor: SubmissionRiskContributor | null;
   riskTier: SubmissionRiskTier;
   reviewFlags: SubmissionRiskFlag[];
@@ -598,6 +645,10 @@ export type SubmissionQueueEntry = {
   sourceNeedsVerification: boolean;
   riskTier: SubmissionRiskTier;
   riskFlags: string[];
+  riskSummary: string;
+  contributorReview: string[];
+  sourceState: SubmissionContributionAnalysis["sourceState"];
+  maintainerActions: string[];
   riskRecommendedAction: string;
   actionDue: "" | "author_input" | "verify_source" | "remind" | "close";
   category: string;
@@ -1083,7 +1134,11 @@ export const SUBMISSION_RISK_COMMENT_MARKER: string;
 export function analyzeIssueSubmissionRisk(
   issue?: Record<string, unknown>,
   validationReport?: SubmissionValidationReport | null,
-  options?: { contributor?: Record<string, unknown> },
+  options?: {
+    contributor?: Record<string, unknown>;
+    githubSourceRepositories?: Array<Record<string, unknown>>;
+    sourceRepositories?: Array<Record<string, unknown>>;
+  },
 ): SubmissionRiskReport;
 export function analyzeDirectContentRisk(
   input?: Record<string, unknown>,

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -965,6 +965,14 @@ function baseReport(subject) {
   };
 }
 
+function selectContributor(contributor, fallbackContributor = {}) {
+  if (normalizeGitHubLogin(contributor?.login)) return contributor;
+  if (normalizeGitHubLogin(fallbackContributor.login)) {
+    return fallbackContributor;
+  }
+  return contributor || fallbackContributor;
+}
+
 export function analyzeIssueSubmissionRisk(
   issue = {},
   validationReport = null,
@@ -991,11 +999,10 @@ export function analyzeIssueSubmissionRisk(
   }
   const fallbackContributor =
     issue.user || (typeof issue.author === "object" ? issue.author : {}) || {};
-  const contributor = normalizeGitHubLogin(options.contributor?.login)
-    ? options.contributor
-    : normalizeGitHubLogin(fallbackContributor.login)
-      ? fallbackContributor
-      : options.contributor || fallbackContributor;
+  const contributor = selectContributor(
+    options.contributor,
+    fallbackContributor,
+  );
   const contributorProfile = contributorSummary(contributor);
   if (contributorProfile) {
     report.provenanceStatus = "passed";

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -973,6 +973,16 @@ function selectContributor(contributor, fallbackContributor = {}) {
   return contributor || fallbackContributor;
 }
 
+function selectSourceRepositories(input = {}) {
+  const githubSourceRepositories = Array.isArray(input.githubSourceRepositories)
+    ? input.githubSourceRepositories
+    : [];
+  if (githubSourceRepositories.length) return githubSourceRepositories;
+  return Array.isArray(input.sourceRepositories)
+    ? input.sourceRepositories
+    : [];
+}
+
 export function analyzeIssueSubmissionRisk(
   issue = {},
   validationReport = null,
@@ -992,9 +1002,7 @@ export function analyzeIssueSubmissionRisk(
     category: validationReport?.category || fields.category || "",
     slug: fields.slug || "",
   });
-  for (const repo of options.githubSourceRepositories ||
-    options.sourceRepositories ||
-    []) {
+  for (const repo of selectSourceRepositories(options)) {
     addGithubSourceRepo(report, repo);
   }
   const fallbackContributor =
@@ -1383,38 +1391,40 @@ function validatePrProvenance(report, entries, input, sourceType) {
 
 function contributorAnalysisTarget(report, input = {}) {
   const pullRequestUser = input.pullRequest?.user || {};
-  if (report.effectiveContributor) {
-    return {
-      contributor: report.effectiveContributor,
-      source: report.contributorSource,
-      fallback: pullRequestUser,
-    };
-  }
-  if (report.contributorSource === "submission_issue_author") {
+  if (
+    report.contributorSource === "submission_issue_author" &&
+    !report.effectiveContributor
+  ) {
     return {
       contributor: {},
       source: report.contributorSource,
       fallback: {},
     };
   }
-  if (contributorSummary(input.contributor)) {
+  const candidates = [
+    [input.contributor, report.contributorSource || "provided_contributor"],
+    [input.pullRequestActor, "pull_request_actor"],
+    [pullRequestUser, "pr_user"],
+  ];
+  for (const [contributor, source] of candidates) {
+    const summary = contributorSummary(contributor);
+    if (!summary) continue;
+    if (
+      report.effectiveContributor &&
+      !sameGitHubLogin(summary.login, report.effectiveContributor.login)
+    ) {
+      continue;
+    }
     return {
-      contributor: input.contributor,
-      source: report.contributorSource || "provided_contributor",
+      contributor,
+      source,
       fallback: pullRequestUser,
     };
   }
-  if (contributorSummary(input.pullRequestActor)) {
+  if (report.effectiveContributor) {
     return {
-      contributor: input.pullRequestActor,
-      source: "pull_request_actor",
-      fallback: pullRequestUser,
-    };
-  }
-  if (contributorSummary(pullRequestUser)) {
-    return {
-      contributor: pullRequestUser,
-      source: "pr_user",
+      contributor: report.effectiveContributor,
+      source: report.contributorSource,
       fallback: pullRequestUser,
     };
   }
@@ -1447,9 +1457,7 @@ export function analyzeDirectContentRisk(input = {}) {
     contentFiles: contentFiles.map((file) => file.filename),
   });
 
-  for (const repo of input.githubSourceRepositories ||
-    input.sourceRepositories ||
-    []) {
+  for (const repo of selectSourceRepositories(input)) {
     addGithubSourceRepo(report, repo);
   }
 
@@ -1524,7 +1532,14 @@ export function analyzeDirectContentRisk(input = {}) {
   validatePrProvenance(report, entries, input, sourceType);
   const analysisTarget = contributorAnalysisTarget(report, input);
   const analysisContributor = contributorSummary(analysisTarget.contributor);
-  if (!report.effectiveContributor && analysisContributor) {
+  if (
+    analysisContributor &&
+    (!report.effectiveContributor ||
+      sameGitHubLogin(
+        analysisContributor.login,
+        report.effectiveContributor.login,
+      ))
+  ) {
     report.effectiveContributor = analysisContributor;
     report.contributorSource = analysisTarget.source;
   }

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -94,11 +94,13 @@ function labelsFromIssue(issue = {}) {
 }
 
 function issueAuthor(issue = {}) {
-  if (typeof issue.author === "string") return issue.author;
+  if (typeof issue.author === "string") {
+    return normalizeGitHubLogin(issue.author) || normalizeText(issue.author);
+  }
   return (
-    normalizeText(issue.author?.login) ||
-    normalizeText(issue.user?.login) ||
-    normalizeText(issue.user?.name)
+    normalizeGitHubLogin(issue.author?.login) ||
+    normalizeGitHubLogin(issue.user?.login) ||
+    ""
   );
 }
 
@@ -171,6 +173,15 @@ function githubUserReference(value) {
   return login ? `@${login}` : markdownCodeSpan(value);
 }
 
+function uniquePush(list, value) {
+  const normalized = normalizeText(value);
+  if (normalized && !list.includes(normalized)) list.push(normalized);
+}
+
+function uniquePushMany(list, values) {
+  for (const value of values || []) uniquePush(list, value);
+}
+
 function splitList(value) {
   return normalizeText(value)
     .split(/[\n,]+/)
@@ -230,44 +241,6 @@ function collectUrls(value) {
   return [...urls];
 }
 
-function contributorSignals(contributor = {}, report) {
-  const login = normalizeText(contributor.login || contributor.name);
-  if (login) {
-    report.trustSignals.push(
-      `Contributor analyzed: ${githubUserReference(login)}`,
-    );
-  }
-
-  const createdAt = Date.parse(contributor.created_at || contributor.createdAt);
-  if (Number.isFinite(createdAt)) {
-    const ageDays = Math.floor((Date.now() - createdAt) / 86_400_000);
-    if (ageDays < 7) {
-      addFlag(
-        report,
-        "high",
-        "new_contributor_account",
-        "Contributor account is less than 7 days old",
-      );
-    } else if (ageDays < 30) {
-      addFlag(
-        report,
-        "medium",
-        "young_contributor_account",
-        "Contributor account is less than 30 days old",
-      );
-    } else {
-      report.trustSignals.push(`Contributor account age: ${ageDays} days`);
-    }
-  }
-
-  const publicRepos = Number(
-    contributor.public_repos ?? contributor.publicRepos,
-  );
-  if (Number.isFinite(publicRepos) && publicRepos > 0) {
-    report.trustSignals.push(`Contributor public repos: ${publicRepos}`);
-  }
-}
-
 function addFlag(report, severity, id, summary, detail = "") {
   if (report.reviewFlags.some((flag) => flag.id === id)) return;
   report.reviewFlags.push({ id, severity, summary, detail });
@@ -294,6 +267,332 @@ function addProvenanceFinding(
   report.provenanceFindings.push({ id, severity, summary, detail, blocking });
 }
 
+function baseContributorAnalysis(source = "") {
+  return {
+    login: "",
+    rawLogin: "",
+    source,
+    profileUrl: "",
+    id: null,
+    accountType: "unknown",
+    resolutionStatus: "unresolved",
+    accountAgeDays: null,
+    publicRepos: null,
+    reviewSignals: [],
+    warnings: [],
+  };
+}
+
+function contributorProfileUrl(contributor = {}, login = "") {
+  const url = normalizeText(contributor.html_url || contributor.htmlUrl);
+  if (url && sameGitHubLogin(url, login)) return url;
+  return login ? `https://github.com/${login}` : "";
+}
+
+function contributorSummary(contributor = {}) {
+  const login = normalizeGitHubLogin(contributor.login);
+  if (!login) return null;
+  return {
+    login,
+    htmlUrl: contributorProfileUrl(contributor, login),
+    id: contributor.id ?? null,
+    accountType: normalizeText(contributor.type) || undefined,
+    createdAt: normalizeText(contributor.created_at || contributor.createdAt),
+    publicRepos: contributor.public_repos ?? contributor.publicRepos ?? null,
+    error: normalizeText(contributor.error),
+  };
+}
+
+function contributorAnalysis(contributor = {}, source = "", fallback = {}) {
+  const profile =
+    contributorSummary(contributor) || contributorSummary(fallback);
+  const analysis = baseContributorAnalysis(source);
+  const rawLogin = normalizeText(
+    contributor.login || fallback.login || contributor.name || fallback.name,
+  );
+  analysis.rawLogin = rawLogin;
+
+  if (!profile) {
+    if (rawLogin) {
+      analysis.warnings.push(
+        `Unresolved GitHub contributor login: ${rawLogin}`,
+      );
+    } else {
+      analysis.warnings.push("No GitHub contributor login was available");
+    }
+    analysis.reviewSignals.push("identity_unresolved");
+    return analysis;
+  }
+
+  analysis.login = profile.login;
+  analysis.profileUrl = profile.htmlUrl;
+  analysis.id = profile.id;
+  analysis.accountType =
+    profile.accountType || (profile.login.endsWith("[bot]") ? "Bot" : "User");
+  analysis.resolutionStatus = profile.error
+    ? "metadata_unavailable"
+    : "resolved";
+  if (profile.error) {
+    analysis.warnings.push(
+      `GitHub profile metadata unavailable: ${profile.error}`,
+    );
+    analysis.reviewSignals.push("profile_metadata_unavailable");
+  }
+  if (analysis.accountType.toLowerCase() === "bot") {
+    analysis.reviewSignals.push("bot_account");
+  }
+
+  const createdAt = Date.parse(profile.createdAt);
+  if (Number.isFinite(createdAt)) {
+    const ageDays = Math.floor((Date.now() - createdAt) / 86_400_000);
+    analysis.accountAgeDays = ageDays;
+    if (ageDays < 7) {
+      analysis.reviewSignals.push("new_account");
+    } else if (ageDays < 30) {
+      analysis.reviewSignals.push("young_account");
+    } else {
+      analysis.reviewSignals.push("established_account");
+    }
+  } else {
+    analysis.reviewSignals.push("account_age_unknown");
+  }
+
+  const hasPublicRepos =
+    profile.publicRepos !== null &&
+    profile.publicRepos !== undefined &&
+    profile.publicRepos !== "";
+  const publicRepos = Number(profile.publicRepos);
+  if (hasPublicRepos && Number.isFinite(publicRepos)) {
+    analysis.publicRepos = publicRepos;
+    if (publicRepos <= 0) analysis.reviewSignals.push("no_public_repositories");
+  } else {
+    analysis.reviewSignals.push("public_repository_count_unknown");
+  }
+
+  return analysis;
+}
+
+function applyContributorAnalysis(
+  report,
+  contributor = {},
+  source = "",
+  fallback = {},
+) {
+  const analysis = contributorAnalysis(contributor, source, fallback);
+  report.contributorAnalysis = analysis;
+
+  if (analysis.login) {
+    report.trustSignals.push(
+      `Contributor analyzed: ${githubUserReference(analysis.login)}`,
+    );
+  } else {
+    const raw = normalizeText(
+      contributor.login || fallback.login || contributor.name,
+    );
+    if (raw) {
+      report.trustSignals.push(
+        `Contributor identity unresolved: ${githubUserReference(raw)}`,
+      );
+    }
+  }
+
+  if (analysis.accountAgeDays !== null) {
+    if (analysis.accountAgeDays < 7) {
+      addFlag(
+        report,
+        "high",
+        "new_contributor_account",
+        "Contributor account is less than 7 days old",
+      );
+    } else if (analysis.accountAgeDays < 30) {
+      addFlag(
+        report,
+        "medium",
+        "young_contributor_account",
+        "Contributor account is less than 30 days old",
+      );
+    } else {
+      report.trustSignals.push(
+        `Contributor account age: ${analysis.accountAgeDays} days`,
+      );
+    }
+  }
+
+  if (Number.isFinite(analysis.publicRepos) && analysis.publicRepos > 0) {
+    report.trustSignals.push(
+      `Contributor public repos: ${analysis.publicRepos}`,
+    );
+  }
+}
+
+const CAPABILITY_BUCKET_BY_FLAG = {
+  embedded_secret: "unsafe_install_or_secret",
+  non_https_executable_source: "unsafe_install_or_secret",
+  unsafe_install_pipeline: "unsafe_install_or_secret",
+  malicious_data_theft_capability: "abuse_or_malware",
+  malware_or_abuse_surface: "abuse_or_malware",
+  prohibited_content: "abuse_or_malware",
+  requires_credentials: "credentials_or_auth",
+  financial_or_identity_sensitive: "financial_or_identity",
+  external_write_capability: "external_write",
+  local_or_personal_data_access: "local_or_personal_data",
+  destructive_actions: "destructive_actions",
+  downloadable_binary_or_installer: "binary_or_installer",
+  no_canonical_source: "source_review",
+  non_https_source_url: "source_review",
+  invalid_source_url: "source_review",
+  schema_skipped: "schema_review",
+  schema_invalid: "schema_review",
+  missing_pr_file_content: "content_review",
+  invalid_frontmatter: "content_review",
+};
+
+function baseContributionAnalysis() {
+  return {
+    schemaState: "not_checked",
+    sourceState: "unknown",
+    contentFiles: [],
+    sourceUrls: [],
+    githubSourceRepos: [],
+    capabilityRiskBuckets: [],
+    provenanceState: "not_applicable",
+    maintainerActionItems: [],
+  };
+}
+
+function schemaStateFromValidation(validationReport) {
+  if (!validationReport) return "not_checked";
+  if (validationReport.skipped) return "skipped";
+  return validationReport.ok ? "passed" : "failed";
+}
+
+function addContentFileAnalysis(report, file = {}) {
+  const existing = report.contributionAnalysis.contentFiles.find(
+    (entry) => entry.filename === file.filename,
+  );
+  if (existing) Object.assign(existing, file);
+  else report.contributionAnalysis.contentFiles.push(file);
+}
+
+function addGithubSourceRepo(report, repo) {
+  const fullName = normalizeText(repo.fullName || repo.full_name || repo);
+  if (!fullName) return;
+  const existing = report.contributionAnalysis.githubSourceRepos.find(
+    (entry) => entry.fullName.toLowerCase() === fullName.toLowerCase(),
+  );
+  const next = {
+    fullName,
+    url: normalizeText(repo.htmlUrl || repo.html_url),
+    defaultBranch: normalizeText(repo.defaultBranch || repo.default_branch),
+    visibility: normalizeText(repo.visibility),
+    archived: repo.archived === undefined ? undefined : Boolean(repo.archived),
+    disabled: repo.disabled === undefined ? undefined : Boolean(repo.disabled),
+    stargazersCount:
+      repo.stargazersCount ?? repo.stargazers_count ?? repo.stars ?? null,
+    forksCount: repo.forksCount ?? repo.forks_count ?? null,
+  };
+  if (existing) {
+    for (const [key, value] of Object.entries(next)) {
+      if (value !== "" && value !== null && value !== undefined) {
+        existing[key] = value;
+      }
+    }
+  } else {
+    report.contributionAnalysis.githubSourceRepos.push(next);
+  }
+}
+
+function setMaintainerAction(report, action) {
+  uniquePush(report.contributionAnalysis.maintainerActionItems, action);
+}
+
+function finalizeContributionAnalysis(report, validationReport) {
+  const analysis = report.contributionAnalysis;
+  analysis.schemaState = schemaStateFromValidation(validationReport);
+  analysis.sourceState = report.reviewFlags.some(
+    (flag) => flag.id === "no_canonical_source",
+  )
+    ? "missing"
+    : report.reviewFlags.some((flag) =>
+          ["non_https_source_url", "invalid_source_url"].includes(flag.id),
+        )
+      ? "needs_verification"
+      : analysis.sourceUrls.length
+        ? "provided"
+        : "unknown";
+  analysis.provenanceState = report.provenanceStatus || "not_applicable";
+
+  for (const flag of report.reviewFlags) {
+    uniquePush(
+      analysis.capabilityRiskBuckets,
+      CAPABILITY_BUCKET_BY_FLAG[flag.id],
+    );
+  }
+  if (report.classificationWarnings.length) {
+    uniquePush(analysis.capabilityRiskBuckets, "classification_review");
+  }
+  if (report.provenanceFindings.some((finding) => finding.blocking)) {
+    uniquePush(analysis.capabilityRiskBuckets, "provenance_review");
+  }
+
+  if (analysis.sourceState === "missing") {
+    setMaintainerAction(
+      report,
+      "Ask for a canonical source, docs, repository, or package URL.",
+    );
+  } else if (analysis.sourceState === "needs_verification") {
+    setMaintainerAction(report, "Verify source URLs before import or merge.");
+  }
+  if (analysis.schemaState === "failed") {
+    setMaintainerAction(report, "Request author input for schema errors.");
+  } else if (analysis.schemaState === "skipped") {
+    setMaintainerAction(
+      report,
+      "Confirm category fit before review continues.",
+    );
+  }
+  if (analysis.capabilityRiskBuckets.includes("credentials_or_auth")) {
+    setMaintainerAction(
+      report,
+      "Check credential scope and setup instructions.",
+    );
+  }
+  if (
+    analysis.capabilityRiskBuckets.some((bucket) =>
+      ["external_write", "destructive_actions"].includes(bucket),
+    )
+  ) {
+    setMaintainerAction(
+      report,
+      "Confirm user-consent and permission boundaries before listing.",
+    );
+  }
+  if (analysis.capabilityRiskBuckets.includes("local_or_personal_data")) {
+    setMaintainerAction(
+      report,
+      "Review local app, browser, workspace, or personal data access.",
+    );
+  }
+  if (analysis.capabilityRiskBuckets.includes("binary_or_installer")) {
+    setMaintainerAction(report, "Verify binary or installer provenance.");
+  }
+  if (analysis.capabilityRiskBuckets.includes("classification_review")) {
+    setMaintainerAction(
+      report,
+      "Confirm this belongs in the submitted category.",
+    );
+  }
+  if (analysis.capabilityRiskBuckets.includes("provenance_review")) {
+    setMaintainerAction(report, "Resolve provenance blockers before merge.");
+  }
+  if (report.riskTier === "critical") {
+    setMaintainerAction(
+      report,
+      "Block import or merge until critical findings are resolved.",
+    );
+  }
+}
+
 function addSourceSignals(report, fields, text) {
   const urls = [
     fields.github_url,
@@ -313,6 +612,7 @@ function addSourceSignals(report, fields, text) {
   report.sourceUrls = [
     ...new Set([...(report.sourceUrls || []), ...uniqueUrls]),
   ];
+  uniquePushMany(report.contributionAnalysis.sourceUrls, uniqueUrls);
 
   const sourceFields = [
     fields.github_url,
@@ -348,6 +648,7 @@ function addSourceSignals(report, fields, text) {
   const githubSources = sourceFields.map(githubRepoFromUrl).filter(Boolean);
   if (githubSources.length) {
     report.trustSignals.push(`GitHub source: ${githubSources.join(", ")}`);
+    for (const source of githubSources) addGithubSourceRepo(report, source);
   }
 
   const docsHost = hostname(fields.docs_url || fields.documentationUrl);
@@ -632,6 +933,7 @@ function finalizeReport(report, validationReport) {
     report.riskTier,
     validationReport,
   );
+  finalizeContributionAnalysis(report, validationReport);
   report.humanReviewNotes = riskNotes(report);
   report.labelDefinitions = SUBMISSION_RISK_LABEL_DEFINITIONS;
   return report;
@@ -648,6 +950,8 @@ function baseReport(subject) {
     contentProvenance: [],
     effectiveContributor: null,
     contributorSource: "",
+    contributorAnalysis: baseContributorAnalysis(),
+    contributionAnalysis: baseContributionAnalysis(),
     pullRequestActor: null,
     riskTier: "low",
     reviewFlags: [],
@@ -680,14 +984,22 @@ export function analyzeIssueSubmissionRisk(
     category: validationReport?.category || fields.category || "",
     slug: fields.slug || "",
   });
-  const contributor = options.contributor || issue.user || issue.author || {};
-  const contributorLogin = normalizeText(contributor.login || contributor.name);
-  if (contributorLogin) {
+  for (const repo of options.githubSourceRepositories ||
+    options.sourceRepositories ||
+    []) {
+    addGithubSourceRepo(report, repo);
+  }
+  const fallbackContributor =
+    issue.user || (typeof issue.author === "object" ? issue.author : {}) || {};
+  const contributor = normalizeGitHubLogin(options.contributor?.login)
+    ? options.contributor
+    : normalizeGitHubLogin(fallbackContributor.login)
+      ? fallbackContributor
+      : options.contributor || fallbackContributor;
+  const contributorProfile = contributorSummary(contributor);
+  if (contributorProfile) {
     report.provenanceStatus = "passed";
-    report.effectiveContributor = {
-      login: contributorLogin,
-      htmlUrl: normalizeText(contributor.html_url || contributor.url),
-    };
+    report.effectiveContributor = contributorProfile;
     report.contributorSource = "issue_author";
   }
 
@@ -695,7 +1007,12 @@ export function analyzeIssueSubmissionRisk(
   addSourceSignals(report, fields, text);
   addContentRiskSignals(report, fields, text);
   addToolListingClassificationSignals(report, fields, text);
-  contributorSignals(contributor, report);
+  applyContributorAnalysis(
+    report,
+    contributor,
+    "issue_author",
+    fallbackContributor,
+  );
 
   return finalizeReport(report, validationReport);
 }
@@ -769,16 +1086,6 @@ function prSourceType(input = {}) {
   const headRef = normalizeText(input.pullRequest?.head?.ref);
   if (/^automation\/submission-\d+-/.test(headRef)) return "automation_import";
   return "direct_pr";
-}
-
-function contributorSummary(contributor = {}) {
-  const login = normalizeText(contributor.login || contributor.name);
-  if (!login) return null;
-  return {
-    login,
-    htmlUrl: normalizeText(contributor.html_url || contributor.url),
-    id: contributor.id ?? null,
-  };
 }
 
 function issueContributorMap(input = {}) {
@@ -921,7 +1228,7 @@ function validatePrProvenance(report, entries, input, sourceType) {
       const issueContributor = issuesByNumber.get(
         provenance.submissionIssueNumber,
       )?.contributor;
-      const issueLogin = normalizeText(issueContributor?.login);
+      const issueLogin = normalizeGitHubLogin(issueContributor?.login);
       if (!issueLogin) {
         addProvenanceFinding(
           report,
@@ -1066,14 +1373,20 @@ export function analyzeDirectContentRisk(input = {}) {
     number: input.pullRequest?.number ?? input.number ?? null,
     title: normalizeText(input.pullRequest?.title || input.title),
     url: normalizeText(input.pullRequest?.html_url || input.url),
-    author: normalizeText(
-      input.contributor?.login ||
-        input.pullRequest?.user?.login ||
-        input.author,
-    ),
+    author:
+      normalizeGitHubLogin(input.contributor?.login) ||
+      normalizeGitHubLogin(input.pullRequest?.user?.login) ||
+      normalizeGitHubLogin(input.author) ||
+      normalizeText(input.author),
     sourceType,
     contentFiles: contentFiles.map((file) => file.filename),
   });
+
+  for (const repo of input.githubSourceRepositories ||
+    input.sourceRepositories ||
+    []) {
+    addGithubSourceRepo(report, repo);
+  }
 
   if (!contentFiles.length) {
     addFlag(
@@ -1117,6 +1430,26 @@ export function analyzeDirectContentRisk(input = {}) {
     const fields = frontmatterFields(parsed.data, category);
     const provenance = frontmatterProvenance(parsed.data);
     entries.push({ filename: file.filename, fields, provenance });
+    addContentFileAnalysis(report, {
+      filename: file.filename,
+      status: normalizeText(file.status),
+      category,
+      slug: fields.slug,
+      sourceUrls: [
+        fields.github_url,
+        fields.docs_url,
+        fields.download_url,
+        fields.website_url,
+      ].filter(Boolean),
+      githubSources: [
+        fields.github_url,
+        fields.docs_url,
+        fields.download_url,
+        fields.website_url,
+      ]
+        .map(githubRepoFromUrl)
+        .filter(Boolean),
+    });
     report.trustSignals.push(`Content file: ${file.filename}`);
     addSourceSignals(report, fields, content);
     addContentRiskSignals(report, fields, content);
@@ -1124,12 +1457,14 @@ export function analyzeDirectContentRisk(input = {}) {
   }
 
   validatePrProvenance(report, entries, input, sourceType);
-  contributorSignals(
+  applyContributorAnalysis(
+    report,
     report.effectiveContributor ||
       input.contributor ||
       input.pullRequest?.user ||
       {},
-    report,
+    report.contributorSource,
+    input.pullRequest?.user || {},
   );
   return finalizeReport(report, null);
 }
@@ -1147,11 +1482,6 @@ export function formatSubmissionRiskMarkdown(report) {
   if (report.provenanceStatus && report.provenanceStatus !== "not_applicable") {
     lines.push("", "### Provenance");
     lines.push(`- Status: \`${report.provenanceStatus}\``);
-    if (report.effectiveContributor?.login) {
-      lines.push(
-        `- Contributor analyzed: ${githubUserReference(report.effectiveContributor.login)}`,
-      );
-    }
     if (
       report.pullRequestActor?.login &&
       !sameGitHubLogin(
@@ -1162,9 +1492,6 @@ export function formatSubmissionRiskMarkdown(report) {
       lines.push(
         `- PR opened by: ${githubUserReference(report.pullRequestActor.login)}`,
       );
-    }
-    if (report.contributorSource) {
-      lines.push(`- Contributor source: \`${report.contributorSource}\``);
     }
     for (const provenance of report.contentProvenance || []) {
       const parts = [];
@@ -1188,6 +1515,72 @@ export function formatSubmissionRiskMarkdown(report) {
       );
     }
   }
+
+  const contributor = report.contributorAnalysis || baseContributorAnalysis();
+  if (
+    contributor.login ||
+    contributor.rawLogin ||
+    contributor.warnings?.length
+  ) {
+    lines.push("", "### Contributor");
+    const analyzed = contributor.login
+      ? githubUserReference(contributor.login)
+      : markdownCodeSpan(contributor.rawLogin);
+    if (analyzed) lines.push(`- Contributor analyzed: ${analyzed}`);
+    if (contributor.source) lines.push(`- Source: \`${contributor.source}\``);
+    lines.push(`- Resolution: \`${contributor.resolutionStatus}\``);
+    if (contributor.accountType) {
+      lines.push(`- Account type: \`${contributor.accountType}\``);
+    }
+    if (contributor.profileUrl) {
+      lines.push(`- Profile: ${markdownCodeSpan(contributor.profileUrl)}`);
+    }
+    if (contributor.accountAgeDays !== null) {
+      lines.push(`- Account age: ${contributor.accountAgeDays} days`);
+    }
+    if (contributor.publicRepos !== null) {
+      lines.push(`- Public repos: ${contributor.publicRepos}`);
+    }
+    if (contributor.reviewSignals?.length) {
+      lines.push(
+        `- Signals: ${contributor.reviewSignals.map((signal) => `\`${signal}\``).join(", ")}`,
+      );
+    }
+    for (const warning of contributor.warnings || []) {
+      lines.push(`- Warning: ${escapeMarkdownText(warning)}`);
+    }
+  }
+
+  const contribution =
+    report.contributionAnalysis || baseContributionAnalysis();
+  lines.push("", "### Contribution");
+  lines.push(`- Schema: \`${contribution.schemaState}\``);
+  lines.push(`- Sources: \`${contribution.sourceState}\``);
+  if (contribution.contentFiles?.length) {
+    const files = contribution.contentFiles
+      .slice(0, 8)
+      .map((file) => markdownCodeSpan(file.filename))
+      .join(", ");
+    lines.push(`- Content files: ${files}`);
+  }
+  if (contribution.sourceUrls?.length) {
+    lines.push(`- Source URLs: ${contribution.sourceUrls.length}`);
+  }
+  if (contribution.githubSourceRepos?.length) {
+    const repos = contribution.githubSourceRepos
+      .slice(0, 8)
+      .map((repo) => markdownCodeSpan(repo.fullName))
+      .join(", ");
+    lines.push(`- GitHub sources: ${repos}`);
+  }
+  if (contribution.capabilityRiskBuckets?.length) {
+    lines.push(
+      `- Capability buckets: ${contribution.capabilityRiskBuckets.map((bucket) => `\`${bucket}\``).join(", ")}`,
+    );
+  } else {
+    lines.push("- Capability buckets: none");
+  }
+  lines.push(`- Provenance: \`${contribution.provenanceState}\``);
 
   if (report.reviewFlags.length) {
     lines.push("", "### Review flags");
@@ -1220,9 +1613,17 @@ export function formatSubmissionRiskMarkdown(report) {
     }
   }
 
-  if (report.humanReviewNotes.length) {
-    lines.push("", "### Maintainer notes");
-    for (const note of report.humanReviewNotes) {
+  const maintainerChecks = [
+    ...(contribution.maintainerActionItems || []),
+    ...(report.humanReviewNotes || []),
+  ].filter(
+    (item, index, list) =>
+      normalizeText(item) &&
+      list.findIndex((candidate) => candidate === item) === index,
+  );
+  if (maintainerChecks.length) {
+    lines.push("", "### Maintainer checks");
+    for (const note of maintainerChecks) {
       lines.push(`- ${escapeMarkdownText(note)}`);
     }
   }

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1197,8 +1197,22 @@ function validatePrProvenance(report, entries, input, sourceType) {
     }
   }
 
-  if (!effectiveContributor) {
-    effectiveContributor = contributorSummary(input.contributor || {});
+  if (
+    !effectiveContributor &&
+    contributorSource !== "submission_issue_author"
+  ) {
+    const fallbackCandidates = [
+      [input.contributor, contributorSource || "provided_contributor"],
+      [input.pullRequestActor, "pull_request_actor"],
+      [input.pullRequest?.user, "pr_user"],
+    ];
+    for (const [candidate, source] of fallbackCandidates) {
+      effectiveContributor = contributorSummary(candidate || {});
+      if (effectiveContributor) {
+        contributorSource = source;
+        break;
+      }
+    }
   }
 
   report.effectiveContributor = effectiveContributor;
@@ -1360,6 +1374,50 @@ function validatePrProvenance(report, entries, input, sourceType) {
   }
 }
 
+function contributorAnalysisTarget(report, input = {}) {
+  const pullRequestUser = input.pullRequest?.user || {};
+  if (report.effectiveContributor) {
+    return {
+      contributor: report.effectiveContributor,
+      source: report.contributorSource,
+      fallback: pullRequestUser,
+    };
+  }
+  if (report.contributorSource === "submission_issue_author") {
+    return {
+      contributor: {},
+      source: report.contributorSource,
+      fallback: {},
+    };
+  }
+  if (contributorSummary(input.contributor)) {
+    return {
+      contributor: input.contributor,
+      source: report.contributorSource || "provided_contributor",
+      fallback: pullRequestUser,
+    };
+  }
+  if (contributorSummary(input.pullRequestActor)) {
+    return {
+      contributor: input.pullRequestActor,
+      source: "pull_request_actor",
+      fallback: pullRequestUser,
+    };
+  }
+  if (contributorSummary(pullRequestUser)) {
+    return {
+      contributor: pullRequestUser,
+      source: "pr_user",
+      fallback: pullRequestUser,
+    };
+  }
+  return {
+    contributor: {},
+    source: report.contributorSource,
+    fallback: pullRequestUser,
+  };
+}
+
 export function analyzeDirectContentRisk(input = {}) {
   const files = Array.isArray(input.files) ? input.files : [];
   const contentFiles = files.filter(
@@ -1457,14 +1515,17 @@ export function analyzeDirectContentRisk(input = {}) {
   }
 
   validatePrProvenance(report, entries, input, sourceType);
+  const analysisTarget = contributorAnalysisTarget(report, input);
+  const analysisContributor = contributorSummary(analysisTarget.contributor);
+  if (!report.effectiveContributor && analysisContributor) {
+    report.effectiveContributor = analysisContributor;
+    report.contributorSource = analysisTarget.source;
+  }
   applyContributorAnalysis(
     report,
-    report.effectiveContributor ||
-      input.contributor ||
-      input.pullRequest?.user ||
-      {},
-    report.contributorSource,
-    input.pullRequest?.user || {},
+    analysisTarget.contributor,
+    analysisTarget.source,
+    analysisTarget.fallback,
   );
   return finalizeReport(report, null);
 }

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -730,6 +730,12 @@ export function buildSubmissionQueue(issues = [], options = {}) {
       const risk = analyzeIssueSubmissionRisk(issue, report);
       const status = submissionQueueStatus(report, issue, options);
       const staleState = submissionStaleState(issue, report, options);
+      const contributorReview =
+        risk.contributorAnalysis?.reviewSignals?.slice(0, 4) || [];
+      const capabilityBuckets =
+        risk.contributionAnalysis?.capabilityRiskBuckets || [];
+      const maintainerActions =
+        risk.contributionAnalysis?.maintainerActionItems || [];
       return {
         number: issue.number ?? null,
         title: String(issue.title || ""),
@@ -750,6 +756,12 @@ export function buildSubmissionQueue(issues = [], options = {}) {
         ),
         riskTier: risk.riskTier,
         riskFlags: risk.reviewFlags.map((flag) => flag.id),
+        riskSummary: capabilityBuckets.length
+          ? `${risk.riskTier}: ${capabilityBuckets.join(", ")}`
+          : risk.riskTier,
+        contributorReview,
+        sourceState: risk.contributionAnalysis?.sourceState || "unknown",
+        maintainerActions,
         riskRecommendedAction: risk.recommendedAction,
         actionDue:
           status === "close_eligible"

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -983,6 +983,20 @@ macOS MCP automation for native apps.`);
         ?.riskFlags,
     ).toContain("requires_credentials");
     expect(
+      queue.entries.find((entry) => entry.slug === "memesio-mcp-server")
+        ?.riskSummary,
+    ).toContain("credentials_or_auth");
+    expect(
+      queue.entries.find((entry) => entry.slug === "christian-merjudio")
+        ?.sourceState,
+    ).toBe("missing");
+    expect(
+      queue.entries.find((entry) => entry.slug === "christian-merjudio")
+        ?.maintainerActions,
+    ).toContain(
+      "Ask for a canonical source, docs, repository, or package URL.",
+    );
+    expect(
       queue.entries.find((entry) => entry.slug === "friday-studio")?.riskFlags,
     ).not.toContain("possible_category_mismatch");
     expect(
@@ -1149,6 +1163,144 @@ Review payloads before posting tweets, replies, DMs, or profile updates.`,
     expect(formatSubmissionRiskMarkdown(report)).toContain(
       "Submission security/safety review",
     );
+    expect(report.contributorAnalysis).toMatchObject({
+      login: "kriptoburak",
+      source: "pull_request_author",
+      resolutionStatus: "resolved",
+      publicRepos: 313,
+    });
+    expect(report.contributionAnalysis.capabilityRiskBuckets).toEqual(
+      expect.arrayContaining(["credentials_or_auth", "external_write"]),
+    );
+    expect(report.contributionAnalysis.sourceState).toBe("provided");
+  });
+
+  it("keeps malformed contributor payloads from becoming GitHub mentions", () => {
+    const body = buildSubmissionIssueDraft({
+      name: "Malformed Contributor MCP",
+      slug: "malformed-contributor-mcp",
+      category: "mcp",
+      docs_url: "https://example.com/docs",
+      description:
+        "MCP server submitted through issue validation with contributor metadata.",
+      card_description: "Contributor metadata regression coverage.",
+      install_command: "npx -y malformed-contributor-mcp",
+      usage_snippet:
+        "claude mcp add malformed-contributor-mcp -- npx -y malformed-contributor-mcp",
+    }).body;
+    const validIssue = {
+      ...issue(body),
+      user: { login: "zjg678", html_url: "https://github.com/zjg678" },
+      author: { login: "zjg678" },
+    };
+    const report = analyzeIssueSubmissionRisk(
+      validIssue,
+      validateSubmission(validIssue),
+      {
+        contributor: {
+          login: "&Analyze user profile system implementation #64;zjg678",
+          name: "&Analyze user profile system implementation #64;zjg678",
+        },
+      },
+    );
+    const markdown = formatSubmissionRiskMarkdown(report);
+
+    expect(report.effectiveContributor?.login).toBe("zjg678");
+    expect(report.contributorAnalysis.login).toBe("zjg678");
+    expect(markdown).toContain("Contributor analyzed: @zjg678");
+    expect(markdown).not.toContain("@&Analyze");
+
+    const malformedIssue = {
+      ...issue(body),
+      user: {
+        login: "&Analyze user profile system implementation #64;zjg678",
+      },
+      author: {
+        login: "&Analyze user profile system implementation #64;zjg678",
+      },
+    };
+    const malformed = analyzeIssueSubmissionRisk(
+      malformedIssue,
+      validateSubmission(malformedIssue),
+      {
+        contributor: {
+          login: "&Analyze user profile system implementation #64;zjg678",
+        },
+      },
+    );
+    const malformedMarkdown = formatSubmissionRiskMarkdown(malformed);
+
+    expect(malformed.effectiveContributor).toBeNull();
+    expect(malformed.contributorAnalysis.resolutionStatus).toBe("unresolved");
+    expect(malformedMarkdown).toContain(
+      "`&Analyze user profile system implementation #64;zjg678`",
+    );
+    expect(malformedMarkdown).not.toContain("@zjg678");
+  });
+
+  it("captures structured contributor states for maintainer review", () => {
+    const body = buildSubmissionIssueDraft({
+      name: "Contributor State MCP",
+      slug: "contributor-state-mcp",
+      category: "mcp",
+      docs_url: "https://example.com/docs",
+      description: "MCP server for contributor analysis coverage.",
+      card_description: "Contributor analysis coverage.",
+      install_command: "npx -y contributor-state-mcp",
+      usage_snippet:
+        "claude mcp add contributor-state-mcp -- npx -y contributor-state-mcp",
+    }).body;
+    const baseIssue = issue(body);
+    const newReport = analyzeIssueSubmissionRisk(
+      baseIssue,
+      validateSubmission(baseIssue),
+      {
+        contributor: {
+          login: "new-user",
+          created_at: new Date().toISOString(),
+          public_repos: 0,
+        },
+      },
+    );
+    const youngReport = analyzeIssueSubmissionRisk(
+      baseIssue,
+      validateSubmission(baseIssue),
+      {
+        contributor: {
+          login: "young-user",
+          created_at: new Date(Date.now() - 14 * 86_400_000).toISOString(),
+          public_repos: 1,
+        },
+      },
+    );
+    const establishedBotReport = analyzeIssueSubmissionRisk(
+      baseIssue,
+      validateSubmission(baseIssue),
+      {
+        contributor: {
+          login: "dependabot[bot]",
+          type: "Bot",
+          created_at: "2018-01-01T00:00:00Z",
+          public_repos: 12,
+        },
+      },
+    );
+
+    expect(newReport.reviewFlags.map((flag) => flag.id)).toContain(
+      "new_contributor_account",
+    );
+    expect(newReport.contributorAnalysis.reviewSignals).toEqual(
+      expect.arrayContaining(["new_account", "no_public_repositories"]),
+    );
+    expect(youngReport.reviewFlags.map((flag) => flag.id)).toContain(
+      "young_contributor_account",
+    );
+    expect(youngReport.contributorAnalysis.reviewSignals).toContain(
+      "young_account",
+    );
+    expect(establishedBotReport.contributorAnalysis.reviewSignals).toEqual(
+      expect.arrayContaining(["bot_account", "established_account"]),
+    );
   });
 
   it("warns when direct PR product listings are outside content/tools", () => {
@@ -1275,9 +1427,91 @@ Run the install command.`,
         expect.objectContaining({ id: "generated_readme_change" }),
       ]),
     );
+    expect(report.contributionAnalysis.capabilityRiskBuckets).toContain(
+      "classification_review",
+    );
+    expect(report.contributionAnalysis.maintainerActionItems).toContain(
+      "Confirm this belongs in the submitted category.",
+    );
     expect(formatSubmissionRiskMarkdown(report)).toContain(
       "README\\.md changes are not accepted in direct content PRs",
     );
+  });
+
+  it("captures multiple content files and GitHub source metadata when provided", () => {
+    const report = analyzeDirectContentRisk({
+      sourceType: "external_direct",
+      pullRequest: {
+        number: 332,
+        title: "Add Example MCP listings",
+        html_url: "https://github.com/JSONbored/awesome-claude/pull/332",
+        user: { login: "source-owner" },
+      },
+      contributor: {
+        login: "source-owner",
+        html_url: "https://github.com/source-owner",
+        created_at: "2020-01-01T00:00:00Z",
+        public_repos: 3,
+      },
+      githubSourceRepositories: [
+        {
+          full_name: "source-owner/example-one",
+          html_url: "https://github.com/source-owner/example-one",
+          default_branch: "main",
+          visibility: "public",
+          stargazers_count: 42,
+          forks_count: 5,
+        },
+      ],
+      files: [
+        {
+          filename: "content/mcp/example-one.mdx",
+          status: "added",
+          content: `---
+title: Example One
+slug: example-one
+category: mcp
+description: Example MCP server with repository metadata.
+submittedBy: source-owner
+submittedByUrl: https://github.com/source-owner
+repoUrl: https://github.com/source-owner/example-one
+documentationUrl: https://example.com/one/docs
+installCommand: "npx -y example-one"
+usageSnippet: "claude mcp add example-one -- npx -y example-one"
+---
+## Usage
+Run the install command.`,
+        },
+        {
+          filename: "content/mcp/example-two.mdx",
+          status: "added",
+          content: `---
+title: Example Two
+slug: example-two
+category: mcp
+description: Second Example MCP server in the same PR.
+submittedBy: source-owner
+submittedByUrl: https://github.com/source-owner
+documentationUrl: https://example.com/two/docs
+installCommand: "npx -y example-two"
+usageSnippet: "claude mcp add example-two -- npx -y example-two"
+---
+## Usage
+Run the install command.`,
+        },
+      ],
+    });
+
+    expect(report.contributionAnalysis.contentFiles).toHaveLength(2);
+    expect(report.contributionAnalysis.githubSourceRepos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fullName: "source-owner/example-one",
+          stargazersCount: 42,
+        }),
+      ]),
+    );
+    expect(formatSubmissionRiskMarkdown(report)).toContain("GitHub sources");
   });
 
   it("attributes automation import PR risk to the original issue submitter", () => {
@@ -1495,6 +1729,10 @@ Run the install command.`,
         }),
       ]),
     );
+    expect(report.contributionAnalysis.provenanceState).toBe("failed");
+    expect(report.contributionAnalysis.capabilityRiskBuckets).toContain(
+      "provenance_review",
+    );
   });
 
   it("fails external direct content PRs without submitter provenance", () => {
@@ -1574,6 +1812,9 @@ Run the install command.`,
           blocking: true,
         }),
       ]),
+    );
+    expect(report.contributionAnalysis.maintainerActionItems).toContain(
+      "Resolve provenance blockers before merge.",
     );
   });
 

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -1514,6 +1514,135 @@ Run the install command.`,
     expect(formatSubmissionRiskMarkdown(report)).toContain("GitHub sources");
   });
 
+  it("falls back to sourceRepositories when GitHub source repositories are empty", () => {
+    const body = buildSubmissionIssueDraft({
+      name: "Fallback Source MCP",
+      slug: "fallback-source-mcp",
+      category: "mcp",
+      docs_url: "https://example.com/docs",
+      description: "MCP server with fallback repository metadata.",
+      card_description: "Fallback repository metadata.",
+      install_command: "npx -y fallback-source-mcp",
+      usage_snippet:
+        "claude mcp add fallback-source-mcp -- npx -y fallback-source-mcp",
+    }).body;
+    const submissionIssue = issue(body);
+    const issueReport = analyzeIssueSubmissionRisk(
+      submissionIssue,
+      validateSubmission(submissionIssue),
+      {
+        githubSourceRepositories: [],
+        sourceRepositories: [
+          {
+            full_name: "fallback/issue-source",
+            stargazers_count: 9,
+          },
+        ],
+      },
+    );
+    const directReport = analyzeDirectContentRisk({
+      sourceType: "external_direct",
+      githubSourceRepositories: [],
+      sourceRepositories: [
+        {
+          full_name: "fallback/direct-source",
+          stargazers_count: 12,
+        },
+      ],
+      pullRequest: {
+        number: 333,
+        title: "Add Fallback Source MCP",
+        html_url: "https://github.com/JSONbored/awesome-claude/pull/333",
+        user: { login: "fallback-user" },
+      },
+      files: [
+        {
+          filename: "content/mcp/fallback-source-mcp.mdx",
+          status: "added",
+          content: `---
+title: Fallback Source MCP
+slug: fallback-source-mcp
+category: mcp
+description: MCP server with fallback source metadata.
+submittedBy: fallback-user
+submittedByUrl: https://github.com/fallback-user
+documentationUrl: https://example.com/docs
+installCommand: "npx -y fallback-source-mcp"
+usageSnippet: "claude mcp add fallback-source-mcp -- npx -y fallback-source-mcp"
+---
+## Usage
+Run the install command.`,
+        },
+      ],
+    });
+
+    expect(issueReport.contributionAnalysis.githubSourceRepos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fullName: "fallback/issue-source",
+          stargazersCount: 9,
+        }),
+      ]),
+    );
+    expect(directReport.contributionAnalysis.githubSourceRepos).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fullName: "fallback/direct-source",
+          stargazersCount: 12,
+        }),
+      ]),
+    );
+  });
+
+  it("preserves richer PR actor metadata for direct contributor analysis", () => {
+    const report = analyzeDirectContentRisk({
+      sourceType: "external_direct",
+      pullRequest: {
+        number: 334,
+        title: "Add Rich Actor MCP",
+        html_url: "https://github.com/JSONbored/awesome-claude/pull/334",
+        user: { login: "rich-actor" },
+      },
+      pullRequestActor: {
+        login: "rich-actor",
+        html_url: "https://github.com/rich-actor",
+        created_at: "2021-01-01T00:00:00Z",
+        public_repos: 7,
+      },
+      files: [
+        {
+          filename: "content/mcp/rich-actor-mcp.mdx",
+          status: "added",
+          content: `---
+title: Rich Actor MCP
+slug: rich-actor-mcp
+category: mcp
+description: MCP server submitted by a direct PR actor.
+submittedBy: rich-actor
+submittedByUrl: https://github.com/rich-actor
+documentationUrl: https://example.com/docs
+installCommand: "npx -y rich-actor-mcp"
+usageSnippet: "claude mcp add rich-actor-mcp -- npx -y rich-actor-mcp"
+---
+## Usage
+Run the install command.`,
+        },
+      ],
+    });
+
+    expect(report.provenanceStatus).toBe("passed");
+    expect(report.effectiveContributor?.login).toBe("rich-actor");
+    expect(report.contributorSource).toBe("pull_request_actor");
+    expect(report.contributorAnalysis).toMatchObject({
+      login: "rich-actor",
+      source: "pull_request_actor",
+      publicRepos: 7,
+    });
+    expect(report.contributorAnalysis.reviewSignals).toContain(
+      "established_account",
+    );
+  });
+
   it("attributes automation import PR risk to the original issue submitter", () => {
     const report = analyzeDirectContentRisk({
       sourceType: "automation_import",

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -1601,6 +1601,78 @@ Run the install command.`,
     );
   });
 
+  it("does not attribute unresolved automation imports to the PR actor", () => {
+    const report = analyzeDirectContentRisk({
+      sourceType: "automation_import",
+      pullRequest: {
+        number: 343,
+        title: "feat(content): add mcp unresolved-import",
+        html_url: "https://github.com/JSONbored/awesome-claude/pull/343",
+        user: { login: "github-actions[bot]" },
+      },
+      pullRequestActor: {
+        login: "github-actions[bot]",
+        created_at: "2018-07-30T09:30:17Z",
+      },
+      submissionIssueContributors: [
+        {
+          issueNumber: 343,
+          issue: null,
+          contributor: null,
+          error: "not found",
+        },
+      ],
+      files: [
+        {
+          filename: "content/mcp/unresolved-import.mdx",
+          status: "added",
+          content: `---
+title: Unresolved Import
+slug: unresolved-import
+category: mcp
+description: Imported MCP server with unresolved issue contributor metadata.
+submittedBy: original-submitter
+submittedByUrl: https://github.com/original-submitter
+submissionIssueNumber: 343
+submissionIssueUrl: https://github.com/JSONbored/awesome-claude/issues/343
+documentationUrl: https://example.com/docs
+installCommand: "npx -y unresolved-import"
+usageSnippet: "claude mcp add unresolved-import -- npx -y unresolved-import"
+---
+## Usage
+Run the install command.`,
+        },
+      ],
+    });
+    const markdown = formatSubmissionRiskMarkdown(report);
+
+    expect(report.provenanceStatus).toBe("failed");
+    expect(report.effectiveContributor).toBeNull();
+    expect(report.contributorSource).toBe("submission_issue_author");
+    expect(report.contributorAnalysis).toMatchObject({
+      login: "",
+      source: "submission_issue_author",
+      resolutionStatus: "unresolved",
+    });
+    expect(report.contributorAnalysis.reviewSignals).toContain(
+      "identity_unresolved",
+    );
+    expect(report.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "missing_issue_contributor_343",
+          blocking: true,
+        }),
+      ]),
+    );
+    expect(report.trustSignals).not.toContain(
+      "Contributor analyzed: @github-actions[bot]",
+    );
+    expect(markdown).not.toContain(
+      "Contributor analyzed: @github-actions[bot]",
+    );
+  });
+
   it("uses content frontmatter provenance for same-repo maintainer PRs", () => {
     const report = analyzeDirectContentRisk({
       sourceType: "same_repo_direct",

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -50,6 +50,13 @@ describe("submission automation workflows", () => {
     expect(source).toContain("pr.head.sha");
     expect(source).toContain("read as data only");
     expect(source).toContain("never checks out PR code");
+    expect(source).toContain("### Contributor");
+    expect(source).toContain("### Contribution");
+    expect(source).toContain("contributorAnalysis");
+    expect(source).toContain("contributionAnalysis");
+    expect(source).toContain("analysis.accountAgeDays < 30");
+    expect(source).not.toContain("} else if (ageDays < 30)");
+    expect(source).toContain("github.rest.repos.get");
     expect(source).toContain("sourceType");
     expect(source).toContain("automation_import");
     expect(source).toContain("submissionIssueContributors");
@@ -277,10 +284,14 @@ diff --git a/README.md b/README.md
     );
 
     expect(source).toContain(
-      "| Issue | Status | Security | Age | Category | Slug | Action | Notes |",
+      "| Issue | Status | Security | Source | Contributor | Age | Category | Slug | Action | Notes |",
     );
+    expect(source).toContain("entry.riskSummary");
     expect(source).toContain("entry.riskFlags");
     expect(source).toContain("entry.riskTier");
+    expect(source).toContain("entry.sourceState");
+    expect(source).toContain("entry.contributorReview");
+    expect(source).toContain("entry.maintainerActions");
   });
 
   it("keeps stale submission automation review-only and label-scoped", () => {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -54,8 +54,14 @@ describe("submission automation workflows", () => {
     expect(source).toContain("### Contribution");
     expect(source).toContain("contributorAnalysis");
     expect(source).toContain("contributionAnalysis");
+    expect(source).toContain("contributorAnalysisTarget");
+    expect(source).toContain('contributorSource !== "submission_issue_author"');
+    expect(source).toContain("analysisTarget.fallback");
     expect(source).toContain("analysis.accountAgeDays < 30");
     expect(source).not.toContain("} else if (ageDays < 30)");
+    expect(source).not.toContain(
+      "report.effectiveContributor || pullRequestActor || pr.user",
+    );
     expect(source).toContain("github.rest.repos.get");
     expect(source).toContain("sourceType");
     expect(source).toContain("automation_import");


### PR DESCRIPTION
## Summary
- harden submission risk reporting with structured contributor and contribution analysis
- fix malformed contributor rendering so invalid payloads stay inert and canonical GitHub logins render correctly
- keep privileged PR review GitHub-only while adding source repo metadata enrichment and better queue context

## What changed
- adds `contributorAnalysis` with canonical login, profile, account age, repo count, account type, resolution state, and review signals
- adds `contributionAnalysis` with content files, schema/source/provenance state, source repo metadata, capability buckets, and maintainer action items
- updates PR risk comments to render explicit Provenance, Contributor, Contribution, Review Flags, Trust Signals, and Maintainer Checks sections
- improves submission queue summaries with source, contributor, security, and action context
- fixes inline `pull_request_target` workflow drift found by Codex Security where young-account handling referenced an out-of-scope `ageDays` binding
- adds regression coverage for malformed contributor payloads, contributor account states, source/provenance mismatches, generated README edits, GitHub source metadata, and workflow safety boundaries

## Why
The old advisory output could produce malformed contributor mentions and gave maintainers too little review context. This keeps identity resolution deterministic, gives maintainers structured provenance and source signals, and preserves the trusted-base workflow boundary.

## Validation
- Codex Security scan: no surviving reportable findings after the workflow fix
- `pnpm test:submission-intake`
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `pnpm validate:packages`
- `pnpm validate:content:strict`
- `pnpm type-check`
- `pnpm exec actionlint .github/workflows/submission-pr-risk.yml .github/workflows/submission-queue.yml`
- `pnpm exec prettier --check packages/registry/src/submission-risk.js packages/registry/src/submission.js packages/registry/src/index.d.ts tests/submission-intake.test.ts tests/submission-workflows.test.ts .github/workflows/submission-pr-risk.yml .github/workflows/submission-queue.yml`
- `git diff --check`

## Notes
- `pull_request_target` still does not checkout, install, or execute contributor-controlled PR code.
- GitHub enrichment is limited to GitHub user and repository metadata.
- The risk review remains advisory except for critical findings and provenance blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Structured contributor and contribution analysis added to submission risk reports and queue entries
  * Submission queue table now shows richer risk, source state, and contributor review details
  * Reports render explicit "Contributor", "Contribution", and deduped "Maintainer checks" sections with recommended actions
  * Type declarations extended to include contributor/contribution analysis and queue risk fields

* **Bug Fixes**
  * Improved GitHub login normalization for more accurate provenance and attribution

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->