### PR TITLE
fix(seo): tighten best-list install trust gate

### DIFF
--- a/apps/web/src/data/entries.ts
+++ b/apps/web/src/data/entries.ts
@@ -113,21 +113,26 @@ const BEST_LIST_SEEDS: BestListSeed[] = seoClusterDefinitions.map((definition) =
   intro: definition.description,
 }));
 
+export function hasBestListInstallTrust(entry: Entry) {
+  const hasInstallSurface = Boolean(
+    entry.installCommand ||
+    entry.configSnippet ||
+    entry.downloadUrl ||
+    entry.copySnippet ||
+    entry.usageSnippet,
+  );
+  const hasTrustedInstall = Boolean(
+    entry.packageVerified || entry.trust === "trusted" || entry.source === "first-party",
+  );
+
+  return hasInstallSurface && hasTrustedInstall;
+}
+
 function matchesBestListSeed(entry: Entry, seed: BestListSeed) {
   if (!seed.categories.includes(entry.category)) return false;
   if (seed.requireSource && entry.source === "unverified") return false;
 
-  if (seed.requireInstallTrust) {
-    const hasInstallSurface = Boolean(
-      entry.installCommand || entry.configSnippet || entry.downloadUrl || entry.fullCopy,
-    );
-    const hasTrustedInstall =
-      entry.packageVerified ||
-      entry.trust === "trusted" ||
-      entry.source === "first-party" ||
-      entry.source === "source-backed";
-    if (!hasInstallSurface || !hasTrustedInstall) return false;
-  }
+  if (seed.requireInstallTrust && !hasBestListInstallTrust(entry)) return false;
 
   return true;
 }

--- a/apps/web/src/data/seo-cluster-definitions.ts
+++ b/apps/web/src/data/seo-cluster-definitions.ts
@@ -111,10 +111,10 @@ export const seoClusterDefinitions: SeoClusterDefinition[] = [
     title: "Safer install paths for Agent Skills",
     eyebrow: "Install trust",
     description:
-      "Agent Skills and related resources with package, source, or copyable install metadata that can be reviewed before use.",
+      "Agent Skills and related resources with package verification, first-party source, or trusted copyable setup metadata that can be reviewed before use.",
     seoTitle: "Safer install paths for Agent Skills",
     seoDescription:
-      "Find Agent Skills with safer install signals, source-backed metadata, package verification context, checksums, and copyable setup guidance.",
+      "Find Agent Skills with safer install signals, package verification context, first-party source, checksums, and trusted setup guidance.",
     categories: ["skills", "rules", "commands", "hooks"],
     tags: ["skills", "security", "workflow", "automation"],
     requireInstallTrust: true,

--- a/tests/atlas-production-data.test.ts
+++ b/tests/atlas-production-data.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from "vitest";
 
 import { ARTIFACT_CONTRACTS } from "@/data/changelog";
 import { ECOSYSTEM_FEEDS } from "@/data/ecosystem-feeds";
-import { BEST_LISTS, ENTRIES, WEEKLY_BRIEF } from "@/data/entries";
+import {
+  BEST_LISTS,
+  ENTRIES,
+  WEEKLY_BRIEF,
+  hasBestListInstallTrust,
+} from "@/data/entries";
 import { getIntegration } from "@/data/integrations";
 import { PLATFORM_MATRIX } from "@/data/platforms";
 import { seoClusterDefinitions } from "@/data/seo-cluster-definitions";
@@ -87,6 +92,40 @@ describe("Atlas production data wiring", () => {
     expect(getIntegration("mcp-server")?.version).toBe(packageJson.version);
   });
 
+  it("does not treat source-backed body copy as install trust", () => {
+    const entry = {
+      category: "skills",
+      slug: "source-backed-body-copy",
+      title: "Source-backed body copy",
+      description: "A source-backed entry with only full body copy.",
+      author: "Example",
+      tags: [],
+      platforms: [],
+      installType: "copy",
+      fullCopy: "curl -fsSL https://example.invalid/install.sh | sh",
+      source: "source-backed",
+      trust: "review",
+      dateAdded: "2026-01-01",
+      packageVerified: false,
+    } satisfies (typeof ENTRIES)[number];
+
+    expect(hasBestListInstallTrust(entry)).toBe(false);
+    expect(
+      hasBestListInstallTrust({
+        ...entry,
+        installType: "cli",
+        installCommand: "npx source-backed-example",
+      }),
+    ).toBe(false);
+    expect(
+      hasBestListInstallTrust({
+        ...entry,
+        source: "first-party",
+        trust: "trusted",
+      }),
+    ).toBe(false);
+  });
+
   it("keeps generated best lists and weekly brief backed by registry entries", () => {
     const entryRefs = new Set(
       ENTRIES.map((entry) => `${entry.category}/${entry.slug}`),
@@ -123,20 +162,10 @@ describe("Atlas production data wiring", () => {
           );
         }
         if (definition!.requireInstallTrust) {
-          const hasInstallSurface = Boolean(
-            entry!.installCommand ||
-            entry!.configSnippet ||
-            entry!.downloadUrl ||
-            entry!.fullCopy,
-          );
-          const hasTrustedInstall = Boolean(
-            entry!.packageVerified ||
-            entry!.trust === "trusted" ||
-            entry!.source === "first-party" ||
-            entry!.source === "source-backed",
-          );
-          expect(hasInstallSurface, `${list.slug}:${pick.ref}`).toBe(true);
-          expect(hasTrustedInstall, `${list.slug}:${pick.ref}`).toBe(true);
+          expect(
+            hasBestListInstallTrust(entry!),
+            `${list.slug}:${pick.ref}`,
+          ).toBe(true);
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Close a supply-chain trust gap where `safe-install-agent-skills` allowed entries to qualify via reviewable `source-backed` metadata or generic `fullCopy` body content, which can surface unverified install commands as "safer" guidance.
- Ensure safer-install curated lists only surface entries with an explicit install/setup surface plus genuine install/package trust signals.

### Description
- Add `hasBestListInstallTrust(entry: Entry)` which requires an explicit install surface (`installCommand`, `configSnippet`, `downloadUrl`, `copySnippet`, or `usageSnippet`) and trusted install evidence (`packageVerified` or `trust === "trusted"` or `source === "first-party"`).
- Replace the permissive install-trust check in `matchesBestListSeed` to use `hasBestListInstallTrust` so SEO clusters with `requireInstallTrust` no longer accept `source-backed` or `fullCopy` alone.
- Update `safe-install-agent-skills` SEO wording to describe package verification, first-party source, checksums, and trusted setup guidance instead of implying `source-backed` provenance equals install trust.
- Add and adapt production-data tests in `tests/atlas-production-data.test.ts` to cover the new predicate and to assert that source-backed body-copy or source-backed commands without verified installs do not pass the gate.

### Testing
- Ran `pnpm --filter web run prebuild` to generate `apps/web/src/generated/atlas-registry.json` and prepare artifacts, which completed successfully.
- Ran `pnpm exec vitest run tests/atlas-production-data.test.ts` and observed the suite pass (`7 tests` passed).
- Ran `pnpm --filter web type-check` (TypeScript `tsc --noEmit`) and `git diff --check`, both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214dc1e4b4832ca9dc35357ae07961)