### PR TITLE
fix(content): tighten MCP auth boundary rules

### DIFF
--- a/content/rules/mcp-remote-authorization-boundary-rules.mdx
+++ b/content/rules/mcp-remote-authorization-boundary-rules.mdx
@@ -31,14 +31,14 @@ copySnippet: |-
   2. Require an OAuth resource indicator tied to the exact MCP resource.
   3. Reject tokens accepted for the wrong audience or another MCP server.
   4. Verify scopes are narrow enough for the advertised tools.
-  5. Block token forwarding unless the source and destination trust boundary is explicit.
+  5. Block forwarding incoming user tokens across MCP servers or backend services.
   6. Document revocation, refresh, storage, and user consent behavior.
   7. Keep source evidence public and credential details private.
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:
   - Remote MCP server URL, transport type, and authorization server metadata.
-  - Protected resource metadata or documented reason it is not required.
+  - Protected resource metadata discovery path for the exact MCP endpoint.
   - Scope list, token audience expectations, and tool permission map.
 safetyNotes:
   - "These rules do not execute the MCP server; they define review requirements before a server is connected to a real account."
@@ -90,7 +90,8 @@ scope map, or public source evidence, mark the submission as incomplete.
 
 - Reject a remote MCP server that accepts a token minted for another resource.
 - Reject a server that requires broad account scopes when narrower scopes exist.
-- Reject silent token forwarding across MCP servers or backend services.
+- Reject forwarding incoming user tokens across MCP servers or backend services;
+  documentation of a trust boundary is not a substitute for token isolation.
 - Reject documentation that says "OAuth supported" without showing issuer,
   resource, scopes, and consent behavior.
 - Reject tools that can write account data without explicit safety and privacy


### PR DESCRIPTION
### Motivation
- The MCP remote authorization checklist had ambiguous guidance that could permit forwarding incoming user tokens or allow missing protected-resource metadata when a "documented reason" was provided, which weakens token isolation and creates confused-deputy/token-exposure risks. 
- The intent of this change is to make the authorization-boundary guidance unambiguous so reviewers must verify resource metadata and must not accept incoming user-token forwarding across MCP servers.

### Description
- Updated `content/rules/mcp-remote-authorization-boundary-rules.mdx` to change the `copySnippet` entry to `Block forwarding incoming user tokens across MCP servers or backend services.` to remove the trust-boundary exception. 
- Replaced the permissive prerequisite `Protected resource metadata or documented reason it is not required.` with `Protected resource metadata discovery path for the exact MCP endpoint.` to require explicit metadata discovery. 
- Tightened the `## Blocking Rules` text to explicitly reject forwarding incoming user tokens across MCP servers and state that documentation of a trust boundary is not a substitute for token isolation. 
- Preserved the original checklist structure, metadata fields, and validation compatibility.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully and reported content validation passed. 
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229bb0fcb4832c8779925a98143da9)