### PR TITLE
Add CoderPlan — LLM API Gateway for Claude Code

### DIFF
--- a/content/tools/coderplan.mdx
+++ b/content/tools/coderplan.mdx
@@ -1,0 +1,36 @@
+---
+title: CoderPlan
+slug: coderplan
+category: tools
+description: LLM API Gateway with OpenAI-compatible interface. Pay-per-use access to Claude, GPT, Gemini, DeepSeek, Grok, and 100+ models. One-line config for Claude Code, Codex CLI, and Gemini CLI.
+cardDescription: OpenAI-compatible LLM API gateway with pay-per-use pricing.
+seoTitle: CoderPlan LLM API Gateway for Claude Code and AI Coding Agents
+seoDescription: CoderPlan is an LLM API gateway with OpenAI-compatible interface. Pay-per-use access to Claude, GPT, Gemini, DeepSeek models. One config for Claude Code, Codex CLI, Gemini CLI.
+author: CoderPlan
+dateAdded: "2026-06-06"
+websiteUrl: "https://coderplan.ai"
+documentationUrl: "https://docs.coderplan.ai"
+apiUrl: "https://api.coderplan.ai"
+pricingModel: freemium
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+tags:
+  - api-gateway
+  - claude-code
+  - openai-compatible
+keywords:
+  - LLM API gateway
+  - Claude Code API
+  - OpenAI compatible
+  - AI coding agent
+  - API relay
+---
+
+## Editorial notes
+
+CoderPlan provides a unified LLM API gateway that simplifies access to multiple model providers through a single OpenAI-compatible endpoint. Particularly useful for developers using Claude Code, Codex CLI, or Gemini CLI who want pay-per-use pricing without managing multiple API keys.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used.


### PR DESCRIPTION
Adds CoderPlan to the **Tools** directory.

CoderPlan is an LLM API Gateway with OpenAI-compatible interface providing pay-per-use access to Claude, GPT, Gemini, DeepSeek, Grok and 100+ models. One-line config for Claude Code, Codex CLI, and Gemini CLI.

**Key features:**
- One-line config for Claude Code, Codex CLI, and Gemini CLI
- OpenAI-compatible API (works with any tool supporting OpenAI format)
- Pay-per-use pricing with free trial credit
- All major models: Claude 4, GPT-5, Gemini 3, DeepSeek R1, Grok 3

**Submission:** Added as content/tools/coderplan.mdx following the existing content schema, with editorial disclosure and relevant tags.