### PR TITLE
ci(validation): fix trusted content policy runtime

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -199,7 +199,22 @@ jobs:
         run: |
           set -euo pipefail
           policy_path="scripts/ci/validate-content-policy.mjs"
-          trusted_policy="${RUNNER_TEMP:-.}/validate-content-policy.mjs"
+          runtime_manifest_path="scripts/ci/content-policy-runtime/package.json"
+          runtime_lock_path="scripts/ci/content-policy-runtime/package-lock.json"
+          trusted_policy_dir="${RUNNER_TEMP:-.}/trusted-content-policy"
+          trusted_policy="$trusted_policy_dir/validate-content-policy.mjs"
+          rm -rf "$trusted_policy_dir"
+          mkdir -p "$trusted_policy_dir"
+
+          if git cat-file -e "$BASE_SHA:$runtime_manifest_path" 2>/dev/null && git cat-file -e "$BASE_SHA:$runtime_lock_path" 2>/dev/null; then
+            git show "$BASE_SHA:$runtime_manifest_path" > "$trusted_policy_dir/package.json"
+            git show "$BASE_SHA:$runtime_lock_path" > "$trusted_policy_dir/package-lock.json"
+          else
+            echo "::error::Trusted content policy runtime lockfile is missing from the base branch."
+            exit 1
+          fi
+
+          (cd "$trusted_policy_dir" && npm ci --ignore-scripts --no-audit --no-fund)
 
           if git cat-file -e "$BASE_SHA:$policy_path" 2>/dev/null; then
             git show "$BASE_SHA:$policy_path" > "$trusted_policy"

--- a/scripts/ci/content-policy-runtime/package-lock.json
+++ b/scripts/ci/content-policy-runtime/package-lock.json
@@ -1,0 +1,123 @@
+{
+  "name": "heyclaude-content-policy-runtime",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "heyclaude-content-policy-runtime",
+      "version": "1.0.0",
+      "dependencies": {
+        "gray-matter": "4.0.3"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    }
+  }
+}

--- a/scripts/ci/content-policy-runtime/package.json
+++ b/scripts/ci/content-policy-runtime/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "heyclaude-content-policy-runtime",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "gray-matter": "4.0.3"
+  }
+}

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -591,6 +591,14 @@ describe("submission automation workflows", () => {
     expect(source).toContain("needs.classify-pr.outputs.packages == 'true'");
     expect(source).toContain("validate-content-policy");
     expect(source).toContain("trusted_policy");
+    expect(source).toContain("trusted_policy_dir");
+    expect(source).toContain("runtime_lock_path");
+    expect(source).toContain(
+      "scripts/ci/content-policy-runtime/package-lock.json",
+    );
+    expect(source).toContain("npm ci --ignore-scripts");
+    expect(source).toContain("--ignore-scripts");
+    expect(source).toContain("--no-audit --no-fund");
     expect(source).toContain("persist-credentials: false");
     expect(source).not.toContain('ln -s "$GITHUB_WORKSPACE/node_modules"');
     expect(source).toContain(


### PR DESCRIPTION
## Summary
- Fix the content policy workflow after the policy script started importing `gray-matter`.
- Install the exact parser dependency into a private trusted runtime with scripts disabled.
- Keep running the base-branch policy script for fork PRs.

## Why
- Fork/documentation PRs were failing because the trusted policy script was copied to the runner temp directory where Node could not resolve repo dependencies.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `pnpm validate:clean`
- `git diff --check`
- Temp-runtime smoke test for `scripts/ci/validate-content-policy.mjs` with `gray-matter@4.0.3` installed under the trusted runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow for content validation to prepare an isolated runtime environment and ensure validation runtime dependencies are installed before executing checks.

*No user-facing changes in this release.*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JSONbored/awesome-claude/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->