### PR TITLE
fix(submissions): add gate attribution footer

### DIFF
--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -1,8 +1,15 @@
 import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 
 export const GATE_DECISION_SCHEMA_VERSION = 2;
-export const GATE_COMMENT_FORMATTER_VERSION = 3;
+export const GATE_COMMENT_FORMATTER_VERSION = 4;
 export const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR = 0.85;
+const HEYCLAUDE_SITE_URL = "https://heyclau.de";
+const HEYCLAUDE_REPO_URL = "https://github.com/JSONbored/awesome-claude";
+const HEYCLAUDE_FORK_URL = "https://github.com/JSONbored/awesome-claude/fork";
+const SHARE_TITLE =
+  "HeyClaude - source-backed Claude and AI workflow directory";
+const SHARE_TEXT =
+  "I just used HeyClaude's maintainer gate for source-backed Claude and AI workflow submissions. It keeps the directory useful, practical, and reviewable.";
 
 export type GateVerdict =
   | "merge"
@@ -577,6 +584,45 @@ function renderDetailsBlock(title: string, bullets: string[]) {
   ].join("\n");
 }
 
+function shareUrl(baseUrl: string, params: Record<string, string>) {
+  const search = new URLSearchParams(params);
+  return `${baseUrl}?${search.toString()}`;
+}
+
+function renderAttributionFooter() {
+  const xUrl = shareUrl("https://twitter.com/intent/tweet", {
+    text: SHARE_TEXT,
+    url: HEYCLAUDE_SITE_URL,
+  });
+  const redditUrl = shareUrl("https://www.reddit.com/submit", {
+    title: SHARE_TITLE,
+    text: `${SHARE_TEXT} ${HEYCLAUDE_SITE_URL}`,
+  });
+  const linkedInUrl = shareUrl(
+    "https://www.linkedin.com/sharing/share-offsite/",
+    {
+      url: HEYCLAUDE_SITE_URL,
+      mini: "true",
+      title: SHARE_TITLE,
+      summary: SHARE_TEXT,
+    },
+  );
+
+  return [
+    `Thanks for using [HeyClaude](${HEYCLAUDE_SITE_URL}) to keep Claude and AI workflow submissions source-backed and useful. If this gate helped, consider starring or forking [JSONbored/awesome-claude](${HEYCLAUDE_REPO_URL}).`,
+    "",
+    "<details>",
+    "<summary><strong>❤️ Share</strong></summary>",
+    "",
+    `- [X](${xUrl})`,
+    `- [Reddit](${redditUrl})`,
+    `- [LinkedIn](${linkedInUrl})`,
+    `- [Fork HeyClaude](${HEYCLAUDE_FORK_URL})`,
+    "",
+    "</details>",
+  ].join("\n");
+}
+
 function sectionPreview(
   section: GateDecisionSection | undefined,
   limit: number,
@@ -668,6 +714,8 @@ function renderDecisionComment(decision: GateDecision, marker: string) {
     card.push(
       "---",
       renderDetailsBlock("Automation notes", footer.split(/\r?\n/)),
+      "",
+      renderAttributionFooter(),
     );
   }
   return renderAlertCard(marker, VERDICT_ALERTS[decision.verdict], card);

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -487,11 +487,17 @@ describe("Cloudflare submission gate helpers", () => {
 
     expect(body).toContain("<!-- heyclaude-submission-gate -->\n> [!WARNING]");
     expect(body).toContain("> ## ❌ Needs changes");
-    expect(body).toContain("> ℹ️ **Formatter:** `gate-comment-v3`");
+    expect(body).toContain("> ℹ️ **Formatter:** `gate-comment-v4`");
     expect(body).toContain("> **Summary**");
     expect(body).toContain("<summary><strong>ℹ️ info · Source Review</strong>");
     expect(body).toContain("> **Recommended action**");
     expect(body).toContain("single-shot submission review");
+    expect(body).toContain("Thanks for using [HeyClaude](https://heyclau.de)");
+    expect(body).toContain("<summary><strong>❤️ Share</strong></summary>");
+    expect(body).toContain("https://twitter.com/intent/tweet");
+    expect(body).toContain("https://www.reddit.com/submit");
+    expect(body).toContain("https://www.linkedin.com/sharing/share-offsite/");
+    expect(body).toContain("https://github.com/JSONbored/awesome-claude/fork");
   });
 
   it("renders accepted submissions as direct merge decisions", () => {
@@ -518,6 +524,8 @@ describe("Cloudflare submission gate helpers", () => {
       "passed content validation, Superagent, and private review",
     );
     expect(body).toContain("merges accepted source PRs directly");
+    expect(body).toContain("JSONbored/awesome-claude");
+    expect(body).toContain("Fork HeyClaude");
   });
 
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {


### PR DESCRIPTION
## Summary
- Adds a CodeRabbit-style attribution footer to terminal HeyClaude maintainer-gate comments.
- Includes a visible HeyClaude/repo attribution line and a collapsed share section for X, Reddit, LinkedIn, and GitHub fork.
- Bumps the gate comment formatter to v4 for auditability.

## What changed
- Terminal gate reports now end with a divider, automation notes, HeyClaude attribution, repo link, and collapsed share links.
- Share URLs use platform-native intent/share endpoints and keep the main review content uncluttered.

## Why
- The review cards are now cleaner, and the footer adds a low-noise growth loop for site traffic, GitHub stars, forks, and social sharing.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/classify-pr-changes.test.ts` passed 82 tests.
- `pnpm build` passed.
- `git diff --check` passed.
- `pnpm --dir apps/submission-gate run deploy:dry-run:prod` passed.
- `pnpm --dir apps/submission-gate run deploy:prod` deployed Worker version `af30b928-7515-405b-b87e-8f47f2230c1f`.
- `curl -fsS https://submission-gate.heyclau.de/health` returned healthy.

## Notes
- GitHub comments do not support custom CSS or buttons, so this uses GitHub-native Markdown links and collapsed details only.
- The live Worker already has this change deployed; this PR brings `main` in sync with production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added social media sharing options to gate comments with direct links to X, Reddit, and LinkedIn
* Introduced collapsible "❤️ Share" attribution footer with repository and fork links
* Updated gate comment format to version 4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->