### PR TITLE
test(content): submit duplicate ccusage listing

### DIFF
--- a/content/tools/ccusage-duplicate-gate-test.mdx
+++ b/content/tools/ccusage-duplicate-gate-test.mdx
@@ -1,0 +1,42 @@
+---
+title: ccusage Duplicate Gate Test
+slug: ccusage-duplicate-gate-test
+category: tools
+description: Duplicate test listing for the existing ccusage Claude Code usage and cost tracking CLI.
+cardDescription: Duplicate ccusage listing for gate rejection testing.
+seoTitle: ccusage duplicate submission gate test
+seoDescription: Duplicate submission test for the existing ccusage tool listing.
+author: ryoppippi
+authorProfileUrl: "https://github.com/ryoppippi"
+dateAdded: "2026-06-02"
+websiteUrl: "https://ccusage.com"
+documentationUrl: "https://ccusage.com/guide/getting-started"
+repoUrl: "https://github.com/ryoppippi/ccusage"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+installCommand: "bunx ccusage"
+tags:
+  - usage-analytics
+  - claude-code
+  - cli
+  - duplicate-test
+keywords:
+  - claude code usage
+  - coding agent cost tracking
+  - token usage cli
+  - duplicate submission test
+privacyNotes:
+  - Reads local coding-agent usage files from the developer machine to calculate token and cost reports.
+safetyNotes:
+  - Run from a trusted package source and review repository/package provenance before using in sensitive workspaces.
+---
+
+## Editorial notes
+
+This is an intentional duplicate of the accepted ccusage listing, using the same canonical website, documentation, package command, and source repository. It exists only to verify that the maintainer agent rejects duplicate content submissions instead of merging them.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary
- Deliberately submits a duplicate ccusage listing to verify the maintainer agent rejects duplicate single-file content submissions.

## Expected gate behavior
- Content validation should pass because the MDX shape is valid.
- Superagent should pass or finish normally.
- The maintainer agent should close this PR as a duplicate of the existing ccusage entry, not merge it.

## Notes
- This PR changes exactly one raw content file and is an intentional negative E2E test.