### PR TITLE
fix(hooks): guard secret scanner grep patterns

### DIFF
--- a/content/hooks/pre-write-secret-scanner.mdx
+++ b/content/hooks/pre-write-secret-scanner.mdx
@@ -106,7 +106,7 @@ scriptBody: |-
   for entry in "${PATTERNS[@]}"; do
     name=${entry%%|*}
     regex=${entry#*|}
-    if printf '%s' "$CONTENT" | grep -Eq "$regex"; then
+    if printf '%s' "$CONTENT" | grep -Eq -- "$regex"; then
       echo "🔒 Secret blocked: possible ${name} in ${FILE:-pending write}." >&2
       FOUND=1
     fi


### PR DESCRIPTION
### Motivation
- Prevent a security-control bypass where the Pre-Write Secret Scanner's PEM private-key regex (which begins with `-`) was interpreted by `grep` as an option, allowing private key blocks to be written instead of blocked.

### Description
- Update `content/hooks/pre-write-secret-scanner.mdx` so the hook script invokes `grep -Eq -- "$regex"`, using an explicit `--` pattern marker so regexes that start with hyphens are treated as patterns rather than options.

### Testing
- Extracted and ran the hook script to confirm a PEM private key input produces exit code `2` and clean content exits `0`, ran `pnpm validate:content:strict` which passed, and ran `git diff --check` with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212c6f6aa0832ca1adbc06fcd6bded)