### PR TITLE
fix(submissions): block critical data theft policy findings

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1228,11 +1228,21 @@ export function directContentRequestChangesReasons(report = {}) {
       "Install instructions include a destructive or remote-code execution pipeline.",
     embedded_secret:
       "Submission appears to include a real secret or API token.",
+    malicious_data_theft_capability:
+      "Submission appears to advertise credential, token, session, or wallet theft.",
     prohibited_content:
       "Submission appears to include clearly unacceptable content.",
   };
   for (const [id, reason] of Object.entries(flagReasons)) {
     if (flags.has(id)) reasons.push(`${reason} (${id}).`);
+  }
+
+  for (const flag of report.reviewFlags || []) {
+    if (flag.severity === "critical" && !flagReasons[flag.id]) {
+      reasons.push(
+        `Critical content policy finding must be resolved (${flag.id}).`,
+      );
+    }
   }
 
   const warningReasons = {

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -768,11 +768,21 @@ function directContentRequestChangesReasons(report = {}) {
       "Install instructions include a destructive or remote-code execution pipeline.",
     embedded_secret:
       "Submission appears to include a real secret or API token.",
+    malicious_data_theft_capability:
+      "Submission appears to advertise credential, token, session, or wallet theft.",
     prohibited_content:
       "Submission appears to include clearly unacceptable content.",
   };
   for (const [id, reason] of Object.entries(flagReasons)) {
     if (flags.has(id)) reasons.push(`${reason} (${id}).`);
+  }
+
+  for (const flag of report.reviewFlags || []) {
+    if (flag.severity === "critical" && !flagReasons[flag.id]) {
+      reasons.push(
+        `Critical content policy finding must be resolved (${flag.id}).`,
+      );
+    }
   }
 
   const warningReasons = {

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -2035,6 +2035,97 @@ Review payloads before posting tweets, replies, DMs, or profile updates.`,
       expect.arrayContaining(["credentials_or_auth", "external_write"]),
     );
     expect(report.contributionAnalysis.sourceState).toBe("provided");
+  });
+
+  it("blocks direct PRs that advertise credential theft even with disclosures", () => {
+    const maliciousContent = `---
+title: Credential Export MCP
+slug: credential-export-mcp
+category: mcp
+description: MCP server that can dump browser session tokens and steal wallet credentials for testing.
+cardDescription: Credential export workflow.
+repoUrl: https://github.com/example/credential-export-mcp
+submittedBy: security-author
+submittedByUrl: https://github.com/security-author
+safetyNotes:
+  - "Only run in an isolated lab; the tool handles credential material."
+privacyNotes:
+  - "Reads browser sessions, tokens, and wallet credentials from the local machine."
+---
+This resource can dump browser session tokens and steal wallet credentials.
+`;
+    const report = analyzeDirectContentRisk({
+      sourceType: "external_direct",
+      pullRequest: {
+        number: 401,
+        title: "Add credential export MCP",
+        user: { login: "security-author" },
+      },
+      files: [
+        {
+          filename: "content/mcp/credential-export-mcp.mdx",
+          status: "added",
+          content: maliciousContent,
+        },
+      ],
+    });
+
+    expect(report.riskTier).toBe("critical");
+    expect(
+      report.classificationWarnings.map((warning) => warning.id),
+    ).not.toEqual(
+      expect.arrayContaining(["missing_safety_notes", "missing_privacy_notes"]),
+    );
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(report.requestChangesReasons).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("malicious_data_theft_capability"),
+      ]),
+    );
+
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-policy-"));
+    const filesPath = path.join(tmpDir, "files.json");
+    const outputPath = path.join(tmpDir, "policy-output.json");
+    fs.writeFileSync(
+      filesPath,
+      `${JSON.stringify([
+        {
+          filename: "content/mcp/credential-export-mcp.mdx",
+          status: "added",
+          content: maliciousContent,
+        },
+      ])}
+`,
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "scripts/ci/validate-content-policy.mjs",
+        "--repo-root",
+        repoRoot,
+        "--files-json",
+        filesPath,
+        "--source-type",
+        "external_direct",
+        "--output",
+        outputPath,
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("malicious_data_theft_capability");
+    const output = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(output.ok).toBe(false);
+    expect(output.riskTier).toBe("critical");
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("malicious_data_theft_capability"),
+      ]),
+    );
   });
 
   it("requests changes for direct PRs that omit required safety/privacy notes", () => {


### PR DESCRIPTION
### Motivation

- The CI policy could mark content as `riskTier: critical` with a `malicious_data_theft_capability` review flag yet still exit successfully because only an explicit allowlist of flag IDs produced blocking failures.  
- Because the `validate-content-policy` script is used as a required PR gate, a critical credential/token theft finding must block merges rather than be left for human review alone.

### Description

- Map the `malicious_data_theft_capability` flag into the direct-PR blocker reasons in both `packages/registry/src/submission-risk.js` and `scripts/ci/validate-content-policy.mjs` by adding an explicit `flagReasons` entry.  
- Add a generic safety-net loop that converts any `reviewFlag` with `severity === "critical"` that is not already mapped into a blocking `requestChanges` reason.  
- Apply the same blocking logic to the standalone CI policy script `scripts/ci/validate-content-policy.mjs` so the workflow gate fails when critical findings are present.  
- Add regression coverage in `tests/submission-intake.test.ts` (test: `blocks direct PRs that advertise credential theft even with disclosures`) and update the test imports to use `spawnSync` for invoking the CI script.

### Testing

- Ran the focused test: `pnpm exec vitest run tests/submission-intake.test.ts --testNamePattern "blocks direct PRs that advertise credential theft even with disclosures"`, which passed.  
- Ran the full registry intake tests with `pnpm test:submission-intake`, and all tests passed.  
- Ran `pnpm validate:clean` and `git diff --check`, both of which succeeded.  
- The new test verifies the CI script exits non-zero and produces a failure entry when an external direct-PR advertises credential/token/wallet theft even if `safetyNotes`/`privacyNotes` are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19608be370832c8ab399a91fdf95de)