### PR TITLE
fix(submissions): calibrate gate confidence cards

### DIFF
--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 
 export const GATE_DECISION_SCHEMA_VERSION = 2;
-export const GATE_COMMENT_FORMATTER_VERSION = 4;
+export const GATE_COMMENT_FORMATTER_VERSION = 5;
 export const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR = 0.85;
 const HEYCLAUDE_SITE_URL = "https://heyclau.de";
 const HEYCLAUDE_REPO_URL = "https://github.com/JSONbored/awesome-claude";
@@ -463,8 +463,21 @@ function bulletsMarkdown(bullets: string[]) {
 
 function confidenceText(value: number | undefined) {
   if (typeof value !== "number" || !Number.isFinite(value))
-    return "not provided";
+    return "not applicable";
   return `${Math.round(value * 100)}%`;
+}
+
+function decisionConfidenceText(decision: GateDecision) {
+  if (
+    typeof decision.confidence === "number" &&
+    Number.isFinite(decision.confidence)
+  ) {
+    return confidenceText(decision.confidence);
+  }
+  if (decision.verdict === "close" || decision.verdict === "request_changes") {
+    return "rule-based";
+  }
+  return "not applicable";
 }
 
 function scopeText(scope?: GateDecisionScope) {
@@ -527,7 +540,7 @@ function checkStatusLabel(status: GateDecisionCheck["status"]) {
 }
 
 function confidenceStatusLabel(value: number | undefined) {
-  if (typeof value !== "number" || !Number.isFinite(value)) return "⚠️";
+  if (typeof value !== "number" || !Number.isFinite(value)) return "ℹ️";
   if (value >= DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR) return "✅";
   return "⚠️";
 }
@@ -563,11 +576,13 @@ function renderAlertCard(
 }
 
 function renderDetails(section: GateDecisionSection) {
+  const bullets = cleanSectionBullets(section);
+  if (!bullets.length) return "";
   return [
     "<details>",
     `<summary><strong>${sectionStatusLabel(section.status)} · ${sectionTitle(section.id, section.title)}</strong></summary>`,
     "",
-    bulletsMarkdown(section.bullets),
+    bulletsMarkdown(bullets),
     "",
     "</details>",
   ].join("\n");
@@ -623,17 +638,72 @@ function renderAttributionFooter() {
   ].join("\n");
 }
 
+function stripBulletMarker(value: string) {
+  return value
+    .trim()
+    .replace(/^[-*]\s+/, "")
+    .replace(/^\d+[.)]\s+/, "")
+    .trim();
+}
+
+function normalizedBulletKey(value: string) {
+  return stripBulletMarker(value)
+    .replace(/^#{1,6}\s+/, "")
+    .replace(/\*\*/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+function isSectionLabelBullet(value: string, section?: GateDecisionSection) {
+  const key = normalizedBulletKey(value).replace(/:$/, "");
+  if (!key) return true;
+  const id = sectionId(key);
+  if (section && id === section.id) return true;
+  return Boolean(SECTION_TITLES[id]);
+}
+
+function isDanglingLeadInBullet(value: string) {
+  const key = normalizedBulletKey(value);
+  return key.endsWith(":") && !key.includes("`") && key.length <= 80;
+}
+
+function isPreviewNoiseBullet(value: string) {
+  const text = stripBulletMarker(value);
+  return isDanglingLeadInBullet(value) || /^`[^`]+`$/.test(text);
+}
+
+function cleanSectionBullets(section: GateDecisionSection) {
+  return section.bullets.filter(
+    (bullet) => !isSectionLabelBullet(bullet, section),
+  );
+}
+
 function sectionPreview(
   section: GateDecisionSection | undefined,
   limit: number,
 ) {
-  return (section?.bullets || []).slice(0, limit);
+  if (!section) return [];
+  return cleanSectionBullets(section)
+    .filter((bullet) => !isPreviewNoiseBullet(bullet))
+    .slice(0, limit);
+}
+
+function detailRemainderBullets(
+  section: GateDecisionSection | undefined,
+  preview: string[],
+) {
+  if (!section) return [];
+  const previewKeys = new Set(preview.map(normalizedBulletKey));
+  return cleanSectionBullets(section).filter(
+    (bullet) => !previewKeys.has(normalizedBulletKey(bullet)),
+  );
 }
 
 function reviewMetadataBullets(decision: GateDecision) {
   return [
     `${verdictStatusLabel(decision.verdict)} **Verdict:** \`${decision.verdict}\``,
-    `${confidenceStatusLabel(decision.confidence)} **Confidence:** ${confidenceText(decision.confidence)}`,
+    `${confidenceStatusLabel(decision.confidence)} **Confidence:** ${decisionConfidenceText(decision)}`,
     `ℹ️ **Scope:** ${scopeText(decision.scope)}`,
     `ℹ️ **Formatter:** \`gate-comment-v${GATE_COMMENT_FORMATTER_VERSION}\``,
   ];
@@ -677,7 +747,7 @@ function renderDecisionComment(decision: GateDecision, marker: string) {
 
   if (summaryPreview.length) {
     card.push("**Summary**", "", bulletsMarkdown(summaryPreview), "");
-    if ((summary?.bullets.length || 0) > summaryPreview.length) {
+    if (detailRemainderBullets(summary, summaryPreview).length) {
       card.push(
         "- More review detail is collapsed below for maintainers and contributors who want the full evidence.",
         "",
@@ -694,19 +764,36 @@ function renderDecisionComment(decision: GateDecision, marker: string) {
     );
   }
 
-  card.push(
-    renderDetailsBlock("Review metadata", reviewMetadataBullets(decision)),
-    "",
-  );
-
-  if (summary && summary.bullets.length > summaryPreview.length) {
-    card.push(renderDetails(summary), "");
+  const summaryRemainder = detailRemainderBullets(summary, summaryPreview);
+  if (summary && summaryRemainder.length) {
+    card.push(
+      renderDetails({
+        ...summary,
+        title: "More Summary Detail",
+        bullets: summaryRemainder,
+      }),
+      "",
+    );
   }
   if (recommended && recommended.bullets.length > recommendedPreview.length) {
-    card.push(renderDetails(recommended), "");
+    const recommendedRemainder = detailRemainderBullets(
+      recommended,
+      recommendedPreview,
+    );
+    if (recommendedRemainder.length) {
+      card.push(
+        renderDetails({
+          ...recommended,
+          title: "More Recommended Action Detail",
+          bullets: recommendedRemainder,
+        }),
+        "",
+      );
+    }
   }
   for (const section of detailSections) {
-    card.push(renderDetails(section), "");
+    const rendered = renderDetails(section);
+    if (rendered) card.push(rendered, "");
   }
 
   const footer = singleShotFooter(decision.verdict);

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -3,6 +3,7 @@ import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 export const GATE_DECISION_SCHEMA_VERSION = 2;
 export const GATE_COMMENT_FORMATTER_VERSION = 5;
 export const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR = 0.85;
+const DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR = 0.75;
 const HEYCLAUDE_SITE_URL = "https://heyclau.de";
 const HEYCLAUDE_REPO_URL = "https://github.com/JSONbored/awesome-claude";
 const HEYCLAUDE_FORK_URL = "https://github.com/JSONbored/awesome-claude/fork";
@@ -467,6 +468,69 @@ function confidenceText(value: number | undefined) {
   return `${Math.round(value * 100)}%`;
 }
 
+function normalizedConfidenceFloor(value: number) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.min(value, 1)
+    : DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR;
+}
+
+function hasFailedChecks(decision: GateDecision) {
+  return (decision.checks || []).some((check) =>
+    ["failed", "error", "cancelled"].includes(check.status),
+  );
+}
+
+function hasBlockingOrAmbiguousSections(decision: GateDecision) {
+  return (decision.sections || []).some((section) =>
+    ["fail", "warn"].includes(section.status),
+  );
+}
+
+function mergeSummarySignalsAcceptance(summary: string) {
+  const value = summary.toLowerCase();
+  return (
+    value.includes("no blocking") ||
+    value.includes("none blocking") ||
+    value.includes("recommend direct merge") ||
+    value.includes("direct merge is recommended") ||
+    value.includes("can be merged directly") ||
+    value.includes("meets all repository policies")
+  );
+}
+
+function mergeSummarySignalsAmbiguity(summary: string) {
+  const value = summary.toLowerCase();
+  const nonBlocking =
+    value.includes("non-blocking") ||
+    value.includes("not a blocker") ||
+    value.includes("not blocking");
+  if (nonBlocking) return false;
+  return (
+    value.includes("unresolved") ||
+    value.includes("ambiguous") ||
+    value.includes("could not verify") ||
+    value.includes("contradictory") ||
+    value.includes("manual review")
+  );
+}
+
+function isCleanStructuredMergeDecision(
+  decision: GateDecision,
+  cleanFloor = DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR,
+) {
+  return (
+    decision.verdict === "merge" &&
+    typeof decision.confidence === "number" &&
+    Number.isFinite(decision.confidence) &&
+    decision.confidence >= cleanFloor &&
+    !(decision.errors || []).length &&
+    !hasFailedChecks(decision) &&
+    !hasBlockingOrAmbiguousSections(decision) &&
+    mergeSummarySignalsAcceptance(decision.summary || "") &&
+    !mergeSummarySignalsAmbiguity(decision.summary || "")
+  );
+}
+
 function decisionConfidenceText(decision: GateDecision) {
   if (
     typeof decision.confidence === "number" &&
@@ -920,15 +984,15 @@ export function enforceAutoMergeConfidenceFloor(
   floor = DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 ): GateDecision {
   if (decision.verdict !== "merge") return decision;
-  const normalizedFloor =
-    typeof floor === "number" && Number.isFinite(floor) && floor >= 0
-      ? Math.min(floor, 1)
-      : DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR;
+  const normalizedFloor = normalizedConfidenceFloor(floor);
   if (
     typeof decision.confidence === "number" &&
     Number.isFinite(decision.confidence) &&
     decision.confidence >= normalizedFloor
   ) {
+    return decision;
+  }
+  if (isCleanStructuredMergeDecision(decision)) {
     return decision;
   }
 

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -592,13 +592,13 @@ describe("Cloudflare submission gate helpers", () => {
     ).toContain("> ## ℹ️ Superseded gate report");
   });
 
-  it("routes low-confidence private merge verdicts to manual review", () => {
+  it("keeps clean default-confidence merge verdicts on the merge path", () => {
     const decision = enforceAutoMergeConfidenceFloor({
       schemaVersion: 2,
       verdict: "merge",
       confidence: 0.76,
       summary:
-        "Summary:\n- Content appears useful, but evidence is not strong enough.",
+        "Summary:\n- No blocking issues detected.\n- The PR meets all repository policies and can be merged directly.\nRecommended Action:\n- Recommend direct merge.",
       labels: ["submission-merged-by-gate"],
       checks: [{ name: "validate-content", status: "passed" }],
       sections: [
@@ -611,8 +611,34 @@ describe("Cloudflare submission gate helpers", () => {
     });
 
     expect(decision).toMatchObject({
-      verdict: "manual",
+      verdict: "merge",
       confidence: 0.76,
+      labels: ["submission-merged-by-gate"],
+    });
+    expect(decision.errors).toBeUndefined();
+  });
+
+  it("routes ambiguous low-confidence private merge verdicts to manual review", () => {
+    const decision = enforceAutoMergeConfidenceFloor({
+      schemaVersion: 2,
+      verdict: "merge",
+      confidence: 0.7,
+      summary:
+        "Summary:\n- Content appears useful, but evidence is not strong enough and the source claims could not be verified.",
+      labels: ["submission-merged-by-gate"],
+      checks: [{ name: "validate-content", status: "passed" }],
+      sections: [
+        {
+          id: "source_review",
+          status: "warn",
+          bullets: ["Source evidence is ambiguous."],
+        },
+      ],
+    });
+
+    expect(decision).toMatchObject({
+      verdict: "manual",
+      confidence: 0.7,
       labels: ["submission-manual-review"],
       errors: [
         {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -487,10 +487,11 @@ describe("Cloudflare submission gate helpers", () => {
 
     expect(body).toContain("<!-- heyclaude-submission-gate -->\n> [!WARNING]");
     expect(body).toContain("> ## ❌ Needs changes");
-    expect(body).toContain("> ℹ️ **Formatter:** `gate-comment-v4`");
+    expect(body).toContain("> ℹ️ **Formatter:** `gate-comment-v5`");
     expect(body).toContain("> **Summary**");
     expect(body).toContain("<summary><strong>ℹ️ info · Source Review</strong>");
     expect(body).toContain("> **Recommended action**");
+    expect(body).not.toContain("<summary><strong>Review metadata</strong>");
     expect(body).toContain("single-shot submission review");
     expect(body).toContain("Thanks for using [HeyClaude](https://heyclau.de)");
     expect(body).toContain("<summary><strong>❤️ Share</strong></summary>");
@@ -519,13 +520,56 @@ describe("Cloudflare submission gate helpers", () => {
     expect(body).toContain("> ## ✅ Accepted and merged");
     expect(body).toContain("> ✅ **Confidence:** 92%");
     expect(body).toContain("`content/mcp/example.mdx`");
-    expect(body).toContain("<summary><strong>Review metadata</strong>");
+    expect(body).not.toContain("<summary><strong>Review metadata</strong>");
     expect(body).toContain(
       "passed content validation, Superagent, and private review",
     );
     expect(body).toContain("merges accepted source PRs directly");
     expect(body).toContain("JSONbored/awesome-claude");
     expect(body).toContain("Fork HeyClaude");
+  });
+
+  it("renders deterministic closures without confidence noise or duplicate summary text", () => {
+    const body = markerComment({
+      verdict: "close",
+      summary: [
+        "Summary:",
+        "- This PR edits protected content identity, provenance, review, disclosure, source, or verification metadata.",
+        "- HeyClaude allows one-file content edits through this gate only when they avoid protected fields and keep the entry identity intact.",
+        "- Protected fields changed:",
+        "- `dateAdded`",
+        "- `packageVerified`",
+        "",
+        "Recommended Action:",
+        "- Close this PR.",
+      ].join("\n"),
+      labels: ["submission-closed-by-gate"],
+      close: true,
+      scope: {
+        filePath: "content/mcp/example.mdx",
+        category: "mcp",
+        slug: "example",
+        status: "modified",
+      },
+      checks: [
+        { name: "validate-content", status: "passed" },
+        { name: "Superagent Security Scan", status: "passed" },
+      ],
+    });
+
+    expect(body).toContain("> ℹ️ **Confidence:** rule-based");
+    expect(body).not.toContain("Confidence:** not provided");
+    const visibleBody = body.slice(0, body.indexOf("<details>"));
+    expect(visibleBody).not.toContain("Protected fields changed");
+    expect(visibleBody).not.toContain("`dateAdded`");
+    expect(body).toContain(
+      "<summary><strong>ℹ️ info · More Summary Detail</strong>",
+    );
+    expect(body).toContain("> - `dateAdded`");
+    expect(body).toContain("> - `packageVerified`");
+    expect(body).not.toContain("<summary><strong>Review metadata</strong>");
+    expect((body.match(/This PR edits protected/g) || []).length).toBe(1);
+    expect((body.match(/✅ `passed` validate-content/g) || []).length).toBe(1);
   });
 
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {


### PR DESCRIPTION
## Summary
- tighten the v5 HeyClaude gate comment renderer for closure/failure states
- show deterministic rule closures as `rule-based` instead of missing confidence
- remove repeated metadata/summary blocks from expanded terminal comments
- keep clean structured merge decisions out of manual review when confidence is only a calibrated/default-like value

## What changed
- filters section label bullets, dangling lead-ins, and code-only field lists out of the visible preview
- keeps detailed evidence available in collapsed sections without repeating the top summary
- removes the duplicate Review metadata toggle because the alert card already shows verdict, confidence, scope, and formatter
- adds regression coverage for deterministic protected-field closures and clean low-confidence merge payloads

## Why
- protected-field closures do not come from the private AI reviewer, so there is no model confidence to display
- expanded close comments were too noisy and repeated the same status/summary content in several places
- accepted submissions were being routed to manual when the private reviewer emitted the old `0.76` default despite recommending direct merge

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/classify-pr-changes.test.ts`
- `pnpm build`
- `git diff --check`
- `pnpm --dir apps/submission-gate run deploy:dry-run:prod`
- `pnpm --dir apps/submission-gate run deploy:prod`
- `curl -fsS https://submission-gate.heyclau.de/health`
- Private reviewer Worker dry-run, production deploy, and health smoke completed separately.

## Live verification
- Reprocessed PR #1603 after deploy; gate merged it with confidence `0.95`.
- Reprocessed PR #1606 after deploy; gate merged it with confidence `0.94`.

## Notes
- Public gate Worker version: `75a6c8fb-8cca-45dd-a590-fbba79ad49c2`.
- Private reviewer Worker version: `c55287ac-798d-4c35-a8ce-29dee6c9d637`.
- No runtime bindings changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced auto-merge enforcement with improved clean merge rule validation and decision logic

* **Bug Fixes**
  * Improved review comment formatting with cleaner section structure
  * Clearer confidence display with "not applicable" status for edge cases
  * Better presentation of Summary and Recommended Action details, showing only relevant information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->