### PR TITLE
fix(content): scope headless ci tool permissions

### DIFF
--- a/content/guides/headless-claude-code-automation-from-scripts-and-ci.mdx
+++ b/content/guides/headless-claude-code-automation-from-scripts-and-ci.mdx
@@ -110,13 +110,18 @@ newline-delimited streaming events.
 ## Auto-approve tools safely
 
 ```bash
-claude -p "Run the test suite and fix any failures" --allowedTools "Bash,Read,Edit"
+claude --bare -p "Run the test suite and summarize any failures" \
+  --permission-mode dontAsk \
+  --allowedTools "Bash(npm test),Bash(git diff *)"
 ```
 
-For a locked-down baseline, pass a permission mode: `--permission-mode dontAsk`
-denies anything not in your allow rules or the read-only command set, which suits
-CI. `--allowedTools` uses permission-rule syntax, so `Bash(git diff *)` allows a
-prefix (note the space before `*`).
+For a locked-down CI baseline, use `--bare` so repository-local instructions,
+hooks, skills, plugins, MCP servers, and CLAUDE.md cannot change the run. Pass a
+permission mode: `--permission-mode dontAsk` denies anything not in your allow
+rules or the read-only command set. `--allowedTools` uses permission-rule syntax,
+so `Bash(git diff *)` allows a prefix (note the space before `*`). Avoid broad
+rules such as `Bash,Read,Edit` in CI because they allow arbitrary shell commands
+and broad repository reads or edits.
 
 ## Continue conversations
 


### PR DESCRIPTION
### Motivation
- The guide presented a copyable auto-approval example that granted unscoped `Bash`, `Read`, and `Edit` permissions and omitted `--bare` and `--permission-mode dontAsk`, contradicting the frontmatter safety advice and enabling dangerous CI automation patterns. 
- This could lead downstream users to run autonomous agents in CI with broad shell and repository write/read capabilities, risking command execution, secret exposure, or unauthorized changes.

### Description
- Update the example in `content/guides/headless-claude-code-automation-from-scripts-and-ci.mdx` to use `--bare`, `--permission-mode dontAsk`, and narrowly scoped allow rules. 
- Replace the unsafe `claude -p "..." --allowedTools "Bash,Read,Edit"` example with `claude --bare -p "..." --permission-mode dontAsk --allowedTools "Bash(npm test),Bash(git diff *)"` to demonstrate a CI-safe baseline. 
- Add explicit guidance explaining why `--bare` matters for CI reproducibility and why broad rules like `Bash,Read,Edit` should be avoided in CI.

### Testing
- Ran `pnpm validate:content -- content/guides/headless-claude-code-automation-from-scripts-and-ci.mdx` and the validation passed. 
- Ran `pnpm validate:content:strict` and the validation passed. 
- Ran `git diff --check` and there were no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2335329198832c92631ec92a6f96af)