### PR TITLE
ci(readme): restore accumulator branch creation

### DIFF
--- a/.github/workflows/readme-refresh-pr.yml
+++ b/.github/workflows/readme-refresh-pr.yml
@@ -79,7 +79,13 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "docs(readme): refresh generated catalog index"
-          git push --force-with-lease origin "$BRANCH_NAME:$BRANCH_NAME"
+
+          remote_branch_sha="$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')"
+          if [[ -n "$remote_branch_sha" ]]; then
+            git push --force-with-lease="refs/heads/$BRANCH_NAME:$remote_branch_sha" origin "$BRANCH_NAME:$BRANCH_NAME"
+          else
+            git push --force-with-lease="refs/heads/$BRANCH_NAME:" origin "$BRANCH_NAME:$BRANCH_NAME"
+          fi
           echo "has-changes=true" >> "$GITHUB_OUTPUT"
 
       - name: Create or update README refresh PR

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -878,6 +878,11 @@ scriptBody: |-
     expect(source).toContain("refresh-readme-automation-readme-refresh");
     expect(source).toContain("git diff --quiet origin/main -- README.md");
     expect(source).toContain("unexpected_files");
+    expect(source).toContain('git ls-remote --heads origin "$BRANCH_NAME"');
+    expect(source).toContain(
+      '--force-with-lease="refs/heads/$BRANCH_NAME:$remote_branch_sha"',
+    );
+    expect(source).toContain('--force-with-lease="refs/heads/$BRANCH_NAME:"');
     expect(source).toContain("git push --force-with-lease");
     expect(source).toContain("Create or update README refresh PR");
     expect(source).toContain(


### PR DESCRIPTION
## Summary
- Fix the README refresh workflow so it can recreate the shared `automation/readme-refresh` branch after the previous accumulator PR is merged and the branch is deleted.

## What changed
- Resolve the current remote accumulator branch SHA before pushing.
- Use an explicit `--force-with-lease` expectation for both existing-branch updates and absent-branch creation.
- Add a regression assertion covering the explicit lease behavior.

## Why
- Recent content merges triggered the README refresh workflow, but the publish step failed with a stale lease after the old accumulator branch was gone. That prevented the next accumulator PR from opening.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts`
- `pnpm generate:readme` confirmed there are pending README updates for merged content.
- `pnpm validate:readme` passed after generation during reproduction.
- `git diff --check`

## Notes
- `README.md` is intentionally not included in this PR. After this workflow fix lands, the next README refresh run should open the proper accumulator PR with the pending content list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced README refresh automation workflow with improved git push safety mechanisms.
  * Updated workflow automation tests to verify enhanced push behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->