### PR TITLE
feat(brief): add weekly workflow brief pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "indexnow:submit": "node scripts/submit-indexnow.mjs",
     "email:render": "tsx scripts/render-email-templates.ts",
     "validate:emails": "tsx scripts/render-email-templates.ts --check",
+    "brief:weekly": "node scripts/generate-weekly-brief.mjs",
     "resend:sync-templates": "tsx scripts/sync-resend-templates.ts",
     "mcp:start": "pnpm --filter @heyclaude/mcp start",
     "mcp:start:local": "pnpm --filter @heyclaude/mcp start:local",

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -50,6 +50,10 @@
       "types": "./src/index.d.ts",
       "default": "./src/llms.js"
     },
+    "./weekly-brief": {
+      "types": "./src/weekly-brief.d.ts",
+      "default": "./src/weekly-brief.js"
+    },
     "./artifacts": {
       "types": "./src/index.d.ts",
       "default": "./src/artifacts.js"

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -873,6 +873,62 @@ export type RegistryEnvelope<T> = {
   entries: T[];
 };
 
+export type WeeklyBriefItem = {
+  key: string;
+  category: string;
+  slug: string;
+  title: string;
+  description: string;
+  url: string;
+  dateAdded: string;
+  reasons: string[];
+  sourceUrls: string[];
+  safetyNotesCount: number;
+  privacyNotesCount: number;
+  downloadTrust: DownloadTrust;
+  packageVerified: boolean;
+};
+
+export type WeeklyBriefChange = {
+  key: string;
+  type: string;
+  category: string;
+  slug: string;
+  title: string;
+  url: string;
+  dateAdded: string;
+};
+
+export type WeeklyBrief = {
+  schemaVersion: number;
+  kind: "weekly-brief-draft";
+  generatedAt: string;
+  title: string;
+  period: {
+    days: number;
+    through: string;
+  };
+  summary: {
+    totalEntries: number;
+    newEntryCount: number;
+    sourceBackedCount: number;
+    saferInstallCount: number;
+    notableChangeCount: number;
+  };
+  sections: {
+    newEntries: WeeklyBriefItem[];
+    sourceBacked: WeeklyBriefItem[];
+    saferInstalls: WeeklyBriefItem[];
+    notableChanges: WeeklyBriefChange[];
+  };
+  publishPolicy: {
+    manualReviewRequired: true;
+    automatedPublishing: false;
+    popularityClaims: false;
+    privateScoringIncluded: false;
+  };
+};
+
 export const categorySpec: RegistryCategorySpec;
 export const registryCategorySpec: RegistryCategorySpec;
 export const ENTRY_SCHEMA_VERSION: number;
@@ -880,6 +936,7 @@ export const RAYCAST_SCHEMA_VERSION: number;
 export const REGISTRY_ARTIFACT_SCHEMA_VERSION: number;
 export const SITE_URL: string;
 export const RAYCAST_COPY_PREVIEW_LIMIT: number;
+export const WEEKLY_BRIEF_SCHEMA_VERSION: number;
 
 export function compactCount(value: number): string;
 export function parseAbbreviatedCount(value: unknown): number | null;
@@ -1074,6 +1131,22 @@ export function buildPluginExportFeed(
 export function buildRegistryChangelogFeed(
   entries: ContentEntry[],
 ): Record<string, unknown>;
+export function buildWeeklyBrief(
+  entries: Partial<DirectoryEntry>[],
+  options?: {
+    generatedAt?: string;
+    days?: number;
+    siteUrl?: string;
+    limits?: Partial<{
+      newEntries: number;
+      sourceBacked: number;
+      saferInstalls: number;
+      notableChanges: number;
+    }>;
+    changelogEntries?: Array<Partial<DirectoryEntry> & { type?: string }>;
+  },
+): WeeklyBrief;
+export function renderWeeklyBriefMarkdown(brief: WeeklyBrief): string;
 export function buildArtifactEnvelope<T>(
   kind: string,
   entries: T[],

--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -14,3 +14,4 @@ export * from "./submission-labels.js";
 export * from "./submission-risk.js";
 export * from "./submission-spec.js";
 export * from "./llms.js";
+export * from "./weekly-brief.js";

--- a/packages/registry/src/weekly-brief.d.ts
+++ b/packages/registry/src/weekly-brief.d.ts
@@ -1,0 +1,11 @@
+export {
+  WEEKLY_BRIEF_SCHEMA_VERSION,
+  buildWeeklyBrief,
+  renderWeeklyBriefMarkdown,
+} from "./index.js";
+
+export type {
+  WeeklyBrief,
+  WeeklyBriefChange,
+  WeeklyBriefItem,
+} from "./index.js";

--- a/packages/registry/src/weekly-brief.js
+++ b/packages/registry/src/weekly-brief.js
@@ -1,0 +1,412 @@
+import { generatedAtForEntries, SITE_URL, truncateText } from "./artifacts.js";
+
+export const WEEKLY_BRIEF_SCHEMA_VERSION = 1;
+
+const DEFAULT_LIMITS = {
+  newEntries: 8,
+  sourceBacked: 6,
+  saferInstalls: 6,
+  notableChanges: 8,
+};
+
+function text(value) {
+  return String(value ?? "").trim();
+}
+
+function list(values) {
+  return Array.isArray(values)
+    ? values.map((value) => text(value)).filter(Boolean)
+    : [];
+}
+
+function keyFor(entry) {
+  const category = text(entry.category);
+  const slug = text(entry.slug);
+  return category && slug ? `${category}:${slug}` : "";
+}
+
+function httpUrl(value) {
+  const normalized = text(value);
+  if (!normalized) return "";
+  try {
+    const url = new URL(normalized);
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? url.href
+      : "";
+  } catch {
+    return "";
+  }
+}
+
+function siteUrlBase(siteUrl) {
+  return httpUrl(siteUrl).replace(/\/$/, "") || SITE_URL;
+}
+
+function entryUrl(entry, siteUrl = SITE_URL) {
+  return (
+    httpUrl(entry.canonicalUrl) ||
+    `${siteUrlBase(siteUrl)}/entry/${encodeURIComponent(
+      text(entry.category),
+    )}/${encodeURIComponent(text(entry.slug))}`
+  );
+}
+
+function entryDescription(entry) {
+  return truncateText(entry.cardDescription || entry.description || "", 180);
+}
+
+function isoDate(value) {
+  const normalized = text(value).slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return "";
+  const parsed = new Date(`${normalized}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === normalized
+    ? normalized
+    : "";
+}
+
+function isoTimestamp(value) {
+  const date = isoDate(value);
+  return date ? `${date}T00:00:00.000Z` : "";
+}
+
+function daysBetween(left, right) {
+  const leftTime = Date.parse(`${left}T00:00:00.000Z`);
+  const rightTime = Date.parse(`${right}T00:00:00.000Z`);
+  if (!Number.isFinite(leftTime) || !Number.isFinite(rightTime)) return null;
+  return Math.floor((rightTime - leftTime) / 86_400_000);
+}
+
+function normalizeDays(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? Math.max(1, Math.min(31, numeric)) : 7;
+}
+
+function markdownText(value) {
+  return text(value)
+    .replace(/\s+/g, " ")
+    .replace(/[\\[\]()`<>]/g, "\\$&");
+}
+
+function markdownUrl(value) {
+  return `<${httpUrl(value) || SITE_URL}>`;
+}
+
+function sourceUrls(entry) {
+  const trustSourceUrls = Array.isArray(entry.trustSignals?.sourceUrls)
+    ? entry.trustSignals.sourceUrls
+    : [];
+  return [
+    entry.repoUrl,
+    entry.githubUrl,
+    entry.documentationUrl,
+    entry.websiteUrl,
+    ...trustSourceUrls,
+  ]
+    .map(httpUrl)
+    .filter(Boolean);
+}
+
+function hasSource(entry) {
+  return (
+    entry.trustSignals?.sourceStatus === "available" ||
+    sourceUrls(entry).length > 0
+  );
+}
+
+function hasInstallSurface(entry) {
+  return Boolean(
+    entry.installable ||
+    entry.installCommand ||
+    entry.configSnippet ||
+    entry.commandSyntax ||
+    entry.downloadUrl,
+  );
+}
+
+function hasSaferInstallSignal(entry) {
+  return (
+    entry.downloadTrust === "first-party" ||
+    entry.packageVerified === true ||
+    entry.trustSignals?.packageVerified === true ||
+    Boolean(entry.downloadSha256) ||
+    Boolean(entry.trustSignals?.checksumPresent) ||
+    (hasSource(entry) && !entry.downloadUrl)
+  );
+}
+
+function trustScore(entry) {
+  return (
+    (hasSource(entry) ? 8 : 0) +
+    (hasSaferInstallSignal(entry) ? 6 : 0) +
+    (list(entry.safetyNotes).length ? 3 : 0) +
+    (list(entry.privacyNotes).length ? 3 : 0) +
+    (entry.claimStatus === "verified" || entry.reviewedBy ? 2 : 0)
+  );
+}
+
+function sortEntries(left, right) {
+  const dateCompare = isoDate(right.dateAdded).localeCompare(
+    isoDate(left.dateAdded),
+  );
+  if (dateCompare !== 0) return dateCompare;
+  const scoreCompare = trustScore(right) - trustScore(left);
+  if (scoreCompare !== 0) return scoreCompare;
+  return text(left.title).localeCompare(text(right.title));
+}
+
+function itemFromEntry(entry, reasons, siteUrl) {
+  return {
+    key: keyFor(entry),
+    category: text(entry.category),
+    slug: text(entry.slug),
+    title: text(entry.title),
+    description: entryDescription(entry),
+    url: entryUrl(entry, siteUrl),
+    dateAdded: isoDate(entry.dateAdded),
+    reasons,
+    sourceUrls: sourceUrls(entry).slice(0, 4),
+    safetyNotesCount: list(entry.safetyNotes).length,
+    privacyNotesCount: list(entry.privacyNotes).length,
+    downloadTrust: entry.downloadTrust || null,
+    packageVerified: entry.packageVerified === true,
+  };
+}
+
+function newEntryReasons(entry) {
+  const reasons = [];
+  const date = isoDate(entry.dateAdded);
+  if (date) reasons.push(`added ${date}`);
+  if (hasSource(entry)) reasons.push("source-backed");
+  if (list(entry.safetyNotes).length) reasons.push("has safety notes");
+  if (list(entry.privacyNotes).length) reasons.push("has privacy notes");
+  return reasons.length ? reasons : ["new registry entry"];
+}
+
+function sourceBackedReasons(entry) {
+  const reasons = ["source-backed"];
+  if (list(entry.safetyNotes).length) reasons.push("safety notes present");
+  if (list(entry.privacyNotes).length) reasons.push("privacy notes present");
+  if (entry.claimStatus === "verified") reasons.push("verified claim");
+  if (entry.reviewedBy) reasons.push("reviewed metadata");
+  return reasons;
+}
+
+function saferInstallReasons(entry) {
+  const reasons = [];
+  if (entry.downloadTrust === "first-party")
+    reasons.push("first-party package");
+  if (entry.packageVerified === true) reasons.push("package verified");
+  if (entry.downloadSha256 || entry.trustSignals?.checksumPresent) {
+    reasons.push("checksum present");
+  }
+  if (hasSource(entry) && !entry.downloadUrl) {
+    reasons.push("source-backed copy/install path");
+  }
+  return reasons.length ? reasons : ["reviewable install metadata"];
+}
+
+function selectEntries(entries, predicate, limit, reasonsFor, siteUrl, seen) {
+  const selected = [];
+  for (const entry of entries.filter(predicate).sort(sortEntries)) {
+    const key = keyFor(entry);
+    if (!key || seen.has(key)) continue;
+    selected.push(itemFromEntry(entry, reasonsFor(entry), siteUrl));
+    seen.add(key);
+    if (selected.length >= limit) break;
+  }
+  return selected;
+}
+
+function changelogItem(change, siteUrl) {
+  return {
+    key: keyFor(change),
+    type: text(change.type) || "added",
+    category: text(change.category),
+    slug: text(change.slug),
+    title: text(change.title),
+    url: httpUrl(change.canonicalUrl) || entryUrl(change, siteUrl),
+    dateAdded: isoDate(change.dateAdded),
+  };
+}
+
+function selectChangelogChanges(changelogEntries, entries, params) {
+  const source = Array.isArray(changelogEntries)
+    ? changelogEntries
+    : entries.map((entry) => ({ ...entry, type: "added" }));
+  const referenceDate = params.referenceDate;
+  const days = params.days;
+  const selected = source
+    .filter((change) => {
+      const date = isoDate(change.dateAdded);
+      if (!date) return false;
+      const age = daysBetween(date, referenceDate);
+      return age !== null && age >= 0 && age < days;
+    })
+    .sort((left, right) => {
+      const dateCompare = isoDate(right.dateAdded).localeCompare(
+        isoDate(left.dateAdded),
+      );
+      return dateCompare || text(left.title).localeCompare(text(right.title));
+    })
+    .slice(0, params.limit)
+    .map((change) => changelogItem(change, params.siteUrl));
+  return selected;
+}
+
+export function buildWeeklyBrief(entries, options = {}) {
+  const normalizedEntries = Array.isArray(entries)
+    ? entries.filter((entry) => keyFor(entry) && text(entry.title))
+    : [];
+  const generatedAt =
+    isoTimestamp(options.generatedAt) ||
+    isoTimestamp(generatedAtForEntries(normalizedEntries)) ||
+    isoTimestamp(new Date().toISOString());
+  const referenceDate = isoDate(generatedAt);
+  const days = normalizeDays(options.days ?? 7);
+  const siteUrl = text(options.siteUrl) || SITE_URL;
+  const limits = { ...DEFAULT_LIMITS, ...(options.limits || {}) };
+  const seen = new Set();
+
+  const newEntries = selectEntries(
+    normalizedEntries,
+    (entry) => {
+      const date = isoDate(entry.dateAdded);
+      const age = daysBetween(date, referenceDate);
+      return age !== null && age >= 0 && age < days;
+    },
+    limits.newEntries,
+    newEntryReasons,
+    siteUrl,
+    seen,
+  );
+  const sourceBacked = selectEntries(
+    normalizedEntries,
+    hasSource,
+    limits.sourceBacked,
+    sourceBackedReasons,
+    siteUrl,
+    seen,
+  );
+  const saferInstalls = selectEntries(
+    normalizedEntries,
+    (entry) => hasInstallSurface(entry) && hasSaferInstallSignal(entry),
+    limits.saferInstalls,
+    saferInstallReasons,
+    siteUrl,
+    seen,
+  );
+  const notableChanges = selectChangelogChanges(
+    options.changelogEntries,
+    normalizedEntries,
+    {
+      days,
+      referenceDate,
+      limit: limits.notableChanges,
+      siteUrl,
+    },
+  );
+
+  return {
+    schemaVersion: WEEKLY_BRIEF_SCHEMA_VERSION,
+    kind: "weekly-brief-draft",
+    generatedAt,
+    title: `Weekly Claude workflow brief - ${referenceDate}`,
+    period: {
+      days,
+      through: referenceDate,
+    },
+    summary: {
+      totalEntries: normalizedEntries.length,
+      newEntryCount: newEntries.length,
+      sourceBackedCount: sourceBacked.length,
+      saferInstallCount: saferInstalls.length,
+      notableChangeCount: notableChanges.length,
+    },
+    sections: {
+      newEntries,
+      sourceBacked,
+      saferInstalls,
+      notableChanges,
+    },
+    publishPolicy: {
+      manualReviewRequired: true,
+      automatedPublishing: false,
+      popularityClaims: false,
+      privateScoringIncluded: false,
+    },
+  };
+}
+
+function bullet(item) {
+  const description = item.description
+    ? ` - ${markdownText(item.description)}`
+    : "";
+  const reasons = item.reasons?.length
+    ? `\n  - Signals: ${item.reasons.map(markdownText).join("; ")}`
+    : "";
+  return `- [${markdownText(item.title)}](${markdownUrl(item.url)}) (${markdownText(item.category)})${description}${reasons}`;
+}
+
+function changeBullet(item) {
+  const date = item.dateAdded ? ` on ${markdownText(item.dateAdded)}` : "";
+  return `- [${markdownText(item.title)}](${markdownUrl(item.url)}) (${markdownText(item.category)}) - ${markdownText(item.type)}${date}`;
+}
+
+function section(lines, title, items, renderItem, emptyText) {
+  lines.push("", `## ${title}`);
+  if (!items.length) {
+    lines.push(`- ${emptyText}`);
+    return;
+  }
+  lines.push(...items.map(renderItem));
+}
+
+export function renderWeeklyBriefMarkdown(brief) {
+  const lines = [
+    `# ${brief.title}`,
+    "",
+    "> Draft for manual review. Generated from HeyClaude registry artifacts; no email, GitHub post, or social post was created.",
+    "",
+    `Coverage: ${brief.summary.totalEntries} registry entries, ${brief.period.days}-day window through ${brief.period.through}.`,
+  ];
+
+  section(
+    lines,
+    "New entries",
+    brief.sections.newEntries,
+    bullet,
+    "No new registry entries matched this brief window.",
+  );
+  section(
+    lines,
+    "Source-backed picks",
+    brief.sections.sourceBacked,
+    bullet,
+    "No source-backed picks were selected.",
+  );
+  section(
+    lines,
+    "Safer install and trust picks",
+    brief.sections.saferInstalls,
+    bullet,
+    "No safer install picks were selected.",
+  );
+  section(
+    lines,
+    "Notable registry changes",
+    brief.sections.notableChanges,
+    changeBullet,
+    "No registry changelog entries matched this brief window.",
+  );
+
+  lines.push(
+    "",
+    "## Review notes",
+    "- Manual publishing is required.",
+    "- Do not describe these picks as high-traffic unless separate measured signals support that claim.",
+    "- This draft excludes private maintainer notes and scoring data.",
+  );
+
+  return `${lines.join("\n")}\n`;
+}

--- a/scripts/generate-weekly-brief.mjs
+++ b/scripts/generate-weekly-brief.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+import {
+  buildWeeklyBrief,
+  renderWeeklyBriefMarkdown,
+} from "@heyclaude/registry/weekly-brief";
+
+const repoRoot = process.cwd();
+const defaultDataDir = path.join(repoRoot, "apps/web/public/data");
+
+function argValue(name, fallback = "") {
+  const prefix = `${name}=`;
+  const match = process.argv.slice(2).find((arg) => arg.startsWith(prefix));
+  return match ? match.slice(prefix.length) : fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.slice(2).includes(name);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function readJson(filePath, artifactName) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Unable to read ${artifactName} at ${filePath}. Original error: ${errorMessage(
+        error,
+      )}`,
+    );
+  }
+}
+
+function envelopeEntries(payload, label) {
+  if (!payload || !Array.isArray(payload.entries)) {
+    throw new Error(`${label} must contain an entries array.`);
+  }
+  return payload.entries;
+}
+
+function usage() {
+  return [
+    "Usage: pnpm brief:weekly [--format=markdown|json] [--days=7] [--data-dir=apps/web/public/data]",
+    "",
+    "Generates a manual-review weekly brief draft from local registry artifacts.",
+    "This command prints to stdout only; it does not publish, email, or write files.",
+  ].join("\n");
+}
+
+if (hasFlag("--help") || hasFlag("-h")) {
+  console.log(usage());
+  process.exit(0);
+}
+
+const format = argValue("--format", "markdown");
+const days = Number(argValue("--days", "7"));
+const dataDir = path.resolve(repoRoot, argValue("--data-dir", defaultDataDir));
+
+if (!["markdown", "json"].includes(format)) {
+  console.error("Invalid --format. Expected markdown or json.");
+  process.exit(1);
+}
+
+if (!Number.isFinite(days) || days < 1 || days > 31) {
+  console.error("Invalid --days. Expected a number from 1 to 31.");
+  process.exit(1);
+}
+
+try {
+  const directoryPayload = readJson(
+    path.join(dataDir, "directory-index.json"),
+    "directory-index.json",
+  );
+  const changelogPayload = readJson(
+    path.join(dataDir, "registry-changelog.json"),
+    "registry-changelog.json",
+  );
+  const entries = envelopeEntries(directoryPayload, "directory-index.json");
+  const changelogEntries = envelopeEntries(
+    changelogPayload,
+    "registry-changelog.json",
+  );
+
+  const brief = buildWeeklyBrief(entries, {
+    generatedAt: directoryPayload.generatedAt || changelogPayload.generatedAt,
+    days,
+    changelogEntries,
+  });
+
+  if (format === "json") {
+    console.log(JSON.stringify(brief, null, 2));
+  } else {
+    process.stdout.write(renderWeeklyBriefMarkdown(brief));
+  }
+} catch (error) {
+  console.error(errorMessage(error));
+  process.exit(1);
+}

--- a/tests/weekly-brief.test.ts
+++ b/tests/weekly-brief.test.ts
@@ -1,0 +1,295 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWeeklyBrief,
+  renderWeeklyBriefMarkdown,
+  type DirectoryEntry,
+} from "@heyclaude/registry";
+
+const DEFAULT_TRUST_SIGNALS: NonNullable<DirectoryEntry["trustSignals"]> = {
+  firstPartyEditorial: false,
+  packageVerified: false,
+  packageTrust: null,
+  packageChecksum: "",
+  checksumPresent: false,
+  sourceUrlCount: 0,
+  sourceUrls: [],
+  sourceStatus: "missing",
+  lastVerifiedAt: "",
+  adapterGenerated: false,
+  platforms: [],
+  supportLevels: [],
+};
+
+function entry(
+  slug: string,
+  overrides: Partial<DirectoryEntry> = {},
+): Partial<DirectoryEntry> {
+  return {
+    category: "mcp",
+    slug,
+    title: slug
+      .split("-")
+      .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+      .join(" "),
+    description: `Registry entry for ${slug}.`,
+    dateAdded: "2026-05-01",
+    canonicalUrl: `https://heyclau.de/entry/mcp/${slug}`,
+    tags: [],
+    keywords: [],
+    trustSignals: {
+      ...DEFAULT_TRUST_SIGNALS,
+    },
+    ...overrides,
+  };
+}
+
+describe("weekly brief generation", () => {
+  it("selects deterministic new, source-backed, safer-install, and changelog sections", () => {
+    const brief = buildWeeklyBrief(
+      [
+        entry("new-weak", {
+          dateAdded: "2026-05-29",
+        }),
+        entry("new-source-backed", {
+          dateAdded: "2026-05-28",
+          documentationUrl: "https://example.com/new-source-backed/docs",
+          safetyNotes: ["Uses network access."],
+          privacyNotes: ["Reads configured account metadata."],
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceStatus: "available",
+            sourceUrls: ["https://example.com/new-source-backed/docs"],
+          },
+        }),
+        entry("older-source", {
+          dateAdded: "2026-05-10",
+          repoUrl: "https://github.com/example/older-source",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceStatus: "available",
+            sourceUrls: ["https://github.com/example/older-source"],
+          },
+        }),
+        entry("safer-install", {
+          dateAdded: "2026-05-09",
+          installable: true,
+          installCommand: "npx -y safer-install",
+          downloadTrust: "first-party",
+          packageVerified: true,
+        }),
+      ],
+      {
+        generatedAt: "2026-05-30T00:00:00.000Z",
+        days: 7,
+        limits: {
+          newEntries: 3,
+          sourceBacked: 2,
+          saferInstalls: 2,
+          notableChanges: 2,
+        },
+        changelogEntries: [
+          {
+            category: "mcp",
+            slug: "older-source",
+            title: "Older Source",
+            type: "added",
+            dateAdded: "2026-05-10",
+          },
+          {
+            category: "mcp",
+            slug: "new-source-backed",
+            title: "New Source Backed",
+            type: "added",
+            dateAdded: "2026-05-28",
+          },
+        ],
+      },
+    );
+
+    expect(brief.summary).toMatchObject({
+      totalEntries: 4,
+      newEntryCount: 2,
+      sourceBackedCount: 1,
+      saferInstallCount: 1,
+      notableChangeCount: 1,
+    });
+    expect(brief.sections.newEntries.map((item) => item.key)).toEqual([
+      "mcp:new-weak",
+      "mcp:new-source-backed",
+    ]);
+    expect(brief.sections.sourceBacked.map((item) => item.key)).toEqual([
+      "mcp:older-source",
+    ]);
+    expect(brief.sections.saferInstalls.map((item) => item.key)).toEqual([
+      "mcp:safer-install",
+    ]);
+    expect(brief.sections.notableChanges.map((item) => item.key)).toEqual([
+      "mcp:new-source-backed",
+    ]);
+  });
+
+  it("handles low-signal data without inventing picks", () => {
+    const brief = buildWeeklyBrief(
+      [
+        entry("old-unsourced", {
+          dateAdded: "2026-01-01",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceStatus: "missing",
+          },
+        }),
+      ],
+      {
+        generatedAt: "2026-05-30T00:00:00.000Z",
+        days: 7,
+        changelogEntries: [],
+      },
+    );
+    const markdown = renderWeeklyBriefMarkdown(brief);
+
+    expect(brief.sections.newEntries).toEqual([]);
+    expect(brief.sections.sourceBacked).toEqual([]);
+    expect(brief.sections.saferInstalls).toEqual([]);
+    expect(brief.sections.notableChanges).toEqual([]);
+    expect(markdown).toContain(
+      "No new registry entries matched this brief window.",
+    );
+    expect(markdown).toContain("No source-backed picks were selected.");
+  });
+
+  it("defaults invalid day windows instead of leaking non-finite output", () => {
+    const brief = buildWeeklyBrief([], {
+      generatedAt: "2026-05-30T00:00:00.000Z",
+      days: Number.NaN,
+    });
+
+    expect(brief.period.days).toBe(7);
+  });
+
+  it("normalizes malformed generatedAt values before emitting the brief", () => {
+    const brief = buildWeeklyBrief(
+      [
+        entry("newer-source", {
+          dateAdded: "2026-05-29",
+        }),
+      ],
+      {
+        generatedAt: "2026-99-99T12:00:00.000Z",
+        days: 7,
+      },
+    );
+
+    expect(brief.generatedAt).toBe("2026-05-29T00:00:00.000Z");
+    expect(brief.period.through).toBe("2026-05-29");
+  });
+
+  it("escapes markdown text and drops unsafe canonical URLs", () => {
+    const brief = buildWeeklyBrief(
+      [
+        entry("unsafe-link", {
+          title: "Bad](javascript:alert(1))",
+          description: "Line one\n[click](javascript:alert(2))",
+          canonicalUrl: "javascript:alert(3)",
+          dateAdded: "2026-05-29",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceUrls: ["javascript:alert(4)"],
+          },
+        }),
+        entry("unsafe-source-only", {
+          dateAdded: "2026-05-10",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceUrls: ["javascript:alert(5)"],
+          },
+        }),
+      ],
+      {
+        generatedAt: "2026-05-30T00:00:00.000Z",
+        days: 7,
+        changelogEntries: [
+          {
+            category: "mcp",
+            slug: "unsafe-link",
+            title: "Bad](javascript:alert(1))",
+            type: "added",
+            dateAdded: "2026-05-29",
+            canonicalUrl: "javascript:alert(6)",
+          },
+        ],
+      },
+    );
+    const markdown = renderWeeklyBriefMarkdown(brief);
+
+    expect(brief.sections.newEntries[0]?.url).toBe(
+      "https://heyclau.de/entry/mcp/unsafe-link",
+    );
+    expect(brief.sections.newEntries[0]?.sourceUrls).toEqual([]);
+    expect(brief.sections.sourceBacked).toEqual([]);
+    expect(brief.sections.notableChanges[0]?.url).toBe(
+      "https://heyclau.de/entry/mcp/unsafe-link",
+    );
+    expect(markdown).toContain(
+      "[Bad\\]\\(javascript:alert\\(1\\)\\)](<https://heyclau.de/entry/mcp/unsafe-link>)",
+    );
+    expect(markdown).not.toContain("](javascript:alert");
+  });
+
+  it("keeps publishing conservative and excludes private or popularity claims", () => {
+    const brief = buildWeeklyBrief([entry("plain-entry")], {
+      generatedAt: "2026-05-30T00:00:00.000Z",
+      days: 7,
+    });
+    const markdown = renderWeeklyBriefMarkdown(brief);
+
+    expect(brief.publishPolicy).toEqual({
+      manualReviewRequired: true,
+      automatedPublishing: false,
+      popularityClaims: false,
+      privateScoringIncluded: false,
+    });
+    expect(markdown).toContain("Draft for manual review.");
+    expect(markdown).toContain("no email, GitHub post, or social post");
+    expect(markdown).not.toMatch(/most popular|trending|Gittensor|reward/i);
+  });
+
+  it("reports clean CLI artifact errors without stack traces", () => {
+    const dataDir = mkdtempSync(join(tmpdir(), "weekly-brief-"));
+
+    try {
+      writeFileSync(
+        join(dataDir, "directory-index.json"),
+        "{ bad json",
+        "utf8",
+      );
+      writeFileSync(
+        join(dataDir, "registry-changelog.json"),
+        JSON.stringify({ entries: [] }),
+        "utf8",
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        ["scripts/generate-weekly-brief.mjs", `--data-dir=${dataDir}`],
+        {
+          cwd: process.cwd(),
+          encoding: "utf8",
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Unable to read directory-index.json");
+      expect(result.stderr).toContain("Original error:");
+      expect(result.stderr).not.toContain("SyntaxError");
+      expect(result.stderr).not.toContain("    at ");
+    } finally {
+      rmSync(dataDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a backend-only weekly Claude workflow brief draft pipeline generated from existing registry artifacts.

Closes #560.

## What changed

- Added a deterministic weekly brief builder in `packages/registry/src/weekly-brief.js`.
- Added `pnpm brief:weekly` via `scripts/generate-weekly-brief.mjs` with Markdown and JSON stdout output.
- Exported the helper through `@heyclaude/registry` and `@heyclaude/registry/weekly-brief`.
- Added focused regression coverage for selection ordering, low-signal data, conservative publishing claims, invalid day windows, and unsafe Markdown/URL input handling.

## Why

This gives maintainers a manual-review draft for weekly workflow briefs without adding UI, email delivery, GitHub posting, external crawling, or generated public artifact churn.

## Validation

- `pnpm exec vitest run tests/weekly-brief.test.ts`
- Direct package API reproduction for unsafe Markdown and URL fallback handling
- `pnpm brief:weekly -- --format=json`
- Invalid `--days` CLI input rejected
- `pnpm test` - 47 files, 511 tests
- `pnpm build`
- `git diff --check`
- Codex Security diff scan completed with no unresolved findings; one Markdown output hardening candidate was fixed before publication

## Notes

The v1 pipeline is intentionally stdout-only and manual-publish. It does not send email, post to GitHub, write generated public artifacts, or claim popularity/private scoring context.
