### PR TITLE
feat(registry): add public /api/registry/tags directory endpoint

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -698,6 +698,237 @@
         }
       }
     },
+    "/api/registry/tags": {
+      "get": {
+        "tags": ["Registry"],
+        "summary": "Registry tag directory",
+        "description": "Lists registry tags with entry counts, per-category breakdown, and a canonical search URL for each tag.",
+        "responses": {
+          "200": {
+            "description": "Cacheable registry response with ETag support where applicable.",
+            "content": {
+              "application/json": { "schema": { "type": "object", "additionalProperties": {} } }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid query, invalid payload, or invalid status transition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin token or invalid webhook signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden origin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Invalid content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Route-level or Cloudflare-native rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Site DB not configured, provider not configured, or endpoint unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/registry/search": {
       "get": {
         "tags": ["Registry"],

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -912,6 +912,265 @@ paths:
                 required:
                   - ok
                   - error
+  /api/registry/tags:
+    get:
+      tags:
+        - Registry
+      summary: Registry tag directory
+      description:
+        Lists registry tags with entry counts, per-category breakdown, and a canonical search
+        URL for each tag.
+      responses:
+        "200":
+          description: Cacheable registry response with ETag support where applicable.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/registry/search:
     get:
       tags:

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -245,6 +245,22 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
     count: 1,
     entries: [{ id: "mcp", label: "MCP servers", count: 42 }],
   },
+  "registry.tags": {
+    schemaVersion: 1,
+    generatedAt: "2026-05-29T00:00:00.000Z",
+    count: 1,
+    entries: [
+      {
+        tag: "github",
+        count: 7,
+        categories: [
+          { category: "mcp", count: 5 },
+          { category: "agents", count: 2 },
+        ],
+        searchUrl: "/api/registry/search?q=github",
+      },
+    ],
+  },
   "registry.search": {
     schemaVersion: 1,
     query: "mcp",

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -840,6 +840,22 @@ export const apiRouteDefinitions = {
       binding: "API_REGISTRY_RATE_LIMIT",
     },
   }),
+  "registry.tags": route({
+    id: "registry.tags",
+    method: "GET",
+    path: "/api/registry/tags",
+    summary: "Registry tag directory",
+    description:
+      "Lists registry tags with entry counts, per-category breakdown, and a canonical search URL for each tag.",
+    tags: ["Registry"],
+    originCheck: true,
+    rateLimit: {
+      scope: "registry-tags",
+      limit: 120,
+      windowMs: 60_000,
+      binding: "API_REGISTRY_RATE_LIMIT",
+    },
+  }),
   "registry.search": route({
     id: "registry.search",
     method: "GET",

--- a/apps/web/src/lib/content.server.ts
+++ b/apps/web/src/lib/content.server.ts
@@ -265,6 +265,50 @@ export const getCategorySummaries = cache(async (): Promise<CategorySummary[]> =
     .filter((entry) => entry.count > 0);
 });
 
+export type TagDirectoryEntry = {
+  tag: string;
+  count: number;
+  categories: Array<{ category: string; count: number }>;
+  searchUrl: string;
+};
+
+export const getTagDirectory = cache(async (): Promise<TagDirectoryEntry[]> => {
+  const entries = await loadSearchIndex();
+  const tagMap = new Map<string, { count: number; categories: Map<string, number> }>();
+
+  for (const entry of entries) {
+    const seen = new Set<string>();
+    for (const rawTag of entry.tags ?? []) {
+      const tag = String(rawTag ?? "")
+        .trim()
+        .toLowerCase();
+      if (!tag || seen.has(tag)) continue;
+      seen.add(tag);
+
+      let bucket = tagMap.get(tag);
+      if (!bucket) {
+        bucket = { count: 0, categories: new Map() };
+        tagMap.set(tag, bucket);
+      }
+      bucket.count += 1;
+      bucket.categories.set(entry.category, (bucket.categories.get(entry.category) ?? 0) + 1);
+    }
+  }
+
+  return [...tagMap.entries()]
+    .map(([tag, bucket]) => ({
+      tag,
+      count: bucket.count,
+      categories: [...bucket.categories.entries()]
+        .map(([category, count]) => ({ category, count }))
+        .sort(
+          (left, right) => right.count - left.count || left.category.localeCompare(right.category),
+        ),
+      searchUrl: `/api/registry/search?q=${encodeURIComponent(tag)}`,
+    }))
+    .sort((left, right) => right.count - left.count || left.tag.localeCompare(right.tag));
+});
+
 export async function getRecentEntries() {
   const entries = await getDirectoryEntries();
   return [...entries]

--- a/apps/web/src/routes/api/registry/tags.ts
+++ b/apps/web/src/routes/api/registry/tags.ts
@@ -1,0 +1,24 @@
+import { createApiFileRoute } from "@/lib/api/file-route";
+
+import { createApiHandler } from "@/lib/api/router";
+import { getRegistryManifest, getTagDirectory } from "@/lib/content.server";
+import { cachedJsonResponse } from "@/lib/http-cache";
+
+export const GET = createApiHandler("registry.tags", async ({ request }) => {
+  const [manifest, tags] = await Promise.all([getRegistryManifest(), getTagDirectory()]);
+
+  return cachedJsonResponse(request, {
+    schemaVersion: 1,
+    generatedAt: manifest.generatedAt,
+    count: tags.length,
+    entries: tags,
+  });
+});
+
+export const Route = createApiFileRoute("/api/registry/tags")({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => GET(request, { params }),
+    },
+  },
+});

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -913,6 +913,265 @@ paths:
                 required:
                   - ok
                   - error
+  /api/registry/tags:
+    get:
+      tags:
+        - Registry
+      summary: Registry tag directory
+      description:
+        Lists registry tags with entry counts, per-category breakdown, and a canonical search
+        URL for each tag.
+      responses:
+        "200":
+          description: Cacheable registry response with ETag support where applicable.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/registry/search:
     get:
       tags:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -18,6 +18,7 @@ function findRouteFiles(directory: string): string[] {
 const apiRoutes = [
   "/api/registry/manifest",
   "/api/registry/categories",
+  "/api/registry/tags",
   "/api/registry/search",
   "/api/registry/feed",
   "/api/registry/trending",


### PR DESCRIPTION
## Summary

Adds a read-only public API endpoint, **`GET /api/registry/tags`**, that lists every registry tag with its entry count, per-category breakdown, and a canonical search URL.

This fills a real discovery gap. The registry already exposes `GET /api/registry/categories` (category summaries) but had no tag-level index — so there was no API to power tag browsing, tag landing pages, or "related by tag" surfaces. Tags are first-class metadata on every entry; this exposes them the same way categories are exposed.

Example response:
```json
{
  "schemaVersion": 1,
  "generatedAt": "2026-05-29T00:00:00.000Z",
  "count": 312,
  "entries": [
    {
      "tag": "github",
      "count": 7,
      "categories": [{ "category": "mcp", "count": 5 }, { "category": "agents", "count": 2 }],
      "searchUrl": "/api/registry/search?q=github"
    }
  ]
}
```

## Quality Evidence

- **Changed surface:** new read-only `GET /api/registry/tags`. No new write paths, no auth, origin-checked, `API_REGISTRY_RATE_LIMIT` tier (120/min) — identical posture to the other registry GET endpoints.
- **Route handler** is a thin central-router adapter mirroring `routes/api/registry/categories.ts` exactly.
- **Logic** lives in `getTagDirectory()` in `content.server`: aggregates tags from the search index, case-folds, de-dupes per entry, ranks by count then name, and attaches a canonical `/api/registry/search?q=<tag>` URL.
- **Invariants:** the route contract feeds `ENDPOINTS` and the generated OpenAPI automatically; `apiRouteDefinitions` ids/paths verified unique (no method collisions); response example contains no `heyclaude.`/raycast placeholders (api-contract test rules).
- **No hand-edited generated drift:** the 3 OpenAPI artifacts were produced by `pnpm generate:openapi`; I confirmed the generator reproduces the committed baseline byte-for-byte before regenerating, so the only OpenAPI change is the new path.
- Screenshots: `No visual impact` (API + contract test + generated schema only).

## Validation

- `pnpm validate:openapi` — regenerated `cloudflare/api-schema-heyclaude-openapi.yaml`, `apps/web/public/openapi.{yaml,json}`; verified the generator reproduces the prior committed output and adds only `/api/registry/tags`.
- `pnpm exec vitest run tests/api-contracts.test.ts` — extended the route-coverage list with `/api/registry/tags`; contract derivation verified offline via the same loader the generator uses (route present, unique id/path, "Registry" tag).
- `git diff --check` clean.

## Notes

I could not run the full Vite build / web vitest locally (the pinned pnpm needs Node 22 and only Node 20 was available here), so the TypeScript build and route runtime are CI-verified. The route handler and helper deliberately mirror the existing `categories` endpoint to keep that risk minimal. Final merge is at maintainer discretion per the repo's automation boundaries (auto-merge is content-only). This is independent of my other open PR #1086 (MCP tool) — different subsystem, no shared files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `/api/registry/tags` API endpoint that provides a directory of registry tags with entry counts, per-category breakdowns, and dedicated search URLs for each tag. The endpoint supports caching and includes comprehensive error handling for common failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->