### PR TITLE
fix(submissions): configure production gate database

### DIFF
--- a/apps/submission-gate/wrangler.jsonc
+++ b/apps/submission-gate/wrangler.jsonc
@@ -37,9 +37,7 @@
     {
       "binding": "SUBMISSION_GATE_DB",
       "database_name": "heyclaude-submission-gate",
-      // Production deploy scripts fail while this placeholder is present.
-      // Replace it only after the production D1 resource exists and migrations are applied.
-      "database_id": "00000000-0000-0000-0000-000000000000",
+      "database_id": "3fc13755-7445-49db-b703-9012ce870cb7",
       "migrations_dir": "migrations",
     },
   ],


### PR DESCRIPTION
## Summary
- Configure the production submission-gate D1 binding now that the production database exists.
- Remove placeholder guard comments so production deployments are reproducible from repo config.

## Submission Source
- [ ] New content file(s) added under `content/<category>/`
- [ ] Existing content updated
- [ ] Submission issue resolved (link it here): N/A
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks
- [ ] `pnpm validate:content` passed
- [ ] `pnpm validate:packages` passed
- [ ] `pnpm scan:packages` passed when package artifacts changed
- [ ] `pnpm audit:content` ran and I reviewed findings
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`)

## Quality Evidence
- Changed routes/components/endpoints/tools: production Cloudflare Worker D1 binding for the submission gate.
- Expected behavior: production submission-gate deploys bind to the real D1 database instead of a placeholder ID.
- Important edge cases or invariants: no content, generated artifacts, routes, UI, or API schema changed in this hotfix.
- Backward compatibility notes: existing dev and preview bindings are unchanged.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact; configuration-only Worker binding change.
  - Mobile: No visual impact; configuration-only Worker binding change.
- Accessibility notes for UI changes: No UI impact.
- Focused tests or reason tests are not practical: focused dry-run, migration, deployment, health, and invalid-draft smoke checks were run for the production gate.

## Validation
- [ ] Local build passed (`pnpm build`)
- [x] I ran the focused checks listed above
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s)

Focused checks run:
- `pnpm submission-gate:dry-run:prod`
- `wrangler d1 migrations apply SUBMISSION_GATE_DB --remote --config wrangler.jsonc`
- production submission-gate deploy succeeded
- production submission-gate `/health` returned ok through the Cloudflare custom domain
- production submission-gate invalid draft request returned the expected validation error and CORS origin
- `git diff --check`

## Notes
- The production Worker is deployed and healthy.
- The production Worker still needs production GitHub App/private-review secrets before GitHub-auth PR creation, webhook review, and automated merge decisions can run in production.
