### PR TITLE
feat(content): add git-secrets-env-risk-statusline

### DIFF
--- a/content/statuslines/git-secrets-env-risk-statusline.mdx
+++ b/content/statuslines/git-secrets-env-risk-statusline.mdx
@@ -1,0 +1,105 @@
+---
+title: git-secrets Environment Risk Statusline
+slug: git-secrets-env-risk-statusline
+category: statuslines
+description: Claude Code statusline that surfaces sensitive environment-file risk and can optionally run git-secrets as a local pre-commit-style scanner.
+cardDescription: Show sensitive environment-file risk with optional git-secrets scanning.
+seoTitle: git-secrets environment risk statusline for Claude Code
+seoDescription: Add a Claude Code statusline that warns about sensitive environment files and optional git-secrets scan results.
+author: MkDev11
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-04"
+documentationUrl: "https://github.com/awslabs/git-secrets"
+repoUrl: "https://github.com/awslabs/git-secrets"
+tags:
+  - security
+  - secrets
+  - environment
+  - claude-code
+keywords:
+  - git secrets statusline
+  - sensitive environment statusline
+  - secret risk statusline
+  - environment file warning
+installable: true
+usageSnippet: "secrets: env files 2 | scan opt-in"
+copySnippet: |-
+  {
+    "statusLine": {
+      "type": "command",
+      "command": "$CLAUDE_PROJECT_DIR/.claude/statuslines/git-secrets-env-risk-statusline.sh"
+    }
+  }
+configSnippet: |-
+  {
+    "statusLine": {
+      "type": "command",
+      "command": "$CLAUDE_PROJECT_DIR/.claude/statuslines/git-secrets-env-risk-statusline.sh"
+    }
+  }
+scriptLanguage: bash
+scriptBody: |-
+  #!/usr/bin/env bash
+  set -u
+
+  main() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "secrets: no repository"
+    exit 0
+  fi
+
+  env_count=$(git status --porcelain=v1 -- .env '.env.*' .npmrc .pypirc .netrc 2>/dev/null | wc -l | tr -d ' ')
+
+  if [ "${GIT_SECRETS_STATUSLINE_SCAN:-0}" != "1" ]; then
+    printf 'secrets: env files %s | scan opt-in\n' "$env_count"
+    exit 0
+  fi
+
+  if command -v git-secrets >/dev/null 2>&1; then
+    if git-secrets --scan -r . >/dev/null 2>&1; then
+      printf 'secrets: env files %s | scan clean\n' "$env_count"
+    else
+      printf 'secrets: env files %s | review scan\n' "$env_count"
+    fi
+  elif git secrets --help >/dev/null 2>&1; then
+    if git secrets --scan -r . >/dev/null 2>&1; then
+      printf 'secrets: env files %s | scan clean\n' "$env_count"
+    else
+      printf 'secrets: env files %s | review scan\n' "$env_count"
+    fi
+  else
+    printf 'secrets: env files %s | git-secrets missing\n' "$env_count"
+  fi
+  }
+
+  case $- in
+    *n*) ;;
+    *) main "$@" ;;
+  esac
+prerequisites:
+  - Git installed and the command run from a repository worktree.
+  - Optional git-secrets installed if GIT_SECRETS_STATUSLINE_SCAN is set to 1.
+  - A slower refresh interval when optional scanning is enabled, because recursive scans can be expensive.
+safetyNotes:
+  - The default mode does not scan file contents; it only counts sensitive-looking environment files in Git status.
+  - Enable recursive git-secrets scanning only in repositories where you are authorized to inspect all files.
+  - Treat any scan warning as a stop-and-review signal before committing, sharing logs, or opening a PR.
+privacyNotes:
+  - The default output prints counts only and does not print filenames or matched values.
+  - Recursive scans read repository files and may inspect sensitive local material.
+  - Terminal recordings can still reveal that a workspace contains sensitive environment files.
+---
+
+## Source notes
+
+- AWS Labs git-secrets documents a Git-focused scanner for preventing secrets from being committed.
+- This entry focuses on local environment-file risk and optional git-secrets scanning rather than Gitleaks, which already has a dedicated tools entry.
+
+## Duplicate check
+
+Checked existing statuslines, live HeyClaude statuslines, open pull requests, and repository content for `git-secrets-env-risk-statusline`, git-secrets, Gitleaks, sensitive environment statuslines, and secret-risk entries. The earlier Gitleaks submission was closed for matching `content/tools/gitleaks.mdx`; this replacement uses AWS Labs git-secrets with a different canonical source and scope.
+
+## Disclosure
+
+Editorial statusline recipe. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary
- Adds a git-secrets environment risk statusline for sensitive file visibility and optional local scanning.
- Replaces the closed Gitleaks submission with a different canonical source and scope.

## What changed
- Adds `content/statuslines/git-secrets-env-risk-statusline.mdx`.
- Uses AWS Labs `git-secrets` as the source instead of the existing Gitleaks tool source.

## Why
- Fills the #809 secret-risk statusline slot while avoiding the `content/tools/gitleaks.mdx` duplicate that closed #962.
- Closes #809.

## Validation
- `git diff --cached --check`
- `bash -n /tmp/git-secrets-env-risk-statusline.sh`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/statusline-809-git-secrets-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref statusline-809-git-secrets-env-risk --pr-author MkDev11`

## Notes
- Replacement for #962 with different canonical source URL and changed value proposition.
- One-file direct submission: `content/statuslines/git-secrets-env-risk-statusline.mdx`.
