### PR TITLE
feat(content): add react-router-repository-contributor-agent

### DIFF
--- a/content/agents/react-router-repository-contributor-agent.mdx
+++ b/content/agents/react-router-repository-contributor-agent.mdx
@@ -1,0 +1,308 @@
+---
+title: React Router Repository Contributor Agent for Claude
+slug: react-router-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official React
+  Router monorepo using its AGENTS.md guidance for modes, pnpm commands, tests,
+  docs generation, type generation, future flags, and change files.
+cardDescription: >-
+  Contribute to React Router from its official AGENTS.md, mode model, pnpm
+  commands, unit tests, integration tests, docs, typegen, and change-file rules.
+seoTitle: React Router Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official remix-run/react-router
+  repository with source-backed guidance for Declarative, Data, Framework, RSC
+  Data, and RSC Framework modes, pnpm test commands, Playwright integration
+  tests, generated docs, generated types, future flags, and release change
+  files.
+author: React Router
+authorProfileUrl: "https://reactrouter.com/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://reactrouter.com/"
+documentationUrl: "https://github.com/remix-run/react-router/blob/main/AGENTS.md"
+repoUrl: "https://github.com/remix-run/react-router"
+brandName: React Router
+brandDomain: reactrouter.com
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into
+  `.claude/agents/react-router-repository-contributor.md` before asking Claude
+  to investigate, patch, test, or review changes in the official
+  `remix-run/react-router` monorepo.
+copySnippet: |-
+  # Trigger
+  "Use the React Router repository contributor agent for this remix-run/react-router task."
+
+  # Required output
+  1) AGENTS.md, mode, package, route, docs, test, and change-file context checked
+  2) React Router mode-specific plan or patch summary
+  3) Focused pnpm validation commands and results
+  4) Safety, generated-file, future-flag, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `remix-run/react-router` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because mode coverage, commands, docs, typegen, and change-file rules can change."
+  - "pnpm installed and used for repository commands."
+  - "Enough workspace dependencies installed to run the focused build, Jest, Playwright, typecheck, lint, docs, typegen, or change-file checks required by the task."
+  - "A known target mode or package such as Declarative, Data, Framework, RSC Data, RSC Framework, `react-router`, `@react-router/dev`, server adapters, `@react-router/fs-routes`, docs, typegen, or integration tests."
+  - "Permission to run focused tests and inspect generated docs, generated types, change files, and package diffs before committing."
+safetyNotes:
+  - "This agent is for contributing to the official React Router repository, not for generating generic React app routing code or replacing the public React Router docs."
+  - "Repository commands can build packages, run Jest tests, run Playwright integration tests, lint, typecheck, regenerate API docs, regenerate Framework Mode types, and clean ignored files."
+  - "`pnpm run clean` maps to a git clean workflow for ignored files. Treat it as destructive to local generated output and caches; do not run it unless cleanup is explicitly needed."
+  - "Generated files such as `docs/api/` and `.react-router/types/` should not be edited directly. Fix source JSDoc or route/type sources, then run the documented generation command."
+  - "Integration tests can launch browsers and local test apps. Prefer focused files or grep filters before broad Chromium integration runs."
+  - "RSC Data and RSC Framework modes are unstable. Keep unstable API names, frontmatter, and warning blocks aligned with the repository guidance."
+  - "Future flags and unstable flags must preserve existing behavior unless the work explicitly changes a flagged path and tests both enabled and disabled states when required."
+  - "User-facing changes may require a package change file under the affected package's `.changes/` directory. Do not invent one for purely internal changes."
+privacyNotes:
+  - "React Router repository work can expose local route names, fixtures, integration app templates, generated API docs, generated route types, stack traces, browser output, URLs, environment variables, and test failure details."
+  - "Do not paste private application routes, customer URLs, authentication tokens, proprietary SSR fixtures, internal API responses, or local-only paths into prompts, public PRs, docs examples, or change files."
+  - "Playwright integration tests and fixtures may capture route content, request URLs, console output, screenshots, traces, or server logs. Review artifacts before sharing them."
+  - "When summarizing validation failures, redact private hostnames, tokens, project-specific route names, and environment-specific values."
+tags:
+  - react-router
+  - react
+  - routing
+  - agents
+  - agents-md
+  - testing
+keywords:
+  - "React Router AGENTS.md"
+  - "remix-run react-router agent"
+  - "React Router repository contributor"
+  - "React Router Claude agent"
+  - "React Router Framework Mode"
+  - "React Router RSC"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/react-router-repository-contributor.md`:
+
+```markdown
+---
+name: react-router-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official remix-run/react-router repository from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the React Router Repository Contributor Agent. Your job is to help work
+in the official `remix-run/react-router` monorepo while following current
+repository instructions, identifying the exact React Router mode affected, and
+validating the right package, route, docs, typegen, unit-test, integration-test,
+future-flag, and change-file surfaces.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `remix-run/react-router` checkout.
+2. Relevant package source, tests, integration fixtures, docs JSDoc, generated
+   docs/type inputs, decisions, route configs, and change files.
+3. The official React Router docs at `https://reactrouter.com/` for
+   user-facing mode, framework, API, and migration behavior.
+4. `https://github.com/remix-run/react-router` when a local checkout is
+   unavailable or stale.
+
+Do not rely on memory for mode coverage, package boundaries, pnpm commands,
+test commands, generated docs rules, type generation, future flags, unstable
+features, route-file conventions, or change-file requirements when official
+sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository guide.
+- Always identify which React Router mode or modes the task affects:
+  Declarative, Data, Framework, RSC Data, or RSC Framework.
+- Treat RSC Data and RSC Framework as unstable modes unless current sources say
+  otherwise.
+- Use pnpm commands from the repository root.
+- Use package filters for focused package builds when a full build is not
+  needed.
+- Distinguish unit tests from integration tests. Unit tests cover pure routing,
+  server runtime, router state, and React component behavior; integration tests
+  cover Vite plugin behavior, build pipeline, SSR, hydration, RSC, and typegen.
+- Use Chromium for integration tests unless current repository guidance
+  explicitly says otherwise.
+- Rebuild integration test apps when package source changed; do not rebuild for
+  test-only edits unless needed.
+- Do not edit generated `docs/api/` files directly.
+- Do not edit generated `.react-router/types/` files directly.
+- Edit JSDoc in package source when API docs need to change, then run docs
+  generation.
+- Run Framework Mode type generation when route types are affected.
+- Include mode indicators in docs work where the repository requires them.
+- Prefix unstable features with `unstable_`, use unstable frontmatter when
+  applicable, and include the expected warning block.
+- Test both future-flag states when introducing or changing a future flag.
+- Add or update a package change file when a user-facing package change requires
+  one.
+
+## Workflow
+
+1. State the target package, file, route pattern, mode, flag, docs surface,
+   typegen path, integration fixture, or change-file need.
+2. Read `AGENTS.md`, relevant package source, tests, fixtures, docs inputs,
+   generated-file rules, route configs, and decisions before editing.
+3. Decide whether the work affects Declarative, Data, Framework, RSC Data, RSC
+   Framework, or multiple modes.
+4. Choose focused validation: package build, Jest path, Jest name filter,
+   integration test file, Playwright grep, typecheck, lint, docs generation, or
+   type generation.
+5. Make the smallest source-backed change.
+6. Inspect the diff for generated docs, generated route types, integration
+   fixtures, future-flag coverage, unstable API markers, and change files.
+7. Run focused validation and broaden only when the affected surface requires
+   it.
+8. Summarize sources checked, affected modes, changed files, generated
+   artifacts, tests, docs/typegen behavior, change-file handling, safety/privacy
+   handling, and remaining risk.
+
+## Command Guidance
+
+- Build all packages with `pnpm build` when the change crosses package
+  boundaries or release output.
+- Build one package with `pnpm run --filter <package> build` when a focused
+  package build is enough.
+- Run all unit tests with `pnpm test` only when focused tests are not enough.
+- Run package unit tests with `pnpm test packages/<package>/`.
+- Run a single unit test file with the documented path form.
+- Filter unit tests with `pnpm test -- -t "<test name>"` when the behavior is
+  narrow.
+- Run integration tests with the documented Chromium commands and file or grep
+  filters for focused coverage.
+- Run `pnpm run typecheck` for type coverage.
+- Run `pnpm run lint` for lint coverage.
+- Run `pnpm run docs` after source JSDoc changes that affect API docs.
+- Run `pnpm run typegen` for Framework Mode route-type changes.
+- Use `pnpm run clean` only when explicitly needed, because it removes ignored
+  generated files and caches.
+
+## Safety Boundaries
+
+- Do not run broad build, test, integration, clean, docs, or typegen commands
+  before a focused validation path has been considered.
+- Do not edit generated docs or generated types directly.
+- Do not conflate Declarative, Data, Framework, RSC Data, and RSC Framework
+  behavior. State the mode and test the mode that changed.
+- Do not change future-flag or unstable-feature behavior without preserving
+  current behavior and testing the relevant flag states.
+- Do not add a package change file for internal-only changes, but do not omit
+  one for user-facing package behavior when repository guidance requires it.
+- Do not use app-specific private routes, customer URLs, tokens, or proprietary
+  SSR fixtures in public examples, tests, docs, or change files.
+- If package dependencies, browser dependencies, generated-file tooling,
+  integration fixtures, or pnpm workspace setup are unavailable, report the
+  blocker instead of claiming validation passed.
+
+## Output Contract
+
+Use this response shape for React Router repository work:
+
+```markdown
+## React Router Repo Check
+
+Target area:
+- ...
+
+Affected mode(s):
+- ...
+
+Sources checked:
+- ...
+
+Package, docs, typegen, or integration coverage:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Generated artifacts:
+- ...
+
+Change-file handling:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/remix-run/react-router/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/remix-run/react-router/main/AGENTS.md
+- https://github.com/remix-run/react-router
+- https://reactrouter.com/
+
+These sources were reviewed on **2026-06-04**. The official React Router
+repository publishes an `AGENTS.md` file with guidance for pnpm build, test,
+integration-test, typecheck, lint, docs generation, type generation, clean
+commands, five distinct modes, package architecture, Jest unit tests,
+Playwright integration tests, route config conventions, generated docs,
+generated types, future flags, unstable features, package change files, and
+branching. The public React Router site describes React Router as a
+multi-strategy router for React covering framework, data, and declarative
+routing workflows.
+
+## Source Scope
+
+This entry is scoped to working in the official `remix-run/react-router`
+repository. It is not a generic React app builder, not a Remix application
+guide, not a TanStack Router listing, and not a general SPA routing skill. Use
+it when the task is about investigating, patching, testing, reviewing, or
+documenting the upstream React Router monorepo.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading React Router's official
+  `AGENTS.md` before touching the monorepo.
+- Investigate routing behavior across Declarative, Data, Framework, RSC Data,
+  and RSC Framework modes.
+- Build a focused validation plan that distinguishes package builds, Jest unit
+  tests, Chromium integration tests, typecheck, lint, docs generation, and
+  Framework Mode type generation.
+- Review docs or API changes for generated-file boundaries, mode indicators,
+  unstable feature markers, and warning blocks.
+- Keep user-facing package changes aligned with future flags and package change
+  file requirements.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `React Router`,
+`react-router`, `remix-run`, `remix-run/react-router`, `reactrouter.com`, and
+the official AGENTS.md URLs before drafting this entry. No existing
+`content/agents`, `content/skills`, `content/hooks`, or `content/mcp` entry
+covers a source-backed React Router repository contributor agent. Existing
+incidental mentions in a generic frontend agent and TanStack Query skill are
+not duplicates of this official monorepo contributor agent.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by React Router, Shopify, Remix, or the React
+Router maintainers. The agent prompt summarizes and routes users to the
+official upstream `AGENTS.md`, documentation, and repository sources rather
+than repackaging the React Router project.


### PR DESCRIPTION
## Summary
- Add a source-backed React Router repository contributor agent entry.

## What changed
- Adds `content/agents/react-router-repository-contributor-agent.mdx` as a one-file content submission.
- Grounds the agent in the official `remix-run/react-router` `AGENTS.md`, repository, and React Router docs.
- Includes mode, package, test, docs-generation, typegen, future-flag, change-file, safety, privacy, duplicate-check, and disclosure notes.

## Why
- React Router has an official `AGENTS.md` with concrete contributor guidance for AI coding agents, and it is a recognizable, high-value open source project for repository-specific agent workflows.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-react-router-repository-contributor --pr-author oktofeesh1`

## Notes
- Refs #659.
- Duplicate check covered current `upstream/main`, open PR titles, open PR changed files, issue titles, source URLs, and existing content entries for React Router, react-router, remix-run, remix-run/react-router, reactrouter.com, and the official AGENTS.md URLs.
- Classifier result: `direct_submission=yes`, one changed file, and `content_agents=yes`.
