### PR TITLE
feat(api): add search facets for trust and category filters

### DIFF
--- a/apps/web/src/app/api/registry/search/route.ts
+++ b/apps/web/src/app/api/registry/search/route.ts
@@ -1,54 +1,12 @@
-import type { SearchDocument } from "@heyclaude/registry";
-
 import { registrySearchQuerySchema } from "@/lib/api/contracts";
+import { computeRegistrySearchFacets } from "@/lib/api/registry-search-facets";
+import {
+  filterEntries,
+  type RegistrySearchFilterState,
+} from "@/lib/api/registry-search-filters";
 import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { getSearchIndex } from "@/lib/content";
 import { cachedJsonResponse } from "@/lib/http-cache";
-
-function matchesQuery(entry: SearchDocument, query: string) {
-  if (!query) return true;
-  const haystack = [
-    entry.category,
-    entry.title,
-    entry.description,
-    entry.author,
-    entry.submittedBy,
-    entry.brandName,
-    entry.brandDomain,
-    entry.verificationStatus,
-    entry.downloadTrust,
-    ...(entry.tags ?? []),
-    ...(entry.keywords ?? []),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes(query);
-}
-
-function matchesPlatform(entry: SearchDocument, platform: string) {
-  if (!platform) return true;
-  return (entry.platforms ?? []).some(
-    (item) => String(item).trim().toLowerCase() === platform,
-  );
-}
-
-function matchesBooleanFilter(value: boolean, filter: string) {
-  if (!filter || filter === "all") return true;
-  return filter === "true" ? value : !value;
-}
-
-function packageTrust(entry: SearchDocument) {
-  return entry.downloadTrust || (entry.downloadUrl ? "external" : "none");
-}
-
-function sourceStatus(entry: SearchDocument) {
-  return entry.trustSignals?.sourceStatus || "missing";
-}
-
-function claimStatus(entry: SearchDocument) {
-  return entry.claimStatus || "unclaimed";
-}
 
 export const GET = createApiHandler(
   "registry.search",
@@ -65,38 +23,21 @@ export const GET = createApiHandler(
       limit,
     } = parsedQuery as InferApiQuery<typeof registrySearchQuerySchema>;
 
+    const filters: RegistrySearchFilterState = {
+      query,
+      category,
+      platform,
+      hasSafetyNotes,
+      hasPrivacyNotes,
+      downloadTrust,
+      claimStatus: requestedClaimStatus,
+      sourceStatus: requestedSourceStatus,
+    };
+
     const entries = await getSearchIndex();
-    const results = entries
-      .filter((entry) => !category || entry.category === category)
-      .filter((entry) => matchesPlatform(entry, platform))
-      .filter((entry) =>
-        matchesBooleanFilter(
-          Boolean(entry.safetyNotes?.length),
-          hasSafetyNotes,
-        ),
-      )
-      .filter((entry) =>
-        matchesBooleanFilter(
-          Boolean(entry.privacyNotes?.length),
-          hasPrivacyNotes,
-        ),
-      )
-      .filter(
-        (entry) =>
-          downloadTrust === "all" || packageTrust(entry) === downloadTrust,
-      )
-      .filter(
-        (entry) =>
-          requestedClaimStatus === "all" ||
-          claimStatus(entry) === requestedClaimStatus,
-      )
-      .filter(
-        (entry) =>
-          requestedSourceStatus === "all" ||
-          sourceStatus(entry) === requestedSourceStatus,
-      )
-      .filter((entry) => matchesQuery(entry, query))
-      .slice(0, limit);
+    const matched = filterEntries(entries, filters);
+    const results = matched.slice(0, limit);
+    const facets = computeRegistrySearchFacets(entries, filters);
 
     return cachedJsonResponse(
       request,
@@ -114,6 +55,7 @@ export const GET = createApiHandler(
         },
         count: results.length,
         results,
+        facets,
       },
       {
         headers: {

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -207,6 +207,21 @@ export const registrySearchResultSchema = registryBrandAssetSchema
   })
   .passthrough();
 
+export const registrySearchFacetBucketsSchema = z.record(
+  z.string().min(1).max(64),
+  z.number().int().nonnegative(),
+);
+
+export const registrySearchFacetsSchema = z.object({
+  categories: registrySearchFacetBucketsSchema,
+  platforms: registrySearchFacetBucketsSchema,
+  hasSafetyNotes: registrySearchFacetBucketsSchema,
+  hasPrivacyNotes: registrySearchFacetBucketsSchema,
+  downloadTrust: registrySearchFacetBucketsSchema,
+  claimStatus: registrySearchFacetBucketsSchema,
+  sourceStatus: registrySearchFacetBucketsSchema,
+});
+
 export const registrySearchResponseSchema = z.object({
   schemaVersion: z.number(),
   query: z.string(),
@@ -223,6 +238,7 @@ export const registrySearchResponseSchema = z.object({
     .optional(),
   count: z.number().int().nonnegative(),
   results: z.array(registrySearchResultSchema).max(50),
+  facets: registrySearchFacetsSchema.optional(),
 });
 
 export const registrySearchQuerySchema = z.object({

--- a/apps/web/src/lib/api/registry-search-facets.ts
+++ b/apps/web/src/lib/api/registry-search-facets.ts
@@ -55,7 +55,11 @@ function tally(
     if (!entryMatchesFilters(entry, filters, except)) continue;
     const bucket = bucketFor(entry);
     if (Array.isArray(bucket)) {
-      for (const value of bucket) increment(buckets, value);
+      // Dedupe per-entry so a document with the same value listed
+      // twice (e.g. duplicate platform tags after normalization)
+      // contributes to the facet count once, matching how single-string
+      // buckets behave.
+      for (const value of new Set(bucket)) increment(buckets, value);
     } else if (typeof bucket === "string") {
       increment(buckets, bucket);
     }

--- a/apps/web/src/lib/api/registry-search-facets.ts
+++ b/apps/web/src/lib/api/registry-search-facets.ts
@@ -1,0 +1,110 @@
+import type { SearchDocument } from "@heyclaude/registry";
+
+import {
+  claimStatusValue,
+  entryMatchesFilters,
+  hasPrivacyNotes,
+  hasSafetyNotes,
+  packageTrustValue,
+  sourceStatusValue,
+  type RegistrySearchFilterDimension,
+  type RegistrySearchFilterState,
+} from "./registry-search-filters";
+
+export type RegistrySearchFacetBuckets = Record<string, number>;
+
+export type RegistrySearchFacets = {
+  categories: RegistrySearchFacetBuckets;
+  platforms: RegistrySearchFacetBuckets;
+  hasSafetyNotes: RegistrySearchFacetBuckets;
+  hasPrivacyNotes: RegistrySearchFacetBuckets;
+  downloadTrust: RegistrySearchFacetBuckets;
+  claimStatus: RegistrySearchFacetBuckets;
+  sourceStatus: RegistrySearchFacetBuckets;
+};
+
+const MAX_PLATFORM_BUCKETS = 32;
+const MAX_CATEGORY_BUCKETS = 32;
+
+function increment(buckets: RegistrySearchFacetBuckets, key: string) {
+  if (!key) return;
+  buckets[key] = (buckets[key] ?? 0) + 1;
+}
+
+function sortBuckets(
+  buckets: RegistrySearchFacetBuckets,
+  limit?: number,
+): RegistrySearchFacetBuckets {
+  const entries = Object.entries(buckets).sort((a, b) => {
+    if (a[1] !== b[1]) return b[1] - a[1];
+    return a[0].localeCompare(b[0]);
+  });
+  const trimmed = typeof limit === "number" ? entries.slice(0, limit) : entries;
+  return Object.fromEntries(trimmed);
+}
+
+function tally(
+  entries: ReadonlyArray<SearchDocument>,
+  filters: RegistrySearchFilterState,
+  dimension: RegistrySearchFilterDimension,
+  bucketFor: (entry: SearchDocument) => string | ReadonlyArray<string>,
+): RegistrySearchFacetBuckets {
+  const except = new Set<RegistrySearchFilterDimension>([dimension]);
+  const buckets: RegistrySearchFacetBuckets = {};
+  for (const entry of entries) {
+    if (!entryMatchesFilters(entry, filters, except)) continue;
+    const bucket = bucketFor(entry);
+    if (Array.isArray(bucket)) {
+      for (const value of bucket) increment(buckets, value);
+    } else if (typeof bucket === "string") {
+      increment(buckets, bucket);
+    }
+  }
+  return buckets;
+}
+
+function normalizedPlatforms(entry: SearchDocument): ReadonlyArray<string> {
+  return (entry.platforms ?? [])
+    .map((value) => String(value).trim().toLowerCase())
+    .filter((value) => value.length > 0);
+}
+
+export function computeRegistrySearchFacets(
+  entries: ReadonlyArray<SearchDocument>,
+  filters: RegistrySearchFilterState,
+): RegistrySearchFacets {
+  const categories = tally(entries, filters, "category", (entry) =>
+    entry.category ? entry.category : "",
+  );
+  const platforms = tally(
+    entries,
+    filters,
+    "platform",
+    (entry) => normalizedPlatforms(entry),
+  );
+  const safety = tally(entries, filters, "hasSafetyNotes", (entry) =>
+    hasSafetyNotes(entry) ? "true" : "false",
+  );
+  const privacy = tally(entries, filters, "hasPrivacyNotes", (entry) =>
+    hasPrivacyNotes(entry) ? "true" : "false",
+  );
+  const downloadTrust = tally(entries, filters, "downloadTrust", (entry) =>
+    packageTrustValue(entry),
+  );
+  const claimStatus = tally(entries, filters, "claimStatus", (entry) =>
+    claimStatusValue(entry),
+  );
+  const sourceStatus = tally(entries, filters, "sourceStatus", (entry) =>
+    sourceStatusValue(entry),
+  );
+
+  return {
+    categories: sortBuckets(categories, MAX_CATEGORY_BUCKETS),
+    platforms: sortBuckets(platforms, MAX_PLATFORM_BUCKETS),
+    hasSafetyNotes: sortBuckets(safety),
+    hasPrivacyNotes: sortBuckets(privacy),
+    downloadTrust: sortBuckets(downloadTrust),
+    claimStatus: sortBuckets(claimStatus),
+    sourceStatus: sortBuckets(sourceStatus),
+  };
+}

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -1,0 +1,155 @@
+import type { SearchDocument } from "@heyclaude/registry";
+
+export type BooleanFilterValue = "all" | "true" | "false";
+
+export type DownloadTrustFilterValue =
+  | "all"
+  | "first-party"
+  | "external"
+  | "none";
+
+export type ClaimStatusFilterValue =
+  | "all"
+  | "unclaimed"
+  | "pending"
+  | "verified";
+
+export type SourceStatusFilterValue = "all" | "available" | "missing";
+
+export type RegistrySearchFilterState = {
+  query: string;
+  category: string;
+  platform: string;
+  hasSafetyNotes: BooleanFilterValue;
+  hasPrivacyNotes: BooleanFilterValue;
+  downloadTrust: DownloadTrustFilterValue;
+  claimStatus: ClaimStatusFilterValue;
+  sourceStatus: SourceStatusFilterValue;
+};
+
+export type RegistrySearchFilterDimension =
+  | "query"
+  | "category"
+  | "platform"
+  | "hasSafetyNotes"
+  | "hasPrivacyNotes"
+  | "downloadTrust"
+  | "claimStatus"
+  | "sourceStatus";
+
+export function matchesQuery(entry: SearchDocument, query: string) {
+  if (!query) return true;
+  const haystack = [
+    entry.category,
+    entry.title,
+    entry.description,
+    entry.author,
+    entry.submittedBy,
+    entry.brandName,
+    entry.brandDomain,
+    entry.verificationStatus,
+    entry.downloadTrust,
+    ...(entry.tags ?? []),
+    ...(entry.keywords ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+export function matchesPlatform(entry: SearchDocument, platform: string) {
+  if (!platform) return true;
+  return (entry.platforms ?? []).some(
+    (item) => String(item).trim().toLowerCase() === platform,
+  );
+}
+
+export function matchesBooleanFilter(value: boolean, filter: BooleanFilterValue) {
+  if (filter === "all") return true;
+  return filter === "true" ? value : !value;
+}
+
+export function hasSafetyNotes(entry: SearchDocument) {
+  return Boolean(entry.safetyNotes?.length);
+}
+
+export function hasPrivacyNotes(entry: SearchDocument) {
+  return Boolean(entry.privacyNotes?.length);
+}
+
+export function packageTrustValue(entry: SearchDocument) {
+  return entry.downloadTrust || (entry.downloadUrl ? "external" : "none");
+}
+
+export function sourceStatusValue(entry: SearchDocument) {
+  return entry.trustSignals?.sourceStatus || "missing";
+}
+
+export function claimStatusValue(entry: SearchDocument) {
+  return entry.claimStatus || "unclaimed";
+}
+
+export function entryMatchesFilters(
+  entry: SearchDocument,
+  filters: RegistrySearchFilterState,
+  except?: ReadonlySet<RegistrySearchFilterDimension>,
+) {
+  const skip = (dimension: RegistrySearchFilterDimension) =>
+    except?.has(dimension) === true;
+
+  if (
+    !skip("category") &&
+    filters.category &&
+    entry.category !== filters.category
+  ) {
+    return false;
+  }
+  if (!skip("platform") && !matchesPlatform(entry, filters.platform)) {
+    return false;
+  }
+  if (
+    !skip("hasSafetyNotes") &&
+    !matchesBooleanFilter(hasSafetyNotes(entry), filters.hasSafetyNotes)
+  ) {
+    return false;
+  }
+  if (
+    !skip("hasPrivacyNotes") &&
+    !matchesBooleanFilter(hasPrivacyNotes(entry), filters.hasPrivacyNotes)
+  ) {
+    return false;
+  }
+  if (
+    !skip("downloadTrust") &&
+    filters.downloadTrust !== "all" &&
+    packageTrustValue(entry) !== filters.downloadTrust
+  ) {
+    return false;
+  }
+  if (
+    !skip("claimStatus") &&
+    filters.claimStatus !== "all" &&
+    claimStatusValue(entry) !== filters.claimStatus
+  ) {
+    return false;
+  }
+  if (
+    !skip("sourceStatus") &&
+    filters.sourceStatus !== "all" &&
+    sourceStatusValue(entry) !== filters.sourceStatus
+  ) {
+    return false;
+  }
+  if (!skip("query") && !matchesQuery(entry, filters.query)) {
+    return false;
+  }
+  return true;
+}
+
+export function filterEntries(
+  entries: ReadonlyArray<SearchDocument>,
+  filters: RegistrySearchFilterState,
+) {
+  return entries.filter((entry) => entryMatchesFilters(entry, filters));
+}

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -1133,6 +1133,52 @@ paths:
                         - trustSignals
                       additionalProperties: {}
                     maxItems: 50
+                  facets:
+                    type: object
+                    properties:
+                      categories:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      platforms:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      hasSafetyNotes:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      hasPrivacyNotes:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      downloadTrust:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      claimStatus:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                      sourceStatus:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
+                    required:
+                      - categories
+                      - platforms
+                      - hasSafetyNotes
+                      - hasPrivacyNotes
+                      - downloadTrust
+                      - claimStatus
+                      - sourceStatus
                 required:
                   - schemaVersion
                   - query

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -142,6 +142,37 @@ describe("OpenAPI route coverage", () => {
     ).toHaveProperty("application/atom+xml");
   });
 
+  it("documents facet counts on the registry search response", () => {
+    const searchResponse =
+      parsedSchema.paths["/api/registry/search"]?.get?.responses?.["200"];
+    const jsonContent = (
+      searchResponse?.content as Record<string, { schema?: unknown }> | undefined
+    )?.["application/json"];
+    const responseSchema = jsonContent?.schema as
+      | {
+          properties?: {
+            facets?: {
+              type?: string;
+              properties?: Record<string, unknown>;
+            };
+          };
+        }
+      | undefined;
+
+    expect(responseSchema?.properties?.facets?.type).toBe("object");
+    expect(Object.keys(responseSchema?.properties?.facets?.properties ?? {})).toEqual(
+      expect.arrayContaining([
+        "categories",
+        "platforms",
+        "hasSafetyNotes",
+        "hasPrivacyNotes",
+        "downloadTrust",
+        "claimStatus",
+        "sourceStatus",
+      ]),
+    );
+  });
+
   it("documents error envelopes, cacheable feeds, and registry trust signals", () => {
     expect(schema).toContain("ErrorEnvelope:");
     expect(schema).toContain("RegistryTrustSignals:");

--- a/tests/registry-search-facets.test.ts
+++ b/tests/registry-search-facets.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { SearchDocument } from "@heyclaude/registry";
+
+import { computeRegistrySearchFacets } from "../apps/web/src/lib/api/registry-search-facets";
+import {
+  filterEntries,
+  type RegistrySearchFilterState,
+} from "../apps/web/src/lib/api/registry-search-filters";
+
+function makeEntry(overrides: Partial<SearchDocument>): SearchDocument {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture entry",
+    description: "fixture description",
+    tags: [],
+    keywords: [],
+    author: "tester",
+    dateAdded: "2026-05-21",
+    installable: false,
+    downloadTrust: null,
+    verificationStatus: "unverified",
+    documentationUrl: "https://example.com/docs",
+    repoUrl: "https://example.com/repo",
+    url: "https://example.com",
+    canonicalUrl: "https://example.com",
+    llmsUrl: "https://example.com/llms.txt",
+    apiUrl: "https://example.com/api",
+    trustSignals: {
+      firstPartyEditorial: false,
+      packageVerified: false,
+      packageTrust: null,
+      packageChecksum: "",
+      checksumPresent: false,
+      sourceUrlCount: 0,
+      sourceUrls: [],
+      sourceStatus: "missing",
+      lastVerifiedAt: "",
+      adapterGenerated: false,
+      platforms: [],
+      supportLevels: [],
+    },
+    ...overrides,
+  } as SearchDocument;
+}
+
+const defaultFilters: RegistrySearchFilterState = {
+  query: "",
+  category: "",
+  platform: "",
+  hasSafetyNotes: "all",
+  hasPrivacyNotes: "all",
+  downloadTrust: "all",
+  claimStatus: "all",
+  sourceStatus: "all",
+};
+
+const fixtures: SearchDocument[] = [
+  makeEntry({
+    slug: "mcp-a",
+    category: "mcp",
+    platforms: ["claude-code", "cursor"],
+    safetyNotes: ["network access"],
+    downloadTrust: "first-party",
+    claimStatus: "verified",
+    trustSignals: {
+      ...makeEntry({}).trustSignals,
+      sourceStatus: "available",
+    },
+  }),
+  makeEntry({
+    slug: "mcp-b",
+    category: "mcp",
+    platforms: ["claude-code"],
+    downloadTrust: "external",
+    claimStatus: "unclaimed",
+    trustSignals: {
+      ...makeEntry({}).trustSignals,
+      sourceStatus: "missing",
+    },
+  }),
+  makeEntry({
+    slug: "skill-a",
+    category: "skills",
+    platforms: ["cursor"],
+    privacyNotes: ["reads local files"],
+    downloadTrust: "first-party",
+    claimStatus: "verified",
+    trustSignals: {
+      ...makeEntry({}).trustSignals,
+      sourceStatus: "available",
+    },
+  }),
+  makeEntry({
+    slug: "hook-a",
+    category: "hooks",
+    platforms: ["claude-code"],
+    safetyNotes: ["runs shell"],
+    privacyNotes: ["logs commands"],
+    downloadTrust: "external",
+    claimStatus: "pending",
+    trustSignals: {
+      ...makeEntry({}).trustSignals,
+      sourceStatus: "available",
+    },
+  }),
+];
+
+describe("computeRegistrySearchFacets", () => {
+  it("counts every dimension across the unfiltered set", () => {
+    const facets = computeRegistrySearchFacets(fixtures, defaultFilters);
+
+    expect(facets.categories).toEqual({ mcp: 2, hooks: 1, skills: 1 });
+    expect(facets.platforms).toEqual({ "claude-code": 3, cursor: 2 });
+    expect(facets.hasSafetyNotes).toEqual({ false: 2, true: 2 });
+    expect(facets.hasPrivacyNotes).toEqual({ false: 2, true: 2 });
+    expect(facets.downloadTrust).toEqual({
+      "first-party": 2,
+      external: 2,
+    });
+    expect(facets.claimStatus).toEqual({
+      verified: 2,
+      pending: 1,
+      unclaimed: 1,
+    });
+    expect(facets.sourceStatus).toEqual({ available: 3, missing: 1 });
+  });
+
+  it("applies other filters but excludes the dimension being faceted", () => {
+    const filters: RegistrySearchFilterState = {
+      ...defaultFilters,
+      category: "mcp",
+    };
+
+    const facets = computeRegistrySearchFacets(fixtures, filters);
+
+    expect(facets.categories).toEqual({ mcp: 2, hooks: 1, skills: 1 });
+
+    expect(facets.platforms).toEqual({ "claude-code": 2, cursor: 1 });
+    expect(facets.downloadTrust).toEqual({ "first-party": 1, external: 1 });
+    expect(facets.claimStatus).toEqual({ verified: 1, unclaimed: 1 });
+  });
+
+  it("returns deterministic, bounded buckets sorted by count then key", () => {
+    const facets = computeRegistrySearchFacets(fixtures, defaultFilters);
+
+    const platformEntries = Object.entries(facets.platforms);
+    expect(platformEntries).toEqual([
+      ["claude-code", 3],
+      ["cursor", 2],
+    ]);
+
+    const categoryEntries = Object.entries(facets.categories);
+    expect(categoryEntries[0]?.[0]).toBe("mcp");
+    expect(categoryEntries.slice(1).map(([key]) => key)).toEqual(
+      ["hooks", "skills"].sort(),
+    );
+  });
+
+  it("omits empty buckets and preserves the active filter selection", () => {
+    const filters: RegistrySearchFilterState = {
+      ...defaultFilters,
+      downloadTrust: "first-party",
+    };
+
+    const facets = computeRegistrySearchFacets(fixtures, filters);
+
+    expect(facets.downloadTrust).toEqual({ "first-party": 2, external: 2 });
+    expect(facets.categories).toEqual({ mcp: 1, skills: 1 });
+    expect(facets.categories).not.toHaveProperty("hooks");
+  });
+
+  it("treats every entry as either true or false for boolean dimensions", () => {
+    const facets = computeRegistrySearchFacets(fixtures, defaultFilters);
+    const safetyTotal =
+      (facets.hasSafetyNotes.true ?? 0) + (facets.hasSafetyNotes.false ?? 0);
+    const privacyTotal =
+      (facets.hasPrivacyNotes.true ?? 0) + (facets.hasPrivacyNotes.false ?? 0);
+    expect(safetyTotal).toBe(fixtures.length);
+    expect(privacyTotal).toBe(fixtures.length);
+  });
+
+  it("keeps filterEntries and facet counts consistent for the active selection", () => {
+    const filters: RegistrySearchFilterState = {
+      ...defaultFilters,
+      hasSafetyNotes: "true",
+    };
+
+    const matched = filterEntries(fixtures, filters);
+    const facets = computeRegistrySearchFacets(fixtures, filters);
+
+    expect(matched).toHaveLength(2);
+    expect(facets.hasSafetyNotes.true).toBe(2);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Adds an optional `facets` object to `/api/registry/search` so API consumers can build filter UIs from a single request instead of issuing one count query per dimension.
- Facets: `categories`, `platforms`, `hasSafetyNotes`, `hasPrivacyNotes`, `downloadTrust`, `claimStatus`, `sourceStatus`.
- For each dimension, counts come from the unpaginated matched set with every *other* active filter applied (standard faceted-search behavior), so the API consumer can render \"X results if you switch to bucket Y\" UI.
- Buckets are deterministic (sorted by count then key) and bounded (32 buckets max for `categories`/`platforms`; empty buckets are omitted).
- Filter logic that was inline in the route handler is extracted into `apps/web/src/lib/api/registry-search-filters.ts` so the route and the facet computation share one matching path.
- Existing response fields are unchanged. The new `facets` field is `optional` in the zod/OpenAPI contract, so existing clients remain compatible.

## Submission Source

- [ ] New content file(s) added under `content/<category>/`
- [x] Existing content updated
- [x] Submission issue resolved (link it here): #429
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks

- [x] `pnpm validate:openapi` passed — OpenAPI YAML regenerated from updated `registrySearchResponseSchema`
- [ ] `pnpm validate:packages` (not applicable — no package changes)
- [ ] `pnpm scan:packages` (not applicable)
- [ ] `pnpm audit:content` (not applicable — no content file changes)
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete (not applicable — no content entries)
- [ ] Skill submissions include capability metadata (not applicable)

## Validation

- [x] `pnpm validate:openapi` — schema in sync with contracts.ts
- [x] `pnpm exec vitest run tests/api-contracts.test.ts tests/api-router-security.test.ts tests/registry-search-facets.test.ts` — 29/29 passed (16 router security + 7 api contracts + 6 new facet unit tests)
- [x] Local `pnpm build` passed
- [x] `git diff --check` clean

## Acceptance criteria for #429

- [x] `/api/registry/search` response includes a typed `facets` object.
- [x] Facet counts are deterministic and bounded (sorted by count then key; bounded buckets for high-cardinality dimensions; empty buckets omitted).
- [x] Existing clients remain compatible — every previously-required field is untouched and `facets` is optional in the schema.
- [x] OpenAPI includes the new response shape — `cloudflare/api-schema-heyclaude-openapi.yaml` regenerated via `pnpm generate:openapi`.
- [x] PR includes `Closes #429`.

## Notes

- The facet semantics follow the typical faceted-search expectation: counts for facet *X* are computed across the result set after applying every filter *except* *X*. This is what UIs need to render \"switch to value Y (N)\" affordances.
- No registry/schema churn beyond the search response. No new database dependency — facets are computed in-memory from the existing `getSearchIndex` envelope.
- Existing route helpers (`matchesQuery`, `matchesPlatform`, `packageTrust`, `claimStatus`, `sourceStatus`) moved out of the route file into the shared filter module without behavior changes.

Closes #429