### PR TITLE
ci(release): fix mcp package tag push auth

### DIFF
--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -101,10 +101,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$RELEASE_TAG" -m "@heyclaude/mcp v$RELEASE_VERSION"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
-          GIT_CONFIG_COUNT=1 \
-            GIT_CONFIG_KEY_0="http.https://github.com/.extraheader" \
-            GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}" \
-            git push origin "$RELEASE_TAG"
+          gh auth setup-git
+          git push origin "$RELEASE_TAG"
 
       - name: Create GitHub release
         env:

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -555,9 +555,8 @@ diff --git a/README.md b/README.md
     expect(releaseSource).not.toContain("NODE_AUTH_TOKEN");
     expect(releaseSource).not.toContain("NPM_TOKEN");
     expect(releaseSource).not.toContain("x-access-token");
-    expect(releaseSource).toContain(
-      'GIT_CONFIG_VALUE_0="AUTHORIZATION: bearer ${GH_TOKEN}"',
-    );
+    expect(releaseSource).not.toContain("AUTHORIZATION: bearer");
+    expect(releaseSource).toContain("gh auth setup-git");
     expect(releaseValidatorSource).toContain(
       "require('./packages/mcp/package.json').version",
     );


### PR DESCRIPTION
## Summary
- Fixes the MCP package publish workflow tag push after `npm publish` succeeds.
- Uses `gh auth setup-git` with the workflow `GH_TOKEN` instead of a malformed bearer extraheader.

## What changed
- Replaces the manual Git extraheader tag-push auth in `.github/workflows/publish-mcp-npm.yml`.
- Keeps the existing manual workflow, protected `npm-production` environment, validation gate, and npm trusted-publishing flow unchanged.

## Why
- `@heyclaude/mcp@0.1.2` published successfully, but the follow-up tag push failed with `fatal: could not read Username for https://github.com`.
- The missing `mcp-v0.1.2` tag and GitHub release were created manually after publish; this prevents the same post-publish failure next time.

## Validation
- `actionlint .github/workflows/publish-mcp-npm.yml`
- `pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp`
- `pnpm --filter @heyclaude/mcp test`
- `pnpm --filter @heyclaude/mcp pack --dry-run`
- `MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package`
- `npm exec -y @heyclaude/mcp@0.1.2 -- --version`

## Notes
- npm trusted publishing for `@heyclaude/mcp` now points at `JSONbored/awesome-claude`, workflow `publish-mcp-npm.yml`, environment `npm-production`.
- PR #367 was closed intentionally to park the 0.2.0 feature release until after this patch release.
