### PR TITLE
fix(content): correct DVC repository provenance

### DIFF
--- a/content/tools/dvc.mdx
+++ b/content/tools/dvc.mdx
@@ -12,7 +12,7 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-03"
 websiteUrl: "https://dvc.org"
 documentationUrl: "https://dvc.org/doc"
-repoUrl: "https://github.com/treeverse/dvc"
+repoUrl: "https://github.com/iterative/dvc"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication
@@ -57,11 +57,11 @@ This is distinct from general evaluation and observability tools already in the 
 - The get started guide shows `uv tool install dvc` or `pipx install dvc`, `dvc init` inside a Git repository, `dvc add` for data tracking, and committing the generated `.dvc` metadata file to Git.
 - The docs describe DVC remotes for storing and sharing artifacts, including local directories, Amazon S3, Azure Blob Storage, Google Cloud Storage, Google Drive, SSH/SFTP, HDFS, HTTP, and WebDAV.
 - The command reference covers `dvc add`, `dvc checkout`, `dvc pull`, `dvc push`, `dvc repro`, experiments, metrics, plots, stages, remotes, and cache management.
-- The GitHub repository is `treeverse/dvc`, is Apache-2.0 licensed, and describes the project as data versioning and ML experiments.
+- The GitHub repository is `iterative/dvc`, is Apache-2.0 licensed, and describes the project as data versioning and ML experiments.
 
 ## Duplicate check
 
-Checked current `content/tools/`, `content/mcp/`, agents, hooks, rules, skills, commands, open pull requests, live issue state, and repository-wide content for `DVC`, `Data Version Control`, `dvc.org`, `github.com/treeverse/dvc`, `treeverse/dvc`, `data versioning`, `model versioning`, `dvc remote`, `dvc pipeline`, and `ML experiments`. No dedicated DVC tools entry, DVC source URL duplicate, or open duplicate PR was found.
+Checked current `content/tools/`, `content/mcp/`, agents, hooks, rules, skills, commands, open pull requests, live issue state, and repository-wide content for `DVC`, `Data Version Control`, `dvc.org`, `github.com/iterative/dvc`, `iterative/dvc`, `data versioning`, `model versioning`, `dvc remote`, `dvc pipeline`, and `ML experiments`. No dedicated DVC tools entry, DVC source URL duplicate, or open duplicate PR was found.
 
 ## Disclosure
 


### PR DESCRIPTION
### Motivation
- Fix incorrect GitHub repository provenance in the DVC listing to prevent propagation of misleading source metadata into registry artifacts and downstream consumers.

### Description
- Update `content/tools/dvc.mdx` to set `repoUrl` to `https://github.com/iterative/dvc` and replace mentions of `treeverse/dvc` with `iterative/dvc` in the source notes and duplicate-check text.

### Testing
- Ran `pnpm validate:content:strict` (content validation passed) and `git diff --check`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2112c9035c832c98b2e6e8b58240bf)