### PR TITLE
fix(submissions): enforce configured merge confidence floor

### DIFF
--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -3,7 +3,6 @@ import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 export const GATE_DECISION_SCHEMA_VERSION = 2;
 export const GATE_COMMENT_FORMATTER_VERSION = 5;
 export const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR = 0.85;
-const DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR = 0.75;
 const HEYCLAUDE_SITE_URL = "https://heyclau.de";
 const HEYCLAUDE_REPO_URL = "https://github.com/JSONbored/awesome-claude";
 const HEYCLAUDE_FORK_URL = "https://github.com/JSONbored/awesome-claude/fork";
@@ -627,63 +626,6 @@ function normalizedConfidenceFloor(value: number) {
     : DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR;
 }
 
-function hasFailedChecks(decision: GateDecision) {
-  return (decision.checks || []).some((check) =>
-    ["failed", "error", "cancelled"].includes(check.status),
-  );
-}
-
-function hasBlockingOrAmbiguousSections(decision: GateDecision) {
-  return (decision.sections || []).some((section) =>
-    ["fail", "warn"].includes(section.status),
-  );
-}
-
-function mergeSummarySignalsAcceptance(summary: string) {
-  const value = summary.toLowerCase();
-  return (
-    value.includes("no blocking") ||
-    value.includes("none blocking") ||
-    value.includes("recommend direct merge") ||
-    value.includes("direct merge is recommended") ||
-    value.includes("can be merged directly") ||
-    value.includes("meets all repository policies")
-  );
-}
-
-function mergeSummarySignalsAmbiguity(summary: string) {
-  const value = summary.toLowerCase();
-  const nonBlocking =
-    value.includes("non-blocking") ||
-    value.includes("not a blocker") ||
-    value.includes("not blocking");
-  if (nonBlocking) return false;
-  return (
-    value.includes("unresolved") ||
-    value.includes("ambiguous") ||
-    value.includes("could not verify") ||
-    value.includes("contradictory") ||
-    value.includes("manual review")
-  );
-}
-
-function isCleanStructuredMergeDecision(
-  decision: GateDecision,
-  cleanFloor = DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR,
-) {
-  return (
-    decision.verdict === "merge" &&
-    typeof decision.confidence === "number" &&
-    Number.isFinite(decision.confidence) &&
-    decision.confidence >= cleanFloor &&
-    !(decision.errors || []).length &&
-    !hasFailedChecks(decision) &&
-    !hasBlockingOrAmbiguousSections(decision) &&
-    mergeSummarySignalsAcceptance(decision.summary || "") &&
-    !mergeSummarySignalsAmbiguity(decision.summary || "")
-  );
-}
-
 function decisionConfidenceText(decision: GateDecision) {
   if (
     typeof decision.confidence === "number" &&
@@ -1180,9 +1122,6 @@ export function enforceAutoMergeConfidenceFloor(
     Number.isFinite(decision.confidence) &&
     decision.confidence >= normalizedFloor
   ) {
-    return decision;
-  }
-  if (isCleanStructuredMergeDecision(decision)) {
     return decision;
   }
 

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -641,7 +641,7 @@ describe("Cloudflare submission gate helpers", () => {
     ).toContain("> ## ℹ️ Superseded gate report");
   });
 
-  it("keeps clean default-confidence merge verdicts on the merge path", () => {
+  it("routes low-confidence clean merge verdicts to manual review", () => {
     const decision = enforceAutoMergeConfidenceFloor({
       schemaVersion: 2,
       verdict: "merge",
@@ -660,11 +660,56 @@ describe("Cloudflare submission gate helpers", () => {
     });
 
     expect(decision).toMatchObject({
-      verdict: "merge",
+      verdict: "manual",
       confidence: 0.76,
-      labels: ["submission-merged-by-gate"],
+      labels: ["submission-manual-review"],
+      errors: [
+        {
+          code: "low_private_review_confidence",
+          retryable: false,
+        },
+      ],
     });
-    expect(decision.errors).toBeUndefined();
+    expect(decision.summary).toContain("unattended merge floor is 85%");
+    expect(markerComment(decision)).toContain("Confidence Review");
+  });
+
+  it("keeps the configured confidence floor authoritative", () => {
+    const cleanMergeDecision = {
+      schemaVersion: 2 as const,
+      verdict: "merge" as const,
+      confidence: 0.91,
+      summary:
+        "Summary:\n- No blocking issues detected.\n- The PR meets all repository policies and can be merged directly.\nRecommended Action:\n- Recommend direct merge.",
+      labels: ["submission-merged-by-gate"],
+      checks: [{ name: "validate-content", status: "passed" as const }],
+      sections: [
+        {
+          id: "source_review",
+          status: "pass" as const,
+          bullets: ["Primary source is reachable."],
+        },
+      ],
+    };
+
+    expect(
+      enforceAutoMergeConfidenceFloor(cleanMergeDecision, 0.9),
+    ).toMatchObject({
+      verdict: "merge",
+      confidence: 0.91,
+    });
+    expect(
+      enforceAutoMergeConfidenceFloor(cleanMergeDecision, 0.95),
+    ).toMatchObject({
+      verdict: "manual",
+      confidence: 0.91,
+      errors: [
+        {
+          code: "low_private_review_confidence",
+          retryable: false,
+        },
+      ],
+    });
   });
 
   it("routes ambiguous low-confidence private merge verdicts to manual review", () => {


### PR DESCRIPTION
## Summary
- Fixes a submission-gate policy bypass where low-confidence private-review merge verdicts could remain on the direct merge path.
- Removes the separate hard-coded clean-merge confidence threshold and summary phrase matching escape hatch.
- Adds regression coverage proving the configured auto-merge confidence floor stays authoritative.

## What changed
- Deleted the clean structured merge bypass that accepted merge verdicts below `AUTO_MERGE_CONFIDENCE_FLOOR` based on free-form acceptance phrases.
- Kept `enforceAutoMergeConfidenceFloor()` as the single enforcement boundary for unattended merge confidence.
- Updated tests so a clean-looking `0.76` merge verdict routes to manual review under the default `0.85` floor.
- Added coverage showing a decision above one configured floor can merge, but the same decision below a stricter configured floor routes to manual review.

## Why
Private reviewer output is influenced by PR-submitted content and metadata. The configured confidence floor is the operator control that prevents uncertain AI review decisions from reaching unattended merge. Free-form summary text should not bypass that control.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "confidence|GateDecisionV2"`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `git diff --check`
- `pnpm build`

## Notes
- `gh` auth is currently invalid in the local shell, so the branch was pushed over the configured JSONbored SSH remote and this PR was opened through the GitHub connector.