### PR TITLE
fix(api): avoid overlapping registry search nextOffset near cap

### DIFF
--- a/apps/web/src/app/api/registry/search/route.ts
+++ b/apps/web/src/app/api/registry/search/route.ts
@@ -41,7 +41,8 @@ export const GET = createApiHandler(
     const matched = filterEntries(entries, filters);
     const results = matched.slice(offset, offset + limit);
     const facets = computeRegistrySearchFacets(entries, filters);
-    const nextOffset = Math.min(offset + limit, MAX_OFFSET);
+    const pageEnd = Math.min(offset + limit, matched.length);
+    const nextOffset = Math.min(pageEnd, MAX_OFFSET);
 
     return cachedJsonResponse(
       request,
@@ -62,7 +63,7 @@ export const GET = createApiHandler(
         limit,
         offset,
         nextOffset:
-          nextOffset < matched.length && nextOffset !== offset
+          nextOffset !== offset && nextOffset === pageEnd && nextOffset < matched.length
             ? nextOffset
             : null,
         results,

--- a/tests/registry-search-api.test.ts
+++ b/tests/registry-search-api.test.ts
@@ -100,7 +100,7 @@ describe("/api/registry/search", () => {
     await expect(cappedPage.json()).resolves.toMatchObject({
       count: 11,
       total: 10_001,
-      nextOffset: 10_000,
+      nextOffset: null,
     });
 
     const finalPage = await GET(


### PR DESCRIPTION
### Motivation
- The registry search endpoint could advertise a `nextOffset` that falls inside the current page when requests are near the configured `10_000` offset cap, causing clients that follow the cursor to receive duplicate results.

### Description
- Compute the actual page end as `pageEnd = Math.min(offset + limit, matched.length)` and clamp `nextOffset` to `Math.min(pageEnd, MAX_OFFSET)` in `apps/web/src/app/api/registry/search/route.ts`.
- Only return `nextOffset` when it exactly equals the current `pageEnd` and there are additional results (`nextOffset < matched.length`), preventing an advertised cursor that points into the current page.
- Preserve existing page slicing (`matched.slice(offset, offset + limit)`) so result contents are unchanged; only the pagination metadata is corrected.
- Update the capped-page test case in `tests/registry-search-api.test.ts` to expect `nextOffset: null` for the `offset=9990&limit=50` scenario.

### Testing
- Ran `pnpm exec vitest run tests/registry-search-api.test.ts`, and all tests in that file passed (2 passed, 0 failed). 
- Ran `git diff --check` as part of validation and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a137477fca483209e66c6f379b6779c)