### PR TITLE
fix(registry): preserve safety metadata in compact indexes

### DIFF
--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -257,6 +257,7 @@ export function buildDirectoryEntries(entries) {
       documentationUrl: entry.documentationUrl || "",
       ...buildEntryProvenanceFields(entry),
       ...buildEntryBrandFields(entry),
+      ...buildEntryNoteFields(entry),
       repoUrl: entry.repoUrl || "",
       downloadUrl: entry.downloadUrl || "",
       downloadTrust: entry.downloadTrust ?? null,
@@ -293,6 +294,7 @@ export function buildSearchEntries(entries) {
       author: entry.author || "",
       ...buildEntryProvenanceFields(entry),
       ...buildEntryBrandFields(entry),
+      ...buildEntryNoteFields(entry),
       dateAdded: entry.dateAdded || "",
       installable: Boolean(
         entry.installable || entry.installCommand || entry.downloadUrl,

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -652,9 +652,21 @@ Use this hook after reviewing the notes.`,
       "Reads local workspace metadata and does not send it to third parties.",
     ]);
 
+    const [directoryEntry] = buildDirectoryEntries([entry]);
+    expect(directoryEntry.safetyNotes).toEqual([
+      "Runs as a background worker during the configured Claude Code session.",
+    ]);
+    expect(directoryEntry.privacyNotes).toEqual([
+      "Reads local workspace metadata and does not send it to third parties.",
+    ]);
+
     const [searchEntry] = buildSearchEntries([entry]);
-    expect(searchEntry.safetyNotes).toBeUndefined();
-    expect(searchEntry.privacyNotes).toBeUndefined();
+    expect(searchEntry.safetyNotes).toEqual([
+      "Runs as a background worker during the configured Claude Code session.",
+    ]);
+    expect(searchEntry.privacyNotes).toEqual([
+      "Reads local workspace metadata and does not send it to third parties.",
+    ]);
     expect(searchEntry.downloadUrl).toBe("");
     expect(buildRaycastDetailMarkdown(entry)).toContain("## Safety notes");
     expect(buildRaycastDetailMarkdown(entry)).toContain("## Privacy notes");
@@ -881,8 +893,6 @@ Use this hook after reviewing the notes.`,
       expect((entry as Record<string, unknown>).copySnippet).toBeUndefined();
       expect((entry as Record<string, unknown>).seoDescription).toBeUndefined();
       expect((entry as Record<string, unknown>).llmsUrl).toBeUndefined();
-      expect((entry as Record<string, unknown>).safetyNotes).toBeUndefined();
-      expect((entry as Record<string, unknown>).privacyNotes).toBeUndefined();
     }
     expect(
       searchEntries.some((entry) => entry.platforms?.includes("Gemini")),


### PR DESCRIPTION
### Motivation
- A recent refactor removed `safetyNotes`/`privacyNotes` from compact `directory-index.json` and `search-index.json`, causing public search filters, facets, and MCP consumers to misclassify entries with reviewed disclosures.
- Consumers and MCP tooling still infer note presence from `entry.safetyNotes`/`entry.privacyNotes`, so the compact artifact change degraded the trust-signal surface used for install/run safety decisions.

### Description
- Restores `...buildEntryNoteFields(entry)` into `buildDirectoryEntries` so directory artifacts include normalized `safetyNotes` and `privacyNotes` (file: `packages/registry/src/artifacts.js`).
- Restores `...buildEntryNoteFields(entry)` into `buildSearchEntries` so search artifacts expose the same note arrays for filtering and MCP/LLM consumers (file: `packages/registry/src/artifacts.js`).
- Updates tests to assert that both directory and search builders preserve normalized note arrays rather than omitting them (file: `tests/registry-artifacts.test.ts`).
- No other behavior changes to `trustSignals` or provenance logic were made.

### Testing
- Ran registry generation with `node scripts/build-content-index.mjs` and it produced the compact artifacts (`apps/web/public/data/*`).
- Ran unit tests with `node_modules/.bin/vitest run tests/registry-artifacts.test.ts tests/registry-search-facets.test.ts` and `node_modules/.bin/vitest run tests/mcp-server.test.ts`, and all targeted test suites passed.
- Ran `git diff --check` to ensure no whitespace or diff errors and verified the change set includes only the intended files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20154f78e8832ca4d8750c60109fb8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Safety and Privacy notes are now displayed in search results and directory entries. When searching or browsing the artifact directory, users will see relevant safety and privacy information alongside listings, providing better visibility into important artifact metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->