### PR TITLE
feat(mcp): add discovery and submission draft tools

### DIFF
--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm test:mcp
 
       - name: Validate production MCP endpoint
-        run: pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp
+        run: pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools
 
       - name: Dry-run MCP package tarball
         run: pnpm --filter @heyclaude/mcp pack --dry-run --json
@@ -121,7 +121,7 @@ jobs:
             printf -- "- npm package: https://www.npmjs.com/package/@heyclaude/mcp/v/%s\n\n" "$RELEASE_VERSION"
             printf "## Validation\n\n"
             printf -- "- \`pnpm test:mcp\`\n"
-            printf -- "- \`pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp\`\n"
+            printf -- "- \`pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools\`\n"
             printf -- "- \`pnpm --filter @heyclaude/mcp pack --dry-run --json\`\n"
             printf -- "- \`MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package\`\n"
           } > "$notes_file"

--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -13,10 +13,12 @@ Configured in [`wrangler.jsonc`](./wrangler.jsonc):
 
 - `SITE_DB` (D1) for durable upvotes, reviewed jobs listings, listing leads, commercial placements, community signals, and future dynamic site state.
 - Shared between `prod` and `dev` environments in the current setup.
-- `API_REGISTRY_RATE_LIMIT`, `API_DYNAMIC_RATE_LIMIT`, and
-  `API_STRICT_RATE_LIMIT` for Cloudflare-native per-route rate limiting. The
-  app also keeps an in-process development fallback, but production should rely
-  on the Worker bindings configured in `wrangler.jsonc`.
+- `API_REGISTRY_RATE_LIMIT`, `API_DYNAMIC_RATE_LIMIT`,
+  `API_STRICT_RATE_LIMIT`, and `API_MCP_RATE_LIMIT` for Cloudflare-native
+  per-route rate limiting. The MCP binding is intentionally separate so the
+  public no-key MCP endpoint keeps a durable `60 requests/minute/IP` production
+  cap. The app also keeps an in-process development fallback, but production
+  should rely on the Worker bindings configured in `wrangler.jsonc`.
 
 ## D1 setup
 

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -483,7 +483,8 @@ export type ApiRouteDefinition = {
     binding?:
       | "API_REGISTRY_RATE_LIMIT"
       | "API_DYNAMIC_RATE_LIMIT"
-      | "API_STRICT_RATE_LIMIT";
+      | "API_STRICT_RATE_LIMIT"
+      | "API_MCP_RATE_LIMIT";
   };
   querySchema?: z.ZodTypeAny;
   paramsSchema?: z.ZodTypeAny;
@@ -615,7 +616,7 @@ export const apiRouteDefinitions = {
     path: "/api/mcp",
     summary: "Read-only HeyClaude MCP endpoint",
     description:
-      "Exposes read-only HeyClaude MCP tools over Streamable HTTP for registry search, entry detail, compatibility lookup, install guidance, platform adapters, and feed discovery. This endpoint does not publish registry content or create submissions.",
+      "Exposes no-key read-only HeyClaude MCP tools over Streamable HTTP for registry search, discovery, entry detail, compatibility lookup, install guidance, platform adapters, feed discovery, and maintainer-reviewed submission draft helpers. This endpoint does not publish registry content or create submissions.",
     tags: ["MCP"],
     originCheck: true,
     requiresJsonBody: true,
@@ -624,7 +625,7 @@ export const apiRouteDefinitions = {
       scope: "mcp-streamable",
       limit: 60,
       windowMs: 60_000,
-      binding: "API_REGISTRY_RATE_LIMIT",
+      binding: "API_MCP_RATE_LIMIT",
     },
   }),
   "brandAsset.read": route({

--- a/apps/web/worker-configuration.d.ts
+++ b/apps/web/worker-configuration.d.ts
@@ -10,6 +10,7 @@ declare namespace Cloudflare {
     API_REGISTRY_RATE_LIMIT: RateLimit;
     API_DYNAMIC_RATE_LIMIT: RateLimit;
     API_STRICT_RATE_LIMIT: RateLimit;
+    API_MCP_RATE_LIMIT: RateLimit;
     ASSETS: Fetcher;
     NEXT_PUBLIC_DISCORD_URL: "https://discord.com/invite/Ax3Py4YDrq";
     NEXT_PUBLIC_TWITTER_URL: "https://x.com/jsonbored";
@@ -29,6 +30,7 @@ declare namespace Cloudflare {
     API_REGISTRY_RATE_LIMIT: RateLimit;
     API_DYNAMIC_RATE_LIMIT: RateLimit;
     API_STRICT_RATE_LIMIT: RateLimit;
+    API_MCP_RATE_LIMIT: RateLimit;
     ASSETS: Fetcher;
     NEXT_PUBLIC_DISCORD_URL: "https://discord.com/invite/Ax3Py4YDrq";
     NEXT_PUBLIC_TWITTER_URL: "https://x.com/jsonbored";

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -55,6 +55,14 @@
         "period": 60,
       },
     },
+    {
+      "name": "API_MCP_RATE_LIMIT",
+      "namespace_id": "1001004",
+      "simple": {
+        "limit": 60,
+        "period": 60,
+      },
+    },
   ],
   "vars": {
     "NEXT_PUBLIC_DISCORD_URL": "https://discord.com/invite/Ax3Py4YDrq",
@@ -117,6 +125,14 @@
         {
           "name": "API_STRICT_RATE_LIMIT",
           "namespace_id": "1002003",
+          "simple": {
+            "limit": 60,
+            "period": 60,
+          },
+        },
+        {
+          "name": "API_MCP_RATE_LIMIT",
+          "namespace_id": "1002004",
           "simple": {
             "limit": 60,
             "period": 60,

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -2357,9 +2357,10 @@ paths:
         - MCP
       summary: Read-only HeyClaude MCP endpoint
       description:
-        Exposes read-only HeyClaude MCP tools over Streamable HTTP for registry search, entry
-        detail, compatibility lookup, install guidance, platform adapters, and feed discovery. This
-        endpoint does not publish registry content or create submissions.
+        Exposes no-key read-only HeyClaude MCP tools over Streamable HTTP for registry search,
+        discovery, entry detail, compatibility lookup, install guidance, platform adapters, feed
+        discovery, and maintainer-reviewed submission draft helpers. This endpoint does not publish
+        registry content or create submissions.
       responses:
         "200":
           description: Request accepted.

--- a/docs/api-security-contract.md
+++ b/docs/api-security-contract.md
@@ -12,6 +12,7 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
 - `/api/registry/diff`
 - `/api/registry/entries/{category}/{slug}`
 - `/api/registry/entries/{category}/{slug}/llms`
+- `/api/mcp`
 - `/data/*.json` registry artifacts
 - `/data/feeds/index.json`
 - `/data/feeds/categories/{category}.json`
@@ -59,9 +60,11 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
 - Production submissions should set `SUBMISSIONS_REQUIRE_TURNSTILE=1` and
   `TURNSTILE_SECRET_KEY`; if the requirement is enabled without a secret, the
   endpoint fails closed instead of accepting direct website submissions.
-- Cloudflare rate-limit bindings are configured for registry, dynamic, and
-  strict routes. In-process limits remain a local/dev fallback when the Worker
-  binding is unavailable.
+- Cloudflare rate-limit bindings are configured for registry, dynamic, strict,
+  and MCP routes. The public no-key MCP endpoint uses a dedicated
+  `API_MCP_RATE_LIMIT` binding with a `60 requests/minute/IP` production cap.
+  In-process limits remain a local/dev fallback when the Worker binding is
+  unavailable.
 - Next and Worker responses attach security headers in code as well as static
   asset headers: CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options`,
   `Referrer-Policy`, `Permissions-Policy`, and `Cross-Origin-Opener-Policy`.

--- a/docs/mcp-package-release.md
+++ b/docs/mcp-package-release.md
@@ -45,6 +45,11 @@ publishing.
    - `npm exec -y @heyclaude/mcp@<version> -- --version`
    - GitHub release `mcp-v<version>`
 
+For release publishing, endpoint validation should use `--strict-tools` after
+the matching Worker code has shipped. Pull-request checks intentionally allow a
+lagging dev Worker as long as the deployed endpoint still exposes the baseline
+read-only MCP tools.
+
 ## Local Auth Check
 
 Local npm auth is only needed for npm scope/package bootstrap work. Check with:
@@ -53,3 +58,18 @@ Local npm auth is only needed for npm scope/package bootstrap work. Check with:
 npm login --registry=https://registry.npmjs.org/
 npm whoami
 ```
+
+## Troubleshooting
+
+If `npm publish --provenance` signs provenance successfully and then fails with
+`E404 Not Found - PUT https://registry.npmjs.org/@heyclaude%2fmcp`, the GitHub
+workflow is reaching npm but the package or scope is rejecting publish access.
+Check the npm package access and trusted publisher settings for:
+
+- package: `@heyclaude/mcp`
+- repository: `JSONbored/awesome-claude`
+- workflow file: `publish-mcp-npm.yml`
+- environment: `npm-production`
+
+Do not create a GitHub release tag manually unless the matching npm package
+version is visible on npm.

--- a/docs/registry-mcp-plan.md
+++ b/docs/registry-mcp-plan.md
@@ -20,14 +20,38 @@ Set `HEYCLAUDE_DATA_DIR=/absolute/path/to/data`, or pass
 `--local --data-dir /absolute/path/to/data`, to read from another generated
 artifact directory.
 
-## V1 Tools
+## Tools
 
 - `search_registry`
+- `server_info`
+- `list_category_entries`
+- `get_recent_updates`
+- `get_related_entries`
 - `get_entry_detail`
 - `get_compatibility`
 - `get_install_guidance`
 - `get_platform_adapter`
 - `list_distribution_feeds`
+- `get_submission_schema`
+- `validate_submission_draft`
+- `search_duplicate_entries`
+- `build_submission_urls`
+- `get_category_submission_guidance`
+- `prepare_submission_draft`
+- `get_submission_examples`
+- `review_submission_draft`
+
+## Access and rate limits
+
+The public MCP endpoint does not require an API key. That is intentional: the
+tool surface is read-only and all submission helpers generate local validation
+reports, issue drafts, and URLs for maintainer review. They do not create
+GitHub issues or publish registry content.
+
+Production uses the dedicated `API_MCP_RATE_LIMIT` Cloudflare binding at
+`60 requests/minute/IP`, plus the route-level 64 KiB body limit and strict JSON
+request validation. Local and preview runs keep an in-process limiter fallback
+when Cloudflare's binding is unavailable.
 
 ## Exclusions
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @heyclaude/mcp Changelog
 
+## 0.2.0 - Discovery and Submission Drafting
+
+- Add read-only discovery tools for server metadata, paginated category
+  browsing, recent updates, and related entries.
+- Add submission helper tools for examples, canonical issue drafts, duplicate
+  review, and maintainer checklist guidance.
+- Document the public no-key access model and the dedicated MCP rate-limit
+  policy.
+
 ## 0.1.2 - Repository Rename
 
 - Update package metadata, README links, and release provenance for the

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/JSONbored/awesome-claude">GitHub</a> •
   <a href="https://www.npmjs.com/package/@heyclaude/mcp">npm</a> •
   <a href="https://heyclau.de/api/mcp">MCP endpoint</a> •
-  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.1.2">v0.1.2 release</a>
+  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.2.0">v0.2.0 release</a>
 </p>
 
 Read-only Model Context Protocol server for the HeyClaude registry.
@@ -22,10 +22,22 @@ adapters, feed discovery, and safe submission-draft helpers. It does not create
 GitHub issues, open pull requests, write local files, publish content, or manage
 accounts.
 
+No API key is required for the public endpoint. Abuse controls are handled with
+strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
+`API_MCP_RATE_LIMIT` binding capped at 60 requests/minute/IP in production.
+
 ## Tools
 
 - `search_registry` - search public registry entries by query, category, and
   platform.
+- `server_info` - fetch package version, registry generation, tool list, public
+  access policy, and rate-limit metadata.
+- `list_category_entries` - browse entries with bounded pagination and optional
+  category, platform, tag, and query filters.
+- `get_recent_updates` - list recently added or upstream-updated entries from
+  generated registry metadata.
+- `get_related_entries` - find related entries based on category, tags,
+  platforms, keywords, and source metadata.
 - `get_entry_detail` - fetch an entry detail payload by category and slug.
 - `get_compatibility` - fetch skill platform compatibility metadata.
 - `get_install_guidance` - fetch install commands, config, package, and platform
@@ -43,6 +55,12 @@ accounts.
   URLs for human review.
 - `get_category_submission_guidance` - fetch category-specific contribution
   guidance and required fields.
+- `prepare_submission_draft` - normalize and validate fields, then return a
+  canonical issue title/body plus prefilled URLs.
+- `get_submission_examples` - fetch category-specific example fields and
+  templates for more complete submissions.
+- `review_submission_draft` - review schema errors, duplicate risk, and
+  maintainer checklist items before a submission issue is opened.
 
 ## Local Stdio
 
@@ -123,8 +141,11 @@ checks the HTTP guards used by the remote route.
 - Submission helpers generate URLs and validation reports only.
 - No GitHub OAuth, tokens, issue creation, PR creation, or repo writes.
 - No local project-file writes or config mutations.
-- Remote endpoint uses route-level rate limits and Cloudflare rate-limit bindings
-  when available.
+- Remote endpoint requires JSON POST bodies, rejects payloads above 64 KiB, and
+  uses the dedicated `API_MCP_RATE_LIMIT` Cloudflare binding at
+  60 requests/minute/IP in production.
+- Submission tools prepare review drafts only; HeyClaude does not auto-publish
+  MCP-submitted content.
 
 ## npm Release Prep
 
@@ -139,7 +160,7 @@ Do not publish until the web branch has shipped, the production endpoint has
 been verified, and the package smoke test passes. The release checklist is:
 
 ```bash
-pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp
+pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools
 pnpm --filter @heyclaude/mcp test
 pnpm --filter @heyclaude/mcp pack --dry-run
 MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heyclaude/mcp",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Read-only MCP server for the HeyClaude registry.",
   "license": "MIT",

--- a/packages/mcp/scripts/validate-endpoint.mjs
+++ b/packages/mcp/scripts/validate-endpoint.mjs
@@ -6,12 +6,30 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { normalizeEndpointUrl } from "../src/endpoint-url.js";
 import { READ_ONLY_TOOL_NAMES } from "../src/registry.js";
 
+const baselineToolNames = [
+  "search_registry",
+  "get_entry_detail",
+  "get_compatibility",
+  "get_install_guidance",
+  "get_platform_adapter",
+  "list_distribution_feeds",
+  "get_submission_schema",
+  "validate_submission_draft",
+  "search_duplicate_entries",
+  "build_submission_urls",
+  "get_category_submission_guidance",
+];
+
 function parseArgs(argv) {
   const args = new Map();
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--") continue;
     if (!value.startsWith("--")) continue;
+    if (value === "--strict-tools") {
+      args.set("strict-tools", "1");
+      continue;
+    }
     args.set(value.slice(2), argv[index + 1] ?? "");
     index += 1;
   }
@@ -75,7 +93,24 @@ async function validateHttpGuards(endpointUrl) {
   );
 }
 
-async function validateMcpTools(endpointUrl) {
+function validateToolList(toolNames, strictTools) {
+  if (strictTools) {
+    assert(
+      JSON.stringify(toolNames) === JSON.stringify(READ_ONLY_TOOL_NAMES),
+      `Unexpected tool list: ${toolNames.join(", ")}`,
+    );
+    return;
+  }
+
+  for (const toolName of baselineToolNames) {
+    assert(
+      toolNames.includes(toolName),
+      `Deployed MCP endpoint is missing baseline tool: ${toolName}`,
+    );
+  }
+}
+
+async function validateMcpTools(endpointUrl, options = {}) {
   const client = new Client({
     name: "heyclaude-endpoint-validator",
     version: "0.1.0",
@@ -87,10 +122,7 @@ async function validateMcpTools(endpointUrl) {
 
     const tools = await client.listTools();
     const toolNames = tools.tools.map((tool) => tool.name);
-    assert(
-      JSON.stringify(toolNames) === JSON.stringify(READ_ONLY_TOOL_NAMES),
-      `Unexpected tool list: ${toolNames.join(", ")}`,
-    );
+    validateToolList(toolNames, options.strictTools);
 
     const search = parseToolResult(
       await client.callTool({
@@ -103,6 +135,38 @@ async function validateMcpTools(endpointUrl) {
       Array.isArray(search.entries) && search.entries.length > 0,
       "search_registry did not return entries.",
     );
+
+    if (toolNames.includes("server_info")) {
+      const info = parseToolResult(
+        await client.callTool({
+          name: "server_info",
+          arguments: {},
+        }),
+      );
+      assert(info.ok === true, "server_info did not return ok.");
+      assert(
+        info.endpoint?.auth === "none",
+        "server_info did not expose the public no-key access model.",
+      );
+      assert(
+        info.endpoint?.rateLimit?.binding === "API_MCP_RATE_LIMIT",
+        "server_info did not expose the MCP rate-limit binding.",
+      );
+    }
+
+    if (toolNames.includes("list_category_entries")) {
+      const listed = parseToolResult(
+        await client.callTool({
+          name: "list_category_entries",
+          arguments: { category: "mcp", limit: 2 },
+        }),
+      );
+      assert(listed.ok === true, "list_category_entries did not return ok.");
+      assert(
+        Array.isArray(listed.entries) && listed.entries.length > 0,
+        "list_category_entries did not return entries.",
+      );
+    }
 
     const first = search.entries[0];
     const detail = parseToolResult(
@@ -163,6 +227,35 @@ async function validateMcpTools(endpointUrl) {
       "build_submission_urls did not return an MCP issue URL.",
     );
 
+    if (toolNames.includes("prepare_submission_draft")) {
+      const prepared = parseToolResult(
+        await client.callTool({
+          name: "prepare_submission_draft",
+          arguments: {
+            fields: {
+              category: "mcp",
+              name: "Endpoint Validation MCP",
+              docs_url: "https://example.com/docs",
+              description:
+                "Endpoint validation draft for the HeyClaude MCP submission helpers.",
+              install_command: "npx -y endpoint-validation-mcp",
+              usage_snippet: "Use this draft to validate MCP route behavior.",
+            },
+          },
+        }),
+      );
+      assert(
+        prepared.issueDraft?.body,
+        "prepare_submission_draft did not return a canonical issue body.",
+      );
+      assert(
+        String(prepared.submissionPolicy || "").includes(
+          "does not auto-publish",
+        ),
+        "prepare_submission_draft did not expose the maintainer-reviewed policy.",
+      );
+    }
+
     const invalid = parseToolResult(
       await client.callTool({
         name: "search_registry",
@@ -182,6 +275,9 @@ async function validateMcpTools(endpointUrl) {
 const args = parseArgs(process.argv.slice(2));
 const endpointUrlRaw = args.get("url") || process.env.MCP_ENDPOINT_URL;
 const endpointUrl = endpointUrlRaw ? normalizeEndpointUrl(endpointUrlRaw) : "";
+const strictTools =
+  args.get("strict-tools") === "1" ||
+  process.env.MCP_ENDPOINT_STRICT_TOOLS === "1";
 
 if (!endpointUrl) {
   console.error(
@@ -192,7 +288,7 @@ if (!endpointUrl) {
 
 try {
   await validateHttpGuards(endpointUrl);
-  await validateMcpTools(endpointUrl);
+  await validateMcpTools(endpointUrl, { strictTools });
   console.log(`Validated HeyClaude MCP endpoint at ${endpointUrl.toString()}`);
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));

--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -21,6 +21,26 @@ export function searchRegistry(
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
 
+export function getServerInfo(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function listCategoryEntries(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getRecentUpdates(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getRelatedEntries(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
 export function getEntryDetail(
   args?: Record<string, unknown>,
   options?: RegistryArtifactLoaders,
@@ -71,6 +91,21 @@ export function getCategorySubmissionGuidance(
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
 
+export function prepareSubmissionDraft(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getSubmissionExamples(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function reviewSubmissionDraft(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
 export function callRegistryTool(
   name: string,
   args?: Record<string, unknown>,
@@ -79,6 +114,10 @@ export function callRegistryTool(
 
 export {
   SearchRegistryInputSchema,
+  ServerInfoInputSchema,
+  ListCategoryEntriesInputSchema,
+  RecentUpdatesInputSchema,
+  RelatedEntriesInputSchema,
   EntryDetailInputSchema,
   CompatibilityInputSchema,
   InstallGuidanceInputSchema,
@@ -90,6 +129,9 @@ export {
   SearchDuplicateEntriesInputSchema,
   BuildSubmissionUrlsInputSchema,
   CategorySubmissionGuidanceInputSchema,
+  PrepareSubmissionDraftInputSchema,
+  GetSubmissionExamplesInputSchema,
+  ReviewSubmissionDraftInputSchema,
   TOOL_INPUT_SCHEMAS,
   jsonSchemaForTool,
   parseToolArguments,

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -7,6 +7,8 @@ import {
   platformFeedSlug,
   SITE_URL,
 } from "./platforms.js";
+import { DEFAULT_REMOTE_MCP_URL } from "./endpoint-url.js";
+import { packageName, packageVersion } from "./package-metadata.js";
 import {
   formatZodError,
   jsonSchemaForTool,
@@ -14,8 +16,11 @@ import {
 } from "./schemas.js";
 import {
   buildSubmissionUrlsFromSpec,
+  getSubmissionExamplesFromSpec,
   getCategorySubmissionGuidanceFromSpec,
+  prepareSubmissionDraftFromSpec,
   getSubmissionSchemaFromSpec,
+  reviewSubmissionDraftFromSpec,
   searchDuplicateEntries,
   validateSubmissionDraftFromSpec,
 } from "./submissions.js";
@@ -43,6 +48,10 @@ const platformAliases = new Map([
 
 export const READ_ONLY_TOOL_NAMES = [
   "search_registry",
+  "server_info",
+  "list_category_entries",
+  "get_recent_updates",
+  "get_related_entries",
   "get_entry_detail",
   "get_compatibility",
   "get_install_guidance",
@@ -53,6 +62,9 @@ export const READ_ONLY_TOOL_NAMES = [
   "search_duplicate_entries",
   "build_submission_urls",
   "get_category_submission_guidance",
+  "prepare_submission_draft",
+  "get_submission_examples",
+  "review_submission_draft",
 ];
 
 export const TOOL_DEFINITIONS = [
@@ -61,6 +73,30 @@ export const TOOL_DEFINITIONS = [
     description:
       "Search read-only HeyClaude registry entries by query, category, and skill platform compatibility.",
     inputSchema: jsonSchemaForTool("search_registry"),
+  },
+  {
+    name: "server_info",
+    description:
+      "Fetch read-only HeyClaude MCP package, registry, tool, and public rate-limit metadata.",
+    inputSchema: jsonSchemaForTool("server_info"),
+  },
+  {
+    name: "list_category_entries",
+    description:
+      "List read-only HeyClaude entries with bounded pagination and optional category, platform, tag, and query filters.",
+    inputSchema: jsonSchemaForTool("list_category_entries"),
+  },
+  {
+    name: "get_recent_updates",
+    description:
+      "List recently added or upstream-updated HeyClaude entries from generated registry metadata.",
+    inputSchema: jsonSchemaForTool("get_recent_updates"),
+  },
+  {
+    name: "get_related_entries",
+    description:
+      "Fetch read-only related HeyClaude entries based on category, tags, platforms, keywords, and source metadata.",
+    inputSchema: jsonSchemaForTool("get_related_entries"),
   },
   {
     name: "get_entry_detail",
@@ -122,6 +158,24 @@ export const TOOL_DEFINITIONS = [
       "Fetch category-specific HeyClaude contribution guidance, required fields, and review expectations.",
     inputSchema: jsonSchemaForTool("get_category_submission_guidance"),
   },
+  {
+    name: "prepare_submission_draft",
+    description:
+      "Build a read-only maintainer-reviewed HeyClaude submission draft with canonical issue text and URLs.",
+    inputSchema: jsonSchemaForTool("prepare_submission_draft"),
+  },
+  {
+    name: "get_submission_examples",
+    description:
+      "Fetch read-only category examples and templates for faster, more accurate HeyClaude submissions.",
+    inputSchema: jsonSchemaForTool("get_submission_examples"),
+  },
+  {
+    name: "review_submission_draft",
+    description:
+      "Review a HeyClaude submission draft locally for schema errors, duplicate risk, and maintainer checklist items without writing to GitHub.",
+    inputSchema: jsonSchemaForTool("review_submission_draft"),
+  },
 ];
 
 function dataDirFromOptions(options = {}) {
@@ -180,6 +234,12 @@ function normalizeLimit(value, fallback = 10) {
   return Math.max(1, Math.min(25, Math.trunc(numeric)));
 }
 
+function normalizeOffset(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.min(5000, Math.trunc(numeric)));
+}
+
 function normalizePlatform(value) {
   const normalized = normalizeText(value).replace(/[^a-z0-9]+/g, "-");
   if (!normalized) return "";
@@ -211,6 +271,13 @@ function entryMatchesPlatform(entry, platform) {
   return (entry.platforms || []).some((candidate) => candidate === platform);
 }
 
+function entryMatchesTag(entry, tag) {
+  if (!tag) return true;
+  return (entry.tags || []).some(
+    (candidate) => normalizeText(candidate) === tag,
+  );
+}
+
 function toSearchResult(entry) {
   return {
     key: `${entry.category}:${entry.slug}`,
@@ -230,6 +297,54 @@ function toSearchResult(entry) {
       entry.url ||
       `${SITE_URL}/${entry.category}/${entry.slug}`,
   };
+}
+
+function toEntrySummary(entry) {
+  return {
+    ...toSearchResult(entry),
+    dateAdded: entry.dateAdded || "",
+    repoUpdatedAt: entry.repoUpdatedAt || null,
+    verificationStatus: entry.verificationStatus || "",
+    installable: Boolean(entry.installable),
+    supportLevels: entry.supportLevels || [],
+  };
+}
+
+function entryUpdatedAt(entry) {
+  return String(
+    entry.repoUpdatedAt || entry.updatedAt || entry.dateAdded || "",
+  );
+}
+
+function sourceHost(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  try {
+    return new URL(text).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function entrySourceHosts(entry) {
+  return [
+    entry.documentationUrl,
+    entry.repoUrl,
+    entry.url,
+    entry.canonicalUrl,
+    entry.llmsUrl,
+    entry.apiUrl,
+  ]
+    .map(sourceHost)
+    .filter(Boolean);
+}
+
+function intersection(left = [], right = [], normalize = normalizeText) {
+  const rightValues = new Set((right || []).map(normalize).filter(Boolean));
+  return (left || [])
+    .map(normalize)
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .filter((value) => rightValues.has(value));
 }
 
 async function readEntry(category, slug, options = {}) {
@@ -281,6 +396,190 @@ export async function searchRegistry(args = {}, options = {}) {
     query: args.query || "",
     category: category || "",
     platform: platform || "",
+    entries,
+  };
+}
+
+export async function getServerInfo(args = {}, options = {}) {
+  const manifest = await readJsonArtifact("registry-manifest.json", options);
+  return {
+    ok: true,
+    package: {
+      name: packageName,
+      version: packageVersion,
+    },
+    endpoint: {
+      url: DEFAULT_REMOTE_MCP_URL,
+      auth: "none",
+      transport: "streamable-http",
+      stdioBridge: "npx -y @heyclaude/mcp",
+      requestBodyLimitBytes: 64 * 1024,
+      rateLimit: {
+        scope: "mcp-streamable",
+        limit: 60,
+        windowSeconds: 60,
+        binding: "API_MCP_RATE_LIMIT",
+        note: "Cloudflare enforces the durable production limit when the binding is available; local/dev falls back to an in-process limiter.",
+      },
+    },
+    registry: {
+      schemaVersion: manifest.schemaVersion,
+      generatedAt: manifest.generatedAt,
+      totalEntries: manifest.totalEntries,
+      categories: manifest.categories || {},
+    },
+    tools: READ_ONLY_TOOL_NAMES,
+    policy: {
+      apiKeyRequired: false,
+      readOnly: true,
+      createsIssues: false,
+      createsPullRequests: false,
+      publishesContent: false,
+    },
+  };
+}
+
+export async function listCategoryEntries(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const platform = normalizePlatform(args.platform);
+  const tag = normalizeText(args.tag);
+  const query = normalizeText(args.query);
+  const offset = normalizeOffset(args.offset);
+  const limit = normalizeLimit(args.limit, 20);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+
+  const entries = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .filter((entry) => entryMatchesPlatform(entry, platform))
+    .filter((entry) => entryMatchesTag(entry, tag))
+    .filter((entry) => entryMatchesQuery(entry, query));
+  const page = entries.slice(offset, offset + limit).map(toEntrySummary);
+
+  return {
+    ok: true,
+    category: category || "",
+    platform: platform || "",
+    tag: tag || "",
+    query: args.query || "",
+    total: entries.length,
+    count: page.length,
+    offset,
+    limit,
+    nextOffset: offset + limit < entries.length ? offset + limit : null,
+    entries: page,
+  };
+}
+
+export async function getRecentUpdates(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const limit = normalizeLimit(args.limit, 10);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const entries = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .slice()
+    .sort((left, right) => {
+      const dateCompare = entryUpdatedAt(right).localeCompare(
+        entryUpdatedAt(left),
+      );
+      if (dateCompare !== 0) return dateCompare;
+      return String(left.title || "").localeCompare(String(right.title || ""));
+    })
+    .slice(0, limit)
+    .map((entry) => ({
+      ...toEntrySummary(entry),
+      updatedAt: entryUpdatedAt(entry),
+      updateKind: entry.repoUpdatedAt ? "upstream_update" : "added",
+    }));
+
+  return {
+    ok: true,
+    category: category || "",
+    count: entries.length,
+    entries,
+  };
+}
+
+function scoreRelatedEntry(target, candidate) {
+  if (
+    target.category === candidate.category &&
+    target.slug === candidate.slug
+  ) {
+    return null;
+  }
+
+  const sharedTags = intersection(target.tags, candidate.tags);
+  const sharedKeywords = intersection(target.keywords, candidate.keywords);
+  const sharedPlatforms = intersection(
+    target.platforms,
+    candidate.platforms,
+    (value) => String(value || ""),
+  );
+  const sharedHosts = intersection(
+    entrySourceHosts(target),
+    entrySourceHosts(candidate),
+    (value) => String(value || ""),
+  );
+  const score =
+    (target.category === candidate.category ? 4 : 0) +
+    sharedTags.length * 3 +
+    Math.min(sharedKeywords.length, 6) +
+    sharedPlatforms.length +
+    sharedHosts.length * 2;
+
+  if (score <= 0) return null;
+  return {
+    score,
+    reasons: [
+      ...(target.category === candidate.category ? ["same_category"] : []),
+      ...sharedTags.map((tag) => `tag:${tag}`),
+      ...sharedPlatforms.map((platform) => `platform:${platform}`),
+      ...sharedHosts.map((host) => `source:${host}`),
+    ],
+  };
+}
+
+export async function getRelatedEntries(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const slug = normalizeText(args.slug);
+  const limit = normalizeLimit(args.limit, 8);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const target = searchIndex.find(
+    (entry) => entry.category === category && entry.slug === slug,
+  );
+  if (!target) {
+    return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
+  }
+
+  const entries = searchIndex
+    .map((entry) => {
+      const related = scoreRelatedEntry(target, entry);
+      return related ? { entry, related } : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const scoreCompare = right.related.score - left.related.score;
+      if (scoreCompare !== 0) return scoreCompare;
+      return entryUpdatedAt(right.entry).localeCompare(
+        entryUpdatedAt(left.entry),
+      );
+    })
+    .slice(0, limit)
+    .map(({ entry, related }) => ({
+      ...toEntrySummary(entry),
+      relatedScore: related.score,
+      relatedReasons: related.reasons,
+    }));
+
+  return {
+    ok: true,
+    key: `${target.category}:${target.slug}`,
+    count: entries.length,
     entries,
   };
 }
@@ -450,6 +749,25 @@ export async function getCategorySubmissionGuidance(args = {}, options = {}) {
   );
 }
 
+export async function prepareSubmissionDraft(args = {}, options = {}) {
+  return prepareSubmissionDraftFromSpec(
+    await readSubmissionSpec(options),
+    args,
+  );
+}
+
+export async function getSubmissionExamples(args = {}, options = {}) {
+  return getSubmissionExamplesFromSpec(await readSubmissionSpec(options), args);
+}
+
+export async function reviewSubmissionDraft(args = {}, options = {}) {
+  const [spec, searchIndex] = await Promise.all([
+    readSubmissionSpec(options),
+    readJsonArtifact("search-index.json", options),
+  ]);
+  return reviewSubmissionDraftFromSpec(spec, args, unwrapEntries(searchIndex));
+}
+
 export async function callRegistryTool(name, args = {}, options = {}) {
   if (!READ_ONLY_TOOL_NAMES.includes(name)) {
     return invalid(`Unknown read-only HeyClaude MCP tool: ${name}`);
@@ -472,6 +790,14 @@ export async function callRegistryTool(name, args = {}, options = {}) {
   switch (name) {
     case "search_registry":
       return searchRegistry(parsedArgs, options);
+    case "server_info":
+      return getServerInfo(parsedArgs, options);
+    case "list_category_entries":
+      return listCategoryEntries(parsedArgs, options);
+    case "get_recent_updates":
+      return getRecentUpdates(parsedArgs, options);
+    case "get_related_entries":
+      return getRelatedEntries(parsedArgs, options);
     case "get_entry_detail":
       return getEntryDetail(parsedArgs, options);
     case "get_compatibility":
@@ -492,5 +818,11 @@ export async function callRegistryTool(name, args = {}, options = {}) {
       return buildSubmissionUrls(parsedArgs, options);
     case "get_category_submission_guidance":
       return getCategorySubmissionGuidance(parsedArgs, options);
+    case "prepare_submission_draft":
+      return prepareSubmissionDraft(parsedArgs, options);
+    case "get_submission_examples":
+      return getSubmissionExamples(parsedArgs, options);
+    case "review_submission_draft":
+      return reviewSubmissionDraft(parsedArgs, options);
   }
 }

--- a/packages/mcp/src/schemas.d.ts
+++ b/packages/mcp/src/schemas.d.ts
@@ -1,6 +1,10 @@
 import type { z } from "zod";
 
 export const SearchRegistryInputSchema: z.ZodType;
+export const ServerInfoInputSchema: z.ZodType;
+export const ListCategoryEntriesInputSchema: z.ZodType;
+export const RecentUpdatesInputSchema: z.ZodType;
+export const RelatedEntriesInputSchema: z.ZodType;
 export const EntryDetailInputSchema: z.ZodType;
 export const CompatibilityInputSchema: z.ZodType;
 export const InstallGuidanceInputSchema: z.ZodType;
@@ -12,6 +16,9 @@ export const ValidateSubmissionDraftInputSchema: z.ZodType;
 export const SearchDuplicateEntriesInputSchema: z.ZodType;
 export const BuildSubmissionUrlsInputSchema: z.ZodType;
 export const CategorySubmissionGuidanceInputSchema: z.ZodType;
+export const PrepareSubmissionDraftInputSchema: z.ZodType;
+export const GetSubmissionExamplesInputSchema: z.ZodType;
+export const ReviewSubmissionDraftInputSchema: z.ZodType;
 export const TOOL_INPUT_SCHEMAS: Record<string, z.ZodType>;
 
 export function jsonSchemaForTool(name: string): Record<string, unknown>;

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -77,6 +77,34 @@ export const SearchRegistryInputSchema = z
   })
   .strict();
 
+export const ServerInfoInputSchema = z.object({}).strict();
+
+export const ListCategoryEntriesInputSchema = z
+  .object({
+    category: pathPart.optional(),
+    platform: platform.optional(),
+    tag: z.string().trim().min(1).max(80).optional(),
+    query: z.string().trim().max(240).optional(),
+    offset: z.number().int().min(0).max(5000).optional(),
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
+export const RecentUpdatesInputSchema = z
+  .object({
+    category: pathPart.optional(),
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
+export const RelatedEntriesInputSchema = z
+  .object({
+    category: pathPart,
+    slug: pathPart,
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
 export const EntryDetailInputSchema = z
   .object({
     category: pathPart,
@@ -145,8 +173,31 @@ export const CategorySubmissionGuidanceInputSchema = z
   })
   .strict();
 
+export const PrepareSubmissionDraftInputSchema = z
+  .object({
+    fields: SubmissionFieldsSchema,
+  })
+  .strict();
+
+export const GetSubmissionExamplesInputSchema = z
+  .object({
+    category: submissionCategory.optional(),
+  })
+  .strict();
+
+export const ReviewSubmissionDraftInputSchema = z
+  .object({
+    fields: SubmissionFieldsSchema,
+    duplicateLimit: z.number().int().min(1).max(10).optional(),
+  })
+  .strict();
+
 export const TOOL_INPUT_SCHEMAS = {
   search_registry: SearchRegistryInputSchema,
+  server_info: ServerInfoInputSchema,
+  list_category_entries: ListCategoryEntriesInputSchema,
+  get_recent_updates: RecentUpdatesInputSchema,
+  get_related_entries: RelatedEntriesInputSchema,
   get_entry_detail: EntryDetailInputSchema,
   get_compatibility: CompatibilityInputSchema,
   get_install_guidance: InstallGuidanceInputSchema,
@@ -157,6 +208,9 @@ export const TOOL_INPUT_SCHEMAS = {
   search_duplicate_entries: SearchDuplicateEntriesInputSchema,
   build_submission_urls: BuildSubmissionUrlsInputSchema,
   get_category_submission_guidance: CategorySubmissionGuidanceInputSchema,
+  prepare_submission_draft: PrepareSubmissionDraftInputSchema,
+  get_submission_examples: GetSubmissionExamplesInputSchema,
+  review_submission_draft: ReviewSubmissionDraftInputSchema,
 };
 
 function stripUnsupportedJsonSchemaFields(value) {

--- a/packages/mcp/src/submissions.d.ts
+++ b/packages/mcp/src/submissions.d.ts
@@ -21,6 +21,19 @@ export function validateSubmissionDraftFromSpec(
   spec: Record<string, unknown>,
   args?: Record<string, unknown>,
 ): Record<string, unknown>;
+export function prepareSubmissionDraftFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+): Record<string, unknown>;
+export function getSubmissionExamplesFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+): Record<string, unknown>;
+export function reviewSubmissionDraftFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+  entries?: Array<Record<string, unknown>>,
+): Record<string, unknown>;
 export function searchDuplicateEntries(
   entries?: Array<Record<string, unknown>>,
   args?: Record<string, unknown>,

--- a/packages/mcp/src/submissions.js
+++ b/packages/mcp/src/submissions.js
@@ -472,6 +472,232 @@ export function validateSubmissionDraftFromSpec(spec, args = {}) {
   };
 }
 
+function singularLabel(value) {
+  const label = normalizeText(value || "Entry");
+  return label.endsWith("s") ? label.slice(0, -1) : label;
+}
+
+function exampleValueForField(fieldId, category, label) {
+  switch (fieldId) {
+    case "name":
+    case "title":
+      return `Example ${singularLabel(label)}`;
+    case "slug":
+      return `example-${category || "entry"}`;
+    case "category":
+      return category;
+    case "github_url":
+      return `https://github.com/example/example-${category || "entry"}`;
+    case "docs_url":
+    case "source_url":
+      return `https://example.com/${category || "entry"}/docs`;
+    case "download_url":
+      return `https://example.com/${category || "entry"}/download.zip`;
+    case "brand_name":
+      return "Example";
+    case "brand_domain":
+      return "example.com";
+    case "author":
+      return "@example";
+    case "contact_email":
+      return "@example";
+    case "tags":
+      return "claude, workflow, example";
+    case "description":
+      return `A practical ${singularLabel(label).toLowerCase()} for Claude users that includes source-backed setup and usage details.`;
+    case "card_description":
+      return `Practical ${singularLabel(label).toLowerCase()} for Claude workflows.`;
+    case "full_copyable_content":
+      return `# Example ${singularLabel(label)}\n\nUse this complete content as the copyable public artifact.`;
+    case "install_command":
+      return `npx -y example-${category || "entry"}`;
+    case "usage_snippet":
+      return `Use this ${singularLabel(label).toLowerCase()} to speed up a Claude workflow.`;
+    case "command_syntax":
+      return `/example-${category || "entry"} <input>`;
+    case "trigger":
+      return "PostToolUse";
+    case "guide_content":
+      return `# Example ${singularLabel(label)}\n\nExplain the setup, usage, verification, and troubleshooting steps.`;
+    case "items":
+      return `- Example ${singularLabel(label)} item\n- Source-backed companion resource`;
+    case "script_language":
+      return "bash";
+    case "skill_type":
+      return "workflow";
+    case "skill_level":
+      return "intermediate";
+    case "verification_status":
+      return "validated";
+    case "verified_at":
+      return "2026-05-17";
+    case "config_snippet":
+      return JSON.stringify({ example: true }, null, 2);
+    case "retrieval_sources":
+      return "- https://example.com/docs";
+    case "tested_platforms":
+      return "Claude Code, Codex, Cursor";
+    case "prerequisites":
+      return "- Node.js 20+\n- Claude-compatible MCP client";
+    case "troubleshooting_section":
+      return "If setup fails, verify the install command and source URL first.";
+    case "installation_order":
+      return "Install dependencies, configure the entry, then run the verification step.";
+    case "estimated_setup_time":
+      return "10 minutes";
+    case "difficulty":
+      return "intermediate";
+    default:
+      return `Example ${fieldId.replaceAll("_", " ")}`;
+  }
+}
+
+function exampleForCategory(spec, category) {
+  const model = modelFor(spec, category);
+  const fields = Object.fromEntries(
+    (model?.fields || []).map((field) => [
+      field.id,
+      exampleValueForField(field.id, category, model?.label),
+    ]),
+  );
+  fields.category = category;
+
+  const minimalFields = {};
+  for (const field of requiredFields(model)) {
+    minimalFields[field] = fields[field];
+  }
+  minimalFields.category = category;
+
+  for (const field of [
+    "name",
+    "description",
+    "github_url",
+    "docs_url",
+    "install_command",
+    "usage_snippet",
+    "download_url",
+    "guide_content",
+    "items",
+  ]) {
+    if (fields[field]) minimalFields[field] = fields[field];
+  }
+
+  return {
+    category,
+    label: model?.label || category,
+    template: model?.template || templateFor(spec, category)?.template || "",
+    requiredFields: requiredFields(model),
+    minimalFields,
+    completeFields: fields,
+    notes: [
+      "Use canonical source URLs and avoid affiliate/referral links.",
+      "The generated issue draft is a maintainer-reviewed submission, not automatic publication.",
+    ],
+  };
+}
+
+export function getSubmissionExamplesFromSpec(spec, args = {}) {
+  const category = selectedCategory(spec, args.category);
+  if (args.category && !category) {
+    return {
+      ok: false,
+      error: {
+        code: "not_found",
+        message: `No HeyClaude submission examples found for ${args.category}.`,
+      },
+    };
+  }
+
+  const categories = category ? [category] : categoryKeys(spec);
+  return {
+    ok: true,
+    categories: categories.map((key) => exampleForCategory(spec, key)),
+    reviewModel:
+      "Examples are draft helpers only; maintainers review accepted submissions before import.",
+  };
+}
+
+export function prepareSubmissionDraftFromSpec(spec, args = {}) {
+  const fields = normalizeSubmissionFields(args.fields || {});
+  const validation = validateAgainstSpec(spec, fields);
+  const issueDraft = validation.category
+    ? buildIssueDraftFromSpec(spec, validation.normalized)
+    : null;
+  const urls = buildSubmissionUrlsFromSpec(spec, {
+    fields: validation.normalized,
+    includeIssueBody: true,
+  });
+
+  return {
+    ok: true,
+    valid: validation.valid,
+    category: validation.category,
+    slug: validation.normalized.slug || "",
+    normalizedFields: validation.normalized,
+    requiredFields: validation.requiredFields || [],
+    missingRequiredFields: validation.missingRequiredFields || [],
+    errors: validation.errors,
+    warnings: validation.warnings,
+    issueDraft,
+    submitUrl: urls.submitUrl,
+    githubIssueUrl: urls.githubIssueUrl,
+    reviewChecklist: [
+      "Confirm category fit and required fields before opening the issue.",
+      "Check for existing registry entries with the same source, slug, or title.",
+      "Verify source URLs, install commands, and copied content before maintainer approval.",
+      "Disclose paid, sponsored, affiliate, or commercial content separately from free community submissions.",
+    ],
+    submissionPolicy:
+      "This tool prepares a review issue only. HeyClaude does not auto-publish MCP-submitted content.",
+  };
+}
+
+export function reviewSubmissionDraftFromSpec(spec, args = {}, entries = []) {
+  const validation = validateAgainstSpec(spec, args.fields || {});
+  const duplicateArgs = {
+    category: validation.category,
+    slug: validation.normalized.slug,
+    title: validation.normalized.title || validation.normalized.name,
+    name: validation.normalized.name,
+    sourceUrl:
+      validation.normalized.github_url ||
+      validation.normalized.docs_url ||
+      validation.normalized.source_url,
+    brandDomain: validation.normalized.brand_domain,
+    limit: args.duplicateLimit || 5,
+  };
+  const duplicates = searchDuplicateEntries(entries, duplicateArgs);
+  const recommendedAction = validation.valid
+    ? duplicates.count > 0
+      ? "review_possible_duplicate"
+      : "open_review_issue"
+    : "fix_required_fields";
+
+  return {
+    ok: true,
+    valid: validation.valid,
+    category: validation.category,
+    slug: validation.normalized.slug || "",
+    recommendedAction,
+    errors: validation.errors,
+    warnings: validation.warnings,
+    missingRequiredFields: validation.missingRequiredFields || [],
+    duplicateReview: duplicates,
+    reviewChecklist: [
+      "Schema-valid is not publish-valid; maintainer review is still required.",
+      "Check category fit against the actual artifact, not only the submitter's selected category.",
+      "Verify source availability, install commands, and any credential/payment-sensitive behavior.",
+      "Reject or request edits for affiliate/referral links, unsupported claims, or unclear paid/sponsored positioning.",
+    ],
+    nextSteps: validation.valid
+      ? [
+          "Open or update the canonical GitHub submission issue.",
+          "Apply maintainer review labels only after source and duplicate checks.",
+        ]
+      : ["Fix required fields and validation errors before opening an issue."],
+  };
+}
+
 function entrySourceUrls(entry) {
   return [
     entry.documentationUrl,

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -248,12 +248,18 @@ describe("central API router security", () => {
     expect(wranglerConfig).toContain('"name": "API_REGISTRY_RATE_LIMIT"');
     expect(wranglerConfig).toContain('"name": "API_DYNAMIC_RATE_LIMIT"');
     expect(wranglerConfig).toContain('"name": "API_STRICT_RATE_LIMIT"');
+    expect(wranglerConfig).toContain('"name": "API_MCP_RATE_LIMIT"');
     expect(apiRouteDefinitions["submissions.create"].rateLimit?.binding).toBe(
       "API_STRICT_RATE_LIMIT",
     );
     expect(apiRouteDefinitions["registry.search"].rateLimit?.binding).toBe(
       "API_REGISTRY_RATE_LIMIT",
     );
+    expect(apiRouteDefinitions["mcp.streamable"].rateLimit).toMatchObject({
+      binding: "API_MCP_RATE_LIMIT",
+      limit: 60,
+      windowMs: 60_000,
+    });
     expect(routerSource).toContain("binding.limit({ key })");
   });
 

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -84,6 +84,10 @@ describe("HeyClaude remote MCP route", () => {
     );
     expect(toolNames).toEqual([
       "search_registry",
+      "server_info",
+      "list_category_entries",
+      "get_recent_updates",
+      "get_related_entries",
       "get_entry_detail",
       "get_compatibility",
       "get_install_guidance",
@@ -94,8 +98,13 @@ describe("HeyClaude remote MCP route", () => {
       "search_duplicate_entries",
       "build_submission_urls",
       "get_category_submission_guidance",
+      "prepare_submission_draft",
+      "get_submission_examples",
+      "review_submission_draft",
     ]);
-    expect(toolNames.join(" ")).not.toMatch(/create|publish|write|delete/i);
+    expect(toolNames.join(" ")).not.toMatch(
+      /create_issue|create_pull_request|publish_content|write_file|delete/i,
+    );
   });
 
   it("searches public registry artifacts without write capabilities", async () => {
@@ -117,6 +126,61 @@ describe("HeyClaude remote MCP route", () => {
     expect(result).toMatchObject({ ok: true, count: 2 });
     expect(result.entries[0]).toHaveProperty("canonicalUrl");
     expect(JSON.stringify(result)).not.toMatch(/admin|token|secret/i);
+  });
+
+  it("serves MCP server metadata and category browse tools", async () => {
+    const infoResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 33,
+        method: "tools/call",
+        params: { name: "server_info", arguments: {} },
+      }),
+    );
+    expect(infoResponse.status).toBe(200);
+    const infoPayload = await json(infoResponse);
+    const info = JSON.parse(infoPayload.result.content[0].text);
+    expect(info).toMatchObject({
+      ok: true,
+      endpoint: {
+        auth: "none",
+        rateLimit: {
+          binding: "API_MCP_RATE_LIMIT",
+          limit: 60,
+        },
+      },
+      policy: {
+        apiKeyRequired: false,
+        createsIssues: false,
+        publishesContent: false,
+      },
+    });
+
+    const listResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 34,
+        method: "tools/call",
+        params: {
+          name: "list_category_entries",
+          arguments: { category: "mcp", limit: 2 },
+        },
+      }),
+    );
+    expect(listResponse.status).toBe(200);
+    const listPayload = await json(listResponse);
+    const list = JSON.parse(listPayload.result.content[0].text);
+    expect(list).toMatchObject({
+      ok: true,
+      category: "mcp",
+      count: 2,
+      entries: [
+        expect.objectContaining({
+          canonicalUrl: expect.stringContaining("/mcp/"),
+        }),
+        expect.any(Object),
+      ],
+    });
   });
 
   it("returns schema validation errors for malformed MCP tool arguments", async () => {
@@ -202,5 +266,46 @@ describe("HeyClaude remote MCP route", () => {
       reviewModel: expect.stringContaining("Issue-first"),
     });
     expect(JSON.stringify(result)).not.toMatch(/token|secret|authorization/i);
+  });
+
+  it("prepares submission drafts without creating GitHub issues", async () => {
+    const response = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: {
+          name: "prepare_submission_draft",
+          arguments: {
+            fields: {
+              category: "guides",
+              name: "Example Guide",
+              docs_url: "https://example.com/guide",
+              description:
+                "Example guide submission used to verify draft-only MCP helpers.",
+              guide_content:
+                "# Example Guide\n\nA complete public guide body for maintainer review.",
+            },
+          },
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const payload = await json(response);
+    expect(payload.result.isError).toBe(false);
+    const result = JSON.parse(payload.result.content[0].text);
+    expect(result).toMatchObject({
+      ok: true,
+      valid: true,
+      githubIssueUrl: expect.stringContaining("template=submit-guide.yml"),
+      issueDraft: {
+        body: expect.stringContaining("### Guide content"),
+      },
+      submissionPolicy: expect.stringContaining("does not auto-publish"),
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /token|secret|authorization|createIssue|createPullRequest/i,
+    );
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -105,9 +105,11 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
     expect(Object.keys(TOOL_INPUT_SCHEMAS)).toEqual(READ_ONLY_TOOL_NAMES);
     for (const tool of TOOL_DEFINITIONS) {
-      expect(tool.name).not.toMatch(/create|publish|write|delete|pr/i);
+      expect(tool.name).not.toMatch(
+        /create_issue|create_pull_request|publish_content|write_file|delete/i,
+      );
       expect(tool.description).toMatch(
-        /read-only|fetch|search|list|validate|build|guidance/i,
+        /read-only|fetch|search|list|validate|build|guidance|review/i,
       );
       expect(tool.inputSchema).toEqual(jsonSchemaForTool(tool.name));
       expect(tool.inputSchema).toMatchObject({
@@ -116,6 +118,38 @@ describe("HeyClaude read-only MCP helpers", () => {
       });
       expect(JSON.stringify(tool.inputSchema)).not.toContain("$schema");
     }
+  });
+
+  it("reports public no-key MCP server metadata and durable rate-limit policy", async () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
+    ) as { name: string; version: string };
+
+    const info = await callRegistryTool("server_info", {}, { dataDir });
+    expect(info).toMatchObject({
+      ok: true,
+      package: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+      endpoint: {
+        auth: "none",
+        requestBodyLimitBytes: 64 * 1024,
+        rateLimit: {
+          binding: "API_MCP_RATE_LIMIT",
+          limit: 60,
+          windowSeconds: 60,
+        },
+      },
+      policy: {
+        apiKeyRequired: false,
+        readOnly: true,
+        createsIssues: false,
+        createsPullRequests: false,
+        publishesContent: false,
+      },
+    });
+    expect(info.tools).toEqual(READ_ONLY_TOOL_NAMES);
   });
 
   it("validates MCP tool arguments from shared Zod schemas", async () => {
@@ -189,6 +223,75 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(result.entries.length).toBeGreaterThan(0);
     expect(result.entries.length).toBeLessThanOrEqual(5);
     expect(result.entries[0].platforms).toContain("Cursor");
+  });
+
+  it("lists category entries with bounded pagination and filters", async () => {
+    const result = await callRegistryTool(
+      "list_category_entries",
+      {
+        category: "skills",
+        platform: "cursor-rules",
+        tag: "evals",
+        limit: 2,
+      },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      category: "skills",
+      platform: "Cursor",
+      tag: "evals",
+      count: expect.any(Number),
+      limit: 2,
+      offset: 0,
+    });
+    expect(result.entries.length).toBeLessThanOrEqual(2);
+    expect(result.entries[0]).toMatchObject({
+      category: "skills",
+      canonicalUrl: expect.stringContaining("/skills/"),
+      dateAdded: expect.any(String),
+    });
+    expect(result.entries[0].tags).toContain("evals");
+    expect(result.entries[0].platforms).toContain("Cursor");
+  });
+
+  it("lists recent updates from generated registry metadata", async () => {
+    const result = await callRegistryTool(
+      "get_recent_updates",
+      { limit: 5 },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({ ok: true, count: 5 });
+    const dates = result.entries.map((entry: any) => entry.updatedAt);
+    expect(dates).toEqual([...dates].sort().reverse());
+    expect(result.entries[0]).toMatchObject({
+      key: expect.stringContaining(":"),
+      updateKind: expect.stringMatching(/added|upstream_update/),
+    });
+  });
+
+  it("returns related entries without returning the requested entry", async () => {
+    const result = await callRegistryTool(
+      "get_related_entries",
+      { category: skill.category, slug: skill.slug, limit: 5 },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      key: `${skill.category}:${skill.slug}`,
+      count: expect.any(Number),
+    });
+    expect(result.entries.length).toBeGreaterThan(0);
+    expect(result.entries.map((entry: any) => entry.key)).not.toContain(
+      `${skill.category}:${skill.slug}`,
+    );
+    expect(result.entries[0]).toMatchObject({
+      relatedScore: expect.any(Number),
+      relatedReasons: expect.arrayContaining([expect.any(String)]),
+    });
   });
 
   it("fetches entry detail and install guidance without write capabilities", async () => {
@@ -332,6 +435,78 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(urls.githubIssueUrl).toContain("template=submit-skill.yml");
     expect(urls.issueDraft.body).toContain("### Brand domain");
     expect(JSON.stringify(urls)).not.toMatch(/token|secret|authorization/i);
+  });
+
+  it("prepares and reviews submission drafts without GitHub writes", async () => {
+    const fields = {
+      category: "mcp",
+      name: "Example Draft MCP",
+      docs_url: "https://example.com/docs",
+      description:
+        "Example MCP server submission used to test stronger draft tooling.",
+      install_command: "npx -y example-draft-mcp",
+      usage_snippet: "Add this server to your MCP client configuration.",
+    };
+
+    const prepared = await callRegistryTool(
+      "prepare_submission_draft",
+      { fields },
+      { dataDir },
+    );
+    expect(prepared).toMatchObject({
+      ok: true,
+      valid: true,
+      category: "mcp",
+      issueDraft: {
+        title: "Submit MCP Server: Example Draft MCP",
+        labels: expect.arrayContaining(["content-submission", "community-mcp"]),
+        body: expect.stringContaining("### Install command"),
+      },
+      githubIssueUrl: expect.stringContaining("template=submit-mcp.yml"),
+      submissionPolicy: expect.stringContaining("does not auto-publish"),
+    });
+
+    const reviewed = await callRegistryTool(
+      "review_submission_draft",
+      { fields },
+      { dataDir },
+    );
+    expect(reviewed).toMatchObject({
+      ok: true,
+      valid: true,
+      recommendedAction: expect.stringMatching(
+        /open_review_issue|review_possible_duplicate/,
+      ),
+      duplicateReview: { ok: true },
+      reviewChecklist: expect.arrayContaining([
+        expect.stringContaining("maintainer review"),
+      ]),
+    });
+    expect(JSON.stringify({ prepared, reviewed })).not.toMatch(
+      /token|secret|authorization|createIssue|createPullRequest/i,
+    );
+  });
+
+  it("returns category submission examples for faster valid drafts", async () => {
+    const examples = await callRegistryTool(
+      "get_submission_examples",
+      { category: "guides" },
+      { dataDir },
+    );
+    expect(examples).toMatchObject({
+      ok: true,
+      categories: [
+        {
+          category: "guides",
+          requiredFields: expect.arrayContaining(["guide_content"]),
+          minimalFields: {
+            category: "guides",
+            guide_content: expect.stringContaining("# Example"),
+          },
+        },
+      ],
+      reviewModel: expect.stringContaining("maintainers review"),
+    });
   });
 
   it("finds likely duplicate entries before submission", async () => {


### PR DESCRIPTION
## Summary
- Adds the next MCP feature slice: discovery tools, submission draft helpers, and package version `0.2.0`.
- Moves `/api/mcp` onto a dedicated `API_MCP_RATE_LIMIT` binding so anonymous public MCP access has a durable 60 requests/minute/IP production cap.
- Updates MCP docs, release runbook, endpoint validation, OpenAPI, and route/package tests.

## What changed
- Added MCP tools: `server_info`, `list_category_entries`, `get_recent_updates`, `get_related_entries`, `prepare_submission_draft`, `get_submission_examples`, and `review_submission_draft`.
- Kept all MCP behavior read-only: submission tools generate validation, issue text, URLs, duplicate review, and maintainer checklists only.
- Added `API_MCP_RATE_LIMIT` to Wrangler config, API route contracts, Worker env types, docs, and API security tests.
- Bumped `@heyclaude/mcp` to `0.2.0` and updated npm-facing README/changelog.

## Why
- The public MCP should stay no-key and low-friction, but the production abuse control should match the documented route limit rather than piggybacking on the broader registry binding.
- Users should be able to discover useful entries and prepare better content submissions through MCP without bypassing maintainer review.

## Validation
- `pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp` before feature changes, for current production `0.1.2` readiness
- `pnpm --filter @heyclaude/mcp test`
- `pnpm exec vitest run tests/mcp-http-route.test.ts tests/api-router-security.test.ts`
- `pnpm validate:mcp-package`
- `pnpm validate:openapi`
- `pnpm validate:content`
- `pnpm validate:raycast-feed`
- `pnpm validate:issue-templates`
- `pnpm test:submission-intake`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- I attempted the requested `@heyclaude/mcp@0.1.2` publish from `main`; validation passed and the `npm-production` environment was approved, but npm rejected `npm publish --provenance` with `E404 Not Found - PUT https://registry.npmjs.org/@heyclaude%2fmcp` after signing provenance. npm still reports latest as `0.1.1`, so nothing partially published. Run: https://github.com/JSONbored/awesome-claude/actions/runs/25980225842
- This points to npm-side package/scope trusted publisher or publish access configuration, not a code validation failure. The release runbook now documents that failure mode.
- Do not publish `0.2.0` until this web change is merged/deployed and npm package access/trusted publishing is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added server information and registry metadata queries
  * Added category browsing with filtering and pagination
  * Added recent updates discovery
  * Added related entries recommendations based on shared attributes
  * Added submission draft preparation and review workflows with example generation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->