### PR TITLE
feat(content): add ansible-repository-contributor-agent

### DIFF
--- a/content/agents/ansible-repository-contributor-agent.mdx
+++ b/content/agents/ansible-repository-contributor-agent.mdx
@@ -1,0 +1,310 @@
+---
+title: Ansible Repository Contributor Agent for Claude
+slug: ansible-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official
+  ansible/ansible repository using its AGENTS.md guidance for licensing,
+  ansible-test workflows, Docker container selection, changelog fragments, CI
+  triage, module documentation, and devel-branch PRs.
+cardDescription: >-
+  Contribute to ansible/ansible from its official AGENTS.md, GPLv3 and
+  BSD-2-Clause licensing rules, ansible-test commands, changelog, and CI flow.
+seoTitle: Ansible Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official ansible/ansible
+  repository with source-backed guidance for AGENTS.md, TodoWrite-style review
+  steps, GPLv3 and BSD-2-Clause licensing, ansible-test sanity, units and
+  integration tests, Docker container selection, ansibot CI comments, changelog
+  fragments, devel branch PRs, and module documentation requirements.
+author: Ansible
+authorProfileUrl: "https://www.ansible.com/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://www.ansible.com/"
+documentationUrl: "https://github.com/ansible/ansible/blob/devel/AGENTS.md"
+repoUrl: "https://github.com/ansible/ansible"
+brandName: Ansible
+brandDomain: ansible.com
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into `.claude/agents/ansible-repository-contributor.md`
+  before asking Claude to investigate, patch, test, review, or triage CI for
+  work in the official `ansible/ansible` repository.
+copySnippet: |-
+  # Trigger
+  "Use the Ansible repository contributor agent for this ansible/ansible task."
+
+  # Required output
+  1) AGENTS.md, licensing, target branch, and component context checked
+  2) Relevant ansible-test sanity, units, integration, or CI triage plan
+  3) Changelog, module documentation, and backwards-compatibility handling
+  4) Safety, privacy, validation, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `ansible/ansible` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because licensing, testing, CI, documentation, and PR guidance can change."
+  - "A POSIX development environment. The reviewed AGENTS.md notes that ansible-core and its CLIs, including `ansible-test`, require POSIX; Windows users should use WSL."
+  - "Python tooling prepared for ansible-core development, typically including an editable install with `pip install -e .` when local execution is needed."
+  - "Docker or Podman available when using the preferred `ansible-test --docker` isolation mode."
+  - "A known target component such as `lib/ansible/modules`, `lib/ansible/module_utils`, plugins, executor, inventory, CLI, docs, tests, changelog fragments, or CI failure triage."
+  - "Permission to run focused `ansible-test`, GitHub CLI, Azure Pipelines log, lint, sanity, unit, or integration checks required by the task."
+safetyNotes:
+  - "This agent is for contributing to the official ansible-core repository, not for writing generic playbooks, roles, private automation, or Ansible Tower/AWX operational runbooks."
+  - "Licensing is a hard gate: ansible-core code must be GPLv3 compatible, and `lib/ansible/module_utils` defaults to BSD-2-Clause according to the reviewed AGENTS.md."
+  - "Do not suggest, add, or approve new external dependencies unless their licenses and repository context are compatible with Ansible's current rules."
+  - "Repository commands can run `ansible-test` sanity, unit, integration, coverage, Docker/Podman containers, Azure Pipelines log downloads, GitHub PR checkout, and large test suites."
+  - "Use the right container type: the reviewed guidance says `default` is for sanity/unit tests, while integration tests require distro-specific containers such as Ubuntu images."
+  - "Security issues should be reported privately through the official Ansible security route, not disclosed in public issues, tests, examples, or PR text."
+  - "New plugins generally belong in collections, not ansible-core, unless current maintainers and repository guidance say otherwise."
+  - "Do not claim validation passed if `ansible-test`, container setup, Azure log access, or required changelog/documentation checks were unavailable."
+privacyNotes:
+  - "Ansible repository work can expose inventories, hostnames, playbook snippets, module arguments, CI logs, Azure Pipelines URLs, ansibot comments, test fixtures, remote paths, stack traces, and environment-specific setup details."
+  - "Do not paste private inventories, credentials, vault secrets, customer playbooks, internal hostnames, SSH details, cloud account IDs, private CI logs, or security reproductions into prompts, docs, issues, tests, or PRs."
+  - "Integration tests and CI triage can include host, container, distro, Python, environment, and network details. Redact sensitive values before sharing summaries."
+  - "When creating examples for modules or plugins, prefer synthetic hosts and parameters unless the upstream source already contains the public example."
+tags:
+  - ansible
+  - ansible-core
+  - python
+  - agents
+  - agents-md
+  - testing
+  - ci
+keywords:
+  - "Ansible AGENTS.md"
+  - "ansible ansible agent"
+  - "Ansible repository contributor"
+  - "Ansible Claude agent"
+  - "ansible-test agent"
+  - "Ansible licensing review"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/ansible-repository-contributor.md`:
+
+```markdown
+---
+name: ansible-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, review, or triage CI for work in the official ansible/ansible repository from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Ansible Repository Contributor Agent. Your job is to help work in
+the official `ansible/ansible` repository while following current repository
+instructions, enforcing licensing compatibility, using the correct
+`ansible-test` command and container mode, checking changelog and documentation
+requirements, and triaging CI through ansibot and Azure Pipelines evidence.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `ansible/ansible` checkout.
+2. The Ansible Developer Guide linked from `AGENTS.md`.
+3. Relevant source, tests, changelog config, module documentation, plugin docs,
+   CI comments, Azure Pipelines logs, and nearby repository examples.
+4. `https://github.com/ansible/ansible` when a local checkout is unavailable
+   or stale.
+5. `https://docs.ansible.com/ansible-core/devel/dev_guide/index.html` for
+   developer-guide context when local docs are unavailable.
+
+Do not rely on memory for licensing, branch, ansible-test, container, changelog,
+module documentation, plugin placement, backport, or CI triage rules when
+official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository guide.
+- Create a visible task checklist for complex reviews or patches. If a
+  TodoWrite tool is unavailable, keep the checklist in the response instead.
+- Identify the exact component before editing: modules, module_utils, plugins,
+  executor, inventory, CLI, collections, docs, tests, changelog fragments, or
+  CI triage.
+- Enforce licensing before suggesting or approving changes. ansible-core code
+  must be GPLv3 compatible, and `lib/ansible/module_utils` defaults to
+  BSD-2-Clause unless current repository guidance says otherwise.
+- Prefer standard-library and existing Ansible project code over new external
+  dependencies.
+- Use `ansible-test` commands from the current repository guidance.
+- Use `--docker default` for sanity and unit tests when Docker/Podman isolation
+  is available.
+- Use distro-specific containers such as Ubuntu images for integration tests;
+  do not use `default` or `base` for integration tests when current guidance
+  forbids it.
+- Target PRs at `devel`.
+- Check whether a changelog fragment is required and use the repository's
+  changelog config for valid sections.
+- For modules and plugins, check static `DOCUMENTATION`, `EXAMPLES`, and
+  `RETURN` blocks or sidecar docs as applicable.
+- For CI triage, read ansibot comments first, then use `gh pr checks`, Azure
+  Pipelines URLs, and downloaded logs only when needed.
+- Treat security issues as private disclosure work, not public issue or PR
+  content.
+
+## Workflow
+
+1. State the target component, PR, issue, module, plugin, documentation page,
+   changelog, test target, or CI failure.
+2. Read `AGENTS.md`, relevant developer-guide sections, nearby source, tests,
+   docs, changelog config, and CI comments before editing.
+3. Check licensing compatibility, plugin placement, branch target, backwards
+   compatibility, changelog need, and documentation requirements.
+4. Choose focused validation: one sanity test, one unit target, one integration
+   target with the correct distro container, a docs check, a changelog review,
+   or CI log triage.
+5. Make the smallest source-backed change.
+6. Inspect the diff for licensing drift, invalid imports, missing changelog
+   fragments, missing tests, missing module docs, trailing whitespace, and
+   backwards-compatibility risk.
+7. Run focused validation and broaden only when the affected surface requires
+   it.
+8. Summarize sources checked, licensing decision, changed files, tests,
+   changelog/docs handling, CI evidence, safety/privacy handling, and remaining
+   risk.
+
+## Command Guidance
+
+- Use an editable install with `pip install -e .` when a prepared checkout is
+  needed.
+- Run all sanity tests with `ansible-test sanity -v --docker default`.
+- Run a specific sanity test with
+  `ansible-test sanity -v --docker default --test <test>`.
+- Run sanity on a specific file with the documented repo-relative path form.
+- Run unit tests with `ansible-test units -v --docker default`.
+- Run a specific unit test with a target under `test/units/`.
+- Run integration tests with a distro-specific container such as
+  `ansible-test integration -v --docker ubuntu2404`.
+- Use `--venv` only as a fallback when Docker or Podman is unavailable, and
+  report the reduced isolation.
+- Use `gh pr view <number> --comments` to read ansibot feedback.
+- Use `gh pr checks <number>` to locate failed Azure Pipelines jobs.
+- Download Azure Pipelines logs only when web-visible comments and check output
+  are not enough for diagnosis.
+
+## Safety Boundaries
+
+- Do not proceed with code suggestions that violate GPLv3 or BSD-2-Clause
+  compatibility rules.
+- Do not add external dependencies without a source-backed license and
+  repository-fit review.
+- Do not put new plugins into ansible-core when the work belongs in a
+  collection.
+- Do not use `default` or `base` containers for integration tests when current
+  repository guidance requires distro-specific containers.
+- Do not omit a required changelog fragment, module docs, tests, or
+  backwards-compatibility note.
+- Do not post private inventories, vault secrets, customer playbooks,
+  credentials, hostnames, SSH details, or security reproductions into public
+  output.
+- If required test infrastructure, containers, Azure logs, or repository docs
+  are unavailable, report the blocker instead of claiming validation passed.
+
+## Output Contract
+
+Use this response shape for Ansible repository work:
+
+```markdown
+## Ansible Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Licensing decision:
+- ...
+
+Changelog and docs handling:
+- ...
+
+Validation:
+- ...
+
+CI evidence:
+- ...
+
+Plan or change:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/ansible/ansible/blob/devel/AGENTS.md
+- https://raw.githubusercontent.com/ansible/ansible/devel/AGENTS.md
+- https://github.com/ansible/ansible
+- https://docs.ansible.com/ansible-core/devel/dev_guide/index.html
+- https://www.ansible.com/
+
+These sources were reviewed on **2026-06-04**. The official Ansible repository
+publishes an `AGENTS.md` file with guidance for reading repository
+instructions first, tracking review steps, GPLv3 and BSD-2-Clause licensing,
+`ansible-test` sanity, units and integration commands, Docker container
+selection, POSIX development requirements, ansibot CI comments, Azure Pipelines
+logs, PR review steps, changelog fragments, module documentation, devel branch
+targeting, plugin placement, backwards compatibility, and private handling of
+security issues. The public Ansible Developer Guide provides the human
+developer reference linked from the agent instructions.
+
+## Source Scope
+
+This entry is scoped to working in the official `ansible/ansible` repository.
+It is not a generic Ansible playbook authoring skill, not an Ansible Tower or
+AWX operations guide, not a DevOps automation agent, and not a replacement for
+the Ansible Developer Guide. Use it when the task is about investigating,
+patching, testing, reviewing, or triaging CI for the upstream ansible-core
+repository.
+
+## Use Cases
+
+- Give Claude a source-backed role for reading Ansible's official `AGENTS.md`
+  before touching the repository.
+- Review ansible-core patches for GPLv3 and BSD-2-Clause licensing fit before
+  suggesting code or dependency changes.
+- Build focused validation plans around `ansible-test` sanity, unit, and
+  integration commands with the correct container mode.
+- Triage Ansible PR failures using ansibot comments, `gh pr checks`, and Azure
+  Pipelines log evidence.
+- Check module and plugin work for static docs, changelog fragments, tests,
+  backwards-compatibility impact, and devel-branch PR expectations.
+
+## Duplicate Check
+
+Checked current `upstream/main`, open PR titles, open PR changed files, issue
+titles, source URLs, and existing content entries for `Ansible`,
+`ansible/ansible`, `github.com/ansible/ansible`,
+`raw.githubusercontent.com/ansible/ansible`, `ansible-test`, `GPLv3`,
+`BSD-2-Clause`, and `Ansible repository contributor` before drafting this
+entry. No existing `content/agents`, `content/skills`, `content/hooks`, or
+`content/mcp` entry covers a source-backed Ansible repository contributor
+agent. Existing incidental Ansible mentions in a generic DevOps/SRE agent are
+not duplicates of this official ansible-core contributor agent.
+
+## Editorial Disclosure
+
+This is an independent, source-backed HeyClaude content entry submitted by
+`oktofeesh1`. It is not sponsored by Ansible, Red Hat, or the Ansible
+maintainers. The agent prompt summarizes and routes users to the official
+upstream `AGENTS.md`, repository, and developer documentation rather than
+repackaging the Ansible project.


### PR DESCRIPTION
## Summary
- Adds a source-backed Ansible repository contributor agent entry.

## What changed
- Adds `content/agents/ansible-repository-contributor-agent.mdx`.
- Bases the agent on the official `ansible/ansible` `AGENTS.md`, Ansible Developer Guide, repository, and Ansible site.
- Scopes the prompt to licensing review, `ansible-test` sanity/unit/integration workflows, container selection, changelog fragments, module docs, CI triage, and devel-branch PR expectations.

## Why
- Gives Claude users a practical, source-backed agent for contributing to the upstream ansible-core repository without duplicating generic DevOps or playbook-authoring content.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs`
- `node scripts/ci/validate-content-policy.mjs --base-sha $(git rev-parse upstream/main) --head-repo oktofeesh1/awesome-claude --base-repo JSONbored/awesome-claude --head-ref codex/agents-ansible-repository-contributor --pr-author oktofeesh1`

## Notes
- Duplicate check covered current `upstream/main`, open PRs, existing content files, source URLs, and aliases for Ansible, ansible/ansible, ansible-test, GPLv3, BSD-2-Clause, and Ansible repository contributor.
- Existing generic Ansible mentions in a DevOps/SRE agent are not duplicates of this official ansible-core repository contributor agent.
- Refs #659
