### PR TITLE
fix(submissions): allow artifact attestation provenance content

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -47,6 +47,12 @@ function compactWhitespace(value) {
 
 const GITHUB_LOGIN_PATTERN =
   /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/;
+const FINANCIAL_OR_IDENTITY_PATTERN =
+  /\b(private key|wallet|kyc|usdc|x402|payment|crypto|on-chain)\b/i;
+const IDENTITY_ATTESTATION_PATTERN =
+  /\battestations?\b[\s\S]{0,120}\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b/i;
+const IDENTITY_ATTESTATION_REVERSE_PATTERN =
+  /\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b[\s\S]{0,120}\battestations?\b/i;
 
 // Keep these Markdown/login helpers in sync with CI policy reporting so issue
 // and PR review summaries escape contributor-controlled text consistently.
@@ -89,6 +95,14 @@ function markdownLabelValue(value) {
       : escapeMarkdownText(label);
   }
   return markdownCodeSpan(text);
+}
+
+function hasFinancialOrIdentitySensitiveSignal(text) {
+  return (
+    FINANCIAL_OR_IDENTITY_PATTERN.test(text) ||
+    IDENTITY_ATTESTATION_PATTERN.test(text) ||
+    IDENTITY_ATTESTATION_REVERSE_PATTERN.test(text)
+  );
 }
 
 function lower(value) {
@@ -878,11 +892,7 @@ function addContentRiskSignals(report, fields, text) {
     );
   }
 
-  if (
-    /\b(private key|wallet|kyc|usdc|x402|payment|crypto|on-chain|attestation)\b/i.test(
-      text,
-    )
-  ) {
+  if (hasFinancialOrIdentitySensitiveSignal(text)) {
     addFlag(
       report,
       "high",

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -220,10 +220,77 @@ Native macOS MCP server.`);
     );
   });
 
+  it("does not classify GitHub artifact attestations as identity-sensitive", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 126,
+        title: "content(guides): add artifact attestation checklist",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "GitHub Artifact Attestation Checklist",
+            slug: "github-artifact-attestation-checklist",
+            category: "guides",
+            description:
+              "Source-backed guide for verifying GitHub Artifact Attestations, release artifact provenance, build workflow identity, and digest evidence.",
+            repoUrl: "https://github.com/github/docs",
+            docsUrl:
+              "https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations",
+            safetyNotes: [
+              "Attestations prove artifact provenance, not malware safety or runtime behavior.",
+            ],
+          }),
+          "content/guides/github-artifact-attestation-checklist.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "financial_or_identity_sensitive",
+    );
+  });
+
+  it("still flags wallet and on-chain attestations as identity-sensitive", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 127,
+        title: "content(mcp): add wallet attestation mcp",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Wallet Attestation MCP",
+            slug: "wallet-attestation-mcp",
+            description:
+              "MCP server for wallet attestations, KYC review, and on-chain identity workflows.",
+            safetyNotes: [
+              "Requires explicit user approval before reading wallet or identity data.",
+            ],
+            privacyNotes: [
+              "Can process wallet, KYC, and on-chain identity records.",
+            ],
+          }),
+          "content/mcp/wallet-attestation-mcp.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "financial_or_identity_sensitive",
+    );
+  });
+
   it("formats risk reports without exposing private reviewer internals", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {
-        number: 125,
+        number: 128,
         title: "content(mcp): add sample mcp",
         user: { login: "contributor" },
         head: { repo: { full_name: "contributor/awesome-claude" } },


### PR DESCRIPTION
## Summary
- Narrows the submission risk classifier so GitHub Artifact Attestation provenance content is not treated as wallet/payment/KYC attestation content.
- Keeps wallet, KYC, payment, crypto, and on-chain attestation submissions high-risk.
- Adds regression coverage for both paths.

## Validation
- pnpm exec vitest run tests/submission-pr-first.test.ts tests/submission-gate-worker.test.ts
- pnpm build
- git diff --check