### PR TITLE
fix(submissions): promote production gate runtime

### DIFF
--- a/apps/submission-gate/container/runner.mjs
+++ b/apps/submission-gate/container/runner.mjs
@@ -136,9 +136,7 @@ export function safeCallbackUrl(value) {
   const url = new URL(String(value || ""));
   if (
     url.protocol !== "https:" ||
-    !["submission-gate.heyclau.de", "submission-gate-dev.heyclau.de"].includes(
-      url.hostname,
-    ) ||
+    url.hostname !== "submission-gate.heyclau.de" ||
     url.pathname !== "/internal/import-complete"
   ) {
     throw new Error("Import callback URL is not allowed.");

--- a/apps/submission-gate/package.json
+++ b/apps/submission-gate/package.json
@@ -4,12 +4,12 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev --config wrangler.jsonc --env dev",
+    "dev": "wrangler dev --config wrangler.jsonc",
     "deploy": "pnpm run deploy:prod",
-    "deploy:dev": "wrangler deploy --config wrangler.jsonc --env dev",
+    "deploy:dev": "pnpm run deploy:prod",
     "deploy:prod": "node ../../scripts/check-submission-gate-prod-config.mjs && wrangler deploy --config wrangler.jsonc --env \"\"",
     "deploy:dry-run": "pnpm run deploy:dry-run:dev",
-    "deploy:dry-run:dev": "wrangler deploy --config wrangler.jsonc --env dev --dry-run",
+    "deploy:dry-run:dev": "pnpm run deploy:dry-run:prod",
     "deploy:dry-run:prod": "node ../../scripts/check-submission-gate-prod-config.mjs && wrangler deploy --config wrangler.jsonc --env \"\" --dry-run",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv worker-configuration.d.ts"
   },

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -327,7 +327,7 @@ async function createDraftRoute(request: Request, env: Env) {
     );
   }
   const fields = draftFieldsFromBody(body);
-  const baseRef = env.PILOT_BASE_REF || "submission-gate-pilot";
+  const baseRef = env.PILOT_BASE_REF || "main";
   let target: ReturnType<typeof buildDraftTarget>;
   try {
     target = buildDraftTarget(fields, baseRef);

--- a/apps/submission-gate/wrangler.jsonc
+++ b/apps/submission-gate/wrangler.jsonc
@@ -21,7 +21,7 @@
     "PUBLIC_REPO": "JSONbored/awesome-claude",
     "ALLOWED_IMPORT_REPOS": "JSONbored/awesome-claude",
     "ALLOWED_CORS_ORIGINS": "https://heyclau.de",
-    "PILOT_BASE_REF": "submission-gate-pilot",
+    "PILOT_BASE_REF": "main",
     "GITHUB_API_VERSION": "2022-11-28",
     "REVIEW_MARKER": "<!-- heyclaude-submission-gate -->",
     "REQUIRED_VALIDATION_CHECKS": "validate-content,Superagent Security Scan",
@@ -104,98 +104,4 @@
       "new_sqlite_classes": ["SubmissionLock", "SubmissionImportRunner"],
     },
   ],
-  "env": {
-    "dev": {
-      "name": "heyclaude-submission-gate-dev",
-      "vars": {
-        "PUBLIC_SITE_URL": "https://dev.heyclau.de",
-        "SUBMISSION_GATE_URL": "https://submission-gate-dev.heyclau.de",
-        "PUBLIC_REPO": "JSONbored/awesome-claude",
-        "ALLOWED_IMPORT_REPOS": "JSONbored/awesome-claude",
-        "ALLOWED_CORS_ORIGINS": "https://heyclaude-dev.zeronode.workers.dev,https://dev.heyclau.de,http://localhost:3000,http://localhost:5173",
-        "PILOT_BASE_REF": "submission-gate-pilot",
-        "GITHUB_API_VERSION": "2022-11-28",
-        "REVIEW_MARKER": "<!-- heyclaude-submission-gate -->",
-        "REQUIRED_VALIDATION_CHECKS": "validate-content,Superagent Security Scan",
-        "REQUIRED_STATUS_CONTEXTS": "",
-      },
-      "routes": [
-        {
-          "pattern": "submission-gate-dev.heyclau.de",
-          "custom_domain": true,
-        },
-      ],
-      "d1_databases": [
-        {
-          "binding": "SUBMISSION_GATE_DB",
-          "database_name": "heyclaude-submission-gate-dev",
-          "database_id": "74bf2511-fb69-47e3-8bb7-7fac3546eef2",
-          "migrations_dir": "migrations",
-        },
-      ],
-      "r2_buckets": [
-        {
-          "binding": "SUBMISSION_GATE_AUDIT",
-          "bucket_name": "heyclaude-submission-gate-audit-dev",
-          "preview_bucket_name": "heyclaude-submission-gate-audit-dev-preview",
-        },
-      ],
-      "queues": {
-        "producers": [
-          {
-            "binding": "SUBMISSION_REVIEW_QUEUE",
-            "queue": "heyclaude-submission-review-dev",
-          },
-          {
-            "binding": "SUBMISSION_IMPORT_QUEUE",
-            "queue": "heyclaude-submission-import-dev",
-          },
-        ],
-        "consumers": [
-          {
-            "queue": "heyclaude-submission-review-dev",
-            "max_batch_size": 1,
-            "max_batch_timeout": 5,
-            "max_retries": 3,
-            "dead_letter_queue": "heyclaude-submission-review-dev-dlq",
-            "max_concurrency": 5,
-          },
-          {
-            "queue": "heyclaude-submission-import-dev",
-            "max_batch_size": 1,
-            "max_batch_timeout": 5,
-            "max_retries": 2,
-            "dead_letter_queue": "heyclaude-submission-import-dev-dlq",
-            "max_concurrency": 2,
-          },
-        ],
-      },
-      "durable_objects": {
-        "bindings": [
-          {
-            "name": "SUBMISSION_LOCK",
-            "class_name": "SubmissionLock",
-          },
-          {
-            "name": "SUBMISSION_IMPORT_RUNNER",
-            "class_name": "SubmissionImportRunner",
-          },
-        ],
-      },
-      "containers": [
-        {
-          "max_instances": 3,
-          "class_name": "SubmissionImportRunner",
-          "image": "./container/Dockerfile",
-          "instance_type": "standard-1",
-        },
-      ],
-      "migrations": [
-        {
-          "tag": "v1",
-          "new_sqlite_classes": ["SubmissionLock", "SubmissionImportRunner"],
-        },
-      ],
-    },
-  },
 }

--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -187,8 +187,7 @@ longer a Next.js app.
 - `NEXT_PUBLIC_POLAR_JOB_BOARD_URL`
 - `VITE_SUBMISSION_GATE_URL` or `NEXT_PUBLIC_SUBMISSION_GATE_URL` set to the
   submission-gate Worker origin:
-  `https://submission-gate-dev.heyclau.de` for development and
-  `https://submission-gate.heyclau.de` for production.
+  `https://submission-gate.heyclau.de`.
 
 Content submission writes are routed through the private submission gate; the
 public website only runs preflight and hands the contributor to GitHub auth.

--- a/apps/web/public/data/registry-manifest.json
+++ b/apps/web/public/data/registry-manifest.json
@@ -3267,7 +3267,7 @@
     "submission-spec.json": {
       "path": "/data/submission-spec.json",
       "type": "json",
-      "sha256": "a79d00eb4dcc6db3030b99b4ef8b6fe9b654f57fb62b3f615dcad929dddee196"
+      "sha256": "6fc0ccac2020757c38c68b41b5903e2fa02c2d2e336e5a9f06796189a8fd32ec"
     },
     "content-quality-report.json": {
       "path": "/data/content-quality-report.json",

--- a/apps/web/public/data/submission-spec.json
+++ b/apps/web/public/data/submission-spec.json
@@ -1186,6 +1186,6 @@
   "prIntake": {
     "mode": "github_app_user_fork_pr",
     "submitUrl": "https://heyclau.de/submit",
-    "pilotBaseRef": "submission-gate-pilot"
+    "pilotBaseRef": "main"
   }
 }

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -331,7 +331,7 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
       title: "Add MCP Server: Example MCP Server",
       targetPath: "content/mcp/example-mcp-server.mdx",
       branchHint: "heyclaude/submit-mcp-example-mcp-server",
-      baseRef: "submission-gate-pilot",
+      baseRef: "main",
       body: "### Name\n\nExample MCP Server",
     },
     blockers: [],

--- a/apps/web/src/generated/atlas-registry.json
+++ b/apps/web/src/generated/atlas-registry.json
@@ -58,8 +58,8 @@
     },
     {
       "path": "/data/submission-spec.json",
-      "bytes": 38633,
-      "sha256": "1c21aab80ef2936ea4ed619c90465568f5997ffa869f89455a4c0961179a63ed",
+      "bytes": 38616,
+      "sha256": "73551ceabc94ae60c2f4325dc77aa4290130f2c238be5af50848a74a6a3bd9ae",
       "builtAt": "2026-06-02T00:00:00.000Z"
     },
     {
@@ -185,7 +185,7 @@
     {
       "path": "/data/registry-manifest.json",
       "bytes": 445169,
-      "sha256": "5851c67355572e35789f4e86056f85763c6c74efd9feacbce56bf76e239ee331",
+      "sha256": "dbdbdcae7f64dd6e97530e41dc02d3853c1b85b1389f95ab13d7c4ce1ce4afd6",
       "builtAt": "2026-06-02T00:00:00.000Z"
     }
   ],

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -27,7 +27,6 @@ const connectSrc = Array.from(
       "https://umami.heyclau.de",
       "https://challenges.cloudflare.com",
       "https://submission-gate.heyclau.de",
-      process.env.NODE_ENV === "production" ? "" : "https://submission-gate-dev.heyclau.de",
       urlOrigin(siteConfig.submissionGateUrl),
     ].filter(Boolean),
   ),

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -54,9 +54,7 @@ export const siteConfig = {
     publicEnv("VITE_SUBMISSION_GATE_URL") || publicEnv("NEXT_PUBLIC_SUBMISSION_GATE_URL"),
   ),
   submissionBaseRef:
-    publicEnv("VITE_SUBMISSION_BASE_REF") ||
-    publicEnv("NEXT_PUBLIC_SUBMISSION_BASE_REF") ||
-    "submission-gate-pilot",
+    publicEnv("VITE_SUBMISSION_BASE_REF") || publicEnv("NEXT_PUBLIC_SUBMISSION_BASE_REF") || "main",
   polarFreeJobUrl: publicEnv("NEXT_PUBLIC_POLAR_FREE_JOB_URL") || "/jobs/post?tier=free",
   polarJobBoardUrl: publicEnv("NEXT_PUBLIC_POLAR_JOB_BOARD_URL") || "/advertise",
   polarFeaturedJobUrl: publicEnv("NEXT_PUBLIC_POLAR_FEATURED_JOB_URL") || "/advertise",

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -219,7 +219,7 @@ function SubmitPage() {
             branchName:
               preflightResult?.prPreview?.branchHint ||
               `heyclaude/submit-${category}-${data.slug || slugify(data.name || "")}`,
-            baseRef: preflightResult?.prPreview?.baseRef || "submission-gate-pilot",
+            baseRef: preflightResult?.prPreview?.baseRef || "main",
             body: prPacket,
           },
         });

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -89,7 +89,7 @@
         "NEXT_PUBLIC_POLAR_JOB_BOARD_URL": "/jobs/post?tier=standard",
         "NEXT_PUBLIC_POLAR_FEATURED_JOB_90_URL": "/jobs/post?tier=featured",
         "NEXT_PUBLIC_POLAR_SPONSORED_JOB_90_URL": "/jobs/post?tier=sponsored",
-        "VITE_SUBMISSION_GATE_URL": "https://submission-gate-dev.heyclau.de",
+        "VITE_SUBMISSION_GATE_URL": "https://submission-gate.heyclau.de",
       },
       "ratelimits": [
         {

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -30,7 +30,6 @@ Development deploys may target the Cloudflare dev Worker only:
 
 ```bash
 pnpm --filter web run deploy:dev
-pnpm --filter @heyclaude/submission-gate run deploy:dev
 ```
 
 The current PR artifact check uses that shared `heyclaude-dev` Worker when the
@@ -40,9 +39,9 @@ environment URL, CI resolves and validates that URL instead.
 For same-repo deployable PRs, missing preview deployment credentials or a missing
 resolved preview URL must fail `validate-pr-preview`.
 
-The private submission gate has its own dev Worker,
-`heyclaude-submission-gate-dev`, and production should not point `/submit` at an
-untested gate.
+The private submission gate is production-only. The single live Worker is
+`heyclaude-submission-gate` at `submission-gate.heyclau.de`; dev and production
+website builds both call that same gate.
 
 Do not run production deploy commands from feature branches. Production updates
 must flow through the protected `main` branch.

--- a/docs/submission-queue-ops.md
+++ b/docs/submission-queue-ops.md
@@ -17,8 +17,8 @@ content directly to `main`.
 
 ## Labels
 
-- `submission-gate-pilot`: opt-in scope for the pilot branch or pilot-labeled
-  PRs.
+- `submission-gate-pilot`: legacy manual escape hatch for explicitly
+  pilot-labeled PRs; normal submission-gate scope is now `main`.
 - `submission-under-review`: the private worker accepted the webhook and queued
   a serialized review job.
 - `submission-needs-changes`: fixable issues were found and the stable marker
@@ -55,8 +55,9 @@ thresholds stay outside the public repo.
 The private gate is hosted as a Cloudflare Worker with supporting bindings:
 
 - Production Worker: `heyclaude-submission-gate`.
-- Development Worker: `heyclaude-submission-gate-dev`, backed by separate dev
-  D1, R2, Queue, and dead-letter Queue resources.
+- Production domain: `submission-gate.heyclau.de`.
+- Production D1, R2, Queue, and dead-letter Queue resources are the only
+  supported submission-gate runtime moving forward.
 - Worker endpoints for GitHub App auth, draft creation, draft status, GitHub
   webhooks, and internal import callbacks.
 - D1 tables for drafts, PR state, verdict summaries, audit rows, and short-lived
@@ -68,19 +69,18 @@ The private gate is hosted as a Cloudflare Worker with supporting bindings:
 - Cloudflare Containers for trusted git, Node, pnpm, validation, generation,
   branch push, and maintainer-owned import PR creation.
 
-Provision queues before deploying the Worker. The dev environment needs
-`heyclaude-submission-review-dev`, `heyclaude-submission-review-dev-dlq`,
-`heyclaude-submission-import-dev`, and `heyclaude-submission-import-dev-dlq`.
-Production needs the same names without the `-dev` suffix. The review consumer
-retries three times before the DLQ; the import consumer retries twice before the
-DLQ.
+Provision queues before deploying the Worker. The production environment needs
+`heyclaude-submission-review`, `heyclaude-submission-review-dlq`,
+`heyclaude-submission-import`, and `heyclaude-submission-import-dlq`.
+The review consumer retries three times before the DLQ; the import consumer
+retries twice before the DLQ.
 
 The Worker can label and comment quickly. Import generation happens in the
 Container because it needs a filesystem, git, pnpm, and the repo validation
 toolchain.
 
-Feature branches must use the dev gate only. Production gate deploys wait until
-the frontend preview and pilot gate behavior are proven.
+Do not deploy the submission gate from unrelated feature branches. It owns the
+production custom domain.
 
 The GitHub App needs read-only access to Checks and commit statuses so the gate
 can wait for repo-owned source validation before running private review. It
@@ -93,8 +93,8 @@ the gate later creates its own formal GitHub check run.
 - Website `/submit` runs public preflight, then posts a draft to the private
   Worker. If the Worker is configured, the contributor continues through GitHub
   App user auth and the gate creates or updates a user-fork branch and PR.
-- Webhook review starts when a PR targets `submission-gate-pilot` during pilot,
-  or `main` after promotion.
+- Webhook review starts when a PR targets the configured base ref, currently
+  `main`, or carries the `submission-gate-pilot` label.
 - The Worker applies `submission-under-review` immediately, enqueues one job per
   PR, and updates one stable marker comment.
 - The review job waits for configured required validation, currently

--- a/packages/registry/src/submission-spec.js
+++ b/packages/registry/src/submission-spec.js
@@ -349,7 +349,7 @@ export function buildSubmissionSpecs(options = {}) {
     prIntake: {
       mode: "github_app_user_fork_pr",
       ...(submitUrl ? { submitUrl } : {}),
-      pilotBaseRef: "submission-gate-pilot",
+      pilotBaseRef: "main",
     },
   };
 }

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -139,7 +139,7 @@ describe("PR preview artifact validation flow", () => {
     expect(jobBlock).toContain("persist-credentials: false");
   });
 
-  it("guards submission-gate production deploys until prod D1 exists", () => {
+  it("routes submission-gate deployments through the production Worker only", () => {
     const packageJson = JSON.parse(
       fs.readFileSync(
         path.join(repoRoot, "apps/submission-gate/package.json"),
@@ -147,19 +147,24 @@ describe("PR preview artifact validation flow", () => {
       ),
     ) as { scripts: Record<string, string> };
 
+    expect(packageJson.scripts["deploy:dev"]).toBe("pnpm run deploy:prod");
     expect(packageJson.scripts["deploy:prod"]).toContain(
       "check-submission-gate-prod-config.mjs",
     );
+    expect(packageJson.scripts["deploy:dry-run:dev"]).toBe(
+      "pnpm run deploy:dry-run:prod",
+    );
     expect(packageJson.scripts["deploy:dry-run:prod"]).toContain(
-      "check-submission-gate-prod-config.mjs",
+      'wrangler deploy --config wrangler.jsonc --env "" --dry-run',
     );
 
     const wranglerConfig = fs.readFileSync(
       path.join(repoRoot, "apps/submission-gate/wrangler.jsonc"),
       "utf8",
     );
-    expect(wranglerConfig).toContain(
-      "Production deploy scripts fail while this placeholder is present.",
-    );
+    expect(wranglerConfig).not.toContain('"env":');
+    expect(wranglerConfig).toContain('"pattern": "submission-gate.heyclau.de"');
+    expect(wranglerConfig).toContain('"PILOT_BASE_REF": "main"');
+    expect(wranglerConfig).toContain('"name": "heyclaude-submission-gate"');
   });
 });

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -68,7 +68,7 @@ describe("website submission preflight API", () => {
         title: "Add MCP Server: Direct Submit API Asset",
         targetPath: "content/mcp/direct-submit-api-asset.mdx",
         branchHint: "heyclaude/submit-mcp-direct-submit-api-asset",
-        baseRef: "submission-gate-pilot",
+        baseRef: "main",
       },
     });
   });

--- a/tests/submission-gate-runner.test.ts
+++ b/tests/submission-gate-runner.test.ts
@@ -149,11 +149,6 @@ describe("submission gate import runner safety", () => {
   it("allows only signed import completion callback URLs", () => {
     expect(
       safeCallbackUrl(
-        "https://submission-gate-dev.heyclau.de/internal/import-complete",
-      ),
-    ).toBe("https://submission-gate-dev.heyclau.de/internal/import-complete");
-    expect(
-      safeCallbackUrl(
         "https://submission-gate.heyclau.de/internal/import-complete",
       ),
     ).toBe("https://submission-gate.heyclau.de/internal/import-complete");
@@ -162,11 +157,16 @@ describe("submission gate import runner safety", () => {
       safeCallbackUrl("https://attacker.example/internal/import-complete"),
     ).toThrow("callback URL");
     expect(() =>
-      safeCallbackUrl("https://submission-gate-dev.heyclau.de/other"),
+      safeCallbackUrl(
+        "https://submission-gate-dev.heyclau.de/internal/import-complete",
+      ),
+    ).toThrow("callback URL");
+    expect(() =>
+      safeCallbackUrl("https://submission-gate.heyclau.de/other"),
     ).toThrow("callback URL");
     expect(() =>
       safeCallbackUrl(
-        "http://submission-gate-dev.heyclau.de/internal/import-complete",
+        "http://submission-gate.heyclau.de/internal/import-complete",
       ),
     ).toThrow("callback URL");
   });

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -74,16 +74,16 @@ describe("Cloudflare submission gate helpers", () => {
     expect(url.searchParams.get("state")).toBe("draft_123.state");
   });
 
-  it("normalizes draft targets to one content file on the pilot branch", () => {
+  it("normalizes draft targets to one content file on the production branch", () => {
     const target = buildDraftTarget(
       { category: "mcp", name: "Example MCP Server" },
-      "submission-gate-pilot",
+      "main",
     );
 
     expect(target).toEqual({
       category: "mcp",
       slug: "example-mcp-server",
-      baseRef: "submission-gate-pilot",
+      baseRef: "main",
       branchName: "heyclaude/submit-mcp-example-mcp-server",
       targetPath: "content/mcp/example-mcp-server.mdx",
     });
@@ -92,7 +92,7 @@ describe("Cloudflare submission gate helpers", () => {
   it("caps generated branch names while keeping the full target slug", () => {
     const target = buildDraftTarget(
       { category: "skills", name: "A".repeat(240) },
-      "submission-gate-pilot",
+      "main",
     );
 
     expect(target.slug).toHaveLength(120);


### PR DESCRIPTION
## Summary
- Make the submission gate production-only by removing the `env.dev` Worker configuration.
- Point website dev/prod submission flows at `https://submission-gate.heyclau.de` and `main`.
- Restrict import callbacks to the production gate host and refresh generated submission-spec hashes.

## Submission Source
- [ ] New content file(s) added under `content/<category>/`
- [ ] Existing content updated
- [ ] Submission issue resolved (link it here): N/A
- [ ] Direct content submissions include `submittedBy` and `submittedByUrl` frontmatter matching the PR author.
- [x] I did not modify `README.md`, generated registry outputs, or `apps/web/public/downloads/**` unless this is a maintainer/internal automation branch.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.

## Schema and Quality Checks
- [ ] `pnpm validate:content` passed
- [ ] `pnpm validate:packages` passed
- [ ] `pnpm scan:packages` passed when package artifacts changed
- [ ] `pnpm audit:content` ran and I reviewed findings
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`)

## Quality Evidence
- Changed routes/components/endpoints/tools: submission-gate Worker deployment config, website submit target config, submission spec metadata, and import callback validation.
- Expected behavior: all content submissions use the production gate, target `main`, and call the production reviewer.
- Important edge cases or invariants: the old dev gate Worker is removed from repo config; import callbacks no longer allow the dev gate hostname.
- Backward compatibility notes: legacy `deploy:dev` scripts for the submission-gate package delegate to the production deploy path to avoid a second gate runtime.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual layout impact; submission endpoint configuration only.
  - Mobile: No visual layout impact; submission endpoint configuration only.
- Accessibility notes for UI changes: No UI impact.
- Focused tests or reason tests are not practical: focused worker, API, registry, dry-run, build, and live smoke checks were run.

## Validation
- [x] Local build passed (`pnpm build` via `pnpm --filter web build`)
- [x] I ran the focused checks listed above
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s)

Focused checks run:
- `pnpm exec vitest run tests/deployment-preview-url.test.ts tests/submission-api.test.ts tests/submission-gate-worker.test.ts tests/submission-gate-runner.test.ts tests/api-contracts.test.ts`
- `pnpm test:registry-artifacts`
- `pnpm validate:openapi`
- `pnpm --filter web type-check`
- `pnpm --filter web build`
- `pnpm submission-gate:dry-run:prod`
- `git diff --check`

Live checks run:
- production reviewer deploy succeeded and `/health` returned ok
- production gate deploy succeeded and `/health` returned ok
- production `/drafts` returned `configured: true`, GitHub auth URL, production callback URL, and `main` base ref
- invalid webhook signature returned `401 invalid_signature`
- old dev gate and reviewer Worker endpoints no longer serve

## Notes
- Production Worker secrets were set in Cloudflare before deployment.
- The GitHub App homepage should be `https://heyclau.de/submit`.
- The generated webhook secret has to match the GitHub App webhook secret setting.
