### PR TITLE
ci(validation): route PR checks by content category

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -12,11 +12,13 @@ permissions:
   deployments: read
 
 jobs:
-  required-pr-gate:
-    name: required-pr-gate
+  classify-pr:
+    name: classify-pr
     runs-on: ubuntu-latest
     outputs:
       content: ${{ steps.classify.outputs.content }}
+      content_config: ${{ steps.classify.outputs.content_config }}
+      content_categories_json: ${{ steps.classify.outputs.content_categories_json }}
       registry: ${{ steps.classify.outputs.registry }}
       web: ${{ steps.classify.outputs.web }}
       mcp: ${{ steps.classify.outputs.mcp }}
@@ -26,7 +28,7 @@ jobs:
       docs: ${{ steps.classify.outputs.docs }}
       full: ${{ steps.classify.outputs.full }}
     concurrency:
-      group: pr-required-gate-${{ github.ref }}
+      group: pr-classify-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
@@ -53,6 +55,13 @@ jobs:
             node "$classifier_path"
           fi
 
+          if ! grep -q '^content_config=' "$GITHUB_OUTPUT"; then
+            echo "content_config=false" >> "$GITHUB_OUTPUT"
+          fi
+          if ! grep -q '^content_categories_json=' "$GITHUB_OUTPUT"; then
+            echo "content_categories_json=[]" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Reject external generated artifact changes
         if: ${{ github.event_name == 'pull_request' }}
         env:
@@ -73,7 +82,8 @@ jobs:
 
   validate-ci:
     name: validate-ci
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.ci == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-ci-${{ github.ref }}
@@ -81,105 +91,172 @@ jobs:
 
     steps:
       - name: Skip unchanged CI lane
-        if: ${{ needs.required-pr-gate.outputs.ci != 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci != 'true' }}
         run: echo "No CI/config validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Validate cleanup policy
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: pnpm validate:clean
 
       - name: Validate task tracker
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: pnpm validate:tasks
 
       - name: Check whitespace
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: git diff --check
 
       - name: Install Trunk CLI
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: |
           curl https://get.trunk.io -fsSL | bash -s -- -y
           echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
 
       - name: Trunk Check
-        if: ${{ needs.required-pr-gate.outputs.ci == 'true' }}
+        if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         run: trunk check --ci --all
+
+  validate-content-category:
+    name: validate-content-${{ matrix.category }}
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.content_categories_json != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        category: ${{ fromJson(needs.classify-pr.outputs.content_categories_json) }}
+    concurrency:
+      group: pr-validate-content-${{ matrix.category }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate ${{ matrix.category }} content schema
+        run: pnpm validate:content:strict -- --category "${{ matrix.category }}"
+
+      - name: Audit ${{ matrix.category }} content report
+        run: pnpm audit:content -- --category "${{ matrix.category }}"
+
+  validate-content-config:
+    name: validate-content-config
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.content_config == 'true' }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-validate-content-config-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.15.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate content schema
+        run: pnpm validate:content:strict
+
+      - name: Validate category submission spec
+        run: pnpm validate:category-spec
+
+      - name: Validate issue templates
+        run: pnpm validate:issue-templates
+
+      - name: Audit content report
+        run: pnpm audit:content
 
   validate-content:
     name: validate-content
-    needs: required-pr-gate
+    needs:
+      - classify-pr
+      - validate-content-category
+      - validate-content-config
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-content-${{ github.ref }}
       cancel-in-progress: true
 
     steps:
-      - name: Skip unchanged content lane
-        if: ${{ needs.required-pr-gate.outputs.content != 'true' }}
-        run: echo "No content validation required for this change set."
+      - name: Summarize content validation
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          node <<'NODE'
+          const needs = JSON.parse(process.env.NEEDS_JSON || "{}");
+          const rows = Object.entries(needs);
 
-      - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
+          console.log("Content validation results:");
+          for (const [name, info] of rows) {
+            console.log(`- ${name}: ${info.result || "unknown"}`);
+          }
 
-      - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+          const failed = rows.filter(([, info]) => {
+            const result = info.result || "unknown";
+            return !["success", "skipped"].includes(result);
+          });
 
-      - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
-        with:
-          node-version: 24.15.0
-          cache: pnpm
-
-      - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        run: pnpm install --frozen-lockfile
-
-      - name: Validate content schema
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        run: pnpm validate:content:strict
-
-      - name: Validate category submission spec
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        run: pnpm validate:category-spec
-
-      - name: Validate issue templates
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        run: pnpm validate:issue-templates
-
-      - name: Audit content report
-        if: ${{ needs.required-pr-gate.outputs.content == 'true' }}
-        run: pnpm audit:content
+          if (failed.length > 0) {
+            console.error("Content validation failed:");
+            for (const [name, info] of failed) {
+              console.error(`- ${name}: ${info.result || "unknown"}`);
+            }
+            process.exit(1);
+          }
+          NODE
 
   validate-registry:
     name: validate-registry
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.registry == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-registry-${{ github.ref }}
@@ -187,49 +264,50 @@ jobs:
 
     steps:
       - name: Skip unchanged registry lane
-        if: ${{ needs.required-pr-gate.outputs.registry != 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry != 'true' }}
         run: echo "No registry artifact validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build registry artifacts
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         run: pnpm --filter web run prebuild
 
       - name: Test registry artifact contracts
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         run: pnpm test:registry-artifacts
 
       - name: Validate generated README
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         run: pnpm validate:readme
 
       - name: Verify generated registry artifacts are current
-        if: ${{ needs.required-pr-gate.outputs.registry == 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         run: git diff --exit-code apps/web/public/data apps/web/src/generated README.md
 
   validate-web:
     name: validate-web
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.web == 'true' }}
     runs-on: ubuntu-latest
     env:
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN || secrets.TRUNK_TOKEN }}
@@ -240,92 +318,93 @@ jobs:
 
     steps:
       - name: Skip unchanged web lane
-        if: ${{ needs.required-pr-gate.outputs.web != 'true' }}
+        if: ${{ needs.classify-pr.outputs.web != 'true' }}
         run: echo "No web/API validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Clean test reports
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: rm -rf reports/junit && mkdir -p reports/junit
 
       - name: Build registry artifacts
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm --filter web run prebuild
 
       - name: Apply local D1 migrations
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm --filter web db:migrate:local
 
       - name: Validate local D1 jobs schema
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm validate:d1-jobs -- --local
 
       - name: Validate generated OpenAPI schema
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm validate:openapi
 
       - name: Run Vitest suite
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm test
 
       - name: Install Playwright Chromium
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run browser regression suite
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm test:e2e
 
       - name: Install Trunk CLI
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         run: |
           curl https://get.trunk.io -fsSL | bash -s -- -y
           echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
 
       - name: Upload test results to Trunk
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         continue-on-error: true
         run: trunk flakytests upload --junit-paths "reports/junit/*.xml" --org-url-slug "$TRUNK_ORG_URL_SLUG" --token "$TRUNK_API_TOKEN"
 
       - name: Validate email templates
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm validate:emails
 
       - name: Dry-run Resend template sync
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm resend:sync-templates -- --dry-run
 
       - name: Type-check web app
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm type-check
 
       - name: Build web app
-        if: ${{ needs.required-pr-gate.outputs.web == 'true' }}
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm build
 
   validate-mcp:
     name: validate-mcp
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-mcp-${{ github.ref }}
@@ -333,55 +412,56 @@ jobs:
 
     steps:
       - name: Skip unchanged MCP lane
-        if: ${{ needs.required-pr-gate.outputs.mcp != 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp != 'true' }}
         run: echo "No MCP validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build registry artifacts
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         run: pnpm --filter web run prebuild
 
       - name: Test MCP package
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         run: pnpm test:mcp
 
       - name: Validate dev MCP endpoint
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         run: pnpm validate:mcp-endpoint -- --url https://heyclaude-dev.zeronode.workers.dev/api/mcp
 
       - name: Dry-run MCP package tarball
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         run: pnpm --filter @heyclaude/mcp pack --dry-run --json
 
       - name: Validate packed MCP package
-        if: ${{ needs.required-pr-gate.outputs.mcp == 'true' }}
+        if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         env:
           MCP_PACKAGE_REMOTE_SMOKE_URL: https://heyclaude-dev.zeronode.workers.dev/api/mcp
         run: pnpm validate:mcp-package
 
   validate-raycast:
     name: validate-raycast
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
     runs-on: ubuntu-latest
     env:
       TRUNK_API_TOKEN: ${{ secrets.TRUNK_API_TOKEN || secrets.TRUNK_TOKEN }}
@@ -392,80 +472,81 @@ jobs:
 
     steps:
       - name: Skip unchanged Raycast lane
-        if: ${{ needs.required-pr-gate.outputs.raycast != 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast != 'true' }}
         run: echo "No Raycast validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build feed artifacts
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         run: pnpm --filter web run prebuild
 
       - name: Clean test reports
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         run: rm -rf reports/junit && mkdir -p reports/junit
 
       - name: Validate Raycast feed
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         run: pnpm validate:raycast-feed
 
       - name: Test registry artifact contracts
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         run: pnpm test:registry-artifacts
 
       - name: Install Raycast dependencies
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm ci
 
       - name: Test Raycast helpers
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm run test:junit
 
       - name: Install Trunk CLI
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         run: |
           curl https://get.trunk.io -fsSL | bash -s -- -y
           echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
 
       - name: Upload Raycast test results to Trunk
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
         continue-on-error: true
         run: trunk flakytests upload --junit-paths "reports/junit/raycast.xml" --org-url-slug "$TRUNK_ORG_URL_SLUG" --token "$TRUNK_API_TOKEN"
 
       - name: Lint Raycast extension
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm run lint
 
       - name: Build Raycast extension
-        if: ${{ needs.required-pr-gate.outputs.raycast == 'true' }}
+        if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         working-directory: integrations/raycast
         run: npm run build
 
   validate-packages:
     name: validate-packages
-    needs: required-pr-gate
+    needs: classify-pr
+    if: ${{ needs.classify-pr.outputs.packages == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-packages-${{ github.ref }}
@@ -473,40 +554,40 @@ jobs:
 
     steps:
       - name: Skip unchanged package artifact lane
-        if: ${{ needs.required-pr-gate.outputs.packages != 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages != 'true' }}
         run: echo "No package artifact validation required for this change set."
 
       - name: Checkout
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup pnpm
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
 
       - name: Setup Node.js
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: 24.15.0
           cache: pnpm
 
       - name: Install dependencies
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Validate package metadata
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         run: pnpm validate:packages
 
       - name: Scan package artifacts
-        if: ${{ needs.required-pr-gate.outputs.packages == 'true' }}
+        if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         run: pnpm scan:packages
 
   validate-pr-preview:
     name: validate-pr-preview
-    if: ${{ github.event_name == 'pull_request' && (needs.required-pr-gate.outputs.web == 'true' || needs.required-pr-gate.outputs.registry == 'true' || needs.required-pr-gate.outputs.mcp == 'true') }}
-    needs: required-pr-gate
+    if: ${{ github.event_name == 'pull_request' && (needs.classify-pr.outputs.web == 'true' || needs.classify-pr.outputs.registry == 'true' || needs.classify-pr.outputs.mcp == 'true') }}
+    needs: classify-pr
     runs-on: ubuntu-latest
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -557,3 +638,49 @@ jobs:
         env:
           MCP_ENDPOINT_URL: ${{ steps.preview-url.outputs.base-url }}/api/mcp
         run: pnpm validate:mcp-endpoint
+
+  required-pr-gate:
+    name: required-pr-gate
+    needs:
+      - classify-pr
+      - validate-ci
+      - validate-content
+      - validate-registry
+      - validate-web
+      - validate-mcp
+      - validate-raycast
+      - validate-packages
+      - validate-pr-preview
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: pr-required-gate-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Summarize required PR validation
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+        run: |
+          node <<'NODE'
+          const needs = JSON.parse(process.env.NEEDS_JSON || "{}");
+          const rows = Object.entries(needs);
+
+          console.log("Required PR validation results:");
+          for (const [name, info] of rows) {
+            console.log(`- ${name}: ${info.result || "unknown"}`);
+          }
+
+          const failed = rows.filter(([, info]) => {
+            const result = info.result || "unknown";
+            return !["success", "skipped"].includes(result);
+          });
+
+          if (failed.length > 0) {
+            console.error("Required PR validation failed:");
+            for (const [name, info] of failed) {
+              console.error(`- ${name}: ${info.result || "unknown"}`);
+            }
+            process.exit(1);
+          }
+          NODE

--- a/scripts/audit-content.mjs
+++ b/scripts/audit-content.mjs
@@ -16,7 +16,40 @@ import {
 
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
-const reportPath = path.join(repoRoot, "content/data/content-audit.json");
+const selectedCategories = new Set();
+
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (arg === "--category" || arg === "--categories") {
+    const value = process.argv[index + 1] || "";
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+    index += 1;
+  } else if (arg.startsWith("--category=")) {
+    const value = arg.slice("--category=".length);
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+  } else if (arg.startsWith("--categories=")) {
+    const value = arg.slice("--categories=".length);
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+  }
+}
+
+const reportPath =
+  selectedCategories.size > 0
+    ? path.join(
+        repoRoot,
+        "reports/content-audit",
+        `${[...selectedCategories].sort().join("-")}.json`,
+      )
+    : path.join(repoRoot, "content/data/content-audit.json");
 
 const report = [];
 const oldBrandOrDomainPattern = new RegExp(
@@ -29,6 +62,10 @@ const oldBrandOrDomainPattern = new RegExp(
 );
 
 for (const category of Object.keys(CATEGORY_SCHEMAS)) {
+  if (selectedCategories.size > 0 && !selectedCategories.has(category)) {
+    continue;
+  }
+
   const categoryDir = path.join(contentRoot, category);
   if (!fs.existsSync(categoryDir)) continue;
 
@@ -139,6 +176,7 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
   }
 }
 
+fs.mkdirSync(path.dirname(reportPath), { recursive: true });
 fs.writeFileSync(
   reportPath,
   await prettier.format(JSON.stringify(report), { parser: "json" }),
@@ -154,6 +192,9 @@ const metadataOnly = report.filter((item) => item.metadataOnly).length;
 const semanticIssues = report.filter((item) => item.issues.length > 0).length;
 
 console.log(`Wrote ${path.relative(repoRoot, reportPath)}`);
+if (selectedCategories.size > 0) {
+  console.log(`Selected categories: ${[...selectedCategories].join(", ")}`);
+}
 console.log(`Entries with missing required fields: ${requiredIssues}`);
 console.log(`Entries with missing recommended fields: ${recommendedIssues}`);
 console.log(`Metadata-only entries: ${metadataOnly}`);

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -9,6 +9,19 @@ const forceFull =
   eventName === "schedule";
 const outputPath = process.env.GITHUB_OUTPUT || "";
 const summaryPath = process.env.GITHUB_STEP_SUMMARY || "";
+const CONTENT_CATEGORIES = [
+  "agents",
+  "commands",
+  "collections",
+  "guides",
+  "hooks",
+  "mcp",
+  "prompts",
+  "rules",
+  "skills",
+  "statuslines",
+  "tools",
+];
 
 function changedFiles() {
   if (forceFull) return [];
@@ -42,29 +55,43 @@ function touches(...patterns) {
   );
 }
 
+function contentCategoriesFromFiles() {
+  if (all) return [...CONTENT_CATEGORIES];
+
+  const categories = new Set();
+  for (const file of files) {
+    const match = /^content\/([^/]+)\/[^/]+\.mdx$/i.exec(file);
+    if (match && CONTENT_CATEGORIES.includes(match[1])) {
+      categories.add(match[1]);
+    }
+  }
+  return [...categories].sort();
+}
+
+const contentCategories = contentCategoriesFromFiles();
+const contentCategoryTouched = contentCategories.length > 0;
+const contentValidationInfra = touches(
+  /^examples\/content\//,
+  /^\.github\/ISSUE_TEMPLATE\//,
+  /^scripts\/(audit-content|generate-issue-templates|validate-category-spec|validate-content)\.mjs$/,
+  /^packages\/registry\/src\/(category-spec|content-builder|submission|index\.d\.ts)/,
+);
+const generatedArtifactInfra = touches(
+  /^packages\/registry\//,
+  /^scripts\/(audit-content|build-content-index|generate-readme|validate-category-spec|validate-content|validate-codebase-clean)\.mjs$/,
+  /^tests\/(registry-artifacts|readme-generation|seo-jsonld)\.test\.ts$/,
+  /^apps\/web\/public\/data\//,
+  /^apps\/web\/src\/generated\//,
+  "README.md",
+);
+
 const flags = {
-  content: touches(
-    /^content\//,
-    /^examples\/content\//,
-    /^\.github\/ISSUE_TEMPLATE\//,
-    /^scripts\/(audit-content|generate-issue-templates|validate-category-spec|validate-content)\.mjs$/,
-    /^packages\/registry\/src\/(category-spec|content-builder|submission|index\.d\.ts)/,
-  ),
-  registry: touches(
-    /^content\//,
-    /^examples\/content\//,
-    /^packages\/registry\//,
-    /^scripts\/(audit-content|build-content-index|generate-readme|validate-category-spec|validate-content|validate-codebase-clean)\.mjs$/,
-    /^tests\/(registry-artifacts|readme-generation|seo-jsonld)\.test\.ts$/,
-    /^apps\/web\/public\/data\//,
-    /^apps\/web\/src\/generated\//,
-    "README.md",
-  ),
+  content: contentCategoryTouched || contentValidationInfra,
+  content_config: contentValidationInfra,
+  registry: generatedArtifactInfra,
   web: touches(
     /^apps\/web\//,
     /^emails\//,
-    /^content\//,
-    /^examples\/content\//,
     /^cloudflare\/api-schema-heyclaude-openapi\.yaml$/,
     /^scripts\/(generate-openapi|run-playwright|validate-d1-jobs|validate-deployment-artifacts)\.(mjs|ts)$/,
     /^tests\/(api-|commercial-intake|discovery-surfaces|seo-jsonld|submission-api|submission-workflows|votes-api).*\.test\.ts$/,
@@ -83,8 +110,6 @@ const flags = {
   ),
   raycast: touches(
     /^integrations\/raycast\//,
-    /^content\//,
-    /^examples\/content\//,
     /^apps\/web\/public\/data\/raycast/,
     /^scripts\/(build-content-index|validate-raycast-feed)\.mjs$/,
     /^tests\/registry-artifacts\.test\.ts$/,
@@ -123,11 +148,17 @@ for (const key of Object.keys(flags)) {
   flags[key] = Boolean(flags[key]);
 }
 
+for (const category of CONTENT_CATEGORIES) {
+  flags[`content_${category}`] = all || contentCategories.includes(category);
+}
+
 const lines = [
   `full=${all ? "true" : "false"}`,
   ...Object.entries(flags).map(
     ([key, value]) => `${key}=${value ? "true" : "false"}`,
   ),
+  `content_categories=${contentCategories.join(",")}`,
+  `content_categories_json=${JSON.stringify(contentCategories)}`,
   `changed_count=${files.length}`,
   `changed_files_json=${JSON.stringify(files)}`,
 ];
@@ -146,6 +177,7 @@ const summary = [
   ...Object.entries(flags).map(
     ([key, value]) => `| ${key} | ${value ? "yes" : "no"} |`,
   ),
+  `| content categories | ${contentCategories.length ? contentCategories.join(", ") : "none"} |`,
   "",
   `<details><summary>Changed files (${files.length})</summary>`,
   "",

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -15,6 +15,31 @@ import {
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
 const strictRecommended = process.argv.includes("--strict-recommended");
+const selectedCategories = new Set();
+
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (arg === "--category" || arg === "--categories") {
+    const value = process.argv[index + 1] || "";
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+    index += 1;
+  } else if (arg.startsWith("--category=")) {
+    const value = arg.slice("--category=".length);
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+  } else if (arg.startsWith("--categories=")) {
+    const value = arg.slice("--categories=".length);
+    for (const category of value.split(",")) {
+      const normalized = category.trim();
+      if (normalized) selectedCategories.add(normalized);
+    }
+  }
+}
 
 const failures = [];
 const warnings = [];
@@ -29,6 +54,10 @@ const oldBrandOrDomainPattern = new RegExp(
 );
 
 for (const category of Object.keys(CATEGORY_SCHEMAS)) {
+  if (selectedCategories.size > 0 && !selectedCategories.has(category)) {
+    continue;
+  }
+
   const categoryDir = path.join(contentRoot, category);
   if (!fs.existsSync(categoryDir)) continue;
 
@@ -192,6 +221,10 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
 }
 
 console.log(`Validated ${filesChecked} content files.`);
+
+if (selectedCategories.size > 0) {
+  console.log(`Selected categories: ${[...selectedCategories].join(", ")}`);
+}
 
 if (warnings.length > 0) {
   console.log(`Warnings (${warnings.length}):`);

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -18,6 +18,62 @@ import {
 import { repoRoot } from "./helpers/registry-fixtures";
 
 describe("submission automation workflows", () => {
+  function writeFile(filePath: string, content: string) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content, "utf8");
+  }
+
+  function git(cwd: string, args: string[]) {
+    return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+  }
+
+  function runClassifierForChangedFiles(files: Record<string, string>) {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-classifier-"),
+    );
+    git(tmpDir, ["init", "-b", "main"]);
+    git(tmpDir, ["config", "user.name", "HeyClaude Test"]);
+    git(tmpDir, ["config", "user.email", "test@example.com"]);
+    writeFile(path.join(tmpDir, "README.md"), "# Test\n");
+    git(tmpDir, ["add", "README.md"]);
+    git(tmpDir, ["commit", "-m", "test: initial content"]);
+    const baseSha = git(tmpDir, ["rev-parse", "HEAD"]);
+
+    for (const [filePath, content] of Object.entries(files)) {
+      writeFile(path.join(tmpDir, filePath), content);
+    }
+    git(tmpDir, ["add", "."]);
+    git(tmpDir, ["commit", "-m", "test: update content"]);
+
+    const outputPath = path.join(tmpDir, "github-output.txt");
+    execFileSync(
+      process.execPath,
+      [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          FORCE_FULL_VALIDATION: "0",
+          GITHUB_EVENT_NAME: "pull_request",
+          GITHUB_OUTPUT: outputPath,
+        },
+      },
+    );
+
+    return Object.fromEntries(
+      fs
+        .readFileSync(outputPath, "utf8")
+        .split(/\r?\n/)
+        .filter(Boolean)
+        .map((line) => {
+          const separator = line.indexOf("=");
+          return [line.slice(0, separator), line.slice(separator + 1)];
+        }),
+    );
+  }
+
   it("keeps public issue validation read-only for imports", () => {
     const source = fs.readFileSync(
       path.join(repoRoot, ".github/workflows/submission-issue-validation.yml"),
@@ -435,6 +491,13 @@ describe("submission automation workflows", () => {
       "utf8",
     );
 
+    expect(source).toContain("classify-pr:");
+    expect(source).toContain("required-pr-gate:");
+    expect(source).toContain("validate-content-${{ matrix.category }}");
+    expect(source).toContain(
+      "fromJson(needs.classify-pr.outputs.content_categories_json)",
+    );
+    expect(source).toContain("Summarize required PR validation");
     expect(source).toContain("validate-pr-preview:");
     expect(source).toContain("github.event_name == 'pull_request'");
     expect(source).toContain("Deploy same-repo PR preview to dev Worker");
@@ -801,6 +864,41 @@ description: Example description
 
     expect(source).toContain('"README.md"');
     expect(source).toContain("/^.*\\.md$/");
+    expect(source).toContain("CONTENT_CATEGORIES");
+    expect(source).toContain("content_categories_json");
+  });
+
+  it("routes hook-only content PRs to hook content validation", () => {
+    const outputs = runClassifierForChangedFiles({
+      "content/hooks/retro-daily.mdx": "---\ntitle: Retro Daily\n---\n",
+    });
+
+    expect(outputs.content).toBe("true");
+    expect(outputs.content_hooks).toBe("true");
+    expect(outputs.content_mcp).toBe("false");
+    expect(outputs.content_categories_json).toBe('["hooks"]');
+    expect(outputs.web).toBe("false");
+    expect(outputs.mcp).toBe("false");
+    expect(outputs.raycast).toBe("false");
+    expect(outputs.packages).toBe("false");
+    expect(outputs.registry).toBe("false");
+    expect(outputs.ci).toBe("false");
+  });
+
+  it("routes multi-category content PRs to only touched category validators", () => {
+    const outputs = runClassifierForChangedFiles({
+      "content/hooks/retro-daily.mdx": "---\ntitle: Retro Daily\n---\n",
+      "content/mcp/example-server.mdx": "---\ntitle: Example Server\n---\n",
+    });
+
+    expect(outputs.content_categories_json).toBe('["hooks","mcp"]');
+    expect(outputs.content_hooks).toBe("true");
+    expect(outputs.content_mcp).toBe("true");
+    expect(outputs.content_skills).toBe("false");
+    expect(outputs.web).toBe("false");
+    expect(outputs.raycast).toBe("false");
+    expect(outputs.packages).toBe("false");
+    expect(outputs.registry).toBe("false");
   });
 
   it("does not document GitHub PATs in MCP process arguments", () => {


### PR DESCRIPTION
## Summary
- Split PR validation into an early `classify-pr` job and a final aggregate `required-pr-gate` job.
- Route direct content submissions by touched category, so a hook-only PR runs `validate-content-hooks` instead of MCP, Raycast, package, registry, and web lanes.
- Add category-scoped content validation and audit support via `--category` / `--categories`.
- Preserve current static check contexts during the transition so the branch can still merge under existing branch protection.

## Why
- Branch protection currently requires every validation lane statically, so simple content PRs show unrelated pending checks.
- The long-term required check should be the aggregate `required-pr-gate`; individual lanes should be implementation details selected by the classifier.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `pnpm validate:content:strict -- --category hooks`
- `pnpm audit:content -- --category hooks`
- `pnpm validate:content:strict`
- `pnpm audit:content`
- `pnpm validate:clean`
- `actionlint .github/workflows/content-validation.yml`
- `git diff --check`

## Notes
- After this lands on `main`, update branch protection to require the aggregate `required-pr-gate` instead of the individual `validate-*` lane checks. Do not make that settings change before this workflow lands, because the current `main` version of `required-pr-gate` is only the classifier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized PR validation orchestration to consolidate gating through unified classification logic.
  * Expanded content validation framework with dedicated lanes for schema verification, audits, and category-specific checks.
  * Enhanced validation aggregation with improved result summarization for more reliable PR quality gates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->