### PR TITLE
fix(ci): avoid provenance blockers on content metadata updates

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -127,6 +127,8 @@ function changedFilesFromJson(filePath) {
           filename: normalizeText(item.filename || item.path),
           status: normalizeText(item.status) || "modified",
           content: typeof item.content === "string" ? item.content : undefined,
+          baseContent:
+            typeof item.baseContent === "string" ? item.baseContent : undefined,
         },
   );
 }
@@ -142,22 +144,45 @@ function readFileContent(repoRoot, filename, status, providedContent) {
   }
 }
 
+function readBaseFileContent(filename, status, providedBaseContent, baseSha) {
+  if (typeof providedBaseContent === "string") return providedBaseContent;
+  if (status === "added") return null;
+  if (!/^[0-9a-f]{40}$/i.test(baseSha || "")) return null;
+
+  try {
+    execFileSync("git", ["cat-file", "-e", `${baseSha}:${filename}`], {
+      stdio: "ignore",
+    });
+    return execFileSync("git", ["show", `${baseSha}:${filename}`], {
+      encoding: "utf8",
+    });
+  } catch {
+    return null;
+  }
+}
+
 function resolveFiles({ repoRoot, args }) {
+  const baseSha = args["base-sha"] || process.env.BASE_SHA || "";
   const source = args["files-json"]
     ? changedFilesFromJson(args["files-json"])
-    : changedFilesFromGit(args["base-sha"] || process.env.BASE_SHA || "");
+    : changedFilesFromGit(baseSha);
 
   return source
-    .map((file) => ({
-      filename: normalizeText(file.filename),
-      status: normalizeText(file.status) || "modified",
-      content: readFileContent(
-        repoRoot,
-        normalizeText(file.filename),
-        normalizeText(file.status) || "modified",
-        file.content,
-      ),
-    }))
+    .map((file) => {
+      const filename = normalizeText(file.filename);
+      const status = normalizeText(file.status) || "modified";
+      return {
+        filename,
+        status,
+        content: readFileContent(repoRoot, filename, status, file.content),
+        baseContent: readBaseFileContent(
+          filename,
+          status,
+          file.baseContent,
+          baseSha,
+        ),
+      };
+    })
     .filter((file) => file.filename);
 }
 
@@ -310,6 +335,20 @@ function frontmatterProvenance(data = {}) {
         : null,
     importPrUrl: normalizeText(data.importPrUrl),
   };
+}
+
+function submitterProvenanceChanged(entry) {
+  const current = entry.provenance || {};
+  const base = entry.baseProvenance || {};
+  return (
+    normalizeText(current.submittedBy) !== normalizeText(base.submittedBy) ||
+    normalizeText(current.submittedByUrl) !== normalizeText(base.submittedByUrl)
+  );
+}
+
+function isNewDirectContentEntry(entry) {
+  if (entry.status === "added" || !entry.baseExists) return true;
+  return false;
 }
 
 function addGeneratedArtifactSignals(report, files, sourceType) {
@@ -600,12 +639,27 @@ function validatePrProvenance(report, entries, prAuthor, sourceType) {
   if (!entries.length) return;
   report.contentProvenance = entries.map((entry) => ({
     filename: entry.filename,
+    status: entry.status,
+    baseExists: entry.baseExists,
     ...entry.provenance,
   }));
 
   if (sourceType !== "external_direct") return;
 
   for (const entry of entries) {
+    if (!isNewDirectContentEntry(entry)) {
+      if (submitterProvenanceChanged(entry)) {
+        addProvenanceFinding(
+          report,
+          "error",
+          `direct_pr_existing_provenance_change_${entry.filename}`,
+          "Direct contributor PRs cannot change submitter provenance on existing content",
+          `${entry.filename}: leave existing submittedBy/submittedByUrl unchanged; maintainers can handle attribution corrections separately.`,
+        );
+      }
+      continue;
+    }
+
     const provenance = entry.provenance;
     if (!provenance.submittedBy || !provenance.submittedByUrl) {
       addProvenanceFinding(
@@ -774,6 +828,11 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
     const category = prFileCategory(file.filename);
     const fields = frontmatterFields(parsed.data, category);
     const provenance = frontmatterProvenance(parsed.data);
+    const baseParsed =
+      typeof file.baseContent === "string"
+        ? parseMdxFrontmatter(file.baseContent)
+        : { data: {} };
+    const baseProvenance = frontmatterProvenance(baseParsed.data);
     if (fields.category && fields.category !== category) {
       addClassificationWarning(
         report,
@@ -794,7 +853,14 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
       );
     }
 
-    entries.push({ filename: file.filename, fields, provenance });
+    entries.push({
+      filename: file.filename,
+      status: normalizeText(file.status) || "modified",
+      baseExists: typeof file.baseContent === "string",
+      fields,
+      provenance,
+      baseProvenance,
+    });
     addContentRiskSignals(report, fields, content);
     addDisclosureNoteSignals(report, fields);
   }

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -75,7 +75,10 @@ describe("submission automation workflows", () => {
   }
 
   function runContentPolicyForChangedFiles(
-    files: Record<string, string>,
+    files: Record<
+      string,
+      string | { content: string; status?: string; baseContent?: string }
+    >,
     options: {
       headRepo?: string;
       baseRepo?: string;
@@ -87,9 +90,17 @@ describe("submission automation workflows", () => {
     );
     const changedFiles = [];
 
-    for (const [filePath, content] of Object.entries(files)) {
+    for (const [filePath, spec] of Object.entries(files)) {
+      const content = typeof spec === "string" ? spec : spec.content;
+      const status = typeof spec === "string" ? "modified" : spec.status;
+      const baseContent =
+        typeof spec === "string" ? undefined : spec.baseContent;
       writeFile(path.join(tmpDir, filePath), content);
-      changedFiles.push({ filename: filePath, status: "modified" });
+      changedFiles.push({
+        filename: filePath,
+        status: status || "modified",
+        ...(baseContent === undefined ? {} : { baseContent }),
+      });
     }
 
     const filesPath = path.join(tmpDir, "changed-files.json");
@@ -639,6 +650,154 @@ description: Daily Claude Code retro dashboard hook.
     expect(result.ok).toBe(false);
     expect(result.report?.failures.join("\n")).toContain(
       "Direct contributor PRs should not edit README.md",
+    );
+  });
+
+  it("blocks new direct content PR entries without submitter provenance", () => {
+    const result = runContentPolicyForChangedFiles({
+      "content/mcp/no-provenance.mdx": {
+        status: "added",
+        content: contentFixture(
+          `
+title: No Provenance MCP
+slug: no-provenance
+category: mcp
+description: Example MCP server without submitter provenance.
+installCommand: "npx -y no-provenance"
+usageSnippet: "claude mcp add no-provenance -- npx -y no-provenance"
+`,
+          "Source-backed MCP server content.",
+        ),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.report?.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "missing_direct_pr_submitter_content/mcp/no-provenance.mdx",
+        }),
+      ]),
+    );
+  });
+
+  it("allows external metadata updates to existing content without submitter provenance", () => {
+    const baseContent = contentFixture(
+      `
+title: Existing Hook
+slug: existing-hook
+category: hooks
+description: Existing SessionStart hook entry.
+`,
+      "This SessionStart hook reads local workspace logs and summarizes user activity.",
+    );
+    const result = runContentPolicyForChangedFiles({
+      "content/hooks/existing-hook.mdx": {
+        status: "modified",
+        baseContent,
+        content: contentFixture(
+          `
+title: Existing Hook
+slug: existing-hook
+category: hooks
+description: Existing SessionStart hook entry.
+safetyNotes:
+  - Runs as a Claude Code SessionStart hook and can execute local shell scripts.
+privacyNotes:
+  - Reads local Claude Code activity and workspace-derived logs for summaries.
+`,
+          "This SessionStart hook reads local workspace logs and summarizes user activity.",
+        ),
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.report?.provenanceFindings).toEqual([]);
+  });
+
+  it("blocks external metadata updates that change existing submitter provenance", () => {
+    const baseContent = contentFixture(
+      `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+submittedBy: original-submitter
+submittedByUrl: https://github.com/original-submitter
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+      "Source-backed MCP server content.",
+    );
+    const result = runContentPolicyForChangedFiles({
+      "content/mcp/existing-mcp.mdx": {
+        status: "modified",
+        baseContent,
+        content: contentFixture(
+          `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+submittedBy: someone-else
+submittedByUrl: https://github.com/someone-else
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+          "Source-backed MCP server content.",
+        ),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.report?.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "direct_pr_existing_provenance_change_content/mcp/existing-mcp.mdx",
+        }),
+      ]),
+    );
+  });
+
+  it("blocks external metadata updates that add provenance to existing content", () => {
+    const baseContent = contentFixture(
+      `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+      "Source-backed MCP server content.",
+    );
+    const result = runContentPolicyForChangedFiles({
+      "content/mcp/existing-mcp.mdx": {
+        status: "modified",
+        baseContent,
+        content: contentFixture(
+          `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+          "Source-backed MCP server content.",
+        ),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.report?.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "direct_pr_existing_provenance_change_content/mcp/existing-mcp.mdx",
+        }),
+      ]),
     );
   });
 


### PR DESCRIPTION
## Summary
- Updates the direct content policy gate so external contributors can improve metadata on existing entries without being forced to claim original submitter provenance.
- Keeps submitter provenance required for newly added content files.
- Continues to block provenance spoofing when a PR changes `submittedBy` or `submittedByUrl` on an existing entry.

## What changed
- Classifies content files with git status plus base-branch frontmatter existence.
- Compares current and base submitter provenance before deciding whether direct PR submitter validation is required.
- Adds regression coverage for new content without provenance, existing safety/privacy metadata updates, and provenance edits on existing entries.

## Why
- PR #457 updates existing hook entries with safety/privacy metadata. That should pass content policy without asking the contributor to add `submittedBy` fields that would incorrectly imply original authorship.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `pnpm exec vitest run tests/submission-workflows.test.ts tests/submission-intake.test.ts`
- Direct local reproduction of PR #457 content-policy pass
- `pnpm validate:content:strict`
- `pnpm validate:clean`
- `git diff --check`

## Notes
- This is the narrow false-positive fix only. The OPA/Conftest policy-as-code migration should stay as a separate follow-up so the required gate remains stable while parity is built.
