### PR TITLE
fix(submissions): link merged content in Discord alerts

### DIFF
--- a/apps/submission-gate/src/notifications.ts
+++ b/apps/submission-gate/src/notifications.ts
@@ -10,6 +10,7 @@ export type DiscordDecisionNotification = {
   verdict: GateVerdict;
   category?: string;
   changedFile?: string;
+  contentUrl?: string;
   ciSummary?: string;
   summary?: string;
   now?: Date;
@@ -105,6 +106,23 @@ function field(name: string, value: unknown, inline = true) {
   };
 }
 
+function contentUrlFromPath(filePath: unknown, categoryHint?: unknown) {
+  const match = /^content\/([a-z0-9-]+)\/([a-z0-9-]+)\.mdx$/i.exec(
+    String(filePath || "").trim(),
+  );
+  if (!match) return "";
+  const [, category, slug] = match;
+  if (categoryHint && String(categoryHint) !== category) return "";
+  return `https://heyclau.de/entry/${encodeURIComponent(category)}/${encodeURIComponent(slug)}`;
+}
+
+function liveContentUrl(notification: DiscordDecisionNotification) {
+  if (notification.verdict !== "merge") return "";
+  const explicitUrl = String(notification.contentUrl || "").trim();
+  if (explicitUrl.startsWith("https://heyclau.de/entry/")) return explicitUrl;
+  return contentUrlFromPath(notification.changedFile, notification.category);
+}
+
 function compactPrSubject(title: unknown) {
   return (
     truncate(
@@ -169,6 +187,18 @@ export function buildDiscordDecisionPayload(
 ) {
   const verdictLabel = VERDICT_LABELS[notification.verdict];
   const subject = compactPrSubject(notification.prTitle);
+  const contentUrl = liveContentUrl(notification);
+  const fields = [
+    field("Result", verdictLabel),
+    field("Category", notification.category || "n/a"),
+    field("Author", notification.author || "n/a"),
+    field("Checks", compactCiSummary(notification.ciSummary), false),
+    field("File", notification.changedFile || "n/a", false),
+  ];
+  if (contentUrl) {
+    fields.push(field("Live", `[View content](${contentUrl})`, false));
+  }
+
   return {
     username: "HeyClaude Maintainer Agent",
     embeds: [
@@ -184,13 +214,7 @@ export function buildDiscordDecisionPayload(
         description:
           sanitizeRationale(notification.summary) ||
           "HeyClaude submission gate completed a decision.",
-        fields: [
-          field("Result", verdictLabel),
-          field("Category", notification.category || "n/a"),
-          field("Author", notification.author || "n/a"),
-          field("Checks", compactCiSummary(notification.ciSummary), false),
-          field("File", notification.changedFile || "n/a", false),
-        ],
+        fields,
         footer: {
           text: `${notification.repoFullName} · HeyClaude submission gate`,
         },

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -514,6 +514,47 @@ describe("Cloudflare submission gate helpers", () => {
     );
   });
 
+  it("adds live HeyClaude entry links to merged content notifications", () => {
+    const payload = buildDiscordDecisionPayload({
+      repoFullName: "JSONbored/awesome-claude",
+      prNumber: 841,
+      prTitle: "content(mcp): update Magic MCP server",
+      prUrl: "https://github.com/JSONbored/awesome-claude/pull/841",
+      author: "JSONbored",
+      verdict: "merge",
+      category: "mcp",
+      changedFile: "content/mcp/magic-mcp-server.mdx",
+      ciSummary: "validate-content passed; Superagent Security Scan passed",
+      summary:
+        "Summary:\n- Updates an existing MCP entry with safer API key guidance.",
+    });
+
+    const fields = payload.embeds[0].fields;
+    expect(fields).toContainEqual({
+      name: "Live",
+      value: "[View content](https://heyclau.de/entry/mcp/magic-mcp-server)",
+      inline: false,
+    });
+  });
+
+  it("does not add live content links to closed notifications", () => {
+    const payload = buildDiscordDecisionPayload({
+      repoFullName: "JSONbored/awesome-claude",
+      prNumber: 839,
+      prTitle: "content(mcp): update Magic MCP server",
+      verdict: "close",
+      category: "mcp",
+      changedFile: "content/mcp/magic-mcp-server.mdx",
+      ciSummary: "validate-content passed; Superagent Security Scan passed",
+      summary:
+        "Summary:\n- Closed because the submitted edit changed protected metadata.",
+    });
+
+    expect(payload.embeds[0].fields.map((item) => item.name)).not.toContain(
+      "Live",
+    );
+  });
+
   it("keeps Discord notifications optional and non-blocking", async () => {
     await expect(
       postDiscordDecisionNotification({


### PR DESCRIPTION
## Summary
- Add a live HeyClaude entry link to Discord notifications for merged content PRs.
- Keep closed/manual notifications from showing a live content link.

## What changed
- Derive `https://heyclau.de/entry/<category>/<slug>` from exact `content/<category>/<slug>.mdx` paths.
- Add a compact `Live` field only for merge verdicts.
- Add regression tests for merged and closed notification payloads.

## Why
- Merged content alerts should let maintainers jump directly from Discord to the live website entry, while rejected PRs should not imply content was published.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `pnpm exec prettier --check apps/submission-gate/src/notifications.ts tests/submission-gate-worker.test.ts`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord notifications for merged content now include a "Live" link for accessing the published entry.

* **Tests**
  * Added test coverage for Discord notification payloads, verifying "Live" links appear for merge verdicts and are omitted for close verdicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->