### PR TITLE
fix(submissions): tune duplicate review policy

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -879,6 +879,15 @@ function isReviewablePullRequestPayload(payload: Record<string, unknown>) {
   return editedPayloadHasBaseRefChange(payload);
 }
 
+function isReopenedPullRequestEvent(
+  eventName: string,
+  webhook?: Record<string, unknown>,
+) {
+  return (
+    eventName === "pull_request" && String(webhook?.action || "") === "reopened"
+  );
+}
+
 function reviewScanKeyForTarget(target: ReviewTarget) {
   return target.headSha
     ? `${target.headSha}:${target.baseRef || "unknown-base"}`
@@ -1890,7 +1899,7 @@ function duplicateCloseDecision(
     summary: [
       "Summary:",
       `- This submission overlaps an existing or earlier pending content item: ${existingTarget}.`,
-      "- HeyClaude closes duplicate or ambiguous same-source submissions in one shot so the directory does not accumulate redundant listings.",
+      "- HeyClaude closes strict duplicates in one shot so the directory does not accumulate redundant listings.",
       "",
       "Duplicate / History Review:",
       ...match.reasons.map((reason) => `- ${reason}.`),
@@ -2160,7 +2169,15 @@ async function enqueueReviewTarget(
     String(existing?.status || "") === "ignored" &&
     reviewScanKey &&
     existingReviewKey !== reviewScanKey;
-  if (!hasTerminalGateDecision(existing) || shouldResetIgnoredScan) {
+  const shouldResetClosedTerminal =
+    String(existing?.status || "") === "closed" &&
+    (isReopenedPullRequestEvent(eventName, webhook) ||
+      eventName === "scheduled");
+  if (
+    !hasTerminalGateDecision(existing) ||
+    shouldResetIgnoredScan ||
+    shouldResetClosedTerminal
+  ) {
     await upsertPrState(env.SUBMISSION_GATE_DB, {
       repo: target.repoFullName,
       number: target.number,
@@ -2174,8 +2191,8 @@ async function enqueueReviewTarget(
       nextReviewAt: null,
       incrementAttempt: true,
       lastReviewKey: reviewScanKey || undefined,
-      clearVerdict: shouldResetIgnoredScan,
-      clearTerminal: shouldResetIgnoredScan,
+      clearVerdict: shouldResetIgnoredScan || shouldResetClosedTerminal,
+      clearTerminal: shouldResetIgnoredScan || shouldResetClosedTerminal,
     });
   }
   await env.SUBMISSION_REVIEW_QUEUE.send({
@@ -3062,6 +3079,12 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 "accepted_history",
                 "rejected_history",
               ],
+              strictDuplicatePolicy:
+                "Only same path, same category+slug, same category+canonical URL/repo, same category+title, or same category+normalized description should block as a duplicate.",
+              relatedContentPolicy:
+                "Cross-category source overlap, same ecosystem/project ownership, and collection-member overlap are related/complementary context, not automatic duplicates.",
+              collectionPolicy:
+                "Collections may bundle existing entries when they add distinct workflow value, ordering, prerequisites, source-backed rationale, and safety/privacy guidance; repeated same-scope collection variants can still close as duplicates.",
             },
           },
         });
@@ -3453,7 +3476,8 @@ async function discoverOpenContentPullRequests(
       repo: target.repoFullName,
       number: target.number,
     });
-    if (hasTerminalGateDecision(state)) continue;
+    const closedTerminalButOpen = String(state?.status || "") === "closed";
+    if (hasTerminalGateDecision(state) && !closedTerminalButOpen) continue;
     const reviewScanKey = reviewScanKeyForTarget(target);
     if (
       state &&

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -407,6 +407,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
+    expect(source).toContain("strictDuplicatePolicy:");
+    expect(source).toContain("relatedContentPolicy:");
+    expect(source).toContain("collectionPolicy:");
     expect(source).toContain("deterministicDuplicateReview");
     expect(source).toContain('eventType: "duplicate_shadow_review"');
     expect(source).toContain('decision: "related_not_strict_duplicate"');
@@ -839,6 +842,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("function isOpenPullRequest");
     expect(source).toContain("function terminalStatusFromPullRequest");
     expect(source).toContain("async function reconcileTerminalPullRequest");
+    expect(source).toContain("function isReopenedPullRequestEvent");
+    expect(source).toContain("shouldResetClosedTerminal");
+    expect(source).toContain('String(state?.status || "") === "closed"');
     expect(source).toContain("labels: [LABELS.underReview]");
     expect(source).toContain(
       "Terminal gate state did not match open GitHub PR",
@@ -855,9 +861,10 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(storageSource).toContain("terminal_at IS NOT NULL");
     expect(storageSource).toContain("status = 'closed'");
-    expect(enqueueBlock).toContain(
-      "if (!hasTerminalGateDecision(existing) || shouldResetIgnoredScan)",
-    );
+    expect(enqueueBlock).toContain("shouldResetClosedTerminal");
+    expect(enqueueBlock).toContain("!hasTerminalGateDecision(existing)");
+    expect(enqueueBlock).toContain("shouldResetIgnoredScan");
+    expect(enqueueBlock).toContain("shouldResetClosedTerminal");
     expect(reviewBlock).toContain("if (hasTerminalGateDecision(existing))");
     expect(enqueueBlock).not.toContain(
       "if (!forceRecheck && hasTerminalGateDecision(existing))",
@@ -1264,6 +1271,47 @@ repoUrl: "https://github.com/langchain-ai/langchain.git"
     );
   });
 
+  it("treats collection member overlap as related context, not a strict duplicate", () => {
+    const existingTool = extractContentDuplicateSignals({
+      filePath: "content/tools/storybook-a11y.mdx",
+      content: `---
+title: Storybook Accessibility Testing
+slug: storybook-a11y
+category: tools
+description: Tooling for accessibility checks inside Storybook.
+docsUrl: "https://storybook.js.org/docs/writing-tests/accessibility-testing"
+---
+`,
+    });
+    const workflowCollection = extractContentDuplicateSignals({
+      filePath: "content/collections/frontend-a11y-browser-qa.mdx",
+      content: `---
+title: Frontend A11y Browser QA Workflow
+slug: frontend-a11y-browser-qa
+category: collections
+description: Ordered workflow for browser QA using Playwright, Storybook, and WCAG references.
+docsUrl: "https://storybook.js.org/docs/writing-tests/accessibility-testing"
+websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(workflowCollection, [existingTool]),
+    ).toBeNull();
+    expect(
+      findRelatedContentMatches(workflowCollection, [existingTool]),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining("across collection/resource categories"),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("treats same canonical repository as a strict duplicate", () => {
     const existing = extractContentDuplicateSignals({
       filePath: "content/mcp/playwright-mcp-server.mdx",
@@ -1290,6 +1338,41 @@ repoUrl: "https://github.com/microsoft/playwright-mcp.git?utm_source=heyclaude"
 
     expect(
       findStrictContentDuplicateMatch(candidate, [existing]),
+    ).toMatchObject({
+      reasons: expect.arrayContaining([
+        expect.stringContaining("same canonical source URL"),
+      ]),
+    });
+  });
+
+  it("treats repeated same-scope collections as strict duplicates", () => {
+    const existingCollection = extractContentDuplicateSignals({
+      filePath: "content/collections/frontend-a11y-browser-qa.mdx",
+      content: `---
+title: Frontend A11y Browser QA Workflow
+slug: frontend-a11y-browser-qa
+category: collections
+description: Ordered browser QA workflow using Playwright, Storybook, and WCAG references.
+docsUrl: "https://playwright.dev/docs/intro"
+websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
+---
+`,
+    });
+    const repeatedCollection = extractContentDuplicateSignals({
+      filePath: "content/collections/frontend-accessibility-qa-stack.mdx",
+      content: `---
+title: Frontend Accessibility QA Stack
+slug: frontend-accessibility-qa-stack
+category: collections
+description: Similar browser QA workflow using Playwright, Storybook, and WCAG references.
+docsUrl: "https://playwright.dev/docs/intro"
+websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(repeatedCollection, [existingCollection]),
     ).toMatchObject({
       reasons: expect.arrayContaining([
         expect.stringContaining("same canonical source URL"),


### PR DESCRIPTION
## Summary
- Clarifies strict duplicate wording in the submission gate.
- Adds explicit private-review policy fields for strict duplicates, related content, and collection overlap.
- Fixes reopened content PR recovery when D1 still has an old terminal `closed` row.
- Adds regression coverage for collection/member overlap, repeated same-scope collections, and stale terminal recovery.

## What changed
- Strict duplicate close comments no longer describe related same-source context as an automatic duplicate.
- Private reviewer packets now distinguish strict duplicates from related/complementary source overlap.
- `pull_request.reopened` and scheduled open-PR discovery can clear stale closed terminal state before queueing review.
- Tests cover collection overlap with existing resources and repeated collection variants.

## Why
- Collection submissions can intentionally reference existing entries while adding workflow value.
- The maintainer agent needs explicit policy context so related resources do not get closed as duplicates.
- Reopened content PRs must be reviewable even when the previous terminal decision is still recorded in D1.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/registry-artifacts.test.ts tests/submission-pr-first.test.ts`
- `pnpm validate:content:strict`
- `pnpm validate:openapi`
- `pnpm validate:raycast-feed`
- `pnpm --filter web type-check`
- `pnpm submission-gate:dry-run`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate duplicate detection with clearer distinction between strict duplicates and related/complementary content.
  * Improved handling of collection content to reduce false-positives for overlapping scope.

* **Behavior Changes**
  * Pull requests with prior closed decisions can be reprocessed when reopened or on scheduled rechecks.
  * Review summaries now explicitly state that strict duplicates are closed in one shot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->