### PR TITLE
content(rules): add commit message and changelog rules for contributor PRs

### DIFF
--- a/content/rules/commit-message-changelog-rules.mdx
+++ b/content/rules/commit-message-changelog-rules.mdx
@@ -1,0 +1,110 @@
+---
+title: Commit Message and Changelog Rules for Contributor PRs
+slug: commit-message-changelog-rules
+category: rules
+description: >-
+  A rules pack that holds Claude to Conventional Commits 1.0.0 for every commit
+  and PR title, keeps a Keep a Changelog 1.1.0 "Unreleased" section in sync, and
+  maps commit types to Semantic Versioning bumps — so contributor pull requests
+  to open-source repositories produce clean, reviewable, release-ready history.
+cardDescription: >-
+  Hold Claude to Conventional Commits, Keep a Changelog, and SemVer when
+  preparing contributor pull requests.
+seoTitle: Commit Message and Changelog Rules for Contributor PRs
+seoDescription: >-
+  Claude rules enforcing Conventional Commits 1.0.0, Keep a Changelog 1.1.0, and
+  Semantic Versioning for clean, release-ready contributor pull requests.
+author: jony376
+submittedBy: jony376
+submittedByUrl: "https://github.com/jony376"
+dateAdded: "2026-06-04"
+documentationUrl: "https://www.conventionalcommits.org/en/v1.0.0/"
+installable: false
+usageSnippet: >-
+  When writing commits, PR titles, and changelog entries, follow Conventional
+  Commits 1.0.0, Keep a Changelog 1.1.0, and Semantic Versioning 2.0.0.
+copySnippet: |-
+  # Commit Message and Changelog Rules
+
+  Apply these rules whenever you create commits, write a pull request title, or
+  update a changelog in this repository.
+
+  ## Conventional Commits (1.0.0)
+
+  - Format every commit and PR title as `type(scope): summary`.
+  - Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`,
+    `build`, `ci`, `chore`, `revert`.
+  - `scope` is optional and names the affected area (package, module, feature).
+  - The summary is imperative mood, lower case, no trailing period, <= 72 chars.
+  - Use the body to explain *why*, not *what*; wrap at 72 columns.
+  - Breaking changes: append `!` after the type/scope (`feat(api)!: ...`) AND add
+    a `BREAKING CHANGE: <description>` footer.
+  - Reference issues in the footer: `Closes #123` (full fix) or `Refs #123`.
+  - One logical change per commit; do not mix refactors with behavior changes.
+
+  ## Keep a Changelog (1.1.0)
+
+  - Maintain a `CHANGELOG.md` with a top `## [Unreleased]` section.
+  - Group entries under `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`,
+    `Security` — never dump a raw commit log.
+  - Write changelog entries for humans (impact-focused), not for machines.
+  - On release, rename `[Unreleased]` to `## [x.y.z] - YYYY-MM-DD` and open a
+    fresh empty `[Unreleased]` above it.
+  - Link versions to their compare/diff URLs at the bottom of the file.
+
+  ## Semantic Versioning (2.0.0)
+
+  - `fix:` -> PATCH bump. `feat:` -> MINOR bump. `BREAKING CHANGE` -> MAJOR bump.
+  - `docs`, `style`, `test`, `chore`, `ci`, `build`, `refactor` (no behavior
+    change) do not bump the version on their own.
+
+  ## Pull request hygiene
+
+  - The PR title is itself a Conventional Commit and becomes the squash-merge
+    subject; keep it accurate.
+  - Summarize what changed, why, and how it was verified.
+  - Keep generated-artifact churn and unrelated reformatting out of the PR.
+tags:
+  - git
+  - conventional-commits
+  - changelog
+  - semver
+  - pull-requests
+keywords:
+  - commit message rules
+  - conventional commits rules
+  - keep a changelog rules
+  - contributor pr rules
+---
+
+These rules keep Claude's commits, pull request titles, and changelog edits consistent with the three specifications most open-source projects already expect: [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/), [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## When to use
+
+- Preparing contributor pull requests to repositories that enforce Conventional Commit titles or run commit-lint in CI.
+- Repositories that maintain a human-readable `CHANGELOG.md`.
+- Any project where squash-merge uses the PR title as the commit subject.
+
+## What it enforces
+
+- **Conventional Commits 1.0.0** — a fixed type set, imperative lower-case summaries under 72 characters, a "why" body, explicit `BREAKING CHANGE` footers, and `Closes`/`Refs` issue links.
+- **Keep a Changelog 1.1.0** — a maintained `## [Unreleased]` section with the standard `Added/Changed/Deprecated/Removed/Fixed/Security` groups, human-focused entries, and a clean release-cut flow.
+- **Semantic Versioning 2.0.0** — the commit-type → version-bump mapping (`fix` → patch, `feat` → minor, `BREAKING CHANGE` → major).
+
+## How to apply
+
+Paste the copy block into your project rules (for example `.claude/rules/`, a `CLAUDE.md` rules section, or your agent's system rules). Claude will then format commits and PR titles accordingly and keep the changelog's `Unreleased` section in sync as it works.
+
+## Safety notes
+
+Not applicable: this is guidance-only text. It does not execute commands, install anything, access the network, or modify files on its own — it only shapes how Claude writes commit messages, PR titles, and changelog entries.
+
+## Privacy notes
+
+Not applicable: the rules contain no credentials, telemetry, or data handling. They process nothing beyond the commit/PR/changelog text you are already authoring.
+
+## Source and references
+
+- Conventional Commits 1.0.0: https://www.conventionalcommits.org/en/v1.0.0/
+- Keep a Changelog 1.1.0: https://keepachangelog.com/en/1.1.0/
+- Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
Closes #739

## Summary

Adds one Rules entry: a commit-message and changelog rules pack for contributor pull requests. It holds Claude to **Conventional Commits 1.0.0** for every commit and PR title, keeps a **Keep a Changelog 1.1.0** `Unreleased` section in sync, and applies the **Semantic Versioning 2.0.0** commit-type → bump mapping — so PRs to open-source repos produce clean, reviewable, release-ready history.

## Source / provenance

- Conventional Commits 1.0.0: https://www.conventionalcommits.org/en/v1.0.0/
- Keep a Changelog 1.1.0: https://keepachangelog.com/en/1.1.0/
- Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html

## Duplicate check

Searched `content/rules/` slugs and titles, the live site, and open PRs for: `commit`, `changelog`, `conventional`, `version`, `semver`, `release`, `pr`, `message`. No existing rules entry covers commit-message formatting, changelog maintenance, or SemVer bumps. No open PR targets this. Distinct from the PR-hygiene-for-content-only-contributions slot (#730).

## Safety / privacy

- **safetyNotes**: not applicable and stated as such — guidance-only text; it executes nothing, installs nothing, makes no network calls, and modifies no files. It only shapes how Claude writes commits, PR titles, and changelog entries.
- **privacyNotes**: not applicable — no credentials, telemetry, or data handling; it processes only the commit/PR/changelog text you are already authoring.

## Checks

Exactly one `content/rules/commit-message-changelog-rules.mdx` file. No edits to `README.md`, generated data, workflows, package files, scripts, or other entries. `git diff --check` clean; frontmatter YAML parses locally. Relying on CI for `pnpm validate:content:strict` (pnpm not available in my environment).
