### PR TITLE
fix(ci): validate artifacts for content PRs

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -88,8 +88,8 @@ const generatedArtifactInfra = touches(
 const flags = {
   content: contentCategoryTouched || contentValidationInfra,
   content_config: contentValidationInfra,
-  registry: generatedArtifactInfra,
-  web: touches(
+  registry: contentCategoryTouched || generatedArtifactInfra,
+  web: contentCategoryTouched || touches(
     /^apps\/web\//,
     /^emails\//,
     /^cloudflare\/api-schema-heyclaude-openapi\.yaml$/,
@@ -107,7 +107,7 @@ const flags = {
     "package.json",
     "pnpm-lock.yaml",
   ),
-  raycast: touches(
+  raycast: contentCategoryTouched || touches(
     /^integrations\/raycast\//,
     /^apps\/web\/public\/data\/raycast/,
     /^scripts\/(build-content-index|validate-raycast-feed)\.mjs$/,

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -89,16 +89,18 @@ const flags = {
   content: contentCategoryTouched || contentValidationInfra,
   content_config: contentValidationInfra,
   registry: contentCategoryTouched || generatedArtifactInfra,
-  web: contentCategoryTouched || touches(
-    /^apps\/web\//,
-    /^emails\//,
-    /^cloudflare\/api-schema-heyclaude-openapi\.yaml$/,
-    /^scripts\/(generate-openapi|validate-d1-jobs|validate-deployment-artifacts)\.(mjs|ts)$/,
-    /^tests\/(api-|commercial-intake|discovery-surfaces|seo-jsonld|submission-api|submission-workflows|votes-api).*\.test\.ts$/,
-    "vitest.config.ts",
-    "package.json",
-    "pnpm-lock.yaml",
-  ),
+  web:
+    contentCategoryTouched ||
+    touches(
+      /^apps\/web\//,
+      /^emails\//,
+      /^cloudflare\/api-schema-heyclaude-openapi\.yaml$/,
+      /^scripts\/(generate-openapi|validate-d1-jobs|validate-deployment-artifacts)\.(mjs|ts)$/,
+      /^tests\/(api-|commercial-intake|discovery-surfaces|seo-jsonld|submission-api|submission-workflows|votes-api).*\.test\.ts$/,
+      "vitest.config.ts",
+      "package.json",
+      "pnpm-lock.yaml",
+    ),
   mcp: touches(
     /^packages\/mcp\//,
     /^apps\/web\/src\/routes\/api\/mcp\.ts$/,
@@ -107,14 +109,16 @@ const flags = {
     "package.json",
     "pnpm-lock.yaml",
   ),
-  raycast: contentCategoryTouched || touches(
-    /^integrations\/raycast\//,
-    /^apps\/web\/public\/data\/raycast/,
-    /^scripts\/(build-content-index|validate-raycast-feed)\.mjs$/,
-    /^tests\/registry-artifacts\.test\.ts$/,
-    "package.json",
-    "pnpm-lock.yaml",
-  ),
+  raycast:
+    contentCategoryTouched ||
+    touches(
+      /^integrations\/raycast\//,
+      /^apps\/web\/public\/data\/raycast/,
+      /^scripts\/(build-content-index|validate-raycast-feed)\.mjs$/,
+      /^tests\/registry-artifacts\.test\.ts$/,
+      "package.json",
+      "pnpm-lock.yaml",
+    ),
   packages: touches(
     /^apps\/web\/public\/downloads\//,
     /^content\/skills\/.*\.zip$/,

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -1,0 +1,74 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const tempDirs: string[] = [];
+
+function git(cwd: string, args: string[]) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function parseOutput(output: string) {
+  return Object.fromEntries(
+    output
+      .trim()
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+}
+
+describe("PR change classifier", () => {
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("routes content entry changes through public artifact validation lanes", () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-classify-"));
+    tempDirs.push(cwd);
+
+    git(cwd, ["init", "--initial-branch=main"]);
+    git(cwd, ["config", "user.email", "test@example.com"]);
+    git(cwd, ["config", "user.name", "Test User"]);
+    fs.writeFileSync(path.join(cwd, "README.md"), "# fixture\n");
+    git(cwd, ["add", "README.md"]);
+    git(cwd, ["commit", "-m", "init"]);
+    const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+
+    const contentDir = path.join(cwd, "content", "agents");
+    fs.mkdirSync(contentDir, { recursive: true });
+    fs.writeFileSync(path.join(contentDir, "example.mdx"), "---\ntitle: Example\n---\n");
+    git(cwd, ["add", "content/agents/example.mdx"]);
+    git(cwd, ["commit", "-m", "add content entry"]);
+
+    const outputPath = path.join(cwd, "github-output.txt");
+    execFileSync("node", [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")], {
+      cwd,
+      env: {
+        ...process.env,
+        BASE_SHA: baseSha,
+        GITHUB_EVENT_NAME: "pull_request",
+        GITHUB_OUTPUT: outputPath,
+      },
+      encoding: "utf8",
+    });
+
+    const outputs = parseOutput(fs.readFileSync(outputPath, "utf8"));
+    expect(outputs).toMatchObject({
+      content: "true",
+      content_agents: "true",
+      registry: "true",
+      raycast: "true",
+      web: "true",
+    });
+  });
+});

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -46,21 +46,28 @@ describe("PR change classifier", () => {
 
     const contentDir = path.join(cwd, "content", "agents");
     fs.mkdirSync(contentDir, { recursive: true });
-    fs.writeFileSync(path.join(contentDir, "example.mdx"), "---\ntitle: Example\n---\n");
+    fs.writeFileSync(
+      path.join(contentDir, "example.mdx"),
+      "---\ntitle: Example\n---\n",
+    );
     git(cwd, ["add", "content/agents/example.mdx"]);
     git(cwd, ["commit", "-m", "add content entry"]);
 
     const outputPath = path.join(cwd, "github-output.txt");
-    execFileSync("node", [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")], {
-      cwd,
-      env: {
-        ...process.env,
-        BASE_SHA: baseSha,
-        GITHUB_EVENT_NAME: "pull_request",
-        GITHUB_OUTPUT: outputPath,
+    execFileSync(
+      "node",
+      [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")],
+      {
+        cwd,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          GITHUB_EVENT_NAME: "pull_request",
+          GITHUB_OUTPUT: outputPath,
+        },
+        encoding: "utf8",
       },
-      encoding: "utf8",
-    });
+    );
 
     const outputs = parseOutput(fs.readFileSync(outputPath, "utf8"));
     expect(outputs).toMatchObject({

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -39,6 +39,7 @@ describe("PR change classifier", () => {
     git(cwd, ["init", "--initial-branch=main"]);
     git(cwd, ["config", "user.email", "test@example.com"]);
     git(cwd, ["config", "user.name", "Test User"]);
+    git(cwd, ["config", "commit.gpgsign", "false"]);
     fs.writeFileSync(path.join(cwd, "README.md"), "# fixture\n");
     git(cwd, ["add", "README.md"]);
     git(cwd, ["commit", "-m", "init"]);

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -695,7 +695,7 @@ describe("submission automation workflows", () => {
     );
   });
 
-  it("routes hook-only content PRs to hook validation only", () => {
+  it("routes hook-only content PRs through hook and public artifact validation", () => {
     const lanes = runClassifierForChangedFiles({
       "content/hooks/retro-daily.mdx": contentFixture(`
 title: Retro Daily
@@ -707,10 +707,10 @@ description: Daily Claude Code retro dashboard hook.
 
     expect(lanes.content).toBe("true");
     expect(lanes.content_categories_json).toBe('["hooks"]');
-    expect(lanes.registry).toBe("false");
-    expect(lanes.web).toBe("false");
+    expect(lanes.registry).toBe("true");
+    expect(lanes.web).toBe("true");
     expect(lanes.mcp).toBe("false");
-    expect(lanes.raycast).toBe("false");
+    expect(lanes.raycast).toBe("true");
     expect(lanes.packages).toBe("false");
   });
 
@@ -1320,7 +1320,7 @@ description: Example description
     expect(source).toContain("content_categories_json");
   });
 
-  it("routes hook-only content PRs to hook content validation", () => {
+  it("routes hook-only content PRs to hook content and public artifact validation", () => {
     const outputs = runClassifierForChangedFiles({
       "content/hooks/retro-daily.mdx": "---\ntitle: Retro Daily\n---\n",
     });
@@ -1329,15 +1329,15 @@ description: Example description
     expect(outputs.content_hooks).toBe("true");
     expect(outputs.content_mcp).toBe("false");
     expect(outputs.content_categories_json).toBe('["hooks"]');
-    expect(outputs.web).toBe("false");
+    expect(outputs.web).toBe("true");
     expect(outputs.mcp).toBe("false");
-    expect(outputs.raycast).toBe("false");
+    expect(outputs.raycast).toBe("true");
     expect(outputs.packages).toBe("false");
-    expect(outputs.registry).toBe("false");
+    expect(outputs.registry).toBe("true");
     expect(outputs.ci).toBe("false");
   });
 
-  it("routes multi-category content PRs to only touched category validators", () => {
+  it("routes multi-category content PRs to touched category and artifact validators", () => {
     const outputs = runClassifierForChangedFiles({
       "content/hooks/retro-daily.mdx": "---\ntitle: Retro Daily\n---\n",
       "content/mcp/example-server.mdx": "---\ntitle: Example Server\n---\n",
@@ -1347,10 +1347,10 @@ description: Example description
     expect(outputs.content_hooks).toBe("true");
     expect(outputs.content_mcp).toBe("true");
     expect(outputs.content_skills).toBe("false");
-    expect(outputs.web).toBe("false");
-    expect(outputs.raycast).toBe("false");
+    expect(outputs.web).toBe("true");
+    expect(outputs.raycast).toBe("true");
     expect(outputs.packages).toBe("false");
-    expect(outputs.registry).toBe("false");
+    expect(outputs.registry).toBe("true");
   });
 
   it("routes generated registry artifacts to artifact validation", () => {


### PR DESCRIPTION
### Motivation
- A regression in the PR classifier caused content-only changes under `content/` to skip the registry, web, and Raycast validation lanes, allowing merges that bypass generated-artifact, feed, and preview checks.

### Description
- Update `scripts/ci/classify-pr-changes.mjs` to enable `registry`, `web`, and `raycast` flags when a content entry (`content/<category>/*.mdx`) is touched by OR-ing those flags with `contentCategoryTouched`.
- Add a regression test `tests/classify-pr-changes.test.ts` that creates a synthetic content-only PR and asserts the classifier emits `content`, `content_<category>`, `registry`, `web`, and `raycast` as `true`.

### Testing
- Ran `./node_modules/.bin/vitest run tests/classify-pr-changes.test.ts` and the new test passed.
- Ran `node --check scripts/ci/classify-pr-changes.mjs` and the script validated successfully.
- Ran `git diff --check` with no problems reported.
- Note: `pnpm exec vitest ...` could not run in this environment because Corepack attempted to download `pnpm@11.4.0` and the proxy returned 403, so the checked-in local Vitest binary was used instead and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ee6186ac832c8381d4ac6c0c80c8)