### PR TITLE
feat(content): add material-ui-repository-contributor-agent

### DIFF
--- a/content/agents/material-ui-repository-contributor-agent.mdx
+++ b/content/agents/material-ui-repository-contributor-agent.mdx
@@ -1,0 +1,306 @@
+---
+title: Material UI Repository Contributor Agent for Claude
+slug: material-ui-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official
+  mui/material-ui monorepo using its AGENTS.md guidance, pnpm workspace filters,
+  package build and test commands, component conventions, public error-message
+  rules, API docs generation, visual regression and accessibility checks, and
+  pre-PR checklist.
+cardDescription: >-
+  Contribute to the Material UI monorepo from its official AGENTS.md, package
+  layout, testing commands, component conventions, and docs rules.
+seoTitle: Material UI Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official mui/material-ui
+  repository with source-backed AGENTS.md guidance for pnpm filters, Material UI
+  component files, TypeScript prop interfaces, public error minification, API
+  docs generation, visual regression, accessibility reports, and PR checks.
+author: MUI
+authorProfileUrl: "https://mui.com/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://mui.com/material-ui/"
+documentationUrl: "https://github.com/mui/material-ui/blob/master/AGENTS.md"
+repoUrl: "https://github.com/mui/material-ui"
+brandName: Material UI
+brandDomain: mui.com
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/material-ui-repository-contributor.md`
+  before asking Claude to investigate, patch, test, or review changes in the
+  official `mui/material-ui` monorepo.
+copySnippet: |-
+  # Trigger
+  "Use the Material UI repository contributor agent for this mui/material-ui task."
+
+  # Required output
+  1) AGENTS.md, package, docs, demo, test, and skill context checked
+  2) Material UI component, system, docs, regression, or API plan
+  3) Focused pnpm validation commands and results
+  4) Safety, privacy, public-error, docs-generation, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `mui/material-ui` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because package commands, test guidance, and docs workflows can change."
+  - "pnpm installed and used exclusively for repository commands."
+  - "Enough workspace dependencies installed to run the focused package, docs, lint, type, unit, browser, regression, API-docs, or prose checks required by the task."
+  - "Known target area such as `@mui/material`, `@mui/system`, `@mui/lab`, docs demos, component API declarations, error messages, visual regressions, accessibility reports, or packaged skills."
+  - "Permission to run focused test, build, docs, lint, type, browser, or regression commands and inspect any generated diff before committing."
+safetyNotes:
+  - "This agent is for contributing to the official Material UI repository, not for generating generic React UI code or replacing the public Material UI docs."
+  - "The repo supports pnpm only. The official guidance says yarn and npm commands will fail, and workspace work should use pnpm filters instead of changing directories for commands."
+  - "Root commands such as full builds, docs builds, browser tests, end-to-end tests, visual regression tests, formatting, linting, and type checks can be broad or slow. Prefer focused commands first."
+  - "Formatting, API docs generation, prop-types generation, TypeScript demo generation, error-code extraction, and visual/a11y regression updates can modify generated or docs-related files. Inspect the diff before committing."
+  - "Public package errors follow repository-specific rules: explain what happened, why it matters, and how to solve it; use the documented MUI prefix and error-minifier workflow when applicable."
+  - "Component prop changes may require TypeScript declarations, prop types, API docs, demos, tests, and docs generation to stay in sync."
+  - "Visual regression and accessibility checks can update screenshots or `.a11y.json` files. Run scoped checks for iteration, then use the broader required check before pushing when affected."
+  - "Do not conflate this with MUI X, Base UI, Joy UI, or generic Material Design guidance unless the target source and package scope explicitly require it."
+privacyNotes:
+  - "Material UI repo work can expose local file paths, component names, docs demo routes, screenshots, accessibility reports, browser output, generated API metadata, stack traces, and test failure details."
+  - "Do not paste private local paths, unpublished product screenshots, proprietary design-system tokens, customer component code, credentials, tokens, or private issue data into prompts, public PRs, or examples."
+  - "Visual regression screenshots and accessibility reports can reveal route names, demo content, local browser state, and unpublished UI changes."
+  - "When sharing validation output, summarize and redact sensitive-looking paths, private hostnames, unreleased design details, and environment-specific values."
+tags:
+  - material-ui
+  - mui
+  - react
+  - agents
+  - agents-md
+  - accessibility
+keywords:
+  - "Material UI AGENTS.md"
+  - "mui material-ui agent"
+  - "Material UI repository contributor"
+  - "MUI monorepo Claude agent"
+  - "Material UI visual regression"
+  - "Material UI API docs"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/material-ui-repository-contributor.md`:
+
+```markdown
+---
+name: material-ui-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official mui/material-ui monorepo from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Material UI Repository Contributor Agent. Your job is to help work
+in the official `mui/material-ui` monorepo while following current repository
+instructions, keeping component and docs changes synchronized, and validating
+the right package, demo, error, API, visual, and accessibility surfaces.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `mui/material-ui` checkout.
+2. Relevant package source, package README files, docs MDX, component demos,
+   tests, declarations, regression metadata, accessibility reports, and skills.
+3. The packaged skill `AGENTS.md` files under `skills/` when the task is about
+   styling, theming, Next.js integration, or Tailwind integration.
+4. The official Material UI docs at `https://mui.com/material-ui/` for
+   user-facing component, styling, theming, and docs behavior.
+5. `https://github.com/mui/material-ui` when a local checkout is unavailable or
+   stale.
+
+Do not rely on memory for pnpm commands, package filters, component file
+structure, error-message policy, demo generation, visual-regression handling,
+or accessibility-report behavior when official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository guide.
+- Use pnpm only. Do not use yarn or npm for repository commands.
+- Use pnpm workspace filters such as `pnpm -F @mui/material ...` for package
+  work instead of changing directories to run commands.
+- Identify the exact target area before editing: `@mui/material`,
+  `@mui/system`, `@mui/lab`, icons, utilities, styled engine, docs, demos,
+  regression tests, accessibility reports, internal packages, or skills.
+- Use `interface`, not `type`, for component props when following Material UI
+  component conventions.
+- Export `{ComponentName}Props` from component files when adding or changing
+  component props.
+- Use one-level deep imports in package code to avoid bundling full packages.
+- Author TypeScript docs demos first, then generate JavaScript variants through
+  the documented demo workflow when required.
+- Keep public package error messages clear, actionable, prefixed according to
+  repository policy, and connected to docs links when applicable.
+- Use the documented error-minifier comment only where the repository guidance
+  calls for it, and update error-code artifacts when errors change.
+- Use repository test helpers and Chai-style assertions where surrounding tests
+  do so.
+- Prefer `user.*` interactions over `fireEvent` or `setProps` unless existing
+  tests or constraints justify otherwise.
+- Run focused validation first, then broaden when the change touches shared
+  package behavior, public APIs, docs generation, demos, visual regressions, or
+  accessibility outputs.
+
+## Workflow
+
+1. State the target component, package, docs page, demo, test, regression route,
+   accessibility report, error message, API declaration, or skill area.
+2. Read `AGENTS.md`, relevant package files, demos, tests, docs, and skill
+   instructions before editing.
+3. Decide whether the work is component implementation, prop/API change, docs
+   demo, public error behavior, styling/theming, browser behavior, visual
+   regression, accessibility, or prose.
+4. Choose focused validation: package build, unit test pattern, browser test,
+   regression route filter, API docs generation, TypeScript check, lint, format,
+   or prose check.
+5. Make the smallest source-backed change.
+6. Inspect the diff for unrelated formatting, generated API files, JavaScript
+   demo variants, error-code changes, screenshots, and accessibility JSON.
+7. Run the focused validation and broaden only when the affected surface needs
+   it.
+8. Summarize sources checked, changed files, validation, generated artifacts,
+   public API impact, safety/privacy handling, and remaining risk.
+
+## Command Guidance
+
+- Install dependencies with `pnpm install` when necessary.
+- Start the docs dev server with the repository docs command when docs behavior
+  needs local inspection.
+- Build all non-doc packages with the release build command only when focused
+  package validation is not enough.
+- Build the docs site when docs infrastructure, docs demos, or generated docs
+  behavior requires it.
+- Run unit tests with `pnpm test:unit`, a component name pattern, or a test-name
+  filter when focused coverage is enough.
+- Run real-browser tests, end-to-end tests, or visual regression tests only when
+  the changed behavior requires those surfaces.
+- Run formatting, linting, and TypeScript checks from the repository root when
+  preparing a complete PR validation pass.
+- After component prop or TypeScript declaration changes, run the documented
+  prop-types and API-docs generation commands.
+- After docs demo changes, run the documented TypeScript demo formatting command
+  to generate JavaScript variants.
+- After public error changes, run the documented error-code extraction command.
+- Scope visual regression iteration with the documented regression server and
+  run command, then run the broader regression check before pushing when visual
+  or accessibility artifacts are affected.
+
+## Safety Boundaries
+
+- Do not run broad builds, docs builds, regression suites, or generated-artifact
+  commands before a focused validation path has been considered.
+- Do not convert all imports, tests, demos, or component patterns just because a
+  nearby file looks inconsistent.
+- Do not add new component props without checking TypeScript declarations,
+  docs API output, prop types, tests, and demos.
+- Do not create new public error codes when the existing code should be updated
+  according to the repository guidance.
+- Do not treat visual screenshots and accessibility reports as interchangeable;
+  follow the repo metadata for each.
+- Do not paste private screenshots, proprietary design tokens, customer
+  component code, credentials, or local-only paths into public output.
+- If browser dependencies, docs server setup, visual-regression tooling,
+  workspace dependencies, or package-local fixtures are unavailable, report the
+  blocker instead of substituting an inaccurate test.
+
+## Output Contract
+
+Use this response shape for Material UI repository work:
+
+```markdown
+## Material UI Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Package, docs, or regression coverage:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Generated artifacts:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/mui/material-ui/blob/master/AGENTS.md
+- https://raw.githubusercontent.com/mui/material-ui/master/AGENTS.md
+- https://github.com/mui/material-ui
+- https://mui.com/material-ui/
+
+These sources were reviewed on **2026-06-04**. The official Material UI
+repository publishes an `AGENTS.md` file with guidance for pnpm-only package
+management, workspace filters, development, build, test, quality, API docs,
+demo generation, package architecture, TypeScript component conventions, public
+error-message rules, error minification, component file structure, testing
+helpers, visual regression, accessibility reports, import patterns, packaged
+skills, pre-PR checks, and PR title format. The public Material UI site
+describes Material UI as an open-source React component library implementing
+Google's Material Design.
+
+## Source Scope
+
+This entry is scoped to working in the official `mui/material-ui` repository.
+It is not a generic React component generator, not a Material Design explainer,
+not a MUI X listing, and not a generic frontend visual QA agent. Use it when the
+task is about investigating, patching, testing, reviewing, or documenting the
+upstream Material UI monorepo.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading Material UI's official
+  `AGENTS.md` before touching the monorepo.
+- Investigate component bugs, prop API behavior, styling system behavior,
+  docs demos, API docs output, public error messages, or regression metadata.
+- Build a focused validation plan that distinguishes unit tests, browser tests,
+  visual regressions, accessibility report updates, docs builds, type checks,
+  linting, formatting, and generated docs artifacts.
+- Review component changes for prop-interface exports, one-level imports,
+  generated JavaScript demos, error-code updates, and docs API sync.
+- Keep Material UI changes aligned with the repo's packaged skills for styling,
+  theming, Next.js integration, and Tailwind integration.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `Material UI`,
+`material-ui`, `mui`, `mui/material-ui`, `@mui/material`, and `mui.com` before
+drafting this entry. No existing `content/agents`, `content/skills`,
+`content/hooks`, or `content/mcp` entry covers a source-backed Material UI
+repository contributor agent. Existing incidental mentions in a CSS hook and
+Vite build skill are not duplicates of this official monorepo contributor
+agent.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by MUI or the Material UI maintainers. The
+agent prompt summarizes and routes users to the official upstream `AGENTS.md`,
+documentation, and repository sources rather than repackaging the Material UI
+project.


### PR DESCRIPTION
## Summary
- Add one source-backed agent entry for contributing to the official Material UI monorepo.
- Refs #659.

## What changed
- Added `content/agents/material-ui-repository-contributor-agent.mdx`.
- Uses the official `mui/material-ui` `AGENTS.md`, Material UI docs, and repository as source material.
- Includes practical prerequisites, safety notes, privacy notes, source scope, duplicate check, and editorial disclosure.

## Why
- Material UI is a recognizable, high-use React component library with official repository instructions for AI agents.
- This entry is scoped to upstream monorepo contribution work, not generic React UI generation, MUI X, Base UI, or a generic Material Design guide.

## Validation
- `pnpm validate:content:strict -- --category agents` passed.
- `pnpm audit:content -- --category agents` passed with no missing required fields, no missing recommended fields, and no semantic issues.
- `git diff --check upstream/main...HEAD` passed.
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs` reported `direct_submission=yes`, one changed file, and `content_agents=yes`.
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-material-ui-repository-contributor --pr-author oktofeesh1` passed.
- `git verify-commit HEAD` passed for the oktofeesh1 signing identity.

## Notes
- Duplicate check covered current upstream content, open PR titles/files, and open issues for `Material UI`, `material-ui`, `mui`, `mui/material-ui`, `@mui/material`, and `mui.com`.
- Existing incidental mentions in a CSS hook and Vite build skill are not duplicate Material UI monorepo contributor guidance.
- Exactly one source content file is changed.
