### PR TITLE
ci(validation): split required PR checks

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -1,27 +1,7 @@
-name: Content Validation
+name: PR Validation
 
 on:
   pull_request:
-    paths:
-      - "apps/web/**"
-      - "packages/**"
-      - "emails/**"
-      - "content/**"
-      - "scripts/**"
-      - "examples/content/**"
-      - "integrations/raycast/**"
-      - "tests/**"
-      - ".trunk/**"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/workflows/**"
-      - "cloudflare/api-schema-heyclaude-openapi.yaml"
-      - "README.md"
-      - "CHANGELOG.md"
-      - "renovate.json"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "playwright.config.ts"
-      - "vitest.config.ts"
   workflow_dispatch:
   schedule:
     - cron: "17 9 * * 1"
@@ -32,13 +12,21 @@ permissions:
   deployments: read
 
 jobs:
-  validate-content:
+  required-pr-gate:
+    name: required-pr-gate
     runs-on: ubuntu-latest
-    env:
-      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN || secrets.TRUNK_TOKEN }}
-      TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG || secrets.TRUNK_ORG_SLUG }}
+    outputs:
+      content: ${{ steps.classify.outputs.content }}
+      registry: ${{ steps.classify.outputs.registry }}
+      web: ${{ steps.classify.outputs.web }}
+      mcp: ${{ steps.classify.outputs.mcp }}
+      raycast: ${{ steps.classify.outputs.raycast }}
+      packages: ${{ steps.classify.outputs.packages }}
+      ci: ${{ steps.classify.outputs.ci }}
+      docs: ${{ steps.classify.outputs.docs }}
+      full: ${{ steps.classify.outputs.full }}
     concurrency:
-      group: content-validation-${{ github.ref }}
+      group: pr-required-gate-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -47,12 +35,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Classify changed files
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          FORCE_FULL_VALIDATION: ${{ github.event_name != 'pull_request' && '1' || '0' }}
+        run: node scripts/ci/classify-pr-changes.mjs
+
       - name: Reject external generated artifact changes
         if: ${{ github.event_name == 'pull_request' }}
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         run: |
+          set -euo pipefail
           if [ "$HEAD_REPO" = "$GITHUB_REPOSITORY" ]; then
             exit 0
           fi
@@ -64,122 +60,442 @@ jobs:
             exit 1
           fi
 
+  validate-ci:
+    name: validate-ci
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-ci-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged CI lane
+        if: ${{ needs.required-pr-gate.outputs.ci != 'true' }}
+        run: echo "No CI/config validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
       - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate cleanup policy
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: pnpm validate:clean
+
+      - name: Validate task tracker
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: pnpm validate:tasks
+
+      - name: Check whitespace
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: git diff --check
+
+      - name: Install Trunk CLI
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: |
+          curl https://get.trunk.io -fsSL | bash -s -- -y
+          echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
+
+      - name: Trunk Check
+        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        run: trunk check --ci --all
+
+  validate-content:
+    name: validate-content
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-content-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged content lane
+        if: ${{ needs.required-pr-gate.outputs.content != 'true' }}
+        run: echo "No content validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate content schema
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        run: pnpm validate:content:strict
+
+      - name: Validate category submission spec
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        run: pnpm validate:category-spec
+
+      - name: Validate issue templates
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        run: pnpm validate:issue-templates
+
+      - name: Audit content report
+        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
+        run: pnpm audit:content
+
+  validate-registry:
+    name: validate-registry
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-registry-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged registry lane
+        if: ${{ needs.required-pr-gate.outputs.registry != 'true' }}
+        run: echo "No registry artifact validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build registry artifacts
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        run: pnpm --filter web run prebuild
+
+      - name: Test registry artifact contracts
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        run: pnpm test:registry-artifacts
+
+      - name: Validate generated README
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        run: pnpm validate:readme
+
+      - name: Verify generated registry artifacts are current
+        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        run: git diff --exit-code apps/web/public/data apps/web/src/generated README.md
+
+  validate-web:
+    name: validate-web
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    env:
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN || secrets.TRUNK_TOKEN }}
+      TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG || secrets.TRUNK_ORG_SLUG }}
+    concurrency:
+      group: pr-validate-web-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged web lane
+        if: ${{ needs.required-pr-gate.outputs.web != 'true' }}
+        run: echo "No web/API validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Clean test reports
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: rm -rf reports/junit && mkdir -p reports/junit
 
       - name: Build registry artifacts
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm --filter web run prebuild
 
-      - name: Regenerate README for pull request validation
-        if: ${{ github.event_name == 'pull_request' }}
-        run: pnpm generate:readme
-
-      - name: Validate cleanup policy
-        run: pnpm validate:clean
-
       - name: Apply local D1 migrations
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm --filter web db:migrate:local
 
       - name: Validate local D1 jobs schema
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm validate:d1-jobs -- --local
 
-      - name: Validate task tracker
-        run: pnpm validate:tasks
+      - name: Validate generated OpenAPI schema
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        run: pnpm validate:openapi
 
       - name: Run Vitest suite
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm test
 
       - name: Install Playwright Chromium
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run browser regression suite
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm test:e2e
 
-      - name: Install Raycast dependencies
-        working-directory: integrations/raycast
-        run: npm ci
-
-      - name: Test Raycast helpers
-        working-directory: integrations/raycast
-        run: npm run test:junit
-
       - name: Install Trunk CLI
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         run: |
           curl https://get.trunk.io -fsSL | bash -s -- -y
           echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
 
       - name: Upload test results to Trunk
-        if: ${{ always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         continue-on-error: true
         run: trunk flakytests upload --junit-paths "reports/junit/*.xml" --org-url-slug "$TRUNK_ORG_URL_SLUG" --token "$TRUNK_API_TOKEN"
 
-      - name: Validate content schema
-        run: pnpm validate:content:strict
-
-      - name: Validate category submission spec
-        run: pnpm validate:category-spec
-
-      - name: Validate issue templates
-        run: pnpm validate:issue-templates
-
-      - name: Validate generated OpenAPI schema
-        run: pnpm validate:openapi
-
-      - name: Validate downloadable packages
-        run: pnpm validate:packages
-
-      - name: Scan downloadable package artifacts
-        run: pnpm scan:packages
-
-      - name: Validate Raycast feed
-        run: pnpm validate:raycast-feed
-
       - name: Validate email templates
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm validate:emails
 
       - name: Dry-run Resend template sync
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm resend:sync-templates -- --dry-run
 
-      - name: Verify generated registry artifacts are current
-        run: git diff --exit-code apps/web/public/data apps/web/src/generated
-
-      - name: Audit content report
-        run: pnpm audit:content
-
-      - name: Verify README is up to date
-        run: pnpm validate:readme
-
       - name: Type-check web app
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm type-check
 
       - name: Build web app
+        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
         run: pnpm build
 
+  validate-mcp:
+    name: validate-mcp
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-mcp-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged MCP lane
+        if: ${{ needs.required-pr-gate.outputs.mcp != 'true' }}
+        run: echo "No MCP validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build registry artifacts
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        run: pnpm --filter web run prebuild
+
+      - name: Test MCP package
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        run: pnpm test:mcp
+
+      - name: Validate dev MCP endpoint
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        run: pnpm validate:mcp-endpoint -- --url https://heyclaude-dev.zeronode.workers.dev/api/mcp
+
+      - name: Dry-run MCP package tarball
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        run: pnpm --filter @heyclaude/mcp pack --dry-run --json
+
+      - name: Validate packed MCP package
+        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        env:
+          MCP_PACKAGE_REMOTE_SMOKE_URL: https://heyclaude-dev.zeronode.workers.dev/api/mcp
+        run: pnpm validate:mcp-package
+
+  validate-raycast:
+    name: validate-raycast
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    env:
+      TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN || secrets.TRUNK_TOKEN }}
+      TRUNK_ORG_URL_SLUG: ${{ secrets.TRUNK_ORG_URL_SLUG || secrets.TRUNK_ORG_SLUG }}
+    concurrency:
+      group: pr-validate-raycast-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged Raycast lane
+        if: ${{ needs.required-pr-gate.outputs.raycast != 'true' }}
+        run: echo "No Raycast validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Build feed artifacts
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        run: pnpm --filter web run prebuild
+
+      - name: Clean test reports
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        run: rm -rf reports/junit && mkdir -p reports/junit
+
+      - name: Validate Raycast feed
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        run: pnpm validate:raycast-feed
+
+      - name: Test registry artifact contracts
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        run: pnpm test:registry-artifacts
+
+      - name: Install Raycast dependencies
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        working-directory: integrations/raycast
+        run: npm ci
+
+      - name: Test Raycast helpers
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        working-directory: integrations/raycast
+        run: npm run test:junit
+
+      - name: Install Trunk CLI
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        run: |
+          curl https://get.trunk.io -fsSL | bash -s -- -y
+          echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
+
+      - name: Upload Raycast test results to Trunk
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        continue-on-error: true
+        run: trunk flakytests upload --junit-paths "reports/junit/raycast.xml" --org-url-slug "$TRUNK_ORG_URL_SLUG" --token "$TRUNK_API_TOKEN"
+
       - name: Lint Raycast extension
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm run lint
 
       - name: Build Raycast extension
+        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm run build
 
-      - name: Trunk Check
-        run: trunk check --ci --all
+  validate-packages:
+    name: validate-packages
+    needs: required-pr-gate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-packages-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Skip unchanged package artifact lane
+        if: ${{ needs.required-pr-gate.outputs.packages != 'true' }}
+        run: echo "No package artifact validation required for this change set."
+
+      - name: Checkout
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup pnpm
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate package metadata
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        run: pnpm validate:packages
+
+      - name: Scan package artifacts
+        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        run: pnpm scan:packages
 
   validate-pr-preview:
-    if: ${{ github.event_name == 'pull_request' }}
+    name: validate-pr-preview
+    if: ${{ github.event_name == 'pull_request' && (needs.required-pr-gate.outputs.web == 'true' || needs.required-pr-gate.outputs.registry == 'true' || needs.required-pr-gate.outputs.mcp == 'true') }}
+    needs: required-pr-gate
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -1,0 +1,162 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+
+const eventName = process.env.GITHUB_EVENT_NAME || "";
+const baseSha = process.env.BASE_SHA || "";
+const forceFull =
+  process.env.FORCE_FULL_VALIDATION === "1" ||
+  eventName === "workflow_dispatch" ||
+  eventName === "schedule";
+const outputPath = process.env.GITHUB_OUTPUT || "";
+const summaryPath = process.env.GITHUB_STEP_SUMMARY || "";
+
+function changedFiles() {
+  if (forceFull) return [];
+  if (eventName !== "pull_request") return [];
+  if (!/^[0-9a-f]{40}$/i.test(baseSha)) {
+    throw new Error("BASE_SHA must be a full Git commit SHA for PR validation");
+  }
+  const output = execFileSync(
+    "git",
+    ["diff", "--name-only", `${baseSha}...HEAD`],
+    {
+      encoding: "utf8",
+    },
+  );
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .sort();
+}
+
+const files = changedFiles();
+const all = forceFull;
+
+function touches(...patterns) {
+  if (all) return true;
+  return files.some((file) =>
+    patterns.some((pattern) =>
+      typeof pattern === "string" ? file === pattern : pattern.test(file),
+    ),
+  );
+}
+
+const flags = {
+  content: touches(
+    /^content\//,
+    /^examples\/content\//,
+    /^\.github\/ISSUE_TEMPLATE\//,
+    /^scripts\/(audit-content|generate-issue-templates|validate-category-spec|validate-content)\.mjs$/,
+    /^packages\/registry\/src\/(category-spec|content-builder|submission|index\.d\.ts)/,
+  ),
+  registry: touches(
+    /^content\//,
+    /^examples\/content\//,
+    /^packages\/registry\//,
+    /^scripts\/(audit-content|build-content-index|generate-readme|validate-category-spec|validate-content|validate-codebase-clean)\.mjs$/,
+    /^tests\/(registry-artifacts|readme-generation|seo-jsonld)\.test\.ts$/,
+    /^apps\/web\/public\/data\//,
+    /^apps\/web\/src\/generated\//,
+    "README.md",
+  ),
+  web: touches(
+    /^apps\/web\//,
+    /^emails\//,
+    /^content\//,
+    /^examples\/content\//,
+    /^cloudflare\/api-schema-heyclaude-openapi\.yaml$/,
+    /^scripts\/(generate-openapi|run-playwright|validate-d1-jobs|validate-deployment-artifacts)\.(mjs|ts)$/,
+    /^tests\/(api-|commercial-intake|discovery-surfaces|seo-jsonld|submission-api|submission-workflows|votes-api).*\.test\.ts$/,
+    "playwright.config.ts",
+    "vitest.config.ts",
+    "package.json",
+    "pnpm-lock.yaml",
+  ),
+  mcp: touches(
+    /^packages\/mcp\//,
+    /^apps\/web\/src\/app\/api\/mcp\//,
+    /^scripts\/validate-mcp-package\.mjs$/,
+    /^tests\/mcp-.*\.test\.ts$/,
+    "package.json",
+    "pnpm-lock.yaml",
+  ),
+  raycast: touches(
+    /^integrations\/raycast\//,
+    /^content\//,
+    /^examples\/content\//,
+    /^apps\/web\/public\/data\/raycast/,
+    /^scripts\/(build-content-index|validate-raycast-feed)\.mjs$/,
+    /^tests\/registry-artifacts\.test\.ts$/,
+    "package.json",
+    "pnpm-lock.yaml",
+  ),
+  packages: touches(
+    /^apps\/web\/public\/downloads\//,
+    /^content\/skills\/.*\.zip$/,
+    /^content\/mcp\/.*\.mcpb$/,
+    /^scripts\/(scan-download-packages|validate-download-packages)\.mjs$/,
+    "package.json",
+    "pnpm-lock.yaml",
+  ),
+  ci: touches(
+    /^\.github\/workflows\//,
+    /^scripts\/ci\//,
+    /^\.trunk\//,
+    "renovate.json",
+    "package.json",
+    "pnpm-lock.yaml",
+    "playwright.config.ts",
+    "vitest.config.ts",
+  ),
+};
+
+flags.docs = touches(
+  /^docs\//,
+  /^.*\.md$/,
+  "AGENTS.md",
+  "CLAUDE.md",
+  "LICENSE",
+);
+
+for (const key of Object.keys(flags)) {
+  flags[key] = Boolean(flags[key]);
+}
+
+const lines = [
+  `full=${all ? "true" : "false"}`,
+  ...Object.entries(flags).map(
+    ([key, value]) => `${key}=${value ? "true" : "false"}`,
+  ),
+  `changed_count=${files.length}`,
+  `changed_files_json=${JSON.stringify(files)}`,
+];
+
+if (outputPath) {
+  fs.appendFileSync(outputPath, `${lines.join("\n")}\n`);
+}
+
+const summary = [
+  "## PR validation lanes",
+  "",
+  `Full validation: ${all ? "yes" : "no"}`,
+  "",
+  "| Lane | Runs |",
+  "| --- | --- |",
+  ...Object.entries(flags).map(
+    ([key, value]) => `| ${key} | ${value ? "yes" : "no"} |`,
+  ),
+  "",
+  `<details><summary>Changed files (${files.length})</summary>`,
+  "",
+  ...files.map((file) => `- \`${file}\``),
+  "",
+  "</details>",
+  "",
+].join("\n");
+
+if (summaryPath) {
+  fs.appendFileSync(summaryPath, summary);
+} else {
+  console.log(summary);
+}


### PR DESCRIPTION
## Summary
- Replace the old all-purpose `Content Validation` PR workflow shape with explicit always-present validation lanes.
- Add a file-change classifier that routes PRs into content, registry, web, MCP, Raycast, package artifact, and CI validation.
- Preserve the existing `validate-content` context during rollout so current branch protection can still pass before settings are updated.

## What changed
- Removed `pull_request.paths` from the required validation workflow so docs-only PRs get required check contexts instead of being blocked by missing checks.
- Added `required-pr-gate` as the always-running classifier and generated-artifact policy gate.
- Split expensive validation into scoped jobs: `validate-ci`, `validate-content`, `validate-registry`, `validate-web`, `validate-mcp`, `validate-raycast`, and `validate-packages`.
- Kept PR preview validation optional and scoped to web/registry/MCP-affecting changes.

## Why
- `validate-content` was both misleading and too broad. It blocked non-content PRs when the workflow did not trigger, and ran a large website/content/Raycast/MCP suite for unrelated changes when it did.
- Branch protection should require clear, always-present checks that can cheaply pass when a lane is irrelevant.

## Validation
- `actionlint .github/workflows/content-validation.yml`
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- Local classifier smoke test for PR and full-validation modes

## Notes
- Closes #400
- After this lands, update branch protection from the legacy required `validate-content`-only context to the clearer required contexts: `required-pr-gate`, `validate-ci`, `validate-content`, `validate-registry`, `validate-web`, `validate-mcp`, `validate-raycast`, and `validate-packages`.
- `validate-pr-preview` should remain optional because it depends on preview deploy availability and only applies to site/API-affecting changes.