### PR TITLE
fix(submissions): preserve retry counters on requeue

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2773,6 +2773,12 @@ async function enqueueReviewTarget(
     shouldResetClosedTerminal ||
     shouldResetManualTerminal;
   if (!shouldQueueReview) return false;
+  const shouldPreserveRetryState =
+    String(existing?.status || "") === "error_retryable" &&
+    String(existing?.headSha || "") === String(target.headSha || "") &&
+    !shouldResetIgnoredScan &&
+    !shouldResetClosedTerminal &&
+    !shouldResetManualTerminal;
 
   await upsertPrState(env.SUBMISSION_GATE_DB, {
     repo: target.repoFullName,
@@ -2796,6 +2802,7 @@ async function enqueueReviewTarget(
       shouldResetIgnoredScan ||
       shouldResetClosedTerminal ||
       shouldResetManualTerminal,
+    preserveRetryState: shouldPreserveRetryState,
   });
   await env.SUBMISSION_REVIEW_QUEUE.send({
     kind: "review_pr",

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -243,6 +243,7 @@ export async function upsertPrState(
     retryFingerprintCount?: number | null;
     retryExhaustedAt?: string | null;
     retryExhaustedReason?: string | null;
+    preserveRetryState?: boolean;
   },
 ) {
   const timestamp = now();
@@ -309,16 +310,19 @@ export async function upsertPrState(
         source_evidence_hash = COALESCE(excluded.source_evidence_hash, submission_prs.source_evidence_hash),
         last_error_code = CASE
           WHEN excluded.last_error_code IS NOT NULL THEN excluded.last_error_code
+          WHEN ? THEN submission_prs.last_error_code
           WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
           ELSE submission_prs.last_error_code
         END,
         last_retry_fingerprint = CASE
           WHEN excluded.last_retry_fingerprint IS NOT NULL THEN excluded.last_retry_fingerprint
+          WHEN ? THEN submission_prs.last_retry_fingerprint
           WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN NULL
           ELSE submission_prs.last_retry_fingerprint
         END,
         retry_fingerprint_count = CASE
           WHEN excluded.last_retry_fingerprint IS NOT NULL THEN excluded.retry_fingerprint_count
+          WHEN ? THEN submission_prs.retry_fingerprint_count
           WHEN excluded.status IN ('queued', 'validation_pending', 'reviewing') THEN 0
           ELSE submission_prs.retry_fingerprint_count
         END,
@@ -375,6 +379,9 @@ export async function upsertPrState(
       params.resetAttemptCount ? 1 : 0,
       params.incrementAttempt ? 1 : 0,
       params.clearTerminal ? 1 : 0,
+      params.preserveRetryState ? 1 : 0,
+      params.preserveRetryState ? 1 : 0,
+      params.preserveRetryState ? 1 : 0,
     )
     .run();
 }

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1761,6 +1761,21 @@ packageUrl: "https://hub.docker.com/r/example/project"
     expect(enqueueBlock).toContain("shouldResetIgnoredScan");
     expect(enqueueBlock).toContain("shouldResetClosedTerminal");
     expect(enqueueBlock).toContain("if (!shouldQueueReview) return false");
+    expect(enqueueBlock).toContain("const shouldPreserveRetryState");
+    expect(enqueueBlock).toContain(
+      'String(existing?.status || "") === "error_retryable"',
+    );
+    expect(enqueueBlock).toContain(
+      'String(existing?.headSha || "") === String(target.headSha || "")',
+    );
+    expect(source).toContain("preserveRetryState: shouldPreserveRetryState");
+    expect(storageSource).toContain("preserveRetryState?: boolean");
+    expect(storageSource).toContain(
+      "WHEN ? THEN submission_prs.last_retry_fingerprint",
+    );
+    expect(storageSource).toContain(
+      "WHEN ? THEN submission_prs.retry_fingerprint_count",
+    );
     expect(reviewBlock).toContain("if (hasTerminalGateDecision(existing))");
     expect(enqueueBlock).not.toContain(
       "if (!forceRecheck && hasTerminalGateDecision(existing))",


### PR DESCRIPTION
### Motivation

- Fix a regression where retry-budget fields (`last_error_code`, `last_retry_fingerprint`, `retry_fingerprint_count`) were being cleared whenever a PR row was requeued, which prevented retry exhaustion from ever being reached for repeat retryable failures. 

### Description

- Add a `preserveRetryState` flag to the `upsertPrState` call and SQL binding so the DB `ON CONFLICT` update can retain retry accounting when requested instead of clearing it.
- Compute `shouldPreserveRetryState` in `enqueueReviewTarget` for the requeue path when the existing row is `error_retryable`, the PR `headSha` is unchanged, and no terminal/reset conditions apply, and pass it to `upsertPrState`.
- Update the SQL `CASE` expressions in `apps/submission-gate/src/storage.ts` to return prior retry fields when `preserveRetryState` is true, preserving `last_error_code`, `last_retry_fingerprint`, and `retry_fingerprint_count` across requeues.
- Add regression assertions in `tests/submission-gate-worker.test.ts` verifying the enqueue/requeue plumbing and storage signatures for the preserve-retry-state path.

### Testing

- Ran the submission-gate worker unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts`, which passed (80 tests passed).
- Performed a full build with `pnpm build`, which completed successfully.
- Ran `git diff --check` to ensure no whitespace/format issues; no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23e86cbbd0832c8bc68b8d32b8028b)