### PR TITLE
fix(submissions): requeue stale terminal content prs

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -3481,6 +3481,7 @@ async function discoverOpenContentPullRequests(
     const reviewScanKey = reviewScanKeyForTarget(target);
     if (
       state &&
+      !closedTerminalButOpen &&
       String(state.status || "") !== "error_retryable" &&
       (!reviewScanKey || String(state.lastReviewKey || "") === reviewScanKey)
     ) {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -892,6 +892,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("listOpenPullRequests({");
     expect(source).toContain("scheduled-discovery-");
     expect(source).toContain(
+      'const closedTerminalButOpen = String(state?.status || "") === "closed"',
+    );
+    expect(source).toContain("!closedTerminalButOpen");
+    expect(source).toContain(
       "await applyUnderReviewToTarget(env, target, reviewScope)",
     );
     expect(source).toContain('"validation_pending"');


### PR DESCRIPTION
## Summary
- fix scheduled open-PR discovery so reopened content PRs with stale closed D1 state are requeued
- add regression coverage for the stale-terminal skip condition

## Why
Reopened content PRs could remain open with `submission-under-review` while D1 still said `closed` if the head SHA had not changed. Scheduled discovery identified the stale terminal state, but then skipped the PR because the existing review key matched.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `git diff --check`