### PR TITLE
fix(web): redact secret-like URL path values

### DIFF
--- a/apps/web/src/lib/mcp-config-validator.ts
+++ b/apps/web/src/lib/mcp-config-validator.ts
@@ -101,9 +101,11 @@ function redactUrlValue(value: string) {
         redacted = true;
       }
     }
+    const serialized = decodePlaceholderTokens(parsed.toString());
+    const fallback = redactEnvValue("url", serialized);
     return {
-      value: decodePlaceholderTokens(parsed.toString()),
-      redactedCount: redacted ? 1 : 0,
+      value: fallback,
+      redactedCount: redacted || fallback !== serialized ? 1 : 0,
     };
   } catch {
     const fallback = redactEnvValue("url", value);

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -96,6 +96,34 @@ describe("MCP config validator", () => {
     }
   });
 
+  it("redacts URL path and fragment secrets from remote URLs and args", () => {
+    const result = validateMcpConfigText(
+      JSON.stringify({
+        mcpServers: {
+          remoteWithPathSecret: {
+            url: "https://example.com/mcp/sk-PATHSECRET1234567890",
+          },
+          stdioWithFragmentSecret: {
+            command: "npx",
+            args: [
+              "-y",
+              "@example/mcp",
+              "https://example.com/mcp#access_token=sk-FRAGSECRET1234567890",
+            ],
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.redactedSecretCount).toBe(2);
+    for (const output of [result.fixedConfigText, result.reportText]) {
+      expect(output).not.toContain("sk-PATHSECRET1234567890");
+      expect(output).not.toContain("sk-FRAGSECRET1234567890");
+      expect(output).toContain("${URL}");
+    }
+  });
+
   it("redacts malformed URL-like values that contain secrets", () => {
     const result = validateMcpConfigText(
       JSON.stringify({


### PR DESCRIPTION
### Motivation
- The URL-specific redactor returned parsed URLs without re-scanning the serialized output for known secret patterns, allowing tokens embedded in URL paths, fragments, or unparsable URL strings to appear in validator outputs.
- Ensure MCP validator outputs never leak recognized secret-like values while preserving existing username/password and query-parameter placeholder behavior.

### Description
- Route the serialized parsed URL through the generic redactor by calling `redactEnvValue("url", serialized)` inside `redactUrlValue` in `apps/web/src/lib/mcp-config-validator.ts` and update the returned `redactedCount` accordingly.
- Preserve existing URL username/password and query-parameter placeholder redactions while adding a fallback that detects secrets in path, fragment, or other serialized URL components.
- Add a regression test `redacts URL path and fragment secrets from remote URLs and args` to `tests/mcp-config-validator.test.ts` that asserts secrets in URL paths and fragment-style URL args are redacted in both `fixedConfigText` and `reportText`.

### Testing
- Ran `pnpm exec vitest run tests/mcp-config-validator.test.ts --reporter=dot` and the test suite passed (13 tests passed, 1 file).
- Ran `pnpm build` and the web build completed successfully without validation errors.
- Ran `git diff --check` as part of validation and there were no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f21b8330832c80e71f4f63b830ef)