### PR TITLE
feat(submissions): add maintainer queue workbench

### DIFF
--- a/apps/web/src/app/submissions/page.tsx
+++ b/apps/web/src/app/submissions/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { buildSubmissionQueue } from "@heyclaude/registry/submission";
+import type { SubmissionQueueEntry } from "@heyclaude/registry";
 
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { EntryCopyButton } from "@/components/entry-copy-button";
 import { JsonLd } from "@/components/json-ld";
 import { buildPageMetadata } from "@/lib/seo";
 import { siteConfig } from "@/lib/site";
@@ -23,6 +25,31 @@ type GitHubIssue = {
   labels: Array<string | { name?: string }>;
   pull_request?: unknown;
 };
+
+type SubmissionFilter =
+  | "all"
+  | "import_ready"
+  | "maintainer_review"
+  | "needs_author_input"
+  | "source_needs_verification"
+  | "stale_reminder_due"
+  | "close_eligible"
+  | "high_risk";
+
+type SubmissionsPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const FILTERS: Array<{ key: SubmissionFilter; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "import_ready", label: "Import ready" },
+  { key: "maintainer_review", label: "Maintainer review" },
+  { key: "needs_author_input", label: "Author input" },
+  { key: "source_needs_verification", label: "Source review" },
+  { key: "stale_reminder_due", label: "Reminder due" },
+  { key: "close_eligible", label: "Close eligible" },
+  { key: "high_risk", label: "High risk" },
+];
 
 export const dynamic = "force-dynamic";
 export const revalidate = 300;
@@ -92,131 +119,424 @@ function statusLabel(status: string) {
   return "Skipped";
 }
 
-export default async function SubmissionsPage() {
-  const { available, error, queue } = await getSubmissionQueue();
-  const jsonLd = [
-    buildBreadcrumbJsonLd([
-      { name: "Home", url: siteConfig.url },
-      { name: "Submissions", url: `${siteConfig.url}/submissions` },
-    ]),
-    buildCollectionPageJsonLd({
-      siteUrl: siteConfig.url,
-      path: "/submissions",
-      name: "Submission queue",
-      description:
-        "Open content submissions grouped by import readiness and validation status.",
-      breadcrumbId: `${siteConfig.url}/submissions#breadcrumb`,
-    }),
-  ];
+function nextActionLabel(action: SubmissionQueueEntry["nextAction"]) {
+  if (action === "import") return "Import after approval";
+  if (action === "review_risk") return "Review risk";
+  if (action === "verify_source") return "Verify source";
+  if (action === "request_author_input") return "Request author input";
+  if (action === "send_stale_reminder") return "Send stale reminder";
+  if (action === "close_stale") return "Close stale submission";
+  return "Skip";
+}
 
-  return (
-    <div className="container-shell space-y-8 py-12">
-      <JsonLd data={jsonLd} />
-      <div className="space-y-4 border-b border-border/80 pb-8">
-        <Breadcrumbs
-          items={[{ label: "Home", href: "/" }, { label: "Submissions" }]}
-        />
-        <span className="eyebrow">Submission queue</span>
-        <h1 className="section-title">Submission queue.</h1>
-        <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
-          This page runs open public GitHub issues through the same registry
-          submission queue contract used by CI. Accepted submissions require
-          maintainer approval before automation opens a content import PR for
-          review.
-        </p>
-        <div className="flex flex-wrap gap-2">
-          <Link
-            href="/submit"
-            className="inline-flex items-center rounded-full border border-primary/40 bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
-          >
-            Submit free resource
-          </Link>
-          <a
-            href={`${siteConfig.githubUrl}/issues?q=is%3Aissue+is%3Aopen+label%3Acontent-submission`}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
-          >
-            Open GitHub queue
-          </a>
-        </div>
-      </div>
+function normalizeFilter(value: string | string[] | undefined) {
+  const normalized = Array.isArray(value) ? value[0] : value;
+  return FILTERS.some((filter) => filter.key === normalized)
+    ? (normalized as SubmissionFilter)
+    : "all";
+}
 
-      <section className="grid gap-4 md:grid-cols-3">
-        {[
-          ["Import ready", queue.summary.importReady],
-          ["Needs author input", queue.summary.needsAuthorInput],
-          ["Source verification", queue.summary.sourceNeedsVerification],
-          ["Tracked issues", queue.count],
-        ].map(([label, value]) => (
-          <div key={label} className="surface-panel p-5">
-            <p className="text-xs uppercase tracking-[0.18em] text-primary">
-              {label}
-            </p>
-            <p className="mt-2 text-3xl font-semibold text-foreground">
-              {value}
-            </p>
+function isHighRisk(entry: SubmissionQueueEntry) {
+  return entry.riskTier === "high" || entry.riskTier === "critical";
+}
+
+function filterEntries(
+  entries: SubmissionQueueEntry[],
+  filter: SubmissionFilter,
+) {
+  if (filter === "all") return entries;
+  if (filter === "high_risk") return entries.filter(isHighRisk);
+  return entries.filter((entry) => entry.status === filter);
+}
+
+function filterCount(
+  entries: SubmissionQueueEntry[],
+  filter: SubmissionFilter,
+) {
+  return filterEntries(entries, filter).length;
+}
+
+function riskClass(entry: SubmissionQueueEntry) {
+  if (entry.riskTier === "critical" || entry.riskTier === "high") {
+    return "border-destructive/40 bg-destructive/10 text-destructive";
+  }
+  if (entry.riskTier === "medium") {
+    return "border-yellow-500/40 bg-yellow-500/10 text-yellow-300";
+  }
+  return "border-emerald-500/35 bg-emerald-500/10 text-emerald-300";
+}
+
+function safeHttpUrl(value: string) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+function submissionFormHref(category: string) {
+  const params = new URLSearchParams();
+  const normalizedCategory = category.trim();
+  if (normalizedCategory) params.set("category", normalizedCategory);
+  const query = params.toString();
+  return query ? `/submit?${query}` : "/submit";
+}
+
+type SubmissionPageLogger = {
+  info: (event: string, meta?: Record<string, unknown>) => void;
+  error: (event: string, meta?: Record<string, unknown>) => void;
+};
+
+function writeSubmissionPageLog(
+  level: "info" | "error",
+  event: string,
+  requestId: string,
+  meta: Record<string, unknown> = {},
+) {
+  const payload = {
+    ts: new Date().toISOString(),
+    level,
+    event,
+    requestId,
+    ...meta,
+  };
+  const line = JSON.stringify(payload);
+  if (level === "error") {
+    console.error(line);
+    return;
+  }
+  console.info(line);
+}
+
+function createSubmissionPageLogger(requestId: string): SubmissionPageLogger {
+  return {
+    info(event, meta = {}) {
+      writeSubmissionPageLog("info", event, requestId, meta);
+    },
+    error(event, meta = {}) {
+      writeSubmissionPageLog("error", event, requestId, meta);
+    },
+  };
+}
+
+async function withDuration<T>(
+  callback: (context: {
+    getDurationMs: () => number;
+    logger: SubmissionPageLogger;
+    requestId: string;
+  }) => Promise<T>,
+) {
+  const startedAt = Date.now();
+  const requestId = crypto.randomUUID();
+  const logger = createSubmissionPageLogger(requestId);
+  const getDurationMs = () => Date.now() - startedAt;
+
+  try {
+    return await callback({ getDurationMs, logger, requestId });
+  } catch (error) {
+    logger.error("submissions.page.failed", {
+      durationMs: getDurationMs(),
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+    throw error;
+  }
+}
+
+export default async function SubmissionsPage({
+  searchParams,
+}: SubmissionsPageProps) {
+  return withDuration(async ({ getDurationMs, logger }) => {
+    const params = await searchParams;
+    const activeFilter = normalizeFilter(params?.filter);
+    const { available, error, queue } = await getSubmissionQueue();
+    const entries = filterEntries(queue.entries, activeFilter);
+    const jsonLd = [
+      buildBreadcrumbJsonLd([
+        { name: "Home", url: siteConfig.url },
+        { name: "Submissions", url: `${siteConfig.url}/submissions` },
+      ]),
+      buildCollectionPageJsonLd({
+        siteUrl: siteConfig.url,
+        path: "/submissions",
+        name: "Submission queue",
+        description:
+          "Open content submissions grouped by import readiness and validation status.",
+        breadcrumbId: `${siteConfig.url}/submissions#breadcrumb`,
+      }),
+    ];
+
+    logger.info("submissions.page.summary", {
+      activeFilter,
+      available,
+      durationMs: getDurationMs(),
+      error: error || undefined,
+      queueLength: queue.entries.length,
+    });
+
+    return (
+      <div className="container-shell space-y-8 py-12">
+        <JsonLd data={jsonLd} />
+        <div className="space-y-4 border-b border-border/80 pb-8">
+          <Breadcrumbs
+            items={[{ label: "Home", href: "/" }, { label: "Submissions" }]}
+          />
+          <span className="eyebrow">Maintainer workbench</span>
+          <h1 className="section-title">Submission queue.</h1>
+          <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
+            Open GitHub issues are grouped into maintainer review states with
+            suggested labels, source checks, risk signals, and copyable reply
+            drafts. This page is read-only and never imports, closes, or
+            comments on submissions.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/submit"
+              className="inline-flex items-center rounded-full border border-primary/40 bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+            >
+              Submit free resource
+            </Link>
+            <a
+              href={`${siteConfig.githubUrl}/issues?q=is%3Aissue+is%3Aopen+label%3Acontent-submission`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+            >
+              Open GitHub queue
+            </a>
           </div>
-        ))}
-      </section>
+        </div>
 
-      {!available ? (
-        <section className="surface-panel p-5 text-sm leading-7 text-muted-foreground">
-          GitHub issue status is temporarily unavailable: {error}. Use the
-          GitHub queue link above for the current source of truth.
+        <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {[
+            ["Import ready", queue.summary.importReady],
+            ["Needs author input", queue.summary.needsAuthorInput],
+            ["Source verification", queue.summary.sourceNeedsVerification],
+            ["High risk", queue.summary.highRisk],
+            ["Reminder due", queue.summary.staleReminderDue],
+            ["Close eligible", queue.summary.closeEligible],
+            ["Maintainer review", queue.summary.maintainerReview],
+            ["Tracked issues", queue.count],
+          ].map(([label, value]) => (
+            <div key={label} className="surface-panel p-5">
+              <p className="text-xs uppercase tracking-[0.18em] text-primary">
+                {label}
+              </p>
+              <p className="mt-2 text-3xl font-semibold text-foreground">
+                {value}
+              </p>
+            </div>
+          ))}
         </section>
-      ) : null}
 
-      <section className="space-y-3">
-        {queue.entries.length ? (
-          queue.entries.map((entry) => (
-            <article key={entry.number} className="surface-panel p-5">
-              <div className="flex flex-wrap items-start justify-between gap-3">
-                <div className="space-y-2">
-                  <p className="text-xs uppercase tracking-[0.18em] text-primary">
-                    {statusLabel(entry.status)}
-                  </p>
-                  <h2 className="text-xl font-semibold tracking-tight text-foreground">
-                    <a
-                      href={entry.url}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="hover:text-primary"
-                    >
-                      #{entry.number} {entry.title}
-                    </a>
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    {entry.category || "unknown"} / {entry.slug || "no slug"}
-                    {entry.ageDays ? ` / ${entry.ageDays}d waiting` : ""}
-                  </p>
-                </div>
-                {entry.importPath ? (
-                  <span className="rounded-full border border-border bg-background px-3 py-1 text-xs text-muted-foreground">
-                    {entry.importPath}
-                  </span>
-                ) : null}
-              </div>
-              {entry.errors.length ? (
-                <ul className="mt-4 list-disc space-y-1 pl-5 text-sm leading-7 text-muted-foreground">
-                  {entry.errors.map((issue) => (
-                    <li key={issue}>{issue}</li>
-                  ))}
-                </ul>
-              ) : null}
-              {entry.actionDue ? (
-                <p className="mt-4 text-sm leading-7 text-muted-foreground">
-                  Next action: {entry.actionDue.replaceAll("_", " ")}
-                </p>
-              ) : null}
-            </article>
-          ))
-        ) : (
-          <section className="surface-panel p-8 text-sm leading-7 text-muted-foreground">
-            No open submission-shaped issues are currently tracked.
+        <nav className="flex flex-wrap gap-2" aria-label="Submission filters">
+          {FILTERS.map((filter) => {
+            const active = filter.key === activeFilter;
+            const href =
+              filter.key === "all"
+                ? "/submissions"
+                : `/submissions?filter=${filter.key}`;
+            return (
+              <Link
+                key={filter.key}
+                href={href}
+                className={`inline-flex items-center rounded-full border px-3 py-1.5 text-xs transition ${
+                  active
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-card text-muted-foreground hover:border-primary/50 hover:text-foreground"
+                }`}
+              >
+                {filter.label}
+                <span className="ml-2 rounded-full bg-background/35 px-1.5 py-0.5 text-[10px]">
+                  {filterCount(queue.entries, filter.key)}
+                </span>
+              </Link>
+            );
+          })}
+        </nav>
+
+        {!available ? (
+          <section className="surface-panel p-5 text-sm leading-7 text-muted-foreground">
+            GitHub issue status is temporarily unavailable: {error}. Use the
+            GitHub queue link above for the current source of truth.
           </section>
-        )}
-      </section>
-    </div>
-  );
+        ) : null}
+
+        <section className="space-y-3">
+          {entries.length ? (
+            entries.map((entry) => {
+              const sourceHref = safeHttpUrl(entry.sourceUrl);
+              const submitHref = submissionFormHref(entry.category || "mcp");
+
+              return (
+                <article key={entry.number} className="surface-panel p-5">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="rounded-full border border-primary/35 bg-primary/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-primary">
+                          {statusLabel(entry.status)}
+                        </span>
+                        <span
+                          className={`rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] ${riskClass(entry)}`}
+                        >
+                          {entry.riskSummary}
+                        </span>
+                      </div>
+                      <h2 className="text-xl font-semibold tracking-tight text-foreground">
+                        <a
+                          href={entry.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-primary"
+                        >
+                          #{entry.number} {entry.title}
+                        </a>
+                      </h2>
+                      <p className="text-sm text-muted-foreground">
+                        {entry.category || "unknown"} /{" "}
+                        {entry.slug || "no slug"}
+                        {entry.author ? ` / @${entry.author}` : ""}
+                        {entry.ageDays ? ` / ${entry.ageDays}d waiting` : ""}
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="rounded-full border border-border bg-background px-3 py-1 text-xs text-muted-foreground">
+                        {nextActionLabel(entry.nextAction)}
+                      </span>
+                      {entry.importPath ? (
+                        <span className="rounded-full border border-border bg-background px-3 py-1 text-xs text-muted-foreground">
+                          {entry.importPath}
+                        </span>
+                      ) : null}
+                    </div>
+                  </div>
+
+                  <div className="mt-5 grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+                    <div className="space-y-4">
+                      {entry.errors.length || entry.warnings.length ? (
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                            Validation
+                          </p>
+                          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-7 text-muted-foreground">
+                            {[...entry.errors, ...entry.warnings].map(
+                              (issue) => (
+                                <li key={issue}>{issue}</li>
+                              ),
+                            )}
+                          </ul>
+                        </div>
+                      ) : null}
+
+                      {entry.reviewChecklist.length ? (
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                            Review checklist
+                          </p>
+                          <ul className="mt-2 list-disc space-y-1 pl-5 text-sm leading-7 text-muted-foreground">
+                            {entry.reviewChecklist.map((item) => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+
+                      {entry.commentDraft ? (
+                        <div className="rounded-lg border border-border bg-background/60 p-4">
+                          <div className="flex flex-wrap items-center justify-between gap-2">
+                            <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                              Suggested reply
+                            </p>
+                            <EntryCopyButton
+                              text={entry.commentDraft}
+                              label="Copy reply"
+                              className="directory-link-chip"
+                            />
+                          </div>
+                          <p className="mt-3 whitespace-pre-line text-sm leading-7 text-muted-foreground">
+                            {entry.commentDraft}
+                          </p>
+                        </div>
+                      ) : null}
+                    </div>
+
+                    <div className="space-y-4 rounded-lg border border-border bg-background/40 p-4">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                          Labels
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {entry.labels.map((label) => (
+                            <span
+                              key={label}
+                              className="rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-muted-foreground"
+                            >
+                              {label}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                      {entry.missingLabels.length ? (
+                        <div>
+                          <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                            Missing suggested labels
+                          </p>
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {entry.missingLabels.map((label) => (
+                              <span
+                                key={label}
+                                className="rounded-full border border-primary/35 bg-primary/10 px-2.5 py-1 text-[11px] text-primary"
+                              >
+                                {label}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      ) : null}
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                          Source state
+                        </p>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {entry.sourceState}
+                        </p>
+                        {sourceHref ? (
+                          <a
+                            href={sourceHref}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-2 inline-flex text-sm text-primary hover:underline"
+                          >
+                            Open submitted source
+                          </a>
+                        ) : null}
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <a
+                          href={entry.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="directory-link-chip"
+                        >
+                          Open issue
+                        </a>
+                        <Link href={submitHref} className="directory-link-chip">
+                          Submit form
+                        </Link>
+                      </div>
+                    </div>
+                  </div>
+                </article>
+              );
+            })
+          ) : (
+            <section className="surface-panel p-8 text-sm leading-7 text-muted-foreground">
+              No open submission-shaped issues match this filter.
+            </section>
+          )}
+        </section>
+      </div>
+    );
+  });
 }

--- a/docs/submission-queue-ops.md
+++ b/docs/submission-queue-ops.md
@@ -34,6 +34,32 @@ stale; it does not publish content directly.
   received the stale reminder label.
 - `skipped`: not a core submission category.
 
+## Workbench Fields
+
+The public `/submissions` page is a read-only maintainer workbench backed by
+the same queue contract as CI. It can suggest actions, labels, and comments, but
+it must not comment on issues, close issues, approve imports, or publish
+content.
+
+Each queue entry includes:
+
+- `nextAction`: `import`, `review_risk`, `verify_source`,
+  `request_author_input`, `send_stale_reminder`, `close_stale`, or `skip`.
+- `missingLabels`: recommended queue labels not currently present on the
+  GitHub issue.
+- `reviewChecklist`: deterministic maintainer checks assembled from schema,
+  source, stale, and security/safety signals.
+- `commentDraft`: copyable maintainer reply text for author-input, source
+  verification, stale-reminder, and stale-close cases.
+- `sourceUrl`: the first submitted GitHub, docs, source, download, or website
+  URL available for maintainer review.
+
+`nextAction=import` is not automatic approval. It means the issue is either
+schema-valid and ready for maintainer review, or already carries a protected
+approval label such as `accepted` or `import-approved`. Maintainers still need
+to verify source fit, category fit, and risk signals before an import PR is
+opened.
+
 ## Automation
 
 - `Submission Queue` runs weekly and on demand. It writes a GitHub Actions
@@ -61,14 +87,18 @@ stale; it does not publish content directly.
 ## Maintainer Flow
 
 1. Review `/submissions` or the `Submission Queue` workflow summary.
-2. For `needs_author_input`, wait for the author to update the issue.
-3. For `source_needs_verification`, verify canonical source/package URLs before
+2. Use the filter tabs to focus on import-ready, author-input,
+   source-verification, stale, close-eligible, or high-risk submissions.
+3. Apply missing labels only when they match the current maintainer decision.
+4. For `needs_author_input`, use the copyable draft as a starting point and wait
+   for the author to update the issue.
+5. For `source_needs_verification`, verify canonical source/package URLs before
    approving.
-4. For `stale_reminder_due`, let the manager add `stale-submission` and post the
+6. For `stale_reminder_due`, let the manager add `stale-submission` and post the
    reminder.
-5. For `close_eligible`, close as not planned only after the stale reminder has
+7. For `close_eligible`, close as not planned only after the stale reminder has
    already been applied.
-6. Apply `accepted` or `import-approved` only after maintainer source review.
+8. Apply `accepted` or `import-approved` only after maintainer source review.
 
 Direct content PRs are allowed for advanced contributors, but they must pass the
 same content validation and deterministic security/safety review. A `risk-high`

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -632,6 +632,7 @@ export type SubmissionQueueEntry = {
   updatedAt: string;
   labels: string[];
   recommendedLabels: string[];
+  missingLabels: string[];
   status:
     | "import_ready"
     | "maintainer_review"
@@ -640,6 +641,14 @@ export type SubmissionQueueEntry = {
     | "stale_reminder_due"
     | "close_eligible"
     | "skipped";
+  nextAction:
+    | "import"
+    | "review_risk"
+    | "verify_source"
+    | "request_author_input"
+    | "send_stale_reminder"
+    | "close_stale"
+    | "skip";
   staleState: "not_applicable" | "fresh" | "reminder_due" | "close_eligible";
   ageDays: number;
   sourceNeedsVerification: boolean;
@@ -654,8 +663,11 @@ export type SubmissionQueueEntry = {
   category: string;
   slug: string;
   name: string;
+  sourceUrl: string;
   errors: string[];
   warnings: string[];
+  reviewChecklist: string[];
+  commentDraft: string;
   importPath: string;
 };
 
@@ -671,6 +683,7 @@ export type SubmissionQueue = {
     sourceNeedsVerification: number;
     staleReminderDue: number;
     closeEligible: number;
+    highRisk: number;
     needsChanges: number;
     skipped: number;
   };

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -786,6 +786,117 @@ export function submissionQueueStatus(report, issue = {}, options = {}) {
   return "import_ready";
 }
 
+function submissionQueueNextAction(status, issue = {}, riskTier = "low") {
+  const labels = new Set(issueLabels(issue));
+  if (labels.has("import-pr-open")) return "skip";
+  if (labels.has("accepted") || labels.has("import-approved")) return "import";
+  if (status === "skipped") return "skip";
+  if (status === "close_eligible") return "close_stale";
+  if (status === "stale_reminder_due") return "send_stale_reminder";
+  if (status === "needs_author_input") return "request_author_input";
+  if (status === "source_needs_verification") return "verify_source";
+  if (riskTier === "high" || riskTier === "critical") return "review_risk";
+  if (status === "maintainer_review") return "review_risk";
+  return "import";
+}
+
+function formatRiskSummary(riskTier, capabilityBuckets = []) {
+  const tier = String(riskTier || "low");
+  const label = `${tier[0]?.toUpperCase() || "L"}${tier.slice(1)} risk`;
+  return capabilityBuckets.length
+    ? `${label}: ${capabilityBuckets.join(", ")}`
+    : label;
+}
+
+function firstSubmissionSourceUrl(fields = {}) {
+  return (
+    normalizeValue(fields.github_url) ||
+    normalizeValue(fields.docs_url) ||
+    normalizeValue(fields.source_url) ||
+    normalizeValue(fields.download_url) ||
+    normalizeValue(fields.website_url) ||
+    ""
+  );
+}
+
+function buildSubmissionReviewChecklist({
+  report,
+  risk,
+  status,
+  sourceNeedsVerification,
+  maintainerActions,
+}) {
+  const items = [];
+  if (report?.skipped) {
+    items.push("Confirm whether this is a supported HeyClaude category.");
+  } else {
+    items.push("Confirm the category, slug, and public-facing metadata.");
+  }
+  if (!report?.ok) {
+    items.push("Wait for the author to fix required fields before import.");
+  }
+  if (sourceNeedsVerification) {
+    items.push(
+      "Verify the canonical source, docs, repository, or package URL.",
+    );
+  }
+  if (risk.riskTier === "high" || risk.riskTier === "critical") {
+    items.push(
+      "Review high-risk permissions, auth, local data, or payment scope.",
+    );
+  } else if (risk.riskTier === "medium") {
+    items.push("Review medium-risk capability and source signals.");
+  }
+  for (const action of maintainerActions) {
+    if (!items.includes(action)) items.push(action);
+  }
+  if (status === "import_ready") {
+    items.push("Apply import-approved only after source and category review.");
+  }
+  return items.slice(0, 7);
+}
+
+function buildSubmissionCommentDraft({ entry, report }) {
+  const title = entry.name || entry.title || "this submission";
+  if (entry.nextAction === "request_author_input") {
+    const problems = [...(report.errors || []), ...(report.warnings || [])]
+      .filter(Boolean)
+      .slice(0, 8)
+      .map((item) => `- ${item}`)
+      .join("\n");
+    return [
+      `Thanks for submitting ${title}. I can't continue review until the issue has the required metadata.`,
+      "",
+      problems ||
+        "- Please update the issue body with the required fields from the category template.",
+      "",
+      "Please edit the issue body with the missing details. Once it is updated, the validator can re-check it and maintainer review can continue.",
+    ].join("\n");
+  }
+  if (entry.nextAction === "verify_source") {
+    return [
+      `Thanks for submitting ${title}. This needs source verification before it can be imported.`,
+      "",
+      "Please make sure the issue includes the canonical GitHub repository, documentation URL, package URL, or other official source maintainers should review.",
+    ].join("\n");
+  }
+  if (entry.nextAction === "send_stale_reminder") {
+    return [
+      `This submission is still waiting on author input before review can continue.`,
+      "",
+      "Please update the issue with the missing details. If there is no update after the stale window, maintainers may close it as not planned. You can reopen or resubmit when the details are ready.",
+    ].join("\n");
+  }
+  if (entry.nextAction === "close_stale") {
+    return [
+      "Closing this submission as not planned because it has been waiting on required author input past the stale window.",
+      "",
+      "You can reopen or resubmit when the missing fields or source details are ready.",
+    ].join("\n");
+  }
+  return "";
+}
+
 export function buildSubmissionQueue(issues = [], options = {}) {
   const entries = issues
     .filter(looksLikeSubmissionIssue)
@@ -800,7 +911,21 @@ export function buildSubmissionQueue(issues = [], options = {}) {
         risk.contributionAnalysis?.capabilityRiskBuckets || [];
       const maintainerActions =
         risk.contributionAnalysis?.maintainerActionItems || [];
-      return {
+      const recommendedLabels = recommendedSubmissionLabels(issue, report);
+      const labels = issueLabels(issue);
+      const missingLabels = recommendedLabels.filter(
+        (label) => !labels.includes(label),
+      );
+      const nextAction = submissionQueueNextAction(
+        status,
+        issue,
+        risk.riskTier,
+      );
+      const sourceNeedsVerification = submissionSourceNeedsVerification(
+        report,
+        issue,
+      );
+      const entry = {
         number: issue.number ?? null,
         title: String(issue.title || ""),
         url: String(issue.url || ""),
@@ -809,20 +934,17 @@ export function buildSubmissionQueue(issues = [], options = {}) {
             ? issue.author
             : String(issue.author?.login || ""),
         updatedAt: String(issue.updatedAt || issue.updated_at || ""),
-        labels: issueLabels(issue),
-        recommendedLabels: recommendedSubmissionLabels(issue, report),
+        labels,
+        recommendedLabels,
+        missingLabels,
         status,
+        nextAction,
         staleState,
         ageDays: submissionAgeDays(issue, options),
-        sourceNeedsVerification: submissionSourceNeedsVerification(
-          report,
-          issue,
-        ),
+        sourceNeedsVerification,
         riskTier: risk.riskTier,
         riskFlags: risk.reviewFlags.map((flag) => flag.id),
-        riskSummary: capabilityBuckets.length
-          ? `${risk.riskTier}: ${capabilityBuckets.join(", ")}`
-          : risk.riskTier,
+        riskSummary: formatRiskSummary(risk.riskTier, capabilityBuckets),
         contributorReview,
         sourceState: risk.contributionAnalysis?.sourceState || "unknown",
         maintainerActions,
@@ -840,6 +962,7 @@ export function buildSubmissionQueue(issues = [], options = {}) {
         category: report.category || "",
         slug: report.fields?.slug || "",
         name: report.fields?.name || "",
+        sourceUrl: firstSubmissionSourceUrl(report.fields),
         errors: report.errors || [],
         warnings: report.warnings || [],
         importPath:
@@ -847,6 +970,15 @@ export function buildSubmissionQueue(issues = [], options = {}) {
             ? `content/${report.category}/${report.fields.slug}.mdx`
             : "",
       };
+      entry.reviewChecklist = buildSubmissionReviewChecklist({
+        report,
+        risk,
+        status,
+        sourceNeedsVerification,
+        maintainerActions,
+      });
+      entry.commentDraft = buildSubmissionCommentDraft({ entry, report });
+      return entry;
     })
     .sort((left, right) => {
       const statusOrder = {
@@ -866,7 +998,7 @@ export function buildSubmissionQueue(issues = [], options = {}) {
     });
 
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     kind: "submission-queue",
     generatedAt: new Date().toISOString(),
     count: entries.length,
@@ -887,6 +1019,9 @@ export function buildSubmissionQueue(issues = [], options = {}) {
       ).length,
       closeEligible: entries.filter(
         (entry) => entry.status === "close_eligible",
+      ).length,
+      highRisk: entries.filter(
+        (entry) => entry.riskTier === "high" || entry.riskTier === "critical",
       ).length,
       needsChanges: entries.filter((entry) =>
         [

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -568,12 +568,30 @@ npx unslop --help`);
       { now: "2026-04-30T00:00:00Z" },
     );
     expect(queue.count).toBe(2);
+    expect(queue.schemaVersion).toBe(2);
     expect(queue.summary.importReady).toBe(1);
     expect(queue.summary.needsChanges).toBe(1);
     expect(queue.entries[0].status).toBe("import_ready");
+    expect(queue.entries[0].nextAction).toBe("import");
     expect(queue.entries[0].importPath).toBe("content/mcp/contrastapi.mdx");
+    expect(queue.entries[0].sourceUrl).toBe(
+      "https://github.com/example/contrastapi",
+    );
+    expect(queue.entries[0].missingLabels).toEqual(
+      expect.arrayContaining(["community-mcp", "needs-review"]),
+    );
+    expect(queue.entries[0].reviewChecklist).toEqual(
+      expect.arrayContaining([
+        "Confirm the category, slug, and public-facing metadata.",
+        "Apply import-approved only after source and category review.",
+      ]),
+    );
     expect(queue.entries[1].status).toBe("needs_author_input");
+    expect(queue.entries[1].nextAction).toBe("request_author_input");
     expect(queue.entries[1].actionDue).toBe("author_input");
+    expect(queue.entries[1].commentDraft).toContain(
+      "can't continue review until the issue has the required metadata",
+    );
   });
 
   it("tracks stale author-input states without touching maintainer-approved issues", () => {
@@ -631,6 +649,27 @@ npx unslop --help`;
         now: "2026-04-30T00:00:00Z",
       }),
     ).toBe("maintainer_review");
+
+    const queue = buildSubmissionQueue(
+      [fresh, reminderDue, closeEligible, approved],
+      { now: "2026-04-30T00:00:00Z" },
+    );
+    expect(
+      queue.entries.find((entry) => entry.status === "stale_reminder_due")
+        ?.nextAction,
+    ).toBe("send_stale_reminder");
+    expect(
+      queue.entries.find((entry) => entry.status === "close_eligible")
+        ?.nextAction,
+    ).toBe("close_stale");
+    expect(
+      queue.entries.find((entry) => entry.status === "maintainer_review")
+        ?.nextAction,
+    ).toBe("import");
+    expect(
+      queue.entries.find((entry) => entry.status === "close_eligible")
+        ?.commentDraft,
+    ).toContain("Closing this submission as not planned");
   });
 
   it("separates source verification from author-input failures", () => {
@@ -672,6 +711,13 @@ claude mcp add source-review-mcp -- npx -y source-review-mcp`,
     ).toBe("source_needs_verification");
     expect(recommendedSubmissionLabels(sourceProblem)).toContain(
       "source-needs-verification",
+    );
+    const queue = buildSubmissionQueue([sourceProblem], {
+      now: "2026-04-30T00:00:00Z",
+    });
+    expect(queue.entries[0].nextAction).toBe("verify_source");
+    expect(queue.entries[0].commentDraft).toContain(
+      "needs source verification before it can be imported",
     );
   });
 


### PR DESCRIPTION
## Summary
- adds richer submission queue metadata for maintainer review
- turns `/submissions` into a read-only workbench with filters, risk/source labels, checklists, and copyable reply drafts
- documents the maintainer workflow and queue fields

## What changed
- bumped the submission queue schema to expose `nextAction`, `missingLabels`, `reviewChecklist`, `commentDraft`, `sourceUrl`, and high-risk summary counts
- expanded the public submission queue page into a filtered maintainer view without adding GitHub write actions
- added intake tests for import, source-verification, author-input, stale-reminder, and close-stale states

## Why
- maintainers need a clearer operational surface for deciding which submissions can be imported, which need source/risk review, and which need author follow-up
- the website should help review the queue without bypassing the issue-first, maintainer-reviewed content flow

## Validation
- `pnpm test:submission-intake`
- `pnpm type-check`
- `pnpm validate:content`
- `pnpm validate:raycast-feed`

## Notes
- this PR is read-only from the website side: it does not comment on issues, close issues, apply labels, or publish/import content


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filtering to submissions queue with per-filter entry counts
  * Risk indicators highlighting high-risk submissions
  * Enhanced submission details including labels, source verification status, and next action guidance
  * Auto-generated review checklists and comment drafts for maintainers
  * Improved messaging for filtered empty states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->