### PR TITLE
fix(ci): enforce direct PR provenance on existing content

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -346,11 +346,6 @@ function submitterProvenanceChanged(entry) {
   );
 }
 
-function isNewDirectContentEntry(entry) {
-  if (entry.status === "added" || !entry.baseExists) return true;
-  return false;
-}
-
 function addGeneratedArtifactSignals(report, files, sourceType) {
   if (sourceType !== "external_direct") return;
 
@@ -647,17 +642,18 @@ function validatePrProvenance(report, entries, prAuthor, sourceType) {
   if (sourceType !== "external_direct") return;
 
   for (const entry of entries) {
-    if (!isNewDirectContentEntry(entry)) {
-      if (submitterProvenanceChanged(entry)) {
-        addProvenanceFinding(
-          report,
-          "error",
-          `direct_pr_existing_provenance_change_${entry.filename}`,
-          "Direct contributor PRs cannot change submitter provenance on existing content",
-          `${entry.filename}: leave existing submittedBy/submittedByUrl unchanged; maintainers can handle attribution corrections separately.`,
-        );
-      }
-      continue;
+    if (
+      entry.status !== "added" &&
+      entry.baseExists &&
+      submitterProvenanceChanged(entry)
+    ) {
+      addProvenanceFinding(
+        report,
+        "error",
+        `direct_pr_existing_provenance_change_${entry.filename}`,
+        "Direct contributor PRs cannot change submitter provenance on existing content",
+        `${entry.filename}: leave existing submittedBy/submittedByUrl unchanged; maintainers can handle attribution corrections separately.`,
+      );
     }
 
     const provenance = entry.provenance;

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -681,7 +681,7 @@ usageSnippet: "claude mcp add no-provenance -- npx -y no-provenance"
     );
   });
 
-  it("allows external metadata updates to existing content without submitter provenance", () => {
+  it("blocks external metadata updates to existing content when submitter provenance is missing", () => {
     const baseContent = contentFixture(
       `
 title: Existing Hook
@@ -711,8 +711,14 @@ privacyNotes:
       },
     });
 
-    expect(result.ok).toBe(true);
-    expect(result.report?.provenanceFindings).toEqual([]);
+    expect(result.ok).toBe(false);
+    expect(result.report?.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "missing_direct_pr_submitter_content/hooks/existing-hook.mdx",
+        }),
+      ]),
+    );
   });
 
   it("blocks external metadata updates that change existing submitter provenance", () => {


### PR DESCRIPTION
### Motivation
- A provenance validation change allowed external PRs to modify trust-sensitive fields on existing content files while preserving original `submittedBy` attribution, weakening the direct-PR provenance gate.
- The intent is to ensure external direct-content PRs always require valid submitter provenance and PR-author matching unless the maintainer import flow explicitly performs the change.

### Description
- Restores provenance enforcement in `validatePrProvenance` so existing external-direct content entries are not exempt from requiring `submittedBy`/`submittedByUrl` and PR-author matching when modified, while still blocking provenance rewrites that change those fields (`direct_pr_existing_provenance_change_*`).
- Removes the now-unnecessary `isNewDirectContentEntry` helper and replaces the previous short-circuit that skipped provenance checks for existing entries with an explicit conditional that only adds the provenance-change finding when provenance fields were edited.
- Updates test coverage in `tests/submission-workflows.test.ts` to assert that metadata edits to existing content without submitter provenance are blocked (expected `missing_direct_pr_submitter_*`).
- Files changed: `scripts/ci/validate-content-policy.mjs` and `tests/submission-workflows.test.ts`.

### Testing
- `git diff --check` was run and produced no issues.
- `pnpm exec vitest run tests/submission-workflows.test.ts` was attempted but could not complete in this environment due to repeated npm registry/attestation network failures; the updated unit test asserts were added and should pass in CI or a developer environment with normal network access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ecb15ffbc83208c94a1e9de164eb8)