### PR TITLE
fix(registry): remove unsafe safer alternative relation

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -359,7 +359,6 @@ function normalizeRelatedEntries(
           item.relation === "works-with" ||
           item.relation === "extends" ||
           item.relation === "alternative" ||
-          item.relation === "safer-alternative" ||
           item.relation === "related"
             ? item.relation
             : "related",

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -94,7 +94,6 @@ export type EntryRelationType =
   | "works-with"
   | "extends"
   | "alternative"
-  | "safer-alternative"
   | "related";
 
 export interface EntryRelation {

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -87,7 +87,6 @@ export type RegistryRelationType =
   | "works-with"
   | "extends"
   | "alternative"
-  | "safer-alternative"
   | "related";
 
 export type RegistryRelation = {

--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -4,7 +4,6 @@ export const REGISTRY_RELATION_TYPES = [
   "works-with",
   "extends",
   "alternative",
-  "safer-alternative",
   "related",
 ];
 
@@ -198,13 +197,6 @@ function relationTypeFor(target, candidate, evidence) {
   if (evidence.sameProject) return "same-project";
   if (
     target.category === candidate.category &&
-    evidence.candidateHasStrongerSafety &&
-    evidence.sharedTokens.length > 0
-  ) {
-    return "safer-alternative";
-  }
-  if (
-    target.category === candidate.category &&
     (evidence.sharedTokens.length > 0 || evidence.sharedDomains.length > 0)
   ) {
     return "alternative";
@@ -245,11 +237,6 @@ function scoreCandidate(target, candidate) {
   );
   const sharedTokens = intersection(textTokens(target), textTokens(candidate));
   const categoryPair = categoryPairKind(target, candidate);
-  const candidateHasStrongerSafety =
-    !notes(target.safetyNotes).length &&
-    notes(candidate.safetyNotes).length > 0 &&
-    candidate.downloadTrust !== "external";
-
   const score =
     (collectionMember ? 100 : 0) +
     (sameProject ? 90 : 0) +
@@ -257,8 +244,7 @@ function scoreCandidate(target, candidate) {
     sharedDomains.length * 16 +
     Math.min(sharedTokens.length, 8) * 4 +
     (target.category === candidate.category ? 10 : 0) +
-    (categoryPair ? 6 : 0) +
-    (candidateHasStrongerSafety ? 5 : 0);
+    (categoryPair ? 6 : 0);
 
   if (score < 18) return null;
 
@@ -269,7 +255,6 @@ function scoreCandidate(target, candidate) {
     sharedDomains,
     sharedTokens,
     categoryPair,
-    candidateHasStrongerSafety,
   };
 
   return {
@@ -285,15 +270,8 @@ function scoreCandidate(target, candidate) {
       ...(categoryPair && categoryPair !== "same-category"
         ? [`category_pair:${categoryPair}`]
         : []),
-      ...(candidateHasStrongerSafety ? ["safer_metadata"] : []),
     ]).slice(0, 6),
   };
-}
-
-function notes(values) {
-  return Array.isArray(values)
-    ? values.map((value) => String(value || "").trim()).filter(Boolean)
-    : [];
 }
 
 function intersection(left = [], right = []) {

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -17,6 +17,7 @@ import {
   buildCursorSkillAdapter,
   buildJsonLdSnapshots,
   buildRegistryChangelogFeed,
+  buildEntryRelations,
   buildRegistryRelationGraph,
   buildRegistryTrustReport,
   buildSourceHealthReport,
@@ -622,6 +623,41 @@ describe("registry artifacts", () => {
         ),
       ),
     ).toEqual(jsonLdSnapshotsPayload);
+  });
+
+  it("does not derive comparative safety relations from safety notes alone", () => {
+    const target = {
+      category: "skills",
+      slug: "shared-target",
+      title: "Shared Workflow Target",
+      description: "A shared workflow target without safety notes.",
+      tags: ["shared"],
+      keywords: [],
+      safetyNotes: [],
+    };
+    const candidate = {
+      category: "skills",
+      slug: "shared-candidate",
+      title: "Shared Workflow Candidate",
+      description: "A shared workflow candidate with self-declared safety notes.",
+      tags: ["shared"],
+      keywords: [],
+      safetyNotes: ["Review permissions before installing."],
+      downloadTrust: "source-backed",
+    };
+
+    const [relation] = buildEntryRelations(target, [target, candidate], {
+      limit: 1,
+    });
+
+    expect(relation).toMatchObject({
+      key: "skills:shared-candidate",
+      relation: "alternative",
+    });
+    expect(relation?.reasons).not.toContain("safer_metadata");
+    expect(
+      buildRegistryRelationGraph([target, candidate]).relationTypes,
+    ).not.toContain("safer-alternative");
   });
 
   it("publishes deterministic relation graph refs into entry details", () => {


### PR DESCRIPTION
### Motivation
- The relationship graph emitted a `safer-alternative` label based only on the presence of `safetyNotes` and shared tokens, which can misrepresent provenance or actual safety and leak a trust-like recommendation to downstream agents. 
- Registry artifacts and the MCP `get_related_entries` tool exposed that label in public payloads and API responses, creating a risk of misleading consumers. 
- The change replaces the weak comparative-safety signal with conservative behavior that preserves non-comparative relations (`alternative`, `related`, `same-project`, `collection-member`, `extends`, `works-with`).

### Description
- Remove the `safer-alternative` relation from `REGISTRY_RELATION_TYPES` and stop deriving it in `relationTypeFor` so comparative safety labels are no longer generated (changes in `packages/registry/src/relationships.js`).
- Stop scoring and serializing `safer_metadata` evidence and remove the `candidateHasStrongerSafety` check from scoring/evidence so `safetyNotes` no longer affect comparative scoring (changes in `packages/registry/src/relationships.js`).
- Remove `safer-alternative` from type declarations and normalize stale/unknown relation values to `related` in web types and normalization logic (`packages/registry/src/index.d.ts`, `apps/web/src/types/registry.ts`, `apps/web/src/data/entry-normalize.ts`).
- Add a regression test that constructs a pair of entries where one only differs by having `safetyNotes` and asserts the graph yields a normal `alternative` relation, no `safer_metadata` reason, and the `safer-alternative` relation type is not present (`tests/registry-artifacts.test.ts`).

### Testing
- Ran the targeted unit test: `pnpm exec vitest run tests/registry-artifacts.test.ts --testNamePattern "does not derive comparative safety relations"`, which passed. 
- Ran the core registry tests: `pnpm exec vitest run tests/registry-artifacts.test.ts tests/mcp-server.test.ts`, and the test suite passed (all tests green). 
- Regenerated artifacts via the repository build and verified `relation-graph.json` no longer contains `safer-alternative` or `safer_metadata`. 
- Executed `pnpm build` and `git diff --check` to ensure build and formatting checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a211e83dcfc832c81f9617a7d4d757f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed the "safer-alternative" relationship type from the registry. Related entries previously classified as safer alternatives are now classified as "alternative".

* **Tests**
  * Added tests to verify relationship derivation and classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->