### PR TITLE
fix(ci): serialize shared preview validation

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -914,7 +914,7 @@ jobs:
     needs: classify-pr
     runs-on: ubuntu-latest
     concurrency:
-      group: deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}
+      group: deployment-artifacts-pr-preview-${{ github.repository }}
       cancel-in-progress: false
 
     steps:

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -65,9 +65,14 @@ describe("PR preview artifact validation flow", () => {
     expect(workflow).toContain(
       "github.event.pull_request.head.repo.full_name == github.repository",
     );
-    expect(workflow).toContain(
-      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    const previewBlock =
+      workflow.match(
+        /\n  validate-pr-preview:[\s\S]*?\n  required-pr-gate:/,
+      )?.[0] || "";
+    expect(previewBlock).toContain(
+      "group: deployment-artifacts-pr-preview-${{ github.repository }}\n",
     );
+    expect(previewBlock).not.toContain("github.event.pull_request.number");
     expect(workflow).toContain("ALLOW_SHARED_DEV_WORKER_PREVIEW");
     expect(workflow).toContain("https://heyclaude-dev.zeronode.workers.dev");
     expect(workflow).toContain("--wait-seconds 600");

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -215,9 +215,14 @@ describe("submission automation workflows", () => {
     expect(source).toContain(
       "github.event.pull_request.head.repo.full_name == github.repository",
     );
-    expect(source).toContain(
-      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    const previewBlock =
+      source.match(
+        /\n  validate-pr-preview:[\s\S]*?\n  required-pr-gate:/,
+      )?.[0] || "";
+    expect(previewBlock).toContain(
+      "group: deployment-artifacts-pr-preview-${{ github.repository }}\n",
     );
+    expect(previewBlock).not.toContain("github.event.pull_request.number");
     expect(source).not.toContain("CLOUDFLARE_API_TOKEN");
     expect(source).not.toContain("CLOUDFLARE_ACCOUNT_ID");
     expect(source).not.toContain("pnpm --filter web run deploy:dev");
@@ -368,9 +373,14 @@ describe("submission automation workflows", () => {
     expect(source).toContain(
       "github.event.pull_request.head.repo.full_name == github.repository",
     );
-    expect(source).toContain(
-      "deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}",
+    const previewBlock =
+      source.match(
+        /\n  validate-pr-preview:[\s\S]*?\n  required-pr-gate:/,
+      )?.[0] || "";
+    expect(previewBlock).toContain(
+      "group: deployment-artifacts-pr-preview-${{ github.repository }}\n",
     );
+    expect(previewBlock).not.toContain("github.event.pull_request.number");
     expect(source).toContain("Resolve PR preview URL");
     expect(source).toContain("--wait-seconds 600");
     expect(source).not.toContain("--allow-missing");


### PR DESCRIPTION
### Motivation
- A per-PR concurrency group for the `validate-pr-preview` job combined with the existing shared dev Worker fallback allowed concurrent validations against a mutable shared deployment, weakening the PR preview merge gate. 
- The change restores the original repository-wide serialization so different PRs cannot validate the same shared Worker at the same time.

### Description
- Replace the concurrency group in `.github/workflows/content-validation.yml` from `deployment-artifacts-pr-preview-${{ github.repository }}-${{ github.event.pull_request.number }}` to `deployment-artifacts-pr-preview-${{ github.repository }}` to serialize preview validation across the repository. 
- Adjust `tests/deployment-preview-url.test.ts` to assert the `validate-pr-preview` block contains the repository-scoped `group` and does not include `github.event.pull_request.number`. 
- Update `tests/submission-workflows.test.ts` with the same preview-block assertions so required PR validation checks are covered. 
- Preserve the existing preview resolution behavior and `ALLOW_SHARED_DEV_WORKER_PREVIEW` fallback so functionality remains unchanged except for serialized access to the shared Worker.

### Testing
- Ran `pnpm exec vitest run tests/deployment-preview-url.test.ts tests/submission-workflows.test.ts` and all tests passed (72 tests total).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2316081618832c80f369d2970c09e8)