### PR TITLE
content(agents): add Bedrock Claude Code Platform Agent

### DIFF
--- a/content/agents/bedrock-claude-code-platform-agent.mdx
+++ b/content/agents/bedrock-claude-code-platform-agent.mdx
@@ -1,0 +1,135 @@
+---
+title: Bedrock Claude Code Platform Agent
+slug: bedrock-claude-code-platform-agent
+category: agents
+description: >-
+  Source-backed agent that helps teams configure and operate Claude Code on
+  Amazon Bedrock, covering provider environment variables, authentication
+  precedence, region and model setup, and least-privilege IAM, grounded in the
+  official Claude Code docs.
+cardDescription: >-
+  Configure and operate Claude Code on Amazon Bedrock: provider env vars, auth
+  precedence, regions, models, and least-privilege IAM.
+seoTitle: Bedrock Claude Code Platform Agent
+seoDescription: >-
+  Reusable agent prompt for running Claude Code on Amazon Bedrock, covering
+  CLAUDE_CODE_USE_BEDROCK, authentication precedence, region and model setup,
+  and least-privilege IAM, grounded in official Claude Code documentation.
+author: JPette1783
+authorProfileUrl: "https://github.com/JPette1783"
+submittedBy: JPette1783
+submittedByUrl: "https://github.com/JPette1783"
+dateAdded: "2026-06-05"
+submittedAt: "2026-06-05"
+documentationUrl: "https://code.claude.com/docs/en/skills"
+installable: false
+usageSnippet: "Use this agent when standing up or troubleshooting Claude Code on Amazon Bedrock, to set provider variables, confirm authentication precedence, and keep IAM scoped to least privilege."
+prerequisites:
+  - "An AWS account with Amazon Bedrock access and the relevant Claude models enabled in the target region."
+  - "AWS credentials available to the environment (profile, SSO, or instance role) for Bedrock calls."
+  - "Claude Code installed, and the ability to set environment variables for the session or CI."
+safetyNotes:
+  - "This agent advises on configuration; it does not provision AWS resources or grant IAM permissions itself."
+  - "Recommend least-privilege IAM scoped to the specific Bedrock model invoke actions and region, not broad account access."
+  - "Cloud provider credentials take precedence when CLAUDE_CODE_USE_BEDROCK is set; confirm the intended account and region are active before running automation."
+privacyNotes:
+  - "On Bedrock, prompts and code context are sent to your AWS Bedrock endpoint and processed under your AWS agreement and region."
+  - "AWS credentials and any bearer tokens should be supplied through the environment or a role, never committed to source control."
+  - "Confirm whether request logging or model-invocation logging is enabled in your AWS account so you know what is retained."
+tags:
+  - claude-code
+  - amazon-bedrock
+  - enterprise
+  - configuration
+  - review
+keywords:
+  - bedrock claude code platform agent
+  - claude code on bedrock
+  - CLAUDE_CODE_USE_BEDROCK
+  - bedrock claude setup
+  - claude code aws iam
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+Bedrock Claude Code Platform Agent is a reusable agent prompt for teams running
+Claude Code against Amazon Bedrock instead of the direct Anthropic API. It helps
+set the provider environment variables, reason about authentication precedence,
+choose region and model identifiers, and keep IAM scoped to least privilege.
+
+Use it when onboarding Claude Code to a Bedrock-backed environment or when
+diagnosing why a Bedrock session is not authenticating or routing to the right
+model and region.
+
+## Agent Prompt
+
+You are a Claude Code on Amazon Bedrock platform specialist. Help the user set up
+and operate Claude Code with Bedrock as the model provider. Use the official
+Claude Code documentation as your reference, and never invent settings.
+
+Setup checklist:
+
+1. Provider selection. Confirm the cloud provider path is enabled (the Bedrock
+   provider environment variable) so Claude Code routes inference to Bedrock.
+2. Authentication. Confirm AWS credentials are available through a profile, SSO,
+   or an instance role. Remember that cloud provider credentials take precedence
+   when the Bedrock provider is enabled.
+3. Region and model. Set the region and the Bedrock model identifiers for the
+   main and small/fast models. Confirm the chosen models are enabled in that
+   region.
+4. IAM. Recommend a least-privilege policy scoped to the specific Bedrock
+   model-invoke actions and region. Avoid broad account-wide grants.
+5. Verification. Confirm the active provider and model with the status command,
+   and run a small test prompt before enabling automation.
+6. Troubleshooting. For auth failures, check credential precedence, a stray
+   ANTHROPIC_API_KEY, region mismatch, or a model not enabled in the region.
+
+Output contract:
+
+- Environment summary: provider, region, model ids, credential source.
+- Findings: misconfiguration, over-broad IAM, region/model mismatch.
+- Recommended changes: specific variables and least-privilege IAM scoping.
+- Verification steps and a go/no-go for automation.
+
+## Features
+
+- Configures Claude Code to use Amazon Bedrock as the model provider.
+- Reasons about authentication precedence and credential sources.
+- Recommends least-privilege IAM scoped to Bedrock model invocation.
+- Provides region/model verification and troubleshooting steps.
+
+## Use Cases
+
+- Stand up Claude Code on Bedrock for an AWS-based organization.
+- Diagnose Bedrock authentication or region/model routing failures.
+- Tighten IAM permissions for Claude Code's Bedrock access.
+- Verify the active provider and model before enabling CI automation.
+
+## Source Notes
+
+- Claude Code supports cloud providers including Amazon Bedrock, selected with a
+  provider environment variable, and cloud provider credentials take precedence
+  in the authentication order when that provider is enabled.
+- Region and model identifiers are configured through environment variables, and
+  the active method can be confirmed with the status command.
+
+## Duplicate Check
+
+The content tree and open PRs were checked for Bedrock, AWS, and Claude Code
+platform agents. No Bedrock platform agent exists. This entry is distinct: it is
+an `agents` prompt focused on configuring and operating Claude Code on Amazon
+Bedrock with least-privilege IAM.
+
+## Editorial Disclosure
+
+Submitted as an independent community agent entry by `JPette1783`, based on
+public Claude Code documentation. No paid placement, referral, or affiliate
+relationship.
+
+## Sources
+
+- Claude Code skills documentation: https://code.claude.com/docs/en/skills
+- Claude Code features overview: https://code.claude.com/docs/en/features-overview
+- Claude Code authentication and identity docs: https://code.claude.com/docs/en/iam


### PR DESCRIPTION
Adds an agents entry: Bedrock Claude Code Platform Agent. The body is a complete, copyable agent prompt grounded in the official Claude Code documentation (skills/iam).

Includes prerequisites, safetyNotes, and privacyNotes with real runtime/privacy context. Provenance fields (submittedBy/submittedByUrl/submittedAt) set per the direct-content-PR policy. ASCII punctuation only; all referenced URLs verified to return 200.

## Duplicate And History Check

Searched content/agents/ and open PRs by slug, title, and topic. No existing entry found.

Closes #1580