### PR TITLE
fix(submissions): add gate retry failsafes

### DIFF
--- a/apps/submission-gate/migrations/0012_submission_gate_retry_failsafe.sql
+++ b/apps/submission-gate/migrations/0012_submission_gate_retry_failsafe.sql
@@ -1,0 +1,17 @@
+ALTER TABLE submission_prs
+  ADD COLUMN last_error_code TEXT;
+
+ALTER TABLE submission_prs
+  ADD COLUMN last_retry_fingerprint TEXT;
+
+ALTER TABLE submission_prs
+  ADD COLUMN retry_fingerprint_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE submission_prs
+  ADD COLUMN retry_exhausted_at TEXT;
+
+ALTER TABLE submission_prs
+  ADD COLUMN retry_exhausted_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_submission_prs_retry_fingerprint
+  ON submission_prs (status, last_error_code, last_retry_fingerprint, retry_fingerprint_count);

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -154,9 +154,12 @@ class SubmissionMergePendingError extends Error {
 }
 
 class SourceEvidenceRetryableError extends Error {
-  constructor(message: string) {
+  sourceEvidence: SourceEvidenceReport;
+
+  constructor(message: string, sourceEvidence: SourceEvidenceReport) {
     super(message);
     this.name = "SourceEvidenceRetryableError";
+    this.sourceEvidence = sourceEvidence;
   }
 }
 
@@ -169,9 +172,16 @@ const MERGE_RETRY_SECONDS = 30;
 const RETRYABLE_ERROR_SECONDS = 60;
 const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
 const PRIVATE_REVIEW_TIMEOUT_MS = 45_000;
-const INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3;
-const SOURCE_EVIDENCE_CONFLICT_MAX_RETRIES = 2;
-const DUPLICATE_EVIDENCE_CONFLICT_MAX_RETRIES = 2;
+const RETRY_BACKOFF_SECONDS = [60, 120, 300, 600, 1_200, 1_800] as const;
+const RETRY_BUDGETS: Record<string, number> = {
+  source_evidence_timeout: 6,
+  private_reviewer_unavailable: 5,
+  invalid_private_response: 5,
+  github_rate_limited: 6,
+  github_api_unavailable: 5,
+  source_evidence_conflict: 2,
+  duplicate_evidence_conflict: 2,
+};
 const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR_TEXT = String(
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 );
@@ -456,7 +466,7 @@ function nextReviewForStatus(status: string) {
     return isoAfter(MERGE_RETRY_SECONDS);
   }
   if (status === "error_retryable") {
-    return isoAfter(RETRYABLE_ERROR_SECONDS);
+    return isoAfter(RETRY_BACKOFF_SECONDS[0]);
   }
   return null;
 }
@@ -485,7 +495,21 @@ function isTimeoutError(error: unknown) {
 
 function retryablePrecheckDecision(error: unknown) {
   if (error instanceof SourceEvidenceRetryableError) {
-    return privateReviewErrorDecision(error.message, "source_evidence_timeout");
+    return {
+      ...privateReviewErrorDecision(error.message, "source_evidence_timeout"),
+      sourceEvidenceHash: error.sourceEvidence.hash,
+      sections: [
+        {
+          id: "source_review",
+          title: "Source Review",
+          status: "warn" as const,
+          bullets: [
+            "Deterministic source evidence could not conclusively verify all canonical source URLs.",
+            sourceEvidenceSummary(error.sourceEvidence),
+          ],
+        },
+      ],
+    };
   }
   if (isGitHubRateLimitError(error)) {
     return privateReviewErrorDecision(
@@ -500,6 +524,26 @@ function retryablePrecheckDecision(error: unknown) {
     );
   }
   return null;
+}
+
+function retryableTargetErrorDecision(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate hit a GitHub rate limit while inspecting the pull request.",
+      "github_rate_limited",
+    );
+  }
+  if (isTimeoutError(error)) {
+    return privateReviewErrorDecision(
+      `Submission gate timed out while inspecting the pull request: ${message}`,
+      "github_api_unavailable",
+    );
+  }
+  return privateReviewErrorDecision(
+    `Submission gate could not inspect the pull request: ${message}`,
+    "github_api_unavailable",
+  );
 }
 
 function normalizeOneShotDecision(decision: GateDecision): GateDecision {
@@ -530,63 +574,145 @@ function hasPrivateReviewErrorCode(decision: GateDecision, code: string) {
   return Boolean(decision.errors?.some((error) => error.code === code));
 }
 
-function invalidPrivateResponseAttempts(
-  existing: Record<string, unknown> | null,
-) {
-  const attempts = Number(existing?.attemptCount || 0);
-  return Number.isFinite(attempts) && attempts > 0 ? attempts : 0;
+function retryErrorCode(decision: GateDecision) {
+  const retryableError = decision.errors?.find(
+    (error) => error.retryable || error.code,
+  );
+  return retryableError?.code || "private_reviewer_unavailable";
 }
 
-function shouldStopRetryingInvalidPrivateResponse(
-  decision: GateDecision,
-  existing: Record<string, unknown> | null,
-) {
-  return (
-    hasPrivateReviewErrorCode(decision, "invalid_private_response") &&
-    invalidPrivateResponseAttempts(existing) >=
-      INVALID_PRIVATE_RESPONSE_MAX_RETRIES
-  );
+function retryBudgetForCode(code: string) {
+  return RETRY_BUDGETS[code] ?? 3;
 }
 
-function shouldStopRetryingSourceEvidenceConflict(
-  decision: GateDecision,
-  existing: Record<string, unknown> | null,
-) {
-  return (
-    hasPrivateReviewErrorCode(decision, "source_evidence_conflict") &&
-    invalidPrivateResponseAttempts(existing) >=
-      SOURCE_EVIDENCE_CONFLICT_MAX_RETRIES
-  );
+function retryBackoffSecondsForCount(count: number) {
+  const index = Math.max(0, Math.min(count - 1, RETRY_BACKOFF_SECONDS.length - 1));
+  return RETRY_BACKOFF_SECONDS[index];
 }
 
-function shouldStopRetryingDuplicateEvidenceConflict(
-  decision: GateDecision,
-  existing: Record<string, unknown> | null,
-) {
-  return (
-    hasPrivateReviewErrorCode(decision, "duplicate_evidence_conflict") &&
-    invalidPrivateResponseAttempts(existing) >=
-      DUPLICATE_EVIDENCE_CONFLICT_MAX_RETRIES
-  );
+function normalizeRetryFingerprintPart(value: unknown, maxLength = 220) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
 }
 
-function invalidPrivateResponseExhaustedDecision(
-  decision: GateDecision,
+function retryFingerprintForDecision(decision: GateDecision) {
+  const code = retryErrorCode(decision);
+  const sourceHash = decision.sourceEvidenceHash
+    ? `source:${decision.sourceEvidenceHash}`
+    : "";
+  const errorText =
+    decision.errors
+      ?.map((error) => `${error.code}:${error.message || ""}`)
+      .join("|") || "";
+  return [
+    code,
+    sourceHash,
+    normalizeRetryFingerprintPart(errorText || decision.summary),
+  ]
+    .filter(Boolean)
+    .join(":");
+}
+
+function retryStateForDecision(
   existing: Record<string, unknown> | null,
+  target: ReviewTarget,
+  decision: GateDecision,
 ) {
-  const attempts = invalidPrivateResponseAttempts(existing);
-  return defaultManualDecision(
-    [
-      `Private corpus review returned invalid response payloads after ${attempts} automatic attempt(s).`,
-      `Last private reviewer error: ${decision.summary}`,
-      "Automatic retries are stopped for this head SHA so the queue cannot loop indefinitely.",
-    ].join(" "),
-    {
-      code: "private_review_contract_exhausted",
-      retryable: false,
-      message: decision.summary,
-    },
-  );
+  const code = retryErrorCode(decision);
+  const fingerprint = retryFingerprintForDecision(decision);
+  const previousSameFingerprint =
+    String(existing?.headSha || "") === String(target.headSha || "") &&
+    String(existing?.lastErrorCode || "") === code &&
+    String(existing?.lastRetryFingerprint || "") === fingerprint;
+  const previousCount = previousSameFingerprint
+    ? Number(existing?.retryFingerprintCount || 0)
+    : 0;
+  const count =
+    Number.isFinite(previousCount) && previousCount > 0
+      ? previousCount + 1
+      : 1;
+  const maxAttempts = retryBudgetForCode(code);
+  const nextReviewAt = isoAfter(retryBackoffSecondsForCount(count));
+  return {
+    code,
+    fingerprint,
+    count,
+    maxAttempts,
+    nextReviewAt,
+    exhausted: count > maxAttempts,
+  };
+}
+
+function retryExhaustedDecision(
+  decision: GateDecision,
+  retryState: ReturnType<typeof retryStateForDecision>,
+): GateDecision {
+  const exhaustedSummary = [
+    "Summary:",
+    `- Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
+    "- This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
+    `- Last retry reason: ${decision.summary.trim()}`,
+    "",
+    "Recommended Action:",
+    "- A maintainer can recheck after the external service recovers, merge manually if review confirms no blocker, or close if review finds a real content issue.",
+  ].join("\n");
+  return {
+    verdict: "manual",
+    labels: [LABELS.manual],
+    confidence: decision.confidence,
+    sourceEvidenceHash: decision.sourceEvidenceHash,
+    summary: exhaustedSummary,
+    errors: [
+      {
+        code: retryState.code,
+        retryable: false,
+        message: `Retry budget exhausted after ${retryState.maxAttempts} automatic attempt(s).`,
+      },
+    ],
+    sections: [
+      {
+        id: "summary",
+        title: "Summary",
+        status: "warn",
+        bullets: [
+          `Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
+          "This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
+          `Last retry reason: ${decision.summary.trim()}`,
+        ],
+      },
+      {
+        id: "recommended_action",
+        title: "Recommended Action",
+        status: "warn",
+        bullets: [
+          "Recheck after the external service recovers.",
+          "Merge manually if maintainer review confirms no blocker.",
+          "Close only if manual review finds a real content issue.",
+        ],
+      },
+      ...(decision.sections || []),
+    ],
+    retryState,
+  } as GateDecision & { retryState: ReturnType<typeof retryStateForDecision> };
+}
+
+function retryExhaustedStorageMetadata(decision: GateDecision) {
+  const retryState = (
+    decision as GateDecision & {
+      retryState?: ReturnType<typeof retryStateForDecision>;
+    }
+  ).retryState;
+  if (!retryState?.exhausted) return {};
+  return {
+    lastError: truncateForQueue(decision.summary),
+    lastErrorCode: retryState.code,
+    lastRetryFingerprint: retryState.fingerprint,
+    retryFingerprintCount: retryState.maxAttempts,
+    retryExhaustedAt: nowIso(),
+    retryExhaustedReason: truncateForQueue(decision.summary),
+  };
 }
 
 function sourceEvidenceConflictDecision(
@@ -2150,6 +2276,7 @@ async function applyTerminalGateDecision(params: {
   } | null;
   deliveryId?: string;
 }) {
+  const retryStorageMetadata = retryExhaustedStorageMetadata(params.decision);
   await upsertPrState(params.env.SUBMISSION_GATE_DB, {
     repo: params.target.repoFullName,
     number: params.target.number,
@@ -2163,6 +2290,7 @@ async function applyTerminalGateDecision(params: {
     nextReviewAt: null,
     clearVerdict: true,
     clearTerminal: true,
+    ...retryStorageMetadata,
   });
   await removeLabels({
     token: params.token,
@@ -2231,6 +2359,7 @@ async function applyTerminalGateDecision(params: {
     verdictSummary: displayDecision.summary,
     nextReviewAt: null,
     terminalAt: TERMINAL_PR_STATUSES.has(params.status) ? nowIso() : null,
+    ...retryStorageMetadata,
     ...decisionMetadata(displayDecision, reportComment),
   });
 }
@@ -2576,6 +2705,7 @@ async function deterministicContentPrecheck(params: {
   if (sourceEvidence.status === "retryable") {
     throw new SourceEvidenceRetryableError(
       `Submission gate deterministic source evidence check was retryable: ${sourceEvidenceSummary(sourceEvidence)}.`,
+      sourceEvidence,
     );
   }
 
@@ -2681,6 +2811,42 @@ async function recordRetryableTargetError(
   deliveryId: string,
   error: unknown,
 ) {
+  const existing = await getPrState(env.SUBMISSION_GATE_DB, {
+    repo: target.repoFullName,
+    number: target.number,
+  });
+  const decision = retryableTargetErrorDecision(error);
+  const retryState = retryStateForDecision(existing, target, decision);
+  const nextReviewAt = isGitHubRateLimitError(error)
+    ? nextReviewForError(error)
+    : retryState.nextReviewAt;
+  if (retryState.exhausted) {
+    const exhaustedDecision = retryExhaustedDecision(decision, retryState);
+    await upsertPrState(env.SUBMISSION_GATE_DB, {
+      repo: target.repoFullName,
+      number: target.number,
+      headRepo: target.headRepo,
+      headRef: target.headRef,
+      headSha: target.headSha,
+      baseRef: target.baseRef || contentGateBaseRef(env),
+      installationId: target.installationId,
+      status: "manual",
+      verdict: "manual",
+      verdictSummary: exhaustedDecision.summary,
+      nextReviewAt: null,
+      terminalAt: nowIso(),
+      lastError: truncateForQueue(exhaustedDecision.summary),
+      lastErrorCode: retryState.code,
+      lastRetryFingerprint: retryState.fingerprint,
+      retryFingerprintCount: retryState.maxAttempts,
+      retryExhaustedAt: nowIso(),
+      retryExhaustedReason: truncateForQueue(exhaustedDecision.summary),
+      deliveryId,
+      ...decisionMetadata(exhaustedDecision),
+    });
+    return;
+  }
+  const errorMessage = error instanceof Error ? error.message : String(error);
   await upsertPrState(env.SUBMISSION_GATE_DB, {
     repo: target.repoFullName,
     number: target.number,
@@ -2690,10 +2856,11 @@ async function recordRetryableTargetError(
     baseRef: target.baseRef || contentGateBaseRef(env),
     installationId: target.installationId,
     status: "error_retryable",
-    nextReviewAt: nextReviewForError(error),
-    lastError: truncateForQueue(
-      error instanceof Error ? error.message : String(error),
-    ),
+    nextReviewAt,
+    lastError: truncateForQueue(errorMessage),
+    lastErrorCode: retryState.code,
+    lastRetryFingerprint: retryState.fingerprint,
+    retryFingerprintCount: retryState.count,
     deliveryId,
     clearVerdict: true,
     clearTerminal: true,
@@ -3032,6 +3199,7 @@ async function persistRetryableGateDecision(params: {
   target: ReviewTarget;
   message: QueueMessage;
   decision: GateDecision;
+  retryState: ReturnType<typeof retryStateForDecision>;
   auditDecision: string;
 }) {
   await upsertPrState(params.env.SUBMISSION_GATE_DB, {
@@ -3043,8 +3211,11 @@ async function persistRetryableGateDecision(params: {
     baseRef: params.target.baseRef || contentGateBaseRef(params.env),
     installationId: params.target.installationId,
     status: "error_retryable",
-    nextReviewAt: nextReviewForStatus("error_retryable"),
+    nextReviewAt: params.retryState.nextReviewAt,
     lastError: truncateForQueue(params.decision.summary),
+    lastErrorCode: params.retryState.code,
+    lastRetryFingerprint: params.retryState.fingerprint,
+    retryFingerprintCount: params.retryState.count,
     deliveryId: String(params.message.payload.deliveryId || ""),
     clearVerdict: true,
     clearTerminal: true,
@@ -3056,6 +3227,13 @@ async function persistRetryableGateDecision(params: {
     marker: params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
     body: retryingReviewComment(
       params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+      {
+        code: params.retryState.code,
+        attempt: params.retryState.count,
+        maxAttempts: params.retryState.maxAttempts,
+        nextReviewAt: params.retryState.nextReviewAt,
+        summary: truncateForQueue(params.decision.summary, 320),
+      },
     ),
     apiVersion: params.env.GITHUB_API_VERSION,
   });
@@ -3068,7 +3246,11 @@ async function persistRetryableGateDecision(params: {
     baseRef: params.target.baseRef || contentGateBaseRef(params.env),
     installationId: params.target.installationId,
     status: "error_retryable",
-    nextReviewAt: nextReviewForStatus("error_retryable"),
+    nextReviewAt: params.retryState.nextReviewAt,
+    lastError: truncateForQueue(params.decision.summary),
+    lastErrorCode: params.retryState.code,
+    lastRetryFingerprint: params.retryState.fingerprint,
+    retryFingerprintCount: params.retryState.count,
     ...decisionMetadata(params.decision, retryComment),
   });
   await insertAudit(params.env.SUBMISSION_GATE_DB, {
@@ -3598,22 +3780,32 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         } catch (error) {
           const retryableDecision = retryablePrecheckDecision(error);
           if (retryableDecision) {
-            await persistRetryableGateDecision({
-              env,
-              token,
-              repo,
+            const retryState = retryStateForDecision(
+              existing,
               target,
-              message,
-              decision: retryableDecision,
-              auditDecision: "deterministic_precheck_retryable",
-            });
-            return;
+              retryableDecision,
+            );
+            if (!retryState.exhausted) {
+              await persistRetryableGateDecision({
+                env,
+                token,
+                repo,
+                target,
+                message,
+                decision: retryableDecision,
+                retryState,
+                auditDecision: "deterministic_precheck_retryable",
+              });
+              return;
+            }
+            decision = retryExhaustedDecision(retryableDecision, retryState);
+          } else {
+            decision = defaultManualDecision(
+              `Submission gate could not complete deterministic duplicate/edit review: ${
+                error instanceof Error ? error.message : "unknown error"
+              }.`,
+            );
           }
-          decision = defaultManualDecision(
-            `Submission gate could not complete deterministic duplicate/edit review: ${
-              error instanceof Error ? error.message : "unknown error"
-            }.`,
-          );
         }
       }
 
@@ -3681,10 +3873,12 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             decision,
             sourceEvidenceForPrivateReview!,
           );
-          decision = shouldStopRetryingSourceEvidenceConflict(
-            conflictDecision,
+          const retryState = retryStateForDecision(
             existing,
-          )
+            target,
+            conflictDecision,
+          );
+          decision = retryState.exhausted
             ? sourceEvidenceConflictMergeDecision(
                 decision,
                 sourceEvidenceForPrivateReview!,
@@ -3701,10 +3895,12 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             decision,
             duplicateReviewForPrivateReview!,
           );
-          decision = shouldStopRetryingDuplicateEvidenceConflict(
-            conflictDecision,
+          const retryState = retryStateForDecision(
             existing,
-          )
+            target,
+            conflictDecision,
+          );
+          decision = retryState.exhausted
             ? duplicateEvidenceConflictMergeDecision(
                 decision,
                 duplicateReviewForPrivateReview!,
@@ -3716,7 +3912,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             decision,
             duplicateReviewForPrivateReview,
           ) &&
-          shouldStopRetryingDuplicateEvidenceConflict(decision, existing)
+          retryStateForDecision(existing, target, decision).exhausted
         ) {
           decision = duplicateEvidenceConflictMergeDecision(
             decision,
@@ -3735,14 +3931,9 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         }
         if (
           isRetryableGateDecision(decision) &&
-          shouldStopRetryingInvalidPrivateResponse(decision, existing)
+          !retryStateForDecision(existing, target, decision).exhausted
         ) {
-          decision = invalidPrivateResponseExhaustedDecision(
-            decision,
-            existing,
-          );
-        }
-        if (isRetryableGateDecision(decision)) {
+          const retryState = retryStateForDecision(existing, target, decision);
           await persistRetryableGateDecision({
             env,
             token,
@@ -3750,9 +3941,16 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             target,
             message,
             decision,
+            retryState,
             auditDecision: "private_review_retryable",
           });
           return;
+        }
+        if (isRetryableGateDecision(decision)) {
+          decision = retryExhaustedDecision(
+            decision,
+            retryStateForDecision(existing, target, decision),
+          );
         }
       }
       decision = normalizeOneShotDecision(decision);
@@ -4025,22 +4223,12 @@ async function recordRetryableQueueError(
   if (message.kind !== "review_pr") return;
   const target = reviewTargetFromMessage(message);
   if (!target) return;
-  const errorMessage = error instanceof Error ? error.message : String(error);
-  await upsertPrState(env.SUBMISSION_GATE_DB, {
-    repo: target.repoFullName,
-    number: target.number,
-    headRepo: target.headRepo,
-    headRef: target.headRef,
-    headSha: target.headSha,
-    baseRef: target.baseRef || contentGateBaseRef(env),
-    installationId: target.installationId,
-    status: "error_retryable",
-    nextReviewAt: nextReviewForError(error),
-    lastError: truncateForQueue(errorMessage),
-    deliveryId: String(message.payload.deliveryId || ""),
-    clearVerdict: true,
-    clearTerminal: true,
-  });
+  await recordRetryableTargetError(
+    env,
+    target,
+    String(message.payload.deliveryId || ""),
+    error,
+  );
 }
 
 async function sweepSubmissionQueue(env: Env) {
@@ -4214,11 +4402,38 @@ async function queueStatusRoute(request: Request, env: Env) {
      ORDER BY status ASC`,
   ).all<Record<string, unknown>>();
   const retryReasons = await env.SUBMISSION_GATE_DB.prepare(
-    `SELECT COALESCE(last_error, 'unknown') AS reason, COUNT(*) AS count,
+    `SELECT COALESCE(last_error_code, 'unknown') AS code,
+        COALESCE(last_error, 'unknown') AS reason,
+        COUNT(*) AS count,
+        MAX(retry_fingerprint_count) AS maxRetryFingerprintCount,
         MIN(updated_at) AS oldestAt, MAX(updated_at) AS newestAt
      FROM submission_prs
      WHERE status = 'error_retryable'
-     GROUP BY COALESCE(last_error, 'unknown')
+     GROUP BY COALESCE(last_error_code, 'unknown'), COALESCE(last_error, 'unknown')
+     ORDER BY count DESC, oldestAt ASC
+     LIMIT 20`,
+  ).all<Record<string, unknown>>();
+  const retryFingerprints = await env.SUBMISSION_GATE_DB.prepare(
+    `SELECT COALESCE(last_error_code, 'unknown') AS code,
+        COALESCE(last_retry_fingerprint, 'unknown') AS fingerprint,
+        COUNT(*) AS count,
+        MAX(retry_fingerprint_count) AS maxRetryFingerprintCount,
+        MIN(updated_at) AS oldestAt,
+        MAX(updated_at) AS newestAt
+     FROM submission_prs
+     WHERE status = 'error_retryable'
+     GROUP BY COALESCE(last_error_code, 'unknown'), COALESCE(last_retry_fingerprint, 'unknown')
+     ORDER BY count DESC, maxRetryFingerprintCount DESC, oldestAt ASC
+     LIMIT 20`,
+  ).all<Record<string, unknown>>();
+  const exhaustedRetries = await env.SUBMISSION_GATE_DB.prepare(
+    `SELECT COALESCE(last_error_code, 'unknown') AS code,
+        COUNT(*) AS count,
+        MIN(retry_exhausted_at) AS oldestAt,
+        MAX(retry_exhausted_at) AS newestAt
+     FROM submission_prs
+     WHERE retry_exhausted_at IS NOT NULL
+     GROUP BY COALESCE(last_error_code, 'unknown')
      ORDER BY count DESC, oldestAt ASC
      LIMIT 20`,
   ).all<Record<string, unknown>>();
@@ -4248,6 +4463,8 @@ async function queueStatusRoute(request: Request, env: Env) {
     ok: true,
     counts: counts.results || [],
     retryReasons: retryReasons.results || [],
+    retryFingerprints: retryFingerprints.results || [],
+    exhaustedRetries: exhaustedRetries.results || [],
     staleStates: staleStates.results || [],
     recentTerminal: recentTerminal.results || [],
     deadLetterQueue: {
@@ -4276,6 +4493,11 @@ async function queueStatusRoute(request: Request, env: Env) {
       decisionId: row.decisionId,
       confidence: row.confidence,
       sourceEvidenceHash: row.sourceEvidenceHash,
+      lastErrorCode: row.lastErrorCode,
+      lastRetryFingerprint: truncateForQueue(row.lastRetryFingerprint, 240),
+      retryFingerprintCount: row.retryFingerprintCount,
+      retryExhaustedAt: row.retryExhaustedAt,
+      retryExhaustedReason: truncateForQueue(row.retryExhaustedReason, 240),
       terminalAt: row.terminalAt,
       updatedAt: row.updatedAt,
     })),

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -104,6 +104,14 @@ export type GateDecision = {
   sourceEvidenceHash?: string;
 };
 
+export type RetryReviewCommentDetails = {
+  code?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  nextReviewAt?: string | null;
+  summary?: string;
+};
+
 export type GateDecisionV2 = GateDecision & {
   schemaVersion: typeof GATE_DECISION_SCHEMA_VERSION;
   verdict: GateDecisionV2Verdict;
@@ -518,6 +526,27 @@ export function normalizePrivateGateDecisionPayload(raw: unknown): {
         code: "invalid_private_response",
         retryable: true,
         message: "Private corpus review returned an unexpected payload.",
+      },
+    };
+  }
+
+  if (isRecord(raw.error)) {
+    return {
+      error: normalizeError(raw.error) || {
+        code: "invalid_private_response",
+        retryable: true,
+        message: "Private corpus review returned an unexpected error payload.",
+      },
+    };
+  }
+
+  if (!raw.verdict && Array.isArray(raw.errors)) {
+    const error = raw.errors.map(normalizeError).find(Boolean);
+    return {
+      error: error || {
+        code: "invalid_private_response",
+        retryable: true,
+        message: "Private corpus review returned an unexpected error payload.",
       },
     };
   }
@@ -1230,7 +1259,23 @@ export function markerComment(
   return renderDecisionComment(decision, marker);
 }
 
-export function retryingReviewComment(marker = DEFAULT_REVIEW_MARKER) {
+export function retryingReviewComment(
+  marker = DEFAULT_REVIEW_MARKER,
+  details: RetryReviewCommentDetails = {},
+) {
+  const retryLine =
+    details.attempt && details.maxAttempts
+      ? `- ⚠️ **Retry:** \`${details.attempt}/${details.maxAttempts}\``
+      : "";
+  const codeLine = details.code
+    ? `- ℹ️ **Error code:** \`${details.code}\``
+    : "";
+  const nextLine = details.nextReviewAt
+    ? `- ⏭️ **Next retry:** \`${details.nextReviewAt}\``
+    : "";
+  const summaryLine = details.summary
+    ? `- **Last issue:** ${details.summary}`
+    : "";
   return renderAlertCard(marker, "IMPORTANT", [
     "## ⚠️ Review retrying",
     "Public validation is green, but the private reviewer returned a retryable infrastructure result.",
@@ -1239,15 +1284,19 @@ export function retryingReviewComment(marker = DEFAULT_REVIEW_MARKER) {
     "",
     "- ✅ **Public validation:** `passed`",
     "- ⚠️ **Private maintainer gate:** `retrying`",
+    retryLine,
+    codeLine,
+    nextLine,
     "",
     "<details>",
     "<summary><strong>Contributor action</strong></summary>",
     "",
     "- No contributor action is needed yet.",
     "- The submission gate will retry automatically.",
+    summaryLine,
     "",
     "</details>",
-  ]);
+  ].filter(Boolean));
 }
 
 export function supersededReviewComment(
@@ -1278,9 +1327,14 @@ export function defaultManualDecision(
   reason = "Private corpus review is not configured.",
   error?: GateDecisionError,
 ): GateDecision {
+  const suffix =
+    /maintainer needs to review/i.test(reason) ||
+    /manual review/i.test(reason)
+      ? ""
+      : " A maintainer needs to review category fit, source of truth, duplicate history, safety/privacy notes, and provenance before merge.";
   return {
     verdict: "manual" as const,
-    summary: `${reason} A maintainer needs to review category fit, source of truth, duplicate history, safety/privacy notes, and provenance before merge.`,
+    summary: `${reason}${suffix}`,
     labels: [LABELS.manual],
     errors: error ? [error] : undefined,
   };

--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -7,8 +7,12 @@ export type SubmittedSourceUrl = {
   url: string;
 };
 
+export type SourceEvidenceRole = "canonical" | "distribution";
+
 export type SourceEvidenceItem = SubmittedSourceUrl & {
   status: "passed" | "hard_failure" | "retryable";
+  role: SourceEvidenceRole;
+  blocking: boolean;
   outcome: string;
   httpStatus?: number;
   finalUrl?: string;
@@ -19,6 +23,7 @@ export type SourceEvidenceReport = {
   status: "passed" | "failed" | "retryable";
   hash: string;
   urls: SourceEvidenceItem[];
+  warnings: SourceEvidenceItem[];
 };
 
 const SOURCE_URL_FIELDS = [
@@ -35,6 +40,23 @@ const SOURCE_URL_FIELDS = [
 
 const SOURCE_URL_LIST_FIELDS = new Set(["sourceUrls"]);
 const SOURCE_EVIDENCE_TIMEOUT_MS = 10_000;
+const DISTRIBUTION_SOURCE_FIELDS = new Set(["downloadUrl", "packageUrl"]);
+const DISTRIBUTION_SOURCE_HOSTS = new Set([
+  "crates.io",
+  "files.pythonhosted.org",
+  "hub.docker.com",
+  "marketplace.visualstudio.com",
+  "mvnrepository.com",
+  "npmjs.com",
+  "packagist.org",
+  "pkg.go.dev",
+  "plugins.gradle.org",
+  "pypi.org",
+  "registry.npmjs.org",
+  "repo1.maven.org",
+  "rubygems.org",
+  "www.npmjs.com",
+]);
 
 function stripYamlComment(value: string) {
   return value.replace(/\s+#.*$/, "").trim();
@@ -114,11 +136,35 @@ export function extractSubmittedSourceUrls(source: string) {
   });
 }
 
+function sourceRole(item: SubmittedSourceUrl): SourceEvidenceRole {
+  if (DISTRIBUTION_SOURCE_FIELDS.has(item.field)) return "distribution";
+  try {
+    const host = new URL(item.url).hostname.toLowerCase();
+    if (DISTRIBUTION_SOURCE_HOSTS.has(host)) return "distribution";
+  } catch {
+    // Malformed URLs are classified separately as hard failures.
+  }
+  return "canonical";
+}
+
+function withSourceDefaults(
+  item: SubmittedSourceUrl,
+  values: Omit<SourceEvidenceItem, keyof SubmittedSourceUrl | "role" | "blocking">,
+): SourceEvidenceItem {
+  return {
+    ...item,
+    ...values,
+    role: sourceRole(item),
+    blocking: true,
+  };
+}
+
 function sourceStatusFromHttpStatus(status: number) {
   if (status >= 200 && status < 400) return "passed" as const;
-  if (status === 408 || status === 429 || status >= 500) {
+  if ([401, 403, 408, 425, 429].includes(status) || status >= 500) {
     return "retryable" as const;
   }
+  if (status === 404 || status === 410) return "hard_failure" as const;
   if (status >= 400 && status < 500) return "hard_failure" as const;
   return "retryable" as const;
 }
@@ -138,18 +184,17 @@ async function fetchSourceUrl(
     signal: AbortSignal.timeout(SOURCE_EVIDENCE_TIMEOUT_MS),
   });
   const status = sourceStatusFromHttpStatus(response.status);
-  return {
-    ...item,
+  return withSourceDefaults(item, {
     status,
     outcome:
       status === "passed"
         ? "reachable"
         : status === "hard_failure"
           ? "http_hard_failure"
-          : "http_retryable",
+          : "source_inconclusive",
     httpStatus: response.status,
     finalUrl: response.url || item.url,
-  };
+  });
 }
 
 async function checkOneSourceUrl(
@@ -159,20 +204,18 @@ async function checkOneSourceUrl(
   try {
     const parsed = new URL(item.url);
     if (!["http:", "https:"].includes(parsed.protocol)) {
-      return {
-        ...item,
+      return withSourceDefaults(item, {
         status: "hard_failure",
         outcome: "invalid_url",
         error: "Source URL must use http or https.",
-      };
+      });
     }
   } catch (error) {
-    return {
-      ...item,
+    return withSourceDefaults(item, {
       status: "hard_failure",
       outcome: "invalid_url",
       error: error instanceof Error ? error.message : "Invalid source URL.",
-    };
+    });
   }
 
   try {
@@ -185,15 +228,14 @@ async function checkOneSourceUrl(
   try {
     return await fetchSourceUrl(item, "GET", fetchImpl);
   } catch (error) {
-    return {
-      ...item,
+    return withSourceDefaults(item, {
       status: "retryable",
       outcome: "fetch_error",
       error:
         error instanceof Error
           ? error.message
           : "Source URL fetch failed before a response was returned.",
-    };
+    });
   }
 }
 
@@ -216,7 +258,21 @@ function sourceEvidenceHashInput(urls: SourceEvidenceItem[]) {
       status: item.status,
       outcome: item.outcome,
       httpStatus: item.httpStatus || null,
+      role: item.role,
+      blocking: item.blocking,
     })),
+  );
+}
+
+function downgradeNonCanonicalRetryWarnings(urls: SourceEvidenceItem[]) {
+  const hasCanonicalPass = urls.some(
+    (item) => item.role === "canonical" && item.status === "passed",
+  );
+  if (!hasCanonicalPass) return urls;
+  return urls.map((item) =>
+    item.role === "distribution" && item.status === "retryable"
+      ? { ...item, blocking: false }
+      : item,
   );
 }
 
@@ -224,19 +280,24 @@ export async function checkSubmittedSourceEvidence(
   source: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<SourceEvidenceReport> {
-  const urls = await Promise.all(
+  const checkedUrls = await Promise.all(
     extractSubmittedSourceUrls(source).map((item) =>
       checkOneSourceUrl(item, fetchImpl),
     ),
   );
-  const status = urls.some((item) => item.status === "hard_failure")
+  const urls = downgradeNonCanonicalRetryWarnings(checkedUrls);
+  const blockingUrls = urls.filter((item) => item.blocking);
+  const status = blockingUrls.some((item) => item.status === "hard_failure")
     ? "failed"
-    : urls.some((item) => item.status === "retryable")
+    : blockingUrls.some((item) => item.status === "retryable")
       ? "retryable"
       : "passed";
   return {
     status,
     urls,
+    warnings: urls.filter(
+      (item) => !item.blocking && item.status !== "passed",
+    ),
     hash: await sha256Hex(sourceEvidenceHashInput(urls)),
   };
 }
@@ -246,7 +307,10 @@ export function sourceEvidenceSummary(report: SourceEvidenceReport) {
   return report.urls
     .map((item) => {
       const status = item.httpStatus ? `HTTP ${item.httpStatus}` : item.outcome;
-      return `${item.field} ${item.url} -> ${status}`;
+      const suffix = item.blocking
+        ? ""
+        : " (non-blocking source-inconclusive warning)";
+      return `${item.field} ${item.url} -> ${status}${suffix}`;
     })
     .join("; ");
 }
@@ -255,7 +319,7 @@ export function sourceEvidenceToDecisionEvidence(
   report: SourceEvidenceReport,
 ): GateDecisionEvidence[] {
   return report.urls
-    .filter((item) => item.status === "hard_failure")
+    .filter((item) => item.blocking && item.status === "hard_failure")
     .map((item) => ({
       ruleId: "source_url_reachability",
       field: item.field,

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -238,6 +238,11 @@ export async function upsertPrState(
     decisionId?: string | null;
     confidence?: number | null;
     sourceEvidenceHash?: string | null;
+    lastErrorCode?: string | null;
+    lastRetryFingerprint?: string | null;
+    retryFingerprintCount?: number | null;
+    retryExhaustedAt?: string | null;
+    retryExhaustedReason?: string | null;
   },
 ) {
   const timestamp = now();
@@ -250,8 +255,8 @@ export async function upsertPrState(
   await db
     .prepare(
       `INSERT INTO submission_prs
-        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, last_review_key, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, comment_id, comment_url, review_id, schema_version, formatter_version, decision_id, confidence, source_evidence_hash, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        (repo, number, head_repo, head_ref, head_sha, base_ref, installation_id, status, verdict, verdict_summary, last_delivery_id, last_review_key, next_review_at, attempt_count, last_error, last_check_summary, terminal_at, comment_id, comment_url, review_id, schema_version, formatter_version, decision_id, confidence, source_evidence_hash, last_error_code, last_retry_fingerprint, retry_fingerprint_count, retry_exhausted_at, retry_exhausted_reason, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(repo, number) DO UPDATE SET
         head_repo = COALESCE(excluded.head_repo, submission_prs.head_repo),
         head_ref = COALESCE(excluded.head_ref, submission_prs.head_ref),
@@ -302,6 +307,31 @@ export async function upsertPrState(
         decision_id = COALESCE(excluded.decision_id, submission_prs.decision_id),
         confidence = COALESCE(excluded.confidence, submission_prs.confidence),
         source_evidence_hash = COALESCE(excluded.source_evidence_hash, submission_prs.source_evidence_hash),
+        last_error_code = CASE
+          WHEN excluded.last_error_code IS NOT NULL THEN excluded.last_error_code
+          WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
+          ELSE submission_prs.last_error_code
+        END,
+        last_retry_fingerprint = CASE
+          WHEN excluded.last_retry_fingerprint IS NOT NULL THEN excluded.last_retry_fingerprint
+          WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
+          ELSE submission_prs.last_retry_fingerprint
+        END,
+        retry_fingerprint_count = CASE
+          WHEN excluded.last_retry_fingerprint IS NOT NULL THEN excluded.retry_fingerprint_count
+          WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN 0
+          ELSE submission_prs.retry_fingerprint_count
+        END,
+        retry_exhausted_at = CASE
+          WHEN excluded.retry_exhausted_at IS NOT NULL THEN excluded.retry_exhausted_at
+          WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
+          ELSE submission_prs.retry_exhausted_at
+        END,
+        retry_exhausted_reason = CASE
+          WHEN excluded.retry_exhausted_reason IS NOT NULL THEN excluded.retry_exhausted_reason
+          WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
+          ELSE submission_prs.retry_exhausted_reason
+        END,
         updated_at = excluded.updated_at`,
     )
     .bind(
@@ -330,6 +360,11 @@ export async function upsertPrState(
       params.decisionId ?? null,
       params.confidence ?? null,
       params.sourceEvidenceHash ?? null,
+      params.lastErrorCode ?? null,
+      params.lastRetryFingerprint ?? null,
+      params.retryFingerprintCount ?? 0,
+      params.retryExhaustedAt ?? null,
+      params.retryExhaustedReason ?? null,
       timestamp,
       timestamp,
       params.clearTerminal ? 1 : 0,
@@ -362,6 +397,11 @@ export async function getPrState(
         review_id AS reviewId, schema_version AS schemaVersion,
         formatter_version AS formatterVersion, decision_id AS decisionId,
         confidence, source_evidence_hash AS sourceEvidenceHash,
+        last_error_code AS lastErrorCode,
+        last_retry_fingerprint AS lastRetryFingerprint,
+        retry_fingerprint_count AS retryFingerprintCount,
+        retry_exhausted_at AS retryExhaustedAt,
+        retry_exhausted_reason AS retryExhaustedReason,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        WHERE repo = ? AND number = ?`,
@@ -394,6 +434,11 @@ export async function listDuePrStates(
         review_id AS reviewId, schema_version AS schemaVersion,
         formatter_version AS formatterVersion, decision_id AS decisionId,
         confidence, source_evidence_hash AS sourceEvidenceHash,
+        last_error_code AS lastErrorCode,
+        last_retry_fingerprint AS lastRetryFingerprint,
+        retry_fingerprint_count AS retryFingerprintCount,
+        retry_exhausted_at AS retryExhaustedAt,
+        retry_exhausted_reason AS retryExhaustedReason,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        WHERE (
@@ -453,6 +498,11 @@ export async function listRecentPrStates(
         review_id AS reviewId, schema_version AS schemaVersion,
         formatter_version AS formatterVersion, decision_id AS decisionId,
         confidence, source_evidence_hash AS sourceEvidenceHash,
+        last_error_code AS lastErrorCode,
+        last_retry_fingerprint AS lastRetryFingerprint,
+        retry_fingerprint_count AS retryFingerprintCount,
+        retry_exhausted_at AS retryExhaustedAt,
+        retry_exhausted_reason AS retryExhaustedReason,
         created_at AS createdAt, updated_at AS updatedAt
        FROM submission_prs
        ORDER BY updated_at DESC

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -409,7 +409,11 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("REVIEWING_STALE_SECONDS");
     expect(source).toContain("QUEUED_STALE_SECONDS");
     expect(source).toContain("PRIVATE_REVIEW_TIMEOUT_MS = 45_000");
-    expect(source).toContain("INVALID_PRIVATE_RESPONSE_MAX_RETRIES = 3");
+    expect(source).toContain("const RETRY_BACKOFF_SECONDS = [60, 120, 300");
+    expect(source).toContain("const RETRY_BUDGETS");
+    expect(source).toContain("invalid_private_response: 5");
+    expect(source).toContain("source_evidence_timeout: 6");
+    expect(source).toContain("github_api_unavailable: 5");
     expect(source).toContain("queuedStaleBeforeIso");
     expect(source).toContain("reviewingStaleBeforeIso");
     expect(source).toContain("lastCheckSummary: validation.summary");
@@ -423,10 +427,12 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("retryablePrecheckDecision(error)");
     expect(source).toContain('"deterministic_precheck_retryable"');
     expect(source).toContain('"source_evidence_timeout"');
-    expect(source).toContain(
-      "shouldStopRetryingInvalidPrivateResponse(decision, existing)",
-    );
-    expect(source).toContain('"private_review_contract_exhausted"');
+    expect(source).toContain("retryStateForDecision(");
+    expect(source).toContain("retryExhaustedDecision(");
+    expect(source).toContain("retryableTargetErrorDecision(error)");
+    expect(source).toContain("await recordRetryableTargetError(");
+    expect(source).toContain("retryFingerprintCount");
+    expect(source).toContain("retryExhaustedReason");
     expect(source).toContain('"invalid_private_response"');
     expect(source).toContain('"private_reviewer_unavailable"');
     expect(source).not.toContain("summary.includes");
@@ -746,6 +752,37 @@ packageUrl: "https://example.com/rate-limited"
     expect(sourceEvidenceCloseDecision(report)).toBeNull();
   });
 
+  it("treats isolated package registry rate limits as warnings when canonical sources pass", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Docker Hub Warning Fixture
+repoUrl: "https://github.com/example/project"
+documentationUrl: "https://example.com/docs"
+packageUrl: "https://hub.docker.com/r/example/project"
+---
+`,
+      vi
+        .fn<typeof fetch>()
+        .mockImplementation(async (url) => {
+          const hostname = new URL(String(url)).hostname;
+          return new Response(null, {
+            status: hostname === "hub.docker.com" ? 429 : 200,
+          });
+        }),
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toMatchObject({
+      field: "packageUrl",
+      status: "retryable",
+      role: "distribution",
+      blocking: false,
+      httpStatus: 429,
+    });
+    expect(sourceEvidenceCloseDecision(report)).toBeNull();
+  });
+
   it("renders pending, retrying, and superseded gate comments as GitHub cards", () => {
     expect(markerComment()).toContain("> ## ℹ️ Public validation running");
     expect(markerComment()).toContain(
@@ -758,6 +795,15 @@ packageUrl: "https://example.com/rate-limited"
     expect(retryingReviewComment()).toContain(
       "> - ⚠️ **Private maintainer gate:** `retrying`",
     );
+    expect(
+      retryingReviewComment("<!-- heyclaude-submission-gate -->", {
+        code: "source_evidence_timeout",
+        attempt: 2,
+        maxAttempts: 6,
+        nextReviewAt: "2026-06-06T09:15:00.000Z",
+        summary: "packageUrl returned HTTP 429.",
+      }),
+    ).toContain("> - ⚠️ **Retry:** `2/6`");
     expect(
       supersededReviewComment(
         "<!-- heyclaude-submission-gate -->",


### PR DESCRIPTION
## Summary
- Adds D1 retry metadata and a retry fingerprint budget so submission-gate infrastructure failures cannot loop forever.
- Treats isolated package/registry transient failures as non-blocking warnings when canonical repo/docs/source URLs pass.
- Improves retry comments and queue status visibility with typed error codes, retry counts, next retry time, exhausted retry summaries, and source evidence hashes.

## What changed
- Adds retry columns and fingerprint indexing for `submission_prs`.
- Adds retry budgets/backoff for source evidence, private-review, GitHub rate-limit, GitHub inspection, and evidence-conflict failures.
- Stops exhausted infrastructure retries as terminal manual states instead of content rejections.
- Preserves source evidence details and downgrades distribution-only `429`/transient failures when canonical sources are reachable.
- Extends Worker tests for retry budgets and registry-rate-limit warning behavior.

## Why
- Some valid content submissions were retrying repeatedly because package registries could return transient edge failures even while canonical sources were reachable.
- Private-review or GitHub inspection failures need bounded retries and clear maintainer visibility, not indefinite scheduled rediscovery.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts` passed 111 tests.
- `pnpm build` passed.
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod` passed.
- Operator kit production dry run passed with Wrangler.
- `git diff --check` passed.

## Notes
- This PR includes the public Worker and D1 migration. The companion private operator-kit parsing/fallback improvements are deployed separately from the private repository lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced retry mechanism with configurable backoff strategies and exhaustion tracking
  * Improved source evidence classification with blocking/non-blocking status

* **Bug Fixes**
  * Better handling of rate limits, timeouts, and private gate error responses
  * Improved detection of non-blocking distribution source failures

* **Tests**
  * Expanded retry framework test coverage with additional edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->