### PR TITLE
ci(validation): make specialized checks manual

### DIFF
--- a/.github/workflows/mcp-package.yml
+++ b/.github/workflows/mcp-package.yml
@@ -1,16 +1,6 @@
 name: MCP Package
 
 on:
-  pull_request:
-    paths:
-      - "packages/mcp/**"
-      - "apps/web/src/app/api/mcp/**"
-      - "scripts/validate-mcp-package.mjs"
-      - "tests/mcp-*.test.ts"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/mcp-package.yml"
-      - ".github/workflows/publish-mcp-npm.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/package-artifact-scan.yml
+++ b/.github/workflows/package-artifact-scan.yml
@@ -1,17 +1,6 @@
 name: Package Artifact Scan
 
 on:
-  pull_request:
-    paths:
-      - "content/skills/*.zip"
-      - "content/skills/**/*.zip"
-      - "content/mcp/*.mcpb"
-      - "content/mcp/**/*.mcpb"
-      - "scripts/scan-download-packages.mjs"
-      - "scripts/validate-download-packages.mjs"
-      - ".github/workflows/package-artifact-scan.yml"
-      - "package.json"
-      - "pnpm-lock.yaml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/raycast-extension.yml
+++ b/.github/workflows/raycast-extension.yml
@@ -1,17 +1,6 @@
 name: Raycast Extension
 
 on:
-  pull_request:
-    paths:
-      - "integrations/raycast/**"
-      - "apps/web/public/data/raycast-index.json"
-      - "apps/web/public/data/raycast/**"
-      - "scripts/build-content-index.mjs"
-      - "scripts/validate-raycast-feed.mjs"
-      - "content/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - ".github/workflows/raycast-extension.yml"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Remove pull request triggers from the older MCP package, Raycast extension, and package artifact scan workflows.
- Keep those workflows available through manual `workflow_dispatch`.
- Let the new unified `PR Validation` workflow own PR-time MCP, Raycast, and package artifact lanes.

## What changed
- `.github/workflows/mcp-package.yml` is now manual-only.
- `.github/workflows/raycast-extension.yml` is now manual-only.
- `.github/workflows/package-artifact-scan.yml` is now manual-only.

## Why
- The split required-check workflow already produces explicit PR contexts for `validate-mcp`, `validate-raycast`, and `validate-packages`.
- Leaving the old path-specific PR workflows active creates duplicate/noisy checks and makes the PR status surface harder to reason about.

## Validation
- `actionlint .github/workflows/content-validation.yml .github/workflows/mcp-package.yml .github/workflows/raycast-extension.yml .github/workflows/package-artifact-scan.yml`
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`

## Notes
- Closes #402
- No validation coverage is removed from PRs; it is routed through the unified `PR Validation` workflow.
- Manual release/package checks remain available from the Actions tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the trigger configuration for multiple GitHub Actions workflows to require manual execution via `workflow_dispatch` instead of automatically running when pull requests are created or updated. Affected workflows include MCP package management, security artifact scanning, and Raycast extension builds. All workflow steps and permissions remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->