### PR TITLE
fix(submissions): harden gate decisions and alerts

### DIFF
--- a/apps/submission-gate/migrations/0008_submission_pr_notifications.sql
+++ b/apps/submission-gate/migrations/0008_submission_pr_notifications.sql
@@ -1,0 +1,2 @@
+ALTER TABLE submission_prs
+  ADD COLUMN last_notification_key TEXT;

--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -265,6 +265,9 @@ export async function getPullRequest(params: {
 }) {
   return githubJson<{
     number: number;
+    title?: string;
+    html_url?: string;
+    user?: { login?: string };
     draft?: boolean;
     base?: { ref?: string; repo?: { full_name?: string } };
     head?: {

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -43,10 +43,10 @@ import {
 import {
   defaultManualDecision,
   markerComment,
-  validationFailedDecision,
   type GateDecision,
   type GateVerdict,
 } from "./review";
+import { postDiscordDecisionNotification } from "./notifications";
 import {
   decryptText,
   encryptText,
@@ -61,6 +61,7 @@ import {
   getDraft,
   getPrState,
   insertAudit,
+  markPrNotificationSent,
   storeDraftUserToken,
   updateDraftAuthState,
   updateDraftStatus,
@@ -83,6 +84,7 @@ type Env = {
   GITHUB_WEBHOOK_SECRET?: string;
   INTERNAL_SHARED_SECRET?: string;
   PRIVATE_GATE_REVIEW_URL?: string;
+  DISCORD_SUBMISSION_WEBHOOK_URL?: string;
   REQUIRED_VALIDATION_CHECKS?: string;
   REQUIRED_STATUS_CONTEXTS?: string;
   SUBMISSION_GATE_DB: D1Database;
@@ -1084,7 +1086,161 @@ function validationGateDecision(validation: {
       close: true,
     };
   }
-  return validationFailedDecision(validation.summary);
+  return {
+    verdict: "close" as const,
+    summary: [
+      "Summary:",
+      `- ${validation.summary}`,
+      "",
+      "Validation Review:",
+      "- Required public validation did not pass, so this direct content PR is not eligible for automated merge.",
+      "- HeyClaude uses one-shot review for content submissions; hard validation failures are closed instead of iterated in place.",
+      "",
+      "Recommended Action:",
+      "- Close this PR and resubmit a clean single-entry content PR after fixing the validation failure.",
+    ].join("\n"),
+    labels: [LABELS.close],
+    close: true,
+  };
+}
+
+function validationSummaryForNotification(
+  validation:
+    | {
+        summary?: string;
+        checks?: Array<{ name: string; status: string; details?: string }>;
+      }
+    | null
+    | undefined,
+) {
+  if (!validation) return "";
+  const checks = validation.checks || [];
+  if (!checks.length) return validation.summary || "";
+  return checks
+    .map((check) =>
+      [check.name, check.status, check.details ? `(${check.details})` : ""]
+        .filter(Boolean)
+        .join(" "),
+    )
+    .join("; ");
+}
+
+function notificationKeyForDecision(params: {
+  target: ReviewTarget;
+  decision: GateDecision;
+  status: string;
+}) {
+  return [
+    params.target.headSha || params.target.headRef || "unknown-head",
+    params.status,
+    params.decision.verdict,
+  ].join(":");
+}
+
+async function insertNotificationAuditSafe(
+  env: Env,
+  params: {
+    targetKey: string;
+    decision: string;
+    summary: string;
+  },
+) {
+  try {
+    await insertAudit(env.SUBMISSION_GATE_DB, {
+      id: crypto.randomUUID(),
+      targetKey: params.targetKey,
+      eventType: "discord_notification",
+      decision: params.decision,
+      summary: params.summary,
+    });
+  } catch (error) {
+    console.warn("submission gate discord notification audit failed", {
+      targetKey: params.targetKey,
+      error,
+    });
+  }
+}
+
+async function notifyGateDecision(
+  env: Env,
+  params: {
+    target: ReviewTarget;
+    targetKey: string;
+    decision: GateDecision;
+    status: string;
+    scope?: DirectContentScope | null;
+    validation?: {
+      summary?: string;
+      checks?: Array<{ name: string; status: string; details?: string }>;
+    } | null;
+    pull?: {
+      title?: string;
+      html_url?: string;
+      user?: { login?: string };
+    } | null;
+  },
+) {
+  if (params.decision.verdict === "ignore") return;
+  const notificationKey = notificationKeyForDecision({
+    target: params.target,
+    decision: params.decision,
+    status: params.status,
+  });
+  try {
+    const state = await getPrState(env.SUBMISSION_GATE_DB, {
+      repo: params.target.repoFullName,
+      number: params.target.number,
+    });
+    if (String(state?.lastNotificationKey || "") === notificationKey) return;
+
+    const result = await postDiscordDecisionNotification({
+      webhookUrl: env.DISCORD_SUBMISSION_WEBHOOK_URL,
+      repoFullName: params.target.repoFullName,
+      prNumber: params.target.number,
+      prTitle: params.pull?.title,
+      prUrl:
+        params.pull?.html_url ||
+        `https://github.com/${params.target.repoFullName}/pull/${params.target.number}`,
+      author: params.pull?.user?.login,
+      verdict: params.decision.verdict,
+      category: params.scope?.category,
+      changedFile: params.scope?.filePath,
+      ciSummary: validationSummaryForNotification(params.validation),
+      summary: params.decision.summary,
+    });
+
+    if (result.ok) {
+      await markPrNotificationSent(env.SUBMISSION_GATE_DB, {
+        repo: params.target.repoFullName,
+        number: params.target.number,
+        notificationKey,
+      });
+      await insertNotificationAuditSafe(env, {
+        targetKey: params.targetKey,
+        decision: "discord_notified",
+        summary: `${params.decision.verdict} notification sent.`,
+      });
+      return;
+    }
+
+    if (!result.skipped) {
+      console.warn("submission gate discord notification failed", {
+        targetKey: params.targetKey,
+        reason: result.reason,
+        status: result.status,
+      });
+      await insertNotificationAuditSafe(env, {
+        targetKey: params.targetKey,
+        decision: "discord_notification_failed",
+        summary: `${result.reason}${result.status ? ` (${result.status})` : ""}`,
+      });
+    }
+  } catch (error) {
+    console.warn("submission gate discord notification error", {
+      targetKey: params.targetKey,
+      error,
+    });
+  }
 }
 
 async function mergeAcceptedPullRequest(params: {
@@ -1803,8 +1959,36 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       );
       if (!token) return;
       const repo = parseRepo(target.repoFullName);
+      let pullForNotification: {
+        title?: string;
+        html_url?: string;
+        user?: { login?: string };
+        head?: { sha?: string };
+      } | null = null;
+      try {
+        pullForNotification = await getPullRequest({
+          token,
+          repo,
+          number: target.number,
+          apiVersion: env.GITHUB_API_VERSION,
+        });
+        if (!target.headSha && pullForNotification.head?.sha) {
+          target.headSha = pullForNotification.head.sha;
+        }
+      } catch (error) {
+        console.warn("submission gate could not refresh PR metadata", {
+          targetKey: message.targetKey,
+          error,
+        });
+      }
       let decision: GateDecision | null = null;
       let validationForPrivateReview: unknown = null;
+      let validationForNotification:
+        | {
+            summary?: string;
+            checks?: Array<{ name: string; status: string; details?: string }>;
+          }
+        | null = null;
       let contentScopeForPrivateReview: DirectContentScope | null = null;
       const reviewability = await directContentReviewabilityForPr({
         token,
@@ -1852,6 +2036,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           requiredStatusContexts: requiredStatusContexts(env),
           apiVersion: env.GITHUB_API_VERSION,
         });
+        validationForNotification = validation;
         if (!decision && validation.state === "pending") {
           await upsertPrState(env.SUBMISSION_GATE_DB, {
             repo: target.repoFullName,
@@ -2030,6 +2215,17 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           apiVersion: env.GITHUB_API_VERSION,
         });
       }
+      if (decision.verdict !== "merge") {
+        await notifyGateDecision(env, {
+          target,
+          targetKey: message.targetKey,
+          decision,
+          status,
+          scope: contentScopeForPrivateReview,
+          validation: validationForNotification,
+          pull: pullForNotification,
+        });
+      }
       if (decision.verdict === "merge" && contentScopeForPrivateReview) {
         try {
           const mergeResult = await mergeAcceptedPullRequest({
@@ -2095,6 +2291,15 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             eventType: message.kind,
             decision: "merged",
             summary: mergedSummary,
+          });
+          await notifyGateDecision(env, {
+            target,
+            targetKey: message.targetKey,
+            decision: mergedDecision,
+            status: "merged",
+            scope: contentScopeForPrivateReview,
+            validation: validationForNotification,
+            pull: pullForNotification,
           });
         } catch (error) {
           if (isRetryableMergeError(error)) {
@@ -2175,6 +2380,15 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             eventType: message.kind,
             decision: "merge_failed",
             summary: manualDecision.summary,
+          });
+          await notifyGateDecision(env, {
+            target,
+            targetKey: message.targetKey,
+            decision: manualDecision,
+            status: "manual",
+            scope: contentScopeForPrivateReview,
+            validation: validationForNotification,
+            pull: pullForNotification,
           });
         }
       }

--- a/apps/submission-gate/src/notifications.ts
+++ b/apps/submission-gate/src/notifications.ts
@@ -1,0 +1,181 @@
+import type { GateVerdict } from "./review";
+
+export type DiscordDecisionNotification = {
+  webhookUrl?: string;
+  repoFullName: string;
+  prNumber: number;
+  prTitle?: string;
+  prUrl?: string;
+  author?: string;
+  verdict: GateVerdict;
+  category?: string;
+  changedFile?: string;
+  ciSummary?: string;
+  summary?: string;
+  now?: Date;
+};
+
+export type DiscordNotificationResult =
+  | { ok: true; skipped?: false; status?: number }
+  | { ok: false; skipped: true; reason: string }
+  | { ok: false; skipped?: false; status?: number; reason: string };
+
+const DISCORD_MAX_FIELD_LENGTH = 1024;
+const DISCORD_MAX_DESCRIPTION_LENGTH = 1800;
+const DISCORD_MAX_TITLE_LENGTH = 256;
+
+const VERDICT_LABELS: Record<GateVerdict, string> = {
+  merge: "Merged",
+  close: "Closed",
+  request_changes: "Changes requested",
+  manual: "Manual review",
+  ignore: "Ignored",
+};
+
+const VERDICT_COLORS: Record<GateVerdict, number> = {
+  merge: 0x238636,
+  close: 0xda3633,
+  request_changes: 0xfb8500,
+  manual: 0x8957e5,
+  ignore: 0x8b949e,
+};
+
+function truncate(value: unknown, limit: number) {
+  const text = String(value || "").replace(/\s+/g, " ").trim();
+  if (text.length <= limit) return text;
+  return `${text.slice(0, Math.max(0, limit - 1)).trimEnd()}...`;
+}
+
+function stripHtmlComments(value: string) {
+  let output = "";
+  let cursor = 0;
+  while (cursor < value.length) {
+    const start = value.indexOf("<!--", cursor);
+    if (start === -1) {
+      output += value.slice(cursor);
+      break;
+    }
+    output += value.slice(cursor, start);
+    const end = value.indexOf("-->", start + 4);
+    if (end === -1) break;
+    cursor = end + 3;
+  }
+  return output;
+}
+
+function sanitizeRationale(summary: unknown) {
+  const lines = String(summary || "")
+    .split(/\r?\n/)
+    .map((line) =>
+      stripHtmlComments(line)
+        .replace(/^#{1,6}\s*/, "")
+        .replace(/^[-*]\s*/, "")
+        .replace(/\*\*/g, "")
+        .replace(/`/g, "")
+        .trim(),
+    )
+    .filter(Boolean)
+    .filter((line) => !/^automated review by heyclaude/i.test(line))
+    .filter((line) => !/^---$/.test(line))
+    .slice(0, 8);
+  return truncate(lines.join("\n"), DISCORD_MAX_DESCRIPTION_LENGTH);
+}
+
+function field(name: string, value: unknown, inline = true) {
+  return {
+    name,
+    value: truncate(value || "n/a", DISCORD_MAX_FIELD_LENGTH),
+    inline,
+  };
+}
+
+function validateDiscordWebhookUrl(value: string) {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:") return null;
+  if (
+    ![
+      "discord.com",
+      "discordapp.com",
+      "canary.discord.com",
+      "ptb.discord.com",
+    ].includes(url.hostname)
+  ) {
+    return null;
+  }
+  if (!url.pathname.startsWith("/api/webhooks/")) return null;
+  return url.toString();
+}
+
+export function buildDiscordDecisionPayload(
+  notification: DiscordDecisionNotification,
+) {
+  const verdictLabel = VERDICT_LABELS[notification.verdict];
+  return {
+    username: "HeyClaude Maintainer Agent",
+    embeds: [
+      {
+        title: truncate(
+          `${verdictLabel}: #${notification.prNumber} ${notification.prTitle || ""}`,
+          DISCORD_MAX_TITLE_LENGTH,
+        ),
+        url:
+          notification.prUrl ||
+          `https://github.com/${notification.repoFullName}/pull/${notification.prNumber}`,
+        color: VERDICT_COLORS[notification.verdict],
+        description:
+          sanitizeRationale(notification.summary) ||
+          "HeyClaude submission gate completed a decision.",
+        fields: [
+          field("Verdict", verdictLabel),
+          field("Category", notification.category || "n/a"),
+          field("Author", notification.author || "n/a"),
+          field("Changed file", notification.changedFile || "n/a", false),
+          field("CI", notification.ciSummary || "n/a", false),
+          field("Repository", notification.repoFullName),
+        ],
+        footer: { text: "HeyClaude submission gate" },
+        timestamp: (notification.now || new Date()).toISOString(),
+      },
+    ],
+  };
+}
+
+export async function postDiscordDecisionNotification(
+  notification: DiscordDecisionNotification,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DiscordNotificationResult> {
+  if (notification.verdict === "ignore") {
+    return { ok: false, skipped: true, reason: "ignored_verdict" };
+  }
+  if (!notification.webhookUrl) {
+    return { ok: false, skipped: true, reason: "not_configured" };
+  }
+  const webhookUrl = validateDiscordWebhookUrl(notification.webhookUrl);
+  if (!webhookUrl) {
+    return { ok: false, skipped: true, reason: "invalid_webhook_url" };
+  }
+
+  try {
+    const response = await fetchImpl(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(buildDiscordDecisionPayload(notification)),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) {
+      return {
+        ok: false,
+        status: response.status,
+        reason: "discord_webhook_failed",
+      };
+    }
+    return { ok: true, status: response.status };
+  } catch {
+    return { ok: false, reason: "discord_webhook_error" };
+  }
+}

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -258,12 +258,27 @@ export async function getPrState(
       `SELECT repo, number, head_repo AS headRepo, head_ref AS headRef,
         base_ref AS baseRef, status, verdict, verdict_summary AS verdictSummary,
         last_delivery_id AS lastDeliveryId,
+        last_notification_key AS lastNotificationKey,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        WHERE repo = ? AND number = ?`,
     )
     .bind(params.repo, params.number)
     .first<Record<string, unknown>>();
+}
+
+export async function markPrNotificationSent(
+  db: D1Database,
+  params: { repo: string; number: number; notificationKey: string },
+) {
+  await db
+    .prepare(
+      `UPDATE submission_prs
+       SET last_notification_key = ?, updated_at = ?
+       WHERE repo = ? AND number = ?`,
+    )
+    .bind(params.notificationKey, now(), params.repo, params.number)
+    .run();
 }
 
 export async function insertAudit(

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -10,20 +10,17 @@ function runContentPolicy(
   tmpDir: string,
   content: string,
   sourceType = "same_repo_direct",
+  files = [
+    {
+      filename: "content/tools/example-tool.mdx",
+      status: "added",
+      content,
+    },
+  ],
 ) {
   const filesJson = path.join(tmpDir, "files.json");
   const outputJson = path.join(tmpDir, "policy-output.json");
-  fs.writeFileSync(
-    filesJson,
-    JSON.stringify([
-      {
-        filename: "content/tools/example-tool.mdx",
-        status: "added",
-        content,
-      },
-    ]),
-    "utf8",
-  );
+  fs.writeFileSync(filesJson, JSON.stringify(files), "utf8");
 
   const args = [
     path.join(repoRoot, "scripts/ci/validate-content-policy.mjs"),
@@ -230,6 +227,117 @@ Example body.
     expect(output.failures).toEqual(
       expect.arrayContaining([
         expect.stringContaining("affiliate_referral_url"),
+      ]),
+    );
+  });
+
+  it("fails direct content PRs with category/path mismatch", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example Guide
+category: tools
+description: Example mismatched category fixture.
+sourceUrl: https://github.com/example/example-guide
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/guides/example-guide.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("category_path_mismatch"),
+      ]),
+    );
+  });
+
+  it("fails external content PRs that set packageVerified", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example MCP
+category: mcp
+description: Example package verification abuse fixture.
+sourceUrl: https://github.com/example/example-mcp
+packageVerified: true
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("unsafe_package_verified_true"),
+      ]),
+    );
+  });
+
+  it("fails external content PRs that edit generated artifacts", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example Tool
+category: tools
+description: Example generated artifact fixture.
+sourceUrl: https://github.com/example/example-tool
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "added",
+        content,
+      },
+      {
+        filename: "apps/web/public/data/directory.json",
+        status: "modified",
+        content: "{}",
+      },
+      {
+        filename: "README.md",
+        status: "modified",
+        content: "# Edited README\n",
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("generated_registry_artifact_change"),
+        expect.stringContaining("generated_readme_change"),
       ]),
     );
   });

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -24,6 +24,10 @@ import {
   protectedFrontmatterChanges,
 } from "../apps/submission-gate/src/duplicates";
 import { markerComment } from "../apps/submission-gate/src/review";
+import {
+  buildDiscordDecisionPayload,
+  postDiscordDecisionNotification,
+} from "../apps/submission-gate/src/notifications";
 import { repoRoot } from "./helpers/registry-fixtures";
 
 function readWorkerSource() {
@@ -32,6 +36,19 @@ function readWorkerSource() {
     "utf8",
   );
 }
+
+const SUPPORTED_DIRECT_CONTENT_CATEGORIES = [
+  "agents",
+  "collections",
+  "commands",
+  "guides",
+  "hooks",
+  "mcp",
+  "rules",
+  "skills",
+  "statuslines",
+  "tools",
+];
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -139,6 +156,37 @@ describe("Cloudflare submission gate helpers", () => {
       "Useful source-backed skill.\n\n## Safety\n\nReview scripts before running.",
     );
   });
+
+  it.each(SUPPORTED_DIRECT_CONTENT_CATEGORIES)(
+    "builds a one-file direct content draft for %s",
+    (category) => {
+      const target = buildDraftTarget(
+        { category, name: `${category} direct fixture` },
+        "main",
+      );
+      const mdx = buildContributorMdx(
+        {
+          category,
+          name: `${category} direct fixture`,
+          description:
+            "Source-backed direct submission fixture for category coverage.",
+          github_url: `https://github.com/example/${category}-direct-fixture`,
+          safety_notes: "Review source provenance before use.",
+          privacy_notes: "Review third-party data handling before use.",
+        },
+        "JSONbored",
+      );
+
+      expect(target.targetPath).toBe(
+        `content/${category}/${category}-direct-fixture.mdx`,
+      );
+      expect(mdx).toContain(`category: "${category}"`);
+      expect(mdx).toContain('submittedBy: "@JSONbored"');
+      expect(mdx).toContain("submittedByUrl: \"https://github.com/JSONbored\"");
+      expect(mdx).not.toContain("README.md");
+      expect(mdx).not.toContain("apps/web/public/data");
+    },
+  );
 
   it("preserves multiline copy snippets as YAML block scalars", () => {
     const mdx = buildContributorMdx({
@@ -300,6 +348,82 @@ describe("Cloudflare submission gate helpers", () => {
     expect(body).toContain("merges accepted source PRs directly");
   });
 
+  it("formats Discord decision notifications without marker or secret text", () => {
+    const payload = buildDiscordDecisionPayload({
+      repoFullName: "JSONbored/awesome-claude",
+      prNumber: 700,
+      prTitle: "feat(content): add useful guide",
+      prUrl: "https://github.com/JSONbored/awesome-claude/pull/700",
+      author: "JSONbored",
+      verdict: "close",
+      category: "guides",
+      changedFile: "content/guides/useful-guide.mdx",
+      ciSummary:
+        "validate-content passed; Superagent Security Scan passed",
+      summary: [
+        "<!-- heyclaude-submission-gate -->",
+        "Summary:",
+        "- Closed because the submission reused an existing source URL.",
+      ].join("\n"),
+      now: new Date("2026-06-02T00:00:00.000Z"),
+    });
+
+    expect(payload.username).toBe("HeyClaude Maintainer Agent");
+    expect(payload.embeds[0]).toMatchObject({
+      title: "Closed: #700 feat(content): add useful guide",
+      url: "https://github.com/JSONbored/awesome-claude/pull/700",
+      color: 0xda3633,
+      timestamp: "2026-06-02T00:00:00.000Z",
+    });
+    expect(JSON.stringify(payload)).toContain("validate-content passed");
+    expect(JSON.stringify(payload)).not.toContain(
+      "<!-- heyclaude-submission-gate -->",
+    );
+  });
+
+  it("keeps Discord notifications optional and non-blocking", async () => {
+    await expect(
+      postDiscordDecisionNotification({
+        repoFullName: "JSONbored/awesome-claude",
+        prNumber: 700,
+        verdict: "merge",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      skipped: true,
+      reason: "not_configured",
+    });
+
+    await expect(
+      postDiscordDecisionNotification(
+        {
+          webhookUrl: "https://discord.com/api/webhooks/123/token",
+          repoFullName: "JSONbored/awesome-claude",
+          prNumber: 700,
+          verdict: "close",
+        },
+        vi.fn().mockResolvedValue(new Response("", { status: 503 })),
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 503,
+      reason: "discord_webhook_failed",
+    });
+
+    await expect(
+      postDiscordDecisionNotification({
+        webhookUrl: "https://discord.com/api/webhooks/123/token",
+        repoFullName: "JSONbored/awesome-claude",
+        prNumber: 700,
+        verdict: "ignore",
+      }),
+    ).resolves.toEqual({
+      ok: false,
+      skipped: true,
+      reason: "ignored_verdict",
+    });
+  });
+
   it("reconciles old verdict labels before applying a new gate decision", () => {
     const source = readWorkerSource();
     const removeIndex = source.indexOf("await removeLabels({");
@@ -373,6 +497,37 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("SubmissionMergePendingError");
     expect(source).toContain('decision: "merge_pending"');
     expect(source).toContain("message.retry({ delaySeconds: 30 })");
+  });
+
+  it("closes direct content PRs when required validation fails", () => {
+    const source = readWorkerSource();
+    const validationBlock =
+      source.match(
+        /function validationGateDecision[\s\S]*?\nfunction validationSummaryForNotification/,
+      )?.[0] || "";
+
+    expect(source).not.toContain("validationFailedDecision");
+    expect(validationBlock).toContain('verdict: "close"');
+    expect(validationBlock).toContain(
+      "hard validation failures are closed instead of iterated in place",
+    );
+    expect(validationBlock).toContain("Superagent did not pass");
+    expect(validationBlock).toContain("Superagent did not return a clear");
+  });
+
+  it("notifies Discord only after actionable gate decisions", () => {
+    const source = readWorkerSource();
+    const ignoreBlock =
+      source.match(
+        /if \(reviewability.kind === "ignore"\) \{[\s\S]*?return;\n      \}/,
+      )?.[0] || "";
+
+    expect(source).toContain("DISCORD_SUBMISSION_WEBHOOK_URL");
+    expect(source).toContain("postDiscordDecisionNotification({");
+    expect(source).toContain("markPrNotificationSent");
+    expect(source).toContain('eventType: "discord_notification"');
+    expect(source).toContain('if (params.decision.verdict === "ignore")');
+    expect(ignoreBlock).not.toContain("notifyGateDecision");
   });
 
   it("keeps one-shot gate verdicts from being overwritten by later check events", () => {


### PR DESCRIPTION
## Summary
- makes direct content validation failures close in one shot instead of waiting for author iteration
- adds optional Discord decision notifications for submission gate merge/close/manual/request-changes outcomes
- records the last Discord notification key per PR to avoid retry/check-event spam
- expands regression coverage for category drafts, Discord payloads, and adversarial content policy cases

## What changed
- Adds a submission gate Discord notification helper with Discord-host validation and non-blocking failure handling.
- Adds D1 migration 0008 for per-PR notification idempotency state.
- Keeps ignored non-content PRs silent while terminal gate decisions can notify your private channel.
- Adds tests for all supported content categories, hard validation close behavior, generated artifact rejection, category mismatch, packageVerified abuse, and notification formatting/failure behavior.

## Why
The content gate is live, but it needed stronger fail-closed behavior and operator visibility before running the wider live adversarial PR matrix.

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts tests/content-policy-validation.test.ts tests/submission-intake.test.ts tests/classify-pr-changes.test.ts
- pnpm validate:content:strict
- pnpm validate:openapi
- pnpm submission-gate:dry-run
- pnpm build
- git diff --check

## Notes
- Deploy requires applying the new submission-gate D1 migration before the updated Worker relies on notification idempotency.
- Discord notifications require setting the Cloudflare Worker secret DISCORD_SUBMISSION_WEBHOOK_URL. The gate still works without it; notifications are skipped until configured.
- Build-time generated registry artifacts were validated but are intentionally not committed in this PR.