### PR TITLE
feat(registry): add content relationship graph

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -1,6 +1,7 @@
 import type {
   Category,
   Entry,
+  EntryRelation,
   HookTrigger,
   InstallType,
   Platform,
@@ -79,6 +80,16 @@ export type RegistryEntry = Record<string, unknown> & {
     platforms?: string[];
     supportLevels?: string[];
   };
+  relatedEntries?: Array<{
+    key?: string;
+    category?: string;
+    slug?: string;
+    title?: string;
+    relation?: string;
+    score?: number;
+    reasons?: string[];
+    url?: string;
+  }>;
   platformCompatibility?: Array<{
     platform: string;
     supportLevel?: string;
@@ -327,6 +338,40 @@ function normalizeRepoStats(entry: RegistryEntry): Entry["repoStats"] {
   };
 }
 
+function normalizeRelatedEntries(
+  value: RegistryEntry["relatedEntries"],
+): EntryRelation[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const rows = value
+    .map((item) => {
+      const category = asCategory(String(item.category || ""));
+      const slug = String(item.slug || "").trim();
+      const title = String(item.title || "").trim();
+      if (!slug || !title) return null;
+      return {
+        key: item.key || `${category}:${slug}`,
+        category,
+        slug,
+        title,
+        relation:
+          item.relation === "same-project" ||
+          item.relation === "collection-member" ||
+          item.relation === "works-with" ||
+          item.relation === "extends" ||
+          item.relation === "alternative" ||
+          item.relation === "safer-alternative" ||
+          item.relation === "related"
+            ? item.relation
+            : "related",
+        score: typeof item.score === "number" ? item.score : 0,
+        reasons: Array.isArray(item.reasons) ? item.reasons.map(String) : [],
+        url: String(item.url || `/entry/${category}/${slug}`),
+      } satisfies EntryRelation;
+    })
+    .filter((item): item is EntryRelation => Boolean(item));
+  return rows.length ? rows : undefined;
+}
+
 export function buildEntry(entry: RegistryEntry): Entry {
   const category = asCategory(entry.category);
   const source = inferSource(entry);
@@ -372,6 +417,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     trust: inferTrust(entry, source),
     source,
     repoStats: normalizeRepoStats(entry),
+    relatedEntries: normalizeRelatedEntries(entry.relatedEntries),
     dateAdded: entry.dateAdded ?? entry.contentUpdatedAt?.slice(0, 10) ?? "2026-01-01",
     reviewed: Boolean(reviewedAt || entry.packageVerified),
     claimed: entry.claimStatus === "verified",

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -66,6 +66,18 @@ export function getEntry(category: string, slug: string): Entry | undefined {
 }
 
 export function related(entry: Entry, limit = 4): Entry[] {
+  const graphEntries = (entry.relatedEntries ?? [])
+    .map((relation) =>
+      ENTRIES.find(
+        (candidate) => candidate.category === relation.category && candidate.slug === relation.slug,
+      ),
+    )
+    .filter((candidate): candidate is Entry => Boolean(candidate))
+    .filter((candidate) => candidate.category !== entry.category || candidate.slug !== entry.slug)
+    .slice(0, limit);
+
+  if (graphEntries.length > 0) return graphEntries;
+
   return ENTRIES.filter((e) => e.slug !== entry.slug)
     .map((e) => {
       let score = 0;

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -88,6 +88,26 @@ export interface RepoStats {
   label?: string;
 }
 
+export type EntryRelationType =
+  | "same-project"
+  | "collection-member"
+  | "works-with"
+  | "extends"
+  | "alternative"
+  | "safer-alternative"
+  | "related";
+
+export interface EntryRelation {
+  key: string;
+  category: Category;
+  slug: string;
+  title: string;
+  relation: EntryRelationType;
+  score: number;
+  reasons: string[];
+  url: string;
+}
+
 export interface EntrySection {
   title: string;
   id: string;
@@ -134,6 +154,7 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
   trust: TrustLevel;
   source: SourceStatus;
   repoStats?: RepoStats;
+  relatedEntries?: EntryRelation[];
   /** @deprecated Repo stars are source metadata, not listing popularity. */
   stars?: number;
   dateAdded: string;

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -1176,6 +1176,39 @@ export async function getRelatedEntries(args = {}, options = {}) {
     return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
   }
 
+  const graph = await readJsonArtifact("relation-graph.json", options).catch(
+    () => null,
+  );
+  const graphRow = Array.isArray(graph?.entries)
+    ? graph.entries.find((entry) => entry.key === `${category}:${slug}`)
+    : null;
+  if (graphRow?.related?.length) {
+    const searchByKey = new Map(
+      searchIndex.map((entry) => [`${entry.category}:${entry.slug}`, entry]),
+    );
+    const entries = graphRow.related
+      .map((relation) => {
+        const entry = searchByKey.get(relation.key);
+        if (!entry) return null;
+        return {
+          ...toEntrySummary(entry),
+          relation: relation.relation,
+          relatedScore: relation.score,
+          relatedReasons: relation.reasons || [],
+        };
+      })
+      .filter(Boolean)
+      .slice(0, limit);
+
+    return {
+      ok: true,
+      key: `${target.category}:${target.slug}`,
+      relationGraph: true,
+      count: entries.length,
+      entries,
+    };
+  }
+
   const entries = searchIndex
     .map((entry) => {
       const related = scoreRelatedEntry(target, entry);

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -10,6 +10,10 @@ import {
 import { renderCorpusLlms, renderEntryLlms } from "./llms.js";
 import { buildEntryJsonLdSnapshot } from "./seo.js";
 import { buildSubmissionSpecs } from "./submission-spec.js";
+import {
+  buildRegistryRelationGraph,
+  relationLookupFromGraph,
+} from "./relationships.js";
 
 export const ENTRY_SCHEMA_VERSION = 1;
 export const RAYCAST_SCHEMA_VERSION = 2;
@@ -756,18 +760,23 @@ export function buildRaycastEntries(entries) {
   });
 }
 
-export function buildEntryDetail(entry) {
+export function buildEntryDetail(entry, params = {}) {
   const {
     codeBlocks: _codeBlocks,
     sections: _sections,
     headings: _headings,
     ...detailEntry
   } = entry;
+  const relatedEntries =
+    params.relatedEntries ??
+    params.relationLookup?.get?.(`${entry.category}:${entry.slug}`) ??
+    undefined;
   return {
     schemaVersion: ENTRY_SCHEMA_VERSION,
     key: `${entry.category}:${entry.slug}`,
     entry: compactDefinedObject({
       ...detailEntry,
+      relatedEntries,
       hasCopySnippet: Boolean(entry.copySnippet || entry.hasCopySnippet),
       hasUsageSnippet: Boolean(entry.usageSnippet),
       hasConfigSnippet: Boolean(entry.configSnippet),
@@ -945,7 +954,16 @@ export function buildPluginExportFeed(entries) {
   };
 }
 
-export function buildRegistryChangelogFeed(entries) {
+export function buildRegistryChangelogFeed(entries, params = {}) {
+  const relationLookup =
+    params.relationLookup ??
+    relationLookupFromGraph(
+      buildRegistryRelationGraph(entries, {
+        siteUrl: params.siteUrl ?? SITE_URL,
+        generatedAt: generatedAtForEntries(entries),
+        limit: params.relationLimit,
+      }),
+    );
   const changes = [...entries]
     .sort((left, right) => {
       const dateCompare = String(right.dateAdded || "").localeCompare(
@@ -963,7 +981,9 @@ export function buildRegistryChangelogFeed(entries) {
       canonicalUrl: entryCanonicalUrl(entry),
       llmsUrl: entryLlmsUrl(entry),
       apiUrl: entryApiUrl(entry),
-      artifactHash: buildArtifactHash(buildEntryDetail(entry)),
+      artifactHash: buildArtifactHash(
+        buildEntryDetail(entry, { ...params, relationLookup }),
+      ),
     }));
 
   const payload = {
@@ -1133,6 +1153,7 @@ export function buildRegistryManifest(entries, extra = {}) {
       registryChangelog: dataUrl("registry-changelog.json"),
       registryManifest: dataUrl("registry-manifest.json"),
       registryTrust: dataUrl("registry-trust-report.json"),
+      relationGraph: dataUrl("relation-graph.json"),
       contentQuality: dataUrl("content-quality-report.json"),
       contentQualityPrompts: dataUrl("content-quality-prompts.json"),
       jsonLdSnapshots: dataUrl("jsonld-snapshots.json"),
@@ -1185,6 +1206,12 @@ export function buildRegistryArtifactSet(entries, params = {}) {
   const siteDescription =
     params.siteDescription ??
     "The Claude directory for agents, MCP servers, skills, commands, hooks, rules, guides, collections, and statuslines.";
+  const relationGraph = buildRegistryRelationGraph(entries, {
+    siteUrl,
+    limit: params.relationLimit,
+    generatedAt: generatedAtForEntries(entries),
+  });
+  const relationLookup = relationLookupFromGraph(relationGraph);
   const files = [
     {
       path: "directory-index.json",
@@ -1222,7 +1249,12 @@ export function buildRegistryArtifactSet(entries, params = {}) {
     {
       path: "registry-changelog.json",
       type: "json",
-      value: buildRegistryChangelogFeed(entries),
+      value: buildRegistryChangelogFeed(entries, { relationLookup }),
+    },
+    {
+      path: "relation-graph.json",
+      type: "json",
+      value: relationGraph,
     },
     {
       path: "registry-trust-report.json",
@@ -1270,7 +1302,7 @@ export function buildRegistryArtifactSet(entries, params = {}) {
       {
         path: `entries/${entry.category}/${entry.slug}.json`,
         type: "json",
-        value: buildEntryDetail(entry),
+        value: buildEntryDetail(entry, { relationLookup }),
       },
       {
         path: `llms/${entry.category}/${entry.slug}.txt`,

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -81,6 +81,45 @@ export type EntryTrustSignals = {
   supportLevels: string[];
 };
 
+export type RegistryRelationType =
+  | "same-project"
+  | "collection-member"
+  | "works-with"
+  | "extends"
+  | "alternative"
+  | "safer-alternative"
+  | "related";
+
+export type RegistryRelation = {
+  key: string;
+  category: string;
+  slug: string;
+  title: string;
+  relation: RegistryRelationType;
+  score: number;
+  reasons: string[];
+  url: string;
+};
+
+export type RegistryRelationGraphEntry = {
+  key: string;
+  category: string;
+  slug: string;
+  title: string;
+  url: string;
+  related: RegistryRelation[];
+};
+
+export type RegistryRelationGraph = {
+  schemaVersion: number;
+  kind: "registry-relation-graph";
+  generatedAt: string;
+  relationTypes: RegistryRelationType[];
+  maxRelationsPerEntry: number;
+  count: number;
+  entries: RegistryRelationGraphEntry[];
+};
+
 export type RegistryTrustReportEntry = {
   key: string;
   category: string;
@@ -263,6 +302,7 @@ export type ContentEntry = {
   llmsUrl?: string;
   apiUrl?: string;
   trustSignals?: EntryTrustSignals;
+  relatedEntries?: RegistryRelation[];
 };
 
 export type DirectoryEntry = Omit<
@@ -868,6 +908,7 @@ export function buildRegistryArtifactSet(
     siteUrl?: string;
     siteName?: string;
     siteDescription?: string;
+    relationLimit?: number;
   },
 ): Array<
   | {
@@ -887,6 +928,19 @@ export function buildSkillPlatformCompatibility(
 export function buildEntryTrustSignals(
   entry: Partial<ContentEntry>,
 ): EntryTrustSignals;
+export const REGISTRY_RELATION_TYPES: RegistryRelationType[];
+export function buildEntryRelations(
+  target: ContentEntry,
+  entries: ContentEntry[],
+  params?: { siteUrl?: string; limit?: number },
+): RegistryRelation[];
+export function buildRegistryRelationGraph(
+  entries: ContentEntry[],
+  params?: { siteUrl?: string; limit?: number; generatedAt?: string },
+): RegistryRelationGraph;
+export function relationLookupFromGraph(
+  graph: Partial<RegistryRelationGraph> | null | undefined,
+): Map<string, RegistryRelation[]>;
 export function buildRegistryTrustReport(
   entries: ContentEntry[],
 ): RegistryTrustReport;

--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -9,6 +9,7 @@ export * from "./content-schema.js";
 export * from "./frontmatter.js";
 export * from "./presentation.js";
 export * from "./quality.js";
+export * from "./relationships.js";
 export * from "./seo.js";
 export * from "./submission.js";
 export * from "./submission-risk.js";

--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -1,0 +1,381 @@
+export const REGISTRY_RELATION_TYPES = [
+  "same-project",
+  "collection-member",
+  "works-with",
+  "extends",
+  "alternative",
+  "safer-alternative",
+  "related",
+];
+
+const DEFAULT_RELATION_LIMIT = 4;
+const GENERIC_SOURCE_DOMAINS = new Set([
+  "github.com",
+  "gitlab.com",
+  "bitbucket.org",
+  "npmjs.com",
+  "pypi.org",
+  "github.io",
+  "heyclau.de",
+]);
+
+const STOP_WORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "into",
+  "your",
+  "claude",
+  "agent",
+  "agents",
+  "server",
+  "tool",
+  "tools",
+  "guide",
+  "workflow",
+  "mcp",
+  "heyclaude",
+  "command",
+  "commands",
+  "resource",
+  "resources",
+]);
+
+function entryKey(entry) {
+  return `${entry.category}:${entry.slug}`;
+}
+
+function entryUrl(entry) {
+  return `/entry/${entry.category}/${entry.slug}`;
+}
+
+function normalizeToken(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function unique(values) {
+  return values.filter(
+    (value, index, list) => value && list.indexOf(value) === index,
+  );
+}
+
+function normalizeUrl(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+
+  try {
+    const url = new URL(text);
+    url.hash = "";
+    for (const key of [...url.searchParams.keys()]) {
+      if (
+        key.toLowerCase().startsWith("utm_") ||
+        ["ref", "ref_src", "source", "fbclid", "gclid"].includes(
+          key.toLowerCase(),
+        )
+      ) {
+        url.searchParams.delete(key);
+      }
+    }
+    url.hostname = url.hostname.toLowerCase().replace(/^www\./, "");
+    url.pathname = url.pathname
+      .replace(/\.git$/, "")
+      .replace(/\/+$/, "")
+      .toLowerCase();
+    url.searchParams.sort();
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return "";
+  }
+}
+
+function sourceDomain(value) {
+  const normalized = normalizeUrl(value);
+  if (!normalized) return "";
+  try {
+    return new URL(normalized).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return "";
+  }
+}
+
+function sourceUrls(entry) {
+  return unique(
+    [
+      entry.repoUrl,
+      entry.documentationUrl,
+      entry.websiteUrl,
+      entry.downloadUrl && !String(entry.downloadUrl).startsWith("/")
+        ? entry.downloadUrl
+        : "",
+      ...(Array.isArray(entry.retrievalSources) ? entry.retrievalSources : []),
+    ]
+      .map(normalizeUrl)
+      .filter(Boolean),
+  );
+}
+
+function sourceDomains(entry) {
+  return unique(sourceUrls(entry).map(sourceDomain)).filter(
+    (domain) => domain && !GENERIC_SOURCE_DOMAINS.has(domain),
+  );
+}
+
+function githubRepoKey(entry) {
+  const repoUrl = normalizeUrl(entry.repoUrl);
+  if (!repoUrl) return "";
+
+  try {
+    const url = new URL(repoUrl);
+    if (url.hostname !== "github.com") return "";
+    const [owner, repo] = url.pathname.split("/").filter(Boolean);
+    if (!owner || !repo) return "";
+    return `${owner}/${repo}`;
+  } catch {
+    return "";
+  }
+}
+
+function textTokens(entry) {
+  const values = [
+    ...(Array.isArray(entry.tags) ? entry.tags : []),
+    ...(Array.isArray(entry.keywords) ? entry.keywords : []),
+    entry.title,
+  ];
+  const tokens = [];
+
+  for (const value of values) {
+    for (const token of String(value || "")
+      .toLowerCase()
+      .split(/[^a-z0-9+#.-]+/)) {
+      const trimmed = token.trim();
+      if (trimmed.length < 3 || STOP_WORDS.has(trimmed)) continue;
+      tokens.push(trimmed);
+    }
+  }
+
+  return unique(tokens);
+}
+
+function collectionRefs(entry) {
+  if (entry.category !== "collections" || !Array.isArray(entry.items)) {
+    return [];
+  }
+
+  return entry.items
+    .map((item) => {
+      if (typeof item === "string") {
+        const [category, slug] = item.split("/");
+        return category && slug ? `${category}:${slug}` : "";
+      }
+      return item?.category && item?.slug
+        ? `${item.category}:${item.slug}`
+        : "";
+    })
+    .filter(Boolean);
+}
+
+function categoryPairKind(target, candidate) {
+  const pair = new Set([target.category, candidate.category]);
+  if (target.category === candidate.category) return "same-category";
+  if (pair.has("collections")) return "collection-adjacent";
+  if (pair.has("guides")) return "guide-adjacent";
+  if (pair.has("mcp") && (pair.has("tools") || pair.has("guides"))) {
+    return "mcp-tooling";
+  }
+  if (pair.has("commands") && pair.has("hooks")) return "workflow-control";
+  if (pair.has("skills") && (pair.has("rules") || pair.has("agents"))) {
+    return "workflow-pack";
+  }
+  return "";
+}
+
+function relationTypeFor(target, candidate, evidence) {
+  if (evidence.collectionMember) return "collection-member";
+  if (evidence.sameProject) return "same-project";
+  if (
+    target.category === candidate.category &&
+    evidence.candidateHasStrongerSafety &&
+    evidence.sharedTokens.length > 0
+  ) {
+    return "safer-alternative";
+  }
+  if (
+    target.category === candidate.category &&
+    (evidence.sharedTokens.length > 0 || evidence.sharedDomains.length > 0)
+  ) {
+    return "alternative";
+  }
+  if (
+    evidence.categoryPair === "guide-adjacent" ||
+    evidence.categoryPair === "collection-adjacent"
+  ) {
+    return "extends";
+  }
+  if (
+    ["mcp-tooling", "workflow-control", "workflow-pack"].includes(
+      evidence.categoryPair,
+    )
+  ) {
+    return "works-with";
+  }
+  return "related";
+}
+
+function scoreCandidate(target, candidate) {
+  if (entryKey(target) === entryKey(candidate)) return null;
+
+  const targetRefs = new Set(collectionRefs(target));
+  const candidateRefs = new Set(collectionRefs(candidate));
+  const targetKey = entryKey(target);
+  const candidateKey = entryKey(candidate);
+  const collectionMember =
+    targetRefs.has(candidateKey) || candidateRefs.has(targetKey);
+  const targetRepo = githubRepoKey(target);
+  const candidateRepo = githubRepoKey(candidate);
+  const sameProject =
+    Boolean(targetRepo && candidateRepo) && targetRepo === candidateRepo;
+  const sharedUrls = intersection(sourceUrls(target), sourceUrls(candidate));
+  const sharedDomains = intersection(
+    sourceDomains(target),
+    sourceDomains(candidate),
+  );
+  const sharedTokens = intersection(textTokens(target), textTokens(candidate));
+  const categoryPair = categoryPairKind(target, candidate);
+  const candidateHasStrongerSafety =
+    !notes(target.safetyNotes).length &&
+    notes(candidate.safetyNotes).length > 0 &&
+    candidate.downloadTrust !== "external";
+
+  const score =
+    (collectionMember ? 100 : 0) +
+    (sameProject ? 90 : 0) +
+    sharedUrls.length * 70 +
+    sharedDomains.length * 16 +
+    Math.min(sharedTokens.length, 8) * 4 +
+    (target.category === candidate.category ? 10 : 0) +
+    (categoryPair ? 6 : 0) +
+    (candidateHasStrongerSafety ? 5 : 0);
+
+  if (score < 18) return null;
+
+  const evidence = {
+    collectionMember,
+    sameProject,
+    sharedUrls,
+    sharedDomains,
+    sharedTokens,
+    categoryPair,
+    candidateHasStrongerSafety,
+  };
+
+  return {
+    score,
+    relation: relationTypeFor(target, candidate, evidence),
+    reasons: unique([
+      ...(collectionMember ? ["collection_member"] : []),
+      ...(sameProject ? [`same_project:${targetRepo}`] : []),
+      ...(sharedUrls.length ? ["shared_source_url"] : []),
+      ...sharedDomains.slice(0, 2).map((domain) => `source_domain:${domain}`),
+      ...sharedTokens.slice(0, 5).map((token) => `topic:${token}`),
+      ...(target.category === candidate.category ? ["same_category"] : []),
+      ...(categoryPair && categoryPair !== "same-category"
+        ? [`category_pair:${categoryPair}`]
+        : []),
+      ...(candidateHasStrongerSafety ? ["safer_metadata"] : []),
+    ]).slice(0, 6),
+  };
+}
+
+function notes(values) {
+  return Array.isArray(values)
+    ? values.map((value) => String(value || "").trim()).filter(Boolean)
+    : [];
+}
+
+function intersection(left = [], right = []) {
+  const rightValues = new Set(right.map(normalizeToken).filter(Boolean));
+  return unique(left.map(normalizeToken).filter(Boolean)).filter((value) =>
+    rightValues.has(value),
+  );
+}
+
+export function buildEntryRelations(target, entries, params = {}) {
+  const limit = params.limit ?? DEFAULT_RELATION_LIMIT;
+
+  return entries
+    .map((candidate) => {
+      const scored = scoreCandidate(target, candidate);
+      if (!scored) return null;
+      return {
+        key: entryKey(candidate),
+        category: candidate.category,
+        slug: candidate.slug,
+        title: candidate.title,
+        relation: scored.relation,
+        score: scored.score,
+        reasons: scored.reasons,
+        url: entryUrl(candidate),
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => {
+      if (right.score !== left.score) return right.score - left.score;
+      if (left.relation !== right.relation) {
+        return (
+          REGISTRY_RELATION_TYPES.indexOf(left.relation) -
+          REGISTRY_RELATION_TYPES.indexOf(right.relation)
+        );
+      }
+      return left.title.localeCompare(right.title);
+    })
+    .slice(0, limit);
+}
+
+export function buildRegistryRelationGraph(entries, params = {}) {
+  const limit = params.limit ?? DEFAULT_RELATION_LIMIT;
+
+  const rows = entries.map((entry) => ({
+    key: entryKey(entry),
+    category: entry.category,
+    slug: entry.slug,
+    title: entry.title,
+    url: entryUrl(entry),
+    related: buildEntryRelations(entry, entries, { limit }),
+  }));
+
+  return {
+    schemaVersion: 1,
+    kind: "registry-relation-graph",
+    generatedAt:
+      params.generatedAt ||
+      (entries[0]?.dateAdded
+        ? `${entries
+            .map((entry) =>
+              String(entry.contentUpdatedAt || entry.dateAdded || "").slice(
+                0,
+                10,
+              ),
+            )
+            .filter(Boolean)
+            .sort()
+            .at(-1)}T00:00:00.000Z`
+        : "1970-01-01T00:00:00.000Z"),
+    relationTypes: REGISTRY_RELATION_TYPES,
+    maxRelationsPerEntry: limit,
+    count: rows.length,
+    entries: rows,
+  };
+}
+
+export function relationLookupFromGraph(graph) {
+  return new Map(
+    (Array.isArray(graph?.entries) ? graph.entries : []).map((row) => [
+      row.key,
+      row.related || [],
+    ]),
+  );
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -900,6 +900,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(result).toMatchObject({
       ok: true,
       key: `${skill.category}:${skill.slug}`,
+      relationGraph: true,
       count: expect.any(Number),
     });
     expect(result.entries.length).toBeGreaterThan(0);
@@ -907,6 +908,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       `${skill.category}:${skill.slug}`,
     );
     expect(result.entries[0]).toMatchObject({
+      relation: expect.any(String),
       relatedScore: expect.any(Number),
       relatedReasons: expect.arrayContaining([expect.any(String)]),
     });

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -17,6 +17,7 @@ import {
   buildCursorSkillAdapter,
   buildJsonLdSnapshots,
   buildRegistryChangelogFeed,
+  buildRegistryRelationGraph,
   buildRegistryTrustReport,
   buildSourceHealthReport,
   buildEntrySourceHealth,
@@ -200,6 +201,9 @@ describe("registry artifacts", () => {
     expect(artifactSize("directory-index.json")).toBeLessThan(1_000_000);
     expect(artifactSize("search-index.json")).toBeLessThan(750_000);
     expect(artifactSize("raycast-index.json")).toBeLessThan(500_000);
+    expect(artifactSize("relation-graph.json")).toBeLessThan(
+      150_000 + entryCount * 1_500,
+    );
     expect(artifactTreeSize("feeds/categories")).toBeLessThan(1_250_000);
     expect(artifactTreeSize("feeds/platforms")).toBeLessThan(1_500_000);
     expect(artifactTreeSize("entries")).toBeLessThan(
@@ -234,7 +238,9 @@ describe("registry artifacts", () => {
     expect(atlasSkill).not.toHaveProperty("copySnippet");
     expect(skillDetail).toMatchObject({
       body: expect.any(String),
+      relatedEntries: expect.any(Array),
     });
+    expect(atlasSkill).not.toHaveProperty("relatedEntries");
     expect(skillDetail).not.toHaveProperty("sections");
     expect(skillDetail).not.toHaveProperty("headings");
     expect(skillDetail).not.toHaveProperty("codeBlocks");
@@ -591,9 +597,17 @@ describe("registry artifacts", () => {
   });
 
   it("derives all generated aggregate artifacts from registry builders", () => {
+    const relationGraphPayload = readDataJson<Record<string, unknown>>(
+      "relation-graph.json",
+    );
     expect(buildDirectoryEntries(contentEntries)).toEqual(directoryEntries);
     expect(buildSearchEntries(contentEntries)).toEqual(searchEntries);
     expect(buildRaycastEnvelope(contentEntries)).toEqual(raycastPayload);
+    expect(
+      buildRegistryRelationGraph(contentEntries, {
+        generatedAt: String(relationGraphPayload.generatedAt),
+      }),
+    ).toEqual(relationGraphPayload);
     expect(buildContentQualityArtifact(contentEntries)).toEqual(qualityPayload);
     expect(buildContentPromptArtifact(contentEntries)).toEqual(
       qualityPromptsPayload,
@@ -608,6 +622,61 @@ describe("registry artifacts", () => {
         ),
       ),
     ).toEqual(jsonLdSnapshotsPayload);
+  });
+
+  it("publishes deterministic relation graph refs into entry details", () => {
+    const graph = readDataJson<{
+      kind: string;
+      count: number;
+      entries: Array<{
+        key: string;
+        related: Array<{
+          key: string;
+          category: string;
+          slug: string;
+          relation: string;
+          score: number;
+          reasons: string[];
+          url: string;
+        }>;
+      }>;
+    }>("relation-graph.json");
+
+    expect(graph).toMatchObject({
+      kind: "registry-relation-graph",
+      count: contentEntries.length,
+    });
+
+    const rowsWithRelations = graph.entries.filter(
+      (entry) => entry.related.length > 0,
+    );
+    expect(rowsWithRelations.length).toBeGreaterThan(0);
+    for (const row of rowsWithRelations.slice(0, 25)) {
+      expect(row.related.length).toBeLessThanOrEqual(4);
+      expect(row.related.map((relation) => relation.key)).not.toContain(
+        row.key,
+      );
+      expect(row.related).toEqual(
+        [...row.related].sort((left, right) => right.score - left.score),
+      );
+    }
+
+    const collectionRow = graph.entries.find(
+      (entry) => entry.key === "collections:browser-automation-mcp-stack",
+    );
+    if (collectionRow) {
+      expect(
+        collectionRow.related.some(
+          (relation) => relation.relation === "collection-member",
+        ),
+      ).toBe(true);
+    }
+
+    const [sample] = rowsWithRelations;
+    const detailPayload = readDataJson<{
+      entry: { relatedEntries?: unknown[] };
+    }>(`entries/${sample.key.replace(":", "/")}.json`);
+    expect(detailPayload.entry.relatedEntries).toEqual(sample.related);
   });
 
   it("derives compact search URLs from unhydrated source entries", () => {


### PR DESCRIPTION
## Summary
- add a deterministic public relation graph for registry entries
- publish bounded related-entry refs in per-entry detail artifacts and the registry manifest
- use graph-backed relationships in web entry pages and the read-only MCP related-entries tool

## What changed
- added `packages/registry/src/relationships.js` for public, deterministic relation scoring from source URLs, collection membership, category adjacency, tags, and source domains
- added `/data/relation-graph.json` to generated artifacts and entry detail payloads
- kept Atlas/list payloads lean by leaving relation refs out of list projections
- updated MCP `get_related_entries` to prefer the generated graph and fall back to the existing scorer for older artifacts
- added artifact budget and relation graph contract tests

## Why
- make content discovery more encyclopedia-like without making contributors author relationship metadata
- give the private reviewer better public context for related-vs-duplicate decisions without exposing private scoring or prompts
- keep generated data bounded after the churn cleanup

## Validation
- `pnpm exec vitest run tests/registry-artifacts.test.ts tests/mcp-server.test.ts`
- `pnpm validate:content:strict`
- `pnpm validate:raycast-feed`
- `pnpm validate:openapi`
- `pnpm --filter web type-check`
- `pnpm --filter web build`
- `pnpm validate:clean`
- `git diff --check`

## Notes
- Generated artifacts remain ignored/untracked build outputs.
- The private reviewer implementation and scoring remain outside the public repo.
- The generated relation graph is currently capped at four related entries per source entry.