### PR TITLE
feat(mcp): add workflow toolbox planner

### DIFF
--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -977,7 +977,7 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
   const query = normalizeText(goal);
   const category = normalizeText(args.category);
   const platform = normalizePlatform(args.platform);
-  const limit = normalizeLimit(args.limit, 6);
+  const limit = Math.min(10, normalizeLimit(args.limit, 6));
   const searchIndex = unwrapEntries(
     await readJsonArtifact("search-index.json", options),
   );

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -410,7 +410,8 @@ function entrySearchText(entry) {
     ...(entry.keywords || []),
   ]
     .map(normalizeText)
-    .join(" ");
+    .join(" ")
+    .toLowerCase();
 }
 
 function scoreSearchEntry(entry, query) {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -12,6 +12,7 @@ import {
   listRegistryPrompts,
   listRegistryResources,
   listRegistryResourceTemplates,
+  planWorkflowToolbox,
   READ_ONLY_TOOL_NAMES,
   readRegistryResource,
   TOOL_DEFINITIONS,
@@ -769,6 +770,36 @@ describe("HeyClaude read-only MCP helpers", () => {
       (entry: any) => entry.slug === "kubernetes-cluster-helper",
     );
     expect(matched.searchScore).toBeGreaterThan(0);
+  });
+
+  it("clamps the planner runtime limit to 10 even when called directly", async () => {
+    // Direct runtime calls bypass the 1-10 input schema, so the tool must
+    // clamp internally. Categories are spread so diversity selection still
+    // fills up to the clamp instead of capping early at 2 per category.
+    const categories = ["mcp", "agents", "skills", "hooks", "commands"];
+    const readJsonArtifact = async (relativePath: string) => {
+      expect(relativePath).toBe("search-index.json");
+      return {
+        entries: Array.from({ length: 15 }, (_, index) => ({
+          category: categories[index % categories.length],
+          slug: `automation-entry-${index}`,
+          title: `Automation Workflow Helper ${index}`,
+          description: "Automates the workflow with guided steps.",
+          tags: ["automation", "workflow"],
+          keywords: ["automation"],
+          platforms: ["Claude"],
+        })),
+      };
+    };
+
+    const result = await planWorkflowToolbox(
+      { goal: "automation workflow", limit: 20 },
+      { readJsonArtifact },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.count).toBe(result.entries.length);
+    expect(result.entries.length).toBeLessThanOrEqual(10);
   });
 
   it("searches registry artifacts with trust filters", async () => {

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -726,6 +726,51 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
+  it("matches a lowercase planner goal against mixed-case entry text", async () => {
+    const readJsonArtifact = async (relativePath: string) => {
+      expect(relativePath).toBe("search-index.json");
+      return {
+        entries: [
+          {
+            category: "mcp",
+            slug: "kubernetes-cluster-helper",
+            title: "Kubernetes CLUSTER Deployment Helper",
+            description: "Manage ROLLOUTS across namespaces with guided steps.",
+            tags: ["DevOps"],
+            keywords: [],
+            platforms: ["Claude"],
+          },
+          {
+            category: "agents",
+            slug: "unrelated-entry",
+            title: "Totally Unrelated Thing",
+            description: "Has nothing to do with the goal.",
+            tags: [],
+            keywords: [],
+            platforms: [],
+          },
+        ],
+      };
+    };
+
+    const result = await callRegistryTool(
+      "plan_workflow_toolbox",
+      { goal: "kubernetes cluster rollouts", limit: 5 },
+      { readJsonArtifact },
+    );
+
+    expect(result).toMatchObject({ ok: true });
+    const slugs = result.entries.map((entry: any) => entry.slug);
+    // Lowercase goal tokens (kubernetes/cluster/rollouts) must match the
+    // mixed-case title ("CLUSTER") and description ("ROLLOUTS").
+    expect(slugs).toContain("kubernetes-cluster-helper");
+    expect(slugs).not.toContain("unrelated-entry");
+    const matched = result.entries.find(
+      (entry: any) => entry.slug === "kubernetes-cluster-helper",
+    );
+    expect(matched.searchScore).toBeGreaterThan(0);
+  });
+
   it("searches registry artifacts with trust filters", async () => {
     const result = await callRegistryTool(
       "search_registry",


### PR DESCRIPTION
## Summary
- Adds a read-only `plan_workflow_toolbox` MCP tool that composes existing registry primitives into a bounded toolbox for a user goal.
- Returns recommended entries with reason codes, caveats, trust metadata, and `nextSteps` pointers to existing tools.
- Surfaces guidance instead of fabricating recommendations when the goal does not match.

## What changed
- Added `plan_workflow_toolbox` to `READ_ONLY_TOOL_NAMES`, `TOOL_DEFINITIONS`, `TOOL_INPUT_SCHEMAS`, the registry dispatcher, and `.d.ts` type surface.
- Required at least one keyword match when the goal is specific, so weak/empty matches return a `guidance[]` payload instead of unrelated entries.
- Diversified across categories by default (`preferDiverseCategories=true`); tagged surfaced entries with `complementary_category` when multiple categories are picked.
- Wired reason codes `query_match`, `category_match`, `same_platform`, `trusted_package`, `source_backed`, `has_safety_notes`, `has_privacy_notes`, `complementary_category`.
- Added protocol-level tests for happy path, constrained category/platform, and weak-match guidance. Extended the MCP HTTP route tool-list assertion.
- Documented the tool in `packages/mcp/README.md`.

## Why
Closes #491.

## Invariants
- Read-only: no external calls, no submission writes, no local file writes.
- All output is metadata-derived from `search-index.json`; no fabricated source stats.
- Tool annotations stay `{ readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false }`.
- `MCP_PUBLIC_POLICY` envelope is applied by the existing `withPublicPolicy` wrapper; not bypassed.
- Bounded: `limit` clamped to 1–10, token count capped at 12.

## Backward compatibility
- Additive only. Existing tool names, input/output schemas, and dispatch behavior are unchanged.
- No changes to `apps/web/public/data/**`, `apps/web/src/generated/**`, `README.md`, or `apps/web/public/downloads/**`.

## Visual impact
No visual impact — MCP tool surface only, no UI/route changes.

## Validation
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-server.test.ts tests/mcp-cli.test.ts tests/mcp-http-route.test.ts`
- `pnpm validate:packages`
- `git diff --check`