### PR TITLE
fix(d1-votes): prune orphans without client scan

### DIFF
--- a/scripts/sync-votes-to-d1.mjs
+++ b/scripts/sync-votes-to-d1.mjs
@@ -36,7 +36,9 @@ if (process.env.DEBUG_SYNC === "1") {
   console.log("sync preview", preview);
 }
 
-function wranglerArgs(runMode, command) {
+const voteTables = new Set(["votes_by_client", "votes_entries"]);
+
+function wranglerArgs(runMode, command, { json = false } = {}) {
   return [
     "d1",
     "execute",
@@ -44,6 +46,7 @@ function wranglerArgs(runMode, command) {
     runMode === "remote" ? "--remote" : "--local",
     "--command",
     command,
+    ...(json ? ["--json"] : []),
   ];
 }
 
@@ -60,11 +63,18 @@ function runWranglerQuery(args) {
     ["--filter", "web", "exec", "wrangler", ...args],
     { cwd: repoRoot, encoding: "utf8" },
   );
-  const jsonMatch = output.match(/(\[\s*\{[\s\S]*\])\s*$/);
-  if (!jsonMatch) {
+  const jsonText = output.trim();
+  if (!jsonText) {
     throw new Error("Could not parse wrangler prune output");
   }
-  return JSON.parse(jsonMatch[1])?.[0]?.results ?? [];
+  const payload = JSON.parse(jsonText);
+  if (Array.isArray(payload)) {
+    const statement = [...payload]
+      .reverse()
+      .find((result) => Array.isArray(result?.results));
+    return statement?.results ?? [];
+  }
+  return Array.isArray(payload?.results) ? payload.results : [];
 }
 
 function sqlString(value) {
@@ -75,7 +85,9 @@ function expectedKeyExclusionPredicate(keys) {
   const chunkSize = 200;
   const sortedKeys = [...keys].sort();
   if (sortedKeys.length === 0) {
-    return "1 = 1";
+    throw new Error(
+      "Refusing to build prune predicate for empty content key set",
+    );
   }
 
   const clauses = [];
@@ -90,13 +102,26 @@ function expectedKeyExclusionPredicate(keys) {
 }
 
 function pruneTableOrphans(runMode, tableName, whereClause) {
-  const rows = runWranglerQuery(
+  if (!voteTables.has(tableName)) {
+    throw new Error(`Refusing to prune unsupported vote table "${tableName}"`);
+  }
+
+  const countRows = runWranglerQuery(
     wranglerArgs(
       runMode,
-      `DELETE FROM ${tableName} WHERE ${whereClause}; SELECT changes() AS pruned;`,
+      `SELECT COUNT(*) AS pruned FROM ${tableName} WHERE ${whereClause};`,
+      { json: true },
     ),
   );
-  return Number(rows?.[0]?.pruned ?? 0);
+  const pruned = Number(countRows?.[0]?.pruned ?? 0);
+  if (pruned === 0) {
+    return 0;
+  }
+
+  runWrangler(
+    wranglerArgs(runMode, `DELETE FROM ${tableName} WHERE ${whereClause};`),
+  );
+  return pruned;
 }
 
 function applyMode(runMode) {
@@ -114,6 +139,13 @@ function applyMode(runMode) {
   }
 
   if (!prune) {
+    return;
+  }
+
+  if (expected.size === 0) {
+    console.warn(
+      `${runMode}: skipping prune because no expected vote keys were enumerated`,
+    );
     return;
   }
 

--- a/scripts/sync-votes-to-d1.mjs
+++ b/scripts/sync-votes-to-d1.mjs
@@ -36,6 +36,17 @@ if (process.env.DEBUG_SYNC === "1") {
   console.log("sync preview", preview);
 }
 
+function wranglerArgs(runMode, command) {
+  return [
+    "d1",
+    "execute",
+    d1Binding,
+    runMode === "remote" ? "--remote" : "--local",
+    "--command",
+    command,
+  ];
+}
+
 function runWrangler(args) {
   execFileSync("pnpm", ["--filter", "web", "exec", "wrangler", ...args], {
     cwd: repoRoot,
@@ -43,29 +54,49 @@ function runWrangler(args) {
   });
 }
 
-function getVoteEntryKeys(runMode, tableName) {
+function runWranglerQuery(args) {
   const output = execFileSync(
     "pnpm",
-    [
-      "--filter",
-      "web",
-      "exec",
-      "wrangler",
-      "d1",
-      "execute",
-      d1Binding,
-      runMode === "remote" ? "--remote" : "--local",
-      "--command",
-      `SELECT entry_key FROM ${tableName};`,
-    ],
+    ["--filter", "web", "exec", "wrangler", ...args],
     { cwd: repoRoot, encoding: "utf8" },
   );
   const jsonMatch = output.match(/(\[\s*\{[\s\S]*\])\s*$/);
   if (!jsonMatch) {
-    throw new Error(`Could not parse wrangler output for ${runMode}`);
+    throw new Error("Could not parse wrangler prune output");
   }
-  const payload = JSON.parse(jsonMatch[1]);
-  return (payload?.[0]?.results ?? []).map((row) => String(row.entry_key));
+  return JSON.parse(jsonMatch[1])?.[0]?.results ?? [];
+}
+
+function sqlString(value) {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function expectedKeyExclusionPredicate(keys) {
+  const chunkSize = 200;
+  const sortedKeys = [...keys].sort();
+  if (sortedKeys.length === 0) {
+    return "1 = 1";
+  }
+
+  const clauses = [];
+  for (let index = 0; index < sortedKeys.length; index += chunkSize) {
+    const inList = sortedKeys
+      .slice(index, index + chunkSize)
+      .map(sqlString)
+      .join(", ");
+    clauses.push(`entry_key NOT IN (${inList})`);
+  }
+  return clauses.join(" AND ");
+}
+
+function pruneTableOrphans(runMode, tableName, whereClause) {
+  const rows = runWranglerQuery(
+    wranglerArgs(
+      runMode,
+      `DELETE FROM ${tableName} WHERE ${whereClause}; SELECT changes() AS pruned;`,
+    ),
+  );
+  return Number(rows?.[0]?.pruned ?? 0);
 }
 
 function applyMode(runMode) {
@@ -86,48 +117,33 @@ function applyMode(runMode) {
     return;
   }
 
-  const actualEntryKeys = getVoteEntryKeys(runMode, "votes_entries");
-  const actualClientKeys = getVoteEntryKeys(runMode, "votes_by_client");
-  const entryOrphans = actualEntryKeys.filter((key) => !expected.has(key));
-  const clientOrphans = actualClientKeys.filter((key) => !expected.has(key));
+  const orphanPredicate = expectedKeyExclusionPredicate(expected);
+  const clientPruned = pruneTableOrphans(
+    runMode,
+    "votes_by_client",
+    orphanPredicate,
+  );
+  const entryPruned = pruneTableOrphans(
+    runMode,
+    "votes_entries",
+    orphanPredicate,
+  );
 
-  const pruneTableKeys = (tableName, keys) => {
-    for (let index = 0; index < keys.length; index += chunkSize) {
-      const chunk = keys.slice(index, index + chunkSize);
-      const inList = chunk
-        .map((key) => `'${key.replaceAll("'", "''")}'`)
-        .join(", ");
-      runWrangler([
-        "d1",
-        "execute",
-        d1Binding,
-        runMode === "remote" ? "--remote" : "--local",
-        "--command",
-        `DELETE FROM ${tableName} WHERE entry_key IN (${inList});`,
-      ]);
-    }
-  };
+  // Defensive reconciliation in case a stale client vote points to a missing entry key.
+  runWrangler(
+    wranglerArgs(
+      runMode,
+      "DELETE FROM votes_by_client WHERE entry_key NOT IN (SELECT entry_key FROM votes_entries);",
+    ),
+  );
 
-  if (entryOrphans.length === 0 && clientOrphans.length === 0) {
+  if (entryPruned === 0 && clientPruned === 0) {
     console.log(`${runMode}: no orphan vote rows to prune`);
     return;
   }
 
-  pruneTableKeys("votes_entries", entryOrphans);
-  pruneTableKeys("votes_by_client", clientOrphans);
-
-  // Defensive reconciliation in case a stale client vote points to a missing entry key.
-  runWrangler([
-    "d1",
-    "execute",
-    d1Binding,
-    runMode === "remote" ? "--remote" : "--local",
-    "--command",
-    "DELETE FROM votes_by_client WHERE entry_key NOT IN (SELECT entry_key FROM votes_entries);",
-  ]);
-
   console.log(
-    `${runMode}: pruned ${entryOrphans.length} orphan votes_entries row(s) and ${clientOrphans.length} orphan votes_by_client row(s)`,
+    `${runMode}: pruned ${entryPruned} orphan votes_entries row(s) and ${clientPruned} orphan votes_by_client row(s)`,
   );
 }
 

--- a/tests/d1-vote-sync.test.ts
+++ b/tests/d1-vote-sync.test.ts
@@ -1,3 +1,8 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -37,5 +42,65 @@ describe("d1 vote key helpers", () => {
     expect(findOrphanVoteKeys(clientVoteKeys, expectedAfterDelete)).toEqual([
       "mcp:deleted-entry",
     ]);
+  });
+
+  it("prunes orphan client votes without reading every votes_by_client row", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-d1-sync-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const logPath = path.join(tmpDir, "pnpm-calls.jsonl");
+    fs.mkdirSync(fakeBin, { recursive: true });
+
+    const fakePnpm = path.join(fakeBin, "pnpm");
+    fs.writeFileSync(
+      fakePnpm,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+fs.appendFileSync(process.env.FAKE_PNPM_LOG, JSON.stringify(args) + "\\n");
+const commandIndex = args.indexOf("--command");
+const command = commandIndex === -1 ? "" : args[commandIndex + 1] || "";
+if (/SELECT\\s+entry_key\\s+FROM\\s+votes_by_client/i.test(command)) {
+  console.error("unbounded votes_by_client scan detected");
+  process.exit(99);
+}
+if (/SELECT\\s+changes\\(\\)\\s+AS\\s+pruned/i.test(command)) {
+  process.stdout.write('[{"results":[{"pruned":0}]}]\\n');
+}
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      ["scripts/sync-votes-to-d1.mjs", "--mode=local"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PNPM_LOG: logPath,
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    const calls = fs
+      .readFileSync(logPath, "utf8")
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as string[]);
+    const commands = calls
+      .map((args) => args[args.indexOf("--command") + 1] ?? "")
+      .filter(Boolean);
+
+    expect(commands.join("\n")).not.toMatch(
+      /SELECT\s+entry_key\s+FROM\s+votes_by_client/i,
+    );
+    expect(commands).toContainEqual(
+      expect.stringMatching(
+        /DELETE FROM votes_by_client WHERE entry_key NOT IN .*SELECT changes\(\) AS pruned;/,
+      ),
+    );
   });
 });

--- a/tests/d1-vote-sync.test.ts
+++ b/tests/d1-vote-sync.test.ts
@@ -57,14 +57,19 @@ describe("d1 vote key helpers", () => {
 const fs = require("node:fs");
 const args = process.argv.slice(2);
 fs.appendFileSync(process.env.FAKE_PNPM_LOG, JSON.stringify(args) + "\\n");
+const json = args.includes("--json");
 const commandIndex = args.indexOf("--command");
 const command = commandIndex === -1 ? "" : args[commandIndex + 1] || "";
 if (/SELECT\\s+entry_key\\s+FROM\\s+votes_by_client/i.test(command)) {
   console.error("unbounded votes_by_client scan detected");
   process.exit(99);
 }
-if (/SELECT\\s+changes\\(\\)\\s+AS\\s+pruned/i.test(command)) {
-  process.stdout.write('[{"results":[{"pruned":0}]}]\\n');
+if (/SELECT\\s+COUNT\\(\\*\\)\\s+AS\\s+pruned/i.test(command)) {
+  if (!json) {
+    console.error("expected --json for prune count query");
+    process.exit(98);
+  }
+  process.stdout.write('[{"results":[{"pruned":1}],"success":true}]\\n');
 }
 `,
       { mode: 0o755 },
@@ -99,8 +104,54 @@ if (/SELECT\\s+changes\\(\\)\\s+AS\\s+pruned/i.test(command)) {
     );
     expect(commands).toContainEqual(
       expect.stringMatching(
-        /DELETE FROM votes_by_client WHERE entry_key NOT IN .*SELECT changes\(\) AS pruned;/,
+        /SELECT COUNT\(\*\) AS pruned FROM votes_by_client WHERE entry_key NOT IN/,
       ),
     );
+    expect(commands).toContainEqual(
+      expect.stringMatching(
+        /DELETE FROM votes_by_client WHERE entry_key NOT IN/,
+      ),
+    );
+  });
+
+  it("skips prune when no content vote keys are enumerated", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-empty-"));
+    const fakeBin = path.join(tmpDir, "bin");
+    const logPath = path.join(tmpDir, "pnpm-calls.jsonl");
+    fs.mkdirSync(fakeBin, { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, "content"), { recursive: true });
+
+    const fakePnpm = path.join(fakeBin, "pnpm");
+    fs.writeFileSync(
+      fakePnpm,
+      `#!/usr/bin/env node
+const fs = require("node:fs");
+fs.appendFileSync(process.env.FAKE_PNPM_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+`,
+      { mode: 0o755 },
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        path.join(process.cwd(), "scripts/sync-votes-to-d1.mjs"),
+        "--mode=local",
+      ],
+      {
+        cwd: tmpDir,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PNPM_LOG: logPath,
+          PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain(
+      "skipping prune because no expected vote keys were enumerated",
+    );
+    expect(fs.existsSync(logPath)).toBe(false);
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent an unbounded client-vote scan in the D1 sync/prune path that materialized `votes_by_client` rows into Node memory and could cause operational DoS during normal `sync:votes:d1` runs.

### Description
- Replace the in-process `SELECT entry_key FROM votes_by_client` materialization with database-side orphan deletion by building an exclusion predicate from `enumerateContentVoteKeys` and issuing `DELETE ...; SELECT changes() AS pruned;` via new helpers `wranglerArgs`, `runWranglerQuery`, `sqlString`, `expectedKeyExclusionPredicate`, and `pruneTableOrphans` in `scripts/sync-votes-to-d1.mjs`.
- Preserve the existing defensive reconciliation `DELETE FROM votes_by_client WHERE entry_key NOT IN (SELECT entry_key FROM votes_entries);` after pruning.
- Add a regression test in `tests/d1-vote-sync.test.ts` that injects a fake `pnpm`/wrangler wrapper and asserts the sync script does not execute `SELECT entry_key FROM votes_by_client` and that pruning is performed via `DELETE` with `SELECT changes()`.

### Testing
- Ran `pnpm exec vitest run tests/d1-vote-sync.test.ts` and all tests passed (the new regression test included).
- Ran `git diff --check` to validate generated/output hygiene and it passed.
- Verified the modified script no longer performs the unbounded `SELECT entry_key FROM votes_by_client` in the test harness and reports prune counts from `SELECT changes()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d5915dd60832c90020780c9012e12)