### PR TITLE
test(raycast): make feed fixture portable

### DIFF
--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -221,10 +221,16 @@ describe("Raycast feed helpers", () => {
       "data",
       "raycast-index.json",
     );
-    const rawFeed = JSON.parse(fs.readFileSync(feedPath, "utf8")) as {
+    const raw = fs.existsSync(feedPath)
+      ? fs.readFileSync(feedPath, "utf8")
+      : JSON.stringify({
+          generatedAt: "2026-04-28T00:00:00.000Z",
+          entries: [sampleEntry],
+        });
+    const rawFeed = JSON.parse(raw) as {
       entries?: unknown[];
     };
-    const parsed = parseFeed(fs.readFileSync(feedPath, "utf8"));
+    const parsed = parseFeed(raw);
 
     assert.equal(parsed.entries.length, rawFeed.entries?.length);
     assert.ok(parsed.entries.length > 0);


### PR DESCRIPTION
## Summary
- make the Raycast feed safety test work when the generated monorepo feed fixture is unavailable

## Why
- the same Raycast extension tests need to run both in this repo and in the upstream `raycast/extensions` package shape
- the fallback keeps the test focused on parser/UI-string safety instead of depending on generated registry artifacts

## Validation
- `npm test` from `integrations/raycast`
- `pnpm validate:raycast-feed`
- `git diff --check`