### PR TITLE
content(hooks): add pre-write secret scanner

### DIFF
--- a/content/hooks/pre-write-secret-scanner.mdx
+++ b/content/hooks/pre-write-secret-scanner.mdx
@@ -1,0 +1,216 @@
+---
+title: Pre-Write Secret Scanner - Claude Code Hook
+slug: pre-write-secret-scanner
+category: hooks
+description: >-
+  PreToolUse hook that scans the exact text Claude Code is about to write or
+  edit for high-confidence secret formats (AWS access keys, GitHub tokens,
+  OpenAI keys, Slack tokens, Google API keys, Stripe keys, and private key
+  blocks) and blocks the write with a non-zero exit before the secret ever
+  reaches disk. Pattern set mirrors the canonical gitleaks rules.
+cardDescription: >-
+  Block writes that would commit AWS, GitHub, OpenAI, Slack, Google, or Stripe
+  secrets before they reach disk.
+seoTitle: Pre-Write Secret Scanner - Claude Code Hook
+seoDescription: >-
+  A Claude Code PreToolUse hook that scans pending Write/Edit/MultiEdit content
+  for high-confidence secret patterns and blocks the write before the secret
+  is saved.
+author: jony376
+submittedBy: jony376
+submittedByUrl: "https://github.com/jony376"
+dateAdded: "2026-06-04"
+documentationUrl: "https://docs.anthropic.com/en/docs/claude-code/hooks"
+repoUrl: "https://github.com/gitleaks/gitleaks"
+installable: true
+installCommand: >-
+  mkdir -p .claude/hooks && touch
+  .claude/hooks/pre-write-secret-scanner.sh && chmod +x
+  .claude/hooks/pre-write-secret-scanner.sh
+usageSnippet: "🔒 Secret blocked: possible GitHub personal access token in src/config.ts."
+copySnippet: |-
+  {
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+            }
+          ]
+        }
+      ]
+    }
+  }
+configSnippet: |-
+  {
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+            }
+          ]
+        }
+      ]
+    }
+  }
+scriptLanguage: bash
+scriptBody: |-
+  #!/usr/bin/env bash
+  set -u
+
+  # Claude Code PreToolUse hook. Scans the text a Write/Edit/MultiEdit call is
+  # about to persist for high-confidence secret formats and blocks the call
+  # (exit code 2) before the secret reaches disk. The stderr message is fed
+  # back to Claude so it can redact and retry. Fails open: any inability to
+  # inspect the input leaves the write unblocked.
+
+  if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  INPUT=$(cat)
+  FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // ""')
+
+  # Only the NEW text this tool would write, across Write/Edit/MultiEdit.
+  CONTENT=$(printf '%s' "$INPUT" | jq -r '
+    [ .tool_input.content,
+      .tool_input.new_string,
+      (.tool_input.edits[]?.new_string) ]
+    | map(select(. != null)) | join("\n")
+  ')
+
+  if [ -z "$CONTENT" ]; then
+    exit 0
+  fi
+
+  # name|ERE pairs for high-confidence secret formats (mirrors gitleaks rules).
+  PATTERNS=(
+    "AWS access key|AKIA[0-9A-Z]{16}"
+    "GitHub token|gh[pousr]_[A-Za-z0-9]{36,}"
+    "GitHub fine-grained token|github_pat_[A-Za-z0-9_]{82}"
+    "OpenAI API key|sk-(proj-)?[A-Za-z0-9_-]{20,}"
+    "Slack token|xox[baprs]-[A-Za-z0-9-]{10,}"
+    "Google API key|AIza[0-9A-Za-z_-]{35}"
+    "Stripe secret key|sk_live_[0-9a-zA-Z]{24,}"
+    "Private key block|-----BEGIN [A-Z ]*PRIVATE KEY-----"
+  )
+
+  FOUND=0
+  for entry in "${PATTERNS[@]}"; do
+    name=${entry%%|*}
+    regex=${entry#*|}
+    if printf '%s' "$CONTENT" | grep -Eq "$regex"; then
+      echo "🔒 Secret blocked: possible ${name} in ${FILE:-pending write}." >&2
+      FOUND=1
+    fi
+  done
+
+  if [ "$FOUND" -ne 0 ]; then
+    echo "Replace the secret with an environment variable or secret-manager reference, then retry." >&2
+    exit 2
+  fi
+
+  exit 0
+trigger: PreToolUse
+prerequisites:
+  - Claude Code CLI with hooks enabled.
+  - bash and jq available on PATH (the hook fails open and does not block if jq is missing).
+safetyNotes:
+  - Runs before every Write, Edit, and MultiEdit and reads the pending content from the tool input on stdin.
+  - Blocks the write with exit code 2 when a high-confidence secret pattern matches; no files are created, deleted, or modified by the hook itself.
+  - Uses regex heuristics, so it can produce false positives (block a non-secret) or false negatives (miss an obfuscated secret); treat it as a guardrail, not proof of safety.
+  - Makes no network calls and runs entirely locally.
+privacyNotes:
+  - Reads the text about to be written but never prints the matched secret value; only the detected secret type and the target file path are written to stderr.
+  - Writes nothing to disk and retains no logs.
+  - The target file path shown in the message may reveal local directory structure in your terminal output.
+tags:
+  - security
+  - secrets
+  - pre-commit
+  - guardrail
+  - gitleaks
+keywords:
+  - pre-write secret scanner hook
+  - claude code secret detection
+  - block secrets before write
+  - gitleaks pattern hook
+---
+
+## Features
+
+- Scans the exact text a `Write`, `Edit`, or `MultiEdit` call would persist — before it reaches disk — and blocks it on a match (exit code 2).
+- Detects high-confidence secret formats whose patterns mirror the canonical [gitleaks](https://github.com/gitleaks/gitleaks) rule set, so detections map to real provider key shapes rather than ad-hoc guesses.
+- Reports the detected secret **type** and target file without ever echoing the secret value.
+- Fails open: if `jq` is unavailable or the tool input carries no new text, the write proceeds untouched.
+- Pure local bash + jq, no network access, no persisted logs.
+
+## How it works
+
+Claude Code passes the pending tool call to the hook as JSON on stdin. The hook extracts only the *new* text the call would write (`tool_input.content` for Write, `new_string` for Edit, and each `edits[].new_string` for MultiEdit), then tests it against a list of named secret patterns. If any match, it prints a redacted message to stderr and exits `2`, which instructs Claude Code to block the call so the secret is never saved.
+
+## Detected secret types
+
+- AWS access key IDs (`AKIA…`)
+- GitHub personal access and OAuth tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`) and fine-grained tokens (`github_pat_…`)
+- OpenAI API keys (`sk-…`, `sk-proj-…`)
+- Slack tokens (`xox[baprs]-…`)
+- Google API keys (`AIza…`)
+- Stripe secret keys (`sk_live_…`)
+- PEM private key blocks (`-----BEGIN … PRIVATE KEY-----`)
+
+## Use cases
+
+- Stop Claude from hardcoding a leaked credential into source, config, or test fixtures during an agentic session.
+- Add a defense-in-depth layer ahead of (not instead of) commit-time scanners like gitleaks in CI.
+- Keep `.env`-style values out of files that are about to be written to a tracked directory.
+
+## Installation
+
+1. Create the hooks directory: `mkdir -p .claude/hooks`
+2. Create the hook file: `touch .claude/hooks/pre-write-secret-scanner.sh`
+3. Paste the script body into that file and make it executable: `chmod +x .claude/hooks/pre-write-secret-scanner.sh`
+4. Add the configuration below to `.claude/settings.json` (project) or `~/.claude/settings.json` (user).
+
+## Requirements
+
+- Claude Code CLI with hooks enabled
+- bash shell
+- jq (for parsing the tool input)
+
+## Hook configuration
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Regex detection cannot catch every secret format and may flag a non-secret that happens to match a shape; tune the `PATTERNS` list for your stack.
+- It inspects only the content of the pending write, not files already on disk — pair it with a repository-wide scanner for full coverage.
+
+## Source and references
+
+- Secret pattern shapes mirror the canonical rules in [gitleaks](https://github.com/gitleaks/gitleaks).
+- Claude Code hook contract and exit-code semantics: [Claude Code hooks documentation](https://docs.anthropic.com/en/docs/claude-code/hooks).


### PR DESCRIPTION
Closes #759

## Summary

Adds one Hooks entry: a `PreToolUse` secret scanner that blocks `Write` / `Edit` / `MultiEdit` calls whose pending content matches a high-confidence secret format — AWS access keys, GitHub tokens (classic + fine-grained), OpenAI keys, Slack tokens, Google API keys, Stripe keys, and PEM private-key blocks — before the secret ever reaches disk (exit code 2). Fails open if `jq` is missing; reports only the detected secret *type* and file, never the value.

## Source / provenance

- Secret pattern shapes mirror the canonical **gitleaks** rules: https://github.com/gitleaks/gitleaks
- Claude Code hook contract and exit-code semantics: https://docs.anthropic.com/en/docs/claude-code/hooks

## Duplicate check

Searched `content/hooks/` slugs and titles, the live site, and open PRs for: `secret`, `scanner`, `gitleaks`, `credential`, `token`, `key`, `env`, `leak`. The closest existing entries are `environment-variable-validator` and `environment-cleanup-handler`, which validate/clean environment-variable *usage* but do **not** scan pending write content against provider secret formats or block the write — distinct scope. No open PR targets a secret scanner.

## Safety / privacy

- **safetyNotes**: runs before Write/Edit/MultiEdit; blocks on match via exit 2; regex heuristic (possible false positives/negatives); no network; the hook mutates no files.
- **privacyNotes**: reads pending content but never prints the matched secret value (only type + path); writes no logs.

## Checks

Exactly one `content/hooks/pre-write-secret-scanner.mdx` file. No edits to `README.md`, generated data, workflows, package files, scripts, or other entries. `git diff --check` clean. Frontmatter YAML parses and `bash -n` on the script passes locally; relying on CI for `pnpm validate:content:strict` (pnpm is not available in my environment).
