### PR TITLE
fix(submissions): fall back for public queue reads

### DIFF
--- a/apps/web/src/routes/api/submissions/queue.ts
+++ b/apps/web/src/routes/api/submissions/queue.ts
@@ -9,6 +9,7 @@ import { getCloudflareEnv } from "@/lib/cloudflare-env";
 const GITHUB_API_VERSION = "2022-11-28";
 const DEFAULT_REPO = "JSONbored/awesome-claude";
 const IMPORT_PR_PATTERN = /https:\/\/github\.com\/JSONbored\/awesome-claude\/pull\/\d+/i;
+const AUTH_FALLBACK_STATUSES = new Set([401, 403]);
 
 type GitHubLabel = string | { name?: string };
 
@@ -131,9 +132,32 @@ async function fetchGitHub<T>(url: string, token: string) {
   return { response, payload };
 }
 
+async function fetchGitHubPublicRead<T>(url: string, token: string) {
+  const first = await fetchGitHub<T>(url, token);
+  if (!token || first.response.ok || !AUTH_FALLBACK_STATUSES.has(first.response.status)) {
+    return {
+      ...first,
+      token,
+      authFallback: false,
+      authFailureStatus: undefined,
+    };
+  }
+
+  const fallback = await fetchGitHub<T>(url, "");
+  return {
+    ...fallback,
+    token: "",
+    authFallback: true,
+    authFailureStatus: first.response.status,
+  };
+}
+
 async function fetchIssueCommentsImportPr(issue: GitHubIssue, token: string) {
   if (!issue.comments_url) return undefined;
-  const { response, payload } = await fetchGitHub<GitHubComment[]>(issue.comments_url, token);
+  const { response, payload } = await fetchGitHubPublicRead<GitHubComment[]>(
+    issue.comments_url,
+    token,
+  );
   if (!response.ok || !Array.isArray(payload)) return undefined;
   for (const comment of [...payload].reverse()) {
     const url = importPrFromText(String(comment.body || ""));
@@ -180,30 +204,63 @@ async function listIssues(params: { repo: string; token: string; limit: number }
   url.searchParams.set("direction", "desc");
   url.searchParams.set("per_page", String(params.limit));
 
-  const { response, payload } = await fetchGitHub<GitHubIssue[]>(url.toString(), params.token);
+  const { response, payload, token, authFallback, authFailureStatus } =
+    await fetchGitHubPublicRead<GitHubIssue[]>(url.toString(), params.token);
   if (!response.ok || !Array.isArray(payload)) {
-    return { ok: false as const, status: response.status, issues: [] };
+    return {
+      ok: false as const,
+      status: response.status,
+      issues: [],
+      token,
+      authFallback,
+      authFailureStatus,
+    };
   }
   return {
     ok: true as const,
     status: response.status,
+    token,
+    authFallback,
+    authFailureStatus,
     issues: payload.filter((issue) => !issue.pull_request),
   };
 }
 
 async function getIssue(params: { repo: string; token: string; number: number }) {
-  const { response, payload } = await fetchGitHub<GitHubIssue>(
-    `https://api.github.com/repos/${params.repo}/issues/${params.number}`,
-    params.token,
-  );
+  const { response, payload, token, authFallback, authFailureStatus } =
+    await fetchGitHubPublicRead<GitHubIssue>(
+      `https://api.github.com/repos/${params.repo}/issues/${params.number}`,
+      params.token,
+    );
   if (!response.ok || !payload || payload.pull_request) {
-    return { ok: false as const, status: response.status, issue: null };
+    return {
+      ok: false as const,
+      status: response.status,
+      issue: null,
+      token,
+      authFallback,
+      authFailureStatus,
+    };
   }
   const labels = labelNames(payload);
   if (!hasLabel(labels, "content-submission")) {
-    return { ok: false as const, status: 404, issue: null };
+    return {
+      ok: false as const,
+      status: 404,
+      issue: null,
+      token,
+      authFallback,
+      authFailureStatus,
+    };
   }
-  return { ok: true as const, status: response.status, issue: payload };
+  return {
+    ok: true as const,
+    status: response.status,
+    issue: payload,
+    token,
+    authFallback,
+    authFailureStatus,
+  };
 }
 
 export const GET = createApiHandler("submissions.queue", async ({ request, query, requestId }) => {
@@ -221,6 +278,13 @@ export const GET = createApiHandler("submissions.queue", async ({ request, query
   const result = parsed.number
     ? await getIssue({ repo, token, number: parsed.number })
     : await listIssues({ repo, token, limit: parsed.limit });
+
+  if (result.authFallback) {
+    logApiWarn(request, "submissions.queue.auth_fallback", {
+      repo,
+      status: result.authFailureStatus,
+    });
+  }
 
   if (!result.ok) {
     const code = parsed.number ? "submission_not_found" : "github_provider_error";
@@ -241,7 +305,7 @@ export const GET = createApiHandler("submissions.queue", async ({ request, query
   const issues = "issue" in result ? [result.issue] : result.issues;
   const entries = [];
   for (const issue of issues) {
-    if (issue) entries.push(await mapIssue(issue, token));
+    if (issue) entries.push(await mapIssue(issue, result.token));
   }
 
   return apiJson(

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -321,6 +321,90 @@ describe("website submission API", () => {
     });
   });
 
+  it("falls back to unauthenticated GitHub reads when the queue token is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ message: "Forbidden" }), {
+            status: 403,
+            headers: { "content-type": "application/json" },
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify([
+              {
+                number: 89,
+                html_url:
+                  "https://github.com/JSONbored/awesome-claude/issues/89",
+                title: "Submit Skill: Public Queue Skill",
+                body: [
+                  "### Name",
+                  "Public Queue Skill",
+                  "",
+                  "### Category",
+                  "skills",
+                ].join("\n"),
+                user: {
+                  login: "submitter",
+                  html_url: "https://github.com/submitter",
+                },
+                labels: [
+                  { name: "content-submission" },
+                  { name: "community-skills" },
+                ],
+                state: "open",
+                created_at: "2026-05-01T00:00:00Z",
+                updated_at: "2026-05-02T00:00:00Z",
+                closed_at: null,
+              },
+            ]),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        ),
+    );
+
+    const { GET } = await import("@/routes/api/submissions/queue");
+    const response = await GET(
+      new Request("https://heyclau.de/api/submissions/queue?limit=5", {
+        headers: {
+          origin: "https://heyclau.de",
+          "cf-connecting-ip": "203.0.113.24",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      count: 1,
+      entries: [
+        {
+          number: 89,
+          category: "skills",
+          slug: "public-queue-skill",
+          status: "queued",
+        },
+      ],
+    });
+
+    const fetchMock = fetch as unknown as {
+      mock: { calls: Array<[RequestInfo | URL, RequestInit]> };
+    };
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    expect(fetchMock.mock.calls[0]?.[1]?.headers).toMatchObject({
+      authorization: "Bearer test-token",
+    });
+    expect(fetchMock.mock.calls[1]?.[1]?.headers).not.toHaveProperty(
+      "authorization",
+    );
+  });
+
   it("does not expose non-submission issues through the queue endpoint", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
## Summary
- Make the public submissions queue retry GitHub reads without Authorization when the configured token is rejected.
- Add regression coverage for token-backed 403 responses so the public queue keeps returning sanitized public issue metadata.

## Why
- Production was returning `502 provider_error` from `/api/submissions/queue` because GitHub rejected the configured read token with 403. The queue only reads public issue metadata, so unauthenticated fallback is safer than breaking the public status page.

## Validation
- `pnpm exec vitest run tests/submission-api.test.ts`
- `pnpm --filter web type-check`
- `pnpm --filter web build`
- `git diff --check`
