### PR TITLE
fix(submissions): trust deterministic source evidence

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -59,6 +59,12 @@ import {
 } from "./review";
 import { postDiscordDecisionNotification } from "./notifications";
 import {
+  checkSubmittedSourceEvidence,
+  sourceEvidenceCloseDecision,
+  sourceEvidenceSummary,
+  type SourceEvidenceReport,
+} from "./source-evidence";
+import {
   decryptText,
   encryptText,
   randomToken,
@@ -147,6 +153,13 @@ class SubmissionMergePendingError extends Error {
   }
 }
 
+class SourceEvidenceRetryableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SourceEvidenceRetryableError";
+  }
+}
+
 const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
 const TERMINAL_PR_STATUSES = new Set(["merged", "closed", "manual", "ignored"]);
 const VALIDATION_REQUEUE_SECONDS = 90;
@@ -157,6 +170,7 @@ const RETRYABLE_ERROR_SECONDS = 60;
 const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
 const PRIVATE_REVIEW_TIMEOUT_MS = 45_000;
 const INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3;
+const SOURCE_EVIDENCE_CONFLICT_MAX_RETRIES = 2;
 const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR_TEXT = String(
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 );
@@ -469,6 +483,9 @@ function isTimeoutError(error: unknown) {
 }
 
 function retryablePrecheckDecision(error: unknown) {
+  if (error instanceof SourceEvidenceRetryableError) {
+    return privateReviewErrorDecision(error.message, "source_evidence_timeout");
+  }
   if (isGitHubRateLimitError(error)) {
     return privateReviewErrorDecision(
       "Submission gate deterministic duplicate/edit review hit a GitHub rate limit.",
@@ -530,6 +547,17 @@ function shouldStopRetryingInvalidPrivateResponse(
   );
 }
 
+function shouldStopRetryingSourceEvidenceConflict(
+  decision: GateDecision,
+  existing: Record<string, unknown> | null,
+) {
+  return (
+    hasPrivateReviewErrorCode(decision, "source_evidence_conflict") &&
+    invalidPrivateResponseAttempts(existing) >=
+      SOURCE_EVIDENCE_CONFLICT_MAX_RETRIES
+  );
+}
+
 function invalidPrivateResponseExhaustedDecision(
   decision: GateDecision,
   existing: Record<string, unknown> | null,
@@ -546,6 +574,90 @@ function invalidPrivateResponseExhaustedDecision(
       retryable: false,
       message: decision.summary,
     },
+  );
+}
+
+function sourceEvidenceConflictDecision(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport,
+) {
+  const conflict = privateReviewErrorDecision(
+    "Private review claimed source_hard_failure, but deterministic source evidence found the submitted source URLs reachable.",
+    "source_evidence_conflict",
+  );
+  return {
+    ...conflict,
+    confidence: decision.confidence,
+    sourceEvidenceHash: sourceEvidence.hash,
+    sections: [
+      {
+        id: "source_review",
+        title: "Source Review",
+        status: "warn" as const,
+        bullets: [
+          "Private review reported a source hard failure that conflicts with deterministic source evidence.",
+          sourceEvidenceSummary(sourceEvidence),
+          "The gate will retry with the deterministic source artifact before falling back to the clean merge path.",
+        ],
+      },
+    ],
+  };
+}
+
+function sourceEvidenceConflictMergeDecision(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport,
+): GateDecision {
+  return {
+    schemaVersion: 2,
+    verdict: "merge",
+    confidence: Math.max(
+      decision.confidence || 0,
+      DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
+    ),
+    sourceEvidenceHash: sourceEvidence.hash,
+    labels: [LABELS.merged],
+    summary: [
+      "Summary:",
+      "- Public validation and deterministic source evidence passed.",
+      "- Private review returned a source_hard_failure that contradicted reachable source evidence.",
+      "- No deterministic blocker remains, so the gate is accepting the source-backed one-file content PR.",
+      "",
+      "Source Review:",
+      `- ${sourceEvidenceSummary(sourceEvidence)}`,
+      "",
+      "Recommended Action:",
+      "- Merge this PR.",
+    ].join("\n"),
+    sections: [
+      {
+        id: "source_review",
+        title: "Source Review",
+        status: "pass",
+        bullets: [
+          "Deterministic source evidence found submitted source URLs reachable.",
+          sourceEvidenceSummary(sourceEvidence),
+        ],
+      },
+      {
+        id: "recommended_action",
+        title: "Recommended Action",
+        status: "pass",
+        bullets: ["Merge this PR."],
+      },
+    ],
+  };
+}
+
+function privateSourceHardFailureContradicted(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport | null,
+) {
+  return (
+    decision.verdict === "close" &&
+    decision.reasonCode === "source_hard_failure" &&
+    sourceEvidence?.status === "passed" &&
+    sourceEvidence.urls.length > 0
   );
 }
 
@@ -2315,6 +2427,21 @@ async function deterministicContentPrecheck(params: {
     }
   }
 
+  const sourceEvidence = await checkSubmittedSourceEvidence(candidateContent);
+  const sourceDecision = sourceEvidenceCloseDecision(sourceEvidence);
+  if (sourceDecision) {
+    return {
+      content: candidateContent,
+      decision: sourceDecision,
+      sourceEvidence,
+    };
+  }
+  if (sourceEvidence.status === "retryable") {
+    throw new SourceEvidenceRetryableError(
+      `Submission gate deterministic source evidence check was retryable: ${sourceEvidenceSummary(sourceEvidence)}.`,
+    );
+  }
+
   const candidate = extractContentDuplicateSignals({
     filePath: params.scope.filePath,
     content: candidateContent,
@@ -2342,6 +2469,7 @@ async function deterministicContentPrecheck(params: {
       candidate,
     ),
     duplicateReview: summarizeDuplicateReview(duplicateReview),
+    sourceEvidence,
   };
 }
 
@@ -3126,6 +3254,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         checks?: Array<{ name: string; status: string; details?: string }>;
       } | null = null;
       let contentScopeForPrivateReview: DirectContentScope | null = null;
+      let sourceEvidenceForPrivateReview: SourceEvidenceReport | null = null;
       const reviewability = await directContentReviewabilityForPr({
         token,
         repo,
@@ -3281,6 +3410,15 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             target,
             scope: contentScopeForPrivateReview,
           });
+          if (precheck.sourceEvidence) {
+            sourceEvidenceForPrivateReview = precheck.sourceEvidence;
+            validationForPrivateReview = {
+              ...(isRecord(validationForPrivateReview)
+                ? validationForPrivateReview
+                : {}),
+              deterministicSourceEvidence: precheck.sourceEvidence,
+            };
+          }
           if (precheck.duplicateReview) {
             validationForPrivateReview = {
               ...(isRecord(validationForPrivateReview)
@@ -3312,6 +3450,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               deterministicPrecheck: {
                 status: "passed",
                 contentStatus: contentScopeForPrivateReview.status,
+                sourceEvidenceHash: sourceEvidenceForPrivateReview?.hash,
               },
             };
           }
@@ -3353,6 +3492,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             },
             validation: validationForPrivateReview,
             contentScope: contentScopeForPrivateReview,
+            sourceEvidence: sourceEvidenceForPrivateReview,
             privateReviewRequirements: {
               finalAction: "merge_or_close",
               duplicateHistoryRequired: true,
@@ -3383,9 +3523,40 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 "Do not close a submission merely because it defensively discusses OAuth, tokens, credentials, authorization, attestations, artifacts, packages, downloads, security, privacy, or destructive-risk prevention. These topics require careful evidence review, but source-backed guides, rules, skills, collections, hooks, tools, and statuslines about safe review practices can merge when validation, sources, scope, and safety/privacy notes pass. A hard safety, secret, package, or abuse close must cite concrete unsafe behavior or a concrete policy violation such as credential theft, exposed secrets, destructive defaults, malware/abuse tooling, unverified package hosting, packageVerified:true by an external contributor, broken source evidence, or promotional/affiliate content. Generic phrases like 'contains patterns that cannot be accepted' are not sufficient evidence for a close verdict.",
               closeEvidenceContract:
                 "Every close verdict must include reasonCode and evidence. Supported reasonCode values are scope_failure, validation_failure, provenance_failure, protected_metadata_edit, strict_duplicate, source_hard_failure, commercial_listing_route, embedded_secret, unsafe_install_pipeline, malicious_data_theft, prohibited_content, and policy_fit_failure. Safety closes must include ruleId, matched snippet or behavior, and whyNotDefensive. Defensive security examples like Claude Code permission auditing or env-leak warning hooks should not close on keyword matches alone.",
+              sourceEvidencePolicy:
+                "Use deterministicSourceEvidence/sourceEvidence for URL reachability. Do not invent HTTP status. If your source_hard_failure finding disagrees with deterministic source evidence, return a retryable source_evidence_conflict error with the conflicting URL instead of a close verdict. You may still close semantic source failures such as unsupported claims, thin promotional content, or policy fit issues, but not by claiming reachable links are dead.",
             },
           },
         });
+        if (
+          privateSourceHardFailureContradicted(
+            decision,
+            sourceEvidenceForPrivateReview,
+          )
+        ) {
+          const conflictDecision = sourceEvidenceConflictDecision(
+            decision,
+            sourceEvidenceForPrivateReview!,
+          );
+          decision = shouldStopRetryingSourceEvidenceConflict(
+            conflictDecision,
+            existing,
+          )
+            ? sourceEvidenceConflictMergeDecision(
+                decision,
+                sourceEvidenceForPrivateReview!,
+              )
+            : conflictDecision;
+        }
+        if (
+          !decision.sourceEvidenceHash &&
+          sourceEvidenceForPrivateReview?.hash
+        ) {
+          decision = {
+            ...decision,
+            sourceEvidenceHash: sourceEvidenceForPrivateReview.hash,
+          };
+        }
         if (
           isRetryableGateDecision(decision) &&
           shouldStopRetryingInvalidPrivateResponse(decision, existing)

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -69,6 +69,13 @@ export type GateDecisionEvidence = {
   behavior?: string;
   policy?: string;
   source?: string;
+  field?: string;
+  url?: string;
+  matchedUrl?: string;
+  finalUrl?: string;
+  outcome?: string;
+  status?: string;
+  httpStatus?: string;
   fix?: string;
   whyNotDefensive?: string;
 };
@@ -137,6 +144,7 @@ const RETRYABLE_PRIVATE_REVIEW_CODES = new Set([
   "private_reviewer_unavailable",
   "github_rate_limited",
   "source_evidence_timeout",
+  "source_evidence_conflict",
 ]);
 
 const VERDICT_HEADLINES: Record<GateVerdict, string> = {
@@ -292,12 +300,22 @@ function normalizeReasonCode(
 
 function normalizeEvidence(value: unknown): GateDecisionEvidence | null {
   if (!isRecord(value)) return null;
+  const rawStatus = cleanText(value.status);
+  const httpStatus =
+    cleanText(value.httpStatus) || (/^\d{3}$/.test(rawStatus) ? rawStatus : "");
   const evidence: GateDecisionEvidence = {
     ruleId: cleanText(value.ruleId) || undefined,
     snippet: cleanText(value.snippet) || undefined,
     behavior: cleanText(value.behavior) || undefined,
     policy: cleanText(value.policy) || undefined,
     source: cleanText(value.source) || undefined,
+    field: cleanText(value.field) || undefined,
+    url: cleanText(value.url) || undefined,
+    matchedUrl: cleanText(value.matchedUrl) || undefined,
+    finalUrl: cleanText(value.finalUrl) || undefined,
+    outcome: cleanText(value.outcome) || undefined,
+    status: rawStatus || undefined,
+    httpStatus: httpStatus || undefined,
     fix: cleanText(value.fix) || undefined,
     whyNotDefensive: cleanText(value.whyNotDefensive) || undefined,
   };
@@ -311,6 +329,13 @@ function evidenceHasConcreteDetail(evidence: GateDecisionEvidence[]) {
       item.behavior,
       item.policy,
       item.source,
+      item.field,
+      item.url,
+      item.matchedUrl,
+      item.finalUrl,
+      item.outcome,
+      item.status,
+      item.httpStatus,
       item.fix,
       item.whyNotDefensive,
     ].some(Boolean),
@@ -815,6 +840,13 @@ function decisionEvidenceSection(
         item.behavior ? `behavior: ${item.behavior}` : "",
         item.snippet ? `snippet: \`${item.snippet}\`` : "",
         item.source ? `source: ${item.source}` : "",
+        item.field ? `field: \`${item.field}\`` : "",
+        item.url ? `url: ${item.url}` : "",
+        item.matchedUrl ? `matched URL: ${item.matchedUrl}` : "",
+        item.finalUrl ? `final URL: ${item.finalUrl}` : "",
+        item.outcome ? `outcome: ${item.outcome}` : "",
+        item.status ? `status: ${item.status}` : "",
+        item.httpStatus ? `HTTP: ${item.httpStatus}` : "",
         item.fix ? `fix: ${item.fix}` : "",
         item.whyNotDefensive
           ? `why not defensive: ${item.whyNotDefensive}`

--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -1,0 +1,310 @@
+import { LABELS } from "./constants";
+import { parseSimpleFrontmatter } from "./duplicates";
+import type { GateDecision, GateDecisionEvidence } from "./review";
+
+export type SubmittedSourceUrl = {
+  field: string;
+  url: string;
+};
+
+export type SourceEvidenceItem = SubmittedSourceUrl & {
+  status: "passed" | "hard_failure" | "retryable";
+  outcome: string;
+  httpStatus?: number;
+  finalUrl?: string;
+  error?: string;
+};
+
+export type SourceEvidenceReport = {
+  status: "passed" | "failed" | "retryable";
+  hash: string;
+  urls: SourceEvidenceItem[];
+};
+
+const SOURCE_URL_FIELDS = [
+  "documentationUrl",
+  "docsUrl",
+  "downloadUrl",
+  "githubUrl",
+  "packageUrl",
+  "repoUrl",
+  "repositoryUrl",
+  "sourceUrl",
+  "websiteUrl",
+] as const;
+
+const SOURCE_URL_LIST_FIELDS = new Set(["sourceUrls"]);
+const SOURCE_EVIDENCE_TIMEOUT_MS = 10_000;
+
+function stripYamlComment(value: string) {
+  return value.replace(/\s+#.*$/, "").trim();
+}
+
+function unquoteYamlValue(value: string) {
+  const trimmed = stripYamlComment(value);
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed.trim();
+}
+
+function frontmatterBlock(source: string) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(
+    String(source || ""),
+  );
+  return match?.[1] || "";
+}
+
+function scalarSourceUrlValues(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed
+      .slice(1, -1)
+      .split(",")
+      .map(unquoteYamlValue)
+      .filter(Boolean);
+  }
+  return [unquoteYamlValue(trimmed)].filter(Boolean);
+}
+
+function listSourceUrlValues(source: string) {
+  const values: SubmittedSourceUrl[] = [];
+  let activeField = "";
+  for (const line of frontmatterBlock(source).split(/\r?\n/)) {
+    const topLevel = /^([A-Za-z][A-Za-z0-9_]*):\s*(.*?)\s*$/.exec(line);
+    if (topLevel) {
+      const [, key, value] = topLevel;
+      activeField = SOURCE_URL_LIST_FIELDS.has(key) ? key : "";
+      if (activeField && value && value !== "|" && value !== ">") {
+        for (const url of scalarSourceUrlValues(value)) {
+          values.push({ field: activeField, url });
+        }
+      }
+      continue;
+    }
+    if (!activeField) continue;
+    const item = /^\s*-\s*(.*?)\s*$/.exec(line);
+    if (!item) continue;
+    const url = unquoteYamlValue(item[1] || "");
+    if (url) values.push({ field: activeField, url });
+  }
+  return values;
+}
+
+export function extractSubmittedSourceUrls(source: string) {
+  const fields = parseSimpleFrontmatter(source);
+  const urls: SubmittedSourceUrl[] = [];
+  for (const field of SOURCE_URL_FIELDS) {
+    for (const url of scalarSourceUrlValues(fields[field] || "")) {
+      urls.push({ field, url });
+    }
+  }
+  urls.push(...listSourceUrlValues(source));
+
+  const seen = new Set<string>();
+  return urls.filter((item) => {
+    const key = `${item.field}\n${item.url}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function sourceStatusFromHttpStatus(status: number) {
+  if (status >= 200 && status < 400) return "passed" as const;
+  if (status === 408 || status === 429 || status >= 500) {
+    return "retryable" as const;
+  }
+  if (status >= 400 && status < 500) return "hard_failure" as const;
+  return "retryable" as const;
+}
+
+async function fetchSourceUrl(
+  item: SubmittedSourceUrl,
+  method: "HEAD" | "GET",
+  fetchImpl: typeof fetch,
+): Promise<SourceEvidenceItem> {
+  const response = await fetchImpl(item.url, {
+    method,
+    redirect: "follow",
+    headers: {
+      accept: "text/html,application/json,text/plain,*/*",
+      "user-agent": "heyclaude-submission-gate",
+    },
+    signal: AbortSignal.timeout(SOURCE_EVIDENCE_TIMEOUT_MS),
+  });
+  const status = sourceStatusFromHttpStatus(response.status);
+  return {
+    ...item,
+    status,
+    outcome:
+      status === "passed"
+        ? "reachable"
+        : status === "hard_failure"
+          ? "http_hard_failure"
+          : "http_retryable",
+    httpStatus: response.status,
+    finalUrl: response.url || item.url,
+  };
+}
+
+async function checkOneSourceUrl(
+  item: SubmittedSourceUrl,
+  fetchImpl: typeof fetch,
+): Promise<SourceEvidenceItem> {
+  try {
+    const parsed = new URL(item.url);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      return {
+        ...item,
+        status: "hard_failure",
+        outcome: "invalid_url",
+        error: "Source URL must use http or https.",
+      };
+    }
+  } catch (error) {
+    return {
+      ...item,
+      status: "hard_failure",
+      outcome: "invalid_url",
+      error: error instanceof Error ? error.message : "Invalid source URL.",
+    };
+  }
+
+  try {
+    const head = await fetchSourceUrl(item, "HEAD", fetchImpl);
+    if (head.status === "passed") return head;
+  } catch {
+    // Some source hosts reject HEAD or transiently fail it. Confirm with GET.
+  }
+
+  try {
+    return await fetchSourceUrl(item, "GET", fetchImpl);
+  } catch (error) {
+    return {
+      ...item,
+      status: "retryable",
+      outcome: "fetch_error",
+      error:
+        error instanceof Error
+          ? error.message
+          : "Source URL fetch failed before a response was returned.",
+    };
+  }
+}
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function sourceEvidenceHashInput(urls: SourceEvidenceItem[]) {
+  return JSON.stringify(
+    urls.map((item) => ({
+      field: item.field,
+      url: item.url,
+      finalUrl: item.finalUrl || "",
+      status: item.status,
+      outcome: item.outcome,
+      httpStatus: item.httpStatus || null,
+    })),
+  );
+}
+
+export async function checkSubmittedSourceEvidence(
+  source: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<SourceEvidenceReport> {
+  const urls = await Promise.all(
+    extractSubmittedSourceUrls(source).map((item) =>
+      checkOneSourceUrl(item, fetchImpl),
+    ),
+  );
+  const status = urls.some((item) => item.status === "hard_failure")
+    ? "failed"
+    : urls.some((item) => item.status === "retryable")
+      ? "retryable"
+      : "passed";
+  return {
+    status,
+    urls,
+    hash: await sha256Hex(sourceEvidenceHashInput(urls)),
+  };
+}
+
+export function sourceEvidenceSummary(report: SourceEvidenceReport) {
+  if (!report.urls.length) return "No source URLs were declared.";
+  return report.urls
+    .map((item) => {
+      const status = item.httpStatus ? `HTTP ${item.httpStatus}` : item.outcome;
+      return `${item.field} ${item.url} -> ${status}`;
+    })
+    .join("; ");
+}
+
+export function sourceEvidenceToDecisionEvidence(
+  report: SourceEvidenceReport,
+): GateDecisionEvidence[] {
+  return report.urls
+    .filter((item) => item.status === "hard_failure")
+    .map((item) => ({
+      ruleId: "source_url_reachability",
+      field: item.field,
+      url: item.url,
+      matchedUrl: item.url,
+      finalUrl: item.finalUrl,
+      outcome: item.outcome,
+      status: item.status,
+      httpStatus: item.httpStatus ? String(item.httpStatus) : undefined,
+      behavior: item.httpStatus
+        ? `${item.field} returned HTTP ${item.httpStatus}`
+        : `${item.field} is not a valid reachable source URL`,
+      fix: "Replace the source URL with a reachable authoritative source and resubmit a new one-file content PR.",
+    }));
+}
+
+export function sourceEvidenceCloseDecision(
+  report: SourceEvidenceReport,
+): GateDecision | null {
+  const evidence = sourceEvidenceToDecisionEvidence(report);
+  if (!evidence.length) return null;
+  return {
+    verdict: "close",
+    reasonCode: "source_hard_failure",
+    evidence,
+    sourceEvidenceHash: report.hash,
+    confidence: 1,
+    summary: [
+      "Summary:",
+      "- Deterministic source evidence found one or more dead or invalid source URLs.",
+      "- Dead source links block one-shot content submissions because the entry cannot be verified.",
+      "",
+      "Source Review:",
+      ...evidence.map((item) =>
+        [
+          `- \`${item.field || "source"}\` ${item.url || item.matchedUrl}`,
+          item.httpStatus ? `returned HTTP ${item.httpStatus}` : item.outcome,
+          item.finalUrl && item.finalUrl !== item.url
+            ? `(final URL: ${item.finalUrl})`
+            : "",
+        ]
+          .filter(Boolean)
+          .join(" "),
+      ),
+      "",
+      "Recommended Action:",
+      "- Close this PR and resubmit with reachable, authoritative source URLs.",
+    ].join("\n"),
+    labels: [LABELS.close],
+    close: true,
+  };
+}

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -41,6 +41,11 @@ import {
   validationFailedDecision,
 } from "../apps/submission-gate/src/review";
 import {
+  checkSubmittedSourceEvidence,
+  extractSubmittedSourceUrls,
+  sourceEvidenceCloseDecision,
+} from "../apps/submission-gate/src/source-evidence";
+import {
   buildDiscordDecisionPayload,
   postDiscordDecisionNotification,
 } from "../apps/submission-gate/src/notifications";
@@ -430,6 +435,13 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(source).toContain('status: "error_retryable"');
     expect(source).toContain("retryingReviewComment(");
+    expect(source).toContain("checkSubmittedSourceEvidence(candidateContent)");
+    expect(source).toContain("sourceEvidenceCloseDecision(sourceEvidence)");
+    expect(source).toContain("deterministicSourceEvidence");
+    expect(source).toContain("sourceEvidencePolicy:");
+    expect(source).toContain("privateSourceHardFailureContradicted(");
+    expect(source).toContain('"source_evidence_conflict"');
+    expect(source).toContain("sourceEvidenceConflictMergeDecision(");
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
@@ -615,6 +627,9 @@ describe("Cloudflare submission gate helpers", () => {
         {
           ruleId: "source_url_reachability",
           source: "https://example.com/docs",
+          matchedUrl: "https://example.com/docs",
+          status: "hard_failure",
+          httpStatus: "404",
           behavior: "documentationUrl returned 404",
           fix: "Replace or remove the dead documentationUrl.",
         },
@@ -629,7 +644,93 @@ describe("Cloudflare submission gate helpers", () => {
     expect(body).toContain("> ℹ️ **Reason:** `source_hard_failure`");
     expect(body).toContain("Decision Evidence");
     expect(body).toContain("source_url_reachability");
+    expect(body).toContain("matched URL: https://example.com/docs");
+    expect(body).toContain("HTTP: 404");
     expect(body).toContain("documentationUrl returned 404");
+  });
+
+  it("extracts and checks deterministic submitted source evidence", async () => {
+    const source = `---
+title: Source Evidence Fixture
+repoUrl: "https://github.com/example/repo"
+documentationUrl: "https://example.com/docs"
+sourceUrls:
+  - "https://example.com/guide"
+  - https://example.com/docs
+---
+`;
+
+    expect(extractSubmittedSourceUrls(source)).toEqual([
+      { field: "documentationUrl", url: "https://example.com/docs" },
+      { field: "repoUrl", url: "https://github.com/example/repo" },
+      { field: "sourceUrls", url: "https://example.com/guide" },
+      { field: "sourceUrls", url: "https://example.com/docs" },
+    ]);
+
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 405 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }))
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const first = await checkSubmittedSourceEvidence(source, fetchImpl);
+    const second = await checkSubmittedSourceEvidence(source, fetchImpl);
+
+    expect(first.status).toBe("passed");
+    expect(first.urls[0]).toMatchObject({
+      field: "documentationUrl",
+      url: "https://example.com/docs",
+      status: "passed",
+      httpStatus: 200,
+    });
+    expect(first.hash).toBe(second.hash);
+  });
+
+  it("turns deterministic source hard failures into close evidence", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Dead Source Fixture
+documentationUrl: "https://example.com/missing"
+---
+`,
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(new Response(null, { status: 404 })),
+    );
+    const decision = sourceEvidenceCloseDecision(report);
+
+    expect(report.status).toBe("failed");
+    expect(decision).toMatchObject({
+      verdict: "close",
+      reasonCode: "source_hard_failure",
+      close: true,
+      evidence: [
+        {
+          field: "documentationUrl",
+          matchedUrl: "https://example.com/missing",
+          httpStatus: "404",
+        },
+      ],
+    });
+  });
+
+  it("keeps transient source evidence failures retryable", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Retry Source Fixture
+documentationUrl: "https://example.com/temporarily-down"
+packageUrl: "https://example.com/rate-limited"
+---
+`,
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValueOnce(new Response(null, { status: 500 }))
+        .mockResolvedValueOnce(new Response(null, { status: 500 }))
+        .mockResolvedValueOnce(new Response(null, { status: 429 }))
+        .mockResolvedValueOnce(new Response(null, { status: 429 })),
+    );
+
+    expect(report.status).toBe("retryable");
+    expect(sourceEvidenceCloseDecision(report)).toBeNull();
   });
 
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {
@@ -788,6 +889,45 @@ describe("Cloudflare submission gate helpers", () => {
     ).toMatchObject({
       code: "invalid_private_response",
       retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.9,
+        reasonCode: "source_hard_failure",
+        evidence: [
+          {
+            ruleId: "source_url_reachability",
+            matchedUrl: "https://example.com/missing",
+            outcome: "hard-failure",
+            status: 404,
+          },
+        ],
+        summary: "Summary:\n- documentationUrl returned 404.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "source_review",
+            status: "fail",
+            bullets: ["documentationUrl returned 404."],
+          },
+        ],
+      }).decision,
+    ).toMatchObject({
+      verdict: "close",
+      reasonCode: "source_hard_failure",
+      evidence: [
+        {
+          ruleId: "source_url_reachability",
+          matchedUrl: "https://example.com/missing",
+          outcome: "hard-failure",
+          status: "404",
+          httpStatus: "404",
+        },
+      ],
     });
 
     expect(


### PR DESCRIPTION
## Summary
- add deterministic source URL evidence to the submission gate before private review
- preserve URL/status fields in GateDecision evidence for source-hard-failure comments
- retry or override contradicted private source-hard-failure decisions instead of terminaling them as manual review

## What changed
- checks submitted source URLs with HEAD plus GET fallback and closes reproducible invalid/4xx links
- treats 429, 5xx, and fetch timeouts as retryable source evidence failures
- passes deterministic source evidence and hash into private review and audit metadata
- keeps reachable public source evidence authoritative when private review claims dead links

## Why
- PR #1784 went manual because private review claimed reachable ACI sources were 404s
- dead links should close automatically, but reachable links should not create manual review churn

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts
- pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts
- pnpm build
- pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod
- pnpm exec prettier --check apps/submission-gate/src/index.ts apps/submission-gate/src/review.ts apps/submission-gate/src/source-evidence.ts tests/submission-gate-worker.test.ts
- git diff --check

## Notes
- After deployment, /recheck on #1784 should merge if its sources remain reachable, or close with exact source evidence if a URL fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic validation of submitted source URLs to verify accessibility and reachability
  * Detects and reports broken or inaccessible source links within submissions
  * Implemented conflict resolution when review decisions contradict source evidence verification results

* **Tests**
  * Added test coverage for source URL validation and evidence reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->