### PR TITLE
fix(submissions): bound queue GitHub hydration

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -4835,7 +4835,7 @@
             "in": "query"
           },
           {
-            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 },
+            "schema": { "type": "integer", "minimum": 1, "maximum": 25, "default": 25 },
             "required": false,
             "name": "limit",
             "in": "query"
@@ -4916,7 +4916,7 @@
                           "createdAt"
                         ]
                       },
-                      "maxItems": 100
+                      "maxItems": 25
                     }
                   },
                   "required": ["ok", "generatedAt", "repo", "count", "entries"]

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -5610,8 +5610,8 @@ paths:
         - schema:
             type: integer
             minimum: 1
-            maximum: 100
-            default: 50
+            maximum: 25
+            default: 25
           required: false
           name: limit
           in: query
@@ -5725,7 +5725,7 @@ paths:
                         - blockers
                         - updatedAt
                         - createdAt
-                    maxItems: 100
+                    maxItems: 25
                 required:
                   - ok
                   - generatedAt

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -484,7 +484,7 @@ export const submissionPreflightBodySchema = z.object({
 
 export const submissionQueueQuerySchema = z.object({
   number: z.coerce.number().int().positive().optional(),
-  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  limit: z.coerce.number().int().min(1).max(25).optional().default(25),
 });
 
 const submissionPreflightNoteSchema = z.object({
@@ -593,7 +593,7 @@ export const submissionQueueResponseSchema = z.object({
   generatedAt: z.string(),
   repo: z.string(),
   count: z.number().int().nonnegative(),
-  entries: z.array(submissionQueueItemSchema).max(100),
+  entries: z.array(submissionQueueItemSchema).max(25),
 });
 
 export const downloadQuerySchema = z.object({

--- a/apps/web/src/routes/api/submissions/queue.ts
+++ b/apps/web/src/routes/api/submissions/queue.ts
@@ -16,6 +16,8 @@ const GITHUB_API_VERSION = "2022-11-28";
 const GITHUB_USER_AGENT = "HeyClaude/1.0 (+https://heyclau.de; JSONbored/awesome-claude)";
 const DEFAULT_REPO = "JSONbored/awesome-claude";
 const IMPORT_PR_PATTERN = /https:\/\/github\.com\/JSONbored\/awesome-claude\/pull\/\d+/i;
+const LIST_ACTIVITY_PAGE_LIMIT = 2;
+const DETAIL_ACTIVITY_PAGE_LIMIT = 10;
 
 type GitHubLabel = string | { name?: string };
 
@@ -169,11 +171,11 @@ function nextPageUrl(response: Response) {
   return match?.[1] || "";
 }
 
-async function fetchGitHubPages<T>(url: string, token: string) {
+async function fetchGitHubPages<T>(url: string, token: string, maxPages: number) {
   const items: T[] = [];
   let nextUrl = withPerPage(url);
 
-  for (let page = 0; page < 10 && nextUrl; page += 1) {
+  for (let page = 0; page < maxPages && nextUrl; page += 1) {
     const { response, payload } = await fetchGitHub<T[]>(nextUrl, token);
     if (!response.ok || !Array.isArray(payload)) return items;
     items.push(...payload);
@@ -183,20 +185,26 @@ async function fetchGitHubPages<T>(url: string, token: string) {
   return items;
 }
 
-async function fetchIssueComments(issue: GitHubIssue, token: string) {
+async function fetchIssueComments(issue: GitHubIssue, token: string, maxPages: number) {
   if (!issue.comments_url) return [];
   try {
-    return await fetchGitHubPages<GitHubComment>(issue.comments_url, token);
+    return await fetchGitHubPages<GitHubComment>(issue.comments_url, token, maxPages);
   } catch {
     return [];
   }
 }
 
-async function fetchIssueTimeline(repo: string, issueNumber: number, token: string) {
+async function fetchIssueTimeline(
+  repo: string,
+  issueNumber: number,
+  token: string,
+  maxPages: number,
+) {
   try {
     return await fetchGitHubPages<GitHubTimelineEvent>(
       `https://api.github.com/repos/${repo}/issues/${issueNumber}/timeline`,
       token,
+      maxPages,
     );
   } catch {
     return [];
@@ -226,19 +234,30 @@ function activityIssue(
   };
 }
 
-async function mapIssue(issue: GitHubIssue, repo: string, token: string) {
+async function mapIssue(
+  issue: GitHubIssue,
+  repo: string,
+  token: string,
+  options: { activityPageLimit: number },
+) {
   const labels = labelNames(issue);
   const fields = parseIssueFormBody(issue.body || "");
   const status = statusFor(issue, labels);
+  const bodyImportPrUrl = importPrFromText(issue.body || "");
+  const needsCommentImportPr =
+    !bodyImportPrUrl && (status === "import_pr_open" || status === "imported");
+  const needsAuthorActivity = status === "needs_author_input";
   const [comments, timeline] = await Promise.all([
-    fetchIssueComments(issue, token),
-    fetchIssueTimeline(repo, issue.number, token),
+    needsCommentImportPr || needsAuthorActivity
+      ? fetchIssueComments(issue, token, options.activityPageLimit)
+      : Promise.resolve([]),
+    needsAuthorActivity
+      ? fetchIssueTimeline(repo, issue.number, token, options.activityPageLimit)
+      : Promise.resolve([]),
   ]);
   const activity = submissionActivityState(activityIssue(issue, comments, timeline));
-  const bodyImportPrUrl = importPrFromText(issue.body || "");
   const importPrUrl =
-    bodyImportPrUrl ||
-    (status === "import_pr_open" || status === "imported" ? commentImportPr(comments) : undefined);
+    bodyImportPrUrl || (needsCommentImportPr ? commentImportPr(comments) : undefined);
   const blockers = blockersFor(labels);
   if (activity.authorCommentedWithoutBodyUpdate) {
     blockers.push("Author replied after review, but the issue body was not updated.");
@@ -358,7 +377,14 @@ export const GET = createApiHandler("submissions.queue", async ({ request, query
   const issues = "issue" in result ? [result.issue] : result.issues;
   const entries = [];
   for (const issue of issues) {
-    if (issue) entries.push(await mapIssue(issue, repo, result.token));
+    if (issue) {
+      entries.push(
+        await mapIssue(issue, repo, result.token, {
+          activityPageLimit:
+            "issue" in result ? DETAIL_ACTIVITY_PAGE_LIMIT : LIST_ACTIVITY_PAGE_LIMIT,
+        }),
+      );
+    }
   }
 
   return apiJson(

--- a/apps/web/src/routes/submissions.tsx
+++ b/apps/web/src/routes/submissions.tsx
@@ -147,7 +147,7 @@ function useSubmissionQueue() {
     async function load() {
       setLoading(true);
       try {
-        const response = await fetch("/api/submissions/queue?limit=100");
+        const response = await fetch("/api/submissions/queue?limit=25");
         const payload = (await response.json().catch(() => null)) as
           | QueueResponse
           | { error?: { message?: string } }

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -5613,8 +5613,8 @@ paths:
         - schema:
             type: integer
             minimum: 1
-            maximum: 100
-            default: 50
+            maximum: 25
+            default: 25
           required: false
           name: limit
           in: query
@@ -5728,7 +5728,7 @@ paths:
                         - blockers
                         - updatedAt
                         - createdAt
-                    maxItems: 100
+                    maxItems: 25
                 required:
                   - ok
                   - generatedAt

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -331,6 +331,119 @@ describe("website submission API", () => {
     });
   });
 
+  it("rejects oversized public submission queue reads", async () => {
+    const { GET } = await import("@/routes/api/submissions/queue");
+    const response = await GET(
+      new Request("https://heyclau.de/api/submissions/queue?limit=100", {
+        headers: {
+          origin: "https://heyclau.de",
+          "cf-connecting-ip": "203.0.113.25",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("bounds GitHub activity hydration for public submission queue lists", async () => {
+    const pagedResponse = (kind: string, page: number) =>
+      new Response(JSON.stringify([{ body: `${kind} page ${page}` }]), {
+        status: 200,
+        headers:
+          page === 1
+            ? {
+                "content-type": "application/json",
+                link: `<https://api.github.com/${kind}?page=2>; rel="next", <https://api.github.com/${kind}?page=3>; rel="last"`,
+              }
+            : { "content-type": "application/json" },
+      });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes("/issues/1/comments")) {
+          return Promise.resolve(
+            pagedResponse("comments", url.includes("page=2") ? 2 : 1),
+          );
+        }
+        if (url.includes("/issues/2/comments")) {
+          return Promise.resolve(
+            pagedResponse("author-comments", url.includes("page=2") ? 2 : 1),
+          );
+        }
+        if (url.includes("/issues/2/timeline")) {
+          return Promise.resolve(
+            pagedResponse("timeline", url.includes("page=2") ? 2 : 1),
+          );
+        }
+        if (url.includes("/issues?")) {
+          const issues = Array.from({ length: 25 }, (_, index) => {
+            const number = index + 1;
+            const labels = [
+              { name: "content-submission" },
+              { name: "community-skills" },
+            ];
+            if (number === 1) labels.push({ name: "import-pr-open" });
+            if (number === 2) labels.push({ name: "needs-author-input" });
+            return {
+              number,
+              html_url: `https://github.com/JSONbored/awesome-claude/issues/${number}`,
+              title: `Submit Skill: Queue Item ${number}`,
+              body: [
+                "### Name",
+                `Queue Item ${number}`,
+                "",
+                "### Slug",
+                `queue-item-${number}`,
+                "",
+                "### Category",
+                "skills",
+              ].join("\n"),
+              user: { login: "submitter" },
+              labels,
+              state: "open",
+              created_at: "2026-05-01T00:00:00Z",
+              updated_at: "2026-05-02T00:00:00Z",
+              closed_at: null,
+              comments_url: `https://api.github.com/repos/JSONbored/awesome-claude/issues/${number}/comments`,
+            };
+          });
+          return Promise.resolve(
+            new Response(JSON.stringify(issues), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            }),
+          );
+        }
+        return Promise.resolve(new Response("{}", { status: 404 }));
+      }),
+    );
+
+    const { GET } = await import("@/routes/api/submissions/queue");
+    const response = await GET(
+      new Request("https://heyclau.de/api/submissions/queue?limit=25", {
+        headers: {
+          origin: "https://heyclau.de",
+          "cf-connecting-ip": "203.0.113.26",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      count: 25,
+    });
+
+    const fetchMock = fetch as unknown as {
+      mock: { calls: Array<[RequestInfo | URL, RequestInit]> };
+    };
+    expect(fetchMock.mock.calls).toHaveLength(7);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("per_page=25");
+  });
+
   it("fails visibly when GitHub rejects a token-backed queue read", async () => {
     vi.stubGlobal(
       "fetch",


### PR DESCRIPTION
### Motivation
- Prevent a public `GET /api/submissions/queue` request from fanning out into hundreds/thousands of paginated GitHub requests and exhausting provider quota or worker time. 
- Keep list responses lightweight while preserving full activity hydration for single-issue detail requests.

### Description
- Tighten the public queue query/response contract to cap list size at 25 by updating `submissionQueueQuerySchema` and the response `entries` max to 25. (`apps/web/src/lib/api/contracts.ts`)
- Avoid unconditional activity hydration for every listed issue by fetching comments/timeline only when required (comment-based import-PR discovery or `needs_author_input` author-activity checks) and by making pagination limits configurable per context. (`apps/web/src/routes/api/submissions/queue.ts`)
- Introduce `LIST_ACTIVITY_PAGE_LIMIT = 2` and `DETAIL_ACTIVITY_PAGE_LIMIT = 10` and thread a `maxPages` parameter through `fetchGitHubPages`, `fetchIssueComments`, `fetchIssueTimeline`, and `mapIssue` so list requests are bounded while detail requests retain full pagination. (`apps/web/src/routes/api/submissions/queue.ts`)
- Update the public submissions UI to request the new supported list limit (`limit=25`). (`apps/web/src/routes/submissions.tsx`)
- Regenerate OpenAPI artifacts so the documented query parameter and response item limits match the implementation. (`apps/web/public/openapi.{json,yaml}`, `cloudflare/api-schema-heyclaude-openapi.yaml`)
- Add regression tests that verify oversized public queue reads are rejected before any GitHub fetch and that a 25-item list produces a bounded number of upstream requests. (`tests/submission-api.test.ts`)

### Testing
- Ran unit/integration tests: `pnpm exec vitest run tests/submission-api.test.ts tests/api-contracts.test.ts tests/api-router-security.test.ts` and all tests passed.
- Ran submission intake tests: `pnpm test:submission-intake` and the suite passed.
- Validated OpenAPI after regeneration: `pnpm validate:openapi` (generated artifacts with `pnpm generate:openapi` then validated) and the check passed.
- Performed a production build: `pnpm build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a6a70fad8832cb5c3babbf2f381bf)