### PR TITLE
fix(ci): skip preview validation for fork PRs

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -910,13 +910,11 @@ jobs:
 
   validate-pr-preview:
     name: validate-pr-preview
-    if: ${{ github.event_name == 'pull_request' && (needs.classify-pr.outputs.web == 'true' || needs.classify-pr.outputs.registry == 'true' || needs.classify-pr.outputs.mcp == 'true') }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && (needs.classify-pr.outputs.web == 'true' || needs.classify-pr.outputs.registry == 'true' || needs.classify-pr.outputs.mcp == 'true') }}
     needs: classify-pr
     runs-on: ubuntu-latest
-    env:
-      REQUIRE_PR_PREVIEW: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
     concurrency:
-      group: deployment-artifacts-pr-preview-${{ github.repository }}
+      group: deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
 
     steps:
@@ -941,15 +939,11 @@ jobs:
       - name: Resolve PR preview URL
         id: preview-url
         env:
-          ALLOW_SHARED_DEV_WORKER_PREVIEW: ${{ github.event.pull_request.head.repo.full_name == github.repository && '1' || '0' }}
+          ALLOW_SHARED_DEV_WORKER_PREVIEW: "1"
           CLOUDFLARE_DEV_WORKER_URL: https://heyclaude-dev.zeronode.workers.dev
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          args=(--wait-seconds 600 --poll-seconds 15)
-          if [ "$REQUIRE_PR_PREVIEW" != "true" ]; then
-            args=(--allow-missing --wait-seconds 0)
-          fi
-          node scripts/resolve-pr-preview-url.mjs "${args[@]}"
+          node scripts/resolve-pr-preview-url.mjs --wait-seconds 600 --poll-seconds 15
 
       - name: Validate deployed artifact contract
         if: ${{ steps.preview-url.outputs.base-url != '' }}

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -59,14 +59,20 @@ describe("PR preview artifact validation flow", () => {
     });
   });
 
-  it("uses resolved PR preview URLs instead of a manual merge-gate variable", () => {
+  it("uses resolved same-repo PR preview URLs instead of a manual merge-gate variable", () => {
     const workflow = readContentValidationWorkflow();
     expect(workflow).toContain("Resolve PR preview URL");
-    expect(workflow).toContain("REQUIRE_PR_PREVIEW");
+    expect(workflow).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+    expect(workflow).toContain(
+      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    );
     expect(workflow).toContain("ALLOW_SHARED_DEV_WORKER_PREVIEW");
     expect(workflow).toContain("https://heyclaude-dev.zeronode.workers.dev");
-    expect(workflow).toContain('[ "$REQUIRE_PR_PREVIEW" != "true" ]');
     expect(workflow).toContain("--wait-seconds 600");
+    expect(workflow).not.toContain("REQUIRE_PR_PREVIEW");
+    expect(workflow).not.toContain("--allow-missing");
     expect(workflow).toContain("pnpm validate:deployment-artifacts");
     expect(workflow).toContain(
       "Deployed preview did not satisfy the artifact contract before timeout.",

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -211,6 +211,12 @@ describe("submission automation workflows", () => {
     expect(source).not.toContain("playwright install");
     expect(source).toContain("Resolve PR preview URL");
     expect(source).toContain("--wait-seconds 600");
+    expect(source).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+    expect(source).toContain(
+      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    );
     expect(source).not.toContain("CLOUDFLARE_API_TOKEN");
     expect(source).not.toContain("CLOUDFLARE_ACCOUNT_ID");
     expect(source).not.toContain("pnpm --filter web run deploy:dev");
@@ -358,8 +364,15 @@ describe("submission automation workflows", () => {
     expect(source).toContain("trunk check --ci --all");
     expect(source).toContain("validate-pr-preview:");
     expect(source).toContain("github.event_name == 'pull_request'");
+    expect(source).toContain(
+      "github.event.pull_request.head.repo.full_name == github.repository",
+    );
+    expect(source).toContain(
+      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    );
     expect(source).toContain("Resolve PR preview URL");
     expect(source).toContain("--wait-seconds 600");
+    expect(source).not.toContain("--allow-missing");
     expect(source).toContain("pnpm validate:deployment-artifacts");
     expect(source).toContain("pnpm validate:mcp-endpoint");
     expect(source).not.toContain("Deploy same-repo PR preview to dev Worker");


### PR DESCRIPTION
## Summary
- Skip PR preview validation for forked PRs, where no same-repo preview is required.
- Scope preview validation concurrency by PR number instead of repository-wide.
- Add workflow assertions for the fork skip and PR-scoped preview queue.

## Why
- Fork PRs were running an allow-missing preview job anyway, and cancelled preview jobs could make `required-pr-gate` fail even after registry/web/content checks passed.
- Repository-wide preview concurrency made multiple refreshed PRs block each other unnecessarily.

## Validation
- `pnpm exec prettier --write .github/workflows/content-validation.yml tests/submission-workflows.test.ts tests/deployment-preview-url.test.ts`
- `pnpm test`
- `git diff --check`

## Notes
- Same-repo PRs still require preview artifact and MCP endpoint validation when web, registry, or MCP surfaces are touched.
- Fork PRs now let `validate-pr-preview` be skipped, which `required-pr-gate` already accepts as a non-blocking result.