### PR TITLE
ci(submissions): harden risk review writeback

### DIFF
--- a/.github/workflows/submission-pr-risk.yml
+++ b/.github/workflows/submission-pr-risk.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   issues: write
+  pull-requests: write
 
 jobs:
   analyze-submission-pr-risk:
@@ -2047,28 +2048,36 @@ jobs:
                   }`
                 );
               }
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                ...context.repo,
-                issue_number: context.payload.pull_request.number,
-                per_page: 100
-              });
-              const existing = comments.find((comment) =>
-                comment.body?.includes(RISK_COMMENT_MARKER)
-              );
-              if (existing) {
-                if (existing.body !== markdownReport) {
-                  await github.rest.issues.updateComment({
+              try {
+                const comments = await github.paginate(github.rest.issues.listComments, {
+                  ...context.repo,
+                  issue_number: context.payload.pull_request.number,
+                  per_page: 100
+                });
+                const existing = comments.find((comment) =>
+                  comment.body?.includes(RISK_COMMENT_MARKER)
+                );
+                if (existing) {
+                  if (existing.body !== markdownReport) {
+                    await github.rest.issues.updateComment({
+                      ...context.repo,
+                      comment_id: existing.id,
+                      body: markdownReport
+                    });
+                  }
+                } else {
+                  await github.rest.issues.createComment({
                     ...context.repo,
-                    comment_id: existing.id,
+                    issue_number: context.payload.pull_request.number,
                     body: markdownReport
                   });
                 }
-              } else {
-                await github.rest.issues.createComment({
-                  ...context.repo,
-                  issue_number: context.payload.pull_request.number,
-                  body: markdownReport
-                });
+              } catch (error) {
+                core.warning(
+                  `Could not sync submission risk comment: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`
+                );
               }
             } else {
               core.info("No content MDX files changed; skipping PR label/comment sync.");

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -374,7 +374,7 @@ describe("submission automation workflows", () => {
 
     expect(source).toContain("pull_request_target:");
     expect(source).not.toContain("- edited");
-    expect(source).not.toContain("pull-requests: write");
+    expect(source).toContain("pull-requests: write");
     expect(source).toContain("Analyze PR content through GitHub API");
     expect(source).not.toContain("actions/checkout");
     expect(source).not.toContain("pnpm install");
@@ -414,6 +414,7 @@ describe("submission automation workflows", () => {
     );
     expect(source).not.toContain("Array.isArray(report.contentFiles)");
     expect(source).toContain("Could not sync submission risk labels");
+    expect(source).toContain("Could not sync submission risk comment");
     expect(source).toContain(
       "No content MDX files changed; skipping PR label/comment sync.",
     );


### PR DESCRIPTION
## Summary
- Fix the submission PR risk workflow so advisory comment/label writeback failures do not fail otherwise-valid content PRs.

## What changed
- Adds `pull-requests: write` alongside existing `issues: write` for the PR risk workflow's PR-thread writeback.
- Wraps risk report comment sync in best-effort error handling, matching the existing label-sync behavior.
- Updates workflow guard tests to preserve the API-only `pull_request_target` invariant while allowing the required PR comment permission.

## Why
The risk analyzer should fail only for deterministic blockers such as critical risk, provenance failures, or direct-content request-change blockers. A GitHub API writeback failure while posting an advisory risk comment should be logged as a warning instead of blocking the PR.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `actionlint .github/workflows/submission-pr-risk.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pull request automation robustness by enhancing error handling for comment synchronization.
  * Workflow no longer terminates completely if comment sync encounters issues; failures now emit warnings only.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->