### PR TITLE
content(mcp): add MCP Registry Server

### DIFF
--- a/content/mcp/mcp-registry-server-mcp-server.mdx
+++ b/content/mcp/mcp-registry-server-mcp-server.mdx
@@ -1,0 +1,186 @@
+---
+title: MCP Registry Server
+slug: mcp-registry-server-mcp-server
+category: mcp
+description: >-
+  Community-driven MCP registry service that lets clients discover published MCP
+  server metadata and lets publishers submit server.json records through a
+  documented API and publisher CLI.
+cardDescription: >-
+  Run or integrate with the official MCP Registry service for server discovery,
+  publishing workflows, namespace verification, metadata validation, and
+  registry aggregator use cases.
+seoTitle: MCP Registry Server for Claude
+seoDescription: >-
+  Use the MCP Registry Server with Claude, MCP clients, publishers, and
+  aggregators to discover MCP server metadata, validate server.json records,
+  publish verified listings, and run a local registry development server.
+author: Model Context Protocol
+authorProfileUrl: "https://github.com/modelcontextprotocol"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-06"
+brandName: MCP Registry
+brandDomain: modelcontextprotocol.io
+repoUrl: "https://github.com/modelcontextprotocol/registry"
+documentationUrl: "https://registry.modelcontextprotocol.io/docs"
+packageUrl: "https://github.com/modelcontextprotocol/registry/pkgs/container/registry"
+installable: true
+installCommand: "make dev-compose"
+usageSnippet: "Run `make dev-compose` from a cloned registry repository to start the local registry service with PostgreSQL-backed development data."
+copySnippet: |-
+  make dev-compose
+configSnippet: |-
+  MCP_REGISTRY_DATABASE_URL=postgres://registry:registry@postgres:5432/registry
+  MCP_REGISTRY_SEED_FROM=data/seed.json
+  MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=false
+estimatedSetupTime: 20 minutes
+difficulty: advanced
+prerequisites:
+  - Docker for the local development environment documented by the registry project.
+  - Go 1.24.x, ko, and golangci-lint when building or validating the registry from source.
+  - PostgreSQL available when running the prebuilt registry container outside the bundled development compose setup.
+  - Understanding of MCP server.json metadata, registry namespaces, and the difference between a registry API and an MCP tool server.
+  - GitHub OAuth, GitHub OIDC, DNS verification, or HTTP verification prepared before publishing under an owned namespace.
+safetyNotes:
+  - The registry service stores and serves MCP server metadata; inaccurate metadata can mislead clients about server packages, remotes, versions, auth requirements, or publisher identity.
+  - Publishing uses namespace ownership checks. Keep GitHub, DNS, HTTP verification, and OIDC configuration limited to namespaces you control.
+  - Local development seeding can mirror production registry behavior or load local seed data; review seed sources before using them in tests or demonstrations.
+  - Do not treat registry inclusion as a security audit of listed MCP servers. Review each referenced server, package, transport, and permission model independently.
+  - Running the prebuilt container outside the compose setup requires a correctly configured database connection and deployment controls.
+privacyNotes:
+  - Published server metadata can include repository URLs, package URLs, remote endpoints, website URLs, organization names, namespaces, versions, and server descriptions.
+  - Publisher authentication and namespace verification can involve GitHub identities, GitHub Actions OIDC claims, DNS records, or HTTP challenge material.
+  - Registry logs, database rows, API requests, publisher CLI output, and validation errors may expose submitted metadata and namespace ownership details.
+  - Aggregators and clients that consume the registry may cache metadata and present it to users or models, so remove secrets and private endpoints before publishing.
+sourceUrls:
+  - "https://github.com/modelcontextprotocol/registry"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/README.md"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/docker-compose.yml"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/.env.example"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/about.mdx"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx"
+  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx"
+  - "https://registry.modelcontextprotocol.io/docs"
+  - "https://github.com/modelcontextprotocol/registry/pkgs/container/registry"
+tags:
+  - registry
+  - discovery
+  - publishing
+  - metadata
+  - aggregator
+keywords:
+  - MCP Registry
+  - MCP Registry Server
+  - modelcontextprotocol registry
+  - MCP server.json
+  - MCP publisher CLI
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+MCP Registry Server is the community-driven registry service for Model Context
+Protocol server metadata. It gives MCP clients, directories, and aggregators a
+standard API for discovering published server records, and gives publishers a
+documented path for submitting validated `server.json` metadata under verified
+namespaces.
+
+The project is not a general MCP tool executor. Its job is registry
+infrastructure: store, validate, serve, and publish metadata about MCP servers.
+That makes it useful when building MCP discovery flows, registry aggregators,
+publisher automation, or local registry development environments.
+
+## Source Review
+
+- https://github.com/modelcontextprotocol/registry
+- https://github.com/modelcontextprotocol/registry/blob/main/README.md
+- https://github.com/modelcontextprotocol/registry/blob/main/docker-compose.yml
+- https://github.com/modelcontextprotocol/registry/blob/main/.env.example
+- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/about.mdx
+- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx
+- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx
+- https://registry.modelcontextprotocol.io/docs
+- https://github.com/modelcontextprotocol/registry/pkgs/container/registry
+
+These sources were reviewed on **2026-06-06**. Prefer the live repository,
+official API docs, publisher quickstart, and aggregator guide for current API
+versions, namespace verification rules, publisher CLI behavior, development
+commands, and container deployment notes.
+
+## Features
+
+- Registry API for MCP server metadata discovery.
+- Publisher workflow for submitting MCP `server.json` records.
+- Namespace verification through GitHub OAuth, GitHub OIDC, DNS, or HTTP
+  challenges.
+- Validation for submitted server metadata.
+- Local development environment through `make dev-compose`.
+- PostgreSQL-backed registry service implementation in Go.
+- Prebuilt GitHub Container Registry images for registry deployments.
+- Documentation for registry aggregators and third-party directory builders.
+- Production API docs for testing registry endpoints.
+
+## Installation
+
+Clone the registry repository and run the documented development environment:
+
+```bash
+make dev-compose
+```
+
+The development compose setup builds the registry image, starts PostgreSQL, and
+seeds the service with registry data for local testing.
+
+When using the prebuilt container image, provide your own PostgreSQL database
+and configure the registry database URL before exposing the service.
+
+## Publisher Workflow
+
+Build the publisher CLI from the repository:
+
+```bash
+make publisher
+```
+
+Then inspect available publishing commands:
+
+```bash
+./bin/mcp-publisher --help
+```
+
+Use the official quickstart before publishing. Namespace ownership checks are a
+core part of the registry trust model.
+
+## Use Cases
+
+- Build MCP client discovery flows backed by a standard registry API.
+- Run a local registry service while developing registry integrations.
+- Test server metadata validation before publishing.
+- Publish MCP server records under verified namespaces.
+- Build registry aggregators, mirrors, or directory sync jobs.
+- Review server package, remote, version, repository, and website metadata in a
+  consistent schema.
+
+## Safety and Privacy
+
+Treat registry records as discovery metadata, not endorsement. Registry entries
+can help users find MCP servers, but each server still needs its own security,
+privacy, package, and source review before installation.
+
+Keep namespace verification credentials and challenge material under tight
+control. Publishing from GitHub Actions should use the least privilege needed
+for OIDC-based namespace proof, and DNS or HTTP challenges should be scoped to
+domains you control.
+
+Before publishing metadata, remove private endpoints, internal package URLs,
+temporary repository links, secrets, tokens, personal contact details, and
+anything that should not be cached by clients, aggregators, or model contexts.
+
+## Duplicate Check
+
+No dedicated `modelcontextprotocol/registry` entry, MCP Registry Server entry,
+or matching registry source URL was found in `content/mcp`. The registry repo
+appears only as a supporting source URL in the Windows MCP entry, not as its own
+catalog entry.


### PR DESCRIPTION
## Summary
- Add a dedicated MCP Registry Server content entry.
- Document the registry service/API, publisher CLI, local development server, namespace verification, and aggregator use cases.
- Closes #1493.

## What changed
- Added `content/mcp/mcp-registry-server-mcp-server.mdx`.
- Included source-backed install/development guidance for `make dev-compose` and the published registry container package.
- Added safety and privacy notes for registry metadata, namespace verification, publisher authentication, and aggregator caching.

## Why
- The registry is a high-popularity official MCP ecosystem project and has a dedicated upstream content issue.
- The repository previously appeared only as a supporting source URL in another MCP entry, not as its own catalog entry.

## Duplicate check
- Checked `content/mcp` for `modelcontextprotocol/registry`, `MCP Registry Server`, and registry source URLs.
- No dedicated registry entry was found; the only match was a supporting source URL in the Windows MCP entry.

## Source links reviewed
- https://github.com/modelcontextprotocol/registry
- https://github.com/modelcontextprotocol/registry/blob/main/README.md
- https://github.com/modelcontextprotocol/registry/blob/main/docker-compose.yml
- https://github.com/modelcontextprotocol/registry/blob/main/.env.example
- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/about.mdx
- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx
- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx
- https://registry.modelcontextprotocol.io/docs
- https://github.com/modelcontextprotocol/registry/pkgs/container/registry

## Safety and privacy notes
- The entry avoids claiming the registry is a general MCP tool executor.
- It calls out that registry inclusion is discovery metadata, not a security audit.
- It documents namespace verification, publisher identity, metadata exposure, aggregator caching, and database/logging considerations.

## Validation
- `pnpm validate:content:strict`
- `node scripts/ci/validate-content-policy.mjs --repo-root . --files-json '["content/mcp/mcp-registry-server-mcp-server.mdx"]'`
- `git diff --check`
- Verified all source URLs in the new content file return HTTP 200.
