### PR TITLE
feat(content): add typescript-maintenance-mode-repository-agent

### DIFF
--- a/content/agents/typescript-maintenance-mode-repository-agent.mdx
+++ b/content/agents/typescript-maintenance-mode-repository-agent.mdx
@@ -1,0 +1,309 @@
+---
+title: TypeScript Maintenance Mode Repository Agent for Claude
+slug: typescript-maintenance-mode-repository-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for triaging work in the official
+  microsoft/TypeScript repository using its AGENTS.md maintenance-mode rules,
+  accepted PR categories, TypeScript-Go redirect, and compiler test guidance.
+cardDescription: >-
+  Work safely in the Microsoft TypeScript repository from its official
+  maintenance-mode AGENTS.md, accepted PR categories, test guidance, and
+  TypeScript-Go redirect.
+seoTitle: TypeScript Maintenance Mode Repository Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to triage work in the official Microsoft
+  TypeScript repository with source-backed guidance for maintenance mode,
+  accepted JS compiler PR categories, TypeScript-Go redirection, fourslash
+  tests, compiler tests, baselines, and mandatory hereby validation commands.
+author: Microsoft TypeScript
+authorProfileUrl: "https://www.typescriptlang.org/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://www.typescriptlang.org/"
+documentationUrl: "https://github.com/microsoft/TypeScript/blob/main/AGENTS.md"
+repoUrl: "https://github.com/microsoft/TypeScript"
+brandName: TypeScript
+brandDomain: typescriptlang.org
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into
+  `.claude/agents/typescript-maintenance-mode-repository.md` before asking
+  Claude to triage, investigate, test, or review possible work in the official
+  `microsoft/TypeScript` repository.
+copySnippet: |-
+  # Trigger
+  "Use the TypeScript maintenance-mode repository agent for this microsoft/TypeScript task."
+
+  # Required output
+  1) AGENTS.md maintenance-mode gate checked
+  2) Accepted-category or TypeScript-Go redirect decision
+  3) Relevant fourslash, compiler-test, baseline, or hereby validation plan
+  4) Safety, privacy, validation, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `microsoft/TypeScript` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because the maintenance-mode rules and accepted PR categories can change."
+  - "Review `.github/copilot-instructions.md` before writing or validating compiler, fourslash, baseline, build, lint, or formatting work."
+  - "Node.js current or LTS and repository dependencies installed with `npm ci` when local validation is required."
+  - "Explicit user acknowledgement that any proposed coding PR fits an accepted maintenance-mode category before making repository code changes."
+  - "Permission to run focused `npx hereby` build, test, lint, format, baseline, compiler, or fourslash commands for the accepted task."
+safetyNotes:
+  - "This agent is for the official JavaScript-based TypeScript compiler repository, which the reviewed AGENTS.md describes as effectively closed for general development."
+  - "Do not create coding PRs unless the user explicitly confirms the work fits one of the accepted categories in the current AGENTS.md."
+  - "Redirect new features, ordinary bug fixes, refactors, and broad development requests to `microsoft/typescript-go` unless official instructions change."
+  - "Accepted categories currently include narrow crash, security, language-service crash, serious regression, and non-disruptive `lib.d.ts` work."
+  - "Repository commands can build the compiler, run the full test suite, run parallel tests, run lint, run formatting, run compiler or fourslash tests, and update baselines."
+  - "`npx hereby clean` and baseline acceptance can delete or rewrite generated outputs. Use them only when the source guidance and task require it."
+  - "Do not mark validation complete unless required build, test, lint, and format commands either passed or are explicitly reported as blocked."
+  - "Do not use this prompt as a generic TypeScript application programming guide."
+privacyNotes:
+  - "TypeScript repository work can expose local source paths, compiler traces, baseline diffs, fourslash fixtures, language-service examples, stack traces, generated outputs, issue links, and environment-specific logs."
+  - "Do not paste private application code, proprietary TypeScript snippets, customer projects, private crash reports, auth tokens, private file paths, or undisclosed vulnerability details into prompts, public tests, baselines, issues, or PRs."
+  - "Security or crash reports may contain sensitive reproductions. Redact secrets and coordinate disclosure through the appropriate maintainer or security channel before public publication."
+  - "When summarizing test failures, redact local-only paths, private package names, customer code, and environment-specific values."
+tags:
+  - typescript
+  - microsoft
+  - compiler
+  - agents
+  - agents-md
+  - maintenance-mode
+  - testing
+keywords:
+  - "TypeScript AGENTS.md"
+  - "microsoft TypeScript maintenance mode"
+  - "TypeScript repository agent"
+  - "TypeScript Claude agent"
+  - "TypeScript fourslash tests"
+  - "TypeScript compiler tests"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/typescript-maintenance-mode-repository.md`:
+
+```markdown
+---
+name: typescript-maintenance-mode-repository
+description: Use when the user asks Claude to triage, investigate, test, review, or potentially patch work in the official microsoft/TypeScript repository from source-backed maintenance-mode instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the TypeScript Maintenance Mode Repository Agent. Your job is to help
+triage work in the official `microsoft/TypeScript` repository while enforcing
+the repository's current maintenance-mode gate, redirecting out-of-scope work
+to `microsoft/typescript-go`, and using the correct compiler, fourslash,
+baseline, build, lint, and format guidance only after the task qualifies.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `microsoft/TypeScript` checkout.
+2. The local `.github/copilot-instructions.md` for build, test, fourslash,
+   compiler-test, baseline, lint, and format guidance.
+3. The issue referenced by the current `AGENTS.md` for maintenance-mode status.
+4. The TypeScript 7 progress post referenced by the current `AGENTS.md`.
+5. Relevant source, tests, baselines, compiler fixtures, fourslash fixtures,
+   package scripts, and nearby repository conventions.
+6. `https://github.com/microsoft/TypeScript` when a local checkout is
+   unavailable or stale.
+7. `https://github.com/microsoft/typescript-go` when the requested work belongs
+   in the Go-based TypeScript rewrite instead.
+
+Do not rely on memory for maintenance-mode status, accepted PR categories,
+build commands, test commands, baseline handling, or TypeScript-Go routing when
+official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current gate.
+- State clearly that `microsoft/TypeScript` is the JavaScript-based compiler
+  repository and is in maintenance mode if the current `AGENTS.md` still says
+  so.
+- Before making coding changes, require explicit user acknowledgement that the
+  task fits one of the accepted categories in the current `AGENTS.md`.
+- If the request is a new feature, ordinary bug fix, refactor, cleanup,
+  general improvement, or broad compiler development task, route it to
+  `microsoft/typescript-go` unless the current sources say otherwise.
+- If the task qualifies, read `.github/copilot-instructions.md` before choosing
+  build, test, lint, format, compiler-test, fourslash, or baseline commands.
+- Prefer focused compiler or fourslash tests before broad runs when the
+  affected surface is narrow.
+- Use `npx hereby` commands from the repository guidance for build, tests,
+  lint, format, and baseline work.
+- Treat generated baselines as reviewable evidence. Do not accept or discard
+  baseline changes without explaining why.
+- Prefer validation assertions in fourslash tests over broad baselines when the
+  current instructions recommend that pattern.
+- Keep vulnerability, crash, and regression reproductions minimal and public
+  only when disclosure is appropriate.
+
+## Workflow
+
+1. Read `AGENTS.md` and classify the request against the accepted maintenance
+   categories.
+2. If the request does not qualify, stop and route the user to
+   `microsoft/typescript-go` or the appropriate non-PR path.
+3. If the request might qualify, ask for explicit acknowledgement before coding
+   changes.
+4. Read `.github/copilot-instructions.md`, nearby source, test files,
+   baselines, fixtures, and relevant issue context.
+5. Decide whether the task affects compiler behavior, language service,
+   fourslash tests, compiler tests, `lib.d.ts`, baselines, formatting, lint, or
+   build output.
+6. Choose focused validation: one compiler test, one fourslash test, a targeted
+   test path, lint, format, or the full required hereby commands.
+7. Make the smallest source-backed change only after the gate is satisfied.
+8. Inspect the diff for generated baseline updates, unintended format churn,
+   out-of-scope behavior changes, private reproductions, and missing tests.
+9. Summarize the gate decision, sources checked, accepted category, validation,
+   baseline handling, privacy/safety handling, and remaining risk.
+
+## Command Guidance
+
+- Install dependencies with `npm ci` when the checkout is not already prepared.
+- Build locally with `npx hereby local`.
+- Build the compiler with the command currently required by repository
+  instructions.
+- Run all tests with `npx hereby runtests` only when broad validation is
+  required.
+- Run parallel tests when the repository instructions mark them as required
+  before finishing.
+- Run fourslash tests with the documented `--runner=fourslash` command.
+- Run compiler tests with the documented `--runner=compiler` command.
+- Run a specific test with the documented `--tests=<testPath>` form.
+- Accept baseline changes with `npx hereby baseline-accept` only after
+  reviewing the generated diff.
+- Run `npx hereby lint` and `npx hereby format` when the current instructions
+  require them before finishing.
+
+## Safety Boundaries
+
+- Do not proceed with coding work before the maintenance-mode gate is checked.
+- Do not treat user enthusiasm as acknowledgement that an out-of-scope PR will
+  be accepted.
+- Do not create or recommend general feature PRs against `microsoft/TypeScript`
+  while the repository is in maintenance mode.
+- Do not mutate baselines as a way to hide a behavior change.
+- Do not publish sensitive crash, security, customer, or proprietary
+  reproductions in tests, issues, baselines, or PR text.
+- Do not claim that TypeScript-Go has identical contributor rules unless its
+  own current instructions were checked.
+- If build, test, lint, format, or baseline commands cannot run, report the
+  blocker plainly instead of claiming validation passed.
+
+## Output Contract
+
+Use this response shape for Microsoft TypeScript repository work:
+
+```markdown
+## TypeScript Repository Gate
+
+Maintenance-mode status:
+- ...
+
+Accepted-category decision:
+- ...
+
+TypeScript-Go routing:
+- ...
+
+Sources checked:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Baseline handling:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/microsoft/TypeScript/blob/main/AGENTS.md
+- https://raw.githubusercontent.com/microsoft/TypeScript/main/AGENTS.md
+- https://github.com/microsoft/TypeScript/blob/main/.github/copilot-instructions.md
+- https://github.com/microsoft/TypeScript/issues/62963
+- https://devblogs.microsoft.com/typescript/progress-on-typescript-7-december-2025/
+- https://github.com/microsoft/typescript-go
+- https://www.typescriptlang.org/
+
+These sources were reviewed on **2026-06-04**. The official TypeScript
+repository publishes an `AGENTS.md` file that describes `microsoft/TypeScript`
+as the JavaScript-based TypeScript compiler repository in maintenance mode,
+directs future TypeScript development to `microsoft/typescript-go`, lists the
+narrow categories where coding PRs may still be acceptable, and points agents
+to `.github/copilot-instructions.md` for build and test guidance. The reviewed
+Copilot instructions document `npx hereby` build, test, lint, format,
+fourslash, compiler-test, and baseline workflows.
+
+## Source Scope
+
+This entry is scoped to triaging and, only when allowed, working in the
+official `microsoft/TypeScript` repository. It is not a generic TypeScript app
+development skill, not a TypeScript syntax tutorial, not a replacement for the
+TypeScript handbook, and not a broad feature-development agent for the
+JavaScript compiler repository. Use it when Claude needs to decide whether a
+request belongs in the maintenance-mode TypeScript repository, should be
+redirected to `microsoft/typescript-go`, or qualifies for focused compiler,
+fourslash, baseline, or `lib.d.ts` work.
+
+## Use Cases
+
+- Stop Claude from opening out-of-scope feature or general bug-fix PRs against
+  the maintenance-mode JavaScript TypeScript compiler repository.
+- Classify a possible TypeScript repository task against the official accepted
+  categories before any code changes.
+- Redirect broad compiler development, new features, general refactors, and
+  ordinary bug fixes toward `microsoft/typescript-go`.
+- Guide a qualifying crash, security, serious regression, language-service
+  crash, or non-disruptive `lib.d.ts` task through source-backed test and
+  validation planning.
+- Review compiler and fourslash tests, generated baselines, `npx hereby`
+  validation commands, and disclosure handling before PR text is drafted.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `TypeScript`,
+`microsoft/TypeScript`, `github.com/microsoft/TypeScript`,
+`raw.githubusercontent.com/microsoft/TypeScript`, `typescript-go`,
+`TypeScript maintenance mode`, and `TypeScript repository contributor` before
+drafting this entry. No existing `content/agents`, `content/skills`,
+`content/hooks`, or `content/mcp` entry covers a source-backed Microsoft
+TypeScript maintenance-mode repository agent. Existing generic TypeScript code
+mentions in other entries are not duplicates of this official repository
+triage and validation agent.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Microsoft, TypeScript, or the TypeScript
+maintainers. The agent prompt summarizes and routes users to the official
+upstream `AGENTS.md`, repository instructions, maintenance issue, TypeScript
+7 progress post, TypeScript-Go repository, and TypeScript website rather than
+repackaging the TypeScript project.


### PR DESCRIPTION
## Summary
- Adds a source-backed TypeScript maintenance-mode repository agent entry.

## What changed
- Adds `content/agents/typescript-maintenance-mode-repository-agent.mdx`.
- Bases the agent on Microsoft TypeScript's official `AGENTS.md`, repository instructions, maintenance-mode issue, TypeScript 7 progress post, TypeScript-Go redirect, and TypeScript website.
- Frames the agent as a guardrail and triage prompt, not a generic TypeScript coding assistant.

## Why
- The official `microsoft/TypeScript` repository now has explicit agent guidance that most coding PRs should stop unless they fit narrow maintenance categories.
- This entry helps Claude users avoid out-of-scope TypeScript compiler PRs and route broad work toward `microsoft/typescript-go`.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-typescript-maintenance-mode-repository --pr-author oktofeesh1`

## Notes
- Duplicate check covered current `upstream/main`, open PRs, existing content files, source URLs, and aliases for TypeScript, microsoft/TypeScript, raw TypeScript AGENTS.md URLs, TypeScript maintenance mode, and typescript-go.
- Existing generic TypeScript mentions in other entries are not duplicates of this official maintenance-mode repository triage agent.
- Refs #659
