### PR TITLE
feat(data): add source health and freshness signals

### DIFF
--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -6,6 +6,7 @@ import {
   buildEntryQuality,
   buildContentPromptReport,
   buildContentQualityReport,
+  buildSourceHealthReport,
 } from "./quality.js";
 import { renderCorpusLlms, renderEntryLlms } from "./llms.js";
 import { buildEntryJsonLdSnapshot } from "./seo.js";
@@ -1094,6 +1095,10 @@ export function buildContentQualityArtifact(entries) {
 
 export function buildContentPromptArtifact(entries) {
   return buildContentPromptReport(entries);
+}
+
+export function buildContentSourceHealthArtifact(entries) {
+  return buildSourceHealthReport(entries);
 }
 
 export function buildJsonLdSnapshots(entries, params = {}) {

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -1075,6 +1075,14 @@ export function buildCorpusLlmsArtifact(
   params?: Record<string, unknown>,
 ): string;
 export const QUALITY_REPORT_SCHEMA_VERSION: number;
+export const SOURCE_HEALTH_REPORT_SCHEMA_VERSION: number;
+export const SOURCE_FRESHNESS_THRESHOLDS: {
+  freshDays: number;
+  agingDays: number;
+  staleDays: number;
+};
+export const SAFETY_RELEVANT_CATEGORIES: readonly string[];
+export const PACKAGEABLE_CATEGORIES: readonly string[];
 export const LLMS_ARTIFACT_SCHEMA_VERSION: number;
 export const SUBMISSION_SPEC_SCHEMA_VERSION: number;
 export function buildSourceProvenance(
@@ -1088,6 +1096,52 @@ export function findDuplicateBodyGroups(
   entries: Partial<ContentEntry>[],
 ): Array<Array<Record<string, unknown>>>;
 export function buildContentQualityReport(
+  entries: Partial<ContentEntry>[],
+): Record<string, unknown>;
+
+export type SourceFreshnessBucket =
+  | "fresh"
+  | "aging"
+  | "stale"
+  | "dormant"
+  | "unknown";
+
+export interface EntrySourceHealth {
+  key: string;
+  category: string;
+  slug: string;
+  title?: string;
+  freshness: {
+    bucket: SourceFreshnessBucket;
+    ageDays: number | null;
+    sourceDate: string;
+    source: string;
+  };
+  sourceBacked: boolean;
+  unprovenancedSource: boolean;
+  hasSafetyNotes: boolean;
+  hasPrivacyNotes: boolean;
+  missingSafetyNotes: boolean;
+  missingPrivacyNotes: boolean;
+  packageTrust: string | null;
+  packageVerified: boolean;
+  missingPackageTrust: boolean;
+  needsAttention: boolean;
+  attentionReasons: string[];
+}
+
+export function deriveSourceFreshness(
+  entry: Partial<ContentEntry>,
+  referenceDate?: Date | string,
+): EntrySourceHealth["freshness"];
+export function buildEntrySourceHealth(
+  entry: Partial<ContentEntry>,
+  referenceDate?: Date | string,
+): EntrySourceHealth;
+export function buildSourceHealthReport(
+  entries: Partial<ContentEntry>[],
+): Record<string, unknown>;
+export function buildContentSourceHealthArtifact(
   entries: Partial<ContentEntry>[],
 ): Record<string, unknown>;
 export function renderEntryLlms(

--- a/packages/registry/src/quality.js
+++ b/packages/registry/src/quality.js
@@ -2,6 +2,36 @@ import categorySpec from "./category-spec.json" with { type: "json" };
 import { getCopyText } from "./presentation.js";
 
 export const QUALITY_REPORT_SCHEMA_VERSION = 2;
+export const SOURCE_HEALTH_REPORT_SCHEMA_VERSION = 1;
+
+// Freshness buckets are derived from the most recent observable source
+// timestamp on an entry (repoUpdatedAt preferred, dateAdded fallback).
+// Bucket thresholds are intentionally aligned with the trust report's
+// verification thresholds (180/365 days) so downstream surfaces can
+// reason about "fresh" / "stale" uniformly across signals.
+export const SOURCE_FRESHNESS_THRESHOLDS = Object.freeze({
+  freshDays: 180,
+  agingDays: 365,
+  staleDays: 730,
+});
+
+// Categories where safety_notes / privacy_notes coverage is meaningful.
+// Pulled from CONTRIBUTING.md and AGENTS.md: hooks, MCP servers,
+// skills, commands, and statuslines should disclose safety/privacy
+// behavior. Other categories (guides, collections, rules) have no
+// runtime side-effects to disclose.
+export const SAFETY_RELEVANT_CATEGORIES = Object.freeze([
+  "hooks",
+  "mcp",
+  "skills",
+  "commands",
+  "statuslines",
+]);
+
+// Categories that ship installable packages whose trust metadata
+// (downloadTrust / packageVerified / packageVerifiedAt) the directory
+// surfaces to users.
+export const PACKAGEABLE_CATEGORIES = Object.freeze(["skills", "mcp"]);
 
 function clean(value) {
   return String(value ?? "").trim();
@@ -332,5 +362,214 @@ export function buildContentPromptReport(entries, maxPrompts = 30) {
     generatedAt: quality.generatedAt,
     count: prompts.length,
     prompts,
+  };
+}
+
+function pickSourceDate(entry) {
+  const repoUpdated = clean(entry.repoUpdatedAt);
+  if (repoUpdated) return { sourceDate: repoUpdated, source: "repoUpdatedAt" };
+  const lastVerified = clean(entry.lastVerifiedAt);
+  if (lastVerified)
+    return { sourceDate: lastVerified, source: "lastVerifiedAt" };
+  const added = clean(entry.dateAdded);
+  if (added) return { sourceDate: added, source: "dateAdded" };
+  return { sourceDate: "", source: "" };
+}
+
+export function deriveSourceFreshness(entry, referenceDate = new Date()) {
+  const { sourceDate, source } = pickSourceDate(entry);
+  if (!sourceDate) {
+    return { bucket: "unknown", ageDays: null, sourceDate: "", source: "" };
+  }
+  const parsed = new Date(sourceDate);
+  if (Number.isNaN(parsed.getTime())) {
+    return { bucket: "unknown", ageDays: null, sourceDate, source };
+  }
+  const referenceTime =
+    referenceDate instanceof Date
+      ? referenceDate.getTime()
+      : new Date(referenceDate).getTime();
+  const ageDays = Math.max(
+    0,
+    Math.floor((referenceTime - parsed.getTime()) / 86_400_000),
+  );
+  let bucket;
+  if (ageDays <= SOURCE_FRESHNESS_THRESHOLDS.freshDays) bucket = "fresh";
+  else if (ageDays <= SOURCE_FRESHNESS_THRESHOLDS.agingDays) bucket = "aging";
+  else if (ageDays <= SOURCE_FRESHNESS_THRESHOLDS.staleDays) bucket = "stale";
+  else bucket = "dormant";
+  return { bucket, ageDays, sourceDate, source };
+}
+
+function hasNonEmptyStringArray(value) {
+  return (
+    Array.isArray(value) &&
+    value.some((item) => clean(typeof item === "string" ? item : "").length > 0)
+  );
+}
+
+function isSafetyRelevant(category) {
+  return SAFETY_RELEVANT_CATEGORIES.includes(category);
+}
+
+function isPackageable(category) {
+  return PACKAGEABLE_CATEGORIES.includes(category);
+}
+
+export function buildEntrySourceHealth(entry, referenceDate = new Date()) {
+  const provenance = buildSourceProvenance(entry);
+  const freshness = deriveSourceFreshness(entry, referenceDate);
+  const hasSafetyNotes = hasNonEmptyStringArray(entry.safetyNotes);
+  const hasPrivacyNotes = hasNonEmptyStringArray(entry.privacyNotes);
+  const sourceBacked =
+    provenance.hasExternalSource ||
+    provenance.hasFirstPartyPackage ||
+    provenance.sourceQuality === "local-editorial-source" ||
+    provenance.sourceQuality === "source-free-first-party";
+  const unprovenancedSource =
+    !provenance.hasExternalSource &&
+    !provenance.hasFirstPartyPackage &&
+    provenance.sourceQuality !== "local-editorial-source" &&
+    provenance.sourceQuality !== "source-free-first-party";
+
+  const safetyRelevant = isSafetyRelevant(entry.category);
+  const packageable = isPackageable(entry.category);
+
+  const missingSafetyNotes = safetyRelevant && !hasSafetyNotes;
+  const missingPrivacyNotes = safetyRelevant && !hasPrivacyNotes;
+  const packageTrust = entry.downloadTrust || null;
+  const packageVerified = entry.packageVerified === true;
+  // Skills/MCP entries that don't disclose a downloadTrust label OR
+  // aren't first-party packages are the ones a tenant needs to evaluate
+  // manually. We don't gate on packageVerified here because community
+  // submissions are intentionally not auto-verified.
+  const missingPackageTrust = packageable && !packageTrust;
+
+  const stale = freshness.bucket === "stale" || freshness.bucket === "dormant";
+  const attentionReasons = [];
+  if (unprovenancedSource) attentionReasons.push("unprovenanced-source");
+  if (stale) attentionReasons.push("stale-source");
+  if (freshness.bucket === "unknown")
+    attentionReasons.push("unknown-source-date");
+  if (missingSafetyNotes) attentionReasons.push("missing-safety-notes");
+  if (missingPrivacyNotes) attentionReasons.push("missing-privacy-notes");
+  if (missingPackageTrust) attentionReasons.push("missing-package-trust");
+
+  return {
+    key: `${entry.category}:${entry.slug}`,
+    category: entry.category,
+    slug: entry.slug,
+    title: entry.title,
+    freshness,
+    sourceBacked,
+    unprovenancedSource,
+    hasSafetyNotes,
+    hasPrivacyNotes,
+    missingSafetyNotes,
+    missingPrivacyNotes,
+    packageTrust,
+    packageVerified,
+    missingPackageTrust,
+    needsAttention: attentionReasons.length > 0,
+    attentionReasons,
+  };
+}
+
+function emptyFreshnessBuckets() {
+  return { fresh: 0, aging: 0, stale: 0, dormant: 0, unknown: 0 };
+}
+
+function incrementBucket(buckets, bucket) {
+  if (Object.hasOwn(buckets, bucket)) {
+    buckets[bucket] += 1;
+  }
+}
+
+function buildSourceHealthCategoryBreakdown(rows) {
+  return Object.fromEntries(
+    categorySpec.categoryOrder.map((category) => {
+      const categoryRows = rows.filter((row) => row.category === category);
+      const buckets = emptyFreshnessBuckets();
+      for (const row of categoryRows) {
+        incrementBucket(buckets, row.freshness.bucket);
+      }
+      return [
+        category,
+        {
+          count: categoryRows.length,
+          freshness: buckets,
+          sourceBackedCount: categoryRows.filter((row) => row.sourceBacked)
+            .length,
+          unprovenancedSourceCount: categoryRows.filter(
+            (row) => row.unprovenancedSource,
+          ).length,
+          missingSafetyNotesCount: categoryRows.filter(
+            (row) => row.missingSafetyNotes,
+          ).length,
+          missingPrivacyNotesCount: categoryRows.filter(
+            (row) => row.missingPrivacyNotes,
+          ).length,
+          missingPackageTrustCount: categoryRows.filter(
+            (row) => row.missingPackageTrust,
+          ).length,
+          packageVerifiedCount: categoryRows.filter(
+            (row) => row.packageVerified,
+          ).length,
+          needsAttentionCount: categoryRows.filter((row) => row.needsAttention)
+            .length,
+        },
+      ];
+    }),
+  );
+}
+
+export function buildSourceHealthReport(entries) {
+  const generatedAt = generatedAtForEntries(entries);
+  const referenceDate = new Date(generatedAt);
+  const rows = entries.map((entry) =>
+    buildEntrySourceHealth(entry, referenceDate),
+  );
+
+  const freshnessBuckets = emptyFreshnessBuckets();
+  for (const row of rows) {
+    incrementBucket(freshnessBuckets, row.freshness.bucket);
+  }
+
+  const sourceBackedCount = rows.filter((row) => row.sourceBacked).length;
+  const unprovenancedSourceCount = rows.filter(
+    (row) => row.unprovenancedSource,
+  ).length;
+  const missingSafetyNotesCount = rows.filter(
+    (row) => row.missingSafetyNotes,
+  ).length;
+  const missingPrivacyNotesCount = rows.filter(
+    (row) => row.missingPrivacyNotes,
+  ).length;
+  const missingPackageTrustCount = rows.filter(
+    (row) => row.missingPackageTrust,
+  ).length;
+  const packageVerifiedCount = rows.filter((row) => row.packageVerified).length;
+  const needsAttentionCount = rows.filter((row) => row.needsAttention).length;
+
+  return {
+    schemaVersion: SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+    kind: "content-source-health-report",
+    generatedAt,
+    count: rows.length,
+    thresholds: { ...SOURCE_FRESHNESS_THRESHOLDS },
+    safetyRelevantCategories: [...SAFETY_RELEVANT_CATEGORIES],
+    packageableCategories: [...PACKAGEABLE_CATEGORIES],
+    summary: {
+      freshness: freshnessBuckets,
+      sourceBackedCount,
+      unprovenancedSourceCount,
+      missingSafetyNotesCount,
+      missingPrivacyNotesCount,
+      missingPackageTrustCount,
+      packageVerifiedCount,
+      needsAttentionCount,
+    },
+    categoryBreakdown: buildSourceHealthCategoryBreakdown(rows),
+    entries: rows,
   };
 }

--- a/tests/source-health-report.test.ts
+++ b/tests/source-health-report.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PACKAGEABLE_CATEGORIES,
+  SAFETY_RELEVANT_CATEGORIES,
+  SOURCE_FRESHNESS_THRESHOLDS,
+  SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+  buildContentSourceHealthArtifact,
+  buildEntrySourceHealth,
+  buildSourceHealthReport,
+  deriveSourceFreshness,
+} from "@heyclaude/registry";
+
+// Reference date is fixed so freshness math is deterministic regardless
+// of when the suite runs. Pick a date that places one entry in each
+// freshness bucket the fixture set exercises.
+const REFERENCE_DATE = new Date("2026-01-01T00:00:00.000Z");
+
+function isoDaysAgo(days: number): string {
+  const d = new Date(REFERENCE_DATE.getTime() - days * 86_400_000);
+  return d.toISOString().slice(0, 10);
+}
+
+describe("deriveSourceFreshness", () => {
+  it("returns fresh when source date is within the fresh threshold", () => {
+    const result = deriveSourceFreshness(
+      { repoUpdatedAt: isoDaysAgo(30) },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("fresh");
+    expect(result.ageDays).toBe(30);
+    expect(result.source).toBe("repoUpdatedAt");
+  });
+
+  it("returns aging when source date is between fresh and aging thresholds", () => {
+    const result = deriveSourceFreshness(
+      { repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.freshDays + 5) },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("aging");
+  });
+
+  it("returns stale when source date is between aging and stale thresholds", () => {
+    const result = deriveSourceFreshness(
+      { repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.agingDays + 5) },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("stale");
+  });
+
+  it("returns dormant when source date is older than the stale threshold", () => {
+    const result = deriveSourceFreshness(
+      { repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.staleDays + 1) },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("dormant");
+  });
+
+  it("falls back to dateAdded when repoUpdatedAt is missing", () => {
+    const result = deriveSourceFreshness(
+      { dateAdded: isoDaysAgo(60) },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("fresh");
+    expect(result.source).toBe("dateAdded");
+  });
+
+  it("returns unknown bucket when no usable date is present", () => {
+    const result = deriveSourceFreshness({}, REFERENCE_DATE);
+    expect(result.bucket).toBe("unknown");
+    expect(result.ageDays).toBeNull();
+    expect(result.source).toBe("");
+  });
+
+  it("returns unknown bucket when the date string fails to parse", () => {
+    const result = deriveSourceFreshness(
+      { repoUpdatedAt: "not-a-date" },
+      REFERENCE_DATE,
+    );
+    expect(result.bucket).toBe("unknown");
+    expect(result.ageDays).toBeNull();
+  });
+});
+
+describe("buildEntrySourceHealth", () => {
+  it("flags safety-relevant categories when safetyNotes / privacyNotes are missing", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "hooks",
+        slug: "test-hook",
+        title: "Test Hook",
+        repoUpdatedAt: isoDaysAgo(10),
+        repoUrl: "https://github.com/example/hook",
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.missingSafetyNotes).toBe(true);
+    expect(result.missingPrivacyNotes).toBe(true);
+    expect(result.attentionReasons).toEqual(
+      expect.arrayContaining(["missing-safety-notes", "missing-privacy-notes"]),
+    );
+    expect(result.needsAttention).toBe(true);
+  });
+
+  it("does not flag categories where safety/privacy notes are not expected", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "guides",
+        slug: "test-guide",
+        title: "Test Guide",
+        repoUpdatedAt: isoDaysAgo(10),
+        documentationUrl: "https://example.com/docs",
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.missingSafetyNotes).toBe(false);
+    expect(result.missingPrivacyNotes).toBe(false);
+  });
+
+  it("flags packageable categories without a downloadTrust label", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "skills",
+        slug: "test-skill",
+        title: "Test Skill",
+        repoUrl: "https://github.com/example/skill",
+        repoUpdatedAt: isoDaysAgo(10),
+        safetyNotes: ["runs in sandbox"],
+        privacyNotes: ["no telemetry"],
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.missingPackageTrust).toBe(true);
+    expect(result.attentionReasons).toContain("missing-package-trust");
+  });
+
+  it("does not flag missingPackageTrust when downloadTrust is provided", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "skills",
+        slug: "trusted-skill",
+        title: "Trusted Skill",
+        repoUrl: "https://github.com/example/trusted",
+        repoUpdatedAt: isoDaysAgo(10),
+        downloadTrust: "first-party",
+        safetyNotes: ["runs in sandbox"],
+        privacyNotes: ["no telemetry"],
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.missingPackageTrust).toBe(false);
+    expect(result.packageTrust).toBe("first-party");
+  });
+
+  it("flags an unprovenanced source when the only source URL is a self-reference", () => {
+    // buildSourceProvenance (existing behavior) treats an entry whose
+    // sole source URL points back at the awesome-claude repo as having
+    // hasExternalSource=false despite hasRepository=true — the edge
+    // case the unprovenanced flag exists to catch.
+    const result = buildEntrySourceHealth(
+      {
+        category: "tools",
+        slug: "self-referencing-entry",
+        title: "Self Referencing Entry",
+        repoUrl: "https://github.com/JSONbored/awesome-claude",
+        repoUpdatedAt: isoDaysAgo(10),
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.unprovenancedSource).toBe(true);
+    expect(result.sourceBacked).toBe(false);
+    expect(result.attentionReasons).toContain("unprovenanced-source");
+  });
+
+  it("flags stale-source when freshness bucket is stale or dormant", () => {
+    const stale = buildEntrySourceHealth(
+      {
+        category: "guides",
+        slug: "stale-guide",
+        title: "Stale Guide",
+        repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.agingDays + 30),
+        documentationUrl: "https://example.com/docs",
+      },
+      REFERENCE_DATE,
+    );
+    expect(stale.freshness.bucket).toBe("stale");
+    expect(stale.attentionReasons).toContain("stale-source");
+
+    const dormant = buildEntrySourceHealth(
+      {
+        category: "guides",
+        slug: "dormant-guide",
+        title: "Dormant Guide",
+        repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.staleDays + 30),
+        documentationUrl: "https://example.com/docs",
+      },
+      REFERENCE_DATE,
+    );
+    expect(dormant.freshness.bucket).toBe("dormant");
+    expect(dormant.attentionReasons).toContain("stale-source");
+  });
+
+  it("treats safetyNotes containing only blank strings as missing", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "mcp",
+        slug: "blank-notes",
+        title: "Blank Notes",
+        repoUrl: "https://github.com/example/mcp",
+        repoUpdatedAt: isoDaysAgo(10),
+        safetyNotes: ["   "],
+        privacyNotes: [""],
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.hasSafetyNotes).toBe(false);
+    expect(result.hasPrivacyNotes).toBe(false);
+    expect(result.missingSafetyNotes).toBe(true);
+    expect(result.missingPrivacyNotes).toBe(true);
+  });
+
+  it("produces an empty attentionReasons array for fully-provisioned entries", () => {
+    const result = buildEntrySourceHealth(
+      {
+        category: "mcp",
+        slug: "well-covered",
+        title: "Well Covered",
+        repoUrl: "https://github.com/example/mcp",
+        documentationUrl: "https://example.com/docs",
+        repoUpdatedAt: isoDaysAgo(10),
+        downloadTrust: "community",
+        packageVerified: true,
+        safetyNotes: ["read-only access"],
+        privacyNotes: ["no data persisted"],
+      },
+      REFERENCE_DATE,
+    );
+    expect(result.attentionReasons).toEqual([]);
+    expect(result.needsAttention).toBe(false);
+    expect(result.packageVerified).toBe(true);
+  });
+});
+
+describe("buildSourceHealthReport", () => {
+  // Pinning the latest dateAdded to the REFERENCE_DATE makes
+  // generatedAtForEntries() return REFERENCE_DATE exactly, so the per-entry
+  // freshness calculations in the report match the isoDaysAgo offsets the
+  // test fixture uses below. Without this, the report would pick the
+  // latest dateAdded in the fixture as its reference and the bucket
+  // assertions would drift.
+  const entries = [
+    // Fresh, fully provisioned mcp entry — no attention needed.
+    {
+      category: "mcp",
+      slug: "fresh-mcp",
+      title: "Fresh MCP",
+      repoUrl: "https://github.com/example/fresh-mcp",
+      documentationUrl: "https://example.com/fresh-mcp",
+      repoUpdatedAt: isoDaysAgo(15),
+      downloadTrust: "first-party",
+      packageVerified: true,
+      safetyNotes: ["sandboxed network access"],
+      privacyNotes: ["no telemetry"],
+      dateAdded: REFERENCE_DATE.toISOString().slice(0, 10),
+    },
+    // Aging hook with missing safety/privacy disclosure — counts toward
+    // every missing-notes aggregate, and needs attention.
+    {
+      category: "hooks",
+      slug: "aging-hook",
+      title: "Aging Hook",
+      repoUrl: "https://github.com/example/aging-hook",
+      repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.freshDays + 30),
+      dateAdded: isoDaysAgo(400),
+    },
+    // Stale guide with documentation — counts as stale freshness, no
+    // safety/privacy flags because guides aren't safety-relevant.
+    {
+      category: "guides",
+      slug: "stale-guide",
+      title: "Stale Guide",
+      documentationUrl: "https://example.com/guide",
+      repoUpdatedAt: isoDaysAgo(SOURCE_FRESHNESS_THRESHOLDS.agingDays + 30),
+      dateAdded: isoDaysAgo(500),
+    },
+    // Unknown-date tool with no usable source — buildSourceProvenance's
+    // default for entries with nothing set is "source-free-first-party",
+    // so this counts as sourceBacked (the "editorial first-party"
+    // default) but registers as unknown-freshness because no date is
+    // available. The unknown-source-date attention reason fires.
+    {
+      category: "tools",
+      slug: "unknown-tool",
+      title: "Unknown Tool",
+    },
+    // Skill missing package trust + safety disclosure — counts toward
+    // both missingPackageTrust and the safety aggregates.
+    {
+      category: "skills",
+      slug: "needs-trust",
+      title: "Needs Trust",
+      repoUrl: "https://github.com/example/needs-trust",
+      repoUpdatedAt: isoDaysAgo(30),
+      dateAdded: isoDaysAgo(50),
+    },
+  ];
+
+  const report = buildSourceHealthReport(entries);
+
+  it("produces the documented schema envelope", () => {
+    expect(report).toMatchObject({
+      schemaVersion: SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
+      kind: "content-source-health-report",
+      count: entries.length,
+      thresholds: SOURCE_FRESHNESS_THRESHOLDS,
+      safetyRelevantCategories: SAFETY_RELEVANT_CATEGORIES,
+      packageableCategories: PACKAGEABLE_CATEGORIES,
+    });
+    // generatedAt must be a fixed ISO derived from the latest dateAdded
+    // — never `now()` — so the artifact stays deterministic across runs.
+    expect(report.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("counts each freshness bucket from the per-entry derivation", () => {
+    const summary = report.summary as Record<string, unknown>;
+    expect(summary.freshness).toEqual({
+      fresh: 2, // fresh-mcp, needs-trust
+      aging: 1, // aging-hook
+      stale: 1, // stale-guide
+      dormant: 0,
+      unknown: 1, // unknown-tool
+    });
+  });
+
+  it("aggregates per-entry health flags into summary counts", () => {
+    const summary = report.summary as Record<string, unknown>;
+    // All five fixture entries register as sourceBacked: fresh-mcp,
+    // aging-hook, stale-guide, and needs-trust have real source URLs;
+    // unknown-tool falls through to the existing buildSourceProvenance
+    // default of "source-free-first-party" (editorial first-party).
+    expect(summary.sourceBackedCount).toBe(5);
+    // None of the fixture entries trip the narrow unprovenanced
+    // condition (self-referencing repo URL with no other source);
+    // that case is exercised in the per-entry test above.
+    expect(summary.unprovenancedSourceCount).toBe(0);
+    // safety-relevant entries missing notes: aging-hook + needs-trust.
+    expect(summary.missingSafetyNotesCount).toBe(2);
+    expect(summary.missingPrivacyNotesCount).toBe(2);
+    // skills/mcp entries without downloadTrust: needs-trust only.
+    expect(summary.missingPackageTrustCount).toBe(1);
+    expect(summary.packageVerifiedCount).toBe(1); // fresh-mcp
+    // Everything except fresh-mcp needs attention: aging-hook (missing
+    // notes), stale-guide (stale-source), unknown-tool (unknown date),
+    // needs-trust (missing notes + missing package trust).
+    expect(summary.needsAttentionCount).toBe(4);
+  });
+
+  it("breaks down counts per category for downstream filter UIs", () => {
+    const breakdown = report.categoryBreakdown as Record<
+      string,
+      { count: number; freshness: Record<string, number>; needsAttentionCount: number }
+    >;
+    expect(breakdown.mcp.count).toBe(1);
+    expect(breakdown.mcp.freshness.fresh).toBe(1);
+    expect(breakdown.mcp.needsAttentionCount).toBe(0);
+    expect(breakdown.hooks.freshness.aging).toBe(1);
+    expect(breakdown.hooks.needsAttentionCount).toBe(1);
+    expect(breakdown.guides.freshness.stale).toBe(1);
+    expect(breakdown.tools.freshness.unknown).toBe(1);
+    expect(breakdown.skills.needsAttentionCount).toBe(1);
+    // Categories with no entries report zero across every bucket — this
+    // keeps the breakdown a stable shape downstream surfaces can rely on.
+    expect(breakdown.agents).toEqual({
+      count: 0,
+      freshness: { fresh: 0, aging: 0, stale: 0, dormant: 0, unknown: 0 },
+      sourceBackedCount: 0,
+      unprovenancedSourceCount: 0,
+      missingSafetyNotesCount: 0,
+      missingPrivacyNotesCount: 0,
+      missingPackageTrustCount: 0,
+      packageVerifiedCount: 0,
+      needsAttentionCount: 0,
+    });
+  });
+
+  it("is deterministic across repeated builds", () => {
+    expect(buildSourceHealthReport(entries)).toEqual(report);
+  });
+
+  it("exposes the same report through buildContentSourceHealthArtifact", () => {
+    expect(buildContentSourceHealthArtifact(entries)).toEqual(report);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Adds a deterministic source-health report builder that flags freshness, source-backing, safety/privacy disclosure, and package-trust coverage on every entry.
- Provides a per-category breakdown plus summary aggregates that downstream surfaces (`/quality`, browse filters, API facets, MCP, Raycast) can consume in follow-up PRs.
- Leaves the existing `buildContentQualityArtifact` shape untouched — the new builder is a separate artifact (`SOURCE_HEALTH_REPORT_SCHEMA_VERSION = 1`), no churn to existing snapshots.

Closes #448

## Submission Source

- [ ] New content file(s) added under `content/<category>/`
- [ ] Existing content updated
- [x] Submission issue resolved (link it here): #448
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks

- [ ] `pnpm validate:content` passed _(this PR adds no content; not applicable)_
- [ ] `pnpm validate:packages` passed _(no package metadata changed)_
- [ ] `pnpm scan:packages` passed when package artifacts changed _(not applicable)_
- [ ] `pnpm audit:content` ran and I reviewed findings _(no content edits)_
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete
- [ ] Skill submissions include capability metadata _(not applicable)_

## Validation

- [x] Local build passed (`pnpm build`)
- [x] I spot-checked the affected detail page(s) _(this PR only adds pure builder functions; existing detail pages and the existing `content-quality-report.json` snapshot test pass unchanged)_

Issue-mandated checks:

```
$ pnpm test:registry-artifacts
✓ tests/registry-artifacts.test.ts (18 tests)
  ✓ derives all generated aggregate artifacts from registry builders   340ms
  ✓ publishes registry moat feeds with deterministic contract hashes   312ms

$ pnpm validate:raycast-feed
Validated 386 Raycast feed entries.

$ pnpm build
... clean ...

$ git diff --check
... clean ...
```

Plus the new test file:

```
$ pnpm exec vitest run tests/source-health-report.test.ts
✓ tests/source-health-report.test.ts (21 tests)
```

## What's in the diff

| File | Change |
| --- | --- |
| `packages/registry/src/quality.js` | New exports: `SOURCE_HEALTH_REPORT_SCHEMA_VERSION`, `SOURCE_FRESHNESS_THRESHOLDS`, `SAFETY_RELEVANT_CATEGORIES`, `PACKAGEABLE_CATEGORIES`, `deriveSourceFreshness`, `buildEntrySourceHealth`, `buildSourceHealthReport`. Existing `buildContentQualityReport` shape and `QUALITY_REPORT_SCHEMA_VERSION` are unchanged. |
| `packages/registry/src/artifacts.js` | New thin wrapper `buildContentSourceHealthArtifact(entries)` so the builder is reachable from the same export surface as the other quality/trust artifact wrappers. Not added to `buildRegistryArtifactSet`'s `files` array — maintainer can wire that in along with the regenerated `apps/web/public/data/**` snapshot. |
| `packages/registry/src/index.d.ts` | TypeScript declarations for the new exports + `EntrySourceHealth` / `SourceFreshnessBucket` types. |
| `tests/source-health-report.test.ts` | 21 deterministic test cases covering each freshness bucket, each attention reason, category-specific gating of safety/privacy/package flags, the unprovenanced-source edge case (self-referencing repo URL), summary aggregates, and per-category breakdown shape. |

## Design notes

- **Freshness thresholds** (180 / 365 / 730 days) intentionally match the existing `registry-trust-report.json` thresholds so downstream consumers can reason about "fresh" uniformly across the two reports.
- **Safety-relevance** (`hooks`, `mcp`, `skills`, `commands`, `statuslines`) and **packageable categories** (`skills`, `mcp`) are pulled from `AGENTS.md` and `CONTRIBUTING.md`. Other categories (`guides`, `collections`, `rules`, etc.) don't get safety/privacy flags because they have no runtime side-effects to disclose.
- **`unprovenancedSource`** triggers only when an entry has `hasRepository`/`hasDocumentation` but every resolved URL is filtered out as a self-reference to `github.com/JSONbored/awesome-claude` — matching the existing `buildContentQualityReport.summary.unprovenancedSourceCount` definition. An entry with NO fields at all still falls through to `buildSourceProvenance`'s default `source-free-first-party` label (editorial first-party), per existing behavior.
- **Source date precedence**: `repoUpdatedAt` > `lastVerifiedAt` > `dateAdded`. The chosen source field is recorded in the per-entry output for transparency.

## Notes

- Generated artifact churn from `pnpm build` under `apps/web/public/data/**` is intentionally not included in this PR per `CONTRIBUTING.md` ("Do not edit these in external content PRs"). Maintainer automation regenerates those outputs and can publish the new `content-source-health-report.json` alongside.
- `Rerank` of `/quality`, browse/API facets, MCP, and Raycast consumption — all marked as follow-ups by the issue's own scope statement — are intentionally left for separate PRs once the underlying report is merged.
- I do not overclaim Gittensor rewards. The repo is listed on Gittensor; eligibility and rewards follow Gittensor's current rules.
