### PR TITLE
fix(submissions): constrain source evidence fetches

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -911,7 +911,8 @@ function privateSourceHardFailureContradicted(
     decision.verdict === "close" &&
     decision.reasonCode === "source_hard_failure" &&
     sourceEvidence?.status === "passed" &&
-    sourceEvidence.urls.length > 0
+    sourceEvidence.urls.length > 0 &&
+    sourceEvidence.urls.every((item) => item.outcome === "reachable")
   );
 }
 

--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -39,7 +39,9 @@ const SOURCE_URL_FIELDS = [
 ] as const;
 
 const SOURCE_URL_LIST_FIELDS = new Set(["sourceUrls"]);
-const SOURCE_EVIDENCE_TIMEOUT_MS = 10_000;
+const SOURCE_EVIDENCE_TIMEOUT_MS = 1_500;
+const MAX_SOURCE_EVIDENCE_URLS = 10;
+const MAX_SOURCE_EVIDENCE_REDIRECTS = 2;
 const DISTRIBUTION_SOURCE_FIELDS = new Set(["downloadUrl", "packageUrl"]);
 const DISTRIBUTION_SOURCE_HOSTS = new Set([
   "crates.io",
@@ -57,6 +59,26 @@ const DISTRIBUTION_SOURCE_HOSTS = new Set([
   "rubygems.org",
   "www.npmjs.com",
 ]);
+
+const TRUSTED_SOURCE_HOSTS = new Set([
+  "bitbucket.org",
+  "crates.io",
+  "deno.land",
+  "docs.anthropic.com",
+  "docs.github.com",
+  "gist.github.com",
+  "github.com",
+  "gitlab.com",
+  "jsr.io",
+  "marketplace.visualstudio.com",
+  "npmjs.com",
+  "pkg.go.dev",
+  "pypi.org",
+  "raw.githubusercontent.com",
+  "www.npmjs.com",
+]);
+
+const TRUSTED_SOURCE_HOST_SUFFIXES = [] as const;
 
 function stripYamlComment(value: string) {
   return value.replace(/\s+#.*$/, "").trim();
@@ -169,31 +191,127 @@ function sourceStatusFromHttpStatus(status: number) {
   return "retryable" as const;
 }
 
+function normalizeHostname(hostname: string) {
+  return hostname.toLowerCase().replace(/\.$/, "");
+}
+
+function sourceHostIsTrusted(hostname: string) {
+  const normalized = normalizeHostname(hostname);
+  return (
+    TRUSTED_SOURCE_HOSTS.has(normalized) ||
+    DISTRIBUTION_SOURCE_HOSTS.has(normalized) ||
+    TRUSTED_SOURCE_HOST_SUFFIXES.some((suffix) => normalized.endsWith(suffix))
+  );
+}
+
+function validateFetchableSourceUrl(url: string) {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch (error) {
+    return {
+      ok: false as const,
+      outcome: "invalid_url",
+      error: error instanceof Error ? error.message : "Invalid source URL.",
+    };
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    return {
+      ok: false as const,
+      outcome: "invalid_url",
+      error: "Source URL must use http or https.",
+    };
+  }
+  if (!sourceHostIsTrusted(parsed.hostname)) {
+    return {
+      ok: false as const,
+      outcome: "source_host_not_checked",
+      error:
+        "Source URL host is outside the deterministic reachability allowlist.",
+    };
+  }
+  return { ok: true as const, parsed };
+}
+
+function redirectLocation(response: Response, currentUrl: string) {
+  const location = response.headers.get("location");
+  if (!location) return "";
+  try {
+    return new URL(location, currentUrl).toString();
+  } catch {
+    return "";
+  }
+}
+
 async function fetchSourceUrl(
   item: SubmittedSourceUrl,
   method: "HEAD" | "GET",
   fetchImpl: typeof fetch,
 ): Promise<SourceEvidenceItem> {
-  const response = await fetchImpl(item.url, {
-    method,
-    redirect: "follow",
-    headers: {
-      accept: "text/html,application/json,text/plain,*/*",
-      "user-agent": "heyclaude-submission-gate",
-    },
-    signal: AbortSignal.timeout(SOURCE_EVIDENCE_TIMEOUT_MS),
-  });
-  const status = sourceStatusFromHttpStatus(response.status);
+  let currentUrl = item.url;
+  for (
+    let redirects = 0;
+    redirects <= MAX_SOURCE_EVIDENCE_REDIRECTS;
+    redirects += 1
+  ) {
+    const validation = validateFetchableSourceUrl(currentUrl);
+    if (!validation.ok) {
+      return withSourceDefaults(item, {
+        status: "hard_failure",
+        outcome: validation.outcome,
+        error: validation.error,
+      });
+    }
+
+    const response = await fetchImpl(currentUrl, {
+      method,
+      redirect: "manual",
+      headers: {
+        accept: "text/html,application/json,text/plain,*/*",
+        "user-agent": "heyclaude-submission-gate",
+      },
+      signal: AbortSignal.timeout(SOURCE_EVIDENCE_TIMEOUT_MS),
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const nextUrl = redirectLocation(response, currentUrl);
+      if (!nextUrl) {
+        return withSourceDefaults(item, {
+          status: "retryable",
+          outcome: "redirect_without_location",
+          httpStatus: response.status,
+          finalUrl: currentUrl,
+        });
+      }
+      if (redirects === MAX_SOURCE_EVIDENCE_REDIRECTS) {
+        return withSourceDefaults(item, {
+          status: "retryable",
+          outcome: "too_many_redirects",
+          httpStatus: response.status,
+          finalUrl: currentUrl,
+        });
+      }
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    const status = sourceStatusFromHttpStatus(response.status);
+    return withSourceDefaults(item, {
+      status,
+      outcome:
+        status === "passed"
+          ? "reachable"
+          : status === "hard_failure"
+            ? "http_hard_failure"
+            : "source_inconclusive",
+      httpStatus: response.status,
+      finalUrl: currentUrl,
+    });
+  }
+
   return withSourceDefaults(item, {
-    status,
-    outcome:
-      status === "passed"
-        ? "reachable"
-        : status === "hard_failure"
-          ? "http_hard_failure"
-          : "source_inconclusive",
-    httpStatus: response.status,
-    finalUrl: response.url || item.url,
+    status: "retryable",
+    outcome: "too_many_redirects",
   });
 }
 
@@ -201,20 +319,13 @@ async function checkOneSourceUrl(
   item: SubmittedSourceUrl,
   fetchImpl: typeof fetch,
 ): Promise<SourceEvidenceItem> {
-  try {
-    const parsed = new URL(item.url);
-    if (!["http:", "https:"].includes(parsed.protocol)) {
-      return withSourceDefaults(item, {
-        status: "hard_failure",
-        outcome: "invalid_url",
-        error: "Source URL must use http or https.",
-      });
-    }
-  } catch (error) {
+  const validation = validateFetchableSourceUrl(item.url);
+  if (!validation.ok) {
+    const invalidProtocol = validation.outcome === "invalid_url";
     return withSourceDefaults(item, {
-      status: "hard_failure",
-      outcome: "invalid_url",
-      error: error instanceof Error ? error.message : "Invalid source URL.",
+      status: invalidProtocol ? "hard_failure" : "passed",
+      outcome: validation.outcome,
+      error: validation.error,
     });
   }
 
@@ -266,7 +377,10 @@ function sourceEvidenceHashInput(urls: SourceEvidenceItem[]) {
 
 function downgradeNonCanonicalRetryWarnings(urls: SourceEvidenceItem[]) {
   const hasCanonicalPass = urls.some(
-    (item) => item.role === "canonical" && item.status === "passed",
+    (item) =>
+      item.role === "canonical" &&
+      item.status === "passed" &&
+      item.outcome === "reachable",
   );
   if (!hasCanonicalPass) return urls;
   return urls.map((item) =>
@@ -280,11 +394,18 @@ export async function checkSubmittedSourceEvidence(
   source: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<SourceEvidenceReport> {
-  const checkedUrls = await Promise.all(
-    extractSubmittedSourceUrls(source).map((item) =>
-      checkOneSourceUrl(item, fetchImpl),
-    ),
-  );
+  const extracted = extractSubmittedSourceUrls(source);
+  const checkedUrls: SourceEvidenceItem[] = [];
+  for (const item of extracted.slice(0, MAX_SOURCE_EVIDENCE_URLS)) {
+    checkedUrls.push(await checkOneSourceUrl(item, fetchImpl));
+  }
+  for (const item of extracted.slice(MAX_SOURCE_EVIDENCE_URLS)) {
+    checkedUrls.push(withSourceDefaults(item, {
+      status: "hard_failure",
+      outcome: "too_many_source_urls",
+      error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
+    }));
+  }
   const urls = downgradeNonCanonicalRetryWarnings(checkedUrls);
   const blockingUrls = urls.filter((item) => item.blocking);
   const status = blockingUrls.some((item) => item.status === "hard_failure")

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -678,18 +678,18 @@ describe("Cloudflare submission gate helpers", () => {
     const source = `---
 title: Source Evidence Fixture
 repoUrl: "https://github.com/example/repo"
-documentationUrl: "https://example.com/docs"
+documentationUrl: "https://github.com/example/docs"
 sourceUrls:
-  - "https://example.com/guide"
-  - https://example.com/docs
+  - "https://github.com/example/guide"
+  - https://github.com/example/docs
 ---
 `;
 
     expect(extractSubmittedSourceUrls(source)).toEqual([
-      { field: "documentationUrl", url: "https://example.com/docs" },
+      { field: "documentationUrl", url: "https://github.com/example/docs" },
       { field: "repoUrl", url: "https://github.com/example/repo" },
-      { field: "sourceUrls", url: "https://example.com/guide" },
-      { field: "sourceUrls", url: "https://example.com/docs" },
+      { field: "sourceUrls", url: "https://github.com/example/guide" },
+      { field: "sourceUrls", url: "https://github.com/example/docs" },
     ]);
 
     const fetchImpl = vi
@@ -703,7 +703,7 @@ sourceUrls:
     expect(first.status).toBe("passed");
     expect(first.urls[0]).toMatchObject({
       field: "documentationUrl",
-      url: "https://example.com/docs",
+      url: "https://github.com/example/docs",
       status: "passed",
       httpStatus: 200,
     });
@@ -714,7 +714,7 @@ sourceUrls:
     const report = await checkSubmittedSourceEvidence(
       `---
 title: Dead Source Fixture
-documentationUrl: "https://example.com/missing"
+documentationUrl: "https://github.com/example/missing"
 ---
 `,
       vi
@@ -731,7 +731,7 @@ documentationUrl: "https://example.com/missing"
       evidence: [
         {
           field: "documentationUrl",
-          matchedUrl: "https://example.com/missing",
+          matchedUrl: "https://github.com/example/missing",
           httpStatus: "404",
         },
       ],
@@ -742,8 +742,8 @@ documentationUrl: "https://example.com/missing"
     const report = await checkSubmittedSourceEvidence(
       `---
 title: Retry Source Fixture
-documentationUrl: "https://example.com/temporarily-down"
-packageUrl: "https://example.com/rate-limited"
+documentationUrl: "https://github.com/example/temporarily-down"
+packageUrl: "https://www.npmjs.com/package/rate-limited"
 ---
 `,
       vi
@@ -787,6 +787,99 @@ packageUrl: "https://hub.docker.com/r/example/project"
       httpStatus: 429,
     });
     expect(sourceEvidenceCloseDecision(report)).toBeNull();
+  });
+
+  it("does not fetch source URLs outside the trusted evidence hosts", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Unsafe Source Fixture
+documentationUrl: "http://127.0.0.1/internal-secret"
+websiteUrl: "https://attacker.example/redirect"
+---
+`,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(report.status).toBe("passed");
+    expect(report.urls).toEqual([
+      expect.objectContaining({
+        field: "documentationUrl",
+        status: "passed",
+        outcome: "source_host_not_checked",
+      }),
+      expect.objectContaining({
+        field: "websiteUrl",
+        status: "passed",
+        outcome: "source_host_not_checked",
+      }),
+    ]);
+  });
+
+  it("validates redirect targets before following source evidence URLs", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://127.0.0.1/internal-secret" },
+      }),
+    );
+
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Redirect Source Fixture
+documentationUrl: "https://github.com/example/redirect"
+---
+`,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      "https://github.com/example/redirect",
+      expect.objectContaining({ method: "HEAD", redirect: "manual" }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      "https://github.com/example/redirect",
+      expect.objectContaining({ method: "GET", redirect: "manual" }),
+    );
+    expect(report.status).toBe("failed");
+    expect(report.urls[0]).toMatchObject({
+      field: "documentationUrl",
+      status: "hard_failure",
+      outcome: "source_host_not_checked",
+    });
+    expect(report.urls[0]?.finalUrl).toBeUndefined();
+  });
+
+  it("caps deterministic source evidence fetches", async () => {
+    const urls = Array.from(
+      { length: 12 },
+      (_, index) => `  - "https://github.com/example/source-${index}"`,
+    ).join("\n");
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(null, { status: 200 }));
+
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Many Source Fixture
+sourceUrls:
+${urls}
+---
+`,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(10);
+    expect(report.status).toBe("failed");
+    expect(report.urls).toHaveLength(12);
+    expect(report.urls.slice(10)).toEqual([
+      expect.objectContaining({ outcome: "too_many_source_urls" }),
+      expect.objectContaining({ outcome: "too_many_source_urls" }),
+    ]);
   });
 
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {
@@ -1062,7 +1155,7 @@ packageUrl: "https://hub.docker.com/r/example/project"
         evidence: [
           {
             ruleId: "source_url_reachability",
-            matchedUrl: "https://example.com/missing",
+            matchedUrl: "https://github.com/example/missing",
             outcome: "hard-failure",
             status: 404,
           },
@@ -1084,7 +1177,7 @@ packageUrl: "https://hub.docker.com/r/example/project"
       evidence: [
         {
           ruleId: "source_url_reachability",
-          matchedUrl: "https://example.com/missing",
+          matchedUrl: "https://github.com/example/missing",
           outcome: "hard-failure",
           status: "404",
           httpStatus: "404",


### PR DESCRIPTION
### Motivation
- Prevent untrusted PR-controlled URLs from being used as a blind SSRF/open-fetch primitive by the deterministic source evidence checker.
- Avoid unbounded concurrent fetches and unsafe redirect following that allow probing internal or attacker-controlled hosts.

### Description
- Add an allowlist of trusted source hosts and suffixes and validate submitted URLs with `validateFetchableSourceUrl` before any network request is attempted.
- Switch redirect handling to manual follow with a `MAX_SOURCE_EVIDENCE_REDIRECTS` cap and validate each redirect target before continuing, and return explicit outcomes for redirect errors.
- Replace the previous `Promise.all` approach with a capped sequential check limited by `MAX_SOURCE_EVIDENCE_URLS`, and hard-fail excessive submitted URLs with a clear `too_many_source_urls` outcome.
- Tighten private-review conflict logic to require deterministic evidence that links are actually `reachable` before treating private `source_hard_failure` decisions as contradicted, and add regression tests for untrusted-host skipping, unsafe redirects, and URL-count caps.

### Testing
- Formatted changed files with `prettier` and ran unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts` which passed (82 tests) and then `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/submission-pr-first.test.ts` which passed (97 tests total).
- Ran the repository-level `pnpm test:submission-pr-first` which passed (15 tests) and verified `git diff --check` produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23a8a753fc832c9fa2227c2e9f9d8e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source-contradiction logic tightened: a private hard-failure is considered contradicted only when all deterministic evidence URLs are reachable.
  * Stricter URL validation: hostname normalization, trusted-host allowlist, scheme checks, and clearer categorized outcomes.
  * Redirect handling hardened with manual follow limits and shorter timeouts; extra URLs are capped and marked as too many.

* **Tests**
  * Updated fixtures and added coverage verifying host allowlist enforcement, redirect validation, and evidence caps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->