### PR TITLE
fix(hooks): quote schema drift output

### DIFF
--- a/content/hooks/api-schema-drift-detector.mdx
+++ b/content/hooks/api-schema-drift-detector.mdx
@@ -102,7 +102,9 @@ scriptBody: |-
     <(jq -r '(.paths // {}) | keys[]' "$FILE" 2>/dev/null | sort -u))
   if [ -n "$removed_paths" ]; then
     echo "API schema drift in $FILE - removed path(s):" >&2
-    printf '   - %s\n' $removed_paths >&2
+    while IFS= read -r path; do
+      printf '   - %s\n' "$path" >&2
+    done <<< "$removed_paths"
     drift=1
   fi
 
@@ -112,7 +114,9 @@ scriptBody: |-
     <(jq -r '(.required // []) | .[]' "$FILE" 2>/dev/null | sort -u))
   if [ -n "$removed_required" ]; then
     echo "API schema drift in $FILE - removed required field(s):" >&2
-    printf '   - %s\n' $removed_required >&2
+    while IFS= read -r field; do
+      printf '   - %s\n' "$field" >&2
+    done <<< "$removed_required"
     drift=1
   fi
 


### PR DESCRIPTION
### Motivation
- The hook emitted removed OpenAPI paths and required-field names using unquoted Bash variable expansion, allowing attacker-controlled keys like `/*` or `*` to undergo word-splitting and pathname expansion and leak local filenames to hook stderr. 
- The change closes this local information-disclosure vector while keeping the hook advisory and read-only.

### Description
- Update the hook implementation in `content/hooks/api-schema-drift-detector.mdx` to print removed entries line-by-line using a safe `while IFS= read -r` loop and quoted `printf` arguments. 
- Replace `printf '   - %s\n' $removed_paths` with a loop that prints each `path` as `printf '   - %s\n' "$path"`, and apply the same change for `removed_required` entries. 
- Preserve existing behavior: the hook remains advisory, fails open when `git`/`jq` are missing, and exits `0`.

### Testing
- Ran `git diff --check` and the check passed. 
- Ran `pnpm validate:content:strict` and content validation passed. 
- Executed a custom reproduction in a temporary git repo that previously leaked `/*` and `*`, and verified the hook now prints the literal `/*` and `*` without expanding local filenames (reproduction passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214dc1bc38832c85d5dd6c1da3e2ee)