### PR TITLE
feat(growth): add discovery and trust surfaces

### DIFF
--- a/apps/web/src/app/[category]/[slug]/page.tsx
+++ b/apps/web/src/app/[category]/[slug]/page.tsx
@@ -236,7 +236,11 @@ export default async function DetailPage({ params }: DetailPageProps) {
     entry.documentationUrl ?? entry.repoUrl ?? entry.githubUrl ?? "";
   const editHref = getGitHubEditUrl(entry.githubUrl);
   const suggestChangeHref = getSuggestChangeUrl(entry);
-  const compareHref = `/browse?collection=${entry.category}:${entry.slug}`;
+  const encodedCategory = encodeURIComponent(entry.category);
+  const encodedSlug = encodeURIComponent(entry.slug);
+  const encodedEntryKey = encodeURIComponent(`${entry.category}:${entry.slug}`);
+  const apiEntryHref = `/api/registry/entries/${encodedCategory}/${encodedSlug}`;
+  const compareHref = `/browse?collection=${encodedEntryKey}`;
   const referenceLabel = entry.documentationUrl
     ? "Open docs"
     : entry.repoUrl
@@ -532,13 +536,13 @@ export default async function DetailPage({ params }: DetailPageProps) {
               Add to compare tray
             </Link>
             <a
-              href={`/api/registry/entries/${entry.category}/${entry.slug}`}
+              href={apiEntryHref}
               className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
             >
               Open API record
             </a>
             <a
-              href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+              href={`${apiEntryHref}/llms`}
               className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
             >
               Open LLM text
@@ -781,13 +785,13 @@ export default async function DetailPage({ params }: DetailPageProps) {
                 Claim/update listing
               </Link>
               <a
-                href={`/api/registry/entries/${entry.category}/${entry.slug}`}
+                href={apiEntryHref}
                 className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
               >
                 API detail
               </a>
               <a
-                href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+                href={`${apiEntryHref}/llms`}
                 className="flex h-9 w-full items-center justify-center gap-2 rounded-lg border border-border bg-background text-muted-foreground transition hover:border-primary/40 hover:text-foreground"
               >
                 LLM text

--- a/apps/web/src/app/[category]/[slug]/page.tsx
+++ b/apps/web/src/app/[category]/[slug]/page.tsx
@@ -236,6 +236,7 @@ export default async function DetailPage({ params }: DetailPageProps) {
     entry.documentationUrl ?? entry.repoUrl ?? entry.githubUrl ?? "";
   const editHref = getGitHubEditUrl(entry.githubUrl);
   const suggestChangeHref = getSuggestChangeUrl(entry);
+  const compareHref = `/browse?collection=${entry.category}:${entry.slug}`;
   const referenceLabel = entry.documentationUrl
     ? "Open docs"
     : entry.repoUrl
@@ -508,6 +509,46 @@ export default async function DetailPage({ params }: DetailPageProps) {
                 <p className="mt-2 text-sm text-foreground">{item.value}</p>
               </div>
             ))}
+          </div>
+        </section>
+
+        <section className="surface-panel p-5">
+          <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+            Use this entry
+          </p>
+          <h2 className="mt-1 text-lg font-semibold tracking-tight text-foreground">
+            Move from static reading to an agent workflow.
+          </h2>
+          <p className="mt-2 text-sm leading-7 text-muted-foreground">
+            Compare it against nearby options, hand it to the registry API, or
+            use the LLM text view when you want an agent to inspect the listing
+            without scraping the page.
+          </p>
+          <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <Link
+              href={compareHref}
+              className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
+            >
+              Add to compare tray
+            </Link>
+            <a
+              href={`/api/registry/entries/${entry.category}/${entry.slug}`}
+              className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
+            >
+              Open API record
+            </a>
+            <a
+              href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+              className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
+            >
+              Open LLM text
+            </a>
+            <Link
+              href="/brief"
+              className="rounded-xl border border-border bg-background px-3 py-2 text-sm font-medium text-foreground transition hover:border-primary/45"
+            >
+              Subscribe for updates
+            </Link>
           </div>
         </section>
 

--- a/apps/web/src/app/api/registry/search/route.ts
+++ b/apps/web/src/app/api/registry/search/route.ts
@@ -2,6 +2,7 @@ import { registrySearchQuerySchema } from "@/lib/api/contracts";
 import { computeRegistrySearchFacets } from "@/lib/api/registry-search-facets";
 import {
   filterEntries,
+  rankSearchEntries,
   type RegistrySearchFilterState,
 } from "@/lib/api/registry-search-filters";
 import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
@@ -39,7 +40,12 @@ export const GET = createApiHandler(
 
     const entries = await getSearchIndex();
     const matched = filterEntries(entries, filters);
-    const results = matched.slice(offset, offset + limit);
+    const ranked = rankSearchEntries(matched, query);
+    const results = ranked.slice(offset, offset + limit).map((item) => ({
+      ...item.entry,
+      searchScore: item.score,
+      searchReasons: item.reasons,
+    }));
     const facets = computeRegistrySearchFacets(entries, filters);
     const pageEnd = Math.min(offset + limit, matched.length);
     const nextOffset = Math.min(pageEnd, MAX_OFFSET);
@@ -63,7 +69,9 @@ export const GET = createApiHandler(
         limit,
         offset,
         nextOffset:
-          nextOffset !== offset && nextOffset === pageEnd && nextOffset < matched.length
+          nextOffset !== offset &&
+          nextOffset === pageEnd &&
+          nextOffset < matched.length
             ? nextOffset
             : null,
         results,

--- a/apps/web/src/app/brief/page.tsx
+++ b/apps/web/src/app/brief/page.tsx
@@ -6,6 +6,7 @@ import { JsonLd } from "@/components/json-ld";
 import { NewsletterSignup } from "@/components/newsletter-signup";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { buildPageMetadata } from "@/lib/seo";
+import { withDuration } from "@/lib/server-page-logging";
 import { siteConfig } from "@/lib/site";
 import {
   buildBreadcrumbJsonLd,
@@ -23,137 +24,149 @@ export const metadata: Metadata = buildPageMetadata({
 });
 
 export default async function WeeklyBriefPage() {
-  const surfaces = await getGrowthSurfaces();
-  const featured = [
-    ...surfaces.newThisWeek,
-    ...surfaces.recentlyVerified,
-    ...surfaces.safeInstall,
-  ].filter(
-    (entry, index, list) =>
-      list.findIndex(
-        (item) => item.category === entry.category && item.slug === entry.slug,
-      ) === index,
-  );
-  const groups = [
-    ["New this week", surfaces.newThisWeek],
-    ["Recently verified", surfaces.recentlyVerified],
-    ["Safe install signals", surfaces.safeInstall],
-    ["Source-backed picks", surfaces.sourceBacked],
-  ] as const;
-  const jsonLd = [
-    buildBreadcrumbJsonLd([
-      { name: "Home", url: siteConfig.url },
-      { name: "Brief", url: `${siteConfig.url}/brief` },
-    ]),
-    buildCollectionPageJsonLd({
-      siteUrl: siteConfig.url,
-      path: "/brief",
-      name: "Weekly Claude workflow brief",
-      description:
-        "A recurring editorial surface built from current HeyClaude registry signals.",
-      breadcrumbId: `${siteConfig.url}/brief#breadcrumb`,
-    }),
-    buildItemListJsonLd(
-      featured.slice(0, 12).map((entry) => ({
-        name: entry.title,
-        url: `${siteConfig.url}/${entry.category}/${entry.slug}`,
-      })),
-      {
-        name: "Weekly Claude workflow brief picks",
+  return withDuration("brief.page", async ({ getDurationMs, logger }) => {
+    const surfaces = await getGrowthSurfaces();
+    const featured = [
+      ...surfaces.newThisWeek,
+      ...surfaces.recentlyVerified,
+      ...surfaces.safeInstall,
+    ].filter(
+      (entry, index, list) =>
+        list.findIndex(
+          (item) =>
+            item.category === entry.category && item.slug === entry.slug,
+        ) === index,
+    );
+    const groups = [
+      ["New this week", surfaces.newThisWeek],
+      ["Recently verified", surfaces.recentlyVerified],
+      ["Safe install signals", surfaces.safeInstall],
+      ["Source-backed picks", surfaces.sourceBacked],
+    ] as const;
+    const jsonLd = [
+      buildBreadcrumbJsonLd([
+        { name: "Home", url: siteConfig.url },
+        { name: "Brief", url: `${siteConfig.url}/brief` },
+      ]),
+      buildCollectionPageJsonLd({
+        siteUrl: siteConfig.url,
+        path: "/brief",
+        name: "Weekly Claude workflow brief",
         description:
-          "New, trusted, source-backed, and practical Claude workflow resources.",
-      },
-    ),
-  ];
+          "A recurring editorial surface built from current HeyClaude registry signals.",
+        breadcrumbId: `${siteConfig.url}/brief#breadcrumb`,
+      }),
+      buildItemListJsonLd(
+        featured.slice(0, 12).map((entry) => ({
+          name: entry.title,
+          url: `${siteConfig.url}/${entry.category}/${entry.slug}`,
+        })),
+        {
+          name: "Weekly Claude workflow brief picks",
+          description:
+            "New, trusted, source-backed, and practical Claude workflow resources.",
+        },
+      ),
+    ];
 
-  return (
-    <main className="container-shell space-y-10 py-12">
-      <JsonLd data={jsonLd} />
-      <section className="space-y-4 border-b border-border/80 pb-8">
-        <Breadcrumbs
-          items={[{ label: "Home", href: "/" }, { label: "Brief" }]}
-        />
-        <span className="eyebrow">Weekly brief</span>
-        <h1 className="section-title text-balance">
-          Claude workflow updates worth actually checking.
-        </h1>
-        <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
-          A compact brief generated from registry changes, trust signals,
-          source-backed updates, and practical install surfaces. The goal is to
-          surface useful Claude Code, MCP, skill, hook, and command resources
-          without turning the directory into a low-signal feed.
-        </p>
-        <div className="flex flex-wrap gap-2">
-          <Link
-            href="/trending"
-            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
-          >
-            Open trending
-          </Link>
-          <Link
-            href="/best/agent-workflow-starter-kits"
-            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
-          >
-            Workflow starter kits
-          </Link>
-          <Link
-            href="/browse?utility=trusted-package"
-            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
-          >
-            Safe install picks
-          </Link>
-        </div>
-      </section>
+    logger.info("summary", {
+      durationMs: getDurationMs(),
+      featuredCount: featured.length,
+      newThisWeekCount: surfaces.newThisWeek.length,
+      recentlyVerifiedCount: surfaces.recentlyVerified.length,
+      safeInstallCount: surfaces.safeInstall.length,
+      sourceBackedCount: surfaces.sourceBacked.length,
+    });
 
-      <section className="grid gap-4 lg:grid-cols-[1fr_22rem]">
-        <div className="space-y-8">
-          {groups
-            .filter(([, entries]) => entries.length > 0)
-            .map(([title, entries]) => (
-              <section key={title} className="space-y-3">
-                <h2 className="text-2xl font-semibold tracking-tight text-foreground">
-                  {title}
-                </h2>
-                <div className="grid gap-3 md:grid-cols-2">
-                  {entries.slice(0, 6).map((entry) => (
-                    <Link
-                      key={`${title}:${entry.category}:${entry.slug}`}
-                      href={`/${entry.category}/${entry.slug}`}
-                      className="rounded-2xl border border-border bg-card p-4 transition hover:border-primary/45"
-                    >
-                      <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
-                        {entry.category}
-                      </p>
-                      <p className="mt-2 text-sm font-semibold text-foreground">
-                        {entry.title}
-                      </p>
-                      <p className="mt-2 line-clamp-2 text-xs leading-6 text-muted-foreground">
-                        {entry.cardDescription || entry.description}
-                      </p>
-                    </Link>
-                  ))}
-                </div>
-              </section>
-            ))}
-        </div>
-
-        <aside className="surface-panel h-fit p-5">
-          <p className="text-xs uppercase tracking-[0.18em] text-primary">
-            Distribution
+    return (
+      <main className="container-shell space-y-10 py-12">
+        <JsonLd data={jsonLd} />
+        <section className="space-y-4 border-b border-border/80 pb-8">
+          <Breadcrumbs
+            items={[{ label: "Home", href: "/" }, { label: "Brief" }]}
+          />
+          <span className="eyebrow">Weekly brief</span>
+          <h1 className="section-title text-balance">
+            Claude workflow updates worth actually checking.
+          </h1>
+          <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
+            A compact brief generated from registry changes, trust signals,
+            source-backed updates, and practical install surfaces. The goal is
+            to surface useful Claude Code, MCP, skill, hook, and command
+            resources without turning the directory into a low-signal feed.
           </p>
-          <h2 className="mt-2 text-xl font-semibold tracking-tight text-foreground">
-            Subscribe for the brief.
-          </h2>
-          <p className="mt-3 text-sm leading-7 text-muted-foreground">
-            Weekly means selective: new useful entries, trust metadata changes,
-            practical install picks, and contributor work that materially
-            improves the registry.
-          </p>
-          <div className="mt-5">
-            <NewsletterSignup source="brief" />
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/trending"
+              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+            >
+              Open trending
+            </Link>
+            <Link
+              href="/best/agent-workflow-starter-kits"
+              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+            >
+              Workflow starter kits
+            </Link>
+            <Link
+              href="/browse?utility=trusted-package"
+              className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+            >
+              Safe install picks
+            </Link>
           </div>
-        </aside>
-      </section>
-    </main>
-  );
+        </section>
+
+        <section className="grid gap-4 lg:grid-cols-[1fr_22rem]">
+          <div className="space-y-8">
+            {groups
+              .filter(([, entries]) => entries.length > 0)
+              .map(([title, entries]) => (
+                <section key={title} className="space-y-3">
+                  <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+                    {title}
+                  </h2>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    {entries.slice(0, 6).map((entry) => (
+                      <Link
+                        key={`${title}:${entry.category}:${entry.slug}`}
+                        href={`/${entry.category}/${entry.slug}`}
+                        className="rounded-2xl border border-border bg-card p-4 transition hover:border-primary/45"
+                      >
+                        <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                          {entry.category}
+                        </p>
+                        <p className="mt-2 text-sm font-semibold text-foreground">
+                          {entry.title}
+                        </p>
+                        <p className="mt-2 line-clamp-2 text-xs leading-6 text-muted-foreground">
+                          {entry.cardDescription || entry.description}
+                        </p>
+                      </Link>
+                    ))}
+                  </div>
+                </section>
+              ))}
+          </div>
+
+          <aside className="surface-panel h-fit p-5">
+            <p className="text-xs uppercase tracking-[0.18em] text-primary">
+              Distribution
+            </p>
+            <h2 className="mt-2 text-xl font-semibold tracking-tight text-foreground">
+              Subscribe for the brief.
+            </h2>
+            <p className="mt-3 text-sm leading-7 text-muted-foreground">
+              Weekly means selective: new useful entries, trust metadata
+              changes, practical install picks, and contributor work that
+              materially improves the registry.
+            </p>
+            <div className="mt-5">
+              <NewsletterSignup source="brief" />
+            </div>
+          </aside>
+        </section>
+      </main>
+    );
+  });
 }

--- a/apps/web/src/app/brief/page.tsx
+++ b/apps/web/src/app/brief/page.tsx
@@ -1,0 +1,159 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { JsonLd } from "@/components/json-ld";
+import { NewsletterSignup } from "@/components/newsletter-signup";
+import { getGrowthSurfaces } from "@/lib/growth-surfaces";
+import { buildPageMetadata } from "@/lib/seo";
+import { siteConfig } from "@/lib/site";
+import {
+  buildBreadcrumbJsonLd,
+  buildCollectionPageJsonLd,
+  buildItemListJsonLd,
+} from "@heyclaude/registry/seo";
+
+export const revalidate = 300;
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Weekly Claude workflow brief",
+  description:
+    "Subscribe to a practical weekly Claude workflow brief built from new, source-backed, trusted, and trending HeyClaude registry signals.",
+  path: "/brief",
+});
+
+export default async function WeeklyBriefPage() {
+  const surfaces = await getGrowthSurfaces();
+  const featured = [
+    ...surfaces.newThisWeek,
+    ...surfaces.recentlyVerified,
+    ...surfaces.safeInstall,
+  ].filter(
+    (entry, index, list) =>
+      list.findIndex(
+        (item) => item.category === entry.category && item.slug === entry.slug,
+      ) === index,
+  );
+  const groups = [
+    ["New this week", surfaces.newThisWeek],
+    ["Recently verified", surfaces.recentlyVerified],
+    ["Safe install signals", surfaces.safeInstall],
+    ["Source-backed picks", surfaces.sourceBacked],
+  ] as const;
+  const jsonLd = [
+    buildBreadcrumbJsonLd([
+      { name: "Home", url: siteConfig.url },
+      { name: "Brief", url: `${siteConfig.url}/brief` },
+    ]),
+    buildCollectionPageJsonLd({
+      siteUrl: siteConfig.url,
+      path: "/brief",
+      name: "Weekly Claude workflow brief",
+      description:
+        "A recurring editorial surface built from current HeyClaude registry signals.",
+      breadcrumbId: `${siteConfig.url}/brief#breadcrumb`,
+    }),
+    buildItemListJsonLd(
+      featured.slice(0, 12).map((entry) => ({
+        name: entry.title,
+        url: `${siteConfig.url}/${entry.category}/${entry.slug}`,
+      })),
+      {
+        name: "Weekly Claude workflow brief picks",
+        description:
+          "New, trusted, source-backed, and practical Claude workflow resources.",
+      },
+    ),
+  ];
+
+  return (
+    <main className="container-shell space-y-10 py-12">
+      <JsonLd data={jsonLd} />
+      <section className="space-y-4 border-b border-border/80 pb-8">
+        <Breadcrumbs
+          items={[{ label: "Home", href: "/" }, { label: "Brief" }]}
+        />
+        <span className="eyebrow">Weekly brief</span>
+        <h1 className="section-title text-balance">
+          Claude workflow updates worth actually checking.
+        </h1>
+        <p className="max-w-3xl text-sm leading-8 text-muted-foreground">
+          A compact brief generated from registry changes, trust signals,
+          source-backed updates, and practical install surfaces. The goal is to
+          surface useful Claude Code, MCP, skill, hook, and command resources
+          without turning the directory into a low-signal feed.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href="/trending"
+            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+          >
+            Open trending
+          </Link>
+          <Link
+            href="/best/agent-workflow-starter-kits"
+            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+          >
+            Workflow starter kits
+          </Link>
+          <Link
+            href="/browse?utility=trusted-package"
+            className="inline-flex items-center rounded-full border border-border bg-card px-4 py-2 text-sm text-foreground transition hover:border-primary/40"
+          >
+            Safe install picks
+          </Link>
+        </div>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1fr_22rem]">
+        <div className="space-y-8">
+          {groups
+            .filter(([, entries]) => entries.length > 0)
+            .map(([title, entries]) => (
+              <section key={title} className="space-y-3">
+                <h2 className="text-2xl font-semibold tracking-tight text-foreground">
+                  {title}
+                </h2>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {entries.slice(0, 6).map((entry) => (
+                    <Link
+                      key={`${title}:${entry.category}:${entry.slug}`}
+                      href={`/${entry.category}/${entry.slug}`}
+                      className="rounded-2xl border border-border bg-card p-4 transition hover:border-primary/45"
+                    >
+                      <p className="text-[11px] uppercase tracking-[0.16em] text-muted-foreground">
+                        {entry.category}
+                      </p>
+                      <p className="mt-2 text-sm font-semibold text-foreground">
+                        {entry.title}
+                      </p>
+                      <p className="mt-2 line-clamp-2 text-xs leading-6 text-muted-foreground">
+                        {entry.cardDescription || entry.description}
+                      </p>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ))}
+        </div>
+
+        <aside className="surface-panel h-fit p-5">
+          <p className="text-xs uppercase tracking-[0.18em] text-primary">
+            Distribution
+          </p>
+          <h2 className="mt-2 text-xl font-semibold tracking-tight text-foreground">
+            Subscribe for the brief.
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-muted-foreground">
+            Weekly means selective: new useful entries, trust metadata changes,
+            practical install picks, and contributor work that materially
+            improves the registry.
+          </p>
+          <div className="mt-5">
+            <NewsletterSignup source="brief" />
+          </div>
+        </aside>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -8,6 +8,7 @@ import { JsonLd } from "@/components/json-ld";
 import { getCategorySummaries, getDirectoryEntries } from "@/lib/content";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { buildPageMetadata } from "@/lib/seo";
+import { getSeoClusterDefinitions } from "@/lib/seo-clusters";
 import { siteConfig } from "@/lib/site";
 import { buildItemListJsonLd } from "@heyclaude/registry/seo";
 
@@ -93,9 +94,15 @@ export default async function HomePage() {
           </div>
         </div>
       </section>
-      <section className="container-shell grid gap-4 py-10 md:grid-cols-3">
+      <section className="container-shell grid gap-4 py-10 md:grid-cols-3 lg:grid-cols-5">
         {[
           ["Trending", "/trending", growthSurfaces.practicalPicks.length],
+          [
+            "Best",
+            "/best/agent-workflow-starter-kits",
+            getSeoClusterDefinitions().length,
+          ],
+          ["Brief", "/brief", growthSurfaces.newThisWeek.length],
           ["Newly added", "/browse?sort=newest", growthSurfaces.newest.length],
           ["API", "/api-docs", directoryEntries.length],
         ].map(([label, href, count]) => (

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -57,6 +57,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     "/platforms",
     "/quality",
     "/trending",
+    "/brief",
     "/llms.txt",
     "/llms-full.txt",
     "/feed.xml",

--- a/apps/web/src/components/browse-directory.tsx
+++ b/apps/web/src/components/browse-directory.tsx
@@ -63,6 +63,14 @@ const utilityFilterOptions = [
   { value: "privacy-notes", label: "Privacy Notes" },
   { value: "troubleshooting", label: "Troubleshooting" },
 ] as const;
+const quickTrustFilterOptions = [
+  { value: "source-backed", label: "Source-backed" },
+  { value: "trusted-package", label: "Trusted package" },
+  { value: "safety-notes", label: "Safety notes" },
+  { value: "privacy-notes", label: "Privacy notes" },
+  { value: "reviewed", label: "Reviewed" },
+  { value: "checksum", label: "Checksum" },
+] as const;
 const platformFilterOptions = [
   { value: "all", label: "All Platforms" },
   ...categorySpec.defaultTestedPlatforms.map((platform) => ({
@@ -176,6 +184,40 @@ function matchesPlatformFilter(entry: DirectoryEntry, filter: string) {
   return (entry.platformCompatibility ?? []).some(
     (item) => item.platform.trim().toLowerCase() === filter,
   );
+}
+
+function entryMatchesBrowseQuery(
+  entry: DirectoryEntry,
+  normalizedQuery: string,
+) {
+  if (!normalizedQuery) return true;
+
+  const haystack = [
+    entry.title,
+    entry.description,
+    entry.author,
+    entry.submittedBy,
+    entry.brandName,
+    entry.brandDomain,
+    entry.trigger,
+    entry.skillType,
+    entry.skillLevel,
+    entry.verificationStatus,
+    entry.downloadTrust,
+    ...(entry.platformCompatibility ?? []).flatMap((item) => [
+      item.platform,
+      item.supportLevel,
+    ]),
+    ...(entry.safetyNotes ?? []),
+    ...(entry.privacyNotes ?? []),
+    ...entry.tags,
+    ...entry.keywords,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  return haystack.includes(normalizedQuery);
 }
 
 export function BrowseDirectory({
@@ -414,34 +456,7 @@ export function BrowseDirectory({
       if (category !== "all" && entry.category !== category) return false;
       if (!matchesUtilityFilter(entry, utilityFilter)) return false;
       if (!matchesPlatformFilter(entry, platformFilter)) return false;
-      if (!normalizedQuery) return true;
-
-      const haystack = [
-        entry.title,
-        entry.description,
-        entry.author,
-        entry.submittedBy,
-        entry.brandName,
-        entry.brandDomain,
-        entry.trigger,
-        entry.skillType,
-        entry.skillLevel,
-        entry.verificationStatus,
-        entry.downloadTrust,
-        ...(entry.platformCompatibility ?? []).flatMap((item) => [
-          item.platform,
-          item.supportLevel,
-        ]),
-        ...(entry.safetyNotes ?? []),
-        ...(entry.privacyNotes ?? []),
-        ...entry.tags,
-        ...entry.keywords,
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-
-      return haystack.includes(normalizedQuery);
+      return entryMatchesBrowseQuery(entry, normalizedQuery);
     });
 
     const sorted = [...matched].sort((left, right) => {
@@ -471,6 +486,23 @@ export function BrowseDirectory({
     sortMode,
     utilityFilter,
   ]);
+
+  const trustChipCounts = useMemo(() => {
+    const scopedEntries = allEntries.filter((entry) => {
+      if (category !== "all" && entry.category !== category) return false;
+      if (!matchesPlatformFilter(entry, platformFilter)) return false;
+      return entryMatchesBrowseQuery(entry, normalizedQuery);
+    });
+
+    return Object.fromEntries(
+      quickTrustFilterOptions.map((option) => [
+        option.value,
+        scopedEntries.filter((entry) =>
+          matchesUtilityFilter(entry, option.value),
+        ).length,
+      ]),
+    ) as Record<(typeof quickTrustFilterOptions)[number]["value"], number>;
+  }, [allEntries, category, normalizedQuery, platformFilter]);
 
   const entryByKey = useMemo(() => {
     return new Map(allEntries.map((entry) => [getEntryKey(entry), entry]));
@@ -749,6 +781,52 @@ export function BrowseDirectory({
         {normalizedQuery ? <p>Filtering for “{deferredQuery}”</p> : null}
       </div>
 
+      <div className="surface-panel p-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-semibold text-foreground">
+              Trust quick filters
+            </p>
+            <p className="mt-1 text-xs leading-6 text-muted-foreground">
+              Narrow discovery by source, install, safety, privacy, and review
+              signals before opening a listing.
+            </p>
+          </div>
+          {utilityFilter !== "all" ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setUtilityFilter("all")}
+              className="h-8 rounded-lg px-3 text-[11px]"
+            >
+              Clear utility filter
+            </Button>
+          ) : null}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          {quickTrustFilterOptions.map((option) => {
+            const isActive = utilityFilter === option.value;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                onClick={() =>
+                  setUtilityFilter(isActive ? "all" : option.value)
+                }
+                className={
+                  isActive
+                    ? "rounded-full border border-primary bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground"
+                    : "rounded-full border border-border bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:border-primary/45 hover:text-foreground"
+                }
+              >
+                {option.label} ({trustChipCounts[option.value] ?? 0})
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
       {collectionKeys.length > 0 ? (
         <section className="surface-panel space-y-4 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -817,17 +895,73 @@ export function BrowseDirectory({
           </div>
 
           {collectionEntries.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {collectionEntries.map((entry) => (
-                <a
-                  key={getEntryKey(entry)}
-                  href={`/${entry.category}/${entry.slug}`}
-                  className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-foreground transition hover:border-primary/45"
-                >
-                  {entry.title}
-                </a>
-              ))}
-            </div>
+            <>
+              <div className="flex flex-wrap gap-2">
+                {collectionEntries.map((entry) => (
+                  <a
+                    key={getEntryKey(entry)}
+                    href={`/${entry.category}/${entry.slug}`}
+                    className="rounded-full border border-border bg-background px-2.5 py-1 text-xs text-foreground transition hover:border-primary/45"
+                  >
+                    {entry.title}
+                  </a>
+                ))}
+              </div>
+              <div className="overflow-x-auto rounded-xl border border-border bg-background">
+                <table className="min-w-full divide-y divide-border text-left text-xs">
+                  <thead className="bg-card/80 text-muted-foreground">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Entry</th>
+                      <th className="px-3 py-2 font-medium">Category</th>
+                      <th className="px-3 py-2 font-medium">Source</th>
+                      <th className="px-3 py-2 font-medium">Install</th>
+                      <th className="px-3 py-2 font-medium">Safety</th>
+                      <th className="px-3 py-2 font-medium">Privacy</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border">
+                    {collectionEntries.map((entry) => (
+                      <tr key={`compare:${getEntryKey(entry)}`}>
+                        <td className="max-w-[14rem] px-3 py-2">
+                          <a
+                            href={`/${entry.category}/${entry.slug}`}
+                            className="font-medium text-foreground transition hover:text-primary"
+                          >
+                            {entry.title}
+                          </a>
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {categoryLabels[entry.category] ?? entry.category}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {entry.trustSignals?.sourceStatus === "available"
+                            ? "Available"
+                            : "Missing"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {entry.downloadTrust === "first-party" ||
+                          entry.packageVerified
+                            ? "Trusted"
+                            : entry.installCommand || entry.downloadUrl
+                              ? "Review"
+                              : "None"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {entry.safetyNotes?.length
+                            ? `${entry.safetyNotes.length} note(s)`
+                            : "Missing"}
+                        </td>
+                        <td className="px-3 py-2 text-muted-foreground">
+                          {entry.privacyNotes?.length
+                            ? `${entry.privacyNotes.length} note(s)`
+                            : "Missing"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </>
           ) : null}
         </section>
       ) : null}

--- a/apps/web/src/components/newsletter-signup.tsx
+++ b/apps/web/src/components/newsletter-signup.tsx
@@ -5,7 +5,11 @@ import { FormEvent, useEffect, useState } from "react";
 
 import { useToast } from "@/components/ui/toast-provider";
 
-export function NewsletterSignup() {
+type NewsletterSignupProps = {
+  source?: string;
+};
+
+export function NewsletterSignup({ source = "footer" }: NewsletterSignupProps) {
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<
     "idle" | "loading" | "success" | "error"
@@ -32,7 +36,7 @@ export function NewsletterSignup() {
         },
         body: JSON.stringify({
           email,
-          source: "footer",
+          source,
         }),
       });
 

--- a/apps/web/src/components/newsletter-signup.tsx
+++ b/apps/web/src/components/newsletter-signup.tsx
@@ -4,6 +4,7 @@ import { Check } from "lucide-react";
 import { FormEvent, useEffect, useState } from "react";
 
 import { useToast } from "@/components/ui/toast-provider";
+import { useLoggedAsync } from "@/hooks/use-logged-async";
 
 type NewsletterSignupProps = {
   source?: string;
@@ -22,20 +23,16 @@ export function NewsletterSignup({ source = "footer" }: NewsletterSignupProps) {
     return () => window.clearTimeout(timer);
   }, [status]);
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!email.trim()) return;
-
-    setStatus("loading");
-
-    try {
+  const subscribeNewsletter = useLoggedAsync(
+    "newsletter.signup_failed",
+    async (emailToSubmit: string) => {
       const response = await fetch("/api/newsletter/subscribe", {
         method: "POST",
         headers: {
           "content-type": "application/json",
         },
         body: JSON.stringify({
-          email,
+          email: emailToSubmit,
           source,
         }),
       });
@@ -48,14 +45,27 @@ export function NewsletterSignup({ source = "footer" }: NewsletterSignupProps) {
         title: "Subscribed",
         description: "You are on the list for launch and major updates.",
       });
-    } catch {
-      setStatus("error");
-      pushToast({
-        variant: "error",
-        title: "Subscription failed",
-        description: "Could not subscribe right now. Try again in a bit.",
-      });
-    }
+    },
+    {
+      meta: () => ({ source }),
+      onError: () => {
+        setStatus("error");
+        pushToast({
+          variant: "error",
+          title: "Subscription failed",
+          description: "Could not subscribe right now. Try again in a bit.",
+        });
+      },
+    },
+  );
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const emailToSubmit = email.trim();
+    if (!emailToSubmit) return;
+
+    setStatus("loading");
+    await subscribeNewsletter(emailToSubmit);
   };
 
   return (

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -87,6 +87,18 @@ export function SiteFooter() {
           >
             Tools
           </Link>
+          <Link
+            href="/best/agent-workflow-starter-kits"
+            className="block transition hover:text-foreground"
+          >
+            Best
+          </Link>
+          <Link
+            href="/brief"
+            className="block transition hover:text-foreground"
+          >
+            Brief
+          </Link>
           <Link href="/jobs" className="block transition hover:text-foreground">
             Jobs
           </Link>

--- a/apps/web/src/hooks/use-logged-async.ts
+++ b/apps/web/src/hooks/use-logged-async.ts
@@ -8,18 +8,35 @@ type AsyncAction<TArgs extends unknown[]> = (
   ...args: TArgs
 ) => Promise<void> | void;
 
+type AsyncLogMeta<TArgs extends unknown[]> =
+  | Record<string, unknown>
+  | ((...args: TArgs) => Record<string, unknown>);
+
+type LoggedAsyncOptions<TArgs extends unknown[]> = {
+  meta?: AsyncLogMeta<TArgs>;
+  onError?: (error: unknown, ...args: TArgs) => void;
+};
+
 export function useLoggedAsync<TArgs extends unknown[]>(
   event: string,
   action: AsyncAction<TArgs>,
+  options: LoggedAsyncOptions<TArgs> = {},
 ) {
+  const { meta, onError } = options;
+
   return useCallback(
     async (...args: TArgs) => {
       try {
         await action(...args);
       } catch (error) {
-        logClientError(event, error);
+        logClientError(
+          event,
+          error,
+          typeof meta === "function" ? meta(...args) : meta,
+        );
+        onError?.(error, ...args);
       }
     },
-    [action, event],
+    [action, event, meta, onError],
   );
 }

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -37,9 +37,18 @@ export type RegistrySearchFilterDimension =
   | "claimStatus"
   | "sourceStatus";
 
-export function matchesQuery(entry: SearchDocument, query: string) {
-  if (!query) return true;
-  const haystack = [
+const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+
+function tokenizeSearchQuery(query: string) {
+  return query
+    .split(TOKEN_SPLIT_PATTERN)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length >= 2)
+    .slice(0, 12);
+}
+
+function normalizedSearchText(entry: SearchDocument) {
+  return [
     entry.category,
     entry.title,
     entry.description,
@@ -55,6 +64,11 @@ export function matchesQuery(entry: SearchDocument, query: string) {
     .filter(Boolean)
     .join(" ")
     .toLowerCase();
+}
+
+export function matchesQuery(entry: SearchDocument, query: string) {
+  if (!query) return true;
+  const haystack = normalizedSearchText(entry);
   return haystack.includes(query);
 }
 
@@ -65,7 +79,10 @@ export function matchesPlatform(entry: SearchDocument, platform: string) {
   );
 }
 
-export function matchesBooleanFilter(value: boolean, filter: BooleanFilterValue) {
+export function matchesBooleanFilter(
+  value: boolean,
+  filter: BooleanFilterValue,
+) {
   if (filter === "all") return true;
   return filter === "true" ? value : !value;
 }
@@ -152,4 +169,109 @@ export function filterEntries(
   filters: RegistrySearchFilterState,
 ) {
   return entries.filter((entry) => entryMatchesFilters(entry, filters));
+}
+
+export type RankedSearchEntry = {
+  entry: SearchDocument;
+  score: number;
+  reasons: string[];
+};
+
+export function scoreSearchEntry(
+  entry: SearchDocument,
+  query: string,
+): Omit<RankedSearchEntry, "entry"> {
+  const tokens = tokenizeSearchQuery(query);
+  if (!tokens.length) return { score: 0, reasons: [] };
+
+  const title = entry.title.toLowerCase();
+  const category = entry.category.toLowerCase();
+  const tags = new Set((entry.tags ?? []).map((tag) => tag.toLowerCase()));
+  const keywords = new Set(
+    (entry.keywords ?? []).map((keyword) => keyword.toLowerCase()),
+  );
+  const haystack = normalizedSearchText(entry);
+  let score = 0;
+  const reasons = new Set<string>();
+
+  if (title.includes(query)) {
+    score += 90;
+    reasons.add("title phrase");
+  }
+  if (category === query) {
+    score += 45;
+    reasons.add("category match");
+  }
+
+  for (const token of tokens) {
+    if (title.includes(token)) {
+      score += 35;
+      reasons.add("title term");
+    }
+    if (tags.has(token)) {
+      score += 24;
+      reasons.add("tag match");
+    }
+    if (keywords.has(token)) {
+      score += 18;
+      reasons.add("keyword match");
+    }
+    if (category.includes(token)) {
+      score += 12;
+      reasons.add("category term");
+    }
+    if (haystack.includes(token)) {
+      score += 4;
+    }
+  }
+
+  if (entry.trustSignals?.sourceStatus === "available") {
+    score += 8;
+    reasons.add("source-backed");
+  }
+  if (
+    entry.downloadTrust === "first-party" ||
+    entry.trustSignals?.packageVerified === true
+  ) {
+    score += 8;
+    reasons.add("trusted package");
+  }
+  if (hasSafetyNotes(entry)) {
+    score += 4;
+    reasons.add("safety notes");
+  }
+  if (hasPrivacyNotes(entry)) {
+    score += 4;
+    reasons.add("privacy notes");
+  }
+  if (entry.claimStatus === "verified" || entry.reviewedBy) {
+    score += 4;
+    reasons.add("reviewed");
+  }
+
+  return {
+    score,
+    reasons: [...reasons].slice(0, 6),
+  };
+}
+
+export function rankSearchEntries(
+  entries: ReadonlyArray<SearchDocument>,
+  query: string,
+): RankedSearchEntry[] {
+  return entries
+    .map((entry, index) => ({
+      entry,
+      index,
+      ...scoreSearchEntry(entry, query),
+    }))
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score;
+      const dateDelta = String(right.entry.dateAdded ?? "").localeCompare(
+        String(left.entry.dateAdded ?? ""),
+      );
+      if (dateDelta !== 0) return dateDelta;
+      return left.index - right.index;
+    })
+    .map(({ entry, score, reasons }) => ({ entry, score, reasons }));
 }

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -67,9 +67,10 @@ function normalizedSearchText(entry: SearchDocument) {
 }
 
 export function matchesQuery(entry: SearchDocument, query: string) {
-  if (!query) return true;
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
   const haystack = normalizedSearchText(entry);
-  return haystack.includes(query);
+  return haystack.includes(normalizedQuery);
 }
 
 export function matchesPlatform(entry: SearchDocument, platform: string) {
@@ -181,7 +182,8 @@ export function scoreSearchEntry(
   entry: SearchDocument,
   query: string,
 ): Omit<RankedSearchEntry, "entry"> {
-  const tokens = tokenizeSearchQuery(query);
+  const normalizedQuery = query.trim().toLowerCase();
+  const tokens = tokenizeSearchQuery(normalizedQuery);
   if (!tokens.length) return { score: 0, reasons: [] };
 
   const title = entry.title.toLowerCase();
@@ -194,11 +196,11 @@ export function scoreSearchEntry(
   let score = 0;
   const reasons = new Set<string>();
 
-  if (title.includes(query)) {
+  if (title.includes(normalizedQuery)) {
     score += 90;
     reasons.add("title phrase");
   }
-  if (category === query) {
+  if (category === normalizedQuery) {
     score += 45;
     reasons.add("category match");
   }

--- a/apps/web/src/lib/seo-clusters.ts
+++ b/apps/web/src/lib/seo-clusters.ts
@@ -172,6 +172,288 @@ export const seoClusterDefinitions: SeoClusterDefinition[] = [
     tags: ["review", "testing", "git", "automation", "quality-gate"],
     itemLimit: 18,
   },
+  {
+    slug: "mcp-servers-for-code-review",
+    title: "MCP servers for code review workflows",
+    eyebrow: "Code review MCP",
+    description:
+      "MCP servers and adjacent agent tools for repository review, pull request triage, quality checks, and source-backed engineering review.",
+    seoTitle: "MCP servers for code review workflows",
+    seoDescription:
+      "Compare MCP servers for code review, pull request triage, source analysis, quality checks, and Claude developer workflow automation.",
+    categories: ["mcp"],
+    tags: ["review", "code-review", "testing", "security", "quality"],
+    keywords: ["pull request", "repository", "code review"],
+    itemLimit: 16,
+  },
+  {
+    slug: "mcp-servers-for-browser-automation",
+    title: "MCP servers for browser automation",
+    eyebrow: "Browser MCP",
+    description:
+      "MCP servers and tools for browser control, screenshots, crawling, testing, scraping, and web workflow automation with Claude.",
+    seoTitle: "MCP servers for browser automation",
+    seoDescription:
+      "Find MCP servers for browser automation, screenshots, web testing, crawling, scraping, and Claude-controlled web workflows.",
+    categories: ["mcp"],
+    tags: ["browser", "automation", "testing", "playwright", "web"],
+    keywords: ["screenshot", "crawl", "scrape"],
+    itemLimit: 16,
+  },
+  {
+    slug: "mcp-servers-for-databases",
+    title: "MCP servers for databases and data workflows",
+    eyebrow: "Database MCP",
+    description:
+      "Database, SQL, analytics, and data workflow MCP servers that help Claude inspect, query, transform, or document structured data.",
+    seoTitle: "MCP servers for databases and data workflows",
+    seoDescription:
+      "Browse MCP servers for databases, SQL, analytics, structured data inspection, and Claude-assisted data workflow automation.",
+    categories: ["mcp"],
+    tags: ["database", "sql", "postgres", "data", "analytics"],
+    keywords: ["sqlite", "mysql", "warehouse"],
+    itemLimit: 16,
+  },
+  {
+    slug: "claude-code-testing-automation",
+    title: "Claude Code testing automation",
+    eyebrow: "Testing automation",
+    description:
+      "Commands, hooks, and skills for generating tests, running checks, enforcing TDD loops, and keeping Claude Code changes verifiable.",
+    seoTitle: "Claude Code testing automation",
+    seoDescription:
+      "Discover Claude Code testing commands, hooks, skills, TDD workflows, and quality checks for safer AI-assisted engineering.",
+    categories: ["commands", "hooks", "skills"],
+    tags: ["testing", "tdd", "automation", "quality", "workflow"],
+    keywords: ["test", "vitest", "unit tests"],
+    itemLimit: 18,
+  },
+  {
+    slug: "claude-code-security-workflows",
+    title: "Claude Code security workflows",
+    eyebrow: "Security workflows",
+    description:
+      "Security commands, hooks, rules, MCP servers, and skills for auditing code, checking risky changes, and tightening agent behavior.",
+    seoTitle: "Claude Code security workflows",
+    seoDescription:
+      "Find Claude Code security workflows for code audits, risky-change checks, repository guardrails, and agent safety review.",
+    categories: ["commands", "hooks", "skills", "rules", "mcp"],
+    tags: ["security", "audit", "compliance", "guardrails", "review"],
+    keywords: ["vulnerability", "secret", "risk"],
+    itemLimit: 18,
+  },
+  {
+    slug: "codex-agent-skills",
+    title: "Codex and agent skills for repeatable work",
+    eyebrow: "Codex skills",
+    description:
+      "Skills, commands, and rules that map well to Codex-style repeatable agent workflows across engineering, docs, deployment, and review.",
+    seoTitle: "Codex skills and agent workflow resources",
+    seoDescription:
+      "Browse Codex-compatible skills, commands, and rules for repeatable agent workflows across engineering, documentation, deployment, and review.",
+    categories: ["skills", "commands", "rules"],
+    tags: ["codex", "workflow", "automation", "openai", "development"],
+    keywords: ["agent skill", "deployment", "review"],
+    itemLimit: 18,
+  },
+  {
+    slug: "claude-skills-for-design",
+    title: "Claude skills for design and frontend work",
+    eyebrow: "Design skills",
+    description:
+      "Claude skills for UI design, frontend implementation, creative direction, visual systems, and repeatable web app production.",
+    seoTitle: "Claude skills for design and frontend work",
+    seoDescription:
+      "Find Claude skills for frontend design, UI implementation, creative direction, visual systems, and repeatable web app production.",
+    categories: ["skills"],
+    tags: ["design", "frontend", "ui", "visual", "web"],
+    keywords: ["tailwind", "react", "component"],
+    itemLimit: 16,
+  },
+  {
+    slug: "claude-skills-for-documentation",
+    title: "Claude skills for documentation workflows",
+    eyebrow: "Documentation skills",
+    description:
+      "Skills, commands, and guides for writing docs, API references, onboarding content, changelogs, READMEs, and technical explainers.",
+    seoTitle: "Claude skills for documentation workflows",
+    seoDescription:
+      "Discover Claude documentation skills, commands, and guides for API docs, READMEs, changelogs, onboarding, and technical writing.",
+    categories: ["skills", "commands", "guides"],
+    tags: ["documentation", "docs", "writing", "api", "readme"],
+    keywords: ["changelog", "explain", "technical writing"],
+    itemLimit: 18,
+  },
+  {
+    slug: "claude-skills-for-data-workflows",
+    title: "Claude skills and MCP tools for data workflows",
+    eyebrow: "Data workflows",
+    description:
+      "Claude skills, MCP servers, and tools for data extraction, SQL, analytics, spreadsheet workflows, enrichment, and reporting.",
+    seoTitle: "Claude skills and MCP tools for data workflows",
+    seoDescription:
+      "Browse Claude skills, MCP servers, and tools for SQL, analytics, data extraction, spreadsheet workflows, enrichment, and reporting.",
+    categories: ["skills", "mcp", "tools"],
+    tags: ["data", "database", "analytics", "spreadsheet", "reporting"],
+    keywords: ["csv", "sql", "enrichment"],
+    itemLimit: 18,
+  },
+  {
+    slug: "safe-mcp-installs",
+    title: "Safe MCP install checklist resources",
+    eyebrow: "Safe MCP installs",
+    description:
+      "MCP servers and install resources that help teams review source, credentials, file access, network behavior, and package trust.",
+    seoTitle: "Safe MCP install checklist resources",
+    seoDescription:
+      "Review MCP install resources by source, credential handling, file access, network behavior, package trust, and privacy notes.",
+    categories: ["mcp"],
+    tags: ["security", "privacy", "install", "credentials", "source"],
+    keywords: ["package", "permissions", "local files"],
+    itemLimit: 18,
+  },
+  {
+    slug: "raycast-claude-workflows",
+    title: "Raycast-friendly Claude workflow resources",
+    eyebrow: "Raycast workflows",
+    description:
+      "Commands, tools, and skills that fit fast launcher workflows for developers who want Claude resources reachable from Raycast.",
+    seoTitle: "Raycast-friendly Claude workflow resources",
+    seoDescription:
+      "Find Claude commands, tools, and skills for Raycast-friendly launcher workflows, fast search, install handoff, and developer utility.",
+    categories: ["commands", "tools", "skills"],
+    tags: ["raycast", "launcher", "workflow", "productivity", "search"],
+    keywords: ["command palette", "shortcut", "handoff"],
+    itemLimit: 18,
+  },
+  {
+    slug: "agent-observability-workflows",
+    title: "Agent observability and status workflows",
+    eyebrow: "Observability",
+    description:
+      "Statuslines, tools, hooks, and MCP servers for usage tracking, cost awareness, latency, health checks, and runtime visibility.",
+    seoTitle: "Agent observability and status workflows",
+    seoDescription:
+      "Browse agent observability resources for usage tracking, cost monitoring, latency, health checks, statuslines, and runtime visibility.",
+    categories: ["statuslines", "tools", "mcp", "hooks"],
+    tags: ["observability", "monitoring", "cost", "usage", "statusline"],
+    keywords: ["latency", "tokens", "health"],
+    itemLimit: 18,
+  },
+  {
+    slug: "claude-code-statuslines",
+    title: "Claude Code statuslines for live workflow context",
+    eyebrow: "Statuslines",
+    description:
+      "Statuslines for model context, costs, timers, git state, MCP health, Docker health, and session-level Claude Code awareness.",
+    seoTitle: "Claude Code statuslines for live workflow context",
+    seoDescription:
+      "Find Claude Code statuslines for costs, timers, git state, MCP health, Docker health, model context, and session awareness.",
+    categories: ["statuslines"],
+    tags: ["statusline", "usage", "cost", "monitoring", "git"],
+    keywords: ["tokens", "timer", "health"],
+    itemLimit: 18,
+  },
+  {
+    slug: "prompt-and-context-engineering",
+    title: "Prompt and context engineering resources",
+    eyebrow: "Context engineering",
+    description:
+      "Rules, guides, commands, and skills for prompt design, CLAUDE.md setup, context hygiene, instructions, and reusable agent memory.",
+    seoTitle: "Prompt and context engineering resources",
+    seoDescription:
+      "Explore Claude prompt and context engineering resources for rules, guides, commands, CLAUDE.md setup, instructions, and agent memory.",
+    categories: ["rules", "guides", "commands", "skills"],
+    tags: ["prompt", "context", "documentation", "workflow", "instructions"],
+    keywords: ["claude.md", "memory", "system prompt"],
+    itemLimit: 18,
+  },
+  {
+    slug: "developer-productivity-agent-stack",
+    title: "Developer productivity agent stack",
+    eyebrow: "Productivity stack",
+    description:
+      "Collections, commands, hooks, skills, and MCP servers for faster commits, reviews, refactors, docs, debugging, and daily coding flow.",
+    seoTitle: "Developer productivity agent stack",
+    seoDescription:
+      "Build a developer productivity agent stack with Claude collections, commands, hooks, skills, MCP servers, reviews, refactors, and docs.",
+    categories: ["collections", "commands", "hooks", "skills", "mcp"],
+    tags: ["productivity", "workflow", "automation", "git", "debugging"],
+    keywords: ["refactor", "commit", "review"],
+    itemLimit: 20,
+  },
+  {
+    slug: "open-source-claude-resources",
+    title: "Open-source Claude workflow resources",
+    eyebrow: "Open source",
+    description:
+      "Source-backed agents, MCP servers, skills, hooks, commands, and guides that teams can inspect before adopting in Claude workflows.",
+    seoTitle: "Open-source Claude workflow resources",
+    seoDescription:
+      "Browse source-backed Claude agents, MCP servers, skills, hooks, commands, and guides that teams can inspect before adoption.",
+    categories: ["agents", "mcp", "skills", "hooks", "commands", "guides"],
+    tags: ["open-source", "github", "source", "development", "workflow"],
+    keywords: ["repository", "source code", "inspect"],
+    requireSource: true,
+    itemLimit: 20,
+  },
+  {
+    slug: "claude-code-command-center",
+    title: "Claude Code command center",
+    eyebrow: "Commands",
+    description:
+      "Slash commands for commits, reviews, tests, docs, security checks, debugging, refactors, MCP setup, and repeatable coding tasks.",
+    seoTitle: "Claude Code command center",
+    seoDescription:
+      "Find Claude Code slash commands for commits, reviews, tests, docs, security checks, debugging, refactors, and MCP setup.",
+    categories: ["commands"],
+    tags: ["git", "review", "testing", "security", "documentation"],
+    keywords: ["slash command", "commit", "refactor"],
+    itemLimit: 20,
+  },
+  {
+    slug: "source-verified-mcp-tools",
+    title: "Source-verified MCP tools and listings",
+    eyebrow: "Source verified",
+    description:
+      "MCP servers and tool listings with visible source metadata for teams that want reviewable install paths and attribution before adoption.",
+    seoTitle: "Source-verified MCP tools and listings",
+    seoDescription:
+      "Compare MCP servers and Claude tools with visible source metadata, reviewable install paths, attribution, and trust signals.",
+    categories: ["mcp", "tools"],
+    tags: ["source", "github", "security", "install", "trust"],
+    keywords: ["source-backed", "repository", "reviewable"],
+    requireSource: true,
+    itemLimit: 20,
+  },
+  {
+    slug: "claude-code-workflow-starter-kit",
+    title: "Claude Code workflow starter kit",
+    eyebrow: "Workflow starter kit",
+    description:
+      "A starter kit of collections, agents, commands, hooks, and skills for teams setting up practical Claude Code workflows.",
+    seoTitle: "Claude Code workflow starter kit",
+    seoDescription:
+      "Build a Claude Code workflow starter kit with collections, agents, commands, hooks, skills, install signals, and reviewable setup paths.",
+    categories: ["collections", "agents", "commands", "hooks", "skills"],
+    tags: ["starter", "workflow", "productivity", "setup", "automation"],
+    keywords: ["starter kit", "onboarding", "team"],
+    itemLimit: 20,
+  },
+  {
+    slug: "local-first-ai-workflows",
+    title: "Local-first AI workflow resources",
+    eyebrow: "Local-first",
+    description:
+      "Claude resources for local files, privacy-aware workflows, repository automation, offline-friendly setup, and reviewable local execution.",
+    seoTitle: "Local-first AI workflow resources",
+    seoDescription:
+      "Find local-first Claude workflow resources for files, privacy-aware automation, repository work, offline-friendly setup, and reviewable execution.",
+    categories: ["mcp", "hooks", "commands", "skills"],
+    tags: ["local", "privacy", "files", "workflow", "automation"],
+    keywords: ["offline", "filesystem", "repository"],
+    itemLimit: 18,
+  },
 ];
 
 function scoreItem(
@@ -188,8 +470,21 @@ function scoreItem(
   const keywordScore = (definition.keywords || []).filter((keyword) =>
     itemKeywords.has(keyword.toLowerCase()),
   ).length;
+  const searchableText = [
+    item.title,
+    item.description,
+    item.cardDescription,
+    item.category,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  const textScore = [
+    ...(definition.tags || []),
+    ...(definition.keywords || []),
+  ].filter((term) => searchableText.includes(term.toLowerCase())).length;
   const pickScore = item.disclosure === "heyclaude_pick" ? 2 : 0;
-  return tagScore * 3 + keywordScore * 2 + pickScore;
+  return tagScore * 3 + keywordScore * 2 + textScore + pickScore;
 }
 
 function toClusterItem(item: DirectoryEntry | ToolListing): SeoClusterItem {
@@ -224,8 +519,7 @@ function matchesClusterRequirements(
       item.installCommand || item.downloadUrl || item.configSnippet,
     );
     const hasTrustedInstall =
-      item.downloadTrust === "first-party" ||
-      item.packageVerified === true;
+      item.downloadTrust === "first-party" || item.packageVerified === true;
     if (!hasInstallSurface || !hasTrustedInstall) return false;
   }
 

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -37,6 +37,8 @@ export const siteConfig = {
     "/jobs/post?tier=sponsored",
   nav: [
     { href: "/browse", label: "Browse" },
+    { href: "/best/agent-workflow-starter-kits", label: "Best" },
+    { href: "/brief", label: "Brief" },
     { href: "/tools", label: "Tools" },
     { href: "/jobs", label: "Jobs" },
     { href: "/about", label: "About" },

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -7,7 +7,10 @@ import {
   platformFeedSlug,
   SITE_URL,
 } from "./platforms.js";
-import { DEFAULT_REMOTE_MCP_URL, normalizeEndpointUrl } from "./endpoint-url.js";
+import {
+  DEFAULT_REMOTE_MCP_URL,
+  normalizeEndpointUrl,
+} from "./endpoint-url.js";
 import { packageName, packageVersion } from "./package-metadata.js";
 import {
   formatZodError,
@@ -62,6 +65,7 @@ const platformAliases = new Map([
 
 export const READ_ONLY_TOOL_NAMES = [
   "search_registry",
+  "plan_workflow_toolbox",
   "server_info",
   "list_category_entries",
   "get_recent_updates",
@@ -95,6 +99,19 @@ export const TOOL_DEFINITIONS = [
       "Search read-only HeyClaude registry entries by query, category, and skill platform compatibility.",
     inputSchema: jsonSchemaForTool("search_registry"),
     outputSchema: jsonSchemaForToolOutput("search_registry"),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "plan_workflow_toolbox",
+    description:
+      "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries with trust, install, and follow-up guidance.",
+    inputSchema: jsonSchemaForTool("plan_workflow_toolbox"),
+    outputSchema: jsonSchemaForToolOutput("plan_workflow_toolbox"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -348,6 +365,121 @@ function entryMatchesQuery(entry, query) {
   return haystack.includes(query);
 }
 
+function searchTokens(query) {
+  return normalizeText(query)
+    .split(/[^a-z0-9+#.-]+/i)
+    .map((token) => token.trim())
+    .filter((token) => token.length >= 2)
+    .slice(0, 12);
+}
+
+function entrySearchText(entry) {
+  return [
+    entry.title,
+    entry.description,
+    entry.cardDescription,
+    entry.category,
+    entry.slug,
+    entry.author,
+    entry.submittedBy,
+    entry.brandName,
+    entry.brandDomain,
+    ...notes(entry.safetyNotes),
+    ...notes(entry.privacyNotes),
+    ...(entry.tags || []),
+    ...(entry.keywords || []),
+  ]
+    .map(normalizeText)
+    .join(" ");
+}
+
+function scoreSearchEntry(entry, query) {
+  const normalizedQuery = normalizeText(query);
+  const tokens = searchTokens(normalizedQuery);
+  if (!tokens.length) return { score: 0, reasons: [] };
+
+  const title = normalizeText(entry.title);
+  const category = normalizeText(entry.category);
+  const tags = new Set((entry.tags || []).map(normalizeText));
+  const keywords = new Set((entry.keywords || []).map(normalizeText));
+  const haystack = entrySearchText(entry);
+  const reasons = new Set();
+  let score = 0;
+
+  if (title.includes(normalizedQuery)) {
+    score += 90;
+    reasons.add("title phrase");
+  }
+  if (category === normalizedQuery) {
+    score += 45;
+    reasons.add("category match");
+  }
+
+  for (const token of tokens) {
+    if (title.includes(token)) {
+      score += 35;
+      reasons.add("title term");
+    }
+    if (tags.has(token)) {
+      score += 24;
+      reasons.add("tag match");
+    }
+    if (keywords.has(token)) {
+      score += 18;
+      reasons.add("keyword match");
+    }
+    if (category.includes(token)) {
+      score += 12;
+      reasons.add("category term");
+    }
+    if (haystack.includes(token)) score += 4;
+  }
+
+  if (entrySourceStatus(entry) === "available") {
+    score += 8;
+    reasons.add("source-backed");
+  }
+  if (
+    entryPackageTrust(entry) === "first-party" ||
+    entry.packageVerified ||
+    entry.trustSignals?.packageVerified
+  ) {
+    score += 8;
+    reasons.add("trusted package");
+  }
+  if (notes(entry.safetyNotes).length) {
+    score += 4;
+    reasons.add("safety notes");
+  }
+  if (notes(entry.privacyNotes).length) {
+    score += 4;
+    reasons.add("privacy notes");
+  }
+  if (entry.claimStatus === "verified" || entry.reviewedBy) {
+    score += 4;
+    reasons.add("reviewed");
+  }
+
+  return { score, reasons: [...reasons].slice(0, 6) };
+}
+
+function rankSearchEntries(entries, query) {
+  return entries
+    .map((entry, index) => ({
+      entry,
+      index,
+      ...scoreSearchEntry(entry, query),
+    }))
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score;
+      const dateCompare = String(right.entry.dateAdded || "").localeCompare(
+        String(left.entry.dateAdded || ""),
+      );
+      if (dateCompare !== 0) return dateCompare;
+      return left.index - right.index;
+    });
+}
+
 function entryMatchesPlatform(entry, platform) {
   if (!platform) return true;
   return (entry.platforms || []).some((candidate) => candidate === platform);
@@ -437,7 +569,7 @@ function parsedTrustArgs(args = {}) {
   };
 }
 
-function toSearchResult(entry) {
+function toSearchResult(entry, ranking = null) {
   return {
     key: `${entry.category}:${entry.slug}`,
     category: entry.category,
@@ -458,6 +590,8 @@ function toSearchResult(entry) {
       entry.canonicalUrl ||
       entry.url ||
       `${SITE_URL}/${entry.category}/${entry.slug}`,
+    searchScore: ranking?.score ?? 0,
+    searchReasons: ranking?.reasons ?? [],
     trust: entryTrustSummary(entry),
   };
 }
@@ -750,13 +884,14 @@ export async function searchRegistry(args = {}, options = {}) {
     await readJsonArtifact("search-index.json", options),
   );
 
-  const entries = searchIndex
+  const matched = searchIndex
     .filter((entry) => !category || entry.category === category)
     .filter((entry) => entryMatchesPlatform(entry, platform))
     .filter((entry) => entryMatchesQuery(entry, query))
-    .filter((entry) => entryMatchesTrustFilters(entry, trustFilters))
+    .filter((entry) => entryMatchesTrustFilters(entry, trustFilters));
+  const entries = rankSearchEntries(matched, query)
     .slice(0, limit)
-    .map(toSearchResult);
+    .map((item) => toSearchResult(item.entry, item));
 
   return {
     ok: true,
@@ -766,6 +901,103 @@ export async function searchRegistry(args = {}, options = {}) {
     platform: platform || "",
     filters: trustFilters,
     entries,
+  };
+}
+
+function selectDiverseRankedEntries(ranked, limit) {
+  const selected = [];
+  const byCategory = new Map();
+
+  for (const item of ranked) {
+    const category = item.entry.category || "";
+    const current = byCategory.get(category) || 0;
+    if (current >= 2) continue;
+    selected.push(item);
+    byCategory.set(category, current + 1);
+    if (selected.length >= limit) return selected;
+  }
+
+  for (const item of ranked) {
+    if (selected.includes(item)) continue;
+    selected.push(item);
+    if (selected.length >= limit) return selected;
+  }
+
+  return selected;
+}
+
+function toolboxFitReasons(entry, ranking) {
+  const reasons = [...(ranking.reasons || [])];
+  if (entry.installCommand || entry.downloadUrl || entry.configSnippet) {
+    reasons.push("actionable setup surface");
+  }
+  if ((entry.platforms || []).length) {
+    reasons.push("platform compatibility metadata");
+  }
+  return unique(reasons).slice(0, 6);
+}
+
+function toolboxCaveats(entry) {
+  const caveats = [];
+  if (entrySourceStatus(entry) !== "available") {
+    caveats.push("Source metadata is missing or incomplete.");
+  }
+  if (entryPackageTrust(entry) === "external") {
+    caveats.push("Package/download is external; verify upstream before use.");
+  }
+  if (!notes(entry.safetyNotes).length) {
+    caveats.push("No structured safety notes are present.");
+  }
+  if (!notes(entry.privacyNotes).length) {
+    caveats.push("No structured privacy notes are present.");
+  }
+  return caveats.slice(0, 4);
+}
+
+export async function planWorkflowToolbox(args = {}, options = {}) {
+  const goal = String(args.goal || "").trim();
+  const query = normalizeText(goal);
+  const category = normalizeText(args.category);
+  const platform = normalizePlatform(args.platform);
+  const limit = normalizeLimit(args.limit, 6);
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const scoped = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .filter((entry) => entryMatchesPlatform(entry, platform));
+  let matched = scoped.filter((entry) => entryMatchesQuery(entry, query));
+  if (!matched.length && searchTokens(query).length) {
+    matched = scoped.filter(
+      (entry) => scoreSearchEntry(entry, query).score > 0,
+    );
+  }
+  const ranked = rankSearchEntries(matched, query);
+  const selected = selectDiverseRankedEntries(ranked, limit).map((item) => ({
+    ...toEntrySummary(item.entry),
+    searchScore: item.score,
+    searchReasons: item.reasons,
+    toolboxReasons: toolboxFitReasons(item.entry, item),
+    caveats: toolboxCaveats(item.entry),
+    nextActions: [
+      `Inspect get_entry_detail with category=${item.entry.category} and slug=${item.entry.slug}.`,
+      `Run explain_entry_trust before copying install or config content.`,
+      `Use compare_entries with nearby candidates before recommending a final stack.`,
+    ],
+  }));
+
+  return {
+    ok: true,
+    goal,
+    category: category || "",
+    platform: platform || "",
+    count: selected.length,
+    entries: selected,
+    plannerNotes: [
+      "This planner ranks public registry metadata only; it does not execute or install entries.",
+      "Prefer source-backed entries with safety/privacy notes for risk-bearing MCP, hooks, skills, commands, and statuslines.",
+      "Use get_copyable_asset only after reviewing trust metadata and upstream source.",
+    ],
   };
 }
 
@@ -1305,7 +1537,9 @@ const DISCOVERY_RESOURCES = [
  * @returns {string} Base URL used to build `/api/...` requests.
  */
 function publicApiBaseUrl(options = {}) {
-  return options.publicApiBaseUrl || process.env.HEYCLAUDE_PUBLIC_API_URL || SITE_URL;
+  return (
+    options.publicApiBaseUrl || process.env.HEYCLAUDE_PUBLIC_API_URL || SITE_URL
+  );
 }
 
 /**
@@ -1561,7 +1795,9 @@ export async function listJobsActive(options = {}) {
     limit: DISCOVERY_RESOURCE_LIMIT,
     count: entries.length,
     totalAvailable:
-      typeof payload?.totalAvailable === "number" ? payload.totalAvailable : null,
+      typeof payload?.totalAvailable === "number"
+        ? payload.totalAvailable
+        : null,
     source: "public-api",
     entries,
   };
@@ -2097,6 +2333,9 @@ export async function callRegistryTool(name, args = {}, options = {}) {
   switch (name) {
     case "search_registry":
       result = await searchRegistry(parsedArgs, options);
+      break;
+    case "plan_workflow_toolbox":
+      result = await planWorkflowToolbox(parsedArgs, options);
       break;
     case "server_info":
       result = await getServerInfo(parsedArgs, options);

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -967,9 +967,10 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
     .filter((entry) => !category || entry.category === category)
     .filter((entry) => entryMatchesPlatform(entry, platform));
   let matched = scoped.filter((entry) => entryMatchesQuery(entry, query));
-  if (!matched.length && searchTokens(query).length) {
-    matched = scoped.filter(
-      (entry) => scoreSearchEntry(entry, query).score > 0,
+  const queryTokens = searchTokens(query);
+  if (!matched.length && queryTokens.length) {
+    matched = scoped.filter((entry) =>
+      queryTokens.some((token) => entrySearchText(entry).includes(token)),
     );
   }
   const ranked = rankSearchEntries(matched, query);

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -106,6 +106,15 @@ export const SearchRegistryInputSchema = z
   })
   .strict();
 
+export const PlanWorkflowToolboxInputSchema = z
+  .object({
+    goal: z.string().trim().min(2).max(240),
+    category: pathPart.optional(),
+    platform: platform.optional(),
+    limit: z.number().int().min(1).max(10).optional(),
+  })
+  .strict();
+
 export const ServerInfoInputSchema = z.object({}).strict();
 
 export const ListCategoryEntriesInputSchema = z
@@ -284,6 +293,7 @@ export const ReviewEntrySafetyInputSchema = z
 
 export const TOOL_INPUT_SCHEMAS = {
   search_registry: SearchRegistryInputSchema,
+  plan_workflow_toolbox: PlanWorkflowToolboxInputSchema,
   server_info: ServerInfoInputSchema,
   list_category_entries: ListCategoryEntriesInputSchema,
   get_recent_updates: RecentUpdatesInputSchema,

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -84,6 +84,7 @@ describe("HeyClaude remote MCP route", () => {
     );
     expect(toolNames).toEqual([
       "search_registry",
+      "plan_workflow_toolbox",
       "server_info",
       "list_category_entries",
       "get_recent_updates",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -82,6 +82,7 @@ const validMcpSubmissionFields = {
 function validToolArguments(name: string) {
   const argsByTool: Record<string, unknown> = {
     search_registry: { query: "mcp", limit: 1 },
+    plan_workflow_toolbox: { goal: "code review automation", limit: 2 },
     server_info: {},
     list_category_entries: { category: "mcp", limit: 1 },
     get_recent_updates: { limit: 1 },
@@ -644,6 +645,44 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(result.entries.length).toBeGreaterThan(0);
     expect(result.entries.length).toBeLessThanOrEqual(5);
     expect(result.entries[0].platforms).toContain("Cursor");
+    expect(result.entries[0]).toMatchObject({
+      searchScore: expect.any(Number),
+      searchReasons: expect.any(Array),
+    });
+  });
+
+  it("plans a ranked read-only workflow toolbox", async () => {
+    const result = await callRegistryTool(
+      "plan_workflow_toolbox",
+      {
+        goal: "skill workflow",
+        category: "skills",
+        limit: 3,
+      },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      goal: "skill workflow",
+      category: "skills",
+      count: expect.any(Number),
+      plannerNotes: expect.arrayContaining([
+        expect.stringContaining("does not execute or install"),
+      ]),
+    });
+    expect(result.entries.length).toBeGreaterThan(0);
+    expect(result.entries.length).toBeLessThanOrEqual(3);
+    expect(result.entries[0]).toMatchObject({
+      category: "skills",
+      searchScore: expect.any(Number),
+      searchReasons: expect.any(Array),
+      toolboxReasons: expect.any(Array),
+      caveats: expect.any(Array),
+      nextActions: expect.arrayContaining([
+        expect.stringContaining("get_entry_detail"),
+      ]),
+    });
   });
 
   it("searches registry artifacts with trust filters", async () => {
@@ -1669,7 +1708,10 @@ describe("HeyClaude read-only MCP helpers", () => {
           index,
           `Expected to find declaration: ${declaration}`,
         ).toBeGreaterThan(-1);
-        const preceding = registrySource.slice(Math.max(0, index - 4000), index);
+        const preceding = registrySource.slice(
+          Math.max(0, index - 4000),
+          index,
+        );
         const trimmed = preceding.trimEnd();
         expect(
           trimmed.endsWith("*/"),
@@ -1737,7 +1779,9 @@ describe("HeyClaude read-only MCP helpers", () => {
       });
       expect(payload.entries.length).toBeGreaterThan(0);
       expect(payload.entries.length).toBeLessThanOrEqual(25);
-      const dates = payload.entries.map((entry: { updatedAt: string }) => entry.updatedAt);
+      const dates = payload.entries.map(
+        (entry: { updatedAt: string }) => entry.updatedAt,
+      );
       expect(dates).toEqual([...dates].sort().reverse());
       expect(payload.entries[0]).toMatchObject({
         key: expect.stringContaining(":"),

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -685,6 +685,47 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
+  it("does not fill planner results with unrelated trust-only matches", async () => {
+    const readJsonArtifact = async (relativePath: string) => {
+      expect(relativePath).toBe("search-index.json");
+      return {
+        entries: [
+          {
+            category: "mcp",
+            slug: "trusted-browser-helper",
+            title: "Browser Helper",
+            description: "Runs browser automation for local QA.",
+            tags: ["browser"],
+            keywords: ["automation"],
+            platforms: ["Claude"],
+            safetyNotes: ["Runs read-only browser automation."],
+            privacyNotes: ["Does not persist submitted page content."],
+            downloadTrust: "first-party",
+            trustSignals: {
+              packageVerified: true,
+              sourceStatus: "available",
+            },
+          },
+        ],
+      };
+    };
+    const result = await callRegistryTool(
+      "plan_workflow_toolbox",
+      {
+        goal: "credential hardened",
+        limit: 3,
+      },
+      { readJsonArtifact },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      goal: "credential hardened",
+      count: 0,
+      entries: [],
+    });
+  });
+
   it("searches registry artifacts with trust filters", async () => {
     const result = await callRegistryTool(
       "search_registry",

--- a/tests/registry-search-api.test.ts
+++ b/tests/registry-search-api.test.ts
@@ -83,6 +83,51 @@ describe("/api/registry/search", () => {
     expect(body.facets.categories.mcp).toBe(3);
   });
 
+  it("ranks exact title and trust matches ahead of broad substring matches", async () => {
+    searchIndexMock.entries = [
+      {
+        ...makeEntry("broad-browser"),
+        title: "Browser helper",
+        description: "MCP server with a passing code review mention.",
+        tags: ["browser"],
+      },
+      {
+        ...makeEntry("code-review-agent"),
+        title: "Code Review MCP Server",
+        description: "Review code changes with source-backed metadata.",
+        tags: ["review"],
+        keywords: ["code-review", "quality"],
+        trustSignals: {
+          ...makeEntry("code-review-agent").trustSignals,
+          sourceStatus: "available",
+          sourceUrlCount: 1,
+        },
+        safetyNotes: ["Runs read-only repository analysis."],
+        privacyNotes: ["Sends selected source snippets to the configured API."],
+      },
+    ];
+
+    const { GET } =
+      await import("../apps/web/src/app/api/registry/search/route");
+    const response = await GET(
+      new Request("https://heyclau.de/api/registry/search?q=code review", {
+        headers: { origin: "https://heyclau.de" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.results.map((entry: SearchDocument) => entry.slug)).toEqual([
+      "code-review-agent",
+      "broad-browser",
+    ]);
+    expect(body.results[0].searchScore).toBeGreaterThan(
+      body.results[1].searchScore,
+    );
+    expect(body.results[0].searchReasons).toContain("title phrase");
+    expect(body.results[0].searchReasons).toContain("source-backed");
+  });
+
   it("does not advertise an offset beyond the documented maximum", async () => {
     searchIndexMock.entries = Array.from({ length: 10_001 }, (_, index) =>
       makeEntry(`fixture-${index}`),

--- a/tests/seo-metadata.test.ts
+++ b/tests/seo-metadata.test.ts
@@ -30,6 +30,7 @@ const staticMetadataPages = [
   "ecosystem",
   "quality",
   "trending",
+  "brief",
   "jobs/post",
   "validators",
   "validators/mcp-config",
@@ -66,6 +67,16 @@ function seoClusterDescription(slug: string) {
   expect(start, slug).toBeGreaterThanOrEqual(0);
   const block = source.slice(start, source.indexOf("},", start));
   return block.match(/seoDescription:\s*"([^"]+)"/)?.[1];
+}
+
+function allSeoClusterDescriptions() {
+  const source = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/lib/seo-clusters.ts"),
+    "utf8",
+  );
+  return [...source.matchAll(/seoDescription:\s*"([^"]+)"/g)].map(
+    (match) => match[1],
+  );
 }
 
 describe("SEO metadata snippets", () => {
@@ -113,5 +124,12 @@ describe("SEO metadata snippets", () => {
     expect(mcpServersDescription).toBeTruthy();
     expect(mcpServersDescription!.length).toBeGreaterThanOrEqual(120);
     expect(mcpServersDescription!.length).toBeLessThanOrEqual(160);
+
+    const clusterDescriptions = allSeoClusterDescriptions();
+    expect(clusterDescriptions.length).toBeGreaterThanOrEqual(25);
+    for (const description of clusterDescriptions) {
+      expect(description.length, description).toBeGreaterThanOrEqual(100);
+      expect(description.length, description).toBeLessThanOrEqual(170);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds the first growth-engine foundation slice for HeyClaude: more indexable use-case pages, stronger browse/detail conversion surfaces, ranked search, and a read-only MCP toolbox planner.

## What changed
- Expanded generated `/best/*` SEO clusters from the initial small set into a broader use-case library for MCP, skills, hooks, commands, statuslines, source-backed resources, safe installs, Raycast, and developer workflows.
- Added `/brief` as a weekly Claude workflow brief landing page wired into nav, footer, sitemap, homepage discovery cards, and newsletter source tracking.
- Added browse trust quick filters with scoped counts plus a compare tray table for source/install/safety/privacy review.
- Added detail-page workflow CTAs for compare, API record, LLM text, and update subscriptions.
- Added ranked registry search metadata to the web API and MCP `search_registry` results.
- Added read-only MCP `plan_workflow_toolbox` for agent-native toolbox recommendations with trust caveats and next actions.

## Why
- The directory already has useful registry, MCP, Raycast, and quality surfaces; this turns them into acquisition and decision-layer surfaces instead of static listings.
- The ranked search and MCP planner make HeyClaude more useful inside agents, not only in a browser.
- Trust chips, comparison, and detail CTAs give users a reason to keep moving through the product.

## Validation
- `pnpm exec vitest run tests/seo-metadata.test.ts tests/registry-search-api.test.ts tests/mcp-server.test.ts`
- `pnpm validate:content:strict`
- `pnpm test:registry-artifacts`
- `pnpm test:mcp`
- `pnpm validate:raycast-feed`
- `pnpm validate:packages`
- `pnpm scan:packages`
- `pnpm validate:issue-templates`
- `pnpm validate:openapi`
- `pnpm build`
- `pnpm test`
- `git diff --check`

## Notes
- `pnpm test` logs an existing `fatal: not a git repository` line from one fixture path, but the suite exits successfully with all tests passing.
- This PR closes only the foundation slice. Broader growth work is tracked in the linked follow-up issues.

Closes #554
Refs #550, #551, #552, #553, #555, #556, #557, #558, #559, #560, #561
Refs #431, #487, #427, #491, #494, #489, #432, #443, #444, #450, #449, #448
