### PR TITLE
fix(web): normalize newsletter API errors

### DIFF
--- a/apps/web/src/lib/api/newsletter.ts
+++ b/apps/web/src/lib/api/newsletter.ts
@@ -5,6 +5,21 @@ type SubscribeInput = {
   source?: string;
 };
 
+type ApiErrorBody = {
+  error?: string | { message?: unknown };
+};
+
+function responseErrorMessage(data: unknown, fallback: string) {
+  if (data && typeof data === "object" && "error" in data) {
+    const error = (data as ApiErrorBody).error;
+    if (typeof error === "string" && error.length > 0) return error;
+    if (error && typeof error === "object" && typeof error.message === "string") {
+      return error.message;
+    }
+  }
+  return fallback;
+}
+
 export async function subscribeToNewsletter(
   input: SubscribeInput,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
@@ -14,8 +29,10 @@ export async function subscribeToNewsletter(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
     });
-    const data = (await res.json().catch(() => ({}))) as { error?: string };
-    if (!res.ok) return { ok: false, error: data.error ?? `Subscribe failed (${res.status}).` };
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return { ok: false, error: responseErrorMessage(data, `Subscribe failed (${res.status}).`) };
+    }
     return { ok: true };
   } catch {
     return { ok: false, error: "Network error. Try again in a moment." };
@@ -32,8 +49,13 @@ export async function unsubscribeFromNewsletter(input: {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
     });
-    const data = (await res.json().catch(() => ({}))) as { error?: string };
-    if (!res.ok) return { ok: false, error: data.error ?? `Unsubscribe failed (${res.status}).` };
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return {
+        ok: false,
+        error: responseErrorMessage(data, `Unsubscribe failed (${res.status}).`),
+      };
+    }
     return { ok: true };
   } catch {
     return { ok: false, error: "Network error. Try again in a moment." };

--- a/tests/newsletter-client.test.ts
+++ b/tests/newsletter-client.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  subscribeToNewsletter,
+  unsubscribeFromNewsletter,
+} from "@/lib/api/newsletter";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("newsletter client helpers", () => {
+  it("normalizes centralized subscribe API errors to displayable strings", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      Response.json(
+        {
+          ok: false,
+          error: { code: "rate_limited", message: "Rate limited" },
+          requestId: "req_123",
+        },
+        { status: 429 },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      subscribeToNewsletter({ email: "reader@example.com", source: "test" }),
+    ).resolves.toEqual({ ok: false, error: "Rate limited" });
+  });
+
+  it("preserves legacy flat newsletter error strings", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      Response.json(
+        { error: "Provider rejected the request" },
+        { status: 502 },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      unsubscribeFromNewsletter({ email: "reader@example.com" }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Provider rejected the request",
+    });
+  });
+
+  it("falls back when a newsletter error body is not displayable", async () => {
+    globalThis.fetch = vi.fn(async () =>
+      Response.json(
+        { ok: false, error: { code: "provider_error" } },
+        { status: 502 },
+      ),
+    ) as typeof fetch;
+
+    await expect(
+      subscribeToNewsletter({ email: "reader@example.com" }),
+    ).resolves.toEqual({
+      ok: false,
+      error: "Subscribe failed (502).",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Centralized API routes return error envelopes like `{ ok: false, error: { code, message, details? } }`, but the newsletter client helpers still assumed `error` was a flat string, which could propagate objects into React state and crash rendering.

### Description
- Add `ApiErrorBody` type and `responseErrorMessage` helper to normalize centralized API error envelopes into displayable strings or fall back to a status-based message. 
- Update `subscribeToNewsletter` and `unsubscribeFromNewsletter` to parse the response JSON and return a normalized `error: string` for non-OK responses. 
- Preserve legacy flat-string errors when present and fall back when the envelope lacks a displayable message. 
- Add `tests/newsletter-client.test.ts` with coverage for centralized object-shaped errors, legacy flat string errors, and fallback behavior.

### Testing
- Ran unit tests with `pnpm exec vitest run tests/newsletter-client.test.ts tests/codeql-regressions.test.ts` and all tests passed. 
- Ran `pnpm type-check` (project type check) and it completed without type errors. 
- Ran `git diff --check` to ensure no whitespace/format issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a6c33fa70832cb853f91b44fd0217)