### PR TITLE
ci(validation): preserve scoped content lanes

### DIFF
--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -901,6 +901,18 @@ description: Example description
     expect(outputs.registry).toBe("false");
   });
 
+  it("routes generated registry artifacts to artifact validation", () => {
+    const outputs = runClassifierForChangedFiles({
+      "apps/web/public/data/raycast/entries.json": "[]\n",
+    });
+
+    expect(outputs.content).toBe("false");
+    expect(outputs.registry).toBe("true");
+    expect(outputs.web).toBe("true");
+    expect(outputs.raycast).toBe("true");
+    expect(outputs.packages).toBe("false");
+  });
+
   it("does not document GitHub PATs in MCP process arguments", () => {
     const source = fs.readFileSync(
       path.join(


### PR DESCRIPTION
## Summary
- Preserve category-scoped content PR validation instead of fanning content-only changes into every generated artifact lane.
- Add coverage proving generated registry/Raycast artifacts still trigger artifact validation when those maintainer-owned outputs change.

## What changed
- Removed the content-only artifact fan-out behavior from the branch.
- Added a classifier test for generated Raycast registry artifacts.

## Why
- Content submissions should run only the touched category validators plus shared content checks.
- Generated artifacts remain maintainer-owned and should still run artifact validation when they are actually changed.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `git diff --check`
