### PR TITLE
fix(submissions): retry validation check read failures

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -546,6 +546,20 @@ function retryableTargetErrorDecision(error: unknown) {
   );
 }
 
+function retryableValidationReadDecision(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate hit a GitHub rate limit while reading public validation checks.",
+      "github_rate_limited",
+    );
+  }
+  return privateReviewErrorDecision(
+    `Submission gate could not read public validation checks: ${message}`,
+    "github_api_unavailable",
+  );
+}
+
 function normalizeOneShotDecision(decision: GateDecision): GateDecision {
   if (decision.verdict === "close" && !decision.close) {
     return {
@@ -3200,8 +3214,11 @@ async function persistRetryableGateDecision(params: {
   message: QueueMessage;
   decision: GateDecision;
   retryState: ReturnType<typeof retryStateForDecision>;
+  nextReviewAt?: string | null;
+  retryStage?: "validation" | "private_review";
   auditDecision: string;
 }) {
+  const nextReviewAt = params.nextReviewAt ?? params.retryState.nextReviewAt;
   await upsertPrState(params.env.SUBMISSION_GATE_DB, {
     repo: params.target.repoFullName,
     number: params.target.number,
@@ -3211,7 +3228,7 @@ async function persistRetryableGateDecision(params: {
     baseRef: params.target.baseRef || contentGateBaseRef(params.env),
     installationId: params.target.installationId,
     status: "error_retryable",
-    nextReviewAt: params.retryState.nextReviewAt,
+    nextReviewAt,
     lastError: truncateForQueue(params.decision.summary),
     lastErrorCode: params.retryState.code,
     lastRetryFingerprint: params.retryState.fingerprint,
@@ -3228,10 +3245,11 @@ async function persistRetryableGateDecision(params: {
     body: retryingReviewComment(
       params.env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
       {
+        stage: params.retryStage,
         code: params.retryState.code,
         attempt: params.retryState.count,
         maxAttempts: params.retryState.maxAttempts,
-        nextReviewAt: params.retryState.nextReviewAt,
+        nextReviewAt,
         summary: truncateForQueue(params.decision.summary, 320),
       },
     ),
@@ -3246,7 +3264,7 @@ async function persistRetryableGateDecision(params: {
     baseRef: params.target.baseRef || contentGateBaseRef(params.env),
     installationId: params.target.installationId,
     status: "error_retryable",
-    nextReviewAt: params.retryState.nextReviewAt,
+    nextReviewAt,
     lastError: truncateForQueue(params.decision.summary),
     lastErrorCode: params.retryState.code,
     lastRetryFingerprint: params.retryState.fingerprint,
@@ -3717,10 +3735,31 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             lastCheckSummary: validation.summary,
           });
         }
-      } catch {
-        decision = defaultManualDecision(
-          "Submission gate could not read public validation checks.",
+      } catch (error) {
+        const retryableDecision = retryableValidationReadDecision(error);
+        const retryState = retryStateForDecision(
+          existing,
+          target,
+          retryableDecision,
         );
+        if (!retryState.exhausted) {
+          await persistRetryableGateDecision({
+            env,
+            token,
+            repo,
+            target,
+            message,
+            decision: retryableDecision,
+            retryState,
+            nextReviewAt: isGitHubRateLimitError(error)
+              ? nextReviewForError(error)
+              : retryState.nextReviewAt,
+            retryStage: "validation",
+            auditDecision: "validation_check_read_retryable",
+          });
+          return;
+        }
+        decision = retryExhaustedDecision(retryableDecision, retryState);
       }
 
       if (!decision && contentScopeForPrivateReview) {

--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -105,6 +105,7 @@ export type GateDecision = {
 };
 
 export type RetryReviewCommentDetails = {
+  stage?: "validation" | "private_review";
   code?: string;
   attempt?: number;
   maxAttempts?: number;
@@ -1257,6 +1258,8 @@ export function retryingReviewComment(
   marker = DEFAULT_REVIEW_MARKER,
   details: RetryReviewCommentDetails = {},
 ) {
+  const validationReadRetry =
+    details.stage === "validation" || details.code === "github_api_unavailable";
   const retryLine =
     details.attempt && details.maxAttempts
       ? `- ⚠️ **Retry:** \`${details.attempt}/${details.maxAttempts}\``
@@ -1272,12 +1275,18 @@ export function retryingReviewComment(
     : "";
   return renderAlertCard(marker, "IMPORTANT", [
     "## ⚠️ Review retrying",
-    "Public validation is green, but the private reviewer returned a retryable infrastructure result.",
+    validationReadRetry
+      ? "HeyClaude could not read the public validation result yet, so the gate will retry automatically."
+      : "Public validation is green, but the private reviewer returned a retryable infrastructure result.",
     "",
     "**Progress**",
     "",
-    "- ✅ **Public validation:** `passed`",
-    "- ⚠️ **Private maintainer gate:** `retrying`",
+    validationReadRetry
+      ? "- ⚠️ **Public validation:** `retrying`"
+      : "- ✅ **Public validation:** `passed`",
+    validationReadRetry
+      ? "- ⏸️ **Private maintainer gate:** `waiting`"
+      : "- ⚠️ **Private maintainer gate:** `retrying`",
     retryLine,
     codeLine,
     nextLine,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -435,9 +435,15 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("retryExhaustedReason");
     expect(source).toContain('"invalid_private_response"');
     expect(source).toContain('"private_reviewer_unavailable"');
+    expect(source).toContain("retryableValidationReadDecision(error)");
+    expect(source).toContain('retryStage: "validation"');
+    expect(source).toContain('"validation_check_read_retryable"');
     expect(source).not.toContain("summary.includes");
     expect(source).not.toContain(
       "ai maintainer review returned an unexpected payload",
+    );
+    expect(source).not.toContain(
+      'defaultManualDecision(\n          "Submission gate could not read public validation checks.',
     );
     expect(source).toContain('status: "error_retryable"');
     expect(source).toContain("retryingReviewComment(");
@@ -804,6 +810,34 @@ packageUrl: "https://hub.docker.com/r/example/project"
         summary: "packageUrl returned HTTP 429.",
       }),
     ).toContain("> - ⚠️ **Retry:** `2/6`");
+    const validationRetry = retryingReviewComment(
+      "<!-- heyclaude-submission-gate -->",
+      {
+        stage: "validation",
+        code: "github_api_unavailable",
+        attempt: 1,
+        maxAttempts: 5,
+        nextReviewAt: "2026-06-06T09:15:00.000Z",
+        summary: "check-runs API returned 503.",
+      },
+    );
+    expect(validationRetry).toContain(
+      "> - ⚠️ **Public validation:** `retrying`",
+    );
+    expect(validationRetry).toContain(
+      "> - ⏸️ **Private maintainer gate:** `waiting`",
+    );
+    expect(validationRetry).not.toContain("Public validation is green");
+    expect(
+      retryingReviewComment("<!-- heyclaude-submission-gate -->", {
+        stage: "validation",
+        code: "github_rate_limited",
+        attempt: 1,
+        maxAttempts: 6,
+        nextReviewAt: "2026-06-06T09:15:00.000Z",
+        summary: "GitHub rate limit while reading validation checks.",
+      }),
+    ).toContain("> - ⚠️ **Public validation:** `retrying`");
     expect(
       supersededReviewComment(
         "<!-- heyclaude-submission-gate -->",


### PR DESCRIPTION
## Summary
- Convert public validation check-read failures into typed retryable gate states instead of immediate manual review.
- Render validation-read retry comments accurately so contributors see validation retrying and the private gate waiting.
- Keep exhausted infrastructure failures manual, with existing retry budget handling.

## What changed
- Added a retryable validation-read decision for GitHub API and rate-limit failures.
- Reused the existing retry persistence/comment path with optional retry timing and stage metadata.
- Added regression coverage for the worker path and validation retry comment rendering.

## Why
- PR #1855 was viable content, but the gate marked it manual because it could not read public validation checks. That should be retried as automation infrastructure, not treated as content ambiguity.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for validation check failures, now distinguishing between rate-limit and API-unavailability scenarios
  * Enhanced retry notifications to clearly indicate which processing stage is undergoing retry
  * Improved retry state persistence across validation and review stages

* **Tests**
  * Expanded test coverage for validation retry scenarios and error classification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->