### PR TITLE
fix(mcp): surface generated package checksums in trust summary

### DIFF
--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -608,7 +608,12 @@ function entryTrustSummary(entry) {
       downloadUrl: source.downloadUrl,
       downloadTrust: packageTrust,
       packageVerified: Boolean(entry.packageVerified),
-      checksum: entry.checksum || entry.packageChecksum || "",
+      checksum:
+        entry.checksum ||
+        entry.packageChecksum ||
+        entry.downloadSha256 ||
+        entry.skillPackage?.sha256 ||
+        "",
     },
     disclosures: {
       safetyNotes,


### PR DESCRIPTION
### Motivation
- MCP trust helpers were returning an empty `trust.package.checksum` for verified downloadable packages because they only read `entry.checksum` and `entry.packageChecksum` while registry generation stores hashes as `entry.downloadSha256` (and for skills as `entry.skillPackage.sha256`).

### Description
- Updated `entryTrustSummary()` in `packages/mcp/src/registry.js` to include registry-generated checksum fields when computing `trust.package.checksum`.
- Added fallback order: `checksum` -> `packageChecksum` -> `downloadSha256` -> `skillPackage.sha256` -> empty string to preserve existing behavior while surfacing available checksums.
- Change is minimal and only adjusts metadata selection logic; no other behavior was modified.

### Testing
- Ran `pnpm exec vitest run tests/mcp-server.test.ts` and the test file passed (all tests succeeded).
- Attempted `pnpm exec vitest run tests/mcp-tools.test.ts` which exited with "No test files found" due to the chosen filter and did not indicate repository regressions.
- Ran `git diff --check` to validate whitespace/check output and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e056e52c0832083d92134144e9ad1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package checksum handling with an expanded fallback sequence that considers multiple checksum sources (including download and nested package checksums). This reduces cases where checksums are missing and improves reliability of package integrity verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->