### PR TITLE
fix(hooks): harden MCP URL allowlist matching

### DIFF
--- a/content/hooks/mcp-server-url-allowlist-hook.mdx
+++ b/content/hooks/mcp-server-url-allowlist-hook.mdx
@@ -31,17 +31,17 @@ installCommand: |-
   input=$(cat)
   file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
   text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
-  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
+  normalized_text=$(printf '%s' "$text" | sed -e 's#\\/#/#g' -e 's#\\[uU]002[fF]#/#g')
 
   case "$file" in
     *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$normalized_text" | grep -Eio 'https?://[^"[:space:]]+' | awk -F/ '{print tolower($3)}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
-  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
+  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr '[:upper:],' '[:lower:] ')
   for host in $hosts; do
     case " $allowlist " in
       *" $host "*) ;;
@@ -100,17 +100,17 @@ scriptBody: |-
   input=$(cat)
   file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
   text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
-  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
+  normalized_text=$(printf '%s' "$text" | sed -e 's#\\/#/#g' -e 's#\\[uU]002[fF]#/#g')
 
   case "$file" in
     *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$normalized_text" | grep -Eio 'https?://[^"[:space:]]+' | awk -F/ '{print tolower($3)}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
-  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
+  allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr '[:upper:],' '[:lower:] ')
   for host in $hosts; do
     case " $allowlist " in
       *" $host "*) ;;


### PR DESCRIPTION
### Motivation
- The original hook only normalized escaped solidus sequences and performed a case-sensitive `https?://` match, allowing JSON-encoded MCP URLs like `HTTPS://...` or `https:\u002f\u002f...` to bypass detection. 
- Harden the detection so JSON-encoded or case-variant schemes cannot be used to sneak unapproved remote MCP endpoints into config.

### Description
- Normalize both `\/` and JSON Unicode-escaped separators (`\u002f` / case variants) via `sed` before scanning in both `installCommand` and `scriptBody` in `content/hooks/mcp-server-url-allowlist-hook.mdx`. 
- Match URL schemes case-insensitively by using `grep -Eio 'https?://[^"[:space:]]+'` and lowercase extracted hosts with `awk -F/ '{print tolower($3)}'`. 
- Normalize the allowlist by lowercasing `ALLOWED_MCP_HOSTS` with `tr '[:upper:],' '[:lower:] '` so comparisons are case-insensitive. 
- Keep `installCommand` and `scriptBody` aligned so the installed hook and the cataloged script behave identically.

### Testing
- Ran a targeted extracted-hook test feeding payloads with `HTTPS://...` and `https:\u002f\u002f...` to ensure unallowlisted hosts are blocked and allowlisted hosts pass, and the test succeeded. 
- Ran `pnpm validate:content:strict` which passed. 
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2317580868832c897066dc56198bbe)