### PR TITLE
feat(content): add ccusage tool listing

### DIFF
--- a/content/tools/ccusage.mdx
+++ b/content/tools/ccusage.mdx
@@ -1,0 +1,46 @@
+---
+title: ccusage
+slug: ccusage
+category: tools
+description: Local CLI for analyzing Claude Code and other coding-agent token usage, costs, sessions, and billing-window activity from local usage data.
+cardDescription: Local CLI for coding-agent token usage and cost reports.
+seoTitle: ccusage coding-agent usage and cost CLI
+seoDescription: ccusage analyzes local Claude Code and coding-agent usage data for daily, weekly, monthly, session, cost, and statusline reports.
+author: ryoppippi
+authorProfileUrl: "https://github.com/ryoppippi"
+dateAdded: "2026-06-02"
+websiteUrl: "https://ccusage.com"
+documentationUrl: "https://ccusage.com/guide/getting-started"
+repoUrl: "https://github.com/ryoppippi/ccusage"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+installCommand: "bunx ccusage"
+tags:
+  - usage-analytics
+  - claude-code
+  - cli
+  - cost-tracking
+keywords:
+  - claude code usage
+  - coding agent cost tracking
+  - token usage cli
+  - agent usage analytics
+privacyNotes:
+  - Reads local coding-agent usage files from the developer machine to calculate token and cost reports.
+  - JSON export can include project or session metadata, so review output before sharing logs or reports publicly.
+safetyNotes:
+  - Run from a trusted package source and review repository/package provenance before using in sensitive workspaces.
+  - Cost estimates depend on local usage data and pricing metadata; treat them as operational estimates, not billing authority.
+---
+
+## Editorial notes
+
+ccusage is useful for developers who need local visibility into Claude Code and other coding-agent usage without building custom log parsers. It can summarize daily, weekly, monthly, and per-session usage, show Claude Code five-hour billing windows, export JSON, and provide a compact statusline-oriented view.
+
+The fit for HeyClaude is strongest for teams that already use Claude Code heavily and want a fast way to understand token volume, cost trends, session shape, and project-level usage from local data.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary
- Add ccusage as a source-backed open-source tool listing for Claude Code and coding-agent usage analytics.

## What changed
- Adds one raw content entry under `content/tools/ccusage.mdx`.
- Includes source, docs, privacy notes, and safety notes.

## Validation
- `pnpm validate:content:strict`
- `node scripts/ci/validate-content-policy.mjs --base-sha <main> --source-type same_repo_direct`
- `pnpm validate:openapi`
- `pnpm test:registry-artifacts`
- `pnpm validate:raycast-feed`
- `git diff --check`

## Notes
- This PR is intentionally a production maintainer-agent smoke test: exactly one source content file, no generated artifacts.