### PR TITLE
fix(submissions): ignore non-content prs in gate

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -19,6 +19,7 @@ jobs:
       direct_submission: ${{ steps.classify.outputs.direct_submission }}
       maintainer_import: ${{ steps.classify.outputs.maintainer_import }}
       source_content_only: ${{ steps.classify.outputs.source_content_only }}
+      readme_only: ${{ steps.classify.outputs.readme_only }}
       content: ${{ steps.classify.outputs.content }}
       content_config: ${{ steps.classify.outputs.content_config }}
       content_categories_json: ${{ steps.classify.outputs.content_categories_json }}
@@ -69,6 +70,9 @@ jobs:
           fi
           if ! grep -q '^source_content_only=' "$GITHUB_OUTPUT"; then
             echo "source_content_only=false" >> "$GITHUB_OUTPUT"
+          fi
+          if ! grep -q '^readme_only=' "$GITHUB_OUTPUT"; then
+            echo "readme_only=false" >> "$GITHUB_OUTPUT"
           fi
           if ! grep -q '^content_config=' "$GITHUB_OUTPUT"; then
             echo "content_config=false" >> "$GITHUB_OUTPUT"
@@ -489,8 +493,35 @@ jobs:
         run: pnpm validate:readme
 
       - name: Verify generated registry artifacts are current
-        if: ${{ needs.classify-pr.outputs.registry == 'true' && needs.classify-pr.outputs.source_content_only != 'true' }}
+        if: ${{ needs.classify-pr.outputs.registry == 'true' && needs.classify-pr.outputs.source_content_only != 'true' && needs.classify-pr.outputs.readme_only != 'true' }}
         run: git diff --exit-code apps/web/public/data apps/web/src/generated README.md
+
+      - name: Verify README-only refresh leaves generated artifacts as build outputs
+        if: ${{ needs.classify-pr.outputs.registry == 'true' && needs.classify-pr.outputs.readme_only == 'true' }}
+        run: |
+          set -euo pipefail
+          # README refresh PRs intentionally commit README.md only. Registry,
+          # LLM, Raycast, manifest, and generated source projections are built
+          # and contract-tested above, but stay deploy/build artifacts.
+          git checkout -- pnpm-lock.yaml
+
+          dirty_files="$(git diff --name-only)"
+          if [ -z "$dirty_files" ]; then
+            echo "No generated artifact drift after README validation."
+            exit 0
+          fi
+
+          disallowed="$(
+            printf '%s\n' "$dirty_files" | grep -Ev '^(apps/web/public/data/.*|apps/web/src/generated/.*|apps/web/src/routeTree\.gen\.ts)$' || true
+          )"
+          if [ -n "$disallowed" ]; then
+            echo "::error::README refresh generation changed non-generated files:"
+            printf '%s\n' "$disallowed"
+            exit 1
+          fi
+
+          echo "Generated artifact changes are build-time outputs for this README refresh:"
+          printf '%s\n' "$dirty_files"
 
       - name: Verify source-only imports produce only build artifacts
         if: ${{ needs.classify-pr.outputs.registry == 'true' && needs.classify-pr.outputs.source_content_only == 'true' }}

--- a/apps/submission-gate/src/constants.ts
+++ b/apps/submission-gate/src/constants.ts
@@ -9,6 +9,7 @@ export const LABELS = {
 } as const;
 
 export const PILOT_LABEL = "submission-gate-pilot";
+export const CONTENT_CATEGORY_LABEL_PREFIX = "category:";
 
 type ReviewablePrAction =
   | "opened"

--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -26,6 +26,46 @@ const MANAGED_LABELS: Record<string, { color: string; description: string }> = {
     color: "0e8a16",
     description: "Private submission gate merged this content PR",
   },
+  "category:agents": {
+    color: "1d76db",
+    description: "Submission category: agents",
+  },
+  "category:collections": {
+    color: "1d76db",
+    description: "Submission category: collections",
+  },
+  "category:commands": {
+    color: "1d76db",
+    description: "Submission category: commands",
+  },
+  "category:guides": {
+    color: "1d76db",
+    description: "Submission category: guides",
+  },
+  "category:hooks": {
+    color: "1d76db",
+    description: "Submission category: hooks",
+  },
+  "category:mcp": {
+    color: "1d76db",
+    description: "Submission category: MCP servers",
+  },
+  "category:rules": {
+    color: "1d76db",
+    description: "Submission category: rules",
+  },
+  "category:skills": {
+    color: "1d76db",
+    description: "Submission category: skills",
+  },
+  "category:statuslines": {
+    color: "1d76db",
+    description: "Submission category: statuslines",
+  },
+  "category:tools": {
+    color: "1d76db",
+    description: "Submission category: tools",
+  },
   "import-pr-open": {
     color: "0e8a16",
     description: "Legacy: a maintainer-owned import PR exists",

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2,6 +2,7 @@ import { Container } from "@cloudflare/containers";
 import { DurableObject } from "cloudflare:workers";
 
 import {
+  CONTENT_CATEGORY_LABEL_PREFIX,
   DEFAULT_REVIEW_MARKER,
   LABELS,
   PILOT_LABEL,
@@ -157,6 +158,7 @@ const TRUSTED_RECHECK_ASSOCIATIONS = new Set([
 ]);
 const MAINTAINER_IMPORT_BRANCH_PREFIX = "automation/submission-pr-";
 const DECISION_LABELS = [
+  LABELS.underReview,
   LABELS.requestChanges,
   LABELS.manual,
   LABELS.close,
@@ -164,6 +166,19 @@ const DECISION_LABELS = [
   LABELS.importOpen,
   LABELS.superseded,
 ];
+const CONTENT_CATEGORY_LABELS = [
+  "agents",
+  "collections",
+  "commands",
+  "guides",
+  "hooks",
+  "mcp",
+  "rules",
+  "skills",
+  "statuslines",
+  "tools",
+].map(categoryLabel);
+const RECONCILED_GATE_LABELS = [...DECISION_LABELS, ...CONTENT_CATEGORY_LABELS];
 
 type ReviewTarget = {
   repoFullName: string;
@@ -181,6 +196,11 @@ type DirectContentScope = {
   slug: string;
   status: string;
 };
+
+type DirectContentReviewability =
+  | { kind: "review"; scope: DirectContentScope }
+  | { kind: "scope_failure"; decision: GateDecision; category?: string }
+  | { kind: "ignore"; reason: string };
 
 function isMaintainerImportRef(ref: string | undefined) {
   return String(ref || "").startsWith(MAINTAINER_IMPORT_BRANCH_PREFIX);
@@ -585,45 +605,11 @@ async function installationTokenForInstallationId(
   });
 }
 
-async function installationTokenForPayload(
+async function applyUnderReviewToTarget(
   env: Env,
-  payload: Record<string, unknown>,
+  target: ReviewTarget,
+  scope?: DirectContentScope,
 ) {
-  return installationTokenForInstallationId(
-    env,
-    installationIdFromPayload(payload),
-  );
-}
-
-async function applyUnderReview(env: Env, payload: Record<string, unknown>) {
-  const pull = payload.pull_request as
-    | {
-        number?: number;
-        base?: { repo?: { full_name?: string } };
-      }
-    | undefined;
-  if (!pull?.number || !pull.base?.repo?.full_name) return;
-  const token = await installationTokenForPayload(env, payload);
-  if (!token) return;
-  const repo = parseRepo(pull.base.repo.full_name);
-  await addLabels({
-    token,
-    repo,
-    issueNumber: pull.number,
-    labels: [LABELS.underReview],
-    apiVersion: env.GITHUB_API_VERSION,
-  });
-  await upsertMarkerComment({
-    token,
-    repo,
-    issueNumber: pull.number,
-    marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-    body: markerComment(undefined, env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER),
-    apiVersion: env.GITHUB_API_VERSION,
-  });
-}
-
-async function applyUnderReviewToTarget(env: Env, target: ReviewTarget) {
   const token = await installationTokenForInstallationId(
     env,
     Number(target.installationId || 0),
@@ -634,7 +620,7 @@ async function applyUnderReviewToTarget(env: Env, target: ReviewTarget) {
     token,
     repo,
     issueNumber: target.number,
-    labels: [LABELS.underReview],
+    labels: [LABELS.underReview, ...gateLabelsForCategory(scope?.category)],
     apiVersion: env.GITHUB_API_VERSION,
   });
   await upsertMarkerComment({
@@ -643,6 +629,29 @@ async function applyUnderReviewToTarget(env: Env, target: ReviewTarget) {
     issueNumber: target.number,
     marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
     body: markerComment(undefined, env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER),
+    apiVersion: env.GITHUB_API_VERSION,
+  });
+}
+
+async function directContentReviewabilityForTarget(
+  env: Env,
+  target: ReviewTarget,
+) {
+  const token = await installationTokenForInstallationId(
+    env,
+    Number(target.installationId || 0),
+  );
+  if (!token) {
+    return {
+      kind: "ignore" as const,
+      reason: "No installation token available for PR file inspection.",
+    };
+  }
+  const repo = parseRepo(target.repoFullName);
+  return directContentReviewabilityForPr({
+    token,
+    repo,
+    number: target.number,
     apiVersion: env.GITHUB_API_VERSION,
   });
 }
@@ -747,50 +756,101 @@ function importContentPathParts(filePath: string) {
   };
 }
 
-async function directContentScopeForPr(params: {
+function categoryLabel(category: string) {
+  return `${CONTENT_CATEGORY_LABEL_PREFIX}${category}`;
+}
+
+function gateLabelsForCategory(category?: string) {
+  return category ? [categoryLabel(category)] : [];
+}
+
+function classifyPullRequestFilesForContentReview(
+  files: Array<{ filename?: string; status?: string }>,
+): DirectContentReviewability {
+  const entryFiles = files
+    .map((file) => ({
+      file,
+      filePath: String(file.filename || ""),
+      pathParts: importContentPathParts(String(file.filename || "")),
+    }))
+    .filter((item) => Boolean(item.pathParts));
+
+  if (entryFiles.length === 0) {
+    return {
+      kind: "ignore",
+      reason: "No source content entry file changed.",
+    };
+  }
+
+  if (files.length !== 1 || entryFiles.length !== 1) {
+    return {
+      kind: "scope_failure",
+      category: entryFiles[0]?.pathParts?.category,
+      decision: scopeFailureDecision(
+        "Direct content submissions must change exactly one source content file and no generated artifacts, README, workflows, scripts, packages, or additional entries.",
+      ),
+    };
+  }
+
+  const entry = entryFiles[0];
+  const status = String(entry.file.status || "");
+  if (status === "removed") {
+    return {
+      kind: "scope_failure",
+      category: entry.pathParts?.category,
+      decision: scopeFailureDecision(
+        "Direct content submissions cannot remove content files.",
+      ),
+    };
+  }
+
+  return {
+    kind: "review",
+    scope: {
+      filePath: entry.filePath,
+      category: entry.pathParts!.category,
+      slug: entry.pathParts!.slug,
+      status,
+    },
+  };
+}
+
+async function directContentReviewabilityForPr(params: {
   token: string;
   repo: ReturnType<typeof parseRepo>;
   number: number;
   apiVersion?: string;
-}): Promise<DirectContentScope> {
+}): Promise<DirectContentReviewability> {
   const files = await listPullRequestFiles({
     token: params.token,
     repo: params.repo,
     number: params.number,
     apiVersion: params.apiVersion,
   });
-  if (files.length !== 1) {
-    throw new Error(
-      "Direct content submissions must change exactly one source content file.",
-    );
-  }
+  return classifyPullRequestFilesForContentReview(files);
+}
 
-  const file = files[0];
-  const filePath = String(file.filename || "");
-  const pathParts = importContentPathParts(filePath);
-  if (!pathParts || !pathParts.slug) {
-    throw new Error(
-      "Direct content submissions must change one content/<category>/<slug>.mdx file.",
-    );
+async function directContentScopeForPr(params: {
+  token: string;
+  repo: ReturnType<typeof parseRepo>;
+  number: number;
+  apiVersion?: string;
+}): Promise<DirectContentScope> {
+  const classification = await directContentReviewabilityForPr(params);
+  if (classification.kind === "review") return classification.scope;
+  if (classification.kind === "scope_failure") {
+    throw new Error(classification.decision.summary);
   }
-  const status = String(file.status || "");
-  if (status === "removed") {
-    throw new Error("Direct content submissions cannot remove content files.");
-  }
-
-  return {
-    filePath,
-    category: pathParts.category,
-    slug: pathParts.slug,
-    status,
-  };
+  throw new Error(classification.reason);
 }
 
 function scopeFailureDecision(error: unknown): GateDecision {
   const message =
     error instanceof Error
       ? error.message
-      : "Direct content scope validation failed.";
+      : typeof error === "string" && error.trim()
+        ? error.trim()
+        : "Direct content scope validation failed.";
   return {
     verdict: "close" as const,
     summary: [
@@ -1168,7 +1228,16 @@ async function githubWebhookRoute(
     }
     if (!isPilotPr(payload, env))
       return json({ ok: true, ignored: true, reason: "outside_pilot" });
-    ctx.waitUntil(applyUnderReview(env, payload));
+    const reviewability = await directContentReviewabilityForTarget(
+      env,
+      target,
+    );
+    if (reviewability.kind === "ignore") {
+      return json({ ok: true, ignored: true, reason: reviewability.reason });
+    }
+    const reviewScope =
+      reviewability.kind === "review" ? reviewability.scope : undefined;
+    ctx.waitUntil(applyUnderReviewToTarget(env, target, reviewScope));
     await enqueueReviewTarget(
       env,
       target,
@@ -1185,7 +1254,16 @@ async function githubWebhookRoute(
   if (eventName === "issue_comment") {
     const target = await targetFromIssueCommentRecheck(env, payload);
     if (!target) return json({ ok: true, ignored: true });
-    await applyUnderReviewToTarget(env, target);
+    const reviewability = await directContentReviewabilityForTarget(
+      env,
+      target,
+    );
+    if (reviewability.kind === "ignore") {
+      return json({ ok: true, ignored: true, reason: reviewability.reason });
+    }
+    const reviewScope =
+      reviewability.kind === "review" ? reviewability.scope : undefined;
+    await applyUnderReviewToTarget(env, target, reviewScope);
     await enqueueReviewTarget(
       env,
       target,
@@ -1203,6 +1281,11 @@ async function githubWebhookRoute(
     const targets = await targetsFromValidationWebhook(env, eventName, payload);
     let queued = 0;
     for (const target of targets) {
+      const reviewability = await directContentReviewabilityForTarget(
+        env,
+        target,
+      );
+      if (reviewability.kind === "ignore") continue;
       if (
         await enqueueReviewTarget(env, target, deliveryId, eventName, payload)
       ) {
@@ -1390,6 +1473,43 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       let decision: GateDecision | null = null;
       let validationForPrivateReview: unknown = null;
       let contentScopeForPrivateReview: DirectContentScope | null = null;
+      const reviewability = await directContentReviewabilityForPr({
+        token,
+        repo,
+        number: target.number,
+        apiVersion: env.GITHUB_API_VERSION,
+      });
+      if (reviewability.kind === "ignore") {
+        await removeLabels({
+          token,
+          repo,
+          issueNumber: target.number,
+          labels: RECONCILED_GATE_LABELS,
+          apiVersion: env.GITHUB_API_VERSION,
+        });
+        await upsertPrState(env.SUBMISSION_GATE_DB, {
+          repo: target.repoFullName,
+          number: target.number,
+          headRepo: target.headRepo,
+          headRef: target.headRef,
+          baseRef: target.baseRef || env.PILOT_BASE_REF,
+          status: "ignored",
+          deliveryId: String(message.payload.deliveryId || ""),
+        });
+        await insertAudit(env.SUBMISSION_GATE_DB, {
+          id: crypto.randomUUID(),
+          targetKey: message.targetKey,
+          eventType: message.kind,
+          decision: "ignored",
+          summary: reviewability.reason,
+        });
+        return;
+      }
+      if (reviewability.kind === "scope_failure") {
+        decision = reviewability.decision;
+      } else {
+        contentScopeForPrivateReview = reviewability.scope;
+      }
       try {
         const validation = await getCommitValidationState({
           token,
@@ -1399,7 +1519,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           requiredStatusContexts: requiredStatusContexts(env),
           apiVersion: env.GITHUB_API_VERSION,
         });
-        if (validation.state === "pending") {
+        if (!decision && validation.state === "pending") {
           await upsertPrState(env.SUBMISSION_GATE_DB, {
             repo: target.repoFullName,
             number: target.number,
@@ -1418,24 +1538,14 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           });
           return;
         }
-        if (validation.state === "failed") {
+        if (!decision && validation.state === "failed") {
           decision = validationGateDecision(validation);
-        } else {
+        } else if (!decision) {
           validationForPrivateReview = {
             state: validation.state,
             summary: validation.summary,
             checks: validation.checks,
           };
-          try {
-            contentScopeForPrivateReview = await directContentScopeForPr({
-              token,
-              repo,
-              number: target.number,
-              apiVersion: env.GITHUB_API_VERSION,
-            });
-          } catch (error) {
-            decision = scopeFailureDecision(error);
-          }
         }
       } catch {
         decision = defaultManualDecision(
@@ -1485,7 +1595,13 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       }
       const status =
         decision.verdict === "merge" ? "merge_accepted" : decision.verdict;
-      const labelsToApply =
+      const categoryLabels = gateLabelsForCategory(
+        contentScopeForPrivateReview?.category ||
+          (reviewability.kind === "scope_failure"
+            ? reviewability.category
+            : undefined),
+      );
+      const decisionLabelsToApply =
         decision.verdict === "merge"
           ? decision.labels.filter(
               (label) =>
@@ -1494,6 +1610,9 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 label !== LABELS.superseded,
             )
           : decision.labels;
+      const labelsToApply = [
+        ...new Set([...decisionLabelsToApply, ...categoryLabels]),
+      ];
 
       await insertAudit(env.SUBMISSION_GATE_DB, {
         id: crypto.randomUUID(),
@@ -1516,7 +1635,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         token,
         repo,
         issueNumber: target.number,
-        labels: DECISION_LABELS.filter(
+        labels: RECONCILED_GATE_LABELS.filter(
           (label) => !labelsToApply.includes(label),
         ),
         apiVersion: env.GITHUB_API_VERSION,
@@ -1572,7 +1691,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           const mergedDecision: GateDecision = {
             ...decision,
             summary: mergedSummary,
-            labels: [LABELS.merged],
+            labels: [LABELS.merged, ...categoryLabels],
           };
           await upsertPrState(env.SUBMISSION_GATE_DB, {
             repo: target.repoFullName,
@@ -1588,14 +1707,17 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             token,
             repo,
             issueNumber: target.number,
-            labels: DECISION_LABELS.filter((label) => label !== LABELS.merged),
+            labels: RECONCILED_GATE_LABELS.filter(
+              (label) =>
+                label !== LABELS.merged && !categoryLabels.includes(label),
+            ),
             apiVersion: env.GITHUB_API_VERSION,
           });
           await addLabels({
             token,
             repo,
             issueNumber: target.number,
-            labels: [LABELS.merged],
+            labels: [LABELS.merged, ...categoryLabels],
             apiVersion: env.GITHUB_API_VERSION,
           });
           await upsertMarkerComment({
@@ -1665,14 +1787,17 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             token,
             repo,
             issueNumber: target.number,
-            labels: DECISION_LABELS.filter((label) => label !== LABELS.manual),
+            labels: RECONCILED_GATE_LABELS.filter(
+              (label) =>
+                label !== LABELS.manual && !categoryLabels.includes(label),
+            ),
             apiVersion: env.GITHUB_API_VERSION,
           });
           await addLabels({
             token,
             repo,
             issueNumber: target.number,
-            labels: manualDecision.labels,
+            labels: [...manualDecision.labels, ...categoryLabels],
             apiVersion: env.GITHUB_API_VERSION,
           });
           await upsertMarkerComment({

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -76,6 +76,11 @@ const sourceContentOnly =
   !all &&
   files.length > 0 &&
   files.every((file) => /^content\/[^/]+\/[^/]+\.mdx$/i.test(file));
+const readmeOnly =
+  eventName === "pull_request" &&
+  !all &&
+  files.length === 1 &&
+  files[0] === "README.md";
 const maintainerImport =
   sourceContentOnly && /^automation\/submission-pr-\d+-/i.test(headRef);
 const directSubmission =
@@ -111,6 +116,7 @@ const flags = {
   direct_submission: directSubmission,
   maintainer_import: maintainerImport,
   source_content_only: sourceContentOnly,
+  readme_only: readmeOnly,
   content: contentCategoryTouched || contentValidationInfra,
   content_config: contentValidationInfra,
   registry:

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -95,10 +95,33 @@ describe("PR change classifier", () => {
       content_agents: "true",
       direct_submission: "true",
       source_content_only: "true",
+      readme_only: "false",
       maintainer_import: "false",
       registry: "false",
       raycast: "false",
       web: "false",
+    });
+  });
+
+  it("routes README-only refresh PRs through registry contract validation without content review", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+
+    fs.writeFileSync(path.join(cwd, "README.md"), "# refreshed\n");
+    git(cwd, ["add", "README.md"]);
+    git(cwd, ["commit", "-m", "refresh readme"]);
+
+    const outputs = runClassifier(cwd, baseSha, {
+      GITHUB_HEAD_REF: "automation/readme-refresh",
+    });
+    expect(outputs).toMatchObject({
+      readme_only: "true",
+      direct_submission: "false",
+      source_content_only: "false",
+      content: "false",
+      registry: "true",
+      docs: "true",
+      web: "false",
+      raycast: "false",
     });
   });
 

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -108,6 +108,7 @@ describe("PR preview artifact validation flow", () => {
 
     expect(workflow).toContain("maintainer_import:");
     expect(workflow).toContain("source_content_only:");
+    expect(workflow).toContain("readme_only:");
     expect(registryBlock).toContain(
       "needs.classify-pr.outputs.source_content_only != 'true'",
     );
@@ -123,6 +124,23 @@ describe("PR preview artifact validation flow", () => {
     );
     expect(registryBlock).toContain("apps/web/public/data/.*");
     expect(registryBlock).toContain("apps/web/src/generated/.*");
+  });
+
+  it("lets README-only refresh PRs validate generated outputs without committing them", () => {
+    const workflow = readContentValidationWorkflow();
+    const registryBlock =
+      workflow.match(/\n  validate-registry:[\s\S]*?\n  validate-web:/)?.[0] ||
+      "";
+
+    expect(registryBlock).toContain(
+      "needs.classify-pr.outputs.readme_only != 'true'",
+    );
+    expect(registryBlock).toContain(
+      "Verify README-only refresh leaves generated artifacts as build outputs",
+    );
+    expect(registryBlock).toContain(
+      "Generated artifact changes are build-time outputs for this README refresh",
+    );
   });
 
   it("does not persist GitHub credentials in the submission-gate validation checkout", () => {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -303,9 +303,55 @@ describe("Cloudflare submission gate helpers", () => {
     const addIndex = source.indexOf("await addLabels({", removeIndex);
 
     expect(source).toContain("const DECISION_LABELS = [");
+    expect(source).toContain("const RECONCILED_GATE_LABELS = [");
+    expect(source).toContain("LABELS.underReview");
+    expect(source).toContain("const CONTENT_CATEGORY_LABELS = [");
+    expect(source).toContain("categoryLabel");
     expect(source).toContain("!labelsToApply.includes(label)");
     expect(removeIndex).toBeGreaterThan(0);
     expect(addIndex).toBeGreaterThan(removeIndex);
+  });
+
+  it("ignores non-content PRs before adding submission labels or comments", () => {
+    const source = readWorkerSource();
+    const pullRequestIndex = source.indexOf(
+      'if (eventName === "pull_request")',
+    );
+    const pullRequestBlock = source.slice(
+      pullRequestIndex,
+      source.indexOf('if (eventName === "issue_comment")', pullRequestIndex),
+    );
+    const classifyIndex = pullRequestBlock.indexOf(
+      "directContentReviewabilityForTarget(",
+    );
+    const applyIndex = pullRequestBlock.indexOf("applyUnderReviewToTarget");
+
+    expect(source).toContain('reason: "No source content entry file changed."');
+    expect(pullRequestBlock).toContain('reviewability.kind === "ignore"');
+    expect(classifyIndex).toBeGreaterThan(0);
+    expect(applyIndex).toBeGreaterThan(classifyIndex);
+  });
+
+  it("distinguishes generated-artifact tampering from ordinary non-content PRs", () => {
+    const source = readWorkerSource();
+    const classifierIndex = source.indexOf(
+      "function classifyPullRequestFilesForContentReview",
+    );
+    const classifierBlock = source.slice(
+      classifierIndex,
+      source.indexOf(
+        "async function directContentReviewabilityForPr",
+        classifierIndex,
+      ),
+    );
+
+    expect(classifierBlock).toContain("entryFiles.length === 0");
+    expect(classifierBlock).toContain('kind: "ignore"');
+    expect(classifierBlock).toContain("files.length !== 1");
+    expect(classifierBlock).toContain('kind: "scope_failure"');
+    expect(classifierBlock).toContain(
+      "no generated artifacts, README, workflows, scripts, packages, or additional entries",
+    );
   });
 
   it("does not apply the merged label before direct merge succeeds", () => {
@@ -317,6 +363,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("label !== LABELS.merged");
     expect(source).toContain("label !== LABELS.importOpen");
     expect(source).toContain("label !== LABELS.superseded");
+    expect(source).toContain(
+      "label !== LABELS.merged && !categoryLabels.includes(label)",
+    );
+    expect(source).toContain("labels: [LABELS.merged, ...categoryLabels]");
     expect(source).toContain('status: "merged"');
     expect(source).toContain("await mergeAcceptedPullRequest({");
     expect(source).toContain("SubmissionMergePendingError");
@@ -384,7 +434,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("mergePullRequest({");
     expect(source).toContain("listPullRequestFiles({");
     expect(source).toContain(
-      "Direct content submissions must change exactly one source content file.",
+      "Direct content submissions must change exactly one source content file and no generated artifacts",
     );
     expect(source).toContain('finalAction: "merge_or_close"');
     expect(source).not.toContain(


### PR DESCRIPTION
## Summary
- Prevent the submission gate from treating every PR to `main` as a content submission.
- Ignore PRs that do not change a source content entry file.
- Keep hard-close behavior for PRs that touch a content entry plus generated artifacts, README, workflows, scripts, packages, or extra entries.
- Reconcile transient review labels and add `category:<name>` labels for content submission outcomes.

## Why
The production gate incorrectly closed a generated README refresh PR because `main` is now the production base. The gate must only act on direct content submissions, not normal automation, docs, code, or generated-artifact maintenance PRs.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run:prod`
- `git diff --check`

## Notes
- Deployed to `heyclaude-submission-gate` before opening this PR to stop the bad production behavior.
- Reopened the affected README refresh PR and removed stale submission-gate labels.