### PR TITLE
fix(ci): use base classifier for PR gate outputs

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -40,7 +40,18 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           FORCE_FULL_VALIDATION: ${{ github.event_name != 'pull_request' && '1' || '0' }}
-        run: node scripts/ci/classify-pr-changes.mjs
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          classifier_path="scripts/ci/classify-pr-changes.mjs"
+
+          if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$BASE_SHA" ]; then
+            trusted_classifier="${RUNNER_TEMP:-.}/classify-pr-changes.mjs"
+            git show "$BASE_SHA:$classifier_path" > "$trusted_classifier"
+            node "$trusted_classifier"
+          else
+            node "$classifier_path"
+          fi
 
       - name: Reject external generated artifact changes
         if: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary
- Run PR validation lane classification through the trusted base-branch classifier instead of the pull request copy.
- Preserve existing full-validation behavior for non-PR events.

## What changed
- The PR validation workflow now fetches `scripts/ci/classify-pr-changes.mjs` from the base commit when running on `pull_request`.
- The trusted classifier is written to a temporary file and executed from there.
- Non-PR events still execute the classifier from the checked-out branch.

## Why
- A pull request should not be able to alter the classifier that decides which required validation lanes run for that same pull request.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `git diff --check`

## Notes
- This only changes the trust boundary for PR classification; lane behavior remains intentionally unchanged.