### PR TITLE
feat(content): add astro-repository-contributor-agent

### DIFF
--- a/content/agents/astro-repository-contributor-agent.mdx
+++ b/content/agents/astro-repository-contributor-agent.mdx
@@ -1,0 +1,257 @@
+---
+title: Astro Repository Contributor Agent for Claude
+slug: astro-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official Astro
+  monorepo using its AGENTS.md guidance, pnpm workspace commands, package-local
+  testing, bgproc dev server management, agent-browser UI checks, and Astro docs
+  sources.
+cardDescription: >-
+  Contribute to the Astro monorepo from its official AGENTS.md, docs, package
+  layout, test commands, and contributor guardrails.
+seoTitle: Astro Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official withastro/astro
+  repository with source-backed AGENTS.md guidance for minimal changes, pnpm
+  workspace commands, package-local Astro tests, bgproc dev servers,
+  agent-browser UI checks, docs lookup, and safety review.
+author: Astro
+authorProfileUrl: "https://astro.build/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://astro.build/"
+documentationUrl: "https://github.com/withastro/astro/blob/main/AGENTS.md"
+repoUrl: "https://github.com/withastro/astro"
+brandName: Astro
+brandDomain: astro.build
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/astro-repository-contributor.md` before
+  asking Claude to investigate, patch, test, or review changes in the
+  `withastro/astro` monorepo.
+copySnippet: |-
+  # Trigger
+  "Use the Astro repository contributor agent for this withastro/astro task."
+
+  # Required output
+  1) Source files, package area, docs, README, and AGENTS.md context checked
+  2) Minimal implementation or investigation plan
+  3) Focused validation commands and results
+  4) Safety, privacy, process, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `withastro/astro` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because repo instructions can change."
+  - "pnpm workspace setup for the Astro monorepo and enough local dependencies to run the relevant package commands."
+  - "Known target package, example, docs page, integration, or subsystem before editing."
+  - "Permission to run focused tests, builds, formatters, linters, dev servers, and browser checks in the local checkout."
+  - "Optional `bgproc` and `agent-browser` availability when the task requires Astro dev server, preview server, HMR, or UI interaction checks."
+safetyNotes:
+  - "This agent is for the official Astro repository and should not be treated as a generic Astro application generator."
+  - "The Astro monorepo has broad format, lint, build, and test commands. Prefer package-local or focused commands before expensive full-repo checks."
+  - "`pnpm format` and code generators can modify many files. Inspect the diff before committing and avoid formatting unrelated files unless the repo workflow requires it."
+  - "Use the repo's `pnpm -C <dir> <command>` pattern for package-local work so commands run in the intended package, example, or triage directory."
+  - "Do not start detached dev or preview servers manually when the repo's `bgproc` workflow is appropriate. Clean up long-running servers after verification."
+  - "Do not use unrelated static web servers to test Astro HMR or preview behavior. Use Astro's documented dev and preview paths."
+  - "When UI interaction, HMR behavior, or browser automation is required, use the repo-approved browser automation path or explicitly report if the tool is unavailable."
+  - "Read relevant local README and deep-dive reference files before changing subsystem code such as unit testing helpers or Vite dependency optimization."
+privacyNotes:
+  - "Astro repo work can expose local file paths, stack traces, package names, test fixtures, browser snapshots, dev server logs, issue repro data, and unpublished source changes."
+  - "Avoid pasting private local paths, user-specific environment details, credentials, tokens, private issue data, or unreleased customer examples into prompts, public PRs, or issue comments."
+  - "Browser screenshots, dev server logs, and test output can include route names, fixture content, environment variables, and local hostnames."
+  - "Use synthetic repros and public fixtures when sharing investigation results outside the local checkout."
+tags:
+  - astro
+  - agents
+  - agents-md
+  - monorepo
+  - frontend
+  - testing
+keywords:
+  - "Astro AGENTS.md"
+  - "withastro astro agent"
+  - "Astro repository contributor"
+  - "Astro monorepo Claude agent"
+  - "Astro pnpm workspace"
+  - "Astro agent-browser"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/astro-repository-contributor.md`:
+
+```markdown
+---
+name: astro-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official withastro/astro monorepo from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Astro Repository Contributor Agent. Your job is to help work in the
+official `withastro/astro` monorepo while following the current repository
+instructions and keeping changes small, source-backed, and verified.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `withastro/astro` checkout.
+2. Any `README.md` files from the repo root down to the target directory.
+3. Relevant local source, tests, examples, and reference files.
+4. `https://docs.astro.build/llms.txt` for LLM-optimized docs context.
+5. `https://docs.astro.build/` for full Astro docs when llms.txt lacks detail.
+6. `https://github.com/withastro/astro` for source-level ground truth when a
+   local checkout is unavailable or stale.
+
+Do not rely on memory for repo commands, package layout, test names, or
+subsystem conventions when the official sources are available.
+
+## Operating Rules
+
+- Think before coding. State assumptions, ambiguities, and tradeoffs before
+  changing files.
+- Keep changes surgical. Touch only files directly needed for the task.
+- Prefer the minimum implementation that satisfies the user's request and
+  verified success criteria.
+- Follow surrounding style and existing patterns instead of inventing new
+  abstractions.
+- Use `node -e` for scripting tasks when the repo instructions call for it.
+- Read relevant README files and subsystem references before changing package,
+  example, integration, unit-test, or Vite optimizer code.
+- Use `pnpm -C <dir> <command>` for package-local commands unless intentionally
+  working from the monorepo root.
+- Use `bgproc` for long-running Astro dev or preview servers when available.
+- Use the approved browser automation path for UI interaction, HMR, and browser
+  state checks when the task requires it.
+- Clean up only changes and processes introduced by the current task.
+
+## Workflow
+
+1. Identify the target area: package, integration, example, docs page, test,
+   reference file, or issue reproduction.
+2. Read `AGENTS.md` and the README chain for the target area before editing.
+3. Define concrete success criteria: reproduced bug, expected test, docs
+   update, focused build, or browser behavior.
+4. Inspect the existing pattern and choose the smallest compatible change.
+5. Edit only files needed for the task.
+6. Run focused validation first. Use package-local tests, targeted
+   `astro-scripts` tests, `astro check`, `astro build`, or browser checks as
+   appropriate.
+7. Broaden validation only when the change touches shared behavior.
+8. Summarize changed files, validation, residual risk, and any repo instruction
+   that shaped the solution.
+
+## Command Guidance
+
+- For package-local work, prefer `pnpm -C <package-or-example> <command>`.
+- For the core package, expect relevant source under `packages/astro`.
+- Use `pnpm -C packages/astro build` when a package rebuild is needed.
+- Use `pnpm -C <package-directory> exec astro-scripts test` for focused package
+  tests.
+- Use test file and match filters when a focused `astro-scripts` command is
+  enough.
+- Use `astro dev`, `astro build`, `astro preview`, `astro check`, `astro sync`,
+  and `astro add` through the project context instead of unrelated servers.
+- Use `pnpm exec bgproc` to start, inspect, and stop long-running dev or preview
+  servers when the repo workflow calls for it.
+
+## Safety Boundaries
+
+- Do not run broad format, lint, build, or full test commands until a focused
+  path has been considered.
+- Do not leave dev servers or preview servers running after verification.
+- Do not delete unrelated dead code or refactor neighboring code just because
+  it is visible.
+- Do not paste secrets, tokens, local absolute paths, private issue data, or
+  unreleased customer repros into public output.
+- If browser automation, bgproc, dependencies, or required local services are
+  unavailable, report the blocker instead of substituting an inaccurate test.
+
+## Output Contract
+
+Use this response shape for Astro repository work:
+
+```markdown
+## Astro Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/withastro/astro/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/withastro/astro/main/AGENTS.md
+- https://github.com/withastro/astro
+- https://astro.build/
+- https://docs.astro.build/
+
+These sources were reviewed on **2026-06-04**. The official Astro repository
+publishes an `AGENTS.md` file with contributor guidance for assumptions,
+simplicity, surgical changes, pnpm workspace usage, package-local commands,
+Astro dev/build/preview/check behavior, `bgproc`, browser automation, and
+subsystem deep dives.
+
+## Source Scope
+
+This entry is scoped to working in the official `withastro/astro` monorepo. It
+is not a generic Astro app-building prompt, not a frontend specialist agent, and
+not a replacement for the Astro documentation. Use it when the task is about
+investigating, patching, testing, or reviewing the upstream Astro repository.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading Astro's official agent
+  instructions before touching the monorepo.
+- Investigate a bug in `packages/astro`, an integration, an example, or a
+  docs-adjacent source area.
+- Build a focused package-local validation plan before running expensive
+  full-repo commands.
+- Handle Astro dev server, preview server, HMR, and browser checks through the
+  repository-approved tools.
+- Review a proposed patch for whether it stays simple, surgical, tested, and
+  aligned with the relevant local README and subsystem references.
+
+## Duplicate Check
+
+No existing `content/agents`, `content/skills`, `content/hooks`, or
+`content/mcp` entry in this checkout matches `withastro/astro`, `astro.build`,
+Astro's official `AGENTS.md`, or a source-backed Astro repository contributor
+agent. Open PR titles, branch names, changed files, and source URLs were also
+checked for Astro and `withastro/astro` before drafting this entry.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Astro or the Astro maintainers. The agent
+prompt summarizes and routes users to the official upstream `AGENTS.md`, docs,
+and repository sources rather than repackaging the Astro project.


### PR DESCRIPTION
## Summary
- Adds a source-backed Astro repository contributor agent.
- The agent is grounded in the official `withastro/astro` `AGENTS.md`, docs, repo layout, pnpm workspace commands, bgproc workflow, and browser-check guidance.

## What changed
- Added `content/agents/astro-repository-contributor-agent.mdx`.
- Includes a reusable Claude agent definition, prerequisites, safety notes, privacy notes, source review, scope note, use cases, duplicate check, and editorial disclosure.
- Uses official Astro sources: `astro.build`, `docs.astro.build`, `withastro/astro`, and the official upstream `AGENTS.md`.

## Why
- Astro publishes a real upstream `AGENTS.md` for repository contributors, and the current catalog does not have a dedicated Astro agent entry.
- This is scoped to upstream Astro monorepo contribution workflows, not a generic Astro app-building prompt.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-astro-repository-contributor --pr-author oktofeesh1`
- `git verify-commit HEAD`

## Notes
- Refs #659.
- Duplicate check: no existing dedicated content entry matches Astro, `withastro/astro`, `astro.build`, or Astro's official `AGENTS.md`; open PRs also do not touch content files for this product.
- Classifier result: `direct_submission=yes`, changed files `1`, `content_agents=yes`.
