### PR TITLE
fix(deploy): restore worker observability sampling

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -9,11 +9,11 @@
     "logs": {
       "enabled": true,
       "invocation_logs": true,
-      "head_sampling_rate": 0.1,
+      "head_sampling_rate": 1,
     },
     "traces": {
       "enabled": true,
-      "head_sampling_rate": 0.1,
+      "head_sampling_rate": 1,
     },
   },
   "logpush": true,


### PR DESCRIPTION
## Summary
- restore Worker logs and traces to 100% head sampling

## What changed
- set `observability.logs.head_sampling_rate` to `1`
- set `observability.traces.head_sampling_rate` to `1`

## Why
- the production Worker should retain full request log and trace coverage during the Atlas cutover and Cloudflare Workers Build reconnect

## Validation
- `pnpm validate:clean`
- `pnpm --filter web exec wrangler deploy --dry-run --config wrangler.jsonc --env ""`
- `git diff --check`
