### PR TITLE
fix(content): harden ref tools install command

### DIFF
--- a/content/mcp/ref-tools-mcp-server.mdx
+++ b/content/mcp/ref-tools-mcp-server.mdx
@@ -22,7 +22,7 @@ brandDomain: ref.tools
 repoUrl: "https://github.com/ref-tools/ref-tools-mcp"
 documentationUrl: "https://raw.githubusercontent.com/ref-tools/ref-tools-mcp/main/README.md"
 installable: true
-installCommand: "Use the hosted streamable HTTP endpoint with a Ref API key, or run the legacy stdio package with `npx -y ref-tools-mcp@latest` and `REF_API_KEY`."
+installCommand: "REF_API_KEY=ref_api_key_here npx -y ref-tools-mcp@3.0.3"
 usageSnippet: "Use `ref_search_documentation` for a specific library, API, or framework question, then pass an exact result URL to `ref_read_url`."
 copySnippet: |-
   {
@@ -38,7 +38,7 @@ configSnippet: |-
     "mcpServers": {
       "Ref": {
         "command": "npx",
-        "args": ["-y", "ref-tools-mcp@latest"],
+        "args": ["-y", "ref-tools-mcp@3.0.3"],
         "env": {
           "REF_API_KEY": "<ref-api-key>"
         }
@@ -154,7 +154,7 @@ For the legacy stdio package, use the npm package with `REF_API_KEY`:
   "mcpServers": {
     "Ref": {
       "command": "npx",
-      "args": ["-y", "ref-tools-mcp@latest"],
+      "args": ["-y", "ref-tools-mcp@3.0.3"],
       "env": {
         "REF_API_KEY": "<ref-api-key>"
       }


### PR DESCRIPTION
### Motivation
- Remove a copyable frontmatter `installCommand` that contained Markdown backticks which trigger POSIX command substitution when pasted into a shell, creating an RCE risk. 
- Pin the mutable `npx ...@latest` invocation so the copyable payload does not cause execution of unpinned remote code.

### Description
- Replace the prose/backticked `installCommand` with a concrete safe command `REF_API_KEY=ref_api_key_here npx -y ref-tools-mcp@3.0.3` in `content/mcp/ref-tools-mcp-server.mdx` to avoid shell substitution. 
- Pin all documented `npx` references from `ref-tools-mcp@latest` to `ref-tools-mcp@3.0.3` in the frontmatter `configSnippet` and the legacy stdio example. 
- Normalize the API key placeholder to `ref_api_key_here` to make the copyable command explicit and non-executable by accident.

### Testing
- Ran `pnpm validate:content:strict`, which passed. 
- Ran `git diff --check` (file checks), which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24e406ae80832c90c1aefeb302fcdf)