### PR TITLE
fix(web): scope admin tokens by route

### DIFF
--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -1,20 +1,22 @@
 import { getCloudflareEnv, getEnvString } from "@/lib/cloudflare-env.server";
 
-const ADMIN_TOKEN_NAMES = [
-  "ADMIN_API_TOKEN",
-  "JOBS_ADMIN_API_TOKEN",
-  "LEADS_ADMIN_TOKEN",
-  "ADMIN_LEADS_TOKEN",
-] as const;
+const PRIMARY_ADMIN_TOKEN_NAMES = ["ADMIN_API_TOKEN"] as const;
+const JOBS_ADMIN_TOKEN_NAMES = ["JOBS_ADMIN_API_TOKEN"] as const;
+const LEADS_ADMIN_TOKEN_NAMES = ["LEADS_ADMIN_TOKEN", "ADMIN_LEADS_TOKEN"] as const;
+
+type AdminTokenName =
+  | (typeof PRIMARY_ADMIN_TOKEN_NAMES)[number]
+  | (typeof JOBS_ADMIN_TOKEN_NAMES)[number]
+  | (typeof LEADS_ADMIN_TOKEN_NAMES)[number];
 
 export function getAdminToken() {
-  return getEnvString(...ADMIN_TOKEN_NAMES);
+  return getEnvString(...PRIMARY_ADMIN_TOKEN_NAMES);
 }
 
-export function getAdminTokens() {
+function getScopedAdminTokens(tokenNames: readonly AdminTokenName[]) {
   const env = getCloudflareEnv();
   const tokens = new Set<string>();
-  for (const name of ADMIN_TOKEN_NAMES) {
+  for (const name of tokenNames) {
     const runtimeValue = env[name];
     if (typeof runtimeValue === "string" && runtimeValue.trim()) {
       tokens.add(runtimeValue.trim());
@@ -27,8 +29,11 @@ export function getAdminTokens() {
   return [...tokens];
 }
 
-export function isAdminAuthorized(request: Request) {
-  const tokens = getAdminTokens();
+export function getAdminTokens() {
+  return getScopedAdminTokens(PRIMARY_ADMIN_TOKEN_NAMES);
+}
+
+function hasAdminToken(request: Request, tokens: readonly string[]) {
   if (tokens.length === 0) return false;
 
   const bearer = request.headers
@@ -37,4 +42,22 @@ export function isAdminAuthorized(request: Request) {
     .trim();
   const headerToken = request.headers.get("x-admin-token")?.trim();
   return tokens.some((token) => bearer === token || headerToken === token);
+}
+
+export function isAdminAuthorized(request: Request) {
+  return hasAdminToken(request, getAdminTokens());
+}
+
+export function isJobsAdminAuthorized(request: Request) {
+  return hasAdminToken(
+    request,
+    getScopedAdminTokens([...PRIMARY_ADMIN_TOKEN_NAMES, ...JOBS_ADMIN_TOKEN_NAMES]),
+  );
+}
+
+export function isLeadsAdminAuthorized(request: Request) {
+  return hasAdminToken(
+    request,
+    getScopedAdminTokens([...PRIMARY_ADMIN_TOKEN_NAMES, ...LEADS_ADMIN_TOKEN_NAMES]),
+  );
 }

--- a/apps/web/src/routes/api/admin/jobs.ts
+++ b/apps/web/src/routes/api/admin/jobs.ts
@@ -12,7 +12,7 @@ import {
   type InferApiBody,
   type InferApiQuery,
 } from "@/lib/api/router";
-import { isAdminAuthorized } from "@/lib/admin-auth";
+import { isJobsAdminAuthorized } from "@/lib/admin-auth";
 import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
 import {
@@ -52,7 +52,7 @@ async function requireReadyJobsDb(request: Request, requestId: string) {
 }
 
 export const GET = createApiHandler("adminJobs.list", async ({ request, query, requestId }) => {
-  if (!isAdminAuthorized(request)) {
+  if (!isJobsAdminAuthorized(request)) {
     logApiWarn(request, "admin.jobs.unauthorized");
     return apiError("unauthorized", 401, { requestId });
   }
@@ -75,7 +75,7 @@ export const GET = createApiHandler("adminJobs.list", async ({ request, query, r
 });
 
 export const POST = createApiHandler("adminJobs.upsert", async ({ request, body, requestId }) => {
-  if (!isAdminAuthorized(request)) {
+  if (!isJobsAdminAuthorized(request)) {
     logApiWarn(request, "admin.jobs.unauthorized");
     return apiError("unauthorized", 401, { requestId });
   }
@@ -117,7 +117,7 @@ export const POST = createApiHandler("adminJobs.upsert", async ({ request, body,
 });
 
 export const PATCH = createApiHandler("adminJobs.update", async ({ request, body, requestId }) => {
-  if (!isAdminAuthorized(request)) {
+  if (!isJobsAdminAuthorized(request)) {
     logApiWarn(request, "admin.jobs.unauthorized");
     return apiError("unauthorized", 401, { requestId });
   }

--- a/apps/web/src/routes/api/admin/jobs/health.ts
+++ b/apps/web/src/routes/api/admin/jobs/health.ts
@@ -1,13 +1,13 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
 import { apiError, apiJson, createApiHandler } from "@/lib/api/router";
-import { isAdminAuthorized } from "@/lib/admin-auth";
+import { isJobsAdminAuthorized } from "@/lib/admin-auth";
 import { logApiError, logApiWarn } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
 import { getJobsHealth } from "@/lib/job-admin";
 
 export const GET = createApiHandler("adminJobs.health", async ({ request, requestId }) => {
-  if (!isAdminAuthorized(request)) {
+  if (!isJobsAdminAuthorized(request)) {
     logApiWarn(request, "admin.jobs.health.unauthorized");
     return apiError("unauthorized", 401, { requestId });
   }

--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -13,7 +13,7 @@ import {
   type InferApiBody,
   type InferApiQuery,
 } from "@/lib/api/router";
-import { isAdminAuthorized } from "@/lib/admin-auth";
+import { isLeadsAdminAuthorized } from "@/lib/admin-auth";
 import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
 import { csvEscape } from "@/lib/csv";
 import { getSiteDb } from "@/lib/db";
@@ -53,7 +53,7 @@ function leadsToCsv(rows: Record<string, unknown>[]) {
 export const GET = createApiHandler(
   "adminListingLeads.list",
   async ({ request, query: parsedQuery, requestId }) => {
-    if (!isAdminAuthorized(request)) {
+    if (!isLeadsAdminAuthorized(request)) {
       logApiWarn(request, "admin.listing_leads.unauthorized");
       return apiError("unauthorized", 401, { requestId });
     }
@@ -130,7 +130,7 @@ export const GET = createApiHandler(
 export const PATCH = createApiHandler(
   "adminListingLeads.update",
   async ({ request, body, requestId }) => {
-    if (!isAdminAuthorized(request)) {
+    if (!isLeadsAdminAuthorized(request)) {
       logApiWarn(request, "admin.listing_leads.unauthorized");
       return apiError("unauthorized", 401, { requestId });
     }

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -408,23 +408,92 @@ describe("central API router security", () => {
     });
   });
 
-  it("accepts a dedicated jobs admin token without replacing the primary admin token", async () => {
+  it("rejects jobs-only tokens on listing lead admin routes", async () => {
     const previousAdmin = process.env.ADMIN_API_TOKEN;
     const previousJobs = process.env.JOBS_ADMIN_API_TOKEN;
-    process.env.ADMIN_API_TOKEN = "primary-admin-token";
+    const previousLeads = process.env.LEADS_ADMIN_TOKEN;
+    const previousAdminLeads = process.env.ADMIN_LEADS_TOKEN;
+    delete process.env.ADMIN_API_TOKEN;
     process.env.JOBS_ADMIN_API_TOKEN = "jobs-admin-token";
+    delete process.env.LEADS_ADMIN_TOKEN;
+    delete process.env.ADMIN_LEADS_TOKEN;
 
     try {
-      const { isAdminAuthorized } = await import("@/lib/admin-auth");
+      const { GET } = await import("@/routes/api/admin/listing-leads");
+      const response = await GET(
+        new Request("https://heyclau.de/api/admin/listing-leads", {
+          headers: { authorization: "Bearer jobs-admin-token" },
+        }),
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: false,
+        error: { code: "unauthorized" },
+      });
+    } finally {
+      if (previousAdmin === undefined) delete process.env.ADMIN_API_TOKEN;
+      else process.env.ADMIN_API_TOKEN = previousAdmin;
+      if (previousJobs === undefined) delete process.env.JOBS_ADMIN_API_TOKEN;
+      else process.env.JOBS_ADMIN_API_TOKEN = previousJobs;
+      if (previousLeads === undefined) delete process.env.LEADS_ADMIN_TOKEN;
+      else process.env.LEADS_ADMIN_TOKEN = previousLeads;
+      if (previousAdminLeads === undefined)
+        delete process.env.ADMIN_LEADS_TOKEN;
+      else process.env.ADMIN_LEADS_TOKEN = previousAdminLeads;
+    }
+  });
+
+  it("scopes dedicated admin tokens to their intended admin routes", async () => {
+    const previousAdmin = process.env.ADMIN_API_TOKEN;
+    const previousJobs = process.env.JOBS_ADMIN_API_TOKEN;
+    const previousLeads = process.env.LEADS_ADMIN_TOKEN;
+    const previousAdminLeads = process.env.ADMIN_LEADS_TOKEN;
+    process.env.ADMIN_API_TOKEN = "primary-admin-token";
+    process.env.JOBS_ADMIN_API_TOKEN = "jobs-admin-token";
+    process.env.LEADS_ADMIN_TOKEN = "leads-admin-token";
+    delete process.env.ADMIN_LEADS_TOKEN;
+
+    try {
+      const { isJobsAdminAuthorized, isLeadsAdminAuthorized } =
+        await import("@/lib/admin-auth");
       expect(
-        isAdminAuthorized(
+        isJobsAdminAuthorized(
           new Request("https://heyclau.de/api/admin/jobs", {
             headers: { authorization: "Bearer jobs-admin-token" },
           }),
         ),
       ).toBe(true);
       expect(
-        isAdminAuthorized(
+        isLeadsAdminAuthorized(
+          new Request("https://heyclau.de/api/admin/listing-leads", {
+            headers: { authorization: "Bearer jobs-admin-token" },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        isLeadsAdminAuthorized(
+          new Request("https://heyclau.de/api/admin/listing-leads", {
+            headers: { "x-admin-token": "leads-admin-token" },
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        isJobsAdminAuthorized(
+          new Request("https://heyclau.de/api/admin/jobs", {
+            headers: { "x-admin-token": "leads-admin-token" },
+          }),
+        ),
+      ).toBe(false);
+      expect(
+        isLeadsAdminAuthorized(
+          new Request("https://heyclau.de/api/admin/listing-leads", {
+            headers: { "x-admin-token": "primary-admin-token" },
+          }),
+        ),
+      ).toBe(true);
+      expect(
+        isJobsAdminAuthorized(
           new Request("https://heyclau.de/api/admin/jobs", {
             headers: { "x-admin-token": "primary-admin-token" },
           }),
@@ -435,6 +504,11 @@ describe("central API router security", () => {
       else process.env.ADMIN_API_TOKEN = previousAdmin;
       if (previousJobs === undefined) delete process.env.JOBS_ADMIN_API_TOKEN;
       else process.env.JOBS_ADMIN_API_TOKEN = previousJobs;
+      if (previousLeads === undefined) delete process.env.LEADS_ADMIN_TOKEN;
+      else process.env.LEADS_ADMIN_TOKEN = previousLeads;
+      if (previousAdminLeads === undefined)
+        delete process.env.ADMIN_LEADS_TOKEN;
+      else process.env.ADMIN_LEADS_TOKEN = previousAdminLeads;
     }
   });
 


### PR DESCRIPTION
### Motivation

- Prevent `JOBS_ADMIN_API_TOKEN` from granting access to lead PII and lead-management actions by enforcing route-level token scoping.
- Restore least-privilege behavior so jobs/source-revalidation credentials cannot operate on listing-leads endpoints.

### Description

- Split the previous global admin-token list into scoped sets: primary (`ADMIN_API_TOKEN`), jobs (`JOBS_ADMIN_API_TOKEN`), and leads (`LEADS_ADMIN_TOKEN`, `ADMIN_LEADS_TOKEN`) in `apps/web/src/lib/admin-auth.ts` and added `isJobsAdminAuthorized` and `isLeadsAdminAuthorized` helpers while preserving `isAdminAuthorized` for primary admin.
- Replaced generic checks with scoped checks so jobs endpoints now call `isJobsAdminAuthorized` and listing-leads endpoints call `isLeadsAdminAuthorized`.
- Added a regression test in `tests/api-router-security.test.ts` that verifies jobs-only tokens are rejected by listing-leads routes and that dedicated tokens remain scoped.

### Testing

- Ran the focused unit test: `pnpm exec vitest run tests/api-router-security.test.ts --reporter=verbose` and it passed (`22 tests` passed).
- Ran type checks with `pnpm type-check` and OpenAPI validation with `pnpm validate:openapi`, both completed without errors.
- Verified formatting with `pnpm exec prettier --check` and repository checks with `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a3caded64832c93186e91c3b70eb6)