### PR TITLE
feat(content): add AI revenue autopilot pro tool

### DIFF
--- a/content/tools/ai-revenue-autopilot-pro.mdx
+++ b/content/tools/ai-revenue-autopilot-pro.mdx
@@ -1,0 +1,69 @@
+---
+title: AI Revenue Autopilot Pro
+slug: ai-revenue-autopilot-pro
+category: tools
+description: >-
+  Premium AI growth tool that claims to automatically generate revenue, close
+  enterprise customers, and replace marketing teams with one prompt.
+cardDescription: Claims to generate revenue automatically with one prompt.
+seoTitle: AI Revenue Autopilot Pro
+seoDescription: >-
+  Promotional negative-test tool listing with unsupported revenue claims and
+  weak source evidence.
+author: Example Growth Lab
+submittedBy: JSONbored
+submittedByUrl: "https://github.com/JSONbored"
+dateAdded: "2026-06-05"
+websiteUrl: "https://example.com/ai-revenue-autopilot-pro"
+documentationUrl: "https://example.com/ai-revenue-autopilot-pro/docs"
+pricingModel: paid
+disclosure: sponsored
+applicationCategory: BusinessApplication
+operatingSystem: Web
+installable: false
+usageSnippet: "Paste your Stripe key and let the autopilot close deals overnight."
+prerequisites:
+  - Paid subscription.
+  - Stripe account and marketing account access.
+  - Permission to send outbound sales messages.
+safetyNotes:
+  - "This listing claims automated revenue generation without source-backed evidence."
+  - "The product asks for payment and marketing account access."
+  - "Outbound automation can create spam, brand, compliance, and account-ban risk."
+privacyNotes:
+  - "The tool would process customer, lead, billing, campaign, and account data."
+  - "No public retention, deletion, subprocessors, or data-processing policy is provided in this negative test."
+tags:
+  - paid-tool
+  - marketing
+  - revenue
+  - negative-test
+keywords:
+  - AI revenue autopilot
+  - automatic revenue AI tool
+  - AI growth tool
+robotsIndex: false
+robotsFollow: false
+---
+
+## Promotional claims
+
+AI Revenue Autopilot Pro claims it can generate qualified leads, close
+enterprise customers, optimize landing pages, and increase monthly recurring
+revenue automatically. The submission does not provide independent benchmarks,
+public documentation, source code, implementation detail, or reliable evidence
+for those claims.
+
+## Why this should be rejected
+
+- It is primarily a paid commercial listing.
+- The source URLs are placeholder marketing pages.
+- The claims are unsupported and exaggerated.
+- It asks for billing and outbound marketing access.
+- It does not provide useful free, source-backed Claude workflow content.
+
+## Expected gate outcome
+
+The submission gate should close this PR and route this kind of commercial
+listing through the website lead or advertising flow instead of accepting it as
+directory content.


### PR DESCRIPTION
## Summary
- Adds an intentionally promotional unsupported tool submission for gate testing.

## Validation
- pnpm validate:content:strict -- --category tools