### PR TITLE
content(agents): add MCP Integration Architect Agent

### DIFF
--- a/content/agents/mcp-integration-architect-agent.mdx
+++ b/content/agents/mcp-integration-architect-agent.mdx
@@ -1,0 +1,249 @@
+---
+title: MCP Integration Architect Agent
+slug: mcp-integration-architect-agent
+category: agents
+description: >-
+  Source-backed agent for deciding whether an integration belongs in MCP, which
+  protocol surface to expose, and how to review tools, resources, prompts,
+  roots, transports, authorization, safety, privacy, and rollout evidence.
+cardDescription: >-
+  Decide when MCP fits, then map capabilities to tools, resources, prompts,
+  roots, transports, auth boundaries, and rollout checks.
+seoTitle: MCP Integration Architect Agent
+seoDescription: >-
+  Reusable AI agent prompt for Model Context Protocol integration architecture:
+  tool/server fit decisions, capability inventory, protocol surface mapping,
+  transport choice, authorization, safety review, privacy, and rollout evidence.
+author: MkDev11
+authorProfileUrl: "https://github.com/MkDev11"
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-05"
+websiteUrl: "https://modelcontextprotocol.io/"
+documentationUrl: "https://modelcontextprotocol.io/specification/2025-06-18"
+repoUrl: "https://github.com/modelcontextprotocol/modelcontextprotocol"
+installable: false
+usageSnippet: "Use this agent before adding or approving an MCP integration when you need to decide whether the capability should be a tool, resource, prompt, root-bound server, remote server, ordinary API, or no MCP integration at all."
+prerequisites:
+  - >-
+    A concrete integration request, user workflow, target MCP client, expected
+    operator, trust boundary, data sources, side effects, and success criteria.
+  - >-
+    Candidate capability inventory covering possible tools, resources, prompts,
+    roots, transport mode, authorization model, credentials, downstream APIs,
+    logs, and rollback path.
+  - >-
+    Security and privacy constraints for files, repositories, SaaS accounts,
+    databases, production systems, customer data, secrets, and audit evidence.
+  - >-
+    Review owners who can approve mutating tools, credential scopes, deployment
+    model, logging policy, rollout phases, and rejection of unsafe MCP surfaces.
+safetyNotes:
+  - >-
+    Do not expose a capability through MCP simply because it can be automated.
+    Reject or delay integrations when the user benefit is vague, the side
+    effects are broad, the runtime cannot be isolated, or rollback is unclear.
+  - >-
+    Treat MCP tools as model-callable actions and MCP resources as data exposure
+    surfaces. Mutating tools, shell access, deployment actions, payments,
+    messaging, database writes, and production changes need explicit approval.
+  - >-
+    Transport and authorization choices change the risk model. Local stdio,
+    local HTTP, streamable HTTP, and remote protected servers should be reviewed
+    with different assumptions about network reach, credentials, and operators.
+  - >-
+    This agent produces architecture decisions and review checklists. It should
+    not silently enable servers, install packages, grant credentials, or approve
+    dangerous tools without a human owner.
+privacyNotes:
+  - >-
+    Tool arguments, resource contents, prompt templates, roots, credentials,
+    logs, traces, errors, downstream API responses, and approval notes can
+    expose private repositories, customer data, secrets, and operational state.
+  - >-
+    Keep capability inventories and review records free of raw tokens, full
+    customer records, private prompts, production incident data, and unpublished
+    source unless the storage and retention policy is approved.
+  - >-
+    Prefer synthetic fixtures, scoped test accounts, redacted logs, minimal
+    roots, and metadata-only summaries until the integration boundary is
+    reviewed and the operator understands where data flows.
+tags:
+  - mcp
+  - architecture
+  - integration-design
+  - tool-design
+  - least-privilege
+keywords:
+  - MCP integration architect agent
+  - Model Context Protocol fit decisions
+  - MCP tool server fit
+  - MCP capability inventory
+  - MCP transport authorization review
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+MCP Integration Architect Agent is a reusable agent prompt for deciding whether
+a requested integration belongs in the Model Context Protocol and, if it does,
+which MCP surface should carry the capability. It turns an integration idea into
+a source-backed fit decision, protocol-surface map, security and privacy review,
+and rollout contract.
+
+Use this agent before building, installing, or approving an MCP server when the
+team still needs to answer basic architecture questions: should this be a tool,
+resource, prompt, root-scoped local server, protected remote server, normal API
+integration, slash command, guide, or no AI-callable integration at all?
+
+## Agent Prompt
+
+You are an MCP integration architect agent. Use the requested workflow, target
+client, operator, trust boundary, capability inventory, data sources, side
+effects, transport options, authorization model, logs, rollout plan, and
+rollback path before recommending any MCP integration. Use official Model
+Context Protocol specification pages and official SDK repositories as the source
+anchors for protocol concepts.
+
+Mission:
+
+- Decide whether MCP is the right integration boundary for a concrete user or
+  operator workflow.
+- Map capabilities to MCP tools, resources, prompts, roots, transport choices,
+  authorization boundaries, server profiles, and review gates.
+- Prefer the smallest useful protocol surface over broad "utility" servers.
+- Give maintainers a clear approve, revise, defer, or reject decision with
+  verifiable evidence and operational safeguards.
+
+Review workflow:
+
+1. Define the workflow. Name the human operator, target MCP client, task
+   frequency, expected inputs, expected outputs, success criteria, and why AI
+   tool access is useful.
+2. Decide whether MCP fits. Compare MCP with a normal API client, CLI command,
+   repository script, static guide, slash command, hosted app, or no automation.
+   Reject MCP when model-callable access adds risk without a clear benefit.
+3. Inventory capabilities. List every proposed action, read surface, reusable
+   prompt, root, credential, downstream API, local file path, database, queue,
+   browser profile, log destination, and side effect.
+4. Choose the MCP surface. Map each capability to a tool, resource, prompt, or
+   root-backed context boundary. Split broad capabilities into smaller
+   read-only, preview, draft, and final mutation steps.
+5. Choose the server shape. Decide whether the integration should be a local
+   stdio server, local HTTP server, streamable HTTP service, protected remote
+   server, or multiple profiles for read-only and mutating work.
+6. Review authorization and credentials. Specify identity, token audience,
+   scopes, service accounts, tenant/project boundaries, credential rotation,
+   token storage, and denial paths.
+7. Review safety gates. Require explicit approval for writes, deletes, shell
+   execution, deployments, emails, messages, payments, database mutations,
+   production access, and other irreversible or externally visible actions.
+8. Review privacy and logs. Identify what prompts, arguments, outputs,
+   resources, traces, cache files, crash reports, and audit records may contain.
+   Define redaction, retention, and safe sharing rules.
+9. Plan implementation evidence. Require schemas, capability docs, denial
+   tests, happy-path tests, dry runs, synthetic fixtures, changelog notes, owner
+   signoff, and rollback steps before enabling the integration broadly.
+10. Produce the fit decision. Recommend approve, revise, defer, reject, or use a
+    non-MCP pattern. State the reason, required changes, and remaining risks.
+
+Output contract:
+
+- Fit decision: approve MCP, revise MCP design, defer, reject, or choose a
+  non-MCP integration pattern.
+- Capability map: tools, resources, prompts, roots, transports, credentials,
+  logs, side effects, approval gates, and owner.
+- Protocol design: tool schemas, resource URI boundaries, prompt templates,
+  server profile, transport, auth model, and denial behavior.
+- Safety and privacy review: mutating actions, data exposure, secret handling,
+  logs, traces, test fixtures, and rollback.
+- Rollout evidence: source links, implementation checklist, test plan,
+  monitoring, version/update policy, and review record.
+
+## Features
+
+- MCP fit decision matrix for when to use MCP, a normal API, CLI, command,
+  guide, hosted UI, or no integration.
+- Capability inventory for tools, resources, prompts, roots, transports,
+  credentials, logs, downstream APIs, side effects, and rollback.
+- Protocol surface mapping that separates read-only context, reusable prompts,
+  preview actions, draft actions, and final mutating tools.
+- Transport review for local stdio, local HTTP, streamable HTTP, and protected
+  remote server boundaries.
+- Authorization and credential review for token audience, scopes, tenants,
+  projects, service accounts, denial paths, and rotation.
+- Approval-gate checklist for shell execution, writes, deletes, deployments,
+  production systems, messaging, payments, database mutations, and other risky
+  side effects.
+- Implementation evidence checklist for schemas, denial tests, dry runs,
+  synthetic fixtures, logs, monitoring, rollback, and owner signoff.
+
+## Use Cases
+
+- Decide whether a SaaS integration should expose model-callable tools or stay
+  as a normal API integration.
+- Split a broad MCP server proposal into safe read-only resources, preview
+  tools, and separately approved mutating tools.
+- Review whether a local developer tool should run as stdio, local HTTP, or a
+  protected remote service.
+- Design a least-privilege credential and authorization plan before a server
+  touches private repositories, tickets, databases, or production systems.
+- Reject a proposed MCP integration when the request lacks owner signoff, safe
+  fixtures, rollback, or clear user value.
+- Prepare a maintainer review packet for adding an MCP server to a team client
+  profile without exposing unnecessary files, tokens, or logs.
+
+## Source Notes
+
+- The Model Context Protocol specification documents tools, resources, prompts,
+  roots, transports, and authorization as separate protocol concepts. Those
+  concepts are the basis for this agent's fit and surface-mapping workflow.
+- The official specification and documentation repository is
+  `modelcontextprotocol/modelcontextprotocol`, uses the `main` branch, and is
+  the source anchor for current protocol documentation.
+- The official TypeScript and Python SDK repositories provide implementation
+  context for building MCP servers and clients, but this entry is an
+  architecture-review agent rather than an SDK tutorial.
+
+## Duplicate Check
+
+Before drafting this entry, the current upstream content tree and PR history
+were checked for `MCP integration architect`, `tool/server fit`, `Model Context
+Protocol agent`, MCP tools, MCP resources, MCP prompts, roots, transports,
+authorization, least privilege, server threat modeling, and local tool access.
+
+Adjacent merged content includes `Claude MCP Skills Integration Agent`, which
+focuses on configuring and orchestrating MCP servers in Claude and Claude
+Desktop; `Threat Model MCP Servers Before Installation`, which focuses on
+pre-installation trust review; `Build MCP Servers with Auth and Least
+Privilege`, which focuses on authoring servers with scoped auth; and `MCP Local
+Tool Access Rules`, which is a rules policy for active local access.
+
+This entry is distinct because it is a single `agents` prompt for architecture
+fit decisions: whether MCP is appropriate at all, which protocol surface should
+carry each capability, when to choose a non-MCP pattern, and what evidence is
+needed before a tool/server design is approved.
+
+No existing content entry or open PR was found for an MCP integration architect
+agent focused on tool/server fit decisions.
+
+## Editorial Disclosure
+
+This is an independently written, source-backed agent prompt. It is not an
+official Model Context Protocol publication, paid listing, affiliate placement,
+or endorsement claim.
+
+## Sources
+
+- https://modelcontextprotocol.io/specification/2025-06-18
+- https://modelcontextprotocol.io/specification/2025-06-18/server/tools
+- https://modelcontextprotocol.io/specification/2025-06-18/server/resources
+- https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
+- https://modelcontextprotocol.io/specification/2025-06-18/client/roots
+- https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
+- https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+- https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
+- https://github.com/modelcontextprotocol/modelcontextprotocol
+- https://github.com/modelcontextprotocol/typescript-sdk
+- https://github.com/modelcontextprotocol/python-sdk


### PR DESCRIPTION
Closes #681

## Summary

Adds MCP Integration Architect Agent as a source-backed `agents` entry for deciding whether an integration belongs in MCP and, if it does, which protocol surface and review boundary should carry it:

- MCP fit decision versus API, CLI, command, guide, hosted UI, or no integration
- capability inventory for tools, resources, prompts, roots, credentials, logs, side effects, and rollback
- protocol surface mapping across tools, resources, prompts, roots, transports, and auth boundaries
- safety gates for mutating actions, production access, shell execution, messages, payments, and database changes
- privacy review for prompts, arguments, resource contents, traces, logs, secrets, and downstream responses
- rollout evidence contract with schemas, denial tests, dry runs, fixtures, monitoring, and owner signoff

## Sources verified

- https://modelcontextprotocol.io/specification/2025-06-18
- https://modelcontextprotocol.io/specification/2025-06-18/server/tools
- https://modelcontextprotocol.io/specification/2025-06-18/server/resources
- https://modelcontextprotocol.io/specification/2025-06-18/server/prompts
- https://modelcontextprotocol.io/specification/2025-06-18/client/roots
- https://modelcontextprotocol.io/specification/2025-06-18/basic/transports
- https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
- https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices
- https://github.com/modelcontextprotocol/modelcontextprotocol
- https://github.com/modelcontextprotocol/typescript-sdk
- https://github.com/modelcontextprotocol/python-sdk

Verification notes:

- Rendered MCP specification/docs URLs returned 200.
- `modelcontextprotocol/modelcontextprotocol` resolves on GitHub, default branch `main`, description "Specification and documentation for the Model Context Protocol".
- `modelcontextprotocol/typescript-sdk` and `modelcontextprotocol/python-sdk` resolve as official SDK repos.
- No license claim is made for repos where the GitHub API reports `NOASSERTION`.

## Duplicate and history check

Checked local content and PR history for:

- `MCP integration architect`
- `tool/server fit`
- `Model Context Protocol agent`
- MCP tools, resources, prompts, roots, transports, authorization, least privilege, server threat modeling, and local tool access

Adjacent merged content exists:

- `Claude MCP Skills Integration Agent`: configures and orchestrates MCP servers in Claude/Claude Desktop.
- `Threat Model MCP Servers Before Installation`: pre-installation trust review.
- `Build MCP Servers with Auth and Least Privilege`: authoring MCP servers with scoped auth.
- `MCP Local Tool Access Rules`: runtime rules policy for active local MCP access.

This PR is distinct because it adds a single `agents` prompt for architecture fit decisions: whether MCP is appropriate at all, which protocol surface should carry each capability, when to choose a non-MCP pattern, and what evidence is needed before approving a tool/server design.

No existing content entry or open PR was found for an MCP integration architect agent focused on tool/server fit decisions.

## Validation

- `git diff --cached --check`
- `node scripts/validate-content.mjs --category agents`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/agents-681-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref agents-681-mcp-integration-architect --pr-author MkDev11`
