### PR TITLE
fix(api): accept empty registry-search and integrity query params

### DIFF
--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -286,19 +286,33 @@ export const registryDiffQuerySchema = z.object({
 const registryIntegrityPairMessage =
   "Provide both artifact and hash together for verification";
 
+// Empty is treated as "snapshot listing" by the route handler at
+// apps/web/src/app/api/registry/integrity/route.ts (`!artifact` → status
+// `snapshot`, `artifact || null` in response). Accept it as a valid value
+// at the field level so clients that round-trip `null → ""` (HTML forms,
+// Raycast) don't get a 400 from the Zod gate. The pair-check below still
+// rejects non-empty artifact paired with empty/absent hash (and vice versa).
 export const registryIntegrityQuerySchema = z
   .object({
     artifact: z
-      .string()
-      .trim()
-      .max(160)
-      .regex(/^\/?(?:[a-z0-9][a-z0-9._-]*\/)*(?:[a-z0-9][a-z0-9._-]*)$/)
+      .union([
+        z.literal(""),
+        z
+          .string()
+          .trim()
+          .max(160)
+          .regex(/^\/?(?:[a-z0-9][a-z0-9._-]*\/)*(?:[a-z0-9][a-z0-9._-]*)$/),
+      ])
       .optional(),
     hash: z
-      .string()
-      .trim()
-      .toLowerCase()
-      .regex(/^[a-f0-9]{64}$/)
+      .union([
+        z.literal(""),
+        z
+          .string()
+          .trim()
+          .toLowerCase()
+          .regex(/^[a-f0-9]{64}$/),
+      ])
       .optional(),
   })
   .superRefine((query, ctx) => {

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -2394,15 +2394,23 @@ paths:
         against the deployed manifest.
       parameters:
         - schema:
-            type: string
-            maxLength: 160
-            pattern: ^\/?(?:[a-z0-9][a-z0-9._-]*\/)*(?:[a-z0-9][a-z0-9._-]*)$
+            anyOf:
+              - type: string
+                enum:
+                  - ""
+              - type: string
+                maxLength: 160
+                pattern: ^\/?(?:[a-z0-9][a-z0-9._-]*\/)*(?:[a-z0-9][a-z0-9._-]*)$
           required: false
           name: artifact
           in: query
         - schema:
-            type: string
-            pattern: ^[a-f0-9]{64}$
+            anyOf:
+              - type: string
+                enum:
+                  - ""
+              - type: string
+                pattern: ^[a-f0-9]{64}$
           required: false
           name: hash
           in: query

--- a/tests/registry-integrity-api.test.ts
+++ b/tests/registry-integrity-api.test.ts
@@ -157,4 +157,60 @@ describe("/api/registry/integrity", () => {
     });
     expect(badArtifact.status).toBe(400);
   });
+
+  it("treats explicit empty artifact and hash as 'snapshot listing'", async () => {
+    const { GET } =
+      await import("../apps/web/src/app/api/registry/integrity/route");
+    const emptyArtifact = await GET(
+      request("/api/registry/integrity?artifact="),
+    );
+    const bothEmpty = await GET(
+      request("/api/registry/integrity?artifact=&hash="),
+    );
+
+    // Empty artifact alone is no longer rejected by the field-level regex,
+    // and the pair-check (#516) treats both-falsy as "no verification
+    // requested" rather than a partial pair, so it returns the snapshot.
+    expect(emptyArtifact.status).toBe(200);
+    await expect(emptyArtifact.json()).resolves.toMatchObject({
+      ok: true,
+      status: "snapshot",
+      artifact: null,
+      hash: null,
+      current: null,
+    });
+
+    expect(bothEmpty.status).toBe(200);
+    await expect(bothEmpty.json()).resolves.toMatchObject({
+      ok: true,
+      status: "snapshot",
+      artifact: null,
+      hash: null,
+    });
+  });
+
+  it("still pair-rejects a non-empty artifact with an explicit empty hash", async () => {
+    // Preserves #516's invariant: a real artifact path must come with a real
+    // hash. Explicit-empty hash is treated as "no hash provided", same as
+    // omitting the param entirely, so the pair-check still fires.
+    const { GET } =
+      await import("../apps/web/src/app/api/registry/integrity/route");
+    const partialPair = await GET(
+      request("/api/registry/integrity?artifact=directory-index.json&hash="),
+    );
+    expect(partialPair.status).toBe(400);
+    await expect(partialPair.json()).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_payload",
+        details: [
+          expect.objectContaining({
+            path: "hash",
+            message: "Provide both artifact and hash together for verification",
+            code: "custom",
+          }),
+        ],
+      },
+    });
+  });
 });

--- a/tests/registry-search-api.test.ts
+++ b/tests/registry-search-api.test.ts
@@ -116,4 +116,44 @@ describe("/api/registry/search", () => {
       nextOffset: null,
     });
   });
+
+  it("treats explicit empty category and platform as 'no filter'", async () => {
+    const { GET } =
+      await import("../apps/web/src/app/api/registry/search/route");
+    const response = await GET(
+      new Request(
+        "https://heyclau.de/api/registry/search?q=fixture&category=&platform=",
+        { headers: { origin: "https://heyclau.de" } },
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({ count: 3, total: 3 });
+    expect(body.results.map((entry: SearchDocument) => entry.slug)).toEqual([
+      "fixture-a",
+      "fixture-b",
+      "fixture-c",
+    ]);
+  });
+
+  it("still rejects malformed non-empty category and platform", async () => {
+    const { GET } =
+      await import("../apps/web/src/app/api/registry/search/route");
+    const badPlatform = await GET(
+      new Request(
+        "https://heyclau.de/api/registry/search?q=fixture&platform=%21bad",
+        { headers: { origin: "https://heyclau.de" } },
+      ),
+    );
+    expect(badPlatform.status).toBe(400);
+
+    const badCategory = await GET(
+      new Request(
+        "https://heyclau.de/api/registry/search?q=fixture&category=NOT_A_SLUG",
+        { headers: { origin: "https://heyclau.de" } },
+      ),
+    );
+    expect(badCategory.status).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary

Four public-query Zod schemas in `apps/web/src/lib/api/contracts.ts` apply `.regex(...)` **before** `.optional().default("")`. Zod's `default(...)` only fires when the field is `undefined`, so an explicit empty string (`?platform=` / `?category=` / `?artifact=` / `?hash=`) reaches the regex and gets rejected with HTTP 400 `invalid_payload`. That is exactly what an HTML form submits when those filter inputs are left blank, and what API clients that round-trip `null → ""` (Raycast, generated typed clients) send today.

The runtime in both routes is already empty-safe:
- `apps/web/src/lib/api/registry-search-filters.ts:62` — `matchesPlatform` short-circuits on empty.
- `apps/web/src/lib/api/registry-search-filters.ts:103` — `entryMatchesFilters` short-circuits on empty `category`.
- `apps/web/src/app/api/registry/integrity/route.ts` — destructures `{ artifact = "", hash = "" }` and emits `status: "snapshot"` with `artifact: null` in the response when artifact is empty.

The sister schema `publicJobsQuerySchema.remote` (line 132) is the precedent: it explicitly accepts `""` in its enum. The Zod gate on these four schemas was the only thing blocking what the rest of the stack is built to accept.

Fixes #517.

## Fix

Each affected schema is rewritten as `z.union([z.literal(""), <existing regex schema>]).optional().default("")`. Non-empty values continue to be regex-validated unchanged.

For the integrity schema, **the pair-check from #516 is preserved verbatim**: a real artifact path still requires a real hash (and vice versa) because the empty literal still reads as falsy through `superRefine`. The combined behavior:

| Request | Before | After |
| --- | --- | --- |
| `?platform=` (search) | 400 invalid_payload | 200 snapshot (no platform filter) |
| `?category=` (search) | 400 invalid_payload | 200 snapshot (no category filter) |
| `?platform=%21bad` (search) | 400 invalid_payload | 400 invalid_payload (unchanged) |
| `?artifact=` (integrity) | 400 invalid_payload | 200 snapshot listing |
| `?artifact=&hash=` (integrity) | 400 invalid_payload | 200 snapshot listing |
| `?artifact=foo&hash=` (integrity) | 400 invalid_payload | **400 partial pair (#516 invariant preserved)** |
| `?artifact=foo&hash=aaaaa...` (integrity) | 200 match | 200 match (unchanged) |

## Tests

- `tests/registry-search-api.test.ts` — 2 new vitest cases:
  - empty `category=` + `platform=` returns 200 with no filter applied
  - malformed non-empty values still return 400
- `tests/registry-integrity-api.test.ts` — 2 new vitest cases:
  - explicit empty `artifact=` and both-empty return 200 `status: "snapshot"`
  - non-empty `artifact` paired with explicit empty `hash` **still 400** (preserves #516)

## OpenAPI

`pnpm generate:openapi` was run; `cloudflare/api-schema-heyclaude-openapi.yaml` now emits `anyOf: [{enum: [""]}, {pattern: ...}]` for each affected param.

## Validation run (from AGENTS.md API-change checklist)

```
pnpm exec vitest run tests/registry-search-api.test.ts tests/registry-integrity-api.test.ts                     tests/api-contracts.test.ts tests/api-router-security.test.ts   # 33/33 pass
pnpm validate:openapi                                                               # clean after regen
pnpm type-check                                                                     # tsc clean
git diff --check                                                                    # no whitespace issues
```

No visual impact (API-only fix; no UI / page changes).
[Allow edits from maintainers] is enabled on this PR.
