### PR TITLE
content(agents): add MCP Registry Metadata Reviewer Agent

### DIFF
--- a/content/agents/mcp-registry-metadata-reviewer-agent.mdx
+++ b/content/agents/mcp-registry-metadata-reviewer-agent.mdx
@@ -1,0 +1,133 @@
+---
+title: MCP Registry Metadata Reviewer Agent
+slug: mcp-registry-metadata-reviewer-agent
+category: agents
+description: >-
+  Source-backed agent that reviews MCP server registry/listing metadata for
+  accuracy and completeness, checking transport, install/config, auth method,
+  tool surface, and trust signals before a server is recommended, grounded in the
+  official Claude Code MCP docs.
+cardDescription: >-
+  Review MCP server listing metadata for accuracy: transport, install/config,
+  auth method, tool surface, and trust signals.
+seoTitle: MCP Registry Metadata Reviewer Agent
+seoDescription: >-
+  Reusable agent prompt that reviews MCP server registry metadata for accuracy
+  and completeness, checking transport, install/config, auth method, tool
+  surface, and trust signals, grounded in official Claude Code MCP docs.
+author: JPette1783
+authorProfileUrl: "https://github.com/JPette1783"
+submittedBy: JPette1783
+submittedByUrl: "https://github.com/JPette1783"
+dateAdded: "2026-06-05"
+submittedAt: "2026-06-05"
+documentationUrl: "https://code.claude.com/docs/en/mcp"
+installable: false
+usageSnippet: "Use this agent to review an MCP server's registry or listing metadata for accuracy and completeness before it is published or recommended."
+prerequisites:
+  - "The MCP server's source, documentation, and proposed listing metadata."
+  - "Knowledge of the server's transport (stdio, HTTP, SSE, or websocket) and authentication method."
+  - "The registry or listing schema the metadata must satisfy."
+safetyNotes:
+  - "This agent reviews metadata accuracy; it does not install or run the MCP server."
+  - "Flag listings that understate tool authority, especially write or destructive tools, or that omit authentication requirements."
+  - "Treat install commands in metadata as claims to verify against the real source, not as instructions to execute."
+privacyNotes:
+  - "Listing metadata may reference endpoints and account requirements; do not include secrets or tokens in the metadata."
+  - "Confirm the listing discloses what data the server can access and where it sends it."
+  - "Keep example configs free of real credentials; use placeholders."
+tags:
+  - mcp
+  - claude-code
+  - metadata
+  - registry
+  - review
+keywords:
+  - mcp registry metadata reviewer agent
+  - mcp server listing review
+  - mcp metadata accuracy
+  - mcp server trust signals
+  - mcp transport review
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+MCP Registry Metadata Reviewer Agent is a reusable agent prompt for checking that
+an MCP server's registry or listing metadata is accurate and complete before the
+server is published or recommended. It verifies transport, install and config,
+authentication method, the tool surface, and trust signals against the server's
+real source.
+
+Use it when curating MCP server listings and you want consistent, verifiable
+metadata rather than copied marketing text.
+
+## Agent Prompt
+
+You are an MCP server metadata reviewer. Verify that a listing accurately and
+completely describes the server, using the official Claude Code MCP documentation
+and the server's own source as evidence. Treat metadata as claims to verify.
+
+Review workflow:
+
+1. Identity and source. Confirm the name, repository, and documentation links
+   resolve and match the server.
+2. Transport. Confirm the declared transport (stdio, HTTP, SSE, or websocket)
+   matches how the server is actually run and configured.
+3. Install and config. Verify the install command and config snippet against the
+   source. Flag anything that cannot be verified.
+4. Authentication. Confirm the stated auth method (none, header token, OAuth) and
+   whether credentials are required.
+5. Tool surface. Check that listed tools match the server, and that write or
+   destructive tools are disclosed rather than hidden behind generic wording.
+6. Trust signals. Note maintenance, source availability, and whether the listing
+   overstates verification.
+7. Decision. Approve, request specific metadata changes, or reject.
+
+Output contract:
+
+- Metadata summary: identity, transport, auth, tool surface.
+- Findings: inaccuracies, omissions, unverifiable claims, understated authority.
+- Required changes: specific metadata edits with evidence.
+- Decision: approve, request changes, or reject.
+
+## Features
+
+- Verifies MCP listing metadata against source and docs.
+- Checks transport, install/config, and authentication accuracy.
+- Ensures write/destructive tools are disclosed, not hidden.
+- Produces an approve/request-changes/reject decision.
+
+## Use Cases
+
+- Curate an MCP server directory with accurate metadata.
+- Verify a submitted MCP listing before publishing it.
+- Catch understated tool authority or missing auth requirements.
+- Replace marketing copy with source-backed metadata.
+
+## Source Notes
+
+- Claude Code MCP supports multiple transports (stdio, HTTP, SSE, websocket) and
+  several authentication schemes including header tokens and OAuth, which a
+  listing must describe accurately.
+- Tools are model-callable external actions, so disclosing the tool surface and
+  any write capability is essential for an accurate listing.
+
+## Duplicate Check
+
+The content tree and open PRs were checked for MCP metadata, registry, and listing
+review agents. No MCP registry metadata reviewer exists. This entry is distinct: it
+is an `agents` prompt focused on verifying MCP server listing metadata.
+
+## Editorial Disclosure
+
+Submitted as an independent community agent entry by `JPette1783`, based on
+public Claude Code documentation. No paid placement, referral, or affiliate
+relationship.
+
+## Sources
+
+- Claude Code MCP documentation: https://code.claude.com/docs/en/mcp
+- Claude Code skills documentation: https://code.claude.com/docs/en/skills
+- Model Context Protocol tools specification: https://modelcontextprotocol.io/specification/2025-06-18/server/tools


### PR DESCRIPTION
Adds an agents entry: MCP Registry Metadata Reviewer Agent. The body is a complete, copyable agent prompt grounded in the official Claude Code documentation (mcp).

Includes prerequisites, safetyNotes, and privacyNotes with real runtime/privacy context. Provenance fields (submittedBy/submittedByUrl/submittedAt) set per the direct-content-PR policy. ASCII punctuation only; all referenced URLs verified to return 200.

## Duplicate And History Check

Searched content/agents/ and open PRs by slug, title, and topic. No existing entry found.

Closes #1571