### PR TITLE
fix(ci): quiet submission review automation

### DIFF
--- a/.github/workflows/submission-issue-validation.yml
+++ b/.github/workflows/submission-issue-validation.yml
@@ -106,145 +106,107 @@ jobs:
             --risk-json .github/tmp/submission-risk.json \
             --output .github/tmp/auto-import-precheck.json
 
-      - name: Auto-label submission issue
-        if: ${{ always() && steps.auto_import_precheck.outputs.eligible != 'true' }}
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553
-        with:
-          script: |
-            const fs = require("node:fs");
-            const reportPath = ".github/tmp/submission-validation.json";
-            if (!fs.existsSync(reportPath)) return;
-            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-
-            const { data: issue } = await github.rest.issues.get({
-              ...context.repo,
-              issue_number: context.issue.number
-            });
-            const managedValidationLabels = new Set([
-              "needs-author-input",
-              "source-needs-verification",
-              "stale-submission",
-              "auto-import-eligible"
-            ]);
-            const currentLabels = (issue.labels || [])
-              .map((label) => typeof label === "string" ? label : label.name)
-              .filter(Boolean);
-            const labels = new Set(
-              currentLabels.filter((label) => !managedValidationLabels.has(label))
-            );
-            for (const label of report.recommendedLabels || []) {
-              if (label) labels.add(label);
-            }
-            const nextLabels = [...labels].filter(Boolean);
-            try {
-              await github.rest.issues.setLabels({
-                ...context.repo,
-                issue_number: context.issue.number,
-                labels: nextLabels
-              });
-            } catch (error) {
-              core.warning(`Could not apply submission labels: ${error.message}`);
-            }
-
-      - name: HeyClaude Submission Bot mark auto-import eligible
-        if: ${{ always() && steps.auto_import_precheck.outputs.eligible == 'true' }}
-        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553
-        with:
-          script: |
-            const label = "auto-import-eligible";
-            const managedValidationLabels = new Set([
-              "needs-author-input",
-              "source-needs-verification",
-              "stale-submission",
-              "auto-import-eligible"
-            ]);
-            try {
-              await github.rest.issues.updateLabel({
-                ...context.repo,
-                name: label,
-                color: "0e8a16",
-                description:
-                  "Submission passed deterministic gates and awaits maintainer-approved import PR"
-              });
-            } catch (error) {
-              if (error.status !== 404) throw error;
-              await github.rest.issues.createLabel({
-                ...context.repo,
-                name: label,
-                color: "0e8a16",
-                description:
-                  "Submission passed deterministic gates and awaits maintainer-approved import PR"
-              });
-            }
-            const { data: issue } = await github.rest.issues.get({
-              ...context.repo,
-              issue_number: context.issue.number
-            });
-            const currentLabels = (issue.labels || [])
-              .map((currentLabel) =>
-                typeof currentLabel === "string" ? currentLabel : currentLabel.name
-              )
-              .filter(Boolean);
-            const nextLabels = new Set(
-              currentLabels.filter(
-                (currentLabel) => !managedValidationLabels.has(currentLabel)
-              )
-            );
-            nextLabels.add(label);
-            await github.rest.issues.setLabels({
-              ...context.repo,
-              issue_number: context.issue.number,
-              labels: [...nextLabels].filter(Boolean)
-            });
-
-      - name: Auto-label submission risk
+      - name: HeyClaude Submission Bot sync labels
         if: always()
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553
+        env:
+          AUTO_IMPORT_ELIGIBLE: ${{ steps.auto_import_precheck.outputs.eligible }}
         with:
           script: |
             const fs = require("node:fs");
-            const reportPath = ".github/tmp/submission-risk.json";
-            if (!fs.existsSync(reportPath)) return;
-            const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
-            const definitions = report.labelDefinitions || {};
-            for (const [name, definition] of Object.entries(definitions)) {
+            const validationPath = ".github/tmp/submission-validation.json";
+            const riskPath = ".github/tmp/submission-risk.json";
+            if (!fs.existsSync(validationPath)) return;
+            const validationReport = JSON.parse(fs.readFileSync(validationPath, "utf8"));
+            const riskReport = fs.existsSync(riskPath)
+              ? JSON.parse(fs.readFileSync(riskPath, "utf8"))
+              : {};
+            const autoImportEligible = process.env.AUTO_IMPORT_ELIGIBLE === "true";
+
+            const { data: issue } = await github.rest.issues.get({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+            const managedValidationLabels = new Set([
+              "needs-author-input",
+              "source-needs-verification",
+              "stale-submission",
+              "auto-import-eligible"
+            ]);
+            const riskLabelDefinitions = riskReport.labelDefinitions || {};
+            const riskLabels = new Set(Object.keys(riskLabelDefinitions));
+
+            async function ensureLabel(name, color, description) {
               try {
-                await github.rest.issues.updateLabel({
+                const { data: existing } = await github.rest.issues.getLabel({
                   ...context.repo,
-                  name,
-                  color: definition.color,
-                  description: definition.description
+                  name
                 });
+                if (
+                  existing.color !== color ||
+                  (existing.description || "") !== description
+                ) {
+                  await github.rest.issues.updateLabel({
+                    ...context.repo,
+                    name,
+                    color,
+                    description
+                  });
+                }
               } catch (error) {
                 if (error.status !== 404) throw error;
                 await github.rest.issues.createLabel({
                   ...context.repo,
                   name,
-                  color: definition.color,
-                  description: definition.description
+                  color,
+                  description
                 });
               }
             }
 
-            const { data: issue } = await github.rest.issues.get({
-              ...context.repo,
-              issue_number: context.issue.number
-            });
-            const riskLabels = new Set(Object.keys(definitions));
+            for (const [name, definition] of Object.entries(riskLabelDefinitions)) {
+              await ensureLabel(name, definition.color, definition.description);
+            }
+
+            if (autoImportEligible) {
+              await ensureLabel(
+                "auto-import-eligible",
+                "0e8a16",
+                "Submission passed deterministic gates and awaits maintainer-approved import PR"
+              );
+            }
+
             const currentLabels = (issue.labels || [])
               .map((label) => typeof label === "string" ? label : label.name)
               .filter(Boolean);
             const labels = new Set(
-              currentLabels.filter((label) => !riskLabels.has(label))
+              currentLabels.filter(
+                (label) =>
+                  !managedValidationLabels.has(label) && !riskLabels.has(label)
+              )
             );
-            for (const label of report.recommendedLabels || []) {
+            const validationLabels = autoImportEligible
+              ? ["auto-import-eligible"]
+              : validationReport.recommendedLabels || [];
+            for (const label of validationLabels) {
               if (label) labels.add(label);
             }
-            await github.rest.issues.setLabels({
-              ...context.repo,
-              issue_number: context.issue.number,
-              labels: [...labels].filter(Boolean)
-            });
+            for (const label of riskReport.recommendedLabels || []) {
+              if (label) labels.add(label);
+            }
+            const nextLabels = [...labels].filter(Boolean).sort();
+            const currentSortedLabels = [...new Set(currentLabels)].sort();
+            if (JSON.stringify(currentSortedLabels) !== JSON.stringify(nextLabels)) {
+              try {
+                await github.rest.issues.setLabels({
+                  ...context.repo,
+                  issue_number: context.issue.number,
+                  labels: nextLabels
+                });
+              } catch (error) {
+                core.warning(`Could not apply submission labels: ${error.message}`);
+              }
+            }
 
       - name: Preview import output
         if: always()
@@ -354,12 +316,14 @@ jobs:
             const existing = comments.find((comment) => comment.body?.includes(marker));
 
             if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body
-              });
+              if (existing.body !== body) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+              }
             } else {
               await github.rest.issues.createComment({
                 owner,
@@ -389,12 +353,14 @@ jobs:
             });
             const existing = comments.find((comment) => comment.body?.includes(marker));
             if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body
-              });
+              if (existing.body !== body) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body
+                });
+              }
             } else {
               await github.rest.issues.createComment({
                 owner,

--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -4,7 +4,6 @@ on:
   pull_request_target:
     types:
       - opened
-      - edited
       - reopened
       - synchronize
     paths:
@@ -14,7 +13,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   analyze-submission-pr-risk:
@@ -37,7 +35,6 @@ jobs:
             // packages/registry/src/submission-risk.js. This pull_request_target
             // workflow intentionally avoids checking out or executing PR code.
             const RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
-            const REVIEW_MARKER = "<!-- heyclaude-submission-bot-review -->";
             const RISK_LABEL_DEFINITIONS = {
               "risk-low": {
                 color: "0e8a16",
@@ -1657,7 +1654,7 @@ jobs:
                 }
               }
               if (report.requestChangesReasons?.length) {
-                lines.push("", "### Requested changes blockers");
+                lines.push("", "### Blocking findings");
                 for (const reason of report.requestChangesReasons) {
                   lines.push(`- ${escapeMarkdownText(reason)}`);
                 }
@@ -1982,64 +1979,99 @@ jobs:
             core.info(
               `Submission security/safety risk: ${report.riskTier} (${report.reviewFlags.length} flags)`
             );
-            const definitions = report.labelDefinitions || {};
-            for (const [name, definition] of Object.entries(definitions)) {
+            const subjectContentFiles = report.subject?.contentFiles;
+            const hasContentFiles =
+              Array.isArray(subjectContentFiles) && subjectContentFiles.length > 0;
+            if (hasContentFiles) {
               try {
-                await github.rest.issues.updateLabel({
+                const definitions = report.labelDefinitions || {};
+                async function ensureLabel(name, color, description) {
+                  try {
+                    const { data: existingLabel } = await github.rest.issues.getLabel({
+                      ...context.repo,
+                      name
+                    });
+                    if (
+                      existingLabel.color !== color ||
+                      (existingLabel.description || "") !== description
+                    ) {
+                      await github.rest.issues.updateLabel({
+                        ...context.repo,
+                        name,
+                        color,
+                        description
+                      });
+                    }
+                  } catch (error) {
+                    if (error.status !== 404) throw error;
+                    await github.rest.issues.createLabel({
+                      ...context.repo,
+                      name,
+                      color,
+                      description
+                    });
+                  }
+                }
+                for (const [name, definition] of Object.entries(definitions)) {
+                  await ensureLabel(name, definition.color, definition.description);
+                }
+                const { data: issue } = await github.rest.issues.get({
                   ...context.repo,
-                  name,
-                  color: definition.color,
-                  description: definition.description
+                  issue_number: context.payload.pull_request.number
                 });
+                const riskLabels = new Set(Object.keys(definitions));
+                const currentLabels = (issue.labels || [])
+                  .map((label) => typeof label === "string" ? label : label.name)
+                  .filter(Boolean);
+                const labels = new Set(
+                  currentLabels.filter((label) => !riskLabels.has(label))
+                );
+                for (const label of report.recommendedLabels || []) {
+                  if (label) labels.add(label);
+                }
+                const nextLabels = [...labels].filter(Boolean).sort();
+                const currentSortedLabels = [...new Set(currentLabels)].sort();
+                if (
+                  JSON.stringify(currentSortedLabels) !== JSON.stringify(nextLabels)
+                ) {
+                  await github.rest.issues.setLabels({
+                    ...context.repo,
+                    issue_number: context.payload.pull_request.number,
+                    labels: nextLabels
+                  });
+                }
               } catch (error) {
-                if (error.status !== 404) throw error;
-                await github.rest.issues.createLabel({
-                  ...context.repo,
-                  name,
-                  color: definition.color,
-                  description: definition.description
-                });
+                core.warning(
+                  `Could not sync submission risk labels: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`
+                );
               }
-            }
-            const { data: issue } = await github.rest.issues.get({
-              ...context.repo,
-              issue_number: context.payload.pull_request.number
-            });
-            const riskLabels = new Set(Object.keys(definitions));
-            const currentLabels = (issue.labels || [])
-              .map((label) => typeof label === "string" ? label : label.name)
-              .filter(Boolean);
-            const labels = new Set(
-              currentLabels.filter((label) => !riskLabels.has(label))
-            );
-            for (const label of report.recommendedLabels || []) {
-              if (label) labels.add(label);
-            }
-            await github.rest.issues.setLabels({
-              ...context.repo,
-              issue_number: context.payload.pull_request.number,
-              labels: [...labels].filter(Boolean)
-            });
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              ...context.repo,
-              issue_number: context.payload.pull_request.number,
-              per_page: 100
-            });
-            const existing = comments.find((comment) =>
-              comment.body?.includes(RISK_COMMENT_MARKER)
-            );
-            if (existing) {
-              await github.rest.issues.updateComment({
-                ...context.repo,
-                comment_id: existing.id,
-                body: markdownReport
-              });
-            } else {
-              await github.rest.issues.createComment({
+              const comments = await github.paginate(github.rest.issues.listComments, {
                 ...context.repo,
                 issue_number: context.payload.pull_request.number,
-                body: markdownReport
+                per_page: 100
               });
+              const existing = comments.find((comment) =>
+                comment.body?.includes(RISK_COMMENT_MARKER)
+              );
+              if (existing) {
+                if (existing.body !== markdownReport) {
+                  await github.rest.issues.updateComment({
+                    ...context.repo,
+                    comment_id: existing.id,
+                    body: markdownReport
+                  });
+                }
+              } else {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: context.payload.pull_request.number,
+                  body: markdownReport
+                });
+              }
+            } else {
+              core.info("No content MDX files changed; skipping PR label/comment sync.");
             }
             const failures = [];
             const provenanceBlockers = (report.provenanceFindings || []).filter(
@@ -2062,38 +2094,9 @@ jobs:
             }
             const requestChangeReasons = report.requestChangesReasons || [];
             if (requestChangeReasons.length) {
-              failures.push("HeyClaude Submission Bot requested changes:");
+              failures.push("Direct content PR risk blockers:");
               for (const reason of requestChangeReasons) {
                 failures.push(`- ${reason}`);
-              }
-              const reviewBody = [
-                REVIEW_MARKER,
-                "## HeyClaude Submission Bot requested changes",
-                "",
-                "Thanks for the submission. The bot found deterministic blockers that need to be fixed before maintainer review can continue:",
-                "",
-                ...requestChangeReasons.map((reason) => `- ${reason}`),
-                "",
-                "This is a review gate only; maintainers still make the final merge decision."
-              ].join("\n");
-              const reviews = await github.paginate(github.rest.pulls.listReviews, {
-                ...context.repo,
-                pull_number: context.payload.pull_request.number,
-                per_page: 100
-              });
-              const existingReview = reviews.find(
-                (review) =>
-                  review.commit_id === pr.head.sha &&
-                  review.body?.includes(REVIEW_MARKER)
-              );
-              if (!existingReview) {
-                await github.rest.pulls.createReview({
-                  ...context.repo,
-                  pull_number: context.payload.pull_request.number,
-                  commit_id: pr.head.sha,
-                  event: "REQUEST_CHANGES",
-                  body: reviewBody
-                });
               }
             }
             if (failures.length) {

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -2116,7 +2116,7 @@ export function formatSubmissionRiskMarkdown(report) {
   }
 
   if (report.requestChangesReasons?.length) {
-    lines.push("", "### Requested changes blockers");
+    lines.push("", "### Blocking findings");
     for (const reason of report.requestChangesReasons) {
       lines.push(`- ${escapeMarkdownText(reason)}`);
     }

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -317,6 +317,8 @@ describe("submission automation workflows", () => {
     );
 
     expect(source).toContain("pull_request_target:");
+    expect(source).not.toContain("- edited");
+    expect(source).not.toContain("pull-requests: write");
     expect(source).toContain("Analyze PR content through GitHub API");
     expect(source).not.toContain("actions/checkout");
     expect(source).not.toContain("pnpm install");
@@ -349,7 +351,20 @@ describe("submission automation workflows", () => {
     expect(source).toContain(
       "Submission security/safety review found critical blockers",
     );
-    expect(source).toContain("REQUEST_CHANGES");
+    expect(source).toContain("Direct content PR risk blockers");
+    expect(source).toContain("### Blocking findings");
+    expect(source).toContain(
+      "const subjectContentFiles = report.subject?.contentFiles",
+    );
+    expect(source).not.toContain("Array.isArray(report.contentFiles)");
+    expect(source).toContain("Could not sync submission risk labels");
+    expect(source).toContain(
+      "No content MDX files changed; skipping PR label/comment sync.",
+    );
+    expect(source).toContain("existing.body !== markdownReport");
+    expect(source).not.toContain("REQUEST_CHANGES");
+    expect(source).not.toContain("pulls.createReview");
+    expect(source).not.toContain("heyclaude-submission-bot-review");
     expect(source).toContain("ARCHIVE_PACKAGE_EXTENSIONS");
     expect(source).toContain("HEYCLAUDE_HOSTNAME");
     expect(source).toContain("const downloadHost = hostname(downloadUrl)");
@@ -359,7 +374,6 @@ describe("submission automation workflows", () => {
     expect(source).toContain("isArchivePackageUrl(downloadUrl)");
     expect(source).toContain("missing_safety_notes");
     expect(source).toContain("missing_privacy_notes");
-    expect(source).toContain("review.body?.includes(REVIEW_MARKER)");
     expect(source).not.toContain("git checkout");
   });
 


### PR DESCRIPTION
## Summary
- stop the direct submission risk workflow from creating `REQUEST_CHANGES` bot reviews
- keep risk reporting as a failing check plus one marker comment, updated only when content changes
- collapse submission issue label sync into one idempotent step to avoid self-triggering label churn
- rename risk report blocker heading from requested changes to blocking findings

## Validation
- `actionlint .github/workflows/submission-pr-risk.yml .github/workflows/submission-issue-validation.yml`
- `pnpm exec vitest run tests/submission-workflows.test.ts tests/submission-intake.test.ts`
- `pnpm test:submission-intake`
- `pnpm validate:clean`
- `pnpm validate:packages`
- `pnpm validate:content:strict`
- `pnpm exec prettier --check .github/workflows/submission-pr-risk.yml .github/workflows/submission-issue-validation.yml packages/registry/src/submission-risk.js tests/submission-workflows.test.ts`
- `git diff --check`

No auto-merge recommended; maintainer review still required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved label synchronization for submission validation and risk reports, creating/updating managed labels and applying label sets only when they change
  * Reduced unnecessary comment updates by only editing validation/risk comments when their rendered content differs
  * Renamed a risk-report heading to clarify reporting language ("Blocking findings")

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->