### PR TITLE
fix(content): guard dependency risk lookups

### DIFF
--- a/content/commands/dependency-risk-review.mdx
+++ b/content/commands/dependency-risk-review.mdx
@@ -33,7 +33,7 @@ safetyNotes:
   - "When the optional scorecard CLI is used to score a repository that is not already in the public dataset, it performs read-only analysis and needs a GitHub token; it never modifies repositories."
   - "The review is advisory - it ranks risk and recommends actions, but it does not pin, update, remove, or vendor any dependency on its own."
 privacyNotes:
-  - "Sends only dependency package names and their already-public source-repository identifiers to the public OpenSSF Scorecard and OSV APIs; it sends no source code, lockfile contents, or credentials."
+  - "External lookups can expose dependency names, versions, scoped package names, and repo identifiers to public Scorecard and OSV APIs; skip private/internal packages and private repos unless the user explicitly approves sharing that metadata."
   - "Scorecard and OSV responses (numeric check scores and advisory text) enter the model context to explain the risk ranking."
   - "It writes nothing to disk beyond any output you choose to redirect."
 tags:
@@ -62,18 +62,19 @@ The `/dependency-risk-review` command assesses **supply-chain posture** — how 
 
 ## What it does
 
-When you invoke this command, follow these steps and only read public data:
+When you invoke this command, follow these steps and avoid disclosing private project metadata:
 
 1. **Pick the targets.** Read direct dependencies from `package.json`, a lockfile, `requirements.txt`, `go.mod`, or `Cargo.toml`. Prioritize dependencies that are widely imported, run at build/CI time, or have many transitive children.
-2. **Resolve source repos.** Map each dependency to its source repository (for example via the registry metadata's `repository` field).
-3. **Look up Scorecard.** Query the public API `https://api.securityscorecards.dev/projects/github.com/<owner>/<repo>` for each repo. If a repo is not in the dataset, optionally run `scorecard --repo=github.com/<owner>/<repo>` locally.
-4. **Read the risk-bearing checks.** Surface low scores for `Maintained`, `Dangerous-Workflow`, `Pinned-Dependencies`, `Signed-Releases`, `Token-Permissions`, `Code-Review`, `Branch-Protection`, and `Vulnerabilities`.
-5. **Cross-reference advisories.** Query OSV (`https://api.osv.dev/v1/query`) for known advisories affecting the installed version of each dependency.
-6. **Rank and recommend.** Rank dependencies by combined risk and, for each high-risk one, recommend a concrete action: pin to a hash, update, replace with a healthier alternative, vendor, or add monitoring.
+2. **Screen for private metadata.** Before any external lookup, identify private or internal package names, private registry hosts, non-public repository URLs, and scoped packages that appear organization-private. Exclude those dependencies from public API calls unless the user explicitly confirms that sharing their names, versions, and repository identifiers with Scorecard and OSV is acceptable.
+3. **Resolve source repos.** Map each remaining public dependency to its source repository (for example via the registry metadata's `repository` field).
+4. **Look up Scorecard.** Query the public API `https://api.securityscorecards.dev/projects/github.com/<owner>/<repo>` only for public repos. If a repo is not in the dataset, optionally run `scorecard --repo=github.com/<owner>/<repo>` locally only after confirming the repo identifier is public or approved to share.
+5. **Read the risk-bearing checks.** Surface low scores for `Maintained`, `Dangerous-Workflow`, `Pinned-Dependencies`, `Signed-Releases`, `Token-Permissions`, `Code-Review`, `Branch-Protection`, and `Vulnerabilities`.
+6. **Cross-reference advisories.** Query OSV (`https://api.osv.dev/v1/query`) for known advisories affecting the installed version of each public or user-approved dependency.
+7. **Rank and recommend.** Rank dependencies by combined risk and, for each high-risk one, recommend a concrete action: pin to a hash, update, replace with a healthier alternative, vendor, or add monitoring.
 
 ## Output format
 
-- **Dependency:** name + version + source repo.
+- **Dependency:** name + version + source repo, or "skipped/private" for dependencies excluded from external lookups.
 - **Scorecard:** aggregate score and the lowest risk-bearing checks.
 - **Advisories:** any OSV matches for the installed version.
 - **Risk:** high / medium / low with the driving signal.
@@ -87,11 +88,11 @@ When you invoke this command, follow these steps and only read public data:
 
 ## Safety notes
 
-The command only reads public data — it queries the OpenSSF Scorecard and OSV APIs with read-only requests and changes nothing in your project or dependencies. The optional `scorecard` CLI performs read-only analysis. The review is advisory: it ranks risk and recommends actions but does not pin, update, remove, or vendor anything itself.
+The command only queries public APIs for dependencies confirmed to be public, or for private/internal dependency metadata that the user explicitly approves sharing. It changes nothing in your project or dependencies. The optional `scorecard` CLI performs read-only analysis. The review is advisory: it ranks risk and recommends actions but does not pin, update, remove, or vendor anything itself.
 
 ## Privacy notes
 
-Only dependency package names and their already-public source-repository identifiers are sent to the public Scorecard and OSV APIs — never source code, lockfile contents, or credentials. The API responses (numeric scores and advisory text) enter the model context to explain the ranking. Nothing is written to disk beyond output you redirect.
+Dependency package names, installed versions, scoped package names, and source repository identifiers may be sensitive in proprietary projects. Do not send private/internal packages or private repository identifiers to the public Scorecard or OSV APIs unless the user explicitly confirms that sharing that metadata is acceptable. Source code, full lockfile contents, and credentials are never sent; API responses (numeric scores and advisory text) enter the model context to explain the ranking. Nothing is written to disk beyond output you redirect.
 
 ## Source and references
 


### PR DESCRIPTION
### Motivation
- The `/dependency-risk-review` command instructed agents to read local manifests and query public Scorecard/OSV APIs without guarding for private or internal packages, which can leak dependency names, versions, scoped package names, and repository identifiers.
- The change prevents accidental disclosure of sensitive dependency-inventory metadata when running the command in proprietary projects.

### Description
- Update `privacyNotes` to warn that external lookups can expose dependency names, versions, scoped package names, and repo identifiers and to require user approval before sharing private/internal metadata. 
- Add a new workflow step `Screen for private metadata` that excludes private/internal package names, private registry hosts, and non-public repo URLs from public API calls unless the user explicitly approves sharing them. 
- Limit Scorecard/OSV queries to public or user-approved dependencies and mark excluded items in the output as `skipped/private`, and update safety and output text to reflect the guarded behavior.

### Testing
- Ran `pnpm validate:content:strict` and content validation passed. 
- Ran `git diff --check` and no diff errors were reported.
- The modified MDX file was linted/validated by the repository content validator and met the privacy item length constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214dc189ec832c989f97a09e83de74)