### PR TITLE
fix(statuslines): default empty repo health counts

### DIFF
--- a/content/statuslines/gh-repo-health-statusline.mdx
+++ b/content/statuslines/gh-repo-health-statusline.mdx
@@ -61,8 +61,10 @@ scriptBody: |-
   name=$(printf '%s' "$repo_json" | jq -r '.nameWithOwner // "unknown"')
   branch=$(printf '%s' "$repo_json" | jq -r '.defaultBranchRef.name // "main"')
   archived=$(printf '%s' "$repo_json" | jq -r '.isArchived // false')
-  prs=$(gh pr list --state open --limit 100 --json number 2>/dev/null | jq 'length' 2>/dev/null || echo 0)
-  issues=$(gh issue list --state open --limit 100 --json number 2>/dev/null | jq 'length' 2>/dev/null || echo 0)
+  prs=$(gh pr list --state open --limit 100 --json number 2>/dev/null | jq 'length' 2>/dev/null)
+  issues=$(gh issue list --state open --limit 100 --json number 2>/dev/null | jq 'length' 2>/dev/null)
+  prs=${prs:-0}
+  issues=${issues:-0}
 
   if [ "$archived" = "true" ]; then
     state="archived"


### PR DESCRIPTION
### Motivation
- Fix a robustness bug in the embedded GitHub repo health statusline where failed `gh pr list`/`gh issue list` calls could leave `prs`/`issues` empty and cause `integer expression expected` errors during numeric comparisons.

### Description
- Replace the pipeline-attached `|| echo 0` fallback with explicit defaults after `jq` by assigning `prs` and `issues` from `jq 'length'` and then normalizing with `prs=${prs:-0}` and `issues=${issues:-0}` so numeric comparisons always see a valid integer.

### Testing
- Ran `pnpm validate:content:strict` (passed), executed the extracted statusline script with a mocked failing `gh` to verify it prints `prs 0` and `issues 0` with no diagnostics, and ran `git diff --check` (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2118cb93d4832c91cb09848240ef3b)