### PR TITLE
content(collections): add frontend a11y browser QA workflow

### DIFF
--- a/content/collections/frontend-a11y-browser-qa-workflow.mdx
+++ b/content/collections/frontend-a11y-browser-qa-workflow.mdx
@@ -1,0 +1,158 @@
+---
+title: Frontend A11y Browser QA Workflow
+slug: frontend-a11y-browser-qa-workflow
+category: collections
+description: >-
+  A source-backed frontend QA collection for AI-assisted UI work: combine WCAG
+  2.2 accessibility expectations, W3C evaluation guidance, Playwright browser
+  automation, Storybook component context, Chrome DevTools inspection,
+  BrowserStack coverage, and local test hooks before shipping user interfaces.
+cardDescription: >-
+  Browser QA bundle for accessibility review, component coverage, Playwright
+  flows, DevTools inspection, and cross-browser validation.
+seoTitle: Frontend A11y Browser QA Workflow
+seoDescription: >-
+  A curated collection for validating AI-built frontend changes with WCAG 2.2,
+  W3C accessibility evaluation guidance, Playwright, Storybook, Chrome
+  DevTools, BrowserStack, and test automation.
+author: MkDev11
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-04"
+documentationUrl: "https://www.w3.org/TR/WCAG22/"
+sourceUrls:
+  - "https://www.w3.org/TR/WCAG22/"
+  - "https://www.w3.org/WAI/test-evaluate/"
+  - "https://playwright.dev/docs/intro"
+  - "https://storybook.js.org/docs/writing-tests/accessibility-testing"
+installable: false
+usageSnippet: >-
+  Start with accessibility and React component test hooks, then add Playwright,
+  Storybook, Chrome DevTools, and BrowserStack for browser-level validation.
+items:
+  - slug: accessibility-checker
+    category: hooks
+  - slug: react-component-test-generator
+    category: hooks
+  - slug: test-runner-hook
+    category: hooks
+  - slug: playwright-e2e-testing
+    category: skills
+  - slug: playwright-mcp-browser-automation-engineer
+    category: skills
+  - slug: playwright-mcp-server
+    category: mcp
+  - slug: storybook-mcp-server
+    category: mcp
+  - slug: chrome-devtools-mcp-server
+    category: mcp
+  - slug: browserstack-mcp-server
+    category: mcp
+  - slug: accessibility-first-statusline
+    category: statuslines
+installationOrder:
+  - accessibility-checker
+  - react-component-test-generator
+  - test-runner-hook
+  - playwright-e2e-testing
+  - playwright-mcp-browser-automation-engineer
+  - playwright-mcp-server
+  - storybook-mcp-server
+  - chrome-devtools-mcp-server
+  - browserstack-mcp-server
+  - accessibility-first-statusline
+estimatedSetupTime: 75 minutes
+difficulty: intermediate
+prerequisites:
+  - A frontend project with a repeatable local dev server and test command.
+  - Agreement on the browser and device matrix before enabling blocking checks.
+  - A target accessibility conformance level and review policy for generated UI changes.
+  - Test credentials or seeded demo data for flows that require login, checkout, dashboards, or user-specific state.
+safetyNotes:
+  - "This collection is read/validation oriented, but browser automation can still submit forms or trigger side effects if pointed at production."
+  - "Run Playwright, BrowserStack, and DevTools workflows against local, preview, or staging environments first."
+  - "Treat automated accessibility findings as review inputs; manual keyboard, screen-reader, and content checks are still needed before release."
+privacyNotes:
+  - "The collection itself stores no data; linked browser tools may capture screenshots, DOM text, network requests, console logs, or session cookies."
+  - "Use test accounts and scrub screenshots, traces, and console logs before sharing them outside the team."
+  - "Cross-browser cloud testing can send page content and assets to a third-party provider."
+tags:
+  - frontend
+  - accessibility
+  - qa
+  - playwright
+  - browser-testing
+keywords:
+  - frontend a11y browser qa collection
+  - ai built interface testing
+  - playwright accessibility workflow
+  - browser qa claude collection
+---
+
+## What this collection sets up
+
+This workflow gives frontend teams a layered QA pass for AI-built interfaces:
+accessibility checks first, component state review next, then scripted browser
+behavior, runtime inspection, and cross-browser coverage. It is organized around
+WCAG 2.2 accessibility expectations, W3C evaluation guidance, and browser
+automation practices that favor observable user behavior.
+
+## Layers
+
+### 1. Local quality gates
+
+- **accessibility-checker** catches accessibility regressions early.
+- **react-component-test-generator** creates component-level coverage for UI
+  states Claude changes.
+- **test-runner-hook** keeps the project test command in the loop.
+
+### 2. Browser behavior and component context
+
+- **playwright-e2e-testing** and **playwright-mcp-browser-automation-engineer**
+  help build durable end-to-end flows.
+- **playwright-mcp-server** gives Claude a controlled browser automation bridge.
+- **storybook-mcp-server** keeps component stories and states visible during
+  review.
+
+### 3. Runtime inspection and device coverage
+
+- **chrome-devtools-mcp-server** surfaces console, network, and performance
+  details.
+- **browserstack-mcp-server** adds cross-browser and device validation.
+- **accessibility-first-statusline** keeps accessibility attention visible
+  during the session.
+
+## Suggested order
+
+Install the local hooks first, then add Playwright and Storybook, then connect
+DevTools and cross-browser services. Keep cloud/browser tools pointed at local,
+preview, or staging URLs until tests and credentials are clearly separated from
+production.
+
+## Source and references
+
+- W3C WCAG 2.2 Recommendation: https://www.w3.org/TR/WCAG22/
+- W3C accessibility testing and evaluation: https://www.w3.org/WAI/test-evaluate/
+- Playwright documentation: https://playwright.dev/docs/intro
+- Storybook accessibility testing: https://storybook.js.org/docs/writing-tests/accessibility-testing
+
+## Duplicate check
+
+Checked existing collections, upstream collection history, open collection PRs,
+and repository content for `frontend-a11y-browser-qa-workflow`, frontend QA,
+accessibility workflow, Playwright collection, browser QA, and AI-built
+interfaces. Existing code-quality and production collections include general
+testing/review items, but no collection focuses on frontend accessibility,
+component states, browser automation, DevTools inspection, and cross-browser QA
+as one workflow.
+
+## Resubmission note
+
+This is a clean resubmission for the closed frontend QA accessibility collection.
+The previous PR used the W3C quick reference URL, which was blocked by HTTP 403
+at review time. This version uses fetchable W3C WCAG 2.2 and WAI evaluation
+sources instead.
+
+## Disclosure
+
+Editorial collection. No paid placement or affiliate link is used.


### PR DESCRIPTION
## Summary

Adds a focused collections entry for frontend accessibility and browser QA workflows.

This is a clean resubmission for the closed frontend QA accessibility PR. The previous version used the W3C WCAG quick reference URL, which the submission gate could not fetch. This version removes that blocked URL and uses reachable W3C WCAG 2.2 and WAI testing/evaluation sources instead.

Fixes #791.

## Validation

- `curl -s -I -L https://www.w3.org/TR/WCAG22/`
- `curl -s -I -L https://www.w3.org/WAI/test-evaluate/`
- `curl -s -I -L https://playwright.dev/docs/intro`
- `curl -s -I -L https://storybook.js.org/docs/writing-tests/accessibility-testing`
- `git diff --check`
- `node scripts/validate-content.mjs --category collections`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/collection-791-resubmit-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref collections-791-frontend-a11y-browser-qa --pr-author MkDev11`
