### PR TITLE
fix(ci): disable executable content frontmatter

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -53,6 +53,17 @@ const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([
   "embedded_secret",
 ]);
 
+const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
+  "Executable JavaScript frontmatter is not allowed in content policy validation";
+
+const SAFE_MATTER_OPTIONS = {
+  engines: {
+    javascript() {
+      throw new Error(UNSAFE_FRONTMATTER_LANGUAGE_ERROR);
+    },
+  },
+};
+
 function parseArgs(argv = process.argv.slice(2)) {
   const args = {};
   for (let index = 0; index < argv.length; index += 1) {
@@ -211,9 +222,12 @@ function stringList(value) {
 
 function parseMdxFrontmatter(content) {
   try {
-    const parsed = matter(String(content));
+    const parsed = matter(String(content), SAFE_MATTER_OPTIONS);
     return { data: parsed.data || {}, content: parsed.content || "" };
-  } catch {
+  } catch (error) {
+    if (error?.message === UNSAFE_FRONTMATTER_LANGUAGE_ERROR) {
+      throw error;
+    }
     return { data: {}, content: String(content) };
   }
 }

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function runContentPolicy(tmpDir: string, content: string) {
+  const filesJson = path.join(tmpDir, "files.json");
+  const outputJson = path.join(tmpDir, "policy-output.json");
+  fs.writeFileSync(
+    filesJson,
+    JSON.stringify([
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "added",
+        content,
+      },
+    ]),
+    "utf8",
+  );
+
+  const args = [
+    path.join(repoRoot, "scripts/ci/validate-content-policy.mjs"),
+    "--repo-root",
+    repoRoot,
+    "--files-json",
+    filesJson,
+    "--output",
+    outputJson,
+    "--source-type",
+    "same_repo_direct",
+  ];
+
+  try {
+    const stdout = execFileSync(process.execPath, args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+    return { status: 0, stdout, outputJson };
+  } catch (error) {
+    const execError = error as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    const status = typeof execError.status === "number" ? execError.status : 1;
+    const stdout = typeof execError.stdout === "string" ? execError.stdout : "";
+    const stderr = typeof execError.stderr === "string" ? execError.stderr : "";
+    return { status, stdout, stderr, outputJson };
+  }
+}
+
+describe("content policy validation", () => {
+  it("parses normal YAML frontmatter", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const result = runContentPolicy(
+      tmpDir,
+      `---
+title: Example Tool
+category: tools
+description: Example policy validation fixture.
+sourceUrl: https://github.com/example/example-tool
+submittedBy: tester
+submittedByUrl: https://github.com/tester
+---
+
+Example body.
+`,
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("HeyClaude content policy passed.");
+    expect(
+      JSON.parse(fs.readFileSync(result.outputJson, "utf8")),
+    ).toMatchObject({ ok: true });
+  });
+
+  it("rejects JavaScript frontmatter without executing it", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const markerPath = path.join(tmpDir, "frontmatter-executed");
+    const result = runContentPolicy(
+      tmpDir,
+      `---js
+require("node:fs").writeFileSync(${JSON.stringify(markerPath)}, "owned");
+process.exit(0)
+---
+
+Example body.
+`,
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(fs.existsSync(markerPath)).toBe(false);
+    expect(fs.existsSync(result.outputJson)).toBe(true);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(false);
+    expect(output.reviewFlags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "invalid_frontmatter" }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- The trusted content-policy validator used `gray-matter` with its default engines which allow `---js`/`---javascript` frontmatter to execute arbitrary JavaScript, enabling PR-based code execution in CI.
- Prevent attacker-controlled MDX frontmatter from executing during the policy validation lane while preserving normal YAML/JSON frontmatter parsing.

### Description
- Add `SAFE_MATTER_OPTIONS` that overrides the `javascript` engine to throw an explicit error instead of executing code and declare `UNSAFE_FRONTMATTER_LANGUAGE_ERROR` for detection. (`scripts/ci/validate-content-policy.mjs`)
- Use `matter(String(content), SAFE_MATTER_OPTIONS)` in `parseMdxFrontmatter` so JavaScript frontmatter is rejected rather than executed, and rethrow the unsafe-language error for upstream handling. (`scripts/ci/validate-content-policy.mjs`)
- Add regression tests that assert normal YAML frontmatter passes and that `---js` frontmatter does not execute (it is reported as invalid frontmatter). (`tests/content-policy-validation.test.ts`)

### Testing
- Ran the new unit tests with `pnpm exec vitest run tests/content-policy-validation.test.ts` and both tests passed. 
- Ran `git diff --check` as part of validation and it returned clean (no whitespace or formatting issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1960c5fd34832cb55e65e7328927ce)