### PR TITLE
fix(submissions): timeout private review body reads

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -3121,46 +3121,78 @@ async function reviewWithPrivateGate(env: Env, message: QueueMessage) {
   }
   const body = JSON.stringify(message);
   const signature = await signInternalPayload(env.INTERNAL_SHARED_SECRET, body);
-  let response: Response;
-  try {
-    response = await fetch(env.PRIVATE_GATE_REVIEW_URL, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-heyclaude-internal-signature": signature,
-      },
-      body,
-      signal: AbortSignal.timeout(PRIVATE_REVIEW_TIMEOUT_MS),
-    });
-  } catch {
-    return privateReviewErrorDecision(
-      "Private corpus review request failed.",
-      "private_reviewer_unavailable",
-    );
-  }
-  if (!response.ok) {
-    return privateReviewErrorDecision(
-      `Private corpus review returned ${response.status}.`,
-      "private_reviewer_unavailable",
-    );
-  }
-  const raw = parsePrivateGateDecisionResponseBody(
-    await response.text().catch(() => ""),
+  const deadline = Date.now() + PRIVATE_REVIEW_TIMEOUT_MS;
+  const controller = new AbortController();
+  const abortId = setTimeout(
+    () => controller.abort(),
+    PRIVATE_REVIEW_TIMEOUT_MS,
   );
-  const normalized = normalizePrivateGateDecisionPayload(raw);
-  if (normalized.error || !normalized.decision) {
-    const error = normalized.error || {
-      code: "invalid_private_response",
-      retryable: true,
-      message: "Private corpus review returned an unexpected payload.",
-    };
-    return privateReviewErrorDecision(
-      error.message || "Private corpus review returned an unexpected payload.",
-      error.code,
-      error.retryable !== false,
+  try {
+    const response = await withPrivateReviewTimeout(
+      fetch(env.PRIVATE_GATE_REVIEW_URL, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-heyclaude-internal-signature": signature,
+        },
+        body,
+        signal: controller.signal,
+      }),
+      deadline,
+      "Private corpus review request timed out.",
     );
+    if (!response.ok) {
+      return privateReviewErrorDecision(
+        `Private corpus review returned ${response.status}.`,
+        "private_reviewer_unavailable",
+      );
+    }
+    const responseText = await withPrivateReviewTimeout(
+      response.text(),
+      deadline,
+      "Private corpus review response body timed out.",
+    );
+    const raw = parsePrivateGateDecisionResponseBody(responseText);
+    const normalized = normalizePrivateGateDecisionPayload(raw);
+    if (normalized.error || !normalized.decision) {
+      const error = normalized.error || {
+        code: "invalid_private_response",
+        retryable: true,
+        message: "Private corpus review returned an unexpected payload.",
+      };
+      return privateReviewErrorDecision(
+        error.message || "Private corpus review returned an unexpected payload.",
+        error.code,
+        error.retryable !== false,
+      );
+    }
+    return normalized.decision;
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Private corpus review request failed.";
+    return privateReviewErrorDecision(message, "private_reviewer_unavailable");
+  } finally {
+    clearTimeout(abortId);
   }
-  return normalized.decision;
+}
+
+async function withPrivateReviewTimeout<T>(
+  promise: Promise<T>,
+  deadline: number,
+  message: string,
+): Promise<T> {
+  const remainingMs = Math.max(1, deadline - Date.now());
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), remainingMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
 }
 
 async function persistRetryableGateDecision(params: {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -417,6 +417,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("REVIEWING_STALE_SECONDS");
     expect(source).toContain("QUEUED_STALE_SECONDS");
     expect(source).toContain("PRIVATE_REVIEW_TIMEOUT_MS = 45_000");
+    expect(source).toContain("withPrivateReviewTimeout(");
+    expect(source).toContain("Private corpus review response body timed out.");
+    expect(source).toContain("controller.abort()");
+    expect(source).toContain("response.text()");
     expect(source).toContain("const RETRY_BACKOFF_SECONDS = [60, 120, 300");
     expect(source).toContain("const RETRY_BUDGETS");
     expect(source).toContain("invalid_private_response: 5");


### PR DESCRIPTION
## Summary
- Add an end-to-end deadline around private maintainer review calls.
- Convert slow or unreadable private-review response bodies into typed retryable private-review outages instead of leaving PRs in `reviewing`.
- Add regression coverage so the Worker keeps the timeout on both request and body-read phases.

## What changed
- Replaced the initial-fetch-only timeout with a shared deadline and abort controller.
- Wrapped `response.text()` in the same private-review deadline.
- Preserved existing `invalid_private_response` handling for successfully read but malformed payloads.

## Why
- Some content PRs could pass deterministic checks and then sit in `reviewing` because the private review request returned headers but did not produce a readable body before the Worker invocation ended.
- The queue should record `private_reviewer_unavailable` and use retry budgets/backoff instead of silently stalling.

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts`
- `pnpm build`
- `pnpm --filter @heyclaude/submission-gate run deploy:dry-run:prod`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout enforcement for private review requests to prevent indefinite waits and ensure timely completion.

* **Tests**
  * Enhanced test coverage to verify private review timeout behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->