### PR TITLE
fix(registry): reject executable frontmatter in content-builder index build

### DIFF
--- a/packages/registry/src/content-builder.js
+++ b/packages/registry/src/content-builder.js
@@ -13,6 +13,20 @@ import {
 } from "./content-schema.js";
 import { buildBrandAssetMetadata } from "./brand-assets.js";
 
+const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
+  "Executable JavaScript frontmatter is not allowed in registry content";
+
+// Reject executable `---js` frontmatter instead of letting gray-matter's
+// JavaScript engine run untrusted submitted code during the content index
+// build. Mirrors the guard added for sibling parsers in #612. See #620.
+const SAFE_MATTER_OPTIONS = {
+  engines: {
+    javascript() {
+      throw new Error(UNSAFE_FRONTMATTER_LANGUAGE_ERROR);
+    },
+  },
+};
+
 export const DEFAULT_DIRECTORY_REPO_URL =
   "https://github.com/JSONbored/awesome-claude";
 
@@ -210,7 +224,7 @@ export function buildContentEntryFromMdx(params) {
     contentUpdatedAt,
     getLocalDownloadSha256 = () => null,
   } = params;
-  const { data, content } = matter(source);
+  const { data, content } = matter(source, SAFE_MATTER_OPTIONS);
   const body = normalizeBody(content, category);
   const headings = extractHeadings(body);
   const codeBlocks = extractCodeBlocks(body);

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -635,6 +635,37 @@ Use this hook after reviewing the notes.`,
     expect(renderEntryLlms(entry)).toContain("## Privacy Notes");
   });
 
+  it("rejects executable JavaScript frontmatter without executing it", () => {
+    // gray-matter's default `javascript` engine executes `---js` frontmatter.
+    // Use a unique global as an execution sentinel: with the SAFE_MATTER_OPTIONS
+    // guard, parsing must throw before the body runs, so the sentinel stays false.
+    const sentinel = `__heyclaudeFrontmatterExecuted_${process.pid}_${Date.now()}`;
+    globalThis[sentinel] = false;
+    const source = [
+      "---js",
+      `globalThis[${JSON.stringify(sentinel)}] = true;`,
+      'module.exports = { title: "Pwned", slug: "pwned", category: "hooks" };',
+      "---",
+      "Body content.",
+    ].join("\n");
+
+    try {
+      expect(() =>
+        buildContentEntryFromMdx({
+          category: "hooks",
+          fileName: "malicious.mdx",
+          filePath: path.join(repoRoot, "content/hooks/malicious.mdx"),
+          repoRoot,
+          contentRoot: path.join(repoRoot, "content"),
+          source,
+        }),
+      ).toThrow(/Executable JavaScript frontmatter is not allowed/);
+      expect(globalThis[sentinel]).toBe(false);
+    } finally {
+      delete globalThis[sentinel];
+    }
+  });
+
   it("deduplicates repeated JSON-LD values while preserving order", () => {
     const [snapshot] = buildJsonLdSnapshots([
       {


### PR DESCRIPTION
Closes #620

Harden the content index builder so executable `---js` frontmatter can no longer run during `buildContentEntryFromMdx`. Mirrors the guard #612 added to the sibling parsers (`submission-risk.js`, `validate-content-policy.mjs`); `content-builder.js` was the one parser it missed.

## Changes
- `packages/registry/src/content-builder.js`: add a local `SAFE_MATTER_OPTIONS` with a throwing `javascript` engine (same pattern as #612), and parse with `matter(source, SAFE_MATTER_OPTIONS)`. `---js` frontmatter now throws instead of executing; YAML parsing is unchanged.
- `tests/registry-artifacts.test.ts`: focused test asserting `---js` frontmatter is rejected (throws) and never executes — a `globalThis` sentinel set inside the frontmatter body stays `false`.

## Quality evidence
- Changed function: `buildContentEntryFromMdx`.
- Invariant: frontmatter parsing must never execute submitted JavaScript.
- Backward compatibility: YAML frontmatter behavior is unchanged.
- No visual impact (registry build logic only).

## Validation (Node 22, local)
- `pnpm exec vitest run tests/registry-artifacts.test.ts` — 37 passed
- `pnpm test:registry-artifacts` — 37 passed
- `pnpm build` — clean
- `git diff --check` — clean

Confirmed against gray-matter 4.0.3 that the default `javascript` engine executes `---js` unguarded, and that the guard both throws and prevents execution.