### PR TITLE
content(mcp): add Chrome MCP Server

### DIFF
--- a/content/mcp/chrome-mcp-server.mdx
+++ b/content/mcp/chrome-mcp-server.mdx
@@ -1,0 +1,168 @@
+---
+title: Chrome MCP Server
+slug: chrome-mcp-server
+category: mcp
+description: >-
+  Chrome extension-based MCP server that exposes an existing Chrome browser
+  profile to AI assistants for tab management, page content, screenshots,
+  interaction, history, bookmarks, and network inspection.
+cardDescription: >-
+  Let MCP clients control and inspect a local Chrome browser through the
+  mcp-chrome extension and bridge.
+seoTitle: Chrome MCP Server for Claude
+seoDescription: >-
+  Configure the extension-based Chrome MCP Server with Claude, Codex, Cursor,
+  and other MCP clients to automate an existing Chrome profile through local
+  streamable HTTP tools.
+author: hangwin
+authorProfileUrl: "https://github.com/hangwin"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-05"
+brandName: Chrome MCP Server
+repoUrl: "https://github.com/hangwin/mcp-chrome"
+documentationUrl: "https://github.com/hangwin/mcp-chrome"
+packageUrl: "https://www.npmjs.com/package/mcp-chrome-bridge"
+installable: true
+installCommand: "npm install -g mcp-chrome-bridge"
+usageSnippet: "Install the Chrome extension and bridge, connect the extension, then add the local streamable HTTP endpoint `http://127.0.0.1:12306/mcp` to an MCP client."
+copySnippet: |-
+  {
+    "mcpServers": {
+      "chrome-mcp-server": {
+        "type": "streamableHttp",
+        "url": "http://127.0.0.1:12306/mcp"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "chrome-mcp-server": {
+        "type": "streamableHttp",
+        "url": "http://127.0.0.1:12306/mcp"
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - Node.js 20 or newer and npm or pnpm.
+  - Chrome or Chromium browser.
+  - Latest Chrome MCP extension release from the project repository.
+  - Globally installed `mcp-chrome-bridge` package.
+  - MCP client that supports streamable HTTP, or the documented stdio fallback.
+safetyNotes:
+  - This server controls the user's existing Chrome browser profile and can reuse logged-in sessions.
+  - Tools can navigate pages, click elements, fill forms, inspect tabs, capture screenshots, inspect network traffic, read history, manage bookmarks, and inject scripts.
+  - Use a dedicated browser profile for agent work and avoid sensitive accounts unless the workflow explicitly requires them.
+  - Do not allow agents to submit forms, make purchases, change account settings, or perform irreversible actions without human approval.
+  - The project describes itself as early-stage and under active development; test carefully before relying on it for critical workflows.
+privacyNotes:
+  - Open tabs, page content, screenshots, browsing history, bookmarks, cookies/session-derived page state, and network request metadata may be exposed to the MCP client and model.
+  - Screenshots and network responses can contain credentials, personal data, customer data, tokens, and private documents.
+  - Browser automation prompts may reveal personal browsing habits, internal applications, and authenticated service access.
+sourceUrls:
+  - "https://github.com/hangwin/mcp-chrome"
+  - "https://github.com/hangwin/mcp-chrome/blob/main/docs/TOOLS.md"
+  - "https://www.npmjs.com/package/mcp-chrome-bridge"
+tags:
+  - chrome
+  - browser
+  - automation
+  - screenshots
+  - local
+keywords:
+  - Chrome MCP Server
+  - mcp-chrome Claude
+  - mcp-chrome-bridge
+  - browser automation MCP
+  - Chrome extension MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+Chrome MCP Server is an extension-based MCP server for controlling and
+inspecting a local Chrome browser. Unlike browser automation servers that launch
+a separate clean browser, this project is designed to work with an existing
+Chrome profile, including open tabs, settings, extensions, and login state.
+
+It uses a Chrome extension plus the `mcp-chrome-bridge` package and documents a
+local streamable HTTP endpoint at:
+
+```text
+http://127.0.0.1:12306/mcp
+```
+
+## Source Review
+
+- https://github.com/hangwin/mcp-chrome
+- https://github.com/hangwin/mcp-chrome/blob/main/docs/TOOLS.md
+- https://www.npmjs.com/package/mcp-chrome-bridge
+
+These sources were reviewed on **2026-06-05**. Prefer the live repository for
+current release downloads, bridge installation steps, supported transports, and
+tool lists.
+
+## Features
+
+- Streamable HTTP MCP endpoint through a local Chrome extension bridge.
+- Access to existing Chrome tabs and logged-in browser state.
+- Browser window and tab listing, switching, navigation, and close operations.
+- Screenshots, page content extraction, semantic tab content search, console
+  output, and interactive element discovery.
+- Network capture and custom request tooling.
+- Click, form fill/select, keyboard, history, and bookmark tools.
+- Optional stdio fallback documented by the project.
+
+## Installation
+
+Install the bridge:
+
+```sh
+npm install -g mcp-chrome-bridge
+```
+
+Then download and load the latest Chrome extension release from the project
+repository, connect it, and add the local endpoint to an MCP client:
+
+```json
+{
+  "mcpServers": {
+    "chrome-mcp-server": {
+      "type": "streamableHttp",
+      "url": "http://127.0.0.1:12306/mcp"
+    }
+  }
+}
+```
+
+If a client only supports stdio, use the fallback path documented in the project
+README.
+
+## Use Cases
+
+- Summarize, inspect, or compare open browser tabs.
+- Capture screenshots and page content for UI debugging.
+- Inspect network requests while reproducing a web application issue.
+- Automate browser actions in a dedicated test profile.
+- Search browser tab content semantically across active work.
+
+## Safety and Privacy
+
+This server is powerful because it works with the user's real Chrome session.
+Prefer a separate Chrome profile for agent work, keep sensitive accounts closed,
+and require human confirmation before actions that submit forms, change account
+state, purchase goods, send messages, or alter data.
+
+Treat screenshots, tab content, browsing history, bookmarks, and network
+captures as sensitive. They may contain private application data or personal
+information.
+
+## Duplicate Check
+
+`content/mcp/chrome-devtools-mcp-server.mdx` covers the official Chrome
+DevTools MCP server. This entry covers the separate `hangwin/mcp-chrome`
+extension-based server that uses an existing Chrome profile.


### PR DESCRIPTION
## Summary
- Add a source-backed MCP entry for the extension-based Chrome MCP Server.
- Document bridge setup, streamable HTTP config, tool surface, and real-browser-profile safety/privacy risks.

## What changed
- Added `content/mcp/chrome-mcp-server.mdx` only.
- Included install/config snippets, prerequisites, source review, safety notes, privacy notes, and duplicate-check context.

## Why
- Refs #660.
- `hangwin/mcp-chrome` is a popular MCP server for controlling an existing Chrome profile through a Chrome extension and local bridge.

## Duplicate check
- Searched `content/mcp/` for `hangwin/mcp-chrome`, `mcp-chrome-bridge`, `chrome-mcp-server`, and the source URL.
- Existing `content/mcp/chrome-devtools-mcp-server.mdx` covers the official Chrome DevTools MCP server.
- This entry covers the separate extension-based Chrome MCP Server project.

## Source review
- https://github.com/hangwin/mcp-chrome
- https://github.com/hangwin/mcp-chrome/blob/main/docs/TOOLS.md
- https://www.npmjs.com/package/mcp-chrome-bridge

## Safety and privacy
- Notes cover real Chrome profile access, logged-in sessions, screenshots, browser history, bookmarks, network capture, form submission, account-state changes, script injection, and early-stage project status.

## Validation
- `pnpm validate:content:strict`
- `git diff --check`
