### PR TITLE
fix(trending): restore ISR caching for growth surfaces

### DIFF
--- a/apps/web/src/app/trending/page.tsx
+++ b/apps/web/src/app/trending/page.tsx
@@ -12,7 +12,6 @@ import {
   buildCollectionPageJsonLd,
 } from "@heyclaude/registry/seo";
 
-export const dynamic = "force-dynamic";
 export const revalidate = 300;
 
 export const metadata: Metadata = buildPageMetadata({


### PR DESCRIPTION
### Motivation
- The trending page exported `dynamic = "force-dynamic"` while calling `getGrowthSurfaces()`, which performs batched D1 aggregate queries over the entire directory and allowed unauthenticated page requests to trigger many per-request D1 SELECTs, so ISR/caching must be restored to amortize that expensive work.

### Description
- Remove the `export const dynamic = "force-dynamic";` line from `apps/web/src/app/trending/page.tsx` so Next.js will honor the existing `revalidate = 300` and allow ISR/caching while preserving the `getGrowthSurfaces()` surface generation.

### Testing
- Ran `pnpm exec vitest run tests/api-contracts.test.ts` and the test suite passed (9 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1761797fc88331ae3bbcb14d6d28e8)