### PR TITLE
feat(discovery): add trust filter counts and quick chips to browse

### DIFF
--- a/apps/web/src/components/browse-directory.tsx
+++ b/apps/web/src/components/browse-directory.tsx
@@ -21,6 +21,13 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { DirectoryEntry } from "@/lib/content";
+import {
+  countTrustFilterChips,
+  matchesUtilityFilter,
+  normalizeUtilityFilter as normalizeUtilityFilterValue,
+  trustFilterChips,
+  utilityFilterOptions,
+} from "@/lib/browse-utility-filters";
 import { useBrowseUrlSync } from "@/hooks/use-browse-url-sync";
 import { useClientId } from "@/hooks/use-client-id";
 import { useLoggedAsync } from "@/hooks/use-logged-async";
@@ -46,23 +53,6 @@ const COLLECTION_QUERY_PARAM = "collection";
 const VOTE_QUERY_BATCH_SIZE = 120;
 const VOTE_QUERY_MAX_ATTEMPTS = 3;
 const VOTE_QUERY_RETRY_DELAYS_MS = [250, 900, 1800] as const;
-const utilityFilterOptions = [
-  { value: "all", label: "All Utility" },
-  { value: "installable", label: "Installable" },
-  { value: "trusted-package", label: "Trusted Package" },
-  { value: "source-backed", label: "Source-backed" },
-  { value: "brand-metadata", label: "Brand Metadata" },
-  { value: "checksum", label: "Checksum" },
-  { value: "adapter", label: "Adapter" },
-  { value: "reviewed", label: "Reviewed" },
-  { value: "verified", label: "Verified/Prod" },
-  { value: "draft", label: "Draft" },
-  { value: "hook-trigger", label: "Hook Trigger" },
-  { value: "prerequisites", label: "Prerequisites" },
-  { value: "safety-notes", label: "Safety Notes" },
-  { value: "privacy-notes", label: "Privacy Notes" },
-  { value: "troubleshooting", label: "Troubleshooting" },
-] as const;
 const platformFilterOptions = [
   { value: "all", label: "All Platforms" },
   ...categorySpec.defaultTestedPlatforms.map((platform) => ({
@@ -84,14 +74,7 @@ function normalizeCategory(value?: string) {
   return siteConfig.categoryOrder.includes(normalized) ? normalized : "all";
 }
 
-function normalizeUtilityFilter(value?: string) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  return utilityFilterOptions.some((option) => option.value === normalized)
-    ? normalized
-    : "all";
-}
+const normalizeUtilityFilter = normalizeUtilityFilterValue;
 
 function normalizePlatformFilter(value?: string) {
   const normalized = String(value || "")
@@ -127,48 +110,6 @@ function normalizeSortMode(value?: string) {
   )
     ? normalized
     : "popular";
-}
-
-function matchesUtilityFilter(entry: DirectoryEntry, filter: string) {
-  switch (filter) {
-    case "installable":
-      return Boolean(
-        entry.installable || entry.installCommand || entry.downloadUrl,
-      );
-    case "trusted-package":
-      return (
-        entry.downloadTrust === "first-party" || entry.packageVerified === true
-      );
-    case "source-backed":
-      return entry.trustSignals?.sourceStatus === "available";
-    case "brand-metadata":
-      return Boolean(entry.brandDomain || entry.brandIconUrl);
-    case "checksum":
-      return entry.trustSignals?.checksumPresent === true;
-    case "adapter":
-      return entry.trustSignals?.adapterGenerated === true;
-    case "reviewed":
-      return Boolean(entry.reviewedBy || entry.claimStatus === "verified");
-    case "verified":
-      return (
-        entry.verificationStatus === "validated" ||
-        entry.verificationStatus === "production"
-      );
-    case "draft":
-      return entry.verificationStatus === "draft";
-    case "hook-trigger":
-      return Boolean(entry.trigger);
-    case "prerequisites":
-      return Boolean(entry.hasPrerequisites || entry.prerequisites?.length);
-    case "safety-notes":
-      return Boolean(entry.safetyNotes?.length);
-    case "privacy-notes":
-      return Boolean(entry.privacyNotes?.length);
-    case "troubleshooting":
-      return entry.hasTroubleshooting === true;
-    default:
-      return true;
-  }
 }
 
 function matchesPlatformFilter(entry: DirectoryEntry, filter: string) {
@@ -408,6 +349,15 @@ export function BrowseDirectory({
       cancelled = true;
     };
   }, [allEntries, clientId]);
+
+  const trustChipCounts = useMemo(
+    () => countTrustFilterChips(allEntries),
+    [allEntries],
+  );
+
+  const handleTrustChipToggle = (value: string) => {
+    setUtilityFilter((current) => (current === value ? "all" : value));
+  };
 
   const filteredEntries = useMemo(() => {
     const matched = allEntries.filter((entry) => {
@@ -742,6 +692,44 @@ export function BrowseDirectory({
             <SelectItem value="title">A-Z</SelectItem>
           </SelectContent>
         </Select>
+      </div>
+
+      <div
+        className="flex flex-wrap items-center gap-2"
+        role="group"
+        aria-label="Trust quick filters"
+      >
+        {trustFilterChips.map((chip) => {
+          const isActive = utilityFilter === chip.value;
+          const count = trustChipCounts[chip.value] ?? 0;
+          return (
+            <button
+              key={chip.value}
+              type="button"
+              onClick={() => handleTrustChipToggle(chip.value)}
+              aria-pressed={isActive}
+              title={chip.description}
+              className={
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-medium transition-colors " +
+                (isActive
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border bg-background text-muted-foreground hover:bg-accent hover:text-accent-foreground")
+              }
+            >
+              <span>{chip.label}</span>
+              <span
+                className={
+                  "rounded-full px-1.5 text-[10px] tabular-nums " +
+                  (isActive
+                    ? "bg-primary-foreground/15 text-primary-foreground"
+                    : "bg-muted text-muted-foreground")
+                }
+              >
+                {count}
+              </span>
+            </button>
+          );
+        })}
       </div>
 
       <div className="flex items-center justify-between gap-4 text-sm text-muted-foreground">

--- a/apps/web/src/lib/browse-utility-filters.ts
+++ b/apps/web/src/lib/browse-utility-filters.ts
@@ -1,0 +1,136 @@
+import type { DirectoryEntry } from "@/lib/content";
+
+export type UtilityFilterOption = {
+  readonly value: string;
+  readonly label: string;
+};
+
+export const utilityFilterOptions = [
+  { value: "all", label: "All Utility" },
+  { value: "installable", label: "Installable" },
+  { value: "trusted-package", label: "Trusted Package" },
+  { value: "source-backed", label: "Source-backed" },
+  { value: "brand-metadata", label: "Brand Metadata" },
+  { value: "checksum", label: "Checksum" },
+  { value: "adapter", label: "Adapter" },
+  { value: "reviewed", label: "Reviewed" },
+  { value: "verified", label: "Verified/Prod" },
+  { value: "draft", label: "Draft" },
+  { value: "hook-trigger", label: "Hook Trigger" },
+  { value: "prerequisites", label: "Prerequisites" },
+  { value: "safety-notes", label: "Safety Notes" },
+  { value: "privacy-notes", label: "Privacy Notes" },
+  { value: "troubleshooting", label: "Troubleshooting" },
+] as const satisfies ReadonlyArray<UtilityFilterOption>;
+
+export type UtilityFilterValue = (typeof utilityFilterOptions)[number]["value"];
+
+export type TrustFilterChip = {
+  readonly value: UtilityFilterValue;
+  readonly label: string;
+  readonly description: string;
+};
+
+export const trustFilterChips: ReadonlyArray<TrustFilterChip> = [
+  {
+    value: "safety-notes",
+    label: "Safety notes",
+    description: "Entries that disclose execution, install, or network safety context.",
+  },
+  {
+    value: "privacy-notes",
+    label: "Privacy notes",
+    description: "Entries that disclose local files, logs, credentials, or telemetry behavior.",
+  },
+  {
+    value: "source-backed",
+    label: "Source-backed",
+    description: "Entries with available source metadata for review.",
+  },
+  {
+    value: "trusted-package",
+    label: "Trusted package",
+    description: "First-party packages or maintainer-verified package downloads.",
+  },
+  {
+    value: "reviewed",
+    label: "Reviewed",
+    description: "Entries with a reviewer or a verified claim.",
+  },
+  {
+    value: "checksum",
+    label: "Checksum",
+    description: "Entries that ship with a recorded package checksum.",
+  },
+];
+
+export function normalizeUtilityFilter(value?: string): string {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  return utilityFilterOptions.some((option) => option.value === normalized)
+    ? normalized
+    : "all";
+}
+
+export function matchesUtilityFilter(
+  entry: DirectoryEntry,
+  filter: string,
+): boolean {
+  switch (filter) {
+    case "installable":
+      return Boolean(
+        entry.installable || entry.installCommand || entry.downloadUrl,
+      );
+    case "trusted-package":
+      return (
+        entry.downloadTrust === "first-party" || entry.packageVerified === true
+      );
+    case "source-backed":
+      return entry.trustSignals?.sourceStatus === "available";
+    case "brand-metadata":
+      return Boolean(entry.brandDomain || entry.brandIconUrl);
+    case "checksum":
+      return entry.trustSignals?.checksumPresent === true;
+    case "adapter":
+      return entry.trustSignals?.adapterGenerated === true;
+    case "reviewed":
+      return Boolean(entry.reviewedBy || entry.claimStatus === "verified");
+    case "verified":
+      return (
+        entry.verificationStatus === "validated" ||
+        entry.verificationStatus === "production"
+      );
+    case "draft":
+      return entry.verificationStatus === "draft";
+    case "hook-trigger":
+      return Boolean(entry.trigger);
+    case "prerequisites":
+      return Boolean(entry.hasPrerequisites || entry.prerequisites?.length);
+    case "safety-notes":
+      return Boolean(entry.safetyNotes?.length);
+    case "privacy-notes":
+      return Boolean(entry.privacyNotes?.length);
+    case "troubleshooting":
+      return entry.hasTroubleshooting === true;
+    default:
+      return true;
+  }
+}
+
+export function countTrustFilterChips(
+  entries: ReadonlyArray<DirectoryEntry>,
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const chip of trustFilterChips) {
+    counts[chip.value] = 0;
+  }
+  for (const entry of entries) {
+    for (const chip of trustFilterChips) {
+      if (matchesUtilityFilter(entry, chip.value)) {
+        counts[chip.value] += 1;
+      }
+    }
+  }
+  return counts;
+}

--- a/tests/browse-utility-filters.test.ts
+++ b/tests/browse-utility-filters.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import type { DirectoryEntry } from "@/lib/content";
+import {
+  countTrustFilterChips,
+  matchesUtilityFilter,
+  normalizeUtilityFilter,
+  trustFilterChips,
+  utilityFilterOptions,
+} from "../apps/web/src/lib/browse-utility-filters";
+
+function makeEntry(overrides: Partial<DirectoryEntry>): DirectoryEntry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "fixture",
+    tags: [],
+    keywords: [],
+    author: "tester",
+    dateAdded: "2026-05-21",
+    installable: false,
+    verificationStatus: "unverified",
+    documentationUrl: "https://example.com",
+    repoUrl: "https://example.com",
+    url: "https://example.com",
+    canonicalUrl: "https://example.com",
+    llmsUrl: "https://example.com/llms.txt",
+    apiUrl: "https://example.com/api",
+    trustSignals: {
+      firstPartyEditorial: false,
+      packageVerified: false,
+      packageTrust: null,
+      packageChecksum: "",
+      checksumPresent: false,
+      sourceUrlCount: 0,
+      sourceUrls: [],
+      sourceStatus: "missing",
+      lastVerifiedAt: "",
+      adapterGenerated: false,
+      platforms: [],
+      supportLevels: [],
+    },
+    ...overrides,
+  } as DirectoryEntry;
+}
+
+describe("normalizeUtilityFilter", () => {
+  it("returns the input when it matches a known option", () => {
+    for (const option of utilityFilterOptions) {
+      expect(normalizeUtilityFilter(option.value)).toBe(option.value);
+    }
+  });
+
+  it("falls back to 'all' for unknown or empty values", () => {
+    expect(normalizeUtilityFilter(undefined)).toBe("all");
+    expect(normalizeUtilityFilter("")).toBe("all");
+    expect(normalizeUtilityFilter("not-a-filter")).toBe("all");
+  });
+
+  it("lowercases and trims input", () => {
+    expect(normalizeUtilityFilter("  Source-Backed  ")).toBe("source-backed");
+  });
+});
+
+describe("matchesUtilityFilter", () => {
+  it("returns true for every entry under the 'all' selector", () => {
+    const entry = makeEntry({});
+    expect(matchesUtilityFilter(entry, "all")).toBe(true);
+  });
+
+  it("matches safety and privacy disclosures by note presence", () => {
+    const withSafety = makeEntry({ safetyNotes: ["runs shell"] });
+    const withPrivacy = makeEntry({ privacyNotes: ["reads local files"] });
+    const baseline = makeEntry({});
+
+    expect(matchesUtilityFilter(withSafety, "safety-notes")).toBe(true);
+    expect(matchesUtilityFilter(baseline, "safety-notes")).toBe(false);
+    expect(matchesUtilityFilter(withPrivacy, "privacy-notes")).toBe(true);
+    expect(matchesUtilityFilter(baseline, "privacy-notes")).toBe(false);
+  });
+
+  it("matches source-backed entries only when sourceStatus is available", () => {
+    const available = makeEntry({
+      trustSignals: { ...makeEntry({}).trustSignals, sourceStatus: "available" },
+    });
+    const missing = makeEntry({});
+    expect(matchesUtilityFilter(available, "source-backed")).toBe(true);
+    expect(matchesUtilityFilter(missing, "source-backed")).toBe(false);
+  });
+
+  it("treats first-party or verified packages as trusted-package", () => {
+    const firstParty = makeEntry({ downloadTrust: "first-party" });
+    const verified = makeEntry({ packageVerified: true });
+    const external = makeEntry({ downloadTrust: "external" });
+    expect(matchesUtilityFilter(firstParty, "trusted-package")).toBe(true);
+    expect(matchesUtilityFilter(verified, "trusted-package")).toBe(true);
+    expect(matchesUtilityFilter(external, "trusted-package")).toBe(false);
+  });
+
+  it("marks reviewed entries with reviewer or verified claim", () => {
+    const reviewed = makeEntry({ reviewedBy: "maintainer" });
+    const claimed = makeEntry({ claimStatus: "verified" });
+    const unreviewed = makeEntry({ claimStatus: "unclaimed" });
+    expect(matchesUtilityFilter(reviewed, "reviewed")).toBe(true);
+    expect(matchesUtilityFilter(claimed, "reviewed")).toBe(true);
+    expect(matchesUtilityFilter(unreviewed, "reviewed")).toBe(false);
+  });
+
+  it("marks checksum-bearing entries via trustSignals", () => {
+    const withChecksum = makeEntry({
+      trustSignals: {
+        ...makeEntry({}).trustSignals,
+        checksumPresent: true,
+      },
+    });
+    const withoutChecksum = makeEntry({});
+    expect(matchesUtilityFilter(withChecksum, "checksum")).toBe(true);
+    expect(matchesUtilityFilter(withoutChecksum, "checksum")).toBe(false);
+  });
+});
+
+describe("countTrustFilterChips", () => {
+  const fixtures: DirectoryEntry[] = [
+    makeEntry({
+      slug: "a",
+      safetyNotes: ["network access"],
+      downloadTrust: "first-party",
+      trustSignals: {
+        ...makeEntry({}).trustSignals,
+        sourceStatus: "available",
+        checksumPresent: true,
+      },
+      reviewedBy: "maintainer",
+    }),
+    makeEntry({
+      slug: "b",
+      privacyNotes: ["reads logs"],
+      packageVerified: true,
+      claimStatus: "verified",
+    }),
+    makeEntry({
+      slug: "c",
+    }),
+  ];
+
+  it("counts every chip across the loaded entry set", () => {
+    const counts = countTrustFilterChips(fixtures);
+
+    expect(counts["safety-notes"]).toBe(1);
+    expect(counts["privacy-notes"]).toBe(1);
+    expect(counts["source-backed"]).toBe(1);
+    expect(counts["trusted-package"]).toBe(2);
+    expect(counts["reviewed"]).toBe(2);
+    expect(counts["checksum"]).toBe(1);
+  });
+
+  it("returns zero for chips that no entry matches", () => {
+    const counts = countTrustFilterChips([
+      makeEntry({ slug: "plain" }),
+      makeEntry({ slug: "plain-two" }),
+    ]);
+
+    for (const chip of trustFilterChips) {
+      expect(counts[chip.value]).toBe(0);
+    }
+  });
+
+  it("produces a count for every defined trust chip", () => {
+    const counts = countTrustFilterChips(fixtures);
+    for (const chip of trustFilterChips) {
+      expect(typeof counts[chip.value]).toBe("number");
+    }
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a compact trust filter chip strip to `/browse` so visitors can apply the highest-value trust filters in one click and see how many entries would match.
- Six chips: Safety notes, Privacy notes, Source-backed, Trusted package, Reviewed, Checksum.
- Each chip toggles the same `?utility=` URL state the existing utility dropdown already drives — clicking an active chip sets it back to \`all\`. The existing dropdown and URL sync behavior are unchanged.
- Counts are computed client-side from the entries already loaded by `BrowseDirectory` (no server-side search infra, no new API calls).
- Refactor: `utilityFilterOptions`, `matchesUtilityFilter`, and `normalizeUtilityFilter` move from the `browse-directory` client component into `apps/web/src/lib/browse-utility-filters.ts` so the predicates can be unit-tested without rendering React. Behavior is preserved (the browse component now imports the same helpers it previously declared inline).

## Submission Source

- [ ] New content file(s) added under `content/<category>/`
- [x] Existing content updated
- [x] Submission issue resolved (link it here): #427
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks

- [ ] `pnpm validate:content` (not applicable — no content changes)
- [ ] `pnpm validate:packages` (not applicable)
- [ ] `pnpm scan:packages` (not applicable)
- [ ] `pnpm audit:content` (not applicable)
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete (not applicable — no content entries)
- [ ] Skill submissions include capability metadata (not applicable)

## Validation

- [x] Local build passed (`pnpm build`)
- [x] `pnpm exec vitest run tests/browse-utility-filters.test.ts tests/discovery-surfaces.test.ts` — 17/17 passed (12 new chip/predicate tests + 5 existing discovery-surfaces tests still green)
- [x] `git diff --check` clean
- [x] Existing utility dropdown still works — the chips and the dropdown both call `setUtilityFilter()` against the same state and URL sync hook

## Acceptance criteria for #427

- [x] The quick filter strip shows counts computed from the currently loaded entries (`allEntries` in `BrowseDirectory`).
- [x] Clicking a trust chip applies the corresponding existing utility filter (same `setUtilityFilter` action the dropdown uses).
- [x] URL sync still works — chips drive the same `?utility=<value>` param the existing utility dropdown already syncs through `useBrowseUrlSync`.
- [x] Empty states remain clear and polished — chips show `0` rather than disappearing, so the visible structure stays stable.
- [x] PR includes `Closes #427`.

## Notes

- Did not redesign the full browse page.
- Did not change content schemas or generated registry artifacts.
- Did not add server-side search infrastructure — counts come from the entries already loaded.
- Did not add multiple simultaneous trust filters — keeping that out of scope per the issue.
- The chip strip uses tailwind utility classes consistent with the rest of the directory UI (rounded-full, border, muted-foreground accent, primary background when active). I did not introduce a new design-system primitive; happy to refactor onto a shared `Chip` component if one is preferred.

Closes #427