### PR TITLE
fix(submissions): keep merge-pending reviews retryable

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -140,7 +140,7 @@ const GATE_VERDICTS = new Set<GateVerdict>([
   "manual",
   "ignore",
 ]);
-const TERMINAL_GATE_VERDICTS = new Set(["merge", "close", "manual", "ignore"]);
+const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
 const SUPPORTED_CONTENT_CATEGORIES = new Set([
   "agents",
   "collections",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -567,7 +567,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("const TERMINAL_GATE_VERDICTS = new Set");
     expect(source).toContain("function hasTerminalGateDecision");
     expect(terminalSetBlock).not.toContain('"request_changes"');
-    expect(terminalSetBlock).toContain('"merge"');
+    expect(terminalSetBlock).not.toContain('"merge"');
     expect(terminalSetBlock).not.toContain('"import"');
     expect(source).toContain("forceRecheck = false");
     expect(source).toContain(
@@ -577,6 +577,7 @@ describe("Cloudflare submission gate helpers", () => {
       'String(message.payload.eventName || "") === "issue_comment"',
     );
     expect(source).toContain('String(state.status || "") === "merged"');
+    expect(source).toContain('status: "merge_accepted"');
     expect(source).toContain(
       "Skipped because this submission already has a terminal gate decision.",
     );


### PR DESCRIPTION
### Motivation
- A recent change treated a stored `verdict: "merge"` as terminal which caused PRs recorded as `status: "merge_accepted"` to be considered final even when the direct merge had not completed, preventing retries and later rechecks.
- This can leave PRs in an accepted-but-not-merged state with stale approvals and block recovery from transient merge failures, harming registry integrity.

### Description
- Remove `"merge"` from `TERMINAL_GATE_VERDICTS` so only an actual `status: "merged"` is treated as a final merge state in `apps/submission-gate/src/index.ts`.
- Update the worker regression test `tests/submission-gate-worker.test.ts` to assert that `"merge"` is not considered terminal and to expect `status: "merge_accepted"` for pending merges.
- Keep existing behavior where `close`, `manual`, and `ignore` remain terminal one-shot decisions.

### Testing
- Ran `./node_modules/.bin/vitest run tests/submission-gate-worker.test.ts` and the test file passed (46 tests passed).
- Ran `git diff --check` to validate formatting and there were no errors.
- Attempted `pnpm exec vitest run tests/submission-gate-worker.test.ts` but the environment's pnpm supply-chain verification retried registry requests, so the local Vitest binary was used instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f54725360832ca1b20b606634d482)