### PR TITLE
fix(trust): gate verified package badge on first-party trust

### DIFF
--- a/apps/web/src/app/[category]/[slug]/page.tsx
+++ b/apps/web/src/app/[category]/[slug]/page.tsx
@@ -301,14 +301,12 @@ export default async function DetailPage({ params }: DetailPageProps) {
     {
       label: "Package",
       value: entry.downloadUrl
-        ? entry.downloadTrust === "first-party" || entry.packageVerified
+        ? entry.downloadTrust === "first-party"
           ? "Verified package"
           : "External package"
         : "No package download",
       tone:
-        !entry.downloadUrl ||
-        entry.downloadTrust === "first-party" ||
-        entry.packageVerified
+        !entry.downloadUrl || entry.downloadTrust === "first-party"
           ? "positive"
           : "warn",
     },

--- a/apps/web/src/components/directory-entry-card.tsx
+++ b/apps/web/src/components/directory-entry-card.tsx
@@ -82,7 +82,7 @@ function getMonogram(entry: DirectoryEntry) {
 function getTrustBadges(entry: DirectoryEntry) {
   const badges = [
     entry.trustSignals?.sourceStatus === "available" ? "Source-backed" : "",
-    entry.downloadTrust === "first-party" || entry.packageVerified === true
+    entry.downloadTrust === "first-party"
       ? "Verified package"
       : entry.downloadUrl
         ? "External package"


### PR DESCRIPTION
### Motivation
- The UI could label externally hosted downloads as "Verified package" because it treated `packageVerified` as equivalent to `downloadTrust === "first-party"`, which weakens the registry's trust boundary and can mislead users.
- The authoritative trust classification is `downloadTrust`, which is only `"first-party"` when the download is a local `/downloads/...` asset and verification is present, so the UI must rely on that value.

### Description
- Change `apps/web/src/app/[category]/[slug]/page.tsx` to stop using `entry.packageVerified` as an OR condition and only show "Verified package" when `entry.downloadTrust === "first-party"`, and update the tone logic accordingly.
- Change `apps/web/src/components/directory-entry-card.tsx` to compute the package badge from `entry.downloadTrust === "first-party"` only, preserving the "External package" and "No package download" cases.
- These edits preserve existing behavior for entries without downloads and explicitly classify external downloads as non-verified.

### Testing
- Ran `pnpm exec vitest run tests/registry-artifacts.test.ts`, and all tests passed (1 file, 17 tests).
- Ran `git diff --check` to ensure no whitespace or lint diffs, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e041ffc1083208f208586a5be7741)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Package status and tone now reflect whether a download URL exists and if the download is marked first-party.
  * Package badges updated to show "Verified package" only when download trust is first-party.
  * This clarifies trust indicators across the directory and reduces misleading verification displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->