### PR TITLE
fix(submissions): paginate gate PR file scans

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,15 @@ Use the website form:
 
 - [heyclau.de/submit](https://heyclau.de/submit)
 
-This runs public preflight checks, asks you to continue with GitHub, then opens a focused PR with exactly one raw `content/<category>/<slug>.mdx` file. Fully valid, source-backed, non-artifact submissions may be copied into a maintainer-owned import PR after the private gate passes. Automation does not auto-merge.
+This runs public preflight checks, asks you to continue with GitHub, then opens a focused PR with exactly one raw `content/<category>/<slug>.mdx` file targeting `main`. Fully valid, source-backed, non-artifact submissions may be merged directly after content validation, Superagent, and private maintainer-agent review pass.
 
-The private gate can close hard failures, request changes for fixable gaps, route high-risk entries to manual review, or open a maintainer-owned import PR for deterministic low-risk passes. `main` remains maintainer-merge only.
+The private gate can close hard failures, request changes for fixable gaps, route rare high-risk or inconclusive entries to manual review, or merge deterministic low-risk passes. This automation is limited to single-entry content PRs; platform, workflow, package, and product PRs remain maintainer-reviewed.
 
 No CLA signature is required. Repo checks focus on submission quality, source verification, contributor trust, and security review.
 
 ### 2. Open a direct PR
 
-Direct PRs are the advanced path. Edit source content under `content/<category>/`, keep the PR focused on one entry, and target the current submission base during pilot.
+Direct PRs are the advanced path. Edit source content under `content/<category>/`, keep the PR focused on one entry, and target `main`.
 
 Keep submissions concrete. Include canonical source URLs, docs, install/config details, and enough context for someone else to verify the entry.
 

--- a/apps/submission-gate/src/constants.ts
+++ b/apps/submission-gate/src/constants.ts
@@ -10,6 +10,7 @@ export const PILOT_LABEL = "submission-gate-pilot";
 export const CONTENT_CATEGORY_LABEL_PREFIX = "category:";
 
 type ReviewablePrAction =
+  | "edited"
   | "opened"
   | "synchronize"
   | "reopened"
@@ -17,6 +18,7 @@ type ReviewablePrAction =
 
 export const REVIEWABLE_PR_ACTIONS: ReadonlySet<string> =
   new Set<ReviewablePrAction>([
+    "edited",
     "opened",
     "synchronize",
     "reopened",

--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -290,22 +290,30 @@ export async function listPullRequestFiles(params: {
   number: number;
   apiVersion?: string;
 }) {
-  return githubJson<
-    Array<{
-      filename?: string;
-      status?: string;
-      raw_url?: string;
-      additions?: number;
-      deletions?: number;
-      changes?: number;
-    }>
-  >(
-    `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/pulls/${params.number}/files?per_page=100`,
-    {
-      token: params.token,
-      apiVersion: params.apiVersion,
-    },
-  );
+  type PullRequestFile = {
+    filename?: string;
+    status?: string;
+    raw_url?: string;
+    additions?: number;
+    deletions?: number;
+    changes?: number;
+  };
+  const files: PullRequestFile[] = [];
+  const perPage = 100;
+
+  for (let page = 1; page <= 30; page += 1) {
+    const pageFiles = await githubJson<PullRequestFile[]>(
+      `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/pulls/${params.number}/files?per_page=${perPage}&page=${page}`,
+      {
+        token: params.token,
+        apiVersion: params.apiVersion,
+      },
+    );
+    files.push(...pageFiles);
+    if (pageFiles.length < perPage) break;
+  }
+
+  return files;
 }
 
 export async function getRepositoryFileContent(params: {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -11,6 +11,7 @@ import {
   buildGitHubAppAuthorizeUrl,
   createGitHubAppJwt,
   getCommitValidationState,
+  listPullRequestFiles,
 } from "../apps/submission-gate/src/github";
 import {
   decryptText,
@@ -33,6 +34,13 @@ import { repoRoot } from "./helpers/registry-fixtures";
 function readWorkerSource() {
   return fs.readFileSync(
     path.join(repoRoot, "apps/submission-gate/src/index.ts"),
+    "utf8",
+  );
+}
+
+function readConstantsSource() {
+  return fs.readFileSync(
+    path.join(repoRoot, "apps/submission-gate/src/constants.ts"),
     "utf8",
   );
 }
@@ -107,6 +115,37 @@ describe("Cloudflare submission gate helpers", () => {
       branchName: "heyclaude/submit-mcp-example-mcp-server",
       targetPath: "content/mcp/example-mcp-server.mdx",
     });
+  });
+
+  it("paginates GitHub pull request files before classifying content scope", async () => {
+    const firstPage = Array.from({ length: 100 }, (_, index) => ({
+      filename: `apps/web/public/data/generated-${index}.json`,
+      status: "modified",
+    }));
+    const secondPage = [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "added",
+        raw_url: "https://raw.githubusercontent.com/example/tool.mdx",
+      },
+    ];
+    const fetchMock = vi.fn(async (url: URL | RequestInfo) => {
+      const value = String(url);
+      return Response.json(value.includes("page=2") ? secondPage : firstPage);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      listPullRequestFiles({
+        token: "ghs_test",
+        repo: { owner: "JSONbored", repo: "awesome-claude" },
+        number: 822,
+      }),
+    ).resolves.toHaveLength(101);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("page=1");
+    expect(String(fetchMock.mock.calls[1][0])).toContain("page=2");
   });
 
   it("caps generated branch names while keeping the full target slug", () => {
@@ -280,6 +319,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"check_run"');
     expect(source).toContain('"check_suite"');
     expect(source).toContain('"status"');
+    expect(readConstantsSource()).toContain('"edited"');
     expect(source).toContain('status: "validation_pending"');
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");


### PR DESCRIPTION
## Summary
- paginate submission-gate PR file scans so generated-artifact churn cannot hide a source content file after GitHub's first 100 changed files
- treat pull request base edits as reviewable gate events
- update contributor docs to target `main` and describe direct content merges

## Why
Some fork content PRs were delivered to the Worker but ignored: pilot-base PRs were outside the production `main` scope, and high-churn main PRs placed the source content file beyond the first GitHub files page. The deployed Worker hotfix now sees the full PR diff and processes base-retarget events.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `pnpm validate:openapi`
- `git diff --check`

## Notes
- Production Worker has already been deployed with this hotfix.
- Missed PRs #819, #820, #821, and #822 were reprocessed; all were closed for generated-artifact/multi-file submission scope failures.
