### PR TITLE
fix(submissions): refine duplicate and related-content review signals

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -16,6 +16,12 @@ export type ContentDuplicateMatch = {
   reasons: string[];
 };
 
+export type ContentDuplicateReview = {
+  legacyDuplicate: ContentDuplicateMatch | null;
+  strictDuplicate: ContentDuplicateMatch | null;
+  relatedCandidates: ContentDuplicateMatch[];
+};
+
 const PROTECTED_FRONTMATTER_FIELDS = new Set([
   "affiliateUrl",
   "author",
@@ -224,6 +230,17 @@ function intersection(left: string[], right: string[]) {
   return left.filter((value) => rightSet.has(value));
 }
 
+function isCollectionBridge(
+  candidate: ContentDuplicateSignals,
+  existing: ContentDuplicateSignals,
+) {
+  return (
+    candidate.category !== existing.category &&
+    (candidate.category === "collections" ||
+      existing.category === "collections")
+  );
+}
+
 export function findContentDuplicateMatch(
   candidate: ContentDuplicateSignals,
   existingItems: ContentDuplicateSignals[],
@@ -289,4 +306,107 @@ export function findContentDuplicateMatch(
     if (reasons.length) return { existing, reasons };
   }
   return null;
+}
+
+export function findStrictContentDuplicateMatch(
+  candidate: ContentDuplicateSignals,
+  existingItems: ContentDuplicateSignals[],
+): ContentDuplicateMatch | null {
+  for (const existing of existingItems) {
+    const reasons: string[] = [];
+    if (candidate.filePath === existing.filePath) {
+      reasons.push(`same content path \`${existing.filePath}\``);
+    }
+    if (
+      candidate.category &&
+      candidate.slug &&
+      candidate.category === existing.category &&
+      candidate.slug === existing.slug
+    ) {
+      reasons.push(`same ${candidate.category} slug \`${candidate.slug}\``);
+    }
+
+    const sharedUrls = intersection(candidate.urls, existing.urls);
+    if (sharedUrls.length && !isCollectionBridge(candidate, existing)) {
+      reasons.push(`same canonical source URL ${sharedUrls[0]}`);
+    }
+
+    if (
+      candidate.category &&
+      candidate.normalizedTitle &&
+      candidate.category === existing.category &&
+      candidate.normalizedTitle === existing.normalizedTitle
+    ) {
+      reasons.push(`same normalized title in ${candidate.category}`);
+    }
+
+    const sharedDomains = intersection(candidate.domains, existing.domains);
+    if (
+      sharedDomains.length &&
+      candidate.normalizedTitle &&
+      candidate.normalizedTitle === existing.normalizedTitle
+    ) {
+      reasons.push(`same source domain ${sharedDomains[0]} and title`);
+    }
+
+    if (reasons.length) return { existing, reasons };
+  }
+  return null;
+}
+
+export function findRelatedContentMatches(
+  candidate: ContentDuplicateSignals,
+  existingItems: ContentDuplicateSignals[],
+  limit = 5,
+): ContentDuplicateMatch[] {
+  const matches: ContentDuplicateMatch[] = [];
+  for (const existing of existingItems) {
+    const reasons: string[] = [];
+    if (candidate.filePath === existing.filePath) continue;
+
+    const sharedUrls = intersection(candidate.urls, existing.urls);
+    if (sharedUrls.length && isCollectionBridge(candidate, existing)) {
+      reasons.push(
+        `same canonical source URL ${sharedUrls[0]} across collection/resource categories`,
+      );
+    }
+
+    const sharedDomains = intersection(candidate.domains, existing.domains);
+    const relatedDomain = sharedDomains.find(
+      (domain) => !DOMAIN_ONLY_EXCLUSIONS.has(domain),
+    );
+    if (relatedDomain && candidate.category && existing.category) {
+      reasons.push(
+        candidate.category === existing.category
+          ? `same non-generic source domain ${relatedDomain} in ${candidate.category}`
+          : `same non-generic source domain ${relatedDomain} across ${candidate.category}/${existing.category}`,
+      );
+    }
+
+    if (
+      candidate.category &&
+      candidate.normalizedDescription &&
+      candidate.category === existing.category &&
+      candidate.normalizedDescription === existing.normalizedDescription
+    ) {
+      reasons.push(`same normalized description in ${candidate.category}`);
+    }
+
+    if (reasons.length) {
+      matches.push({ existing, reasons });
+      if (matches.length >= limit) break;
+    }
+  }
+  return matches;
+}
+
+export function buildContentDuplicateReview(
+  candidate: ContentDuplicateSignals,
+  existingItems: ContentDuplicateSignals[],
+): ContentDuplicateReview {
+  return {
+    legacyDuplicate: findContentDuplicateMatch(candidate, existingItems),
+    strictDuplicate: findStrictContentDuplicateMatch(candidate, existingItems),
+    relatedCandidates: findRelatedContentMatches(candidate, existingItems),
+  };
 }

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -13,9 +13,11 @@ import {
   slugify,
 } from "./drafts";
 import {
+  buildContentDuplicateReview,
   extractContentDuplicateSignals,
   findContentDuplicateMatch,
   protectedFrontmatterChanges,
+  type ContentDuplicateReview,
   type ContentDuplicateSignals,
 } from "./duplicates";
 import {
@@ -1801,6 +1803,34 @@ function duplicateCloseDecision(
   };
 }
 
+function summarizeDuplicateReview(review: ContentDuplicateReview) {
+  return {
+    legacyDuplicate: review.legacyDuplicate
+      ? {
+          target:
+            review.legacyDuplicate.existing.label ||
+            review.legacyDuplicate.existing.filePath,
+          url: review.legacyDuplicate.existing.url,
+          reasons: review.legacyDuplicate.reasons,
+        }
+      : null,
+    strictDuplicate: review.strictDuplicate
+      ? {
+          target:
+            review.strictDuplicate.existing.label ||
+            review.strictDuplicate.existing.filePath,
+          url: review.strictDuplicate.existing.url,
+          reasons: review.strictDuplicate.reasons,
+        }
+      : null,
+    relatedCandidates: review.relatedCandidates.map((match) => ({
+      target: match.existing.label || match.existing.filePath,
+      url: match.existing.url,
+      reasons: match.reasons,
+    })),
+  };
+}
+
 function protectedEditCloseDecision(changedFields: string[]): GateDecision {
   return {
     verdict: "close" as const,
@@ -1972,12 +2002,14 @@ async function deterministicContentPrecheck(params: {
       apiVersion: params.env.GITHUB_API_VERSION,
     })),
   ];
+  const duplicateReview = buildContentDuplicateReview(candidate, existing);
   return {
     content: candidateContent,
     decision: duplicateCloseDecision(
-      findContentDuplicateMatch(candidate, existing),
+      duplicateReview.legacyDuplicate,
       candidate,
     ),
+    duplicateReview: summarizeDuplicateReview(duplicateReview),
   };
 }
 
@@ -2753,6 +2785,27 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             target,
             scope: contentScopeForPrivateReview,
           });
+          if (precheck.duplicateReview) {
+            validationForPrivateReview = {
+              ...(isRecord(validationForPrivateReview)
+                ? validationForPrivateReview
+                : {}),
+              deterministicDuplicateReview: precheck.duplicateReview,
+            };
+            if (
+              precheck.duplicateReview.legacyDuplicate &&
+              !precheck.duplicateReview.strictDuplicate
+            ) {
+              await insertAudit(env.SUBMISSION_GATE_DB, {
+                id: crypto.randomUUID(),
+                targetKey: message.targetKey,
+                eventType: "duplicate_shadow_review",
+                decision: "related_not_strict_duplicate",
+                summary:
+                  "Legacy duplicate classifier matched, but strict duplicate classifier only found related-content context.",
+              });
+            }
+          }
           if (precheck.decision) {
             decision = precheck.decision;
           } else {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -20,8 +20,11 @@ import {
   verifyGitHubWebhookSignature,
 } from "../apps/submission-gate/src/security";
 import {
+  buildContentDuplicateReview,
   extractContentDuplicateSignals,
   findContentDuplicateMatch,
+  findRelatedContentMatches,
+  findStrictContentDuplicateMatch,
   protectedFrontmatterChanges,
 } from "../apps/submission-gate/src/duplicates";
 import {
@@ -404,6 +407,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
+    expect(source).toContain("deterministicDuplicateReview");
+    expect(source).toContain('eventType: "duplicate_shadow_review"');
+    expect(source).toContain('decision: "related_not_strict_duplicate"');
     expect(source).toContain("function ignoreOutOfScopeReviewTarget");
     expect(source).toContain(
       "Skipped because this PR no longer targets the configured content gate base.",
@@ -1099,6 +1105,104 @@ websiteUrl: "https://example-agent-tool.dev/pricing"
     expect(findContentDuplicateMatch(candidate, [existing])).toMatchObject({
       reasons: expect.arrayContaining([
         expect.stringContaining("same non-generic source domain"),
+      ]),
+    });
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toMatchObject([
+      {
+        reasons: expect.arrayContaining([
+          expect.stringContaining("same non-generic source domain"),
+        ]),
+      },
+    ]);
+    expect(buildContentDuplicateReview(candidate, [existing])).toMatchObject({
+      legacyDuplicate: {
+        reasons: expect.arrayContaining([
+          expect.stringContaining("same non-generic source domain"),
+        ]),
+      },
+      strictDuplicate: null,
+      relatedCandidates: [
+        {
+          reasons: expect.arrayContaining([
+            expect.stringContaining("same non-generic source domain"),
+          ]),
+        },
+      ],
+    });
+  });
+
+  it("distinguishes related vendor resources from strict duplicates", () => {
+    const collection = extractContentDuplicateSignals({
+      filePath: "content/collections/cloudflare-ai-workflow-stack.mdx",
+      content: `---
+title: Cloudflare AI Workflow Stack
+slug: cloudflare-ai-workflow-stack
+category: collections
+description: A collection of Cloudflare tools for building AI workflow systems.
+websiteUrl: "https://developers.cloudflare.com/workers-ai/"
+docsUrl: "https://developers.cloudflare.com/ai-gateway/"
+---
+`,
+    });
+    const specificTool = extractContentDuplicateSignals({
+      filePath: "content/tools/cloudflare-ai-gateway.mdx",
+      content: `---
+title: Cloudflare AI Gateway
+slug: cloudflare-ai-gateway
+category: tools
+description: Observability and routing gateway for AI model calls.
+websiteUrl: "https://developers.cloudflare.com/ai-gateway/"
+docsUrl: "https://developers.cloudflare.com/ai-gateway/get-started/"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(specificTool, [collection]),
+    ).toBeNull();
+    expect(findRelatedContentMatches(specificTool, [collection])).toMatchObject(
+      [
+        {
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://developers.cloudflare.com/ai-gateway across collection/resource categories",
+            ),
+          ]),
+        },
+      ],
+    );
+  });
+
+  it("treats same canonical repository as a strict duplicate", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/mcp/playwright-mcp-server.mdx",
+      content: `---
+title: Playwright MCP Server
+slug: playwright-mcp-server
+category: mcp
+description: MCP server for browser automation through Playwright.
+repoUrl: "https://github.com/microsoft/playwright-mcp"
+---
+`,
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/browser-automation-mcp.mdx",
+      content: `---
+title: Browser Automation MCP
+slug: browser-automation-mcp
+category: mcp
+description: Browser automation MCP server for Claude.
+repoUrl: "https://github.com/microsoft/playwright-mcp.git?utm_source=heyclaude"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(candidate, [existing]),
+    ).toMatchObject({
+      reasons: expect.arrayContaining([
+        expect.stringContaining("same canonical source URL"),
       ]),
     });
   });


### PR DESCRIPTION
## Summary
- add strict duplicate and related-resource classifiers alongside the existing legacy duplicate matcher
- pass shadow duplicate context into the private review payload and audit old-vs-new classifier divergence
- add regression fixtures for same-domain related resources, collection-vs-entry overlap, and strict same-repository duplicates

## What changed
- legacy duplicate close behavior is preserved for this PR
- strict duplicate matching treats same source identity, slug/title, and same repo/package/docs identity as high-confidence duplicates
- related matching captures same vendor/domain, same normalized description, and collection/resource overlap as context
- worker audit records cases where the legacy matcher closes but the stricter model only sees related-content context

## Why
- reduce future false duplicate decisions without changing live merge/close behavior before shadow observations and fixtures prove the tuning is safe
- give the private reviewer better duplicate-vs-related context while keeping scoring and prompts private

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts tests/content-policy-validation.test.ts tests/classify-pr-changes.test.ts
- pnpm submission-gate:dry-run
- pnpm validate:clean
- pnpm validate:content:strict
- pnpm validate:openapi
- pnpm test:registry-artifacts
- pnpm validate:raycast-feed
- pnpm --filter web type-check
- pnpm --filter web build
- git diff --check

## Notes
- This is intentionally shadow-first. It does not loosen or tighten the production close path yet.