### PR TITLE
fix(submissions): filter stale risk labels

### DIFF
--- a/.github/workflows/submission-issue-validation.yml
+++ b/.github/workflows/submission-issue-validation.yml
@@ -192,7 +192,7 @@ jobs:
               ? ["auto-import-eligible"]
               : validationReport.recommendedLabels || [];
             for (const label of validationLabels) {
-              if (label) labels.add(label);
+              if (label && !riskLabels.has(label)) labels.add(label);
             }
             for (const label of riskReport.recommendedLabels || []) {
               if (label) labels.add(label);

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -236,6 +236,9 @@ describe("submission automation workflows", () => {
     expect(source).toContain("HeyClaude Submission Bot");
     expect(source).toContain("steps.auto_import_precheck.outputs.eligible");
     expect(source).toContain("managedValidationLabels");
+    expect(source).toContain(
+      "if (label && !riskLabels.has(label)) labels.add(label);",
+    );
     expect(source).toContain("issues.setLabels");
     expect(source).toContain("Post HeyClaude submission check comment");
     expect(source).toContain("<!-- heyclaude-submission-check -->");


### PR DESCRIPTION
### Motivation
- The unified submission label sync could re-add stale risk labels because `validationReport.recommendedLabels` was seeded from existing issue labels and was applied before the current risk labels, which can leave both old and new `risk-*` labels on an issue.

### Description
- Update the issue-label sync in `/.github/workflows/submission-issue-validation.yml` to skip any label present in the `riskLabels` set when applying `validationReport.recommendedLabels`, i.e. `if (label && !riskLabels.has(label)) labels.add(label);`.
- Add workflow test coverage in `tests/submission-workflows.test.ts` to assert the validation-label loop is risk-filtered before `issues.setLabels` is called.
- Run Prettier on the modified files to keep formatting consistent.

### Testing
- Ran `node_modules/.bin/prettier --check .github/workflows/submission-issue-validation.yml tests/submission-workflows.test.ts`, which succeeded. 
- Ran `node_modules/.bin/vitest run tests/submission-workflows.test.ts`, and the test suite passed (`64 passed`).
- Ran `git diff --check`/format checks to ensure no diff errors, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19ef366f60832c91fa532e3b3170b1)