### PR TITLE
content(rules): add AI assistant secret handling rules

### DIFF
--- a/content/rules/ai-assistant-secret-handling-rules.mdx
+++ b/content/rules/ai-assistant-secret-handling-rules.mdx
@@ -1,0 +1,226 @@
+---
+title: AI Assistant Secret Handling Rules
+slug: ai-assistant-secret-handling-rules
+category: rules
+description: >-
+  Source-backed rules for AI coding assistants that must avoid exposing,
+  copying, logging, committing, or normalizing secrets while editing code,
+  configs, tests, prompts, documentation, and CI workflows.
+cardDescription: >-
+  Keep AI coding assistants from leaking secrets by using redaction, approved
+  secret stores, pre-commit checks, rotation triggers, and privacy-safe notes.
+seoTitle: AI Assistant Secret Handling Rules
+seoDescription: >-
+  Practical secret-handling rules for AI coding assistants: do not paste
+  credentials, redact logs, use environment variables and secret stores, block
+  generated leaks, and rotate exposed secrets.
+author: MkDev11
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-04"
+documentationUrl: "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html"
+sourceUrls:
+  - "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html"
+  - "https://12factor.net/config"
+  - "https://git-scm.com/docs/gitignore"
+  - "https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage"
+  - "https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets"
+  - "https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository"
+installable: false
+usageSnippet: >-
+  Apply these rules before an AI coding assistant edits credentials,
+  environment files, CI secrets, configs, logs, fixtures, prompts, generated
+  docs, or any code path that can reveal tokens, keys, passwords, or private
+  identifiers.
+copySnippet: |-
+  You are handling secrets while assisting with code.
+
+  Rules:
+  1. Never paste, invent, normalize, echo, summarize, or commit real secrets.
+  2. Replace secrets with placeholders and name the required secret store or
+     environment variable.
+  3. Keep credentials out of prompts, transcripts, generated artifacts, logs,
+     tests, screenshots, and public review comments.
+  4. Stop and request rotation when a real secret appears in a diff, log,
+     message, branch, issue, PR, or generated file.
+  5. Use `.gitignore`, CI secret stores, credential helpers, and local-only
+     examples instead of hardcoded values.
+estimatedSetupTime: 10 minutes
+difficulty: beginner
+prerequisites:
+  - A repository, task, or assistant session that may touch credentials, environment variables, CI secrets, API tokens, private keys, webhook secrets, cookies, sessions, or private identifiers.
+  - A known project policy for secret storage, such as environment variables, CI secret stores, local credential helpers, or an approved vault.
+  - Permission to stop work, redact content, or request rotation if a real secret is found.
+  - Access to a scanner, review checklist, or manual inspection process before committing assistant-generated files.
+safetyNotes:
+  - "Treat any discovered credential as compromised until an owner confirms it is fake, expired, or rotated."
+  - "Do not ask the assistant to test live production credentials, print secrets for debugging, or copy token values into issue comments, PR bodies, generated docs, fixtures, or screenshots."
+  - "Block merge when generated artifacts, logs, snapshots, notebooks, lockfiles, or config examples include real-looking secrets or private identifiers."
+privacyNotes:
+  - "Secrets often appear next to private account IDs, customer names, repository paths, internal hostnames, prompt text, and incident context; redact surrounding context, not only the token."
+  - "A model transcript, debug log, trace, or review comment can become a secondary copy of a secret even when the code diff is later cleaned."
+  - "Use synthetic examples such as `EXAMPLE_API_KEY` and document the secret name or storage location without revealing the value."
+tags:
+  - secrets
+  - secret-handling
+  - ai-coding-assistants
+  - credential-safety
+  - environment-variables
+  - redaction
+keywords:
+  - AI assistant secret handling rules
+  - coding assistant credentials safety
+  - prevent secrets in generated code
+  - redact tokens from AI prompts
+  - CI secret store rules
+readingTime: 6
+difficultyScore: 38
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Purpose
+
+Use these rules when an AI coding assistant can see, edit, summarize, test, or
+publish code that might contain secrets. Secrets include API keys, passwords,
+private keys, SSH keys, tokens, cookies, session identifiers, webhook secrets,
+database URLs, cloud credentials, signing keys, and sensitive internal
+identifiers.
+
+The safest assistant behavior is boring and explicit: do not reveal the value,
+do not preserve it in generated output, do not move it into another public
+place, and do not treat cleanup as enough when a real credential was exposed.
+
+## Secret Classification
+
+Classify a value as secret or potentially secret when it is:
+
+- a credential value, private key, token, password, cookie, webhook secret, or
+  connection string;
+- a live-looking value in `.env`, config, CI, deployment, container, cloud, or
+  package-publish settings;
+- a generated fixture, screenshot, log, trace, notebook output, prompt, or
+  documentation sample that resembles a credential;
+- an internal hostname, account ID, customer identifier, database name, or
+  incident detail that should not be public;
+- a value the assistant cannot prove is synthetic.
+
+When uncertain, handle the value as sensitive and ask for a safe placeholder.
+
+## Assistant Rules
+
+- Never paste real secret values into prompts, model output, PR descriptions,
+  issue comments, commit messages, generated docs, test fixtures, or examples.
+- Replace discovered values with stable placeholders such as
+  `EXAMPLE_API_KEY`, `REDACTED_DATABASE_URL`, or `YOUR_SERVICE_TOKEN`.
+- Name the required variable or secret store key, but not the value.
+- Preserve local-only files in `.gitignore` when the project expects secrets in
+  untracked environment files.
+- Prefer CI secret stores, deployment secret stores, or credential helpers over
+  hardcoded config.
+- Do not transform a secret into another leak, such as a base64 string, partial
+  token, screenshot, log line, or generated summary.
+- Stop and escalate when a real secret appears in history, public review text,
+  CI logs, chat transcripts, or generated artifacts.
+
+## Commit And PR Rules
+
+Before committing assistant-generated work:
+
+1. Check staged files, untracked generated files, snapshots, notebooks, reports,
+   logs, and docs for real-looking secrets.
+2. Verify `.gitignore` covers local credential files, but do not rely on
+   `.gitignore` after a secret has already been committed.
+3. Review CI workflow changes for accidental secret printing, broad environment
+   export, unsafe debugging, or untrusted pull request exposure.
+4. Keep the PR body privacy-safe: describe the secret name or storage mechanism
+   without revealing values, account IDs, or private incident context.
+5. If a secret was exposed, request rotation and history cleanup from the owner
+   before presenting the PR as safe.
+
+## Storage Rules
+
+- Store local development values in local-only environment files or credential
+  helpers according to the project policy.
+- Store CI and deployment values in the platform's secret store, not in YAML,
+  shell scripts, Dockerfiles, docs, or committed examples.
+- Keep sample files synthetic and obvious: `example.env`, `.env.example`, and
+  docs should contain placeholders, not copied local values.
+- Scope secrets narrowly by environment, service, permission, and expiration
+  where the platform supports it.
+- Do not create new long-lived credentials to make an assistant task easier.
+
+## Rotation And Cleanup Rules
+
+Editing the file is not enough when a real secret was exposed.
+
+- Mark the credential as exposed.
+- Notify the owner or security channel.
+- Rotate, revoke, or expire the secret according to the project's policy.
+- Remove or rewrite public history only through the maintainer-approved path.
+- Check secondary copies: CI logs, issue comments, PR bodies, screenshots,
+  traces, notebooks, generated docs, package artifacts, and assistant
+  transcripts.
+- Add or update a scanner or review checklist so the same leak is less likely to
+  recur.
+
+## Review Checklist
+
+- [ ] {"task": "No real values", "description": "Diffs, prompts, docs, tests, fixtures, logs, screenshots, and generated artifacts contain placeholders instead of real secrets"}
+- [ ] {"task": "Storage named", "description": "The entry or PR names the expected environment variable, CI secret, vault key, or credential helper without revealing the value"}
+- [ ] {"task": "Local files ignored", "description": "Local credential files are untracked or ignored according to project policy"}
+- [ ] {"task": "CI is safe", "description": "Workflow changes do not print secrets, export them broadly, or expose them to untrusted pull requests"}
+- [ ] {"task": "Exposure escalated", "description": "Real or suspected exposed secrets trigger owner notification, rotation, and cleanup review"}
+- [ ] {"task": "Public notes redacted", "description": "PR and issue text avoid raw tokens, private IDs, customer details, and incident context"}
+
+## Do Not Merge When
+
+- a real-looking secret remains in the source diff, generated files, docs,
+  examples, tests, screenshots, logs, or notebook output;
+- a PR claims "secret removed" but does not mention rotation or owner review
+  after exposure;
+- a workflow prints environment variables, dumps contexts, or exposes secrets to
+  untrusted code paths;
+- a sample config uses a copied local value instead of a placeholder;
+- the assistant included token fragments, hashes, screenshots, or summaries that
+  still help identify the secret;
+- cleanup requires private security handling but the public PR contains the
+  sensitive evidence.
+
+## Troubleshooting
+
+- **A value might be fake:** treat it as sensitive until the owner confirms it is
+  synthetic or expired.
+- **The secret is already in history:** stop normal review and follow the
+  repository's history-cleanup and rotation process.
+- **The tests need credentials:** use test doubles, local-only environment
+  variables, or CI secret stores; do not commit the value.
+- **A scanner reports a false positive:** document why it is synthetic, then
+  keep the example clearly fake.
+- **The assistant needs context:** provide the secret name, permission scope,
+  and storage location, not the value.
+
+## Duplicate Check
+
+Checked existing rules, guides, collections, hooks, agents, skills, commands,
+open PRs, and closed PR history for secret-handling rules, credential safety,
+secret scanning, environment variable review, pre-write secret checks, and AI
+assistant privacy guidance.
+
+Adjacent content includes secret-scanning hooks, environment-variable validation,
+privacy metadata rules, and secure workflow guides. This entry is distinct
+because it gives portable do/don't behavior for AI coding assistants deciding
+how to handle secrets in prompts, diffs, generated artifacts, CI workflows, and
+public review notes.
+
+## References
+
+- OWASP Secrets Management Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
+- The Twelve-Factor App config guidance: https://12factor.net/config
+- Git gitignore documentation: https://git-scm.com/docs/gitignore
+- Git credential storage documentation: https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage
+- GitHub Actions secrets documentation: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets
+- GitHub sensitive-data removal documentation: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository


### PR DESCRIPTION
## Summary

Adds one source-backed rules entry for AI coding assistant secret handling: redaction, safe storage, generated artifact review, CI secret boundaries, and rotation when exposure is suspected.

Closes #731

## Duplicate check

Checked existing rules, guides, collections, hooks, agents, skills, commands, open PRs, and closed PR history for secret-handling rules, credential safety, secret scanning, environment variable review, pre-write secret checks, and AI assistant privacy guidance.

Adjacent entries cover scanners, hooks, and broader privacy/security workflows. This rules entry is distinct because it gives portable do/don't behavior for AI coding assistants handling secrets in prompts, diffs, generated artifacts, CI workflows, and public review notes.

## Validation

- `node scripts/validate-content.mjs --category rules`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/rules-731-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref rules-731-secret-handling --pr-author MkDev11`
- `git diff --cached --check`
