### PR TITLE
fix(ci): classify submission automation changes

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -84,13 +84,20 @@ const generatedArtifactInfra = touches(
   /^apps\/web\/src\/generated\//,
   "README.md",
 );
+const submissionAutomationInfra = touches(
+  /^scripts\/(analyze-submission-risk|import-submission-issue|validate-submission-issue)\.mjs$/,
+);
 
 const flags = {
   content: contentCategoryTouched || contentValidationInfra,
   content_config: contentValidationInfra,
-  registry: contentCategoryTouched || generatedArtifactInfra,
+  registry:
+    contentCategoryTouched ||
+    generatedArtifactInfra ||
+    submissionAutomationInfra,
   web:
     contentCategoryTouched ||
+    submissionAutomationInfra ||
     touches(
       /^apps\/web\//,
       /^emails\//,
@@ -127,15 +134,17 @@ const flags = {
     "package.json",
     "pnpm-lock.yaml",
   ),
-  ci: touches(
-    /^\.github\/workflows\//,
-    /^scripts\/ci\//,
-    /^\.trunk\//,
-    "renovate.json",
-    "package.json",
-    "pnpm-lock.yaml",
-    "vitest.config.ts",
-  ),
+  ci:
+    submissionAutomationInfra ||
+    touches(
+      /^\.github\/workflows\//,
+      /^scripts\/ci\//,
+      /^\.trunk\//,
+      "renovate.json",
+      "package.json",
+      "pnpm-lock.yaml",
+      "vitest.config.ts",
+    ),
 };
 
 flags.docs = touches(

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -25,6 +25,44 @@ function parseOutput(output: string) {
   );
 }
 
+function createFixtureRepo() {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-classify-"));
+  tempDirs.push(cwd);
+
+  git(cwd, ["init", "--initial-branch=main"]);
+  git(cwd, ["config", "user.email", "test@example.com"]);
+  git(cwd, ["config", "user.name", "Test User"]);
+  git(cwd, ["config", "commit.gpgsign", "false"]);
+  fs.writeFileSync(path.join(cwd, "README.md"), "# fixture\n");
+  git(cwd, ["add", "README.md"]);
+  git(cwd, ["commit", "-m", "init"]);
+
+  return {
+    cwd,
+    baseSha: git(cwd, ["rev-parse", "HEAD"]),
+  };
+}
+
+function runClassifier(cwd: string, baseSha: string) {
+  const outputPath = path.join(cwd, "github-output.txt");
+  execFileSync(
+    "node",
+    [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")],
+    {
+      cwd,
+      env: {
+        ...process.env,
+        BASE_SHA: baseSha,
+        GITHUB_EVENT_NAME: "pull_request",
+        GITHUB_OUTPUT: outputPath,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  return parseOutput(fs.readFileSync(outputPath, "utf8"));
+}
+
 describe("PR change classifier", () => {
   afterEach(() => {
     for (const dir of tempDirs.splice(0)) {
@@ -33,17 +71,7 @@ describe("PR change classifier", () => {
   });
 
   it("routes content entry changes through public artifact validation lanes", () => {
-    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-classify-"));
-    tempDirs.push(cwd);
-
-    git(cwd, ["init", "--initial-branch=main"]);
-    git(cwd, ["config", "user.email", "test@example.com"]);
-    git(cwd, ["config", "user.name", "Test User"]);
-    git(cwd, ["config", "commit.gpgsign", "false"]);
-    fs.writeFileSync(path.join(cwd, "README.md"), "# fixture\n");
-    git(cwd, ["add", "README.md"]);
-    git(cwd, ["commit", "-m", "init"]);
-    const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+    const { cwd, baseSha } = createFixtureRepo();
 
     const contentDir = path.join(cwd, "content", "agents");
     fs.mkdirSync(contentDir, { recursive: true });
@@ -54,28 +82,32 @@ describe("PR change classifier", () => {
     git(cwd, ["add", "content/agents/example.mdx"]);
     git(cwd, ["commit", "-m", "add content entry"]);
 
-    const outputPath = path.join(cwd, "github-output.txt");
-    execFileSync(
-      "node",
-      [path.join(repoRoot, "scripts/ci/classify-pr-changes.mjs")],
-      {
-        cwd,
-        env: {
-          ...process.env,
-          BASE_SHA: baseSha,
-          GITHUB_EVENT_NAME: "pull_request",
-          GITHUB_OUTPUT: outputPath,
-        },
-        encoding: "utf8",
-      },
-    );
-
-    const outputs = parseOutput(fs.readFileSync(outputPath, "utf8"));
+    const outputs = runClassifier(cwd, baseSha);
     expect(outputs).toMatchObject({
       content: "true",
       content_agents: "true",
       registry: "true",
       raycast: "true",
+      web: "true",
+    });
+  });
+
+  it("routes submission automation changes through full owned validation lanes", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+    const scriptDir = path.join(cwd, "scripts");
+    fs.mkdirSync(scriptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scriptDir, "import-submission-issue.mjs"),
+      "console.log('changed');\n",
+    );
+    git(cwd, ["add", "scripts/import-submission-issue.mjs"]);
+    git(cwd, ["commit", "-m", "update submission automation"]);
+
+    const outputs = runClassifier(cwd, baseSha);
+    expect(outputs).toMatchObject({
+      ci: "true",
+      content: "false",
+      registry: "true",
       web: "true",
     });
   });


### PR DESCRIPTION
### Motivation
- Close a CI supply-chain bypass by ensuring changes to privileged submission automation scripts trigger full validation lanes instead of being skipped by a PR-controlled classifier.

### Description
- Add a `submissionAutomationInfra` classifier that matches `scripts/analyze-submission-risk.mjs`, `scripts/import-submission-issue.mjs`, and `scripts/validate-submission-issue.mjs`.
- Route `submissionAutomationInfra` into the `registry`, `web`, and `ci` flags so changes to those scripts cause the corresponding validation lanes to run (`registry = generatedArtifactInfra || submissionAutomationInfra`, `web = submissionAutomationInfra || touches(...)`, `ci = submissionAutomationInfra || touches(...)`).
- Apply code formatting with Prettier to the modified file `scripts/ci/classify-pr-changes.mjs`.

### Testing
- Checked syntax with `node --check scripts/ci/classify-pr-changes.mjs` and formatting with `pnpm exec prettier --check` which passed after `--write`.
- Ran a smoke test that simulates a PR by creating a base commit and touching the three submission scripts, then executed the classifier with `GITHUB_EVENT_NAME=pull_request BASE_SHA=<base> GITHUB_OUTPUT=<out> node scripts/ci/classify-pr-changes.mjs`, which produced `registry=true`, `web=true`, and `ci=true` as expected.
- Verified `git diff --check` returned no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f0ebc230832cb4052d8415a7903f)