### PR TITLE
feat(content): add ragas

### DIFF
--- a/content/tools/ragas.mdx
+++ b/content/tools/ragas.mdx
@@ -1,0 +1,58 @@
+---
+title: Ragas
+slug: ragas
+category: tools
+description: Open-source evaluation framework for testing RAG systems, prompts, agents, workflows, and other LLM application behavior.
+cardDescription: Open-source evaluation framework for RAG and LLM application testing.
+seoTitle: Ragas open-source RAG and LLM evaluation framework
+seoDescription: Ragas helps teams build systematic evaluation loops for RAG systems, prompts, agents, workflows, and other LLM applications.
+author: Vibrant Labs
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-03"
+websiteUrl: "https://docs.ragas.io"
+documentationUrl: "https://docs.ragas.io"
+repoUrl: "https://github.com/vibrantlabsai/ragas"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+tags:
+  - rag
+  - evaluation
+  - open-source
+keywords:
+  - rag evaluation
+  - llm evals
+  - retrieval quality testing
+prerequisites:
+  - Python environment for installing and running Ragas.
+  - Test data, application outputs, or production-aligned examples for the RAG, prompt, workflow, or agent behavior being evaluated.
+  - Model provider credentials when using LLM-based metrics or generated test data.
+safetyNotes:
+  - Ragas scores should be treated as decision support, not a substitute for domain review of critical outputs.
+  - LLM-based metrics can call configured model providers, so evaluation runs should be scoped and budgeted before use on large datasets.
+  - Generated test data and evaluator prompts should be reviewed before they influence release, ranking, or regression decisions.
+privacyNotes:
+  - Evaluation examples may include prompts, retrieved context, generated responses, references, and metadata from the application under test.
+  - LLM-based metrics can send evaluation payloads to the configured model provider unless a local model path is used.
+  - The upstream README says Ragas collects minimal, anonymized usage analytics; review or disable analytics where policy requires it.
+---
+
+## Editorial notes
+
+Ragas is a strong fit for Claude and agent teams that need repeatable RAG quality checks instead of manual "looks good" review. It supports evaluation loops around retrieval, prompts, workflows, and agents, with prebuilt metrics plus custom metrics for project-specific behavior.
+
+## Source notes
+
+- The official documentation describes Ragas as a library for moving from subjective checks to systematic evaluation loops for AI applications.
+- The get started docs include tutorials for evaluating prompts, simple RAG systems, AI workflows, and AI agents.
+- The GitHub README documents Ragas metrics, production-aligned test set generation, integrations with common LLM frameworks, and the `ragas quickstart rag_eval` template.
+
+## Duplicate check
+
+Checked current `content/tools/`, open pull requests, live HeyClaude search results, and repository-wide content for `Ragas`, `docs.ragas.io`, `github.com/vibrantlabsai/ragas`, `RAG evaluation`, `LLM evals`, and `retrieval quality testing`. No existing Ragas listing or open duplicate PR was found.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary
- Adds Ragas as a source-backed tools entry for RAG and LLM application evaluation.

## What changed
- Added `content/tools/ragas.mdx` with official documentation and GitHub sources.
- Included prerequisites plus safety/privacy notes for LLM-based evaluation, model-provider calls, evaluation payloads, and upstream analytics.
- Documented duplicate checks against current content, open PRs, live search, and source URLs.

## Why
- Ragas fits the #700 request for a RAG evaluation tool for retrieval quality testing.
- Its official documentation and README support the listing: systematic evaluation loops, RAG tutorials, prompt/workflow/agent evaluation, custom metrics, integrations, and a `ragas quickstart rag_eval` template.

## Validation
- `pnpm validate:content:strict -- --category tools`
- `pnpm audit:content -- --category tools`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha <upstream-main-sha> --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/tools-ragas-rag-evaluation --pr-author oktofeesh1`

## Notes
- Duplicate check covered `content/tools/`, open pull requests, live HeyClaude search results, and repository-wide content for `Ragas`, `docs.ragas.io`, `github.com/vibrantlabsai/ragas`, `RAG evaluation`, `LLM evals`, and `retrieval quality testing`.
- No package URL or generated artifacts are included.
- Closes #700.