### PR TITLE
fix(content): remove unverified Ragas repo provenance

### DIFF
--- a/content/tools/ragas.mdx
+++ b/content/tools/ragas.mdx
@@ -12,7 +12,6 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-03"
 websiteUrl: "https://docs.ragas.io"
 documentationUrl: "https://docs.ragas.io"
-repoUrl: "https://github.com/vibrantlabsai/ragas"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication
@@ -47,11 +46,11 @@ Ragas is a strong fit for Claude and agent teams that need repeatable RAG qualit
 
 - The official documentation describes Ragas as a library for moving from subjective checks to systematic evaluation loops for AI applications.
 - The get started docs include tutorials for evaluating prompts, simple RAG systems, AI workflows, and AI agents.
-- The GitHub README documents Ragas metrics, production-aligned test set generation, integrations with common LLM frameworks, and the `ragas quickstart rag_eval` template.
+- The published documentation and package metadata describe Ragas metrics, production-aligned test set generation, integrations with common LLM frameworks, and the `ragas quickstart rag_eval` template.
 
 ## Duplicate check
 
-Checked current `content/tools/`, open pull requests, live HeyClaude search results, and repository-wide content for `Ragas`, `docs.ragas.io`, `github.com/vibrantlabsai/ragas`, `RAG evaluation`, `LLM evals`, and `retrieval quality testing`. No existing Ragas listing or open duplicate PR was found.
+Checked current `content/tools/`, open pull requests, live HeyClaude search results, and repository-wide content for `Ragas`, `docs.ragas.io`, `RAG evaluation`, `LLM evals`, and `retrieval quality testing`. No existing Ragas listing or open duplicate PR was found.
 
 ## Disclosure
 


### PR DESCRIPTION
### Motivation
- A new `content/tools/ragas.mdx` entry included a `repoUrl` pointing to `https://github.com/vibrantlabsai/ragas`, which could be promoted by site normalization as a source-backed repository and thus surface an unverified provenance signal to users and downstream agents.

### Description
- Removed the `repoUrl` front-matter from `content/tools/ragas.mdx` and reworded the source notes to cite published documentation and package metadata instead of the GitHub README or repository URL.

### Testing
- Ran `pnpm validate:content:strict`, which passed, and `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20970e7028832c97d1b0c60cc99292)