### PR TITLE
feat(jobs): add richer public job filters

### DIFF
--- a/apps/web/src/app/api/jobs/route.ts
+++ b/apps/web/src/app/api/jobs/route.ts
@@ -7,6 +7,8 @@ import {
   type PublicJobListing,
 } from "@/lib/jobs";
 
+const MAX_OFFSET = 10_000;
+
 function matchesQuery(job: PublicJobListing, query: string) {
   if (!query) return true;
   const haystack = [
@@ -30,6 +32,24 @@ function matchesQuery(job: PublicJobListing, query: string) {
   return haystack.includes(query);
 }
 
+function matchesBoolFilter(
+  filter: "all" | "true" | "false" | "",
+  value: boolean,
+) {
+  if (!filter || filter === "all") return true;
+  return filter === "true" ? value : !value;
+}
+
+function jobPostedAtMs(job: PublicJobListing): number | null {
+  const candidates = [job.postedAt, job.firstSeenAt];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = Date.parse(candidate);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
 export const GET = createApiHandler(
   "jobs.list",
   async ({ request, query: parsedQuery }) => {
@@ -37,20 +57,63 @@ export const GET = createApiHandler(
       q: query,
       tier,
       remote,
+      location,
+      type,
+      sourceKind,
+      compensation,
+      claimedEmployer,
+      postedAfter,
       limit,
+      offset,
     } = parsedQuery as InferApiQuery<typeof publicJobsQuerySchema>;
+
+    const postedAfterMs = postedAfter ? Date.parse(postedAfter) : NaN;
+    const postedAfterCursor = Number.isFinite(postedAfterMs)
+      ? postedAfterMs
+      : null;
+
     const payload = buildPublicJobsIndex(
       await getJobs(),
       new URL(request.url).origin,
     );
-    const entries = payload.entries
+
+    const matched = payload.entries
       .filter((job) => !tier || tier === "all" || job.tier === tier)
       .filter((job) => {
         if (!remote || remote === "all") return true;
         return remote === "true" ? Boolean(job.isRemote) : !job.isRemote;
       })
-      .filter((job) => matchesQuery(job, query))
-      .slice(0, limit);
+      .filter((job) => {
+        if (!location) return true;
+        return (job.location ?? "").toLowerCase().includes(location);
+      })
+      .filter((job) => {
+        if (!type) return true;
+        return (job.type ?? "").toLowerCase().includes(type);
+      })
+      .filter((job) => {
+        if (!sourceKind || sourceKind === "all") return true;
+        return job.sourceKind === sourceKind;
+      })
+      .filter((job) =>
+        matchesBoolFilter(compensation, Boolean(job.compensation)),
+      )
+      .filter((job) =>
+        matchesBoolFilter(claimedEmployer, Boolean(job.claimedEmployer)),
+      )
+      .filter((job) => {
+        if (postedAfterCursor === null) return true;
+        const jobMs = jobPostedAtMs(job);
+        return jobMs !== null && jobMs >= postedAfterCursor;
+      })
+      .filter((job) => matchesQuery(job, query));
+
+    const entries = matched.slice(offset, offset + limit);
+    const nextCandidate = Math.min(offset + limit, MAX_OFFSET);
+    const nextOffset =
+      nextCandidate < matched.length && nextCandidate !== offset
+        ? nextCandidate
+        : null;
 
     return cachedJsonResponse(
       request,
@@ -59,8 +122,20 @@ export const GET = createApiHandler(
         query,
         tier: tier || "all",
         remote: remote || "all",
+        filters: {
+          location,
+          type,
+          sourceKind: sourceKind || "all",
+          compensation: compensation || "all",
+          claimedEmployer: claimedEmployer || "all",
+          postedAfter: postedAfter || "",
+        },
         count: entries.length,
+        total: matched.length,
         totalAvailable: payload.entries.length,
+        limit,
+        offset,
+        nextOffset,
         entries,
       },
       {

--- a/apps/web/src/app/api/jobs/route.ts
+++ b/apps/web/src/app/api/jobs/route.ts
@@ -71,6 +71,8 @@ export const GET = createApiHandler(
     const postedAfterCursor = Number.isFinite(postedAfterMs)
       ? postedAfterMs
       : null;
+    const locationNeedle = (location ?? "").toLowerCase();
+    const typeNeedle = (type ?? "").toLowerCase();
 
     const payload = buildPublicJobsIndex(
       await getJobs(),
@@ -84,12 +86,12 @@ export const GET = createApiHandler(
         return remote === "true" ? Boolean(job.isRemote) : !job.isRemote;
       })
       .filter((job) => {
-        if (!location) return true;
-        return (job.location ?? "").toLowerCase().includes(location);
+        if (!locationNeedle) return true;
+        return (job.location ?? "").toLowerCase().includes(locationNeedle);
       })
       .filter((job) => {
-        if (!type) return true;
-        return (job.type ?? "").toLowerCase().includes(type);
+        if (!typeNeedle) return true;
+        return (job.type ?? "").toLowerCase().includes(typeNeedle);
       })
       .filter((job) => {
         if (!sourceKind || sourceKind === "all") return true;

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -110,19 +110,9 @@ const optionalHttpsUrlSchema = z
   .default("");
 
 const isoDateLikeSchema = z
-  .string()
-  .trim()
-  .max(40)
+  .union([z.literal(""), z.iso.datetime({ offset: true }), z.iso.date()])
   .optional()
-  .default("")
-  .refine(
-    (value) => {
-      if (!value) return true;
-      const parsed = Date.parse(value);
-      return Number.isFinite(parsed);
-    },
-    { message: "Invalid ISO date" },
-  );
+  .default("");
 
 export const jobSourceKindFilterSchema = z
   .enum([

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -142,7 +142,13 @@ export const publicJobsQuerySchema = z.object({
     .default("all"),
   postedAfter: isoDateLikeSchema,
   limit: z.coerce.number().int().min(1).max(100).optional().default(100),
-  offset: z.coerce.number().int().min(0).max(10_000).optional().default(0),
+  offset: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(10_000)
+    .default(0)
+    .meta({ type: "integer", minimum: 0, maximum: 10_000, default: 0 }),
 });
 
 export const apiErrorEnvelopeSchema = z.object({

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -109,6 +109,32 @@ const optionalHttpsUrlSchema = z
   .optional()
   .default("");
 
+const isoDateLikeSchema = z
+  .string()
+  .trim()
+  .max(40)
+  .optional()
+  .default("")
+  .refine(
+    (value) => {
+      if (!value) return true;
+      const parsed = Date.parse(value);
+      return Number.isFinite(parsed);
+    },
+    { message: "Invalid ISO date" },
+  );
+
+export const jobSourceKindFilterSchema = z
+  .enum([
+    "all",
+    "official_ats",
+    "employer_careers",
+    "employer_submitted",
+    "",
+  ])
+  .optional()
+  .default("all");
+
 export const publicJobsQuerySchema = z.object({
   q: z.string().trim().toLowerCase().max(120).optional().default(""),
   tier: z
@@ -116,7 +142,17 @@ export const publicJobsQuerySchema = z.object({
     .optional()
     .default("all"),
   remote: z.enum(["all", "true", "false", ""]).optional().default("all"),
+  location: z.string().trim().toLowerCase().max(120).optional().default(""),
+  type: z.string().trim().toLowerCase().max(60).optional().default(""),
+  sourceKind: jobSourceKindFilterSchema,
+  compensation: z.enum(["all", "true", "false", ""]).optional().default("all"),
+  claimedEmployer: z
+    .enum(["all", "true", "false", ""])
+    .optional()
+    .default("all"),
+  postedAfter: isoDateLikeSchema,
   limit: z.coerce.number().int().min(1).max(100).optional().default(100),
+  offset: z.coerce.number().int().min(0).max(10_000).optional().default(0),
 });
 
 export const apiErrorEnvelopeSchema = z.object({

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6278,9 +6278,7 @@ paths:
           name: limit
           in: query
         - schema:
-            type:
-              - integer
-              - "null"
+            type: integer
             minimum: 0
             maximum: 10000
             default: 0

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6257,8 +6257,14 @@ paths:
           name: claimedEmployer
           in: query
         - schema:
-            type: string
-            maxLength: 40
+            anyOf:
+              - type: string
+                enum:
+                  - ""
+              - type: string
+                format: date-time
+              - type: string
+                format: date
             default: ""
           required: false
           name: postedAfter

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -6209,12 +6209,77 @@ paths:
           name: remote
           in: query
         - schema:
+            type: string
+            maxLength: 120
+            default: ""
+          required: false
+          name: location
+          in: query
+        - schema:
+            type: string
+            maxLength: 60
+            default: ""
+          required: false
+          name: type
+          in: query
+        - schema:
+            type: string
+            enum:
+              - all
+              - official_ats
+              - employer_careers
+              - employer_submitted
+              - ""
+            default: all
+          required: false
+          name: sourceKind
+          in: query
+        - schema:
+            type: string
+            enum:
+              - all
+              - "true"
+              - "false"
+              - ""
+            default: all
+          required: false
+          name: compensation
+          in: query
+        - schema:
+            type: string
+            enum:
+              - all
+              - "true"
+              - "false"
+              - ""
+            default: all
+          required: false
+          name: claimedEmployer
+          in: query
+        - schema:
+            type: string
+            maxLength: 40
+            default: ""
+          required: false
+          name: postedAfter
+          in: query
+        - schema:
             type: integer
             minimum: 1
             maximum: 100
             default: 100
           required: false
           name: limit
+          in: query
+        - schema:
+            type:
+              - integer
+              - "null"
+            minimum: 0
+            maximum: 10000
+            default: 0
+          required: false
+          name: offset
           in: query
       responses:
         "200":

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -183,6 +183,20 @@ describe("OpenAPI route coverage", () => {
     );
   });
 
+  it("documents richer public job filters and pagination cursor", () => {
+    expect(parsedSchema.paths["/api/jobs"]?.get?.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "location", in: "query" }),
+        expect.objectContaining({ name: "type", in: "query" }),
+        expect.objectContaining({ name: "sourceKind", in: "query" }),
+        expect.objectContaining({ name: "compensation", in: "query" }),
+        expect.objectContaining({ name: "claimedEmployer", in: "query" }),
+        expect.objectContaining({ name: "postedAfter", in: "query" }),
+        expect.objectContaining({ name: "offset", in: "query" }),
+      ]),
+    );
+  });
+
   it("documents registry search pagination metadata", () => {
     const searchResponse =
       parsedSchema.paths["/api/registry/search"]?.get?.responses?.["200"];

--- a/tests/jobs-api.test.ts
+++ b/tests/jobs-api.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { JobListing } from "../apps/web/src/lib/jobs";
+
+const jobsMock = vi.hoisted(() => ({
+  value: [] as JobListing[],
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: () => ({ env: {} }),
+}));
+
+vi.mock("@/lib/jobs", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/jobs")>("@/lib/jobs");
+  return {
+    ...actual,
+    getJobs: () => Promise.resolve(jobsMock.value),
+  };
+});
+
+function makeJob(overrides: Partial<JobListing> = {}): JobListing {
+  return {
+    slug: "fixture-job",
+    title: "Fixture Engineer",
+    company: "Fixture Co",
+    location: "Remote",
+    description: "Build fixture-grade products.",
+    applyUrl: "https://example.com/apply/fixture",
+    featured: false,
+    tier: "standard",
+    status: "active",
+    source: "manual",
+    sourceKind: "employer_submitted",
+    sourceUrl: "https://example.com/apply/fixture",
+    postedAt: "2026-05-20T00:00:00.000Z",
+    firstSeenAt: "2026-05-20T00:00:00.000Z",
+    isRemote: true,
+    isWorldwide: false,
+    claimedEmployer: false,
+    ...overrides,
+  };
+}
+
+function request(query: string) {
+  return new Request(`https://heyclau.de/api/jobs${query}`, {
+    headers: { origin: "https://heyclau.de" },
+  });
+}
+
+describe("/api/jobs", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    jobsMock.value = [
+      makeJob({
+        slug: "remote-eu-compensated",
+        title: "Senior Platform Engineer",
+        company: "Aether",
+        location: "Remote (EU)",
+        type: "Full-time",
+        compensation: "€90k–€130k",
+        sourceKind: "official_ats",
+        claimedEmployer: true,
+        postedAt: "2026-05-22T00:00:00.000Z",
+        firstSeenAt: "2026-05-22T00:00:00.000Z",
+        isRemote: true,
+      }),
+      makeJob({
+        slug: "onsite-us-no-comp",
+        title: "Staff Frontend Engineer",
+        company: "Borealis",
+        location: "New York City, NY, US",
+        type: "Full-time",
+        compensation: undefined,
+        sourceKind: "employer_careers",
+        claimedEmployer: false,
+        postedAt: "2026-04-30T00:00:00.000Z",
+        firstSeenAt: "2026-04-30T00:00:00.000Z",
+        isRemote: false,
+      }),
+      makeJob({
+        slug: "remote-worldwide-contract",
+        title: "Contract MCP Engineer",
+        company: "Cirrus",
+        location: "Worldwide",
+        type: "Contract",
+        compensation: "$120/hr",
+        sourceKind: "employer_submitted",
+        claimedEmployer: false,
+        postedAt: "2026-03-10T00:00:00.000Z",
+        firstSeenAt: "2026-03-10T00:00:00.000Z",
+        isRemote: true,
+        isWorldwide: true,
+      }),
+    ];
+  });
+
+  it("returns every active job with pagination metadata when no filters are applied", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(request(""));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      kind: "jobs-index",
+      count: 3,
+      total: 3,
+      totalAvailable: 3,
+      limit: 100,
+      offset: 0,
+      nextOffset: null,
+    });
+    expect(body.entries).toHaveLength(3);
+  });
+
+  it("combines region, compensation, sourceKind, and claimedEmployer filters", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(
+      request(
+        "?location=eu&compensation=true&sourceKind=official_ats&claimedEmployer=true",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      count: 1,
+      total: 1,
+      filters: {
+        location: "eu",
+        sourceKind: "official_ats",
+        compensation: "true",
+        claimedEmployer: "true",
+      },
+    });
+    expect(body.entries[0].slug).toBe("remote-eu-compensated");
+  });
+
+  it("applies postedAfter as an inclusive date cursor", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(
+      request("?postedAfter=2026-05-01T00:00:00.000Z"),
+    );
+
+    const body = await response.json();
+    expect(body.count).toBe(1);
+    expect(body.entries.map((job: { slug: string }) => job.slug)).toEqual([
+      "remote-eu-compensated",
+    ]);
+  });
+
+  it("filters by job type via case-insensitive substring", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(request("?type=contract"));
+
+    const body = await response.json();
+    expect(body.count).toBe(1);
+    expect(body.entries[0].slug).toBe("remote-worldwide-contract");
+  });
+
+  it("returns an empty entries array but valid metadata when filters match nothing", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(
+      request(
+        "?location=mars&compensation=true&sourceKind=official_ats&claimedEmployer=true",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      count: 0,
+      total: 0,
+      totalAvailable: 3,
+      offset: 0,
+      nextOffset: null,
+    });
+    expect(body.entries).toEqual([]);
+  });
+
+  it("paginates with offset/limit and advertises nextOffset only when more results remain", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const first = await GET(request("?limit=2&offset=0"));
+    const firstBody = await first.json();
+    expect(firstBody).toMatchObject({
+      count: 2,
+      total: 3,
+      limit: 2,
+      offset: 0,
+      nextOffset: 2,
+    });
+
+    const second = await GET(request("?limit=2&offset=2"));
+    const secondBody = await second.json();
+    expect(secondBody).toMatchObject({
+      count: 1,
+      total: 3,
+      limit: 2,
+      offset: 2,
+      nextOffset: null,
+    });
+  });
+
+  it("rejects an invalid postedAfter value", async () => {
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(request("?postedAfter=not-a-date"));
+    expect(response.status).toBe(400);
+  });
+});

--- a/tests/jobs-api.test.ts
+++ b/tests/jobs-api.test.ts
@@ -136,6 +136,34 @@ describe("/api/jobs", () => {
     expect(body.entries[0].slug).toBe("remote-eu-compensated");
   });
 
+  it("falls back to firstSeenAt when postedAt is missing for the postedAfter cursor", async () => {
+    jobsMock.value = [
+      makeJob({
+        slug: "first-seen-only",
+        title: "Edge case engineer",
+        postedAt: undefined,
+        firstSeenAt: "2026-05-22T00:00:00.000Z",
+      }),
+      makeJob({
+        slug: "old-first-seen-only",
+        title: "Older engineer",
+        postedAt: undefined,
+        firstSeenAt: "2025-12-01T00:00:00.000Z",
+      }),
+    ];
+
+    const { GET } = await import("../apps/web/src/app/api/jobs/route");
+    const response = await GET(
+      request("?postedAfter=2026-05-01T00:00:00.000Z"),
+    );
+
+    const body = await response.json();
+    expect(body.count).toBe(1);
+    expect(body.entries.map((job: { slug: string }) => job.slug)).toEqual([
+      "first-seen-only",
+    ]);
+  });
+
   it("applies postedAfter as an inclusive date cursor", async () => {
     const { GET } = await import("../apps/web/src/app/api/jobs/route");
     const response = await GET(


### PR DESCRIPTION
## Summary

- Extend `/api/jobs` with public filters for `location`, `type`, `sourceKind`, `compensation`, `claimedEmployer`, and `postedAfter` on top of the existing `q`/`tier`/`remote`.
- Add `offset` + `total` + `nextOffset` pagination metadata so paginating clients (Raycast, web jobs board) can walk the active jobs list.
- Echo applied filters in the response under `filters` so Raycast can rely on a single source of truth instead of duplicating filter logic locally.
- Regenerate `cloudflare/api-schema-heyclaude-openapi.yaml` via `pnpm generate:openapi`.

## Why

Closes #495. The public jobs API previously accepted only `q`, `tier`, `remote`, and `limit`, which forced Raycast and the public jobs board to re-filter on the client and made paginating impossible.

Intended labels: `feature`, `data`, `raycast`, `user-facing`.

## New query params

| Param             | Type / values                                                          | Behavior                                                               |
| ----------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| `location`        | string (≤120, lowercased)                                              | Case-insensitive substring match on `job.location`.                    |
| `type`            | string (≤60, lowercased)                                               | Case-insensitive substring match on `job.type` (e.g. `contract`).      |
| `sourceKind`      | `all` \| `official_ats` \| `employer_careers` \| `employer_submitted`  | Exact match on `job.sourceKind`.                                       |
| `compensation`    | `all` \| `true` \| `false`                                             | Whether `job.compensation` is present.                                 |
| `claimedEmployer` | `all` \| `true` \| `false`                                             | Whether the job is from a claimed employer.                            |
| `postedAfter`     | ISO date string                                                        | Inclusive cursor on `postedAt` (falls back to `firstSeenAt`).          |
| `offset`          | integer 0–10,000                                                       | Pagination cursor. `nextOffset` echoed only while more results remain. |

## Invariants preserved

- Private review, payment, and contact fields stay excluded. No new fields added to `PublicJobListing`; filters operate only on already-public payload fields.
- Default behavior with no new query params is unchanged: still returns up to 100 active jobs sorted by tier and `postedAt`.
- Same response cache headers (`public, max-age=60, stale-while-revalidate=300`).
- All new query params are optional with `default("all")` / `default("")` / `default(0)` semantics, so existing clients keep working without modification.
- `postedAfter` is validated as a parseable ISO date — invalid values return a `400` via the existing router error envelope.

## Tests

- New `tests/jobs-api.test.ts` covers the default unfiltered response with pagination metadata, combined filter narrowing, the `postedAfter` date cursor, case-insensitive `type` matching, empty-result metadata, `offset`/`limit` paging with `nextOffset`, and `400` validation for non-date `postedAfter` input.
- `tests/api-contracts.test.ts` adds a coverage assertion that the new query params appear in the generated OpenAPI document.

## Validation

- `pnpm validate:openapi`
- `pnpm exec vitest run tests/jobs-api.test.ts tests/api-contracts.test.ts`
- `pnpm --filter web build`
- `git diff --check`

## Notes

- No visual impact (API/contract change only).
- No edits to `apps/web/public/data/**`, `apps/web/src/generated/**`, or `README.md`; maintainer automation regenerates those.
- `.husky/commit-msg` gains a `#!/usr/bin/env sh` shebang and a `corepack pnpm` fallback so the hook spawns and resolves `pnpm` on environments where pnpm is corepack-managed. Behavior is unchanged when `pnpm` is on PATH.