### PR TITLE
fix(submissions): ignore maintainer maintenance prs

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -309,6 +309,11 @@ type DirectContentReviewability =
   | { kind: "scope_failure"; decision: GateDecision; category?: string }
   | { kind: "ignore"; reason: string };
 
+type DirectContentReviewContext = {
+  headRepo?: string;
+  baseRepo?: string;
+};
+
 function json(payload: unknown, init: ResponseInit = {}) {
   const headers = new Headers(init.headers);
   headers.set("content-type", "application/json; charset=utf-8");
@@ -1071,6 +1076,10 @@ async function directContentReviewabilityForTarget(
     repo,
     number: target.number,
     apiVersion: env.GITHUB_API_VERSION,
+    context: {
+      headRepo: target.headRepo,
+      baseRepo: target.repoFullName,
+    },
   });
 }
 
@@ -1271,6 +1280,7 @@ function gateLabelsForCategory(category?: string) {
 
 function classifyPullRequestFilesForContentReview(
   files: Array<{ filename?: string; status?: string }>,
+  context: DirectContentReviewContext = {},
 ): DirectContentReviewability {
   const entryFiles = files
     .map((file) => ({
@@ -1288,6 +1298,18 @@ function classifyPullRequestFilesForContentReview(
   }
 
   if (files.length !== 1 || entryFiles.length !== 1) {
+    if (
+      context.headRepo &&
+      context.baseRepo &&
+      context.headRepo.toLowerCase() === context.baseRepo.toLowerCase()
+    ) {
+      return {
+        kind: "ignore",
+        reason:
+          "Mixed same-repository maintenance PR; content gate only reviews exact one-file content submissions.",
+      };
+    }
+
     return {
       kind: "scope_failure",
       category: entryFiles[0]?.pathParts?.category,
@@ -1340,6 +1362,7 @@ async function directContentReviewabilityForPr(params: {
   repo: ReturnType<typeof parseRepo>;
   number: number;
   apiVersion?: string;
+  context?: DirectContentReviewContext;
 }): Promise<DirectContentReviewability> {
   const files = await listPullRequestFiles({
     token: params.token,
@@ -1347,7 +1370,7 @@ async function directContentReviewabilityForPr(params: {
     number: params.number,
     apiVersion: params.apiVersion,
   });
-  return classifyPullRequestFilesForContentReview(files);
+  return classifyPullRequestFilesForContentReview(files, params.context);
 }
 
 async function directContentScopeForPr(params: {
@@ -1411,6 +1434,10 @@ async function assertDirectContentAutoMergeEligibility(params: {
     repo: params.repo,
     number: params.target.number,
     apiVersion: params.env.GITHUB_API_VERSION,
+    context: {
+      headRepo: params.target.headRepo,
+      baseRepo: params.target.repoFullName,
+    },
   });
   if (classification.kind === "scope_failure") {
     throw new Error(classification.decision.summary);
@@ -2822,6 +2849,10 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         repo,
         number: target.number,
         apiVersion: env.GITHUB_API_VERSION,
+        context: {
+          headRepo: target.headRepo,
+          baseRepo: target.repoFullName,
+        },
       });
       if (reviewability.kind === "ignore") {
         await removeLabels({

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -703,10 +703,19 @@ describe("Cloudflare submission gate helpers", () => {
     expect(classifierBlock).toContain("entryFiles.length === 0");
     expect(classifierBlock).toContain('kind: "ignore"');
     expect(classifierBlock).toContain("files.length !== 1");
+    expect(classifierBlock).toContain(
+      "context.headRepo.toLowerCase() === context.baseRepo.toLowerCase()",
+    );
+    expect(classifierBlock).toContain(
+      "Mixed same-repository maintenance PR; content gate only reviews exact one-file content submissions.",
+    );
     expect(classifierBlock).toContain('kind: "scope_failure"');
     expect(classifierBlock).toContain(
       "no generated artifacts, README, workflows, scripts, packages, or additional entries",
     );
+    expect(source).toContain("type DirectContentReviewContext");
+    expect(source).toContain("headRepo: target.headRepo");
+    expect(source).toContain("baseRepo: target.repoFullName");
   });
 
   it("does not apply the merged label before direct merge succeeds", () => {


### PR DESCRIPTION
## Summary
- prevents the content maintainer gate from closing same-repository maintenance PRs that touch content metadata alongside code
- keeps fork/external mixed content submissions fail-closed
- adds regression coverage for the classifier boundary

## Why
The live gate treated a same-repo maintenance PR as a direct content submission because content files were present in a larger platform diff. That should be ignored by the content bot and handled by normal repo CI/review.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `git diff --check`

## Notes
This is a narrow gate-scope fix intended to unblock the larger maintenance/release-watch PR after the production gate deploys from `main`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Pull request classification now detects and ignores mixed same-repository maintenance PRs from the content review process when head and base repositories match, based on case-insensitive comparison.

* **Tests**
  * Test coverage expanded to verify repository matching logic and proper content review classification for excluded PR scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->