### PR TITLE
fix(mcp): reject optional GET streams on worker endpoint

### DIFF
--- a/apps/web/src/app/api/mcp/route.ts
+++ b/apps/web/src/app/api/mcp/route.ts
@@ -25,7 +25,7 @@ const DATA_ORIGIN = "https://heyclau.de";
 
 const mcpCorsHeaders = {
   "access-control-allow-origin": "*",
-  "access-control-allow-methods": "GET, POST, DELETE, OPTIONS",
+  "access-control-allow-methods": "POST, DELETE, OPTIONS",
   "access-control-allow-headers":
     "content-type, accept, mcp-session-id, mcp-protocol-version, mcp-method, mcp-name, last-event-id",
   "access-control-expose-headers": "mcp-session-id, mcp-protocol-version",
@@ -99,6 +99,28 @@ function mcpError(
 ) {
   logApiWarn(request, `${route.id}.${code}`);
   return applyMcpHeaders(apiError(code, status, { requestId, message }));
+}
+
+function mcpMethodNotAllowed() {
+  return applyMcpHeaders(
+    new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Method not allowed.",
+        },
+        id: null,
+      }),
+      {
+        status: 405,
+        headers: {
+          allow: "POST, DELETE, OPTIONS",
+          "content-type": "application/json",
+        },
+      },
+    ),
+  );
 }
 
 async function validateMcpRequest(request: Request) {
@@ -178,8 +200,8 @@ export function OPTIONS(request: Request) {
   return applyMcpHeaders(new Response(null, { status: 204 }));
 }
 
-export async function GET(request: Request) {
-  return handleMcpRequest(request);
+export async function GET() {
+  return mcpMethodNotAllowed();
 }
 
 export async function POST(request: Request) {

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { OPTIONS, POST } from "../apps/web/src/app/api/mcp/route";
+import { GET, OPTIONS, POST } from "../apps/web/src/app/api/mcp/route";
 
 function mcpRequest(body: unknown, headers: Record<string, string> = {}) {
   return new Request("https://heyclau.de/api/mcp", {
@@ -32,6 +32,30 @@ describe("HeyClaude remote MCP route", () => {
       "POST",
     );
     expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("returns 405 for optional GET SSE streams on the stateless Worker endpoint", async () => {
+    const response = await GET(
+      new Request("https://heyclau.de/api/mcp", {
+        method: "GET",
+        headers: {
+          host: "heyclau.de",
+          accept: "text/event-stream",
+          "mcp-protocol-version": "2025-11-25",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST, DELETE, OPTIONS");
+    expect(response.headers.get("access-control-allow-methods")).not.toContain(
+      "GET",
+    );
+    expect(await json(response)).toMatchObject({
+      jsonrpc: "2.0",
+      error: { code: -32000, message: "Method not allowed." },
+      id: null,
+    });
   });
 
   it("rejects browser origins outside the HeyClaude allowlist", async () => {


### PR DESCRIPTION
## Summary
- Return a fast `405` for optional `GET /api/mcp` SSE negotiation on the stateless Worker endpoint
- Keep the POST Streamable HTTP JSON-RPC MCP path unchanged
- Add route coverage for the 405 GET response and CORS allow-methods behavior

## What changed
- Removed `GET` from the MCP endpoint CORS allow-methods list
- Added a JSON-RPC-shaped 405 response for GET requests
- Added a regression test for clients probing `GET /api/mcp` with `Accept: text/event-stream`

## Why
Cloudflare Workers Observability shows repeated `heyclaude-prod` exceptions on `GET /api/mcp`: the MCP SDK opens a standalone SSE stream for GET and writes no initial bytes, which Cloudflare classifies as a hung Worker request and returns as a 1101/500. The SDK client treats HTTP 405 as the expected signal that a Streamable HTTP server does not offer the optional GET SSE stream, then continues using POST.

## Validation
- `pnpm test -- tests/mcp-http-route.test.ts` (runs full Vitest suite here: 27 files / 218 tests passed)
- `pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp`
- `pnpm type-check`
- `pnpm validate:deployment-artifacts -- --base-url https://heyclau.de`
- `pnpm build`
- `git diff --check`

## Notes
- Live production POST MCP behavior is currently healthy; the production error source is the optional GET/SSE probe path.
- Latest observed failing production Worker version: `c120080a-6012-4242-92ef-3838619a10f9`.
