### PR TITLE
fix(commands): remove ci triage bash allowlist

### DIFF
--- a/content/commands/ci-failure-triage.mdx
+++ b/content/commands/ci-failure-triage.mdx
@@ -26,10 +26,6 @@ installCommand: "/ci-failure-triage [run-id]"
 commandSyntax: "/ci-failure-triage [run-id]"
 usageSnippet: "/ci-failure-triage 26872683174"
 copySnippet: "/ci-failure-triage [run-id]"
-allowedTools:
-  - "Bash(gh run list:*)"
-  - "Bash(gh run view:*)"
-  - "Bash(git branch:*)"
 tags:
   - ci
   - github-actions


### PR DESCRIPTION
### Motivation
- Remove an overbroad Bash allowlist metadata from `/ci-failure-triage` frontmatter which exported `Bash(gh run list:*)`, `Bash(gh run view:*)`, and `Bash(git branch:*)`, because pre-approving those patterns weakens the safety boundary for a command that processes untrusted CI logs.

### Description
- Deleted the `allowedTools` block from `content/commands/ci-failure-triage.mdx` so the entry no longer exports broad shell allowlist patterns while preserving the documented read-only triage workflow and safety guidance.

### Testing
- Ran `pnpm validate:content:strict` which passed and `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2155d86744832c990f27abf27a0ca2)