### PR TITLE
fix(hooks): quote lockfile path in advice

### DIFF
--- a/content/hooks/lockfile-provenance-checker.mdx
+++ b/content/hooks/lockfile-provenance-checker.mdx
@@ -80,7 +80,8 @@ scriptBody: |-
   case "$FILE" in
     *package-lock.json|*npm-shrinkwrap.json) : ;;
     *yarn.lock|*pnpm-lock.yaml)
-      echo "Lockfile changed - run 'npx lockfile-lint --path $FILE --validate-https --validate-integrity' to check resolved hosts and integrity." >&2
+      printf -v SAFE_FILE '%q' "$FILE"
+      echo "Lockfile changed - run 'npx lockfile-lint --path $SAFE_FILE --validate-https --validate-integrity' to check resolved hosts and integrity." >&2
       exit 0 ;;
     *) exit 0 ;;
   esac


### PR DESCRIPTION
### Motivation
- Prevent a potential shell-injection vector where an attacker-controlled lockfile path was interpolated unescaped into the emitted `npx lockfile-lint --path $FILE --validate-https --validate-integrity` suggestion.

### Description
- Shell-quote the path before emitting it by adding `printf -v SAFE_FILE '%q' "$FILE"` and using `SAFE_FILE` in the suggested command in `content/hooks/lockfile-provenance-checker.mdx`.

### Testing
- Ran `pnpm validate:content:strict` which passed.
- Ran `git diff --check` which passed.
- Extracted the hook `scriptBody` and simulated a malicious path with a fake `npx` shim to confirm the suggested command keeps the path as a single `--path` argument and does not allow injected shell syntax.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214dc1d038832c843a6435028b2631)