### PR TITLE
fix(submissions): enforce one-shot terminal gate decisions

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -140,7 +140,7 @@ const GATE_VERDICTS = new Set<GateVerdict>([
   "manual",
   "ignore",
 ]);
-const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
+const TERMINAL_GATE_VERDICTS = new Set(["merge", "close", "manual", "ignore"]);
 const SUPPORTED_CONTENT_CATEGORIES = new Set([
   "agents",
   "collections",
@@ -1191,7 +1191,18 @@ async function notifyGateDecision(
       repo: params.target.repoFullName,
       number: params.target.number,
     });
-    if (String(state?.lastNotificationKey || "") === notificationKey) return;
+    const lastNotificationKey = String(state?.lastNotificationKey || "");
+    if (lastNotificationKey === notificationKey) return;
+    const headSha = params.target.headSha || "unknown";
+    if (headSha !== "unknown" && lastNotificationKey.startsWith(`${headSha}:`)) {
+      await insertNotificationAuditSafe(env, {
+        targetKey: params.targetKey,
+        decision: "discord_notification_skipped",
+        summary:
+          "Skipped Discord notification because this PR head already has a terminal gate notification.",
+      });
+      return;
+    }
 
     const result = await postDiscordDecisionNotification({
       webhookUrl: env.DISCORD_SUBMISSION_WEBHOOK_URL,
@@ -1543,7 +1554,7 @@ async function enqueueReviewTarget(
     repo: target.repoFullName,
     number: target.number,
   });
-  if (!forceRecheck && hasTerminalGateDecision(existing)) return false;
+  if (hasTerminalGateDecision(existing)) return false;
   await upsertPrState(env.SUBMISSION_GATE_DB, {
     repo: target.repoFullName,
     number: target.number,
@@ -1942,14 +1953,16 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         repo: target.repoFullName,
         number: target.number,
       });
-      if (!forceRecheck && hasTerminalGateDecision(existing)) {
+      if (hasTerminalGateDecision(existing)) {
         await insertAudit(env.SUBMISSION_GATE_DB, {
           id: crypto.randomUUID(),
           targetKey: message.targetKey,
           eventType: message.kind,
           decision: "ignored",
           summary:
-            "Skipped because this submission already has a terminal gate decision.",
+            forceRecheck
+              ? "Skipped trusted recheck because this submission already has a terminal gate decision."
+              : "Skipped because this submission already has a terminal gate decision.",
         });
         return;
       }

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -526,6 +526,11 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("postDiscordDecisionNotification({");
     expect(source).toContain("markPrNotificationSent");
     expect(source).toContain('eventType: "discord_notification"');
+    expect(source).toContain("lastNotificationKey.startsWith(`${headSha}:`)");
+    expect(source).toContain("discord_notification_skipped");
+    expect(source).toContain(
+      "Skipped Discord notification because this PR head already has a terminal gate notification.",
+    );
     expect(source).toContain('if (params.decision.verdict === "ignore")');
     expect(ignoreBlock).not.toContain("notifyGateDecision");
   });
@@ -541,6 +546,7 @@ describe("Cloudflare submission gate helpers", () => {
       "await upsertPrState(env.SUBMISSION_GATE_DB",
       enqueueIndex,
     );
+    const enqueueBlock = source.slice(enqueueIndex, enqueueWriteIndex);
     const reviewIndex = source.indexOf('if (message.kind === "review_pr")');
     const reviewReadIndex = source.indexOf(
       "getPrState(env.SUBMISSION_GATE_DB",
@@ -550,6 +556,7 @@ describe("Cloudflare submission gate helpers", () => {
       "getCommitValidationState({",
       reviewIndex,
     );
+    const reviewBlock = source.slice(reviewIndex, validationIndex);
     const terminalSetIndex = source.indexOf("const TERMINAL_GATE_VERDICTS");
     const terminalSetEndIndex = source.indexOf("]);", terminalSetIndex);
     const terminalSetBlock = source.slice(
@@ -560,7 +567,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("const TERMINAL_GATE_VERDICTS = new Set");
     expect(source).toContain("function hasTerminalGateDecision");
     expect(terminalSetBlock).not.toContain('"request_changes"');
-    expect(terminalSetBlock).not.toContain('"merge"');
+    expect(terminalSetBlock).toContain('"merge"');
     expect(terminalSetBlock).not.toContain('"import"');
     expect(source).toContain("forceRecheck = false");
     expect(source).toContain(
@@ -572,6 +579,17 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('String(state.status || "") === "merged"');
     expect(source).toContain(
       "Skipped because this submission already has a terminal gate decision.",
+    );
+    expect(source).toContain(
+      "Skipped trusted recheck because this submission already has a terminal gate decision.",
+    );
+    expect(enqueueBlock).toContain("if (hasTerminalGateDecision(existing))");
+    expect(reviewBlock).toContain("if (hasTerminalGateDecision(existing))");
+    expect(enqueueBlock).not.toContain(
+      "if (!forceRecheck && hasTerminalGateDecision(existing))",
+    );
+    expect(reviewBlock).not.toContain(
+      "if (!forceRecheck && hasTerminalGateDecision(existing))",
     );
     expect(enqueueReadIndex).toBeGreaterThan(enqueueIndex);
     expect(enqueueWriteIndex).toBeGreaterThan(enqueueReadIndex);


### PR DESCRIPTION
## Summary
- treat merged content PRs as terminal gate decisions
- prevent maintainer /recheck from reprocessing terminal PRs
- suppress additional Discord notifications for the same PR head SHA once a terminal notification has been sent

## Why
- the content gate is one-shot; a closed or merged PR should not be retried into contradictory decisions
- Discord should show one actionable terminal outcome per submission head, not repair-cycle noise

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts
- pnpm submission-gate:dry-run
- git diff --check
