### PR TITLE
fix(submissions): reset closed rechecks

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2632,7 +2632,8 @@ async function enqueueReviewTarget(
     existingReviewKey !== reviewScanKey;
   const shouldResetClosedTerminal =
     String(existing?.status || "") === "closed" &&
-    (isReopenedPullRequestEvent(eventName, webhook) ||
+    (forceRecheck === true ||
+      isReopenedPullRequestEvent(eventName, webhook) ||
       eventName === "scheduled");
   const shouldResetManualTerminal =
     forceRecheck === true && String(existing?.status || "") === "manual";
@@ -2655,7 +2656,7 @@ async function enqueueReviewTarget(
     deliveryId,
     nextReviewAt: null,
     incrementAttempt: true,
-    resetAttemptCount: shouldResetManualTerminal,
+    resetAttemptCount: shouldResetManualTerminal || shouldResetClosedTerminal,
     lastReviewKey: reviewScanKey || undefined,
     clearVerdict:
       shouldResetIgnoredScan ||

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -515,9 +515,15 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"COLLABORATOR"');
     expect(source).toContain("targetFromIssueCommentRecheck");
     expect(source).toContain("shouldResetManualTerminal");
-    expect(source).toContain("resetAttemptCount: shouldResetManualTerminal");
+    expect(source).toContain("shouldResetClosedTerminal");
+    expect(source).toContain(
+      "resetAttemptCount: shouldResetManualTerminal || shouldResetClosedTerminal",
+    );
     expect(source).toContain(
       'forceRecheck === true && String(existing?.status || "") === "manual"',
+    );
+    expect(source).toContain(
+      "forceRecheck === true ||\n      isReopenedPullRequestEvent",
     );
     expect(issueCommentBlock).toContain("payload,\n      true,");
   });
@@ -1473,7 +1479,9 @@ packageUrl: "https://example.com/rate-limited"
     expect(source).toContain("existingReviewKey !== reviewScanKey");
     expect(source).toContain("shouldResetIgnoredScan");
     expect(source).toContain("shouldResetManualTerminal");
-    expect(source).toContain("resetAttemptCount: shouldResetManualTerminal");
+    expect(source).toContain(
+      "resetAttemptCount: shouldResetManualTerminal || shouldResetClosedTerminal",
+    );
     expect(source).toContain("clearTerminal:");
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
     expect(source).toContain('reason: "already_reviewed"');


### PR DESCRIPTION
## Summary
- Allow trusted `/recheck` comments to reset a previously closed gate row when the PR has been reopened.
- Reset retry attempts for closed/manual terminal rechecks so fresh reviews do not inherit stale terminal counters.

## What changed
- `shouldResetClosedTerminal` now includes trusted forced rechecks.
- `resetAttemptCount` now applies to manual and closed terminal resets.
- Updated regression assertions for trusted recheck and terminal-state reset behavior.

## Why
- After reopening PR #1784, the gate stayed stuck on the old `closed` D1 row because `/recheck` only reset manual terminal states.
- A maintainer-triggered recheck of an open PR should clear stale gate terminal state and queue a fresh review.

## Validation
- `pnpm exec prettier --write apps/submission-gate/src/index.ts tests/submission-gate-worker.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts`
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `pnpm build`
- `git diff --check`

## Notes
- This does not reopen PRs automatically. It only lets trusted maintainer rechecks work after a PR is already open again.