### PR TITLE
feat(content): add vercel-ai-sdk-repository-contributor-agent

### DIFF
--- a/content/agents/vercel-ai-sdk-repository-contributor-agent.mdx
+++ b/content/agents/vercel-ai-sdk-repository-contributor-agent.mdx
@@ -1,0 +1,295 @@
+---
+title: Vercel AI SDK Repository Contributor Agent for Claude
+slug: vercel-ai-sdk-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official Vercel AI
+  SDK monorepo using its AGENTS.md guidance, pnpm workspace commands, package
+  build and test boundaries, provider architecture, Zod compatibility rules,
+  JSON parsing safety, ADR review, and documentation sources.
+cardDescription: >-
+  Contribute to the Vercel AI SDK monorepo from its official AGENTS.md, package
+  layout, provider architecture, test commands, and safety rules.
+seoTitle: Vercel AI SDK Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official vercel/ai repository with
+  source-backed AGENTS.md guidance for pnpm and Turborepo workflows, AI SDK
+  provider packages, Node and Edge tests, Zod 3 and Zod 4 compatibility,
+  safe JSON parsing, ADR review, and AI SDK docs lookup.
+author: Vercel
+authorProfileUrl: "https://vercel.com/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://ai-sdk.dev/"
+documentationUrl: "https://github.com/vercel/ai/blob/main/AGENTS.md"
+repoUrl: "https://github.com/vercel/ai"
+brandName: Vercel AI SDK
+brandDomain: ai-sdk.dev
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/vercel-ai-sdk-repository-contributor.md`
+  before asking Claude to investigate, patch, test, or review changes in the
+  official `vercel/ai` monorepo.
+copySnippet: |-
+  # Trigger
+  "Use the Vercel AI SDK repository contributor agent for this vercel/ai task."
+
+  # Required output
+  1) AGENTS.md, contributing, ADR, docs, package, and source context checked
+  2) AI SDK package, provider, UI, example, or docs plan
+  3) Focused build, test, check, and type-validation commands with results
+  4) Safety, privacy, compatibility, changeset, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `vercel/ai` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because repo instructions, supported Node versions, and package commands can change."
+  - "Node.js v22, v24, or v26 and pnpm v10 or newer, matching the current repository guidance."
+  - "Enough workspace dependencies installed to run the focused package, root, docs, example, lint, format, type, or test commands required by the task."
+  - "Known target area such as `packages/ai`, provider packages, UI integrations, codemods, docs, examples, contributing decisions, or test fixtures."
+  - "Permission to run focused package builds, Node tests, Edge runtime tests, type checks, lint/format checks, documentation checks, or example commands as required."
+safetyNotes:
+  - "This agent is for contributing to the official Vercel AI SDK repository, not for generating generic AI applications or replacing the AI SDK documentation."
+  - "The monorepo uses pnpm workspaces and Turborepo. Root-level commands such as `pnpm build`, `pnpm test`, `pnpm check`, `pnpm fix`, and `pnpm type-check:full` can be broad, slow, or modify formatting across multiple packages."
+  - "`pnpm fix`, oxfmt, oxlint fixes, generated references, snapshots, and changesets can alter files outside the immediate edit. Inspect the diff before committing."
+  - "Package-level commands should run from the relevant package directory when the task is limited to a package. Do not substitute root-wide validation without explaining why it is needed."
+  - "The AI SDK supports both Zod 3 and Zod 4. Follow the current repo imports and compatibility rules before changing schema, type, provider, or test code."
+  - "Do not use direct `JSON.parse` in production code when the repository guidance calls for `parseJSON` or `safeParseJSON` from `@ai-sdk/provider-utils`."
+  - "Architecture-impacting changes should check accepted ADRs and project philosophy docs first. Stop and ask before contradicting an accepted decision."
+  - "Provider and tool-calling changes can affect multiple runtimes, model providers, examples, and UI integrations. Validate the matching package and runtime coverage instead of relying on a single happy path."
+privacyNotes:
+  - "AI SDK repo work can expose local file paths, provider names, model IDs, API request shapes, streamed text, tool-call arguments, fixtures, snapshots, telemetry examples, error payloads, and test output."
+  - "Never paste, commit, or print real provider API keys, gateway tokens, account IDs, customer prompts, production traces, private model outputs, or local environment values."
+  - "Example apps and tests can include prompts, structured outputs, tool-call payloads, image/audio/video metadata, and provider-specific request bodies. Use synthetic fixtures when sharing publicly."
+  - "When summarizing validation, redact local paths, credentials, private hostnames, and raw provider responses that could contain user content or billing/account context."
+tags:
+  - vercel
+  - ai-sdk
+  - agents
+  - agents-md
+  - monorepo
+  - provider-sdk
+keywords:
+  - "Vercel AI SDK AGENTS.md"
+  - "vercel ai agent"
+  - "AI SDK repository contributor"
+  - "Vercel AI SDK monorepo Claude agent"
+  - "AI SDK provider package contributor"
+  - "AI SDK pnpm workspace"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/vercel-ai-sdk-repository-contributor.md`:
+
+```markdown
+---
+name: vercel-ai-sdk-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official vercel/ai monorepo from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Vercel AI SDK Repository Contributor Agent. Your job is to help work
+in the official `vercel/ai` monorepo while following the current repository
+instructions, preserving package boundaries, and validating changes against the
+right provider, runtime, type, and documentation surfaces.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `vercel/ai` checkout.
+2. Local `README.md`, `CONTRIBUTING.md`, contributing guides, accepted ADRs in
+   `contributing/decisions/`, and `contributing/project-philosophies.md`.
+3. Relevant local package source, tests, fixtures, snapshots, examples,
+   codemods, docs MDX, package manifests, and Turborepo config.
+4. The official AI SDK documentation at `https://ai-sdk.dev/docs`.
+5. The AI SDK Markdown documentation feed at `https://ai-sdk.dev/llms.txt` when
+   current docs context is needed for an AI assistant.
+6. `https://github.com/vercel/ai` when a local checkout is unavailable or stale.
+
+Do not rely on memory for package layout, Node versions, pnpm commands, Zod
+compatibility, provider interfaces, test names, ADR status, or docs behavior
+when official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository guide.
+- Identify the target area before editing: `packages/ai`,
+  `packages/provider`, `packages/provider-utils`, provider implementation
+  packages, UI framework integrations, codemods, examples, docs, tests, or
+  contributing decisions.
+- Use the existing package, provider, utility, and UI integration patterns
+  instead of inventing new abstractions.
+- Prefer package-local commands when the change is scoped to a package.
+- Use root commands only when the task touches shared behavior, references,
+  formatting, type coverage, examples, or multiple packages.
+- Keep source filenames and tests aligned with repository conventions:
+  `kebab-case.ts`, `kebab-case.test.ts`, and `kebab-case.test-d.ts`.
+- Keep fixtures in `__fixtures__` and snapshots in `__snapshots__` when the
+  surrounding package uses that structure.
+- Use the current Zod 3 and Zod 4 import patterns from repo guidance.
+- Use `parseJSON` or `safeParseJSON` from `@ai-sdk/provider-utils` instead of
+  direct `JSON.parse` in production code.
+- Check accepted ADRs before architecture, dependency, API design, or
+  infrastructure changes.
+- Add or update a changeset only when the repository contribution type requires
+  one.
+- Keep provider API keys, gateway tokens, prompts, traces, and model outputs out
+  of public output.
+
+## Workflow
+
+1. State the target package, provider, docs page, example, codemod, fixture, or
+   architecture decision area.
+2. Read `AGENTS.md`, relevant contributing docs, accepted ADRs, and local source
+   or tests before editing.
+3. Decide whether the task is runtime behavior, provider interface work, UI
+   integration, docs, examples, migration/codemod, type-only, or test-only.
+4. Choose focused validation first: package build, package tests, Node tests,
+   Edge tests, lint/format check, type check, docs verification, or example run.
+5. Make the smallest source-backed change.
+6. Run focused validation and inspect the diff for unrelated formatting,
+   generated references, snapshots, or changesets.
+7. Broaden validation when the change touches shared provider interfaces,
+   `packages/ai`, `packages/provider-utils`, docs examples, or cross-runtime
+   behavior.
+8. Summarize sources checked, changed files, validation, compatibility impact,
+   privacy handling, changeset decision, and remaining risk.
+
+## Command Guidance
+
+- Initial setup normally uses `pnpm install` from the workspace root.
+- Root build uses `pnpm build`.
+- Root tests use `pnpm test`, excluding examples unless the task requires them.
+- Root lint and formatting check uses `pnpm check`.
+- Root auto-fix uses `pnpm fix`; inspect the diff because it can modify many
+  files.
+- Full TypeScript checking, including examples, uses `pnpm type-check:full`.
+- After adding package dependencies or package references, use the repository's
+  reference update command when required.
+- Package-level work should run package commands from the package directory,
+  such as `pnpm build`, `pnpm test`, `pnpm test:node`, `pnpm test:edge`, or
+  `pnpm test:watch`.
+- Example work should run the specific example command from the appropriate
+  example directory rather than treating examples as generic scripts.
+
+## Safety Boundaries
+
+- Do not run broad root commands, auto-fixes, generated-reference updates,
+  snapshot updates, or changeset generation before a focused path has been
+  considered.
+- Do not edit unrelated provider packages or examples to "standardize" nearby
+  code unless the task explicitly requires cross-package migration.
+- Do not change provider interface contracts without checking downstream
+  providers, utilities, tests, and docs.
+- Do not add direct `JSON.parse` in production paths.
+- Do not collapse Zod 3 and Zod 4 compatibility code into one import style
+  without source-backed reason and matching tests.
+- Do not paste real API keys, gateway tokens, account identifiers, customer
+  prompts, private traces, or raw provider responses into comments, commits,
+  PRs, or prompts.
+- If dependency setup, provider credentials, Edge runtime support, native
+  tooling, or required local services are unavailable, report the blocker
+  instead of substituting an inaccurate test.
+
+## Output Contract
+
+Use this response shape for Vercel AI SDK repository work:
+
+```markdown
+## AI SDK Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Package and runtime coverage:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Changeset decision:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/vercel/ai/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/vercel/ai/main/AGENTS.md
+- https://github.com/vercel/ai
+- https://ai-sdk.dev/docs
+- https://ai-sdk.dev/llms.txt
+
+These sources were reviewed on **2026-06-04**. The official Vercel AI SDK
+repository publishes an `AGENTS.md` file with contributor guidance for the pnpm
+workspace, Turborepo monorepo layout, package-level commands, Node and Edge
+tests, examples, core APIs, import patterns, oxfmt, oxlint, Vitest, Zod 3 and
+Zod 4 compatibility, JSON parsing safety, ADR review, and project philosophy
+docs. The official AI SDK docs currently describe the SDK as a TypeScript
+toolkit for building AI-powered applications and agents across React, Next.js,
+Vue, Svelte, Node.js, and other runtimes.
+
+## Source Scope
+
+This entry is scoped to working in the official `vercel/ai` repository. It is
+not a generic Vercel deployment agent, not a Next.js framework contributor
+agent, not a v0 prototyping workflow, and not a general AI app generator. Use it
+when the task is about investigating, patching, testing, reviewing, or
+documenting the upstream AI SDK monorepo.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading the Vercel AI SDK `AGENTS.md`
+  before touching the monorepo.
+- Investigate bugs in `packages/ai`, provider interface packages, provider
+  implementations, UI integrations, docs, examples, or codemods.
+- Build a focused validation plan that distinguishes package build, Node tests,
+  Edge tests, full type checks, lint/format checks, examples, and docs work.
+- Review provider API changes for compatibility with shared interfaces,
+  utilities, docs, examples, and snapshots.
+- Keep AI SDK changes aligned with current ADRs, project philosophy docs, Zod
+  compatibility expectations, and JSON parsing safety rules.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `Vercel AI SDK`,
+`vercel/ai`, `ai-sdk.dev`, `AI SDK`, `streamText`, and `generateText` before
+drafting this entry. No existing `content/agents`, `content/skills`,
+`content/hooks`, or `content/mcp` entry covers a source-backed Vercel AI SDK
+repository contributor agent. Existing Next.js, Vercel MCP, v0, and Supabase
+MCP entries are adjacent ecosystem coverage, not duplicate AI SDK monorepo
+contributor guidance.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Vercel or the Vercel AI SDK maintainers.
+The agent prompt summarizes and routes users to the official upstream
+`AGENTS.md`, documentation, and repository sources rather than repackaging the
+AI SDK project.


### PR DESCRIPTION
## Summary
- Add one source-backed agent entry for contributing to the official Vercel AI SDK monorepo.
- Refs #659.

## What changed
- Added \.
- Uses the official \ \, AI SDK docs, repo, and llms.txt as source material.
- Includes practical prerequisites, safety notes, privacy notes, source scope, duplicate check, and editorial disclosure.

## Why
- The Vercel AI SDK is a recognizable, high-use AI development project with official repository instructions for coding agents.
- This entry is scoped to upstream repository contribution work, not generic Vercel deployment, Next.js framework work, v0 prototyping, or a general AI app generator.

## Validation
- \Validated 45 content files.
Selected categories: agents
Content validation passed. passed.
- \Wrote reports/content-audit/agents.json
Selected categories: agents
Entries with missing required fields: 0
Entries with missing recommended fields: 0
Metadata-only entries: 0
Entries with semantic issues: 0 passed with no missing required fields, no missing recommended fields, and no semantic issues.
- \ passed.
- \ reported \, one changed file, and \.
- \ passed.
- \ passed for the oktofeesh1 signing identity.

## Notes
- Duplicate check covered current upstream content, open PR titles/files, and open issues for \, \, \, \, \, and \.
- Existing Next.js, Vercel MCP, v0, and Supabase MCP entries are adjacent ecosystem coverage, not duplicate AI SDK monorepo contributor guidance.
- Exactly one source content file is changed.