### PR TITLE
fix(content): block MCP default secret expansions

### DIFF
--- a/content/hooks/mcp-config-privacy-scanner-hook.mdx
+++ b/content/hooks/mcp-config-privacy-scanner-hook.mdx
@@ -132,7 +132,7 @@ scriptBody: |-
       | select(
           (.key | test("(TOKEN|KEY|SECRET|PASSWORD|PAT|COOKIE|SESSION|PRIVATE|CREDENTIAL|AUTHORIZATION)"; "i"))
           and (.value | type == "string")
-          and ((.value | test("^(Bearer\\s+)?\\$\\{?[A-Za-z_][A-Za-z0-9_]*(:-[^}]*)?\\}?$|^<[^>]+>$|^$|^REPLACE_|^your-|^example"; "i")) | not)
+          and ((.value | test("^(Bearer\\s+)?(\\$[A-Za-z_][A-Za-z0-9_]*|\\$\\{[A-Za-z_][A-Za-z0-9_]*\\})$|^<[^>]+>$|^$|^REPLACE_|^your-|^example"; "i")) | not)
         )
       | .key
     ' 2>/dev/null | sort -u)
@@ -165,9 +165,14 @@ scriptBody: |-
 
   secret_name_re='(TOKEN|KEY|SECRET|PASSWORD|PAT|COOKIE|SESSION|PRIVATE|CREDENTIAL|AUTHORIZATION)'
   literal_secret_re="\"[A-Za-z0-9_ -]*${secret_name_re}[A-Za-z0-9_ -]*\"[[:space:]]*:[[:space:]]*\"(Bearer[[:space:]]+)?[^\"\\$<{][^\"]{8,}\""
+  default_expansion_secret_re="\"[A-Za-z0-9_ -]*${secret_name_re}[A-Za-z0-9_ -]*\"[[:space:]]*:[[:space:]]*\"(Bearer[[:space:]]+)?\\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}\"]{8,}\}\""
   credential_url_re='https?://[^[:space:]"<>]+[?&](access_token|api_key|token|password|client_secret)='
 
   if printf '%s\n' "$content" | grep -Eiq -- "$literal_secret_re"; then
+    add_finding "inline credential value in env or headers"
+  fi
+
+  if printf '%s\n' "$content" | grep -Eiq -- "$default_expansion_secret_re"; then
     add_finding "inline credential value in env or headers"
   fi
 


### PR DESCRIPTION
### Motivation
- The MCP config privacy scanner treated shell-style defaults like `${VAR:-fallback}` as safe placeholders even when the fallback contained a literal secret, allowing literal tokens to be written into project MCP files.
- The change prevents that bypass by flagging shell default expansions that embed credential-like literal values while keeping legitimate variable-only references permissive.

### Description
- Tighten the JSON placeholder allow-pattern so it only treats direct environment-variable references (`$VAR` or `${VAR}`) as safe and no longer accepts `:-` default expansions in the `jq` test.
- Add a new `default_expansion_secret_re` text-regex and a `grep -Eiq` check that detects `${VAR:-literal}`-style fallbacks containing credential-like values under `env`/`headers` and reports them as findings.
- Preserve existing behavior for direct variable references, advisory mode, and the `MCP_CONFIG_PRIVACY_ALLOWLIST` override; the change is confined to `content/hooks/mcp-config-privacy-scanner-hook.mdx` script body.

### Testing
- Ran a syntax check on the extracted hook with `bash -n` and it succeeded.
- Executed the hook with a bypass case containing `"${API_TOKEN:-sk_live_hiddenliteral123}"` and confirmed the hook now exits non-zero (blocked) as expected.
- Executed the hook with a safe direct reference `"${API_TOKEN}"` and confirmed the hook still exits `0` (allowed) as expected.
- Ran `pnpm validate:content:strict` and `git diff --check` and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2267e0d304832c97f3b42903198e28)