### PR TITLE
fix(mcp): block remote proxy redirects in fetch wrapper

### DIFF
--- a/packages/mcp/src/remote-proxy.js
+++ b/packages/mcp/src/remote-proxy.js
@@ -34,7 +34,11 @@ function createTimeoutFetch(timeoutMs) {
     }
 
     try {
-      return await fetch(url, { ...init, signal: controller.signal });
+      return await fetch(url, {
+        ...init,
+        redirect: "error",
+        signal: controller.signal,
+      });
     } finally {
       clearTimeout(timeout);
       if (inputSignal) {


### PR DESCRIPTION
### Motivation
- Prevent client-side SSRF/CSRF where a validated HTTPS MCP endpoint could issue a redirect that causes MCP traffic to be delivered to unvalidated cleartext/private hosts (e.g. localhost) because `fetch` followed redirects by default.

### Description
- Harden the remote MCP stdio proxy by updating `createTimeoutFetch` in `packages/mcp/src/remote-proxy.js` to call `fetch` with `redirect: "error"`, preserving the existing timeout and abort propagation behavior.

### Testing
- Ran `pnpm exec vitest run tests/mcp-server.test.ts tests/mcp-cli.test.ts` which passed (2 files, 17 tests); an alternate invocation `pnpm --dir ../.. exec vitest ...` failed in this environment due to package-manifest resolution but is unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09463d69508320a97450dc1470f86c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated HTTP redirect handling for remote MCP calls to treat redirects as errors instead of following them.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->