### PR TITLE
fix(submissions): preserve terminal gate verdicts

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -1212,7 +1212,6 @@ async function reconcileTerminalPullRequest(params: {
     nextReviewAt: null,
     lastError: "GitHub terminal state verified.",
     terminalAt: nowIso(),
-    clearVerdict: status === "closed",
   });
   await insertAudit(params.env.SUBMISSION_GATE_DB, {
     id: crypto.randomUUID(),

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -813,6 +813,14 @@ describe("Cloudflare submission gate helpers", () => {
       terminalSetIndex,
       terminalSetEndIndex,
     );
+    const reconcileIndex = source.indexOf(
+      "async function reconcileTerminalPullRequest",
+    );
+    const reconcileEndIndex = source.indexOf(
+      "async function ignoreOutOfScopeReviewTarget",
+      reconcileIndex,
+    );
+    const reconcileBlock = source.slice(reconcileIndex, reconcileEndIndex);
 
     expect(source).toContain("const TERMINAL_GATE_VERDICTS = new Set");
     expect(source).toContain("const TERMINAL_PR_STATUSES = new Set");
@@ -856,6 +864,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('decision: "github_terminal_reconciled"');
     expect(source).toContain("clearVerdict: true");
     expect(source).toContain("clearTerminal: true");
+    expect(reconcileBlock).not.toContain("clearVerdict");
     expect(storageSource).toContain(
       "COALESCE(last_error, '') != 'GitHub terminal state verified.'",
     );


### PR DESCRIPTION
## Summary
- preserve an existing gate close verdict when later queue messages reconcile that GitHub is already terminal
- add regression coverage so terminal reconciliation cannot erase the stored verdict again

## Why
A duplicate queue message after a bot close could verify that GitHub was closed and overwrite the D1 ledger so `status=closed` but `verdict` became empty. GitHub comments and labels stayed correct, but queue/audit reporting lost the actual gate decision.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `git diff --check`