### PR TITLE
fix(submissions): avoid duplicate closes for MCP catalog repos

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -82,6 +82,14 @@ const DOMAIN_ONLY_EXCLUSIONS = new Set([
   "registry.npmjs.org",
 ]);
 
+const MULTI_ENTRY_CATALOG_URLS = new Set([
+  "https://github.com/awslabs/mcp",
+  "https://github.com/microsoft/mcp",
+  "https://github.com/modelcontextprotocol/servers",
+  "https://github.com/snowflake-labs/mcp",
+  "https://github.com/twilio-labs/mcp",
+]);
+
 function unquoteYamlScalar(value: string) {
   const trimmed = value.trim();
   if (
@@ -230,6 +238,14 @@ function intersection(left: string[], right: string[]) {
   return left.filter((value) => rightSet.has(value));
 }
 
+function strictDuplicateUrls(sharedUrls: string[]) {
+  return sharedUrls.filter((url) => !MULTI_ENTRY_CATALOG_URLS.has(url));
+}
+
+function sharedCatalogUrls(sharedUrls: string[]) {
+  return sharedUrls.filter((url) => MULTI_ENTRY_CATALOG_URLS.has(url));
+}
+
 function isCollectionBridge(
   candidate: ContentDuplicateSignals,
   existing: ContentDuplicateSignals,
@@ -327,12 +343,13 @@ export function findStrictContentDuplicateMatch(
     }
 
     const sharedUrls = intersection(candidate.urls, existing.urls);
+    const blockingSharedUrls = strictDuplicateUrls(sharedUrls);
     if (
-      sharedUrls.length &&
+      blockingSharedUrls.length &&
       candidate.category &&
       candidate.category === existing.category
     ) {
-      reasons.push(`same canonical source URL ${sharedUrls[0]}`);
+      reasons.push(`same canonical source URL ${blockingSharedUrls[0]}`);
     }
 
     if (
@@ -376,6 +393,16 @@ export function findRelatedContentMatches(
         isCollectionBridge(candidate, existing)
           ? `same canonical source URL ${sharedUrls[0]} across collection/resource categories`
           : `same canonical source URL ${sharedUrls[0]} across ${candidate.category}/${existing.category}`,
+      );
+    }
+    const catalogUrls = sharedCatalogUrls(sharedUrls);
+    if (
+      catalogUrls.length &&
+      candidate.category &&
+      candidate.category === existing.category
+    ) {
+      reasons.push(
+        `same multi-entry catalog source URL ${catalogUrls[0]} in ${candidate.category}`,
       );
     }
 

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -3163,7 +3163,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 "rejected_history",
               ],
               strictDuplicatePolicy:
-                "Only same path, same category+slug, same category+canonical URL/repo, same category+title, or same category+normalized description should block as a duplicate.",
+                "Only same path, same category+slug, same category+canonical URL/repo, same category+title, or same category+normalized description should block as a duplicate. Shared official multi-entry catalog repositories, such as organization MCP catalogs that host multiple distinct servers, are related context rather than automatic duplicates when title, slug, package, documentation URL, and endpoint differ.",
               relatedContentPolicy:
                 "Cross-category source overlap, same ecosystem/project ownership, and collection-member overlap are related/complementary context, not automatic duplicates.",
               collectionPolicy:

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1674,6 +1674,49 @@ repoUrl: "https://github.com/microsoft/playwright-mcp.git?utm_source=heyclaude"
     });
   });
 
+  it("treats shared multi-entry MCP catalogs as related context", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/mcp/azure-mcp-server.mdx",
+      content: `---
+title: Azure MCP Server
+slug: azure-mcp-server
+category: mcp
+description: Official Microsoft Azure MCP server for Azure resource workflows.
+documentationUrl: "https://learn.microsoft.com/en-us/azure/developer/azure-mcp-server/"
+repoUrl: "https://github.com/microsoft/mcp"
+packageUrl: "https://www.npmjs.com/package/@azure/mcp"
+---
+`,
+      label: "accepted entry content/mcp/azure-mcp-server.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/microsoft-learn-mcp-server.mdx",
+      content: `---
+title: Microsoft Learn MCP Server
+slug: microsoft-learn-mcp-server
+category: mcp
+description: Official Microsoft Learn remote MCP server for documentation search.
+documentationUrl: "https://devblogs.microsoft.com/engineering-at-microsoft/how-we-built-the-microsoft-learn-mcp-server/"
+repoUrl: "https://github.com/microsoft/mcp"
+sourceUrl: "https://learn.microsoft.com/api/mcp"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same multi-entry catalog source URL https://github.com/microsoft/mcp in mcp",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("treats repeated same-scope collections as strict duplicates", () => {
     const existingCollection = extractContentDuplicateSignals({
       filePath: "content/collections/frontend-a11y-browser-qa.mdx",


### PR DESCRIPTION
## Summary
- Stops the submission gate from treating known official multi-entry MCP catalog repositories as strict duplicates when the title, slug, package, docs URL, and endpoint differ.
- Adds a regression test for the Microsoft Learn MCP versus Azure MCP shape that surfaced during live gate probing.
- Updates the private-review context so shared catalog repos are treated as related context, not automatic closes.

## Why
Microsoft's `microsoft/mcp` repo hosts multiple distinct MCP resources. A Microsoft Learn MCP probe passed public validation but was closed as a strict duplicate of Azure MCP solely because both referenced the shared catalog repo.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/classify-pr-changes.test.ts`
- `git diff --check`
