### PR TITLE
feat(mcp): add discovery and submission draft tools

### DIFF
--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm test:mcp
 
       - name: Validate production MCP endpoint
-        run: pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp
+        run: pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools
 
       - name: Dry-run MCP package tarball
         run: pnpm --filter @heyclaude/mcp pack --dry-run --json
@@ -119,7 +119,7 @@ jobs:
             printf -- "- npm package: https://www.npmjs.com/package/@heyclaude/mcp/v/%s\n\n" "$RELEASE_VERSION"
             printf "## Validation\n\n"
             printf -- "- \`pnpm test:mcp\`\n"
-            printf -- "- \`pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp\`\n"
+            printf -- "- \`pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools\`\n"
             printf -- "- \`pnpm --filter @heyclaude/mcp pack --dry-run --json\`\n"
             printf -- "- \`MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package\`\n"
           } > "$notes_file"

--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -13,10 +13,12 @@ Configured in [`wrangler.jsonc`](./wrangler.jsonc):
 
 - `SITE_DB` (D1) for durable upvotes, reviewed jobs listings, listing leads, commercial placements, community signals, and future dynamic site state.
 - Shared between `prod` and `dev` environments in the current setup.
-- `API_REGISTRY_RATE_LIMIT`, `API_DYNAMIC_RATE_LIMIT`, and
-  `API_STRICT_RATE_LIMIT` for Cloudflare-native per-route rate limiting. The
-  app also keeps an in-process development fallback, but production should rely
-  on the Worker bindings configured in `wrangler.jsonc`.
+- `API_REGISTRY_RATE_LIMIT`, `API_DYNAMIC_RATE_LIMIT`,
+  `API_STRICT_RATE_LIMIT`, and `API_MCP_RATE_LIMIT` for Cloudflare-native
+  per-route rate limiting. The MCP binding is intentionally separate so the
+  public no-key MCP endpoint keeps a durable `60 requests/minute/IP` production
+  cap. The app also keeps an in-process development fallback, but production
+  should rely on the Worker bindings configured in `wrangler.jsonc`.
 
 ## D1 setup
 

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -483,7 +483,8 @@ export type ApiRouteDefinition = {
     binding?:
       | "API_REGISTRY_RATE_LIMIT"
       | "API_DYNAMIC_RATE_LIMIT"
-      | "API_STRICT_RATE_LIMIT";
+      | "API_STRICT_RATE_LIMIT"
+      | "API_MCP_RATE_LIMIT";
   };
   querySchema?: z.ZodTypeAny;
   paramsSchema?: z.ZodTypeAny;
@@ -615,7 +616,7 @@ export const apiRouteDefinitions = {
     path: "/api/mcp",
     summary: "Read-only HeyClaude MCP endpoint",
     description:
-      "Exposes read-only HeyClaude MCP tools over Streamable HTTP for registry search, entry detail, compatibility lookup, install guidance, platform adapters, and feed discovery. This endpoint does not publish registry content or create submissions.",
+      "Exposes no-key read-only HeyClaude MCP tools, resources, and prompts over Streamable HTTP for registry search, discovery, entry detail, copyable assets, comparison, compatibility lookup, install guidance, platform adapters, feed discovery, client setup, and maintainer-reviewed submission draft helpers. This endpoint does not publish registry content or create submissions.",
     tags: ["MCP"],
     originCheck: true,
     requiresJsonBody: true,
@@ -624,7 +625,7 @@ export const apiRouteDefinitions = {
       scope: "mcp-streamable",
       limit: 60,
       windowMs: 60_000,
-      binding: "API_REGISTRY_RATE_LIMIT",
+      binding: "API_MCP_RATE_LIMIT",
     },
   }),
   "brandAsset.read": route({

--- a/apps/web/worker-configuration.d.ts
+++ b/apps/web/worker-configuration.d.ts
@@ -10,6 +10,7 @@ declare namespace Cloudflare {
     API_REGISTRY_RATE_LIMIT: RateLimit;
     API_DYNAMIC_RATE_LIMIT: RateLimit;
     API_STRICT_RATE_LIMIT: RateLimit;
+    API_MCP_RATE_LIMIT: RateLimit;
     ASSETS: Fetcher;
     NEXT_PUBLIC_DISCORD_URL: "https://discord.com/invite/Ax3Py4YDrq";
     NEXT_PUBLIC_TWITTER_URL: "https://x.com/jsonbored";
@@ -29,6 +30,7 @@ declare namespace Cloudflare {
     API_REGISTRY_RATE_LIMIT: RateLimit;
     API_DYNAMIC_RATE_LIMIT: RateLimit;
     API_STRICT_RATE_LIMIT: RateLimit;
+    API_MCP_RATE_LIMIT: RateLimit;
     ASSETS: Fetcher;
     NEXT_PUBLIC_DISCORD_URL: "https://discord.com/invite/Ax3Py4YDrq";
     NEXT_PUBLIC_TWITTER_URL: "https://x.com/jsonbored";

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -55,6 +55,14 @@
         "period": 60,
       },
     },
+    {
+      "name": "API_MCP_RATE_LIMIT",
+      "namespace_id": "1001004",
+      "simple": {
+        "limit": 60,
+        "period": 60,
+      },
+    },
   ],
   "vars": {
     "NEXT_PUBLIC_DISCORD_URL": "https://discord.com/invite/Ax3Py4YDrq",
@@ -117,6 +125,14 @@
         {
           "name": "API_STRICT_RATE_LIMIT",
           "namespace_id": "1002003",
+          "simple": {
+            "limit": 60,
+            "period": 60,
+          },
+        },
+        {
+          "name": "API_MCP_RATE_LIMIT",
+          "namespace_id": "1002004",
           "simple": {
             "limit": 60,
             "period": 60,

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -2357,9 +2357,11 @@ paths:
         - MCP
       summary: Read-only HeyClaude MCP endpoint
       description:
-        Exposes read-only HeyClaude MCP tools over Streamable HTTP for registry search, entry
-        detail, compatibility lookup, install guidance, platform adapters, and feed discovery. This
-        endpoint does not publish registry content or create submissions.
+        Exposes no-key read-only HeyClaude MCP tools, resources, and prompts over Streamable
+        HTTP for registry search, discovery, entry detail, copyable assets, comparison,
+        compatibility lookup, install guidance, platform adapters, feed discovery, client setup, and
+        maintainer-reviewed submission draft helpers. This endpoint does not publish registry
+        content or create submissions.
       responses:
         "200":
           description: Request accepted.

--- a/docs/api-security-contract.md
+++ b/docs/api-security-contract.md
@@ -12,6 +12,7 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
 - `/api/registry/diff`
 - `/api/registry/entries/{category}/{slug}`
 - `/api/registry/entries/{category}/{slug}/llms`
+- `/api/mcp`
 - `/data/*.json` registry artifacts
 - `/data/feeds/index.json`
 - `/data/feeds/categories/{category}.json`
@@ -59,9 +60,11 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
 - Production submissions should set `SUBMISSIONS_REQUIRE_TURNSTILE=1` and
   `TURNSTILE_SECRET_KEY`; if the requirement is enabled without a secret, the
   endpoint fails closed instead of accepting direct website submissions.
-- Cloudflare rate-limit bindings are configured for registry, dynamic, and
-  strict routes. In-process limits remain a local/dev fallback when the Worker
-  binding is unavailable.
+- Cloudflare rate-limit bindings are configured for registry, dynamic, strict,
+  and MCP routes. The public no-key MCP endpoint uses a dedicated
+  `API_MCP_RATE_LIMIT` binding with a `60 requests/minute/IP` production cap.
+  In-process limits remain a local/dev fallback when the Worker binding is
+  unavailable.
 - Next and Worker responses attach security headers in code as well as static
   asset headers: CSP, HSTS, `X-Frame-Options`, `X-Content-Type-Options`,
   `Referrer-Policy`, `Permissions-Policy`, and `Cross-Origin-Opener-Policy`.

--- a/docs/mcp-package-release.md
+++ b/docs/mcp-package-release.md
@@ -45,6 +45,11 @@ publishing.
    - `npm exec -y @heyclaude/mcp@<version> -- --version`
    - GitHub release `mcp-v<version>`
 
+For release publishing, endpoint validation should use `--strict-tools` after
+the matching Worker code has shipped. Pull-request checks intentionally allow a
+lagging dev Worker as long as the deployed endpoint still exposes the baseline
+read-only MCP tools.
+
 ## Local Auth Check
 
 Local npm auth is only needed for npm scope/package bootstrap work. Check with:
@@ -53,3 +58,18 @@ Local npm auth is only needed for npm scope/package bootstrap work. Check with:
 npm login --registry=https://registry.npmjs.org/
 npm whoami
 ```
+
+## Troubleshooting
+
+If `npm publish --provenance` signs provenance successfully and then fails with
+`E404 Not Found - PUT https://registry.npmjs.org/@heyclaude%2fmcp`, the GitHub
+workflow is reaching npm but the package or scope is rejecting publish access.
+Check the npm package access and trusted publisher settings for:
+
+- package: `@heyclaude/mcp`
+- repository: `JSONbored/awesome-claude`
+- workflow file: `publish-mcp-npm.yml`
+- environment: `npm-production`
+
+Do not create a GitHub release tag manually unless the matching npm package
+version is visible on npm.

--- a/docs/registry-mcp-plan.md
+++ b/docs/registry-mcp-plan.md
@@ -20,14 +20,55 @@ Set `HEYCLAUDE_DATA_DIR=/absolute/path/to/data`, or pass
 `--local --data-dir /absolute/path/to/data`, to read from another generated
 artifact directory.
 
-## V1 Tools
+## Tools
 
 - `search_registry`
+- `server_info`
+- `list_category_entries`
+- `get_recent_updates`
+- `get_related_entries`
 - `get_entry_detail`
+- `get_copyable_asset`
+- `compare_entries`
+- `get_registry_stats`
+- `get_client_setup`
 - `get_compatibility`
 - `get_install_guidance`
 - `get_platform_adapter`
 - `list_distribution_feeds`
+- `get_submission_schema`
+- `validate_submission_draft`
+- `search_duplicate_entries`
+- `build_submission_urls`
+- `get_category_submission_guidance`
+- `prepare_submission_draft`
+- `get_submission_examples`
+- `review_submission_draft`
+
+## Resources
+
+- `heyclaude://feeds/directory`
+- `heyclaude://category/{category}`
+- `heyclaude://entry/{category}/{slug}`
+
+## Prompts
+
+- `find_best_asset`
+- `prepare_submission`
+- `review_submission_before_issue`
+- `install_asset_safely`
+
+## Access and rate limits
+
+The public MCP endpoint does not require an API key. That is intentional: the
+tool surface is read-only and all submission helpers generate local validation
+reports, issue drafts, and URLs for maintainer review. They do not create
+GitHub issues or publish registry content.
+
+Production uses the dedicated `API_MCP_RATE_LIMIT` Cloudflare binding at
+`60 requests/minute/IP`, plus the route-level 64 KiB body limit and strict JSON
+request validation. Local and preview runs keep an in-process limiter fallback
+when Cloudflare's binding is unavailable.
 
 ## Exclusions
 

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @heyclaude/mcp Changelog
 
+## 0.2.0 - Discovery and Submission Drafting
+
+- Add read-only discovery tools for server metadata, paginated category
+  browsing, recent updates, and related entries.
+- Add copyable asset, entry comparison, registry stats, and client setup tools
+  for richer MCP client workflows.
+- Add read-only MCP resources and workflow prompts for discovery, submission
+  drafting, pre-issue review, and safe install guidance.
+- Add submission helper tools for examples, canonical issue drafts, duplicate
+  review, and maintainer checklist guidance.
+- Document the public no-key access model and the dedicated MCP rate-limit
+  policy.
+
 ## 0.1.2 - Repository Rename
 
 - Update package metadata, README links, and release provenance for the

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/JSONbored/awesome-claude">GitHub</a> •
   <a href="https://www.npmjs.com/package/@heyclaude/mcp">npm</a> •
   <a href="https://heyclau.de/api/mcp">MCP endpoint</a> •
-  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.1.2">v0.1.2 release</a>
+  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.2.0">v0.2.0 release</a>
 </p>
 
 Read-only Model Context Protocol server for the HeyClaude registry.
@@ -22,11 +22,32 @@ adapters, feed discovery, and safe submission-draft helpers. It does not create
 GitHub issues, open pull requests, write local files, publish content, or manage
 accounts.
 
+No API key is required for the public endpoint. Abuse controls are handled with
+strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
+`API_MCP_RATE_LIMIT` binding capped at 60 requests/minute/IP in production.
+
 ## Tools
 
 - `search_registry` - search public registry entries by query, category, and
   platform.
+- `server_info` - fetch package version, registry generation, tool list, public
+  access policy, and rate-limit metadata.
+- `list_category_entries` - browse entries with bounded pagination and optional
+  category, platform, tag, and query filters.
+- `get_recent_updates` - list recently added or upstream-updated entries from
+  generated registry metadata, optionally filtered with `since`.
+- `get_related_entries` - find related entries based on category, tags,
+  platforms, keywords, and source metadata.
 - `get_entry_detail` - fetch an entry detail payload by category and slug.
+- `get_copyable_asset` - fetch the category-aware copy/install asset for an
+  entry, such as full prompt text, config snippets, commands, scripts, or
+  collection items.
+- `compare_entries` - compare 2-5 entries by fit, category, platform support,
+  install complexity, and source metadata.
+- `get_registry_stats` - fetch aggregate counts, freshness metadata, and real
+  source-signal coverage without implying popularity when stats are absent.
+- `get_client_setup` - fetch tested setup snippets for Codex, Claude Desktop,
+  Cursor, Windsurf, and raw Streamable HTTP clients.
 - `get_compatibility` - fetch skill platform compatibility metadata.
 - `get_install_guidance` - fetch install commands, config, package, and platform
   guidance.
@@ -43,6 +64,27 @@ accounts.
   URLs for human review.
 - `get_category_submission_guidance` - fetch category-specific contribution
   guidance and required fields.
+- `prepare_submission_draft` - normalize and validate fields, then return a
+  canonical issue title/body plus prefilled URLs.
+- `get_submission_examples` - fetch category-specific example fields and
+  templates for more complete submissions.
+- `review_submission_draft` - review schema errors, duplicate risk, and
+  maintainer checklist items before a submission issue is opened.
+
+## Resources and Prompts
+
+The server also exposes read-only MCP resources:
+
+- `heyclaude://feeds/directory`
+- `heyclaude://category/{category}`
+- `heyclaude://entry/{category}/{slug}`
+
+Workflow prompts are available for common client flows:
+
+- `find_best_asset`
+- `prepare_submission`
+- `review_submission_before_issue`
+- `install_asset_safely`
 
 ## Local Stdio
 
@@ -123,8 +165,11 @@ checks the HTTP guards used by the remote route.
 - Submission helpers generate URLs and validation reports only.
 - No GitHub OAuth, tokens, issue creation, PR creation, or repo writes.
 - No local project-file writes or config mutations.
-- Remote endpoint uses route-level rate limits and Cloudflare rate-limit bindings
-  when available.
+- Remote endpoint requires JSON POST bodies, rejects payloads above 64 KiB, and
+  uses the dedicated `API_MCP_RATE_LIMIT` Cloudflare binding at
+  60 requests/minute/IP in production.
+- Submission tools prepare review drafts only; HeyClaude does not auto-publish
+  MCP-submitted content.
 
 ## npm Release Prep
 
@@ -139,7 +184,7 @@ Do not publish until the web branch has shipped, the production endpoint has
 been verified, and the package smoke test passes. The release checklist is:
 
 ```bash
-pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp
+pnpm validate:mcp-endpoint -- --url https://heyclau.de/api/mcp --strict-tools
 pnpm --filter @heyclaude/mcp test
 pnpm --filter @heyclaude/mcp pack --dry-run
 MCP_PACKAGE_REMOTE_SMOKE_URL=https://heyclau.de/api/mcp pnpm validate:mcp-package

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heyclaude/mcp",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "type": "module",
   "description": "Read-only MCP server for the HeyClaude registry.",
   "license": "MIT",

--- a/packages/mcp/scripts/validate-endpoint.mjs
+++ b/packages/mcp/scripts/validate-endpoint.mjs
@@ -6,12 +6,30 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { normalizeEndpointUrl } from "../src/endpoint-url.js";
 import { READ_ONLY_TOOL_NAMES } from "../src/registry.js";
 
+const baselineToolNames = [
+  "search_registry",
+  "get_entry_detail",
+  "get_compatibility",
+  "get_install_guidance",
+  "get_platform_adapter",
+  "list_distribution_feeds",
+  "get_submission_schema",
+  "validate_submission_draft",
+  "search_duplicate_entries",
+  "build_submission_urls",
+  "get_category_submission_guidance",
+];
+
 function parseArgs(argv) {
   const args = new Map();
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--") continue;
     if (!value.startsWith("--")) continue;
+    if (value === "--strict-tools") {
+      args.set("strict-tools", "1");
+      continue;
+    }
     args.set(value.slice(2), argv[index + 1] ?? "");
     index += 1;
   }
@@ -75,7 +93,24 @@ async function validateHttpGuards(endpointUrl) {
   );
 }
 
-async function validateMcpTools(endpointUrl) {
+function validateToolList(toolNames, strictTools) {
+  if (strictTools) {
+    assert(
+      JSON.stringify(toolNames) === JSON.stringify(READ_ONLY_TOOL_NAMES),
+      `Unexpected tool list: ${toolNames.join(", ")}`,
+    );
+    return;
+  }
+
+  for (const toolName of baselineToolNames) {
+    assert(
+      toolNames.includes(toolName),
+      `Deployed MCP endpoint is missing baseline tool: ${toolName}`,
+    );
+  }
+}
+
+async function validateMcpTools(endpointUrl, options = {}) {
   const client = new Client({
     name: "heyclaude-endpoint-validator",
     version: "0.1.0",
@@ -87,10 +122,49 @@ async function validateMcpTools(endpointUrl) {
 
     const tools = await client.listTools();
     const toolNames = tools.tools.map((tool) => tool.name);
-    assert(
-      JSON.stringify(toolNames) === JSON.stringify(READ_ONLY_TOOL_NAMES),
-      `Unexpected tool list: ${toolNames.join(", ")}`,
-    );
+    validateToolList(toolNames, options.strictTools);
+    const hasVersionTwoSurface = toolNames.includes("get_registry_stats");
+    if (hasVersionTwoSurface) {
+      assert(
+        tools.tools.every((tool) => tool.annotations?.readOnlyHint === true),
+        "All HeyClaude MCP tools must advertise read-only annotations.",
+      );
+      assert(
+        tools.tools.every((tool) => tool.outputSchema?.type === "object"),
+        "All HeyClaude MCP tools must expose object output schemas.",
+      );
+
+      const resources = await client.listResources();
+      assert(
+        resources.resources.some(
+          (resource) => resource.uri === "heyclaude://feeds/directory",
+        ),
+        "MCP resources did not expose the directory feed resource.",
+      );
+      const directoryResource = await client.readResource({
+        uri: "heyclaude://feeds/directory",
+      });
+      assert(
+        directoryResource.contents?.[0]?.mimeType === "application/json",
+        "Directory resource did not return JSON content.",
+      );
+
+      const prompts = await client.listPrompts();
+      assert(
+        prompts.prompts.some((prompt) => prompt.name === "find_best_asset"),
+        "MCP prompts did not expose find_best_asset.",
+      );
+      const installPrompt = await client.getPrompt({
+        name: "install_asset_safely",
+        arguments: { category: "mcp", slug: "example", platform: "Codex" },
+      });
+      assert(
+        installPrompt.messages?.[0]?.content?.text?.includes(
+          "get_install_guidance",
+        ),
+        "install_asset_safely prompt did not mention install guidance.",
+      );
+    }
 
     const search = parseToolResult(
       await client.callTool({
@@ -104,6 +178,52 @@ async function validateMcpTools(endpointUrl) {
       "search_registry did not return entries.",
     );
 
+    if (toolNames.includes("server_info")) {
+      const info = parseToolResult(
+        await client.callTool({
+          name: "server_info",
+          arguments: {},
+        }),
+      );
+      assert(info.ok === true, "server_info did not return ok.");
+      assert(
+        info.endpoint?.auth === "none",
+        "server_info did not expose the public no-key access model.",
+      );
+      assert(
+        info.endpoint?.rateLimit?.binding === "API_MCP_RATE_LIMIT",
+        "server_info did not expose the MCP rate-limit binding.",
+      );
+    }
+
+    if (toolNames.includes("list_category_entries")) {
+      const listed = parseToolResult(
+        await client.callTool({
+          name: "list_category_entries",
+          arguments: { category: "mcp", limit: 2 },
+        }),
+      );
+      assert(listed.ok === true, "list_category_entries did not return ok.");
+      assert(
+        Array.isArray(listed.entries) && listed.entries.length > 0,
+        "list_category_entries did not return entries.",
+      );
+    }
+
+    if (toolNames.includes("get_registry_stats")) {
+      const stats = parseToolResult(
+        await client.callTool({
+          name: "get_registry_stats",
+          arguments: {},
+        }),
+      );
+      assert(stats.ok === true, "get_registry_stats did not return ok.");
+      assert(
+        stats.policy?.readOnly === true,
+        "get_registry_stats did not expose the no-write policy.",
+      );
+    }
+
     const first = search.entries[0];
     const detail = parseToolResult(
       await client.callTool({
@@ -116,6 +236,20 @@ async function validateMcpTools(endpointUrl) {
       detail.key === `${first.category}:${first.slug}`,
       "get_entry_detail returned the wrong entry.",
     );
+
+    if (toolNames.includes("get_copyable_asset")) {
+      const asset = parseToolResult(
+        await client.callTool({
+          name: "get_copyable_asset",
+          arguments: { category: first.category, slug: first.slug },
+        }),
+      );
+      assert(asset.ok === true, "get_copyable_asset did not return ok.");
+      assert(
+        asset.primaryAsset || asset.assets?.length,
+        "get_copyable_asset did not return any copyable asset.",
+      );
+    }
 
     const feeds = parseToolResult(
       await client.callTool({
@@ -163,6 +297,35 @@ async function validateMcpTools(endpointUrl) {
       "build_submission_urls did not return an MCP issue URL.",
     );
 
+    if (toolNames.includes("prepare_submission_draft")) {
+      const prepared = parseToolResult(
+        await client.callTool({
+          name: "prepare_submission_draft",
+          arguments: {
+            fields: {
+              category: "mcp",
+              name: "Endpoint Validation MCP",
+              docs_url: "https://example.com/docs",
+              description:
+                "Endpoint validation draft for the HeyClaude MCP submission helpers.",
+              install_command: "npx -y endpoint-validation-mcp",
+              usage_snippet: "Use this draft to validate MCP route behavior.",
+            },
+          },
+        }),
+      );
+      assert(
+        prepared.issueDraft?.body,
+        "prepare_submission_draft did not return a canonical issue body.",
+      );
+      assert(
+        String(prepared.submissionPolicy || "").includes(
+          "does not auto-publish",
+        ),
+        "prepare_submission_draft did not expose the maintainer-reviewed policy.",
+      );
+    }
+
     const invalid = parseToolResult(
       await client.callTool({
         name: "search_registry",
@@ -182,6 +345,9 @@ async function validateMcpTools(endpointUrl) {
 const args = parseArgs(process.argv.slice(2));
 const endpointUrlRaw = args.get("url") || process.env.MCP_ENDPOINT_URL;
 const endpointUrl = endpointUrlRaw ? normalizeEndpointUrl(endpointUrlRaw) : "";
+const strictTools =
+  args.get("strict-tools") === "1" ||
+  process.env.MCP_ENDPOINT_STRICT_TOOLS === "1";
 
 if (!endpointUrl) {
   console.error(
@@ -192,7 +358,7 @@ if (!endpointUrl) {
 
 try {
   await validateHttpGuards(endpointUrl);
-  await validateMcpTools(endpointUrl);
+  await validateMcpTools(endpointUrl, { strictTools });
   console.log(`Validated HeyClaude MCP endpoint at ${endpointUrl.toString()}`);
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));

--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -14,9 +14,35 @@ export const TOOL_DEFINITIONS: Array<{
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+  outputSchema: Record<string, unknown>;
+  annotations: Record<string, unknown>;
 }>;
 
+export const MCP_PUBLIC_POLICY: Record<string, unknown>;
+export const RESOURCE_TEMPLATES: Array<Record<string, unknown>>;
+export const PROMPT_DEFINITIONS: Array<Record<string, unknown>>;
+
 export function searchRegistry(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getServerInfo(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function listCategoryEntries(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getRecentUpdates(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getRelatedEntries(
   args?: Record<string, unknown>,
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
@@ -25,6 +51,44 @@ export function getEntryDetail(
   args?: Record<string, unknown>,
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
+
+export function getCopyableAsset(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function compareEntries(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getRegistryStats(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getClientSetup(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function listRegistryResources(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<Record<string, unknown>>;
+
+export function listRegistryResourceTemplates(): Record<string, unknown>;
+
+export function readRegistryResource(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<Record<string, unknown>>;
+
+export function listRegistryPrompts(): Record<string, unknown>;
+
+export function getRegistryPrompt(
+  args?: Record<string, unknown>,
+): Record<string, unknown>;
 
 export function getCompatibility(
   args?: Record<string, unknown>,
@@ -71,6 +135,21 @@ export function getCategorySubmissionGuidance(
   options?: RegistryArtifactLoaders,
 ): Promise<RegistryToolResult>;
 
+export function prepareSubmissionDraft(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function getSubmissionExamples(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
+export function reviewSubmissionDraft(
+  args?: Record<string, unknown>,
+  options?: RegistryArtifactLoaders,
+): Promise<RegistryToolResult>;
+
 export function callRegistryTool(
   name: string,
   args?: Record<string, unknown>,
@@ -79,7 +158,15 @@ export function callRegistryTool(
 
 export {
   SearchRegistryInputSchema,
+  ServerInfoInputSchema,
+  ListCategoryEntriesInputSchema,
+  RecentUpdatesInputSchema,
+  RelatedEntriesInputSchema,
   EntryDetailInputSchema,
+  CopyableAssetInputSchema,
+  CompareEntriesInputSchema,
+  RegistryStatsInputSchema,
+  ClientSetupInputSchema,
   CompatibilityInputSchema,
   InstallGuidanceInputSchema,
   PlatformAdapterInputSchema,
@@ -90,8 +177,12 @@ export {
   SearchDuplicateEntriesInputSchema,
   BuildSubmissionUrlsInputSchema,
   CategorySubmissionGuidanceInputSchema,
+  PrepareSubmissionDraftInputSchema,
+  GetSubmissionExamplesInputSchema,
+  ReviewSubmissionDraftInputSchema,
   TOOL_INPUT_SCHEMAS,
   jsonSchemaForTool,
+  jsonSchemaForToolOutput,
   parseToolArguments,
   formatZodError,
 } from "./schemas.js";

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -7,15 +7,21 @@ import {
   platformFeedSlug,
   SITE_URL,
 } from "./platforms.js";
+import { DEFAULT_REMOTE_MCP_URL } from "./endpoint-url.js";
+import { packageName, packageVersion } from "./package-metadata.js";
 import {
   formatZodError,
   jsonSchemaForTool,
+  jsonSchemaForToolOutput,
   parseToolArguments,
 } from "./schemas.js";
 import {
   buildSubmissionUrlsFromSpec,
+  getSubmissionExamplesFromSpec,
   getCategorySubmissionGuidanceFromSpec,
+  prepareSubmissionDraftFromSpec,
   getSubmissionSchemaFromSpec,
+  reviewSubmissionDraftFromSpec,
   searchDuplicateEntries,
   validateSubmissionDraftFromSpec,
 } from "./submissions.js";
@@ -26,6 +32,17 @@ const repoRoot = path.resolve(
 );
 const defaultDataDir = path.join(repoRoot, "apps", "web", "public", "data");
 const safePathPartPattern = /^[a-z0-9-]+$/;
+const jsonMimeType = "application/json";
+
+export const MCP_PUBLIC_POLICY = {
+  apiKeyRequired: false,
+  readOnly: true,
+  createsIssues: false,
+  createsPullRequests: false,
+  publishesContent: false,
+  writesLocalFiles: false,
+  note: "HeyClaude MCP tools only read public registry artifacts or prepare maintainer-reviewed submission drafts.",
+};
 
 const platformAliases = new Map([
   ["claude", "Claude"],
@@ -43,7 +60,15 @@ const platformAliases = new Map([
 
 export const READ_ONLY_TOOL_NAMES = [
   "search_registry",
+  "server_info",
+  "list_category_entries",
+  "get_recent_updates",
+  "get_related_entries",
   "get_entry_detail",
+  "get_copyable_asset",
+  "compare_entries",
+  "get_registry_stats",
+  "get_client_setup",
   "get_compatibility",
   "get_install_guidance",
   "get_platform_adapter",
@@ -53,6 +78,9 @@ export const READ_ONLY_TOOL_NAMES = [
   "search_duplicate_entries",
   "build_submission_urls",
   "get_category_submission_guidance",
+  "prepare_submission_draft",
+  "get_submission_examples",
+  "review_submission_draft",
 ];
 
 export const TOOL_DEFINITIONS = [
@@ -61,12 +89,67 @@ export const TOOL_DEFINITIONS = [
     description:
       "Search read-only HeyClaude registry entries by query, category, and skill platform compatibility.",
     inputSchema: jsonSchemaForTool("search_registry"),
+    outputSchema: jsonSchemaForToolOutput("search_registry"),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "server_info",
+    description:
+      "Fetch read-only HeyClaude MCP package, registry, tool, and public rate-limit metadata.",
+    inputSchema: jsonSchemaForTool("server_info"),
+  },
+  {
+    name: "list_category_entries",
+    description:
+      "List read-only HeyClaude entries with bounded pagination and optional category, platform, tag, and query filters.",
+    inputSchema: jsonSchemaForTool("list_category_entries"),
+  },
+  {
+    name: "get_recent_updates",
+    description:
+      "List recently added or upstream-updated HeyClaude entries from generated registry metadata.",
+    inputSchema: jsonSchemaForTool("get_recent_updates"),
+  },
+  {
+    name: "get_related_entries",
+    description:
+      "Fetch read-only related HeyClaude entries based on category, tags, platforms, keywords, and source metadata.",
+    inputSchema: jsonSchemaForTool("get_related_entries"),
   },
   {
     name: "get_entry_detail",
     description:
       "Fetch a read-only HeyClaude registry entry detail payload by category and slug.",
     inputSchema: jsonSchemaForTool("get_entry_detail"),
+  },
+  {
+    name: "get_copyable_asset",
+    description:
+      "Fetch the category-aware copy/install asset for a HeyClaude entry without writing local files.",
+    inputSchema: jsonSchemaForTool("get_copyable_asset"),
+  },
+  {
+    name: "compare_entries",
+    description:
+      "Compare 2-5 read-only HeyClaude entries by fit, category, platforms, source metadata, and install complexity.",
+    inputSchema: jsonSchemaForTool("compare_entries"),
+  },
+  {
+    name: "get_registry_stats",
+    description:
+      "Fetch aggregate read-only registry stats, freshness, category counts, and real source-signal coverage.",
+    inputSchema: jsonSchemaForTool("get_registry_stats"),
+  },
+  {
+    name: "get_client_setup",
+    description:
+      "Fetch read-only MCP client setup snippets for Codex, Claude Desktop, Cursor, Windsurf, or remote HTTP clients.",
+    inputSchema: jsonSchemaForTool("get_client_setup"),
   },
   {
     name: "get_compatibility",
@@ -122,7 +205,35 @@ export const TOOL_DEFINITIONS = [
       "Fetch category-specific HeyClaude contribution guidance, required fields, and review expectations.",
     inputSchema: jsonSchemaForTool("get_category_submission_guidance"),
   },
+  {
+    name: "prepare_submission_draft",
+    description:
+      "Build a read-only maintainer-reviewed HeyClaude submission draft with canonical issue text and URLs.",
+    inputSchema: jsonSchemaForTool("prepare_submission_draft"),
+  },
+  {
+    name: "get_submission_examples",
+    description:
+      "Fetch read-only category examples and templates for faster, more accurate HeyClaude submissions.",
+    inputSchema: jsonSchemaForTool("get_submission_examples"),
+  },
+  {
+    name: "review_submission_draft",
+    description:
+      "Review a HeyClaude submission draft locally for schema errors, duplicate risk, and maintainer checklist items without writing to GitHub.",
+    inputSchema: jsonSchemaForTool("review_submission_draft"),
+  },
 ];
+
+for (const tool of TOOL_DEFINITIONS) {
+  tool.outputSchema ||= jsonSchemaForToolOutput(tool.name);
+  tool.annotations ||= {
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  };
+}
 
 function dataDirFromOptions(options = {}) {
   return options.dataDir || process.env.HEYCLAUDE_DATA_DIR || defaultDataDir;
@@ -180,6 +291,12 @@ function normalizeLimit(value, fallback = 10) {
   return Math.max(1, Math.min(25, Math.trunc(numeric)));
 }
 
+function normalizeOffset(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.min(5000, Math.trunc(numeric)));
+}
+
 function normalizePlatform(value) {
   const normalized = normalizeText(value).replace(/[^a-z0-9]+/g, "-");
   if (!normalized) return "";
@@ -211,6 +328,13 @@ function entryMatchesPlatform(entry, platform) {
   return (entry.platforms || []).some((candidate) => candidate === platform);
 }
 
+function entryMatchesTag(entry, tag) {
+  if (!tag) return true;
+  return (entry.tags || []).some(
+    (candidate) => normalizeText(candidate) === tag,
+  );
+}
+
 function toSearchResult(entry) {
   return {
     key: `${entry.category}:${entry.slug}`,
@@ -230,6 +354,170 @@ function toSearchResult(entry) {
       entry.url ||
       `${SITE_URL}/${entry.category}/${entry.slug}`,
   };
+}
+
+function toEntrySummary(entry) {
+  return {
+    ...toSearchResult(entry),
+    dateAdded: entry.dateAdded || "",
+    repoUpdatedAt: entry.repoUpdatedAt || null,
+    verificationStatus: entry.verificationStatus || "",
+    installable: Boolean(entry.installable),
+    supportLevels: entry.supportLevels || [],
+  };
+}
+
+function entryUpdatedAt(entry) {
+  return String(
+    entry.repoUpdatedAt || entry.updatedAt || entry.dateAdded || "",
+  );
+}
+
+function sourceHost(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  try {
+    return new URL(text).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function entrySourceHosts(entry) {
+  return [
+    entry.documentationUrl,
+    entry.repoUrl,
+    entry.url,
+    entry.canonicalUrl,
+    entry.llmsUrl,
+    entry.apiUrl,
+  ]
+    .map(sourceHost)
+    .filter(Boolean);
+}
+
+function intersection(left = [], right = [], normalize = normalizeText) {
+  const rightValues = new Set((right || []).map(normalize).filter(Boolean));
+  return (left || [])
+    .map(normalize)
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .filter((value) => rightValues.has(value));
+}
+
+function unique(values = []) {
+  return values.filter(
+    (value, index, list) => value && list.indexOf(value) === index,
+  );
+}
+
+function normalizeDateFloor(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const timestamp = Date.parse(text);
+  if (!Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toISOString().slice(0, 10);
+}
+
+function withPublicPolicy(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  if (result.policy) return result;
+  return { ...result, policy: MCP_PUBLIC_POLICY };
+}
+
+function sourceSummary(entry) {
+  return {
+    repoUrl: entry.repoUrl || entry.githubUrl || "",
+    documentationUrl: entry.documentationUrl || "",
+    downloadUrl: entry.downloadUrl || "",
+    sourceHosts: unique(entrySourceHosts(entry)),
+    githubStars:
+      typeof entry.githubStars === "number" ? entry.githubStars : null,
+    githubForks:
+      typeof entry.githubForks === "number" ? entry.githubForks : null,
+    repoUpdatedAt: entry.repoUpdatedAt || null,
+    downloadTrust: entry.downloadTrust || null,
+  };
+}
+
+function contentAsset(type, label, content, format = "markdown") {
+  const text =
+    content && typeof content === "object"
+      ? JSON.stringify(content, null, 2)
+      : String(content || "").trim();
+  if (!text) return null;
+  return {
+    type,
+    label,
+    format,
+    content: text,
+    length: text.length,
+  };
+}
+
+function categoryPrimaryAsset(entry) {
+  const assets = [
+    contentAsset(
+      "full_content",
+      "Full usable entry content",
+      entry.fullCopyableContent || entry.copySnippet || entry.body,
+    ),
+    contentAsset(
+      "install_command",
+      "Install command",
+      entry.installCommand,
+      "shell",
+    ),
+    contentAsset(
+      "config_snippet",
+      "Configuration snippet",
+      entry.configSnippet,
+      "text",
+    ),
+    contentAsset("script", "Script body", entry.scriptBody, "text"),
+    contentAsset(
+      "command_syntax",
+      "Command syntax",
+      entry.commandSyntax,
+      "text",
+    ),
+    contentAsset("usage", "Usage snippet", entry.usageSnippet, "markdown"),
+    contentAsset("items", "Collection items", entry.items, "json"),
+  ].filter(Boolean);
+
+  const preferredByCategory = {
+    agents: ["full_content", "usage"],
+    rules: ["full_content", "script", "usage"],
+    hooks: ["config_snippet", "script", "install_command", "usage"],
+    mcp: ["config_snippet", "install_command", "usage"],
+    skills: ["install_command", "full_content", "usage"],
+    statuslines: ["config_snippet", "script", "full_content", "usage"],
+    commands: ["command_syntax", "install_command", "full_content", "usage"],
+    collections: ["items", "full_content", "usage"],
+    guides: ["full_content", "usage"],
+  };
+  const preferred = preferredByCategory[entry.category] || ["full_content"];
+  return (
+    preferred
+      .map((type) => assets.find((asset) => asset.type === type))
+      .find(Boolean) ||
+    assets[0] ||
+    null
+  );
+}
+
+function entryInstallComplexity(entry) {
+  const pieces = [
+    entry.installCommand,
+    entry.configSnippet,
+    entry.downloadUrl,
+    entry.prerequisites,
+  ].filter((value) => String(value || "").trim());
+  if (pieces.length >= 3) return "higher";
+  if (pieces.length === 2) return "medium";
+  if (pieces.length === 1) return "low";
+  return "unknown";
 }
 
 async function readEntry(category, slug, options = {}) {
@@ -285,6 +573,190 @@ export async function searchRegistry(args = {}, options = {}) {
   };
 }
 
+export async function getServerInfo(args = {}, options = {}) {
+  const manifest = await readJsonArtifact("registry-manifest.json", options);
+  return {
+    ok: true,
+    package: {
+      name: packageName,
+      version: packageVersion,
+    },
+    endpoint: {
+      url: DEFAULT_REMOTE_MCP_URL,
+      auth: "none",
+      transport: "streamable-http",
+      stdioBridge: "npx -y @heyclaude/mcp",
+      requestBodyLimitBytes: 64 * 1024,
+      rateLimit: {
+        scope: "mcp-streamable",
+        limit: 60,
+        windowSeconds: 60,
+        binding: "API_MCP_RATE_LIMIT",
+        note: "Cloudflare enforces the durable production limit when the binding is available; local/dev falls back to an in-process limiter.",
+      },
+    },
+    registry: {
+      schemaVersion: manifest.schemaVersion,
+      generatedAt: manifest.generatedAt,
+      totalEntries: manifest.totalEntries,
+      categories: manifest.categories || {},
+    },
+    tools: READ_ONLY_TOOL_NAMES,
+    policy: MCP_PUBLIC_POLICY,
+  };
+}
+
+export async function listCategoryEntries(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const platform = normalizePlatform(args.platform);
+  const tag = normalizeText(args.tag);
+  const query = normalizeText(args.query);
+  const offset = normalizeOffset(args.offset);
+  const limit = normalizeLimit(args.limit, 20);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+
+  const entries = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .filter((entry) => entryMatchesPlatform(entry, platform))
+    .filter((entry) => entryMatchesTag(entry, tag))
+    .filter((entry) => entryMatchesQuery(entry, query));
+  const page = entries.slice(offset, offset + limit).map(toEntrySummary);
+
+  return {
+    ok: true,
+    category: category || "",
+    platform: platform || "",
+    tag: tag || "",
+    query: args.query || "",
+    total: entries.length,
+    count: page.length,
+    offset,
+    limit,
+    nextOffset: offset + limit < entries.length ? offset + limit : null,
+    entries: page,
+  };
+}
+
+export async function getRecentUpdates(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const since = args.since ? normalizeDateFloor(args.since) : "";
+  if (args.since && !since) {
+    return invalid("since must be a parseable date such as 2026-05-01.");
+  }
+  const limit = normalizeLimit(args.limit, 10);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const entries = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .filter((entry) => !since || entryUpdatedAt(entry) >= since)
+    .slice()
+    .sort((left, right) => {
+      const dateCompare = entryUpdatedAt(right).localeCompare(
+        entryUpdatedAt(left),
+      );
+      if (dateCompare !== 0) return dateCompare;
+      return String(left.title || "").localeCompare(String(right.title || ""));
+    })
+    .slice(0, limit)
+    .map((entry) => ({
+      ...toEntrySummary(entry),
+      updatedAt: entryUpdatedAt(entry),
+      updateKind: entry.repoUpdatedAt ? "upstream_update" : "added",
+    }));
+
+  return {
+    ok: true,
+    category: category || "",
+    since,
+    count: entries.length,
+    entries,
+  };
+}
+
+function scoreRelatedEntry(target, candidate) {
+  if (
+    target.category === candidate.category &&
+    target.slug === candidate.slug
+  ) {
+    return null;
+  }
+
+  const sharedTags = intersection(target.tags, candidate.tags);
+  const sharedKeywords = intersection(target.keywords, candidate.keywords);
+  const sharedPlatforms = intersection(
+    target.platforms,
+    candidate.platforms,
+    (value) => String(value || ""),
+  );
+  const sharedHosts = intersection(
+    entrySourceHosts(target),
+    entrySourceHosts(candidate),
+    (value) => String(value || ""),
+  );
+  const score =
+    (target.category === candidate.category ? 4 : 0) +
+    sharedTags.length * 3 +
+    Math.min(sharedKeywords.length, 6) +
+    sharedPlatforms.length +
+    sharedHosts.length * 2;
+
+  if (score <= 0) return null;
+  return {
+    score,
+    reasons: [
+      ...(target.category === candidate.category ? ["same_category"] : []),
+      ...sharedTags.map((tag) => `tag:${tag}`),
+      ...sharedPlatforms.map((platform) => `platform:${platform}`),
+      ...sharedHosts.map((host) => `source:${host}`),
+    ],
+  };
+}
+
+export async function getRelatedEntries(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const slug = normalizeText(args.slug);
+  const limit = normalizeLimit(args.limit, 8);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const target = searchIndex.find(
+    (entry) => entry.category === category && entry.slug === slug,
+  );
+  if (!target) {
+    return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
+  }
+
+  const entries = searchIndex
+    .map((entry) => {
+      const related = scoreRelatedEntry(target, entry);
+      return related ? { entry, related } : null;
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      const scoreCompare = right.related.score - left.related.score;
+      if (scoreCompare !== 0) return scoreCompare;
+      return entryUpdatedAt(right.entry).localeCompare(
+        entryUpdatedAt(left.entry),
+      );
+    })
+    .slice(0, limit)
+    .map(({ entry, related }) => ({
+      ...toEntrySummary(entry),
+      relatedScore: related.score,
+      relatedReasons: related.reasons,
+    }));
+
+  return {
+    ok: true,
+    key: `${target.category}:${target.slug}`,
+    count: entries.length,
+    entries,
+  };
+}
+
 export async function getEntryDetail(args = {}, options = {}) {
   const category = normalizeText(args.category);
   const slug = normalizeText(args.slug);
@@ -302,6 +774,493 @@ export async function getEntryDetail(args = {}, options = {}) {
     key: `${entry.category}:${entry.slug}`,
     canonicalUrl: `${SITE_URL}/${entry.category}/${entry.slug}`,
     entry,
+  };
+}
+
+export async function getCopyableAsset(args = {}, options = {}) {
+  const category = normalizeText(args.category);
+  const slug = normalizeText(args.slug);
+  const platform = normalizePlatform(args.platform);
+  if (!category || !slug) {
+    return invalid("category and slug are required.");
+  }
+
+  const entry = await readEntry(category, slug, options);
+  if (!entry) {
+    return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
+  }
+
+  const primary = categoryPrimaryAsset(entry);
+  const assets = [
+    contentAsset(
+      "full_content",
+      "Full usable entry content",
+      entry.fullCopyableContent || entry.copySnippet || entry.body,
+    ),
+    contentAsset(
+      "install_command",
+      "Install command",
+      entry.installCommand,
+      "shell",
+    ),
+    contentAsset(
+      "config_snippet",
+      "Configuration snippet",
+      entry.configSnippet,
+      "text",
+    ),
+    contentAsset("script", "Script body", entry.scriptBody, "text"),
+    contentAsset(
+      "command_syntax",
+      "Command syntax",
+      entry.commandSyntax,
+      "text",
+    ),
+    contentAsset("usage", "Usage snippet", entry.usageSnippet, "markdown"),
+    contentAsset("items", "Collection items", entry.items, "json"),
+  ].filter(Boolean);
+  const compatibility = buildSkillPlatformCompatibility(entry);
+
+  return {
+    ok: true,
+    key: `${entry.category}:${entry.slug}`,
+    category: entry.category,
+    slug: entry.slug,
+    title: entry.title,
+    canonicalUrl: `${SITE_URL}/${entry.category}/${entry.slug}`,
+    platform: platform || "",
+    primaryAsset: primary,
+    assets,
+    installCommand: entry.installCommand || "",
+    configSnippet: entry.configSnippet || "",
+    usageSnippet: entry.usageSnippet || "",
+    downloadUrl: entry.downloadUrl || "",
+    platformCompatibility: compatibility,
+    source: sourceSummary(entry),
+  };
+}
+
+export async function compareEntries(args = {}, options = {}) {
+  const platform = normalizePlatform(args.platform);
+  const entries = [];
+  for (const target of args.entries || []) {
+    const category = normalizeText(target.category);
+    const slug = normalizeText(target.slug);
+    const entry = await readEntry(category, slug, options);
+    if (!entry) {
+      return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
+    }
+    entries.push(entry);
+  }
+
+  const compared = entries.map((entry) => {
+    const compatibility = buildSkillPlatformCompatibility(entry);
+    const selectedCompatibility = platform
+      ? compatibility.find((item) => item.platform === platform) || null
+      : null;
+    return {
+      key: `${entry.category}:${entry.slug}`,
+      category: entry.category,
+      slug: entry.slug,
+      title: entry.title,
+      description: entry.description,
+      canonicalUrl: `${SITE_URL}/${entry.category}/${entry.slug}`,
+      tags: entry.tags || [],
+      platforms: entry.platforms || [],
+      selectedCompatibility,
+      installComplexity: entryInstallComplexity(entry),
+      copyableAssetTypes: [
+        categoryPrimaryAsset(entry)?.type,
+        entry.configSnippet ? "config_snippet" : "",
+        entry.installCommand ? "install_command" : "",
+        entry.scriptBody ? "script" : "",
+      ].filter(Boolean),
+      source: sourceSummary(entry),
+    };
+  });
+
+  return {
+    ok: true,
+    platform: platform || "",
+    count: compared.length,
+    sharedTags: intersection(
+      compared[0]?.tags || [],
+      compared.slice(1).flatMap((entry) => entry.tags || []),
+    ),
+    entries: compared,
+    comparisonNotes: [
+      "Prefer exact category fit before source popularity.",
+      "Treat GitHub stars/forks as source signals only when present; absence is not a negative ranking.",
+      "Install complexity is derived from available install/config/download/prerequisite metadata.",
+    ],
+  };
+}
+
+export async function getRegistryStats(args = {}, options = {}) {
+  const [manifest, searchIndexPayload] = await Promise.all([
+    readJsonArtifact("registry-manifest.json", options),
+    readJsonArtifact("search-index.json", options),
+  ]);
+  const entries = unwrapEntries(searchIndexPayload);
+  const platformCounts = new Map();
+  const tagCounts = new Map();
+  for (const entry of entries) {
+    for (const platform of entry.platforms || []) {
+      platformCounts.set(platform, (platformCounts.get(platform) || 0) + 1);
+    }
+    for (const tag of entry.tags || []) {
+      tagCounts.set(tag, (tagCounts.get(tag) || 0) + 1);
+    }
+  }
+
+  return {
+    ok: true,
+    package: {
+      name: packageName,
+      version: packageVersion,
+    },
+    registry: {
+      schemaVersion: manifest.schemaVersion,
+      generatedAt: manifest.generatedAt,
+      totalEntries: manifest.totalEntries,
+      categories: manifest.categories || {},
+    },
+    freshness: {
+      entriesWithRepoUpdatedAt: entries.filter((entry) => entry.repoUpdatedAt)
+        .length,
+      entriesAddedLast30Days: entries.filter((entry) => {
+        const added = Date.parse(entry.dateAdded || "");
+        return (
+          Number.isFinite(added) &&
+          Date.now() - added <= 30 * 24 * 60 * 60 * 1000
+        );
+      }).length,
+    },
+    sourceSignals: {
+      entriesWithGithubStats: entries.filter(
+        (entry) => typeof entry.githubStars === "number",
+      ).length,
+      installableEntries: entries.filter((entry) => entry.installable).length,
+    },
+    platforms: Object.fromEntries(
+      [...platformCounts.entries()].sort((left, right) =>
+        left[0].localeCompare(right[0]),
+      ),
+    ),
+    topTags: [...tagCounts.entries()]
+      .sort(
+        (left, right) => right[1] - left[1] || left[0].localeCompare(right[0]),
+      )
+      .slice(0, 20)
+      .map(([tag, count]) => ({ tag, count })),
+  };
+}
+
+export async function getClientSetup(args = {}) {
+  const endpointUrl = args.endpointUrl || DEFAULT_REMOTE_MCP_URL;
+  const snippets = {
+    codex: {
+      label: "Codex stdio bridge",
+      config: {
+        mcpServers: {
+          heyclaude: {
+            command: "npx",
+            args: ["-y", "@heyclaude/mcp"],
+          },
+        },
+      },
+    },
+    "claude-desktop": {
+      label: "Claude Desktop stdio bridge",
+      config: {
+        mcpServers: {
+          heyclaude: {
+            command: "npx",
+            args: ["-y", "@heyclaude/mcp"],
+          },
+        },
+      },
+    },
+    cursor: {
+      label: "Cursor remote MCP",
+      config: {
+        mcpServers: {
+          heyclaude: {
+            url: endpointUrl,
+          },
+        },
+      },
+    },
+    windsurf: {
+      label: "Windsurf remote MCP",
+      config: {
+        mcpServers: {
+          heyclaude: {
+            serverUrl: endpointUrl,
+          },
+        },
+      },
+    },
+    "remote-http": {
+      label: "Streamable HTTP endpoint",
+      endpointUrl,
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+    },
+  };
+  const client = args.client || "";
+  return {
+    ok: true,
+    endpointUrl,
+    apiKeyRequired: false,
+    selectedClient: client,
+    snippets: client ? { [client]: snippets[client] } : snippets,
+    notes: [
+      "The public endpoint is read-only and does not need an API key.",
+      "Submission tools prepare maintainer-reviewed drafts; they do not open GitHub issues.",
+      "Use --url only when testing a custom preview or deployment.",
+    ],
+  };
+}
+
+export const RESOURCE_TEMPLATES = [
+  {
+    uriTemplate: "heyclaude://entry/{category}/{slug}",
+    name: "HeyClaude entry detail",
+    title: "HeyClaude entry detail",
+    description:
+      "Read a single generated HeyClaude entry detail artifact as JSON.",
+    mimeType: jsonMimeType,
+  },
+  {
+    uriTemplate: "heyclaude://category/{category}",
+    name: "HeyClaude category entries",
+    title: "HeyClaude category entries",
+    description:
+      "Read generated summary entries for one HeyClaude category as JSON.",
+    mimeType: jsonMimeType,
+  },
+];
+
+export const PROMPT_DEFINITIONS = [
+  {
+    name: "find_best_asset",
+    title: "Find the best Claude asset",
+    description:
+      "Guide a client through searching, comparing, and recommending HeyClaude entries for a use case.",
+    arguments: [
+      {
+        name: "use_case",
+        description: "The task, workflow, or problem the user wants to solve.",
+        required: true,
+      },
+      {
+        name: "category",
+        description: "Optional HeyClaude category to constrain discovery.",
+      },
+      {
+        name: "platform",
+        description:
+          "Optional client/platform such as Claude, Codex, Cursor, or Windsurf.",
+      },
+    ],
+  },
+  {
+    name: "prepare_submission",
+    title: "Prepare a HeyClaude submission",
+    description:
+      "Guide a user through drafting a maintainer-reviewed HeyClaude submission without opening an issue automatically.",
+    arguments: [
+      { name: "category", description: "Submission category.", required: true },
+      { name: "name", description: "Submission name or title." },
+      {
+        name: "source_url",
+        description: "Primary source, docs, package, or repo URL.",
+      },
+    ],
+  },
+  {
+    name: "review_submission_before_issue",
+    title: "Review submission before opening issue",
+    description:
+      "Check a draft for schema gaps, duplicate risk, source review, and maintainer checklist items.",
+    arguments: [
+      {
+        name: "draft",
+        description: "A concise description or JSON-shaped draft fields.",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "install_asset_safely",
+    title: "Install a HeyClaude asset safely",
+    description:
+      "Guide installation/use of one entry while keeping source and secret-handling checks explicit.",
+    arguments: [
+      { name: "category", description: "Entry category.", required: true },
+      { name: "slug", description: "Entry slug.", required: true },
+      { name: "platform", description: "Optional target client/platform." },
+    ],
+  },
+];
+
+export async function listRegistryResources(args = {}, options = {}) {
+  const manifest = await readJsonArtifact("registry-manifest.json", options);
+  const categories = Object.keys(manifest.categories || {}).sort();
+  return {
+    resources: [
+      {
+        uri: "heyclaude://feeds/directory",
+        name: "HeyClaude directory index",
+        title: "HeyClaude directory index",
+        description: "Generated public directory index artifact.",
+        mimeType: jsonMimeType,
+      },
+      ...categories.map((category) => ({
+        uri: `heyclaude://category/${category}`,
+        name: `HeyClaude ${category} category`,
+        title: `HeyClaude ${category}`,
+        description: `Generated public ${category} category summary entries.`,
+        mimeType: jsonMimeType,
+      })),
+    ],
+  };
+}
+
+export function listRegistryResourceTemplates() {
+  return {
+    resourceTemplates: RESOURCE_TEMPLATES,
+  };
+}
+
+export async function readRegistryResource(args = {}, options = {}) {
+  const uri = String(args.uri || "");
+  const resourcePayload = (payload) => ({
+    contents: [
+      {
+        uri: uri || "heyclaude://error",
+        mimeType: jsonMimeType,
+        text: JSON.stringify(withPublicPolicy(payload), null, 2),
+      },
+    ],
+  });
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return resourcePayload(
+      notFound(`Unsupported HeyClaude resource URI: ${uri}`),
+    );
+  }
+  if (parsed.protocol !== "heyclaude:") {
+    return resourcePayload(
+      notFound(`Unsupported HeyClaude resource URI: ${uri}`),
+    );
+  }
+
+  const parts = parsed.pathname.split("/").filter(Boolean);
+  let payload;
+  if (parsed.hostname === "feeds" && parts[0] === "directory") {
+    payload = await readJsonArtifact("directory-index.json", options);
+  } else if (parsed.hostname === "category" && parts.length === 1) {
+    const category = normalizeText(parts[0]);
+    if (!isSafePathPart(category)) {
+      return resourcePayload(
+        invalid("Category resource path is not slug-safe."),
+      );
+    }
+    const entries = unwrapEntries(
+      await readJsonArtifact("search-index.json", options),
+    )
+      .filter((entry) => entry.category === category)
+      .map(toEntrySummary);
+    payload = {
+      ok: true,
+      category,
+      total: entries.length,
+      entries,
+    };
+  } else if (parsed.hostname === "entry" && parts.length === 2) {
+    const [category, slug] = parts.map(normalizeText);
+    const detail = await getEntryDetail({ category, slug }, options);
+    payload = detail;
+  } else {
+    return resourcePayload(
+      notFound(`Unsupported HeyClaude resource URI: ${uri}`),
+    );
+  }
+
+  return resourcePayload(payload);
+}
+
+function promptArgument(args, name) {
+  return String(args?.[name] || "").trim();
+}
+
+export function listRegistryPrompts() {
+  return {
+    prompts: PROMPT_DEFINITIONS,
+  };
+}
+
+export function getRegistryPrompt(args = {}) {
+  const name = String(args.name || "");
+  const prompt = PROMPT_DEFINITIONS.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!prompt) {
+    return {
+      description: "Unknown HeyClaude MCP prompt.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Unknown HeyClaude MCP prompt: ${name}`,
+          },
+        },
+      ],
+    };
+  }
+  const values = args.arguments || {};
+  const useCase = promptArgument(values, "use_case");
+  const category = promptArgument(values, "category");
+  const platform = promptArgument(values, "platform");
+  const slug = promptArgument(values, "slug");
+  const sourceUrl = promptArgument(values, "source_url");
+  const draft = promptArgument(values, "draft");
+
+  const promptTextByName = {
+    find_best_asset: `Find the best HeyClaude asset for this use case: ${useCase || "(not provided)"}.
+
+Use the read-only HeyClaude MCP tools. Start with search_registry or list_category_entries${category ? ` in category ${category}` : ""}${platform ? ` for platform ${platform}` : ""}. Compare credible candidates with compare_entries, inspect details with get_entry_detail, and cite exact category/slug pairs. Do not invent popularity metrics when source stats are absent.`,
+    prepare_submission: `Prepare a HeyClaude submission draft${category ? ` for category ${category}` : ""}${promptArgument(values, "name") ? ` named ${promptArgument(values, "name")}` : ""}${sourceUrl ? ` from ${sourceUrl}` : ""}.
+
+Use get_submission_schema, get_submission_examples, prepare_submission_draft, review_submission_draft, and search_duplicate_entries. Return missing fields and the canonical issue draft URL/body. Do not create a GitHub issue or publish content.`,
+    review_submission_before_issue: `Review this HeyClaude submission draft before an issue is opened:
+
+${draft || "(draft not provided)"}
+
+Use review_submission_draft and search_duplicate_entries where structured fields are available. Treat schema-valid as not publish-valid, call out source-review needs, and keep the result maintainer-reviewed.`,
+    install_asset_safely: `Help install or use the HeyClaude entry ${category || "(category)"}/${slug || "(slug)"}${platform ? ` for ${platform}` : ""}.
+
+Use get_install_guidance and get_copyable_asset. Include source links, config/install text exactly as returned, and secret-handling cautions where relevant. Do not write local files or claim the install was completed.`,
+  };
+
+  return {
+    description: prompt.description,
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: promptTextByName[name],
+        },
+      },
+    ],
   };
 }
 
@@ -450,6 +1409,25 @@ export async function getCategorySubmissionGuidance(args = {}, options = {}) {
   );
 }
 
+export async function prepareSubmissionDraft(args = {}, options = {}) {
+  return prepareSubmissionDraftFromSpec(
+    await readSubmissionSpec(options),
+    args,
+  );
+}
+
+export async function getSubmissionExamples(args = {}, options = {}) {
+  return getSubmissionExamplesFromSpec(await readSubmissionSpec(options), args);
+}
+
+export async function reviewSubmissionDraft(args = {}, options = {}) {
+  const [spec, searchIndex] = await Promise.all([
+    readSubmissionSpec(options),
+    readJsonArtifact("search-index.json", options),
+  ]);
+  return reviewSubmissionDraftFromSpec(spec, args, unwrapEntries(searchIndex));
+}
+
 export async function callRegistryTool(name, args = {}, options = {}) {
   if (!READ_ONLY_TOOL_NAMES.includes(name)) {
     return invalid(`Unknown read-only HeyClaude MCP tool: ${name}`);
@@ -469,28 +1447,75 @@ export async function callRegistryTool(name, args = {}, options = {}) {
     throw error;
   }
 
+  let result;
   switch (name) {
     case "search_registry":
-      return searchRegistry(parsedArgs, options);
+      result = await searchRegistry(parsedArgs, options);
+      break;
+    case "server_info":
+      result = await getServerInfo(parsedArgs, options);
+      break;
+    case "list_category_entries":
+      result = await listCategoryEntries(parsedArgs, options);
+      break;
+    case "get_recent_updates":
+      result = await getRecentUpdates(parsedArgs, options);
+      break;
+    case "get_related_entries":
+      result = await getRelatedEntries(parsedArgs, options);
+      break;
     case "get_entry_detail":
-      return getEntryDetail(parsedArgs, options);
+      result = await getEntryDetail(parsedArgs, options);
+      break;
+    case "get_copyable_asset":
+      result = await getCopyableAsset(parsedArgs, options);
+      break;
+    case "compare_entries":
+      result = await compareEntries(parsedArgs, options);
+      break;
+    case "get_registry_stats":
+      result = await getRegistryStats(parsedArgs, options);
+      break;
+    case "get_client_setup":
+      result = await getClientSetup(parsedArgs, options);
+      break;
     case "get_compatibility":
-      return getCompatibility(parsedArgs, options);
+      result = await getCompatibility(parsedArgs, options);
+      break;
     case "get_install_guidance":
-      return getInstallGuidance(parsedArgs, options);
+      result = await getInstallGuidance(parsedArgs, options);
+      break;
     case "get_platform_adapter":
-      return getPlatformAdapter(parsedArgs, options);
+      result = await getPlatformAdapter(parsedArgs, options);
+      break;
     case "list_distribution_feeds":
-      return listDistributionFeeds(parsedArgs, options);
+      result = await listDistributionFeeds(parsedArgs, options);
+      break;
     case "get_submission_schema":
-      return getSubmissionSchema(parsedArgs, options);
+      result = await getSubmissionSchema(parsedArgs, options);
+      break;
     case "validate_submission_draft":
-      return validateSubmissionDraft(parsedArgs, options);
+      result = await validateSubmissionDraft(parsedArgs, options);
+      break;
     case "search_duplicate_entries":
-      return searchDuplicateRegistryEntries(parsedArgs, options);
+      result = await searchDuplicateRegistryEntries(parsedArgs, options);
+      break;
     case "build_submission_urls":
-      return buildSubmissionUrls(parsedArgs, options);
+      result = await buildSubmissionUrls(parsedArgs, options);
+      break;
     case "get_category_submission_guidance":
-      return getCategorySubmissionGuidance(parsedArgs, options);
+      result = await getCategorySubmissionGuidance(parsedArgs, options);
+      break;
+    case "prepare_submission_draft":
+      result = await prepareSubmissionDraft(parsedArgs, options);
+      break;
+    case "get_submission_examples":
+      result = await getSubmissionExamples(parsedArgs, options);
+      break;
+    case "review_submission_draft":
+      result = await reviewSubmissionDraft(parsedArgs, options);
+      break;
   }
+
+  return withPublicPolicy(result);
 }

--- a/packages/mcp/src/remote-proxy.d.ts
+++ b/packages/mcp/src/remote-proxy.d.ts
@@ -14,6 +14,26 @@ export function createRemoteMcpProxyServer(
   timeoutMs: number;
 }>;
 
+export function createRemoteMcpProxyServerFromClient(
+  client: {
+    getServerCapabilities: () => Record<string, unknown> | undefined;
+    listTools: (...args: unknown[]) => Promise<{ tools: Array<unknown> }>;
+    callTool: (...args: unknown[]) => Promise<unknown>;
+    listResources?: (...args: unknown[]) => Promise<unknown>;
+    listResourceTemplates?: (...args: unknown[]) => Promise<unknown>;
+    readResource?: (...args: unknown[]) => Promise<unknown>;
+    listPrompts?: (...args: unknown[]) => Promise<unknown>;
+    getPrompt?: (...args: unknown[]) => Promise<unknown>;
+    close?: () => Promise<void>;
+  },
+  options?: RemoteProxyOptions,
+): Promise<{
+  server: Server;
+  client: unknown;
+  endpointUrl: URL;
+  timeoutMs: number;
+}>;
+
 export function runRemoteStdioProxy(
   options?: RemoteProxyOptions,
 ): Promise<void>;

--- a/packages/mcp/src/remote-proxy.js
+++ b/packages/mcp/src/remote-proxy.js
@@ -4,12 +4,17 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  GetPromptRequestSchema,
   ListToolsRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
+  ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { normalizeEndpointUrl, normalizeTimeoutMs } from "./endpoint-url.js";
 import { packageVersion } from "./package-metadata.js";
-import { READ_ONLY_TOOL_NAMES, TOOL_DEFINITIONS } from "./registry.js";
+import { MCP_PUBLIC_POLICY, READ_ONLY_TOOL_NAMES } from "./registry.js";
 
 function toError(error) {
   if (error instanceof Error) return error;
@@ -49,47 +54,189 @@ function createTimeoutFetch(timeoutMs) {
 }
 
 function invalidToolResult(name) {
+  const structuredContent = {
+    ok: false,
+    error: {
+      code: "invalid_request",
+      message: `Unknown or unsupported HeyClaude MCP tool: ${name}`,
+    },
+    policy: MCP_PUBLIC_POLICY,
+  };
   return {
     isError: true,
+    structuredContent,
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            ok: false,
-            error: {
-              code: "invalid_request",
-              message: `Unknown or unsupported HeyClaude MCP tool: ${name}`,
-            },
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify(structuredContent, null, 2),
       },
     ],
   };
 }
 
 function errorToolResult(error) {
+  const structuredContent = {
+    ok: false,
+    error: {
+      code: "remote_mcp_error",
+      message: safeErrorMessage(error),
+    },
+    policy: MCP_PUBLIC_POLICY,
+  };
   return {
     isError: true,
+    structuredContent,
     content: [
       {
         type: "text",
-        text: JSON.stringify(
-          {
-            ok: false,
-            error: {
-              code: "remote_mcp_error",
-              message: safeErrorMessage(error),
-            },
-          },
-          null,
-          2,
-        ),
+        text: JSON.stringify(structuredContent, null, 2),
       },
     ],
   };
+}
+
+function readOnlyToolDefinition(tool) {
+  if (!READ_ONLY_TOOL_NAMES.includes(tool?.name)) return null;
+  return {
+    ...tool,
+    annotations: {
+      ...(tool.annotations || {}),
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  };
+}
+
+function parseTextToolPayload(result) {
+  const text = result?.content?.find((item) => item.type === "text")?.text;
+  if (!text) return null;
+  try {
+    const parsed = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function withPolicy(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  if (payload.policy) return payload;
+  return { ...payload, policy: MCP_PUBLIC_POLICY };
+}
+
+function normalizeForwardedToolResult(result) {
+  if (!result || typeof result !== "object") return result;
+  if (result.structuredContent) {
+    return {
+      ...result,
+      structuredContent: withPolicy(result.structuredContent),
+    };
+  }
+
+  const parsed = parseTextToolPayload(result);
+  if (parsed) {
+    return {
+      ...result,
+      structuredContent: withPolicy(parsed),
+    };
+  }
+
+  return {
+    ...result,
+    structuredContent: {
+      ok: result.isError !== true,
+      policy: MCP_PUBLIC_POLICY,
+    },
+  };
+}
+
+export async function createRemoteMcpProxyServerFromClient(
+  client,
+  options = {},
+) {
+  const endpointUrl = normalizeEndpointUrl(options.url);
+  const timeoutMs = normalizeTimeoutMs(options.timeoutMs);
+  const remoteCapabilities = client.getServerCapabilities() || {};
+  const remoteTools = await client.listTools(undefined, { timeout: timeoutMs });
+  const toolDefinitions = remoteTools.tools
+    .map(readOnlyToolDefinition)
+    .filter(Boolean);
+  const supportedToolNames = new Set(toolDefinitions.map((tool) => tool.name));
+  const capabilities = {
+    tools: {},
+    ...(remoteCapabilities.resources ? { resources: {} } : {}),
+    ...(remoteCapabilities.prompts ? { prompts: {} } : {}),
+  };
+
+  const server = new Server(
+    {
+      name: "heyclaude-registry",
+      version: packageVersion,
+    },
+    { capabilities },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: toolDefinitions,
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const name = request.params.name;
+    if (!supportedToolNames.has(name)) {
+      return invalidToolResult(name);
+    }
+
+    try {
+      const result = await client.callTool(
+        {
+          name,
+          arguments: request.params.arguments || {},
+        },
+        undefined,
+        { timeout: timeoutMs },
+      );
+      return normalizeForwardedToolResult(result);
+    } catch (error) {
+      return errorToolResult(error);
+    }
+  });
+
+  if (remoteCapabilities.resources) {
+    server.setRequestHandler(ListResourcesRequestSchema, async (request) =>
+      client.listResources(request.params || {}, { timeout: timeoutMs }),
+    );
+    server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      async (request) =>
+        client.listResourceTemplates(request.params || {}, {
+          timeout: timeoutMs,
+        }),
+    );
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
+      client.readResource(request.params || {}, { timeout: timeoutMs }),
+    );
+  }
+
+  if (remoteCapabilities.prompts) {
+    server.setRequestHandler(ListPromptsRequestSchema, async (request) =>
+      client.listPrompts(request.params || {}, { timeout: timeoutMs }),
+    );
+    server.setRequestHandler(GetPromptRequestSchema, async (request) =>
+      client.getPrompt(request.params || {}, { timeout: timeoutMs }),
+    );
+  }
+
+  server.onclose = () => {
+    client.close().catch(() => {});
+  };
+
+  return { server, client, endpointUrl, timeoutMs };
 }
 
 export async function createRemoteMcpProxyServer(options = {}) {
@@ -104,48 +251,10 @@ export async function createRemoteMcpProxyServer(options = {}) {
   });
 
   await client.connect(remoteTransport, { timeout: timeoutMs });
-
-  const server = new Server(
-    {
-      name: "heyclaude-registry",
-      version: packageVersion,
-    },
-    {
-      capabilities: {
-        tools: {},
-      },
-    },
-  );
-
-  server.setRequestHandler(ListToolsRequestSchema, async () => ({
-    tools: TOOL_DEFINITIONS,
-  }));
-
-  server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const name = request.params.name;
-    if (!READ_ONLY_TOOL_NAMES.includes(name)) {
-      return invalidToolResult(name);
-    }
-
-    try {
-      return await client.callTool(
-        {
-          name,
-          arguments: request.params.arguments || {},
-        },
-        undefined,
-        { timeout: timeoutMs },
-      );
-    } catch (error) {
-      return errorToolResult(error);
-    }
+  return createRemoteMcpProxyServerFromClient(client, {
+    url: endpointUrl,
+    timeoutMs,
   });
-
-  server.onclose = () => {
-    client.close().catch(() => {});
-  };
-
-  return { server, client, endpointUrl, timeoutMs };
 }
 
 export async function runRemoteStdioProxy(options = {}) {

--- a/packages/mcp/src/schemas.d.ts
+++ b/packages/mcp/src/schemas.d.ts
@@ -1,7 +1,15 @@
 import type { z } from "zod";
 
 export const SearchRegistryInputSchema: z.ZodType;
+export const ServerInfoInputSchema: z.ZodType;
+export const ListCategoryEntriesInputSchema: z.ZodType;
+export const RecentUpdatesInputSchema: z.ZodType;
+export const RelatedEntriesInputSchema: z.ZodType;
 export const EntryDetailInputSchema: z.ZodType;
+export const CopyableAssetInputSchema: z.ZodType;
+export const CompareEntriesInputSchema: z.ZodType;
+export const RegistryStatsInputSchema: z.ZodType;
+export const ClientSetupInputSchema: z.ZodType;
 export const CompatibilityInputSchema: z.ZodType;
 export const InstallGuidanceInputSchema: z.ZodType;
 export const PlatformAdapterInputSchema: z.ZodType;
@@ -12,9 +20,13 @@ export const ValidateSubmissionDraftInputSchema: z.ZodType;
 export const SearchDuplicateEntriesInputSchema: z.ZodType;
 export const BuildSubmissionUrlsInputSchema: z.ZodType;
 export const CategorySubmissionGuidanceInputSchema: z.ZodType;
+export const PrepareSubmissionDraftInputSchema: z.ZodType;
+export const GetSubmissionExamplesInputSchema: z.ZodType;
+export const ReviewSubmissionDraftInputSchema: z.ZodType;
 export const TOOL_INPUT_SCHEMAS: Record<string, z.ZodType>;
 
 export function jsonSchemaForTool(name: string): Record<string, unknown>;
+export function jsonSchemaForToolOutput(name: string): Record<string, unknown>;
 export function parseToolArguments(
   name: string,
   args?: Record<string, unknown>,

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -8,6 +8,13 @@ const pathPart = z
   .regex(/^[a-z0-9-]+$/, "Use lowercase slug-safe path parts only.");
 
 const platform = z.string().trim().min(1).max(80);
+const clientName = z.enum([
+  "codex",
+  "claude-desktop",
+  "cursor",
+  "windsurf",
+  "remote-http",
+]);
 const submissionCategory = z.enum([
   "agents",
   "rules",
@@ -77,10 +84,73 @@ export const SearchRegistryInputSchema = z
   })
   .strict();
 
+export const ServerInfoInputSchema = z.object({}).strict();
+
+export const ListCategoryEntriesInputSchema = z
+  .object({
+    category: pathPart.optional(),
+    platform: platform.optional(),
+    tag: z.string().trim().min(1).max(80).optional(),
+    query: z.string().trim().max(240).optional(),
+    offset: z.number().int().min(0).max(5000).optional(),
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
+export const RecentUpdatesInputSchema = z
+  .object({
+    category: pathPart.optional(),
+    since: z.string().trim().min(4).max(40).optional(),
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
+export const RelatedEntriesInputSchema = z
+  .object({
+    category: pathPart,
+    slug: pathPart,
+    limit: z.number().int().min(1).max(25).optional(),
+  })
+  .strict();
+
 export const EntryDetailInputSchema = z
   .object({
     category: pathPart,
     slug: pathPart,
+  })
+  .strict();
+
+export const CopyableAssetInputSchema = z
+  .object({
+    category: pathPart,
+    slug: pathPart,
+    platform: platform.optional(),
+  })
+  .strict();
+
+export const CompareEntriesInputSchema = z
+  .object({
+    entries: z
+      .array(
+        z
+          .object({
+            category: pathPart,
+            slug: pathPart,
+          })
+          .strict(),
+      )
+      .min(2)
+      .max(5),
+    platform: platform.optional(),
+  })
+  .strict();
+
+export const RegistryStatsInputSchema = z.object({}).strict();
+
+export const ClientSetupInputSchema = z
+  .object({
+    client: clientName.optional(),
+    endpointUrl: z.string().trim().url().max(500).optional(),
   })
   .strict();
 
@@ -145,9 +215,36 @@ export const CategorySubmissionGuidanceInputSchema = z
   })
   .strict();
 
+export const PrepareSubmissionDraftInputSchema = z
+  .object({
+    fields: SubmissionFieldsSchema,
+  })
+  .strict();
+
+export const GetSubmissionExamplesInputSchema = z
+  .object({
+    category: submissionCategory.optional(),
+  })
+  .strict();
+
+export const ReviewSubmissionDraftInputSchema = z
+  .object({
+    fields: SubmissionFieldsSchema,
+    duplicateLimit: z.number().int().min(1).max(10).optional(),
+  })
+  .strict();
+
 export const TOOL_INPUT_SCHEMAS = {
   search_registry: SearchRegistryInputSchema,
+  server_info: ServerInfoInputSchema,
+  list_category_entries: ListCategoryEntriesInputSchema,
+  get_recent_updates: RecentUpdatesInputSchema,
+  get_related_entries: RelatedEntriesInputSchema,
   get_entry_detail: EntryDetailInputSchema,
+  get_copyable_asset: CopyableAssetInputSchema,
+  compare_entries: CompareEntriesInputSchema,
+  get_registry_stats: RegistryStatsInputSchema,
+  get_client_setup: ClientSetupInputSchema,
   get_compatibility: CompatibilityInputSchema,
   get_install_guidance: InstallGuidanceInputSchema,
   get_platform_adapter: PlatformAdapterInputSchema,
@@ -157,6 +254,9 @@ export const TOOL_INPUT_SCHEMAS = {
   search_duplicate_entries: SearchDuplicateEntriesInputSchema,
   build_submission_urls: BuildSubmissionUrlsInputSchema,
   get_category_submission_guidance: CategorySubmissionGuidanceInputSchema,
+  prepare_submission_draft: PrepareSubmissionDraftInputSchema,
+  get_submission_examples: GetSubmissionExamplesInputSchema,
+  review_submission_draft: ReviewSubmissionDraftInputSchema,
 };
 
 function stripUnsupportedJsonSchemaFields(value) {
@@ -178,6 +278,25 @@ export function jsonSchemaForTool(name) {
     throw new Error(`Unknown HeyClaude MCP tool schema: ${name}`);
   }
   return stripUnsupportedJsonSchemaFields(z.toJSONSchema(schema));
+}
+
+export function jsonSchemaForToolOutput(name) {
+  if (!TOOL_INPUT_SCHEMAS[name]) {
+    throw new Error(`Unknown HeyClaude MCP tool output schema: ${name}`);
+  }
+
+  return {
+    type: "object",
+    properties: {
+      ok: { type: "boolean" },
+      policy: {
+        type: "object",
+        additionalProperties: true,
+      },
+    },
+    required: ["ok"],
+    additionalProperties: true,
+  };
 }
 
 export function parseToolArguments(name, args = {}) {

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -2,11 +2,24 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
+  ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
 import { packageVersion } from "./package-metadata.js";
-import { callRegistryTool, TOOL_DEFINITIONS } from "./registry.js";
+import {
+  callRegistryTool,
+  getRegistryPrompt,
+  listRegistryPrompts,
+  listRegistryResources,
+  listRegistryResourceTemplates,
+  readRegistryResource,
+  TOOL_DEFINITIONS,
+} from "./registry.js";
 
 export function createHeyClaudeMcpServer(options = {}) {
   const server = new Server(
@@ -16,6 +29,8 @@ export function createHeyClaudeMcpServer(options = {}) {
     },
     {
       capabilities: {
+        prompts: {},
+        resources: {},
         tools: {},
       },
     },
@@ -33,6 +48,10 @@ export function createHeyClaudeMcpServer(options = {}) {
     );
     return {
       isError: result.ok === false,
+      structuredContent:
+        result && typeof result === "object" && !Array.isArray(result)
+          ? result
+          : { result },
       content: [
         {
           type: "text",
@@ -41,6 +60,26 @@ export function createHeyClaudeMcpServer(options = {}) {
       ],
     };
   });
+
+  server.setRequestHandler(ListResourcesRequestSchema, async (request) =>
+    listRegistryResources(request.params || {}, options),
+  );
+
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async () =>
+    listRegistryResourceTemplates(),
+  );
+
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
+    readRegistryResource(request.params || {}, options),
+  );
+
+  server.setRequestHandler(ListPromptsRequestSchema, async () =>
+    listRegistryPrompts(),
+  );
+
+  server.setRequestHandler(GetPromptRequestSchema, async (request) =>
+    getRegistryPrompt(request.params || {}),
+  );
 
   return server;
 }

--- a/packages/mcp/src/submissions.d.ts
+++ b/packages/mcp/src/submissions.d.ts
@@ -21,6 +21,19 @@ export function validateSubmissionDraftFromSpec(
   spec: Record<string, unknown>,
   args?: Record<string, unknown>,
 ): Record<string, unknown>;
+export function prepareSubmissionDraftFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+): Record<string, unknown>;
+export function getSubmissionExamplesFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+): Record<string, unknown>;
+export function reviewSubmissionDraftFromSpec(
+  spec: Record<string, unknown>,
+  args?: Record<string, unknown>,
+  entries?: Array<Record<string, unknown>>,
+): Record<string, unknown>;
 export function searchDuplicateEntries(
   entries?: Array<Record<string, unknown>>,
   args?: Record<string, unknown>,

--- a/packages/mcp/src/submissions.js
+++ b/packages/mcp/src/submissions.js
@@ -472,6 +472,232 @@ export function validateSubmissionDraftFromSpec(spec, args = {}) {
   };
 }
 
+function singularLabel(value) {
+  const label = normalizeText(value || "Entry");
+  return label.endsWith("s") ? label.slice(0, -1) : label;
+}
+
+function exampleValueForField(fieldId, category, label) {
+  switch (fieldId) {
+    case "name":
+    case "title":
+      return `Example ${singularLabel(label)}`;
+    case "slug":
+      return `example-${category || "entry"}`;
+    case "category":
+      return category;
+    case "github_url":
+      return `https://github.com/example/example-${category || "entry"}`;
+    case "docs_url":
+    case "source_url":
+      return `https://example.com/${category || "entry"}/docs`;
+    case "download_url":
+      return `https://example.com/${category || "entry"}/download.zip`;
+    case "brand_name":
+      return "Example";
+    case "brand_domain":
+      return "example.com";
+    case "author":
+      return "@example";
+    case "contact_email":
+      return "@example";
+    case "tags":
+      return "claude, workflow, example";
+    case "description":
+      return `A practical ${singularLabel(label).toLowerCase()} for Claude users that includes source-backed setup and usage details.`;
+    case "card_description":
+      return `Practical ${singularLabel(label).toLowerCase()} for Claude workflows.`;
+    case "full_copyable_content":
+      return `# Example ${singularLabel(label)}\n\nUse this complete content as the copyable public artifact.`;
+    case "install_command":
+      return `npx -y example-${category || "entry"}`;
+    case "usage_snippet":
+      return `Use this ${singularLabel(label).toLowerCase()} to speed up a Claude workflow.`;
+    case "command_syntax":
+      return `/example-${category || "entry"} <input>`;
+    case "trigger":
+      return "PostToolUse";
+    case "guide_content":
+      return `# Example ${singularLabel(label)}\n\nExplain the setup, usage, verification, and troubleshooting steps.`;
+    case "items":
+      return `- Example ${singularLabel(label)} item\n- Source-backed companion resource`;
+    case "script_language":
+      return "bash";
+    case "skill_type":
+      return "workflow";
+    case "skill_level":
+      return "intermediate";
+    case "verification_status":
+      return "validated";
+    case "verified_at":
+      return "2026-05-17";
+    case "config_snippet":
+      return JSON.stringify({ example: true }, null, 2);
+    case "retrieval_sources":
+      return "- https://example.com/docs";
+    case "tested_platforms":
+      return "Claude Code, Codex, Cursor";
+    case "prerequisites":
+      return "- Node.js 20+\n- Claude-compatible MCP client";
+    case "troubleshooting_section":
+      return "If setup fails, verify the install command and source URL first.";
+    case "installation_order":
+      return "Install dependencies, configure the entry, then run the verification step.";
+    case "estimated_setup_time":
+      return "10 minutes";
+    case "difficulty":
+      return "intermediate";
+    default:
+      return `Example ${fieldId.replaceAll("_", " ")}`;
+  }
+}
+
+function exampleForCategory(spec, category) {
+  const model = modelFor(spec, category);
+  const fields = Object.fromEntries(
+    (model?.fields || []).map((field) => [
+      field.id,
+      exampleValueForField(field.id, category, model?.label),
+    ]),
+  );
+  fields.category = category;
+
+  const minimalFields = {};
+  for (const field of requiredFields(model)) {
+    minimalFields[field] = fields[field];
+  }
+  minimalFields.category = category;
+
+  for (const field of [
+    "name",
+    "description",
+    "github_url",
+    "docs_url",
+    "install_command",
+    "usage_snippet",
+    "download_url",
+    "guide_content",
+    "items",
+  ]) {
+    if (fields[field]) minimalFields[field] = fields[field];
+  }
+
+  return {
+    category,
+    label: model?.label || category,
+    template: model?.template || templateFor(spec, category)?.template || "",
+    requiredFields: requiredFields(model),
+    minimalFields,
+    completeFields: fields,
+    notes: [
+      "Use canonical source URLs and avoid affiliate/referral links.",
+      "The generated issue draft is a maintainer-reviewed submission, not automatic publication.",
+    ],
+  };
+}
+
+export function getSubmissionExamplesFromSpec(spec, args = {}) {
+  const category = selectedCategory(spec, args.category);
+  if (args.category && !category) {
+    return {
+      ok: false,
+      error: {
+        code: "not_found",
+        message: `No HeyClaude submission examples found for ${args.category}.`,
+      },
+    };
+  }
+
+  const categories = category ? [category] : categoryKeys(spec);
+  return {
+    ok: true,
+    categories: categories.map((key) => exampleForCategory(spec, key)),
+    reviewModel:
+      "Examples are draft helpers only; maintainers review accepted submissions before import.",
+  };
+}
+
+export function prepareSubmissionDraftFromSpec(spec, args = {}) {
+  const fields = normalizeSubmissionFields(args.fields || {});
+  const validation = validateAgainstSpec(spec, fields);
+  const issueDraft = validation.category
+    ? buildIssueDraftFromSpec(spec, validation.normalized)
+    : null;
+  const urls = buildSubmissionUrlsFromSpec(spec, {
+    fields: validation.normalized,
+    includeIssueBody: true,
+  });
+
+  return {
+    ok: true,
+    valid: validation.valid,
+    category: validation.category,
+    slug: validation.normalized.slug || "",
+    normalizedFields: validation.normalized,
+    requiredFields: validation.requiredFields || [],
+    missingRequiredFields: validation.missingRequiredFields || [],
+    errors: validation.errors,
+    warnings: validation.warnings,
+    issueDraft,
+    submitUrl: urls.submitUrl,
+    githubIssueUrl: urls.githubIssueUrl,
+    reviewChecklist: [
+      "Confirm category fit and required fields before opening the issue.",
+      "Check for existing registry entries with the same source, slug, or title.",
+      "Verify source URLs, install commands, and copied content before maintainer approval.",
+      "Disclose paid, sponsored, affiliate, or commercial content separately from free community submissions.",
+    ],
+    submissionPolicy:
+      "This tool prepares a review issue only. HeyClaude does not auto-publish MCP-submitted content.",
+  };
+}
+
+export function reviewSubmissionDraftFromSpec(spec, args = {}, entries = []) {
+  const validation = validateAgainstSpec(spec, args.fields || {});
+  const duplicateArgs = {
+    category: validation.category,
+    slug: validation.normalized.slug,
+    title: validation.normalized.title || validation.normalized.name,
+    name: validation.normalized.name,
+    sourceUrl:
+      validation.normalized.github_url ||
+      validation.normalized.docs_url ||
+      validation.normalized.source_url,
+    brandDomain: validation.normalized.brand_domain,
+    limit: args.duplicateLimit || 5,
+  };
+  const duplicates = searchDuplicateEntries(entries, duplicateArgs);
+  const recommendedAction = validation.valid
+    ? duplicates.count > 0
+      ? "review_possible_duplicate"
+      : "open_review_issue"
+    : "fix_required_fields";
+
+  return {
+    ok: true,
+    valid: validation.valid,
+    category: validation.category,
+    slug: validation.normalized.slug || "",
+    recommendedAction,
+    errors: validation.errors,
+    warnings: validation.warnings,
+    missingRequiredFields: validation.missingRequiredFields || [],
+    duplicateReview: duplicates,
+    reviewChecklist: [
+      "Schema-valid is not publish-valid; maintainer review is still required.",
+      "Check category fit against the actual artifact, not only the submitter's selected category.",
+      "Verify source availability, install commands, and any credential/payment-sensitive behavior.",
+      "Reject or request edits for affiliate/referral links, unsupported claims, or unclear paid/sponsored positioning.",
+    ],
+    nextSteps: validation.valid
+      ? [
+          "Open or update the canonical GitHub submission issue.",
+          "Apply maintainer review labels only after source and duplicate checks.",
+        ]
+      : ["Fix required fields and validation errors before opening an issue."],
+  };
+}
+
 function entrySourceUrls(entry) {
   return [
     entry.documentationUrl,

--- a/scripts/validate-mcp-package.mjs
+++ b/scripts/validate-mcp-package.mjs
@@ -64,6 +64,12 @@ async function smokeMcpServer(command, args, label) {
       toolNames.includes("search_registry"),
       `${label} smoke did not expose search_registry.`,
     );
+    if (toolNames.includes("get_registry_stats")) {
+      assert(
+        tools.tools.every((tool) => tool.annotations?.readOnlyHint === true),
+        `${label} smoke tools did not all advertise read-only annotations.`,
+      );
+    }
 
     const search = await client.callTool(
       {
@@ -77,6 +83,92 @@ async function smokeMcpServer(command, args, label) {
     assert(text, `${label} smoke did not return a text tool result.`);
     const result = JSON.parse(text);
     assert(result.ok === true, `${label} smoke search did not return ok.`);
+    if (toolNames.includes("get_registry_stats")) {
+      assert(
+        search.structuredContent?.policy?.readOnly === true,
+        `${label} smoke search did not include structured read-only policy.`,
+      );
+
+      const stats = await client.callTool(
+        { name: "get_registry_stats", arguments: {} },
+        undefined,
+        { timeout: 30000 },
+      );
+      assert(
+        stats.structuredContent?.ok === true,
+        `${label} smoke registry stats did not return structured ok.`,
+      );
+      assert(
+        stats.structuredContent?.policy?.apiKeyRequired === false,
+        `${label} smoke registry stats did not expose no-key policy.`,
+      );
+
+      const setup = await client.callTool(
+        { name: "get_client_setup", arguments: { client: "codex" } },
+        undefined,
+        { timeout: 30000 },
+      );
+      assert(
+        setup.structuredContent?.snippets?.codex?.config?.mcpServers?.heyclaude
+          ?.command === "npx",
+        `${label} smoke client setup did not return Codex npx config.`,
+      );
+
+      const resources = await client.listResources(undefined, {
+        timeout: 30000,
+      });
+      assert(
+        resources.resources.some(
+          (resource) => resource.uri === "heyclaude://feeds/directory",
+        ),
+        `${label} smoke did not expose directory resource.`,
+      );
+      const resourceTemplates = await client.listResourceTemplates(undefined, {
+        timeout: 30000,
+      });
+      assert(
+        resourceTemplates.resourceTemplates.some(
+          (resource) =>
+            resource.uriTemplate === "heyclaude://entry/{category}/{slug}",
+        ),
+        `${label} smoke did not expose entry resource template.`,
+      );
+      const directory = await client.readResource(
+        { uri: "heyclaude://feeds/directory" },
+        { timeout: 30000 },
+      );
+      assert(
+        directory.contents.some(
+          (content) =>
+            content.mimeType === "application/json" &&
+            String(content.text || "").includes('"entries"'),
+        ),
+        `${label} smoke did not read directory resource JSON.`,
+      );
+
+      const prompts = await client.listPrompts(undefined, { timeout: 30000 });
+      assert(
+        prompts.prompts.some((prompt) => prompt.name === "find_best_asset"),
+        `${label} smoke did not expose workflow prompts.`,
+      );
+      const prompt = await client.getPrompt(
+        {
+          name: "install_asset_safely",
+          arguments: {
+            category: "skills",
+            slug: "agent-evals-regression-gate",
+            platform: "Codex",
+          },
+        },
+        { timeout: 30000 },
+      );
+      assert(
+        prompt.messages.some((message) =>
+          String(message.content?.text || "").includes("get_copyable_asset"),
+        ),
+        `${label} smoke did not return install_asset_safely prompt content.`,
+      );
+    }
   } finally {
     await client.close().catch(() => {});
   }

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -248,12 +248,18 @@ describe("central API router security", () => {
     expect(wranglerConfig).toContain('"name": "API_REGISTRY_RATE_LIMIT"');
     expect(wranglerConfig).toContain('"name": "API_DYNAMIC_RATE_LIMIT"');
     expect(wranglerConfig).toContain('"name": "API_STRICT_RATE_LIMIT"');
+    expect(wranglerConfig).toContain('"name": "API_MCP_RATE_LIMIT"');
     expect(apiRouteDefinitions["submissions.create"].rateLimit?.binding).toBe(
       "API_STRICT_RATE_LIMIT",
     );
     expect(apiRouteDefinitions["registry.search"].rateLimit?.binding).toBe(
       "API_REGISTRY_RATE_LIMIT",
     );
+    expect(apiRouteDefinitions["mcp.streamable"].rateLimit).toMatchObject({
+      binding: "API_MCP_RATE_LIMIT",
+      limit: 60,
+      windowMs: 60_000,
+    });
     expect(routerSource).toContain("binding.limit({ key })");
   });
 

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -84,7 +84,15 @@ describe("HeyClaude remote MCP route", () => {
     );
     expect(toolNames).toEqual([
       "search_registry",
+      "server_info",
+      "list_category_entries",
+      "get_recent_updates",
+      "get_related_entries",
       "get_entry_detail",
+      "get_copyable_asset",
+      "compare_entries",
+      "get_registry_stats",
+      "get_client_setup",
       "get_compatibility",
       "get_install_guidance",
       "get_platform_adapter",
@@ -94,8 +102,90 @@ describe("HeyClaude remote MCP route", () => {
       "search_duplicate_entries",
       "build_submission_urls",
       "get_category_submission_guidance",
+      "prepare_submission_draft",
+      "get_submission_examples",
+      "review_submission_draft",
     ]);
-    expect(toolNames.join(" ")).not.toMatch(/create|publish|write|delete/i);
+    expect(payload.result.tools[0]).toMatchObject({
+      outputSchema: { type: "object" },
+      annotations: { readOnlyHint: true, destructiveHint: false },
+    });
+    expect(toolNames.join(" ")).not.toMatch(
+      /create_issue|create_pull_request|publish_content|write_file|delete/i,
+    );
+  });
+
+  it("exposes read-only registry resources and workflow prompts over Streamable HTTP", async () => {
+    const resourcesResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 22,
+        method: "resources/list",
+        params: {},
+      }),
+    );
+    expect(resourcesResponse.status).toBe(200);
+    const resourcesPayload = await json(resourcesResponse);
+    expect(resourcesPayload.result.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          uri: "heyclaude://feeds/directory",
+          mimeType: "application/json",
+        }),
+      ]),
+    );
+
+    const readResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 23,
+        method: "resources/read",
+        params: { uri: "heyclaude://feeds/directory" },
+      }),
+    );
+    expect(readResponse.status).toBe(200);
+    const readPayload = await json(readResponse);
+    expect(readPayload.result.contents[0]).toMatchObject({
+      uri: "heyclaude://feeds/directory",
+      mimeType: "application/json",
+    });
+
+    const promptsResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 24,
+        method: "prompts/list",
+        params: {},
+      }),
+    );
+    expect(promptsResponse.status).toBe(200);
+    const promptsPayload = await json(promptsResponse);
+    expect(promptsPayload.result.prompts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "find_best_asset" }),
+        expect.objectContaining({ name: "install_asset_safely" }),
+      ]),
+    );
+
+    const promptResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 25,
+        method: "prompts/get",
+        params: {
+          name: "install_asset_safely",
+          arguments: {
+            category: "mcp",
+            slug: "legal-fournier-spain-legal-mcp",
+          },
+        },
+      }),
+    );
+    expect(promptResponse.status).toBe(200);
+    const promptPayload = await json(promptResponse);
+    expect(promptPayload.result.messages[0].content.text).toContain(
+      "get_copyable_asset",
+    );
   });
 
   it("searches public registry artifacts without write capabilities", async () => {
@@ -113,10 +203,69 @@ describe("HeyClaude remote MCP route", () => {
     expect(response.status).toBe(200);
 
     const payload = await json(response);
+    expect(payload.result.structuredContent).toMatchObject({
+      ok: true,
+      policy: { readOnly: true },
+    });
     const result = JSON.parse(payload.result.content[0].text);
     expect(result).toMatchObject({ ok: true, count: 2 });
     expect(result.entries[0]).toHaveProperty("canonicalUrl");
     expect(JSON.stringify(result)).not.toMatch(/admin|token|secret/i);
+  });
+
+  it("serves MCP server metadata and category browse tools", async () => {
+    const infoResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 33,
+        method: "tools/call",
+        params: { name: "server_info", arguments: {} },
+      }),
+    );
+    expect(infoResponse.status).toBe(200);
+    const infoPayload = await json(infoResponse);
+    const info = JSON.parse(infoPayload.result.content[0].text);
+    expect(info).toMatchObject({
+      ok: true,
+      endpoint: {
+        auth: "none",
+        rateLimit: {
+          binding: "API_MCP_RATE_LIMIT",
+          limit: 60,
+        },
+      },
+      policy: {
+        apiKeyRequired: false,
+        createsIssues: false,
+        publishesContent: false,
+      },
+    });
+
+    const listResponse = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 34,
+        method: "tools/call",
+        params: {
+          name: "list_category_entries",
+          arguments: { category: "mcp", limit: 2 },
+        },
+      }),
+    );
+    expect(listResponse.status).toBe(200);
+    const listPayload = await json(listResponse);
+    const list = JSON.parse(listPayload.result.content[0].text);
+    expect(list).toMatchObject({
+      ok: true,
+      category: "mcp",
+      count: 2,
+      entries: [
+        expect.objectContaining({
+          canonicalUrl: expect.stringContaining("/mcp/"),
+        }),
+        expect.any(Object),
+      ],
+    });
   });
 
   it("returns schema validation errors for malformed MCP tool arguments", async () => {
@@ -202,5 +351,46 @@ describe("HeyClaude remote MCP route", () => {
       reviewModel: expect.stringContaining("Issue-first"),
     });
     expect(JSON.stringify(result)).not.toMatch(/token|secret|authorization/i);
+  });
+
+  it("prepares submission drafts without creating GitHub issues", async () => {
+    const response = await POST(
+      mcpRequest({
+        jsonrpc: "2.0",
+        id: 6,
+        method: "tools/call",
+        params: {
+          name: "prepare_submission_draft",
+          arguments: {
+            fields: {
+              category: "guides",
+              name: "Example Guide",
+              docs_url: "https://example.com/guide",
+              description:
+                "Example guide submission used to verify draft-only MCP helpers.",
+              guide_content:
+                "# Example Guide\n\nA complete public guide body for maintainer review.",
+            },
+          },
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+
+    const payload = await json(response);
+    expect(payload.result.isError).toBe(false);
+    const result = JSON.parse(payload.result.content[0].text);
+    expect(result).toMatchObject({
+      ok: true,
+      valid: true,
+      githubIssueUrl: expect.stringContaining("template=submit-guide.yml"),
+      issueDraft: {
+        body: expect.stringContaining("### Guide content"),
+      },
+      submissionPolicy: expect.stringContaining("does not auto-publish"),
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /token|secret|authorization|createIssue|createPullRequest/i,
+    );
   });
 });

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,10 +1,18 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { createRemoteMcpProxyServerFromClient } from "../packages/mcp/src/remote-proxy.js";
+import { createHeyClaudeMcpServer } from "../packages/mcp/src/server.js";
 import {
   callRegistryTool,
+  getRegistryPrompt,
+  listRegistryPrompts,
+  listRegistryResources,
+  listRegistryResourceTemplates,
   READ_ONLY_TOOL_NAMES,
+  readRegistryResource,
   TOOL_DEFINITIONS,
 } from "../packages/mcp/src/registry.js";
 import {
@@ -15,6 +23,15 @@ import {
 import { repoRoot } from "./helpers/registry-fixtures";
 
 const dataDir = path.join(repoRoot, "apps/web/public/data");
+const packageRequire = createRequire(
+  path.join(repoRoot, "packages/mcp/package.json"),
+);
+const { Client } = await import(
+  packageRequire.resolve("@modelcontextprotocol/sdk/client/index.js")
+);
+const { InMemoryTransport } = await import(
+  packageRequire.resolve("@modelcontextprotocol/sdk/inMemory.js")
+);
 
 function firstSkill() {
   const payload = JSON.parse(
@@ -30,6 +47,206 @@ function firstSkill() {
 }
 
 const skill = firstSkill();
+
+function secondSkill() {
+  const payload = JSON.parse(
+    fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
+  ) as {
+    entries: Array<{ category: string; slug: string; title: string }>;
+  };
+  const entry = payload.entries.find(
+    (candidate) =>
+      candidate.category === skill.category && candidate.slug !== skill.slug,
+  );
+  if (!entry) throw new Error("Expected at least two skill entries.");
+  return entry;
+}
+
+const otherSkill = secondSkill();
+
+const validMcpSubmissionFields = {
+  category: "mcp",
+  name: "Example Protocol MCP",
+  docs_url: "https://example.com/docs",
+  description:
+    "Example MCP server submission used to verify the protocol-level tool surface.",
+  install_command: "npx -y example-protocol-mcp",
+  usage_snippet: "Add this server to your MCP client configuration.",
+};
+
+function validToolArguments(name: string) {
+  const argsByTool: Record<string, unknown> = {
+    search_registry: { query: "mcp", limit: 1 },
+    server_info: {},
+    list_category_entries: { category: "mcp", limit: 1 },
+    get_recent_updates: { limit: 1 },
+    get_related_entries: {
+      category: skill.category,
+      slug: skill.slug,
+      limit: 1,
+    },
+    get_entry_detail: { category: skill.category, slug: skill.slug },
+    get_copyable_asset: {
+      category: skill.category,
+      slug: skill.slug,
+      platform: "claude",
+    },
+    compare_entries: {
+      entries: [
+        { category: skill.category, slug: skill.slug },
+        { category: otherSkill.category, slug: otherSkill.slug },
+      ],
+      platform: "claude",
+    },
+    get_registry_stats: {},
+    get_client_setup: { client: "codex" },
+    get_compatibility: { slug: skill.slug },
+    get_install_guidance: {
+      category: skill.category,
+      slug: skill.slug,
+      platform: "claude",
+    },
+    get_platform_adapter: { slug: skill.slug, platform: "cursor-rules" },
+    list_distribution_feeds: {},
+    get_submission_schema: { category: "mcp" },
+    validate_submission_draft: { fields: validMcpSubmissionFields },
+    search_duplicate_entries: {
+      category: skill.category,
+      slug: skill.slug,
+      limit: 1,
+    },
+    build_submission_urls: { fields: validMcpSubmissionFields },
+    get_category_submission_guidance: { category: "mcp" },
+    prepare_submission_draft: { fields: validMcpSubmissionFields },
+    get_submission_examples: { category: "mcp" },
+    review_submission_draft: { fields: validMcpSubmissionFields },
+  };
+  if (!(name in argsByTool)) {
+    throw new Error(`Missing protocol test arguments for ${name}.`);
+  }
+  return argsByTool[name];
+}
+
+async function withMcpClient<T>(run: (client: any) => Promise<T>) {
+  const server = createHeyClaudeMcpServer({ dataDir });
+  return withMcpClientForServer(server, run);
+}
+
+async function withMcpClientForServer<T>(
+  server: any,
+  run: (client: any) => Promise<T>,
+) {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "heyclaude-protocol-test",
+    version: "0.0.0",
+  });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    return await run(client);
+  } finally {
+    await client.close().catch(() => {});
+    await server.close().catch(() => {});
+  }
+}
+
+function fakeRemoteClient() {
+  const directoryResource = {
+    uri: "heyclaude://feeds/directory",
+    name: "directory",
+    title: "directory",
+    mimeType: "application/json",
+  };
+  return {
+    getServerCapabilities() {
+      return { tools: {}, resources: {}, prompts: {} };
+    },
+    async listTools() {
+      return {
+        tools: [
+          {
+            name: "search_registry",
+            description: "Remote search.",
+            inputSchema: { type: "object", additionalProperties: true },
+            outputSchema: {
+              type: "object",
+              properties: { ok: { type: "boolean" } },
+              required: ["ok"],
+              additionalProperties: true,
+            },
+            annotations: {
+              readOnlyHint: false,
+              destructiveHint: true,
+              idempotentHint: false,
+            },
+          },
+        ],
+      };
+    },
+    async callTool() {
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ok: true, count: 0, entries: [] }),
+          },
+        ],
+      };
+    },
+    async listResources() {
+      return { resources: [directoryResource] };
+    },
+    async listResourceTemplates() {
+      return {
+        resourceTemplates: [
+          {
+            uriTemplate: "heyclaude://entry/{category}/{slug}",
+            name: "entry",
+            title: "entry",
+            mimeType: "application/json",
+          },
+        ],
+      };
+    },
+    async readResource() {
+      return {
+        contents: [
+          {
+            uri: directoryResource.uri,
+            mimeType: "application/json",
+            text: JSON.stringify({ ok: true, entries: [] }),
+          },
+        ],
+      };
+    },
+    async listPrompts() {
+      return {
+        prompts: [
+          {
+            name: "find_best_asset",
+            description: "Remote prompt.",
+            arguments: [],
+          },
+        ],
+      };
+    },
+    async getPrompt() {
+      return {
+        description: "Remote prompt.",
+        messages: [
+          {
+            role: "user",
+            content: { type: "text", text: "Use remote discovery tools." },
+          },
+        ],
+      };
+    },
+    async close() {},
+  };
+}
 
 describe("HeyClaude read-only MCP helpers", () => {
   it("keeps the MCP package publishable without private workspace dependencies", () => {
@@ -105,10 +322,21 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
     expect(Object.keys(TOOL_INPUT_SCHEMAS)).toEqual(READ_ONLY_TOOL_NAMES);
     for (const tool of TOOL_DEFINITIONS) {
-      expect(tool.name).not.toMatch(/create|publish|write|delete|pr/i);
-      expect(tool.description).toMatch(
-        /read-only|fetch|search|list|validate|build|guidance/i,
+      expect(tool.name).not.toMatch(
+        /create_issue|create_pull_request|publish_content|write_file|delete/i,
       );
+      expect(tool.description).toMatch(
+        /read-only|fetch|search|list|validate|build|guidance|review/i,
+      );
+      expect(tool.annotations).toMatchObject({
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+      });
+      expect(tool.outputSchema).toMatchObject({
+        type: "object",
+        required: ["ok"],
+      });
       expect(tool.inputSchema).toEqual(jsonSchemaForTool(tool.name));
       expect(tool.inputSchema).toMatchObject({
         type: "object",
@@ -116,6 +344,188 @@ describe("HeyClaude read-only MCP helpers", () => {
       });
       expect(JSON.stringify(tool.inputSchema)).not.toContain("$schema");
     }
+  });
+
+  it("serves every public tool with structured output through the MCP SDK", async () => {
+    await withMcpClient(async (client) => {
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(
+        READ_ONLY_TOOL_NAMES,
+      );
+      for (const tool of tools.tools) {
+        expect(tool.outputSchema).toMatchObject({
+          type: "object",
+          required: ["ok"],
+        });
+        expect(tool.annotations).toMatchObject({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+        });
+      }
+
+      for (const name of READ_ONLY_TOOL_NAMES) {
+        const result = await client.callTool({
+          name,
+          arguments: validToolArguments(name),
+        });
+        expect(result.isError).not.toBe(true);
+        expect(result.structuredContent).toMatchObject({
+          ok: true,
+          policy: {
+            apiKeyRequired: false,
+            readOnly: true,
+            createsIssues: false,
+            createsPullRequests: false,
+            publishesContent: false,
+            writesLocalFiles: false,
+          },
+        });
+        const text = result.content?.find((item) => item.type === "text")?.text;
+        expect(text).toBeTruthy();
+        expect(JSON.parse(String(text))).toEqual(result.structuredContent);
+      }
+    });
+  });
+
+  it("serves resources and prompts through the MCP SDK", async () => {
+    await withMcpClient(async (client) => {
+      const resources = await client.listResources();
+      expect(resources.resources).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            uri: "heyclaude://feeds/directory",
+            mimeType: "application/json",
+          }),
+          expect.objectContaining({ uri: "heyclaude://category/skills" }),
+        ]),
+      );
+
+      const templates = await client.listResourceTemplates();
+      expect(templates.resourceTemplates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            uriTemplate: "heyclaude://entry/{category}/{slug}",
+          }),
+          expect.objectContaining({
+            uriTemplate: "heyclaude://category/{category}",
+          }),
+        ]),
+      );
+
+      const entryResource = await client.readResource({
+        uri: `heyclaude://entry/${skill.category}/${skill.slug}`,
+      });
+      const entryPayload = JSON.parse(entryResource.contents[0].text);
+      expect(entryPayload).toMatchObject({
+        ok: true,
+        key: `${skill.category}:${skill.slug}`,
+        policy: { readOnly: true },
+      });
+
+      const prompts = await client.listPrompts();
+      expect(prompts.prompts.map((prompt) => prompt.name)).toEqual([
+        "find_best_asset",
+        "prepare_submission",
+        "review_submission_before_issue",
+        "install_asset_safely",
+      ]);
+
+      const prompt = await client.getPrompt({
+        name: "find_best_asset",
+        arguments: {
+          use_case: "find an MCP server for code review",
+          category: "mcp",
+          platform: "Codex",
+        },
+      });
+      expect(prompt.messages[0].content.text).toContain("compare_entries");
+      expect(prompt.messages[0].content.text).toContain(
+        "Do not invent popularity metrics",
+      );
+    });
+  });
+
+  it("normalizes remote proxy tools, annotations, and structured output", async () => {
+    const { server } = await createRemoteMcpProxyServerFromClient(
+      fakeRemoteClient(),
+      {
+        url: "https://example.com/api/mcp",
+        timeoutMs: 1000,
+      },
+    );
+
+    await withMcpClientForServer(server, async (client) => {
+      const tools = await client.listTools();
+      expect(tools.tools).toEqual([
+        expect.objectContaining({
+          name: "search_registry",
+          annotations: expect.objectContaining({
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          }),
+        }),
+      ]);
+
+      const result = await client.callTool({
+        name: "search_registry",
+        arguments: { query: "mcp" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        ok: true,
+        count: 0,
+        policy: {
+          apiKeyRequired: false,
+          readOnly: true,
+          createsIssues: false,
+          createsPullRequests: false,
+          publishesContent: false,
+          writesLocalFiles: false,
+        },
+      });
+
+      const resources = await client.listResources();
+      expect(resources.resources[0]).toMatchObject({
+        uri: "heyclaude://feeds/directory",
+      });
+      const prompts = await client.listPrompts();
+      expect(prompts.prompts[0]).toMatchObject({ name: "find_best_asset" });
+    });
+  });
+
+  it("reports public no-key MCP server metadata and durable rate-limit policy", async () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
+    ) as { name: string; version: string };
+
+    const info = await callRegistryTool("server_info", {}, { dataDir });
+    expect(info).toMatchObject({
+      ok: true,
+      package: {
+        name: packageJson.name,
+        version: packageJson.version,
+      },
+      endpoint: {
+        auth: "none",
+        requestBodyLimitBytes: 64 * 1024,
+        rateLimit: {
+          binding: "API_MCP_RATE_LIMIT",
+          limit: 60,
+          windowSeconds: 60,
+        },
+      },
+      policy: {
+        apiKeyRequired: false,
+        readOnly: true,
+        createsIssues: false,
+        createsPullRequests: false,
+        publishesContent: false,
+      },
+    });
+    expect(info.tools).toEqual(READ_ONLY_TOOL_NAMES);
   });
 
   it("validates MCP tool arguments from shared Zod schemas", async () => {
@@ -191,6 +601,85 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(result.entries[0].platforms).toContain("Cursor");
   });
 
+  it("lists category entries with bounded pagination and filters", async () => {
+    const result = await callRegistryTool(
+      "list_category_entries",
+      {
+        category: "skills",
+        platform: "cursor-rules",
+        tag: "evals",
+        limit: 2,
+      },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      category: "skills",
+      platform: "Cursor",
+      tag: "evals",
+      count: expect.any(Number),
+      limit: 2,
+      offset: 0,
+    });
+    expect(result.entries.length).toBeLessThanOrEqual(2);
+    expect(result.entries[0]).toMatchObject({
+      category: "skills",
+      canonicalUrl: expect.stringContaining("/skills/"),
+      dateAdded: expect.any(String),
+    });
+    expect(result.entries[0].tags).toContain("evals");
+    expect(result.entries[0].platforms).toContain("Cursor");
+  });
+
+  it("lists recent updates from generated registry metadata", async () => {
+    const result = await callRegistryTool(
+      "get_recent_updates",
+      { limit: 5 },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({ ok: true, count: 5 });
+    const dates = result.entries.map((entry: any) => entry.updatedAt);
+    expect(dates).toEqual([...dates].sort().reverse());
+    expect(result.entries[0]).toMatchObject({
+      key: expect.stringContaining(":"),
+      updateKind: expect.stringMatching(/added|upstream_update/),
+    });
+
+    const since = await callRegistryTool(
+      "get_recent_updates",
+      { since: result.entries[0].updatedAt, limit: 5 },
+      { dataDir },
+    );
+    expect(since).toMatchObject({
+      ok: true,
+      since: result.entries[0].updatedAt,
+    });
+  });
+
+  it("returns related entries without returning the requested entry", async () => {
+    const result = await callRegistryTool(
+      "get_related_entries",
+      { category: skill.category, slug: skill.slug, limit: 5 },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      key: `${skill.category}:${skill.slug}`,
+      count: expect.any(Number),
+    });
+    expect(result.entries.length).toBeGreaterThan(0);
+    expect(result.entries.map((entry: any) => entry.key)).not.toContain(
+      `${skill.category}:${skill.slug}`,
+    );
+    expect(result.entries[0]).toMatchObject({
+      relatedScore: expect.any(Number),
+      relatedReasons: expect.arrayContaining([expect.any(String)]),
+    });
+  });
+
   it("fetches entry detail and install guidance without write capabilities", async () => {
     const detail = await callRegistryTool(
       "get_entry_detail",
@@ -214,6 +703,168 @@ describe("HeyClaude read-only MCP helpers", () => {
       platform: "Claude",
     });
     expect(guidance).not.toHaveProperty("writePath");
+  });
+
+  it("returns category-aware copyable assets and comparison metadata", async () => {
+    const asset = await callRegistryTool(
+      "get_copyable_asset",
+      { category: skill.category, slug: skill.slug, platform: "claude" },
+      { dataDir },
+    );
+    expect(asset).toMatchObject({
+      ok: true,
+      key: `${skill.category}:${skill.slug}`,
+      primaryAsset: {
+        type: expect.stringMatching(/install_command|full_content|usage/),
+        content: expect.any(String),
+      },
+      source: {
+        sourceHosts: expect.any(Array),
+      },
+      policy: {
+        readOnly: true,
+        writesLocalFiles: false,
+      },
+    });
+    expect(JSON.stringify(asset)).not.toMatch(
+      /createIssue|createPullRequest|publish_content|writePath/i,
+    );
+
+    const directory = JSON.parse(
+      fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
+    ) as {
+      entries: Array<{ category: string; slug: string }>;
+    };
+    const second = directory.entries.find(
+      (entry) => entry.category === skill.category && entry.slug !== skill.slug,
+    );
+    expect(second).toBeTruthy();
+    const compared = await callRegistryTool(
+      "compare_entries",
+      {
+        entries: [
+          { category: skill.category, slug: skill.slug },
+          { category: second?.category, slug: second?.slug },
+        ],
+        platform: "claude",
+      },
+      { dataDir },
+    );
+    expect(compared).toMatchObject({
+      ok: true,
+      count: 2,
+      platform: "Claude",
+      entries: [
+        expect.objectContaining({
+          key: `${skill.category}:${skill.slug}`,
+          installComplexity: expect.stringMatching(/unknown|low|medium|higher/),
+        }),
+        expect.any(Object),
+      ],
+      policy: { readOnly: true },
+    });
+  });
+
+  it("returns registry stats and client setup snippets without auth requirements", async () => {
+    const stats = await callRegistryTool("get_registry_stats", {}, { dataDir });
+    expect(stats).toMatchObject({
+      ok: true,
+      package: { name: "@heyclaude/mcp" },
+      registry: {
+        totalEntries: expect.any(Number),
+        categories: expect.any(Object),
+      },
+      sourceSignals: {
+        entriesWithGithubStats: expect.any(Number),
+        installableEntries: expect.any(Number),
+      },
+      policy: { apiKeyRequired: false, readOnly: true },
+    });
+
+    const setup = await callRegistryTool(
+      "get_client_setup",
+      { client: "codex" },
+      { dataDir },
+    );
+    expect(setup).toMatchObject({
+      ok: true,
+      apiKeyRequired: false,
+      snippets: {
+        codex: {
+          config: {
+            mcpServers: {
+              heyclaude: {
+                command: "npx",
+                args: ["-y", "@heyclaude/mcp"],
+              },
+            },
+          },
+        },
+      },
+      policy: { createsIssues: false },
+    });
+  });
+
+  it("exposes registry resources and workflow prompts through MCP helpers", async () => {
+    await expect(listRegistryResources({}, { dataDir })).resolves.toMatchObject(
+      {
+        resources: expect.arrayContaining([
+          expect.objectContaining({
+            uri: "heyclaude://feeds/directory",
+            mimeType: "application/json",
+          }),
+          expect.objectContaining({
+            uri: "heyclaude://category/skills",
+          }),
+        ]),
+      },
+    );
+    expect(listRegistryResourceTemplates()).toMatchObject({
+      resourceTemplates: expect.arrayContaining([
+        expect.objectContaining({
+          uriTemplate: "heyclaude://entry/{category}/{slug}",
+        }),
+      ]),
+    });
+    await expect(
+      readRegistryResource(
+        { uri: `heyclaude://entry/${skill.category}/${skill.slug}` },
+        { dataDir },
+      ),
+    ).resolves.toMatchObject({
+      contents: [
+        {
+          mimeType: "application/json",
+          text: expect.stringContaining(`"${skill.slug}"`),
+        },
+      ],
+    });
+
+    expect(listRegistryPrompts()).toMatchObject({
+      prompts: expect.arrayContaining([
+        expect.objectContaining({ name: "find_best_asset" }),
+        expect.objectContaining({ name: "install_asset_safely" }),
+      ]),
+    });
+    expect(
+      getRegistryPrompt({
+        name: "install_asset_safely",
+        arguments: {
+          category: skill.category,
+          slug: skill.slug,
+          platform: "Claude",
+        },
+      }),
+    ).toMatchObject({
+      messages: [
+        {
+          role: "user",
+          content: {
+            text: expect.stringContaining("get_install_guidance"),
+          },
+        },
+      ],
+    });
   });
 
   it("returns compatibility and generated Cursor adapter content", async () => {
@@ -334,6 +985,78 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(JSON.stringify(urls)).not.toMatch(/token|secret|authorization/i);
   });
 
+  it("prepares and reviews submission drafts without GitHub writes", async () => {
+    const fields = {
+      category: "mcp",
+      name: "Example Draft MCP",
+      docs_url: "https://example.com/docs",
+      description:
+        "Example MCP server submission used to test stronger draft tooling.",
+      install_command: "npx -y example-draft-mcp",
+      usage_snippet: "Add this server to your MCP client configuration.",
+    };
+
+    const prepared = await callRegistryTool(
+      "prepare_submission_draft",
+      { fields },
+      { dataDir },
+    );
+    expect(prepared).toMatchObject({
+      ok: true,
+      valid: true,
+      category: "mcp",
+      issueDraft: {
+        title: "Submit MCP Server: Example Draft MCP",
+        labels: expect.arrayContaining(["content-submission", "community-mcp"]),
+        body: expect.stringContaining("### Install command"),
+      },
+      githubIssueUrl: expect.stringContaining("template=submit-mcp.yml"),
+      submissionPolicy: expect.stringContaining("does not auto-publish"),
+    });
+
+    const reviewed = await callRegistryTool(
+      "review_submission_draft",
+      { fields },
+      { dataDir },
+    );
+    expect(reviewed).toMatchObject({
+      ok: true,
+      valid: true,
+      recommendedAction: expect.stringMatching(
+        /open_review_issue|review_possible_duplicate/,
+      ),
+      duplicateReview: { ok: true },
+      reviewChecklist: expect.arrayContaining([
+        expect.stringContaining("maintainer review"),
+      ]),
+    });
+    expect(JSON.stringify({ prepared, reviewed })).not.toMatch(
+      /token|secret|authorization|createIssue|createPullRequest/i,
+    );
+  });
+
+  it("returns category submission examples for faster valid drafts", async () => {
+    const examples = await callRegistryTool(
+      "get_submission_examples",
+      { category: "guides" },
+      { dataDir },
+    );
+    expect(examples).toMatchObject({
+      ok: true,
+      categories: [
+        {
+          category: "guides",
+          requiredFields: expect.arrayContaining(["guide_content"]),
+          minimalFields: {
+            category: "guides",
+            guide_content: expect.stringContaining("# Example"),
+          },
+        },
+      ],
+      reviewModel: expect.stringContaining("maintainers review"),
+    });
+  });
+
   it("finds likely duplicate entries before submission", async () => {
     const duplicate = await callRegistryTool(
       "search_duplicate_entries",
@@ -377,6 +1100,30 @@ describe("HeyClaude read-only MCP helpers", () => {
         details: [
           expect.objectContaining({
             path: "fields",
+            code: "unrecognized_keys",
+          }),
+        ],
+      },
+    });
+
+    await expect(
+      callRegistryTool(
+        "compare_entries",
+        {
+          entries: [
+            { category: "skills", slug: skill.slug },
+            { category: "skills", slug: skill.slug, writePath: "/tmp/x" },
+          ],
+        },
+        { dataDir },
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_request",
+        details: [
+          expect.objectContaining({
+            path: "entries.1",
             code: "unrecognized_keys",
           }),
         ],


### PR DESCRIPTION
## Summary
- Expand the MCP 0.2.0 release with richer read-only discovery, copyable asset, comparison, stats, client setup, resources, and prompt workflows.
- Keep the public no-key model and no-write security boundary intact.
- Extend endpoint/package validation so tools advertise read-only annotations, structured outputs, resources, and prompts.

## What changed
- Added get_copyable_asset, compare_entries, get_registry_stats, and get_client_setup MCP tools.
- Added read-only MCP resources for directory, category, and entry artifacts.
- Added workflow prompts for finding assets, preparing submissions, reviewing drafts, and safe install guidance.
- Added structuredContent and outputSchema support for tool calls.
- Updated package docs, release notes, OpenAPI description, endpoint/package validators, and route/server tests.

## Why
- Makes the 0.2.0 MCP release useful for real client workflows instead of only raw search/detail calls.
- Preserves maintainer-reviewed submissions and avoids anonymous GitHub writes or local file mutations.

## Validation
- pnpm exec vitest run tests/mcp-server.test.ts tests/mcp-http-route.test.ts tests/api-router-security.test.ts
- pnpm --filter @heyclaude/mcp test
- pnpm --filter web type-check
- pnpm validate:mcp-package
- pnpm validate:openapi
- pnpm --filter @heyclaude/mcp pack --dry-run
- pnpm validate:content
- pnpm validate:raycast-feed
- pnpm build
- trunk check --ci on touched MCP/docs/test files

## Notes
- Do not publish 0.2.0 until the merged Worker code is deployed and the production MCP endpoint passes strict endpoint validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added registry discovery and browsing tools including server information, category listings, related entries, and recent updates
  * Added entry comparison and asset retrieval tools
  * Added registry statistics functionality
  * Enhanced submission workflow with draft preparation, example generation, and review tools
  * Added support for MCP resources and prompts

* **Chores**
  * Enhanced CI workflow validation with strict tooling verification

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/373?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->