### PR TITLE
content(mcp): add CVE MCP Server

### DIFF
--- a/content/mcp/cve-mcp-server.mdx
+++ b/content/mcp/cve-mcp-server.mdx
@@ -1,0 +1,238 @@
+---
+title: CVE MCP Server
+slug: cve-mcp-server
+category: mcp
+description: >-
+  Security intelligence MCP server that lets Claude look up CVEs, EPSS scores,
+  CISA KEV status, OSV package vulnerabilities, exploit indicators, MITRE
+  mappings, IP reputation, passive DNS, Shodan host data, malware intelligence,
+  URL safety, and risk reports across optional third-party APIs.
+cardDescription: Connect Claude to CVE, vulnerability, exploit, and threat-intelligence lookup tools.
+seoTitle: CVE MCP Server for Claude
+seoDescription: >-
+  Configure CVE MCP Server with Claude to query CVE records, EPSS, CISA KEV,
+  OSV package vulnerabilities, exploit signals, MITRE mappings, IP reputation,
+  passive DNS, Shodan, VirusTotal, URLScan, and security risk reports.
+author: Mahipal Jangra
+authorProfileUrl: "https://github.com/mukul975"
+submittedBy: oktofeesh1
+submittedByUrl: "https://github.com/oktofeesh1"
+dateAdded: "2026-06-06"
+brandName: CVE MCP Server
+brandDomain: github.com/mukul975/cve-mcp-server
+websiteUrl: "https://github.com/mukul975/cve-mcp-server"
+repoUrl: "https://github.com/mukul975/cve-mcp-server"
+documentationUrl: "https://github.com/mukul975/cve-mcp-server/blob/main/README.md"
+packageUrl: "https://pypi.org/pypi/cve-mcp-server/json"
+installable: true
+installCommand: "pip install cve-mcp-server"
+usageSnippet: "Ask Claude to look up an approved CVE, package, IP, domain, URL, or hash, then verify important remediation decisions against vendor advisories and source records."
+copySnippet: |-
+  {
+    "mcpServers": {
+      "cve-mcp": {
+        "command": "cve-mcp",
+        "env": {
+          "NVD_API_KEY": "",
+          "GITHUB_TOKEN": ""
+        }
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "cve-mcp": {
+        "command": "cve-mcp",
+        "env": {
+          "NVD_API_KEY": "",
+          "GITHUB_TOKEN": "",
+          "VULNCHECK_TOKEN": "",
+          "ABUSEIPDB_KEY": "",
+          "VIRUSTOTAL_KEY": "",
+          "URLSCAN_KEY": "",
+          "SHODAN_KEY": "",
+          "GREYNOISE_API_KEY": "",
+          "CIRCL_PDNS_USER": "",
+          "CIRCL_PDNS_PASS": "",
+          "CACHE_DB_PATH": "",
+          "AUDIT_LOG_PATH": ""
+        }
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - Python 3.10 or newer for the source project, or a Python version supported by the currently published package.
+  - pip, uv, or another supported Python package installer.
+  - Network access to the selected vulnerability, threat-intelligence, and package-advisory APIs.
+  - Optional API keys for NVD, GitHub, VulnCheck, AbuseIPDB, VirusTotal, URLScan, Shodan, GreyNoise, or CIRCL Passive DNS when those integrations are needed.
+  - Authorization to query the CVEs, packages, domains, IP addresses, URLs, hashes, repositories, and security-investigation targets being analyzed.
+safetyNotes:
+  - CVE, CVSS, EPSS, KEV, exploit, PoC, MITRE, package-advisory, malware, and IP-reputation data can be stale, incomplete, provider-specific, or false positive.
+  - Treat generated risk scores and vulnerability reports as triage aids, not patch policy, incident-response authority, or compliance evidence by themselves.
+  - Some tools can submit or query URLs, IP addresses, domains, file hashes, package names, repository search terms, and exploit indicators against third-party services.
+  - Shodan, URLScan, VirusTotal, AbuseIPDB, GreyNoise, CIRCL, GitHub, VulnCheck, NVD, OSV, and other providers may apply rate limits, visibility rules, account terms, and retention policies.
+  - Review provider defaults before scanning URLs or infrastructure because some services can expose submitted targets or scan metadata publicly.
+  - The project documentation says the server uses outbound HTTPS only and blocks private/internal IP lookups, but users should still avoid unauthorized reconnaissance or sensitive internal target submission.
+privacyNotes:
+  - Security queries can reveal vulnerable products, internal triage priorities, asset names, IP addresses, domains, URLs, file hashes, package versions, malware interests, and investigation targets to upstream APIs.
+  - API keys are loaded from environment variables; keep them scoped, rotated, and out of model transcripts, shell history, and shared configuration files.
+  - The implementation initializes a local SQLite cache and rotating audit log, which can retain query parameters, statuses, timings, source results, and security-investigation context.
+  - Audit logging redacts fields whose names include key or token, but other query values can still be sensitive and should be protected as security data.
+  - The repository license file is Apache-2.0 while the README badge and pyproject classifier currently mention MIT, so verify current licensing before redistribution or commercial reuse.
+sourceUrls:
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/pyproject.toml"
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/server.py"
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/config.py"
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/audit.py"
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/SECURITY.md"
+  - "https://github.com/mukul975/cve-mcp-server/blob/main/LICENSE"
+tags:
+  - security
+  - cve
+  - threat-intelligence
+  - vulnerability-management
+  - incident-response
+keywords:
+  - CVE MCP Server
+  - cve-mcp-server
+  - vulnerability MCP
+  - threat intelligence MCP
+  - EPSS MCP
+  - CISA KEV MCP
+  - Shodan MCP
+  - VirusTotal MCP
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+CVE MCP Server is a Python Model Context Protocol server for security
+intelligence and vulnerability triage. It exposes Claude to tools for CVE
+lookup, NVD search, OSV dependency checks, EPSS scoring, CISA KEV checks, CVSS
+parsing, vendor-advisory retrieval, exploit and PoC availability checks, MITRE
+attack mapping, timeline generation, dependency scans, repository secret search,
+IP reputation, passive DNS, Shodan host lookup, malware-family lookup, URL
+safety checks, ransomware intelligence, risk scoring, and vulnerability reports.
+
+The server runs over stdio with `cve-mcp`, uses outbound HTTPS for upstream data
+sources, and supports optional API keys for higher-rate or provider-specific
+integrations. Its implementation initializes a SQLite cache and rotating audit
+log, validates selected inputs, and redacts audit fields whose names include
+key or token.
+
+## Source Review
+
+- https://github.com/mukul975/cve-mcp-server
+- https://github.com/mukul975/cve-mcp-server/blob/main/README.md
+- https://pypi.org/pypi/cve-mcp-server/json
+- https://github.com/mukul975/cve-mcp-server/blob/main/pyproject.toml
+- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/server.py
+- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/config.py
+- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/audit.py
+- https://github.com/mukul975/cve-mcp-server/blob/main/.env.example
+- https://github.com/mukul975/cve-mcp-server/blob/main/SECURITY.md
+- https://github.com/mukul975/cve-mcp-server/blob/main/LICENSE
+
+These sources were reviewed on **2026-06-06**. Prefer the live repository,
+README, PyPI metadata, package metadata, implementation files, environment
+template, security policy, and license file for current install commands, tool
+behavior, optional credentials, audit/cache behavior, provider requirements, and
+licensing.
+
+## Features
+
+- Python package and stdio MCP server launched with `cve-mcp`.
+- CVE lookup and search through NVD, with optional API key support for higher
+  request limits.
+- EPSS scoring, CISA KEV status checks, CVSS vector parsing, and vendor-advisory
+  lookup workflows.
+- OSV package vulnerability checks, dependency-list scans, container package
+  scans, and GitHub advisory or repository search workflows.
+- Exploit and PoC availability checks, MITRE attack mapping, CVE timeline
+  generation, risk scoring, CVE comparison, and vulnerability report generation.
+- Threat-intelligence workflows for IP reputation, passive DNS, Shodan host
+  data, file-hash intelligence, malware-family lookup, ransomware indicators,
+  and URL safety.
+- Optional provider credentials for NVD, GitHub, VulnCheck, AbuseIPDB,
+  VirusTotal, URLScan, Shodan, GreyNoise, and CIRCL Passive DNS.
+- SQLite cache and rotating audit log paths configurable through environment
+  variables.
+
+## Installation
+
+Install the package, then configure your MCP client:
+
+```sh
+pip install cve-mcp-server
+```
+
+```json
+{
+  "mcpServers": {
+    "cve-mcp": {
+      "command": "cve-mcp",
+      "env": {
+        "NVD_API_KEY": "",
+        "GITHUB_TOKEN": "",
+        "ABUSEIPDB_KEY": "",
+        "VIRUSTOTAL_KEY": "",
+        "URLSCAN_KEY": "",
+        "SHODAN_KEY": "",
+        "GREYNOISE_API_KEY": ""
+      }
+    }
+  }
+}
+```
+
+Restart the MCP client, then ask Claude to analyze an approved CVE, package,
+domain, IP address, file hash, or URL. Add only the provider keys needed for the
+specific tools you plan to use.
+
+## Use Cases
+
+- Triage a CVE by combining NVD details, EPSS probability, CISA KEV status,
+  exploit availability, and vendor advisory context.
+- Prioritize a backlog of vulnerabilities with transparent source evidence
+  before patch-window planning.
+- Check whether a package and version appears in OSV or GitHub advisory data.
+- Enrich an approved incident-response indicator with IP reputation, passive
+  DNS, malware, ransomware, URL, or file-hash intelligence.
+- Compare multiple CVEs and draft an evidence-backed vulnerability report for
+  human review.
+- Map vulnerability findings to MITRE attack context for security notes or
+  remediation discussions.
+
+## Safety and Privacy
+
+Use CVE MCP Server as an intelligence retrieval and prioritization aid, not as a
+replacement for vendor advisories, asset ownership checks, change-management
+approval, or incident-response judgment. Security datasets differ by provider,
+can change quickly, and can contain false positives or stale records.
+
+Queries to third-party services can expose sensitive security context, including
+assets, vulnerable packages, domains, IP addresses, file hashes, URLs, and
+investigation focus. Review each provider's terms, visibility defaults, and
+retention behavior before submitting sensitive targets. Protect the local cache,
+rotating audit log, environment variables, MCP client configuration, and model
+conversation history as security data.
+
+The source repository's security notes say the server makes outbound HTTPS
+requests only, does not open inbound ports, does not log API keys, and blocks
+private/internal IP lookups. Those controls reduce risk, but they do not replace
+authorization checks or provider-specific privacy review.
+
+## Duplicate Check
+
+Existing MCP content includes security-adjacent entries such as ContrastAPI,
+Socket, and HexStrike AI. CVE MCP Server is distinct because it covers
+`mukul975/cve-mcp-server`, a Python stdio MCP server focused on CVE and
+threat-intelligence lookup with optional provider keys, local SQLite cache,
+rotating audit logs, and tools spanning CVE, EPSS, KEV, OSV, exploit signals,
+MITRE mappings, IP/domain/hash/URL intelligence, risk scoring, and report
+generation. No matching CVE MCP Server source URL or dedicated entry was found
+in `content/mcp`.


### PR DESCRIPTION
## Summary
- Adds a source-backed MCP entry for CVE MCP Server, a Python stdio server for CVE, vulnerability, exploit, package-advisory, and threat-intelligence lookup workflows.

## What changed
- Added \.
- Documented install/config snippets, optional provider credentials, source-review evidence, duplicate-check context, and risk-specific safety/privacy notes.
- Noted the repository license metadata mismatch: the license file is Apache-2.0 while the README badge and pyproject classifier currently mention MIT.

## Why
- CVE MCP Server has strong popularity signals and fills a distinct vulnerability-triage/security-intelligence niche in the MCP catalog without duplicating the existing ContrastAPI, Socket, or HexStrike AI entries.

## Source Links Reviewed
- https://github.com/mukul975/cve-mcp-server
- https://github.com/mukul975/cve-mcp-server/blob/main/README.md
- https://pypi.org/pypi/cve-mcp-server/json
- https://github.com/mukul975/cve-mcp-server/blob/main/pyproject.toml
- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/server.py
- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/config.py
- https://github.com/mukul975/cve-mcp-server/blob/main/src/cve_mcp/audit.py
- https://github.com/mukul975/cve-mcp-server/blob/main/.env.example
- https://github.com/mukul975/cve-mcp-server/blob/main/SECURITY.md
- https://github.com/mukul975/cve-mcp-server/blob/main/LICENSE

## Duplicate Check
- Checked local content for \, \, \, and \.
- Existing security-adjacent MCP entries cover ContrastAPI, Socket, and HexStrike AI, but this entry is specific to \, a Python stdio MCP server with CVE, EPSS, KEV, OSV, exploit, MITRE, IP/domain/hash/URL intelligence, SQLite cache, and rotating audit-log workflows.

## Safety And Privacy Notes
- Security data from CVE, CVSS, EPSS, KEV, exploit, MITRE, advisory, malware, and reputation sources can be stale, incomplete, provider-specific, or false positive.
- The server can query third-party services with CVEs, packages, domains, IP addresses, URLs, hashes, repository search terms, and other investigation targets.
- The entry calls out provider visibility/retention concerns, especially for URL and infrastructure scanning, and recommends authorization before reconnaissance-like use.
- The implementation uses environment variables for credentials, initializes a local SQLite cache, and writes a rotating audit log that can retain sensitive security context.

## Validation
- \undefined
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command "validate:content:strict\" not found

Did you mean "pnpm validate:content:strict"?
- \
- \ returned passed with 10 reachable declared URLs
- \
- \

## Notes
- No upstream issue is claimed for this entry.
- This PR is intended as a one-shot content submission; no generated artifacts are included.