### PR TITLE
fix(submissions): preserve defensive security review content

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -83,6 +83,8 @@ const DOMAIN_ONLY_EXCLUSIONS = new Set([
 ]);
 
 const MULTI_ENTRY_CATALOG_URLS = new Set([
+  "https://code.claude.com/docs/en/hooks",
+  "https://code.claude.com/docs/en/statusline",
   "https://github.com/awslabs/mcp",
   "https://github.com/microsoft/mcp",
   "https://github.com/modelcontextprotocol/servers",

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -3168,6 +3168,8 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 "Cross-category source overlap, same ecosystem/project ownership, and collection-member overlap are related/complementary context, not automatic duplicates.",
               collectionPolicy:
                 "Collections may bundle existing entries when they add distinct workflow value, ordering, prerequisites, source-backed rationale, and safety/privacy guidance; repeated same-scope collection variants can still close as duplicates.",
+              defensiveSecurityPolicy:
+                "Do not close a submission merely because it defensively discusses OAuth, tokens, credentials, authorization, attestations, artifacts, packages, downloads, security, privacy, or destructive-risk prevention. These topics require careful evidence review, but source-backed guides, rules, skills, collections, hooks, tools, and statuslines about safe review practices can merge when validation, sources, scope, and safety/privacy notes pass. A hard safety, secret, package, or abuse close must cite concrete unsafe behavior or a concrete policy violation such as credential theft, exposed secrets, destructive defaults, malware/abuse tooling, unverified package hosting, packageVerified:true by an external contributor, broken source evidence, or promotional/affiliate content. Generic phrases like 'contains patterns that cannot be accepted' are not sufficient evidence for a close verdict.",
             },
           },
         });

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -419,6 +419,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("strictDuplicatePolicy:");
     expect(source).toContain("relatedContentPolicy:");
     expect(source).toContain("collectionPolicy:");
+    expect(source).toContain("defensiveSecurityPolicy:");
+    expect(source).toContain(
+      "Do not close a submission merely because it defensively discusses OAuth",
+    );
     expect(source).toContain("deterministicDuplicateReview");
     expect(source).toContain('eventType: "duplicate_shadow_review"');
     expect(source).toContain('decision: "related_not_strict_duplicate"');
@@ -1710,6 +1714,44 @@ sourceUrl: "https://learn.microsoft.com/api/mcp"
           reasons: expect.arrayContaining([
             expect.stringContaining(
               "same multi-entry catalog source URL https://github.com/microsoft/mcp in mcp",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("treats generic Claude docs pages as related context for statuslines", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/statuslines/context-pressure-statusline.mdx",
+      content: `---
+title: Context Pressure Statusline
+slug: context-pressure-statusline
+category: statuslines
+description: Claude Code statusline for context pressure.
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+---
+`,
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/statuslines/mcp-auth-surface-statusline.mdx",
+      content: `---
+title: MCP Auth Surface Statusline
+slug: mcp-auth-surface-statusline
+category: statuslines
+description: Claude Code statusline for MCP authorization surface hints.
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same multi-entry catalog source URL https://code.claude.com/docs/en/statusline in statuslines",
             ),
           ]),
         }),


### PR DESCRIPTION
## Summary
- Treat generic Claude hooks/statusline docs as shared source context instead of strict duplicate evidence.
- Adds a private-review policy that defensive OAuth/token/attestation/security content should not be closed without concrete unsafe behavior or a policy violation.
- Adds regressions for the statusline duplicate case and defensive security policy payload.

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts tests/submission-pr-first.test.ts
- pnpm build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a defensive security policy for submission review that prevents automatic closure solely for defensive discussions of security topics; requires concrete evidence of unsafe behavior or policy violations to justify closure.

* **Tests**
  * Added test coverage for defensive security policy enforcement and multi-entry catalog URL handling in duplicate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->