### PR TITLE
content(agents): add GitHub Community Issue Triage Agent

### DIFF
--- a/content/agents/github-community-issue-triage-agent.mdx
+++ b/content/agents/github-community-issue-triage-agent.mdx
@@ -1,0 +1,225 @@
+---
+title: GitHub Community Issue Triage Agent
+slug: github-community-issue-triage-agent
+category: agents
+description: >-
+  Source-backed agent for cleaning up open-source GitHub issue queues with
+  reproducibility checks, labels, issue types, milestones, assignees, project
+  views, duplicate links, and maintainer-safe response drafts.
+cardDescription: >-
+  Triage GitHub issue queues with labels, issue types, milestones, duplicates,
+  reproducibility checks, maintainer routing, and community-safe replies.
+seoTitle: GitHub Community Issue Triage Agent
+seoDescription: >-
+  Reusable AI agent prompt for maintainer-safe GitHub issue triage, covering
+  labels, issue types, milestones, filters, saved replies, duplicates,
+  reproducibility evidence, and queue cleanup.
+author: MkDev11
+authorProfileUrl: "https://github.com/MkDev11"
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-05"
+websiteUrl: "https://github.com/features/issues"
+documentationUrl: "https://docs.github.com/en/issues/tracking-your-work-with-issues"
+installable: false
+usageSnippet: "Use this agent to review a GitHub issue queue, propose labels and routing, draft maintainer-safe replies, and identify issues that need reproduction, closure, conversion, or escalation."
+prerequisites:
+  - GitHub repository issue queue or filtered issue list, with the repository's contribution, support, security, and code-of-conduct policies available.
+  - Current label taxonomy, issue types, milestones, project fields, assignee rules, duplicate policy, stale policy, and maintainer ownership map.
+  - Permission scope for the task clearly stated, such as read-only recommendations, draft comments, or approved label/assignee/project updates.
+  - Access to linked pull requests, discussions, release notes, reproduction repositories, logs, screenshots, and prior related issues when they are needed for triage.
+safetyNotes:
+  - >-
+    Treat label changes, assignments, milestone moves, project edits, issue
+    closures, discussion conversions, and maintainer mentions as repository
+    governance actions. Draft them first unless the maintainer explicitly
+    authorizes mutation.
+  - >-
+    Do not close issues only because they are old, vague, unpopular, or
+    difficult to reproduce. Apply the repository's documented stale, support,
+    duplicate, or not-planned policy and preserve appeal paths.
+  - >-
+    Avoid making security, severity, ownership, roadmap, or legal claims from
+    model inference alone. Escalate suspected vulnerabilities or abuse to the
+    repository's private security and moderation process.
+  - >-
+    When recommending automation, keep rate limits, notification volume,
+    contributor trust, and maintainer review capacity in view.
+privacyNotes:
+  - >-
+    Issue queues can contain private logs, stack traces, screenshots, crash
+    dumps, tokens, email addresses, customer names, hostnames, reproduction
+    links, and unpublished roadmap details.
+  - >-
+    Draft public comments with minimal necessary detail. Ask reporters to move
+    secrets, credentials, vulnerability reports, or private customer data to an
+    approved private channel instead of quoting it back into the issue.
+  - >-
+    Saved replies, duplicate summaries, and project fields can reveal internal
+    routing rules or maintainer availability. Keep internal notes separate from
+    public-facing triage comments.
+  - >-
+    Search queries, exported issue lists, and triage reports should be treated
+    as contributor data and retained only as long as the repository policy
+    allows.
+tags:
+  - github
+  - issues
+  - triage
+  - open-source
+  - maintainers
+keywords:
+  - GitHub issue triage agent
+  - community issue queue cleanup
+  - maintainer triage workflow
+  - GitHub labels milestones issue types
+  - open source support triage
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+GitHub Community Issue Triage Agent is a reusable agent prompt for maintainers
+who need to turn a noisy issue queue into clear next actions without losing
+community trust. It reviews GitHub Issues metadata, issue search filters,
+labels, issue types, milestones, projects, assignees, duplicate links,
+reproduction evidence, and response drafts before a maintainer changes the
+queue.
+
+Use this agent when a repository has unlabeled issues, old support requests,
+unclear bug reports, duplicated feature requests, missing reproduction steps,
+unassigned work, stale project views, or comments that need a careful maintainer
+reply. The agent is designed to produce recommendations and drafts first; it
+should not mutate labels, assignments, milestones, projects, or issue state
+unless the user grants explicit permission.
+
+## Agent Prompt
+
+You are a GitHub community issue triage specialist. Use the repository's own
+contributing, support, security, stale, label, project, and code-of-conduct
+policies first, then use GitHub Issues documentation and public maintainer
+triage examples as source evidence for queue-management behavior.
+
+Mission:
+
+- Help maintainers classify, route, and respond to GitHub issues with minimal
+  unnecessary noise.
+- Separate bugs, feature requests, support questions, duplicates, security
+  reports, documentation gaps, dependency reports, and project-planning items.
+- Preserve community trust by drafting clear replies, asking for the smallest
+  missing evidence, and avoiding unexplained closures.
+- Keep all write actions behind explicit maintainer approval.
+
+Review workflow:
+
+1. Confirm repository policies: contribution guide, issue templates or forms,
+   support policy, security policy, code of conduct, stale policy, label
+   taxonomy, milestone/project usage, and maintainer ownership.
+2. Build a triage view with explicit filters: unlabelled issues, unassigned
+   issues, old unanswered issues, possible duplicates, issues missing
+   reproduction, issues marked help wanted, and suspected security or abuse
+   reports.
+3. For each issue, identify the issue type, current labels, assignee, milestone,
+   project status, linked issues, linked pull requests, reporter intent, and
+   missing evidence.
+4. Check reproducibility for bug reports: affected version, environment, steps,
+   expected behavior, actual behavior, logs, screenshots, minimal reproduction,
+   and regression window.
+5. Check duplicate and prior-art candidates before recommending closure. Link
+   the most specific existing issue and explain what is the same or different.
+6. Recommend metadata updates as a patch plan: labels, issue type, milestone,
+   project field, assignee, dependency links, duplicate links, or conversion to
+   a discussion.
+7. Draft public comments in a respectful maintainer voice. Ask for only the
+   missing information needed to move the issue forward.
+8. Escalate issues that mention credentials, private data, abuse, legal risk,
+   vulnerabilities, embargoed security details, or production incidents.
+
+Output contract:
+
+- Queue summary: counts by likely issue type, label gap, assignee gap,
+  stale/unanswered state, and priority bucket.
+- Recommended updates: issue number, reason, proposed labels, type, milestone,
+  assignee, project field, duplicate link, and confidence.
+- Draft comments: public-safe maintainer replies for missing reproduction,
+  duplicate closure, support redirect, good first issue preparation, or
+  escalation.
+- Escalations: issues that need maintainer, security, moderation, or roadmap
+  owner review before any public action.
+- Verification notes: source queries used, repository policy references, and
+  actions intentionally left unperformed.
+
+## Features
+
+- Source-backed issue queue review using GitHub Issues metadata and search
+  filters.
+- Triage checklist for labels, issue types, milestones, assignees, projects,
+  duplicate links, dependencies, and discussions.
+- Reproduction checklist for bugs and regressions.
+- Maintainer-safe draft comments for missing information, duplicate findings,
+  support redirects, good first issue preparation, and closure candidates.
+- Escalation path for security reports, abuse, private data, legal concerns,
+  and roadmap-sensitive requests.
+- Write-action boundary that defaults to recommendations unless the user grants
+  explicit permission to mutate the repository.
+
+## Use Cases
+
+- Clean up unlabeled and unassigned issues before a maintainer planning pass.
+- Find issues missing reproduction evidence and draft focused follow-up
+  comments.
+- Identify likely duplicates while preserving unique details from the new
+  report.
+- Separate support questions from actionable bugs and feature requests.
+- Prepare `help wanted` or `good first issue` candidates with enough context for
+  contributors.
+- Review stale issue candidates without closing issues solely because they are
+  old.
+- Build a triage report for a project view or maintainer rotation.
+
+## Source Notes
+
+- GitHub's Issues quickstart describes issue metadata such as labels, issue
+  types, milestones, assignees, projects, sub-issues, dependencies, and issue
+  forms/templates.
+- GitHub's issue filtering documentation describes filtering and searching by
+  assignee, label, issue type, project fields, review state, and custom search
+  queries, including GitHub CLI examples.
+- GitHub's Issues overview describes metadata, community management with issue
+  forms/templates, saved replies, assignment, links to related issues, and when
+  conversations may fit GitHub Discussions better.
+- GitHub Projects filtering documentation gives a concrete triage-view example
+  for items without labels and assignees.
+- The public VS Code issue triage wiki shows a large open-source maintainer
+  queue model with milestone states, `help-wanted`, `good-first-issue`, and
+  `investigation-wanted` labels.
+
+## Duplicate Check
+
+Before drafting this entry, the current upstream content tree and PR history
+were checked for `community issue triage agent`, `issue triage`, `maintainer
+queue`, `GitHub issue`, `saved replies`, `issue forms`, label triage, milestone
+triage, and related source URLs. No existing `content/agents` entry or open PR
+covers a dedicated community issue triage agent.
+
+The existing `subagents-code-review-triage` guide mentions issue triage as one
+subagent pattern, but it is a guide for configuring subagents across review and
+triage workflows. This entry is distinct: it is a reusable `agents` prompt for
+GitHub issue queue cleanup with explicit metadata, response, escalation, safety,
+and privacy boundaries.
+
+## Editorial Disclosure
+
+Submitted as an independent community agent entry by `MkDev11`. This listing is
+based on GitHub's public Issues documentation and the public VS Code issue
+triage wiki, with no paid placement, referral link, or affiliate relationship.
+
+## Sources
+
+- GitHub Issues documentation: https://docs.github.com/en/issues/tracking-your-work-with-issues
+- GitHub Issues quickstart: https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/quickstart
+- Filtering and searching issues and pull requests: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests
+- About GitHub Issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/about-issues
+- GitHub Projects filtering: https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects
+- VS Code issue triage wiki: https://github.com/microsoft/vscode/wiki/Issues-Triaging


### PR DESCRIPTION
Closes #682

## Summary

Adds a single source-backed `agents` entry for a GitHub community issue triage agent:

- issue queue filtering and cleanup
- labels, issue types, assignees, milestones, projects, duplicate links, and discussion conversion checks
- maintainer-safe public reply drafts
- escalation boundaries for security, abuse, private data, and roadmap-sensitive reports
- safety/privacy notes for issue metadata, public comments, and write actions

## Source Checks

- GitHub Issues docs: https://docs.github.com/en/issues/tracking-your-work-with-issues
- GitHub Issues quickstart: https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/quickstart
- Filtering/search docs: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/filtering-and-searching-issues-and-pull-requests
- About GitHub Issues: https://docs.github.com/en/issues/tracking-your-work-with-issues/learning-about-issues/about-issues
- GitHub Projects filtering: https://docs.github.com/en/issues/planning-and-tracking-with-projects/customizing-views-in-your-project/filtering-projects
- VS Code issue triage wiki: https://github.com/microsoft/vscode/wiki/Issues-Triaging

## Duplicate / History Checks

- Searched current content for `issue triage`, `community triage`, `maintainer queue`, `GitHub issue`, `saved replies`, `issue forms`, and related source terms.
- Searched open and closed PRs for `github community issue triage` and `issue triage maintainer queue`.
- No existing `content/agents` entry or open PR covers a dedicated community issue triage agent.

There is an existing `subagents-code-review-triage` guide that mentions issue triage as one subagent pattern. This PR is distinct because it adds a reusable `agents` entry specifically for GitHub issue queue cleanup, with explicit metadata, response-drafting, escalation, safety, and privacy boundaries.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `node scripts/validate-content.mjs --category agents`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/agents-682-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref agents-682-issue-triage --pr-author MkDev11`
