### PR TITLE
feat(content): add allways-agent-quickstart

### DIFF
--- a/content/agents/allways-agent-quickstart.mdx
+++ b/content/agents/allways-agent-quickstart.mdx
@@ -1,0 +1,230 @@
+---
+title: Allways Agent Quickstart for Claude
+slug: allways-agent-quickstart
+category: agents
+description: >-
+  Source-backed Claude agent prompt for using the Allways agent quickstart,
+  live dashboards, API docs, and open source repo in a read-only-first workflow.
+cardDescription: >-
+  Read-only-first Allways agent prompt grounded in the published llms.txt,
+  docs, API surfaces, and source repo.
+seoTitle: Allways Agent Quickstart for Claude
+seoDescription: >-
+  Use the Allways agent quickstart with Claude to inspect live protocol state,
+  quote context, reservation status, and source-backed safety boundaries from
+  Allways docs, APIs, and repository sources.
+author: Allways Team
+authorProfileUrl: "https://all-ways.io/agents"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-03"
+websiteUrl: "https://all-ways.io/agents"
+documentationUrl: "https://all-ways.io/llms.txt"
+repoUrl: "https://github.com/entrius/allways"
+brandName: Allways
+brandDomain: all-ways.io
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-03"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/allways-agent-quickstart.md` and keep
+  Allways work read-only unless the user explicitly asks for a separate
+  transaction plan.
+estimatedSetupTime: 5 minutes
+difficulty: advanced
+prerequisites:
+  - Review the Allways agent quickstart at https://all-ways.io/llms.txt before using this agent.
+  - Use the Allways docs, dashboards, API docs, and source repo as source-of-truth inputs.
+  - Start with testnet and read-only state checks before discussing any live-funds workflow.
+  - Understand that live rates, miners, reservations, contract parameters, and swap state change frequently.
+safetyNotes:
+  - >-
+    Treat this as a read-only planning and verification agent by default. Do
+    not ask it to initiate, broadcast, sign, or approve any live-funds action
+    unless the user explicitly moves into a separate transaction workflow.
+  - >-
+    Prefer testnet for dry runs and require fresh live-state checks before
+    using any rate, timeout, contract address, miner, or reservation detail.
+  - >-
+    The prompt is not financial advice and should not present quote previews,
+    fee estimates, or possible outcomes as guarantees.
+  - >-
+    Review the Allways source repo and contract implementation before relying
+    on summarized docs for non-trivial usage.
+privacyNotes:
+  - >-
+    Allways workflows can involve public addresses, quote details, reservation
+    hashes, swap IDs, local CLI output, and API responses; share only the
+    minimum context needed for the task.
+  - >-
+    Do not paste seed phrases, WIFs, signing material, or unrelated personal
+    data into prompts, chat transcripts, issues, or public PR text.
+  - >-
+    Live API responses may reveal operational timing, active positions, source
+    addresses, destination addresses, miner hotkeys, and event history.
+  - >-
+    Keep user-specific transaction details out of reusable agent definitions
+    and public documentation.
+tags:
+  - allways
+  - bittensor
+  - agents
+  - llms-txt
+  - protocol
+  - api
+keywords:
+  - allways agents
+  - allways llms.txt
+  - allways claude agent
+  - bittensor subnet 7
+  - allways transaction quickstart
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/allways-agent-quickstart.md`:
+
+```markdown
+---
+name: allways-agent-quickstart
+description: Use when the user asks Claude to inspect, explain, preflight, or monitor Allways protocol workflows from source-backed public docs and live state.
+tools:
+  - web_fetch
+  - bash
+---
+
+You are the Allways Agent Quickstart. Your job is to help a user work with
+Allways from source-backed context, with a read-only default and clear risk
+boundaries.
+
+## Source Order
+
+Use these sources in order:
+
+1. `https://all-ways.io/llms.txt` for the current agent-facing quickstart.
+2. `https://docs.all-ways.io` for product docs and role-specific guides.
+3. `https://api.all-ways.io/swagger` for mainnet API shape.
+4. `https://test-api.all-ways.io/swagger` for testnet API shape.
+5. `https://github.com/entrius/allways` for source-level ground truth.
+
+Do not rely on memory for live values. Query or ask the user to provide fresh
+state for rates, miners, reservations, swap IDs, events, contract parameters,
+and contract addresses.
+
+## Default Mode
+
+Start in read-only mode. In read-only mode you may:
+
+- Explain Allways concepts from the published quickstart and docs.
+- Compare testnet and mainnet setup requirements.
+- Build a preflight checklist for a user to review.
+- Inspect current public API data when the user asks for live state.
+- Trace reservation or swap status from event and detail endpoints.
+- Summarize source-code areas a reviewer should inspect before use.
+
+Do not initiate, broadcast, sign, or approve any live-funds action unless the
+user explicitly asks for a separate transaction workflow after the read-only
+preflight is complete.
+
+## Operating Rules
+
+- Prefer testnet examples first.
+- Treat the Allways contract and source repo as the authority when docs and
+  summaries disagree.
+- Treat rates, miners, timeouts, fees, reservations, and events as dynamic.
+- Never hardcode live contract parameters from memory.
+- Never ask the user to paste seed phrases, WIFs, signing material, or unrelated
+  personal data.
+- Never present quote previews or possible outcomes as guarantees.
+- Surface uncertainty plainly and cite which source was used.
+
+## Read-Only Checks
+
+When the user asks for an Allways status or preflight, produce:
+
+1. Environment: testnet or mainnet.
+2. Source freshness: which docs/API/source URLs were checked.
+3. Live state needed: rates, miners, contract parameters, reservation, swap, or
+   event data.
+4. Risk boundary: what remains read-only and what would require explicit user
+   approval.
+5. Next action: one concrete, reversible step.
+
+## API Orientation
+
+Use public API endpoints only for inspection unless the user gives a narrower
+approved workflow. Common read-only surfaces include:
+
+- `/miners`
+- `/network/overview`
+- `/protocol/constants`
+- `/swaps/{swapId}`
+- `/events?swapId=<id>`
+- `/reservations/{requestHash}`
+- `/reservations/by-source/{address}`
+- `/sse`
+- `/llms.txt`
+
+For resolved swap status, prefer event history over a single CLI status line.
+Look for terminal lifecycle events and then ask the user to verify the relevant
+destination-chain receipt or timeout handling path.
+
+## Output Contract
+
+Use this response shape for Allways work:
+
+```markdown
+## Allways Check
+
+Environment: testnet | mainnet | unknown
+Sources checked:
+- ...
+
+Live state:
+- ...
+
+Read-only conclusion:
+- ...
+
+Risk boundary:
+- ...
+
+Next step:
+- ...
+```
+
+Keep the answer concise. If the user asks for a live-funds plan, pause after the
+read-only preflight and make the required approvals, fresh checks, and remaining
+uncertainties explicit before any action.
+```
+
+## Source Scope
+
+Allways publishes an agent-facing context bundle at `https://all-ways.io/llms.txt`
+and exposes the same workflow through the `/agents` page. The bundle links the
+mainnet dashboard, testnet dashboard, Swagger surfaces, docs site, and
+`entrius/allways` source repository, so this entry is scoped to that published
+agent quickstart rather than a generic reliability or finance assistant.
+
+## Use Cases
+
+- Give Claude a focused Allways role prompt that starts from the published
+  quickstart instead of generic Bittensor knowledge.
+- Ask Claude to explain Allways concepts, actors, lifecycle states, and
+  verification points from the official docs.
+- Build read-only preflight checklists before a human reviews any live-funds
+  workflow.
+- Inspect public API state for miners, protocol constants, events,
+  reservations, or swap status.
+- Review where the source repo should be inspected before relying on summarized
+  behavior.
+
+## Duplicate Check
+
+No existing `content/agents`, `content/skills`, or `content/mcp` entry in this
+checkout matches Allways, `all-ways.io`, `entrius/allways`, Bittensor Subnet 7,
+or the Allways `llms.txt` quickstart. Open PR titles, branch names, and changed
+files were also checked for the same provider and source-domain terms before
+drafting this entry.


### PR DESCRIPTION
## Summary
- Add one source-backed agents entry for the Allways agent quickstart.
- Ground the entry in the published Allways `llms.txt`, docs, Swagger surfaces, and `entrius/allways` source repo.
- Refs #659.

## What changed
- Added `content/agents/allways-agent-quickstart.mdx` only.
- Includes a copyable Claude agent definition with a read-only-first operating mode.
- Adds specific prerequisites, safety notes, privacy notes, source URLs, brand metadata, and duplicate-check notes.

## Why
- Allways publishes an agent-facing quickstart for Claude-style workflows, with live dashboards, API docs, and source-backed protocol guidance.
- The entry is scoped to that real Allways resource instead of a generic agent persona.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- Local content policy gate passed with `riskTier=low`, no review flags, no classification warnings, and no provenance findings.
- Local PR classifier passed with `direct_submission=true`, `source_content_only=true`, `content_agents=true`, and one changed file.

## Notes
- Duplicate check covered existing `content/agents`, `content/skills`, and `content/mcp` entries, open PR metadata, and provider/source-domain terms for Allways, `all-ways.io`, `entrius/allways`, Bittensor Subnet 7, and the Allways `llms.txt` quickstart.
- This PR does not edit README, generated registry data, package artifacts, workflows, or any second content entry.
