### PR TITLE
fix(security): redact split CLI flag secrets

### DIFF
--- a/apps/web/src/lib/mcp-config-validator.ts
+++ b/apps/web/src/lib/mcp-config-validator.ts
@@ -24,8 +24,24 @@ const SENSITIVE_ENV_PATTERN =
 const PLACEHOLDER_PATTERN =
   /(\$\{[A-Z0-9_]+\}|YOUR_|REPLACE_|INSERT_|<[^>]+>|\bxxx+\b|\bTODO\b)/i;
 const SECRET_VALUE_PATTERN =
-  /\b(ghp_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{40,}|sk-[A-Za-z0-9]{20,}|AKIA[0-9A-Z]{16}|Bearer\s+[A-Za-z0-9._~+/=-]{16,})\b/;
+  /\b(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{40,}|glpat-[A-Za-z0-9_-]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|AIza[0-9A-Za-z_-]{20,}|Bearer\s+[A-Za-z0-9._~+/=-]{16,})\b/;
 const SHELL_OPERATOR_PATTERN = /(?:&&|\|\||[;|`<>]|\$\()/;
+const SENSITIVE_SPLIT_ARG_KEYS = new Set([
+  "api_key",
+  "apikey",
+  "auth",
+  "authorization",
+  "bearer",
+  "client_secret",
+  "clientsecret",
+  "password",
+  "private_key",
+  "privatekey",
+  "secret",
+  "token",
+  "x_api_key",
+  "xapikey",
+]);
 
 function decodePlaceholderTokens(value: string) {
   return value
@@ -119,6 +135,52 @@ function redactArgValue(value: string) {
   return { value, redactedCount: 0 };
 }
 
+function splitArgPlaceholder(value: string) {
+  const normalized = value.trim();
+  if (!normalized.startsWith("-") || normalized.includes("=")) return "";
+  const key = normalized
+    .replace(/^-+/, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return SENSITIVE_SPLIT_ARG_KEYS.has(key)
+    ? key.toUpperCase().replace(/[^A-Z0-9_]/g, "_")
+    : "";
+}
+
+function redactArgArray(values: unknown[]): SanitizedValue {
+  let redactedCount = 0;
+  let pendingPlaceholder = "";
+  const sanitizedItems = values.map((item) => {
+    if (typeof item !== "string") {
+      pendingPlaceholder = "";
+      const sanitized = sanitizeConfigValue("args", item);
+      redactedCount += sanitized.redactedCount;
+      return sanitized.value;
+    }
+
+    const normalized = item.trim();
+    if (
+      pendingPlaceholder &&
+      normalized &&
+      !normalized.startsWith("-") &&
+      !PLACEHOLDER_PATTERN.test(normalized)
+    ) {
+      const placeholder = pendingPlaceholder;
+      redactedCount += 1;
+      pendingPlaceholder = "";
+      return `\${${placeholder || "SECRET"}}`;
+    }
+
+    const sanitized = redactArgValue(item);
+    redactedCount += sanitized.redactedCount;
+    pendingPlaceholder = splitArgPlaceholder(item);
+    return sanitized.value;
+  });
+  return { value: sanitizedItems, redactedCount };
+}
+
 type SanitizedValue = {
   value: unknown;
   redactedCount: number;
@@ -126,6 +188,7 @@ type SanitizedValue = {
 
 function sanitizeConfigValue(key: string, value: unknown): SanitizedValue {
   if (Array.isArray(value)) {
+    if (key.toLowerCase() === "args") return redactArgArray(value);
     let redactedCount = 0;
     const sanitizedItems = value.map((item) => {
       const sanitized = sanitizeConfigValue(key, item);
@@ -292,9 +355,11 @@ function validateServer(name: string, raw: unknown) {
       "command must be an executable name/path, not a shell pipeline.",
     );
   }
-  for (const arg of args) {
+  for (const [index, arg] of args.entries()) {
     if (SHELL_OPERATOR_PATTERN.test(arg)) {
-      warnings.push(`Argument contains shell-like syntax: ${arg}`);
+      warnings.push(
+        `Argument contains shell-like syntax: ${sanitizedArgs[index] ?? "${SECRET}"}`,
+      );
     }
   }
   if (command) {

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -96,6 +96,89 @@ describe("MCP config validator", () => {
     }
   });
 
+  it("redacts values after sensitive split CLI flags", () => {
+    const result = validateMcpConfigText(
+      JSON.stringify({
+        mcpServers: {
+          splitFlagSecrets: {
+            command: "npx",
+            args: [
+              "-y",
+              "@example/secure-mcp",
+              "--api-key",
+              "live_api_key_value_that_must;not_leak",
+              "--mode",
+              "read",
+              "--client-secret",
+              "sk-proj-clientsecretvaluethatmustnotleak",
+              "--token",
+              "${EXISTING_TOKEN}",
+              "--authorization",
+              "Bearer abcdefghijklmnopqrstuvwxyz123456",
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.redactedSecretCount).toBe(3);
+    expect(result.servers[0]).toMatchObject({
+      packageName: "@example/secure-mcp",
+    });
+    const fixed = JSON.parse(result.fixedConfigText);
+    expect(fixed.mcpServers.splitFlagSecrets.args).toEqual([
+      "-y",
+      "@example/secure-mcp",
+      "--api-key",
+      "${API_KEY}",
+      "--mode",
+      "read",
+      "--client-secret",
+      "${CLIENT_SECRET}",
+      "--token",
+      "${EXISTING_TOKEN}",
+      "--authorization",
+      "${AUTHORIZATION}",
+    ]);
+    for (const output of [result.fixedConfigText, result.reportText]) {
+      expect(output).not.toContain("live_api_key_value_that_must;not_leak");
+      expect(output).not.toContain("sk-proj-clientsecretvaluethatmustnotleak");
+      expect(output).not.toContain("abcdefghijklmnopqrstuvwxyz123456");
+    }
+    expect(result.reportText).toContain(
+      "Argument contains shell-like syntax: ${API_KEY}",
+    );
+  });
+
+  it("redacts modern raw token prefixes from command args", () => {
+    const result = validateMcpConfigText(
+      JSON.stringify({
+        mcpServers: {
+          rawTokenArgs: {
+            command: "npx",
+            args: [
+              "-y",
+              "@example/token-mcp",
+              "gho_abcdefghijklmnopqrstuvwxyz123456",
+              "glpat-abcdefghijklmnopqrstuvwxyz123456",
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.redactedSecretCount).toBe(2);
+    expect(result.fixedConfigText).not.toContain(
+      "gho_abcdefghijklmnopqrstuvwxyz123456",
+    );
+    expect(result.fixedConfigText).not.toContain(
+      "glpat-abcdefghijklmnopqrstuvwxyz123456",
+    );
+    expect(result.fixedConfigText).toContain("${SECRET}");
+  });
+
   it("preserves non-sensitive primitive values in fixed snippets", () => {
     const result = validateMcpConfigText(
       JSON.stringify({


### PR DESCRIPTION
## Summary
- Redact values that follow sensitive MCP command flags before validator output is rendered.
- Extend raw token prefix detection for common modern token formats.
- Keep package names and non-sensitive args intact while ensuring shell-syntax warnings use sanitized args.

## Why
Closes #483.

Intended labels: `bug`, `security`, `mcp`.

## Validation
- `pnpm exec vitest run tests/mcp-config-validator.test.ts`
- `pnpm build`
- `pnpm test`
- `git diff --check`
- Codex Security diff scan: 0 reportable findings
