### PR TITLE
fix(content): harden readme validator grep to prevent option injection

### DIFF
--- a/content/hooks/readme-refresh-validator.mdx
+++ b/content/hooks/readme-refresh-validator.mdx
@@ -85,7 +85,7 @@ scriptBody: |-
     *) exit 0 ;;
   esac
 
-  dir=$(dirname "$FILE")
+  dir=$(dirname -- "$FILE")
   if [ -z "$readme" ]; then
     for c in "$dir/README.md" "README.md" "$dir/readme.md"; do
       [ -f "$c" ] && { readme="$c"; break; }
@@ -114,10 +114,10 @@ scriptBody: |-
     bins=$(jq -r '
       if (.bin | type) == "object" then (.bin | keys[])
       elif (.bin | type) == "string" then (.name // empty)
-      else empty end' "$pkg" 2>/dev/null)
+      else empty end' -- "$pkg" 2>/dev/null)
     printf '%s\n' "$bins" | while IFS= read -r b; do
       [ -z "$b" ] && continue
-      if ! grep -qiF "$b" "$readme"; then
+      if ! grep -qiF -e "$b" -- "$readme"; then
         echo "README refresh: CLI command '$b' (from package.json bin) is not mentioned in $readme." >&2
       fi
     done


### PR DESCRIPTION
### Motivation
- Prevent a grep option-injection/DoS introduced in the README refresh hook where attacker-controlled `package.json` `bin` keys beginning with `-` could be parsed as `grep` options and hang the hook (file: `content/hooks/readme-refresh-validator.mdx`).

### Description
- Treat extracted bin names as fixed-string patterns by using `grep -qiF -e "$b" -- "$readme"` and delimit the README operand with `--` to avoid option parsing.
- Add option delimiters for file/path handling by calling `dirname -- "$FILE"` and `jq ... -- "$pkg"` to prevent paths beginning with `-` from being interpreted as options.

### Testing
- Ran `pnpm validate:content:strict` with no failures.
- Ran `git diff --check` which passed.
- Performed a manual regression by running the hook against a `package.json` containing a bin name of `--exclude-from=/dev/zero` under `timeout 5`, which produced an advisory message and did not hang (fix verified).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214dc16704832c84a2fbe81a3a40c2)