### PR TITLE
fix(security): harden release issue labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/product-feature.yml
+++ b/.github/ISSUE_TEMPLATE/product-feature.yml
@@ -3,7 +3,6 @@ description: Propose contributor work for HeyClaude product, website, API, MCP, 
 title: "feat: "
 labels:
   - help wanted
-  - gittensor:feature
 body:
   - type: markdown
     attributes:

--- a/scripts/check-mcp-release-due.mjs
+++ b/scripts/check-mcp-release-due.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import {
   buildMcpReleaseIssue,
   buildMcpReleaseReport,
+  isTrustedReleaseWatchIssue,
   latestSemverTag,
   MCP_RELEASE_DUE_MARKER,
 } from "./lib/release-watch-core.mjs";
@@ -129,6 +130,7 @@ async function upsertIssue({ marker, issue, userAgent }) {
     repo,
     token,
     marker,
+    expectedLabels: issue.labels,
     userAgent,
   });
   if (existingIssue) {
@@ -160,7 +162,14 @@ async function upsertIssue({ marker, issue, userAgent }) {
   process.stdout.write(`Opened issue #${created.number}: ${issue.title}\n`);
 }
 
-async function findExistingIssue({ owner, repo, token, marker, userAgent }) {
+async function findExistingIssue({
+  owner,
+  repo,
+  token,
+  marker,
+  expectedLabels,
+  userAgent,
+}) {
   for (let page = 1; page <= 10; page += 1) {
     const issues = await githubRequest({
       token,
@@ -171,9 +180,9 @@ async function findExistingIssue({ owner, repo, token, marker, userAgent }) {
     if (!Array.isArray(issues) || issues.length === 0) return null;
     const match = issues.find(
       (issue) =>
-        !issue.pull_request &&
         typeof issue.body === "string" &&
-        issue.body.includes(marker),
+        issue.body.includes(marker) &&
+        isTrustedReleaseWatchIssue(issue, expectedLabels),
     );
     if (match) return match;
   }

--- a/scripts/check-raycast-release-due.mjs
+++ b/scripts/check-raycast-release-due.mjs
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 import {
   buildRaycastReleaseIssue,
   buildRaycastReleaseReport,
+  isTrustedReleaseWatchIssue,
   latestSemverTag,
   RAYCAST_RELEASE_DUE_MARKER,
 } from "./lib/release-watch-core.mjs";
@@ -113,6 +114,7 @@ async function upsertIssue({ marker, issue, userAgent }) {
     repo,
     token,
     marker,
+    expectedLabels: issue.labels,
     userAgent,
   });
   if (existingIssue) {
@@ -144,7 +146,14 @@ async function upsertIssue({ marker, issue, userAgent }) {
   process.stdout.write(`Opened issue #${created.number}: ${issue.title}\n`);
 }
 
-async function findExistingIssue({ owner, repo, token, marker, userAgent }) {
+async function findExistingIssue({
+  owner,
+  repo,
+  token,
+  marker,
+  expectedLabels,
+  userAgent,
+}) {
   for (let page = 1; page <= 10; page += 1) {
     const issues = await githubRequest({
       token,
@@ -155,9 +164,9 @@ async function findExistingIssue({ owner, repo, token, marker, userAgent }) {
     if (!Array.isArray(issues) || issues.length === 0) return null;
     const match = issues.find(
       (issue) =>
-        !issue.pull_request &&
         typeof issue.body === "string" &&
-        issue.body.includes(marker),
+        issue.body.includes(marker) &&
+        isTrustedReleaseWatchIssue(issue, expectedLabels),
     );
     if (match) return match;
   }

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -137,6 +137,28 @@ export function buildRaycastReleaseReport({
   };
 }
 
+export function isTrustedReleaseWatchIssue(issue, expectedLabels = []) {
+  if (!issue || issue.pull_request) return false;
+  if (issue.user?.login === "github-actions[bot]") return true;
+
+  const issueLabels = new Set(
+    Array.isArray(issue.labels)
+      ? issue.labels
+          .map((label) => {
+            if (typeof label === "string") return label;
+            if (typeof label?.name === "string") return label.name;
+            return null;
+          })
+          .filter(Boolean)
+      : [],
+  );
+
+  return (
+    expectedLabels.length > 0 &&
+    expectedLabels.every((label) => issueLabels.has(label))
+  );
+}
+
 export function buildMcpReleaseIssue(report, options = {}) {
   const config = options.config ?? readReleaseWatchConfig(options);
   return buildReleaseIssue({

--- a/tests/release-watch.test.ts
+++ b/tests/release-watch.test.ts
@@ -5,6 +5,7 @@ import {
   buildMcpReleaseReport,
   buildRaycastReleaseIssue,
   buildRaycastReleaseReport,
+  isTrustedReleaseWatchIssue,
   latestSemverTag,
   MCP_RELEASE_DUE_MARKER,
   RAYCAST_RELEASE_DUE_MARKER,
@@ -82,6 +83,39 @@ describe("release watch", () => {
     expect(issue.labels).toEqual(["release", "raycast"]);
     expect(issue.assignees).toEqual(["release-maintainer"]);
     expect(issue.body).toContain(RAYCAST_RELEASE_DUE_MARKER);
+  });
+
+  it("only trusts existing release-watch issues from automation or trusted labels", () => {
+    expect(
+      isTrustedReleaseWatchIssue(
+        {
+          body: MCP_RELEASE_DUE_MARKER,
+          user: { login: "contributor" },
+          labels: [],
+        },
+        ["release", "mcp"],
+      ),
+    ).toBe(false);
+    expect(
+      isTrustedReleaseWatchIssue(
+        {
+          body: MCP_RELEASE_DUE_MARKER,
+          user: { login: "github-actions[bot]" },
+          labels: [],
+        },
+        ["release", "mcp"],
+      ),
+    ).toBe(true);
+    expect(
+      isTrustedReleaseWatchIssue(
+        {
+          body: MCP_RELEASE_DUE_MARKER,
+          user: { login: "maintainer-triaged" },
+          labels: [{ name: "release" }, { name: "mcp" }],
+        },
+        ["release", "mcp"],
+      ),
+    ).toBe(true);
   });
 
   it("escapes backslashes and pipes in commit subjects before issue upserts", () => {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -173,6 +173,7 @@ describe("submission automation workflows", () => {
     );
 
     expect(source).toContain("Product or feature improvement");
+    expect(source).not.toContain("gittensor:feature");
     expect(source).toContain("id: quality_evidence");
     expect(source).toContain("desktop and mobile screenshots");
     expect(source).toContain("No visual impact");


### PR DESCRIPTION
## Summary
- Removes the trusted `gittensor:feature` label from the public product-feature issue template so public reporters cannot get that trust signal by default.
- Hardens MCP/Raycast release-watch issue upserts so an existing marker issue is reused only when it is automation-owned or already carries the expected trusted release labels.
- Rebuilt the branch as a clean one-commit PR on current `main`, removing the stale merge commits from the branch history.

## Issue / rationale
No separate issue. This is a focused security hardening change for release-watch automation and public issue-template trust boundaries.

## What changed
- `.github/ISSUE_TEMPLATE/product-feature.yml`: drops the trusted feature label from public issue creation.
- `scripts/lib/release-watch-core.mjs`: adds `isTrustedReleaseWatchIssue`.
- `scripts/check-mcp-release-due.mjs` and `scripts/check-raycast-release-due.mjs`: require trusted existing issues before updating labels/assignees.
- `tests/release-watch.test.ts` and `tests/submission-workflows.test.ts`: cover the trust check and template label removal.

## Validation
- `pnpm exec vitest run tests/release-watch.test.ts tests/submission-workflows.test.ts` - passed, 68 tests.
- `git diff --check` - passed.
