### PR TITLE
fix(submissions): retry gate infrastructure failures

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -51,6 +51,7 @@ import {
   isRetryableGateDecision,
   markerComment,
   normalizePrivateGateDecisionPayload,
+  parsePrivateGateDecisionResponseBody,
   privateReviewErrorDecision,
   retryingReviewComment,
   type GateDecision,
@@ -454,6 +455,33 @@ function retryDelayForError(error: unknown) {
 
 function nextReviewForError(error: unknown) {
   return isoAfter(retryDelayForError(error));
+}
+
+function isTimeoutError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "AbortError" ||
+    error.name === "TimeoutError" ||
+    /(?:operation was aborted due to timeout|aborted due to timeout|timed out|timeout)/i.test(
+      error.message,
+    )
+  );
+}
+
+function retryablePrecheckDecision(error: unknown) {
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate deterministic duplicate/edit review hit a GitHub rate limit.",
+      "github_rate_limited",
+    );
+  }
+  if (isTimeoutError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate deterministic duplicate/edit review timed out while reading source or duplicate evidence.",
+      "source_evidence_timeout",
+    );
+  }
+  return null;
 }
 
 function normalizeOneShotDecision(decision: GateDecision): GateDecision {
@@ -2702,7 +2730,9 @@ async function reviewWithPrivateGate(env: Env, message: QueueMessage) {
       "private_reviewer_unavailable",
     );
   }
-  const raw = await response.json().catch(() => null);
+  const raw = parsePrivateGateDecisionResponseBody(
+    await response.text().catch(() => ""),
+  );
   const normalized = normalizePrivateGateDecisionPayload(raw);
   if (normalized.error || !normalized.decision) {
     const error = normalized.error || {
@@ -2717,6 +2747,61 @@ async function reviewWithPrivateGate(env: Env, message: QueueMessage) {
     );
   }
   return normalized.decision;
+}
+
+async function persistRetryableGateDecision(params: {
+  env: Env;
+  token: string;
+  repo: ReturnType<typeof parseRepo>;
+  target: ReviewTarget;
+  message: QueueMessage;
+  decision: GateDecision;
+  auditDecision: string;
+}) {
+  await upsertPrState(params.env.SUBMISSION_GATE_DB, {
+    repo: params.target.repoFullName,
+    number: params.target.number,
+    headRepo: params.target.headRepo,
+    headRef: params.target.headRef,
+    headSha: params.target.headSha,
+    baseRef: params.target.baseRef || contentGateBaseRef(params.env),
+    installationId: params.target.installationId,
+    status: "error_retryable",
+    nextReviewAt: nextReviewForStatus("error_retryable"),
+    lastError: truncateForQueue(params.decision.summary),
+    deliveryId: String(params.message.payload.deliveryId || ""),
+    clearVerdict: true,
+    clearTerminal: true,
+  });
+  const retryComment = await upsertMarkerComment({
+    token: params.token,
+    repo: params.repo,
+    issueNumber: params.target.number,
+    marker: params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+    body: retryingReviewComment(
+      params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+    ),
+    apiVersion: params.env.GITHUB_API_VERSION,
+  });
+  await upsertPrState(params.env.SUBMISSION_GATE_DB, {
+    repo: params.target.repoFullName,
+    number: params.target.number,
+    headRepo: params.target.headRepo,
+    headRef: params.target.headRef,
+    headSha: params.target.headSha,
+    baseRef: params.target.baseRef || contentGateBaseRef(params.env),
+    installationId: params.target.installationId,
+    status: "error_retryable",
+    nextReviewAt: nextReviewForStatus("error_retryable"),
+    ...decisionMetadata(params.decision, retryComment),
+  });
+  await insertAudit(params.env.SUBMISSION_GATE_DB, {
+    id: crypto.randomUUID(),
+    targetKey: params.message.targetKey,
+    eventType: params.message.kind,
+    decision: params.auditDecision,
+    summary: params.decision.summary,
+  });
 }
 
 async function withSubmissionLock(
@@ -3222,6 +3307,19 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             };
           }
         } catch (error) {
+          const retryableDecision = retryablePrecheckDecision(error);
+          if (retryableDecision) {
+            await persistRetryableGateDecision({
+              env,
+              token,
+              repo,
+              target,
+              message,
+              decision: retryableDecision,
+              auditDecision: "deterministic_precheck_retryable",
+            });
+            return;
+          }
           decision = defaultManualDecision(
             `Submission gate could not complete deterministic duplicate/edit review: ${
               error instanceof Error ? error.message : "unknown error"
@@ -3289,55 +3387,14 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           );
         }
         if (isRetryableGateDecision(decision)) {
-          await upsertPrState(env.SUBMISSION_GATE_DB, {
-            repo: target.repoFullName,
-            number: target.number,
-            headRepo: target.headRepo,
-            headRef: target.headRef,
-            headSha: target.headSha,
-            baseRef: target.baseRef || contentGateBaseRef(env),
-            installationId: target.installationId,
-            status: "error_retryable",
-            nextReviewAt: nextReviewForStatus("error_retryable"),
-            lastError: truncateForQueue(decision.summary),
-            deliveryId: String(message.payload.deliveryId || ""),
-            clearVerdict: true,
-            clearTerminal: true,
-          });
-          const retryComment = await upsertMarkerComment({
+          await persistRetryableGateDecision({
+            env,
             token,
             repo,
-            issueNumber: target.number,
-            marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-            body: retryingReviewComment(
-              env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-            ),
-            apiVersion: env.GITHUB_API_VERSION,
-          });
-          await upsertPrState(env.SUBMISSION_GATE_DB, {
-            repo: target.repoFullName,
-            number: target.number,
-            headRepo: target.headRepo,
-            headRef: target.headRef,
-            headSha: target.headSha,
-            baseRef: target.baseRef || contentGateBaseRef(env),
-            installationId: target.installationId,
-            status: "error_retryable",
-            nextReviewAt: nextReviewForStatus("error_retryable"),
-            commentId: retryComment.id,
-            commentUrl: retryComment.url,
-            schemaVersion: decision.schemaVersion ?? 1,
-            formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
-            decisionId: decision.decisionId || crypto.randomUUID(),
-            confidence: decision.confidence ?? null,
-            sourceEvidenceHash: decision.sourceEvidenceHash ?? null,
-          });
-          await insertAudit(env.SUBMISSION_GATE_DB, {
-            id: crypto.randomUUID(),
-            targetKey: message.targetKey,
-            eventType: message.kind,
-            decision: "private_review_retryable",
-            summary: decision.summary,
+            target,
+            message,
+            decision,
+            auditDecision: "private_review_retryable",
           });
           return;
         }

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -353,6 +353,61 @@ function looksLikeGenericSafetyClose(summary: string) {
   );
 }
 
+function extractJsonFromText(value: string): unknown {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const fenced = trimmed.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const candidates = fenced ? [fenced[1].trim(), trimmed] : [trimmed];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+  }
+  return value;
+}
+
+function unwrapPrivateGatePayload(raw: unknown, depth = 0): unknown {
+  if (depth > 3) return raw;
+  if (typeof raw === "string") {
+    const parsed = extractJsonFromText(raw);
+    return parsed === raw ? raw : unwrapPrivateGatePayload(parsed, depth + 1);
+  }
+  if (!isRecord(raw)) return raw;
+  for (const key of ["decision", "gateDecision", "result", "review"]) {
+    if (raw[key] !== undefined) {
+      return unwrapPrivateGatePayload(raw[key], depth + 1);
+    }
+  }
+  return raw;
+}
+
+export function parsePrivateGateDecisionResponseBody(body: string) {
+  return unwrapPrivateGatePayload(body);
+}
+
+function looksLikePrivateReviewInfrastructureManual(params: {
+  verdict: GateDecisionV2Verdict;
+  summary: string;
+  sections: GateDecisionSection[] | null;
+  errors?: GateDecisionError[];
+}) {
+  if (params.verdict !== "manual" || params.errors?.length) return false;
+  const text = [
+    params.summary,
+    ...(params.sections || []).flatMap((section) => [
+      section.title || section.id,
+      ...section.bullets,
+    ]),
+  ].join("\n");
+  return /(?:AI maintainer review returned an unexpected payload|private .*review.*unexpected payload|unexpected payload|invalid GateDecision|malformed private|could not parse|parse failure)/i.test(
+    text,
+  );
+}
+
 export function privateReviewErrorDecision(
   reason: string,
   code: string,
@@ -375,6 +430,9 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
   decision?: GateDecision;
   error?: GateDecisionError;
 } {
+  const unwrapped = unwrapPrivateGatePayload(raw);
+  if (unwrapped !== raw) return normalizePrivateGateDecisionPayload(unwrapped);
+
   if (!isRecord(raw)) {
     return {
       error: {
@@ -400,6 +458,11 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
           .map(normalizeSection)
           .filter((section): section is GateDecisionSection => Boolean(section))
       : null;
+    const errors = Array.isArray(raw.errors)
+      ? raw.errors
+          .map(normalizeError)
+          .filter((error): error is GateDecisionError => Boolean(error))
+      : undefined;
     const reasonCode = normalizeReasonCode(raw.reasonCode);
     const evidence = Array.isArray(raw.evidence)
       ? raw.evidence
@@ -420,6 +483,23 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
           retryable: true,
           message:
             "Private corpus review returned an invalid GateDecisionV2 payload.",
+        },
+      };
+    }
+    if (
+      looksLikePrivateReviewInfrastructureManual({
+        verdict,
+        summary,
+        sections,
+        errors,
+      })
+    ) {
+      return {
+        error: {
+          code: "invalid_private_response",
+          retryable: true,
+          message:
+            "Private corpus review surfaced an internal payload parsing failure.",
         },
       };
     }
@@ -444,11 +524,6 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
           slug: cleanText(raw.scope.slug) || undefined,
           status: cleanText(raw.scope.status) || undefined,
         }
-      : undefined;
-    const errors = Array.isArray(raw.errors)
-      ? raw.errors
-          .map(normalizeError)
-          .filter((error): error is GateDecisionError => Boolean(error))
       : undefined;
 
     return {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -35,6 +35,7 @@ import {
   isRetryableGateDecision,
   markerComment,
   normalizePrivateGateDecisionPayload,
+  parsePrivateGateDecisionResponseBody,
   retryingReviewComment,
   supersededReviewComment,
   validationFailedDecision,
@@ -411,7 +412,12 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("target: {");
     expect(source).toContain("installationId: target.installationId");
     expect(source).toContain("normalizePrivateGateDecisionPayload(raw)");
+    expect(source).toContain("parsePrivateGateDecisionResponseBody(");
     expect(source).toContain("isRetryableGateDecision(decision)");
+    expect(source).toContain("function persistRetryableGateDecision");
+    expect(source).toContain("retryablePrecheckDecision(error)");
+    expect(source).toContain('"deterministic_precheck_retryable"');
+    expect(source).toContain('"source_evidence_timeout"');
     expect(source).toContain(
       "shouldStopRetryingInvalidPrivateResponse(decision, existing)",
     );
@@ -706,33 +712,78 @@ describe("Cloudflare submission gate helpers", () => {
   });
 
   it("normalizes GateDecisionV2 and rejects malformed private review payloads", () => {
-    expect(
-      normalizePrivateGateDecisionPayload({
-        schemaVersion: 2,
-        verdict: "merge",
-        confidence: 0.91,
-        summary: ["Summary:", "- Looks good."],
-        labels: ["submission-merged-by-gate"],
-        scope: {
-          filePath: "content/mcp/example.mdx",
-          category: "mcp",
-          slug: "example",
-          status: "added",
+    const validMergeDecision = {
+      schemaVersion: 2,
+      verdict: "merge",
+      confidence: 0.91,
+      summary: ["Summary:", "- Looks good."],
+      labels: ["submission-merged-by-gate"],
+      scope: {
+        filePath: "content/mcp/example.mdx",
+        category: "mcp",
+        slug: "example",
+        status: "added",
+      },
+      checks: [{ name: "validate-content", status: "passed" }],
+      sections: [
+        {
+          id: "recommended_action",
+          status: "pass",
+          bullets: ["Merge this PR."],
         },
-        checks: [{ name: "validate-content", status: "passed" }],
-        sections: [
-          {
-            id: "recommended_action",
-            status: "pass",
-            bullets: ["Merge this PR."],
-          },
-        ],
-      }).decision,
+      ],
+    };
+
+    expect(
+      normalizePrivateGateDecisionPayload(validMergeDecision).decision,
     ).toMatchObject({
       schemaVersion: 2,
       verdict: "merge",
       confidence: 0.91,
       checks: [{ name: "validate-content", status: "passed" }],
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        decision: validMergeDecision,
+      }).decision,
+    ).toMatchObject({
+      schemaVersion: 2,
+      verdict: "merge",
+      confidence: 0.91,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload(
+        parsePrivateGateDecisionResponseBody(
+          `\`\`\`json\n${JSON.stringify(validMergeDecision)}\n\`\`\``,
+        ),
+      ).decision,
+    ).toMatchObject({
+      schemaVersion: 2,
+      verdict: "merge",
+      confidence: 0.91,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "manual",
+        confidence: 0.66,
+        summary: "AI maintainer review returned an unexpected payload.",
+        labels: ["submission-manual-review"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "summary",
+            status: "warn",
+            bullets: ["AI maintainer review returned an unexpected payload."],
+          },
+        ],
+      }).error,
+    ).toMatchObject({
+      code: "invalid_private_response",
+      retryable: true,
     });
 
     expect(


### PR DESCRIPTION
## Summary
- Keep deterministic duplicate/edit timeouts and GitHub rate-limit failures retryable instead of terminal manual-review outcomes.
- Harden private review response parsing for text, fenced JSON, and common wrapper envelopes.
- Reject V2 manual decisions that are clearly private-review parser/infrastructure failures rather than content-review outcomes.

## What changed
- Added a shared retry persistence path for private-review and deterministic-precheck infrastructure failures.
- Changed private review response parsing to read text and normalize wrapped/fenced JSON payloads.
- Added regression tests for wrapped private responses, parser-failure manual payloads, and deterministic precheck retry wiring.

## Why
- Recent content PRs #1759 and #1761 were routed to manual review even though public validation and Superagent passed.
- #1759 surfaced an internal private-review payload failure as a final manual decision.
- #1761 terminaled manual because deterministic duplicate/edit review timed out instead of retrying.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `pnpm exec prettier --check apps/submission-gate/src/index.ts apps/submission-gate/src/review.ts tests/submission-gate-worker.test.ts`
- `git diff --check`

## Notes
- This does not weaken deterministic hard closes. Strict duplicates, protected metadata edits, validation failures, and explicit private close decisions still behave as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submission reviews now automatically retry when encountering timeout or rate-limit errors
  * Enhanced response parsing to better handle varying submission review response formats

* **Bug Fixes**
  * Improved detection and recovery from infrastructure-related submission response failures
  * Refined error handling for more reliable submission gate decisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->