### PR TITLE
ci(readme): classify dispatched accumulator diffs

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -49,7 +49,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-          FORCE_FULL_VALIDATION: ${{ github.event_name != 'pull_request' && '1' || '0' }}
+          FORCE_FULL_VALIDATION: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref_name != 'automation/readme-refresh')) && '1' || '0' }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
         run: |

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -5,9 +5,20 @@ const eventName = process.env.GITHUB_EVENT_NAME || "";
 const baseSha = process.env.BASE_SHA || "";
 const baseRef = process.env.BASE_REF || process.env.GITHUB_BASE_REF || "";
 const headSha = process.env.HEAD_SHA || "";
+const headRef =
+  process.env.HEAD_REF ||
+  process.env.GITHUB_HEAD_REF ||
+  process.env.GITHUB_REF_NAME ||
+  "";
+const workflowDispatchBaseRef =
+  process.env.WORKFLOW_DISPATCH_BASE_REF || "main";
+const workflowDispatchDiff =
+  eventName === "workflow_dispatch" &&
+  (headRef === "automation/readme-refresh" ||
+    process.env.GITHUB_REF_NAME === "automation/readme-refresh");
 const forceFull =
   process.env.FORCE_FULL_VALIDATION === "1" ||
-  eventName === "workflow_dispatch" ||
+  (eventName === "workflow_dispatch" && !workflowDispatchDiff) ||
   eventName === "schedule";
 const outputPath = process.env.GITHUB_OUTPUT || "";
 const summaryPath = process.env.GITHUB_STEP_SUMMARY || "";
@@ -43,7 +54,11 @@ function pullRequestDiffRange() {
       : "HEAD";
   const candidates = [];
 
-  if (baseRef) {
+  if (workflowDispatchDiff) {
+    candidates.push(`refs/remotes/origin/${workflowDispatchBaseRef}`);
+    candidates.push(`origin/${workflowDispatchBaseRef}`);
+    candidates.push(workflowDispatchBaseRef);
+  } else if (baseRef) {
     candidates.push(`refs/remotes/origin/${baseRef}`);
     candidates.push(`origin/${baseRef}`);
     candidates.push(baseRef);
@@ -64,7 +79,7 @@ function pullRequestDiffRange() {
 
 function changedFiles() {
   if (forceFull) return [];
-  if (eventName !== "pull_request") return [];
+  if (eventName !== "pull_request" && !workflowDispatchDiff) return [];
   const output = execFileSync(
     "git",
     ["diff", "--name-only", ...pullRequestDiffRange()],
@@ -81,6 +96,8 @@ function changedFiles() {
 
 const files = changedFiles();
 const all = forceFull;
+const diffClassifiedEvent =
+  eventName === "pull_request" || workflowDispatchDiff;
 
 function touches(...patterns) {
   if (all) return true;
@@ -107,17 +124,14 @@ function contentCategoriesFromFiles() {
 const contentCategories = contentCategoriesFromFiles();
 const contentCategoryTouched = contentCategories.length > 0;
 const sourceContentOnly =
-  eventName === "pull_request" &&
+  diffClassifiedEvent &&
   !all &&
   files.length > 0 &&
   files.every((file) => /^content\/[^/]+\/[^/]+\.mdx$/i.test(file));
 const readmeOnly =
-  eventName === "pull_request" &&
-  !all &&
-  files.length === 1 &&
-  files[0] === "README.md";
+  diffClassifiedEvent && !all && files.length === 1 && files[0] === "README.md";
 const directSubmission =
-  eventName === "pull_request" &&
+  diffClassifiedEvent &&
   !all &&
   files.length === 1 &&
   contentCategories.length === 1 &&

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -61,10 +61,10 @@ function runClassifier(
         HEAD_SHA: "",
         GITHUB_HEAD_REF: "contributor/source-entry",
         HEAD_REF: "contributor/source-entry",
-        ...extraEnv,
         BASE_SHA: baseSha,
         GITHUB_EVENT_NAME: "pull_request",
         GITHUB_OUTPUT: outputPath,
+        ...extraEnv,
       },
       encoding: "utf8",
     },
@@ -121,6 +121,35 @@ describe("PR change classifier", () => {
       source_content_only: "false",
       content: "false",
       registry: "true",
+      docs: "true",
+      web: "false",
+      raycast: "false",
+    });
+  });
+
+  it("routes dispatched README refresh validation as README-only", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+
+    git(cwd, ["update-ref", "refs/remotes/origin/main", baseSha]);
+    fs.writeFileSync(path.join(cwd, "README.md"), "# refreshed\n");
+    git(cwd, ["add", "README.md"]);
+    git(cwd, ["commit", "-m", "refresh readme"]);
+
+    const outputs = runClassifier(cwd, baseSha, {
+      FORCE_FULL_VALIDATION: "0",
+      GITHUB_EVENT_NAME: "workflow_dispatch",
+      GITHUB_HEAD_REF: "",
+      GITHUB_REF_NAME: "automation/readme-refresh",
+      HEAD_REF: "",
+    });
+    expect(outputs).toMatchObject({
+      full: "false",
+      readme_only: "true",
+      direct_submission: "false",
+      source_content_only: "false",
+      content: "false",
+      registry: "true",
+      ci: "false",
       docs: "true",
       web: "false",
       raycast: "false",


### PR DESCRIPTION
## Summary
- Route manually dispatched README accumulator validation as a README-only diff instead of full validation.

## What changed
- Let `workflow_dispatch` on `automation/readme-refresh` compare the branch against `origin/main`.
- Keep full validation for scheduled runs and other manual dispatches.
- Add a regression test proving dispatched README refresh validation sets `readme_only=true` and keeps the CI lane off.

## Why
- The README accumulator PR opened correctly, but its manually triggered validation run lacked pull-request context and forced full validation, causing the CI lane to run on a generated README-only branch.

## Validation
- `pnpm exec prettier --check scripts/ci/classify-pr-changes.mjs .github/workflows/content-validation.yml tests/classify-pr-changes.test.ts`
- `pnpm exec vitest run tests/classify-pr-changes.test.ts tests/submission-workflows.test.ts tests/deployment-preview-url.test.ts`
- `git diff --check`