### PR TITLE
feat(submissions): add V2 maintainer gate review cards

### DIFF
--- a/apps/submission-gate/migrations/0011_submission_gate_report_metadata.sql
+++ b/apps/submission-gate/migrations/0011_submission_gate_report_metadata.sql
@@ -1,0 +1,23 @@
+ALTER TABLE submission_prs
+  ADD COLUMN comment_id INTEGER;
+
+ALTER TABLE submission_prs
+  ADD COLUMN comment_url TEXT;
+
+ALTER TABLE submission_prs
+  ADD COLUMN review_id INTEGER;
+
+ALTER TABLE submission_prs
+  ADD COLUMN schema_version INTEGER;
+
+ALTER TABLE submission_prs
+  ADD COLUMN formatter_version INTEGER;
+
+ALTER TABLE submission_prs
+  ADD COLUMN decision_id TEXT;
+
+ALTER TABLE submission_prs
+  ADD COLUMN confidence REAL;
+
+ALTER TABLE submission_prs
+  ADD COLUMN source_evidence_hash TEXT;

--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -1,4 +1,5 @@
 import { base64UrlEncode } from "./security";
+import { supersededReviewComment } from "./review";
 
 const encoder = new TextEncoder();
 const PKCS8_PEM_HEADER = ["-----BEGIN", "PRIVATE", "KEY-----"].join(" ");
@@ -783,9 +784,21 @@ export async function upsertMarkerComment(params: {
   body: string;
   apiVersion?: string;
 }) {
-  const comments: Array<{ id: number; body?: string }> = [];
+  const comments: Array<{
+    id: number;
+    body?: string;
+    html_url?: string;
+    user?: { login?: string; type?: string };
+  }> = [];
   for (let page = 1; page <= 20; page += 1) {
-    const pageComments = await githubJson<Array<{ id: number; body?: string }>>(
+    const pageComments = await githubJson<
+      Array<{
+        id: number;
+        body?: string;
+        html_url?: string;
+        user?: { login?: string; type?: string };
+      }>
+    >(
       `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/issues/${params.issueNumber}/comments?per_page=100&page=${page}`,
       {
         token: params.token,
@@ -795,19 +808,52 @@ export async function upsertMarkerComment(params: {
     comments.push(...pageComments);
     if (pageComments.length < 100) break;
   }
-  const existing = comments.find((comment) =>
+  const markerComments = comments.filter((comment) =>
     comment.body?.includes(params.marker),
   );
+  const botMarkerComments = markerComments.filter(
+    (comment) => comment.user?.type === "Bot",
+  );
+  const existing = botMarkerComments.at(-1);
   const endpoint = existing
     ? `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/issues/comments/${existing.id}`
     : `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/issues/${params.issueNumber}/comments`;
-  await githubJson(endpoint, {
+  const canonical = await githubJson<{
+    id: number;
+    html_url?: string;
+    user?: { login?: string; type?: string };
+  }>(endpoint, {
     method: existing ? "PATCH" : "POST",
     token: params.token,
     apiVersion: params.apiVersion,
     headers: { "content-type": "application/json" },
     body: JSON.stringify({ body: params.body }),
   });
+  const supersededIds: number[] = [];
+  for (const comment of botMarkerComments) {
+    if (comment.id === canonical.id) continue;
+    await githubJson(
+      `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/issues/comments/${comment.id}`,
+      {
+        method: "PATCH",
+        token: params.token,
+        apiVersion: params.apiVersion,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          body: supersededReviewComment(
+            params.marker,
+            canonical.html_url || existing?.html_url,
+          ),
+        }),
+      },
+    );
+    supersededIds.push(comment.id);
+  }
+  return {
+    id: canonical.id,
+    url: canonical.html_url || existing?.html_url || "",
+    supersededIds,
+  };
 }
 
 export async function closeIssueOrPullRequest(params: {
@@ -835,7 +881,7 @@ export async function approvePullRequest(params: {
   body: string;
   apiVersion?: string;
 }) {
-  await githubJson(
+  return githubJson<{ id?: number; html_url?: string }>(
     `https://api.github.com/repos/${params.repo.owner}/${params.repo.repo}/pulls/${params.number}/reviews`,
     {
       method: "POST",

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -43,8 +43,14 @@ import {
   upsertMarkerComment,
 } from "./github";
 import {
+  approvalReviewBody,
   defaultManualDecision,
+  GATE_COMMENT_FORMATTER_VERSION,
+  isRetryableGateDecision,
   markerComment,
+  normalizePrivateGateDecisionPayload,
+  privateReviewErrorDecision,
+  retryingReviewComment,
   type GateDecision,
   type GateVerdict,
 } from "./review";
@@ -137,13 +143,6 @@ class SubmissionMergePendingError extends Error {
   }
 }
 
-const GATE_VERDICTS = new Set<GateVerdict>([
-  "merge",
-  "request_changes",
-  "close",
-  "manual",
-  "ignore",
-]);
 const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
 const TERMINAL_PR_STATUSES = new Set(["merged", "closed", "manual", "ignored"]);
 const VALIDATION_REQUEUE_SECONDS = 90;
@@ -355,6 +354,77 @@ function decisionStatus(verdict: GateVerdict) {
   return "closed";
 }
 
+function gateCheckStatus(status: string) {
+  const normalized = status.toLowerCase();
+  if (
+    ["passed", "pending", "failed", "neutral", "skipped", "unknown"].includes(
+      normalized,
+    )
+  ) {
+    return normalized as NonNullable<GateDecision["checks"]>[number]["status"];
+  }
+  return "unknown" as const;
+}
+
+function checksForDecision(
+  validation:
+    | {
+        checks?: Array<{ name: string; status: string; details?: string }>;
+      }
+    | null
+    | undefined,
+) {
+  return (validation?.checks || []).map((check) => ({
+    name: check.name,
+    status: gateCheckStatus(check.status),
+    details: check.details,
+  }));
+}
+
+function decisionWithReviewContext(
+  decision: GateDecision,
+  params: {
+    scope?: DirectContentScope | null;
+    validation?: {
+      checks?: Array<{ name: string; status: string; details?: string }>;
+    } | null;
+  } = {},
+): GateDecision {
+  return {
+    ...decision,
+    scope:
+      decision.scope ||
+      (params.scope
+        ? {
+            filePath: params.scope.filePath,
+            category: params.scope.category,
+            slug: params.scope.slug,
+            status: params.scope.status,
+          }
+        : undefined),
+    checks: decision.checks?.length
+      ? decision.checks
+      : checksForDecision(params.validation),
+  };
+}
+
+function decisionMetadata(
+  decision: GateDecision,
+  comment?: { id?: number; url?: string },
+  review?: { id?: number },
+) {
+  return {
+    commentId: comment?.id ?? null,
+    commentUrl: comment?.url || null,
+    reviewId: review?.id ?? null,
+    schemaVersion: decision.schemaVersion ?? 1,
+    formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
+    decisionId: decision.decisionId || crypto.randomUUID(),
+    confidence: decision.confidence ?? null,
+    sourceEvidenceHash: decision.sourceEvidenceHash ?? null,
+  };
+}
+
 function nextReviewForStatus(status: string) {
   if (status === "validation_pending") {
     return isoAfter(VALIDATION_REQUEUE_SECONDS);
@@ -401,29 +471,6 @@ function normalizeOneShotDecision(decision: GateDecision): GateDecision {
       "- Please resubmit a new focused one-file content PR after fixing the issue.",
     ].join("\n"),
   };
-}
-
-function isRetryablePrivateReviewerDecision(decision: GateDecision) {
-  if (decision.verdict !== "manual") return false;
-  const summary = decision.summary.toLowerCase();
-  return (
-    summary.includes("could not determine the github app installation") ||
-    summary.includes("ai maintainer review returned an unexpected payload") ||
-    summary.includes("private corpus review request failed") ||
-    summary.includes("private corpus review returned") ||
-    summary.includes("private corpus review returned an unexpected payload")
-  );
-}
-
-function retryingReviewComment(marker = DEFAULT_REVIEW_MARKER) {
-  return [
-    marker,
-    "Review retrying",
-    "",
-    "The public validation lane is green, but the private reviewer returned a retryable infrastructure result. The submission gate will retry automatically.",
-    "",
-    "No contributor action is needed yet.",
-  ].join("\n");
 }
 
 function allowedCorsOrigins(env: Env) {
@@ -1527,6 +1574,7 @@ function validationGateDecision(validation: {
       ].join("\n"),
       labels: [LABELS.close],
       close: true,
+      checks: checksForDecision(validation),
     };
   }
   return {
@@ -1544,6 +1592,7 @@ function validationGateDecision(validation: {
     ].join("\n"),
     labels: [LABELS.close],
     close: true,
+    checks: checksForDecision(validation),
   };
 }
 
@@ -1753,13 +1802,17 @@ async function applyTerminalGateDecision(params: {
       apiVersion: params.env.GITHUB_API_VERSION,
     });
   }
-  await upsertMarkerComment({
+  const displayDecision = decisionWithReviewContext(params.decision, {
+    scope: params.scope,
+    validation: params.validation,
+  });
+  const reportComment = await upsertMarkerComment({
     token: params.token,
     repo: params.repo,
     issueNumber: params.target.number,
     marker: params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
     body: markerComment(
-      params.decision,
+      displayDecision,
       params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
     ),
     apiVersion: params.env.GITHUB_API_VERSION,
@@ -1794,10 +1847,11 @@ async function applyTerminalGateDecision(params: {
     baseRef: params.target.baseRef || contentGateBaseRef(params.env),
     installationId: params.target.installationId,
     status: params.status,
-    verdict: params.decision.verdict,
-    verdictSummary: params.decision.summary,
+    verdict: displayDecision.verdict,
+    verdictSummary: displayDecision.summary,
     nextReviewAt: null,
     terminalAt: TERMINAL_PR_STATUSES.has(params.status) ? nowIso() : null,
+    ...decisionMetadata(displayDecision, reportComment),
   });
 }
 
@@ -1808,6 +1862,7 @@ async function mergeAcceptedPullRequest(params: {
   target: ReviewTarget;
   decision: GateDecision;
   scope: DirectContentScope;
+  reportCommentUrl?: string;
 }) {
   const expectedHeadSha = params.target.headSha || "";
   if (!expectedHeadSha) {
@@ -1821,18 +1876,11 @@ async function mergeAcceptedPullRequest(params: {
     expectedScope: params.scope,
     expectedHeadSha,
   });
-  const reviewBody = [
-    "Automated review by HeyClaude Maintainer Agent.",
-    "",
-    "This content-only PR passed content validation, Superagent, duplicate/history review, source/provenance review, category-fit review, and safety/privacy review.",
-    "",
-    "The agent is approving and merging this PR directly. Generated artifacts are produced during build/deploy and are not committed by contributors.",
-  ].join("\n");
-  await approvePullRequest({
+  const review = await approvePullRequest({
     token: params.token,
     repo: params.repo,
     number: params.target.number,
-    body: reviewBody,
+    body: approvalReviewBody(params.reportCommentUrl),
     apiVersion: params.env.GITHUB_API_VERSION,
   });
   const result = await mergePullRequest({
@@ -1853,7 +1901,7 @@ async function mergeAcceptedPullRequest(params: {
   if (result.merged === false) {
     throw new Error(result.message || "GitHub did not merge the pull request.");
   }
-  return result;
+  return { ...result, reviewId: review.id, reviewUrl: review.html_url };
 }
 
 async function fetchRawPullRequestFileContent(rawUrl: unknown) {
@@ -2523,29 +2571,32 @@ async function reviewWithPrivateGate(env: Env, message: QueueMessage) {
       signal: AbortSignal.timeout(PRIVATE_REVIEW_TIMEOUT_MS),
     });
   } catch {
-    return defaultManualDecision("Private corpus review request failed.");
+    return privateReviewErrorDecision(
+      "Private corpus review request failed.",
+      "private_reviewer_unavailable",
+    );
   }
   if (!response.ok) {
-    return defaultManualDecision(
+    return privateReviewErrorDecision(
       `Private corpus review returned ${response.status}.`,
+      "private_reviewer_unavailable",
     );
   }
-  const raw = (await response
-    .json()
-    .catch(() => null)) as Partial<GateDecision> | null;
-  if (!raw || !GATE_VERDICTS.has(raw.verdict as GateVerdict)) {
-    return defaultManualDecision(
-      "Private corpus review returned an unexpected payload.",
+  const raw = await response.json().catch(() => null);
+  const normalized = normalizePrivateGateDecisionPayload(raw);
+  if (normalized.error || !normalized.decision) {
+    const error = normalized.error || {
+      code: "invalid_private_response",
+      retryable: true,
+      message: "Private corpus review returned an unexpected payload.",
+    };
+    return privateReviewErrorDecision(
+      error.message || "Private corpus review returned an unexpected payload.",
+      error.code,
+      error.retryable !== false,
     );
   }
-  return {
-    verdict: raw.verdict as GateVerdict,
-    summary: typeof raw.summary === "string" ? raw.summary : "",
-    labels: Array.isArray(raw.labels)
-      ? raw.labels.filter((label): label is string => typeof label === "string")
-      : [],
-    close: raw.close === true,
-  };
+  return normalized.decision;
 }
 
 async function withSubmissionLock(
@@ -2943,7 +2994,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             nextReviewAt: nextReviewForStatus("validation_pending"),
             lastCheckSummary: validation.summary,
           });
-          await upsertMarkerComment({
+          const pendingComment = await upsertMarkerComment({
             token,
             repo,
             issueNumber: target.number,
@@ -2953,6 +3004,22 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
             ),
             apiVersion: env.GITHUB_API_VERSION,
+          });
+          await upsertPrState(env.SUBMISSION_GATE_DB, {
+            repo: target.repoFullName,
+            number: target.number,
+            headRepo: target.headRepo,
+            headRef: target.headRef,
+            headSha: target.headSha,
+            baseRef: target.baseRef || contentGateBaseRef(env),
+            installationId: target.installationId,
+            status: "validation_pending",
+            deliveryId: String(message.payload.deliveryId || ""),
+            nextReviewAt: nextReviewForStatus("validation_pending"),
+            lastCheckSummary: validation.summary,
+            commentId: pendingComment.id,
+            commentUrl: pendingComment.url,
+            formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
           });
           await insertAudit(env.SUBMISSION_GATE_DB, {
             id: crypto.randomUUID(),
@@ -3088,7 +3155,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             },
           },
         });
-        if (isRetryablePrivateReviewerDecision(decision)) {
+        if (isRetryableGateDecision(decision)) {
           await upsertPrState(env.SUBMISSION_GATE_DB, {
             repo: target.repoFullName,
             number: target.number,
@@ -3104,7 +3171,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             clearVerdict: true,
             clearTerminal: true,
           });
-          await upsertMarkerComment({
+          const retryComment = await upsertMarkerComment({
             token,
             repo,
             issueNumber: target.number,
@@ -3113,6 +3180,24 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
             ),
             apiVersion: env.GITHUB_API_VERSION,
+          });
+          await upsertPrState(env.SUBMISSION_GATE_DB, {
+            repo: target.repoFullName,
+            number: target.number,
+            headRepo: target.headRepo,
+            headRef: target.headRef,
+            headSha: target.headSha,
+            baseRef: target.baseRef || contentGateBaseRef(env),
+            installationId: target.installationId,
+            status: "error_retryable",
+            nextReviewAt: nextReviewForStatus("error_retryable"),
+            commentId: retryComment.id,
+            commentUrl: retryComment.url,
+            schemaVersion: decision.schemaVersion ?? 1,
+            formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
+            decisionId: decision.decisionId || crypto.randomUUID(),
+            confidence: decision.confidence ?? null,
+            sourceEvidenceHash: decision.sourceEvidenceHash ?? null,
           });
           await insertAudit(env.SUBMISSION_GATE_DB, {
             id: crypto.randomUUID(),
@@ -3178,6 +3263,13 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       }
       if (decision.verdict === "merge" && contentScopeForPrivateReview) {
         let mergeResult: Awaited<ReturnType<typeof mergeAcceptedPullRequest>>;
+        const acceptedDecision = decisionWithReviewContext(decision, {
+          scope: contentScopeForPrivateReview,
+          validation: validationForNotification,
+        });
+        let acceptedReport:
+          | Awaited<ReturnType<typeof upsertMarkerComment>>
+          | undefined;
         try {
           const latestPull = await getPullRequest({
             token,
@@ -3197,13 +3289,25 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           ) {
             return;
           }
+          acceptedReport = await upsertMarkerComment({
+            token,
+            repo,
+            issueNumber: target.number,
+            marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+            body: markerComment(
+              acceptedDecision,
+              env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+            ),
+            apiVersion: env.GITHUB_API_VERSION,
+          });
           mergeResult = await mergeAcceptedPullRequest({
             env,
             token,
             repo,
             target,
-            decision,
+            decision: acceptedDecision,
             scope: contentScopeForPrivateReview,
+            reportCommentUrl: acceptedReport.url,
           });
         } catch (error) {
           if (isRetryableMergeError(error)) {
@@ -3229,6 +3333,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               verdictSummary: pendingSummary,
               nextReviewAt: nextReviewForStatus("merge_pending"),
               lastError: error instanceof Error ? error.message : "unknown",
+              ...decisionMetadata(acceptedDecision, acceptedReport),
             });
             await insertAudit(env.SUBMISSION_GATE_DB, {
               id: crypto.randomUUID(),
@@ -3270,13 +3375,13 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           return;
         }
         const mergedSummary = [
-          decision.summary.trim(),
+          acceptedDecision.summary.trim(),
           "",
           "Merge Result:",
           `- Merged this PR directly at \`${mergeResult.sha || target.headSha || "unknown"}\`.`,
         ].join("\n");
         const mergedDecision: GateDecision = {
-          ...decision,
+          ...acceptedDecision,
           summary: mergedSummary,
           labels: [LABELS.merged, ...categoryLabels],
         };
@@ -3297,7 +3402,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           labels: [LABELS.merged, ...categoryLabels],
           apiVersion: env.GITHUB_API_VERSION,
         });
-        await upsertMarkerComment({
+        const mergedReport = await upsertMarkerComment({
           token,
           repo,
           issueNumber: target.number,
@@ -3337,6 +3442,9 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           verdictSummary: mergedSummary,
           nextReviewAt: null,
           terminalAt: nowIso(),
+          ...decisionMetadata(mergedDecision, mergedReport || acceptedReport, {
+            id: mergeResult.reviewId,
+          }),
         });
         return;
       }
@@ -3555,10 +3663,48 @@ async function queueStatusRoute(request: Request, env: Env) {
      GROUP BY status
      ORDER BY status ASC`,
   ).all<Record<string, unknown>>();
+  const retryReasons = await env.SUBMISSION_GATE_DB.prepare(
+    `SELECT COALESCE(last_error, 'unknown') AS reason, COUNT(*) AS count,
+        MIN(updated_at) AS oldestAt, MAX(updated_at) AS newestAt
+     FROM submission_prs
+     WHERE status = 'error_retryable'
+     GROUP BY COALESCE(last_error, 'unknown')
+     ORDER BY count DESC, oldestAt ASC
+     LIMIT 20`,
+  ).all<Record<string, unknown>>();
+  const staleStates = await env.SUBMISSION_GATE_DB.prepare(
+    `SELECT status, COUNT(*) AS count, MIN(updated_at) AS oldestAt
+     FROM submission_prs
+     WHERE terminal_at IS NULL
+       AND status IN ('queued', 'validation_pending', 'reviewing', 'merge_pending', 'error_retryable')
+       AND updated_at <= ?
+     GROUP BY status
+     ORDER BY oldestAt ASC`,
+  )
+    .bind(isoBefore(REVIEWING_STALE_SECONDS))
+    .all<Record<string, unknown>>();
+  const recentTerminal = await env.SUBMISSION_GATE_DB.prepare(
+    `SELECT status, verdict, COUNT(*) AS count, MAX(terminal_at) AS newestAt
+     FROM submission_prs
+     WHERE terminal_at IS NOT NULL
+       AND terminal_at >= ?
+     GROUP BY status, verdict
+     ORDER BY newestAt DESC`,
+  )
+    .bind(isoBefore(24 * 60 * 60))
+    .all<Record<string, unknown>>();
   const recent = await listRecentPrStates(env.SUBMISSION_GATE_DB, { limit });
   return json({
     ok: true,
     counts: counts.results || [],
+    retryReasons: retryReasons.results || [],
+    staleStates: staleStates.results || [],
+    recentTerminal: recentTerminal.results || [],
+    deadLetterQueue: {
+      available: false,
+      reason:
+        "Cloudflare Queue DLQ depth is not exposed through the Worker queue binding; use Cloudflare metrics for exact DLQ depth.",
+    },
     recent: (recent.results || []).map((row) => ({
       repo: row.repo,
       number: row.number,
@@ -3572,6 +3718,14 @@ async function queueStatusRoute(request: Request, env: Env) {
       attemptCount: row.attemptCount,
       lastError: truncateForQueue(row.lastError, 240),
       lastCheckSummary: truncateForQueue(row.lastCheckSummary, 240),
+      commentId: row.commentId,
+      commentUrl: row.commentUrl,
+      reviewId: row.reviewId,
+      schemaVersion: row.schemaVersion,
+      formatterVersion: row.formatterVersion,
+      decisionId: row.decisionId,
+      confidence: row.confidence,
+      sourceEvidenceHash: row.sourceEvidenceHash,
       terminalAt: row.terminalAt,
       updatedAt: row.updatedAt,
     })),

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -1,5 +1,8 @@
 import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 
+export const GATE_DECISION_SCHEMA_VERSION = 2;
+export const GATE_COMMENT_FORMATTER_VERSION = 2;
+
 export type GateVerdict =
   | "merge"
   | "request_changes"
@@ -7,33 +10,571 @@ export type GateVerdict =
   | "manual"
   | "ignore";
 
+export type GateDecisionV2Verdict = Exclude<GateVerdict, "request_changes">;
+
+export type GateDecisionSectionStatus = "pass" | "warn" | "fail" | "info";
+
+export type GateDecisionSection = {
+  id: string;
+  title?: string;
+  status?: GateDecisionSectionStatus;
+  bullets: string[];
+};
+
+export type GateDecisionCheck = {
+  name: string;
+  status: "passed" | "pending" | "failed" | "neutral" | "skipped" | "unknown";
+  details?: string;
+};
+
+export type GateDecisionScope = {
+  filePath?: string;
+  category?: string;
+  slug?: string;
+  status?: string;
+};
+
+export type GateDecisionError = {
+  code: string;
+  retryable?: boolean;
+  message?: string;
+};
+
 export type GateDecision = {
   verdict: GateVerdict;
   summary: string;
   labels: string[];
   close?: boolean;
+  schemaVersion?: typeof GATE_DECISION_SCHEMA_VERSION;
+  confidence?: number;
+  scope?: GateDecisionScope;
+  checks?: GateDecisionCheck[];
+  sections?: GateDecisionSection[];
+  errors?: GateDecisionError[];
+  decisionId?: string;
+  sourceEvidenceHash?: string;
 };
 
-const VERDICT_HEADLINES: Record<GateVerdict, string> = {
-  merge: "Verdict: Accepted and merged",
-  request_changes: "Verdict: Request changes",
-  close: "Verdict: Close",
-  manual: "Verdict: Manual review",
-  ignore: "Verdict: Ignore",
+export type GateDecisionV2 = GateDecision & {
+  schemaVersion: typeof GATE_DECISION_SCHEMA_VERSION;
+  verdict: GateDecisionV2Verdict;
+  confidence: number;
+  checks: GateDecisionCheck[];
+  sections: GateDecisionSection[];
 };
+
+const V1_GATE_VERDICTS = new Set<GateVerdict>([
+  "merge",
+  "request_changes",
+  "close",
+  "manual",
+  "ignore",
+]);
+const V2_GATE_VERDICTS = new Set<GateDecisionV2Verdict>([
+  "merge",
+  "close",
+  "manual",
+  "ignore",
+]);
+
+const RETRYABLE_PRIVATE_REVIEW_CODES = new Set([
+  "invalid_private_response",
+  "private_reviewer_unavailable",
+  "github_rate_limited",
+  "source_evidence_timeout",
+]);
+
+const VERDICT_HEADLINES: Record<GateVerdict, string> = {
+  merge: "Accepted and merged",
+  request_changes: "Needs changes",
+  close: "Closed by gate",
+  manual: "Manual review needed",
+  ignore: "Ignored",
+};
+
+const VERDICT_ALERTS: Record<GateVerdict, string> = {
+  merge: "TIP",
+  request_changes: "WARNING",
+  close: "CAUTION",
+  manual: "IMPORTANT",
+  ignore: "NOTE",
+};
+
+const VERDICT_ACTIONS: Record<GateVerdict, string> = {
+  merge: "Accepted by the maintainer gate.",
+  request_changes: "Close and resubmit a clean one-file content PR.",
+  close:
+    "Close this PR and resubmit a clean one-file content PR if appropriate.",
+  manual: "A maintainer needs to review this before automation continues.",
+  ignore: "No content-gate action is required.",
+};
+
+const SECTION_TITLES: Record<string, string> = {
+  summary: "Summary",
+  recommended_action: "Recommended Action",
+  ci: "CI",
+  scope: "Scope",
+  source_review: "Source Review",
+  source: "Source Review",
+  duplicate_history: "Duplicate and History Review",
+  duplicate: "Duplicate and History Review",
+  safety_privacy: "Safety and Privacy",
+  safety: "Safety and Privacy",
+  privacy: "Safety and Privacy",
+  factual_editorial_issues: "Factual and Editorial Issues",
+  validation_review: "Validation Review",
+  security_review: "Security Review",
+  required_shape: "Required Shape",
+  merge_result: "Merge Result",
+  one_shot_review: "One-shot Review",
+  raw_evidence: "Raw Evidence",
+};
+
+const DETAILS_SECTION_ORDER = [
+  "source_review",
+  "duplicate_history",
+  "safety_privacy",
+  "factual_editorial_issues",
+  "ci",
+  "scope",
+  "validation_review",
+  "security_review",
+  "required_shape",
+  "merge_result",
+  "one_shot_review",
+  "raw_evidence",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cleanText(value: unknown) {
+  return String(value || "").trim();
+}
+
+function normalizeSummary(value: unknown) {
+  if (Array.isArray(value)) {
+    return value.map(cleanText).filter(Boolean).join("\n");
+  }
+  return cleanText(value);
+}
+
+function normalizeLabels(value: unknown) {
+  return Array.isArray(value) ? value.map(cleanText).filter(Boolean) : [];
+}
+
+function normalizeConfidence(value: unknown) {
+  const confidence = Number(value);
+  if (!Number.isFinite(confidence)) return null;
+  if (confidence < 0 || confidence > 1) return null;
+  return confidence;
+}
+
+function normalizeCheck(value: unknown): GateDecisionCheck | null {
+  if (!isRecord(value)) return null;
+  const name = cleanText(value.name);
+  if (!name) return null;
+  const rawStatus = cleanText(value.status).toLowerCase();
+  const status = (
+    ["passed", "pending", "failed", "neutral", "skipped", "unknown"].includes(
+      rawStatus,
+    )
+      ? rawStatus
+      : "unknown"
+  ) as GateDecisionCheck["status"];
+  return {
+    name,
+    status,
+    details: cleanText(value.details) || undefined,
+  };
+}
+
+function normalizeSection(value: unknown): GateDecisionSection | null {
+  if (!isRecord(value)) return null;
+  const id = sectionId(cleanText(value.id || value.title));
+  if (!id) return null;
+  const bullets = Array.isArray(value.bullets)
+    ? value.bullets.map(cleanText).filter(Boolean)
+    : normalizeSummary(value.bullets)
+        .split("\n")
+        .map(cleanText)
+        .filter(Boolean);
+  if (!bullets.length) return null;
+  const rawStatus = cleanText(value.status).toLowerCase();
+  const status = (
+    ["pass", "warn", "fail", "info"].includes(rawStatus) ? rawStatus : "info"
+  ) as GateDecisionSectionStatus;
+  return {
+    id,
+    title: cleanText(value.title) || SECTION_TITLES[id],
+    status,
+    bullets,
+  };
+}
+
+function normalizeError(value: unknown): GateDecisionError | null {
+  if (!isRecord(value)) return null;
+  const code = cleanText(value.code);
+  if (!code) return null;
+  return {
+    code,
+    retryable: value.retryable === true,
+    message: cleanText(value.message) || undefined,
+  };
+}
+
+export function privateReviewErrorDecision(
+  reason: string,
+  code: string,
+  retryable = true,
+) {
+  return defaultManualDecision(reason, { code, retryable, message: reason });
+}
+
+export function isRetryableGateDecision(decision: GateDecision) {
+  if (decision.verdict !== "manual") return false;
+  if (
+    decision.errors?.some(
+      (error) =>
+        error.retryable || RETRYABLE_PRIVATE_REVIEW_CODES.has(error.code),
+    )
+  ) {
+    return true;
+  }
+  const summary = decision.summary.toLowerCase();
+  return (
+    summary.includes("could not determine the github app installation") ||
+    summary.includes("ai maintainer review returned an unexpected payload") ||
+    summary.includes("private corpus review request failed") ||
+    summary.includes("private corpus review returned") ||
+    summary.includes("private corpus review returned an unexpected payload")
+  );
+}
+
+export function normalizePrivateGateDecisionPayload(raw: unknown): {
+  decision?: GateDecision;
+  error?: GateDecisionError;
+} {
+  if (!isRecord(raw)) {
+    return {
+      error: {
+        code: "invalid_private_response",
+        retryable: true,
+        message: "Private corpus review returned an unexpected payload.",
+      },
+    };
+  }
+
+  if (raw.schemaVersion === GATE_DECISION_SCHEMA_VERSION) {
+    const verdict = cleanText(raw.verdict) as GateDecisionV2Verdict;
+    const confidence = normalizeConfidence(raw.confidence);
+    const summary = normalizeSummary(raw.summary);
+    const labels = normalizeLabels(raw.labels);
+    const checks = Array.isArray(raw.checks)
+      ? raw.checks
+          .map(normalizeCheck)
+          .filter((check): check is GateDecisionCheck => Boolean(check))
+      : null;
+    const sections = Array.isArray(raw.sections)
+      ? raw.sections
+          .map(normalizeSection)
+          .filter((section): section is GateDecisionSection => Boolean(section))
+      : null;
+
+    if (
+      !V2_GATE_VERDICTS.has(verdict) ||
+      confidence === null ||
+      !summary ||
+      !checks ||
+      !sections
+    ) {
+      return {
+        error: {
+          code: "invalid_private_response",
+          retryable: true,
+          message:
+            "Private corpus review returned an invalid GateDecisionV2 payload.",
+        },
+      };
+    }
+
+    const scope = isRecord(raw.scope)
+      ? {
+          filePath: cleanText(raw.scope.filePath) || undefined,
+          category: cleanText(raw.scope.category) || undefined,
+          slug: cleanText(raw.scope.slug) || undefined,
+          status: cleanText(raw.scope.status) || undefined,
+        }
+      : undefined;
+    const errors = Array.isArray(raw.errors)
+      ? raw.errors
+          .map(normalizeError)
+          .filter((error): error is GateDecisionError => Boolean(error))
+      : undefined;
+
+    return {
+      decision: {
+        schemaVersion: GATE_DECISION_SCHEMA_VERSION,
+        verdict,
+        confidence,
+        summary,
+        labels,
+        close: raw.close === true,
+        checks,
+        sections,
+        scope,
+        errors,
+        decisionId: cleanText(raw.decisionId) || undefined,
+        sourceEvidenceHash: cleanText(raw.sourceEvidenceHash) || undefined,
+      },
+    };
+  }
+
+  if (raw.schemaVersion !== undefined) {
+    return {
+      error: {
+        code: "invalid_private_response",
+        retryable: true,
+        message:
+          "Private corpus review returned an unsupported schema version.",
+      },
+    };
+  }
+
+  const verdict = cleanText(raw.verdict) as GateVerdict;
+  if (!V1_GATE_VERDICTS.has(verdict)) {
+    return {
+      error: {
+        code: "invalid_private_response",
+        retryable: true,
+        message: "Private corpus review returned an unexpected payload.",
+      },
+    };
+  }
+  return {
+    decision: {
+      verdict,
+      summary: normalizeSummary(raw.summary),
+      labels: normalizeLabels(raw.labels),
+      close: raw.close === true,
+      confidence: normalizeConfidence(raw.confidence) ?? undefined,
+      sourceEvidenceHash: cleanText(raw.sourceEvidenceHash) || undefined,
+    },
+  };
+}
+
+function sectionId(value: string) {
+  let id = "";
+  const appendToken = (token: string) => {
+    id += token;
+  };
+  const appendSeparator = () => {
+    if (id && !id.endsWith("_")) id += "_";
+  };
+
+  for (const char of value.toLowerCase()) {
+    if (char === "&") {
+      appendToken("and");
+    } else if ((char >= "a" && char <= "z") || (char >= "0" && char <= "9")) {
+      appendToken(char);
+    } else {
+      appendSeparator();
+    }
+  }
+
+  return id.endsWith("_") ? id.slice(0, -1) : id;
+}
+
+function sectionTitle(id: string, fallback?: string) {
+  return fallback || SECTION_TITLES[id] || id.replace(/_/g, " ");
+}
+
+function splitLegacySummary(summary: string) {
+  const sections: GateDecisionSection[] = [];
+  let current: GateDecisionSection = {
+    id: "summary",
+    title: "Summary",
+    status: "info",
+    bullets: [],
+  };
+  const pushCurrent = () => {
+    if (current.bullets.length) sections.push(current);
+  };
+
+  for (const line of summary.split("\n")) {
+    const trimmed = line.trim();
+    const heading = trimmed.match(/^(?:#{1,3}\s*)?([A-Za-z][A-Za-z0-9 /-]+):$/);
+    if (heading) {
+      const id = sectionId(heading[1]);
+      if (SECTION_TITLES[id]) {
+        pushCurrent();
+        current = {
+          id,
+          title: SECTION_TITLES[id],
+          status: "info",
+          bullets: [],
+        };
+        continue;
+      }
+    }
+    if (trimmed) current.bullets.push(trimmed);
+  }
+  pushCurrent();
+  return sections;
+}
+
+function mergeDecisionSections(decision: GateDecision) {
+  const structured = decision.sections?.length ? decision.sections : [];
+  const legacy = splitLegacySummary(decision.summary);
+  const seen = new Set<string>();
+  const sections: GateDecisionSection[] = [];
+  for (const section of [...structured, ...legacy]) {
+    if (seen.has(section.id)) continue;
+    seen.add(section.id);
+    sections.push(section);
+  }
+  return sections;
+}
+
+function bulletsMarkdown(bullets: string[]) {
+  return bullets
+    .map((bullet) => {
+      const trimmed = bullet.trim();
+      if (!trimmed) return "";
+      if (/^[-*]\s+/.test(trimmed) || /^\d+[.)]\s+/.test(trimmed)) {
+        return trimmed;
+      }
+      return `- ${trimmed}`;
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function escapeTableCell(value: unknown) {
+  return String(value || "")
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, " ")
+    .trim();
+}
+
+function confidenceText(value: number | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value))
+    return "not provided";
+  return `${Math.round(value * 100)}%`;
+}
+
+function scopeText(scope?: GateDecisionScope) {
+  if (!scope) return "not provided";
+  const path = scope.filePath ? `\`${scope.filePath}\`` : "";
+  const parts = [path, scope.category, scope.slug, scope.status]
+    .filter(Boolean)
+    .join(" · ");
+  return parts || "not provided";
+}
+
+function checksSection(decision: GateDecision): GateDecisionSection | null {
+  if (!decision.checks?.length) return null;
+  return {
+    id: "ci",
+    title: "CI",
+    status: decision.checks.some((check) => check.status === "failed")
+      ? "fail"
+      : decision.checks.some((check) => check.status === "pending")
+        ? "warn"
+        : "pass",
+    bullets: decision.checks.map((check) =>
+      [
+        `\`${check.status}\` ${check.name}`,
+        check.details ? `- ${check.details}` : "",
+      ]
+        .filter(Boolean)
+        .join(" "),
+    ),
+  };
+}
+
+function renderDetails(section: GateDecisionSection) {
+  return [
+    "<details>",
+    `<summary><strong>${sectionTitle(section.id, section.title)}</strong> · ${section.status || "info"}</summary>`,
+    "",
+    bulletsMarkdown(section.bullets),
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+function renderDecisionComment(decision: GateDecision, marker: string) {
+  const sections = mergeDecisionSections(decision);
+  const summary = sections.find((section) => section.id === "summary");
+  const recommended = sections.find(
+    (section) => section.id === "recommended_action",
+  );
+  const checks = checksSection(decision);
+  const detailSections = [
+    ...(checks ? [checks] : []),
+    ...sections.filter(
+      (section) =>
+        section.id !== "summary" &&
+        section.id !== "recommended_action" &&
+        section.id !== "ci",
+    ),
+  ].sort((left, right) => {
+    const leftIndex = DETAILS_SECTION_ORDER.indexOf(left.id);
+    const rightIndex = DETAILS_SECTION_ORDER.indexOf(right.id);
+    return (
+      (leftIndex === -1 ? DETAILS_SECTION_ORDER.length : leftIndex) -
+      (rightIndex === -1 ? DETAILS_SECTION_ORDER.length : rightIndex)
+    );
+  });
+
+  const parts = [
+    marker,
+    `> [!${VERDICT_ALERTS[decision.verdict]}]`,
+    `> **${VERDICT_HEADLINES[decision.verdict]}**`,
+    `> ${VERDICT_ACTIONS[decision.verdict]}`,
+    "",
+    "| Field | Result |",
+    "| --- | --- |",
+    `| Verdict | \`${escapeTableCell(decision.verdict)}\` |`,
+    `| Confidence | ${escapeTableCell(confidenceText(decision.confidence))} |`,
+    `| Scope | ${escapeTableCell(scopeText(decision.scope))} |`,
+    `| Formatter | \`gate-comment-v${GATE_COMMENT_FORMATTER_VERSION}\` |`,
+    "",
+  ];
+
+  if (summary?.bullets.length) {
+    parts.push("## Summary", "", bulletsMarkdown(summary.bullets), "");
+  }
+  if (recommended?.bullets.length) {
+    parts.push(
+      "## Recommended Action",
+      "",
+      bulletsMarkdown(recommended.bullets),
+      "",
+    );
+  }
+  for (const section of detailSections) {
+    parts.push(renderDetails(section), "");
+  }
+
+  const footer = singleShotFooter(decision.verdict);
+  if (footer) parts.push("---", footer);
+  return parts.join("\n").trim();
+}
 
 function singleShotFooter(verdict: GateVerdict) {
   if (verdict === "ignore") return "";
   if (verdict === "merge") {
     return [
-      "---",
       "Automated review by HeyClaude Maintainer Agent.",
       "",
       "This content-only PR passed content validation, Superagent, and private review. HeyClaude merges accepted source PRs directly; generated artifacts are produced at build/deploy time.",
     ].join("\n");
   }
   return [
-    "---",
     "Automated review by HeyClaude Maintainer Agent.",
     "",
     "HeyClaude uses single-shot submission review for direct content PRs. Rejected PRs should be resubmitted as a new focused PR instead of iterated in place.",
@@ -47,29 +588,86 @@ export function markerComment(
   if (!decision) {
     return [
       marker,
-      "Thanks for the submission. The public validation lane is running now.",
+      "> [!NOTE]",
+      "> **Public validation running**",
+      "> HeyClaude is checking this direct content submission before private review.",
       "",
-      "After the required validation checks are green, the private submission gate will review category fit, source of truth, duplicate history, safety/privacy, provenance, and generated-artifact scope.",
+      "| Stage | Status |",
+      "| --- | --- |",
+      "| Public validation | `pending` |",
+      "| Private maintainer gate | `waiting` |",
+      "",
+      "<details>",
+      "<summary><strong>What happens next</strong></summary>",
+      "",
+      "- Required validation checks must pass first.",
+      "- The private gate then reviews category fit, source of truth, duplicate history, safety/privacy, provenance, and generated-artifact scope.",
+      "- No contributor action is needed unless the gate posts a terminal decision.",
+      "",
+      "</details>",
     ].join("\n");
   }
 
-  const headline = VERDICT_HEADLINES[decision.verdict];
-  const footer = singleShotFooter(decision.verdict);
+  return renderDecisionComment(decision, marker);
+}
 
-  const parts = [marker, headline, "", decision.summary.trim()];
-  if (footer) {
-    parts.push("", footer);
-  }
-  return parts.join("\n");
+export function retryingReviewComment(marker = DEFAULT_REVIEW_MARKER) {
+  return [
+    marker,
+    "> [!IMPORTANT]",
+    "> **Review retrying**",
+    "> Public validation is green, but the private reviewer returned a retryable infrastructure result.",
+    "",
+    "| Stage | Status |",
+    "| --- | --- |",
+    "| Public validation | `passed` |",
+    "| Private maintainer gate | `retrying` |",
+    "",
+    "<details>",
+    "<summary><strong>Contributor action</strong></summary>",
+    "",
+    "- No contributor action is needed yet.",
+    "- The submission gate will retry automatically.",
+    "",
+    "</details>",
+  ].join("\n");
+}
+
+export function supersededReviewComment(
+  marker = DEFAULT_REVIEW_MARKER,
+  canonicalUrl?: string,
+) {
+  return [
+    marker,
+    "> [!NOTE]",
+    "> **Superseded gate report**",
+    "> A newer canonical HeyClaude maintainer-gate report replaced this comment.",
+    "",
+    canonicalUrl
+      ? `Current report: ${canonicalUrl}`
+      : "Current report: see the newest HeyClaude maintainer-gate comment on this PR.",
+  ].join("\n");
+}
+
+export function approvalReviewBody(reportUrl?: string) {
+  return [
+    "Approved by HeyClaude Maintainer Agent.",
+    "",
+    reportUrl
+      ? `Full gate report: ${reportUrl}`
+      : "The full gate report is in the canonical HeyClaude maintainer-gate comment on this PR.",
+  ].join("\n");
 }
 
 export function defaultManualDecision(
   reason = "Private corpus review is not configured.",
+  error?: GateDecisionError,
 ): GateDecision {
   return {
     verdict: "manual" as const,
     summary: `${reason} A maintainer needs to review category fit, source of truth, duplicate history, safety/privacy notes, and provenance before merge.`,
     labels: [LABELS.manual],
+    errors: error ? [error] : undefined,
   };
 }
 

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -229,6 +229,14 @@ export async function upsertPrState(
     clearVerdict?: boolean;
     clearTerminal?: boolean;
     lastReviewKey?: string | null;
+    commentId?: number | null;
+    commentUrl?: string | null;
+    reviewId?: number | null;
+    schemaVersion?: number | null;
+    formatterVersion?: number | null;
+    decisionId?: string | null;
+    confidence?: number | null;
+    sourceEvidenceHash?: string | null;
   },
 ) {
   const timestamp = now();
@@ -241,8 +249,8 @@ export async function upsertPrState(
   await db
     .prepare(
       `INSERT INTO submission_prs
-        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, last_review_key, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, last_review_key, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, comment_id, comment_url, review_id, schema_version, formatter_version, decision_id, confidence, source_evidence_hash, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo, number) DO UPDATE SET
         head_repo = COALESCE(excluded.head_repo, submission_prs.head_repo),
         head_ref = COALESCE(excluded.head_ref, submission_prs.head_ref),
@@ -276,6 +284,14 @@ export async function upsertPrState(
           WHEN excluded.terminal_at IS NOT NULL THEN excluded.terminal_at
           ELSE submission_prs.terminal_at
         END,
+        comment_id = COALESCE(excluded.comment_id, submission_prs.comment_id),
+        comment_url = COALESCE(excluded.comment_url, submission_prs.comment_url),
+        review_id = COALESCE(excluded.review_id, submission_prs.review_id),
+        schema_version = COALESCE(excluded.schema_version, submission_prs.schema_version),
+        formatter_version = COALESCE(excluded.formatter_version, submission_prs.formatter_version),
+        decision_id = COALESCE(excluded.decision_id, submission_prs.decision_id),
+        confidence = COALESCE(excluded.confidence, submission_prs.confidence),
+        source_evidence_hash = COALESCE(excluded.source_evidence_hash, submission_prs.source_evidence_hash),
         updated_at = excluded.updated_at`,
     )
     .bind(
@@ -296,6 +312,14 @@ export async function upsertPrState(
       params.lastError ?? null,
       params.lastCheckSummary ?? null,
       terminalAt,
+      params.commentId ?? null,
+      params.commentUrl ?? null,
+      params.reviewId ?? null,
+      params.schemaVersion ?? null,
+      params.formatterVersion ?? null,
+      params.decisionId ?? null,
+      params.confidence ?? null,
+      params.sourceEvidenceHash ?? null,
       timestamp,
       timestamp,
       params.clearVerdict ? 1 : 0,
@@ -320,6 +344,10 @@ export async function getPrState(
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,
+        comment_id AS commentId, comment_url AS commentUrl,
+        review_id AS reviewId, schema_version AS schemaVersion,
+        formatter_version AS formatterVersion, decision_id AS decisionId,
+        confidence, source_evidence_hash AS sourceEvidenceHash,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        WHERE repo = ? AND number = ?`,
@@ -348,6 +376,10 @@ export async function listDuePrStates(
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,
+        comment_id AS commentId, comment_url AS commentUrl,
+        review_id AS reviewId, schema_version AS schemaVersion,
+        formatter_version AS formatterVersion, decision_id AS decisionId,
+        confidence, source_evidence_hash AS sourceEvidenceHash,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        WHERE (
@@ -403,6 +435,10 @@ export async function listRecentPrStates(
         attempt_count AS attemptCount, last_error AS lastError,
         last_check_summary AS lastCheckSummary, terminal_at AS terminalAt,
         last_notification_key AS lastNotificationKey,
+        comment_id AS commentId, comment_url AS commentUrl,
+        review_id AS reviewId, schema_version AS schemaVersion,
+        formatter_version AS formatterVersion, decision_id AS decisionId,
+        confidence, source_evidence_hash AS sourceEvidenceHash,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        ORDER BY updated_at DESC

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -12,6 +12,7 @@ import {
   createGitHubAppJwt,
   getCommitValidationState,
   listPullRequestFiles,
+  upsertMarkerComment,
 } from "../apps/submission-gate/src/github";
 import {
   decryptText,
@@ -28,7 +29,11 @@ import {
   protectedFrontmatterChanges,
 } from "../apps/submission-gate/src/duplicates";
 import {
+  approvalReviewBody,
   markerComment,
+  normalizePrivateGateDecisionPayload,
+  retryingReviewComment,
+  supersededReviewComment,
   validationFailedDecision,
 } from "../apps/submission-gate/src/review";
 import {
@@ -401,10 +406,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("target.headSha = pullForNotification.head.sha");
     expect(source).toContain("target: {");
     expect(source).toContain("installationId: target.installationId");
-    expect(source).toContain("isRetryablePrivateReviewerDecision(decision)");
-    expect(source).toContain(
-      "ai maintainer review returned an unexpected payload",
-    );
+    expect(source).toContain("normalizePrivateGateDecisionPayload(raw)");
+    expect(source).toContain("isRetryableGateDecision(decision)");
+    expect(source).toContain('"invalid_private_response"');
+    expect(source).toContain('"private_reviewer_unavailable"');
     expect(source).toContain('status: "error_retryable"');
     expect(source).toContain("retryingReviewComment(");
     expect(source).toContain("validation: validationForPrivateReview");
@@ -479,11 +484,12 @@ describe("Cloudflare submission gate helpers", () => {
       close: true,
     });
 
-    expect(body).toContain(
-      "<!-- heyclaude-submission-gate -->\nVerdict: Request changes\n\nSummary:",
-    );
-    expect(body).toContain("Source Review:");
-    expect(body).toContain("Recommended Action:");
+    expect(body).toContain("<!-- heyclaude-submission-gate -->\n> [!WARNING]");
+    expect(body).toContain("**Needs changes**");
+    expect(body).toContain("| Formatter | `gate-comment-v2` |");
+    expect(body).toContain("## Summary");
+    expect(body).toContain("<summary><strong>Source Review</strong>");
+    expect(body).toContain("## Recommended Action");
     expect(body).toContain("single-shot submission review");
   });
 
@@ -493,13 +499,180 @@ describe("Cloudflare submission gate helpers", () => {
       summary:
         "Summary:\n- Accepted after duplicate/history and source review.",
       labels: ["submission-merged-by-gate"],
+      confidence: 0.92,
+      scope: {
+        filePath: "content/mcp/example.mdx",
+        category: "mcp",
+        slug: "example",
+        status: "added",
+      },
     });
 
-    expect(body).toContain("Verdict: Accepted and merged");
+    expect(body).toContain("> [!TIP]");
+    expect(body).toContain("**Accepted and merged**");
+    expect(body).toContain("| Confidence | 92% |");
+    expect(body).toContain("`content/mcp/example.mdx`");
     expect(body).toContain(
       "passed content validation, Superagent, and private review",
     );
     expect(body).toContain("merges accepted source PRs directly");
+  });
+
+  it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {
+    expect(markerComment()).toContain("**Public validation running**");
+    expect(markerComment()).toContain(
+      "| Private maintainer gate | `waiting` |",
+    );
+    expect(retryingReviewComment()).toContain("**Review retrying**");
+    expect(retryingReviewComment()).toContain(
+      "| Private maintainer gate | `retrying` |",
+    );
+    expect(
+      supersededReviewComment(
+        "<!-- heyclaude-submission-gate -->",
+        "https://github.com/JSONbored/awesome-claude/pull/1#issuecomment-2",
+      ),
+    ).toContain("**Superseded gate report**");
+  });
+
+  it("normalizes GateDecisionV2 and rejects malformed private review payloads", () => {
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "merge",
+        confidence: 0.91,
+        summary: ["Summary:", "- Looks good."],
+        labels: ["submission-merged-by-gate"],
+        scope: {
+          filePath: "content/mcp/example.mdx",
+          category: "mcp",
+          slug: "example",
+          status: "added",
+        },
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "recommended_action",
+            status: "pass",
+            bullets: ["Merge this PR."],
+          },
+        ],
+      }).decision,
+    ).toMatchObject({
+      schemaVersion: 2,
+      verdict: "merge",
+      confidence: 0.91,
+      checks: [{ name: "validate-content", status: "passed" }],
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "request_changes",
+        confidence: 0.5,
+        summary: "No longer valid in V2.",
+        labels: [],
+        checks: [],
+        sections: [],
+      }).error,
+    ).toMatchObject({
+      code: "invalid_private_response",
+      retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        verdict: "request_changes",
+        summary: "Temporary V1 fallback.",
+        labels: ["submission-closed-by-gate"],
+      }).decision,
+    ).toMatchObject({
+      verdict: "request_changes",
+      summary: "Temporary V1 fallback.",
+    });
+  });
+
+  it("keeps approval reviews short and links to the canonical report", () => {
+    expect(
+      approvalReviewBody(
+        "https://github.com/JSONbored/awesome-claude/pull/1#issuecomment-2",
+      ),
+    ).toBe(
+      [
+        "Approved by HeyClaude Maintainer Agent.",
+        "",
+        "Full gate report: https://github.com/JSONbored/awesome-claude/pull/1#issuecomment-2",
+      ].join("\n"),
+    );
+  });
+
+  it("updates the newest bot marker comment and supersedes older bot reports", async () => {
+    const fetchMock = vi.fn(
+      async (url: URL | RequestInfo, init?: RequestInit) => {
+        const value = String(url);
+        if (value.includes("/issues/42/comments?")) {
+          return Response.json([
+            {
+              id: 1,
+              body: "<!-- heyclaude-submission-gate -->\nOld report",
+              html_url:
+                "https://github.com/JSONbored/awesome-claude/pull/42#issuecomment-1",
+              user: { login: "heyclaude-submission-agent[bot]", type: "Bot" },
+            },
+            {
+              id: 2,
+              body: "<!-- heyclaude-submission-gate -->\nCurrent report",
+              html_url:
+                "https://github.com/JSONbored/awesome-claude/pull/42#issuecomment-2",
+              user: { login: "heyclaude-submission-agent[bot]", type: "Bot" },
+            },
+            {
+              id: 3,
+              body: "<!-- heyclaude-submission-gate -->\nPasted marker",
+              html_url:
+                "https://github.com/JSONbored/awesome-claude/pull/42#issuecomment-3",
+              user: { login: "contributor", type: "User" },
+            },
+          ]);
+        }
+        const body = JSON.parse(String(init?.body || "{}")) as {
+          body?: string;
+        };
+        if (value.endsWith("/issues/comments/2")) {
+          expect(init?.method).toBe("PATCH");
+          expect(body.body).toBe("new canonical report");
+          return Response.json({
+            id: 2,
+            html_url:
+              "https://github.com/JSONbored/awesome-claude/pull/42#issuecomment-2",
+            user: { login: "heyclaude-submission-agent[bot]", type: "Bot" },
+          });
+        }
+        if (value.endsWith("/issues/comments/1")) {
+          expect(init?.method).toBe("PATCH");
+          expect(body.body).toContain("Superseded gate report");
+          return Response.json({ id: 1 });
+        }
+        throw new Error(`Unexpected URL ${value}`);
+      },
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      upsertMarkerComment({
+        token: "ghs_test",
+        repo: { owner: "JSONbored", repo: "awesome-claude" },
+        issueNumber: 42,
+        marker: "<!-- heyclaude-submission-gate -->",
+        body: "new canonical report",
+      }),
+    ).resolves.toEqual({
+      id: 2,
+      url: "https://github.com/JSONbored/awesome-claude/pull/42#issuecomment-2",
+      supersededIds: [1],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 
   it("formats Discord decision notifications without marker or secret text", () => {
@@ -736,6 +909,8 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("labels: [LABELS.merged, ...categoryLabels]");
     expect(source).toContain('status: "merged"');
     expect(source).toContain("await mergeAcceptedPullRequest({");
+    expect(source).toContain("approvalReviewBody(params.reportCommentUrl)");
+    expect(source).toContain("reportCommentUrl: acceptedReport.url");
     expect(source).toContain("        const mergedSummary = [");
     expect(source).not.toContain(
       [
@@ -935,6 +1110,16 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("listRecentPrStates(env.SUBMISSION_GATE_DB");
     expect(source).toContain("lastCheckSummary");
     expect(source).toContain("attemptCount");
+    expect(source).toContain("retryReasons");
+    expect(source).toContain("staleStates");
+    expect(source).toContain("recentTerminal");
+    expect(source).toContain("deadLetterQueue");
+    expect(source).toContain("commentUrl");
+    expect(source).toContain("formatterVersion");
+    expect(readStorageSource()).toContain("comment_id AS commentId");
+    expect(readStorageSource()).toContain(
+      "formatter_version AS formatterVersion",
+    );
   });
 
   it("records pull request inspection failures before returning from webhooks", () => {


### PR DESCRIPTION
## Summary
- add a structured GateDecisionV2 contract for private maintainer review responses
- render canonical GitHub-native gate report comments with alerts, status tables, and collapsible review sections
- dedupe bot marker comments, persist report/review metadata, and shorten approval reviews to link to the canonical report
- add D1 migration fields for report metadata and expand the maintainer queue status response

## What changed
- Added V2 decision validation with a temporary V1 fallback for private reviewer responses.
- Reworked submission-gate comments for pending, retrying, terminal, merged, and superseded states.
- Updated GitHub comment upsert behavior to update the newest bot marker comment and supersede older bot reports.
- Added queue/report metadata fields and tests for V2 payloads, rendering, approval links, and dedupe behavior.

## Why
- Content PR review output should be more readable, deterministic, and robust without exposing private reviewer internals.
- The public gate needs one canonical report comment per PR and a short approval review instead of duplicate full bot responses.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/classify-pr-changes.test.ts`
- `pnpm build`
- `pnpm submission-gate:dry-run`
- `git diff --check`
- Private reviewer regression and Wrangler dev/prod dry-runs passed locally.

## Notes
- Apply the new submission-gate D1 migration before deploying the updated public Worker, because the Worker now selects the new report metadata columns.
