### PR TITLE
fix(submissions): calibrate security-aware gate closures

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -349,9 +349,22 @@ export function findStrictContentDuplicateMatch(
     if (
       blockingSharedUrls.length &&
       candidate.category &&
-      candidate.category === existing.category
+      candidate.category === existing.category &&
+      candidate.normalizedDescription &&
+      candidate.normalizedDescription === existing.normalizedDescription
     ) {
-      reasons.push(`same canonical source URL ${blockingSharedUrls[0]}`);
+      reasons.push(
+        `same canonical source URL ${blockingSharedUrls[0]} and same normalized description`,
+      );
+    }
+    if (
+      blockingSharedUrls.length >= 2 &&
+      candidate.category === "collections" &&
+      existing.category === "collections"
+    ) {
+      reasons.push(
+        `same collection source set including ${blockingSharedUrls[0]}`,
+      );
     }
 
     if (
@@ -395,6 +408,14 @@ export function findRelatedContentMatches(
         isCollectionBridge(candidate, existing)
           ? `same canonical source URL ${sharedUrls[0]} across collection/resource categories`
           : `same canonical source URL ${sharedUrls[0]} across ${candidate.category}/${existing.category}`,
+      );
+    } else if (
+      sharedUrls.length &&
+      candidate.category &&
+      candidate.category === existing.category
+    ) {
+      reasons.push(
+        `same canonical source URL ${sharedUrls[0]} in ${candidate.category}, but not a strict duplicate without the same title, slug, or purpose`,
       );
     }
     const catalogUrls = sharedCatalogUrls(sharedUrls);

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -1541,6 +1541,14 @@ function scopeFailureDecision(error: unknown): GateDecision {
         : "Direct content scope validation failed.";
   return {
     verdict: "close" as const,
+    reasonCode: "scope_failure",
+    evidence: [
+      {
+        ruleId: "direct_content_scope",
+        behavior: message,
+        fix: "Submit exactly one raw content/<category>/<slug>.mdx file.",
+      },
+    ],
     summary: [
       "Summary:",
       `- ${message}`,
@@ -1556,6 +1564,39 @@ function scopeFailureDecision(error: unknown): GateDecision {
     labels: [LABELS.close],
     close: true,
   };
+}
+
+function validationReasonCode(validation: {
+  summary: string;
+  checks: Array<{ name: string; status: string; details?: string }>;
+}) {
+  const text = `${validation.summary} ${validation.checks
+    .map((check) => `${check.name} ${check.details || ""}`)
+    .join(" ")}`;
+  return /provenance|submittedBy|submittedByUrl|submitter/i.test(text)
+    ? ("provenance_failure" as const)
+    : ("validation_failure" as const);
+}
+
+function validationEvidence(validation: {
+  summary: string;
+  checks: Array<{ name: string; status: string; details?: string }>;
+}) {
+  const failed = validation.checks.filter((check) => check.status === "failed");
+  const checkText = failed
+    .map((check) => `${check.name} ${check.details || ""}`.trim())
+    .join("; ");
+  return [
+    {
+      ruleId: validationReasonCode(validation),
+      behavior: validation.summary,
+      source: checkText || "required public validation checks",
+      fix:
+        validationReasonCode(validation) === "provenance_failure"
+          ? "Fix submitter provenance fields and resubmit a clean one-file content PR."
+          : "Fix the failing validation check and resubmit a clean one-file content PR.",
+    },
+  ];
 }
 
 function validationGateDecision(validation: {
@@ -1578,6 +1619,8 @@ function validationGateDecision(validation: {
     }
     return {
       verdict: "close" as const,
+      reasonCode: "validation_failure",
+      evidence: validationEvidence(validation),
       summary: [
         "Summary:",
         `- ${validation.summary}`,
@@ -1595,6 +1638,8 @@ function validationGateDecision(validation: {
   }
   return {
     verdict: "close" as const,
+    reasonCode: validationReasonCode(validation),
+    evidence: validationEvidence(validation),
     summary: [
       "Summary:",
       `- ${validation.summary}`,
@@ -1960,6 +2005,15 @@ function duplicateCloseDecision(
     : existing.label || existing.filePath;
   return {
     verdict: "close" as const,
+    reasonCode: "strict_duplicate",
+    evidence: [
+      {
+        ruleId: "strict_duplicate",
+        behavior: match.reasons.join("; "),
+        source: existingTarget,
+        fix: "Resubmit only if the resource has a clearly different canonical source, title, scope, and value proposition.",
+      },
+    ],
     summary: [
       "Summary:",
       `- This submission overlaps an existing or earlier pending content item: ${existingTarget}.`,
@@ -2009,6 +2063,14 @@ function summarizeDuplicateReview(review: ContentDuplicateReview) {
 function protectedEditCloseDecision(changedFields: string[]): GateDecision {
   return {
     verdict: "close" as const,
+    reasonCode: "protected_metadata_edit",
+    evidence: [
+      {
+        ruleId: "protected_frontmatter_fields",
+        behavior: changedFields.map((field) => `\`${field}\``).join(", "),
+        fix: "Resubmit a focused content edit without changing protected identity, provenance, source, or verification fields.",
+      },
+    ],
     summary: [
       "Summary:",
       "- This PR edits protected content identity, provenance, review, disclosure, source, or verification metadata.",
@@ -3163,13 +3225,15 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 "rejected_history",
               ],
               strictDuplicatePolicy:
-                "Only same path, same category+slug, same category+canonical URL/repo, same category+title, or same category+normalized description should block as a duplicate. Shared official multi-entry catalog repositories, such as organization MCP catalogs that host multiple distinct servers, are related context rather than automatic duplicates when title, slug, package, documentation URL, and endpoint differ.",
+                "Only same path, same category+slug, same category+title, same category+normalized description, or same upstream product/source with the same purpose should block as a duplicate. Shared official docs, shared safety doctrine, same broad source domain, and same ecosystem are related/complementary context unless the submitted resource has the same action surface and value proposition.",
               relatedContentPolicy:
-                "Cross-category source overlap, same ecosystem/project ownership, and collection-member overlap are related/complementary context, not automatic duplicates.",
+                "Cross-category source overlap, same ecosystem/project ownership, collection-member overlap, shared official docs, and adjacent controls such as different hook trigger points are related/complementary context, not automatic duplicates. Call out possible complementary content, then close only true repeats.",
               collectionPolicy:
                 "Collections may bundle existing entries when they add distinct workflow value, ordering, prerequisites, source-backed rationale, and safety/privacy guidance; repeated same-scope collection variants can still close as duplicates.",
               defensiveSecurityPolicy:
                 "Do not close a submission merely because it defensively discusses OAuth, tokens, credentials, authorization, attestations, artifacts, packages, downloads, security, privacy, or destructive-risk prevention. These topics require careful evidence review, but source-backed guides, rules, skills, collections, hooks, tools, and statuslines about safe review practices can merge when validation, sources, scope, and safety/privacy notes pass. A hard safety, secret, package, or abuse close must cite concrete unsafe behavior or a concrete policy violation such as credential theft, exposed secrets, destructive defaults, malware/abuse tooling, unverified package hosting, packageVerified:true by an external contributor, broken source evidence, or promotional/affiliate content. Generic phrases like 'contains patterns that cannot be accepted' are not sufficient evidence for a close verdict.",
+              closeEvidenceContract:
+                "Every close verdict must include reasonCode and evidence. Supported reasonCode values are scope_failure, validation_failure, provenance_failure, protected_metadata_edit, strict_duplicate, source_hard_failure, commercial_listing_route, embedded_secret, unsafe_install_pipeline, malicious_data_theft, prohibited_content, and policy_fit_failure. Safety closes must include ruleId, matched snippet or behavior, and whyNotDefensive. Defensive security examples like Claude Code permission auditing or env-leak warning hooks should not close on keyword matches alone.",
             },
           },
         });

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -49,11 +49,37 @@ export type GateDecisionError = {
   message?: string;
 };
 
+export type GateDecisionReasonCode =
+  | "scope_failure"
+  | "validation_failure"
+  | "provenance_failure"
+  | "protected_metadata_edit"
+  | "strict_duplicate"
+  | "source_hard_failure"
+  | "commercial_listing_route"
+  | "embedded_secret"
+  | "unsafe_install_pipeline"
+  | "malicious_data_theft"
+  | "prohibited_content"
+  | "policy_fit_failure";
+
+export type GateDecisionEvidence = {
+  ruleId?: string;
+  snippet?: string;
+  behavior?: string;
+  policy?: string;
+  source?: string;
+  fix?: string;
+  whyNotDefensive?: string;
+};
+
 export type GateDecision = {
   verdict: GateVerdict;
   summary: string;
   labels: string[];
   close?: boolean;
+  reasonCode?: GateDecisionReasonCode;
+  evidence?: GateDecisionEvidence[];
   schemaVersion?: typeof GATE_DECISION_SCHEMA_VERSION;
   confidence?: number;
   scope?: GateDecisionScope;
@@ -84,6 +110,26 @@ const V2_GATE_VERDICTS = new Set<GateDecisionV2Verdict>([
   "close",
   "manual",
   "ignore",
+]);
+const CLOSE_REASON_CODES = new Set<GateDecisionReasonCode>([
+  "scope_failure",
+  "validation_failure",
+  "provenance_failure",
+  "protected_metadata_edit",
+  "strict_duplicate",
+  "source_hard_failure",
+  "commercial_listing_route",
+  "embedded_secret",
+  "unsafe_install_pipeline",
+  "malicious_data_theft",
+  "prohibited_content",
+  "policy_fit_failure",
+]);
+const SAFETY_CLOSE_REASON_CODES = new Set<GateDecisionReasonCode>([
+  "embedded_secret",
+  "unsafe_install_pipeline",
+  "malicious_data_theft",
+  "prohibited_content",
 ]);
 
 const RETRYABLE_PRIVATE_REVIEW_CODES = new Set([
@@ -137,6 +183,7 @@ const SECTION_TITLES: Record<string, string> = {
   required_shape: "Required Shape",
   merge_result: "Merge Result",
   one_shot_review: "One-shot Review",
+  decision_evidence: "Decision Evidence",
   raw_evidence: "Raw Evidence",
 };
 
@@ -153,6 +200,7 @@ const DETAILS_SECTION_ORDER = [
   "required_shape",
   "merge_result",
   "one_shot_review",
+  "decision_evidence",
   "raw_evidence",
 ];
 
@@ -235,6 +283,76 @@ function normalizeError(value: unknown): GateDecisionError | null {
   };
 }
 
+function normalizeReasonCode(
+  value: unknown,
+): GateDecisionReasonCode | undefined {
+  const code = cleanText(value) as GateDecisionReasonCode;
+  return CLOSE_REASON_CODES.has(code) ? code : undefined;
+}
+
+function normalizeEvidence(value: unknown): GateDecisionEvidence | null {
+  if (!isRecord(value)) return null;
+  const evidence: GateDecisionEvidence = {
+    ruleId: cleanText(value.ruleId) || undefined,
+    snippet: cleanText(value.snippet) || undefined,
+    behavior: cleanText(value.behavior) || undefined,
+    policy: cleanText(value.policy) || undefined,
+    source: cleanText(value.source) || undefined,
+    fix: cleanText(value.fix) || undefined,
+    whyNotDefensive: cleanText(value.whyNotDefensive) || undefined,
+  };
+  return Object.values(evidence).some(Boolean) ? evidence : null;
+}
+
+function evidenceHasConcreteDetail(evidence: GateDecisionEvidence[]) {
+  return evidence.some((item) =>
+    [
+      item.snippet,
+      item.behavior,
+      item.policy,
+      item.source,
+      item.fix,
+      item.whyNotDefensive,
+    ].some(Boolean),
+  );
+}
+
+function closeEvidenceContractError(params: {
+  reasonCode?: GateDecisionReasonCode;
+  evidence?: GateDecisionEvidence[];
+}) {
+  if (!params.reasonCode) {
+    return "Private close decisions must include a supported reasonCode.";
+  }
+  const evidence = params.evidence || [];
+  if (!evidence.length || !evidenceHasConcreteDetail(evidence)) {
+    return "Private close decisions must include public-safe evidence.";
+  }
+  if (SAFETY_CLOSE_REASON_CODES.has(params.reasonCode)) {
+    const hasRule = evidence.some((item) => item.ruleId);
+    const hasMatchedBehavior = evidence.some(
+      (item) => item.snippet || item.behavior,
+    );
+    const hasDefensiveAssessment = evidence.some(
+      (item) => item.whyNotDefensive,
+    );
+    if (!hasRule || !hasMatchedBehavior || !hasDefensiveAssessment) {
+      return "Private safety close decisions must include ruleId, matched behavior, and whyNotDefensive evidence.";
+    }
+  }
+  return "";
+}
+
+function looksLikeGenericSafetyClose(summary: string) {
+  return (
+    /\bhard safety\b/i.test(summary) ||
+    /\bsecret, package, or abuse gate\b/i.test(summary) ||
+    /\bcontains patterns that cannot be accepted\b/i.test(summary) ||
+    /\bcredential-theft,? or malware\/abuse pattern\b/i.test(summary) ||
+    /\bmatched pattern is concrete enough\b/i.test(summary)
+  );
+}
+
 export function privateReviewErrorDecision(
   reason: string,
   code: string,
@@ -292,6 +410,12 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
           .map(normalizeSection)
           .filter((section): section is GateDecisionSection => Boolean(section))
       : null;
+    const reasonCode = normalizeReasonCode(raw.reasonCode);
+    const evidence = Array.isArray(raw.evidence)
+      ? raw.evidence
+          .map(normalizeEvidence)
+          .filter((item): item is GateDecisionEvidence => Boolean(item))
+      : undefined;
 
     if (
       !V2_GATE_VERDICTS.has(verdict) ||
@@ -306,6 +430,19 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
           retryable: true,
           message:
             "Private corpus review returned an invalid GateDecisionV2 payload.",
+        },
+      };
+    }
+    const closeContractError =
+      verdict === "close"
+        ? closeEvidenceContractError({ reasonCode, evidence })
+        : "";
+    if (closeContractError) {
+      return {
+        error: {
+          code: "invalid_private_response",
+          retryable: true,
+          message: closeContractError,
         },
       };
     }
@@ -332,6 +469,8 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
         summary,
         labels,
         close: raw.close === true,
+        reasonCode,
+        evidence,
         checks,
         sections,
         scope,
@@ -363,12 +502,36 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
       },
     };
   }
+  const summary = normalizeSummary(raw.summary);
+  const reasonCode = normalizeReasonCode(raw.reasonCode);
+  const evidence = Array.isArray(raw.evidence)
+    ? raw.evidence
+        .map(normalizeEvidence)
+        .filter((item): item is GateDecisionEvidence => Boolean(item))
+    : undefined;
+  if (
+    verdict === "close" &&
+    !reasonCode &&
+    !evidence?.length &&
+    looksLikeGenericSafetyClose(summary)
+  ) {
+    return {
+      error: {
+        code: "invalid_private_response",
+        retryable: true,
+        message:
+          "Private safety close decisions must include public-safe evidence.",
+      },
+    };
+  }
   return {
     decision: {
       verdict,
-      summary: normalizeSummary(raw.summary),
+      summary,
       labels: normalizeLabels(raw.labels),
       close: raw.close === true,
+      reasonCode,
+      evidence,
       confidence: normalizeConfidence(raw.confidence) ?? undefined,
       sourceEvidenceHash: cleanText(raw.sourceEvidenceHash) || undefined,
     },
@@ -574,6 +737,40 @@ function checksSection(decision: GateDecision): GateDecisionSection | null {
   };
 }
 
+function decisionEvidenceSection(
+  decision: GateDecision,
+): GateDecisionSection | null {
+  const evidence = decision.evidence || [];
+  if (!evidence.length) return null;
+  const bullets = evidence
+    .map((item) =>
+      [
+        item.ruleId ? `rule: \`${item.ruleId}\`` : "",
+        item.policy ? `policy: ${item.policy}` : "",
+        item.behavior ? `behavior: ${item.behavior}` : "",
+        item.snippet ? `snippet: \`${item.snippet}\`` : "",
+        item.source ? `source: ${item.source}` : "",
+        item.fix ? `fix: ${item.fix}` : "",
+        item.whyNotDefensive
+          ? `why not defensive: ${item.whyNotDefensive}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join("; "),
+    )
+    .filter(Boolean);
+  if (!bullets.length) return null;
+  return {
+    id: "decision_evidence",
+    title: "Decision Evidence",
+    status:
+      decision.verdict === "close" || decision.verdict === "request_changes"
+        ? "fail"
+        : "info",
+    bullets,
+  };
+}
+
 function sectionStatusLabel(status?: GateDecisionSectionStatus) {
   switch (status) {
     case "pass":
@@ -768,9 +965,10 @@ function reviewMetadataBullets(decision: GateDecision) {
   return [
     `${verdictStatusLabel(decision.verdict)} **Verdict:** \`${decision.verdict}\``,
     `${confidenceStatusLabel(decision.confidence)} **Confidence:** ${decisionConfidenceText(decision)}`,
+    decision.reasonCode ? `ℹ️ **Reason:** \`${decision.reasonCode}\`` : "",
     `ℹ️ **Scope:** ${scopeText(decision.scope)}`,
     `ℹ️ **Formatter:** \`gate-comment-v${GATE_COMMENT_FORMATTER_VERSION}\``,
-  ];
+  ].filter(Boolean);
 }
 
 function renderDecisionComment(decision: GateDecision, marker: string) {
@@ -780,8 +978,10 @@ function renderDecisionComment(decision: GateDecision, marker: string) {
     (section) => section.id === "recommended_action",
   );
   const checks = checksSection(decision);
+  const evidence = decisionEvidenceSection(decision);
   const detailSections = [
     ...(checks ? [checks] : []),
+    ...(evidence ? [evidence] : []),
     ...sections.filter(
       (section) =>
         section.id !== "summary" &&
@@ -1048,6 +1248,14 @@ export function enforceAutoMergeConfidenceFloor(
 export function validationFailedDecision(summary: string): GateDecision {
   return {
     verdict: "close" as const,
+    reasonCode: "validation_failure",
+    evidence: [
+      {
+        ruleId: "validation_failure",
+        behavior: summary,
+        fix: "Fix public validation failures before private review can run.",
+      },
+    ],
     summary: `${summary} The private content review will run after the public validation lane is green.`,
     labels: [LABELS.close],
     close: true,

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -53,6 +53,10 @@ const IDENTITY_ATTESTATION_PATTERN =
   /\battestations?\b[\s\S]{0,120}\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b/i;
 const IDENTITY_ATTESTATION_REVERSE_PATTERN =
   /\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b[\s\S]{0,120}\battestations?\b/i;
+const DEFENSIVE_SECURITY_CONTEXT_PATTERN =
+  /\b(prevent|protect|warn|warning|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const ABUSE_ENABLEMENT_PATTERN =
+  /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 
 // Keep these Markdown/login helpers in sync with CI policy reporting so issue
 // and PR review summaries escape contributor-controlled text consistently.
@@ -103,6 +107,37 @@ function hasFinancialOrIdentitySensitiveSignal(text) {
     IDENTITY_ATTESTATION_PATTERN.test(text) ||
     IDENTITY_ATTESTATION_REVERSE_PATTERN.test(text)
   );
+}
+
+function hasDefensiveSecuritySafeHarbor(text) {
+  return (
+    DEFENSIVE_SECURITY_CONTEXT_PATTERN.test(text) &&
+    !ABUSE_ENABLEMENT_PATTERN.test(text)
+  );
+}
+
+function looksLikeCommercialApiRelay(fields, text) {
+  const body = lower(
+    [
+      text,
+      fields.title,
+      fields.description,
+      fields.pricing_model,
+      fields.pricingModel,
+      fields.disclosure,
+      fields.website_url,
+      fields.websiteUrl,
+    ].join("\n"),
+  );
+  const relaySignal =
+    /\b(api relay|api proxy|llm api relay|llm proxy|model gateway|api gateway)\b/i.test(
+      body,
+    );
+  const commercialSignal =
+    /\b(pay[- ]?per[- ]?use|paid|pricing|credits?|billing|subscription|commercial|monetiz(?:e|ation))\b/i.test(
+      body,
+    );
+  return relaySignal && commercialSignal;
 }
 
 function lower(value) {
@@ -501,6 +536,7 @@ const CAPABILITY_BUCKET_BY_FLAG = {
   embedded_secret: "unsafe_install_or_secret",
   community_local_download_request: "package_policy",
   community_archive_download: "package_policy",
+  commercial_listing_route: "commercial_or_listing_route",
   non_https_executable_source: "unsafe_install_or_secret",
   unsafe_install_pipeline: "unsafe_install_or_secret",
   malicious_data_theft_capability: "abuse_or_malware",
@@ -770,6 +806,16 @@ function addContentRiskSignals(report, fields, text) {
   );
   const executableSourceUrls = collectUrls(installText);
 
+  if (looksLikeCommercialApiRelay(fields, text)) {
+    addFlag(
+      report,
+      "high",
+      "commercial_listing_route",
+      "Commercial API relays, paid gateways, and pay-per-use proxy services belong in the tools/listing flow",
+      "Use the commercial listing route instead of the free content queue",
+    );
+  }
+
   if (
     /\b(ghp_[a-z0-9_]{20,}|github_pat_[a-z0-9_]{40,}|sk-[a-z0-9]{20,}|akia[0-9a-z]{16}|xq_[a-f0-9]{40,})\b/i.test(
       text,
@@ -836,12 +882,13 @@ function addContentRiskSignals(report, fields, text) {
   }
 
   if (
-    /\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
+    !hasDefensiveSecuritySafeHarbor(text) &&
+    (/\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
       text,
     ) ||
-    /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
-      text,
-    )
+      /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
+        text,
+      ))
   ) {
     addFlag(
       report,
@@ -1237,6 +1284,8 @@ export function directContentRequestChangesReasons(report = {}) {
       "Content file could not be read through the GitHub API.",
     community_local_download_request:
       "Community PRs cannot request HeyClaude-hosted /downloads package URLs.",
+    commercial_listing_route:
+      "Commercial API relays, paid gateways, and pay-per-use proxy services belong in the tools/listing flow.",
     non_https_executable_source:
       "Install or usage instructions fetch executable content from a non-HTTPS URL.",
     unsafe_install_pipeline:

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -55,6 +55,10 @@ const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([
 
 const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
   "Executable JavaScript frontmatter is not allowed in content policy validation";
+const DEFENSIVE_SECURITY_CONTEXT_PATTERN =
+  /\b(prevent|protect|warn|warning|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const ABUSE_ENABLEMENT_PATTERN =
+  /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 
 const SAFE_MATTER_OPTIONS = {
   engines: {
@@ -87,6 +91,41 @@ function normalizeText(value) {
 
 function normalizeRepo(value) {
   return normalizeText(value).toLowerCase();
+}
+
+function hasDefensiveSecuritySafeHarbor(text) {
+  return (
+    DEFENSIVE_SECURITY_CONTEXT_PATTERN.test(text) &&
+    !ABUSE_ENABLEMENT_PATTERN.test(text)
+  );
+}
+
+function lower(value) {
+  return normalizeText(value).toLowerCase();
+}
+
+function looksLikeCommercialApiRelay(fields, text) {
+  const body = lower(
+    [
+      text,
+      fields.title,
+      fields.description,
+      fields.pricing_model,
+      fields.pricingModel,
+      fields.disclosure,
+      fields.website_url,
+      fields.websiteUrl,
+    ].join("\n"),
+  );
+  const relaySignal =
+    /\b(api relay|api proxy|llm api relay|llm proxy|model gateway|api gateway)\b/i.test(
+      body,
+    );
+  const commercialSignal =
+    /\b(pay[- ]?per[- ]?use|paid|pricing|credits?|billing|subscription|commercial|monetiz(?:e|ation))\b/i.test(
+      body,
+    );
+  return relaySignal && commercialSignal;
 }
 
 function annotationText(value) {
@@ -539,6 +578,16 @@ function addContentRiskSignals(report, fields, content) {
     fields.affiliate_url,
   ].filter(Boolean);
 
+  if (looksLikeCommercialApiRelay(fields, text)) {
+    addFlag(
+      report,
+      "high",
+      "commercial_listing_route",
+      "Commercial API relays, paid gateways, and pay-per-use proxy services belong in the tools/listing flow",
+      "Use the commercial listing route instead of the free content queue",
+    );
+  }
+
   if (submittedSourceUrls.some(isLikelyAffiliateUrl)) {
     addFlag(
       report,
@@ -615,12 +664,13 @@ function addContentRiskSignals(report, fields, content) {
   }
 
   if (
-    /\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
+    !hasDefensiveSecuritySafeHarbor(text) &&
+    (/\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
       text,
     ) ||
-    /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
-      text,
-    )
+      /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
+        text,
+      ))
   ) {
     addFlag(
       report,
@@ -875,6 +925,8 @@ function directContentRequestChangesReasons(report = {}) {
       "Content file could not be read through the GitHub API.",
     community_local_download_request:
       "Community PRs cannot request HeyClaude-hosted /downloads package URLs.",
+    commercial_listing_route:
+      "Commercial API relays, paid gateways, and pay-per-use proxy services belong in the tools/listing flow.",
     affiliate_referral_url:
       "Contributor content cannot include affiliate or referral URL parameters.",
     non_https_executable_source:

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -386,4 +386,77 @@ Example body.
       ]),
     );
   });
+
+  it("does not hard-fail defensive security hooks for secret-related wording alone", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Environment Leak Warning Hook
+category: hooks
+description: Defensive hook that warns before commands dump tokens or harvest credentials from shell output.
+sourceUrl: https://docs.anthropic.com/en/docs/claude-code/hooks
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Inspects command text before execution and blocks risky output patterns.
+privacyNotes:
+  - Does not read secret values or send command text to third parties.
+---
+
+This hook detects commands that dump tokens or harvest credentials and blocks
+them before they run. It is defensive guidance for preventing accidental leaks.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/hooks/environment-leak-warning-hook.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "malicious_data_theft_capability" }),
+      ]),
+    );
+  });
+
+  it("routes commercial API relay submissions out of the free content queue", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: CoderPlan LLM API Relay
+category: tools
+description: Pay-per-use LLM API relay for routing paid model requests through a hosted API gateway.
+sourceUrl: https://example.com/coderplan
+websiteUrl: https://example.com/coderplan/pricing
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+This commercial API relay sells credits and billing-backed access to multiple
+LLM providers through a proxy gateway.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/tools/coderplan.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("commercial_listing_route"),
+      ]),
+    );
+  });
 });

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -423,6 +423,8 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain(
       "Do not close a submission merely because it defensively discusses OAuth",
     );
+    expect(source).toContain("closeEvidenceContract:");
+    expect(source).toContain("Every close verdict must include reasonCode");
     expect(source).toContain("deterministicDuplicateReview");
     expect(source).toContain('eventType: "duplicate_shadow_review"');
     expect(source).toContain('decision: "related_not_strict_duplicate"');
@@ -443,12 +445,20 @@ describe("Cloudflare submission gate helpers", () => {
   });
 
   it("closes public validation failures instead of requesting changes", () => {
-    expect(validationFailedDecision("Required validation failed.")).toEqual({
+    expect(
+      validationFailedDecision("Required validation failed."),
+    ).toMatchObject({
       verdict: "close",
+      reasonCode: "validation_failure",
       summary:
         "Required validation failed. The private content review will run after the public validation lane is green.",
       labels: ["submission-closed-by-gate"],
       close: true,
+      evidence: [
+        {
+          ruleId: "validation_failure",
+        },
+      ],
     });
   });
 
@@ -576,6 +586,31 @@ describe("Cloudflare submission gate helpers", () => {
     expect((body.match(/✅ `passed` validate-content/g) || []).length).toBe(1);
   });
 
+  it("renders close reason codes and concrete evidence in collapsed detail", () => {
+    const body = markerComment({
+      verdict: "close",
+      reasonCode: "source_hard_failure",
+      evidence: [
+        {
+          ruleId: "source_url_reachability",
+          source: "https://example.com/docs",
+          behavior: "documentationUrl returned 404",
+          fix: "Replace or remove the dead documentationUrl.",
+        },
+      ],
+      summary:
+        "Summary:\n- The entry is otherwise viable, but documentationUrl returned 404.",
+      labels: ["submission-closed-by-gate"],
+      close: true,
+      confidence: 0.86,
+    });
+
+    expect(body).toContain("> ℹ️ **Reason:** `source_hard_failure`");
+    expect(body).toContain("Decision Evidence");
+    expect(body).toContain("source_url_reachability");
+    expect(body).toContain("documentationUrl returned 404");
+  });
+
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {
     expect(markerComment()).toContain("> ## ℹ️ Public validation running");
     expect(markerComment()).toContain(
@@ -698,6 +733,106 @@ describe("Cloudflare submission gate helpers", () => {
         labels: [],
         checks: [],
         sections: [],
+      }).error,
+    ).toMatchObject({
+      code: "invalid_private_response",
+      retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.9,
+        reasonCode: "malicious_data_theft",
+        evidence: [
+          {
+            ruleId: "malicious_data_theft_capability",
+            snippet: "harvest cookies from browser sessions",
+            behavior:
+              "The submission instructs users to collect session cookies.",
+            whyNotDefensive:
+              "The content enables collection instead of warning, blocking, or redacting it.",
+          },
+        ],
+        summary: "Summary:\n- Concrete credential-theft behavior is present.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "safety_privacy",
+            status: "fail",
+            bullets: ["Concrete credential-theft behavior is present."],
+          },
+        ],
+      }).decision,
+    ).toMatchObject({
+      verdict: "close",
+      reasonCode: "malicious_data_theft",
+      evidence: [
+        {
+          ruleId: "malicious_data_theft_capability",
+        },
+      ],
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.86,
+        summary:
+          "Summary:\n- Matches an explicit secret, credential-theft, or malware/abuse pattern.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "safety_privacy",
+            status: "fail",
+            bullets: ["The matched pattern is concrete enough to close."],
+          },
+        ],
+      }).error,
+    ).toMatchObject({
+      code: "invalid_private_response",
+      retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.86,
+        reasonCode: "malicious_data_theft",
+        evidence: [
+          {
+            ruleId: "malicious_data_theft_capability",
+            behavior: "A keyword pattern matched.",
+          },
+        ],
+        summary: "Summary:\n- A safety keyword pattern matched.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "safety_privacy",
+            status: "fail",
+            bullets: ["A safety keyword pattern matched."],
+          },
+        ],
+      }).error,
+    ).toMatchObject({
+      code: "invalid_private_response",
+      retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        verdict: "close",
+        summary:
+          "Summary:\n- content/hooks/example.mdx fails a hard safety, secret, package, or abuse gate.\n\nSafety / Privacy:\n- The submission contains patterns that cannot be accepted through automatic content intake.",
+        labels: ["submission-closed-by-gate"],
+        close: true,
       }).error,
     ).toMatchObject({
       code: "invalid_private_response",
@@ -1645,7 +1780,7 @@ websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
     );
   });
 
-  it("treats same canonical repository as a strict duplicate", () => {
+  it("treats same canonical repository and same purpose as a strict duplicate", () => {
     const existing = extractContentDuplicateSignals({
       filePath: "content/mcp/playwright-mcp-server.mdx",
       content: `---
@@ -1663,7 +1798,7 @@ repoUrl: "https://github.com/microsoft/playwright-mcp"
 title: Browser Automation MCP
 slug: browser-automation-mcp
 category: mcp
-description: Browser automation MCP server for Claude.
+description: MCP server for browser automation through Playwright.
 repoUrl: "https://github.com/microsoft/playwright-mcp.git?utm_source=heyclaude"
 ---
 `,
@@ -1676,6 +1811,124 @@ repoUrl: "https://github.com/microsoft/playwright-mcp.git?utm_source=heyclaude"
         expect.stringContaining("same canonical source URL"),
       ]),
     });
+  });
+
+  it("treats shared safety doctrine as related context unless purpose also matches", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/hooks/environment-variable-validator.mdx",
+      content: `---
+title: Environment Variable Validator Hook
+slug: environment-variable-validator
+category: hooks
+description: PostToolUse hook that checks environment configuration file edits.
+sourceUrl: "https://12factor.net/config"
+---
+`,
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/hooks/environment-output-safety-reminder-hook.mdx",
+      content: `---
+title: Environment Output Safety Reminder Hook
+slug: environment-output-safety-reminder-hook
+category: hooks
+description: PreToolUse hook that warns before shell commands print broad environment output.
+sourceUrl: "https://12factor.net/config"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://12factor.net/config in hooks",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("treats shared Claude Code skills docs as related context for distinct agent prompts", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/agents/agent-skills-enterprise-librarian-agent.mdx",
+      content: `---
+title: Agent Skills Enterprise Librarian Agent
+slug: agent-skills-enterprise-librarian-agent
+category: agents
+description: Source-backed agent that curates an organization's Agent Skills library.
+documentationUrl: "https://code.claude.com/docs/en/skills"
+---
+`,
+      label:
+        "accepted entry content/agents/agent-skills-enterprise-librarian-agent.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/agents/ai-agent-cost-governance-analyst-agent.mdx",
+      content: `---
+title: AI Agent Cost Governance Analyst Agent
+slug: ai-agent-cost-governance-analyst-agent
+category: agents
+description: Source-backed agent that analyzes and governs Claude Code spend from OpenTelemetry data.
+documentationUrl: "https://code.claude.com/docs/en/skills"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://code.claude.com/docs/en/skills in agents",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("treats shared Claude Code MCP docs as related context for distinct MCP agent prompts", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/agents/mcp-tool-result-budget-review-agent.mdx",
+      content: `---
+title: MCP Tool Result Budget Review Agent
+slug: mcp-tool-result-budget-review-agent
+category: agents
+description: Source-backed agent that reviews MCP tool result payload size and budget policy.
+documentationUrl: "https://code.claude.com/docs/en/mcp"
+---
+`,
+      label:
+        "accepted entry content/agents/mcp-tool-result-budget-review-agent.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/agents/mcp-oauth-integration-reviewer-agent.mdx",
+      content: `---
+title: MCP OAuth Integration Reviewer Agent
+slug: mcp-oauth-integration-reviewer-agent
+category: agents
+description: Source-backed agent that reviews OAuth-based MCP server integrations in Claude Code.
+documentationUrl: "https://code.claude.com/docs/en/mcp"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://code.claude.com/docs/en/mcp in agents",
+            ),
+          ]),
+        }),
+      ]),
+    );
   });
 
   it("treats shared multi-entry MCP catalogs as related context", () => {
@@ -1789,7 +2042,7 @@ websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
       findStrictContentDuplicateMatch(repeatedCollection, [existingCollection]),
     ).toMatchObject({
       reasons: expect.arrayContaining([
-        expect.stringContaining("same canonical source URL"),
+        expect.stringContaining("same collection source set"),
       ]),
     });
   });

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -254,6 +254,79 @@ Native macOS MCP server.`);
     );
   });
 
+  it("keeps defensive security submissions out of credential-theft hard-close risk", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 129,
+        title: "content(hooks): add environment leak warning hook",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Environment Leak Warning Hook",
+            slug: "environment-leak-warning-hook",
+            category: "hooks",
+            description:
+              "Defensive hook that warns before commands dump tokens or harvest credentials from shell output.",
+            repoUrl: "https://github.com/example/environment-leak-warning-hook",
+            docsUrl: "https://docs.anthropic.com/en/docs/claude-code/hooks",
+            safetyNotes: [
+              "Inspects command text and blocks risky output patterns before execution.",
+            ],
+            privacyNotes: [
+              "Does not read secret values or send command text to third parties.",
+            ],
+          }),
+          "content/hooks/environment-leak-warning-hook.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).not.toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(directContentRequestChangesReasons(report).join("\n")).not.toContain(
+      "credential, token, session, or wallet theft",
+    );
+  });
+
+  it("routes commercial API relays to the listing flow", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 130,
+        title: "content(tools): add CoderPlan",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "CoderPlan LLM API Relay",
+            slug: "coderplan",
+            category: "tools",
+            description:
+              "Pay-per-use LLM API relay for routing paid model requests through a hosted API gateway.",
+            repoUrl: "https://github.com/example/coderplan",
+            docsUrl: "https://example.com/coderplan",
+            pricingModel: "paid credits",
+          }),
+          "content/tools/coderplan.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "commercial_listing_route",
+    );
+    expect(directContentRequestChangesReasons(report).join("\n")).toContain(
+      "commercial_listing_route",
+    );
+  });
+
   it("still flags wallet and on-chain attestations as identity-sensitive", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
## Summary
- Calibrates the submission gate so terminal close decisions require structured, public-safe reason codes and evidence.
- Prevents distinct defensive/security content and adjacent content submissions from being auto-closed on vague safety or duplicate wording.
- Tightens duplicate handling so shared official docs and broad source overlap are related context, not strict duplicate proof.

## What changed
- Added close `reasonCode` and `evidence` handling to the gate decision contract and comment renderer.
- Rejects generic private-review safety closes that do not include concrete evidence and why the content is not defensive.
- Adds defensive-security safe harbor handling for content about tokens, OAuth, env vars, malware prevention, redaction, auditing, and safe configuration.
- Updates deterministic duplicate handling so same canonical source only blocks when the resource also has the same purpose, title, slug, path, or normalized description.
- Adds regression tests for shared Claude Code `skills` and `mcp` docs across distinct agent prompts.

## Why
- Recent content bursts exposed that the gate could close distinct agent submissions solely because they shared Claude Code documentation URLs. That should be treated as related review context, not a strict duplicate.
- Prior safety-close output could also accept generic private-review language such as matched secret/malware patterns without concrete public-safe evidence.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm submission-gate:dry-run`
- `pnpm build`
- `git diff --check`

## Notes
- Audit finding: many recent duplicate closures in the large agent batch were over-aggressive because they relied on shared `code.claude.com/docs/en/skills` or `code.claude.com/docs/en/mcp` URLs. Future submissions with distinct purpose should now pass deterministic duplicate precheck and go to private review with related-content context.
- No linked issue: maintainer-initiated production gate calibration from live duplicate/safety audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Submission decisions now include structured reason codes and evidence, surfaced in reviewer comments.
  * Detection and routing for commercial API-relay style listings added.

* **Bug Fixes**
  * Refined duplicate and related-content matching for more accurate match reasons across categories and descriptions.
  * Content-risk logic now treats defensive-security phrasing as a safe-harbor in certain cases.

* **Tests**
  * Expanded tests for policy signals, decision payloads, duplicate logic, and routing for commercial listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->