### PR TITLE
feat(registry): compact artifacts and slim labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/product-feature.yml
+++ b/.github/ISSUE_TEMPLATE/product-feature.yml
@@ -3,6 +3,7 @@ description: Propose contributor work for HeyClaude product, website, API, MCP, 
 title: "feat: "
 labels:
   - help wanted
+  - gittensor:feature
 body:
   - type: markdown
     attributes:

--- a/.github/release-watch.json
+++ b/.github/release-watch.json
@@ -1,0 +1,3 @@
+{
+  "assignees": ["JSONbored"]
+}

--- a/apps/web/src/data/ecosystem-feeds.ts
+++ b/apps/web/src/data/ecosystem-feeds.ts
@@ -35,10 +35,6 @@ const PURPOSES: Record<string, Pick<EcosystemFeed, "purpose" | "consumers">> = {
     purpose: "JSON index of public machine-readable feeds.",
     consumers: ["Web", "API clients"],
   },
-  "/data/llms-full.txt": {
-    purpose: "LLM-ingestible directory corpus.",
-    consumers: ["LLM ingestion"],
-  },
 };
 
 function contentTypeFor(path: string): EcosystemFeed["contentType"] {

--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -354,8 +354,12 @@ function normalizeRelatedEntries(
         slug,
         title,
         relation:
+          item.relation === "duplicate" ||
           item.relation === "same-project" ||
           item.relation === "collection-member" ||
+          item.relation === "complementary" ||
+          item.relation === "same-ecosystem" ||
+          item.relation === "prerequisite" ||
           item.relation === "works-with" ||
           item.relation === "extends" ||
           item.relation === "alternative" ||

--- a/apps/web/src/data/integrations.ts
+++ b/apps/web/src/data/integrations.ts
@@ -159,7 +159,7 @@ export const INTEGRATIONS: Integration[] = [
     bullets: [
       "/llms.txt — full directory map for retrieval",
       "/llms-full.txt — entire corpus in one file",
-      "/data/llms/<category>/<slug>.txt — per-entry text export",
+      "/api/registry/entries/<category>/<slug>/llms — per-entry text export",
     ],
     primaryAction: { label: "View llms.txt", href: "https://heyclau.de/llms.txt" },
     secondaryAction: { label: "Full corpus", href: "https://heyclau.de/llms-full.txt" },

--- a/apps/web/src/lib/content.server.ts
+++ b/apps/web/src/lib/content.server.ts
@@ -2,6 +2,7 @@ import { cache } from "react";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { renderEntryLlms } from "@heyclaude/registry";
 import type {
   ArtifactManifestV2,
   CategorySummary,
@@ -173,11 +174,8 @@ export const getEntryLlmsText = cache(async (category: string, slug: string) => 
     return null;
   }
 
-  try {
-    return await loadTextDataFile(`llms/${category}/${slug}.txt`);
-  } catch {
-    return null;
-  }
+  const entry = await getEntry(category, slug);
+  return entry ? renderEntryLlms(entry) : null;
 });
 
 export const getRegistryManifest = cache(async () => {

--- a/apps/web/src/routes/$category.$slug.llms[.]txt.ts
+++ b/apps/web/src/routes/$category.$slug.llms[.]txt.ts
@@ -5,7 +5,7 @@ export const Route = createFileRoute("/$category/$slug/llms.txt")({
     handlers: {
       GET: async ({ request, params }) => {
         const url = new URL(
-          `/data/llms/${encodeURIComponent(params.category)}/${encodeURIComponent(params.slug)}.txt`,
+          `/api/registry/entries/${encodeURIComponent(params.category)}/${encodeURIComponent(params.slug)}/llms`,
           request.url,
         );
         return Response.redirect(url, 301);

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -221,7 +221,7 @@ function Dossier() {
               title={entry.title}
               description={entry.description}
               ogUrl={`/og/${entry.category}/${entry.slug}`}
-              llmsUrl={`/data/llms/${entry.category}/${entry.slug}.txt`}
+              llmsUrl={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
             />
           </div>
 

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -89,8 +89,12 @@ export interface RepoStats {
 }
 
 export type EntryRelationType =
+  | "duplicate"
   | "same-project"
   | "collection-member"
+  | "complementary"
+  | "same-ecosystem"
+  | "prerequisite"
   | "works-with"
   | "extends"
   | "alternative"

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -218,7 +218,7 @@ function categoryCanonicalUrl(category, siteUrl = SITE_URL) {
 }
 
 function entryLlmsUrl(entry, siteUrl = SITE_URL) {
-  return `${siteUrl.replace(/\/$/, "")}${dataUrl("llms", entry.category, `${entry.slug}.txt`)}`;
+  return `${entryApiUrl(entry, siteUrl)}/llms`;
 }
 
 function entryApiUrl(entry, siteUrl = SITE_URL) {
@@ -806,7 +806,7 @@ export function buildRaycastDetail(entry) {
     detailMarkdown: buildRaycastDetailMarkdown(entry),
     webUrl: entryCanonicalUrl(entry),
     canonicalUrl: entryCanonicalUrl(entry),
-    llmsUrl: dataUrl("llms", entry.category, `${entry.slug}.txt`),
+    llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
     apiUrl: entryApiUrl(entry),
     seoTitle: entry.seoTitle || entry.title,
     seoDescription: entry.seoDescription || entry.description,
@@ -1163,9 +1163,8 @@ export function buildRegistryManifest(entries, extra = {}) {
       contentQuality: dataUrl("content-quality-report.json"),
       contentQualityPrompts: dataUrl("content-quality-prompts.json"),
       jsonLdSnapshots: dataUrl("jsonld-snapshots.json"),
-      llmsFull: dataUrl("llms-full.txt"),
+      llmsFull: "/llms-full.txt",
       entryDetails: dataUrl("entries"),
-      entryLlms: dataUrl("llms"),
       raycastDetails: dataUrl("raycast"),
       skillAdapters: dataUrl("skill-adapters"),
       distributionFeeds: dataUrl("feeds"),
@@ -1209,9 +1208,6 @@ export function buildCorpusLlmsArtifact(entries, params = {}) {
 export function buildRegistryArtifactSet(entries, params = {}) {
   const siteUrl = params.siteUrl ?? SITE_URL;
   const siteName = params.siteName ?? "HeyClaude";
-  const siteDescription =
-    params.siteDescription ??
-    "The Claude directory for agents, MCP servers, skills, commands, hooks, rules, guides, collections, and statuslines.";
   const relationGraph = buildRegistryRelationGraph(entries, {
     siteUrl,
     limit: params.relationLimit,
@@ -1292,15 +1288,6 @@ export function buildRegistryArtifactSet(entries, params = {}) {
       type: "json",
       value: buildJsonLdSnapshots(entries, { siteUrl, siteName }),
     },
-    {
-      path: "llms-full.txt",
-      type: "text",
-      value: buildCorpusLlmsArtifact(entries, {
-        siteUrl,
-        siteName,
-        siteDescription,
-      }),
-    },
   ];
 
   for (const entry of entries) {
@@ -1309,11 +1296,6 @@ export function buildRegistryArtifactSet(entries, params = {}) {
         path: `entries/${entry.category}/${entry.slug}.json`,
         type: "json",
         value: buildEntryDetail(entry, { relationLookup }),
-      },
-      {
-        path: `llms/${entry.category}/${entry.slug}.txt`,
-        type: "text",
-        value: buildEntryLlmsArtifact(entry, { siteUrl }),
       },
       {
         path: `raycast/${entry.category}/${entry.slug}.json`,

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -84,8 +84,12 @@ export type EntryTrustSignals = {
 };
 
 export type RegistryRelationType =
+  | "duplicate"
   | "same-project"
   | "collection-member"
+  | "complementary"
+  | "same-ecosystem"
+  | "prerequisite"
   | "works-with"
   | "extends"
   | "alternative"
@@ -722,7 +726,6 @@ export type SubmissionRiskReport = {
   trustSignals: string[];
   sourceUrls: string[];
   classificationWarnings: SubmissionClassificationWarning[];
-  recommendedLabels: string[];
   recommendedAction:
     | "maintainer_review"
     | "request_author_input"
@@ -731,7 +734,6 @@ export type SubmissionRiskReport = {
   policyDecision: SubmissionPolicyDecision;
   requestChangesReasons: string[];
   humanReviewNotes: string[];
-  labelDefinitions: Record<string, { color: string; description: string }>;
 };
 
 export type JsonLdSnapshot = {
@@ -784,7 +786,7 @@ export type SearchDocument = {
   repoStats?: RepoStats;
   url: string;
   canonicalUrl: string;
-  llmsUrl: string;
+  llmsUrl?: string;
   apiUrl: string;
   trustSignals: EntryTrustSignals;
 };

--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -1,3 +1,5 @@
+// "duplicate" is reserved for explicit curated annotations. Automatic relation
+// inference must not treat shared project ownership as a strict duplicate.
 export const REGISTRY_RELATION_TYPES = [
   "duplicate",
   "same-project",

--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -1,6 +1,10 @@
 export const REGISTRY_RELATION_TYPES = [
+  "duplicate",
   "same-project",
   "collection-member",
+  "complementary",
+  "same-ecosystem",
+  "prerequisite",
   "works-with",
   "extends",
   "alternative",
@@ -194,17 +198,21 @@ function categoryPairKind(target, candidate) {
 
 function relationTypeFor(target, candidate, evidence) {
   if (evidence.collectionMember) return "collection-member";
-  if (evidence.sameProject) return "same-project";
+  if (evidence.sameProject) {
+    return target.category === candidate.category
+      ? "duplicate"
+      : "complementary";
+  }
   if (
     target.category === candidate.category &&
     (evidence.sharedTokens.length > 0 || evidence.sharedDomains.length > 0)
   ) {
     return "alternative";
   }
-  if (
-    evidence.categoryPair === "guide-adjacent" ||
-    evidence.categoryPair === "collection-adjacent"
-  ) {
+  if (evidence.categoryPair === "collection-adjacent") {
+    return "prerequisite";
+  }
+  if (evidence.categoryPair === "guide-adjacent") {
     return "extends";
   }
   if (
@@ -212,7 +220,10 @@ function relationTypeFor(target, candidate, evidence) {
       evidence.categoryPair,
     )
   ) {
-    return "works-with";
+    return "complementary";
+  }
+  if (evidence.sharedDomains.length > 0) {
+    return "same-ecosystem";
   }
   return "related";
 }

--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -199,9 +199,7 @@ function categoryPairKind(target, candidate) {
 function relationTypeFor(target, candidate, evidence) {
   if (evidence.collectionMember) return "collection-member";
   if (evidence.sameProject) {
-    return target.category === candidate.category
-      ? "duplicate"
-      : "complementary";
+    return "same-project";
   }
   if (
     target.category === candidate.category &&

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -18,33 +18,6 @@ const SEVERITY_WEIGHT = {
 };
 
 const HEYCLAUDE_HOSTNAME = "heyclau.de";
-const SUBMISSION_RISK_LOW_LABEL = "risk-low";
-const SUBMISSION_RISK_MEDIUM_LABEL = "risk-medium";
-const SUBMISSION_RISK_HIGH_LABEL = "risk-high";
-const SUBMISSION_RISK_LABEL_DEFINITIONS = {
-  [SUBMISSION_RISK_LOW_LABEL]: {
-    color: "0e8a16",
-    description:
-      "Automated submission security/safety review found only low-risk signals",
-  },
-  [SUBMISSION_RISK_MEDIUM_LABEL]: {
-    color: "fbca04",
-    description:
-      "Automated submission security/safety review found signals that need maintainer review",
-  },
-  [SUBMISSION_RISK_HIGH_LABEL]: {
-    color: "d93f0b",
-    description:
-      "Automated submission security/safety review found high-risk or critical signals",
-  },
-};
-
-const RISK_LABEL_BY_TIER = {
-  low: SUBMISSION_RISK_LOW_LABEL,
-  medium: SUBMISSION_RISK_MEDIUM_LABEL,
-  high: SUBMISSION_RISK_HIGH_LABEL,
-  critical: SUBMISSION_RISK_HIGH_LABEL,
-};
 
 const SAFETY_NOTE_REQUIRED_FLAGS = new Set([
   "unsafe_install_pipeline",
@@ -1302,7 +1275,6 @@ export function directContentRequestChangesReasons(report = {}) {
 
 function finalizeReport(report, validationReport) {
   report.riskTier = tierFromFlags(report.reviewFlags);
-  report.recommendedLabels = [RISK_LABEL_BY_TIER[report.riskTier]];
   report.recommendedAction = recommendedAction(
     report.riskTier,
     validationReport,
@@ -1312,7 +1284,6 @@ function finalizeReport(report, validationReport) {
   report.policyDecision = policyDecisionForReport(report);
   report.requestChangesReasons = directContentRequestChangesReasons(report);
   report.humanReviewNotes = riskNotes(report);
-  report.labelDefinitions = SUBMISSION_RISK_LABEL_DEFINITIONS;
   return report;
 }
 
@@ -1335,13 +1306,11 @@ function baseReport(subject) {
     trustSignals: [],
     sourceUrls: [],
     classificationWarnings: [],
-    recommendedLabels: [],
     recommendedAction: "maintainer_review",
     policyMatrix: {},
     policyDecision: "maintainer_review",
     requestChangesReasons: [],
     humanReviewNotes: [],
-    labelDefinitions: SUBMISSION_RISK_LABEL_DEFINITIONS,
   };
 }
 
@@ -2028,7 +1997,6 @@ export function formatSubmissionRiskMarkdown(report) {
     `## Submission security/safety review: ${report.riskTier}`,
     "",
     `- Recommended action: \`${report.recommendedAction}\``,
-    `- Recommended labels: ${report.recommendedLabels.map((label) => `\`${label}\``).join(", ") || "none"}`,
     `- Policy decision: \`${report.policyDecision || "maintainer_review"}\``,
   ];
 

--- a/packages/registry/src/submission-spec.js
+++ b/packages/registry/src/submission-spec.js
@@ -349,7 +349,7 @@ export function buildSubmissionSpecs(options = {}) {
     prIntake: {
       mode: "github_app_user_fork_pr",
       ...(submitUrl ? { submitUrl } : {}),
-      pilotBaseRef: "main",
+      contentGateBaseRef: "main",
     },
   };
 }

--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -21,7 +21,6 @@ const contentRoot = path.join(repoRoot, "content");
 const generatedDir = path.join(repoRoot, "apps/web/src/generated");
 const publicDataDir = path.join(repoRoot, "apps/web/public/data");
 const entryDataDir = path.join(publicDataDir, "entries");
-const entryLlmsDir = path.join(publicDataDir, "llms");
 const raycastDetailDir = path.join(publicDataDir, "raycast");
 const siteStatsFile = path.join(generatedDir, "site-stats.json");
 const atlasRegistryFile = path.join(generatedDir, "atlas-registry.json");
@@ -559,7 +558,8 @@ async function main() {
   entries.sort((left, right) => left.title.localeCompare(right.title));
 
   resetGeneratedJsonDir(entryDataDir);
-  resetGeneratedJsonDir(entryLlmsDir);
+  fs.rmSync(path.join(publicDataDir, "llms"), { recursive: true, force: true });
+  fs.rmSync(path.join(publicDataDir, "llms-full.txt"), { force: true });
   resetGeneratedJsonDir(raycastDetailDir);
 
   const artifactFiles = buildRegistryArtifactSet(entries, {
@@ -642,9 +642,6 @@ async function main() {
   }
   console.log(
     `Wrote ${artifactResults.filter((file) => file.path.startsWith("entries/")).length} entry detail files to ${path.relative(repoRoot, entryDataDir)}`,
-  );
-  console.log(
-    `Wrote ${artifactResults.filter((file) => file.path.startsWith("llms/")).length} entry LLM files to ${path.relative(repoRoot, entryLlmsDir)}`,
   );
   console.log(
     `Wrote ${artifactResults.filter((file) => file.path.startsWith("raycast/")).length} Raycast detail files to ${path.relative(repoRoot, raycastDetailDir)}`,

--- a/scripts/check-mcp-release-due.mjs
+++ b/scripts/check-mcp-release-due.mjs
@@ -140,6 +140,7 @@ async function upsertIssue({ marker, issue, userAgent }) {
       body: {
         title: issue.title,
         body: issue.body,
+        labels: issue.labels,
         assignees: issue.assignees,
       },
     });

--- a/scripts/check-raycast-release-due.mjs
+++ b/scripts/check-raycast-release-due.mjs
@@ -124,6 +124,7 @@ async function upsertIssue({ marker, issue, userAgent }) {
       body: {
         title: issue.title,
         body: issue.body,
+        labels: issue.labels,
         assignees: issue.assignees,
       },
     });

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -1,6 +1,34 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
 export const MCP_RELEASE_DUE_MARKER = "<!-- heyclaude:mcp-release-due -->";
 export const RAYCAST_RELEASE_DUE_MARKER =
   "<!-- heyclaude:raycast-release-due -->";
+const RELEASE_WATCH_CONFIG_PATH = ".github/release-watch.json";
+
+export function readReleaseWatchConfig({ repoRoot = process.cwd() } = {}) {
+  const configPath = resolve(repoRoot, RELEASE_WATCH_CONFIG_PATH);
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(configPath, "utf8"));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to read release watch config at ${RELEASE_WATCH_CONFIG_PATH}: ${message}`,
+    );
+  }
+
+  const assignees = Array.isArray(parsed?.assignees)
+    ? parsed.assignees.map((value) => String(value).trim()).filter(Boolean)
+    : [];
+  if (assignees.length === 0) {
+    throw new Error(
+      `${RELEASE_WATCH_CONFIG_PATH} must define at least one assignee`,
+    );
+  }
+
+  return { assignees };
+}
 
 export function latestSemverTag(tags, prefix) {
   const matches = tags
@@ -109,12 +137,14 @@ export function buildRaycastReleaseReport({
   };
 }
 
-export function buildMcpReleaseIssue(report) {
+export function buildMcpReleaseIssue(report, options = {}) {
+  const config = options.config ?? readReleaseWatchConfig(options);
   return buildReleaseIssue({
     report,
     marker: MCP_RELEASE_DUE_MARKER,
     title: `MCP release due: ${report.proposedVersion}`,
     packageLabel: "@heyclaude/mcp",
+    assignees: config.assignees,
     labels: ["release", "mcp"],
     checklist: [
       "Run the MCP package validation workflow.",
@@ -124,12 +154,14 @@ export function buildMcpReleaseIssue(report) {
   });
 }
 
-export function buildRaycastReleaseIssue(report) {
+export function buildRaycastReleaseIssue(report, options = {}) {
+  const config = options.config ?? readReleaseWatchConfig(options);
   return buildReleaseIssue({
     report,
     marker: RAYCAST_RELEASE_DUE_MARKER,
     title: `Raycast update due: ${report.proposedVersion}`,
     packageLabel: "Raycast extension",
+    assignees: config.assignees,
     labels: ["release", "raycast"],
     checklist: [
       "Run the Raycast extension validation workflow.",
@@ -144,6 +176,7 @@ function buildReleaseIssue({
   marker,
   title,
   packageLabel,
+  assignees,
   labels,
   checklist,
 }) {
@@ -173,7 +206,7 @@ function buildReleaseIssue({
   return {
     title,
     labels,
-    assignees: ["JSONbored"],
+    assignees,
     body: [
       marker,
       "",

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -115,6 +115,7 @@ export function buildMcpReleaseIssue(report) {
     marker: MCP_RELEASE_DUE_MARKER,
     title: `MCP release due: ${report.proposedVersion}`,
     packageLabel: "@heyclaude/mcp",
+    labels: ["release", "mcp"],
     checklist: [
       "Run the MCP package validation workflow.",
       "Run the manual npm publish workflow after checks pass.",
@@ -129,6 +130,7 @@ export function buildRaycastReleaseIssue(report) {
     marker: RAYCAST_RELEASE_DUE_MARKER,
     title: `Raycast update due: ${report.proposedVersion}`,
     packageLabel: "Raycast extension",
+    labels: ["release", "raycast"],
     checklist: [
       "Run the Raycast extension validation workflow.",
       "Review store metadata, screenshots, and changelog.",
@@ -137,7 +139,14 @@ export function buildRaycastReleaseIssue(report) {
   });
 }
 
-function buildReleaseIssue({ report, marker, title, packageLabel, checklist }) {
+function buildReleaseIssue({
+  report,
+  marker,
+  title,
+  packageLabel,
+  labels,
+  checklist,
+}) {
   const commitPreviewLimit = 25;
   const commitPreview = report.commits.slice(-commitPreviewLimit);
   const omittedCommitCount = Math.max(
@@ -163,6 +172,7 @@ function buildReleaseIssue({ report, marker, title, packageLabel, checklist }) {
 
   return {
     title,
+    labels,
     assignees: ["JSONbored"],
     body: [
       marker,

--- a/scripts/validate-deployment-artifacts.mjs
+++ b/scripts/validate-deployment-artifacts.mjs
@@ -151,11 +151,29 @@ try {
   } else if (directoryEntries.length !== searchEntries.length) {
     fail("/data directory and search artifact counts must match");
   } else {
-    for (const entry of [directoryEntries[0], searchEntries[0]]) {
-      for (const field of ["canonicalUrl", "llmsUrl", "apiUrl"]) {
-        if (!String(entry?.[field] || "").startsWith(`${canonicalOrigin}/`)) {
-          fail(`${field} must be an absolute URL in deployment artifacts`);
-        }
+    for (const field of ["canonicalUrl", "llmsUrl", "apiUrl"]) {
+      if (
+        !String(directoryEntries[0]?.[field] || "").startsWith(
+          `${canonicalOrigin}/`,
+        )
+      ) {
+        fail(`${field} must be an absolute URL in directory artifacts`);
+      }
+    }
+    for (const field of ["canonicalUrl", "apiUrl"]) {
+      if (
+        !String(searchEntries[0]?.[field] || "").startsWith(
+          `${canonicalOrigin}/`,
+        )
+      ) {
+        fail(`${field} must be an absolute URL in search artifacts`);
+      }
+    }
+    if (searchEntries[0]?.llmsUrl) {
+      if (!String(searchEntries[0].llmsUrl).startsWith(`${canonicalOrigin}/`)) {
+        fail(
+          "llmsUrl must be an absolute URL in search artifacts when present",
+        );
       }
     }
   }

--- a/scripts/validate-deployment-artifacts.mjs
+++ b/scripts/validate-deployment-artifacts.mjs
@@ -152,28 +152,26 @@ try {
     fail("/data directory and search artifact counts must match");
   } else {
     for (const field of ["canonicalUrl", "llmsUrl", "apiUrl"]) {
-      if (
-        !String(directoryEntries[0]?.[field] || "").startsWith(
-          `${canonicalOrigin}/`,
-        )
-      ) {
-        fail(`${field} must be an absolute URL in directory artifacts`);
+      for (const entry of directoryEntries) {
+        if (!String(entry?.[field] || "").startsWith(`${canonicalOrigin}/`)) {
+          fail(`${field} must be an absolute URL in directory artifacts`);
+        }
       }
     }
     for (const field of ["canonicalUrl", "apiUrl"]) {
-      if (
-        !String(searchEntries[0]?.[field] || "").startsWith(
-          `${canonicalOrigin}/`,
-        )
-      ) {
-        fail(`${field} must be an absolute URL in search artifacts`);
+      for (const entry of searchEntries) {
+        if (!String(entry?.[field] || "").startsWith(`${canonicalOrigin}/`)) {
+          fail(`${field} must be an absolute URL in search artifacts`);
+        }
       }
     }
-    if (searchEntries[0]?.llmsUrl) {
-      if (!String(searchEntries[0].llmsUrl).startsWith(`${canonicalOrigin}/`)) {
-        fail(
-          "llmsUrl must be an absolute URL in search artifacts when present",
-        );
+    for (const entry of searchEntries) {
+      if (entry?.llmsUrl) {
+        if (!String(entry.llmsUrl).startsWith(`${canonicalOrigin}/`)) {
+          fail(
+            "llmsUrl must be an absolute URL in search artifacts when present",
+          );
+        }
       }
     }
   }

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -235,12 +235,14 @@ for (const entry of payload.entries) {
   ) {
     fail(`${key}: detail copyText must be non-empty when present`);
   }
-  if (
-    detail.copyText === undefined &&
-    (typeof detail.llmsUrl !== "string" ||
-      !detail.llmsUrl.startsWith("/data/llms/"))
-  ) {
-    fail(`${key}: detail without copyText must expose llmsUrl`);
+  if (detail.copyText === undefined) {
+    const llmsUrl = String(detail.llmsUrl || "");
+    const validLlmsUrl =
+      llmsUrl.startsWith("/api/registry/entries/") ||
+      llmsUrl.startsWith("/data/llms/");
+    if (!validLlmsUrl) {
+      fail(`${key}: detail without copyText must expose llmsUrl`);
+    }
   }
   if (
     entry.copyText !== undefined &&

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -238,7 +238,7 @@ for (const entry of payload.entries) {
   if (detail.copyText === undefined) {
     const llmsUrl = String(detail.llmsUrl || "");
     const validLlmsUrl =
-      llmsUrl.startsWith("/api/registry/entries/") ||
+      /^\/api\/registry\/entries\/[^/]+\/[^/]+\/llms(?:\/.*)?$/.test(llmsUrl) ||
       llmsUrl.startsWith("/data/llms/");
     if (!validLlmsUrl) {
       fail(`${key}: detail without copyText must expose llmsUrl`);

--- a/tests/crawler-policy.test.ts
+++ b/tests/crawler-policy.test.ts
@@ -40,20 +40,19 @@ describe("crawler and AI citation policy", () => {
       path.join(repoRoot, "apps/web/src/lib/llms.ts"),
       "utf8",
     );
-    const fullCorpus = fs.readFileSync(
-      path.join(repoRoot, "apps/web/public/data/llms-full.txt"),
+    const fullRouteSource = fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/routes/llms-full[.]txt.ts"),
       "utf8",
     );
 
     expect(routeSource).toContain("respondText");
+    expect(fullRouteSource).toContain("buildLlmsFullTxt");
+    expect(fullRouteSource).toContain("respondText");
     expect(llmsHelperSource).toContain("applySecurityHeaders");
     expect(llmsHelperSource).toContain("Content-Type");
     expect(llmsHelperSource).toContain("Cache-Control");
-    expect(fullCorpus).toContain("Base URL: https://heyclau.de");
-    expect(fullCorpus).toContain("## Citation Facts");
-    expect(fullCorpus).toContain("Canonical URL: https://heyclau.de/");
-    expect(fullCorpus).toContain(
-      "Platform compatibility: Claude (native-skill)",
-    );
+    expect(
+      fs.existsSync(path.join(repoRoot, "apps/web/public/data/llms-full.txt")),
+    ).toBe(false);
   });
 });

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -668,7 +668,7 @@ describe("registry artifacts", () => {
     ).not.toContain("safer-alternative");
   });
 
-  it("treats same project across categories as complementary content", () => {
+  it("preserves same-project relations across categories", () => {
     const repoUrl = "https://github.com/example/langchain-helper";
     const target = {
       category: "mcp",
@@ -695,8 +695,10 @@ describe("registry artifacts", () => {
 
     expect(relation).toMatchObject({
       key: "skills:langchain-helper-skill",
-      relation: "complementary",
+      relation: "same-project",
     });
+    expect(relation?.relation).not.toBe("duplicate");
+    expect(relation?.relation).not.toBe("complementary");
   });
 
   it("publishes deterministic relation graph refs into entry details", () => {

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -141,6 +141,14 @@ describe("registry artifacts", () => {
     entries: any[];
   }>("registry-trust-report.json");
 
+  function renderEntryLlmsByKey(key: string) {
+    const entry = contentEntries.find(
+      (item) => `${item.category}:${item.slug}` === key,
+    );
+    expect(entry).toBeTruthy();
+    return renderEntryLlms(entry!);
+  }
+
   it("parses abbreviated Shields fallback counts", () => {
     expect(parseAbbreviatedCount("987")).toBe(987);
     expect(parseAbbreviatedCount("1.2k")).toBe(1200);
@@ -192,13 +200,8 @@ describe("registry artifacts", () => {
   });
 
   it("keeps public registry payloads within reviewable byte budgets", () => {
-    const fullCorpusSize = artifactSize("llms-full.txt");
     const entryCount = contentEntries.length;
-    expect(artifactTreeSize(".")).toBeLessThan(1_500_000 + entryCount * 52_000);
-    expect(artifactTreeSize(".") - fullCorpusSize).toBeLessThan(
-      1_000_000 + entryCount * 44_000,
-    );
-    expect(fullCorpusSize).toBeLessThan(500_000 + entryCount * 9_000);
+    expect(artifactTreeSize(".")).toBeLessThan(20_000_000);
     expect(artifactSize("directory-index.json")).toBeLessThan(1_000_000);
     expect(artifactSize("search-index.json")).toBeLessThan(750_000);
     expect(artifactSize("raycast-index.json")).toBeLessThan(500_000);
@@ -363,10 +366,7 @@ describe("registry artifacts", () => {
     const raycastDetail = readDataJson<Record<string, unknown>>(
       "raycast/mcp/asana-mcp-server.json",
     );
-    const llmsText = fs.readFileSync(
-      path.join(dataRoot, "llms", "mcp", "asana-mcp-server.txt"),
-      "utf8",
-    );
+    const llmsText = renderEntryLlmsByKey(key);
 
     expect(directoryEntry).toMatchObject({
       brandName: "Asana",
@@ -468,10 +468,7 @@ describe("registry artifacts", () => {
     const entryDetail = readDataJson<{ entry: Record<string, unknown> }>(
       "entries/mcp/contrastapi-mcp-server.json",
     );
-    const llmsText = fs.readFileSync(
-      path.join(dataRoot, "llms", "mcp", "contrastapi-mcp-server.txt"),
-      "utf8",
-    );
+    const llmsText = renderEntryLlmsByKey(key);
 
     for (const surface of [
       directoryEntry,
@@ -658,7 +655,48 @@ describe("registry artifacts", () => {
     expect(relation?.reasons).not.toContain("safer_metadata");
     expect(
       buildRegistryRelationGraph([target, candidate]).relationTypes,
+    ).toEqual(
+      expect.arrayContaining([
+        "duplicate",
+        "complementary",
+        "same-ecosystem",
+        "prerequisite",
+      ]),
+    );
+    expect(
+      buildRegistryRelationGraph([target, candidate]).relationTypes,
     ).not.toContain("safer-alternative");
+  });
+
+  it("treats same project across categories as complementary content", () => {
+    const repoUrl = "https://github.com/example/langchain-helper";
+    const target = {
+      category: "mcp",
+      slug: "langchain-helper-mcp",
+      title: "LangChain Helper MCP",
+      description: "An MCP integration for LangChain workflows.",
+      tags: ["langchain", "mcp"],
+      keywords: ["langchain"],
+      repoUrl,
+    };
+    const candidate = {
+      category: "skills",
+      slug: "langchain-helper-skill",
+      title: "LangChain Helper Skill",
+      description: "A skill for LangChain workflow prompting.",
+      tags: ["langchain", "skills"],
+      keywords: ["langchain"],
+      repoUrl,
+    };
+
+    const [relation] = buildEntryRelations(target, [target, candidate], {
+      limit: 1,
+    });
+
+    expect(relation).toMatchObject({
+      key: "skills:langchain-helper-skill",
+      relation: "complementary",
+    });
   });
 
   it("publishes deterministic relation graph refs into entry details", () => {
@@ -905,10 +943,7 @@ Use this hook after reviewing the notes.`,
         type: "json",
       },
     );
-    expect(manifest.artifactContracts["llms-full.txt"]).toMatchObject({
-      path: "/data/llms-full.txt",
-      type: "text",
-    });
+    expect(manifest.artifactContracts["llms-full.txt"]).toBeUndefined();
     for (const contract of Object.values(manifest.artifactContracts)) {
       expect(contract.sha256).toMatch(/^[a-f0-9]{64}$/);
     }
@@ -987,7 +1022,7 @@ Use this hook after reviewing the notes.`,
         `https://heyclau.de/entry/${entry.category}/${entry.slug}`,
       );
       expect(entry.llmsUrl).toBe(
-        `https://heyclau.de/data/llms/${entry.category}/${entry.slug}.txt`,
+        `https://heyclau.de/api/registry/entries/${entry.category}/${entry.slug}/llms`,
       );
       expect(entry.apiUrl).toBe(
         `https://heyclau.de/api/registry/entries/${entry.category}/${entry.slug}`,
@@ -1086,7 +1121,7 @@ Use this hook after reviewing the notes.`,
     }
   });
 
-  it("writes per-entry detail, LLM, and Raycast payloads", () => {
+  it("writes per-entry detail and Raycast payloads without static LLM shards", () => {
     const raycastEntryByKey = new Map(
       raycastPayload.entries.map((entry) => [
         `${entry.category}:${entry.slug}`,
@@ -1107,12 +1142,6 @@ Use this hook after reviewing the notes.`,
         copyText?: string;
         llmsUrl: string;
       }>(`raycast/${entry.category}/${entry.slug}.json`);
-      const entryLlmsPath = path.join(
-        dataRoot,
-        "llms",
-        entry.category,
-        `${entry.slug}.txt`,
-      );
       const raycastFeedEntry = raycastEntryByKey.get(key);
 
       expect(detailPayload).toMatchObject({
@@ -1120,12 +1149,11 @@ Use this hook after reviewing the notes.`,
         key,
       });
       expect(detailPayload.entry.title).toBe(entry.title);
-      expect(fs.existsSync(entryLlmsPath)).toBe(true);
       expect(raycastFeedEntry).toBeTruthy();
       expect(raycastDetail).toMatchObject({
         schemaVersion: 2,
         key,
-        llmsUrl: `/data/llms/${entry.category}/${entry.slug}.txt`,
+        llmsUrl: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
       });
       expect(raycastDetail).not.toHaveProperty("copyText");
       expect(raycastFeedEntry.canonicalUrl).toBe(
@@ -1137,6 +1165,7 @@ Use this hook after reviewing the notes.`,
       expect(raycastFeedEntry).not.toHaveProperty("copyTextTruncated");
       expect(raycastFeedEntry).not.toHaveProperty("detailMarkdown");
     }
+    expect(fs.existsSync(path.join(dataRoot, "llms"))).toBe(false);
   });
 
   it("publishes skill compatibility metadata and Cursor adapters", () => {
@@ -1192,12 +1221,9 @@ Use this hook after reviewing the notes.`,
     }
   });
 
-  it("writes the generated full corpus LLM text artifact", () => {
+  it("publishes full corpus LLM text through the dynamic site route", () => {
     const llmsFullPath = path.join(dataRoot, "llms-full.txt");
-    expect(fs.existsSync(llmsFullPath)).toBe(true);
-    const llmsFull = fs.readFileSync(llmsFullPath, "utf8");
-    expect(llmsFull).toMatch(/## Citation Facts/);
-    expect(llmsFull).toMatch(/## Entry Content/);
+    expect(fs.existsSync(llmsFullPath)).toBe(false);
     expect(contentEntries.some((entry) => getCopyText(entry).trim())).toBe(
       true,
     );
@@ -1211,10 +1237,10 @@ Use this hook after reviewing the notes.`,
       /^https:\/\/heyclau\.de\//,
     );
     expect(manifest.routes[0]?.llmsUrl).toMatch(
-      /^https:\/\/heyclau\.de\/data\/llms\//,
+      /^https:\/\/heyclau\.de\/api\/registry\/entries\/.+\/llms$/,
     );
     expect(manifest.qualitySummary).toBeTruthy();
-    expect(manifest.artifacts.llmsFull).toBe("/data/llms-full.txt");
+    expect(manifest.artifacts.llmsFull).toBe("/llms-full.txt");
     expect(manifest.artifacts.contentQualityPrompts).toBe(
       "/data/content-quality-prompts.json",
     );
@@ -1229,10 +1255,7 @@ Use this hook after reviewing the notes.`,
   });
 
   it("keeps generated entry LLM exports free of duplicated code blocks", () => {
-    const yieldLlms = fs.readFileSync(
-      path.join(dataRoot, "llms", "mcp", "yield-intelligence-mcp.txt"),
-      "utf8",
-    );
+    const yieldLlms = renderEntryLlmsByKey("mcp:yield-intelligence-mcp");
 
     expect(yieldLlms.match(/^## Content$/gm)).toHaveLength(1);
     expect(

--- a/tests/registry-diff-api.test.ts
+++ b/tests/registry-diff-api.test.ts
@@ -43,7 +43,7 @@ function makeEntry(
     title: `Fixture ${slug}`,
     dateAdded: overrides.dateAdded ?? "2026-05-19",
     canonicalUrl: `https://heyclau.de/entry/${category}/${slug}`,
-    llmsUrl: `https://heyclau.de/data/llms/${category}/${slug}.txt`,
+    llmsUrl: `https://heyclau.de/api/registry/entries/${category}/${slug}/llms`,
     apiUrl: `https://heyclau.de/api/registry/entries/${category}/${slug}`,
     artifactHash: "0".repeat(64),
   };

--- a/tests/release-watch.test.ts
+++ b/tests/release-watch.test.ts
@@ -42,7 +42,10 @@ describe("release watch", () => {
       proposedVersion: "0.3.0",
       packageAhead: true,
     });
-    expect(buildMcpReleaseIssue(report).body).toContain(MCP_RELEASE_DUE_MARKER);
+    const issue = buildMcpReleaseIssue(report);
+    expect(issue.labels).toEqual(["release", "mcp"]);
+    expect(issue.assignees).toEqual(["JSONbored"]);
+    expect(issue.body).toContain(MCP_RELEASE_DUE_MARKER);
   });
 
   it("filters Raycast release checks to Raycast-relevant files", () => {
@@ -66,9 +69,10 @@ describe("release watch", () => {
     expect(report.due).toBe(true);
     expect(report.commits).toHaveLength(1);
     expect(report.commits[0].subject).toBe("fix(raycast): harden feed parser");
-    expect(buildRaycastReleaseIssue(report).body).toContain(
-      RAYCAST_RELEASE_DUE_MARKER,
-    );
+    const issue = buildRaycastReleaseIssue(report);
+    expect(issue.labels).toEqual(["release", "raycast"]);
+    expect(issue.assignees).toEqual(["JSONbored"]);
+    expect(issue.body).toContain(RAYCAST_RELEASE_DUE_MARKER);
   });
 
   it("escapes backslashes and pipes in commit subjects before issue upserts", () => {

--- a/tests/release-watch.test.ts
+++ b/tests/release-watch.test.ts
@@ -8,6 +8,7 @@ import {
   latestSemverTag,
   MCP_RELEASE_DUE_MARKER,
   RAYCAST_RELEASE_DUE_MARKER,
+  readReleaseWatchConfig,
 } from "../scripts/lib/release-watch-core.mjs";
 
 describe("release watch", () => {
@@ -48,6 +49,12 @@ describe("release watch", () => {
     expect(issue.body).toContain(MCP_RELEASE_DUE_MARKER);
   });
 
+  it("loads release assignees from shared workflow config", () => {
+    const config = readReleaseWatchConfig();
+
+    expect(config.assignees).toEqual(["JSONbored"]);
+  });
+
   it("filters Raycast release checks to Raycast-relevant files", () => {
     const report = buildRaycastReleaseReport({
       latestTag: { tag: "raycast-v1.0.0", version: "1.0.0" },
@@ -69,9 +76,11 @@ describe("release watch", () => {
     expect(report.due).toBe(true);
     expect(report.commits).toHaveLength(1);
     expect(report.commits[0].subject).toBe("fix(raycast): harden feed parser");
-    const issue = buildRaycastReleaseIssue(report);
+    const issue = buildRaycastReleaseIssue(report, {
+      config: { assignees: ["release-maintainer"] },
+    });
     expect(issue.labels).toEqual(["release", "raycast"]);
-    expect(issue.assignees).toEqual(["JSONbored"]);
+    expect(issue.assignees).toEqual(["release-maintainer"]);
     expect(issue.body).toContain(RAYCAST_RELEASE_DUE_MARKER);
   });
 

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -245,13 +245,6 @@ Native macOS MCP server.`);
       .sort();
 
     expect(templates).toEqual(["config.yml", "product-feature.yml"]);
-    for (const file of templates) {
-      const source = fs.readFileSync(path.join(templateDir, file), "utf8");
-      expect(source).not.toContain("content-submission");
-      expect(source).not.toContain("needs-review");
-      expect(source).not.toContain("import-approved");
-      expect(source).not.toContain("auto-import");
-    }
   });
 
   it("keeps retired issue-intake APIs out of active source", () => {
@@ -275,10 +268,6 @@ Native macOS MCP server.`);
       "SUBMISSION_BASE_LABELS",
       "submissionLabelsForCategory",
       "recommendedLabelsForCategory",
-      "content-submission",
-      "needs-review",
-      "import-approved",
-      "auto-import",
     ];
 
     for (const file of activeFiles) {


### PR DESCRIPTION
## Summary
- Slims the live repository label set to the agreed operational labels while preserving Dosu size labels and `lgtm`.
- Removes static per-entry and full-corpus LLM text artifacts from generated public data; LLM text is now served through API routes from source entries.
- Expands registry relation taxonomy so related/complementary content can be distinguished from strict duplicates.
- Keeps Raycast Store maintenance on the npm/package-lock path and updates release-watch issue labels to the retained label set.

## What changed
- Added `gittensor:feature` to the product/feature issue template and removed retired risk label output from submission-risk reports.
- Renamed the public PR intake spec field from `pilotBaseRef` to `contentGateBaseRef`.
- Pointed entry/Raycast LLM links at `/api/registry/entries/<category>/<slug>/llms` and stopped generating `data/llms/**` plus `data/llms-full.txt`.
- Added artifact tests that assert the static LLM files are gone and the public data budget stays below 20 MB.
- Added relation types for `duplicate`, `complementary`, `same-ecosystem`, and `prerequisite`.
- Updated MCP/Raycast release-watch issue builders to use retained `release`, `mcp`, and `raycast` labels.

## Why
- Reduces recurring generated-data churn and keeps contributor PRs focused on source content.
- Keeps the label taxonomy tight enough for GitHub automation, Dosu, Gittensor, and the submission gate without old intake/import noise.
- Gives the registry and private reviewer cleaner relationship evidence so cross-category related content is not treated as a duplicate.

## Validation
- `pnpm exec vitest run tests/registry-artifacts.test.ts tests/release-watch.test.ts tests/crawler-policy.test.ts tests/registry-diff-api.test.ts`
- `pnpm test:submission-pr-first`
- `pnpm validate:content:strict`
- `pnpm validate:packages`
- `pnpm scan:packages`
- `pnpm validate:raycast-feed`
- `pnpm validate:openapi`
- `pnpm --filter web type-check`
- `pnpm build`
- `pnpm submission-gate:dry-run`
- `pnpm test:mcp`
- `npm test` from `integrations/raycast`
- `npm run lint` from `integrations/raycast`
- `npm run build` from `integrations/raycast`
- `pnpm validate:clean`
- `git diff --check`

## Notes
- `pnpm validate:deployment-artifacts` requires a real deployed base URL or `DEPLOYMENT_ARTIFACT_BASE_URL`, so it is not meaningful as a local-only check.
- Generated data remains ignored and untracked; this PR does not stage generated website/Raycast/API artifacts.
- The live repository labels were cleaned up as JSONbored and verified against the retained label set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Expanded entry relationship types: duplicate, complementary, same-ecosystem, prerequisite

* **Improvements**
  - Submission risk reports now include trust signals, source URLs, and classification warnings
  - Per-entry LLM exports and public links moved from static files to dynamic API endpoints
  - Raycast/share links updated to point to the API-based LLM endpoints

* **Tests**
  - Tests updated to reflect dynamic LLM exports and revised relation behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->