### PR TITLE
fix(registry): preserve compact note presence filters

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -115,6 +115,8 @@
               },
               "lastVerifiedAt": { "type": "string" },
               "adapterGenerated": { "type": "boolean" },
+              "hasSafetyNotes": { "type": "boolean" },
+              "hasPrivacyNotes": { "type": "boolean" },
               "platforms": { "type": "array", "items": { "type": "string" }, "maxItems": 12 },
               "supportLevels": { "type": "array", "items": { "type": "string" }, "maxItems": 12 }
             }
@@ -226,6 +228,8 @@
           },
           "lastVerifiedAt": { "type": "string" },
           "adapterGenerated": { "type": "boolean" },
+          "hasSafetyNotes": { "type": "boolean" },
+          "hasPrivacyNotes": { "type": "boolean" },
           "platforms": { "type": "array", "items": { "type": "string" }, "maxItems": 12 },
           "supportLevels": { "type": "array", "items": { "type": "string" }, "maxItems": 12 }
         }
@@ -921,6 +925,8 @@
                               },
                               "lastVerifiedAt": { "type": "string" },
                               "adapterGenerated": { "type": "boolean" },
+                              "hasSafetyNotes": { "type": "boolean" },
+                              "hasPrivacyNotes": { "type": "boolean" },
                               "platforms": {
                                 "type": "array",
                                 "items": { "type": "string" },

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -220,6 +220,10 @@ components:
               type: string
             adapterGenerated:
               type: boolean
+            hasSafetyNotes:
+              type: boolean
+            hasPrivacyNotes:
+              type: boolean
             platforms:
               type: array
               items:
@@ -379,6 +383,10 @@ components:
         lastVerifiedAt:
           type: string
         adapterGenerated:
+          type: boolean
+        hasSafetyNotes:
+          type: boolean
+        hasPrivacyNotes:
           type: boolean
         platforms:
           type: array
@@ -1232,6 +1240,10 @@ paths:
                             lastVerifiedAt:
                               type: string
                             adapterGenerated:
+                              type: boolean
+                            hasSafetyNotes:
+                              type: boolean
+                            hasPrivacyNotes:
                               type: boolean
                             platforms:
                               type: array

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -235,6 +235,8 @@ export const registryTrustSignalsSchema = z.object({
   sourceStatus: z.enum(["available", "missing"]).or(z.string()).optional(),
   lastVerifiedAt: z.string().optional(),
   adapterGenerated: z.boolean().optional(),
+  hasSafetyNotes: z.boolean().optional(),
+  hasPrivacyNotes: z.boolean().optional(),
   platforms: z.array(z.string()).max(12).optional(),
   supportLevels: z.array(z.string()).max(12).optional(),
 });

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -2,17 +2,9 @@ import type { SearchDocument } from "@heyclaude/registry";
 
 export type BooleanFilterValue = "all" | "true" | "false";
 
-export type DownloadTrustFilterValue =
-  | "all"
-  | "first-party"
-  | "external"
-  | "none";
+export type DownloadTrustFilterValue = "all" | "first-party" | "external" | "none";
 
-export type ClaimStatusFilterValue =
-  | "all"
-  | "unclaimed"
-  | "pending"
-  | "verified";
+export type ClaimStatusFilterValue = "all" | "unclaimed" | "pending" | "verified";
 
 export type SourceStatusFilterValue = "all" | "available" | "missing";
 
@@ -75,25 +67,20 @@ export function matchesQuery(entry: SearchDocument, query: string) {
 
 export function matchesPlatform(entry: SearchDocument, platform: string) {
   if (!platform) return true;
-  return (entry.platforms ?? []).some(
-    (item) => String(item).trim().toLowerCase() === platform,
-  );
+  return (entry.platforms ?? []).some((item) => String(item).trim().toLowerCase() === platform);
 }
 
-export function matchesBooleanFilter(
-  value: boolean,
-  filter: BooleanFilterValue,
-) {
+export function matchesBooleanFilter(value: boolean, filter: BooleanFilterValue) {
   if (filter === "all") return true;
   return filter === "true" ? value : !value;
 }
 
 export function hasSafetyNotes(entry: SearchDocument) {
-  return Boolean(entry.safetyNotes?.length);
+  return Boolean(entry.trustSignals?.hasSafetyNotes || entry.safetyNotes?.length);
 }
 
 export function hasPrivacyNotes(entry: SearchDocument) {
-  return Boolean(entry.privacyNotes?.length);
+  return Boolean(entry.trustSignals?.hasPrivacyNotes || entry.privacyNotes?.length);
 }
 
 export function packageTrustValue(entry: SearchDocument) {
@@ -113,14 +100,9 @@ export function entryMatchesFilters(
   filters: RegistrySearchFilterState,
   except?: ReadonlySet<RegistrySearchFilterDimension>,
 ) {
-  const skip = (dimension: RegistrySearchFilterDimension) =>
-    except?.has(dimension) === true;
+  const skip = (dimension: RegistrySearchFilterDimension) => except?.has(dimension) === true;
 
-  if (
-    !skip("category") &&
-    filters.category &&
-    entry.category !== filters.category
-  ) {
+  if (!skip("category") && filters.category && entry.category !== filters.category) {
     return false;
   }
   if (!skip("platform") && !matchesPlatform(entry, filters.platform)) {
@@ -189,9 +171,7 @@ export function scoreSearchEntry(
   const title = entry.title.toLowerCase();
   const category = entry.category.toLowerCase();
   const tags = new Set((entry.tags ?? []).map((tag) => tag.toLowerCase()));
-  const keywords = new Set(
-    (entry.keywords ?? []).map((keyword) => keyword.toLowerCase()),
-  );
+  const keywords = new Set((entry.keywords ?? []).map((keyword) => keyword.toLowerCase()));
   const haystack = normalizedSearchText(entry);
   let score = 0;
   const reasons = new Set<string>();
@@ -231,10 +211,7 @@ export function scoreSearchEntry(
     score += 8;
     reasons.add("source-backed");
   }
-  if (
-    entry.downloadTrust === "first-party" ||
-    entry.trustSignals?.packageVerified === true
-  ) {
+  if (entry.downloadTrust === "first-party" || entry.trustSignals?.packageVerified === true) {
     score += 8;
     reasons.add("trusted package");
   }

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -221,6 +221,10 @@ components:
               type: string
             adapterGenerated:
               type: boolean
+            hasSafetyNotes:
+              type: boolean
+            hasPrivacyNotes:
+              type: boolean
             platforms:
               type: array
               items:
@@ -380,6 +384,10 @@ components:
         lastVerifiedAt:
           type: string
         adapterGenerated:
+          type: boolean
+        hasSafetyNotes:
+          type: boolean
+        hasPrivacyNotes:
           type: boolean
         platforms:
           type: array
@@ -1233,6 +1241,10 @@ paths:
                             lastVerifiedAt:
                               type: string
                             adapterGenerated:
+                              type: boolean
+                            hasSafetyNotes:
+                              type: boolean
+                            hasPrivacyNotes:
                               type: boolean
                             platforms:
                               type: array

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -415,6 +415,8 @@ export function buildEntryTrustSignals(entry) {
   const packageChecksum =
     entry.downloadSha256 || entry.skillPackage?.sha256 || "";
   const sourceUrls = sourceUrlsForEntry(entry);
+  const hasSafetyNotes = noteList(entry.safetyNotes).length > 0;
+  const hasPrivacyNotes = noteList(entry.privacyNotes).length > 0;
 
   return {
     firstPartyEditorial: entry.disclosure === "heyclaude_pick",
@@ -427,6 +429,8 @@ export function buildEntryTrustSignals(entry) {
     sourceStatus: sourceUrls.length ? "available" : "missing",
     lastVerifiedAt: lastVerifiedForEntry(entry),
     adapterGenerated,
+    hasSafetyNotes,
+    hasPrivacyNotes,
     platforms: platformCompatibility.map((item) => item.platform),
     supportLevels: platformCompatibility.map((item) => item.supportLevel),
   };
@@ -439,6 +443,8 @@ function buildListTrustSignals(entry) {
     packageVerified: trustSignals.packageVerified,
     sourceStatus: trustSignals.sourceStatus,
     lastVerifiedAt: trustSignals.lastVerifiedAt,
+    hasSafetyNotes: trustSignals.hasSafetyNotes,
+    hasPrivacyNotes: trustSignals.hasPrivacyNotes,
     platforms: trustSignals.platforms,
     supportLevels: trustSignals.supportLevels,
   };

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -77,6 +77,8 @@ export type EntryTrustSignals = {
   sourceStatus: "available" | "missing" | string;
   lastVerifiedAt: string;
   adapterGenerated: boolean;
+  hasSafetyNotes: boolean;
+  hasPrivacyNotes: boolean;
   platforms: string[];
   supportLevels: string[];
 };

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -639,7 +639,8 @@ describe("registry artifacts", () => {
       category: "skills",
       slug: "shared-candidate",
       title: "Shared Workflow Candidate",
-      description: "A shared workflow candidate with self-declared safety notes.",
+      description:
+        "A shared workflow candidate with self-declared safety notes.",
       tags: ["shared"],
       keywords: [],
       safetyNotes: ["Review permissions before installing."],
@@ -762,9 +763,21 @@ Use this hook after reviewing the notes.`,
       "Reads local workspace metadata and does not send it to third parties.",
     ]);
 
+    const [directoryEntry] = buildDirectoryEntries([entry]);
+    expect(directoryEntry.safetyNotes).toBeUndefined();
+    expect(directoryEntry.privacyNotes).toBeUndefined();
+    expect(directoryEntry.trustSignals).toMatchObject({
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
+    });
+
     const [searchEntry] = buildSearchEntries([entry]);
     expect(searchEntry.safetyNotes).toBeUndefined();
     expect(searchEntry.privacyNotes).toBeUndefined();
+    expect(searchEntry.trustSignals).toMatchObject({
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
+    });
     expect(searchEntry.downloadUrl).toBe("");
     expect(buildRaycastDetailMarkdown(entry)).toContain("## Safety notes");
     expect(buildRaycastDetailMarkdown(entry)).toContain("## Privacy notes");
@@ -993,6 +1006,8 @@ Use this hook after reviewing the notes.`,
       expect((entry as Record<string, unknown>).llmsUrl).toBeUndefined();
       expect((entry as Record<string, unknown>).safetyNotes).toBeUndefined();
       expect((entry as Record<string, unknown>).privacyNotes).toBeUndefined();
+      expect(entry.trustSignals).toHaveProperty("hasSafetyNotes");
+      expect(entry.trustSignals).toHaveProperty("hasPrivacyNotes");
     }
     expect(
       searchEntries.some((entry) => entry.platforms?.includes("Gemini")),

--- a/tests/registry-search-facets.test.ts
+++ b/tests/registry-search-facets.test.ts
@@ -38,6 +38,8 @@ function makeEntry(overrides: Partial<SearchDocument>): SearchDocument {
       sourceStatus: "missing",
       lastVerifiedAt: "",
       adapterGenerated: false,
+      hasSafetyNotes: false,
+      hasPrivacyNotes: false,
       platforms: [],
       supportLevels: [],
     },
@@ -67,6 +69,7 @@ const fixtures: SearchDocument[] = [
     trustSignals: {
       ...makeEntry({}).trustSignals,
       sourceStatus: "available",
+      hasSafetyNotes: true,
     },
   }),
   makeEntry({
@@ -90,6 +93,7 @@ const fixtures: SearchDocument[] = [
     trustSignals: {
       ...makeEntry({}).trustSignals,
       sourceStatus: "available",
+      hasPrivacyNotes: true,
     },
   }),
   makeEntry({
@@ -103,6 +107,8 @@ const fixtures: SearchDocument[] = [
     trustSignals: {
       ...makeEntry({}).trustSignals,
       sourceStatus: "available",
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
     },
   }),
 ];
@@ -192,5 +198,29 @@ describe("computeRegistrySearchFacets", () => {
 
     expect(matched).toHaveLength(2);
     expect(facets.hasSafetyNotes.true).toBe(2);
+  });
+
+  it("uses compact trust-signal booleans when full note text is omitted", () => {
+    const compact = makeEntry({
+      slug: "compact-notes",
+      trustSignals: {
+        ...makeEntry({}).trustSignals,
+        hasSafetyNotes: true,
+        hasPrivacyNotes: true,
+      },
+    });
+
+    expect(
+      filterEntries([compact], {
+        ...defaultFilters,
+        hasSafetyNotes: "true",
+      }),
+    ).toHaveLength(1);
+    expect(
+      computeRegistrySearchFacets([compact], defaultFilters),
+    ).toMatchObject({
+      hasSafetyNotes: { true: 1 },
+      hasPrivacyNotes: { true: 1 },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add compact `hasSafetyNotes` and `hasPrivacyNotes` trust-signal booleans to registry artifacts
- teach registry search filters/facets to use those booleans when full note text is omitted
- keep directory/search payloads lean by not restoring full safety/privacy note arrays
- update OpenAPI contracts and regression coverage

## Why
#880 correctly identified that note-based filters could misclassify compact search entries, but restoring full note text to list/search artifacts works against the payload-compaction direction. This keeps the filter signal without bloating compact feeds.

## Validation
- `pnpm exec vitest run tests/registry-artifacts.test.ts tests/registry-search-facets.test.ts tests/registry-search-api.test.ts`
- `pnpm validate:openapi`
- `pnpm validate:raycast-feed`
- `pnpm --filter web type-check`
- `pnpm build`
- `git diff --check`

## Notes
- Supersedes #880 with a compact-payload implementation.
