### PR TITLE
fix(submissions): limit edited PR rescans

### DIFF
--- a/apps/submission-gate/migrations/0009_submission_pr_review_dedupe.sql
+++ b/apps/submission-gate/migrations/0009_submission_pr_review_dedupe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE submission_prs
+  ADD COLUMN last_review_key TEXT;

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -694,6 +694,61 @@ function installationIdFromPayload(payload: Record<string, unknown>) {
   return Number((payload.installation as { id?: number } | undefined)?.id || 0);
 }
 
+function editedPayloadHasBaseRefChange(payload: Record<string, unknown>) {
+  const changes = payload.changes;
+  if (!isRecord(changes) || !isRecord(changes.base)) return false;
+  const refChange = changes.base.ref;
+  return isRecord(refChange) && typeof refChange.from === "string";
+}
+
+function isReviewablePullRequestPayload(payload: Record<string, unknown>) {
+  const action = String(payload.action || "");
+  if (!REVIEWABLE_PR_ACTIONS.has(action)) return false;
+  if (action !== "edited") return true;
+  return editedPayloadHasBaseRefChange(payload);
+}
+
+function reviewScanKeyForTarget(target: ReviewTarget) {
+  return target.headSha
+    ? `${target.headSha}:${target.baseRef || "unknown-base"}`
+    : "";
+}
+
+async function recordReviewedScanKey(
+  env: Env,
+  target: ReviewTarget,
+  deliveryId: string,
+  status: string,
+) {
+  const reviewScanKey = reviewScanKeyForTarget(target);
+  if (!reviewScanKey) return;
+  await upsertPrState(env.SUBMISSION_GATE_DB, {
+    repo: target.repoFullName,
+    number: target.number,
+    headRepo: target.headRepo,
+    headRef: target.headRef,
+    baseRef: target.baseRef || env.PILOT_BASE_REF,
+    status,
+    deliveryId,
+    lastReviewKey: reviewScanKey,
+  });
+}
+
+async function shouldInspectPullRequestFilesForWebhook(
+  env: Env,
+  target: ReviewTarget,
+) {
+  const existing = await getPrState(env.SUBMISSION_GATE_DB, {
+    repo: target.repoFullName,
+    number: target.number,
+  });
+  if (hasTerminalGateDecision(existing)) return false;
+  const reviewScanKey = reviewScanKeyForTarget(target);
+  return (
+    !reviewScanKey || String(existing?.lastReviewKey || "") !== reviewScanKey
+  );
+}
+
 function reviewTargetFromPullPayload(
   payload: Record<string, unknown>,
 ): ReviewTarget | null {
@@ -1563,6 +1618,7 @@ async function enqueueReviewTarget(
     baseRef: target.baseRef || env.PILOT_BASE_REF,
     status: "queued",
     deliveryId,
+    lastReviewKey: reviewScanKeyForTarget(target) || undefined,
   });
   await env.SUBMISSION_REVIEW_QUEUE.send({
     kind: "review_pr",
@@ -1722,18 +1778,25 @@ async function githubWebhookRoute(
   );
 
   if (eventName === "pull_request") {
-    const action = String(payload.action || "");
     const target = reviewTargetFromPullPayload(payload);
-    if (!REVIEWABLE_PR_ACTIONS.has(action) || !target) {
+    if (!isReviewablePullRequestPayload(payload) || !target) {
       return json({ ok: true, ignored: true });
     }
     if (!isPilotPr(payload, env))
       return json({ ok: true, ignored: true, reason: "outside_pilot" });
+    const shouldInspect = await shouldInspectPullRequestFilesForWebhook(
+      env,
+      target,
+    );
+    if (!shouldInspect) {
+      return json({ ok: true, ignored: true, reason: "already_reviewed" });
+    }
     const reviewability = await directContentReviewabilityForTarget(
       env,
       target,
     );
     if (reviewability.kind === "ignore") {
+      await recordReviewedScanKey(env, target, deliveryId, "ignore");
       return json({ ok: true, ignored: true, reason: reviewability.reason });
     }
     const reviewScope =

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -215,14 +215,15 @@ export async function upsertPrState(
     verdict?: string;
     verdictSummary?: string;
     deliveryId?: string;
+    lastReviewKey?: string;
   },
 ) {
   const timestamp = now();
   await db
     .prepare(
       `INSERT INTO submission_prs
-        (repo, number, head_repo, head_ref, base_ref, status, verdict, verdict_summary, last_delivery_id, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (repo, number, head_repo, head_ref, base_ref, status, verdict, verdict_summary, last_delivery_id, last_review_key, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo, number) DO UPDATE SET
         head_repo = COALESCE(excluded.head_repo, submission_prs.head_repo),
         head_ref = COALESCE(excluded.head_ref, submission_prs.head_ref),
@@ -231,6 +232,7 @@ export async function upsertPrState(
         verdict = COALESCE(excluded.verdict, submission_prs.verdict),
         verdict_summary = COALESCE(excluded.verdict_summary, submission_prs.verdict_summary),
         last_delivery_id = COALESCE(excluded.last_delivery_id, submission_prs.last_delivery_id),
+        last_review_key = COALESCE(excluded.last_review_key, submission_prs.last_review_key),
         updated_at = excluded.updated_at`,
     )
     .bind(
@@ -243,6 +245,7 @@ export async function upsertPrState(
       params.verdict ?? null,
       params.verdictSummary ?? null,
       params.deliveryId ?? null,
+      params.lastReviewKey ?? null,
       timestamp,
       timestamp,
     )
@@ -258,6 +261,7 @@ export async function getPrState(
       `SELECT repo, number, head_repo AS headRepo, head_ref AS headRef,
         base_ref AS baseRef, status, verdict, verdict_summary AS verdictSummary,
         last_delivery_id AS lastDeliveryId,
+        last_review_key AS lastReviewKey,
         last_notification_key AS lastNotificationKey,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -320,6 +320,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"check_suite"');
     expect(source).toContain('"status"');
     expect(readConstantsSource()).toContain('"edited"');
+    expect(source).toContain("function editedPayloadHasBaseRefChange");
+    expect(source).toContain('if (action !== "edited") return true;');
+    expect(source).toContain("return editedPayloadHasBaseRefChange(payload);");
     expect(source).toContain('status: "validation_pending"');
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
@@ -488,14 +491,25 @@ describe("Cloudflare submission gate helpers", () => {
       pullRequestIndex,
       source.indexOf('if (eventName === "issue_comment")', pullRequestIndex),
     );
+    const inspectIndex = pullRequestBlock.indexOf(
+      "shouldInspectPullRequestFilesForWebhook(",
+    );
     const classifyIndex = pullRequestBlock.indexOf(
       "directContentReviewabilityForTarget(",
     );
     const applyIndex = pullRequestBlock.indexOf("applyUnderReviewToTarget");
 
     expect(source).toContain('reason: "No source content entry file changed."');
+    expect(source).toContain("function recordReviewedScanKey");
+    expect(source).toContain(
+      "function shouldInspectPullRequestFilesForWebhook",
+    );
+    expect(source).toContain(
+      'String(existing?.lastReviewKey || "") !== reviewScanKey',
+    );
     expect(pullRequestBlock).toContain('reviewability.kind === "ignore"');
-    expect(classifyIndex).toBeGreaterThan(0);
+    expect(inspectIndex).toBeGreaterThan(0);
+    expect(classifyIndex).toBeGreaterThan(inspectIndex);
     expect(applyIndex).toBeGreaterThan(classifyIndex);
   });
 


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled PR title/body `edited` events from triggering costly, paginated file scans and repeated work by the submission gate. 
- Avoid repeated GitHub API consumption and queue pressure by deduplicating scans for the same PR revision.

### Description
- Only treat `pull_request.edited` as reviewable when the webhook `payload.changes` contains a `base.ref` transition by adding `editedPayloadHasBaseRefChange` and `isReviewablePullRequestPayload` and using that guard in the webhook route. 
- Add a review-scan dedupe key derived from `headSha` and `baseRef` with `reviewScanKeyForTarget`, persist it in PR state (`lastReviewKey`), and skip repeated inspections via `shouldInspectPullRequestFilesForWebhook`. 
- Record scan keys for queued/ignored outcomes with `recordReviewedScanKey` and write the key into `enqueueReviewTarget`/`upsertPrState` so subsequent identical webhooks are ignored. 
- Persist schema update: add D1 migration `apps/submission-gate/migrations/0009_submission_pr_review_dedupe.sql` to add `last_review_key TEXT`. 
- Update tests to assert the edited-event guard and pre-scan dedupe behavior in `tests/submission-gate-worker.test.ts`.

### Testing
- Ran the focused unit suite with `PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false pnpm exec vitest run tests/submission-gate-worker.test.ts`, and the test file `tests/submission-gate-worker.test.ts` passed (47 tests passed). 
- Verified repository hygiene with `git diff --check` with no errors. 
- Note: an initial `pnpm` dependency-verification step against the registry failed due to transient network/registry fetch issues, so the vitest run above was executed with dependency verification disabled to exercise the updated tests and validate the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fab122fa0832c858803fdfe316104)