### PR TITLE
fix(submissions): retry ai reviewer payload failures

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -408,6 +408,7 @@ function isRetryablePrivateReviewerDecision(decision: GateDecision) {
   const summary = decision.summary.toLowerCase();
   return (
     summary.includes("could not determine the github app installation") ||
+    summary.includes("ai maintainer review returned an unexpected payload") ||
     summary.includes("private corpus review request failed") ||
     summary.includes("private corpus review returned") ||
     summary.includes("private corpus review returned an unexpected payload")

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -402,6 +402,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("target: {");
     expect(source).toContain("installationId: target.installationId");
     expect(source).toContain("isRetryablePrivateReviewerDecision(decision)");
+    expect(source).toContain(
+      "ai maintainer review returned an unexpected payload",
+    );
     expect(source).toContain('status: "error_retryable"');
     expect(source).toContain("retryingReviewComment(");
     expect(source).toContain("validation: validationForPrivateReview");


### PR DESCRIPTION
## Summary
- treat AI maintainer unexpected-payload responses as retryable reviewer infrastructure failures
- add regression coverage so these failures do not terminal-route content PRs to manual review

## Why
The private reviewer can return a manual verdict when a model payload cannot be normalized. That is infrastructure/parser failure, not a content decision. The public gate already retried older private-review payload failures; this extends the same behavior to the current AI maintainer wording.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm submission-gate:dry-run`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced submission processing to automatically retry when encountering AI maintainer review payload errors, improving system reliability and reducing manual intervention needs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->