### PR TITLE
feat(content): add agenta

### DIFF
--- a/content/tools/agenta.mdx
+++ b/content/tools/agenta.mdx
@@ -1,0 +1,59 @@
+---
+title: Agenta
+slug: agenta
+category: tools
+description: Open-source LLMOps platform for prompt management, prompt versioning, evaluation, and observability across LLM applications.
+cardDescription: Open-source prompt management, evaluation, and observability for LLM apps.
+seoTitle: Agenta open-source prompt management and LLMOps platform
+seoDescription: Agenta helps teams manage, version, evaluate, deploy, and observe prompts and LLM application variants.
+author: Agenta
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-03"
+websiteUrl: "https://agenta.ai"
+documentationUrl: "https://agenta.ai/docs/"
+repoUrl: "https://github.com/Agenta-AI/agenta"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux, Web, Self-hosted
+tags:
+  - prompt-management
+  - llmops
+  - open-source
+keywords:
+  - prompt versioning
+  - prompt registry
+  - llm evaluation
+prerequisites:
+  - LLM application, prompt workflow, or agent workflow whose prompts and configurations need shared management.
+  - Access to Agenta Cloud or a reviewed self-hosted Agenta deployment.
+  - Provider credentials and a release policy for test sets, traces, prompt versions, and production deployment approvals.
+safetyNotes:
+  - Agenta can manage and deploy prompt or configuration changes, so production updates should go through review and rollback controls.
+  - Webhooks and GitHub automations tied to prompt or deployment changes should be scoped to trusted repositories and guarded workflows.
+  - Evaluation and online monitoring results should support, not replace, domain review for high-risk application behavior.
+privacyNotes:
+  - Prompt records, variants, test sets, traces, model inputs and outputs, feedback, annotations, and evaluation results may be stored in Agenta.
+  - Hosted Agenta use sends that data to Agenta Cloud; self-hosted deployments still require retention, access-control, and backup policies.
+  - Review Agenta's sensitive-data redaction and retention guidance before sending production, customer, or regulated data.
+---
+
+## Editorial notes
+
+Agenta is a good fit for teams that need prompt and configuration changes to move through a real shared workflow instead of living only in code, spreadsheets, or ad hoc playgrounds. It combines prompt organization, side-by-side playground comparison, prompt versioning, deployment management, evaluation, and production observability around the same LLM application lifecycle.
+
+## Source notes
+
+- The official docs describe Agenta as an open-source LLMOps platform for prompt management, evaluation, and observability.
+- The docs cover prompt and deployment registries, prompt organization, prompt versioning, prompt variants, GitHub automations, and webhooks for prompt or deployment changes.
+- The GitHub README describes side-by-side prompt comparison, multi-model support, version control with branching and environments, complex configuration schemas, evaluation workflows, observability, and self-hosting.
+- The project is published at `github.com/Agenta-AI/agenta` and describes itself as open source.
+
+## Duplicate check
+
+Checked current `content/tools/`, open pull requests, live HeyClaude search results, and repository-wide content for `Agenta`, `agenta.ai`, `github.com/Agenta-AI/agenta`, `prompt management`, `prompt versioning`, `prompt registry`, and `deployment registry`. Langfuse already exists and mentions prompt management, but no dedicated Agenta tools entry, Agenta source URL, or open duplicate PR was found.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary
- Add Agenta as a source-backed tools entry for prompt/version management workflows.

## What changed
- Added `content/tools/agenta.mdx` with canonical website, docs, and repository URLs.
- Included practical prerequisites, safety notes, privacy notes, source notes, and duplicate-check context.

## Why
- Closes #703 with a recognizable open-source LLMOps platform focused on prompt management, prompt versioning, evaluation, and observability.

## Validation
- `pnpm validate:content:strict -- --category tools`
- `pnpm audit:content -- --category tools`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/tools-agenta-prompt-management --pr-author oktofeesh1`

## Notes
- Duplicate check covered `content/tools/`, open PRs, live HeyClaude search, and repository-wide content for Agenta, agenta.ai, github.com/Agenta-AI/agenta, prompt management, prompt versioning, prompt registry, and deployment registry.
- Langfuse already exists and mentions prompt management, but no dedicated Agenta entry, Agenta source URL, or open duplicate PR was found.
- This PR changes exactly one file and does not include generated artifacts, README changes, package files, or registry output.