### PR TITLE
fix(seo): share k unit across shorthand salary ranges in JobPosting JSON-LD

### DIFF
--- a/packages/registry/src/seo.js
+++ b/packages/registry/src/seo.js
@@ -423,9 +423,16 @@ function parseJobCompensation(value) {
     );
   };
 
-  const minSuffix = amounts[0].toLowerCase().endsWith("k") ? "k" : "";
-  const minValue = parseAmount(amounts[0]);
-  const maxValue = parseAmount(amounts[1], minSuffix);
+  // A "k" unit is commonly written once for the whole range ("$120-150k"),
+  // and on either endpoint. Share it across both so the unit-less endpoint
+  // isn't read at face value (e.g. "$120-150k" -> 120000..150000, not 120..150000).
+  const sharedSuffix =
+    amounts[0].toLowerCase().endsWith("k") ||
+    amounts[1].toLowerCase().endsWith("k")
+      ? "k"
+      : "";
+  const minValue = parseAmount(amounts[0], sharedSuffix);
+  const maxValue = parseAmount(amounts[1], sharedSuffix);
   if (!minValue || !maxValue) return undefined;
 
   return {

--- a/tests/seo-jsonld.test.ts
+++ b/tests/seo-jsonld.test.ts
@@ -267,4 +267,44 @@ describe("SEO JSON-LD policy", () => {
       ),
     ).toBeNull();
   });
+
+  it("shares a 'k' unit across a shorthand salary range", () => {
+    const jsonLd = buildJobPostingJsonLd(
+      {
+        slug: "shorthand-comp",
+        title: "AI Engineer",
+        company: "Example",
+        description:
+          "Build Claude workflow systems for a verified employer listing with production AI integrations, source-backed role details, and developer-facing infrastructure ownership.",
+        descriptionMd:
+          "## Role brief\n\nOwn integrations across Claude workflow systems and developer-facing AI infrastructure for a team shipping production agent and MCP surfaces. The reviewed detail gives candidates enough context about responsibilities, requirements, source verification, and the employer-owned application path before they continue.",
+        postedAt: "2026-04-26",
+        expiresAt: "2026-05-26",
+        applyUrl: "https://example.com/jobs/ai-engineer",
+        sourceUrl: "https://example.com/jobs/ai-engineer",
+        sourceCheckedAt: "2026-04-26",
+        // Unit written once, on the max endpoint — must apply to both.
+        compensation: "$120 – 150k",
+        responsibilities: [
+          "Ship Claude integrations",
+          "Maintain source-verified role detail",
+        ],
+        requirements: [
+          "TypeScript experience",
+          "Comfort with LLM developer tooling",
+        ],
+      },
+      { siteUrl: "https://heyclau.de" },
+    );
+    expect(jsonLd?.baseSalary).toMatchObject({
+      "@type": "MonetaryAmount",
+      currency: "USD",
+      value: {
+        "@type": "QuantitativeValue",
+        minValue: 120000,
+        maxValue: 150000,
+        unitText: "YEAR",
+      },
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Closes #1750

`parseJobCompensation` (`packages/registry/src/seo.js`) derived the shared `k` unit from the **min** endpoint only and applied it just to the max, so a range with the unit written once on the last number (`"$120-150k"` — a standard human format) parsed as `minValue: 120, maxValue: 150000`. That invalid $120 annual minimum was emitted in `JobPosting` `baseSalary` JSON-LD, which Google consumes for job rich-results.

## Change
- `packages/registry/src/seo.js` — derive the suffix from **either** endpoint (`amounts[0]` or `amounts[1]`) and apply it to both `parseAmount` calls.
- `tests/seo-jsonld.test.ts` — add a regression test asserting `"$120 – 150k"` → `minValue 120000 / maxValue 150000`.

## Why it's safe (no regressions)
The function already *intended* to share a suffix (the now-misdirected `minSuffix` proves it). Behavior is identical for every already-correct input:

| input | before | after |
|---|---|---|
| `$150K – $190K` | 150000 / 190000 | 150000 / 190000 |
| `$120 – 150k` | **120 / 150000** | 120000 / 150000 |
| `$120k - 150` | 120000 / 150000 | 120000 / 150000 |
| `150000-190000` | 150000 / 190000 | 150000 / 190000 |

No false ×1000 is introduced for unit-less ranges (suffix stays `""` when neither endpoint has `k`).

## Verification
- `pnpm test:seo-jsonld` → **9 passed** (8 existing + 1 new), including the existing `$150K – $190K` JobPosting case (unchanged).
- Generated artifacts (`apps/web/public/data/**`, `apps/web/src/generated/**`) are not included — only `seo.js` + the test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed salary range parsing to correctly interpret shorthand notation (e.g., "$120-150k") by consistently applying unit suffixes across both endpoints of the range.

* **Tests**
  * Added test coverage for job posting compensation range parsing to verify proper conversion to standardized salary values and units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->