### PR TITLE
fix(web): harden newsletter mutations

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -3699,6 +3699,17 @@
                 "type": "object",
                 "properties": {
                   "email": { "type": "string", "maxLength": 320 },
+                  "segments": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "minLength": 1,
+                      "maxLength": 64,
+                      "pattern": "^[a-z0-9:_-]+$/i"
+                    },
+                    "maxItems": 20,
+                    "default": []
+                  },
                   "source": { "type": "string", "maxLength": 64, "default": "site" }
                 },
                 "required": ["email"]

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -4299,6 +4299,15 @@ paths:
                 email:
                   type: string
                   maxLength: 320
+                segments:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 64
+                    pattern: ^[a-z0-9:_-]+$/i
+                  maxItems: 20
+                  default: []
                 source:
                   type: string
                   maxLength: 64

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -382,8 +382,16 @@ export const votesToggleBodySchema = z.object({
   vote: z.boolean(),
 });
 
+const newsletterSegmentIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9:_-]+$/i);
+
 export const newsletterSubscribeBodySchema = z.object({
   email: safeEmailSchema,
+  segments: z.array(newsletterSegmentIdSchema).max(20).optional().default([]),
   source: z.string().trim().max(64).optional().default("site"),
 });
 

--- a/apps/web/src/lib/api/newsletter.ts
+++ b/apps/web/src/lib/api/newsletter.ts
@@ -1,4 +1,4 @@
-/** Tiny client helper for /api/public/newsletter/*. */
+/** Tiny client helper for newsletter API routes. */
 type SubscribeInput = {
   email: string;
   segments?: string[];
@@ -9,7 +9,7 @@ export async function subscribeToNewsletter(
   input: SubscribeInput,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   try {
-    const res = await fetch("/api/public/newsletter/subscribe", {
+    const res = await fetch("/api/newsletter/subscribe", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),

--- a/apps/web/src/routes/api/newsletter/subscribe.ts
+++ b/apps/web/src/routes/api/newsletter/subscribe.ts
@@ -5,11 +5,17 @@ import { apiError, apiJson, createApiHandler, type InferApiBody } from "@/lib/ap
 import { logApiError, logApiInfo, redactEmail } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env";
 
+function envSegmentId(followId: string): string | undefined {
+  const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
+  return getEnvString(key) || undefined;
+}
+
 export const POST = createApiHandler(
   "newsletter.subscribe",
   async ({ request, body, requestId }) => {
     const payload = body as InferApiBody<typeof newsletterSubscribeBodySchema>;
     const email = payload.email;
+    const segments = payload.segments;
     const source = payload.source;
 
     const resendApiKey = getEnvString("RESEND_API_KEY");
@@ -20,6 +26,12 @@ export const POST = createApiHandler(
       return apiError("newsletter_not_configured", 503, { requestId });
     }
 
+    const segmentIds = new Set<string>([resendSegmentId]);
+    for (const segment of segments) {
+      const segmentId = envSegmentId(segment);
+      if (segmentId) segmentIds.add(segmentId);
+    }
+
     const requestBody: Record<string, unknown> = {
       email,
       unsubscribed: false,
@@ -28,7 +40,7 @@ export const POST = createApiHandler(
       metadata: {
         source,
       },
-      segments: [{ id: resendSegmentId }],
+      segments: [...segmentIds].map((id) => ({ id })),
     };
 
     let response: Response;

--- a/apps/web/src/routes/api/public/newsletter/subscribe.ts
+++ b/apps/web/src/routes/api/public/newsletter/subscribe.ts
@@ -1,125 +1,12 @@
-/**
- * POST /api/public/newsletter/subscribe
- *
- * Mimics the legacy awesome-claude pattern: raw fetch to Resend's Contacts API,
- * no SDK. Resolves abstract follow IDs (e.g. "category:mcp", "changelog:security")
- * to Resend segment IDs via env vars; unknown IDs are dropped silently so we
- * never reveal which segments exist.
- *
- * Required Cloudflare Worker secrets:
- *   RESEND_API_KEY           — required, no-ops cleanly if absent (returns 503)
- *   RESEND_SEGMENT_ID        — general newsletter segment (always added)
- *   RESEND_SEGMENT_<NAME>    — per-follow segments, where NAME is upper-snake
- *                              of the follow id (e.g. category:mcp →
- *                              RESEND_SEGMENT_CATEGORY_MCP)
- */
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
 
-import { getEnvString } from "@/lib/cloudflare-env";
-
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
-} as const;
-
-const Schema = z.object({
-  email: z.string().email().max(255),
-  segments: z
-    .array(
-      z
-        .string()
-        .min(1)
-        .max(64)
-        .regex(/^[a-z0-9:_-]+$/i),
-    )
-    .max(20)
-    .optional(),
-  source: z
-    .string()
-    .min(1)
-    .max(64)
-    .regex(/^[a-z0-9_-]+$/i)
-    .optional(),
-});
-
-function envSegmentId(followId: string): string | undefined {
-  const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
-  return getEnvString(key) || undefined;
-}
-
-function json(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json", ...CORS },
-  });
-}
+import { POST } from "@/routes/api/newsletter/subscribe";
 
 // @ts-ignore Generated API route is added to routeTree during Vite build.
 export const Route = createFileRoute("/api/public/newsletter/subscribe")({
   server: {
     handlers: {
-      OPTIONS: async () => new Response(null, { status: 204, headers: CORS }),
-      POST: async ({ request }) => {
-        const apiKey = getEnvString("RESEND_API_KEY");
-        const generalSegment = getEnvString("RESEND_SEGMENT_ID");
-        if (!apiKey || !generalSegment) {
-          return json({ error: "Newsletter is not configured yet." }, 503);
-        }
-
-        let raw: unknown;
-        try {
-          raw = await request.json();
-        } catch {
-          return json({ error: "Invalid JSON body." }, 400);
-        }
-
-        const parsed = Schema.safeParse(raw);
-        if (!parsed.success) {
-          return json({ error: "Invalid request.", details: parsed.error.flatten() }, 400);
-        }
-
-        const { email, segments = [], source = "site" } = parsed.data;
-
-        const segmentIds = new Set<string>([generalSegment]);
-        for (const s of segments) {
-          const id = envSegmentId(s);
-          if (id) segmentIds.add(id);
-        }
-
-        const body = {
-          email,
-          unsubscribed: false,
-          first_name: "",
-          last_name: "",
-          metadata: { source },
-          segments: [...segmentIds].map((id) => ({ id })),
-        };
-
-        let res: Response;
-        try {
-          res = await fetch("https://api.resend.com/contacts", {
-            method: "POST",
-            headers: {
-              Authorization: `Bearer ${apiKey}`,
-              "Content-Type": "application/json",
-            },
-            body: JSON.stringify(body),
-            signal: AbortSignal.timeout(8000),
-          });
-        } catch {
-          return json({ error: "Newsletter provider is unreachable." }, 502);
-        }
-
-        // Resend returns 409 for duplicate contacts — treat as success so we
-        // never leak whether an address is already subscribed.
-        if (!res.ok && res.status !== 409) {
-          return json({ error: "Subscribe failed." }, 502);
-        }
-
-        return json({ ok: true });
-      },
+      POST: async ({ request, params }) => POST(request, { params }),
     },
   },
 });

--- a/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
+++ b/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
@@ -1,105 +1,153 @@
 /**
  * POST /api/public/newsletter/unsubscribe
  *
- * Best-effort: removes the contact from the resolved Resend segments, or
- * marks them unsubscribed on the general audience when no segments resolve.
- * Always returns { ok: true } when Resend accepts the request so we never
- * leak whether an address is on file.
+ * Best-effort: removes the contact from the resolved Resend segments, or from
+ * the general newsletter segment when no segments resolve. The endpoint keeps
+ * compatibility with the Atlas client path while applying the same origin,
+ * content-type, body-size, and rate-limit controls as dynamic API routes.
  */
 import { createFileRoute } from "@tanstack/react-router";
-import { z } from "zod";
+import { z, ZodError } from "zod";
 
+import { apiError, apiJson } from "@/lib/api/router";
+import {
+  BodyTooLargeError,
+  hasJsonContentType,
+  isAllowedOrigin,
+  isRateLimited,
+  readRequestTextWithinLimit,
+} from "@/lib/api-security";
+import { logApiError, logApiWarn, redactEmail } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env";
 
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Access-Control-Allow-Headers": "Content-Type",
+const BODY_LIMIT_BYTES = 8 * 1024;
+const RATE_LIMIT = {
+  scope: "newsletter-unsubscribe",
+  limit: 15,
+  windowMs: 60_000,
 } as const;
 
 const Schema = z.object({
-  email: z.string().email().max(255),
+  email: z.string().trim().toLowerCase().email().max(320),
   segments: z
     .array(
       z
         .string()
+        .trim()
         .min(1)
         .max(64)
         .regex(/^[a-z0-9:_-]+$/i),
     )
     .max(20)
-    .optional(),
+    .optional()
+    .default([]),
 });
+
+type UnsubscribePayload = z.infer<typeof Schema>;
+
+function getRequestId(request: Request) {
+  return (
+    request.headers.get("cf-ray") || request.headers.get("x-request-id") || crypto.randomUUID()
+  );
+}
 
 function envSegmentId(followId: string): string | undefined {
   const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
   return getEnvString(key) || undefined;
 }
 
-function json(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json", ...CORS },
-  });
+async function parsePayload(request: Request): Promise<UnsubscribePayload> {
+  const rawBody = await readRequestTextWithinLimit(request, BODY_LIMIT_BYTES);
+  return Schema.parse(JSON.parse(rawBody)) as UnsubscribePayload;
+}
+
+async function POST(request: Request): Promise<Response> {
+  const requestId = getRequestId(request);
+
+  if (!isAllowedOrigin(request)) {
+    logApiWarn(request, "newsletter.unsubscribe.forbidden_origin");
+    return apiError("forbidden_origin", 403, { requestId });
+  }
+
+  if (!hasJsonContentType(request)) {
+    logApiWarn(request, "newsletter.unsubscribe.invalid_content_type");
+    return apiError("invalid_content_type", 415, { requestId });
+  }
+
+  if (isRateLimited({ request, ...RATE_LIMIT })) {
+    logApiWarn(request, "newsletter.unsubscribe.rate_limited");
+    return apiError("rate_limited", 429, { requestId });
+  }
+
+  let payload: UnsubscribePayload;
+  try {
+    payload = await parsePayload(request);
+  } catch (error) {
+    if (error instanceof BodyTooLargeError) {
+      logApiWarn(request, "newsletter.unsubscribe.payload_too_large");
+      return apiError("payload_too_large", 413, { requestId });
+    }
+    if (error instanceof SyntaxError) {
+      logApiWarn(request, "newsletter.unsubscribe.invalid_json");
+      return apiError("invalid_json", 400, { requestId });
+    }
+    if (error instanceof ZodError) {
+      logApiWarn(request, "newsletter.unsubscribe.invalid_payload");
+      return apiError("invalid_payload", 400, { requestId });
+    }
+    throw error;
+  }
+
+  const apiKey = getEnvString("RESEND_API_KEY");
+  const generalSegment = getEnvString("RESEND_SEGMENT_ID");
+  if (!apiKey || !generalSegment) {
+    logApiError(request, "newsletter.unsubscribe.not_configured");
+    return apiError("newsletter_not_configured", 503, { requestId });
+  }
+
+  const resolved = new Set<string>();
+  for (const segment of payload.segments) {
+    const id = envSegmentId(segment);
+    if (id) resolved.add(id);
+  }
+  if (resolved.size === 0) resolved.add(generalSegment);
+
+  let lastError: string | null = null;
+  for (const id of resolved) {
+    try {
+      const res = await fetch(
+        `https://api.resend.com/audiences/${id}/contacts/${encodeURIComponent(payload.email)}`,
+        {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${apiKey}` },
+          signal: AbortSignal.timeout(8000),
+        },
+      );
+      // 404 = not subscribed; treat as success (don't leak membership).
+      if (!res.ok && res.status !== 404) {
+        lastError = `HTTP ${res.status}`;
+      }
+    } catch {
+      lastError = "network";
+    }
+  }
+
+  if (lastError && lastError !== "network") {
+    logApiError(request, "newsletter.unsubscribe.provider_error", {
+      email: redactEmail(payload.email),
+      error: lastError,
+    });
+    return apiError("provider_error", 502, { requestId });
+  }
+
+  return apiJson({ ok: true });
 }
 
 // @ts-ignore Generated API route is added to routeTree during Vite build.
 export const Route = createFileRoute("/api/public/newsletter/unsubscribe")({
   server: {
     handlers: {
-      OPTIONS: async () => new Response(null, { status: 204, headers: CORS }),
-      POST: async ({ request }) => {
-        const apiKey = getEnvString("RESEND_API_KEY");
-        const generalSegment = getEnvString("RESEND_SEGMENT_ID");
-        if (!apiKey || !generalSegment) {
-          return json({ error: "Newsletter is not configured yet." }, 503);
-        }
-
-        let raw: unknown;
-        try {
-          raw = await request.json();
-        } catch {
-          return json({ error: "Invalid JSON body." }, 400);
-        }
-
-        const parsed = Schema.safeParse(raw);
-        if (!parsed.success) {
-          return json({ error: "Invalid request." }, 400);
-        }
-
-        const { email, segments = [] } = parsed.data;
-        const resolved = new Set<string>();
-        for (const s of segments) {
-          const id = envSegmentId(s);
-          if (id) resolved.add(id);
-        }
-        if (resolved.size === 0) resolved.add(generalSegment);
-
-        let lastError: string | null = null;
-        for (const id of resolved) {
-          try {
-            const res = await fetch(
-              `https://api.resend.com/audiences/${id}/contacts/${encodeURIComponent(email)}`,
-              {
-                method: "DELETE",
-                headers: { Authorization: `Bearer ${apiKey}` },
-                signal: AbortSignal.timeout(8000),
-              },
-            );
-            // 404 = not subscribed; treat as success (don't leak membership).
-            if (!res.ok && res.status !== 404) {
-              lastError = `HTTP ${res.status}`;
-            }
-          } catch {
-            lastError = "network";
-          }
-        }
-
-        if (lastError && lastError !== "network") {
-          return json({ error: "Unsubscribe failed." }, 502);
-        }
-        return json({ ok: true });
-      },
+      POST: async ({ request }) => POST(request),
     },
   },
 });

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4302,6 +4302,15 @@ paths:
                 email:
                   type: string
                   maxLength: 320
+                segments:
+                  type: array
+                  items:
+                    type: string
+                    minLength: 1
+                    maxLength: 64
+                    pattern: ^[a-z0-9:_-]+$/i
+                  maxItems: 20
+                  default: []
                 source:
                   type: string
                   maxLength: 64

--- a/tests/codeql-regressions.test.ts
+++ b/tests/codeql-regressions.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -40,7 +42,7 @@ describe("CodeQL regression coverage", () => {
         email: "Reader@Example.com",
         source: "footer",
       }),
-    ).toEqual({ email: "reader@example.com", source: "footer" });
+    ).toEqual({ email: "reader@example.com", segments: [], source: "footer" });
 
     expect(() =>
       newsletterSubscribeBodySchema.parse({
@@ -58,5 +60,34 @@ describe("CodeQL regression coverage", () => {
         applyUrl: "https://example.com/jobs/ai-engineer",
       }),
     ).toThrow();
+  });
+
+  it("keeps newsletter mutations behind bounded same-origin handlers", () => {
+    const repoRoot = new URL("..", import.meta.url);
+    const read = (relativePath: string) =>
+      fs.readFileSync(new URL(relativePath, repoRoot), "utf8");
+
+    const subscribeRoute = read(
+      "apps/web/src/routes/api/public/newsletter/subscribe.ts",
+    );
+    const unsubscribeRoute = read(
+      "apps/web/src/routes/api/public/newsletter/unsubscribe.ts",
+    );
+    const newsletterClient = read("apps/web/src/lib/api/newsletter.ts");
+
+    expect(subscribeRoute).not.toContain("Access-Control-Allow-Origin");
+    expect(subscribeRoute).not.toContain("request.json()");
+    expect(subscribeRoute).toContain("POST(request, { params })");
+
+    expect(unsubscribeRoute).not.toContain("Access-Control-Allow-Origin");
+    expect(unsubscribeRoute).not.toContain("request.json()");
+    expect(unsubscribeRoute).toContain("readRequestTextWithinLimit");
+    expect(unsubscribeRoute).toContain("isAllowedOrigin");
+    expect(unsubscribeRoute).toContain("isRateLimited");
+
+    expect(newsletterClient).toContain('fetch("/api/newsletter/subscribe"');
+    expect(newsletterClient).not.toContain(
+      'fetch("/api/public/newsletter/subscribe"',
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Close an anti-abuse/authentication gap where public newsletter endpoints parsed unbounded JSON and used the server Resend API key without origin, body-size, or rate-limit protections.
- Preserve existing newsletter functionality (subscribe/unsubscribe and per-follow segment resolution) while ensuring mutations go through the centralized, protected API surface.

### Description
- Route the public subscribe compatibility path to the central protected handler by importing the protected `POST` handler in `apps/web/src/routes/api/public/newsletter/subscribe.ts` so the request benefits from origin, body-size, and rate-limit enforcement.
- Extend the protected subscribe schema/handler to accept `segments` and resolve follow IDs to Resend segment IDs before calling Resend, keeping validation and rate limits in `apps/web/src/routes/api/newsletter/subscribe.ts` and `apps/web/src/lib/api/contracts.ts`.
- Harden the public unsubscribe compatibility route by removing wildcard CORS/OPTIONS and adding same-origin checks, JSON content-type validation, an 8 KiB body-size limit, and per-IP rate limiting before any provider DELETE calls in `apps/web/src/routes/api/public/newsletter/unsubscribe.ts`.
- Update the client helper to call `/api/newsletter/subscribe` instead of the raw public endpoint and add regression test assertions and regenerated OpenAPI artifacts to cover the subscribe body change.

### Testing
- Ran formatting with `./node_modules/.bin/prettier --write` on modified files and the run completed successfully.
- Ran unit/regression suites with `./node_modules/.bin/vitest run tests/codeql-regressions.test.ts tests/api-contracts.test.ts` and both tests passed.
- Verified OpenAPI generation and checks with `./node_modules/.bin/tsx scripts/generate-openapi.ts --check` (OpenAPI regenerated and check passed).
- Type-checked the web app with `cd apps/web && ./node_modules/.bin/tsc --noEmit` and it succeeded, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19eb76cc08832ca339e334e7b98478)