### PR TITLE
fix(submissions): record successful gate merges

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2842,77 +2842,79 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             decision: "merge_failed",
             summary: manualDecision.summary,
           });
+          return;
         }
+        const mergedSummary = [
+          decision.summary.trim(),
+          "",
+          "Merge Result:",
+          `- Merged this PR directly at \`${mergeResult.sha || target.headSha || "unknown"}\`.`,
+        ].join("\n");
+        const mergedDecision: GateDecision = {
+          ...decision,
+          summary: mergedSummary,
+          labels: [LABELS.merged, ...categoryLabels],
+        };
+        await removeLabels({
+          token,
+          repo,
+          issueNumber: target.number,
+          labels: RECONCILED_GATE_LABELS.filter(
+            (label) =>
+              label !== LABELS.merged && !categoryLabels.includes(label),
+          ),
+          apiVersion: env.GITHUB_API_VERSION,
+        });
+        await addLabels({
+          token,
+          repo,
+          issueNumber: target.number,
+          labels: [LABELS.merged, ...categoryLabels],
+          apiVersion: env.GITHUB_API_VERSION,
+        });
+        await upsertMarkerComment({
+          token,
+          repo,
+          issueNumber: target.number,
+          marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+          body: markerComment(
+            mergedDecision,
+            env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+          ),
+          apiVersion: env.GITHUB_API_VERSION,
+        });
+        await insertAudit(env.SUBMISSION_GATE_DB, {
+          id: crypto.randomUUID(),
+          targetKey: message.targetKey,
+          eventType: message.kind,
+          decision: "merged",
+          summary: mergedSummary,
+        });
+        await notifyGateDecision(env, {
+          target,
+          targetKey: message.targetKey,
+          decision: mergedDecision,
+          status: "merged",
+          scope: contentScopeForPrivateReview,
+          validation: validationForNotification,
+          pull: pullForNotification,
+        });
+        await upsertPrState(env.SUBMISSION_GATE_DB, {
+          repo: target.repoFullName,
+          number: target.number,
+          headRepo: target.headRepo,
+          headRef: target.headRef,
+          headSha: target.headSha,
+          baseRef: target.baseRef || contentGateBaseRef(env),
+          installationId: target.installationId,
+          status: "merged",
+          verdict: "merge",
+          verdictSummary: mergedSummary,
+          nextReviewAt: null,
+          terminalAt: nowIso(),
+        });
         return;
       }
-      const mergedSummary = [
-        decision.summary.trim(),
-        "",
-        "Merge Result:",
-        `- Merged this PR directly at \`${mergeResult.sha || target.headSha || "unknown"}\`.`,
-      ].join("\n");
-      const mergedDecision: GateDecision = {
-        ...decision,
-        summary: mergedSummary,
-        labels: [LABELS.merged, ...categoryLabels],
-      };
-      await removeLabels({
-        token,
-        repo,
-        issueNumber: target.number,
-        labels: RECONCILED_GATE_LABELS.filter(
-          (label) => label !== LABELS.merged && !categoryLabels.includes(label),
-        ),
-        apiVersion: env.GITHUB_API_VERSION,
-      });
-      await addLabels({
-        token,
-        repo,
-        issueNumber: target.number,
-        labels: [LABELS.merged, ...categoryLabels],
-        apiVersion: env.GITHUB_API_VERSION,
-      });
-      await upsertMarkerComment({
-        token,
-        repo,
-        issueNumber: target.number,
-        marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-        body: markerComment(
-          mergedDecision,
-          env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-        ),
-        apiVersion: env.GITHUB_API_VERSION,
-      });
-      await insertAudit(env.SUBMISSION_GATE_DB, {
-        id: crypto.randomUUID(),
-        targetKey: message.targetKey,
-        eventType: message.kind,
-        decision: "merged",
-        summary: mergedSummary,
-      });
-      await notifyGateDecision(env, {
-        target,
-        targetKey: message.targetKey,
-        decision: mergedDecision,
-        status: "merged",
-        scope: contentScopeForPrivateReview,
-        validation: validationForNotification,
-        pull: pullForNotification,
-      });
-      await upsertPrState(env.SUBMISSION_GATE_DB, {
-        repo: target.repoFullName,
-        number: target.number,
-        headRepo: target.headRepo,
-        headRef: target.headRef,
-        headSha: target.headSha,
-        baseRef: target.baseRef || contentGateBaseRef(env),
-        installationId: target.installationId,
-        status: "merged",
-        verdict: "merge",
-        verdictSummary: mergedSummary,
-        nextReviewAt: null,
-        terminalAt: nowIso(),
-      });
     }
   });
 }

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -624,6 +624,15 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("labels: [LABELS.merged, ...categoryLabels]");
     expect(source).toContain('status: "merged"');
     expect(source).toContain("await mergeAcceptedPullRequest({");
+    expect(source).toContain("        const mergedSummary = [");
+    expect(source).not.toContain(
+      [
+        "        }",
+        "        return;",
+        "      }",
+        "      const mergedSummary = [",
+      ].join("\n"),
+    );
     expect(source).toContain("SubmissionMergePendingError");
     expect(source).toContain('status: "merge_pending"');
     expect(source).toContain('decision: "merge_pending"');


### PR DESCRIPTION
### Motivation
- A successful direct-merge path returned early so the merged-state follow-up (label/comment/audit/notification and D1 state update) was never executed, leaving accepted submissions in a non-terminal state.
- The unreachable merged-summary referenced `mergeResult` outside its scope which could cause runtime errors and prevented audit/notification from running.

### Description
- Keep the successful direct-merge handling (merged summary, label/comment updates, audit insert, notification, and `upsertPrState` with `status: "merged"`) inside the `if (decision.verdict === "merge" && contentScopeForPrivateReview)` block so `mergeResult` is in scope and the follow-up steps run before returning in the merge path by returning only after those steps complete in that branch (file: `apps/submission-gate/src/index.ts`).
- Add an immediate `return` after the non-retryable merge-failure branch to avoid fall-through into the successful-merge handling (file: `apps/submission-gate/src/index.ts`).
- Add a regression assertion to the worker source test to ensure the merged-summary block is present in the correct place and the old early-return/fall-through pattern is absent (file: `tests/submission-gate-worker.test.ts`).

### Testing
- Ran unit tests with `./node_modules/.bin/vitest run tests/submission-gate-worker.test.ts`, and all tests passed (`51 tests` passed).
- Ran `./node_modules/.bin/prettier --write` on the modified files and verified no `git diff --check` errors remained locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fd0746920832cbfc796cfbfcf0d68)