### PR TITLE
feat(seo): add use-case landing pages for rules, data MCP, and slash commands

### DIFF
--- a/apps/web/src/lib/seo-clusters.ts
+++ b/apps/web/src/lib/seo-clusters.ts
@@ -172,6 +172,58 @@ export const seoClusterDefinitions: SeoClusterDefinition[] = [
     tags: ["review", "testing", "git", "automation", "quality-gate"],
     itemLimit: 18,
   },
+  {
+    slug: "claude-rules-for-engineering-teams",
+    title: "Claude rules for engineering teams",
+    eyebrow: "Claude rules",
+    description:
+      "CLAUDE.md and rule resources that codify TypeScript, React, security, and performance expectations for engineering teams.",
+    seoTitle: "Claude rules for engineering teams",
+    seoDescription:
+      "Browse Claude rules for engineering teams covering TypeScript, React, security, OWASP, and performance expectations across language and framework stacks.",
+    categories: ["rules"],
+    tags: ["typescript", "react", "security", "performance", "owasp"],
+    itemLimit: 16,
+  },
+  {
+    slug: "mcp-servers-for-databases-and-data",
+    title: "MCP servers for databases and data workflows",
+    eyebrow: "Data MCP servers",
+    description:
+      "MCP servers for Claude teams working with databases, analytics platforms, and structured data pipelines.",
+    seoTitle: "MCP servers for databases and data workflows",
+    seoDescription:
+      "Find Claude MCP servers for databases, analytics, and structured data workflows covering project data, infrastructure, deployment, and operations integrations.",
+    categories: ["mcp"],
+    tags: [
+      "database",
+      "project-management",
+      "infrastructure",
+      "deployment",
+      "devops",
+    ],
+    itemLimit: 14,
+  },
+  {
+    slug: "slash-commands-for-claude-code",
+    title: "Slash commands for Claude Code",
+    eyebrow: "Slash commands",
+    description:
+      "Reusable slash commands for testing, documentation, refactoring, performance, and everyday Claude Code workflows.",
+    seoTitle: "Slash commands for Claude Code",
+    seoDescription:
+      "Browse Claude Code slash commands for testing, documentation, refactoring, performance, security audits, and everyday workflow automation across teams.",
+    categories: ["commands"],
+    tags: [
+      "testing",
+      "documentation",
+      "refactoring",
+      "performance",
+      "security",
+      "automation",
+    ],
+    itemLimit: 16,
+  },
 ];
 
 function scoreItem(


### PR DESCRIPTION
# Pull Request

## Summary

- Adds three new use-case landing pages to the existing `/best/[slug]` system so visitors can browse the registry by intent instead of registry category.
- New slugs target gaps in the current 10 clusters — no existing cluster headlines `rules` or `commands`, and there is no narrow data/database-focused MCP page:
  - `/best/claude-rules-for-engineering-teams` — TypeScript, React, security, OWASP, performance rules
  - `/best/mcp-servers-for-databases-and-data` — database, infra, deployment, and ops MCP servers
  - `/best/slash-commands-for-claude-code` — testing, documentation, refactoring, performance, security audits, automation
- Pages are generated from existing registry data via `seoClusterDefinitions` in `apps/web/src/lib/seo-clusters.ts`; the route, scoring, JSON-LD, sitemap, and `generateStaticParams` already handle new slugs automatically.

## Submission Source

- [ ] New content file(s) added under `content/<category>/`
- [x] Existing content updated
- [x] Submission issue resolved (link it here): #431
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks

- [x] `pnpm validate:content` passed (`pnpm validate:content:strict` — 386 files validated)
- [ ] `pnpm validate:packages` passed (not applicable — no package changes)
- [ ] `pnpm scan:packages` passed when package artifacts changed (not applicable)
- [ ] `pnpm audit:content` ran and I reviewed findings (not applicable — no content file changes)
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete (not applicable — no content entries)
- [ ] Skill submissions include capability metadata (not applicable)

## Validation

- [x] Local build passed (`pnpm build`) — `/best/[slug]` now prerenders 13 paths (10 existing + 3 new)
- [x] I spot-checked the affected detail page(s) via the suggested vitest suites:
  - `pnpm exec vitest run tests/seo-jsonld.test.ts tests/discovery-surfaces.test.ts tests/seo-metadata.test.ts` — 16/16 passed
- [x] `git diff --check` clean
- [x] All three `seoDescription` values are within the 120–160 character bound enforced by `tests/seo-metadata.test.ts` (153, 159, 151)

## Acceptance criteria for #431

- [x] At least three useful use-case pages are added (3 new slugs, none duplicating the existing 10).
- [x] Pages are generated from existing registry data — same `getSeoCluster`/`scoreItem` path as the existing clusters.
- [x] Page copy is concise, practical, and non-promotional.
- [x] SEO metadata is present — same `generateMetadata` + JSON-LD helpers (`buildBreadcrumbJsonLd`, `buildCollectionPageJsonLd`, `buildItemListJsonLd`) used by the existing clusters.
- [x] PR includes `Closes #431`.

## Notes

- No registry/schema churn. No new routes. No generated artifact changes.
- Sitemap and `generateStaticParams` automatically pick up the new slugs through `getSeoClusterDefinitions()`.
- Slug rationale:
  - `rules` and `commands` were not previously headline categories in any of the 10 existing clusters — these add long-tail intent pages.
  - `mcp-servers-for-databases-and-data` complements the broad `mcp-servers` cluster with a narrower data-focused intent ("Claude MCP database", "Postgres MCP", etc.).

Closes #431