### PR TITLE
fix(submissions): avoid source evidence retry loops

### DIFF
--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -79,6 +79,12 @@ const TRUSTED_SOURCE_HOSTS = new Set([
 ]);
 
 const TRUSTED_SOURCE_HOST_SUFFIXES = [] as const;
+const PRIMARY_CANONICAL_SOURCE_FIELDS = new Set([
+  "githubUrl",
+  "repoUrl",
+  "repositoryUrl",
+  "sourceUrl",
+]);
 
 function stripYamlComment(value: string) {
   return value.replace(/\s+#.*$/, "").trim();
@@ -375,16 +381,25 @@ function sourceEvidenceHashInput(urls: SourceEvidenceItem[]) {
   );
 }
 
-function downgradeNonCanonicalRetryWarnings(urls: SourceEvidenceItem[]) {
-  const hasCanonicalPass = urls.some(
+function hasVerifiableCanonicalSource(urls: SourceEvidenceItem[]) {
+  const reachableCanonical = urls.filter(
     (item) =>
       item.role === "canonical" &&
       item.status === "passed" &&
       item.outcome === "reachable",
   );
-  if (!hasCanonicalPass) return urls;
+  return (
+    reachableCanonical.length >= 2 ||
+    reachableCanonical.some((item) =>
+      PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field),
+    )
+  );
+}
+
+function downgradeInconclusiveSourceWarnings(urls: SourceEvidenceItem[]) {
+  if (!hasVerifiableCanonicalSource(urls)) return urls;
   return urls.map((item) =>
-    item.role === "distribution" && item.status === "retryable"
+    item.status === "retryable"
       ? { ...item, blocking: false }
       : item,
   );
@@ -406,7 +421,7 @@ export async function checkSubmittedSourceEvidence(
       error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
     }));
   }
-  const urls = downgradeNonCanonicalRetryWarnings(checkedUrls);
+  const urls = downgradeInconclusiveSourceWarnings(checkedUrls);
   const blockingUrls = urls.filter((item) => item.blocking);
   const status = blockingUrls.some((item) => item.status === "hard_failure")
     ? "failed"

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -800,6 +800,37 @@ packageUrl: "https://hub.docker.com/r/example/project"
     expect(sourceEvidenceCloseDecision(report)).toBeNull();
   });
 
+  it("treats isolated auxiliary source fetch errors as warnings when canonical evidence passes", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: GitHub Blob Warning Fixture
+repoUrl: "https://github.com/example/project"
+packageUrl: "https://pypi.org/project/example-project/"
+sourceUrls:
+  - "https://github.com/example/project/blob/main/README.md"
+  - "https://github.com/example/project/blob/main/flaky-source.py"
+---
+`,
+      vi.fn<typeof fetch>().mockImplementation(async (url) => {
+        if (String(url).includes("flaky-source.py")) {
+          throw new Error("edge fetch timeout");
+        }
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toMatchObject({
+      field: "sourceUrls",
+      status: "retryable",
+      outcome: "fetch_error",
+      role: "canonical",
+      blocking: false,
+    });
+    expect(sourceEvidenceCloseDecision(report)).toBeNull();
+  });
+
   it("does not fetch source URLs outside the trusted evidence hosts", async () => {
     const fetchImpl = vi.fn<typeof fetch>();
     const report = await checkSubmittedSourceEvidence(


### PR DESCRIPTION
## Summary
- Treat transient auxiliary source URL fetch failures as warnings when deterministic canonical source evidence is already reachable.
- Keep hard source failures blocking and keep all-source-inconclusive cases retryable.

## What changed
- Added a canonical-source quorum for source evidence checks.
- Downgraded retryable source URL fetch errors to non-blocking warnings only after enough canonical evidence passes.
- Added regression coverage for a flaky GitHub blob/source URL with reachable repo evidence.

## Why
- Recent one-file content PRs were stuck retrying because individual GitHub blob URLs intermittently failed from the Worker edge even though repo/package/other official source URLs were reachable.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source evidence verification logic to reduce noise from inconclusive warnings when canonical evidence is available.
  * Auxiliary source fetch failures are now correctly classified as retryable issues rather than blocking failures.

* **Tests**
  * Added test coverage for source evidence handling with fetch errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->