### PR TITLE
fix(submissions): reject contradicted duplicate closes

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -171,6 +171,7 @@ const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
 const PRIVATE_REVIEW_TIMEOUT_MS = 45_000;
 const INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3;
 const SOURCE_EVIDENCE_CONFLICT_MAX_RETRIES = 2;
+const DUPLICATE_EVIDENCE_CONFLICT_MAX_RETRIES = 2;
 const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR_TEXT = String(
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 );
@@ -558,6 +559,17 @@ function shouldStopRetryingSourceEvidenceConflict(
   );
 }
 
+function shouldStopRetryingDuplicateEvidenceConflict(
+  decision: GateDecision,
+  existing: Record<string, unknown> | null,
+) {
+  return (
+    hasPrivateReviewErrorCode(decision, "duplicate_evidence_conflict") &&
+    invalidPrivateResponseAttempts(existing) >=
+      DUPLICATE_EVIDENCE_CONFLICT_MAX_RETRIES
+  );
+}
+
 function invalidPrivateResponseExhaustedDecision(
   decision: GateDecision,
   existing: Record<string, unknown> | null,
@@ -649,6 +661,108 @@ function sourceEvidenceConflictMergeDecision(
   };
 }
 
+function duplicateReviewSummaryLine(duplicateReview: ContentDuplicateReview) {
+  const relatedCount = duplicateReview.relatedCandidates.length;
+  return duplicateReview.strictDuplicate
+    ? `strict duplicate: ${
+        duplicateReview.strictDuplicate.existing.label ||
+        duplicateReview.strictDuplicate.existing.filePath
+      }`
+    : `no strict duplicate${
+        relatedCount ? `; ${relatedCount} related candidate(s)` : ""
+      }`;
+}
+
+function duplicateEvidenceConflictDecision(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview,
+) {
+  const conflict = privateReviewErrorDecision(
+    "Private review claimed strict_duplicate, but deterministic duplicate review found no strict duplicate.",
+    "duplicate_evidence_conflict",
+  );
+  return {
+    ...conflict,
+    confidence: decision.confidence,
+    sections: [
+      {
+        id: "duplicate_history",
+        title: "Duplicate and History Review",
+        status: "warn" as const,
+        bullets: [
+          "Private review reported a strict duplicate that conflicts with deterministic duplicate review.",
+          duplicateReviewSummaryLine(duplicateReview),
+          "The gate will retry with the deterministic duplicate artifact before falling back to the clean merge path.",
+        ],
+      },
+    ],
+  };
+}
+
+function duplicateEvidenceConflictMergeDecision(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview,
+  sourceEvidence: SourceEvidenceReport | null,
+): GateDecision {
+  const sourceBullets =
+    sourceEvidence?.status === "passed"
+      ? [
+          {
+            id: "source_review",
+            title: "Source Review",
+            status: "pass" as const,
+            bullets: [
+              "Deterministic source evidence found submitted source URLs reachable.",
+              sourceEvidenceSummary(sourceEvidence),
+            ],
+          },
+        ]
+      : [];
+  return {
+    schemaVersion: 2,
+    verdict: "merge",
+    confidence: Math.max(
+      decision.confidence || 0,
+      DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
+    ),
+    sourceEvidenceHash: sourceEvidence?.hash,
+    labels: [LABELS.merged],
+    summary: [
+      "Summary:",
+      "- Public validation and deterministic duplicate review passed.",
+      "- Private review returned a strict_duplicate decision that contradicted deterministic duplicate evidence.",
+      "- No deterministic blocker remains, so the gate is accepting the one-file content PR.",
+      "",
+      "Duplicate / History Review:",
+      `- ${duplicateReviewSummaryLine(duplicateReview)}.`,
+      "",
+      ...(sourceEvidence
+        ? ["Source Review:", `- ${sourceEvidenceSummary(sourceEvidence)}.`, ""]
+        : []),
+      "Recommended Action:",
+      "- Merge this PR.",
+    ].join("\n"),
+    sections: [
+      {
+        id: "duplicate_history",
+        title: "Duplicate and History Review",
+        status: "pass",
+        bullets: [
+          "Deterministic duplicate review found no strict duplicate.",
+          duplicateReviewSummaryLine(duplicateReview),
+        ],
+      },
+      ...sourceBullets,
+      {
+        id: "recommended_action",
+        title: "Recommended Action",
+        status: "pass",
+        bullets: ["Merge this PR."],
+      },
+    ],
+  };
+}
+
 function privateSourceHardFailureContradicted(
   decision: GateDecision,
   sourceEvidence: SourceEvidenceReport | null,
@@ -658,6 +772,29 @@ function privateSourceHardFailureContradicted(
     decision.reasonCode === "source_hard_failure" &&
     sourceEvidence?.status === "passed" &&
     sourceEvidence.urls.length > 0
+  );
+}
+
+function privateStrictDuplicateContradicted(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview | null,
+) {
+  return (
+    decision.verdict === "close" &&
+    decision.reasonCode === "strict_duplicate" &&
+    Boolean(duplicateReview) &&
+    !duplicateReview?.strictDuplicate
+  );
+}
+
+function duplicateConflictRetryableContradicted(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview | null,
+) {
+  return (
+    hasPrivateReviewErrorCode(decision, "duplicate_evidence_conflict") &&
+    Boolean(duplicateReview) &&
+    !duplicateReview?.strictDuplicate
   );
 }
 
@@ -3256,6 +3393,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       } | null = null;
       let contentScopeForPrivateReview: DirectContentScope | null = null;
       let sourceEvidenceForPrivateReview: SourceEvidenceReport | null = null;
+      let duplicateReviewForPrivateReview: ContentDuplicateReview | null = null;
       const reviewability = await directContentReviewabilityForPr({
         token,
         repo,
@@ -3421,6 +3559,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             };
           }
           if (precheck.duplicateReview) {
+            duplicateReviewForPrivateReview = precheck.duplicateReview;
             validationForPrivateReview = {
               ...(isRecord(validationForPrivateReview)
                 ? validationForPrivateReview
@@ -3523,9 +3662,11 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               defensiveSecurityPolicy:
                 "Do not close a submission merely because it defensively discusses OAuth, tokens, credentials, authorization, attestations, artifacts, packages, downloads, security, privacy, or destructive-risk prevention. These topics require careful evidence review, but source-backed guides, rules, skills, collections, hooks, tools, and statuslines about safe review practices can merge when validation, sources, scope, and safety/privacy notes pass. A hard safety, secret, package, or abuse close must cite concrete unsafe behavior or a concrete policy violation such as credential theft, exposed secrets, destructive defaults, malware/abuse tooling, unverified package hosting, packageVerified:true by an external contributor, broken source evidence, or promotional/affiliate content. Generic phrases like 'contains patterns that cannot be accepted' are not sufficient evidence for a close verdict.",
               closeEvidenceContract:
-                "Every close verdict must include reasonCode and evidence. Supported reasonCode values are scope_failure, validation_failure, provenance_failure, protected_metadata_edit, strict_duplicate, source_hard_failure, commercial_listing_route, embedded_secret, unsafe_install_pipeline, malicious_data_theft, prohibited_content, and policy_fit_failure. Safety closes must include ruleId, matched snippet or behavior, and whyNotDefensive. Defensive security examples like Claude Code permission auditing or env-leak warning hooks should not close on keyword matches alone.",
+                "Every close verdict must include reasonCode and evidence. Supported reasonCode values are scope_failure, validation_failure, provenance_failure, protected_metadata_edit, strict_duplicate, source_hard_failure, commercial_listing_route, embedded_secret, unsafe_install_pipeline, malicious_data_theft, prohibited_content, and policy_fit_failure. strict_duplicate closes must identify the duplicated entry path, source URL, or PR in evidence. Safety closes must include ruleId, matched snippet or behavior, and whyNotDefensive. Defensive security examples like Claude Code permission auditing or env-leak warning hooks should not close on keyword matches alone.",
               sourceEvidencePolicy:
                 "Use deterministicSourceEvidence/sourceEvidence for URL reachability. Do not invent HTTP status. If your source_hard_failure finding disagrees with deterministic source evidence, return a retryable source_evidence_conflict error with the conflicting URL instead of a close verdict. You may still close semantic source failures such as unsupported claims, thin promotional content, or policy fit issues, but not by claiming reachable links are dead.",
+              duplicateEvidencePolicy:
+                "Use deterministicDuplicateReview for duplicate status. If your strict_duplicate finding disagrees with deterministic duplicate review, return a retryable duplicate_evidence_conflict error with the conflicting duplicate target instead of a close verdict.",
             },
           },
         });
@@ -3548,6 +3689,39 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
                 sourceEvidenceForPrivateReview!,
               )
             : conflictDecision;
+        }
+        if (
+          privateStrictDuplicateContradicted(
+            decision,
+            duplicateReviewForPrivateReview,
+          )
+        ) {
+          const conflictDecision = duplicateEvidenceConflictDecision(
+            decision,
+            duplicateReviewForPrivateReview!,
+          );
+          decision = shouldStopRetryingDuplicateEvidenceConflict(
+            conflictDecision,
+            existing,
+          )
+            ? duplicateEvidenceConflictMergeDecision(
+                decision,
+                duplicateReviewForPrivateReview!,
+                sourceEvidenceForPrivateReview,
+              )
+            : conflictDecision;
+        } else if (
+          duplicateConflictRetryableContradicted(
+            decision,
+            duplicateReviewForPrivateReview,
+          ) &&
+          shouldStopRetryingDuplicateEvidenceConflict(decision, existing)
+        ) {
+          decision = duplicateEvidenceConflictMergeDecision(
+            decision,
+            duplicateReviewForPrivateReview!,
+            sourceEvidenceForPrivateReview,
+          );
         }
         if (
           !decision.sourceEvidenceHash &&

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -69,6 +69,14 @@ export type GateDecisionEvidence = {
   policy?: string;
   source?: string;
   field?: string;
+  duplicatePath?: string;
+  duplicateTitle?: string;
+  duplicateSlug?: string;
+  duplicateUrl?: string;
+  matchedPath?: string;
+  matchedTitle?: string;
+  matchedSlug?: string;
+  matchedSourceUrl?: string;
   url?: string;
   matchedUrl?: string;
   finalUrl?: string;
@@ -144,6 +152,7 @@ const RETRYABLE_PRIVATE_REVIEW_CODES = new Set([
   "github_rate_limited",
   "source_evidence_timeout",
   "source_evidence_conflict",
+  "duplicate_evidence_conflict",
 ]);
 
 const VERDICT_HEADLINES: Record<GateVerdict, string> = {
@@ -309,6 +318,14 @@ function normalizeEvidence(value: unknown): GateDecisionEvidence | null {
     policy: cleanText(value.policy) || undefined,
     source: cleanText(value.source) || undefined,
     field: cleanText(value.field) || undefined,
+    duplicatePath: cleanText(value.duplicatePath) || undefined,
+    duplicateTitle: cleanText(value.duplicateTitle) || undefined,
+    duplicateSlug: cleanText(value.duplicateSlug) || undefined,
+    duplicateUrl: cleanText(value.duplicateUrl) || undefined,
+    matchedPath: cleanText(value.matchedPath) || undefined,
+    matchedTitle: cleanText(value.matchedTitle) || undefined,
+    matchedSlug: cleanText(value.matchedSlug) || undefined,
+    matchedSourceUrl: cleanText(value.matchedSourceUrl) || undefined,
     url: cleanText(value.url) || undefined,
     matchedUrl: cleanText(value.matchedUrl) || undefined,
     finalUrl: cleanText(value.finalUrl) || undefined,
@@ -329,6 +346,14 @@ function evidenceHasConcreteDetail(evidence: GateDecisionEvidence[]) {
       item.policy,
       item.source,
       item.field,
+      item.duplicatePath,
+      item.duplicateTitle,
+      item.duplicateSlug,
+      item.duplicateUrl,
+      item.matchedPath,
+      item.matchedTitle,
+      item.matchedSlug,
+      item.matchedSourceUrl,
       item.url,
       item.matchedUrl,
       item.finalUrl,
@@ -338,6 +363,30 @@ function evidenceHasConcreteDetail(evidence: GateDecisionEvidence[]) {
       item.fix,
       item.whyNotDefensive,
     ].some(Boolean),
+  );
+}
+
+function hasStrictDuplicateTargetEvidence(evidence: GateDecisionEvidence[]) {
+  const joined = evidence
+    .flatMap((item) => [
+      item.duplicatePath,
+      item.duplicateUrl,
+      item.matchedPath,
+      item.matchedSourceUrl,
+      item.url,
+      item.matchedUrl,
+      item.finalUrl,
+      item.source && item.source !== "private-reviewer" ? item.source : "",
+      item.behavior,
+      item.snippet,
+    ])
+    .filter(Boolean)
+    .join("\n");
+  return (
+    /(?:^|[\s`"'(])content\/[\w-]+\/[\w.-]+\.mdx\b/i.test(joined) ||
+    /https?:\/\/\S+/i.test(joined) ||
+    /(?:^|[\s`"'(])#\d+\b/.test(joined) ||
+    /\/pull\/\d+\b/i.test(joined)
   );
 }
 
@@ -351,6 +400,12 @@ function closeEvidenceContractError(params: {
   const evidence = params.evidence || [];
   if (!evidence.length || !evidenceHasConcreteDetail(evidence)) {
     return "Private close decisions must include public-safe evidence.";
+  }
+  if (
+    params.reasonCode === "strict_duplicate" &&
+    !hasStrictDuplicateTargetEvidence(evidence)
+  ) {
+    return "Private strict_duplicate close decisions must identify the duplicated entry path, source URL, or PR.";
   }
   if (SAFETY_CLOSE_REASON_CODES.has(params.reasonCode)) {
     const hasRule = evidence.some((item) => item.ruleId);
@@ -534,7 +589,10 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
     if (closeContractError) {
       return {
         error: {
-          code: "invalid_private_response",
+          code:
+            reasonCode === "strict_duplicate"
+              ? "duplicate_evidence_conflict"
+              : "invalid_private_response",
           retryable: true,
           message: closeContractError,
         },
@@ -783,6 +841,16 @@ function decisionEvidenceSection(
         item.snippet ? `snippet: \`${item.snippet}\`` : "",
         item.source ? `source: ${item.source}` : "",
         item.field ? `field: \`${item.field}\`` : "",
+        item.duplicatePath ? `duplicate path: \`${item.duplicatePath}\`` : "",
+        item.duplicateTitle ? `duplicate title: ${item.duplicateTitle}` : "",
+        item.duplicateSlug ? `duplicate slug: \`${item.duplicateSlug}\`` : "",
+        item.duplicateUrl ? `duplicate URL: ${item.duplicateUrl}` : "",
+        item.matchedPath ? `matched path: \`${item.matchedPath}\`` : "",
+        item.matchedTitle ? `matched title: ${item.matchedTitle}` : "",
+        item.matchedSlug ? `matched slug: \`${item.matchedSlug}\`` : "",
+        item.matchedSourceUrl
+          ? `matched source URL: ${item.matchedSourceUrl}`
+          : "",
         item.url ? `url: ${item.url}` : "",
         item.matchedUrl ? `matched URL: ${item.matchedUrl}` : "",
         item.finalUrl ? `final URL: ${item.finalUrl}` : "",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -442,6 +442,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("privateSourceHardFailureContradicted(");
     expect(source).toContain('"source_evidence_conflict"');
     expect(source).toContain("sourceEvidenceConflictMergeDecision(");
+    expect(source).toContain('"duplicate_evidence_conflict"');
+    expect(source).toContain("privateStrictDuplicateContradicted(");
+    expect(source).toContain("duplicateEvidenceConflictMergeDecision(");
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
@@ -454,6 +457,9 @@ describe("Cloudflare submission gate helpers", () => {
     );
     expect(source).toContain("closeEvidenceContract:");
     expect(source).toContain("Every close verdict must include reasonCode");
+    expect(source).toContain(
+      "strict_duplicate closes must identify the duplicated entry path",
+    );
     expect(source).toContain("deterministicDuplicateReview");
     expect(source).toContain('eventType: "duplicate_shadow_review"');
     expect(source).toContain('decision: "related_not_strict_duplicate"');
@@ -972,6 +978,77 @@ packageUrl: "https://example.com/rate-limited"
           outcome: "hard-failure",
           status: "404",
           httpStatus: "404",
+        },
+      ],
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.86,
+        reasonCode: "strict_duplicate",
+        evidence: [
+          {
+            ruleId: "strict_duplicate",
+            policy: "strict_duplicate",
+            behavior:
+              "PR adds a new MCP entry for ACI MCP Servers (slug aci-mcp-servers).",
+            source: "private-reviewer",
+          },
+        ],
+        summary:
+          "Summary:\n- Duplicate review: no strict duplicate.\n- No blocking issues; approve direct merge.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "duplicate_history",
+            status: "pass",
+            bullets: ["No duplicate entry exists."],
+          },
+        ],
+      }).error,
+    ).toMatchObject({
+      code: "duplicate_evidence_conflict",
+      retryable: true,
+    });
+
+    expect(
+      normalizePrivateGateDecisionPayload({
+        schemaVersion: 2,
+        verdict: "close",
+        confidence: 0.9,
+        reasonCode: "strict_duplicate",
+        evidence: [
+          {
+            ruleId: "strict_duplicate",
+            matchedPath: "content/mcp/existing-server.mdx",
+            matchedSourceUrl: "https://github.com/example/server",
+            behavior: "same category slug and canonical source",
+            fix: "Resubmit only if the resource is distinct.",
+          },
+        ],
+        summary:
+          "Summary:\n- Matches existing `content/mcp/existing-server.mdx`.",
+        labels: ["submission-closed-by-gate"],
+        checks: [{ name: "validate-content", status: "passed" }],
+        sections: [
+          {
+            id: "duplicate_history",
+            status: "fail",
+            bullets: ["Existing content item is the same resource."],
+          },
+        ],
+      }).decision,
+    ).toMatchObject({
+      verdict: "close",
+      reasonCode: "strict_duplicate",
+      evidence: [
+        {
+          ruleId: "strict_duplicate",
+          matchedPath: "content/mcp/existing-server.mdx",
+          matchedSourceUrl: "https://github.com/example/server",
         },
       ],
     });


### PR DESCRIPTION
## Summary
- Prevent private `strict_duplicate` close verdicts from terminating a PR when deterministic duplicate review found no strict duplicate.
- Require duplicate close evidence to identify the duplicated entry path, source URL, or PR.
- Add a retryable duplicate-evidence conflict path with an otherwise-clean merge fallback.

## What changed
- Preserved duplicate-specific evidence fields in `GateDecisionV2`.
- Added `duplicate_evidence_conflict` as a retryable private-review error code.
- Reconciled private duplicate closes against deterministic duplicate review before applying terminal decisions.
- Added regression coverage for malformed ACI-style duplicate evidence and valid duplicate evidence.

## Why
- A live recheck proved the source-evidence fix worked, but the private reviewer then returned an incoherent `strict_duplicate` close while also saying no duplicate existed.
- The public worker should not close viable content on a private duplicate claim that contradicts its deterministic duplicate artifact.

## Validation
- `pnpm exec prettier --write apps/submission-gate/src/index.ts apps/submission-gate/src/review.ts tests/submission-gate-worker.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `pnpm build`
- `git diff --check`

## Notes
- Deterministic duplicate closes are unchanged.
- This only blocks private duplicate closes that lack concrete target evidence or contradict the public duplicate scan.