### PR TITLE
fix(submissions): preserve terminal gate states

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2341,28 +2341,28 @@ async function enqueueReviewTarget(
     String(existing?.status || "") === "closed" &&
     (isReopenedPullRequestEvent(eventName, webhook) ||
       eventName === "scheduled");
-  if (
+  const shouldQueueReview =
     !hasTerminalGateDecision(existing) ||
     shouldResetIgnoredScan ||
-    shouldResetClosedTerminal
-  ) {
-    await upsertPrState(env.SUBMISSION_GATE_DB, {
-      repo: target.repoFullName,
-      number: target.number,
-      headRepo: target.headRepo,
-      headRef: target.headRef,
-      headSha: target.headSha,
-      baseRef: target.baseRef || contentGateBaseRef(env),
-      installationId: target.installationId,
-      status: "queued",
-      deliveryId,
-      nextReviewAt: null,
-      incrementAttempt: true,
-      lastReviewKey: reviewScanKey || undefined,
-      clearVerdict: shouldResetIgnoredScan || shouldResetClosedTerminal,
-      clearTerminal: shouldResetIgnoredScan || shouldResetClosedTerminal,
-    });
-  }
+    shouldResetClosedTerminal;
+  if (!shouldQueueReview) return false;
+
+  await upsertPrState(env.SUBMISSION_GATE_DB, {
+    repo: target.repoFullName,
+    number: target.number,
+    headRepo: target.headRepo,
+    headRef: target.headRef,
+    headSha: target.headSha,
+    baseRef: target.baseRef || contentGateBaseRef(env),
+    installationId: target.installationId,
+    status: "queued",
+    deliveryId,
+    nextReviewAt: null,
+    incrementAttempt: true,
+    lastReviewKey: reviewScanKey || undefined,
+    clearVerdict: shouldResetIgnoredScan || shouldResetClosedTerminal,
+    clearTerminal: shouldResetIgnoredScan || shouldResetClosedTerminal,
+  });
   await env.SUBMISSION_REVIEW_QUEUE.send({
     kind: "review_pr",
     targetKey,

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -257,7 +257,14 @@ export async function upsertPrState(
         head_sha = COALESCE(excluded.head_sha, submission_prs.head_sha),
         base_ref = excluded.base_ref,
         installation_id = COALESCE(excluded.installation_id, submission_prs.installation_id),
-        status = excluded.status,
+        status = CASE
+          WHEN ? = 0
+            AND submission_prs.terminal_at IS NOT NULL
+            AND excluded.terminal_at IS NULL
+            AND excluded.status NOT IN ('merged', 'closed', 'manual', 'ignored')
+          THEN submission_prs.status
+          ELSE excluded.status
+        END,
         verdict = CASE
           WHEN ? THEN NULL
           ELSE COALESCE(excluded.verdict, submission_prs.verdict)
@@ -322,6 +329,7 @@ export async function upsertPrState(
       params.sourceEvidenceHash ?? null,
       timestamp,
       timestamp,
+      params.clearTerminal ? 1 : 0,
       params.clearVerdict ? 1 : 0,
       params.clearVerdict ? 1 : 0,
       params.incrementAttempt ? 1 : 0,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1352,10 +1352,16 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(storageSource).toContain("terminal_at IS NOT NULL");
     expect(storageSource).toContain("status = 'closed'");
+    expect(storageSource).toContain(
+      "excluded.status NOT IN ('merged', 'closed', 'manual', 'ignored')",
+    );
+    expect(storageSource).toContain("THEN submission_prs.status");
     expect(enqueueBlock).toContain("shouldResetClosedTerminal");
+    expect(enqueueBlock).toContain("const shouldQueueReview");
     expect(enqueueBlock).toContain("!hasTerminalGateDecision(existing)");
     expect(enqueueBlock).toContain("shouldResetIgnoredScan");
     expect(enqueueBlock).toContain("shouldResetClosedTerminal");
+    expect(enqueueBlock).toContain("if (!shouldQueueReview) return false");
     expect(reviewBlock).toContain("if (hasTerminalGateDecision(existing))");
     expect(enqueueBlock).not.toContain(
       "if (!forceRecheck && hasTerminalGateDecision(existing))",


### PR DESCRIPTION
## Summary
- Prevent terminal gate rows from being overwritten back to transient queue states by late webhook/check events.
- Stop `enqueueReviewTarget` from sending review jobs when the target already has a terminal gate decision and has not been explicitly reset.
- Add regression assertions around terminal status preservation.

## What changed
- `enqueueReviewTarget` now returns before writing/sending when a PR is already terminal.
- D1 `upsertPrState` preserves existing terminal status when a later non-terminal write arrives without `clearTerminal`.
- Tests assert both queue-send and storage-level protections.

## Why
- PR #1631 had `terminal_at` and `verdict=close`, but a late event left `status=queued`, making queue/status reporting misleading.
- Terminal state should be stable unless a deliberate reopen/reset path clears it.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `git diff --check`

## Notes
- Repaired the existing inconsistent D1 row for #1631; it now reports `status=closed`.