### PR TITLE
fix(ci): restrict existing content provenance exemptions

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -365,14 +365,52 @@ function isNewDirectContentEntry(entry) {
   return false;
 }
 
-function existingEntryHasOnlyMetadataUpdates(entry) {
-  const current = entry.fields || {};
-  const base = entry.baseFields || {};
-  const metadataKeys = new Set(["safety_notes", "privacy_notes"]);
+const EXISTING_ENTRY_METADATA_UPDATE_KEYS = new Set([
+  "privacyNotes",
+  "safetyNotes",
+]);
 
-  for (const key of Object.keys({ ...current, ...base })) {
-    if (metadataKeys.has(key)) continue;
-    if (normalizeText(current[key]) !== normalizeText(base[key])) return false;
+function canonicalFrontmatterValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalFrontmatterValue(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalFrontmatterValue(value[key])]),
+    );
+  }
+
+  return normalizeText(value);
+}
+
+function frontmatterChangedOutsideAllowedMetadata(
+  currentData = {},
+  baseData = {},
+) {
+  for (const key of Object.keys({ ...currentData, ...baseData }).sort()) {
+    if (EXISTING_ENTRY_METADATA_UPDATE_KEYS.has(key)) continue;
+    if (
+      JSON.stringify(canonicalFrontmatterValue(currentData[key])) !==
+      JSON.stringify(canonicalFrontmatterValue(baseData[key]))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function existingEntryHasOnlyMetadataUpdates(entry) {
+  if (
+    frontmatterChangedOutsideAllowedMetadata(
+      entry.frontmatterData,
+      entry.baseFrontmatterData,
+    )
+  ) {
+    return false;
   }
 
   return (
@@ -676,10 +714,7 @@ function validatePrProvenance(report, entries, prAuthor, sourceType) {
   if (sourceType !== "external_direct") return;
 
   for (const entry of entries) {
-    if (
-      !isNewDirectContentEntry(entry) &&
-      existingEntryHasOnlyMetadataUpdates(entry)
-    ) {
+    if (!isNewDirectContentEntry(entry)) {
       if (submitterProvenanceChanged(entry)) {
         addProvenanceFinding(
           report,
@@ -688,8 +723,12 @@ function validatePrProvenance(report, entries, prAuthor, sourceType) {
           "Direct contributor PRs cannot change submitter provenance on existing content",
           `${entry.filename}: leave existing submittedBy/submittedByUrl unchanged; maintainers can handle attribution corrections separately.`,
         );
+        continue;
       }
-      continue;
+
+      if (existingEntryHasOnlyMetadataUpdates(entry)) {
+        continue;
+      }
     }
 
     const provenance = entry.provenance;
@@ -874,7 +913,6 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
       typeof file.baseContent === "string"
         ? parseMdxFrontmatter(file.baseContent)
         : { data: {} };
-    const baseFields = frontmatterFields(baseParsed.data, category);
     const baseProvenance = frontmatterProvenance(baseParsed.data);
     if (fields.category && fields.category !== category) {
       addClassificationWarning(
@@ -901,9 +939,10 @@ function buildReport({ args, files, headRepo, baseRepo, headRef, sourceType }) {
       status: normalizeText(file.status) || "modified",
       baseExists: typeof file.baseContent === "string",
       fields,
-      baseFields,
       provenance,
       baseProvenance,
+      frontmatterData: parsed.data || {},
+      baseFrontmatterData: baseParsed.data || {},
       contentBody: parsed.content || "",
       baseContentBody: baseParsed.content || "",
     });

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -917,6 +917,52 @@ usageSnippet: "claude mcp add attacker-mcp -- npx -y attacker-mcp"
     );
   });
 
+  it("blocks external trust metadata updates on existing entries with stale provenance", () => {
+    const baseContent = contentFixture(
+      `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+submittedBy: original-submitter
+submittedByUrl: https://github.com/original-submitter
+submissionIssueUrl: https://github.com/JSONbored/awesome-claude/issues/1
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+      "Source-backed MCP server content.",
+    );
+    const result = runContentPolicyForChangedFiles({
+      "content/mcp/existing-mcp.mdx": {
+        status: "modified",
+        baseContent,
+        content: contentFixture(
+          `
+title: Existing MCP
+slug: existing-mcp
+category: mcp
+description: Existing MCP server entry.
+submittedBy: original-submitter
+submittedByUrl: https://github.com/original-submitter
+submissionIssueUrl: https://github.com/JSONbored/awesome-claude/issues/999
+installCommand: "npx -y existing-mcp"
+usageSnippet: "claude mcp add existing-mcp -- npx -y existing-mcp"
+`,
+          "Source-backed MCP server content.",
+        ),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.report?.provenanceFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "direct_pr_submitter_mismatch_content/mcp/existing-mcp.mdx",
+        }),
+      ]),
+    );
+  });
+
   it("blocks community local download requests through content policy", () => {
     const result = runContentPolicyForChangedFiles({
       "content/skills/example-skill.mdx": contentFixture(


### PR DESCRIPTION
### Motivation
- Prevent external direct PRs from bypassing submitter provenance checks by ensuring the exemption only applies to true metadata-only updates and not arbitrary frontmatter or body/installation changes.
- Restore a stronger automated supply-chain integrity control so attackers cannot change install commands, usage snippets, download URLs, or other trust-relevant fields while preserving original submitter fields.

### Description
- Update `scripts/ci/validate-content-policy.mjs` to canonicalize and compare full frontmatter and body content and to record `frontmatterData`/`baseFrontmatterData` on entries for accurate diffs.
- Add `canonicalFrontmatterValue` and `frontmatterChangedOutsideAllowedMetadata` helpers and a whitelist `EXISTING_ENTRY_METADATA_UPDATE_KEYS` permitting only `safetyNotes`/`privacyNotes` metadata updates for the existing-entry exemption.
- Rework `validatePrProvenance` so `submitterProvenanceChanged` is checked before any metadata exemption and the metadata-only exemption is applied only when both frontmatter (excluding allowed keys) and body are unchanged.
- Add a regression test in `tests/submission-workflows.test.ts` that ensures changing trust metadata on an existing entry with stale provenance is blocked.

### Testing
- Ran `./node_modules/.bin/vitest run tests/submission-workflows.test.ts` and the updated test suite passed (65 tests, 0 failures).
- An earlier `pnpm exec vitest run tests/submission-workflows.test.ts` attempt in this environment encountered external registry/attestation fetch retries and did not complete, so the local Vitest binary was used for verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ef8d9494832ca646a0d54a29ca12)