### PR TITLE
ci(readme): ignore lockfile churn in refresh publish

### DIFF
--- a/.github/workflows/readme-refresh-pr.yml
+++ b/.github/workflows/readme-refresh-pr.yml
@@ -63,6 +63,11 @@ jobs:
             exit 0
           fi
 
+          # Hosted installs can normalize tracked dependency metadata. This
+          # accumulator publishes README.md only, so discard workspace churn
+          # before carrying README onto the shared branch.
+          git restore --worktree --staged -- . ':!README.md'
+
           cp README.md "$RUNNER_TEMP/README.md"
           git fetch origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" || true
           git switch -C "$BRANCH_NAME" origin/main

--- a/tests/generated-churn-policy.test.ts
+++ b/tests/generated-churn-policy.test.ts
@@ -118,6 +118,9 @@ describe("generated churn policy", () => {
     expect(source).toContain("BRANCH_NAME: automation/readme-refresh");
     expect(source).toContain("refresh-readme-automation-readme-refresh");
     expect(source).toContain("git diff --quiet origin/main -- README.md");
+    expect(source).toContain(
+      "git restore --worktree --staged -- . ':!README.md'",
+    );
     expect(source).toContain('git switch -C "$BRANCH_NAME" origin/main');
     expect(source).toContain("unexpected_files");
     expect(source).toContain("git diff --name-only -- . ':!README.md'");

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -962,7 +962,7 @@ Use this hook after reviewing the notes.`,
     for (const contract of Object.values(manifest.artifactContracts)) {
       expect(contract.sha256).toMatch(/^[a-f0-9]{64}$/);
     }
-  });
+  }, 60_000);
 
   it("publishes category and platform sharded distribution feeds", () => {
     const feedIndex = readDataJson<{

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -877,6 +877,9 @@ scriptBody: |-
     expect(source).toContain("Publish README refresh branch");
     expect(source).toContain("refresh-readme-automation-readme-refresh");
     expect(source).toContain("git diff --quiet origin/main -- README.md");
+    expect(source).toContain(
+      "git restore --worktree --staged -- . ':!README.md'",
+    );
     expect(source).toContain("unexpected_files");
     expect(source).toContain('git ls-remote --heads origin "$BRANCH_NAME"');
     expect(source).toContain(


### PR DESCRIPTION
## Summary
- Keep the README accumulator branch README-only when hosted dependency setup leaves tracked lockfile churn in the Actions workspace.
- Keep CI stable as the registry artifact contract test grows with the catalog.

## What changed
- Restore tracked non-README workspace changes before copying the generated README onto `automation/readme-refresh`.
- Keep the existing non-README diff guard after the branch switch.
- Add workflow policy assertions for the restore step.
- Give the known heavy registry moat-feed contract test an explicit timeout instead of relaxing the whole Vitest suite.

## Why
- The README refresh workflow was failing while publishing the accumulator branch because `pnpm-lock.yaml` appeared dirty even though the automation is supposed to commit only `README.md`.
- The PR check also exposed a catalog-growth timeout in the deterministic registry artifact test; that failure was unrelated to this branch but would keep blocking PRs.

## Validation
- `pnpm exec prettier --check tests/registry-artifacts.test.ts .github/workflows/readme-refresh-pr.yml tests/submission-workflows.test.ts tests/generated-churn-policy.test.ts`
- `pnpm exec vitest run tests/registry-artifacts.test.ts -t "publishes registry moat feeds with deterministic contract hashes"`
- `pnpm exec vitest run tests/submission-workflows.test.ts tests/generated-churn-policy.test.ts`
- `git diff --check`
- Verified the `git restore --worktree --staged -- . ':!README.md'` pathspec leaves README changes intact while discarding lockfile churn.