### PR TITLE
fix(submissions): prevent website contact provenance spoofing

### DIFF
--- a/scripts/import-submission-issue.mjs
+++ b/scripts/import-submission-issue.mjs
@@ -164,7 +164,7 @@ function submissionIdentity(issue, fields) {
   const submittedVia = normalizeValue(fields.submitted_via).toLowerCase();
   const contactIdentity = githubIdentityFromPublicContact(fields.contact_email);
   if (submittedVia === "website" && isTrustedWebsiteIssueAuthor(issue)) {
-    return contactIdentity;
+    return null;
   }
   return githubIdentityFromIssueAuthor(issue) || contactIdentity;
 }

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -217,6 +217,40 @@ describe("submission intake", () => {
     expect(output).not.toContain("maintainer@example.com");
   });
 
+  it("does not trust website public contact handles as submitter provenance", () => {
+    const output = importSubmissionDryRun({
+      number: 780,
+      html_url: "https://github.com/JSONbored/awesome-claude/issues/780",
+      created_at: "2026-04-28T12:34:56Z",
+      user: {
+        login: "JSONbored",
+        html_url: "https://github.com/JSONbored",
+      },
+      body: buildSubmissionIssueDraft({
+        name: "Website Contact Spoof MCP",
+        slug: "website-contact-spoof-mcp",
+        category: "mcp",
+        author: "Example Team",
+        contact_email: "victim-user",
+        submitted_via: "website",
+        docs_url: "https://example.com/docs",
+        description:
+          "MCP server submitted through the website with an unverified public contact handle.",
+        card_description: "Website public contact provenance spoof coverage.",
+        install_command: "npx -y website-contact-spoof-mcp",
+        usage_snippet:
+          "claude mcp add website-contact-spoof-mcp -- npx -y website-contact-spoof-mcp",
+      }).body,
+      labels: [{ name: "content-submission" }, { name: "community-mcp" }],
+    });
+
+    expect(output).not.toContain("submittedBy:");
+    expect(output).not.toContain("submittedByUrl:");
+    expect(output).not.toContain("submittedBy: victim-user");
+    expect(output).not.toContain("https://github.com/victim-user");
+    expect(output).not.toContain("submittedBy: JSONbored");
+  });
+
   it("does not trust submitted_via from direct GitHub issue bodies", () => {
     const output = importSubmissionDryRun({
       number: 779,


### PR DESCRIPTION
## Summary
- Prevent unauthenticated website public-contact fields from becoming trusted `submittedBy` provenance.
- Keep direct GitHub issue attribution on the GitHub issue author even if a user forges `Submitted Via: website`.
- Add regression coverage for the spoof path described in the security finding.

## What changed
- Website submissions created by the trusted site issue author now omit `submittedBy`/`submittedByUrl` instead of using unverified `contact_email` handles.
- Direct GitHub submissions continue to attribute to the issue author.

## Why
- `contact_email` is public, user-controlled, and not proof of GitHub-account ownership. Using it as `submittedBy` let accepted website submissions spoof arbitrary GitHub users in detail pages and contributor grouping.

## Validation
- `pnpm exec vitest run tests/submission-intake.test.ts`
- `pnpm test:submission-intake`
- `trunk check --ci scripts/import-submission-issue.mjs tests/submission-intake.test.ts`
