### PR TITLE
fix(submissions): reset manual recheck attempts

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2518,6 +2518,7 @@ async function enqueueReviewTarget(
     deliveryId,
     nextReviewAt: null,
     incrementAttempt: true,
+    resetAttemptCount: shouldResetManualTerminal,
     lastReviewKey: reviewScanKey || undefined,
     clearVerdict:
       shouldResetIgnoredScan ||

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -223,6 +223,7 @@ export async function upsertPrState(
     deliveryId?: string;
     nextReviewAt?: string | null;
     incrementAttempt?: boolean;
+    resetAttemptCount?: boolean;
     lastError?: string | null;
     lastCheckSummary?: string | null;
     terminalAt?: string | null;
@@ -277,6 +278,8 @@ export async function upsertPrState(
         last_review_key = COALESCE(excluded.last_review_key, submission_prs.last_review_key),
         next_review_at = excluded.next_review_at,
         attempt_count = CASE
+          WHEN ? AND ? THEN 1
+          WHEN ? THEN 0
           WHEN ? THEN submission_prs.attempt_count + 1
           ELSE submission_prs.attempt_count
         END,
@@ -332,6 +335,9 @@ export async function upsertPrState(
       params.clearTerminal ? 1 : 0,
       params.clearVerdict ? 1 : 0,
       params.clearVerdict ? 1 : 0,
+      params.resetAttemptCount ? 1 : 0,
+      params.incrementAttempt ? 1 : 0,
+      params.resetAttemptCount ? 1 : 0,
       params.incrementAttempt ? 1 : 0,
       params.clearTerminal ? 1 : 0,
     )

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -509,6 +509,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"COLLABORATOR"');
     expect(source).toContain("targetFromIssueCommentRecheck");
     expect(source).toContain("shouldResetManualTerminal");
+    expect(source).toContain("resetAttemptCount: shouldResetManualTerminal");
     expect(source).toContain(
       'forceRecheck === true && String(existing?.status || "") === "manual"',
     );
@@ -1395,6 +1396,7 @@ packageUrl: "https://example.com/rate-limited"
     expect(source).toContain("existingReviewKey !== reviewScanKey");
     expect(source).toContain("shouldResetIgnoredScan");
     expect(source).toContain("shouldResetManualTerminal");
+    expect(source).toContain("resetAttemptCount: shouldResetManualTerminal");
     expect(source).toContain("clearTerminal:");
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
     expect(source).toContain('reason: "already_reviewed"');


### PR DESCRIPTION
## Summary
- Reset stale review attempt counts when a trusted `/recheck` reopens a manual terminal submission.
- Prevent old manual-review state from immediately exhausting a fresh recheck after a gate fix deploy.

## What changed
- Added a `resetAttemptCount` path to submission PR state upserts.
- Applied it only when `/recheck` intentionally resets a manual terminal state.
- Added regression assertions for trusted manual recheck and terminal-state reset behavior.

## Why
- PR #1784 was reopened after the source-evidence fix, but the stored attempt count from the old manual state caused one new private-review failure to become attempt 4 immediately.
- A fresh trusted recheck should start from clean retry accounting while still incrementing normal queued review attempts.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `pnpm exec prettier --check apps/submission-gate/src/index.ts apps/submission-gate/src/storage.ts tests/submission-gate-worker.test.ts`
- `pnpm build`
- `git diff --check`

## Notes
- This is a follow-up to the deterministic source-evidence gate fix.
- No schema migration is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attempt count reset logic for pull requests during recheck operations to properly manage state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->