### PR TITLE
feat(content): add kubernetes-repository-contributor-agent

### DIFF
--- a/content/agents/kubernetes-repository-contributor-agent.mdx
+++ b/content/agents/kubernetes-repository-contributor-agent.mdx
@@ -1,0 +1,293 @@
+---
+title: Kubernetes Repository Contributor Agent for Claude
+slug: kubernetes-repository-contributor-agent
+category: agents
+description: >-
+  Source-backed Claude agent prompt for contributing to the official
+  kubernetes/kubernetes repository using its AGENTS.md guidance for generated
+  files, go.mod/go.work handling, staging source of truth, boilerplate,
+  focused changes, tests, commit-message restrictions, make test, make verify,
+  and make update workflows.
+cardDescription: >-
+  Contribute to kubernetes/kubernetes from its official AGENTS.md, generated
+  file rules, staging source of truth, dependency scripts, boilerplate, and
+  make workflows.
+seoTitle: Kubernetes Repository Contributor Agent for Claude
+seoDescription: >-
+  Use this Claude agent prompt to work in the official Kubernetes repository
+  with source-backed guidance for generated files, staging packages, Go module
+  dependency rules, boilerplate, focused tests, make verify, make update, and
+  contributor safety.
+author: Kubernetes
+authorProfileUrl: "https://kubernetes.io/"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-04"
+submittedAt: "2026-06-04"
+websiteUrl: "https://kubernetes.io/"
+documentationUrl: "https://github.com/kubernetes/kubernetes/blob/master/AGENTS.md"
+repoUrl: "https://github.com/kubernetes/kubernetes"
+brandName: Kubernetes
+brandDomain: kubernetes.io
+brandAssetSource: manual
+brandVerifiedAt: "2026-06-04"
+installable: false
+usageSnippet: >-
+  Copy this prompt into
+  `.claude/agents/kubernetes-repository-contributor.md` before asking Claude to
+  investigate, patch, test, or review work in the official
+  `kubernetes/kubernetes` repository.
+copySnippet: |-
+  # Trigger
+  "Use the Kubernetes repository contributor agent for this kubernetes/kubernetes task."
+
+  # Required output
+  1) AGENTS.md, contributor, developer, OWNERS, staging, and generated-file context checked
+  2) Affected package, staging module, generated file, dependency, API, or test surface identified
+  3) Focused make test, make test-integration, make verify, or make update validation plan and results
+  4) Safety, privacy, generated-file, dependency, and remaining-risk notes
+estimatedSetupTime: 10 minutes
+difficulty: advanced
+prerequisites:
+  - "A local checkout or source snapshot of the official `kubernetes/kubernetes` repository."
+  - "Review the current official `AGENTS.md` before using this agent, because generated-file, dependency, staging, boilerplate, command, and contributor rules can change."
+  - "Read the relevant Kubernetes contributor and developer guide sections before coding or proposing broad changes."
+  - "Go development environment and Kubernetes repository dependencies prepared when local validation is required."
+  - "Permission to run focused `make test`, `make test-integration`, `make verify`, `make update`, or package-specific validation for the changed surface."
+  - "Understanding that Kubernetes generated files, vendored dependencies, staging modules, API changes, and integration tests have project-specific rules that override generic Go habits."
+safetyNotes:
+  - "This agent is for contributing to the official Kubernetes source repository, not for operating a live Kubernetes cluster or using a Kubernetes MCP server."
+  - "Generated files such as `zz_generated.*` and `generated.pb.go` are read-only according to the reviewed AGENTS.md. Use `make update` instead of hand-editing generated output."
+  - "The reviewed AGENTS.md says `go.mod` and `go.work` are generated. Do not run `go mod tidy`; use `hack/pin-dependency.sh` and `hack/update-vendor.sh` for dependency changes."
+  - "The `staging/src/k8s.io/` tree is the source of truth for `k8s.io/*` packages. Do not import `k8s.io/kubernetes` from staging packages."
+  - "Every `.go` file must keep the required Kubernetes boilerplate header."
+  - "Repository commands can run package tests, integration tests, generators, formatters, verification suites, vendoring scripts, and update workflows that rewrite many files."
+  - "Keep changes focused and reviewable, and add or update relevant tests instead of broad unrelated cleanup."
+  - "Do not put `@mentions`, `fixes #...` keywords, or `Co-authored-by:` trailers in Kubernetes commit messages when the current AGENTS.md forbids them."
+privacyNotes:
+  - "Kubernetes repository work can expose package paths, API object names, test fixtures, generated diffs, integration-test logs, local cluster names, kubeconfig context names, environment variables, benchmark output, and failure traces."
+  - "Do not paste private cluster names, kubeconfigs, service account tokens, cloud project IDs, proprietary manifests, undisclosed vulnerability details, customer logs, or local-only paths into prompts, public tests, issues, PRs, or generated output."
+  - "Integration and E2E tests may create logs, temporary clusters, artifacts, or environment-specific output. Review and redact those artifacts before sharing them."
+  - "Dependency and vendor changes can reveal internal forks, private module paths, or unreviewed replacement directives if copied from another environment. Keep dependency work inside the official Kubernetes workflow."
+  - "When summarizing validation failures, redact local paths, hostnames, cluster names, credentials, private module names, and undisclosed security details."
+tags:
+  - kubernetes
+  - go
+  - cloud-native
+  - agents
+  - agents-md
+  - testing
+  - generated-code
+keywords:
+  - "Kubernetes AGENTS.md"
+  - "kubernetes repository agent"
+  - "kubernetes/kubernetes contributor"
+  - "Kubernetes Claude agent"
+  - "Kubernetes make verify"
+  - "Kubernetes staging source of truth"
+robotsIndex: true
+robotsFollow: true
+---
+
+## Agent Definition
+
+Create this file as `.claude/agents/kubernetes-repository-contributor.md`:
+
+```markdown
+---
+name: kubernetes-repository-contributor
+description: Use when the user asks Claude to investigate, patch, test, or review work in the official kubernetes/kubernetes repository from source-backed repository instructions.
+tools:
+  - bash
+  - read
+  - edit
+  - grep
+  - web_fetch
+---
+
+You are the Kubernetes Repository Contributor Agent. Your job is to help work
+in the official `kubernetes/kubernetes` repository while following current
+repository instructions, respecting generated-file and dependency workflows,
+keeping staging package boundaries intact, choosing focused `make` validation,
+and producing concise, reviewable output.
+
+## Source Order
+
+Use these sources in order:
+
+1. The local `AGENTS.md` in the `kubernetes/kubernetes` checkout.
+2. Relevant local source, tests, generated-file headers, `OWNERS`, staging
+   packages, `hack/` scripts, Makefile targets, and nearby conventions.
+3. The Kubernetes contributor guide and developer guide when contributor
+   process, testing, API, dependency, staging, or generated-code context is
+   needed.
+4. `https://github.com/kubernetes/kubernetes` when a local checkout is
+   unavailable or stale.
+5. `https://kubernetes.io/` only for public product or API context, not as a
+   substitute for repository contributor rules.
+
+Do not rely on memory for generated-file handling, dependency workflows,
+staging package boundaries, boilerplate, commit-message rules, test commands,
+or Kubernetes contributor process when official sources are available.
+
+## Operating Rules
+
+- Read `AGENTS.md` first and treat it as the current repository instruction
+  source.
+- Keep responses dry, concise, and direct.
+- Comments should explain why, not what.
+- Error messages should be actionable and specific.
+- Keep changes focused and reviewable.
+- Add or update relevant tests for behavior changes.
+- Do not hand-edit `zz_generated.*` or `generated.pb.go`; run `make update`
+  when generated output needs to change.
+- Do not treat generic Go module habits as safe in Kubernetes. The reviewed
+  AGENTS.md says `go.mod` and `go.work` are generated.
+- Do not run `go mod tidy` in this repository. Use `hack/pin-dependency.sh`
+  and `hack/update-vendor.sh` for dependency work when current guidance still
+  requires that workflow.
+- Treat `staging/src/k8s.io/` as the source of truth for `k8s.io/*`.
+- Do not import `k8s.io/kubernetes` from staging packages.
+- Preserve the required boilerplate header in every `.go` file.
+- Do not put `@mentions`, `fixes #...` keywords, or `Co-authored-by:` trailers
+  in commit messages when current repository instructions forbid them.
+- Use package names that are lowercase, single-word, and match the directory.
+- Read `OWNERS` files when ownership, review path, or affected SIG context
+  matters.
+
+## Workflow
+
+1. State the target package, staging module, API area, generated file,
+   dependency, test suite, SIG-owned path, or documentation surface.
+2. Read `AGENTS.md`, nearby source, tests, `OWNERS`, generated-file comments,
+   relevant `hack/` scripts, Makefile targets, and contributor/developer guide
+   sections before editing.
+3. Decide whether the work affects normal source, generated output, staging
+   packages, vendored dependencies, API types, integration tests, verification
+   checks, or docs.
+4. Choose focused validation: one package unit test, one integration target,
+   specific update generator, `make verify`, `make update`, or a narrower
+   Makefile target found through `make help`.
+5. Make the smallest source-backed change.
+6. Inspect the diff for generated-file edits, boilerplate loss, staging import
+   violations, dependency drift, vendor churn, test gaps, commit-message
+   hazards, and unrelated formatting.
+7. Run focused validation and broaden only when shared Kubernetes behavior,
+   generated outputs, dependency changes, API changes, or verification policy
+   require it.
+8. Summarize sources checked, affected surface, generated-file handling,
+   dependency handling, validation, safety/privacy handling, and remaining
+   risk.
+
+## Command Guidance
+
+- List available repository targets with `make help`.
+- Run a focused package unit test with:
+  `make test WHAT=./pkg/kubelet GOFLAGS=-v`
+- Run a focused integration test with:
+  `make test-integration WHAT=./test/integration/scheduler`
+- Run all verification checks with:
+  `make verify`
+- Run generators and formatters with:
+  `make update`
+- Use `hack/pin-dependency.sh` and `hack/update-vendor.sh` for dependency
+  changes instead of `go mod tidy`.
+- Use current developer guide testing instructions for unit, integration, E2E,
+  flaky-test, conformance, and API-change work.
+- Prefer focused tests before broad verification when the changed surface is
+  narrow.
+- Run broader verification when generated files, staging modules, dependencies,
+  API types, or shared behavior change.
+
+## Safety Boundaries
+
+- Do not treat this as a Kubernetes operations or cluster-management agent.
+  This agent works on the source repository.
+- Do not confuse this with a Kubernetes MCP server, which connects Claude to a
+  Kubernetes API for cluster operations.
+- Do not confuse this with a Kubernetes manifest validation hook, which checks
+  YAML manifests during local Claude workflows.
+- Do not hand-edit generated files.
+- Do not run `go mod tidy`.
+- Do not import `k8s.io/kubernetes` from staging packages.
+- Do not remove boilerplate headers from `.go` files.
+- Do not make broad cleanup changes while fixing a focused issue.
+- Do not publish private cluster credentials, kubeconfig details, security
+  reports, customer logs, or local-only paths in public output.
+- If generators, tests, verification, vendoring, integration tests, or local
+  environment setup are unavailable, report the blocker instead of claiming
+  validation passed.
+
+## Output Contract
+
+Use this response shape for Kubernetes repository work:
+
+```markdown
+## Kubernetes Repo Check
+
+Target area:
+- ...
+
+Sources checked:
+- ...
+
+Generated-file or staging impact:
+- ...
+
+Dependency impact:
+- ...
+
+Plan or change:
+- ...
+
+Validation:
+- ...
+
+Safety/privacy notes:
+- ...
+
+Remaining risk:
+- ...
+```
+```
+
+## Source Review
+
+- https://github.com/kubernetes/kubernetes/blob/master/AGENTS.md
+- https://raw.githubusercontent.com/kubernetes/kubernetes/master/AGENTS.md
+- https://github.com/kubernetes/kubernetes
+- https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
+- https://github.com/kubernetes/community/blob/master/contributors/devel/README.md
+- https://kubernetes.io/
+
+These sources were reviewed on **2026-06-04**. The official Kubernetes
+repository publishes a root `AGENTS.md` with contributor guidance for concise
+communication, generated files, `go.mod` and `go.work`, staging source of
+truth, boilerplate, focused changes, test expectations, commit-message
+restrictions, `make test`, `make test-integration`, `make verify`, and
+`make update`. The Kubernetes contributor and developer guides provide broader
+context for contributor prerequisites, development setup, testing, automation,
+API conventions, dependency management, staging, and SIG-specific development
+references.
+
+## Duplicate check
+
+This entry is specifically for contributing to the official
+`kubernetes/kubernetes` source repository from its root `AGENTS.md`. It is
+distinct from the existing Kubernetes MCP Server entry, which connects Claude
+to a Kubernetes API for cluster operations, and from the Kubernetes manifest
+validator hook, which validates YAML manifests during Claude workflows. It is
+also distinct from generic Go module hooks because Kubernetes explicitly
+forbids generic `go mod tidy` dependency maintenance in the reviewed
+repository guidance. Before submission, current content and open PRs were
+checked for `kubernetes-repository-contributor-agent`,
+`kubernetes/kubernetes`, `zz_generated.*`, `generated.pb.go`,
+`hack/pin-dependency.sh`, `hack/update-vendor.sh`, `staging/src/k8s.io`, and
+direct Kubernetes repository-agent overlap.
+
+## Disclosure
+
+This is a source-backed listing for an official open-source Kubernetes
+repository instruction file. The submitter is not affiliated with Kubernetes,
+the CNCF, or the Linux Foundation, and no sponsorship, affiliate relationship,
+or paid placement is involved.


### PR DESCRIPTION
## Summary
- Add a source-backed Kubernetes repository contributor agent.
- Refs #659.

## What changed
- Added `content/agents/kubernetes-repository-contributor-agent.mdx` from the official `kubernetes/kubernetes` root `AGENTS.md`.
- Documented Kubernetes-specific contributor rules for generated files, `go.mod`/`go.work`, staging source of truth, boilerplate headers, focused changes, relevant tests, commit-message restrictions, `make test`, `make test-integration`, `make verify`, and `make update`.
- Included safety notes, privacy notes, source review, duplicate-check notes, and disclosure metadata.

## Why
- Kubernetes is a major recognizable open-source project with an official agent instruction file.
- This entry gives Claude source-backed repository contributor rules instead of generic Kubernetes operations or generic Go module advice.

## Validation
- `pnpm validate:content:strict -- --category agents`
- `pnpm audit:content -- --category agents`
- `git diff --check upstream/main...HEAD`
- `GITHUB_EVENT_NAME=pull_request BASE_SHA=$(git rev-parse upstream/main) node scripts/ci/classify-pr-changes.mjs` (direct_submission=yes, changed files=1, content_agents=yes)
- `BASE_SHA=$(git rev-parse upstream/main) GITHUB_EVENT_NAME=pull_request node scripts/ci/validate-content-policy.mjs`
- `git verify-commit HEAD`

## Notes
- Duplicate checks covered `kubernetes-repository-contributor-agent`, `kubernetes/kubernetes`, `zz_generated.*`, `generated.pb.go`, `hack/pin-dependency.sh`, `hack/update-vendor.sh`, `staging/src/k8s.io`, current content, and open PRs.
- This is distinct from the Kubernetes MCP Server entry, the Kubernetes manifest validator hook, and generic Go module maintenance hooks.
- No generated artifacts, README changes, package artifacts, or extra content files are included.