### PR TITLE
ci(deps): schedule weekly Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "timezone": "America/Denver",
+  "timezone": "America/Phoenix",
+  "schedule": ["before 6am on monday"],
   "labels": ["dependencies"],
   "rangeStrategy": "pin",
   "dependencyDashboard": true,


### PR DESCRIPTION
## Summary
- move Renovate onto a weekly update window
- align Renovate scheduling with the maintainer's Phoenix timezone

## Why
- dependency updates should arrive as a predictable weekly batch instead of appearing opportunistically throughout the week
- the single-PR queue and major-update approval gate remain in place

## Validation
- `corepack pnpm@10.23.0 dlx --package renovate renovate-config-validator renovate.json`
- `pnpm validate:clean`
- `git diff --check`

## Notes
- lockfile maintenance remains disabled because direct dependencies are pinned and weekly lockfile-only PRs would likely add noise without much benefit right now
