### PR TITLE
fix(ci): restrict dispatched readme diff classification

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -16,7 +16,7 @@ const workflowDispatchDiff =
   eventName === "workflow_dispatch" &&
   (headRef === "automation/readme-refresh" ||
     process.env.GITHUB_REF_NAME === "automation/readme-refresh");
-const forceFull =
+const forceFullFromEvent =
   process.env.FORCE_FULL_VALIDATION === "1" ||
   (eventName === "workflow_dispatch" && !workflowDispatchDiff) ||
   eventName === "schedule";
@@ -78,7 +78,7 @@ function pullRequestDiffRange() {
 }
 
 function changedFiles() {
-  if (forceFull) return [];
+  if (forceFullFromEvent) return [];
   if (eventName !== "pull_request" && !workflowDispatchDiff) return [];
   const output = execFileSync(
     "git",
@@ -95,9 +95,12 @@ function changedFiles() {
 }
 
 const files = changedFiles();
-const all = forceFull;
+const workflowDispatchReadmeOnly =
+  workflowDispatchDiff && files.length === 1 && files[0] === "README.md";
+const all =
+  forceFullFromEvent || (workflowDispatchDiff && !workflowDispatchReadmeOnly);
 const diffClassifiedEvent =
-  eventName === "pull_request" || workflowDispatchDiff;
+  eventName === "pull_request" || workflowDispatchReadmeOnly;
 
 function touches(...patterns) {
   if (all) return true;

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -156,6 +156,40 @@ describe("PR change classifier", () => {
     });
   });
 
+  it("forces full validation for dispatched README refresh content changes", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+
+    git(cwd, ["update-ref", "refs/remotes/origin/main", baseSha]);
+    const contentDir = path.join(cwd, "content", "agents");
+    fs.mkdirSync(contentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, "example.mdx"),
+      "---\ntitle: Example\n---\n",
+    );
+    git(cwd, ["add", "content/agents/example.mdx"]);
+    git(cwd, ["commit", "-m", "add content entry"]);
+
+    const outputs = runClassifier(cwd, baseSha, {
+      FORCE_FULL_VALIDATION: "0",
+      GITHUB_EVENT_NAME: "workflow_dispatch",
+      GITHUB_HEAD_REF: "",
+      GITHUB_REF_NAME: "automation/readme-refresh",
+      HEAD_REF: "",
+    });
+    expect(outputs).toMatchObject({
+      full: "true",
+      readme_only: "false",
+      direct_submission: "false",
+      source_content_only: "false",
+      content: "true",
+      content_agents: "true",
+      registry: "true",
+      ci: "true",
+      web: "true",
+      raycast: "true",
+    });
+  });
+
   it("uses the current base ref and PR head SHA instead of stale merge refs", () => {
     const { cwd, baseSha } = createFixtureRepo();
 


### PR DESCRIPTION
### Motivation

- Prevent a validation bypass where `workflow_dispatch` runs on `automation/readme-refresh` could be diff-classified like PRs and skip PR-only content validators when the diff included a single content MDX change.

### Description

- Limit the dispatched README refresh short-circuit so only an exact single-file `README.md` diff is eligible for the reduced README-only path by adding a `workflowDispatchReadmeOnly` gate and deriving `all` from that and the pre-diff event-level flag.
- Rename the pre-diff force flag to `forceFullFromEvent` and ensure `changedFiles()` still runs for dispatched README refreshes, but forces full validation for any non-README dispatched diffs. 
- Adjust `diffClassifiedEvent` so only PRs or the dispatched README-only case count as diff-classified events. 
- Add a regression test that asserts a `workflow_dispatch` run on `automation/readme-refresh` that changes a `content/` MDX file forces full validation lanes. 

### Testing

- Ran `pnpm exec prettier --write scripts/ci/classify-pr-changes.mjs tests/classify-pr-changes.test.ts` which completed successfully. 
- Ran `pnpm exec vitest run tests/classify-pr-changes.test.ts` and all tests passed (7 tests). 
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23f837e370832c9d7c6d197a79ef31)