### PR TITLE
fix(submissions): allow trusted manual rechecks

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2369,10 +2369,13 @@ async function enqueueReviewTarget(
     String(existing?.status || "") === "closed" &&
     (isReopenedPullRequestEvent(eventName, webhook) ||
       eventName === "scheduled");
+  const shouldResetManualTerminal =
+    forceRecheck === true && String(existing?.status || "") === "manual";
   const shouldQueueReview =
     !hasTerminalGateDecision(existing) ||
     shouldResetIgnoredScan ||
-    shouldResetClosedTerminal;
+    shouldResetClosedTerminal ||
+    shouldResetManualTerminal;
   if (!shouldQueueReview) return false;
 
   await upsertPrState(env.SUBMISSION_GATE_DB, {
@@ -2388,8 +2391,14 @@ async function enqueueReviewTarget(
     nextReviewAt: null,
     incrementAttempt: true,
     lastReviewKey: reviewScanKey || undefined,
-    clearVerdict: shouldResetIgnoredScan || shouldResetClosedTerminal,
-    clearTerminal: shouldResetIgnoredScan || shouldResetClosedTerminal,
+    clearVerdict:
+      shouldResetIgnoredScan ||
+      shouldResetClosedTerminal ||
+      shouldResetManualTerminal,
+    clearTerminal:
+      shouldResetIgnoredScan ||
+      shouldResetClosedTerminal ||
+      shouldResetManualTerminal,
   });
   await env.SUBMISSION_REVIEW_QUEUE.send({
     kind: "review_pr",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -496,6 +496,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"MEMBER"');
     expect(source).toContain('"COLLABORATOR"');
     expect(source).toContain("targetFromIssueCommentRecheck");
+    expect(source).toContain("shouldResetManualTerminal");
+    expect(source).toContain(
+      'forceRecheck === true && String(existing?.status || "") === "manual"',
+    );
     expect(issueCommentBlock).toContain("payload,\n      true,");
   });
 
@@ -1205,7 +1209,8 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(source).toContain("existingReviewKey !== reviewScanKey");
     expect(source).toContain("shouldResetIgnoredScan");
-    expect(source).toContain("clearTerminal: shouldResetIgnoredScan");
+    expect(source).toContain("shouldResetManualTerminal");
+    expect(source).toContain("clearTerminal:");
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
     expect(source).toContain('reason: "already_reviewed"');
     expect(pullRequestBlock).toContain('reviewability.kind === "ignore"');


### PR DESCRIPTION
## Summary
- Let trusted `/recheck` comments reset open PRs stuck in terminal `manual` gate state.
- Keep closed and merged terminal states protected.

## What changed
- Added a manual-terminal reset condition to the submission gate queue path when `forceRecheck` is true.
- Clear stale verdict and terminal metadata before requeueing a trusted manual recheck.
- Added source assertions for the manual recheck reset path.

## Why
- The gate hotfix made parser/timeouts retryable, but existing manual PRs still could not be rerun because terminal `manual` state blocked queue creation before the recheck message was processed.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts`
- `pnpm exec prettier --check apps/submission-gate/src/index.ts tests/submission-gate-worker.test.ts`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `git diff --check`
