### PR TITLE
fix(submissions): harden intake comments and restore awesome badge

### DIFF
--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -99,15 +99,10 @@ jobs:
               /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/;
             const isGitHubLogin = (value) =>
               GITHUB_LOGIN_PATTERN.test(normalizeText(value));
-            const neutralizeMarkdownControl = (value) =>
-              normalizeText(value)
-                .replace(/#(?=\d)/g, "&#35;")
-                .replace(/@/g, "&#64;");
             const escapeMarkdownText = (value) =>
-              neutralizeMarkdownControl(compactWhitespace(value)).replace(
-                /([\\`*_{}\[\]()#+\-.!|>])/g,
-                "\\$1"
-              );
+              compactWhitespace(value)
+                .replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1")
+                .replace(/@/g, "\\@");
             const markdownCodeSpan = (value) => {
               const text = compactWhitespace(value).slice(0, 1000);
               if (!text) return "";
@@ -123,6 +118,19 @@ jobs:
             const markdownDetail = (value) => {
               const detail = markdownCodeSpan(value);
               return detail ? ` - ${detail}` : "";
+            };
+            const markdownLabelValue = (value) => {
+              const text = compactWhitespace(value);
+              if (!text) return "";
+              const delimiter = text.indexOf(":");
+              if (delimiter > 0 && delimiter <= 48) {
+                const label = text.slice(0, delimiter);
+                const detail = text.slice(delimiter + 1).trim();
+                return detail
+                  ? `${escapeMarkdownText(label)}: ${markdownCodeSpan(detail)}`
+                  : escapeMarkdownText(label);
+              }
+              return markdownCodeSpan(text);
             };
             const lower = (value) => normalizeText(value).toLowerCase();
             const frontmatterValue = (value) => {
@@ -444,20 +452,6 @@ jobs:
             ) => {
               const analysis = contributorAnalysis(contributor, source, fallback);
               report.contributorAnalysis = analysis;
-              if (analysis.login) {
-                report.trustSignals.push(
-                  `Contributor analyzed: ${githubUserReference(analysis.login)}`
-                );
-              } else {
-                const raw = normalizeText(
-                  contributor.login || fallback.login || contributor.name
-                );
-                if (raw) {
-                  report.trustSignals.push(
-                    `Contributor identity unresolved: ${githubUserReference(raw)}`
-                  );
-                }
-              }
               if (analysis.accountAgeDays !== null) {
                 if (analysis.accountAgeDays < 7) {
                   addFlag(
@@ -1473,7 +1467,8 @@ jobs:
               if (report.trustSignals.length) {
                 lines.push("", "### Trust signals");
                 for (const signal of report.trustSignals.slice(0, 12)) {
-                  lines.push(`- ${escapeMarkdownText(signal)}`);
+                  const formatted = markdownLabelValue(signal);
+                  if (formatted) lines.push(`- ${formatted}`);
                 }
               }
               const maintainerChecks = [

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 [Feeds](https://heyclau.de/api/registry/feed) • [RSS](https://heyclau.de/feed.xml) • [Atom](https://heyclau.de/atom.xml) • [LLM export](https://heyclau.de/llms-full.txt) • [Raycast](integrations/raycast) • [MCP endpoint](https://heyclau.de/api/mcp) • [Claim/update](https://heyclau.de/claim)
 
+[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code/blob/main/README_ALTERNATIVES/README_EXTRA.md#workflows--knowledge-guides-)
+
 </div>
 
 ---

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -48,17 +48,10 @@ function isGitHubLogin(value) {
   return GITHUB_LOGIN_PATTERN.test(normalizeText(value));
 }
 
-function neutralizeMarkdownControl(value) {
-  return normalizeText(value)
-    .replace(/#(?=\d)/g, "&#35;")
-    .replace(/@/g, "&#64;");
-}
-
 function escapeMarkdownText(value) {
-  return neutralizeMarkdownControl(compactWhitespace(value)).replace(
-    /([\\`*_{}\[\]()#+\-.!|>])/g,
-    "\\$1",
-  );
+  return compactWhitespace(value)
+    .replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1")
+    .replace(/@/g, "\\@");
 }
 
 function markdownCodeSpan(value) {
@@ -76,6 +69,20 @@ function markdownCodeSpan(value) {
 function markdownDetail(value) {
   const detail = markdownCodeSpan(value);
   return detail ? ` - ${detail}` : "";
+}
+
+function markdownLabelValue(value) {
+  const text = compactWhitespace(value);
+  if (!text) return "";
+  const delimiter = text.indexOf(":");
+  if (delimiter > 0 && delimiter <= 48) {
+    const label = text.slice(0, delimiter);
+    const detail = text.slice(delimiter + 1).trim();
+    return detail
+      ? `${escapeMarkdownText(label)}: ${markdownCodeSpan(detail)}`
+      : escapeMarkdownText(label);
+  }
+  return markdownCodeSpan(text);
 }
 
 function lower(value) {
@@ -380,21 +387,6 @@ function applyContributorAnalysis(
 ) {
   const analysis = contributorAnalysis(contributor, source, fallback);
   report.contributorAnalysis = analysis;
-
-  if (analysis.login) {
-    report.trustSignals.push(
-      `Contributor analyzed: ${githubUserReference(analysis.login)}`,
-    );
-  } else {
-    const raw = normalizeText(
-      contributor.login || fallback.login || contributor.name,
-    );
-    if (raw) {
-      report.trustSignals.push(
-        `Contributor identity unresolved: ${githubUserReference(raw)}`,
-      );
-    }
-  }
 
   if (analysis.accountAgeDays !== null) {
     if (analysis.accountAgeDays < 7) {
@@ -1692,7 +1684,8 @@ export function formatSubmissionRiskMarkdown(report) {
   if (report.trustSignals.length) {
     lines.push("", "### Trust signals");
     for (const signal of report.trustSignals.slice(0, 12)) {
-      lines.push(`- ${escapeMarkdownText(signal)}`);
+      const formatted = markdownLabelValue(signal);
+      if (formatted) lines.push(`- ${formatted}`);
     }
   }
 

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -112,6 +112,8 @@ ${total}+ file-backed entries covering agents, MCP servers, tools, skills, hooks
 
 [Feeds](https://heyclau.de/api/registry/feed) • [RSS](https://heyclau.de/feed.xml) • [Atom](https://heyclau.de/atom.xml) • [LLM export](https://heyclau.de/llms-full.txt) • [Raycast](integrations/raycast) • [MCP endpoint](https://heyclau.de/api/mcp) • [Claim/update](https://heyclau.de/claim)
 
+[![Mentioned in Awesome Claude Code](https://awesome.re/mentioned-badge.svg)](https://github.com/hesreallyhim/awesome-claude-code/blob/main/README_ALTERNATIVES/README_EXTRA.md#workflows--knowledge-guides-)
+
 </div>
 
 ---

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -1320,6 +1320,11 @@ Review payloads before posting tweets, replies, DMs, or profile updates.`,
     expect(report.effectiveContributor?.login).toBe("zjg678");
     expect(report.contributorAnalysis.login).toBe("zjg678");
     expect(markdown).toContain("Contributor analyzed: @zjg678");
+    expect(markdown).not.toContain(
+      "Analyze user profile system implementation",
+    );
+    expect(markdown).not.toContain("&#64;");
+    expect(markdown).not.toContain("&#35;");
     expect(markdown).not.toContain("@&Analyze");
 
     const malformedIssue = {
@@ -1825,11 +1830,11 @@ Run the install command.`,
     expect(report.contributorSource).toBe("submission_issue_author");
     expect(report.trustSignals).toEqual(
       expect.arrayContaining([
-        "Contributor analyzed: @vy35",
         "PR opened by: @github-actions[bot]",
         "Submission issue: #325",
       ]),
     );
+    expect(report.trustSignals).not.toContain("Contributor analyzed: @vy35");
     expect(report.classificationWarnings).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({ id: "generated_readme_change" }),
@@ -1976,10 +1981,10 @@ Review payloads before posting tweets, replies, DMs, or profile updates.`,
     expect(report.pullRequestActor?.login).toBe("JSONbored");
     expect(report.contributorSource).toBe("content_frontmatter");
     expect(report.trustSignals).toEqual(
-      expect.arrayContaining([
-        "Contributor analyzed: @kriptoburak",
-        "PR opened by: @JSONbored",
-      ]),
+      expect.arrayContaining(["PR opened by: @JSONbored"]),
+    );
+    expect(report.trustSignals).not.toContain(
+      "Contributor analyzed: @kriptoburak",
     );
     expect(report.classificationWarnings).not.toEqual(
       expect.arrayContaining([
@@ -2196,8 +2201,11 @@ claude mcp add malicious-source-mcp -- npx -y malicious-source-mcp`);
       ...report,
       trustSignals: ["Reference bait: word#123 @octocat"],
     });
-    expect(trustMarkdown).toContain("word&\\#35;123");
-    expect(trustMarkdown).toContain("&\\#64;octocat");
+    expect(trustMarkdown).toContain("- Reference bait: `word#123 @octocat`");
+    expect(trustMarkdown).not.toContain("&#35;");
+    expect(trustMarkdown).not.toContain("&\\#35;");
+    expect(trustMarkdown).not.toContain("&#64;");
+    expect(trustMarkdown).not.toContain("&\\#64;");
   });
 
   it("rejects non-GitHub submittedBy provenance in content metadata", () => {


### PR DESCRIPTION
## Summary
- harden submission risk Markdown so Trust signals no longer emit numeric HTML entities that GitHub can misrender as issue/user references
- keep contributor identity in the dedicated Contributor section instead of duplicating it in Trust signals
- restore the generated README "Mentioned in Awesome Claude Code" badge and regenerate README output
- posted a maintainer reply on issue #365 explaining the free public guide path versus paid/sponsored listing path

## What changed
- Replaced `&#64;` / `&#35;` neutralization with safer Markdown escaping and code-span Trust signal rendering.
- Kept the registry formatter and inline `submission-pr-risk.yml` workflow logic in sync.
- Added regression expectations for the old contributor rendering artifact and numeric entity output.
- Added the Awesome Claude Code badge to `scripts/generate-readme.mjs` and regenerated `README.md`.

## Why
GitHub can interpret the numeric entity text in rendered issue comments in surprising ways, including linking the `#64` portion of `&#64;`. Contributor analysis is already represented in a structured Contributor section, so Trust signals should avoid mention/reference-shaped output entirely.

## Validation
- `pnpm test:submission-intake`
- `pnpm validate:issue-templates`
- `pnpm validate:readme`
- `pnpm generate:readme --check`
- `actionlint .github/workflows/submission-pr-risk.yml .github/workflows/submission-issue-validation.yml`
- `git diff --check`

## Notes
- Issue #365 remains open and unresolved until the submitter chooses the free public guide path or the paid/sponsored listing path.
- The README badge links to the current upstream Awesome Claude Code listing evidence rather than implying sponsorship or endorsement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced formatting of trust signals in risk reports with improved code highlighting for labels and values.
  * Removed identity unresolved status indicators from trust signal displays.
  * Improved whitespace handling in risk report markdown rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->