### PR TITLE
fix(statuslines): avoid git secrets alias fallback

### DIFF
--- a/content/statuslines/git-secrets-env-risk-statusline.mdx
+++ b/content/statuslines/git-secrets-env-risk-statusline.mdx
@@ -62,12 +62,6 @@ scriptBody: |-
     else
       printf 'secrets: env files %s | review scan\n' "$env_count"
     fi
-  elif git secrets --help >/dev/null 2>&1; then
-    if git secrets --scan -r . >/dev/null 2>&1; then
-      printf 'secrets: env files %s | scan clean\n' "$env_count"
-    else
-      printf 'secrets: env files %s | review scan\n' "$env_count"
-    fi
   else
     printf 'secrets: env files %s | git-secrets missing\n' "$env_count"
   fi
@@ -84,6 +78,7 @@ prerequisites:
 safetyNotes:
   - The default mode does not scan file contents; it only counts sensitive-looking environment files in Git status.
   - Enable recursive git-secrets scanning only in repositories where you are authorized to inspect all files.
+  - Scanner mode invokes the git-secrets executable directly and does not fall back to Git aliases.
   - Treat any scan warning as a stop-and-review signal before committing, sharing logs, or opening a PR.
 privacyNotes:
   - The default output prints counts only and does not print filenames or matched values.


### PR DESCRIPTION
### Motivation
- Prevent a local command-execution risk where optional scanner mode could fall back to running `git secrets` and thus execute a malicious Git alias named `secrets` when `GIT_SECRETS_STATUSLINE_SCAN=1`.

### Description
- Remove the `git secrets --help` / `git secrets --scan` fallback from `content/statuslines/git-secrets-env-risk-statusline.mdx` so the statusline only invokes the `git-secrets` executable found via `command -v git-secrets`, and add a `safetyNotes` line clarifying scanner mode invokes the `git-secrets` binary directly.

### Testing
- Extracted and ran the statusline script in a temporary Git repo with a crafted `alias.secrets` and `GIT_SECRETS_STATUSLINE_SCAN=1` to verify the alias was not executed, ran `pnpm validate:content:strict` which passed, and ran `git diff --check` which showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212c705098832c93374c62d8d1342f)