### PR TITLE
fix(submissions): stop summary-based review retries

### DIFF
--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -363,21 +363,11 @@ export function privateReviewErrorDecision(
 
 export function isRetryableGateDecision(decision: GateDecision) {
   if (decision.verdict !== "manual") return false;
-  if (
+  return Boolean(
     decision.errors?.some(
       (error) =>
         error.retryable || RETRYABLE_PRIVATE_REVIEW_CODES.has(error.code),
-    )
-  ) {
-    return true;
-  }
-  const summary = decision.summary.toLowerCase();
-  return (
-    summary.includes("could not determine the github app installation") ||
-    summary.includes("ai maintainer review returned an unexpected payload") ||
-    summary.includes("private corpus review request failed") ||
-    summary.includes("private corpus review returned") ||
-    summary.includes("private corpus review returned an unexpected payload")
+    ),
   );
 }
 

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -31,6 +31,7 @@ import {
 import {
   approvalReviewBody,
   enforceAutoMergeConfidenceFloor,
+  isRetryableGateDecision,
   markerComment,
   normalizePrivateGateDecisionPayload,
   retryingReviewComment,
@@ -411,6 +412,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("isRetryableGateDecision(decision)");
     expect(source).toContain('"invalid_private_response"');
     expect(source).toContain('"private_reviewer_unavailable"');
+    expect(source).not.toContain("summary.includes");
+    expect(source).not.toContain(
+      "ai maintainer review returned an unexpected payload",
+    );
     expect(source).toContain('status: "error_retryable"');
     expect(source).toContain("retryingReviewComment(");
     expect(source).toContain("validation: validationForPrivateReview");
@@ -849,6 +854,33 @@ describe("Cloudflare submission gate helpers", () => {
       verdict: "request_changes",
       summary: "Temporary V1 fallback.",
     });
+  });
+
+  it("retries private review only from structured retry errors", () => {
+    expect(
+      isRetryableGateDecision({
+        verdict: "manual",
+        summary:
+          "Private corpus review request failed. A maintainer needs to review this.",
+        labels: ["submission-manual-review"],
+      }),
+    ).toBe(false);
+
+    expect(
+      isRetryableGateDecision({
+        verdict: "manual",
+        summary:
+          "Private corpus review returned an unexpected payload. A maintainer needs to review this.",
+        labels: ["submission-manual-review"],
+        errors: [
+          {
+            code: "invalid_private_response",
+            retryable: true,
+            message: "Private corpus review returned an unexpected payload.",
+          },
+        ],
+      }),
+    ).toBe(true);
   });
 
   it("keeps approval reviews short and links to the canonical report", () => {


### PR DESCRIPTION
## Summary
- Stops private-review retry decisions from being inferred from free-form `decision.summary` text.
- Keeps the current structured `GateDecisionError` retry model from `main`: only explicit retryable error metadata or known retryable private-review error codes can schedule an automatic retry.
- Rebased the branch onto current `main` and resolved the submission-gate conflicts without reintroducing the older `retryableInfrastructure` flag.

## Issue / rationale
No separate issue. This is a focused security hardening follow-up for the submission-gate private reviewer path.

## What changed
- `apps/submission-gate/src/review.ts`: `isRetryableGateDecision` no longer scans arbitrary summary text for retry phrases.
- `tests/submission-gate-worker.test.ts`: added regression coverage proving a manual decision with retry-looking summary text does not retry unless structured retry error metadata is present.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts` - passed, 70 tests.
- `pnpm test:submission-pr-first` - passed, 12 tests.
- `git diff --check` - passed.
