### PR TITLE
content(agents): add Dependency Update Triage Agent

### DIFF
--- a/content/agents/dependency-update-triage-agent.mdx
+++ b/content/agents/dependency-update-triage-agent.mdx
@@ -1,0 +1,233 @@
+---
+title: Dependency Update Triage Agent
+slug: dependency-update-triage-agent
+category: agents
+description: >-
+  Source-backed agent for triaging dependency update pull requests with SemVer
+  risk, Dependabot context, GitHub dependency review, OSV advisories, OpenSSF
+  Scorecard signals, lockfile changes, test evidence, and privacy-safe notes.
+cardDescription: >-
+  Triage dependency update PRs with release evidence, lockfile review,
+  advisories, Scorecard signals, tests, and merge recommendations.
+seoTitle: Dependency Update Triage Agent
+seoDescription: >-
+  Reusable AI agent prompt for dependency update pull request triage using
+  SemVer, Dependabot context, GitHub dependency review, OSV advisories, OpenSSF
+  Scorecard, lockfile review, supply-chain checks, and privacy-safe evidence.
+author: MkDev11
+authorProfileUrl: "https://github.com/MkDev11"
+submittedBy: MkDev11
+submittedByUrl: "https://github.com/MkDev11"
+dateAdded: "2026-06-05"
+documentationUrl: "https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependency-review"
+installable: false
+usageSnippet: "Use this agent when a dependency update PR, bot batch, lockfile diff, or security update needs source-backed triage before approve, split, rerun, defer, or block."
+prerequisites:
+  - >-
+    Dependency update pull request, manifest diff, lockfile diff, package
+    manager, workspace path, current CI results, and the bot or maintainer
+    reason for the update.
+  - >-
+    Direct dependency names and versions, release notes or changelogs,
+    migration notes, advisory links, GitHub dependency review output, and test
+    commands that cover affected code paths.
+  - >-
+    Project policy for supported runtimes, registries, package managers,
+    licenses, security updates, grouped updates, automerge, and rollback.
+  - >-
+    Permission to keep private package names, internal registries, private repo
+    URLs, full lockfiles, and advisory details out of public lookups or public
+    PR comments unless explicitly approved.
+safetyNotes:
+  - >-
+    Dependency updates can change runtime code, install scripts, build plugins,
+    native binaries, package-manager behavior, transitive trees, generated
+    clients, CI actions, and deployment artifacts.
+  - >-
+    Do not approve broad grouped updates, major upgrades, new registries, git
+    dependencies, postinstall scripts, or package-manager changes without owner
+    review, targeted tests, and a rollback path.
+  - >-
+    Security updates should move quickly, but the agent must still separate the
+    minimal fixed version from unrelated modernization work and document
+    compatibility evidence.
+  - >-
+    Treat external API lookups as read-only advisory checks. This agent should
+    not modify manifests, regenerate lockfiles, run install scripts, or enable
+    automerge unless a human owner explicitly approves the action.
+privacyNotes:
+  - >-
+    Dependency names, versions, lockfile entries, private registry hosts,
+    scoped package names, source repository URLs, advisory matches, and CI
+    failure logs can reveal proprietary architecture or unreleased work.
+  - >-
+    Do not send private package identifiers, private repository URLs, internal
+    registry hosts, or full private lockfiles to public OSV, Scorecard, package
+    registries, or PR comments without explicit approval.
+  - >-
+    Summarize private dependency risk with redacted package names, internal
+    channels, or metadata-only language when the PR is public.
+tags:
+  - dependencies
+  - supply-chain
+  - dependabot
+  - osv
+  - openssf-scorecard
+keywords:
+  - dependency update triage agent
+  - supply chain dependency PR review
+  - Dependabot triage agent
+  - OSV advisory dependency update
+  - OpenSSF Scorecard dependency review
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+Dependency Update Triage Agent is a reusable agent prompt for reviewing
+dependency update pull requests before they merge. It turns a bot update,
+security patch, lockfile churn, grouped update, or manual version bump into a
+source-backed triage packet with update classification, advisory context,
+package-health checks, compatibility evidence, privacy boundaries, and a clear
+merge recommendation.
+
+Use this agent when a dependency PR needs more judgment than "tests passed" or
+"the bot opened it." The agent helps maintainers decide whether to approve,
+split, rerun, defer, pin, replace, or block an update.
+
+## Agent Prompt
+
+You are a dependency update triage agent. Use the dependency update PR, manifest
+diff, lockfile diff, package manager, workspace, bot reason, advisory context,
+release notes, dependency review output, OSV results, OpenSSF Scorecard
+signals, CI evidence, runtime impact, privacy boundary, and rollback plan before
+recommending approval.
+
+Mission:
+
+- Classify dependency updates by urgency, compatibility risk, supply-chain
+  risk, lockfile impact, and evidence quality.
+- Keep security fixes focused while separating unrelated modernization,
+  grouping, and package-manager churn.
+- Protect private dependency metadata before using public advisory or
+  package-health services.
+- Give maintainers a concise approve, split, rerun, defer, pin, replace, or
+  block recommendation with source-backed reasoning.
+
+Review workflow:
+
+1. Identify the update. List changed manifests, lockfiles, package managers,
+   workspaces, direct dependencies, transitive churn, current version, target
+   version, and whether the PR came from Dependabot, another bot, or a human.
+2. Classify the update. Mark security fix, patch, minor, major, build-tool,
+   runtime dependency, dev dependency, new dependency, registry/source change,
+   grouped batch, transitive-only churn, or package-manager change.
+3. Read source evidence. Link release notes, changelogs, migration guides,
+   advisories, Dependabot alert context, GitHub dependency review output, OSV
+   records, SemVer expectations, and package-health signals.
+4. Review lockfiles. Confirm manifest and lockfile changes match the expected
+   package manager, workspace, registry, integrity hashes, generated artifacts,
+   and transitive dependency movement.
+5. Check supply-chain posture. Use public OpenSSF Scorecard signals only for
+   public dependency repositories or approved metadata. Note maintenance,
+   branch protection, releases, pinned dependencies, token-permissions,
+   packaging, and dangerous workflow signals when available.
+6. Check advisory impact. Use OSV, GitHub dependency review, or project-approved
+   advisory data to confirm affected ranges, fixed ranges, severity, exploit
+   notes, and whether the selected version actually resolves the issue.
+7. Review compatibility evidence. Map the update to imports, generated clients,
+   server startup, browser bundles, plugins, migrations, CLIs, tests, deploy
+   artifacts, and smoke checks that should run before merge.
+8. Protect private metadata. Do not disclose private package names, private
+   registry hosts, internal repository URLs, full lockfiles, or vulnerability
+   details in public comments or public APIs without approval.
+9. Decide the action. Recommend approve, split, rerun CI, request release-note
+   evidence, pin, replace, defer, block, or escalate to package owner/security
+   owner/release owner.
+
+Output contract:
+
+- Update inventory: files changed, package manager, direct updates, transitive
+  churn, update class, bot/human source, and affected workspace.
+- Evidence table: release notes, advisories, dependency review, OSV, Scorecard,
+  SemVer expectations, CI, targeted tests, and missing evidence.
+- Risk assessment: compatibility, supply chain, install-time execution,
+  lockfile integrity, build/deploy impact, privacy exposure, and rollback.
+- Recommendation: approve, split, rerun, defer, pin, replace, block, or
+  escalate, with the minimum follow-up needed.
+
+## Features
+
+- Dependency update classification for security, patch, minor, major, build
+  tooling, runtime, dev-only, new dependency, registry, grouped, and
+  transitive-only changes.
+- Lockfile review checklist for workspace scope, integrity movement, generated
+  artifacts, registry changes, and package-manager consistency.
+- Supply-chain checks that combine GitHub dependency review, OSV advisories,
+  OpenSSF Scorecard health signals, SemVer expectations, and release evidence.
+- Privacy guardrails for private packages, scoped names, internal registries,
+  private repository URLs, full lockfiles, and advisory details.
+- Decision templates for approve, split, rerun, defer, pin, replace, block, or
+  escalate to security, package, or release owners.
+
+## Use Cases
+
+- Triage a Dependabot security update and confirm the selected version is in
+  the fixed range without bundling unrelated upgrades.
+- Review a grouped dependency PR and decide which packages should be split for
+  safer testing and rollback.
+- Explain why a passing lockfile-only PR still needs release notes, dependency
+  review output, or targeted smoke tests.
+- Evaluate a new direct dependency for source, maintenance, install scripts,
+  registry provenance, and package-health signals.
+- Keep public PR comments useful while redacting private package metadata and
+  internal advisory details.
+- Decide whether a major framework, bundler, package manager, or CI action
+  update needs release-owner review before merge.
+
+## Source Notes
+
+- GitHub dependency review is the source anchor for reviewing dependency changes
+  in pull requests and surfacing vulnerable dependencies before merge.
+- GitHub Dependabot documentation provides the bot-update and security-update
+  context used to distinguish routine version updates from advisory-driven
+  updates.
+- OSV documentation is the source anchor for advisory range checks.
+- OpenSSF Scorecard is used as an optional public package-health signal for
+  public dependency repositories; it is not a complete safety verdict.
+- SemVer is used as an expectation-setting signal, not proof of compatibility.
+
+## Duplicate Check
+
+Before drafting this entry, the current upstream content tree and PR history
+were checked for dependency update triage agents, Dependabot agents, Renovate
+agents, OSV agents, OpenSSF Scorecard agents, dependency review agents,
+dependency update rules, supply-chain dependency review, lockfile review,
+dependency risk commands, dependency hooks, and Renovate capability packs.
+
+Adjacent merged content exists for `Dependency Update Review Rules`, the
+`/dependency-risk-review` command, dependency update/security hooks, and a
+Renovate-specific skill. This entry is distinct because it is a single
+`agents` prompt for human-in-the-loop triage of dependency update PRs across
+bot and human workflows: it produces an update inventory, evidence table, risk
+assessment, privacy boundary, and merge recommendation rather than a reusable
+rules policy, a slash command, a hook, or a Renovate-only capability pack.
+
+No existing `agents` entry or open PR was found for a dependency update triage
+agent focused on supply-chain-aware PR decisions.
+
+## Editorial Disclosure
+
+This is an independently written, source-backed agent prompt. It is not an
+official GitHub, OSV, OpenSSF, SemVer, paid listing, affiliate placement, or
+endorsement claim.
+
+## Sources
+
+- https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependency-review
+- https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates
+- https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-security-updates
+- https://google.github.io/osv.dev/
+- https://securityscorecards.dev/
+- https://semver.org/


### PR DESCRIPTION
Closes #677

## Summary

Adds Dependency Update Triage Agent as a source-backed `agents` entry for dependency update PR review:

- update inventory for manifests, lockfiles, direct updates, transitive churn, package manager, and bot/human source
- update classification for security, patch, minor, major, runtime, dev-only, grouped, transitive-only, registry, and package-manager changes
- supply-chain checks using GitHub dependency review, Dependabot context, OSV advisories, OpenSSF Scorecard signals, SemVer expectations, release notes, and CI evidence
- privacy guardrails for private packages, internal registries, private repo URLs, advisory details, and full lockfiles
- merge recommendation contract: approve, split, rerun, defer, pin, replace, block, or escalate

## Sources verified

- https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependency-review
- https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates
- https://docs.github.com/en/code-security/concepts/supply-chain-security/about-dependabot-security-updates
- https://google.github.io/osv.dev/
- https://securityscorecards.dev/
- https://semver.org/

Verification notes:

- All cited source URLs returned 200.
- Redirecting GitHub Dependabot URLs were avoided in favor of canonical docs paths already used by accepted content.
- No package version or latest-release claim is made.

## Duplicate and history check

Checked local content and PR history for:

- dependency update triage agents
- Dependabot agents
- Renovate agents
- OSV agents
- OpenSSF Scorecard agents
- dependency review agents
- dependency update rules
- supply-chain dependency review
- lockfile review
- dependency risk commands
- dependency hooks
- Renovate capability packs

Adjacent merged content exists for `Dependency Update Review Rules`, `/dependency-risk-review`, dependency update/security hooks, and a Renovate-specific skill. This PR is distinct because it adds a single `agents` prompt for human-in-the-loop triage of dependency update PRs across bot and human workflows: update inventory, evidence table, risk assessment, privacy boundary, and merge recommendation. It is not a rules policy, slash command, hook, or Renovate-only capability pack.

No existing `agents` entry or open PR was found for a dependency update triage agent focused on supply-chain-aware PR decisions.

## Validation

- `git diff --cached --check`
- `node scripts/validate-content.mjs --category agents`
- `node scripts/ci/validate-content-policy.mjs --files-json /tmp/agents-677-files.json --head-repo MkDev11/awesome-claude --base-repo JSONbored/awesome-claude --head-ref agents-677-dependency-triage --pr-author MkDev11`
