### PR TITLE
feat(submissions): improve maintainer queue triage

### DIFF
--- a/.github/workflows/submission-queue.yml
+++ b/.github/workflows/submission-queue.yml
@@ -65,15 +65,17 @@ jobs:
           const lines = [
             "# Submission Queue",
             "",
-            `- Import ready: ${queue.summary.importReady}`,
+            `- Ready: ${queue.summary.ready}`,
+            `- Blocked: ${queue.summary.blocked}`,
+            `- Likely promo/spam: ${queue.summary.likelyPromoSpam}`,
             `- Needs author input: ${queue.summary.needsAuthorInput}`,
             `- Source needs verification: ${queue.summary.sourceNeedsVerification}`,
-            `- Stale reminder due: ${queue.summary.staleReminderDue}`,
+            `- Stale reminder due: ${queue.summary.stale}`,
             `- Close eligible: ${queue.summary.closeEligible}`,
             `- Skipped: ${queue.summary.skipped}`,
             "",
-            "| Issue | Status | Security | Policy | Source | Contributor | Age | Category | Slug | Action | Notes |",
-            "| --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
+            "| Issue | Group | Status | Security | Policy | Source | Contributor | Age | Category | Slug | Action | Notes |",
+            "| --- | --- | --- | --- | --- | --- | --- | ---: | --- | --- | --- | --- |",
           ];
           const cell = (value) => String(value || "-").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>");
           for (const entry of queue.entries) {
@@ -90,7 +92,7 @@ jobs:
             const contributor = entry.contributorReview?.length
               ? entry.contributorReview.join(", ")
               : "-";
-            lines.push(`| ${issue} | ${cell(entry.status)} | ${cell(risk)} | ${cell(entry.policyDecision)} | ${cell(entry.sourceState)} | ${cell(contributor)} | ${entry.ageDays ?? 0}d | ${cell(entry.category)} | ${cell(entry.slug)} | ${cell(entry.actionDue)} | ${cell(notes)} |`);
+            lines.push(`| ${issue} | ${cell(entry.triageGroup)} | ${cell(entry.status)} | ${cell(risk)} | ${cell(entry.policyDecision)} | ${cell(entry.sourceState)} | ${cell(contributor)} | ${entry.ageDays ?? 0}d | ${cell(entry.category)} | ${cell(entry.slug)} | ${cell(entry.actionDue)} | ${cell(notes)} |`);
           }
           fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\n")}\n`);
           NODE

--- a/apps/web/src/app/submissions/page.tsx
+++ b/apps/web/src/app/submissions/page.tsx
@@ -26,15 +26,8 @@ type GitHubIssue = {
   pull_request?: unknown;
 };
 
-type SubmissionFilter =
-  | "all"
-  | "import_ready"
-  | "maintainer_review"
-  | "needs_author_input"
-  | "source_needs_verification"
-  | "stale_reminder_due"
-  | "close_eligible"
-  | "high_risk";
+type SubmissionTriageGroup = SubmissionQueueEntry["triageGroup"];
+type SubmissionFilter = "all" | SubmissionTriageGroup;
 
 type SubmissionsPageProps = {
   searchParams?: Promise<Record<string, string | string[] | undefined>>;
@@ -42,13 +35,15 @@ type SubmissionsPageProps = {
 
 const FILTERS: Array<{ key: SubmissionFilter; label: string }> = [
   { key: "all", label: "All" },
-  { key: "import_ready", label: "Import ready" },
+  { key: "ready", label: "Ready" },
+  { key: "blocked", label: "Blocked" },
   { key: "maintainer_review", label: "Maintainer review" },
   { key: "needs_author_input", label: "Author input" },
-  { key: "source_needs_verification", label: "Source review" },
-  { key: "stale_reminder_due", label: "Reminder due" },
+  { key: "source_verification", label: "Source review" },
+  { key: "likely_promo_spam", label: "Promo/spam" },
+  { key: "stale", label: "Reminder due" },
   { key: "close_eligible", label: "Close eligible" },
-  { key: "high_risk", label: "High risk" },
+  { key: "skipped", label: "Skipped" },
 ];
 
 export const dynamic = "force-dynamic";
@@ -129,6 +124,18 @@ function nextActionLabel(action: SubmissionQueueEntry["nextAction"]) {
   return "Skip";
 }
 
+function triageLabel(group: SubmissionTriageGroup) {
+  if (group === "ready") return "Ready";
+  if (group === "blocked") return "Blocked";
+  if (group === "needs_author_input") return "Needs author input";
+  if (group === "source_verification") return "Source verification";
+  if (group === "likely_promo_spam") return "Likely promo/spam";
+  if (group === "stale") return "Reminder due";
+  if (group === "close_eligible") return "Close eligible";
+  if (group === "maintainer_review") return "Maintainer review";
+  return "Skipped";
+}
+
 function normalizeFilter(value: string | string[] | undefined) {
   const normalized = Array.isArray(value) ? value[0] : value;
   return FILTERS.some((filter) => filter.key === normalized)
@@ -136,17 +143,12 @@ function normalizeFilter(value: string | string[] | undefined) {
     : "all";
 }
 
-function isHighRisk(entry: SubmissionQueueEntry) {
-  return entry.riskTier === "high" || entry.riskTier === "critical";
-}
-
 function filterEntries(
   entries: SubmissionQueueEntry[],
   filter: SubmissionFilter,
 ) {
   if (filter === "all") return entries;
-  if (filter === "high_risk") return entries.filter(isHighRisk);
-  return entries.filter((entry) => entry.status === filter);
+  return entries.filter((entry) => entry.triageGroup === filter);
 }
 
 function filterCount(
@@ -310,11 +312,12 @@ export default async function SubmissionsPage({
 
         <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {[
-            ["Import ready", queue.summary.importReady],
+            ["Ready", queue.summary.ready],
+            ["Blocked", queue.summary.blocked],
+            ["Likely promo/spam", queue.summary.likelyPromoSpam],
             ["Needs author input", queue.summary.needsAuthorInput],
             ["Source verification", queue.summary.sourceNeedsVerification],
-            ["High risk", queue.summary.highRisk],
-            ["Reminder due", queue.summary.staleReminderDue],
+            ["Reminder due", queue.summary.stale],
             ["Close eligible", queue.summary.closeEligible],
             ["Maintainer review", queue.summary.maintainerReview],
             ["Tracked issues", queue.count],
@@ -367,6 +370,12 @@ export default async function SubmissionsPage({
           {entries.length ? (
             entries.map((entry) => {
               const sourceHref = safeHttpUrl(entry.sourceUrl);
+              const sourceUrls = entry.sourceUrls
+                .map((url) => safeHttpUrl(url))
+                .filter(Boolean);
+              const contributorProfileHref = safeHttpUrl(
+                entry.contributorContext.profileUrl,
+              );
               const submitHref = submissionFormHref(entry.category || "mcp");
 
               return (
@@ -375,6 +384,9 @@ export default async function SubmissionsPage({
                     <div className="space-y-2">
                       <div className="flex flex-wrap items-center gap-2">
                         <span className="rounded-full border border-primary/35 bg-primary/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-primary">
+                          {triageLabel(entry.triageGroup)}
+                        </span>
+                        <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
                           {statusLabel(entry.status)}
                         </span>
                         <span
@@ -387,7 +399,7 @@ export default async function SubmissionsPage({
                         </span>
                         {entry.autoImportEligible ? (
                           <span className="rounded-full border border-primary/35 bg-primary/10 px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-primary">
-                            Auto PR eligible
+                            Approval-gated PR eligible
                           </span>
                         ) : null}
                       </div>
@@ -406,6 +418,9 @@ export default async function SubmissionsPage({
                         {entry.slug || "no slug"}
                         {entry.author ? ` / @${entry.author}` : ""}
                         {entry.ageDays ? ` / ${entry.ageDays}d waiting` : ""}
+                      </p>
+                      <p className="max-w-3xl text-sm leading-7 text-muted-foreground">
+                        {entry.triageReason}
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
@@ -450,28 +465,30 @@ export default async function SubmissionsPage({
                         </div>
                       ) : null}
 
-                      {entry.policyMatrix &&
-                      Object.keys(entry.policyMatrix).length ? (
+                      {entry.policyReasons.length ? (
                         <div>
                           <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
                             Policy matrix
                           </p>
                           <div className="mt-2 grid gap-2 sm:grid-cols-2">
-                            {Object.entries(entry.policyMatrix).map(
-                              ([name, gate]) => (
-                                <div
-                                  key={name}
-                                  className="rounded-lg border border-border bg-background/60 px-3 py-2"
-                                >
-                                  <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
-                                    {name} / {gate?.status || "unknown"}
+                            {entry.policyReasons.map((gate) => (
+                              <div
+                                key={gate.name}
+                                className="rounded-lg border border-border bg-background/60 px-3 py-2"
+                              >
+                                <p className="text-[11px] uppercase tracking-[0.14em] text-muted-foreground">
+                                  {gate.name} / {gate.status}
+                                </p>
+                                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                                  {gate.summary || "No summary available."}
+                                </p>
+                                {gate.detail.length ? (
+                                  <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                                    {gate.detail.slice(0, 3).join(", ")}
                                   </p>
-                                  <p className="mt-1 text-xs leading-5 text-muted-foreground">
-                                    {gate?.summary || "No summary available."}
-                                  </p>
-                                </div>
-                              ),
-                            )}
+                                ) : null}
+                              </div>
+                            ))}
                           </div>
                         </div>
                       ) : null}
@@ -498,10 +515,31 @@ export default async function SubmissionsPage({
                     <div className="space-y-4 rounded-lg border border-border bg-background/40 p-4">
                       <div>
                         <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
-                          Labels
+                          Current labels
                         </p>
                         <div className="mt-2 flex flex-wrap gap-1.5">
-                          {entry.labels.map((label) => (
+                          {entry.labels.length ? (
+                            entry.labels.map((label) => (
+                              <span
+                                key={label}
+                                className="rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-muted-foreground"
+                              >
+                                {label}
+                              </span>
+                            ))
+                          ) : (
+                            <span className="text-sm text-muted-foreground">
+                              No managed labels yet
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                          Recommended labels
+                        </p>
+                        <div className="mt-2 flex flex-wrap gap-1.5">
+                          {entry.recommendedLabels.map((label) => (
                             <span
                               key={label}
                               className="rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-muted-foreground"
@@ -530,19 +568,71 @@ export default async function SubmissionsPage({
                       ) : null}
                       <div>
                         <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
-                          Source state
+                          Source context
                         </p>
                         <p className="mt-2 text-sm text-muted-foreground">
                           {entry.sourceState}
                         </p>
-                        {sourceHref ? (
+                        <div className="mt-2 space-y-1">
+                          {[sourceHref, ...sourceUrls]
+                            .filter(Boolean)
+                            .filter(
+                              (url, index, urls) => urls.indexOf(url) === index,
+                            )
+                            .slice(0, 4)
+                            .map((url) => (
+                              <a
+                                key={url}
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="block truncate text-sm text-primary hover:underline"
+                              >
+                                {url}
+                              </a>
+                            ))}
+                        </div>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.16em] text-muted-foreground">
+                          Contributor context
+                        </p>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {entry.contributorContext.login ||
+                            entry.author ||
+                            "Unknown contributor"}
+                          {" / "}
+                          {entry.contributorContext.resolutionStatus}
+                        </p>
+                        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                          {entry.contributorContext.accountAgeDays === null
+                            ? "Account age unknown"
+                            : `${entry.contributorContext.accountAgeDays}d account age`}
+                          {" / "}
+                          {entry.contributorContext.publicRepos === null
+                            ? "public repos unknown"
+                            : `${entry.contributorContext.publicRepos} public repos`}
+                        </p>
+                        {entry.contributorContext.signals.length ? (
+                          <div className="mt-2 flex flex-wrap gap-1.5">
+                            {entry.contributorContext.signals.map((signal) => (
+                              <span
+                                key={signal}
+                                className="rounded-full border border-border bg-card px-2.5 py-1 text-[11px] text-muted-foreground"
+                              >
+                                {signal}
+                              </span>
+                            ))}
+                          </div>
+                        ) : null}
+                        {contributorProfileHref ? (
                           <a
-                            href={sourceHref}
+                            href={contributorProfileHref}
                             target="_blank"
                             rel="noopener noreferrer"
                             className="mt-2 inline-flex text-sm text-primary hover:underline"
                           >
-                            Open submitted source
+                            Open contributor profile
                           </a>
                         ) : null}
                       </div>

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -685,6 +685,17 @@ export type SubmissionQueueEntry = {
     | "send_stale_reminder"
     | "close_stale"
     | "skip";
+  triageGroup:
+    | "ready"
+    | "blocked"
+    | "needs_author_input"
+    | "source_verification"
+    | "likely_promo_spam"
+    | "stale"
+    | "close_eligible"
+    | "maintainer_review"
+    | "skipped";
+  triageReason: string;
   staleState: "not_applicable" | "fresh" | "reminder_due" | "close_eligible";
   ageDays: number;
   sourceNeedsVerification: boolean;
@@ -703,6 +714,22 @@ export type SubmissionQueueEntry = {
   slug: string;
   name: string;
   sourceUrl: string;
+  sourceUrls: string[];
+  contributorContext: {
+    login: string;
+    profileUrl: string;
+    resolutionStatus: string;
+    accountAgeDays: number | null;
+    publicRepos: number | null;
+    signals: string[];
+    warnings: string[];
+  };
+  policyReasons: Array<{
+    name: string;
+    status: string;
+    summary: string;
+    detail: string[];
+  }>;
   errors: string[];
   warnings: string[];
   reviewChecklist: string[];
@@ -716,6 +743,10 @@ export type SubmissionQueue = {
   generatedAt: string;
   count: number;
   summary: {
+    ready: number;
+    blocked: number;
+    likelyPromoSpam: number;
+    stale: number;
     importReady: number;
     maintainerReview: number;
     needsAuthorInput: number;

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -861,6 +861,122 @@ function formatRiskSummary(riskTier, capabilityBuckets = []) {
     : label;
 }
 
+function policyHasBlockingGate(policyMatrix = {}, options = {}) {
+  const { ignoredGates = [] } = options;
+  const ignored = new Set(ignoredGates);
+  return Object.entries(policyMatrix || {}).some(
+    ([name, gate]) => gate?.status === "block" && !ignored.has(name),
+  );
+}
+
+function textMatchesAny(values = [], patterns = []) {
+  const text = values.flat().filter(Boolean).join("\n");
+  return patterns.some((pattern) => pattern.test(text));
+}
+
+function submissionLooksPromotional({ report, risk }) {
+  const classificationIds = new Set(
+    (risk.classificationWarnings || []).map((warning) => warning.id),
+  );
+  if (
+    classificationIds.has("tools_category_routing") ||
+    classificationIds.has("tools_listing_metadata_missing")
+  ) {
+    return true;
+  }
+
+  return textMatchesAny(
+    [
+      report?.errors || [],
+      report?.warnings || [],
+      risk.reviewFlags?.map((flag) => flag.summary) || [],
+    ],
+    [
+      /tools\/app listing flow/i,
+      /paid listing/i,
+      /affiliate\/referral/i,
+      /hosted tool\/app\/service\/product/i,
+    ],
+  );
+}
+
+function submissionLooksBlocked({ report, risk }) {
+  if (
+    policyHasBlockingGate(risk.policyMatrix, {
+      ignoredGates: ["schema", "source", "quality"],
+    })
+  ) {
+    return true;
+  }
+  if (risk.riskTier === "critical") return true;
+
+  return textMatchesAny(
+    [
+      report?.errors || [],
+      report?.warnings || [],
+      risk.reviewFlags?.map((flag) => flag.id) || [],
+    ],
+    [
+      /local \/downloads hosting/i,
+      /community.*(?:zip|mcpb|archive|package)/i,
+      /community_local_download_request/i,
+      /community_archive_download/i,
+      /unsafe packageverified/i,
+      /forbidden \/downloads/i,
+    ],
+  );
+}
+
+function submissionTriageGroup({ report, risk, status }) {
+  if (status === "skipped") return "skipped";
+  if (status === "close_eligible") return "close_eligible";
+  if (status === "stale_reminder_due") return "stale";
+  if (submissionLooksBlocked({ report, risk })) return "blocked";
+  if (submissionLooksPromotional({ report, risk })) {
+    return "likely_promo_spam";
+  }
+  if (status === "needs_author_input") return "needs_author_input";
+  if (status === "source_needs_verification") return "source_verification";
+  if (status === "import_ready") return "ready";
+  return "maintainer_review";
+}
+
+function submissionTriageReason({ entry, report, risk }) {
+  if (entry.triageGroup === "ready") {
+    return entry.autoImportEligible
+      ? "Deterministic gates passed; maintainer approval is still required before import."
+      : "Schema passed and the submission is ready for maintainer review.";
+  }
+  if (entry.triageGroup === "blocked") {
+    const blockedGate = Object.entries(risk.policyMatrix || {}).find(
+      ([, gate]) => gate?.status === "block",
+    );
+    if (blockedGate) {
+      return `${blockedGate[0]} gate is blocking: ${blockedGate[1]?.summary || "review required"}`;
+    }
+    return "A deterministic policy or package safety blocker must be resolved first.";
+  }
+  if (entry.triageGroup === "likely_promo_spam") {
+    return "This looks like a hosted product, paid placement, affiliate, or tools listing flow rather than free community content.";
+  }
+  if (entry.triageGroup === "needs_author_input") {
+    return "Required schema fields or category metadata are missing or invalid.";
+  }
+  if (entry.triageGroup === "source_verification") {
+    return "Maintainers need to verify the canonical source, docs, package, or repository.";
+  }
+  if (entry.triageGroup === "stale") {
+    return "Author input has been pending long enough for a reminder.";
+  }
+  if (entry.triageGroup === "close_eligible") {
+    return "Author input has been pending past the close window.";
+  }
+  if (report?.skipped) {
+    return "The issue does not resolve cleanly to a supported submission category.";
+  }
+  return "Maintainer judgment is required before this can progress.";
+}
+
 function firstSubmissionSourceUrl(fields = {}) {
   return (
     normalizeValue(fields.github_url) ||
@@ -1028,6 +1144,25 @@ export function buildSubmissionQueue(issues = [], options = {}) {
         slug: report.fields?.slug || "",
         name: report.fields?.name || "",
         sourceUrl: firstSubmissionSourceUrl(report.fields),
+        sourceUrls: risk.contributionAnalysis?.sourceUrls?.slice(0, 5) || [],
+        contributorContext: {
+          login: risk.contributorAnalysis?.login || "",
+          profileUrl: risk.contributorAnalysis?.profileUrl || "",
+          resolutionStatus:
+            risk.contributorAnalysis?.resolutionStatus || "unresolved",
+          accountAgeDays: risk.contributorAnalysis?.accountAgeDays ?? null,
+          publicRepos: risk.contributorAnalysis?.publicRepos ?? null,
+          signals: contributorReview,
+          warnings: risk.contributorAnalysis?.warnings || [],
+        },
+        policyReasons: Object.entries(risk.policyMatrix || {}).map(
+          ([name, gate]) => ({
+            name,
+            status: gate?.status || "unknown",
+            summary: gate?.summary || "",
+            detail: gate?.detail || [],
+          }),
+        ),
         errors: report.errors || [],
         warnings: report.warnings || [],
         importPath:
@@ -1035,6 +1170,8 @@ export function buildSubmissionQueue(issues = [], options = {}) {
             ? `content/${report.category}/${report.fields.slug}.mdx`
             : "",
       };
+      entry.triageGroup = submissionTriageGroup({ report, risk, status });
+      entry.triageReason = submissionTriageReason({ entry, report, risk });
       entry.reviewChecklist = buildSubmissionReviewChecklist({
         report,
         risk,
@@ -1063,11 +1200,18 @@ export function buildSubmissionQueue(issues = [], options = {}) {
     });
 
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     kind: "submission-queue",
     generatedAt: new Date().toISOString(),
     count: entries.length,
     summary: {
+      ready: entries.filter((entry) => entry.triageGroup === "ready").length,
+      blocked: entries.filter((entry) => entry.triageGroup === "blocked")
+        .length,
+      likelyPromoSpam: entries.filter(
+        (entry) => entry.triageGroup === "likely_promo_spam",
+      ).length,
+      stale: entries.filter((entry) => entry.triageGroup === "stale").length,
       importReady: entries.filter((entry) => entry.status === "import_ready")
         .length,
       maintainerReview: entries.filter(

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -606,14 +606,28 @@ npx unslop --help`);
       { now: "2026-04-30T00:00:00Z" },
     );
     expect(queue.count).toBe(2);
-    expect(queue.schemaVersion).toBe(2);
+    expect(queue.schemaVersion).toBe(3);
+    expect(queue.summary.ready).toBe(1);
     expect(queue.summary.importReady).toBe(1);
     expect(queue.summary.needsChanges).toBe(1);
     expect(queue.entries[0].status).toBe("import_ready");
+    expect(queue.entries[0].triageGroup).toBe("ready");
+    expect(queue.entries[0].triageReason).toContain(
+      "maintainer approval is still required",
+    );
     expect(queue.entries[0].nextAction).toBe("import");
     expect(queue.entries[0].importPath).toBe("content/mcp/contrastapi.mdx");
     expect(queue.entries[0].sourceUrl).toBe(
       "https://github.com/example/contrastapi",
+    );
+    expect(queue.entries[0].sourceUrls).toEqual(
+      expect.arrayContaining(["https://github.com/example/contrastapi"]),
+    );
+    expect(queue.entries[0].contributorContext.login).toBe("contributor");
+    expect(queue.entries[0].policyReasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "schema", status: "pass" }),
+      ]),
     );
     expect(queue.entries[0].missingLabels).toEqual(
       expect.arrayContaining(["community-mcp", "needs-review"]),
@@ -627,6 +641,7 @@ npx unslop --help`);
     expect(queue.entries[0].autoImportEligible).toBe(true);
     expect(queue.entries[0].policyDecision).toBe("auto_import_eligible");
     expect(queue.entries[1].status).toBe("needs_author_input");
+    expect(queue.entries[1].triageGroup).toBe("needs_author_input");
     expect(queue.entries[1].nextAction).toBe("request_author_input");
     expect(queue.entries[1].actionDue).toBe("author_input");
     expect(queue.entries[1].commentDraft).toContain(
@@ -699,9 +714,17 @@ npx unslop --help`;
         ?.nextAction,
     ).toBe("send_stale_reminder");
     expect(
+      queue.entries.find((entry) => entry.status === "stale_reminder_due")
+        ?.triageGroup,
+    ).toBe("stale");
+    expect(
       queue.entries.find((entry) => entry.status === "close_eligible")
         ?.nextAction,
     ).toBe("close_stale");
+    expect(
+      queue.entries.find((entry) => entry.status === "close_eligible")
+        ?.triageGroup,
+    ).toBe("close_eligible");
     expect(
       queue.entries.find((entry) => entry.status === "maintainer_review")
         ?.nextAction,
@@ -756,9 +779,77 @@ claude mcp add source-review-mcp -- npx -y source-review-mcp`,
       now: "2026-04-30T00:00:00Z",
     });
     expect(queue.entries[0].nextAction).toBe("verify_source");
+    expect(queue.entries[0].triageGroup).toBe("source_verification");
     expect(queue.entries[0].commentDraft).toContain(
       "needs source verification before it can be imported",
     );
+  });
+
+  it("groups deterministic blockers and likely promo submissions separately", () => {
+    const blockedPackage = issue(`### Name
+Blocked Skill Package
+
+### Slug
+blocked-skill-package
+
+### Category
+skills
+
+### Public contact
+dev@example.com
+
+### Description
+Skill package that asks HeyClaude to host an uploaded archive.
+
+### Card description
+Archive-hosted skill package.
+
+### Download URL
+/downloads/community-skill.zip
+
+### Usage snippet
+Use the packaged skill.`);
+    const promoProduct = issue(`### Name
+Promo Product
+
+### Slug
+promo-product
+
+### Category
+mcp
+
+### Public contact
+dev@example.com
+
+### Website URL
+https://promo.example.com
+
+### Description
+Hosted SaaS product with pricing, paid plans, and a dashboard for teams.
+
+### Card description
+Hosted SaaS product for teams.
+
+### Install command
+npx promo-product
+
+### Usage snippet
+npx promo-product`);
+
+    const queue = buildSubmissionQueue([blockedPackage, promoProduct], {
+      now: "2026-04-30T00:00:00Z",
+    });
+
+    expect(queue.summary.blocked).toBe(1);
+    expect(queue.summary.likelyPromoSpam).toBe(1);
+    expect(
+      queue.entries.find((entry) => entry.slug === "blocked-skill-package")
+        ?.triageGroup,
+    ).toBe("blocked");
+    expect(
+      queue.entries.find((entry) => entry.slug === "promo-product")
+        ?.triageGroup,
+    ).toBe("likely_promo_spam");
   });
 
   it("rejects missing required category fields", () => {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -625,7 +625,7 @@ description: Example description
     );
 
     expect(source).toContain(
-      "| Issue | Status | Security | Policy | Source | Contributor | Age | Category | Slug | Action | Notes |",
+      "| Issue | Group | Status | Security | Policy | Source | Contributor | Age | Category | Slug | Action | Notes |",
     );
     expect(source).toContain("entry.riskSummary");
     expect(source).toContain("entry.riskFlags");


### PR DESCRIPTION
## Summary
- adds explicit maintainer triage groups for ready, blocked, author-input, source-review, promo/spam, stale, and close-eligible submission issues
- upgrades `/submissions` into a richer read-only review workbench with contributor/source context, policy reasons, recommended labels, and copyable reply drafts
- updates the scheduled submission queue workflow summary to report the same triage groups

## What changed
- extends `buildSubmissionQueue` with `triageGroup`, `triageReason`, source URLs, contributor context, and policy reason rows
- keeps existing validation status and next-action fields stable for workflow consumers
- adds tests for ready, source review, stale, blocked package-hosting requests, and likely promo/product submissions
- refreshes the `/submissions` UI filters and cards around the new triage groups

## Why
- gives maintainers a faster read-only queue for deciding what can become real content, what needs author input, and what should be treated as promo/spam or blocked package risk
- keeps human approval in the import path; this does not add issue comments, merges, closures, or direct publication

## Validation
- `pnpm test:submission-intake`
- `pnpm submission:queue -- --issues-json .github/tmp/open-issues-empty.json --output .github/tmp/submission-queue-test.json`
- `pnpm build`
- `pnpm validate:clean`
- `git diff --check`

## Notes
- Attempted `pnpm test:e2e -- tests/e2e/site-regression.spec.ts --project=desktop-chromium --grep "renders /submissions"`, but the local Playwright Chromium executable is not installed. The failure happened before page assertions and was not caused by this branch.
- GitHub Actions remains the mutating automation path, and import PR creation still requires `accepted` or `import-approved`.