### PR TITLE
feat(submissions): add contributor preflight

### DIFF
--- a/apps/web/src/app/api/submissions/preflight/route.ts
+++ b/apps/web/src/app/api/submissions/preflight/route.ts
@@ -10,7 +10,7 @@ export const POST = createApiHandler(
     if (String(payload.honeypot ?? "").trim()) {
       logApiInfo(request, "submissions.preflight.honeypot_discarded");
       return apiJson(
-        { ok: true, queued: false },
+        { ok: true, valid: false, queued: false },
         { headers: { "cache-control": "no-store" } },
       );
     }

--- a/apps/web/src/app/api/submissions/preflight/route.ts
+++ b/apps/web/src/app/api/submissions/preflight/route.ts
@@ -1,0 +1,27 @@
+import { buildSubmissionPreflight } from "@/lib/submission-preflight";
+import { apiJson, createApiHandler, type InferApiBody } from "@/lib/api/router";
+import { submissionPreflightBodySchema } from "@/lib/api/contracts";
+import { logApiInfo } from "@/lib/api-logs";
+
+export const POST = createApiHandler(
+  "submissions.preflight",
+  async ({ request, body }) => {
+    const payload = body as InferApiBody<typeof submissionPreflightBodySchema>;
+    if (String(payload.honeypot ?? "").trim()) {
+      logApiInfo(request, "submissions.preflight.honeypot_discarded");
+      return apiJson(
+        { ok: true, queued: false },
+        { headers: { "cache-control": "no-store" } },
+      );
+    }
+
+    const fields =
+      payload.fields && typeof payload.fields === "object"
+        ? payload.fields
+        : {};
+    const preflight = await buildSubmissionPreflight(fields);
+    return apiJson(preflight, {
+      headers: { "cache-control": "no-store" },
+    });
+  },
+);

--- a/apps/web/src/components/submit-form.tsx
+++ b/apps/web/src/components/submit-form.tsx
@@ -12,7 +12,10 @@ import {
 import { categorySpec } from "@heyclaude/registry";
 import { categoryLabels, siteConfig } from "@/lib/site";
 import { SubmitPreviewCard } from "@/components/submit-preview-card";
-import { SubmitReadinessCard } from "@/components/submit-readiness-card";
+import {
+  SubmitReadinessCard,
+  type SubmissionPreflightSummary,
+} from "@/components/submit-readiness-card";
 import { buildSubmissionFieldModel } from "@heyclaude/registry/submission-spec";
 
 type SubmissionCategorySpec = {
@@ -66,6 +69,10 @@ type SubmitStatus =
   | { state: "submitting" }
   | { state: "success"; issueUrl: string }
   | { state: "error"; message: string; fallbackUrl: string };
+
+type SubmissionPreflightResponse = SubmissionPreflightSummary & {
+  ok?: boolean;
+};
 
 function getApiErrorPayloadMessage(result: {
   error?: string | { code?: string; message?: string; details?: unknown };
@@ -180,6 +187,9 @@ export function SubmitForm() {
   const [honeypot, setHoneypot] = useState("");
   const [turnstileToken, setTurnstileToken] = useState("");
   const [submitStatus, setSubmitStatus] = useState<SubmitStatus>({
+    state: "idle",
+  });
+  const [preflight, setPreflight] = useState<SubmissionPreflightSummary>({
     state: "idle",
   });
   const turnstileRef = useRef<HTMLDivElement | null>(null);
@@ -477,6 +487,65 @@ export function SubmitForm() {
     : 0;
 
   const isReady = Boolean(category) && missingReadinessItems.length === 0;
+  const preflightBlocksSubmission =
+    preflight.state === "success" &&
+    (preflight.routeSuggestion === "fix_required" ||
+      preflight.routeSuggestion === "tools_form" ||
+      Boolean(preflight.blockers?.length));
+  const canSubmit =
+    isReady &&
+    !preflightBlocksSubmission &&
+    submitStatus.state !== "submitting";
+
+  useEffect(() => {
+    if (!category && !toolName && !normalizedSlug) {
+      setPreflight({ state: "idle" });
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeout = window.setTimeout(async () => {
+      setPreflight((current) => ({
+        ...current,
+        state: "loading",
+      }));
+      try {
+        const response = await fetch("/api/submissions/preflight", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            fields: submissionFieldValues,
+            honeypot,
+          }),
+          signal: controller.signal,
+        });
+        const result = (await response
+          .json()
+          .catch(() => ({}))) as SubmissionPreflightResponse;
+        if (!response.ok || result.ok !== true) {
+          setPreflight({ state: "error" });
+          return;
+        }
+        setPreflight({
+          state: "success",
+          routeSuggestion: result.routeSuggestion,
+          blockers: result.blockers ?? [],
+          warnings: result.warnings ?? [],
+          duplicates: result.duplicates ?? [],
+          risk: result.risk,
+          nextAction: result.nextAction,
+        });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        setPreflight({ state: "error" });
+      }
+    }, 350);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, [category, honeypot, normalizedSlug, submissionFieldValues, toolName]);
 
   const resetTurnstile = () => {
     setTurnstileToken("");
@@ -487,7 +556,7 @@ export function SubmitForm() {
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!isReady || submitStatus.state === "submitting") return;
+    if (!canSubmit) return;
 
     setSubmitStatus({ state: "submitting" });
     try {
@@ -1056,25 +1125,28 @@ export function SubmitForm() {
         category={category}
         items={readinessItems}
         sourceWarning={sourceWarning}
+        preflight={preflight}
       />
 
-      <SubmitPreviewCard
-        title={toolName}
-        slug={normalizedSlug}
-        category={category}
-        author={author}
-        description={description}
-        cardDescription={cardDescription}
-        tags={tags}
-        githubUrl={githubUrl}
-        docsUrl={docsUrl}
-        brandName={brandName}
-        brandDomain={brandDomain}
-        installCommand={installCommand}
-        assetContent={assetContent || usageSnippet || installCommand}
-        readinessScore={readinessScore}
-        sourceWarning={sourceWarning}
-      />
+      {!preflightBlocksSubmission ? (
+        <SubmitPreviewCard
+          title={toolName}
+          slug={normalizedSlug}
+          category={category}
+          author={author}
+          description={description}
+          cardDescription={cardDescription}
+          tags={tags}
+          githubUrl={githubUrl}
+          docsUrl={docsUrl}
+          brandName={brandName}
+          brandDomain={brandDomain}
+          installCommand={installCommand}
+          assetContent={assetContent || usageSnippet || installCommand}
+          readinessScore={readinessScore}
+          sourceWarning={sourceWarning}
+        />
+      ) : null}
 
       <div className="rounded-xl border border-border bg-background px-4 py-3 text-xs leading-6 text-muted-foreground">
         This creates a reviewable GitHub issue from the website. If the direct
@@ -1123,7 +1195,7 @@ export function SubmitForm() {
       <button
         type="submit"
         className="submit-primary-button"
-        disabled={!isReady || submitStatus.state === "submitting"}
+        disabled={!canSubmit}
       >
         {submitStatus.state === "submitting"
           ? "Submitting..."

--- a/apps/web/src/components/submit-readiness-card.tsx
+++ b/apps/web/src/components/submit-readiness-card.tsx
@@ -49,7 +49,11 @@ export function SubmitReadinessCard({
           Submission readiness
         </span>
         <div className="flex flex-wrap items-center gap-2">
-          {preflight?.state === "loading" ? <span>Checking...</span> : null}
+          {preflight?.state === "loading" ? (
+            <span role="status" aria-live="polite">
+              Checking...
+            </span>
+          ) : null}
           {preflight?.risk?.tier ? (
             <span className="rounded-full border border-border bg-card px-2 py-0.5">
               {preflight.risk.tier} risk
@@ -100,9 +104,10 @@ export function SubmitReadinessCard({
         <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2">
           <p className="font-medium text-foreground">Fix before submitting</p>
           <ul className="mt-1 list-disc space-y-1 pl-4">
-            {blockers.slice(0, 4).map((item) => (
-              <li key={`${item.code}-${item.message}`}>{item.message}</li>
+            {blockers.slice(0, 4).map((item, index) => (
+              <li key={`${item.code}-${index}`}>{item.message}</li>
             ))}
+            {blockers.length > 4 ? <li>+{blockers.length - 4} more</li> : null}
           </ul>
         </div>
       ) : null}
@@ -110,9 +115,10 @@ export function SubmitReadinessCard({
         <div className="mt-3 rounded-lg border border-border bg-card/70 px-3 py-2">
           <p className="font-medium text-foreground">Review notes</p>
           <ul className="mt-1 list-disc space-y-1 pl-4">
-            {warnings.slice(0, 5).map((item) => (
-              <li key={`${item.code}-${item.message}`}>{item.message}</li>
+            {warnings.slice(0, 5).map((item, index) => (
+              <li key={`${item.code}-${index}`}>{item.message}</li>
             ))}
+            {warnings.length > 5 ? <li>+{warnings.length - 5} more</li> : null}
           </ul>
         </div>
       ) : null}
@@ -130,7 +136,9 @@ export function SubmitReadinessCard({
                 >
                   {item.title}
                 </a>{" "}
-                <span>({item.reasons.join(", ")})</span>
+                {item.reasons?.length ? (
+                  <span>({item.reasons.join(", ")})</span>
+                ) : null}
               </li>
             ))}
           </ul>

--- a/apps/web/src/components/submit-readiness-card.tsx
+++ b/apps/web/src/components/submit-readiness-card.tsx
@@ -3,18 +3,44 @@ export type SubmitReadinessItem = {
   ready: boolean;
 };
 
+export type SubmissionPreflightSummary = {
+  state: "idle" | "loading" | "success" | "error";
+  routeSuggestion?: "github_issue" | "fix_required" | "tools_form";
+  blockers?: Array<{ code: string; message: string }>;
+  warnings?: Array<{ code: string; message: string }>;
+  duplicates?: Array<{
+    key: string;
+    title: string;
+    url: string;
+    reasons: string[];
+  }>;
+  risk?: {
+    tier?: string;
+    policyDecision?: string;
+  };
+  nextAction?: {
+    label: string;
+    url: string;
+  };
+};
+
 type SubmitReadinessCardProps = {
   category: string;
   items: SubmitReadinessItem[];
   sourceWarning: boolean;
+  preflight?: SubmissionPreflightSummary;
 };
 
 export function SubmitReadinessCard({
   category,
   items,
   sourceWarning,
+  preflight,
 }: SubmitReadinessCardProps) {
   const missingItems = items.filter((item) => !item.ready);
+  const blockers = preflight?.blockers ?? [];
+  const warnings = preflight?.warnings ?? [];
+  const duplicates = preflight?.duplicates ?? [];
 
   return (
     <div className="rounded-xl border border-border bg-background px-4 py-3 text-xs leading-6 text-muted-foreground">
@@ -22,15 +48,23 @@ export function SubmitReadinessCard({
         <span className="font-medium text-foreground">
           Submission readiness
         </span>
-        <span>
-          {category
-            ? missingItems.length === 0
-              ? "Likely to pass required field checks"
-              : `${missingItems.length} required field${
-                  missingItems.length === 1 ? "" : "s"
-                } missing`
-            : "Select a category to preview required fields"}
-        </span>
+        <div className="flex flex-wrap items-center gap-2">
+          {preflight?.state === "loading" ? <span>Checking...</span> : null}
+          {preflight?.risk?.tier ? (
+            <span className="rounded-full border border-border bg-card px-2 py-0.5">
+              {preflight.risk.tier} risk
+            </span>
+          ) : null}
+          <span>
+            {category
+              ? missingItems.length === 0
+                ? "Likely to pass required field checks"
+                : `${missingItems.length} required field${
+                    missingItems.length === 1 ? "" : "s"
+                  } missing`
+              : "Select a category to preview required fields"}
+          </span>
+        </div>
       </div>
       {items.length ? (
         <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -54,6 +88,68 @@ export function SubmitReadinessCard({
           Source URL is not currently required by the validator, but submissions
           without GitHub or docs links are harder to review and may need
           follow-up before maintainer review.
+        </p>
+      ) : null}
+      {preflight?.state === "error" ? (
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          Live preflight is temporarily unavailable. The final submission
+          endpoint will still run the same validation before creating an issue.
+        </p>
+      ) : null}
+      {blockers.length ? (
+        <div className="mt-3 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2">
+          <p className="font-medium text-foreground">Fix before submitting</p>
+          <ul className="mt-1 list-disc space-y-1 pl-4">
+            {blockers.slice(0, 4).map((item) => (
+              <li key={`${item.code}-${item.message}`}>{item.message}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {warnings.length ? (
+        <div className="mt-3 rounded-lg border border-border bg-card/70 px-3 py-2">
+          <p className="font-medium text-foreground">Review notes</p>
+          <ul className="mt-1 list-disc space-y-1 pl-4">
+            {warnings.slice(0, 5).map((item) => (
+              <li key={`${item.code}-${item.message}`}>{item.message}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {duplicates.length ? (
+        <div className="mt-3 rounded-lg border border-border bg-card/70 px-3 py-2">
+          <p className="font-medium text-foreground">Possible duplicates</p>
+          <ul className="mt-1 space-y-1">
+            {duplicates.map((item) => (
+              <li key={item.key}>
+                <a
+                  href={item.url}
+                  className="text-primary underline underline-offset-4"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {item.title}
+                </a>{" "}
+                <span>({item.reasons.join(", ")})</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {preflight?.nextAction?.url ? (
+        <p className="mt-3">
+          Suggested next step:{" "}
+          <a
+            href={preflight.nextAction.url}
+            className="text-primary underline underline-offset-4"
+          >
+            {preflight.nextAction.label}
+          </a>
+          .
+        </p>
+      ) : preflight?.nextAction?.label ? (
+        <p className="mt-3">
+          Suggested next step: {preflight.nextAction.label}.
         </p>
       ) : null}
     </div>

--- a/apps/web/src/components/submit-readiness-card.tsx
+++ b/apps/web/src/components/submit-readiness-card.tsx
@@ -20,7 +20,7 @@ export type SubmissionPreflightSummary = {
   };
   nextAction?: {
     label: string;
-    url: string;
+    url?: string;
   };
 };
 
@@ -30,6 +30,19 @@ type SubmitReadinessCardProps = {
   sourceWarning: boolean;
   preflight?: SubmissionPreflightSummary;
 };
+
+function safeHttpUrl(value?: string) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  try {
+    const url = new URL(text);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : "";
+  } catch {
+    return "";
+  }
+}
 
 export function SubmitReadinessCard({
   category,
@@ -126,21 +139,28 @@ export function SubmitReadinessCard({
         <div className="mt-3 rounded-lg border border-border bg-card/70 px-3 py-2">
           <p className="font-medium text-foreground">Possible duplicates</p>
           <ul className="mt-1 space-y-1">
-            {duplicates.map((item) => (
-              <li key={item.key}>
-                <a
-                  href={item.url}
-                  className="text-primary underline underline-offset-4"
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  {item.title}
-                </a>{" "}
-                {item.reasons?.length ? (
-                  <span>({item.reasons.join(", ")})</span>
-                ) : null}
-              </li>
-            ))}
+            {duplicates.map((item) => {
+              const href = safeHttpUrl(item.url);
+              return (
+                <li key={item.key}>
+                  {href ? (
+                    <a
+                      href={href}
+                      className="text-primary underline underline-offset-4"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {item.title}
+                    </a>
+                  ) : (
+                    <span>{item.title}</span>
+                  )}{" "}
+                  {item.reasons?.length ? (
+                    <span>({item.reasons.join(", ")})</span>
+                  ) : null}
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/apps/web/src/components/submit-readiness-card.tsx
+++ b/apps/web/src/components/submit-readiness-card.tsx
@@ -54,6 +54,8 @@ export function SubmitReadinessCard({
   const blockers = preflight?.blockers ?? [];
   const warnings = preflight?.warnings ?? [];
   const duplicates = preflight?.duplicates ?? [];
+  const nextActionLabel = preflight?.nextAction?.label;
+  const nextActionHref = safeHttpUrl(preflight?.nextAction?.url);
 
   return (
     <div className="rounded-xl border border-border bg-background px-4 py-3 text-xs leading-6 text-muted-foreground">
@@ -164,21 +166,19 @@ export function SubmitReadinessCard({
           </ul>
         </div>
       ) : null}
-      {preflight?.nextAction?.url ? (
+      {nextActionHref ? (
         <p className="mt-3">
           Suggested next step:{" "}
           <a
-            href={preflight.nextAction.url}
+            href={nextActionHref}
             className="text-primary underline underline-offset-4"
           >
-            {preflight.nextAction.label}
+            {nextActionLabel}
           </a>
           .
         </p>
-      ) : preflight?.nextAction?.label ? (
-        <p className="mt-3">
-          Suggested next step: {preflight.nextAction.label}.
-        </p>
+      ) : nextActionLabel ? (
+        <p className="mt-3">Suggested next step: {nextActionLabel}.</p>
       ) : null}
     </div>
   );

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -261,6 +261,11 @@ export const submissionBodySchema = z.object({
   honeypot: z.string().max(256).optional().default(""),
 });
 
+export const submissionPreflightBodySchema = z.object({
+  fields: z.record(z.string(), z.unknown()).optional().default({}),
+  honeypot: z.string().max(256).optional().default(""),
+});
+
 export const downloadQuerySchema = z.object({
   asset: z.string().trim().max(256),
 });
@@ -728,6 +733,24 @@ export const apiRouteDefinitions = {
       limit: 8,
       windowMs: 60_000,
       binding: "API_STRICT_RATE_LIMIT",
+    },
+  }),
+  "submissions.preflight": route({
+    id: "submissions.preflight",
+    method: "POST",
+    path: "/api/submissions/preflight",
+    summary: "Preflight a content submission draft",
+    description:
+      "Runs read-only schema, duplicate, source, package, and safety/privacy checks before a contributor opens a public GitHub submission issue. This endpoint never creates issues, labels, branches, pull requests, registry content, or package artifacts.",
+    tags: ["Submissions"],
+    originCheck: true,
+    bodySchema: submissionPreflightBodySchema,
+    bodyLimitBytes: 64 * 1024,
+    rateLimit: {
+      scope: "submissions-preflight",
+      limit: 30,
+      windowMs: 60_000,
+      binding: "API_DYNAMIC_RATE_LIMIT",
     },
   }),
   download: route({

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -266,6 +266,73 @@ export const submissionPreflightBodySchema = z.object({
   honeypot: z.string().max(256).optional().default(""),
 });
 
+const submissionPreflightNoteSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+});
+
+const submissionPreflightDuplicateSchema = z.object({
+  key: z.string(),
+  category: z.string(),
+  slug: z.string(),
+  title: z.string(),
+  url: z.string(),
+  reasons: z.array(z.string()),
+});
+
+const submissionPreflightSuccessResponseSchema = z
+  .object({
+    ok: z.literal(true),
+    valid: z.boolean(),
+    routeSuggestion: z.enum(["github_issue", "fix_required", "tools_form"]),
+    category: z.string(),
+    slug: z.string(),
+    fallbackUrl: z.string().url(),
+    issuePreview: z.object({
+      title: z.string(),
+      labels: z.array(z.string()),
+      body: z.string(),
+    }),
+    schema: z.object({
+      ok: z.boolean(),
+      skipped: z.boolean(),
+      errors: z.array(z.string()),
+      warnings: z.array(z.string()),
+      fields: z.record(z.string(), z.unknown()),
+    }),
+    risk: z.object({
+      tier: z.string().optional(),
+      policyDecision: z.string().optional(),
+      policyMatrix: z.record(z.string(), z.unknown()),
+      reviewFlags: z.array(z.string()),
+      classificationWarnings: z.array(z.unknown()),
+    }),
+    expectedNotes: z.object({
+      safety: z.boolean(),
+      privacy: z.boolean(),
+      reasons: z.array(z.string()),
+    }),
+    blockers: z.array(submissionPreflightNoteSchema),
+    warnings: z.array(submissionPreflightNoteSchema),
+    duplicates: z.array(submissionPreflightDuplicateSchema),
+    nextAction: z.object({
+      label: z.string(),
+      url: z.string(),
+    }),
+  })
+  .passthrough();
+
+const submissionPreflightDiscardResponseSchema = z.object({
+  ok: z.literal(true),
+  valid: z.literal(false),
+  queued: z.literal(false),
+});
+
+export const submissionPreflightResponseSchema = z.union([
+  submissionPreflightSuccessResponseSchema,
+  submissionPreflightDiscardResponseSchema,
+]);
+
 export const downloadQuerySchema = z.object({
   asset: z.string().trim().max(256),
 });
@@ -745,6 +812,7 @@ export const apiRouteDefinitions = {
     tags: ["Submissions"],
     originCheck: true,
     bodySchema: submissionPreflightBodySchema,
+    responseSchema: submissionPreflightResponseSchema,
     bodyLimitBytes: 64 * 1024,
     rateLimit: {
       scope: "submissions-preflight",

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -280,47 +280,45 @@ const submissionPreflightDuplicateSchema = z.object({
   reasons: z.array(z.string().max(80)).max(8),
 });
 
-const submissionPreflightSuccessResponseSchema = z
-  .object({
-    ok: z.literal(true),
-    valid: z.boolean(),
-    routeSuggestion: z.enum(["github_issue", "fix_required", "tools_form"]),
-    category: z.string(),
-    slug: z.string(),
-    fallbackUrl: z.string().url(),
-    issuePreview: z.object({
-      title: z.string().max(300),
-      labels: z.array(z.string().max(80)).max(12),
-      body: z.string().max(32_000),
-    }),
-    schema: z.object({
-      ok: z.boolean(),
-      skipped: z.boolean(),
-      errors: z.array(z.string().max(500)).max(32),
-      warnings: z.array(z.string().max(500)).max(32),
-      fields: z.record(z.string(), z.unknown()),
-    }),
-    risk: z.object({
-      tier: z.string().optional(),
-      policyDecision: z.string().optional(),
-      policyMatrix: z.record(z.string(), z.unknown()),
-      reviewFlags: z.array(z.string().max(120)).max(32),
-      classificationWarnings: z.array(z.unknown()).max(32),
-    }),
-    expectedNotes: z.object({
-      safety: z.boolean(),
-      privacy: z.boolean(),
-      reasons: z.array(z.string().max(500)).max(8),
-    }),
-    blockers: z.array(submissionPreflightNoteSchema).max(24),
-    warnings: z.array(submissionPreflightNoteSchema).max(24),
-    duplicates: z.array(submissionPreflightDuplicateSchema).max(5),
-    nextAction: z.object({
-      label: z.string().max(160),
-      url: z.string().max(4096).optional(),
-    }),
-  })
-  .passthrough();
+const submissionPreflightSuccessResponseSchema = z.object({
+  ok: z.literal(true),
+  valid: z.boolean(),
+  routeSuggestion: z.enum(["github_issue", "fix_required", "tools_form"]),
+  category: z.string(),
+  slug: z.string(),
+  fallbackUrl: z.string().url(),
+  issuePreview: z.object({
+    title: z.string().max(300),
+    labels: z.array(z.string().max(80)).max(12),
+    body: z.string().max(32_000),
+  }),
+  schema: z.object({
+    ok: z.boolean(),
+    skipped: z.boolean(),
+    errors: z.array(z.string().max(500)).max(32),
+    warnings: z.array(z.string().max(500)).max(32),
+    fields: z.record(z.string(), z.unknown()),
+  }),
+  risk: z.object({
+    tier: z.string().optional(),
+    policyDecision: z.string().optional(),
+    policyMatrix: z.record(z.string(), z.unknown()),
+    reviewFlags: z.array(z.string().max(120)).max(32),
+    classificationWarnings: z.array(z.unknown()).max(32),
+  }),
+  expectedNotes: z.object({
+    safety: z.boolean(),
+    privacy: z.boolean(),
+    reasons: z.array(z.string().max(500)).max(8),
+  }),
+  blockers: z.array(submissionPreflightNoteSchema).max(24),
+  warnings: z.array(submissionPreflightNoteSchema).max(24),
+  duplicates: z.array(submissionPreflightDuplicateSchema).max(5),
+  nextAction: z.object({
+    label: z.string().max(160),
+    url: z.string().max(4096).optional(),
+  }),
+});
 
 const submissionPreflightDiscardResponseSchema = z.object({
   ok: z.literal(true),

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -317,7 +317,7 @@ const submissionPreflightSuccessResponseSchema = z
     duplicates: z.array(submissionPreflightDuplicateSchema).max(5),
     nextAction: z.object({
       label: z.string().max(160),
-      url: z.string().max(4096),
+      url: z.string().max(4096).optional(),
     }),
   })
   .passthrough();

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -267,17 +267,17 @@ export const submissionPreflightBodySchema = z.object({
 });
 
 const submissionPreflightNoteSchema = z.object({
-  code: z.string(),
-  message: z.string(),
+  code: z.string().max(80),
+  message: z.string().max(500),
 });
 
 const submissionPreflightDuplicateSchema = z.object({
-  key: z.string(),
-  category: z.string(),
-  slug: z.string(),
-  title: z.string(),
-  url: z.string(),
-  reasons: z.array(z.string()),
+  key: z.string().max(160),
+  category: z.string().max(80),
+  slug: z.string().max(160),
+  title: z.string().max(240),
+  url: z.string().url().max(2048),
+  reasons: z.array(z.string().max(80)).max(8),
 });
 
 const submissionPreflightSuccessResponseSchema = z
@@ -289,35 +289,35 @@ const submissionPreflightSuccessResponseSchema = z
     slug: z.string(),
     fallbackUrl: z.string().url(),
     issuePreview: z.object({
-      title: z.string(),
-      labels: z.array(z.string()),
-      body: z.string(),
+      title: z.string().max(300),
+      labels: z.array(z.string().max(80)).max(12),
+      body: z.string().max(32_000),
     }),
     schema: z.object({
       ok: z.boolean(),
       skipped: z.boolean(),
-      errors: z.array(z.string()),
-      warnings: z.array(z.string()),
+      errors: z.array(z.string().max(500)).max(32),
+      warnings: z.array(z.string().max(500)).max(32),
       fields: z.record(z.string(), z.unknown()),
     }),
     risk: z.object({
       tier: z.string().optional(),
       policyDecision: z.string().optional(),
       policyMatrix: z.record(z.string(), z.unknown()),
-      reviewFlags: z.array(z.string()),
-      classificationWarnings: z.array(z.unknown()),
+      reviewFlags: z.array(z.string().max(120)).max(32),
+      classificationWarnings: z.array(z.unknown()).max(32),
     }),
     expectedNotes: z.object({
       safety: z.boolean(),
       privacy: z.boolean(),
-      reasons: z.array(z.string()),
+      reasons: z.array(z.string().max(500)).max(8),
     }),
-    blockers: z.array(submissionPreflightNoteSchema),
-    warnings: z.array(submissionPreflightNoteSchema),
-    duplicates: z.array(submissionPreflightDuplicateSchema),
+    blockers: z.array(submissionPreflightNoteSchema).max(24),
+    warnings: z.array(submissionPreflightNoteSchema).max(24),
+    duplicates: z.array(submissionPreflightDuplicateSchema).max(5),
     nextAction: z.object({
-      label: z.string(),
-      url: z.string(),
+      label: z.string().max(160),
+      url: z.string().max(4096),
     }),
   })
   .passthrough();

--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -1,0 +1,297 @@
+import {
+  buildSubmissionIssueDraft,
+  validateSubmission,
+} from "@heyclaude/registry/submission";
+import { analyzeIssueSubmissionRisk } from "@heyclaude/registry/submission-risk";
+
+import { getDirectoryEntries, type DirectoryEntry } from "@/lib/content";
+import { siteConfig } from "@/lib/site";
+
+const DEFAULT_REPO = "JSONbored/awesome-claude";
+const TOOL_LISTING_FORM_URL = "/tools/submit";
+
+type DuplicateCandidate = {
+  key: string;
+  category: string;
+  slug: string;
+  title: string;
+  url: string;
+  reasons: string[];
+};
+
+function normalizeText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function normalizeComparable(value: unknown) {
+  return normalizeText(value).toLowerCase().replace(/\s+/g, " ");
+}
+
+function normalizeUrl(value: unknown) {
+  const text = normalizeText(value);
+  if (!text) return "";
+  try {
+    const url = new URL(text);
+    url.hash = "";
+    if (url.pathname !== "/" && url.pathname.endsWith("/")) {
+      url.pathname = url.pathname.slice(0, -1);
+    }
+    return url.toString().toLowerCase();
+  } catch {
+    return text.toLowerCase();
+  }
+}
+
+function githubIssueFallbackUrl(issue: { title: string; body: string }) {
+  const url = new URL(`https://github.com/${DEFAULT_REPO}/issues/new`);
+  url.searchParams.set("title", issue.title);
+  url.searchParams.set("body", issue.body);
+  return url.toString();
+}
+
+function submittedSourceUrls(fields: Record<string, unknown>) {
+  return [
+    fields.github_url,
+    fields.docs_url,
+    fields.source_url,
+    fields.download_url,
+  ]
+    .map(normalizeUrl)
+    .filter(Boolean);
+}
+
+function entrySourceUrls(entry: DirectoryEntry) {
+  return [
+    entry.repoUrl,
+    entry.githubUrl,
+    entry.documentationUrl,
+    entry.downloadUrl,
+    ...(entry.trustSignals?.sourceUrls ?? []),
+  ]
+    .map(normalizeUrl)
+    .filter(Boolean);
+}
+
+function duplicateCandidates(params: {
+  entries: DirectoryEntry[];
+  fields: Record<string, unknown>;
+  category: string;
+  slug: string;
+}) {
+  const title = normalizeComparable(
+    params.fields.name || params.fields.title || "",
+  );
+  const sourceUrls = submittedSourceUrls(params.fields);
+  const sourceUrlSet = new Set(sourceUrls);
+  const candidates: DuplicateCandidate[] = [];
+
+  for (const entry of params.entries) {
+    const reasons: string[] = [];
+    if (params.category && params.slug) {
+      if (entry.category === params.category && entry.slug === params.slug) {
+        reasons.push("slug");
+      }
+    }
+
+    if (title && normalizeComparable(entry.title) === title) {
+      reasons.push("title");
+    }
+
+    if (sourceUrlSet.size) {
+      const shared = entrySourceUrls(entry).find((url) =>
+        sourceUrlSet.has(url),
+      );
+      if (shared) reasons.push("source_url");
+    }
+
+    if (!reasons.length) continue;
+    candidates.push({
+      key: `${entry.category}:${entry.slug}`,
+      category: entry.category,
+      slug: entry.slug,
+      title: entry.title,
+      url:
+        entry.canonicalUrl ||
+        `${siteConfig.url}/${entry.category}/${entry.slug}`,
+      reasons: [...new Set(reasons)],
+    });
+  }
+
+  return candidates.slice(0, 5);
+}
+
+function blocker(code: string, message: string) {
+  return { code, message };
+}
+
+function warning(code: string, message: string) {
+  return { code, message };
+}
+
+function isToolsRouteError(message: string) {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("tools/app lead form") ||
+    normalized.includes("change the category to tools")
+  );
+}
+
+function missingNoteWarnings(
+  risk: ReturnType<typeof analyzeIssueSubmissionRisk>,
+) {
+  const warnings = risk.classificationWarnings ?? [];
+  const safety = warnings.find((item) => item.id === "missing_safety_notes");
+  const privacy = warnings.find((item) => item.id === "missing_privacy_notes");
+  return { safety, privacy };
+}
+
+export async function buildSubmissionPreflight(
+  fields: Record<string, unknown>,
+) {
+  const issue = buildSubmissionIssueDraft({
+    ...fields,
+    submitted_via: "website-preflight",
+  });
+  const validation = validateSubmission({
+    title: issue.title,
+    body: issue.body,
+    labels: issue.labels,
+  });
+  const risk = analyzeIssueSubmissionRisk(
+    {
+      title: issue.title,
+      body: issue.body,
+      labels: issue.labels,
+      author: "website-preflight",
+    },
+    validation,
+  );
+  const fallbackUrl = githubIssueFallbackUrl(issue);
+  const category = normalizeText(validation.category || risk.subject?.category);
+  const slug = normalizeText(validation.fields?.slug || risk.subject?.slug);
+  const entries = await getDirectoryEntries().catch(() => []);
+  const duplicates = duplicateCandidates({
+    entries,
+    fields: validation.fields || fields,
+    category,
+    slug,
+  });
+  const noteWarnings = missingNoteWarnings(risk);
+
+  const blockers = [];
+  const warnings = [];
+
+  if (validation.skipped) {
+    blockers.push(
+      blocker(
+        "unsupported_category",
+        "Choose one of the supported HeyClaude submission categories.",
+      ),
+    );
+  }
+
+  for (const error of validation.errors || []) {
+    blockers.push(blocker("schema_invalid", error));
+  }
+
+  for (const duplicate of duplicates) {
+    if (
+      duplicate.reasons.includes("slug") ||
+      duplicate.reasons.includes("source_url")
+    ) {
+      blockers.push(
+        blocker("duplicate_existing", `Likely duplicate of ${duplicate.key}.`),
+      );
+    }
+  }
+
+  for (const duplicate of duplicates) {
+    if (duplicate.reasons.includes("title")) {
+      warnings.push(
+        warning(
+          "possible_duplicate_title",
+          `Similar existing title: ${duplicate.key}.`,
+        ),
+      );
+    }
+  }
+
+  const sourceGate = risk.policyMatrix?.source;
+  if (sourceGate?.status && sourceGate.status !== "pass") {
+    warnings.push(
+      warning(
+        "source_needs_review",
+        sourceGate.summary || "Add a canonical GitHub, docs, or source URL.",
+      ),
+    );
+  }
+
+  if (noteWarnings.safety) {
+    warnings.push(warning("missing_safety_notes", noteWarnings.safety.summary));
+  }
+  if (noteWarnings.privacy) {
+    warnings.push(
+      warning("missing_privacy_notes", noteWarnings.privacy.summary),
+    );
+  }
+
+  const routeSuggestion = validation.errors?.some(isToolsRouteError)
+    ? "tools_form"
+    : blockers.length
+      ? "fix_required"
+      : "github_issue";
+
+  return {
+    ok: true,
+    valid: !validation.skipped && validation.ok && blockers.length === 0,
+    routeSuggestion,
+    category,
+    slug,
+    fallbackUrl,
+    issuePreview: {
+      title: issue.title,
+      labels: issue.labels,
+      body: issue.body,
+    },
+    schema: {
+      ok: validation.ok,
+      skipped: validation.skipped,
+      errors: validation.errors || [],
+      warnings: validation.warnings || [],
+      fields: validation.fields || {},
+    },
+    risk: {
+      tier: risk.riskTier,
+      policyDecision: risk.policyDecision,
+      policyMatrix: risk.policyMatrix || {},
+      reviewFlags: risk.reviewFlags || [],
+      classificationWarnings: risk.classificationWarnings || [],
+    },
+    expectedNotes: {
+      safety: Boolean(noteWarnings.safety),
+      privacy: Boolean(noteWarnings.privacy),
+      reasons: [
+        noteWarnings.safety?.detail,
+        noteWarnings.privacy?.detail,
+      ].filter(Boolean),
+    },
+    blockers,
+    warnings,
+    duplicates,
+    nextAction:
+      routeSuggestion === "tools_form"
+        ? {
+            label: "Use the paid/editorial tool listing flow",
+            url: TOOL_LISTING_FORM_URL,
+          }
+        : routeSuggestion === "fix_required"
+          ? {
+              label: "Fix blockers before opening a submission issue",
+              url: "",
+            }
+          : {
+              label: "Open a reviewable GitHub issue",
+              url: fallbackUrl,
+            },
+  };
+}

--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -287,7 +287,6 @@ export async function buildSubmissionPreflight(
         : routeSuggestion === "fix_required"
           ? {
               label: "Fix blockers before opening a submission issue",
-              url: "",
             }
           : {
               label: "Open a reviewable GitHub issue",

--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -9,6 +9,9 @@ import { siteConfig } from "@/lib/site";
 
 const DEFAULT_REPO = "JSONbored/awesome-claude";
 const TOOL_LISTING_FORM_URL = "/tools/submit";
+const MAX_FALLBACK_BODY_BYTES = 6000;
+const FALLBACK_BODY_TRUNCATION_NOTE =
+  "\n\n[HeyClaude preflight note: this fallback URL shortened the issue body. Submit from the website to keep the full draft.]";
 
 type DuplicateCandidate = {
   key: string;
@@ -42,10 +45,37 @@ function normalizeUrl(value: unknown) {
   }
 }
 
+function normalizeError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return { message: String(error) };
+}
+
+function truncateFallbackBody(value: string) {
+  const encoder = new TextEncoder();
+  if (encoder.encode(value).length <= MAX_FALLBACK_BODY_BYTES) return value;
+
+  const noteBytes = encoder.encode(FALLBACK_BODY_TRUNCATION_NOTE).length;
+  const budget = Math.max(0, MAX_FALLBACK_BODY_BYTES - noteBytes);
+  let bytes = 0;
+  let body = "";
+  for (const char of value) {
+    const nextBytes = encoder.encode(char).length;
+    if (bytes + nextBytes > budget) break;
+    body += char;
+    bytes += nextBytes;
+  }
+  return `${body.trimEnd()}${FALLBACK_BODY_TRUNCATION_NOTE}`;
+}
+
 function githubIssueFallbackUrl(issue: { title: string; body: string }) {
   const url = new URL(`https://github.com/${DEFAULT_REPO}/issues/new`);
   url.searchParams.set("title", issue.title);
-  url.searchParams.set("body", issue.body);
+  url.searchParams.set("body", truncateFallbackBody(issue.body));
   return url.toString();
 }
 
@@ -169,7 +199,17 @@ export async function buildSubmissionPreflight(
   const fallbackUrl = githubIssueFallbackUrl(issue);
   const category = normalizeText(validation.category || risk.subject?.category);
   const slug = normalizeText(validation.fields?.slug || risk.subject?.slug);
-  const entries = await getDirectoryEntries().catch(() => []);
+  const entries = await getDirectoryEntries().catch((error) => {
+    console.warn(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        level: "warn",
+        event: "submissions.preflight.directory_entries_failed",
+        error: normalizeError(error),
+      }),
+    );
+    return [];
+  });
   const duplicates = duplicateCandidates({
     entries,
     fields: validation.fields || fields,

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4297,8 +4297,197 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: {}
+                anyOf:
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                      routeSuggestion:
+                        type: string
+                        enum:
+                          - github_issue
+                          - fix_required
+                          - tools_form
+                      category:
+                        type: string
+                      slug:
+                        type: string
+                      fallbackUrl:
+                        type: string
+                        format: uri
+                      issuePreview:
+                        type: object
+                        properties:
+                          title:
+                            type: string
+                          labels:
+                            type: array
+                            items:
+                              type: string
+                          body:
+                            type: string
+                        required:
+                          - title
+                          - labels
+                          - body
+                      schema:
+                        type: object
+                        properties:
+                          ok:
+                            type: boolean
+                          skipped:
+                            type: boolean
+                          errors:
+                            type: array
+                            items:
+                              type: string
+                          warnings:
+                            type: array
+                            items:
+                              type: string
+                          fields:
+                            type: object
+                            additionalProperties: {}
+                        required:
+                          - ok
+                          - skipped
+                          - errors
+                          - warnings
+                          - fields
+                      risk:
+                        type: object
+                        properties:
+                          tier:
+                            type: string
+                          policyDecision:
+                            type: string
+                          policyMatrix:
+                            type: object
+                            additionalProperties: {}
+                          reviewFlags:
+                            type: array
+                            items:
+                              type: string
+                          classificationWarnings:
+                            type: array
+                            items: {}
+                        required:
+                          - policyMatrix
+                          - reviewFlags
+                          - classificationWarnings
+                      expectedNotes:
+                        type: object
+                        properties:
+                          safety:
+                            type: boolean
+                          privacy:
+                            type: boolean
+                          reasons:
+                            type: array
+                            items:
+                              type: string
+                        required:
+                          - safety
+                          - privacy
+                          - reasons
+                      blockers:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            code:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - code
+                            - message
+                      warnings:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            code:
+                              type: string
+                            message:
+                              type: string
+                          required:
+                            - code
+                            - message
+                      duplicates:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            category:
+                              type: string
+                            slug:
+                              type: string
+                            title:
+                              type: string
+                            url:
+                              type: string
+                            reasons:
+                              type: array
+                              items:
+                                type: string
+                          required:
+                            - key
+                            - category
+                            - slug
+                            - title
+                            - url
+                            - reasons
+                      nextAction:
+                        type: object
+                        properties:
+                          label:
+                            type: string
+                          url:
+                            type: string
+                        required:
+                          - label
+                          - url
+                    required:
+                      - ok
+                      - valid
+                      - routeSuggestion
+                      - category
+                      - slug
+                      - fallbackUrl
+                      - issuePreview
+                      - schema
+                      - risk
+                      - expectedNotes
+                      - blockers
+                      - warnings
+                      - duplicates
+                      - nextAction
+                    additionalProperties: {}
+                  - type: object
+                    properties:
+                      ok:
+                        type: boolean
+                        enum:
+                          - true
+                      valid:
+                        type: boolean
+                        enum:
+                          - false
+                      queued:
+                        type: boolean
+                        enum:
+                          - false
+                    required:
+                      - ok
+                      - valid
+                      - queued
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4268,6 +4268,280 @@ paths:
                 required:
                   - ok
                   - error
+  /api/submissions/preflight:
+    post:
+      tags:
+        - Submissions
+      summary: Preflight a content submission draft
+      description:
+        Runs read-only schema, duplicate, source, package, and safety/privacy checks before a
+        contributor opens a public GitHub submission issue. This endpoint never creates issues,
+        labels, branches, pull requests, registry content, or package artifacts.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                fields:
+                  type: object
+                  additionalProperties: {}
+                  default: {}
+                honeypot:
+                  type: string
+                  maxLength: 256
+                  default: ""
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/download:
     get:
       tags:

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4324,12 +4324,16 @@ paths:
                         properties:
                           title:
                             type: string
+                            maxLength: 300
                           labels:
                             type: array
                             items:
                               type: string
+                              maxLength: 80
+                            maxItems: 12
                           body:
                             type: string
+                            maxLength: 32000
                         required:
                           - title
                           - labels
@@ -4345,10 +4349,14 @@ paths:
                             type: array
                             items:
                               type: string
+                              maxLength: 500
+                            maxItems: 32
                           warnings:
                             type: array
                             items:
                               type: string
+                              maxLength: 500
+                            maxItems: 32
                           fields:
                             type: object
                             additionalProperties: {}
@@ -4372,9 +4380,12 @@ paths:
                             type: array
                             items:
                               type: string
+                              maxLength: 120
+                            maxItems: 32
                           classificationWarnings:
                             type: array
                             items: {}
+                            maxItems: 32
                         required:
                           - policyMatrix
                           - reviewFlags
@@ -4390,6 +4401,8 @@ paths:
                             type: array
                             items:
                               type: string
+                              maxLength: 500
+                            maxItems: 8
                         required:
                           - safety
                           - privacy
@@ -4401,11 +4414,14 @@ paths:
                           properties:
                             code:
                               type: string
+                              maxLength: 80
                             message:
                               type: string
+                              maxLength: 500
                           required:
                             - code
                             - message
+                        maxItems: 24
                       warnings:
                         type: array
                         items:
@@ -4413,11 +4429,14 @@ paths:
                           properties:
                             code:
                               type: string
+                              maxLength: 80
                             message:
                               type: string
+                              maxLength: 500
                           required:
                             - code
                             - message
+                        maxItems: 24
                       duplicates:
                         type: array
                         items:
@@ -4425,18 +4444,26 @@ paths:
                           properties:
                             key:
                               type: string
+                              maxLength: 160
                             category:
                               type: string
+                              maxLength: 80
                             slug:
                               type: string
+                              maxLength: 160
                             title:
                               type: string
+                              maxLength: 240
                             url:
                               type: string
+                              maxLength: 2048
+                              format: uri
                             reasons:
                               type: array
                               items:
                                 type: string
+                                maxLength: 80
+                              maxItems: 8
                           required:
                             - key
                             - category
@@ -4444,13 +4471,16 @@ paths:
                             - title
                             - url
                             - reasons
+                        maxItems: 5
                       nextAction:
                         type: object
                         properties:
                           label:
                             type: string
+                            maxLength: 160
                           url:
                             type: string
+                            maxLength: 4096
                         required:
                           - label
                           - url

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4483,7 +4483,6 @@ paths:
                             maxLength: 4096
                         required:
                           - label
-                          - url
                     required:
                       - ok
                       - valid

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4498,7 +4498,6 @@ paths:
                       - warnings
                       - duplicates
                       - nextAction
-                    additionalProperties: {}
                   - type: object
                     properties:
                       ok:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -30,6 +30,7 @@ const apiRoutes = [
   "/api/newsletter/webhook",
   "/api/og",
   "/api/submissions",
+  "/api/submissions/preflight",
   "/api/download",
   "/api/jobs",
   "/api/listing-leads",

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -252,6 +252,9 @@ describe("central API router security", () => {
     expect(apiRouteDefinitions["submissions.create"].rateLimit?.binding).toBe(
       "API_STRICT_RATE_LIMIT",
     );
+    expect(
+      apiRouteDefinitions["submissions.preflight"].rateLimit?.binding,
+    ).toBe("API_DYNAMIC_RATE_LIMIT");
     expect(apiRouteDefinitions["registry.search"].rateLimit?.binding).toBe(
       "API_REGISTRY_RATE_LIMIT",
     );

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -32,8 +32,9 @@ function request(
   body: Record<string, unknown>,
   ip = "203.0.113.10",
   headers: Record<string, string> = {},
+  url = "https://heyclau.de/api/submissions",
 ) {
-  return new Request("https://heyclau.de/api/submissions", {
+  return new Request(url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -43,6 +44,19 @@ function request(
     },
     body: JSON.stringify(body),
   });
+}
+
+function preflightRequest(
+  body: Record<string, unknown>,
+  ip = "203.0.113.10",
+  headers: Record<string, string> = {},
+) {
+  return request(
+    body,
+    ip,
+    headers,
+    "https://heyclau.de/api/submissions/preflight",
+  );
 }
 
 function githubIssueResponse(number = 42) {
@@ -212,7 +226,7 @@ describe("website submission API", () => {
   it("preflights valid submissions without GitHub writes", async () => {
     const { POST } = await import("@/app/api/submissions/preflight/route");
     const response = await POST(
-      request({ fields: validFields() }, "203.0.113.20"),
+      preflightRequest({ fields: validFields() }, "203.0.113.20"),
     );
 
     expect(response.status).toBe(200);
@@ -249,7 +263,7 @@ describe("website submission API", () => {
     ]);
     const { POST } = await import("@/app/api/submissions/preflight/route");
     const response = await POST(
-      request({ fields: validFields() }, "203.0.113.21"),
+      preflightRequest({ fields: validFields() }, "203.0.113.21"),
     );
 
     expect(response.status).toBe(200);
@@ -271,7 +285,7 @@ describe("website submission API", () => {
   it("preflights product-shaped submissions toward the tools flow", async () => {
     const { POST } = await import("@/app/api/submissions/preflight/route");
     const response = await POST(
-      request({
+      preflightRequest({
         fields: validFields({
           name: "Paid SaaS AI Platform",
           slug: "paid-saas-ai-platform",
@@ -300,7 +314,7 @@ describe("website submission API", () => {
   it("preflights local download requests as blockers", async () => {
     const { POST } = await import("@/app/api/submissions/preflight/route");
     const response = await POST(
-      request({
+      preflightRequest({
         fields: validFields({
           category: "skills",
           skill_type: "general",
@@ -327,7 +341,7 @@ describe("website submission API", () => {
   it("preflights risky drafts with expected safety and privacy notes", async () => {
     const { POST } = await import("@/app/api/submissions/preflight/route");
     const response = await POST(
-      request({
+      preflightRequest({
         fields: validFields({
           name: "Workspace Sync Hook",
           slug: "workspace-sync-hook",

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -209,6 +209,158 @@ describe("website submission API", () => {
     expect(fetch).toHaveBeenCalledTimes(1);
   });
 
+  it("preflights valid submissions without GitHub writes", async () => {
+    const { POST } = await import("@/app/api/submissions/preflight/route");
+    const response = await POST(
+      request({ fields: validFields() }, "203.0.113.20"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      valid: true,
+      routeSuggestion: "github_issue",
+      category: "mcp",
+      slug: "direct-submit-api-asset",
+      blockers: [],
+      duplicates: [],
+      issuePreview: {
+        title: "Submit MCP Server: Direct Submit API Asset",
+        labels: expect.arrayContaining(["content-submission"]),
+      },
+      risk: {
+        policyDecision: expect.any(String),
+        policyMatrix: expect.any(Object),
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preflights existing duplicate registry entries before issue creation", async () => {
+    directoryEntriesMock.mockResolvedValue([
+      {
+        category: "mcp",
+        slug: "direct-submit-api-asset",
+        title: "Direct Submit API Asset",
+        canonicalUrl: "https://heyclau.de/mcp/direct-submit-api-asset",
+        documentationUrl: "https://example.com/docs",
+        trustSignals: { sourceUrls: ["https://example.com/docs"] },
+      },
+    ]);
+    const { POST } = await import("@/app/api/submissions/preflight/route");
+    const response = await POST(
+      request({ fields: validFields() }, "203.0.113.21"),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      valid: false,
+      routeSuggestion: "fix_required",
+      blockers: [expect.objectContaining({ code: "duplicate_existing" })],
+      duplicates: [
+        expect.objectContaining({
+          key: "mcp:direct-submit-api-asset",
+          reasons: expect.arrayContaining(["slug", "source_url", "title"]),
+        }),
+      ],
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preflights product-shaped submissions toward the tools flow", async () => {
+    const { POST } = await import("@/app/api/submissions/preflight/route");
+    const response = await POST(
+      request({
+        fields: validFields({
+          name: "Paid SaaS AI Platform",
+          slug: "paid-saas-ai-platform",
+          category: "mcp",
+          docs_url: "https://example.com/pricing",
+          install_command: "Use the hosted dashboard at https://example.com",
+          usage_snippet: "Create an account and use the hosted dashboard.",
+          description:
+            "Commercial AI SaaS platform with pricing plans, subscription tiers, and a hosted product signup flow.",
+          card_description: "Commercial AI SaaS platform.",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      routeSuggestion: "tools_form",
+      nextAction: {
+        url: "/tools/submit",
+      },
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preflights local download requests as blockers", async () => {
+    const { POST } = await import("@/app/api/submissions/preflight/route");
+    const response = await POST(
+      request({
+        fields: validFields({
+          category: "skills",
+          skill_type: "general",
+          skill_level: "advanced",
+          verification_status: "validated",
+          download_url: "/downloads/skills/submitted.zip",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.routeSuggestion).toBe("fix_required");
+    expect(
+      body.blockers.map((item: { message: string }) => item.message),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Community submissions cannot request local"),
+      ]),
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("preflights risky drafts with expected safety and privacy notes", async () => {
+    const { POST } = await import("@/app/api/submissions/preflight/route");
+    const response = await POST(
+      request({
+        fields: validFields({
+          name: "Workspace Sync Hook",
+          slug: "workspace-sync-hook",
+          category: "hooks",
+          trigger: "PostToolUse",
+          script_language: "bash",
+          install_command: "curl -fsSL https://example.com/install.sh | sh",
+          description:
+            "Runs a background sync worker that reads the local workspace and requires an API key for a third-party API.",
+          card_description: "Background sync hook for project files.",
+          full_copyable_content:
+            "curl -fsSL https://example.com/install.sh | sh\nexport API_TOKEN=...",
+          safety_notes: "",
+          privacy_notes: "",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      expectedNotes: {
+        safety: true,
+        privacy: true,
+      },
+      warnings: expect.arrayContaining([
+        expect.objectContaining({ code: "missing_safety_notes" }),
+        expect.objectContaining({ code: "missing_privacy_notes" }),
+      ]),
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("silently discards honeypot submissions", async () => {
     const { POST } = await import("@/app/api/submissions/route");
     const response = await POST(

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -328,6 +328,10 @@ describe("website submission API", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.routeSuggestion).toBe("fix_required");
+    expect(body.nextAction).toMatchObject({
+      label: "Fix blockers before opening a submission issue",
+    });
+    expect(body.nextAction.url).toBeUndefined();
     expect(
       body.blockers.map((item: { message: string }) => item.message),
     ).toEqual(


### PR DESCRIPTION
## Summary
- Add a read-only submission preflight endpoint for contributor drafts.
- Surface schema, duplicate, source/package, safety/privacy, and route guidance in the submit form before issue creation.
- Keep issue creation, labeling, branching, PR opening, and publishing out of the preflight path.

## What changed
- Added POST /api/submissions/preflight with central API router coverage and OpenAPI docs.
- Added registry-only duplicate candidate detection for slug, source URL, and title matches.
- Reused the existing submission validator and risk/policy scanner for blockers and warnings.
- Updated /submit readiness UI to show blockers, review notes, duplicates, risk tier, and tools-flow routing.
- Hid the dry-run preview while deterministic preflight blockers are present.

## Why
- Contributors need feedback before opening public GitHub issues.
- Maintainers need fewer duplicate, product-promo, local-download, and missing safety/privacy submissions reaching the queue.

## Validation
- pnpm validate:openapi
- pnpm exec vitest run tests/submission-api.test.ts tests/api-contracts.test.ts tests/api-router-security.test.ts
- pnpm test:submission-intake
- pnpm validate:content:strict
- pnpm build
- pnpm validate:clean

## Notes
- Preflight does not call GitHub and does not require Turnstile; it is origin-checked and rate-limited through the dynamic API rate-limit binding.
- Pending duplicate GitHub issues are still checked only by the final /api/submissions create path, where the configured GitHub token already exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-driven preflight check runs live as you fill the form, guiding submission readiness.
  * Form shows blockers to fix, review notes, possible duplicates, and a risk-tier badge.
  * Submit button is disabled until preflight allows submission; preview hides when blocked.
  * Suggested next steps and safe external links are surfaced from the preflight analysis.
  * New read-only preflight API powers these checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Tracking
- Closes #394
