### PR TITLE
fix(api): reject cache-busting trending queries

### DIFF
--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -307,11 +307,13 @@ export const registrySearchQuerySchema = z.object({
   offset: z.coerce.number().int().min(0).max(10_000).optional().default(0),
 });
 
-export const registryTrendingQuerySchema = z.object({
-  category: categorySchema,
-  platform: platformSchema,
-  limit: z.coerce.number().int().min(1).max(50).optional().default(12),
-});
+export const registryTrendingQuerySchema = z
+  .object({
+    category: categorySchema,
+    platform: platformSchema,
+    limit: z.coerce.number().int().min(1).max(50).optional().default(12),
+  })
+  .strict();
 
 export const registryDiffQuerySchema = z.object({
   since: z.string().trim().max(128).optional().default(""),

--- a/tests/registry-trending-api.test.ts
+++ b/tests/registry-trending-api.test.ts
@@ -7,19 +7,31 @@ const state = vi.hoisted(() => ({
   votes: { available: true, counts: {} as Counts },
   community: { available: true, counts: {} as Counts },
   intent: { available: true, counts: {} as Counts },
+  voteReads: 0,
+  communityReads: 0,
+  intentReads: 0,
 }));
 
 vi.mock("@/data/entries", () => ({ ENTRIES: state.entries }));
 vi.mock("@/lib/votes", () => ({
-  safeVoteCounts: () => Promise.resolve(state.votes),
+  safeVoteCounts: () => {
+    state.voteReads += 1;
+    return Promise.resolve(state.votes);
+  },
 }));
 vi.mock("@/lib/community-signals", () => ({
   entryCommunityTarget: (category: string, slug: string) =>
     `entry:${category}/${slug}`,
-  safeCommunitySignalCounts: () => Promise.resolve(state.community),
+  safeCommunitySignalCounts: () => {
+    state.communityReads += 1;
+    return Promise.resolve(state.community);
+  },
 }));
 vi.mock("@/lib/intent-events", () => ({
-  safeIntentEventCounts: () => Promise.resolve(state.intent),
+  safeIntentEventCounts: () => {
+    state.intentReads += 1;
+    return Promise.resolve(state.intent);
+  },
 }));
 
 function entry(slug: string, overrides: Record<string, unknown> = {}) {
@@ -70,6 +82,9 @@ describe("/api/registry/trending", () => {
         "mcp:beta": { copy: 1, open: 1, install: 1, download: 0, vote: 0 },
       },
     };
+    state.voteReads = 0;
+    state.communityReads = 0;
+    state.intentReads = 0;
   });
 
   it("returns bounded privacy-safe trending entries with filters and reasons", async () => {
@@ -148,5 +163,18 @@ describe("/api/registry/trending", () => {
     const response = await GET(request("/api/registry/trending?limit=1000"));
 
     expect(response.status).toBe(400);
+  });
+
+  it("rejects unknown query parameters before route execution", async () => {
+    const { GET } =
+      await import("../apps/web/src/routes/api/registry/trending");
+    const response = await GET(
+      request("/api/registry/trending?limit=1&cachebust=abc123"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(state.voteReads).toBe(0);
+    expect(state.communityReads).toBe(0);
+    expect(state.intentReads).toBe(0);
   });
 });


### PR DESCRIPTION
### Motivation

- The public `/api/registry/trending` handler accepted and ignored unknown query parameters, allowing cache-busting URLs to trigger expensive state aggregation across the whole registry before the response limit was applied.

### Description

- Make the `registryTrendingQuerySchema` strict so unknown query parameters are rejected at parse time by Zod (`apps/web/src/lib/api/contracts.ts`).
- Add regression coverage that asserts unknown query parameters return `400` and that dynamic state helpers (`safeVoteCounts`, `safeCommunitySignalCounts`, `safeIntentEventCounts`) are not invoked when the query is rejected (`tests/registry-trending-api.test.ts`).
- Changes are limited to input validation and tests and do not alter the trending ranking algorithm or response shape.

### Testing

- Ran `pnpm exec vitest run tests/registry-trending-api.test.ts tests/api-contracts.test.ts` and all tests passed. 
- Ran `pnpm validate:openapi` and `git diff --check` with no errors reported. 
- New test verifies unknown query params are rejected with `400` and that no state reads occur when a request is rejected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f22345d0832c9e6ca931b600a685)