### PR TITLE
content(tools): add Goose

### DIFF
--- a/content/tools/goose.mdx
+++ b/content/tools/goose.mdx
@@ -1,0 +1,95 @@
+---
+title: Goose
+slug: goose
+category: tools
+description: >-
+  Open-source, extensible AI agent that goes beyond code suggestions to install,
+  execute, edit, and test with any LLM, available as a desktop app, CLI, and API
+  with 70+ MCP extensions.
+cardDescription: >-
+  Open-source, extensible AI agent that installs, executes, edits, and tests
+  with any LLM, as a desktop app, CLI, and API.
+seoTitle: Goose — Open-Source Extensible AI Agent
+seoDescription: >-
+  Goose is an Apache-2.0 extensible AI agent that installs, executes, edits, and
+  tests with any LLM. Desktop app, CLI, and API, 15+ providers, and 70+ MCP
+  extensions. Hosted by the Agentic AI Foundation.
+author: Agentic AI Foundation
+dateAdded: "2026-06-05"
+submittedBy: JPette1783
+submittedByUrl: "https://github.com/JPette1783"
+submittedAt: "2026-06-05"
+websiteUrl: "https://goose-docs.ai"
+repoUrl: "https://github.com/aaif-goose/goose"
+documentationUrl: "https://goose-docs.ai/docs"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+prerequisites:
+  - "An LLM provider API key, or an existing Claude, ChatGPT, or Gemini subscription via an ACP provider."
+  - "macOS, Linux, or Windows for the desktop app or CLI."
+  - "MCP-compatible extensions if you want to expand Goose beyond its built-in tools."
+safetyNotes:
+  - "Goose installs, executes, edits, and tests code and runs commands locally, so it can change files and system state on your machine."
+  - "It connects to 70+ MCP extensions; each extension adds capabilities and its own integration risk, so enable only those you trust."
+  - "Review actions and generated code before allowing changes to important repositories or systems."
+  - "Because it works across 15+ providers, confirm which provider and model a session uses before sending sensitive context."
+privacyNotes:
+  - "Your code and prompts are sent to whichever LLM provider you configure; data handling follows that provider's policies."
+  - "API keys and provider credentials should be stored securely and never committed to source control."
+  - "MCP extensions can access local files and external services depending on their scope; review what each extension can reach."
+tags:
+  - ai-agent
+  - cli
+  - desktop-app
+  - mcp
+  - open-source
+  - automation
+keywords:
+  - goose
+  - goose ai agent
+  - open source ai agent
+  - extensible ai agent
+  - mcp agent
+  - aaif goose
+---
+
+## Overview
+
+Goose is an open-source, extensible AI agent that goes beyond code suggestions —
+it installs, executes, edits, and tests with any LLM. It runs as a native
+desktop app, a CLI, and an API, and is used for research, writing, automation,
+data analysis, and code tasks.
+
+It is released under the Apache-2.0 license and is primarily Rust. The project
+moved from `block/goose` to the Agentic AI Foundation (AAIF) at the Linux
+Foundation, and its current home is `aaif-goose/goose`.
+
+## Features
+
+- Works as a desktop app, CLI, and API.
+- Provider flexibility across 15+ providers including Anthropic, OpenAI, Google,
+  Ollama, OpenRouter, Azure, and Bedrock.
+- Connects to 70+ extensions via the Model Context Protocol (MCP).
+- ACP integration to use existing Claude, ChatGPT, or Gemini subscriptions.
+- General-purpose automation beyond code generation.
+
+## Use Cases
+
+- Run a local AI agent that can execute and test changes, not just suggest them.
+- Use your preferred provider or an existing subscription via ACP.
+- Extend the agent with MCP extensions for tools and data sources.
+- Automate research, writing, and data tasks alongside coding.
+
+## Installation
+
+Install the desktop app or CLI from the official installation guide at
+[goose-docs.ai](https://goose-docs.ai/docs/getting-started/installation). Choose
+your platform build and configure an LLM provider before first use.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate relationship. Goose is open
+source under Apache-2.0 and hosted by the Agentic AI Foundation; using it
+requires your own LLM provider access.


### PR DESCRIPTION
Adds a tools entry for [Goose](https://github.com/aaif-goose/goose), Apache-2.0 extensible AI agent that installs, executes, edits, and tests with any LLM, as a desktop app, CLI, and API with 70+ MCP extensions. Moved from block/goose to the Agentic AI Foundation (AAIF).

Includes prerequisites, safetyNotes, and privacyNotes with real runtime/privacy context. Provenance fields (submittedBy/submittedByUrl/submittedAt) set per the direct-content-PR policy.

## Duplicate And History Check

Searched content/tools/ by slug, title, repo URL (github.com/aaif-goose/goose), docs URL (goose-docs.ai), provider name, and source domain. No existing entry or references found.

Closes #1589