### PR TITLE
fix(api): reject mismatched community signal targets

### DIFF
--- a/apps/web/src/app/api/community-signals/query/route.ts
+++ b/apps/web/src/app/api/community-signals/query/route.ts
@@ -6,8 +6,7 @@ import {
   type InferApiBody,
 } from "@/lib/api/router";
 import {
-  normalizeCommunityTargetKey,
-  normalizeCommunityTargetKind,
+  normalizeCommunitySignalTarget,
   safeCommunitySignalCounts,
   type CommunitySignalTarget,
 } from "@/lib/community-signals";
@@ -21,16 +20,18 @@ export const POST = createApiHandler(
     const targets: CommunitySignalTarget[] = [];
 
     for (const target of payload.targets || []) {
-      const targetKind = normalizeCommunityTargetKind(target.targetKind);
-      const targetKey = normalizeCommunityTargetKey(target.targetKey);
-      if (!targetKind || !targetKey) {
+      const normalizedTarget = normalizeCommunitySignalTarget(
+        target.targetKind,
+        target.targetKey,
+      );
+      if (!normalizedTarget) {
         return apiError("invalid_payload", 400, {
           requestId,
           message:
             "Provide targets as entry/tool with keys like entry:<category>/<slug> or tool:<slug>.",
         });
       }
-      targets.push({ targetKind, targetKey });
+      targets.push(normalizedTarget);
     }
 
     const { available, counts } = await safeCommunitySignalCounts(targets);

--- a/apps/web/src/app/api/community-signals/route.ts
+++ b/apps/web/src/app/api/community-signals/route.ts
@@ -12,9 +12,8 @@ import {
 import { logApiWarn } from "@/lib/api-logs";
 import {
   normalizeCommunityClientId,
+  normalizeCommunitySignalTarget,
   normalizeCommunitySignalType,
-  normalizeCommunityTargetKey,
-  normalizeCommunityTargetKind,
   queryCommunitySignalCounts,
   safeCommunitySignalCounts,
   ZERO_COMMUNITY_SIGNAL_COUNTS,
@@ -25,10 +24,12 @@ export const GET = createApiHandler(
   "communitySignals.read",
   async ({ query, requestId }) => {
     const payload = query as InferApiQuery<typeof communitySignalsQuerySchema>;
-    const targetKind = normalizeCommunityTargetKind(payload.targetKind);
-    const targetKey = normalizeCommunityTargetKey(payload.targetKey);
+    const target = normalizeCommunitySignalTarget(
+      payload.targetKind,
+      payload.targetKey,
+    );
 
-    if (!targetKind || !targetKey) {
+    if (!target) {
       return apiError("invalid_payload", 400, {
         requestId,
         message:
@@ -36,9 +37,8 @@ export const GET = createApiHandler(
       });
     }
 
-    const { available, counts } = await safeCommunitySignalCounts([
-      { targetKind, targetKey },
-    ]);
+    const { targetKind, targetKey } = target;
+    const { available, counts } = await safeCommunitySignalCounts([target]);
     return apiJson({
       ok: true,
       available,
@@ -53,18 +53,21 @@ export const POST = createApiHandler(
   "communitySignals.write",
   async ({ body, request, requestId }) => {
     const payload = body as InferApiBody<typeof communitySignalsBodySchema>;
-    const targetKind = normalizeCommunityTargetKind(payload.targetKind);
-    const targetKey = normalizeCommunityTargetKey(payload.targetKey);
+    const target = normalizeCommunitySignalTarget(
+      payload.targetKind,
+      payload.targetKey,
+    );
     const signalType = normalizeCommunitySignalType(payload.signalType);
     const clientId = normalizeCommunityClientId(payload.clientId);
 
-    if (!targetKind || !targetKey || !signalType || !clientId) {
+    if (!target || !signalType || !clientId) {
       return apiError("invalid_payload", 400, {
         requestId,
         message: "Provide targetKind, targetKey, signalType, and clientId.",
       });
     }
 
+    const { targetKind, targetKey } = target;
     try {
       const db = getSiteDb();
       if (!db) {
@@ -108,9 +111,7 @@ export const POST = createApiHandler(
           .run();
       }
 
-      const counts = await queryCommunitySignalCounts(db, [
-        { targetKind, targetKey },
-      ]);
+      const counts = await queryCommunitySignalCounts(db, [target]);
       return apiJson(
         {
           ok: true,
@@ -136,9 +137,7 @@ export const POST = createApiHandler(
         });
       }
 
-      const { counts } = await safeCommunitySignalCounts([
-        { targetKind, targetKey },
-      ]);
+      const { counts } = await safeCommunitySignalCounts([target]);
       return apiJson(
         {
           ok: true,

--- a/apps/web/src/lib/community-signals.ts
+++ b/apps/web/src/lib/community-signals.ts
@@ -52,6 +52,23 @@ export function normalizeCommunityTargetKey(
     : null;
 }
 
+export function normalizeCommunitySignalTarget(
+  targetKindValue: string | null | undefined,
+  targetKeyValue: string | null | undefined,
+): CommunitySignalTarget | null {
+  const targetKind = normalizeCommunityTargetKind(targetKindValue);
+  const targetKey = normalizeCommunityTargetKey(targetKeyValue);
+  if (!targetKind || !targetKey) return null;
+
+  const isEntryTarget =
+    targetKind === "entry" &&
+    /^entry:[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9-]*$/.test(targetKey);
+  const isToolTarget =
+    targetKind === "tool" && /^tool:[a-z0-9][a-z0-9-]*$/.test(targetKey);
+
+  return isEntryTarget || isToolTarget ? { targetKind, targetKey } : null;
+}
+
 export function normalizeCommunityClientId(
   value: string | null | undefined,
 ): string | null {

--- a/tests/d1-dynamic-state.test.ts
+++ b/tests/d1-dynamic-state.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../apps/web/src/lib/votes";
 import {
   getFallbackCommunitySignalCounts,
+  normalizeCommunitySignalTarget,
   queryCommunitySignalCounts,
 } from "../apps/web/src/lib/community-signals";
 import {
@@ -325,6 +326,30 @@ describe("D1 dynamic state helpers", () => {
       "entry:mcp/example-server": { used: 2, works: 1, broken: 0 },
       "tool:cursor": { used: 0, works: 0, broken: 1 },
     });
+  });
+
+  it("normalizes community signal target kind and key together", () => {
+    expect(
+      normalizeCommunitySignalTarget("entry", "entry:mcp/example-server"),
+    ).toEqual({
+      targetKind: "entry",
+      targetKey: "entry:mcp/example-server",
+    });
+    expect(normalizeCommunitySignalTarget("tool", "tool:cursor")).toEqual({
+      targetKind: "tool",
+      targetKey: "tool:cursor",
+    });
+
+    expect(normalizeCommunitySignalTarget("entry", "tool:cursor")).toBeNull();
+    expect(
+      normalizeCommunitySignalTarget("tool", "entry:mcp/example-server"),
+    ).toBeNull();
+    expect(
+      normalizeCommunitySignalTarget("entry", "entry:missing-slug"),
+    ).toBeNull();
+    expect(
+      normalizeCommunitySignalTarget("tool", "tool:cursor/extra"),
+    ).toBeNull();
   });
 
   it("aggregates 30-day intent events by entry key", async () => {

--- a/tests/dynamic-api-routes.test.ts
+++ b/tests/dynamic-api-routes.test.ts
@@ -59,6 +59,22 @@ describe("dynamic API route fallback behavior", () => {
     });
   });
 
+  it("rejects mismatched community-signal read targets", async () => {
+    const { GET } = await import("@/app/api/community-signals/route");
+
+    const response = await GET(
+      new Request(
+        "https://heyclau.de/api/community-signals?targetKind=entry&targetKey=tool:cursor",
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_payload" },
+    });
+  });
+
   it("accepts community-signal writes without storing when SITE_DB is unavailable", async () => {
     const { POST } = await import("@/app/api/community-signals/route");
 
@@ -78,6 +94,26 @@ describe("dynamic API route fallback behavior", () => {
       stored: false,
       available: false,
       counts: { used: 0, works: 0, broken: 0 },
+    });
+  });
+
+  it("rejects mismatched community-signal write targets", async () => {
+    const { POST } = await import("@/app/api/community-signals/route");
+
+    const response = await POST(
+      jsonRequest("/api/community-signals", {
+        targetKind: "tool",
+        targetKey: "entry:mcp/asana-mcp-server",
+        signalType: "used",
+        clientId: "dynamic-route-client-0001",
+        active: true,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_payload" },
     });
   });
 
@@ -102,6 +138,27 @@ describe("dynamic API route fallback behavior", () => {
       counts: {
         "entry:mcp/asana-mcp-server": { used: 0, works: 0, broken: 0 },
       },
+    });
+  });
+
+  it("rejects mismatched batch community-signal targets", async () => {
+    const { POST } = await import("@/app/api/community-signals/query/route");
+
+    const response = await POST(
+      jsonRequest("/api/community-signals/query", {
+        targets: [
+          {
+            targetKind: "entry",
+            targetKey: "tool:cursor",
+          },
+        ],
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_payload" },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Validate community signal target kind and key as one normalized pair.
- Reject mismatched entry/tool targets across read, write, and batch signal routes.
- Add regression coverage for mismatched targets before dynamic state is read or written.

## Why
Closes #481.

## Validation
- `pnpm exec vitest run tests/d1-dynamic-state.test.ts tests/dynamic-api-routes.test.ts tests/api-contracts.test.ts`
- `pnpm validate:openapi`
- `pnpm build`
- `pnpm test`
- `git diff --check`
- Codex Security diff scan: 0 reportable findings
