### PR TITLE
fix(registry): avoid unbounded shell scan regexes

### DIFF
--- a/packages/registry/src/command-safety.js
+++ b/packages/registry/src/command-safety.js
@@ -2,41 +2,172 @@
 // scripts, MCP commands, install snippets). Advisory only — a triage signal for
 // human/maintainer review, never a sandbox or a guarantee of safety.
 
+const REMOVE_PATTERN = /\brm\s+-[a-z]*r[a-z]*f|\brm\s+-[a-z]*f[a-z]*r/i;
+const CHMOD_PATTERN = /\bchmod\s+(?:-R\s+)?0?777\b/i;
+const MKFS_PATTERN = /\bmkfs(?:\.\w+)?\b/i;
+const FORK_BOMB_PATTERN = /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/;
+const INLINE_EVAL_PATTERN = /\beval\s+["'`]?\$\(/i;
+
+function isWordCharacter(char) {
+  return /[a-z0-9_]/i.test(char || "");
+}
+
+function findCommandToken(line, lowerLine, token, fromIndex = 0) {
+  while (fromIndex < line.length) {
+    const index = lowerLine.indexOf(token, fromIndex);
+    if (index === -1) return -1;
+
+    const before = line[index - 1] || "";
+    const after = line[index + token.length] || "";
+    if (!isWordCharacter(before) && !isWordCharacter(after)) return index;
+
+    fromIndex = index + token.length;
+  }
+  return -1;
+}
+
+function hasCommandToken(line, lowerLine, tokens) {
+  return tokens.some(
+    (token) => findCommandToken(line, lowerLine, token) !== -1,
+  );
+}
+
+function hasShellAfterPipe(line, lowerLine, pipeIndex) {
+  let index = pipeIndex + 1;
+  while (/\s/.test(line[index] || "")) index += 1;
+
+  if (
+    lowerLine.startsWith("sudo", index) &&
+    !isWordCharacter(line[index + 4] || "")
+  ) {
+    index += 4;
+    while (/\s/.test(line[index] || "")) index += 1;
+  }
+
+  for (const shell of ["bash", "zsh", "sh"]) {
+    if (
+      lowerLine.startsWith(shell, index) &&
+      !isWordCharacter(line[index + shell.length] || "")
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasTokenAt(line, lowerLine, token, index) {
+  return (
+    lowerLine.startsWith(token, index) &&
+    !isWordCharacter(line[index - 1] || "") &&
+    !isWordCharacter(line[index + token.length] || "")
+  );
+}
+
+function hasAnyTokenAt(line, lowerLine, tokens, index) {
+  return tokens.some((token) => hasTokenAt(line, lowerLine, token, index));
+}
+
+function hasPipeToShellInstall(line, lowerLine) {
+  let sawDownloaderBeforePipe = false;
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] === "|") {
+      if (
+        sawDownloaderBeforePipe &&
+        hasShellAfterPipe(line, lowerLine, index)
+      ) {
+        return true;
+      }
+      sawDownloaderBeforePipe = false;
+    } else if (hasAnyTokenAt(line, lowerLine, ["curl", "wget"], index)) {
+      sawDownloaderBeforePipe = true;
+    }
+  }
+  return false;
+}
+
+function findBase64DecodeFlagEnd(line, lowerLine, commandEndIndex) {
+  let index = commandEndIndex;
+  let sawWhitespace = false;
+  while (/\s/.test(line[index] || "")) {
+    sawWhitespace = true;
+    index += 1;
+  }
+  if (!sawWhitespace) return -1;
+
+  for (const flag of ["--decode", "-d"]) {
+    if (
+      lowerLine.startsWith(flag, index) &&
+      !isWordCharacter(line[index + flag.length] || "")
+    ) {
+      return index + flag.length;
+    }
+  }
+  return -1;
+}
+
+function hasBase64DecodedShell(line, lowerLine) {
+  let sawDecodedBase64BeforePipe = false;
+  for (let index = 0; index < line.length; index += 1) {
+    if (line[index] === "|") {
+      if (
+        sawDecodedBase64BeforePipe &&
+        hasShellAfterPipe(line, lowerLine, index)
+      ) {
+        return true;
+      }
+      sawDecodedBase64BeforePipe = false;
+    } else if (hasTokenAt(line, lowerLine, "base64", index)) {
+      sawDecodedBase64BeforePipe ||=
+        findBase64DecodeFlagEnd(line, lowerLine, index + "base64".length) !==
+        -1;
+    }
+  }
+  return false;
+}
+
 // Each entry is a recognizable, high-confidence destructive or remote-exec
 // pattern. Kept conservative to avoid flagging ordinary scripts.
-const DANGEROUS_PATTERNS = [
+const DANGEROUS_CHECKS = [
   {
     label: "pipe-to-shell install",
-    pattern: /(?:curl|wget)\b[^\n|]*\|\s*(?:sudo\s+)?(?:ba|z)?sh\b/i,
+    test: hasPipeToShellInstall,
   },
   {
     label: "recursive force remove",
-    pattern: /\brm\s+-[a-z]*r[a-z]*f|\brm\s+-[a-z]*f[a-z]*r/i,
+    test: (line) => REMOVE_PATTERN.test(line),
   },
   {
     label: "world-writable chmod",
-    pattern: /\bchmod\s+(?:-R\s+)?0?777\b/i,
+    test: (line) => CHMOD_PATTERN.test(line),
   },
   {
     label: "raw disk write",
-    pattern: /\bdd\b[^\n]*\bof=\/dev\/|\bmkfs(?:\.\w+)?\b/i,
+    test: (line, lowerLine) =>
+      (hasCommandToken(line, lowerLine, ["dd"]) &&
+        lowerLine.includes("of=/dev/")) ||
+      MKFS_PATTERN.test(line),
   },
   {
     label: "base64-decoded shell",
-    pattern: /\bbase64\s+(?:-d|--decode)\b[^\n|]*\|\s*(?:ba|z)?sh\b/i,
+    test: hasBase64DecodedShell,
   },
   {
     label: "fork bomb",
-    pattern: /:\s*\(\s*\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:/,
+    test: (line) => FORK_BOMB_PATTERN.test(line),
   },
   {
     label: "inline eval of command substitution",
-    pattern: /\beval\s+["'`]?\$\(/i,
+    test: (line) => INLINE_EVAL_PATTERN.test(line),
   },
 ];
 
 /**
  * Scan text for high-risk shell patterns.
+ *
+ * The scanner intentionally evaluates one line at a time with bounded,
+ * command-token searches instead of running unanchored wildcard regexes across
+ * the whole submission. That keeps reviewer-side package validation responsive
+ * even when an attacker submits very long lines with many repeated prefixes.
  *
  * @param {unknown} text
  * @returns {string[]} Labels of the matched patterns (empty when none match).
@@ -45,9 +176,13 @@ export function scanDangerousShellPatterns(text) {
   const value = String(text ?? "");
   if (!value) return [];
 
-  const labels = [];
-  for (const { label, pattern } of DANGEROUS_PATTERNS) {
-    if (pattern.test(value)) labels.push(label);
+  const labels = new Set();
+  for (const line of value.split(/\r?\n/)) {
+    const lowerLine = line.toLowerCase();
+    for (const { label, test } of DANGEROUS_CHECKS) {
+      if (!labels.has(label) && test(line, lowerLine)) labels.add(label);
+    }
+    if (labels.size === DANGEROUS_CHECKS.length) break;
   }
-  return labels;
+  return [...labels];
 }

--- a/tests/command-safety.test.ts
+++ b/tests/command-safety.test.ts
@@ -4,9 +4,9 @@ import { scanDangerousShellPatterns } from "@heyclaude/registry/command-safety";
 
 describe("scanDangerousShellPatterns", () => {
   it("flags each high-risk shell pattern", () => {
-    expect(scanDangerousShellPatterns("curl https://x.test/i.sh | sh")).toContain(
-      "pipe-to-shell install",
-    );
+    expect(
+      scanDangerousShellPatterns("curl https://x.test/i.sh | sh"),
+    ).toContain("pipe-to-shell install");
     expect(
       scanDangerousShellPatterns("wget -qO- https://x.test | sudo bash"),
     ).toContain("pipe-to-shell install");
@@ -16,9 +16,9 @@ describe("scanDangerousShellPatterns", () => {
     expect(scanDangerousShellPatterns("chmod -R 777 /app")).toContain(
       "world-writable chmod",
     );
-    expect(
-      scanDangerousShellPatterns("dd if=/dev/zero of=/dev/sda"),
-    ).toContain("raw disk write");
+    expect(scanDangerousShellPatterns("dd if=/dev/zero of=/dev/sda")).toContain(
+      "raw disk write",
+    );
     expect(scanDangerousShellPatterns("mkfs.ext4 /dev/sdb")).toContain(
       "raw disk write",
     );
@@ -38,5 +38,16 @@ describe("scanDangerousShellPatterns", () => {
     expect(scanDangerousShellPatterns("npm install && npm test")).toEqual([]);
     expect(scanDangerousShellPatterns("")).toEqual([]);
     expect(scanDangerousShellPatterns(null)).toEqual([]);
+  });
+  it("handles long repeated command prefixes without quadratic regex scans", () => {
+    const repeatedCurlWithoutShellPipe = `${"curl https://example.test/install ".repeat(50_000)}| node`;
+    expect(scanDangerousShellPatterns(repeatedCurlWithoutShellPipe)).toEqual(
+      [],
+    );
+
+    const repeatedBase64WithoutShellPipe = `${"base64 -d payload ".repeat(50_000)}| node`;
+    expect(scanDangerousShellPatterns(repeatedBase64WithoutShellPipe)).toEqual(
+      [],
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- The previous scanner used unanchored, greedy regexes across the entire file which can exhibit quadratic CPU behavior on crafted long lines and allow reviewer/browser-side validator hangs.
- The goal is to preserve advisory detection while eliminating ReDoS-style availability risks by bounding scanning work.

### Description
- Replace whole-text wildcard regex checks with a line-local, token-driven scanner that searches for command tokens and pipes in-bounds (new helpers: `findCommandToken`, `hasShellAfterPipe`, `hasPipeToShellInstall`, `hasBase64DecodedShell`, etc.).
- Convert the `DANGEROUS_PATTERNS` approach to `DANGEROUS_CHECKS` where each check exposes a `test` function and `scanDangerousShellPatterns` iterates lines and collects labels into a set.
- Preserve the original advisory labels and validator integration so callers still receive the same warnings when patterns are present.
- Add a regression test to ensure long repeated `curl`/`base64` prefixes do not trigger quadratic regex scans and do not falsely flag when followed by a non-shell pipe.

### Testing
- Ran `pnpm exec vitest run tests/command-safety.test.ts tests/skill-package-validator.test.ts` and all tests passed (tests in both files succeeded).
- Ran formatting on modified files with `pnpm exec prettier --write` and validated the updated tests execute successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a232ba5b508832ca23e8b8aa2fb1da8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Enhanced dangerous shell command pattern detection with improved accuracy.
  * Optimized performance when processing extremely long command inputs.
  * Better identification of various malicious command constructs and patterns.
  * Reduced false positives in command safety scanning.

* **Tests**
  * Expanded test suite with comprehensive coverage of edge cases and performance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->