### PR TITLE
fix(ci): handle README slug/filename mismatch in refresh body builder

### DIFF
--- a/scripts/build-readme-refresh-body.mjs
+++ b/scripts/build-readme-refresh-body.mjs
@@ -171,16 +171,41 @@ async function fetchAssociatedPullRequest({ repository, commitSha, token }) {
 }
 
 function readContentFrontmatter(repoRoot, change) {
-  const relativePath = path.join(
+  const categoryDir = path.join(repoRoot, "content", change.category);
+  const directRelativePath = path.join(
     "content",
     change.category,
     `${change.slug}.mdx`,
   );
-  const contentPath = path.join(repoRoot, relativePath);
+  const directPath = path.join(repoRoot, directRelativePath);
+
+  let relativePath = directRelativePath;
+  let contentPath = directPath;
+
   if (!fs.existsSync(contentPath)) {
-    throw new Error(
-      `README entry ${change.key} does not map to ${relativePath}.`,
-    );
+    if (!fs.existsSync(categoryDir)) {
+      throw new Error(
+        `README entry ${change.key} does not map to ${directRelativePath}.`,
+      );
+    }
+
+    const candidate = fs.readdirSync(categoryDir).find((name) => {
+      if (!name.endsWith(".mdx")) return false;
+      {
+        const source = fs.readFileSync(path.join(categoryDir, name), "utf8");
+        const { data } = matter(source);
+        return String(data.slug ?? name.replace(/\.mdx$/, "")) === change.slug;
+      }
+    });
+
+    if (!candidate) {
+      throw new Error(
+        `README entry ${change.key} does not map to ${directRelativePath}.`,
+      );
+    }
+
+    relativePath = path.join("content", change.category, candidate);
+    contentPath = path.join(repoRoot, relativePath);
   }
 
   const { data } = matter(fs.readFileSync(contentPath, "utf8"));

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   buildReadmeRefreshBody,
   extractReadmeEntryChanges,
+  resolveReadmeEntryChange,
   summarizeReadmeEntryChange,
 } from "../scripts/build-readme-refresh-body.mjs";
 import {
@@ -298,6 +299,39 @@ diff --git a/README.md b/README.md
     );
     expect(body).toContain(
       "- Added Memesio MCP Server content submission (#330) by @vy35 via issue #325",
+    );
+  });
+
+  it("resolves README entries when frontmatter slug differs from filename", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-readme-"));
+    const categoryDir = path.join(tmpDir, "content", "mcp");
+    fs.mkdirSync(categoryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(categoryDir, "example-file.mdx"),
+      `---
+title: Example Entry
+slug: example
+description: Example description
+---
+`,
+      "utf8",
+    );
+
+    const resolved = await resolveReadmeEntryChange(
+      {
+        changeType: "added",
+        category: "mcp",
+        slug: "example",
+        title: "Example Entry",
+        description: "Example description",
+        key: "mcp/example",
+      },
+      { repoRoot: tmpDir, repository: "", token: "" },
+    );
+
+    expect(resolved.relativePath).toBe("content/mcp/example-file.mdx");
+    expect(resolved.summary).toContain(
+      "Added Example Entry content submission",
     );
   });
 


### PR DESCRIPTION
### Motivation
- The README refresh body generator could crash when a README entry URL used the frontmatter `slug` that did not match the MDX filename, causing the workflow to throw before creating the PR.  

### Description
- Update `readContentFrontmatter` in `scripts/build-readme-refresh-body.mjs` to keep the existing fast path (`content/<category>/<slug>.mdx`) and, if that file is missing, fall back to scanning `content/<category>/*.mdx` for a matching frontmatter `slug` before throwing.  
- Preserve existing error behavior when neither a direct filename nor a frontmatter match is found.  
- Add a regression test in `tests/submission-workflows.test.ts` that verifies `resolveReadmeEntryChange` resolves an MDX file whose filename differs from its frontmatter `slug`.  

### Testing
- Ran `pnpm vitest tests/submission-workflows.test.ts` and all tests passed (`22 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094773d79c83208e173d98343c99d5)