### PR TITLE
fix(statuslines): harden context pressure arithmetic inputs

### DIFF
--- a/content/statuslines/context-pressure-statusline.mdx
+++ b/content/statuslines/context-pressure-statusline.mdx
@@ -47,18 +47,19 @@ scriptBody: |-
   limit="${CLAUDE_CONTEXT_LIMIT:-200000}"
   used=$(printf '%s' "$input" | jq -r '.session.totalTokens // .usage.input_tokens // .cost.total_tokens // 0')
 
-  if ! printf '%s' "$limit" | grep -Eq '^[0-9]+$'; then
-    limit=200000
-  fi
-  if ! printf '%s' "$used" | grep -Eq '^[0-9]+$'; then
-    used=0
-  fi
+  case "$limit" in
+    ''|*[!0-9]*) limit=200000 ;;
+  esac
+  case "$used" in
+    ''|*[!0-9]*) used=0 ;;
+  esac
 
-  if [ "$limit" -le 0 ]; then
-    limit=200000
-  fi
+  case "$limit" in
+    *[1-9]*) ;;
+    *) limit=200000 ;;
+  esac
 
-  pct=$((used * 100 / limit))
+  pct=$((10#$used * 100 / 10#$limit))
   if [ "$pct" -ge 85 ]; then
     state="compress"
   elif [ "$pct" -ge 65 ]; then


### PR DESCRIPTION
### Motivation
- A statusline Bash script accepted attacker-controlled JSON or environment values that passed line-oriented `grep` checks but could execute command substitutions via Bash arithmetic, creating a local RCE risk for users who install the statusline. 
- The change aims to ensure numeric inputs cannot contain newlines or non-digit characters and cannot be interpreted as arithmetic expressions before being used in `(( ))` evaluation.

### Description
- Replace line-oriented `grep -Eq '^[0-9]+$'` validation with shell pattern checks that reject empty, multiline, or non-digit `used` and `limit` values (using `case` patterns). 
- Enforce a non-zero positive `limit` via an explicit pattern check and fallback to the configured default when invalid. 
- Use explicit base-10 arithmetic (`10#$used` and `10#$limit`) to prevent recursive arithmetic interpretation of validated digit strings while preserving percentage calculation semantics. 
- Preserve the original output format and threshold logic (`ok`, `watch`, `compress`) so existing behavior and UX remain intact.

### Testing
- Ran an extraction/PoC harness that pipes a benign JSON input and two malicious payloads (one via JSON `.session.totalTokens` and one via `CLAUDE_CONTEXT_LIMIT`) into the script, and verified the exploit payloads no longer trigger command execution (PoC blocked). 
- Executed `pnpm validate:content:strict` which completed successfully and reported content validation passed. 
- Ran repository checks including `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212da5f7ec832caaffc3a5ea45d324)