### PR TITLE
fix(hooks): avoid large migration safety gate bypass

### DIFF
--- a/content/hooks/database-migration-safety-gate.mdx
+++ b/content/hooks/database-migration-safety-gate.mdx
@@ -95,8 +95,7 @@ scriptBody: |-
     fi
 
     if [ -n "$EXISTING_FILE" ]; then
-      EXISTING_CONTENT=$(cat -- "$EXISTING_FILE")
-      CONTENT=$(printf '%s' "$INPUT" | jq -r --arg content "$EXISTING_CONTENT" '
+      if ! CONTENT=$(printf '%s' "$INPUT" | jq -r --rawfile content "$EXISTING_FILE" '
         def replace_once($old; $new):
           if ($old == "") then .
           else (index($old) as $ix
@@ -116,13 +115,19 @@ scriptBody: |-
           else
             $content
           end
-      ')
+      '); then
+        echo "Unable to reconstruct edited migration for ${FILE:-pending write}; blocked by the safety gate." >&2
+        exit 2
+      fi
     else
-      CONTENT=$(printf '%s' "$INPUT" | jq -r '
+      if ! CONTENT=$(printf '%s' "$INPUT" | jq -r '
         [ .tool_input.new_string,
           (.tool_input.edits[]?.new_string) ]
         | map(select(. != null)) | join("\n")
-      ')
+      '); then
+        echo "Unable to inspect edited migration for ${FILE:-pending write}; blocked by the safety gate." >&2
+        exit 2
+      fi
     fi
   fi
 


### PR DESCRIPTION
### Motivation
- A safety bypass was possible when reconstructed Edit/MultiEdit content was passed to `jq` via a command-line argument because very large existing migration files could exceed the OS argument-size limit, causing `jq` to fail and the hook to fail open (allowing unsafe edits). 

### Description
- Replace passing full file contents with `jq --rawfile content "$EXISTING_FILE"` so large files are not injected into the command-line argument vector. 
- Remove the intermediate `cat`/`--arg` usage and add explicit `if ! CONTENT=...; then ... exit 2` checks so any `jq` reconstruction or inspection failure fails closed. 
- Change is contained in `content/hooks/database-migration-safety-gate.mdx` and preserves existing detection heuristics and the `-- safety-gate: allow` escape hatch.

### Testing
- Ran `git diff --check` which reported no whitespace or patch issues. 
- Ran `pnpm validate:content:strict` which completed and reported content validation passed. 
- Extracted and executed the hook against a generated large migration file and simulated an `Edit` that replaces a safe statement with `DROP TABLE`; the hook printed the unsafe findings and exited with status `2`, confirming the fail-closed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a215969c484832c9e64638725e84387)