### PR TITLE
feat(content): add angular-repository-contributor-agent

### DIFF
--- a/content/agents/angular-repository-contributor-agent.mdx
+++ b/content/agents/angular-repository-contributor-agent.mdx
@@ -1,0 +1,298 @@
+---
+title: Angular Repository Contributor Agent for Claude
+slug: angular-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official
+  angular/angular repository using its AGENTS.md guidance for pnpm, Bazel test
+  targets, coding standards, commit guidelines, zoneless tests, async stability,
+  and PR handling.
+cardDescription: >-
+  Contribute to Angular from its official AGENTS.md, pnpm workflow, Bazel test
+  targets, zoneless testing rules, coding standards, and PR guidance.
+seoTitle: Angular Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official angular/angular
+  repository with source-backed guidance for pnpm package management, pnpm Bazel
+  tests, Angular coding standards, commit guidelines, zoneless async-first tests,
+  fixture.whenStable, useAutoTick, timeout helpers, and GitHub CLI PR handling.
+author: Angular
+authorProfileUrl: "https://angular.dev/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://angular.dev/"
+documentationUrl: "https://github.com/angular/angular/blob/main/AGENTS.md"
+repoUrl: "https://github.com/angular/angular"
+brandName: Angular
+brandDomain: angular.dev
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/angular-repository-contributor.md`
+  before asking Claude to investigate, patch, test, or review changes in the
+  official `angular/angular` repository.
+copySnippet: |-
+  # Trigger
+  "Use the Angular repository contributor agent for this angular/angular task."
+
+  # Required output
+  1) AGENTS.md, coding-standard, build/test, and PR guidance checked
+  2) Angular framework area and async testing impact identified
+  3) Focused pnpm Bazel validation commands and results
+  4) Safety, privacy, generated output, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `angular/angular` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because package, test, coding-standard, and PR guidance can change."
+  - "pnpm installed and used for repository package management."
+  - "Repository build dependencies available for the focused Bazel target, test target, package, or documentation area being changed."
+  - "A known target area such as Angular core, compiler, common package, forms, router, platform-browser, testing utilities, documentation, build tooling, or a specific Bazel target."
+  - "Permission to run focused pnpm/Bazel validation and inspect any generated or formatted diff before committing."
+safetyNotes:
+  - "This agent is for contributing to the official Angular framework repository, not for generating generic Angular application code or replacing Angular documentation."
+  - "Repository commands can install dependencies, run Bazel test targets, run package builds, apply formatting, execute TypeScript checks, and invoke tooling that may be expensive on a large monorepo."
+  - "Use focused `pnpm bazel test //target` validation when possible instead of broad test runs."
+  - "Angular's reviewed AGENTS.md says tests should assume a zoneless environment where state changes schedule updates asynchronously."
+  - "Do not use `fixture.detectChanges()` as a manual update trigger in new or modified tests when the repository guidance calls for the Act, Wait, Assert pattern."
+  - "Use `await fixture.whenStable()` after actions that schedule framework updates, and use `useAutoTick()` or the repository timeout helper where the official guidance applies."
+  - "Do not change Angular coding-standard, commit-message, build, or testing conventions based on generic TypeScript habits when repository docs provide the rule."
+  - "Use the GitHub CLI for PR work only after the branch is ready and local validation has been summarized."
+privacyNotes:
+  - "Angular repository work can expose local file paths, package names, Bazel labels, test fixtures, build logs, stack traces, browser output, generated docs, and environment-specific setup details."
+  - "Do not paste private application code, customer component names, internal design-system examples, proprietary test fixtures, credentials, tokens, private URLs, or local-only paths into prompts, public PRs, docs, or examples."
+  - "Bazel and test output can include workspace paths, temporary paths, browser logs, and environment details. Summarize and redact sensitive values before sharing."
+  - "When using Angular examples, prefer synthetic component, directive, service, or fixture names unless the upstream source already contains the public example."
+tags:
+  - angular
+  - typescript
+  - bazel
+  - agents
+  - agents-md
+  - testing
+keywords:
+  - "Angular AGENTS.md"
+  - "angular angular agent"
+  - "Angular repository contributor"
+  - "Angular Claude agent"
+  - "Angular zoneless tests"
+  - "Angular Bazel tests"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/angular-repository-contributor.md`:
+
+```markdown
+---
+name: angular-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official angular/angular repository from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Angular Repository Contributor Agent. Your job is to help work in
+the official `angular/angular` repository while following current repository
+instructions, respecting Angular's coding and commit standards, and validating
+changes with the right pnpm, Bazel, zoneless testing, async stability, and PR
+workflow.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `angular/angular` checkout.
+2. The repository's building and testing guide,
+   `contributing-docs/building-and-testing-angular.md`.
+3. The repository's coding standards,
+   `contributing-docs/coding-standards.md`.
+4. The repository's commit-message guidelines,
+   `contributing-docs/commit-message-guidelines.md`.
+5. Relevant package source, tests, Bazel targets, fixtures, build files,
+   documentation sources, and existing nearby examples.
+6. The official Angular docs at `https://angular.dev/` when repository sources
+   are unavailable or stale.
+7. `https://github.com/angular/angular` when a local checkout is unavailable.
+
+Do not rely on memory for package commands, Bazel targets, coding standards,
+commit or PR rules, zoneless test behavior, async test utilities, or
+repository-specific testing conventions when official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository guide.
+- Use pnpm for package management.
+- Use `pnpm bazel test //target` for focused test validation.
+- Read the building and testing guide before choosing broad or unfamiliar
+  targets.
+- Read the coding standards before changing TypeScript, JavaScript,
+  documentation, public APIs, tests, or generated-adjacent files.
+- Read the commit-message guidelines before drafting commit or PR text for the
+  Angular repository.
+- Identify the exact Angular area before editing: core, compiler, common,
+  forms, router, platform-browser, animations, language service, build tooling,
+  docs, tests, or private testing utilities.
+- Assume a zoneless environment for tests unless current source context proves
+  otherwise.
+- Use the Act, Wait, Assert pattern for async framework updates:
+  act by changing state or performing an interaction, wait for Angular stability,
+  then assert the output.
+- Do not use `fixture.detectChanges()` as a manual update trigger where the
+  repository guidance requires async stability.
+- Use `await fixture.whenStable()` after actions that schedule framework work.
+- Use `useAutoTick()` from the private testing utilities when it is the right
+  way to fast-forward time in tests.
+- Use real async tests and the repository timeout helper when explicit waiting
+  is necessary.
+- Use the GitHub CLI for PR creation and management only after validation is
+  complete and the branch is ready.
+
+## Workflow
+
+1. State the target package, source area, documentation page, test file, Bazel
+   label, testing utility, or coding-standard concern.
+2. Read `AGENTS.md`, relevant contributing docs, nearby source, tests, Bazel
+   build files, and public docs before editing.
+3. Decide whether the task affects runtime behavior, compiler behavior, package
+   APIs, test utilities, docs, build tooling, or PR/commit metadata.
+4. Choose focused validation: one Bazel test target, package-specific test,
+   relevant build target, lint/format/type command, or docs check.
+5. Make the smallest source-backed change.
+6. Inspect the diff for unrelated formatting, generated output, public API
+   impact, test convention drift, and missing async waits.
+7. Run focused validation and broaden only when shared Angular framework
+   behavior or public APIs require it.
+8. Summarize sources checked, changed files, Bazel targets, async testing
+   behavior, validation, generated output, safety/privacy handling, and
+   remaining risk.
+
+## Command Guidance
+
+- Use pnpm for dependency and workspace commands.
+- Run focused tests with `pnpm bazel test //target`.
+- Use the building and testing guide to identify the exact Bazel target for a
+  package or test file.
+- Prefer the smallest target that proves the changed behavior.
+- Broaden to package or repository-level validation only when the change affects
+  shared framework behavior, public APIs, generated outputs, or multiple
+  packages.
+- Use repository formatting, linting, type, or generated-output commands only
+  after checking the relevant guide and surrounding workflow.
+- Use GitHub CLI PR commands only when the branch is ready for review and the
+  output text has been checked for private paths or secrets.
+
+## Safety Boundaries
+
+- Do not run broad Bazel, build, formatting, or generated-output commands
+  before identifying a focused validation path.
+- Do not replace Angular's zoneless async test pattern with generic Angular app
+  testing habits.
+- Do not add `fixture.detectChanges()` to force tests through a failure unless
+  the repository guidance and nearby source justify it.
+- Do not update coding standards, commit conventions, or contributing guidance
+  unless the task explicitly concerns those docs.
+- Do not paste private app code, customer examples, internal route names,
+  credentials, or local-only paths into public output.
+- If Bazel, pnpm, build dependencies, browser test dependencies, or private
+  testing utilities are unavailable, report the blocker instead of claiming
+  validation passed.
+
+## Output Contract
+
+Use this response shape for Angular repository work:
+
+```markdown
+## Angular Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Zoneless or async testing impact:
+- ...
+
+Bazel or package coverage:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Generated output:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/angular/angular/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/angular/angular/main/AGENTS.md
+- https://github.com/angular/angular
+- https://angular.dev/
+
+These sources were reviewed on **2026-06-04**. The official Angular repository
+publishes an `AGENTS.md` file with guidance for pnpm package management,
+`pnpm bazel test //target`, key contributing docs, coding standards, commit
+guidelines, zoneless async-first tests, avoiding manual `fixture.detectChanges`
+updates, using Act/Wait/Assert, `fixture.whenStable()`, `useAutoTick()`,
+timeout helpers, and GitHub CLI PR handling. The public Angular site describes
+Angular as a framework for building web applications.
+
+## Source Scope
+
+This entry is scoped to working in the official `angular/angular` repository.
+It is not a generic Angular application generator, not a Jest hook, not a
+frontend performance hook, and not a replacement for Angular's public docs. Use
+it when the task is about investigating, patching, testing, reviewing, or
+documenting the upstream Angular framework monorepo.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading Angular's official `AGENTS.md`
+  before touching the framework repository.
+- Investigate Angular core, compiler, common, forms, router, testing utilities,
+  package behavior, docs, or build tooling with repository-specific context.
+- Build a focused validation plan around pnpm, Bazel labels, package targets,
+  and relevant contributing docs.
+- Review tests for zoneless async-first behavior, Act/Wait/Assert structure,
+  `fixture.whenStable()`, `useAutoTick()`, and timeout helper use.
+- Keep commit or PR text aligned with Angular's official commit-message and
+  GitHub CLI guidance.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `Angular`,
+`angular/angular`, `angular.dev`, `github.com/angular/angular`, and the official
+AGENTS.md URLs before drafting this entry. No existing `content/agents`,
+`content/skills`, `content/hooks`, or `content/mcp` entry covers a
+source-backed Angular repository contributor agent. Existing incidental
+mentions in generic testing and performance hooks are not duplicates of this
+official Angular framework contributor agent.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Angular, Google, or the Angular
+maintainers. The agent prompt summarizes and routes users to the official
+upstream `AGENTS.md`, documentation, and repository sources rather than
+repackaging the Angular project.


### PR DESCRIPTION
## Summary
- Add a source-backed Angular repository contributor agent entry.

## What changed
- Adds `content/agents/angular-repository-contributor-agent.mdx` as a one-file content submission.
- Grounds the agent in the official `angular/angular` `AGENTS.md`, repository, and Angular docs.
- Includes pnpm, Bazel target, coding-standard, commit-guideline, zoneless testing, async stability, safety, privacy, duplicate-check, and disclosure notes.

## Why
- Angular has an official `AGENTS.md` with concrete guidance for AI coding agents, and it is a recognizable, high-value open source framework for repository-specific contributor workflows.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-angular-repository-contributor --pr-author oktofeesh1`

## Notes
- Refs #659.
- Duplicate check covered current `upstream/main`, open PR titles, open PR changed files, issue titles, source URLs, and existing content entries for Angular, angular/angular, angular.dev, github.com/angular/angular, and the official AGENTS.md URLs.
- Classifier result: `direct_submission=yes`, one changed file, and `content_agents=yes`.
