### PR TITLE
fix(submissions): cap invalid private review retries

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -155,6 +155,7 @@ const MERGE_RETRY_SECONDS = 30;
 const RETRYABLE_ERROR_SECONDS = 60;
 const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
 const PRIVATE_REVIEW_TIMEOUT_MS = 45_000;
+const INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3;
 const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR_TEXT = String(
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 );
@@ -477,6 +478,47 @@ function normalizeOneShotDecision(decision: GateDecision): GateDecision {
       "- Please resubmit a new focused one-file content PR after fixing the issue.",
     ].join("\n"),
   };
+}
+
+function hasPrivateReviewErrorCode(decision: GateDecision, code: string) {
+  return Boolean(decision.errors?.some((error) => error.code === code));
+}
+
+function invalidPrivateResponseAttempts(
+  existing: Record<string, unknown> | null,
+) {
+  const attempts = Number(existing?.attemptCount || 0);
+  return Number.isFinite(attempts) && attempts > 0 ? attempts : 0;
+}
+
+function shouldStopRetryingInvalidPrivateResponse(
+  decision: GateDecision,
+  existing: Record<string, unknown> | null,
+) {
+  return (
+    hasPrivateReviewErrorCode(decision, "invalid_private_response") &&
+    invalidPrivateResponseAttempts(existing) >=
+      INVALID_PRIVATE_RESPONSE_MAX_RETRIES
+  );
+}
+
+function invalidPrivateResponseExhaustedDecision(
+  decision: GateDecision,
+  existing: Record<string, unknown> | null,
+) {
+  const attempts = invalidPrivateResponseAttempts(existing);
+  return defaultManualDecision(
+    [
+      `Private corpus review returned invalid response payloads after ${attempts} automatic attempt(s).`,
+      `Last private reviewer error: ${decision.summary}`,
+      "Automatic retries are stopped for this head SHA so the queue cannot loop indefinitely.",
+    ].join(" "),
+    {
+      code: "private_review_contract_exhausted",
+      retryable: false,
+      message: decision.summary,
+    },
+  );
 }
 
 function allowedCorsOrigins(env: Env) {
@@ -3237,6 +3279,15 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             },
           },
         });
+        if (
+          isRetryableGateDecision(decision) &&
+          shouldStopRetryingInvalidPrivateResponse(decision, existing)
+        ) {
+          decision = invalidPrivateResponseExhaustedDecision(
+            decision,
+            existing,
+          );
+        }
         if (isRetryableGateDecision(decision)) {
           await upsertPrState(env.SUBMISSION_GATE_DB, {
             repo: target.repoFullName,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -402,6 +402,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("REVIEWING_STALE_SECONDS");
     expect(source).toContain("QUEUED_STALE_SECONDS");
     expect(source).toContain("PRIVATE_REVIEW_TIMEOUT_MS = 45_000");
+    expect(source).toContain("INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3");
     expect(source).toContain("queuedStaleBeforeIso");
     expect(source).toContain("reviewingStaleBeforeIso");
     expect(source).toContain("lastCheckSummary: validation.summary");
@@ -410,6 +411,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("installationId: target.installationId");
     expect(source).toContain("normalizePrivateGateDecisionPayload(raw)");
     expect(source).toContain("isRetryableGateDecision(decision)");
+    expect(source).toContain(
+      "shouldStopRetryingInvalidPrivateResponse(decision, existing)",
+    );
+    expect(source).toContain('"private_review_contract_exhausted"');
     expect(source).toContain('"invalid_private_response"');
     expect(source).toContain('"private_reviewer_unavailable"');
     expect(source).not.toContain("summary.includes");


### PR DESCRIPTION
## Summary
- Stop invalid private reviewer payloads from retrying indefinitely.
- Convert exhausted invalid private responses into the existing manual-review terminal path after three automatic attempts.

## What changed
- Added an `invalid_private_response` retry cap in the submission-gate Worker.
- Left true transient reviewer errors, GitHub rate limits, and source timeouts on the retry path.
- Added worker test coverage assertions for the cap and terminal contract-exhaustion code.

## Why
- A malformed private close payload can otherwise leave a PR in `error_retryable` forever.
- The queue should recover from transient infrastructure, but deterministic contract drift needs to stop and surface cleanly.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `git diff --check`

## Notes
- The private reviewer fix was deployed separately; this PR hardens the public worker against future private-contract drift.