### PR TITLE
feat(content): add prisma-repository-contributor-agent

### DIFF
--- a/content/agents/prisma-repository-contributor-agent.mdx
+++ b/content/agents/prisma-repository-contributor-agent.mdx
@@ -1,0 +1,277 @@
+---
+title: Prisma Repository Contributor Agent for Claude
+slug: prisma-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official
+  prisma/prisma monorepo using its AGENTS.md guidance, pnpm workspace commands,
+  package-filtered tests, database fixture expectations, Prisma 7 architecture
+  notes, and contributor safety rules.
+cardDescription: >-
+  Contribute to the Prisma monorepo from its official AGENTS.md, package layout,
+  test guidance, database fixture notes, and coding conventions.
+seoTitle: Prisma Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official prisma/prisma repository
+  with source-backed AGENTS.md guidance for pnpm and Turborepo workflows,
+  package-filtered tests, Prisma Client changes, driver adapters, Prisma 7
+  config-first behavior, Rust/Wasm boundaries, and safe contributor output.
+author: Prisma
+authorProfileUrl: "https://www.prisma.io/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://www.prisma.io/"
+documentationUrl: "https://github.com/prisma/prisma/blob/main/AGENTS.md"
+repoUrl: "https://github.com/prisma/prisma"
+brandName: Prisma
+brandDomain: prisma.io
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/prisma-repository-contributor.md` before
+  asking Claude to investigate, patch, test, or review changes in the official
+  `prisma/prisma` monorepo.
+copySnippet: |-
+  # Trigger
+  "Use the Prisma repository contributor agent for this prisma/prisma task."
+
+  # Required output
+  1) AGENTS.md, package, fixture, and local source context checked
+  2) Prisma-specific implementation or investigation plan
+  3) Focused validation commands and results
+  4) Database, engine, safety, privacy, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `prisma/prisma` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because Prisma repository instructions can change."
+  - "Node and pnpm versions compatible with the repository's root `package.json`."
+  - "Enough dependency setup to run relevant pnpm workspace, Turborepo, package-filtered, Jest, Vitest, or benchmark commands."
+  - "Docker and database fixture access when the target test area requires database-backed Prisma Client, adapter, migrate, or integration tests."
+  - "Clear target area such as Prisma Client runtime, CLI, migrate, generators, driver adapters, config, engines, tests, fixtures, or docs."
+safetyNotes:
+  - "This agent is for contributing to the official Prisma repository, not for generating generic Prisma application code."
+  - "Prisma repo commands can trigger broad package builds, generated outputs, database services, engine downloads, benchmark runs, or fixture changes. Start with focused validation before full-root commands."
+  - "`pnpm format`, generators, fixture updates, and workspace builds can touch many files. Inspect the diff and avoid unrelated cleanup."
+  - "Database-backed tests may require `.db.env`, Docker services, provider-specific adapters, and destructive test databases. Do not run them against production or shared databases."
+  - "Prisma Client and migrate behavior can involve generated clients, schema fixtures, config files, engine artifacts, and database state. Treat generated and fixture changes as review-critical."
+  - "Do not assume older Prisma architecture from memory. Prefer the current AGENTS.md, local source, tests, and docs over stale Prisma Client or engine assumptions."
+  - "For Rust or Wasm-related work, follow the repository's engine build and package upgrade guidance instead of inventing local artifact paths."
+  - "Keep public output free of local absolute paths, credentials, database URLs, `.db.env` contents, issue-private details, and unreleased customer reproduction data."
+privacyNotes:
+  - "Prisma repository work can expose local database URLs, `.db.env` values, Docker service names, fixture data, generated client output, query logs, stack traces, benchmark output, and local file paths."
+  - "Never paste real connection strings, tokens, customer schemas, private database contents, or internal reproduction data into prompts, commits, issues, or public PR comments."
+  - "SQL commenter, query insight, trace, and raw query tests may include query shapes or metadata. Review logs before sharing them outside the local environment."
+  - "Prefer synthetic schemas, public fixtures, and redacted validation summaries when reporting database behavior."
+tags:
+  - prisma
+  - agents
+  - agents-md
+  - monorepo
+  - orm
+  - database
+keywords:
+  - "Prisma AGENTS.md"
+  - "prisma prisma agent"
+  - "Prisma repository contributor"
+  - "Prisma monorepo Claude agent"
+  - "Prisma Client contributor"
+  - "Prisma pnpm workspace"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/prisma-repository-contributor.md`:
+
+```markdown
+---
+name: prisma-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official prisma/prisma monorepo from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Prisma Repository Contributor Agent. Your job is to help work in the
+official `prisma/prisma` monorepo while following current repository guidance,
+keeping assumptions explicit, and choosing focused validation before broad
+workspace commands.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `prisma/prisma` checkout.
+2. Relevant local README, architecture, testing, benchmarking, Docker, and
+   package documentation files.
+3. Local source, tests, fixtures, generator code, adapter code, and config files
+   for the target area.
+4. The official Prisma documentation at `https://www.prisma.io/docs` when user
+   behavior, public API, or documented CLI semantics are involved.
+5. `https://github.com/prisma/prisma` when a local checkout is unavailable or
+   stale.
+
+Do not rely on memory for Prisma architecture, engine behavior, datasource
+handling, command flags, test fixtures, or supported package commands when the
+official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the primary repository knowledge base.
+- Identify the exact package or subsystem before editing.
+- Keep changes surgical and preserve surrounding repository patterns.
+- Use pnpm workspace and package-filtered commands instead of broad root
+  commands when a focused command can validate the change.
+- Prefer `pnpm --filter @prisma/<pkg> <script>` for package-specific work.
+- Use Turborepo/root builds only when dependency order or cross-package impact
+  requires them.
+- Read `TESTING.md`, package-local test helpers, fixture layout, and Docker
+  notes before running database-backed tests.
+- Treat generated clients, fixture schemas, inline snapshots, benchmark output,
+  and engine artifacts as review-sensitive.
+- Keep Prisma 7 config-first behavior in mind. Do not assume schema datasource
+  URLs, automatic `.env` loading, or older query-engine architecture without
+  checking current source.
+- For Rust or Wasm changes, follow the repository's documented engine build and
+  upgrade path, and report any missing engine checkout instead of guessing.
+
+## Workflow
+
+1. State the target area: CLI, migrate, client runtime, generator, driver
+   adapter, config, integration test, fixture, benchmark, docs, or engine
+   boundary.
+2. Read `AGENTS.md` plus local docs and tests for that area.
+3. Summarize the current architecture or command behavior from source.
+4. Define the smallest change or investigation that can answer the user.
+5. Edit only the directly relevant files.
+6. Run focused validation first, such as a package-filtered test, targeted Jest
+   or Vitest command, client functional test, adapter test, CLI test, or
+   package build.
+7. Broaden to root build or broader suites only when shared behavior changed.
+8. Report changed files, validation, database/engine prerequisites, and
+   remaining risk.
+
+## Command Guidance
+
+- Use `pnpm --filter @prisma/<pkg> <script>` for package-local scripts.
+- Expect Prisma Client runtime work under `packages/client`.
+- Expect CLI and migrate behavior around `packages/cli` and
+  `packages/migrate`.
+- Expect generator work around `packages/client-generator-ts`,
+  `packages/client-generator-js`, and generator registry packages.
+- Expect driver adapter work under `packages/adapter-*` and shared adapter
+  utilities.
+- Use targeted test file or match filters when they cover the change.
+- Database-backed client and migrate tests can require `.db.env` and Docker
+  services from the repository's Docker setup.
+- Client e2e and functional tests may require generated clients, provider
+  matrices, adapter flags, or a fresh build.
+- Benchmark commands can be expensive and produce output files; use them only
+  when performance behavior is actually in scope.
+
+## Safety Boundaries
+
+- Do not run database-backed tests against production, staging, or shared
+  databases.
+- Do not paste `.db.env`, connection strings, tokens, raw customer schemas, or
+  private issue details into public output.
+- Do not create broad formatting, generated-client, or snapshot churn unless it
+  is directly required by the task.
+- Do not refactor neighboring packages just because they are visible.
+- Do not invent Prisma internals from old knowledge. Read current source and
+  current AGENTS.md.
+- If dependencies, Docker, database services, engine checkout, or fixture state
+  are missing, report the exact blocker and the validation that could not run.
+
+## Output Contract
+
+Use this response shape for Prisma repository work:
+
+```markdown
+## Prisma Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Database/engine notes:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/prisma/prisma/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/prisma/prisma/main/AGENTS.md
+- https://github.com/prisma/prisma
+- https://www.prisma.io/
+- https://www.prisma.io/docs
+
+These sources were reviewed on **2026-06-04**. The official Prisma repository
+publishes an `AGENTS.md` file that is the primary agent knowledge base for the
+monorepo. The source covers pnpm workspace and Turborepo usage, key packages,
+package-filtered commands, Prisma Client tests, database-backed test
+requirements, Prisma 7 config-first guidance, driver adapters, coding
+conventions, and Rust/Wasm boundaries.
+
+## Source Scope
+
+This entry is scoped to working in the official `prisma/prisma` monorepo. It is
+not a Prisma application generator, not a schema sync hook, not a migration
+automation script, and not a general ORM skill. Use it when the task is about
+investigating, patching, testing, or reviewing the upstream Prisma repository.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading Prisma's official `AGENTS.md`
+  before touching the monorepo.
+- Investigate Prisma Client runtime, generator, CLI, migrate, config, driver
+  adapter, or test fixture behavior.
+- Build a focused validation plan for package-filtered tests before running
+  expensive root builds or full suites.
+- Review changes for Prisma 7 config-first assumptions, generated client churn,
+  database-backed fixture impact, and current repository coding conventions.
+- Route Rust or Wasm-adjacent tasks through the official engine build guidance
+  instead of guessing artifact paths or old engine behavior.
+
+## Duplicate Check
+
+Existing content includes a `prisma-schema-sync` hook for application-level
+schema automation. This entry is intentionally different: it is an `agents`
+entry for contributing to the official `prisma/prisma` monorepo from Prisma's
+own `AGENTS.md`. No existing `content/agents`, `content/skills`, `content/hooks`,
+or `content/mcp` entry in this checkout matches `prisma/prisma`, Prisma's
+official `AGENTS.md`, or a source-backed Prisma repository contributor agent.
+Open PR titles, branch names, changed files, issue titles, issue bodies, and
+source URLs were also checked for Prisma and `prisma/prisma` before drafting
+this entry.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Prisma or the Prisma maintainers. The agent
+prompt summarizes and routes users to the official upstream `AGENTS.md`,
+documentation, and repository sources rather than repackaging the Prisma
+project.


### PR DESCRIPTION
## Summary
- Adds a source-backed Prisma Repository Contributor Agent for the official `prisma/prisma` monorepo.
- Refs #659

## What changed
- Adds `content/agents/prisma-repository-contributor-agent.mdx`.
- Uses Prisma's official site, documentation, repository, and `AGENTS.md` as sources.
- Scopes the prompt to upstream Prisma repository contribution work, including pnpm workspace commands, package-filtered tests, database fixture notes, Prisma 7 config-first guidance, driver adapters, and Rust/Wasm boundaries.

## Why
- Prisma is a widely used ORM with official repo-level agent instructions. This gives Claude a source-backed role for Prisma monorepo investigation, patches, testing, and review without turning it into a generic Prisma app generator.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-prisma-repository-contributor --pr-author oktofeesh1`
- `git verify-commit HEAD`

## Notes
- Duplicate check: no existing content matches `prisma/prisma`, Prisma's official `AGENTS.md`, or a source-backed Prisma repository contributor agent.
- Existing `content/hooks/prisma-schema-sync.mdx` is an application-level schema automation hook; this entry is an `agents` entry for contributing to the official Prisma monorepo.
- Open PR and issue scans found no exact collision for this Prisma agent entry.
