### PR TITLE
feat(content): add sentence-transformers

### DIFF
--- a/content/tools/sentence-transformers.mdx
+++ b/content/tools/sentence-transformers.mdx
@@ -1,0 +1,75 @@
+---
+title: Sentence Transformers
+slug: sentence-transformers
+category: tools
+description: Apache-2.0 Python framework from Hugging Face for dense embeddings, sparse embeddings, semantic search, reranking, multimodal retrieval, and embedding-model training.
+cardDescription: Build embeddings, sparse encoders, rerankers, and semantic search pipelines.
+seoTitle: Sentence Transformers embeddings and reranking framework
+seoDescription: Sentence Transformers is an Apache-2.0 Python framework from Hugging Face for dense embeddings, sparse embeddings, semantic search, reranking, multimodal retrieval, and embedding-model training.
+author: Hugging Face
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-03"
+websiteUrl: "https://www.sbert.net/"
+documentationUrl: "https://www.sbert.net/"
+repoUrl: "https://github.com/huggingface/sentence-transformers"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+tags:
+  - embeddings
+  - retrieval
+  - reranking
+keywords:
+  - Sentence Transformers
+  - SBERT
+  - text embeddings
+  - semantic search
+  - reranker models
+prerequisites:
+  - Python 3.10 or newer, PyTorch, Transformers, and the optional Sentence Transformers extras needed for text, image, audio, video, training, ONNX, or OpenVINO workflows.
+  - Approved embedding, sparse encoder, cross-encoder, or multimodal model selection with model license, dimensionality, hardware needs, language coverage, and benchmark fit reviewed.
+  - Retrieval design for chunking, query/document encoding, vector database integration, sparse retrieval, reranking, evaluation datasets, and source-attribution behavior.
+  - Hardware and runtime plan for CPU, GPU, CUDA, ONNX, OpenVINO, batching, caching, model downloads, local inference, hosted inference, and production latency targets.
+  - Privacy, retention, and model-cache plan for source documents, prompts, embeddings, training data, evaluation records, local model files, logs, and exported model artifacts.
+safetyNotes:
+  - Sentence Transformers can power RAG, semantic search, clustering, duplicate detection, multimodal retrieval, and reranking, but embedding similarity is not proof of factual correctness or permission fit.
+  - Pretrained models, MTEB leaderboard positions, and benchmark scores are starting points; teams should evaluate candidate models on their own documents, languages, query patterns, and failure cases.
+  - Cross-encoder rerankers can improve retrieval quality, but they are slower than bi-encoder embedding search and can add cost, latency, and provider exposure depending on deployment.
+  - Sparse encoders, dense embeddings, multimodal models, and hybrid retrieval need careful index configuration, score calibration, normalization, and regression tests before agent workflows depend on them.
+  - Fine-tuning can overfit, leak training examples, degrade general retrieval quality, or create undocumented model behavior if datasets, losses, evaluations, and model cards are weak.
+  - Generated answers, automated actions, and retrieval summaries that depend on Sentence Transformers outputs should remain reviewable, attributable to retrieved sources, and tested against stale or irrelevant context.
+privacyNotes:
+  - Inputs can include text, documents, images, audio, video, chat-style messages, query logs, labels, evaluation examples, and training datasets that may contain sensitive project or user data.
+  - Embeddings can encode information about source records and should follow the same retention, deletion, backup, access-control, and tenant-isolation policies as the underlying data.
+  - Hugging Face Hub downloads, hosted inference, model providers, vector databases, experiment trackers, training logs, and observability systems may process model names, prompts, documents, embeddings, metrics, or artifacts depending on setup.
+  - Local model caches, dataset caches, checkpoints, exported ONNX or OpenVINO artifacts, and fine-tuned models can retain sensitive training or evaluation context outside the application database.
+  - Teams should define who can inspect retrieval traces, reranking scores, embedding datasets, failed-query examples, model cards, logs, checkpoints, and pushed Hub artifacts before exposing these workflows to users.
+---
+
+## Editorial notes
+
+Sentence Transformers is useful when Claude-adjacent teams need a practical framework for generating embeddings, training task-specific embedding models, building semantic search, adding dense and sparse retrieval, reranking retrieved passages, evaluating retrieval quality, and supporting multimodal search. It is especially relevant for teams building RAG pipelines where the quality of chunk embeddings, query embeddings, sparse signals, and reranking determines how useful Claude's retrieved context will be.
+
+This is distinct from existing retrieval storage entries. Chroma, Weaviate, Milvus, and LanceDB focus on storing and querying records, vectors, metadata, and indexes. Sentence Transformers is the model and pipeline layer that creates embeddings, sparse vectors, reranker scores, and fine-tuned retrieval models that can feed those databases. Existing content only mentions sentence-transformers incidentally as an embedding option or model name; there is no dedicated Sentence Transformers tools entry.
+
+## Source notes
+
+- The official README describes Sentence Transformers as a framework for computing embeddings, calculating similarity scores with cross-encoder reranker models, and generating sparse embeddings.
+- The README lists applications including semantic search, semantic textual similarity, paraphrase mining, retrieval, reranking, sparse encoders, and multimodal use cases.
+- The README says more than 15,000 pretrained Sentence Transformers models are available on Hugging Face and that users can train or fine-tune embedding, reranker, and sparse encoder models.
+- The installation docs recommend Python 3.10 or newer, PyTorch, and Transformers, and document extras for image, audio, video, training, ONNX, OpenVINO, and development workflows.
+- The quickstart docs describe Sentence Transformer bi-encoder models for fixed-size vectors, Cross Encoder rerankers for scoring input pairs, and Sparse Encoder models for sparse vector representations.
+- The quickstart docs describe text, image, audio, video, and multimodal model support when the selected model and dependencies support those modalities.
+- The pretrained models docs describe original and community Sentence Transformer models on Hugging Face, semantic-search models, multilingual models, multimodal models, and model-selection cautions.
+- The training docs describe fine-tuning with datasets, loss functions, evaluators, trainer components, multi-dataset training, and optional model publishing to the Hugging Face Hub.
+- The repository is `huggingface/sentence-transformers`, is Apache-2.0 licensed, and describes the project as state-of-the-art embeddings, retrieval, and reranking.
+
+## Duplicate check
+
+Checked current `content/tools/`, `content/mcp/`, agents, hooks, rules, skills, commands, guides, open pull requests, live issue state, and repository-wide content for `Sentence Transformers`, `sentence-transformers`, `SBERT`, `sbert.net`, `huggingface/sentence-transformers`, `UKPLab/sentence-transformers`, `sentence_transformers`, `semantic search`, and `reranker models`. Existing content contains only incidental mentions: Qdrant MCP references a specific `sentence-transformers/all-MiniLM-L6-v2` model, and Chroma mentions sentence-transformers as one possible embedding function. No dedicated Sentence Transformers tools entry, Sentence Transformers source URL duplicate, or open duplicate PR was found.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used. Sentence Transformers is Apache-2.0 open-source software maintained under Hugging Face; individual pretrained models and datasets on the Hugging Face Hub may have their own licenses and terms.


### PR DESCRIPTION
## Summary
- Adds Sentence Transformers as a tools content entry for embeddings, sparse encoders, semantic search, reranking, multimodal retrieval, and embedding-model training.

## What changed
- Adds `content/tools/sentence-transformers.mdx` with full metadata, prerequisites, safety notes, privacy notes, source notes, duplicate check, and editorial disclosure.
- Uses official SBERT documentation and the canonical `huggingface/sentence-transformers` repository source.

## Why
- Sentence Transformers is a recognizable Apache-2.0 framework for building the embedding and reranking layer behind RAG and retrieval workflows.
- Refs #661.

## Validation
- `pnpm validate:content:strict -- --category tools`
- `pnpm audit:content -- --category tools`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/tools-sentence-transformers-embeddings --pr-author oktofeesh1`

## Notes
- Duplicate check found no existing dedicated Sentence Transformers content entry, source URL duplicate, open duplicate PR, or open duplicate issue.
- Existing content only mentions sentence-transformers incidentally as an embedding option/model name; this entry covers the framework itself.
- This entry is distinct from vector database entries: Sentence Transformers creates embeddings, sparse vectors, reranker scores, and fine-tuned retrieval models that can feed retrieval stores.
- Editorial listing only; no paid placement or affiliate link is used.