### PR TITLE
fix(ci): parse content policy frontmatter with gray-matter

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -2,6 +2,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import matter from "gray-matter";
 
 const STATUS_BY_CODE = {
   A: "added",
@@ -183,52 +184,13 @@ function stringList(value) {
     .filter(Boolean);
 }
 
-function parseScalar(value) {
-  const text = normalizeText(value);
-  if (/^(true|false)$/i.test(text)) return text.toLowerCase() === "true";
-  const quoted = text.match(/^(['"])([\s\S]*)\1$/);
-  return quoted ? quoted[2] : text;
-}
-
-function parseFrontmatterBlock(block) {
-  const data = {};
-  let listKey = "";
-  for (const rawLine of block.split(/\r?\n/)) {
-    const line = rawLine.replace(/\s+#.*$/, "");
-    if (!line.trim()) continue;
-
-    const listItem = line.match(/^\s*-\s*(.*)$/);
-    if (listItem && listKey) {
-      if (!Array.isArray(data[listKey])) data[listKey] = [];
-      data[listKey].push(parseScalar(listItem[1]));
-      continue;
-    }
-
-    const field = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/);
-    if (!field) {
-      listKey = "";
-      continue;
-    }
-
-    const [, key, value = ""] = field;
-    if (value === "") {
-      data[key] = [];
-      listKey = key;
-    } else {
-      data[key] = parseScalar(value);
-      listKey = "";
-    }
-  }
-  return data;
-}
-
 function parseMdxFrontmatter(content) {
-  const match = String(content).match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*/);
-  if (!match) return { data: {}, content };
-  return {
-    data: parseFrontmatterBlock(match[1]),
-    content: content.slice(match[0].length),
-  };
+  try {
+    const parsed = matter(String(content));
+    return { data: parsed.data || {}, content: parsed.content || "" };
+  } catch {
+    return { data: {}, content: String(content) };
+  }
 }
 
 function urlPathname(value) {


### PR DESCRIPTION
### Motivation
- The CI content policy gate used a small custom frontmatter parser that did not handle YAML folded/literal block scalars, allowing policy-sensitive fields (e.g., `downloadUrl: >-`) to be hidden from validation while the registry builder accepted them.
- The goal is to ensure the policy gate parses frontmatter with the same YAML semantics as the registry build path to prevent bypasses of deterministic checks.

### Description
- Replace the ad-hoc frontmatter parsing in `scripts/ci/validate-content-policy.mjs` with `gray-matter` to parse MDX frontmatter consistently. 
- Remove the fragile custom scalar/list parsing logic by delegating frontmatter extraction to `gray-matter` and preserving the original content body.
- Keep a safe fallback so that when parsing fails the script returns empty frontmatter data and the content body as-is.
- Change is constrained to `scripts/ci/validate-content-policy.mjs` and preserves downstream behavior that consumes parsed `data` fields.

### Testing
- Ran `pnpm exec vitest run tests/submission-workflows.test.ts` and the suite passed (`36 passed`).
- The test run produced a subprocess notice about `fatal: not a git repository`, but the `vitest` tests themselves completed successfully.
- The change was validated locally by ensuring frontmatter with block scalars (e.g., `downloadUrl: >-`) is now parsed into the expected `data` fields by the policy script (aligning with `gray-matter`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9c70b5748320a1be7114c434d600)