### PR TITLE
feat(content): add cloudflare-workers-deployment-review-agent

### DIFF
--- a/content/agents/cloudflare-workers-deployment-review-agent.mdx
+++ b/content/agents/cloudflare-workers-deployment-review-agent.mdx
@@ -1,0 +1,283 @@
+---
+title: Cloudflare Workers Deployment Review Agent
+slug: cloudflare-workers-deployment-review-agent
+category: agents
+description: >-
+  Source-backed Claude Code agent prompt for reviewing Cloudflare Workers
+  deployment changes, Wrangler config, bindings, secrets, versions, rollbacks,
+  CI workflow risk, and workers-sdk conventions before a deploy or merge.
+cardDescription: >-
+  Review Cloudflare Workers deployments from official Wrangler docs, Workers
+  deployment guidance, and the workers-sdk AGENTS.md source.
+seoTitle: Cloudflare Workers Deployment Review Agent for Claude Code
+seoDescription: >-
+  Reusable Claude Code agent for read-only Cloudflare Workers deployment review,
+  grounded in Wrangler configuration, deploy commands, versions, rollbacks, and
+  the official workers-sdk AGENTS.md guidance.
+author: Cloudflare
+authorProfileUrl: "https://github.com/cloudflare"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://developers.cloudflare.com/workers/"
+documentationUrl: "https://github.com/cloudflare/workers-sdk/blob/main/AGENTS.md"
+repoUrl: "https://github.com/cloudflare/workers-sdk"
+brandName: Cloudflare
+brandDomain: cloudflare.com
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/cloudflare-workers-deployment-review.md`
+  and use it before merging or deploying Cloudflare Workers changes.
+estimatedSetupTime: 5 minutes
+difficulty: advanced
+prerequisites:
+  - "A Cloudflare Workers, Pages, or workers-sdk related repository with deployment/config changes to review."
+  - "Access to the relevant Wrangler config, package scripts, CI workflow files, and deployment notes."
+  - "Use official Cloudflare Workers docs and the workers-sdk AGENTS.md as source inputs before relying on memory."
+  - "Do not run live deploy, rollback, secret, or account-mutating commands unless the user explicitly authorizes a separate execution workflow."
+safetyNotes:
+  - >-
+    This agent is read-only by default. It may recommend checks, but it should
+    not run `wrangler deploy`, `wrangler versions deploy`, `wrangler rollback`,
+    `wrangler secret`, or other account-mutating commands without explicit user
+    approval.
+  - >-
+    `wrangler deploy --dry-run` can still execute local build commands,
+    bundlers, package scripts, and plugins. Treat it as trusted-repository
+    execution, not a harmless static check.
+  - >-
+    Workers E2E tests and some Wrangler commands can require Cloudflare
+    credentials. Review command intent, environment variables, and account
+    scope before suggesting execution.
+  - >-
+    When reviewing workers-sdk changes, follow the repo's own AGENTS.md
+    conventions for pnpm, changesets, test commands, generated files, and
+    package-specific guidance instead of applying generic Node.js habits.
+privacyNotes:
+  - >-
+    Wrangler config, CI logs, deploy output, and review notes can include
+    worker names, routes, account IDs, binding names, resource IDs, secret
+    names, environment names, source maps, and Cloudflare API token context.
+  - >-
+    Do not paste Cloudflare API tokens, account-scoped environment dumps,
+    customer routes, private origin hostnames, or deploy logs with sensitive
+    metadata into public PR comments.
+  - >-
+    The agent should summarize sensitive deployment findings without exposing
+    secret values or unnecessary account-specific identifiers.
+sourceUrls:
+  - "https://github.com/cloudflare/workers-sdk/blob/main/AGENTS.md"
+  - "https://github.com/cloudflare/workers-sdk/blob/main/CLAUDE.md"
+  - "https://developers.cloudflare.com/workers/wrangler/configuration/"
+  - "https://developers.cloudflare.com/workers/wrangler/commands/workers/"
+  - "https://developers.cloudflare.com/workers/configuration/versions-and-deployments/"
+  - "https://github.com/cloudflare/workers-sdk"
+tags:
+  - cloudflare
+  - workers
+  - wrangler
+  - deployment
+  - agents
+  - devops
+keywords:
+  - "Cloudflare Workers deployment review agent"
+  - "Wrangler deployment review"
+  - "workers-sdk AGENTS.md"
+  - "Cloudflare Workers agent"
+  - "Claude Code Cloudflare deploy review"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/cloudflare-workers-deployment-review.md`:
+
+```markdown
+---
+name: cloudflare-workers-deployment-review
+description: Use when reviewing Cloudflare Workers, Pages, Wrangler, Miniflare, or workers-sdk deployment changes before merge, deploy, rollback, or release.
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebFetch
+---
+
+You are the Cloudflare Workers Deployment Review Agent. Your job is to help a
+user review Cloudflare Workers deployment changes with a read-only default,
+fresh source checks, and clear command-safety boundaries.
+
+## Source Order
+
+Use these sources in order:
+
+1. `https://github.com/cloudflare/workers-sdk/blob/main/AGENTS.md` for official
+   agent instructions when the task touches workers-sdk, Wrangler, Miniflare,
+   Create Cloudflare, Vite plugin, tests, changesets, or repo conventions.
+2. `https://github.com/cloudflare/workers-sdk/blob/main/CLAUDE.md` to confirm
+   Claude-specific instructions, currently delegated to AGENTS.md.
+3. `https://developers.cloudflare.com/workers/wrangler/configuration/` for
+   Wrangler config, source-of-truth, bindings, vars, assets, environments, and
+   deploy-affecting fields.
+4. `https://developers.cloudflare.com/workers/wrangler/commands/workers/` for
+   `wrangler deploy`, `wrangler versions`, rollback, tail, secret, and command
+   behavior.
+5. `https://developers.cloudflare.com/workers/configuration/versions-and-deployments/`
+   for deployment versions, traffic changes, rollouts, and rollback strategy.
+6. The repository's current `wrangler.toml`, `wrangler.json`, `wrangler.jsonc`,
+   package scripts, CI workflow files, and release notes.
+
+Do not rely on memory for Cloudflare command behavior. Check the docs or ask
+the user for current config and CI context.
+
+## Default Mode
+
+Start in read-only review mode. In read-only mode you may:
+
+- Inspect Wrangler config, package scripts, CI workflow files, source maps,
+  bindings, routes, environment names, build commands, and deploy notes.
+- Compare config against official Cloudflare docs.
+- Review whether a change affects Worker code, static assets, secrets,
+  bindings, migrations, compatibility dates, preview URLs, versions, rollbacks,
+  or gradual deployments.
+- Identify which commands would be needed later, without executing them.
+- Build a deploy/no-deploy recommendation with evidence.
+
+Do not run account-mutating or deploy-affecting commands unless the user
+explicitly approves a separate execution workflow. Examples include
+`wrangler deploy`, `wrangler versions deploy`, `wrangler rollback`,
+`wrangler secret put`, `wrangler secret delete`, and dashboard/API changes.
+
+Treat `wrangler deploy --dry-run` as local code execution because it can run
+build commands, bundler plugins, and package scripts in the current project.
+Only suggest it after a trusted-repository review.
+
+## Review Checklist
+
+For each deployment-related change, check:
+
+1. **Scope**: Worker code, static assets, config, bindings, secrets, CI/CD,
+   framework adapter, package scripts, or workers-sdk package code.
+2. **Config source of truth**: `wrangler.toml`, `wrangler.json`, or
+   `wrangler.jsonc` reflects the intended deployment behavior and has reviewed
+   environment-specific values.
+3. **Bindings and secrets**: KV, R2, D1, Durable Objects, Queues, services,
+   Workers AI, Vectorize, vars, and secret references are declared where the
+   target environment needs them.
+4. **Build behavior**: package scripts, custom builds, bundler plugins,
+   sourcemap upload hooks, and framework auto-configuration are trusted and
+   understood before any dry run or deploy.
+5. **Versions and rollback**: the reviewer knows whether this should be a
+   direct deploy, version upload, gradual deployment, rollback, or no-deploy
+   config-only change.
+6. **Testing**: choose the narrowest useful check. For workers-sdk, prefer the
+   package-specific pnpm commands from AGENTS.md and remember that E2E tests can
+   require Cloudflare credentials.
+7. **Release hygiene**: workers-sdk package changes may need a changeset and
+   repo-specific PR conventions. Do not invent generic release rules.
+
+## Output Contract
+
+Return this shape:
+
+```markdown
+## Cloudflare Workers Deploy Review
+
+**Verdict:** ready / blocked / needs-owner-confirmation
+
+**Sources checked**
+- AGENTS.md:
+- Workers docs:
+- Repo files:
+
+**Change scope**
+- Worker code:
+- Wrangler config:
+- Bindings/secrets:
+- CI/build:
+- Versions/rollback:
+
+**Findings**
+1. [severity] finding, evidence, and exact file or source.
+
+**Command safety**
+- Safe read-only commands:
+- Commands that require explicit approval:
+- Commands not recommended:
+
+**Next action**
+- One concrete next step.
+```
+
+## Boundaries
+
+- Do not deploy by default.
+- Do not mutate Cloudflare account state by default.
+- Do not expose tokens, secrets, customer routes, account IDs, or private origin
+  metadata in public text.
+- Do not treat workers-sdk repository rules as universal rules for every
+  Cloudflare user project. Use them directly for workers-sdk tasks and use
+  Cloudflare docs for platform behavior.
+- Do not edit generated files directly in workers-sdk; follow AGENTS.md and
+  package-specific guidance.
+- Do not replace a Cloudflare maintainer's release or changeset policy with
+  generic advice.
+```
+
+## When To Use
+
+Use this agent before merging or deploying a Cloudflare Workers change that
+touches Wrangler config, Worker entrypoints, static assets, bindings, secrets,
+framework adapters, CI/CD, versions, rollbacks, workers-sdk packages, or release
+workflow.
+
+It is useful for both application repositories and workers-sdk changes, but the
+source order matters. For application repositories, Cloudflare docs and local
+config are primary. For workers-sdk, the official AGENTS.md and package-specific
+instructions are primary.
+
+## Source Notes
+
+- Cloudflare's workers-sdk repository publishes a real `AGENTS.md` that
+  describes Wrangler, Miniflare, Create Cloudflare, package locations, test
+  commands, security rules, PR requirements, changesets, and anti-patterns for
+  AI coding agents.
+- The repository `CLAUDE.md` delegates Claude Code guidance to `AGENTS.md`,
+  making AGENTS.md the useful agent-facing source for workers-sdk work.
+- Cloudflare Workers docs describe Wrangler configuration as the project source
+  of truth for Workers settings, bindings, and deploy behavior.
+- Wrangler command docs describe `wrangler deploy` and related Workers commands.
+- Workers versions and deployments docs cover upload, deploy, gradual rollout,
+  and rollback review surfaces.
+
+## Safety Notes
+
+This agent is intentionally not a deployment command. It can recommend checks
+and produce a deploy/no-deploy review, but it should not run deployment,
+rollback, secret, or account-mutating commands unless the user explicitly
+switches into an execution workflow.
+
+Dry runs still need care. A Wrangler dry run can execute build commands and
+project-controlled tooling. Review package scripts, bundler plugins, and
+repository trust before recommending it.
+
+## Privacy Notes
+
+Deployment review can expose sensitive operational context even when secret
+values are not printed. Treat worker names, route patterns, account IDs, binding
+names, resource IDs, environment names, and secret names as review material that
+should be minimized in public comments.
+
+## Duplicate Check
+
+This is distinct from the existing Cloudflare deploy-readiness slash command,
+which provides a command workflow for a trusted deploy preflight. It is also
+distinct from the Wrangler deployment operations skill, which is a capability
+pack for Wrangler operations. This entry is a reusable Claude Code agent role
+with activation scope, source order, read-only review behavior, output contract,
+and explicit deployment boundaries.


### PR DESCRIPTION
## Summary
- Adds a source-backed Cloudflare Workers deployment review agent for Claude Code.
- Grounds the agent in Cloudflare workers-sdk `AGENTS.md`, the delegated `CLAUDE.md`, Wrangler configuration docs, Workers command docs, and versions/deployments docs.

## What changed
- Added `content/agents/cloudflare-workers-deployment-review-agent.mdx`.
- Includes a reusable agent definition with source order, read-only default mode, review checklist, output contract, safety/privacy boundaries, source notes, and duplicate-check notes.
- Keeps deploy, rollback, secret, and account-mutating Wrangler commands out of the default workflow.

## Why
- Closes #674.
- Cloudflare Workers deployment reviews need a clearer agent role than a slash command or generic Wrangler operations skill, especially around config source of truth, bindings, secrets, versions, rollback, build-script risk, and workers-sdk repo conventions.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-cloudflare-workers-deployment-review --pr-author oktofeesh1`

## Notes
- Duplicate check: no existing `content/agents/cloudflare-workers-deployment-review-agent.mdx`, no open PR touching this file, and no existing Cloudflare Workers deployment review agent was found.
- Adjacent content exists for Cloudflare deploy readiness, the Wrangler deployment operations skill, and the static Wrangler config guard hook; this entry is specifically a reusable agent role with activation scope, source order, read-only review behavior, and an output contract.
- Classifier result: `direct_submission=yes`, changed files: `1`, category flag: `content_agents=yes`.
