### PR TITLE
fix(submissions): stop duplicate conflict auto-merge

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -46,6 +46,7 @@ import {
   approvalReviewBody,
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
   defaultManualDecision,
+  duplicateEvidenceContractExhaustedDecision,
   enforceAutoMergeConfidenceFloor,
   GATE_COMMENT_FORMATTER_VERSION,
   isRetryableGateDecision,
@@ -832,75 +833,23 @@ function duplicateEvidenceConflictDecision(
         bullets: [
           "Private review reported a strict duplicate that conflicts with deterministic duplicate review.",
           duplicateReviewSummaryLine(duplicateReview),
-          "The gate will retry with the deterministic duplicate artifact before falling back to the clean merge path.",
+          "The gate will retry with the deterministic duplicate artifact before falling back to manual review.",
         ],
       },
     ],
   };
 }
 
-function duplicateEvidenceConflictMergeDecision(
+function duplicateEvidenceConflictExhaustedDecision(
   decision: GateDecision,
   duplicateReview: ContentDuplicateReview,
   sourceEvidence: SourceEvidenceReport | null,
 ): GateDecision {
-  const sourceBullets =
-    sourceEvidence?.status === "passed"
-      ? [
-          {
-            id: "source_review",
-            title: "Source Review",
-            status: "pass" as const,
-            bullets: [
-              "Deterministic source evidence found submitted source URLs reachable.",
-              sourceEvidenceSummary(sourceEvidence),
-            ],
-          },
-        ]
-      : [];
-  return {
-    schemaVersion: 2,
-    verdict: "merge",
-    confidence: Math.max(
-      decision.confidence || 0,
-      DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
-    ),
-    sourceEvidenceHash: sourceEvidence?.hash,
-    labels: [LABELS.merged],
-    summary: [
-      "Summary:",
-      "- Public validation and deterministic duplicate review passed.",
-      "- Private review returned a strict_duplicate decision that contradicted deterministic duplicate evidence.",
-      "- No deterministic blocker remains, so the gate is accepting the one-file content PR.",
-      "",
-      "Duplicate / History Review:",
-      `- ${duplicateReviewSummaryLine(duplicateReview)}.`,
-      "",
-      ...(sourceEvidence
-        ? ["Source Review:", `- ${sourceEvidenceSummary(sourceEvidence)}.`, ""]
-        : []),
-      "Recommended Action:",
-      "- Merge this PR.",
-    ].join("\n"),
-    sections: [
-      {
-        id: "duplicate_history",
-        title: "Duplicate and History Review",
-        status: "pass",
-        bullets: [
-          "Deterministic duplicate review found no strict duplicate.",
-          duplicateReviewSummaryLine(duplicateReview),
-        ],
-      },
-      ...sourceBullets,
-      {
-        id: "recommended_action",
-        title: "Recommended Action",
-        status: "pass",
-        bullets: ["Merge this PR."],
-      },
-    ],
-  };
+  return duplicateEvidenceContractExhaustedDecision({
+    decision,
+    duplicateSummary: duplicateReviewSummaryLine(duplicateReview),
+    sourceSummary: sourceEvidence ? sourceEvidenceSummary(sourceEvidence) : null,
+  });
 }
 
 function privateSourceHardFailureContradicted(
@@ -3948,7 +3897,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             conflictDecision,
           );
           decision = retryState.exhausted
-            ? duplicateEvidenceConflictMergeDecision(
+            ? duplicateEvidenceConflictExhaustedDecision(
                 decision,
                 duplicateReviewForPrivateReview!,
                 sourceEvidenceForPrivateReview,
@@ -3961,7 +3910,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           ) &&
           retryStateForDecision(existing, target, decision).exhausted
         ) {
-          decision = duplicateEvidenceConflictMergeDecision(
+          decision = duplicateEvidenceConflictExhaustedDecision(
             decision,
             duplicateReviewForPrivateReview!,
             sourceEvidenceForPrivateReview,

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -613,10 +613,7 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
     if (closeContractError) {
       return {
         error: {
-          code:
-            reasonCode === "strict_duplicate"
-              ? "duplicate_evidence_conflict"
-              : "invalid_private_response",
+          code: "invalid_private_response",
           retryable: true,
           message: closeContractError,
         },
@@ -1341,6 +1338,29 @@ export function defaultManualDecision(
     labels: [LABELS.manual],
     errors: error ? [error] : undefined,
   };
+}
+
+export function duplicateEvidenceContractExhaustedDecision(params: {
+  decision: GateDecision;
+  duplicateSummary: string;
+  sourceSummary?: string | null;
+}) {
+  return defaultManualDecision(
+    [
+      "Private review repeatedly returned duplicate evidence that conflicts with deterministic duplicate review.",
+      `Duplicate review: ${params.duplicateSummary}.`,
+      params.sourceSummary ? `Source review: ${params.sourceSummary}.` : "",
+      "Automatic retries are stopped for this head SHA so a maintainer can review category, safety, privacy, policy, and duplicate evidence before merging.",
+      `Last private reviewer error: ${params.decision.summary}`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    {
+      code: "duplicate_evidence_contract_exhausted",
+      retryable: false,
+      message: params.decision.summary,
+    },
+  );
 }
 
 export function enforceAutoMergeConfidenceFloor(

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../apps/submission-gate/src/duplicates";
 import {
   approvalReviewBody,
+  duplicateEvidenceContractExhaustedDecision,
   enforceAutoMergeConfidenceFloor,
   isRetryableGateDecision,
   markerComment,
@@ -54,6 +55,13 @@ import { repoRoot } from "./helpers/registry-fixtures";
 function readWorkerSource() {
   return fs.readFileSync(
     path.join(repoRoot, "apps/submission-gate/src/index.ts"),
+    "utf8",
+  );
+}
+
+function readReviewSource() {
+  return fs.readFileSync(
+    path.join(repoRoot, "apps/submission-gate/src/review.ts"),
     "utf8",
   );
 }
@@ -456,7 +464,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("sourceEvidenceConflictMergeDecision(");
     expect(source).toContain('"duplicate_evidence_conflict"');
     expect(source).toContain("privateStrictDuplicateContradicted(");
-    expect(source).toContain("duplicateEvidenceConflictMergeDecision(");
+    expect(source).toContain("duplicateEvidenceConflictExhaustedDecision(");
+    expect(source).toContain("duplicateEvidenceContractExhaustedDecision(");
+    expect(readReviewSource()).toContain("duplicate_evidence_contract_exhausted");
+    expect(source).not.toContain("duplicateEvidenceConflictMergeDecision(");
     expect(source).toContain("validation: validationForPrivateReview");
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
@@ -1047,6 +1058,34 @@ ${urls}
     );
   });
 
+  it("routes exhausted duplicate-evidence conflicts to non-retryable manual review", () => {
+    const decision = duplicateEvidenceContractExhaustedDecision({
+      decision: {
+        verdict: "close",
+        reasonCode: "strict_duplicate",
+        summary:
+          "Summary:\n- Private reviewer reported a strict duplicate without deterministic support.",
+        labels: ["submission-closed-by-gate"],
+        confidence: 0.9,
+      },
+      duplicateSummary: "no strict duplicate; 2 related candidate(s)",
+      sourceSummary: "repoUrl https://github.com/example/repo -> HTTP 200",
+    });
+
+    expect(decision).toMatchObject({
+      verdict: "manual",
+      labels: ["submission-manual-review"],
+      errors: [
+        {
+          code: "duplicate_evidence_contract_exhausted",
+          retryable: false,
+        },
+      ],
+    });
+    expect(decision.summary).toContain("no strict duplicate");
+    expect(decision.summary).toContain("Last private reviewer error");
+  });
+
   it("normalizes GateDecisionV2 and rejects malformed private review payloads", () => {
     const validMergeDecision = {
       schemaVersion: 2,
@@ -1213,7 +1252,7 @@ ${urls}
         ],
       }).error,
     ).toMatchObject({
-      code: "duplicate_evidence_conflict",
+      code: "invalid_private_response",
       retryable: true,
     });
 


### PR DESCRIPTION
### Motivation
- Prevent malformed or contradicted private `strict_duplicate` close responses from being mapped into a retryable `duplicate_evidence_conflict` path that can exhaust retries and auto-merge unreviewed content. 
- Ensure exhausted duplicate-evidence retries route to manual maintainer review so category, safety, privacy and policy checks are preserved.

### Description
- Route close-contract failures (including malformed `strict_duplicate` evidence) to the `invalid_private_response` error path inside `normalizePrivateGateDecisionPayload` so they are treated as invalid private responses rather than a duplicate-evidence conflict (change in `apps/submission-gate/src/review.ts`).
- Replace the prior exhausted duplicate-evidence *auto-merge* helper with a manual-review exhaustion helper `duplicateEvidenceConflictExhaustedDecision` that returns a non-retryable manual decision `duplicate_evidence_contract_exhausted` (new behavior in `apps/submission-gate/src/index.ts`).
- Update retry/branching to invoke the new exhaustion helper instead of the old merge helper where duplicate-evidence retries are exhausted (changes in `apps/submission-gate/src/index.ts`).
- Update regression test expectations to assert malformed `strict_duplicate` payloads normalize as invalid private responses and that the exhausted duplicate conflict path no longer uses a merge helper (`tests/submission-gate-worker.test.ts`).

### Testing
- Ran the focused unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts --testNamePattern "normalizes GateDecisionV2|Cloudflare submission gate source"` and the full submission-gate worker test file with `pnpm exec vitest run tests/submission-gate-worker.test.ts`, both of which passed (all relevant tests green).
- Ran `git diff --check` and `pnpm validate:openapi`, both completed successfully.
- Changes touch `apps/submission-gate/src/review.ts`, `apps/submission-gate/src/index.ts`, and `tests/submission-gate-worker.test.ts` and the test suite covers the modified normalization and retry exhaustion behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2396b57564832c971d91cc03aa5bb3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced duplicate evidence conflict resolution to properly route exhausted retry attempts to manual review instead of automated merge processing.
  * Standardized error response codes for invalid submission payloads.

* **Tests**
  * Updated submission-gate worker tests to reflect changes in conflict handling and error code validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->