### PR TITLE
fix(readme): use absolute logo assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
   <tr>
     <td width="58%" valign="top">
       <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="apps/web/public/heyclaude-wordmark-dark.svg">
-        <img src="apps/web/public/heyclaude-wordmark.svg" alt="HeyClaude" width="260">
+        <source media="(prefers-color-scheme: dark)" srcset="https://heyclau.de/heyclaude-wordmark-dark.svg">
+        <img src="https://heyclau.de/heyclaude-wordmark.svg" alt="HeyClaude" width="260">
       </picture>
       <h3>Curated Claude workflow infrastructure.</h3>
       <p>

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -133,8 +133,8 @@ const readme = `<table>
   <tr>
     <td width="58%" valign="top">
       <picture>
-        <source media="(prefers-color-scheme: dark)" srcset="apps/web/public/heyclaude-wordmark-dark.svg">
-        <img src="apps/web/public/heyclaude-wordmark.svg" alt="HeyClaude" width="260">
+        <source media="(prefers-color-scheme: dark)" srcset="https://heyclau.de/heyclaude-wordmark-dark.svg">
+        <img src="https://heyclau.de/heyclaude-wordmark.svg" alt="HeyClaude" width="260">
       </picture>
       <h3>Curated Claude workflow infrastructure.</h3>
       <p>


### PR DESCRIPTION
## Summary
- Replace repo-relative README logo paths with absolute HeyClaude asset URLs.
- Regenerate README from the generator so Gittensor and other external README renderers do not resolve the logo against their own route.

## Validation
- `pnpm generate:readme`
- `pnpm validate:readme`
- `pnpm exec vitest run tests/readme-generation.test.ts`
- `git diff --check`
- Verified both logo URLs return `200` with `image/svg+xml`.

## Notes
- This keeps the existing light/dark `<picture>` behavior, but removes the fragile relative `srcset`/`src` paths that broke on Gittensor.