### PR TITLE
fix(registry): disable executable frontmatter parsing

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -32,6 +32,17 @@ const RISK_LABEL_BY_TIER = {
   critical: SUBMISSION_RISK_HIGH_LABEL,
 };
 
+const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
+  "Executable JavaScript frontmatter is not allowed in submission risk analysis";
+
+const SAFE_MATTER_OPTIONS = {
+  engines: {
+    javascript() {
+      throw new Error(UNSAFE_FRONTMATTER_LANGUAGE_ERROR);
+    },
+  },
+};
+
 const SAFETY_NOTE_REQUIRED_FLAGS = new Set([
   "unsafe_install_pipeline",
   "financial_or_identity_sensitive",
@@ -227,7 +238,7 @@ function stringList(value) {
 function parseContentFrontmatter(value) {
   const content = String(value ?? "").replace(/^\uFEFF/, "");
   try {
-    const parsed = matter(content);
+    const parsed = matter(content, SAFE_MATTER_OPTIONS);
     return { data: parsed.data || {}, content: parsed.content || "" };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/tests/submission-intake.test.ts
+++ b/tests/submission-intake.test.ts
@@ -2327,6 +2327,49 @@ Review payloads before posting tweets, replies, DMs, or profile updates.`,
     expect(report.contributionAnalysis.sourceState).toBe("provided");
   });
 
+  it("rejects executable JavaScript frontmatter without running it", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-risk-"));
+    const markerPath = path.join(tmpDir, "js-frontmatter-executed");
+    const escapedMarkerPath = JSON.stringify(markerPath);
+
+    const report = analyzeDirectContentRisk({
+      sourceType: "external_direct",
+      pullRequest: {
+        number: 329,
+        title: "Add executable frontmatter listing",
+        user: { login: "external-author" },
+      },
+      files: [
+        {
+          filename: "content/mcp/executable-frontmatter-mcp.mdx",
+          status: "added",
+          content: `---js
+require("node:fs").writeFileSync(${escapedMarkerPath}, "executed");
+module.exports = {
+  title: "Executable Frontmatter MCP",
+  slug: "executable-frontmatter-mcp",
+  category: "mcp",
+  description: "MCP server with executable frontmatter.",
+  cardDescription: "Executable frontmatter fixture.",
+  repoUrl: "https://github.com/example/executable-frontmatter-mcp",
+  submittedBy: "external-author",
+  submittedByUrl: "https://github.com/external-author",
+  safetyNotes: ["Fixture should not execute frontmatter."],
+  privacyNotes: ["Fixture should not access local data."]
+};
+---
+Executable frontmatter should be rejected without being evaluated.
+`,
+        },
+      ],
+    });
+
+    expect(fs.existsSync(markerPath)).toBe(false);
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "invalid_frontmatter",
+    );
+  });
+
   it("flags risky install commands in YAML block scalars with chomping indicators", () => {
     const report = analyzeDirectContentRisk({
       sourceType: "external_direct",


### PR DESCRIPTION
### Motivation
- Gray-matter's default engines allow executable JavaScript frontmatter (e.g. `---js`) which can evaluate attacker-controlled code when parsing PR-supplied content, creating an RCE/vector for CI or maintainer automation. 
- The submission risk analyzer parses untrusted MDX files via `analyzeDirectContentRisk`, so parsing must be restricted to safe YAML semantics or explicitly forbid JS frontmatter before any evaluation occurs.

### Description
- Added a `SAFE_MATTER_OPTIONS` object that overrides gray-matter's `javascript` engine to throw, and a descriptive `UNSAFE_FRONTMATTER_LANGUAGE_ERROR` message. 
- Updated `parseContentFrontmatter` to call `matter(content, SAFE_MATTER_OPTIONS)` so JS frontmatter is rejected instead of executed in `packages/registry/src/submission-risk.js`. 
- Added a regression test in `tests/submission-intake.test.ts` that supplies `---js` frontmatter attempting to write a file and verifies the marker is not created and the content is flagged as `invalid_frontmatter`.

### Testing
- Ran `pnpm test:submission-intake` which executes the relevant vitest suite and completed successfully (`71 tests` passed). 
- Ran repository checks including `git diff --check` to validate formatting and no check failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b905d8c90832cb669c817ea3ba793)