### PR TITLE
feat(growth): surface community discovery signals

### DIFF
--- a/.github/workflows/github-stats-refresh-pr.yml
+++ b/.github/workflows/github-stats-refresh-pr.yml
@@ -1,0 +1,64 @@
+name: GitHub Stats Refresh PR
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "43 8 * * 2"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-github-stats:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    concurrency:
+      group: github-stats-refresh
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Refresh GitHub source signals
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm refresh:github-stats
+
+      - name: Create GitHub stats refresh PR
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
+        with:
+          branch: automation/github-stats-refresh
+          title: "chore(stats): refresh GitHub source signals"
+          commit-message: "chore(stats): refresh GitHub source signals"
+          body: |
+            ## Summary
+            - refreshes generated GitHub stars, forks, and upstream update timestamps
+
+            ## Validation
+            - `pnpm refresh:github-stats`
+
+            ## Notes
+            - runs only from the default branch schedule or manual dispatch
+            - does not deploy Cloudflare Workers or create preview deployments
+          labels: |
+            automation
+            data
+          add-paths: |
+            apps/web/public/data/**
+            apps/web/src/generated/site-stats.json

--- a/apps/web/src/app/[category]/[slug]/page.tsx
+++ b/apps/web/src/app/[category]/[slug]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 
 import { BrandAsset } from "@/components/brand-asset";
+import { CommunitySignalPanel } from "@/components/community-signal-panel";
 import { ContentSections } from "@/components/content-sections";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { DetailToc } from "@/components/detail-toc";
@@ -560,6 +561,8 @@ export default async function DetailPage({ params }: DetailPageProps) {
                 <EntryCopyButton
                   text={entry.installCommand}
                   label="Copy install"
+                  intentType="install"
+                  entryKey={`${entry.category}:${entry.slug}`}
                   className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
                 />
               ) : null}
@@ -567,6 +570,8 @@ export default async function DetailPage({ params }: DetailPageProps) {
                 <EntryCopyButton
                   text={entry.configSnippet}
                   label="Copy config"
+                  intentType="copy"
+                  entryKey={`${entry.category}:${entry.slug}`}
                   className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
                 />
               ) : null}
@@ -891,6 +896,11 @@ export default async function DetailPage({ params }: DetailPageProps) {
             </div>
           </div>
         </div>
+
+        <CommunitySignalPanel
+          targetKind="entry"
+          targetKey={`entry:${entry.category}/${entry.slug}`}
+        />
 
         {entry.category === "skills" && entry.platformCompatibility?.length ? (
           <div className="surface-panel p-4">

--- a/apps/web/src/app/api-docs/page.tsx
+++ b/apps/web/src/app/api-docs/page.tsx
@@ -114,6 +114,11 @@ const examples = [
     href: "/api/community-signals?targetKind=tool&targetKey=tool:cursor",
     code: "curl 'https://heyclau.de/api/community-signals?targetKind=tool&targetKey=tool:cursor'",
   },
+  {
+    title: "Batch Community Signals",
+    href: "/api/community-signals/query",
+    code: 'curl -X POST https://heyclau.de/api/community-signals/query -H \'content-type: application/json\' -d \'{"targets":[{"targetKind":"entry","targetKey":"entry:mcp/asana-mcp-server"}]}\'',
+  },
 ];
 
 export default function ApiDocsPage() {

--- a/apps/web/src/app/api/community-signals/query/route.ts
+++ b/apps/web/src/app/api/community-signals/query/route.ts
@@ -1,0 +1,48 @@
+import { communitySignalsBatchQueryBodySchema } from "@/lib/api/contracts";
+import {
+  apiError,
+  apiJson,
+  createApiHandler,
+  type InferApiBody,
+} from "@/lib/api/router";
+import {
+  normalizeCommunityTargetKey,
+  normalizeCommunityTargetKind,
+  safeCommunitySignalCounts,
+  type CommunitySignalTarget,
+} from "@/lib/community-signals";
+
+export const POST = createApiHandler(
+  "communitySignals.query",
+  async ({ body, requestId }) => {
+    const payload = body as InferApiBody<
+      typeof communitySignalsBatchQueryBodySchema
+    >;
+    const targets: CommunitySignalTarget[] = [];
+
+    for (const target of payload.targets || []) {
+      const targetKind = normalizeCommunityTargetKind(target.targetKind);
+      const targetKey = normalizeCommunityTargetKey(target.targetKey);
+      if (!targetKind || !targetKey) {
+        return apiError("invalid_payload", 400, {
+          requestId,
+          message:
+            "Provide targets as entry/tool with keys like entry:<category>/<slug> or tool:<slug>.",
+        });
+      }
+      targets.push({ targetKind, targetKey });
+    }
+
+    const { available, counts } = await safeCommunitySignalCounts(targets);
+    return apiJson(
+      {
+        ok: true,
+        available,
+        counts,
+      },
+      {
+        headers: { "cache-control": "no-store" },
+      },
+    );
+  },
+);

--- a/apps/web/src/app/api/community-signals/route.ts
+++ b/apps/web/src/app/api/community-signals/route.ts
@@ -9,108 +9,24 @@ import {
   type InferApiBody,
   type InferApiQuery,
 } from "@/lib/api/router";
-import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
-
-const SIGNAL_TYPES = ["used", "works", "broken"] as const;
-const TARGET_KINDS = ["entry", "tool"] as const;
-const ZERO_COUNTS = { used: 0, works: 0, broken: 0 };
-
-type SignalType = (typeof SIGNAL_TYPES)[number];
-type TargetKind = (typeof TARGET_KINDS)[number];
-type SignalCounts = Record<SignalType, number>;
-
-type SignalRow = {
-  signal_type: SignalType;
-  count: number;
-};
-
-function normalizeTargetKind(
-  value: string | null | undefined,
-): TargetKind | null {
-  return value && (TARGET_KINDS as readonly string[]).includes(value)
-    ? (value as TargetKind)
-    : null;
-}
-
-function normalizeSignalType(
-  value: string | null | undefined,
-): SignalType | null {
-  return value && (SIGNAL_TYPES as readonly string[]).includes(value)
-    ? (value as SignalType)
-    : null;
-}
-
-function normalizeTargetKey(value: string | null | undefined): string | null {
-  const normalized = (value || "").trim().toLowerCase();
-  return /^(entry|tool):[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)?$/.test(
-    normalized,
-  )
-    ? normalized
-    : null;
-}
-
-function normalizeClientId(value: string | null | undefined): string | null {
-  const normalized = (value || "").trim();
-  return /^[a-zA-Z0-9_-]{16,96}$/.test(normalized) ? normalized : null;
-}
-
-function isExpectedUnavailableD1Error(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error ?? "");
-  return (
-    message.includes("no such table: community_signals") ||
-    message.includes("SITE_DB")
-  );
-}
-
-async function readCounts(
-  db: D1DatabaseLike,
-  targetKind: TargetKind,
-  targetKey: string,
-): Promise<SignalCounts> {
-  const counts = { ...ZERO_COUNTS };
-  const { results } = await db
-    .prepare(
-      `SELECT signal_type, COUNT(*) AS count
-       FROM community_signals
-       WHERE target_kind = ? AND target_key = ?
-       GROUP BY signal_type`,
-    )
-    .bind(targetKind, targetKey)
-    .all<SignalRow>();
-
-  for (const row of results || []) {
-    if (SIGNAL_TYPES.includes(row.signal_type)) {
-      counts[row.signal_type] = Number(row.count) || 0;
-    }
-  }
-
-  return counts;
-}
-
-async function safeCounts(targetKind: TargetKind, targetKey: string) {
-  try {
-    const db = await getSiteDb();
-    if (!db) {
-      return { available: false, counts: { ...ZERO_COUNTS } };
-    }
-    return {
-      available: true,
-      counts: await readCounts(db, targetKind, targetKey),
-    };
-  } catch (error) {
-    if (!isExpectedUnavailableD1Error(error)) {
-      console.warn("[community-signals] failed to read counts", error);
-    }
-    return { available: false, counts: { ...ZERO_COUNTS } };
-  }
-}
+import { logApiWarn } from "@/lib/api-logs";
+import {
+  normalizeCommunityClientId,
+  normalizeCommunitySignalType,
+  normalizeCommunityTargetKey,
+  normalizeCommunityTargetKind,
+  queryCommunitySignalCounts,
+  safeCommunitySignalCounts,
+  ZERO_COMMUNITY_SIGNAL_COUNTS,
+} from "@/lib/community-signals";
+import { getSiteDb } from "@/lib/db";
 
 export const GET = createApiHandler(
   "communitySignals.read",
   async ({ query, requestId }) => {
     const payload = query as InferApiQuery<typeof communitySignalsQuerySchema>;
-    const targetKind = normalizeTargetKind(payload.targetKind);
-    const targetKey = normalizeTargetKey(payload.targetKey);
+    const targetKind = normalizeCommunityTargetKind(payload.targetKind);
+    const targetKey = normalizeCommunityTargetKey(payload.targetKey);
 
     if (!targetKind || !targetKey) {
       return apiError("invalid_payload", 400, {
@@ -120,25 +36,27 @@ export const GET = createApiHandler(
       });
     }
 
-    const { available, counts } = await safeCounts(targetKind, targetKey);
+    const { available, counts } = await safeCommunitySignalCounts([
+      { targetKind, targetKey },
+    ]);
     return apiJson({
       ok: true,
       available,
       targetKind,
       targetKey,
-      counts,
+      counts: counts[targetKey] || { ...ZERO_COMMUNITY_SIGNAL_COUNTS },
     });
   },
 );
 
 export const POST = createApiHandler(
   "communitySignals.write",
-  async ({ body, requestId }) => {
+  async ({ body, request, requestId }) => {
     const payload = body as InferApiBody<typeof communitySignalsBodySchema>;
-    const targetKind = normalizeTargetKind(payload.targetKind);
-    const targetKey = normalizeTargetKey(payload.targetKey);
-    const signalType = normalizeSignalType(payload.signalType);
-    const clientId = normalizeClientId(payload.clientId);
+    const targetKind = normalizeCommunityTargetKind(payload.targetKind);
+    const targetKey = normalizeCommunityTargetKey(payload.targetKey);
+    const signalType = normalizeCommunitySignalType(payload.signalType);
+    const clientId = normalizeCommunityClientId(payload.clientId);
 
     if (!targetKind || !targetKey || !signalType || !clientId) {
       return apiError("invalid_payload", 400, {
@@ -148,7 +66,7 @@ export const POST = createApiHandler(
     }
 
     try {
-      const db = await getSiteDb();
+      const db = getSiteDb();
       if (!db) {
         return apiJson(
           {
@@ -157,7 +75,7 @@ export const POST = createApiHandler(
             available: false,
             targetKind,
             targetKey,
-            counts: { ...ZERO_COUNTS },
+            counts: { ...ZERO_COMMUNITY_SIGNAL_COUNTS },
           },
           { status: 200 },
         );
@@ -190,6 +108,9 @@ export const POST = createApiHandler(
           .run();
       }
 
+      const counts = await queryCommunitySignalCounts(db, [
+        { targetKind, targetKey },
+      ]);
       return apiJson(
         {
           ok: true,
@@ -197,16 +118,27 @@ export const POST = createApiHandler(
           available: true,
           targetKind,
           targetKey,
-          counts: await readCounts(db, targetKind, targetKey),
+          counts: counts[targetKey] || { ...ZERO_COMMUNITY_SIGNAL_COUNTS },
         },
         { status: 200 },
       );
     } catch (error) {
-      if (!isExpectedUnavailableD1Error(error)) {
-        console.warn("[community-signals] failed to store signal", error);
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        !message.includes("no such table: community_signals") &&
+        !message.includes("SITE_DB")
+      ) {
+        logApiWarn(request, "community_signals.store_failed", {
+          error: message,
+          signalType,
+          targetKey,
+          targetKind,
+        });
       }
 
-      const { counts } = await safeCounts(targetKind, targetKey);
+      const { counts } = await safeCommunitySignalCounts([
+        { targetKind, targetKey },
+      ]);
       return apiJson(
         {
           ok: true,
@@ -214,7 +146,7 @@ export const POST = createApiHandler(
           available: false,
           targetKind,
           targetKey,
-          counts,
+          counts: counts[targetKey] || { ...ZERO_COMMUNITY_SIGNAL_COUNTS },
         },
         { status: 200 },
       );

--- a/apps/web/src/app/api/intent-events/route.ts
+++ b/apps/web/src/app/api/intent-events/route.ts
@@ -7,35 +7,19 @@ import {
 } from "@/lib/api/router";
 import { logApiWarn } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
-
-const EVENT_TYPES = new Set(["copy", "open", "install", "download", "vote"]);
-
-function normalizeEventType(value: unknown) {
-  const normalized = String(value ?? "")
-    .trim()
-    .toLowerCase();
-  return EVENT_TYPES.has(normalized) ? normalized : "";
-}
-
-function normalizeEntryKey(value: unknown) {
-  const normalized = String(value ?? "")
-    .trim()
-    .toLowerCase();
-  return /^[a-z0-9-]+:[a-z0-9-]+$/.test(normalized) ? normalized : "";
-}
-
-function normalizeSessionId(value: unknown) {
-  const normalized = String(value ?? "").trim();
-  return normalized.length <= 128 ? normalized : "";
-}
+import {
+  normalizeIntentEntryKey,
+  normalizeIntentEventType,
+  normalizeIntentSessionId,
+} from "@/lib/intent-events";
 
 export const POST = createApiHandler(
   "intentEvents.create",
   async ({ request, body, requestId }) => {
     const payload = body as InferApiBody<typeof intentEventsBodySchema>;
-    const eventType = normalizeEventType(payload.type);
-    const entryKey = normalizeEntryKey(payload.entryKey);
-    const sessionId = normalizeSessionId(payload.sessionId);
+    const eventType = normalizeIntentEventType(payload.type);
+    const entryKey = normalizeIntentEntryKey(payload.entryKey);
+    const sessionId = normalizeIntentSessionId(payload.sessionId);
     if (!eventType) {
       return apiError("invalid_payload", 400, { requestId });
     }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -94,7 +94,7 @@ export default async function HomePage() {
       </section>
       <section className="container-shell grid gap-4 py-10 md:grid-cols-3">
         {[
-          ["Trending", "/trending", growthSurfaces.trendingCandidates.length],
+          ["Trending", "/trending", growthSurfaces.practicalPicks.length],
           ["Newly added", "/browse?sort=newest", growthSurfaces.newest.length],
           ["API", "/api-docs", directoryEntries.length],
         ].map(([label, href, count]) => (

--- a/apps/web/src/app/trending/page.tsx
+++ b/apps/web/src/app/trending/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { DirectoryEntryCard } from "@/components/directory-entry-card";
 import { JsonLd } from "@/components/json-ld";
+import { entryCommunityTarget } from "@/lib/community-signals";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { buildPageMetadata } from "@/lib/seo";
 import { siteConfig } from "@/lib/site";
@@ -10,6 +11,9 @@ import {
   buildBreadcrumbJsonLd,
   buildCollectionPageJsonLd,
 } from "@heyclaude/registry/seo";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 300;
 
 export const metadata: Metadata = buildPageMetadata({
   title: "Popular, trending, and new Claude resources",
@@ -36,8 +40,9 @@ export default async function TrendingPage() {
   ];
 
   const groups = [
+    ["Community trending", surfaces.communityTrending],
     ["Popular by source signals", surfaces.popularBySourceSignals],
-    ["Trending candidates", surfaces.trendingCandidates],
+    ["Practical picks", surfaces.practicalPicks],
     ["Newly added", surfaces.newest],
     ["Recently updated upstream", surfaces.recentlyUpdated],
   ] as const;
@@ -52,27 +57,48 @@ export default async function TrendingPage() {
         <span className="eyebrow">Discovery</span>
         <h1 className="section-title">Popular, trending, and new resources.</h1>
         <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
-          These surfaces use visible registry fields, upstream source signals,
-          and freshness data. They do not claim private usage popularity unless
-          those metrics are explicitly collected and labeled.
+          These surfaces use visible registry fields, source-backed repository
+          signals when present, and aggregate community actions from the last 30
+          days. Empty signal groups are hidden instead of implying popularity
+          that has not been measured.
         </p>
       </div>
 
-      {groups.map(([title, entries]) => (
-        <section key={title} className="space-y-4">
-          <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-            {title}
-          </h2>
-          <div className="space-y-4">
-            {entries.slice(0, 4).map((entry) => (
-              <DirectoryEntryCard
-                key={`${title}:${entry.category}:${entry.slug}`}
-                entry={entry}
-              />
-            ))}
-          </div>
-        </section>
-      ))}
+      {groups
+        .filter(([, entries]) => entries.length > 0)
+        .map(([title, entries]) => (
+          <section key={title} className="space-y-4">
+            <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+              {title}
+            </h2>
+            <div className="space-y-4">
+              {entries.slice(0, 4).map((entry) => {
+                const key = `${entry.category}:${entry.slug}`;
+                const signalKey = entryCommunityTarget(
+                  entry.category,
+                  entry.slug,
+                );
+                const intentCounts = surfaces.intentCounts[key];
+                const intentCount = intentCounts
+                  ? intentCounts.copy +
+                    intentCounts.open +
+                    intentCounts.install +
+                    intentCounts.download +
+                    intentCounts.vote
+                  : 0;
+                return (
+                  <DirectoryEntryCard
+                    key={`${title}:${entry.category}:${entry.slug}`}
+                    entry={entry}
+                    voteCount={surfaces.voteCounts[key] ?? 0}
+                    communitySignals={surfaces.communitySignals[signalKey]}
+                    intentCount={intentCount}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        ))}
     </div>
   );
 }

--- a/apps/web/src/components/directory-entry-card.tsx
+++ b/apps/web/src/components/directory-entry-card.tsx
@@ -30,6 +30,12 @@ type DirectoryEntryCardProps = {
   entry: DirectoryEntry;
   voteCount?: number;
   hasVoted?: boolean;
+  communitySignals?: {
+    used?: number;
+    works?: number;
+    broken?: number;
+  };
+  intentCount?: number;
   onToggleVote?: (
     entry: DirectoryEntry,
     nextVote: boolean,
@@ -77,6 +83,8 @@ export function DirectoryEntryCard({
   entry,
   voteCount,
   hasVoted: hasVotedProp = false,
+  communitySignals,
+  intentCount = 0,
   onToggleVote,
 }: DirectoryEntryCardProps) {
   const baseVotes = 0;
@@ -93,6 +101,16 @@ export function DirectoryEntryCard({
     () => getDistributionBadges(entry),
     [entry],
   );
+  const visibleSignals = [
+    communitySignals?.used ? `Used ${compactCount(communitySignals.used)}` : "",
+    communitySignals?.works
+      ? `Works ${compactCount(communitySignals.works)}`
+      : "",
+    communitySignals?.broken
+      ? `Broken ${compactCount(communitySignals.broken)}`
+      : "",
+    intentCount ? `30d actions ${compactCount(intentCount)}` : "",
+  ].filter(Boolean);
   const repoHref = entry.repoUrl || entry.githubUrl;
   const isGitHubRepo = Boolean(repoHref && /github\.com/i.test(repoHref));
   const isGitHubSource = Boolean(
@@ -333,6 +351,14 @@ export function DirectoryEntryCard({
               title={badge.title}
             >
               {badge.label}
+            </span>
+          ))}
+          {visibleSignals.map((signal) => (
+            <span
+              key={signal}
+              className="rounded-full border border-primary/35 bg-primary/10 px-2.5 py-1 text-[11px] font-medium text-primary"
+            >
+              {signal}
             </span>
           ))}
         </div>

--- a/apps/web/src/components/entry-copy-button.tsx
+++ b/apps/web/src/components/entry-copy-button.tsx
@@ -14,6 +14,8 @@ type EntryCopyButtonProps = {
   className?: string;
   iconOnly?: boolean;
   title?: string;
+  intentType?: "copy" | "install" | "download";
+  entryKey?: string;
 };
 
 export function EntryCopyButton({
@@ -23,6 +25,8 @@ export function EntryCopyButton({
   className,
   iconOnly = false,
   title,
+  intentType,
+  entryKey,
 }: EntryCopyButtonProps) {
   const [copied, setCopied] = useState(false);
   const { pushToast } = useToast();
@@ -39,6 +43,21 @@ export function EntryCopyButton({
     try {
       await navigator.clipboard.writeText(value);
       setCopied(true);
+      const resolvedEntryKey =
+        entryKey ?? (entry ? `${entry.category}:${entry.slug}` : "");
+      const resolvedIntentType =
+        intentType ??
+        (label.toLowerCase().includes("install") ? "install" : "copy");
+      if (resolvedEntryKey) {
+        window.dispatchEvent(
+          new CustomEvent("heyclaude:intent", {
+            detail: {
+              type: resolvedIntentType,
+              entryKey: resolvedEntryKey,
+            },
+          }),
+        );
+      }
       pushToast({
         variant: "success",
         title: "Copied",

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -433,6 +433,10 @@ export const communitySignalsBodySchema = communitySignalsQuerySchema.extend({
   active: z.boolean().optional().default(true),
 });
 
+export const communitySignalsBatchQueryBodySchema = z.object({
+  targets: z.array(communitySignalsQuerySchema).max(100).optional().default([]),
+});
+
 export const ogQuerySchema = z.object({
   title: z.string().trim().max(120).optional().default("HeyClaude"),
   description: z
@@ -920,6 +924,24 @@ export const apiRouteDefinitions = {
     rateLimit: {
       scope: "community-signals-write",
       limit: 45,
+      windowMs: 60_000,
+      binding: "API_DYNAMIC_RATE_LIMIT",
+    },
+  }),
+  "communitySignals.query": route({
+    id: "communitySignals.query",
+    method: "POST",
+    path: "/api/community-signals/query",
+    summary: "Read community signal counts for multiple targets",
+    description:
+      "Returns aggregate used/works/broken counts for up to 100 entry or tool targets without exposing client identifiers.",
+    tags: ["Dynamic"],
+    originCheck: true,
+    bodySchema: communitySignalsBatchQueryBodySchema,
+    bodyLimitBytes: 16 * 1024,
+    rateLimit: {
+      scope: "community-signals-query",
+      limit: 90,
       windowMs: 60_000,
       binding: "API_DYNAMIC_RATE_LIMIT",
     },

--- a/apps/web/src/lib/community-signals.ts
+++ b/apps/web/src/lib/community-signals.ts
@@ -1,0 +1,158 @@
+import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
+
+export const COMMUNITY_SIGNAL_TYPES = ["used", "works", "broken"] as const;
+export const COMMUNITY_TARGET_KINDS = ["entry", "tool"] as const;
+export const ZERO_COMMUNITY_SIGNAL_COUNTS = {
+  used: 0,
+  works: 0,
+  broken: 0,
+};
+
+export type CommunitySignalType = (typeof COMMUNITY_SIGNAL_TYPES)[number];
+export type CommunityTargetKind = (typeof COMMUNITY_TARGET_KINDS)[number];
+export type CommunitySignalCounts = Record<CommunitySignalType, number>;
+export type CommunitySignalTarget = {
+  targetKind: CommunityTargetKind;
+  targetKey: string;
+};
+
+type SignalRow = {
+  target_kind: CommunityTargetKind;
+  target_key: string;
+  signal_type: CommunitySignalType;
+  count: number;
+};
+
+const D1_SAFE_TARGET_BATCH_SIZE = 25;
+
+export function normalizeCommunityTargetKind(
+  value: string | null | undefined,
+): CommunityTargetKind | null {
+  return value && (COMMUNITY_TARGET_KINDS as readonly string[]).includes(value)
+    ? (value as CommunityTargetKind)
+    : null;
+}
+
+export function normalizeCommunitySignalType(
+  value: string | null | undefined,
+): CommunitySignalType | null {
+  return value && (COMMUNITY_SIGNAL_TYPES as readonly string[]).includes(value)
+    ? (value as CommunitySignalType)
+    : null;
+}
+
+export function normalizeCommunityTargetKey(
+  value: string | null | undefined,
+): string | null {
+  const normalized = (value || "").trim().toLowerCase();
+  return /^(entry|tool):[a-z0-9][a-z0-9-]*(\/[a-z0-9][a-z0-9-]*)?$/.test(
+    normalized,
+  )
+    ? normalized
+    : null;
+}
+
+export function normalizeCommunityClientId(
+  value: string | null | undefined,
+): string | null {
+  const normalized = (value || "").trim();
+  return /^[a-zA-Z0-9_-]{16,96}$/.test(normalized) ? normalized : null;
+}
+
+export function communitySignalTargetId(target: CommunitySignalTarget) {
+  return target.targetKey;
+}
+
+export function entryCommunityTarget(category: string, slug: string) {
+  return `entry:${category}/${slug}`;
+}
+
+export function getFallbackCommunitySignalCounts(
+  targets: CommunitySignalTarget[],
+) {
+  const counts: Record<string, CommunitySignalCounts> = {};
+  for (const target of targets) {
+    counts[communitySignalTargetId(target)] = {
+      ...ZERO_COMMUNITY_SIGNAL_COUNTS,
+    };
+  }
+  return counts;
+}
+
+export function isExpectedUnavailableCommunitySignalError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return (
+    message.includes("no such table: community_signals") ||
+    message.includes("SITE_DB")
+  );
+}
+
+export async function queryCommunitySignalCounts(
+  db: D1DatabaseLike,
+  targets: CommunitySignalTarget[],
+) {
+  const uniqueTargets = [
+    ...new Map(
+      targets.map((target) => [communitySignalTargetId(target), target]),
+    ).values(),
+  ];
+  const counts = getFallbackCommunitySignalCounts(uniqueTargets);
+  if (!uniqueTargets.length) return counts;
+
+  for (
+    let index = 0;
+    index < uniqueTargets.length;
+    index += D1_SAFE_TARGET_BATCH_SIZE
+  ) {
+    const batch = uniqueTargets.slice(index, index + D1_SAFE_TARGET_BATCH_SIZE);
+    const where = batch.map(() => "(target_kind = ? AND target_key = ?)");
+    const values = batch.flatMap((target) => [
+      target.targetKind,
+      target.targetKey,
+    ]);
+    const { results } = await db
+      .prepare(
+        `SELECT target_kind, target_key, signal_type, COUNT(*) AS count
+         FROM community_signals
+         WHERE ${where.join(" OR ")}
+         GROUP BY target_kind, target_key, signal_type`,
+      )
+      .bind(...values)
+      .all<SignalRow>();
+
+    for (const row of results || []) {
+      if (!COMMUNITY_SIGNAL_TYPES.includes(row.signal_type)) continue;
+      const key = row.target_key;
+      counts[key] = counts[key] || { ...ZERO_COMMUNITY_SIGNAL_COUNTS };
+      counts[key][row.signal_type] = Number(row.count) || 0;
+    }
+  }
+
+  return counts;
+}
+
+export async function safeCommunitySignalCounts(
+  targets: CommunitySignalTarget[],
+) {
+  try {
+    const db = getSiteDb();
+    if (!db) {
+      return {
+        available: false,
+        counts: getFallbackCommunitySignalCounts(targets),
+      };
+    }
+    return {
+      available: true,
+      counts: await queryCommunitySignalCounts(db, targets),
+    };
+  } catch (error) {
+    if (!isExpectedUnavailableCommunitySignalError(error)) {
+      console.warn("[community-signals] failed to read counts", error);
+    }
+    return {
+      available: false,
+      counts: getFallbackCommunitySignalCounts(targets),
+    };
+  }
+}

--- a/apps/web/src/lib/growth-ranking.ts
+++ b/apps/web/src/lib/growth-ranking.ts
@@ -1,0 +1,32 @@
+import type { CommunitySignalCounts } from "@/lib/community-signals";
+import type { IntentEventCounts } from "@/lib/intent-events";
+
+export function totalIntentCount(counts: IntentEventCounts | undefined) {
+  if (!counts) return 0;
+  return (
+    counts.copy +
+    counts.open +
+    counts.install * 3 +
+    counts.download * 2 +
+    counts.vote
+  );
+}
+
+export function communityDiscoveryScore(params: {
+  communitySignals?: CommunitySignalCounts;
+  intentCounts?: IntentEventCounts;
+  votes?: number;
+  firstPartyPackage?: boolean;
+  productionVerified?: boolean;
+}) {
+  const signals = params.communitySignals;
+  return (
+    (params.votes ?? 0) * 4 +
+    (signals?.used ?? 0) * 3 +
+    (signals?.works ?? 0) * 5 -
+    (signals?.broken ?? 0) * 5 +
+    totalIntentCount(params.intentCounts) +
+    (params.firstPartyPackage ? 2 : 0) +
+    (params.productionVerified ? 2 : 0)
+  );
+}

--- a/apps/web/src/lib/growth-surfaces.ts
+++ b/apps/web/src/lib/growth-surfaces.ts
@@ -3,9 +3,36 @@ import "server-only";
 import { cache } from "react";
 
 import { getDirectoryEntries } from "@/lib/content";
+import {
+  entryCommunityTarget,
+  safeCommunitySignalCounts,
+} from "@/lib/community-signals";
+import { communityDiscoveryScore } from "@/lib/growth-ranking";
+import { safeIntentEventCounts } from "@/lib/intent-events";
+import { safeVoteCounts } from "@/lib/votes";
+
+type GrowthEntry = Awaited<ReturnType<typeof getDirectoryEntries>>[number];
+
+function entryKey(entry: GrowthEntry) {
+  return `${entry.category}:${entry.slug}`;
+}
+
+function signalTarget(entry: GrowthEntry) {
+  return entryCommunityTarget(entry.category, entry.slug);
+}
 
 export const getGrowthSurfaces = cache(async () => {
   const entries = await getDirectoryEntries();
+  const entryKeys = entries.map(entryKey);
+  const communityTargets = entries.map((entry) => ({
+    targetKind: "entry" as const,
+    targetKey: signalTarget(entry),
+  }));
+  const [voteState, communityState, intentState] = await Promise.all([
+    safeVoteCounts(entryKeys),
+    safeCommunitySignalCounts(communityTargets),
+    safeIntentEventCounts(entryKeys),
+  ]);
   const newest = [...entries]
     .filter((entry) => entry.dateAdded)
     .sort((left, right) =>
@@ -19,10 +46,12 @@ export const getGrowthSurfaces = cache(async () => {
     )
     .slice(0, 12);
   const popularBySourceSignals = [...entries]
-    .filter((entry) => typeof entry.githubStars === "number")
+    .filter(
+      (entry) => typeof entry.githubStars === "number" && entry.githubStars > 0,
+    )
     .sort((left, right) => (right.githubStars ?? 0) - (left.githubStars ?? 0))
     .slice(0, 12);
-  const trendingCandidates = [...entries]
+  const practicalPicks = [...entries]
     .filter(
       (entry) =>
         Boolean(
@@ -42,11 +71,39 @@ export const getGrowthSurfaces = cache(async () => {
       return String(right.dateAdded).localeCompare(String(left.dateAdded));
     })
     .slice(0, 12);
+  const communityTrending = [...entries]
+    .map((entry) => ({
+      entry,
+      score: communityDiscoveryScore({
+        communitySignals: communityState.counts[signalTarget(entry)],
+        intentCounts: intentState.counts[entryKey(entry)],
+        votes: voteState.counts[entryKey(entry)] ?? 0,
+        firstPartyPackage: entry.downloadTrust === "first-party",
+        productionVerified: entry.verificationStatus === "production",
+      }),
+    }))
+    .filter((item) => item.score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        String(right.entry.dateAdded).localeCompare(
+          String(left.entry.dateAdded),
+        ),
+    )
+    .slice(0, 12)
+    .map((item) => item.entry);
 
   return {
     newest,
     recentlyUpdated,
     popularBySourceSignals,
-    trendingCandidates,
+    practicalPicks,
+    communityTrending,
+    communitySignals: communityState.counts,
+    communitySignalsAvailable: communityState.available,
+    voteCounts: voteState.counts,
+    votesAvailable: voteState.available,
+    intentCounts: intentState.counts,
+    intentEventsAvailable: intentState.available,
   };
 });

--- a/apps/web/src/lib/intent-events.ts
+++ b/apps/web/src/lib/intent-events.ts
@@ -1,0 +1,122 @@
+import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
+
+export const INTENT_EVENT_TYPES = [
+  "copy",
+  "open",
+  "install",
+  "download",
+  "vote",
+] as const;
+export const INTENT_EVENT_WINDOW_DAYS = 30;
+export const ZERO_INTENT_EVENT_COUNTS = {
+  copy: 0,
+  open: 0,
+  install: 0,
+  download: 0,
+  vote: 0,
+};
+
+export type IntentEventType = (typeof INTENT_EVENT_TYPES)[number];
+export type IntentEventCounts = Record<IntentEventType, number>;
+
+type IntentEventRow = {
+  entry_key: string;
+  event_type: IntentEventType;
+  count: number;
+};
+
+const D1_SAFE_VARIABLE_BATCH_SIZE = 25;
+
+export function normalizeIntentEventType(value: unknown) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return (INTENT_EVENT_TYPES as readonly string[]).includes(normalized)
+    ? (normalized as IntentEventType)
+    : "";
+}
+
+export function normalizeIntentEntryKey(value: unknown) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return /^[a-z0-9-]+:[a-z0-9-]+$/.test(normalized) ? normalized : "";
+}
+
+export function normalizeIntentSessionId(value: unknown) {
+  const normalized = String(value ?? "").trim();
+  return normalized.length <= 128 ? normalized : "";
+}
+
+export function getFallbackIntentEventCounts(keys: string[]) {
+  const counts: Record<string, IntentEventCounts> = {};
+  for (const key of keys) counts[key] = { ...ZERO_INTENT_EVENT_COUNTS };
+  return counts;
+}
+
+export async function queryIntentEventCounts(
+  db: D1DatabaseLike,
+  keys: string[],
+  windowDays = INTENT_EVENT_WINDOW_DAYS,
+) {
+  const uniqueKeys = [...new Set(keys.filter(Boolean))];
+  const counts = getFallbackIntentEventCounts(uniqueKeys);
+  if (!uniqueKeys.length) return counts;
+
+  for (
+    let index = 0;
+    index < uniqueKeys.length;
+    index += D1_SAFE_VARIABLE_BATCH_SIZE
+  ) {
+    const batch = uniqueKeys.slice(index, index + D1_SAFE_VARIABLE_BATCH_SIZE);
+    const placeholders = batch.map(() => "?").join(", ");
+    const { results } = await db
+      .prepare(
+        `SELECT entry_key, event_type, COUNT(*) AS count
+         FROM intent_events
+         WHERE entry_key IN (${placeholders})
+           AND created_at >= datetime('now', ?)
+         GROUP BY entry_key, event_type`,
+      )
+      .bind(...batch, `-${Math.max(1, windowDays)} days`)
+      .all<IntentEventRow>();
+
+    for (const row of results || []) {
+      if (!INTENT_EVENT_TYPES.includes(row.event_type)) continue;
+      counts[row.entry_key] = counts[row.entry_key] || {
+        ...ZERO_INTENT_EVENT_COUNTS,
+      };
+      counts[row.entry_key][row.event_type] = Number(row.count) || 0;
+    }
+  }
+
+  return counts;
+}
+
+export async function safeIntentEventCounts(keys: string[]) {
+  try {
+    const db = getSiteDb();
+    if (!db) {
+      return {
+        available: false,
+        counts: getFallbackIntentEventCounts(keys),
+      };
+    }
+    return {
+      available: true,
+      counts: await queryIntentEventCounts(db, keys),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      !message.includes("no such table: intent_events") &&
+      !message.includes("SITE_DB")
+    ) {
+      console.warn("[intent-events] failed to read counts", error);
+    }
+    return {
+      available: false,
+      counts: getFallbackIntentEventCounts(keys),
+    };
+  }
+}

--- a/apps/web/src/lib/votes.ts
+++ b/apps/web/src/lib/votes.ts
@@ -58,6 +58,34 @@ export async function queryVoteCounts(db: D1DatabaseLike, keys: string[]) {
   return counts;
 }
 
+export async function safeVoteCounts(keys: string[]) {
+  try {
+    const db = getVotesDb();
+    if (!db) {
+      return {
+        available: false,
+        counts: getFallbackVoteCounts(keys),
+      };
+    }
+    return {
+      available: true,
+      counts: await queryVoteCounts(db, keys),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (
+      !message.includes("no such table: votes_entries") &&
+      !message.includes("SITE_DB")
+    ) {
+      console.warn("[votes] failed to read counts", error);
+    }
+    return {
+      available: false,
+      counts: getFallbackVoteCounts(keys),
+    };
+  }
+}
+
 export async function queryVotesByClient(
   db: D1DatabaseLike,
   keys: string[],

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -7845,6 +7845,290 @@ paths:
                 required:
                   - ok
                   - error
+  /api/community-signals/query:
+    post:
+      tags:
+        - Dynamic
+      summary: Read community signal counts for multiple targets
+      description:
+        Returns aggregate used/works/broken counts for up to 100 entry or tool targets without
+        exposing client identifiers.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                targets:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      targetKind:
+                        type: string
+                        enum:
+                          - entry
+                          - tool
+                      targetKey:
+                        type: string
+                        minLength: 1
+                        maxLength: 160
+                    required:
+                      - targetKind
+                      - targetKey
+                  maxItems: 100
+                  default: []
+      responses:
+        "200":
+          description: Request accepted. Dynamic state may fail open when D1 is unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/github-stats:
     get:
       tags:

--- a/docs/api-security-contract.md
+++ b/docs/api-security-contract.md
@@ -24,6 +24,7 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
 - `/api/votes/query`
 - `/api/votes/toggle`
 - `/api/community-signals`
+- `/api/community-signals/query`
 - `/api/intent-events`
 - `/api/newsletter/subscribe`
 - `/api/newsletter/webhook`

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -38,6 +38,7 @@ const apiRoutes = [
   "/api/admin/jobs/health",
   "/api/intent-events",
   "/api/community-signals",
+  "/api/community-signals/query",
   "/api/github-stats",
   "/feed.xml",
   "/atom.xml",

--- a/tests/d1-dynamic-state.test.ts
+++ b/tests/d1-dynamic-state.test.ts
@@ -9,8 +9,18 @@ import {
   isValidEntryKey,
   queryVoteCounts,
   queryVotesByClient,
+  safeVoteCounts,
   toggleVote,
 } from "../apps/web/src/lib/votes";
+import {
+  getFallbackCommunitySignalCounts,
+  queryCommunitySignalCounts,
+} from "../apps/web/src/lib/community-signals";
+import {
+  getFallbackIntentEventCounts,
+  queryIntentEventCounts,
+  safeIntentEventCounts,
+} from "../apps/web/src/lib/intent-events";
 import {
   buildPublicJobsIndex,
   normalizeJobLocation,
@@ -32,6 +42,17 @@ class FakeD1 implements D1DatabaseLike {
   voteCounts = new Map<string, number>();
   votesByClient = new Set<string>();
   jobRows: QueryResult[] = [];
+  communitySignalRows: Array<{
+    target_kind: string;
+    target_key: string;
+    signal_type: string;
+    client_id: string;
+  }> = [];
+  intentEventRows: Array<{
+    entry_key: string;
+    event_type: string;
+    created_at: string;
+  }> = [];
   runCalls: Array<{ query: string; values: unknown[] }> = [];
 
   prepare(query: string) {
@@ -191,6 +212,36 @@ class FakeD1 implements D1DatabaseLike {
         .filter((key) => this.votesByClient.has(`${key}:${clientId}`))
         .map((key) => ({ entry_key: key })) as T[];
     }
+    if (query.includes("FROM community_signals")) {
+      const targets = new Set<string>();
+      for (let index = 0; index < values.length; index += 2) {
+        targets.add(`${String(values[index])}:${String(values[index + 1])}`);
+      }
+      const grouped = new Map<string, number>();
+      for (const row of this.communitySignalRows) {
+        const target = `${row.target_kind}:${row.target_key}`;
+        if (!targets.has(target)) continue;
+        const groupKey = `${row.target_kind}\u0000${row.target_key}\u0000${row.signal_type}`;
+        grouped.set(groupKey, (grouped.get(groupKey) ?? 0) + 1);
+      }
+      return [...grouped].map(([key, count]) => {
+        const [target_kind, target_key, signal_type] = key.split("\u0000");
+        return { target_kind, target_key, signal_type, count };
+      }) as T[];
+    }
+    if (query.includes("FROM intent_events")) {
+      const keys = new Set(values.slice(0, -1).map(String));
+      const grouped = new Map<string, number>();
+      for (const row of this.intentEventRows) {
+        if (!keys.has(row.entry_key)) continue;
+        const groupKey = `${row.entry_key}\u0000${row.event_type}`;
+        grouped.set(groupKey, (grouped.get(groupKey) ?? 0) + 1);
+      }
+      return [...grouped].map(([key, count]) => {
+        const [entry_key, event_type] = key.split("\u0000");
+        return { entry_key, event_type, count };
+      }) as T[];
+    }
     return [];
   }
 }
@@ -233,6 +284,116 @@ describe("D1 dynamic state helpers", () => {
     ).resolves.toEqual({
       count: 0,
       voted: false,
+    });
+  });
+
+  it("queries batch community signal counts without exposing clients", async () => {
+    const db = new FakeD1();
+    db.communitySignalRows = [
+      {
+        target_kind: "entry",
+        target_key: "entry:mcp/example-server",
+        signal_type: "used",
+        client_id: "client-a",
+      },
+      {
+        target_kind: "entry",
+        target_key: "entry:mcp/example-server",
+        signal_type: "used",
+        client_id: "client-b",
+      },
+      {
+        target_kind: "entry",
+        target_key: "entry:mcp/example-server",
+        signal_type: "works",
+        client_id: "client-a",
+      },
+      {
+        target_kind: "tool",
+        target_key: "tool:cursor",
+        signal_type: "broken",
+        client_id: "client-c",
+      },
+    ];
+
+    await expect(
+      queryCommunitySignalCounts(db, [
+        { targetKind: "entry", targetKey: "entry:mcp/example-server" },
+        { targetKind: "tool", targetKey: "tool:cursor" },
+      ]),
+    ).resolves.toEqual({
+      "entry:mcp/example-server": { used: 2, works: 1, broken: 0 },
+      "tool:cursor": { used: 0, works: 0, broken: 1 },
+    });
+  });
+
+  it("aggregates 30-day intent events by entry key", async () => {
+    const db = new FakeD1();
+    db.intentEventRows = [
+      {
+        entry_key: "mcp:example-server",
+        event_type: "copy",
+        created_at: "2026-05-01T00:00:00Z",
+      },
+      {
+        entry_key: "mcp:example-server",
+        event_type: "install",
+        created_at: "2026-05-01T00:00:00Z",
+      },
+      {
+        entry_key: "mcp:example-server",
+        event_type: "install",
+        created_at: "2026-05-02T00:00:00Z",
+      },
+    ];
+
+    await expect(
+      queryIntentEventCounts(db, ["mcp:example-server"]),
+    ).resolves.toEqual({
+      "mcp:example-server": {
+        copy: 1,
+        open: 0,
+        install: 2,
+        download: 0,
+        vote: 0,
+      },
+    });
+  });
+
+  it("returns zero dynamic discovery fallbacks when D1 is unavailable", async () => {
+    expect(
+      getFallbackCommunitySignalCounts([
+        { targetKind: "entry", targetKey: "entry:mcp/example-server" },
+      ]),
+    ).toEqual({
+      "entry:mcp/example-server": { used: 0, works: 0, broken: 0 },
+    });
+    expect(getFallbackIntentEventCounts(["mcp:example-server"])).toEqual({
+      "mcp:example-server": {
+        copy: 0,
+        open: 0,
+        install: 0,
+        download: 0,
+        vote: 0,
+      },
+    });
+    await expect(safeVoteCounts(["mcp:example-server"])).resolves.toEqual({
+      available: false,
+      counts: { "mcp:example-server": 0 },
+    });
+    await expect(
+      safeIntentEventCounts(["mcp:example-server"]),
+    ).resolves.toEqual({
+      available: false,
+      counts: {
+        "mcp:example-server": {
+          copy: 0,
+          open: 0,
+          install: 0,
+          download: 0,
+          vote: 0,
+        },
+      },
     });
   });
 

--- a/tests/dynamic-api-routes.test.ts
+++ b/tests/dynamic-api-routes.test.ts
@@ -80,4 +80,28 @@ describe("dynamic API route fallback behavior", () => {
       counts: { used: 0, works: 0, broken: 0 },
     });
   });
+
+  it("returns batch community-signal fallbacks when SITE_DB is unavailable", async () => {
+    const { POST } = await import("@/app/api/community-signals/query/route");
+
+    const response = await POST(
+      jsonRequest("/api/community-signals/query", {
+        targets: [
+          {
+            targetKind: "entry",
+            targetKey: "entry:mcp/asana-mcp-server",
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      available: false,
+      counts: {
+        "entry:mcp/asana-mcp-server": { used: 0, works: 0, broken: 0 },
+      },
+    });
+  });
 });

--- a/tests/growth-ranking.test.ts
+++ b/tests/growth-ranking.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  communityDiscoveryScore,
+  totalIntentCount,
+} from "../apps/web/src/lib/growth-ranking";
+
+describe("growth ranking", () => {
+  it("weights aggregate community and intent signals without requiring GitHub stats", () => {
+    const activeEntryScore = communityDiscoveryScore({
+      communitySignals: { used: 2, works: 2, broken: 0 },
+      intentCounts: { copy: 3, open: 5, install: 2, download: 1, vote: 0 },
+      votes: 4,
+      firstPartyPackage: true,
+      productionVerified: true,
+    });
+    const staleEntryScore = communityDiscoveryScore({
+      communitySignals: { used: 1, works: 0, broken: 2 },
+      intentCounts: { copy: 1, open: 1, install: 0, download: 0, vote: 0 },
+      votes: 0,
+    });
+
+    expect(activeEntryScore).toBeGreaterThan(staleEntryScore);
+    expect(staleEntryScore).toBeLessThan(0);
+  });
+
+  it("counts install and download actions more heavily than passive opens", () => {
+    expect(
+      totalIntentCount({
+        copy: 1,
+        open: 1,
+        install: 1,
+        download: 1,
+        vote: 1,
+      }),
+    ).toBe(8);
+  });
+});


### PR DESCRIPTION
## Summary
- adds batch community-signal reads and shared D1 fallback helpers for community, vote, and intent metrics
- surfaces community signals on entry detail pages and trending cards
- makes `/trending` use truthful community/source/fallback groups and hides empty signal groups
- adds a main/manual-only GitHub stats refresh PR workflow without Cloudflare deploy side effects

## What changed
- added `POST /api/community-signals/query` and updated OpenAPI/API docs/route coverage
- added 30-day aggregate intent helpers, safe vote-count fallbacks, and community signal batch helpers
- instrumented entry copy/install actions and added entry-level community signal panels
- renamed the fallback discovery surface to practical picks while keeping source-popularity sections conditional on real stats
- added a GitHub-hosted stats refresh workflow that opens a generated-data PR only from the default branch/manual dispatch

## Why
- the app already had dynamic state tables and event routes, but discovery was not using those signals yet
- trending should not imply GitHub popularity when generated `githubStars`/`repoUpdatedAt` fields are empty
- stats refresh should happen through reviewed PRs and should not consume Cloudflare build/deploy quota

## Validation
- `pnpm exec vitest run tests/api-contracts.test.ts tests/dynamic-api-routes.test.ts`
- `pnpm exec vitest run tests/d1-dynamic-state.test.ts tests/growth-ranking.test.ts`
- `pnpm validate:openapi`
- `actionlint .github/workflows/github-stats-refresh-pr.yml`
- `pnpm test:submission-intake`
- `pnpm type-check`
- `pnpm validate:content`
- `pnpm validate:raycast-feed`
- `pnpm build`
- `pnpm validate:clean`
- `pnpm validate:packages`
- `pnpm test`
- browser smoke against local dev server: `/submissions`, `/trending`, `/mcp/asana-mcp-server`

## Notes
- stacked on #363; base branch is `codex/submissions-workbench`
- public reads expose aggregate counts only, not client/session identifiers
- workflow does not deploy Cloudflare Workers or create preview deployments
