### PR TITLE
fix(content): pin DevDocs installer source

### DIFF
--- a/content/mcp/devdocs-mcp-server.mdx
+++ b/content/mcp/devdocs-mcp-server.mdx
@@ -22,9 +22,9 @@ dateAdded: "2026-06-06"
 brandName: DevDocs
 brandDomain: github.com
 repoUrl: "https://github.com/cyberagiinc/DevDocs"
-documentationUrl: "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docs/mcp/MCP_DOCKER_SETUP.md"
+documentationUrl: "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docs/mcp/MCP_DOCKER_SETUP.md"
 installable: true
-installCommand: "Clone the DevDocs repository, run the Docker start script, then configure Claude to call the `devdocs-mcp` container with `docker exec -i`."
+installCommand: "Clone the DevDocs repository, check out reviewed commit 9845479d0aeb7523abaab85723d0dfcf832fe1d3, run the Docker start script from that pinned revision, then configure Claude to call the `devdocs-mcp` container with `docker exec -i`."
 usageSnippet: "Start the DevDocs Docker stack, point Claude at the `fast_markdown_mcp.server` command inside `devdocs-mcp`, and ask it to list or search the crawled Markdown files."
 copySnippet: |-
   {
@@ -66,12 +66,12 @@ estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:
   - Docker and Docker Compose available on the host that will run DevDocs.
-  - Git access to clone the DevDocs repository and run the Docker startup script.
+  - Git access to clone the DevDocs repository and check out reviewed commit `9845479d0aeb7523abaab85723d0dfcf832fe1d3` before running the Docker startup script.
   - MCP client support for launching stdio servers through `docker exec -i`.
   - Documentation URLs reviewed for crawling permissions, robots rules, and terms of service.
   - Storage, logs, crawl results, and Markdown output directories scoped to documentation you are authorized to crawl and query.
 safetyNotes:
-  - DevDocs runs a multi-container Docker stack with frontend, backend, MCP, and Crawl4AI services.
+  - DevDocs runs a multi-container Docker stack with frontend, backend, MCP, and Crawl4AI services; use the reviewed commit below instead of executing a moving branch tip.
   - The crawler can fetch and process external websites, so review crawl targets, rate limits, robots rules, and site terms before crawling.
   - The backend and crawler use a Crawl4AI API token; replace the demo token before shared or production use.
   - The MCP container mounts generated Markdown and logs, and its tools can read, search, sync, and expose that content to the MCP client.
@@ -86,14 +86,16 @@ disclosure: >-
   Apache-2.0-licensed open-source project. The entry focuses on the repository's
   Docker-backed Fast Markdown MCP server and documentation-crawling workflow.
 sourceUrls:
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/README.md"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/LICENSE"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/claude_mcp_settings.json"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docker/dockerfiles/Dockerfile.mcp"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docker/compose/docker-compose.yml"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/pyproject.toml"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/src/fast_markdown_mcp/server.py"
-  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/src/fast_markdown_mcp/document_structure.py"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/README.md"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/LICENSE"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/claude_mcp_settings.json"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker/dockerfiles/Dockerfile.mcp"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker/compose/docker-compose.yml"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker-start.sh"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/scripts/docker/docker-start.sh"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/pyproject.toml"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/src/fast_markdown_mcp/server.py"
+  - "https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/src/fast_markdown_mcp/document_structure.py"
 tags:
   - documentation
   - crawler
@@ -127,20 +129,22 @@ rather than a public network endpoint.
 ## Source Review
 
 - https://github.com/cyberagiinc/DevDocs
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docs/mcp/MCP_DOCKER_SETUP.md
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/README.md
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/LICENSE
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/claude_mcp_settings.json
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docker/dockerfiles/Dockerfile.mcp
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/docker/compose/docker-compose.yml
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/pyproject.toml
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/src/fast_markdown_mcp/server.py
-- https://raw.githubusercontent.com/cyberagiinc/DevDocs/feature-main/fast-markdown-mcp/src/fast_markdown_mcp/document_structure.py
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docs/mcp/MCP_DOCKER_SETUP.md
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/README.md
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/LICENSE
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/claude_mcp_settings.json
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker/dockerfiles/Dockerfile.mcp
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker/compose/docker-compose.yml
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/docker-start.sh
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/scripts/docker/docker-start.sh
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/pyproject.toml
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/src/fast_markdown_mcp/server.py
+- https://raw.githubusercontent.com/cyberagiinc/DevDocs/9845479d0aeb7523abaab85723d0dfcf832fe1d3/fast-markdown-mcp/src/fast_markdown_mcp/document_structure.py
 
-These sources were reviewed on **2026-06-06**. Prefer the live repository, MCP
-Docker setup guide, Claude MCP settings, Dockerfiles, Compose file, Python
-package metadata, MCP server implementation, and document-structure parser for
-current behavior.
+These sources were reviewed on **2026-06-06** at commit
+`9845479d0aeb7523abaab85723d0dfcf832fe1d3`. Use the pinned commit for the
+Docker startup script and MCP setup reviewed here; inspect upstream changes
+before running newer branch tips.
 
 ## Features
 
@@ -158,11 +162,13 @@ current behavior.
 
 ## Installation
 
-Clone the repository and start the Docker stack using the upstream scripts:
+Clone the repository, check out the reviewed commit, and start the Docker stack
+using the pinned upstream scripts:
 
 ```bash
 git clone https://github.com/cyberagiinc/DevDocs.git
 cd DevDocs
+git checkout 9845479d0aeb7523abaab85723d0dfcf832fe1d3
 ./docker-start.sh
 ```
 

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -37,6 +37,7 @@ const ARCHIVE_PACKAGE_EXTENSIONS = new Set([
 
 const SAFETY_NOTE_REQUIRED_FLAGS = new Set([
   "unsafe_install_pipeline",
+  "mutable_script_install_source",
   "financial_or_identity_sensitive",
   "external_write_capability",
   "destructive_actions",
@@ -63,6 +64,9 @@ const CREDENTIAL_THEFT_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
 const ABUSE_ENABLEMENT_PATTERN =
   /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
+const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
+const LOCAL_SCRIPT_REFERENCE_PATTERN =
+  /(?:^|[\s`;&|])(?:(?:bash|sh|zsh|pwsh|powershell)\s+)?(?:\.{1,2}\/|[\w.-]+\/)?[\w./-]*(?:install|setup|start|bootstrap|init)[\w.-]*\.(?:sh|bash|zsh|ps1)\b/im;
 
 const SAFE_MATTER_OPTIONS = {
   engines: {
@@ -347,6 +351,61 @@ function collectUrls(text) {
   return [...matches].map((match) => match[0]).slice(0, 50);
 }
 
+function githubSourceRef(value) {
+  const raw = normalizeText(value);
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    const parts = url.pathname.split("/").filter(Boolean);
+    if (url.protocol !== "https:") return null;
+    if (url.hostname.toLowerCase() === "raw.githubusercontent.com") {
+      if (parts.length < 4) return null;
+      return {
+        ref: parts[2],
+        path: parts.slice(3).join("/"),
+      };
+    }
+    if (
+      url.hostname.toLowerCase() === "github.com" &&
+      parts.length >= 5 &&
+      (parts[2] === "blob" || parts[2] === "raw")
+    ) {
+      return {
+        ref: parts[3],
+        path: parts.slice(4).join("/"),
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function isScriptPath(value) {
+  return /\.(?:sh|bash|zsh|ps1)$/i.test(normalizeText(value));
+}
+
+function isImmutableGithubScriptSourceUrl(value) {
+  const source = githubSourceRef(value);
+  return Boolean(
+    source &&
+    FULL_COMMIT_SHA_PATTERN.test(source.ref) &&
+    isScriptPath(source.path),
+  );
+}
+
+function isMutableGithubSourceUrl(value) {
+  const source = githubSourceRef(value);
+  return Boolean(source && !FULL_COMMIT_SHA_PATTERN.test(source.ref));
+}
+
+function referencesClonedLocalScriptInstall(value) {
+  const text = normalizeText(value);
+  return (
+    /\bgit\s+clone\b/i.test(text) && LOCAL_SCRIPT_REFERENCE_PATTERN.test(text)
+  );
+}
+
 function sameGitHubLogin(value, login) {
   const expected = normalizeText(login).replace(/^@/, "").toLowerCase();
   if (!expected) return false;
@@ -404,6 +463,7 @@ function frontmatterFields(data = {}, category = "") {
     slug: normalizeText(data.slug),
     github_url: normalizeText(data.repoUrl),
     source_url: normalizeText(data.sourceUrl),
+    source_urls: stringList(data.sourceUrls).join("\n"),
     website_url: normalizeText(data.websiteUrl),
     docs_url: normalizeText(data.documentationUrl || data.projectUrl),
     download_url: normalizeText(data.downloadUrl),
@@ -558,6 +618,7 @@ function addContentRiskSignals(report, fields, content) {
   const text = [
     fields.github_url,
     fields.source_url,
+    fields.source_urls,
     fields.website_url,
     fields.docs_url,
     fields.download_url,
@@ -577,6 +638,7 @@ function addContentRiskSignals(report, fields, content) {
   const submittedSourceUrls = [
     fields.github_url,
     fields.source_url,
+    ...stringList(fields.source_urls),
     fields.website_url,
     fields.docs_url,
     fields.download_url,
@@ -665,6 +727,22 @@ function addContentRiskSignals(report, fields, content) {
       "critical",
       "unsafe_install_pipeline",
       "Install instructions include a destructive or remote-code execution pipeline",
+    );
+  }
+
+  if (
+    referencesClonedLocalScriptInstall(installText) &&
+    !submittedSourceUrls.some(isImmutableGithubScriptSourceUrl)
+  ) {
+    const mutableSources = submittedSourceUrls.filter(isMutableGithubSourceUrl);
+    addFlag(
+      report,
+      "critical",
+      "mutable_script_install_source",
+      "Install instructions run a cloned local installer script without immutable script source evidence",
+      mutableSources.length
+        ? `Mutable GitHub source refs: ${mutableSources.slice(0, 5).join(", ")}`
+        : "Add a raw GitHub URL pinned to a full commit SHA for the executed installer script, or replace the script execution with reviewed commands.",
     );
   }
 
@@ -933,6 +1011,8 @@ function directContentRequestChangesReasons(report = {}) {
       "Install or usage instructions fetch executable content from a non-HTTPS URL.",
     unsafe_install_pipeline:
       "Install instructions include a destructive or remote-code execution pipeline.",
+    mutable_script_install_source:
+      "Install instructions run a cloned local installer script without immutable script source evidence.",
     embedded_secret:
       "Submission appears to include a real secret or API token.",
     malicious_data_theft_capability:

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -109,6 +109,101 @@ Example body.
     );
   });
 
+  it("blocks cloned local scripts without immutable script source evidence", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example MCP
+category: mcp
+description: Example MCP server with a Docker startup script.
+repoUrl: https://github.com/example/example-mcp
+documentationUrl: https://raw.githubusercontent.com/example/example-mcp/main/docs/setup.md
+installCommand: Clone the repository, then run ./docker-start.sh.
+safetyNotes:
+  - Runs a local Docker stack from the reviewed source.
+sourceUrls:
+  - https://raw.githubusercontent.com/example/example-mcp/main/README.md
+  - https://raw.githubusercontent.com/example/example-mcp/main/docker-compose.yml
+---
+
+Clone the repository and start the stack:
+
+\`\`\`bash
+git clone https://github.com/example/example-mcp.git
+cd example-mcp
+./docker-start.sh
+\`\`\`
+`;
+
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(false);
+    expect(output.reviewFlags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "mutable_script_install_source" }),
+      ]),
+    );
+    expect(output.failures.join("\n")).toContain(
+      "cloned local installer script without immutable script source evidence",
+    );
+  });
+
+  it("allows cloned local scripts with immutable script source evidence", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const revision = "9845479d0aeb7523abaab85723d0dfcf832fe1d3";
+    const content = `---
+title: Example MCP
+category: mcp
+description: Example MCP server with a pinned Docker startup script.
+repoUrl: https://github.com/example/example-mcp
+documentationUrl: https://raw.githubusercontent.com/example/example-mcp/${revision}/docs/setup.md
+installCommand: Clone the repository, check out reviewed commit ${revision}, then run ./docker-start.sh.
+safetyNotes:
+  - Runs a local Docker stack from the reviewed commit.
+sourceUrls:
+  - https://raw.githubusercontent.com/example/example-mcp/${revision}/README.md
+  - https://raw.githubusercontent.com/example/example-mcp/${revision}/docker-compose.yml
+  - https://raw.githubusercontent.com/example/example-mcp/${revision}/docker-start.sh
+---
+
+Clone the repository and start the stack:
+
+\`\`\`bash
+git clone https://github.com/example/example-mcp.git
+cd example-mcp
+git checkout ${revision}
+./docker-start.sh
+\`\`\`
+`;
+
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "mutable_script_install_source" }),
+      ]),
+    );
+  });
+
   it("allows maintainer-owned content to reference HeyClaude-hosted downloads when disclosures are present", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
## Summary
- Pin the DevDocs MCP entry to reviewed upstream commit `9845479d0aeb7523abaab85723d0dfcf832fe1d3` before users run the Docker startup script.
- Add immutable raw source evidence for the executed `docker-start.sh` scripts.
- Add content-policy coverage for cloned local shell scripts that lack immutable script source evidence.

## What changed
- Updated `content/mcp/devdocs-mcp-server.mdx` to use commit-pinned source and documentation URLs.
- Updated the install instructions to check out the reviewed commit before running `./docker-start.sh`.
- Added a `mutable_script_install_source` content-policy finding and regression tests.

## Why
- Refs #2016.
- The previous one-file PR was closed by the direct content gate because protected source metadata changed. That closure is correct for normal contributor content edits, but this is a maintainer/security fix with validator coverage.
- The old entry presented a mutable upstream branch script as reviewed install guidance.

## Validation
- `pnpm exec vitest run tests/submission-workflows.test.ts tests/content-policy-validation.test.ts`
- `node scripts/validate-content.mjs --category=mcp`
- `pnpm validate:content:strict -- --category=mcp`
- `pnpm exec prettier --check scripts/ci/validate-content-policy.mjs tests/content-policy-validation.test.ts content/mcp/devdocs-mcp-server.mdx`
- `git diff --check`
- Verified all pinned DevDocs raw source URLs returned HTTP 200.

## Notes
- No visual impact.
- No generated registry artifacts are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safety validation requiring disclosure of mutable (unpinned) installer script sources.
  * Installation instructions are now checked for locally cloned scripts and must reference immutable, commit-pinned GitHub sources.

* **Tests**
  * Added test coverage for script installation safety policy validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->