### PR TITLE
fix(submissions): dedupe content gate rescans

### DIFF
--- a/apps/submission-gate/migrations/0010_submission_pr_review_dedupe.sql
+++ b/apps/submission-gate/migrations/0010_submission_pr_review_dedupe.sql
@@ -1,0 +1,2 @@
+ALTER TABLE submission_prs
+  ADD COLUMN last_review_key TEXT;

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -290,6 +290,7 @@ type PrQueueState = Record<string, unknown> & {
   installationId?: number;
   status?: string;
   verdict?: string;
+  lastReviewKey?: string;
   updatedAt?: string;
 };
 
@@ -848,6 +849,72 @@ function requiredStatusContexts(env: Env) {
 
 function installationIdFromPayload(payload: Record<string, unknown>) {
   return Number((payload.installation as { id?: number } | undefined)?.id || 0);
+}
+
+function editedPayloadHasBaseRefChange(payload: Record<string, unknown>) {
+  const changes = payload.changes;
+  if (!isRecord(changes) || !isRecord(changes.base)) return false;
+  const refChange = changes.base.ref;
+  return isRecord(refChange) && typeof refChange.from === "string";
+}
+
+function isReviewablePullRequestPayload(payload: Record<string, unknown>) {
+  const action = String(payload.action || "");
+  if (!REVIEWABLE_PR_ACTIONS.has(action)) return false;
+  if (action !== "edited") return true;
+  return editedPayloadHasBaseRefChange(payload);
+}
+
+function reviewScanKeyForTarget(target: ReviewTarget) {
+  return target.headSha
+    ? `${target.headSha}:${target.baseRef || "unknown-base"}`
+    : "";
+}
+
+async function recordReviewedScanKey(params: {
+  env: Env;
+  target: ReviewTarget;
+  deliveryId: string;
+  status: string;
+}) {
+  const reviewScanKey = reviewScanKeyForTarget(params.target);
+  if (!reviewScanKey) return;
+  await upsertPrState(params.env.SUBMISSION_GATE_DB, {
+    repo: params.target.repoFullName,
+    number: params.target.number,
+    headRepo: params.target.headRepo,
+    headRef: params.target.headRef,
+    headSha: params.target.headSha,
+    baseRef: params.target.baseRef || contentGateBaseRef(params.env),
+    installationId: params.target.installationId,
+    status: params.status,
+    deliveryId: params.deliveryId,
+    lastReviewKey: reviewScanKey,
+  });
+}
+
+async function shouldInspectPullRequestFilesForWebhook(
+  env: Env,
+  target: ReviewTarget,
+) {
+  const existing = await getPrState(env.SUBMISSION_GATE_DB, {
+    repo: target.repoFullName,
+    number: target.number,
+  });
+  const reviewScanKey = reviewScanKeyForTarget(target);
+  const existingReviewKey = String(existing?.lastReviewKey || "");
+  if (
+    hasTerminalGateDecision(existing) &&
+    String(existing?.status || "") !== "closed" &&
+    !(
+      String(existing?.status || "") === "ignored" &&
+      reviewScanKey &&
+      existingReviewKey !== reviewScanKey
+    )
+  ) {
+    return false;
+  }
+  return !reviewScanKey || existingReviewKey !== reviewScanKey;
 }
 
 function reviewTargetFromPullPayload(
@@ -1902,11 +1969,17 @@ async function enqueueReviewTarget(
 ) {
   if (!pilotScoped && target.baseRef !== contentGateBaseRef(env)) return false;
   const targetKey = targetKeyForReview(target);
+  const reviewScanKey = reviewScanKeyForTarget(target);
   const existing = await getPrState(env.SUBMISSION_GATE_DB, {
     repo: target.repoFullName,
     number: target.number,
   });
-  if (!hasTerminalGateDecision(existing)) {
+  const existingReviewKey = String(existing?.lastReviewKey || "");
+  const shouldResetIgnoredScan =
+    String(existing?.status || "") === "ignored" &&
+    reviewScanKey &&
+    existingReviewKey !== reviewScanKey;
+  if (!hasTerminalGateDecision(existing) || shouldResetIgnoredScan) {
     await upsertPrState(env.SUBMISSION_GATE_DB, {
       repo: target.repoFullName,
       number: target.number,
@@ -1919,6 +1992,9 @@ async function enqueueReviewTarget(
       deliveryId,
       nextReviewAt: null,
       incrementAttempt: true,
+      lastReviewKey: reviewScanKey || undefined,
+      clearVerdict: shouldResetIgnoredScan,
+      clearTerminal: shouldResetIgnoredScan,
     });
   }
   await env.SUBMISSION_REVIEW_QUEUE.send({
@@ -2090,18 +2166,30 @@ async function githubWebhookRoute(
   );
 
   if (eventName === "pull_request") {
-    const action = String(payload.action || "");
     const target = reviewTargetFromPullPayload(payload);
-    if (!REVIEWABLE_PR_ACTIONS.has(action) || !target) {
+    if (!isReviewablePullRequestPayload(payload) || !target) {
       return json({ ok: true, ignored: true });
     }
     if (!isContentGatePr(payload, env))
       return json({ ok: true, ignored: true, reason: "outside_content_gate" });
+    const shouldInspect = await shouldInspectPullRequestFilesForWebhook(
+      env,
+      target,
+    );
+    if (!shouldInspect) {
+      return json({ ok: true, ignored: true, reason: "already_reviewed" });
+    }
     const reviewability = await directContentReviewabilityForTarget(
       env,
       target,
     );
     if (reviewability.kind === "ignore") {
+      await recordReviewedScanKey({
+        env,
+        target,
+        deliveryId,
+        status: "ignored",
+      });
       return json({ ok: true, ignored: true, reason: reviewability.reason });
     }
     const reviewScope =

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -228,6 +228,7 @@ export async function upsertPrState(
     terminalAt?: string | null;
     clearVerdict?: boolean;
     clearTerminal?: boolean;
+    lastReviewKey?: string | null;
   },
 ) {
   const timestamp = now();
@@ -240,8 +241,8 @@ export async function upsertPrState(
   await db
     .prepare(
       `INSERT INTO submission_prs
-        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, last_review_key, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo, number) DO UPDATE SET
         head_repo = COALESCE(excluded.head_repo, submission_prs.head_repo),
         head_ref = COALESCE(excluded.head_ref, submission_prs.head_ref),
@@ -258,6 +259,7 @@ export async function upsertPrState(
           ELSE COALESCE(excluded.verdict_summary, submission_prs.verdict_summary)
         END,
         last_delivery_id = COALESCE(excluded.last_delivery_id, submission_prs.last_delivery_id),
+        last_review_key = COALESCE(excluded.last_review_key, submission_prs.last_review_key),
         next_review_at = excluded.next_review_at,
         attempt_count = CASE
           WHEN ? THEN submission_prs.attempt_count + 1
@@ -288,6 +290,7 @@ export async function upsertPrState(
       params.verdict ?? null,
       params.verdictSummary ?? null,
       params.deliveryId ?? null,
+      params.lastReviewKey ?? null,
       params.nextReviewAt ?? null,
       params.incrementAttempt ? 1 : 0,
       params.lastError ?? null,
@@ -312,7 +315,8 @@ export async function getPrState(
       `SELECT repo, number, head_repo AS headRepo, head_ref AS headRef,
         head_sha AS headSha, base_ref AS baseRef, installation_id AS installationId,
         status, verdict, verdict_summary AS verdictSummary,
-        last_delivery_id AS lastDeliveryId, next_review_at AS nextReviewAt,
+        last_delivery_id AS lastDeliveryId, last_review_key AS lastReviewKey,
+        next_review_at AS nextReviewAt,
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,
@@ -339,7 +343,8 @@ export async function listDuePrStates(
       `SELECT repo, number, head_repo AS headRepo, head_ref AS headRef,
         head_sha AS headSha, base_ref AS baseRef, installation_id AS installationId,
         status, verdict, verdict_summary AS verdictSummary,
-        last_delivery_id AS lastDeliveryId, next_review_at AS nextReviewAt,
+        last_delivery_id AS lastDeliveryId, last_review_key AS lastReviewKey,
+        next_review_at AS nextReviewAt,
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,
@@ -393,7 +398,8 @@ export async function listRecentPrStates(
       `SELECT repo, number, head_repo AS headRepo, head_ref AS headRef,
         head_sha AS headSha, base_ref AS baseRef, installation_id AS installationId,
         status, verdict, verdict_summary AS verdictSummary,
-        last_delivery_id AS lastDeliveryId, next_review_at AS nextReviewAt,
+        last_delivery_id AS lastDeliveryId, last_review_key AS lastReviewKey,
+        next_review_at AS nextReviewAt,
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -364,6 +364,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("CONTENT_GATE_BASE_REF");
     expect(source).toContain("function contentGateBaseRef");
     expect(source).toContain("function isContentGatePr");
+    expect(source).toContain("function editedPayloadHasBaseRefChange");
+    expect(source).toContain('if (action !== "edited") return true;');
+    expect(source).toContain("return editedPayloadHasBaseRefChange(payload);");
     expect(source).toContain(
       'const DEFAULT_REQUIRED_VALIDATION_CHECKS = [\n  "validate-content",\n  "Superagent Security Scan",\n]',
     );
@@ -579,14 +582,27 @@ describe("Cloudflare submission gate helpers", () => {
       pullRequestIndex,
       source.indexOf('if (eventName === "issue_comment")', pullRequestIndex),
     );
+    const inspectIndex = pullRequestBlock.indexOf(
+      "shouldInspectPullRequestFilesForWebhook(",
+    );
     const classifyIndex = pullRequestBlock.indexOf(
       "directContentReviewabilityForTarget(",
     );
     const applyIndex = pullRequestBlock.indexOf("applyUnderReviewToTarget");
 
     expect(source).toContain('reason: "No source content entry file changed."');
+    expect(source).toContain("function recordReviewedScanKey");
+    expect(source).toContain(
+      "function shouldInspectPullRequestFilesForWebhook",
+    );
+    expect(source).toContain("existingReviewKey !== reviewScanKey");
+    expect(source).toContain("shouldResetIgnoredScan");
+    expect(source).toContain("clearTerminal: shouldResetIgnoredScan");
+    expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
+    expect(source).toContain('reason: "already_reviewed"');
     expect(pullRequestBlock).toContain('reviewability.kind === "ignore"');
-    expect(classifyIndex).toBeGreaterThan(0);
+    expect(inspectIndex).toBeGreaterThan(0);
+    expect(classifyIndex).toBeGreaterThan(inspectIndex);
     expect(applyIndex).toBeGreaterThan(classifyIndex);
   });
 
@@ -733,7 +749,9 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(storageSource).toContain("terminal_at IS NOT NULL");
     expect(storageSource).toContain("status = 'closed'");
-    expect(enqueueBlock).toContain("if (!hasTerminalGateDecision(existing))");
+    expect(enqueueBlock).toContain(
+      "if (!hasTerminalGateDecision(existing) || shouldResetIgnoredScan)",
+    );
     expect(reviewBlock).toContain("if (hasTerminalGateDecision(existing))");
     expect(enqueueBlock).not.toContain(
       "if (!forceRecheck && hasTerminalGateDecision(existing))",


### PR DESCRIPTION
## Summary
- Replaces the viable part of #836 with a clean, rebased implementation against current `main`.
- Adds a stored review scan key so repeated pull request webhook events do not repeatedly inspect the same head/base file set.
- Uses migration `0010_submission_pr_review_dedupe.sql` instead of the stale conflicting `0009` migration from #836.

## What changed
- Adds `submission_prs.last_review_key` via migration `0010`.
- Stores a `headSha:baseRef` review scan key for queued review attempts.
- Skips duplicate PR file inspection for the same already-seen head/base combination.
- Ignores ordinary `edited` events unless the base ref changed.
- Allows a previously ignored non-content PR to be inspected again when a new head SHA arrives.
- Adds regression assertions for edited-event filtering, scan-key recording, and ignored-scan reset.

## Why
- #836 conflicted with the hardened gate changes and had a migration number collision.
- The useful behavior is still worth keeping: it reduces noisy repeated webhook rescans without weakening the one-shot content gate.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/classify-pr-changes.test.ts`
- `pnpm submission-gate:dry-run`
- `git diff --check`

## Notes
- This PR should supersede #836 after checks pass.
- Deploy requires applying migration `0010_submission_pr_review_dedupe.sql` to the production D1 database before deploying the Worker version that writes `last_review_key`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced submission gate review logic to properly re-run file inspections when a PR's base reference changes, ensuring review verdicts from previous scans (particularly "ignore" decisions) are not incorrectly reused on modified pull requests.

* **Chores**
  * Updated internal database schema and review state tracking infrastructure to better support accurate deduplication of review scans and verdicts across PR lifecycle changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->