### PR TITLE
fix(submissions): tighten defensive theft safe harbor

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -53,8 +53,12 @@ const IDENTITY_ATTESTATION_PATTERN =
   /\battestations?\b[\s\S]{0,120}\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b/i;
 const IDENTITY_ATTESTATION_REVERSE_PATTERN =
   /\b(wallet|kyc|payment|crypto|on-chain identity|identity proof|identity verification|proof of personhood|verifiable credential)\b[\s\S]{0,120}\battestations?\b/i;
-const DEFENSIVE_SECURITY_CONTEXT_PATTERN =
-  /\b(prevent|protect|warn|warning|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const DEFENSIVE_SECURITY_MITIGATION_PATTERN =
+  /\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure))\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const RESOURCE_THEFT_CAPABILITY_PATTERN =
+  /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
+const CREDENTIAL_THEFT_PATTERN =
+  /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
 const ABUSE_ENABLEMENT_PATTERN =
   /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 
@@ -111,7 +115,8 @@ function hasFinancialOrIdentitySensitiveSignal(text) {
 
 function hasDefensiveSecuritySafeHarbor(text) {
   return (
-    DEFENSIVE_SECURITY_CONTEXT_PATTERN.test(text) &&
+    DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
+    !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
     !ABUSE_ENABLEMENT_PATTERN.test(text)
   );
 }
@@ -883,12 +888,7 @@ function addContentRiskSignals(report, fields, text) {
 
   if (
     !hasDefensiveSecuritySafeHarbor(text) &&
-    (/\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
-      text,
-    ) ||
-      /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
-        text,
-      ))
+    CREDENTIAL_THEFT_PATTERN.test(text)
   ) {
     addFlag(
       report,

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -55,8 +55,12 @@ const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([
 
 const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
   "Executable JavaScript frontmatter is not allowed in content policy validation";
-const DEFENSIVE_SECURITY_CONTEXT_PATTERN =
-  /\b(prevent|protect|warn|warning|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const DEFENSIVE_SECURITY_MITIGATION_PATTERN =
+  /\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure))\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
+const RESOURCE_THEFT_CAPABILITY_PATTERN =
+  /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
+const CREDENTIAL_THEFT_PATTERN =
+  /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
 const ABUSE_ENABLEMENT_PATTERN =
   /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 
@@ -95,7 +99,8 @@ function normalizeRepo(value) {
 
 function hasDefensiveSecuritySafeHarbor(text) {
   return (
-    DEFENSIVE_SECURITY_CONTEXT_PATTERN.test(text) &&
+    DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
+    !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
     !ABUSE_ENABLEMENT_PATTERN.test(text)
   );
 }
@@ -665,12 +670,7 @@ function addContentRiskSignals(report, fields, content) {
 
   if (
     !hasDefensiveSecuritySafeHarbor(text) &&
-    (/\b(credential|password|cookie|session|token|wallet)\b[\s\S]{0,80}\b(steal|exfiltrat|harvest|dump)\b/i.test(
-      text,
-    ) ||
-      /\b(steal|exfiltrat|harvest|dump)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)\b/i.test(
-        text,
-      ))
+    CREDENTIAL_THEFT_PATTERN.test(text)
   ) {
     addFlag(
       report,

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -425,6 +425,46 @@ them before they run. It is defensive guidance for preventing accidental leaks.
     );
   });
 
+  it("does not let broad defensive keywords bypass credential-theft blocking", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Credential Audit Hook
+category: hooks
+description: Warning audit hook that can steal tokens and harvest credentials from shell output.
+sourceUrl: https://github.com/example/credential-audit-hook
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Runs before commands and inspects shell output.
+privacyNotes:
+  - Reads token and credential material from user shell sessions.
+---
+
+This audit hook can steal tokens and harvest credentials from shell output for review.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/hooks/credential-audit-hook.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "malicious_data_theft_capability" }),
+      ]),
+    );
+    expect(output.requestChangesReasons.join("\n")).toContain(
+      "credential, token, session, or wallet theft",
+    );
+  });
+
   it("routes commercial API relay submissions out of the free content queue", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -293,6 +293,43 @@ Native macOS MCP server.`);
     );
   });
 
+  it("keeps credential-theft request changes when defensive keywords are incidental", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 130,
+        title: "content(hooks): add credential audit hook",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Credential Audit Hook",
+            slug: "credential-audit-hook",
+            category: "hooks",
+            description:
+              "Warning audit hook that can steal tokens and harvest credentials from shell output.",
+            repoUrl: "https://github.com/example/credential-audit-hook",
+            docsUrl: "https://example.com/credential-audit-hook",
+            safetyNotes: ["Runs before commands and inspects shell output."],
+            privacyNotes: [
+              "Reads token and credential material from user shell sessions.",
+            ],
+          }),
+          "content/hooks/credential-audit-hook.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(directContentRequestChangesReasons(report).join("\n")).toContain(
+      "credential, token, session, or wallet theft",
+    );
+  });
+
   it("routes commercial API relays to the listing flow", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
### Motivation
- A previously added broad defensive-keyword safe harbor could be abused to suppress the `malicious_data_theft_capability` flag when submissions contained generic words like "warn", "audit", or "review" anywhere in the text. 
- The change restores deterministic blocking for credential/token/session theft by requiring actual mitigation context and by ensuring explicit theft-enablement wording is still detected. 

### Description
- Replace the single-word `DEFENSIVE_SECURITY_CONTEXT_PATTERN` with a `DEFENSIVE_SECURITY_MITIGATION_PATTERN` that requires mitigation-context proximity to credential/secret terms in both `scripts/ci/validate-content-policy.mjs` and `packages/registry/src/submission-risk.js`. 
- Add `RESOURCE_THEFT_CAPABILITY_PATTERN` and `CREDENTIAL_THEFT_PATTERN` to detect resource-theft behaviors and canonical credential-theft phrasings and prevent broad safe-harbor suppression. 
- Update `hasDefensiveSecuritySafeHarbor` to require the mitigation pattern and to reject matches when a resource-theft capability is present or when the narrow `ABUSE_ENABLEMENT_PATTERN` matches. 
- Add regression tests in `tests/content-policy-validation.test.ts` and `tests/submission-pr-first.test.ts` that assert defensive leak-prevention hooks remain allowed while malicious credential-theft wording triggers request-changes. 

### Testing
- Ran `pnpm exec vitest run tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts` and all tests passed. 
- Executed `pnpm validate:packages` and `git diff --check` as part of validation and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232baa9e28832c924d71b0b04b00cd)