### PR TITLE
content(collections): add Raycast Claude power workflow

### DIFF
--- a/content/collections/raycast-claude-power-workflow.mdx
+++ b/content/collections/raycast-claude-power-workflow.mdx
@@ -1,0 +1,171 @@
+---
+title: Raycast Claude Power Workflow
+slug: raycast-claude-power-workflow
+category: collections
+description: >-
+  A source-backed collection for keyboard-first Claude power users on macOS:
+  Raycast launcher access, HeyClaude API/MCP/Raycast surface selection, MCP
+  setup, skill installation, reusable slash commands, and Raycast extension
+  development or publishing.
+cardDescription: >-
+  Raycast-centered Claude workflow for launcher lookup, HeyClaude surfaces, MCP
+  setup, skills, slash commands, and extension publishing.
+seoTitle: Raycast Claude Power Workflow Collection
+seoDescription: >-
+  Build a Raycast power-user Claude workflow with Raycast, HeyClaude API/MCP
+  guidance, MCP setup, skills installation, slash commands, and Raycast
+  extension publishing.
+author: MkDev11
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-04"
+documentationUrl: "https://developers.raycast.com/"
+sourceUrls:
+  - "https://developers.raycast.com/"
+  - "https://developers.raycast.com/basics/getting-started"
+  - "https://developers.raycast.com/basics/publish-an-extension"
+  - "https://heyclau.de/data/raycast-index.json"
+  - "https://github.com/JSONbored/awesome-claude/blob/main/integrations/raycast/README.md"
+  - "https://modelcontextprotocol.io/docs/getting-started/intro"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://code.claude.com/docs/en/slash-commands"
+installable: false
+usageSnippet: >-
+  Use Raycast for quick HeyClaude lookup and copy actions, map API/MCP/Raycast
+  surfaces to each task, install approved skills, wire MCP servers, and turn
+  repeat workflows into slash commands or Raycast extensions.
+items:
+  - slug: raycast
+    category: tools
+  - slug: heyclaude-api-mcp-raycast-workflows
+    category: guides
+  - slug: mcp-setup
+    category: commands
+  - slug: skills-installer
+    category: commands
+  - slug: slash-command-gen
+    category: commands
+  - slug: raycast-extension-dev-publish-capability-pack
+    category: skills
+installationOrder:
+  - raycast
+  - heyclaude-api-mcp-raycast-workflows
+  - mcp-setup
+  - skills-installer
+  - slash-command-gen
+  - raycast-extension-dev-publish-capability-pack
+estimatedSetupTime: 55 minutes
+difficulty: intermediate
+prerequisites:
+  - macOS with Raycast installed and the user account authorized for any extensions, AI features, clipboard actions, or team workflows being used.
+  - Claude Code installed with a reviewed project workspace, approved MCP servers, and a clear boundary for what Raycast should open, copy, or launch.
+  - HeyClaude workflow goals such as resource discovery, install guidance, daily lookup, MCP context, submission drafting, or extension development.
+  - Policy for local favorites, cached feeds, snippets, copied install commands, extension permissions, API keys, and team-shared Raycast artifacts.
+safetyNotes:
+  - Raycast is a fast launcher surface; review any copied install command, MCP config, skill archive, slash command, or extension action before applying it to a real workspace.
+  - MCP setup can connect Claude to tools with file, network, database, browser, or account access, so approve server permissions and credentials before launching from Raycast.
+  - Slash commands and Raycast extensions can wrap multi-step workflows; keep destructive operations, publishing, submissions, and credentialed actions behind explicit human confirmation.
+  - Extension publishing should be tested against Raycast guidance, permission needs, metadata, icons, screenshots, and store-readiness checks before public release.
+privacyNotes:
+  - Raycast searches, local favorites, clipboard history, copied install snippets, extension preferences, AI prompts, and cached feed data can reveal what resources and workflows a user is researching.
+  - MCP tool arguments, server responses, local files, browser targets, API tokens, and Claude Code transcripts may be surfaced through launcher-initiated workflows.
+  - Team-shared Raycast extensions, Quicklinks, snippets, and screenshots can expose internal URLs, project names, resource choices, or contribution drafts if not reviewed first.
+tags:
+  - raycast
+  - claude-code
+  - mcp
+  - launcher
+  - skills
+  - slash-commands
+  - productivity
+keywords:
+  - Raycast Claude power workflow
+  - Raycast HeyClaude MCP collection
+  - Claude Code launcher workflow
+  - Raycast slash commands skills MCP
+  - Raycast extension Claude workflow
+---
+
+## What this collection sets up
+
+This collection is for users who want Raycast to be the keyboard-first surface
+around Claude and HeyClaude. It combines quick lookup, install-copy actions,
+API/MCP/Raycast surface selection, MCP setup, skill installation, reusable slash
+commands, and Raycast extension development.
+
+The intent is speed with review. Raycast should make approved actions easy to
+find and launch, but commands, skills, MCP servers, and extensions still need
+normal source, permission, and privacy review before they touch a real project.
+
+## Layers
+
+### 1. Launcher and surface selection
+
+- **raycast** is the macOS launcher and extension platform for commands,
+  automations, AI workflows, copy actions, and developer integrations.
+- **heyclaude-api-mcp-raycast-workflows** explains when to use the HeyClaude
+  API, MCP server, or Raycast extension surface for discovery, comparison,
+  install guidance, feed sync, and contribution workflows.
+
+### 2. Claude workspace setup from Raycast-discovered resources
+
+- **mcp-setup** helps connect approved MCP servers to Claude Code after the
+  server source, credentials, and tool permissions are reviewed.
+- **skills-installer** installs approved skills so Raycast-discovered resources
+  can become reusable Claude Code capabilities.
+- **slash-command-gen** turns repeat tasks into explicit slash commands that can
+  be launched or copied from a keyboard-first workflow.
+
+### 3. Building the Raycast surface
+
+- **raycast-extension-dev-publish-capability-pack** guides command design,
+  extension architecture, testing, metadata, and publish-readiness for teams
+  that want to build or ship their own Raycast extension.
+
+## Suggested order
+
+Start by setting up Raycast and deciding which daily actions belong in the
+launcher. Use the HeyClaude API/MCP/Raycast guide to choose the right surface
+for lookup, context, install guidance, and submission drafting. Add MCP servers
+only after permissions and credentials are reviewed. Install skills from trusted
+sources, then turn repeated work into slash commands. Build or publish Raycast
+extensions last, after the workflow has been used enough to justify a dedicated
+launcher command.
+
+## Power-user checklist
+
+- [ ] {"task": "Surface is chosen", "description": "Raycast, API, and MCP responsibilities are mapped before workflows are automated"}
+- [ ] {"task": "Install commands are reviewed", "description": "Copied snippets and skill archives are checked before running in a workspace"}
+- [ ] {"task": "MCP permissions are scoped", "description": "Servers, credentials, and tool side effects are approved before launcher access"}
+- [ ] {"task": "Slash commands are explicit", "description": "Repeated workflows have clear inputs, outputs, safety stops, and review points"}
+- [ ] {"task": "Extension metadata is ready", "description": "Permissions, screenshots, icons, categories, and store guidance are checked before publishing"}
+- [ ] {"task": "Local traces are understood", "description": "Favorites, feed caches, clipboard data, prompts, and extension preferences have retention rules"}
+
+## Source and references
+
+- Raycast developer documentation: https://developers.raycast.com/
+- Raycast getting started: https://developers.raycast.com/basics/getting-started
+- Raycast extension publishing: https://developers.raycast.com/basics/publish-an-extension
+- HeyClaude Raycast feed: https://heyclau.de/data/raycast-index.json
+- HeyClaude Raycast README: https://github.com/JSONbored/awesome-claude/blob/main/integrations/raycast/README.md
+- Model Context Protocol introduction: https://modelcontextprotocol.io/docs/getting-started/intro
+- Claude Code MCP documentation: https://code.claude.com/docs/en/mcp
+- Claude Code skills documentation: https://code.claude.com/docs/en/skills
+- Claude Code slash commands documentation: https://code.claude.com/docs/en/slash-commands
+
+## Duplicate check
+
+Checked existing collections, guides, tools, commands, skills, open PRs, closed
+PRs, and issue history for `raycast-claude-power-workflow`, Raycast Claude
+workflow, HeyClaude Raycast, Raycast MCP, Raycast extension publishing, skills
+installer, slash command generator, and launcher workflows.
+`heyclaude-api-mcp-raycast-workflows` is a guide for choosing between
+integration surfaces. The `raycast` tool entry documents the launcher, and the
+Raycast extension skill covers extension development. This collection bundles
+those pieces into a power-user workflow for daily lookup, setup, automation, and
+extension building.
+
+## Disclosure
+
+Editorial collection. No paid placement or affiliate link is used.


### PR DESCRIPTION
Closes #801

## Summary

- Adds one source-backed `collections` entry for a Raycast-centered Claude power-user workflow.
- Bundles existing entries for Raycast, HeyClaude API/MCP/Raycast surface guidance, MCP setup, skills installation, slash command generation, and Raycast extension development/publishing.
- Includes practical prerequisites, safety notes, privacy notes, source URLs, and a power-user checklist.

## Duplicate / History Check

- Checked existing collections, guides, tools, commands, skills, open PRs, closed PRs, and issue history for `raycast-claude-power-workflow`, Raycast Claude workflow, HeyClaude Raycast, Raycast MCP, Raycast extension publishing, skills installer, slash command generator, and launcher workflows.
- `heyclaude-api-mcp-raycast-workflows` is a guide for choosing between integration surfaces.
- The `raycast` tool entry documents the launcher, and the Raycast extension skill covers extension development.
- This collection bundles those pieces into a daily power-user workflow for lookup, setup, automation, and extension building.

## Validation

- `git diff --check upstream/main...HEAD`
- `node scripts/validate-content.mjs --category collections`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/collection-801-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref collections-801-raycast-claude-power-workflow --pr-author MkDev11`
- Verified source URLs return HTTP 200.
