### PR TITLE
docs(contributing): require quality evidence

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "HeyClaude",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-24-bookworm",
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@11.1.3 --activate",
+  "forwardPorts": [3000, 3111],
+  "portsAttributes": {
+    "3000": {
+      "label": "Next.js app",
+      "onAutoForward": "notify"
+    },
+    "3111": {
+      "label": "Playwright dev server",
+      "onAutoForward": "silent"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-playwright.playwright"
+      ]
+    }
+  }
+}

--- a/.github/ISSUE_TEMPLATE/product-feature.yml
+++ b/.github/ISSUE_TEMPLATE/product-feature.yml
@@ -1,0 +1,113 @@
+name: Product or feature improvement
+description: Propose contributor work for HeyClaude product, website, API, MCP, Raycast, discovery, or design improvements.
+title: "feat: "
+labels:
+  - help wanted
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for maintainer-authored product and feature work. Do not use it for free content submissions; use the category-specific submission forms instead.
+
+        Good issues are narrow enough for one PR, explicit about what is out of scope, and clear about the proof required before merge.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: One clear outcome this issue should deliver.
+      placeholder: "Add trust filter chips to browse so visitors can quickly narrow entries by safety/privacy metadata."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why this matters
+      description: Explain the user, contributor, traffic, trust, or product-growth value.
+      placeholder: "This helps visitors evaluate resources faster and supports higher-quality community contributions."
+    validations:
+      required: true
+  - type: textarea
+    id: current_behavior
+    attributes:
+      label: Current behavior
+      description: Link relevant pages, files, APIs, or docs.
+      placeholder: "Browse currently supports utility filters in the sidebar, but there is no quick count strip above results."
+    validations:
+      required: true
+  - type: textarea
+    id: desired_behavior
+    attributes:
+      label: Desired behavior
+      description: Describe exactly what should exist after the PR lands.
+      placeholder: "The browse page shows quick filter chips with counts, shares state with the existing dropdown, and preserves URL state."
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List allowed areas to edit.
+      placeholder: |
+        - apps/web/src/components/browse-directory.tsx
+        - apps/web/src/lib/search helpers
+        - focused tests
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: Explicitly forbid unrelated rewrites, generated artifact churn, and automation changes when not part of the issue.
+      placeholder: |
+        - Full browse redesign
+        - Generated registry artifacts
+        - Content imports
+        - CI or automation behavior
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Concrete behavior, quality, accessibility, data, SEO, or compatibility requirements.
+      placeholder: |
+        - PR includes `Closes #<issue>`.
+        - Filter state is reflected in the URL.
+        - Empty states remain clear.
+        - Existing filters still work.
+    validations:
+      required: true
+  - type: textarea
+    id: quality_evidence
+    attributes:
+      label: Quality evidence required in the PR
+      description: Say exactly what screenshots, invariants, and review proof the contributor must provide.
+      placeholder: |
+        - Frontend/page/UI changes require desktop and mobile screenshots, or a clear `No visual impact` note.
+        - New features must list changed routes/components/endpoints/tools, expected behavior, and important edge cases.
+        - API/MCP/Raycast changes must list invariants and backward-compatibility notes.
+        - Accessibility-sensitive UI must mention keyboard, focus, label, and mobile behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Exact commands contributors should run from the repo root.
+      placeholder: |
+        pnpm build
+        pnpm exec vitest run tests/example.test.ts
+        git diff --check
+    validations:
+      required: true
+  - type: checkboxes
+    id: guardrails
+    attributes:
+      label: Contributor guardrails
+      options:
+        - label: Generated artifacts stay out of scope unless this issue explicitly asks for them.
+          required: true
+        - label: PRs should use a Conventional Commit-style title and include `Closes #<issue>`.
+          required: true
+        - label: UI or page changes must include screenshots in the PR, or explain `No visual impact`.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,10 +23,24 @@
 - [ ] Install/use/copy paths are practical and complete
 - [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`)
 
+## Quality Evidence
+
+- Changed routes/components/endpoints/tools:
+- Expected behavior:
+- Important edge cases or invariants:
+- Backward compatibility notes:
+- Screenshots for frontend/page/UI changes:
+  - Desktop:
+  - Mobile:
+- If screenshots do not apply, write `No visual impact` and explain why.
+- Accessibility notes for UI changes:
+- Focused tests or reason tests are not practical:
+
 ## Validation
 
 - [ ] Local build passed (`pnpm build`)
-- [ ] I spot-checked the affected detail page(s)
+- [ ] I ran the focused checks listed above
+- [ ] I spot-checked the affected detail page(s), route(s), or integration surface(s)
 
 ## Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,37 @@ Do not edit these in external content PRs:
 
 Maintainer automation regenerates those outputs.
 
+For frontend, page, product, API, MCP, Raycast, or other feature work, include enough review evidence for maintainers to understand the behavior without guessing:
+
+- Frontend/page/UI changes: attach desktop and mobile screenshots in the PR, or clearly write `No visual impact` when the change is non-visual.
+- New features: list changed routes, pages, components, commands, tools, or endpoints, plus the expected behavior and important edge cases.
+- Backend/API/MCP/Raycast changes: list the invariants that must remain true, validation commands, and any backward-compatibility notes.
+- Accessibility-sensitive UI changes: mention keyboard, focus, label, and mobile behavior where relevant.
+- Content-only changes that do not alter rendering may skip screenshots, but should say so explicitly.
+
+Screenshots are manual-review evidence, not a separate CI gate. Maintainers may request changes when UI or feature PRs omit screenshots, invariants, or meaningful validation.
+
+## Development environment
+
+Use the local environment you prefer, or open the repo in the included minimal devcontainer/Codespaces setup. The devcontainer standardizes Node and pnpm but intentionally avoids heavy browser installs by default.
+
+Inside a fresh environment:
+
+```sh
+corepack enable
+corepack prepare pnpm@11.1.3 --activate
+pnpm install --frozen-lockfile
+```
+
+For browser validation, install Playwright Chromium when needed:
+
+```sh
+pnpm exec playwright install --with-deps chromium
+pnpm test:e2e
+```
+
+CI remains the source of truth for merge readiness.
+
 ## Package and artifact policy
 
 Community submissions should be source-backed, not artifact-hosting requests.

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -148,6 +148,50 @@ describe("submission automation workflows", () => {
     return `---\n${frontmatter.trim()}\n---\n\n${body}\n`;
   }
 
+  it("keeps direct PR quality evidence requirements visible", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, ".github/pull_request_template.md"),
+      "utf8",
+    );
+
+    expect(source).toContain("## Quality Evidence");
+    expect(source).toContain("Desktop:");
+    expect(source).toContain("Mobile:");
+    expect(source).toContain("No visual impact");
+    expect(source).toContain("Important edge cases or invariants");
+    expect(source).toContain("Backward compatibility notes");
+    expect(source).toContain("Accessibility notes for UI changes");
+  });
+
+  it("keeps product feature issues scoped with screenshot expectations", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, ".github/ISSUE_TEMPLATE/product-feature.yml"),
+      "utf8",
+    );
+
+    expect(source).toContain("Product or feature improvement");
+    expect(source).toContain("id: quality_evidence");
+    expect(source).toContain("desktop and mobile screenshots");
+    expect(source).toContain("No visual impact");
+    expect(source).toContain("Generated artifacts stay out of scope");
+    expect(source).toContain("Closes #<issue>");
+  });
+
+  it("keeps the devcontainer minimal and manual-install oriented", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, ".devcontainer/devcontainer.json"),
+      "utf8",
+    );
+    const config = JSON.parse(source);
+
+    expect(config.image).toContain("javascript-node");
+    expect(config.image).toContain("24");
+    expect(config.postCreateCommand).toContain("corepack enable");
+    expect(config.postCreateCommand).toContain("pnpm@11.1.3");
+    expect(config.postCreateCommand).not.toContain("pnpm install");
+    expect(config.postCreateCommand).not.toContain("playwright install");
+  });
+
   it("keeps public issue validation read-only for imports", () => {
     const source = fs.readFileSync(
       path.join(repoRoot, ".github/workflows/submission-issue-validation.yml"),


### PR DESCRIPTION
## Summary
- add manual-review screenshot and quality-evidence expectations for frontend, page, feature, API, MCP, and Raycast PRs
- add a scoped product/feature issue template for contributor-ready work
- add a minimal devcontainer for Node 24 and pnpm setup
- add regression tests that keep these contributor guardrails visible

## What changed
- PR template now asks for changed surfaces, expected behavior, invariants, compatibility notes, screenshots, accessibility notes, and focused tests.
- CONTRIBUTING documents screenshot expectations, validation proof, and the minimal devcontainer workflow.
- New product/feature issue form asks maintainers to define scope, out-of-scope work, acceptance criteria, validation, and required quality evidence.

## Why
- Frontend and product contributions need reviewable proof without turning screenshots into noisy CI blockers.
- Contributors need a consistent local setup path without requiring heavy browser installs by default.

## Validation
- pnpm validate:issue-templates
- pnpm exec vitest run tests/submission-workflows.test.ts
- pnpm validate:clean
- git diff --check
- Parsed .devcontainer/devcontainer.json as JSON
- Parsed .github/ISSUE_TEMPLATE/product-feature.yml as YAML

## Notes
- Screenshot requirements are manual-review enforced, not a required CI gate.
- The devcontainer intentionally prepares pnpm only; contributors install dependencies and Playwright browsers when needed.
