### PR TITLE
fix(content): harden MCP allowlist hook

### DIFF
--- a/content/hooks/mcp-server-url-allowlist-hook.mdx
+++ b/content/hooks/mcp-server-url-allowlist-hook.mdx
@@ -18,8 +18,43 @@ dateAdded: "2026-06-05"
 documentationUrl: "https://code.claude.com/docs/en/hooks"
 repoUrl: "https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization"
 installable: true
-installCommand: >-
-  mkdir -p .claude/hooks && touch .claude/hooks/mcp-server-url-allowlist.sh && chmod +x .claude/hooks/mcp-server-url-allowlist.sh
+installCommand: |-
+  mkdir -p .claude/hooks
+  cat > .claude/hooks/mcp-server-url-allowlist.sh <<'MCP_SERVER_URL_ALLOWLIST_HOOK'
+  #!/usr/bin/env bash
+  set -u
+
+  if ! command -v jq >/dev/null 2>&1; then
+    exit 0
+  fi
+
+  input=$(cat)
+  file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
+  text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
+  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
+
+  case "$file" in
+    *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
+    *) exit 0 ;;
+  esac
+
+  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  [ -z "$hosts" ] && exit 0
+
+  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
+  for host in $hosts; do
+    case " $allowlist " in
+      *" $host "*) ;;
+      *)
+        echo "Blocked remote MCP URL: $host is not in ALLOWED_MCP_HOSTS." >&2
+        exit 2
+        ;;
+    esac
+  done
+
+  exit 0
+  MCP_SERVER_URL_ALLOWLIST_HOOK
+  chmod +x .claude/hooks/mcp-server-url-allowlist.sh
 usageSnippet: "Blocked remote MCP URL: host is not in ALLOWED_MCP_HOSTS."
 copySnippet: |-
   {
@@ -65,16 +100,17 @@ scriptBody: |-
   input=$(cat)
   file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
   text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
+  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
 
   case "$file" in
     *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
-  allowlist=$(printf '%s' "$ALLOWED_MCP_HOSTS" | tr ',' ' ')
+  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
   for host in $hosts; do
     case " $allowlist " in
       *" $host "*) ;;


### PR DESCRIPTION
### Motivation
- Prevent a security bypass where JSON-escaped URLs like `https:\/\/evil.example\/sse` were not detected by the hook and therefore skipped from allowlist enforcement.
- Ensure the advertised `installCommand` actually installs an executable hook body instead of creating an empty file that gives a false sense of protection.

### Description
- Replace the empty `installCommand` with one that writes the full hook script to `.claude/hooks/mcp-server-url-allowlist.sh` and marks it executable using a heredoc and `chmod`.
- Normalize JSON-escaped solidus sequences before scanning by adding `normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')` and use `normalized_text` for URL extraction.
- Treat an unset `ALLOWED_MCP_HOSTS` safely by expanding it as `${ALLOWED_MCP_HOSTS:-}` when building the runtime `allowlist`.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully and validated content semantics.
- Ran `git diff --check` which produced no issues.
- Extracted the `scriptBody` and executed the hook against both literal and JSON-escaped MCP URL events to confirm that unallowlisted literal and escaped URLs exit with status `2`, while an allowlisted escaped URL exits with `0`.
- Extracted and executed the new `installCommand` in a temporary directory and confirmed it creates a non-empty executable hook file that blocks an escaped unallowlisted URL as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a229c99c8bc832c966419aa4baaef93)