### PR TITLE
fix(submissions): reject non-tool affiliate URLs

### DIFF
--- a/packages/registry/src/content-builder.js
+++ b/packages/registry/src/content-builder.js
@@ -289,7 +289,10 @@ export function buildContentEntryFromMdx(params) {
       : undefined,
     websiteUrl: data.websiteUrl ? String(data.websiteUrl) : undefined,
     ...brandAssets,
-    affiliateUrl: data.affiliateUrl ? String(data.affiliateUrl) : undefined,
+    affiliateUrl:
+      category === "tools" && data.affiliateUrl
+        ? String(data.affiliateUrl)
+        : undefined,
     pricingModel: data.pricingModel ? String(data.pricingModel) : undefined,
     disclosure: data.disclosure ? String(data.disclosure) : undefined,
     applicationCategory: data.applicationCategory

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -1625,6 +1625,12 @@ export function validateSubmission(issue) {
     }
   }
 
+  if (normalizeValue(fields.affiliate_url) && category !== TOOLS_CATEGORY) {
+    errors.push(
+      "Contributor submissions cannot include affiliate_url outside maintainer-reviewed tools listings",
+    );
+  }
+
   if (category === "skills" && isGitHubSourcePath(fields.download_url)) {
     errors.push(
       "download_url must point to a package, archive, or release download; use github_url or retrieval_sources for GitHub source tree/blob paths",

--- a/scripts/import-submission-issue.mjs
+++ b/scripts/import-submission-issue.mjs
@@ -340,7 +340,8 @@ function buildContent(issue, report) {
     brandDomain: fields.brand_domain,
     brandAssetSource: fields.brand_domain ? "brandfetch" : "",
     websiteUrl: normalizeHttpsUrl(fields.website_url),
-    affiliateUrl: normalizeHttpsUrl(fields.affiliate_url),
+    affiliateUrl:
+      category === "tools" ? normalizeHttpsUrl(fields.affiliate_url) : "",
     repoUrl: fields.github_url,
     documentationUrl: fields.docs_url,
     pricingModel: fields.pricing_model,

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -1825,6 +1825,45 @@ claude mcp add referral-tool -- npx referral-tool`),
     );
   });
 
+  it("rejects affiliate URLs on non-tool submissions", () => {
+    const report = validateSubmission(
+      issue(`### Name
+Affiliate Bypass MCP
+
+### Slug
+affiliate-bypass-mcp
+
+### Category
+mcp
+
+### Public contact
+dev@example.com
+
+### GitHub URL
+https://github.com/example/affiliate-bypass-mcp
+
+### Affiliate URL
+https://merchant.example/deal?referral_code=attacker&utm_source=submission
+
+### Description
+MCP server attempting to submit a monetized tracking URL.
+
+### Card description
+MCP server affiliate URL bypass coverage.
+
+### Install command
+npx affiliate-bypass-mcp
+
+### Usage snippet
+claude mcp add affiliate-bypass-mcp -- npx affiliate-bypass-mcp`),
+    );
+
+    expect(report.ok).toBe(false);
+    expect(report.errors).toContain(
+      "Contributor submissions cannot include affiliate_url outside maintainer-reviewed tools listings",
+    );
+  });
+
   it("rejects malformed or non-https contributor URLs", () => {
     const report = validateSubmission(
       issue(`### Name


### PR DESCRIPTION
### Motivation
- The submission intake allowed `affiliate_url` to be parsed and persisted but skipped affiliate/referral detection for that field, permitting contributor-controlled affiliate/tracking links to pass validation for non-`tools` categories and be exposed in generated registry data.

### Description
- Add a validation check in `validateSubmission` to reject `affiliate_url` for any category other than `tools` so contributor submissions cannot carry affiliate/tracking URLs through the normal intake flow.
- Harden the import path in `scripts/import-submission-issue.mjs` to only emit `affiliateUrl` frontmatter when the imported entry `category` is `tools` as a defense-in-depth guard.
- Update `packages/registry/src/content-builder.js` to suppress `affiliateUrl` in built registry entries unless the entry `category` is `tools` to avoid exposing non-tool affiliate links in artifacts.
- Add regression coverage in `tests/submission-intake.test.ts` to assert that a non-tool MCP submission with an `Affiliate URL` is rejected.

### Testing
- Ran the submission tests with `pnpm exec vitest run tests/submission-intake.test.ts` and `pnpm test:submission-intake`, both of which passed (all tests green).
- Ran `pnpm test:registry-artifacts` to ensure build-time artifacts remain valid, which also passed.
- Verified `git diff --check` style checks (no remaining whitespace/format issues) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19f251d4ac832cbcc8f9f7b8c3ccb1)