### PR TITLE
fix(content): harden kibana lint command

### DIFF
--- a/content/agents/kibana-repository-contributor-agent.mdx
+++ b/content/agents/kibana-repository-contributor-agent.mdx
@@ -204,8 +204,8 @@ Kibana contribution process when official sources are available.
   is explicitly needed.
 - Do not target `.buildkite/` with `scripts/type_check`; typecheck Buildkite
   code from inside `.buildkite/` using its workspace command.
-- Fix lint in changed files with:
-  `node scripts/eslint --fix $(git diff --name-only)`
+- Fix lint in changed files with NUL-delimited paths and an option terminator:
+  `git diff --name-only -z --diff-filter=ACMR | xargs -0 node scripts/eslint --fix --`
 - Run i18n checks when user-facing strings change:
   `node scripts/i18n_check --fix`
 - Use the `bk` CLI when Buildkite interaction is required and credentials are


### PR DESCRIPTION
### Motivation
- Close an injected-argument risk in the Kibana contributor agent where `node scripts/eslint --fix $(git diff --name-only)` could allow option/argument injection from crafted file names by hardening the recommended command.

### Description
- Updated the guidance in `content/agents/kibana-repository-contributor-agent.mdx` to use a NUL-delimited pipeline and an explicit option terminator by replacing the unsafe command with `git diff --name-only -z --diff-filter=ACMR | xargs -0 node scripts/eslint --fix --`.

### Testing
- Ran `pnpm validate:content:strict` which passed.  
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a220813972c832cb23318f66be764cd)