### PR TITLE
fix(ci): stabilize PR validation for stale branches

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -31,6 +31,7 @@ jobs:
       ci: ${{ steps.classify.outputs.ci }}
       docs: ${{ steps.classify.outputs.docs }}
       full: ${{ steps.classify.outputs.full }}
+      changed_files_json: ${{ steps.classify.outputs.changed_files_json }}
     concurrency:
       group: pr-classify-${{ github.ref }}
       cancel-in-progress: true
@@ -46,6 +47,8 @@ jobs:
         id: classify
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
           FORCE_FULL_VALIDATION: ${{ github.event_name != 'pull_request' && '1' || '0' }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
@@ -75,6 +78,9 @@ jobs:
           fi
           if ! grep -q '^content_categories_json=' "$GITHUB_OUTPUT"; then
             echo "content_categories_json=[]" >> "$GITHUB_OUTPUT"
+          fi
+          if ! grep -q '^changed_files_json=' "$GITHUB_OUTPUT"; then
+            echo "changed_files_json=[]" >> "$GITHUB_OUTPUT"
           fi
           if ! grep -q '^submission_gate=' "$GITHUB_OUTPUT"; then
             if [ "$EVENT_NAME" = "pull_request" ] && [ -n "$BASE_SHA" ] && git diff --name-only "$BASE_SHA"...HEAD | grep -Eq '^(apps/submission-gate/.*|tests/submission-gate-.*|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$)'; then
@@ -245,6 +251,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          CHANGED_FILES_JSON: ${{ needs.classify-pr.outputs.changed_files_json }}
         run: |
           set -euo pipefail
           policy_path="scripts/ci/validate-content-policy.mjs"
@@ -252,8 +259,10 @@ jobs:
           runtime_lock_path="scripts/ci/content-policy-runtime/package-lock.json"
           trusted_policy_dir="${RUNNER_TEMP:-.}/trusted-content-policy"
           trusted_policy="$trusted_policy_dir/validate-content-policy.mjs"
+          changed_files_json_path="$trusted_policy_dir/changed-files.json"
           rm -rf "$trusted_policy_dir"
           mkdir -p "$trusted_policy_dir"
+          printf '%s\n' "${CHANGED_FILES_JSON:-[]}" > "$changed_files_json_path"
 
           if git cat-file -e "$BASE_SHA:$runtime_manifest_path" 2>/dev/null && git cat-file -e "$BASE_SHA:$runtime_lock_path" 2>/dev/null; then
             git show "$BASE_SHA:$runtime_manifest_path" > "$trusted_policy_dir/package.json"
@@ -274,7 +283,7 @@ jobs:
             exit 1
           fi
 
-          node "$trusted_policy" --repo-root "$GITHUB_WORKSPACE"
+          node "$trusted_policy" --repo-root "$GITHUB_WORKSPACE" --files-json "$changed_files_json_path"
 
   validate-submission-source:
     name: validate-submission-source
@@ -323,6 +332,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          CHANGED_FILES_JSON: ${{ needs.classify-pr.outputs.changed_files_json }}
         run: |
           set -euo pipefail
           policy_path="scripts/ci/validate-content-policy.mjs"
@@ -330,8 +340,10 @@ jobs:
           runtime_lock_path="scripts/ci/content-policy-runtime/package-lock.json"
           trusted_policy_dir="${RUNNER_TEMP:-.}/trusted-content-policy"
           trusted_policy="$trusted_policy_dir/validate-content-policy.mjs"
+          changed_files_json_path="$trusted_policy_dir/changed-files.json"
           rm -rf "$trusted_policy_dir"
           mkdir -p "$trusted_policy_dir"
+          printf '%s\n' "${CHANGED_FILES_JSON:-[]}" > "$changed_files_json_path"
 
           if git cat-file -e "$BASE_SHA:$runtime_manifest_path" 2>/dev/null && git cat-file -e "$BASE_SHA:$runtime_lock_path" 2>/dev/null; then
             git show "$BASE_SHA:$runtime_manifest_path" > "$trusted_policy_dir/package.json"
@@ -352,7 +364,7 @@ jobs:
             exit 1
           fi
 
-          node "$trusted_policy" --repo-root "$GITHUB_WORKSPACE"
+          node "$trusted_policy" --repo-root "$GITHUB_WORKSPACE" --files-json "$changed_files_json_path"
 
       - name: Check submitted source whitespace
         env:
@@ -403,7 +415,7 @@ jobs:
       - validate-content-policy
       - validate-submission-source
       - validate-content-config
-    if: ${{ always() }}
+    if: ${{ always() && needs.classify-pr.outputs.content == 'true' }}
     runs-on: ubuntu-latest
     concurrency:
       group: pr-validate-content-${{ github.ref }}

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -3,6 +3,8 @@ import fs from "node:fs";
 
 const eventName = process.env.GITHUB_EVENT_NAME || "";
 const baseSha = process.env.BASE_SHA || "";
+const baseRef = process.env.BASE_REF || process.env.GITHUB_BASE_REF || "";
+const headSha = process.env.HEAD_SHA || "";
 const forceFull =
   process.env.FORCE_FULL_VALIDATION === "1" ||
   eventName === "workflow_dispatch" ||
@@ -22,15 +24,50 @@ const CONTENT_CATEGORIES = [
   "tools",
 ];
 
+function gitCommitExists(revision) {
+  if (!revision) return false;
+  try {
+    execFileSync("git", ["rev-parse", "--verify", `${revision}^{commit}`], {
+      stdio: "ignore",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function pullRequestDiffRange() {
+  const head =
+    /^[0-9a-f]{40}$/i.test(headSha) && gitCommitExists(headSha)
+      ? headSha
+      : "HEAD";
+  const candidates = [];
+
+  if (baseRef) {
+    candidates.push(`refs/remotes/origin/${baseRef}`);
+    candidates.push(`origin/${baseRef}`);
+    candidates.push(baseRef);
+  }
+
+  for (const candidate of candidates) {
+    if (gitCommitExists(candidate)) {
+      return [`${candidate}...${head}`];
+    }
+  }
+
+  if (/^[0-9a-f]{40}$/i.test(baseSha)) {
+    return [`${baseSha}...${head}`];
+  }
+
+  throw new Error("BASE_SHA must be a full Git commit SHA for PR validation");
+}
+
 function changedFiles() {
   if (forceFull) return [];
   if (eventName !== "pull_request") return [];
-  if (!/^[0-9a-f]{40}$/i.test(baseSha)) {
-    throw new Error("BASE_SHA must be a full Git commit SHA for PR validation");
-  }
   const output = execFileSync(
     "git",
-    ["diff", "--name-only", `${baseSha}...HEAD`],
+    ["diff", "--name-only", ...pullRequestDiffRange()],
     {
       encoding: "utf8",
     },

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -56,6 +56,9 @@ function runClassifier(
       cwd,
       env: {
         ...process.env,
+        BASE_REF: "",
+        GITHUB_BASE_REF: "",
+        HEAD_SHA: "",
         GITHUB_HEAD_REF: "contributor/source-entry",
         HEAD_REF: "contributor/source-entry",
         ...extraEnv,
@@ -122,6 +125,45 @@ describe("PR change classifier", () => {
       web: "false",
       raycast: "false",
     });
+  });
+
+  it("uses the current base ref and PR head SHA instead of stale merge refs", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+
+    git(cwd, ["switch", "-c", "feature"]);
+    const registryDir = path.join(cwd, "packages", "registry", "src");
+    fs.mkdirSync(registryDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(registryDir, "package-spec.js"),
+      "export const packageSpec = {};\n",
+    );
+    git(cwd, ["add", "packages/registry/src/package-spec.js"]);
+    git(cwd, ["commit", "-m", "update registry package spec"]);
+    const headSha = git(cwd, ["rev-parse", "HEAD"]);
+
+    git(cwd, ["switch", "main"]);
+    const contentDir = path.join(cwd, "content", "mcp");
+    fs.mkdirSync(contentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, "already-merged.mdx"),
+      "---\ntitle: Already Merged\n---\n",
+    );
+    git(cwd, ["add", "content/mcp/already-merged.mdx"]);
+    git(cwd, ["commit", "-m", "add unrelated base content"]);
+
+    const outputs = runClassifier(cwd, baseSha, {
+      BASE_REF: "main",
+      HEAD_SHA: headSha,
+    });
+    expect(outputs).toMatchObject({
+      content: "false",
+      registry: "true",
+      web: "false",
+      raycast: "false",
+    });
+    expect(JSON.parse(outputs.changed_files_json)).toEqual([
+      "packages/registry/src/package-spec.js",
+    ]);
   });
 
   it("routes direct PR submission automation changes through full owned validation lanes", () => {

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -201,15 +201,28 @@ describe("registry artifacts", () => {
 
   it("keeps public registry payloads within reviewable byte budgets", () => {
     const entryCount = contentEntries.length;
-    expect(artifactTreeSize(".")).toBeLessThan(20_000_000);
-    expect(artifactSize("directory-index.json")).toBeLessThan(1_000_000);
-    expect(artifactSize("search-index.json")).toBeLessThan(750_000);
-    expect(artifactSize("raycast-index.json")).toBeLessThan(500_000);
+    // These budgets are growth guards, not fixed caps. The public registry
+    // grows with curated content, so keep them per-entry to catch runaway
+    // artifact bloat without failing every normal catalog expansion.
+    expect(artifactTreeSize(".")).toBeLessThan(2_000_000 + entryCount * 38_500);
+    expect(artifactSize("directory-index.json")).toBeLessThan(
+      200_000 + entryCount * 2_000,
+    );
+    expect(artifactSize("search-index.json")).toBeLessThan(
+      125_000 + entryCount * 1_600,
+    );
+    expect(artifactSize("raycast-index.json")).toBeLessThan(
+      100_000 + entryCount * 1_100,
+    );
     expect(artifactSize("relation-graph.json")).toBeLessThan(
       150_000 + entryCount * 1_500,
     );
-    expect(artifactTreeSize("feeds/categories")).toBeLessThan(1_250_000);
-    expect(artifactTreeSize("feeds/platforms")).toBeLessThan(1_500_000);
+    expect(artifactTreeSize("feeds/categories")).toBeLessThan(
+      150_000 + entryCount * 2_000,
+    );
+    expect(artifactTreeSize("feeds/platforms")).toBeLessThan(
+      150_000 + entryCount * 2_000,
+    );
     expect(artifactTreeSize("entries")).toBeLessThan(
       500_000 + entryCount * 17_500,
     );

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -53,8 +53,11 @@ describe("submission automation workflows", () => {
         env: {
           ...process.env,
           BASE_SHA: baseSha,
+          BASE_REF: "",
           FORCE_FULL_VALIDATION: "0",
+          GITHUB_BASE_REF: "",
           GITHUB_EVENT_NAME: "pull_request",
+          HEAD_SHA: "",
           GITHUB_OUTPUT: outputPath,
           GITHUB_HEAD_REF: "contributor/source-entry",
           HEAD_REF: "contributor/source-entry",
@@ -342,7 +345,13 @@ describe("submission automation workflows", () => {
     expect(source).toContain("required-pr-gate:");
     expect(source).toContain("validate-content-${{ matrix.category }}");
     expect(source).toContain(
+      "always() && needs.classify-pr.outputs.content == 'true'",
+    );
+    expect(source).toContain(
       "fromJson(needs.classify-pr.outputs.content_categories_json)",
+    );
+    expect(source).toContain(
+      "changed_files_json: ${{ steps.classify.outputs.changed_files_json }}",
     );
     expect(source).toContain("Summarize required PR validation");
     expect(source).toContain('trunk check --ci --upstream "$BASE_SHA"');
@@ -376,6 +385,8 @@ describe("submission automation workflows", () => {
     expect(source).toContain("trusted_policy");
     expect(source).toContain("trusted_policy_dir");
     expect(source).toContain("runtime_lock_path");
+    expect(source).toContain("CHANGED_FILES_JSON:");
+    expect(source).toContain('--files-json "$changed_files_json_path"');
     expect(source).toContain(
       "scripts/ci/content-policy-runtime/package-lock.json",
     );


### PR DESCRIPTION
## Summary
- make registry artifact byte budgets scale with catalog entry count instead of fixed caps that current `main` already exceeds
- classify PR changed files against the current base ref plus PR head SHA to avoid stale synthetic merge diffs
- pass the classifier changed-file JSON into content-policy validation so it does not rescan unrelated already-merged content
- skip the aggregate `validate-content` summary job when no content lane is active

## Why
Several open PRs were failing `PR Validation` even though their changed-file lists were small and unrelated. Current `main` also failed `tests/registry-artifacts.test.ts` because the generated public data tree had outgrown a fixed 20 MB cap. Stale branches also caused policy validation to see already-merged content through the synthetic merge checkout.

## Validation
- `pnpm exec vitest run tests/classify-pr-changes.test.ts tests/submission-workflows.test.ts tests/content-policy-validation.test.ts tests/registry-artifacts.test.ts`
- `pnpm build`
- `git diff --check`

## Notes
Existing stale PRs need a new PR event after this lands, such as update branch or push, so their validation run uses the fixed base workflow and classifier.