### PR TITLE
fix(content): harden shellcheck hook install

### DIFF
--- a/content/hooks/shellcheck-static-analysis-hook.mdx
+++ b/content/hooks/shellcheck-static-analysis-hook.mdx
@@ -24,7 +24,62 @@ websiteUrl: "https://www.shellcheck.net/"
 documentationUrl: "https://github.com/koalaman/shellcheck/wiki"
 repoUrl: "https://github.com/koalaman/shellcheck"
 installable: true
-installCommand: "mkdir -p .claude/hooks && touch .claude/hooks/shellcheck-static-analysis.sh && chmod +x .claude/hooks/shellcheck-static-analysis.sh"
+installCommand: |-
+  mkdir -p .claude/hooks
+  hook_path=.claude/hooks/shellcheck-static-analysis.sh
+  tmp_path="$(mktemp "${hook_path}.tmp.XXXXXX")" || exit 1
+  cat > "$tmp_path" <<'SHELLCHECK_STATIC_ANALYSIS_HOOK'
+  #!/usr/bin/env bash
+  set -uo pipefail
+
+  input="$(cat)"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "ShellCheck hook skipped: jq is required to parse Claude Code hook input." >&2
+    exit 0
+  fi
+
+  tool_name="$(printf '%s' "$input" | jq -r '.tool_name // .toolName // empty')"
+  file_path="$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // .toolInput.file_path // .toolInput.path // empty')"
+
+  case "$tool_name" in
+    Write|Edit|MultiEdit|write|edit|multiedit) ;;
+    *) exit 0 ;;
+  esac
+
+  if [ -z "$file_path" ] || [ ! -f "$file_path" ] || [ ! -r "$file_path" ]; then
+    exit 0
+  fi
+
+  case "$file_path" in
+    *.sh|*.bash|*.bats|*.ksh) ;;
+    *)
+      first_line="$(LC_ALL=C sed -n '1p' "$file_path" 2>/dev/null || true)"
+      case "$first_line" in
+        '#!'*'/sh'*|'#!'*' bash'*|'#!'*'/bash'*|'#!'*' dash'*|'#!'*'/dash'*|'#!'*' ksh'*|'#!'*'/ksh'*) ;;
+        *) exit 0 ;;
+      esac
+      ;;
+  esac
+
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "ShellCheck hook skipped: install shellcheck to enable shell diagnostics." >&2
+    exit 0
+  fi
+
+  echo "ShellCheck hook: checking $file_path" >&2
+  shellcheck --format=gcc "$file_path"
+  status=$?
+
+  if [ "$status" -ne 0 ]; then
+    echo "ShellCheck hook: diagnostics found. Review quoting, expansion, portability, and error-handling issues before asking Claude to continue." >&2
+  fi
+
+  exit "$status"
+  SHELLCHECK_STATIC_ANALYSIS_HOOK
+  chmod 755 "$tmp_path"
+  rm -f -- "$hook_path"
+  mv -- "$tmp_path" "$hook_path"
 usageSnippet: >-
   Install ShellCheck locally, save the script as
   `.claude/hooks/shellcheck-static-analysis.sh`, and configure it as a


### PR DESCRIPTION
### Motivation
- The original `installCommand` used `touch` and `chmod` on a predictable hook path which could make a pre-existing attacker-controlled file or symlink executable and thus run malicious code when the hook is enabled.

### Description
- Replace `installCommand` in `content/hooks/shellcheck-static-analysis-hook.mdx` with a heredoc-based installer that writes the reviewed `scriptBody` into a temporary file and makes that file executable.
- The installer creates a `tmp_path` via `mktemp`, writes the reviewed hook script into the temp file, `chmod 755` the temp file, `rm -f -- "$hook_path"` to remove any existing destination (including symlinks), and `mv` the temp file into place to atomically install the hook.
- Ensure the embedded heredoc in `installCommand` matches `scriptBody` so the installed file is exactly the reviewed script and preserves the hook's original read-only ShellCheck diagnostics behavior.

### Testing
- Ran `pnpm validate:content:strict` which passed.
- Ran `git diff --check` which reported no issues.
- Executed a dynamic install-command PoC that verified a pre-existing file and a symlink are replaced and do not result in executing attacker-controlled payloads, and that the installed hook file is the reviewed script and executable.
- Ran a Node-based check that the heredoc embedded in `installCommand` matches the `scriptBody`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b53e3738832c9446f4a87929f9f4)