### PR TITLE
fix(content): gate npm statusline whoami check

### DIFF
--- a/content/statuslines/npm-publish-readiness-statusline.mdx
+++ b/content/statuslines/npm-publish-readiness-statusline.mdx
@@ -2,10 +2,10 @@
 title: npm Publish Readiness Statusline
 slug: npm-publish-readiness-statusline
 category: statuslines
-description: Claude Code statusline that checks package publish readiness from package.json, npm login visibility, package privacy, and dirty package metadata files.
+description: Claude Code statusline that checks package publish readiness from package.json, optional npm login visibility, package privacy, and dirty package metadata files.
 cardDescription: Show npm package publish readiness without publishing.
 seoTitle: npm publish readiness statusline for Claude Code
-seoDescription: Add a Claude Code statusline that checks package name, version, private flag, npm login visibility, and dirty package files before publishing.
+seoDescription: Add a Claude Code statusline that checks package name, version, private flag, optional npm login visibility, and dirty package files before publishing.
 author: MkDev11
 submittedBy: MkDev11
 submittedByUrl: "https://github.com/MkDev11"
@@ -22,7 +22,7 @@ keywords:
   - package json statusline
   - release readiness
 installable: true
-usageSnippet: "npm: my-package@1.2.3 | clean | logged-in | ready"
+usageSnippet: "npm: my-package@1.2.3 | clean | auth-unchecked | review"
 copySnippet: |-
   {
     "statusLine": {
@@ -57,10 +57,17 @@ scriptBody: |-
   private=$(jq -r '.private // false' package.json)
   dirty=$(git status --porcelain=v1 -- package.json package-lock.json npm-shrinkwrap.json pnpm-lock.yaml yarn.lock 2>/dev/null | wc -l | tr -d ' ')
 
-  if command -v npm >/dev/null 2>&1 && npm whoami >/dev/null 2>&1; then
-    login="logged-in"
-  else
-    login="login-missing"
+  login="auth-unchecked"
+  if [ "${NPM_STATUSLINE_CHECK_WHOAMI:-}" = "1" ] && command -v npm >/dev/null 2>&1; then
+    if command -v timeout >/dev/null 2>&1; then
+      if timeout 3s npm whoami >/dev/null 2>&1; then
+        login="logged-in"
+      else
+        login="login-missing"
+      fi
+    else
+      login="whoami-timeout-missing"
+    fi
   fi
 
   if [ "$private" = "true" ]; then
@@ -69,6 +76,8 @@ scriptBody: |-
     state="review"
   elif [ "$login" = "login-missing" ]; then
     state="auth"
+  elif [ "$login" != "logged-in" ]; then
+    state="review"
   else
     state="ready"
   fi
@@ -88,21 +97,23 @@ scriptBody: |-
 prerequisites:
   - Node.js project with package.json.
   - jq available for reading package metadata.
-  - npm CLI installed if login visibility should be shown.
+  - npm CLI installed only if optional login visibility is enabled with `NPM_STATUSLINE_CHECK_WHOAMI=1`.
 safetyNotes:
-  - The script does not run `npm publish`; it only reads metadata and login visibility.
+  - The script does not run `npm publish`; by default it only reads local package metadata and git status.
+  - npm login visibility is disabled by default because `npm whoami` can contact the configured registry; set `NPM_STATUSLINE_CHECK_WHOAMI=1` only for trusted projects.
+  - Optional `npm whoami` checks require the `timeout` command and are capped at 3 seconds to avoid stalled statusline rendering.
   - Readiness is a checklist signal, not approval to publish; run `npm pack --dry-run` and project release checks separately.
   - Dirty lockfiles or package metadata should be reviewed before release tagging.
 privacyNotes:
   - The output prints package name and version, which can reveal unreleased package plans in screenshots.
-  - npm login visibility follows local npm configuration but does not print account names.
+  - With `NPM_STATUSLINE_CHECK_WHOAMI=1`, npm login visibility follows local npm configuration and can send credentials to the configured registry.
   - package.json can contain private package names; avoid sharing terminal output when those names are sensitive.
 ---
 
 ## Source notes
 
 - npm documents `npm publish` behavior and package metadata that affects publication.
-- npm also documents `npm pack --dry-run`; this statusline intentionally stays read-only and leaves dry-run verification to a separate release command.
+- npm also documents `npm pack --dry-run`; this statusline intentionally avoids publishing and leaves dry-run verification to a separate release command.
 
 ## Duplicate check
 


### PR DESCRIPTION
### Motivation
- The statusline ran `npm whoami` automatically which can perform credential-bearing network requests using project `.npmrc` and stall statusline rendering, creating token-exfiltration and DoS risks. 
- The change aims to eliminate automatic registry access while preserving the statusline's local metadata checks and usefulness.

### Description
- Gate the `npm whoami` check behind an explicit opt-in environment variable `NPM_STATUSLINE_CHECK_WHOAMI=1` so it is not executed by default in `content/statuslines/npm-publish-readiness-statusline.mdx`. 
- Add a 3 second enforced timeout using the external `timeout` command for the optional `npm whoami` path and report `whoami-timeout-missing` when `timeout` is unavailable. 
- Change the default login state to `auth-unchecked` and adjust readiness mapping so unchecked or non-logged-in states surface as `review`/`auth` rather than `ready`. 
- Update `usageSnippet`, `prerequisites`, `safetyNotes`, and `privacyNotes` and minor SEO/description text to disclose the opt-in network behavior and timeout requirement.

### Testing
- Ran `pnpm validate:content:strict` which passed content validation. 
- Performed an extracted-script test with a fake `npm` binary verifying that `npm` is not invoked by default and is invoked only when `NPM_STATUSLINE_CHECK_WHOAMI=1` is set. 
- Ran `git diff --check` to validate whitespace/formatting and committed the change as `fix(content): gate npm statusline whoami check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a212c705078832cb701e552c7709b0a)