### PR TITLE
fix(raycast): tolerate malformed search rows

### DIFF
--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -151,6 +151,7 @@ export type ParsedRegistrySearch = {
   limit: number;
   offset: number;
   nextOffset: number | null;
+  skippedMalformedEntries?: number;
 };
 
 export type RegistrySearchUrlOptions = {
@@ -555,22 +556,32 @@ export function parseRegistrySearch(value: string): ParsedRegistrySearch {
     throw new Error("Registry search payload was malformed");
   }
 
+  const total = readRequiredNumber(parsed.total, "total");
+  const limit = readRequiredNumber(parsed.limit, "limit");
+  const offset = readRequiredNumber(parsed.offset, "offset");
+  const nextOffset = readRequiredNextOffset(parsed.nextOffset);
   const normalizedEntries = parsed.results.map(normalizeRegistrySearchEntry);
   const entries = normalizedEntries.filter(
     (entry): entry is RaycastEntry => entry !== null,
   );
-  if (entries.length !== normalizedEntries.length) {
-    throw new Error("Registry search payload contained malformed entries");
+  const skippedMalformedEntries = normalizedEntries.length - entries.length;
+  if (skippedMalformedEntries > 0) {
+    console.warn(
+      `Skipped ${skippedMalformedEntries} malformed registry search result${
+        skippedMalformedEntries === 1 ? "" : "s"
+      }.`,
+    );
   }
 
   return {
     entries,
     query: optionalString(parsed.query),
     category: optionalString(parsed.category) || "all",
-    total: readRequiredNumber(parsed.total, "total"),
-    limit: readRequiredNumber(parsed.limit, "limit"),
-    offset: readRequiredNumber(parsed.offset, "offset"),
-    nextOffset: readRequiredNextOffset(parsed.nextOffset),
+    total,
+    limit,
+    offset,
+    nextOffset,
+    skippedMalformedEntries: skippedMalformedEntries || undefined,
   };
 }
 

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -41,6 +41,8 @@ import { entryDetailMetadata, entrySnippetKeyword } from "./raycast-ui";
 
 const cache = new Cache();
 const SEARCH_PAGE_SIZE = 20;
+const SERVER_SEARCH_UNAVAILABLE_MESSAGE =
+  "Search is temporarily unavailable. Try again shortly.";
 
 type RegistryCommandOptions = {
   fixedCategory?: string;
@@ -478,7 +480,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
       filter === "favorites"
         ? "Add favorites from any category to keep them here."
         : serverSearch.error && canUseServerSearch
-          ? serverSearch.error
+          ? SERVER_SEARCH_UNAVAILABLE_MESSAGE
           : "Try another query or filter.";
 
     return (

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -108,6 +108,31 @@ const sampleEntry: RaycastEntry = {
   verificationStatus: "validated",
 };
 
+function sampleSearchResult(overrides: Record<string, unknown> = {}) {
+  return {
+    category: sampleEntry.category,
+    slug: sampleEntry.slug,
+    title: sampleEntry.title,
+    description: sampleEntry.description,
+    tags: sampleEntry.tags,
+    author: sampleEntry.author,
+    brandName: sampleEntry.brandName,
+    brandDomain: sampleEntry.brandDomain,
+    brandIconUrl: sampleEntry.brandIconUrl,
+    canonicalUrl: sampleEntry.webUrl,
+    repoUrl: sampleEntry.repoUrl,
+    documentationUrl: sampleEntry.documentationUrl,
+    llmsUrl: sampleEntry.llmsUrl,
+    apiUrl: sampleEntry.apiUrl,
+    downloadTrust: sampleEntry.downloadTrust,
+    verificationStatus: sampleEntry.verificationStatus,
+    platforms: ["claude-code"],
+    searchScore: 137,
+    searchReasons: ["title phrase", "source-backed"],
+    ...overrides,
+  };
+}
+
 const sampleJob: RaycastJob = {
   slug: "ai-systems-engineer",
   title: "AI Systems Engineer",
@@ -157,6 +182,19 @@ function response(body: unknown, init: ResponseInit = {}) {
     headers: { "content-type": "application/json" },
     ...init,
   });
+}
+
+async function captureConsoleWarnings<T>(callback: () => T | Promise<T>) {
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (...messages: unknown[]) => {
+    warnings.push(messages.map(String).join(" "));
+  };
+  try {
+    return { value: await callback(), warnings };
+  } finally {
+    console.warn = originalWarn;
+  }
 }
 
 function readSourceFiles(dir: string): string[] {
@@ -272,29 +310,7 @@ describe("Raycast feed helpers", () => {
         limit: 1,
         offset: 0,
         nextOffset: 1,
-        results: [
-          {
-            category: sampleEntry.category,
-            slug: sampleEntry.slug,
-            title: sampleEntry.title,
-            description: sampleEntry.description,
-            tags: sampleEntry.tags,
-            author: sampleEntry.author,
-            brandName: sampleEntry.brandName,
-            brandDomain: sampleEntry.brandDomain,
-            brandIconUrl: sampleEntry.brandIconUrl,
-            canonicalUrl: sampleEntry.webUrl,
-            repoUrl: sampleEntry.repoUrl,
-            documentationUrl: sampleEntry.documentationUrl,
-            llmsUrl: sampleEntry.llmsUrl,
-            apiUrl: sampleEntry.apiUrl,
-            downloadTrust: sampleEntry.downloadTrust,
-            verificationStatus: sampleEntry.verificationStatus,
-            platforms: ["claude-code"],
-            searchScore: 137,
-            searchReasons: ["title phrase", "source-backed"],
-          },
-        ],
+        results: [sampleSearchResult()],
       }),
     );
 
@@ -310,10 +326,33 @@ describe("Raycast feed helpers", () => {
     assert.match(parsed.entries[0].copyText, /https:\/\/heyclau.de\/mcp/);
     assert.match(parsed.entries[0].detailMarkdown, /## Source/);
     assert.deepEqual(parsed.entries[0].platformCompatibility, ["claude-code"]);
+    assert.equal(parsed.skippedMalformedEntries, undefined);
+  });
+
+  it("skips malformed registry search rows without discarding valid results", async () => {
+    const { value: parsed, warnings } = await captureConsoleWarnings(() =>
+      parseRegistrySearch(
+        JSON.stringify({
+          schemaVersion: 1,
+          query: "context",
+          category: "mcp",
+          total: 2,
+          limit: 2,
+          offset: 0,
+          nextOffset: null,
+          results: [sampleSearchResult(), { slug: "bad" }],
+        }),
+      ),
+    );
+
+    assert.equal(parsed.entries.length, 1);
+    assert.equal(parsed.entries[0].slug, sampleEntry.slug);
+    assert.equal(parsed.skippedMalformedEntries, 1);
+    assert.match(warnings[0], /Skipped 1 malformed registry search result/);
 
     assert.throws(
       () => parseRegistrySearch(JSON.stringify({ results: [{ slug: "bad" }] })),
-      /malformed entries/,
+      /missing numeric total/,
     );
   });
 
@@ -826,6 +865,23 @@ describe("Raycast feed helpers", () => {
     assert.match(jobsSource, /Action\.CreateQuicklink/);
   });
 
+  it("keeps server search empty states user friendly", () => {
+    const registrySource = fs.readFileSync(
+      path.join(process.cwd(), "src", "registry-command.tsx"),
+      "utf8",
+    );
+
+    assert.match(
+      registrySource,
+      /Search is temporarily unavailable\. Try again shortly\./,
+    );
+    assert.match(
+      registrySource,
+      /\?\s*SERVER_SEARCH_UNAVAILABLE_MESSAGE\s*:/,
+    );
+    assert.doesNotMatch(registrySource, /\?\s*serverSearch\.error\s*:/);
+  });
+
   it("keeps the discovery Open Source action tied to repoUrl only", () => {
     const discoverySource = fs.readFileSync(
       path.join(process.cwd(), "src", "discovery-command.tsx"),
@@ -1078,13 +1134,22 @@ describe("Raycast feed helpers", () => {
     assert.equal(search.entries.length, 1);
     assert.equal(search.nextOffset, 20);
 
-    await assert.rejects(
+    const { value: tolerantSearch, warnings } = await captureConsoleWarnings(() =>
       fetchRegistrySearch({
         query: "context",
-        fetchFn: async () => response({ results: [{ slug: "broken" }] }),
+        fetchFn: async () =>
+          response({
+            total: 2,
+            limit: 20,
+            offset: 0,
+            nextOffset: null,
+            results: [sampleSearchResult(), { slug: "broken" }],
+          }),
       }),
-      /malformed entries/,
     );
+    assert.equal(tolerantSearch.entries.length, 1);
+    assert.equal(tolerantSearch.skippedMalformedEntries, 1);
+    assert.match(warnings[0], /Skipped 1 malformed registry search result/);
 
     await assert.rejects(
       fetchRegistrySearch({


### PR DESCRIPTION
## Summary
- skip malformed server-search rows instead of failing the full Raycast search page
- keep malformed-envelope pagination errors strict so paging contracts remain valid
- replace raw server-search errors in empty-state copy with user-friendly fallback text

## What changed
- adds a skipped-row count to parsed registry search responses
- logs a warning when otherwise valid search pages contain malformed rows
- adds regressions for tolerant row parsing, fetch behavior, and empty-state copy

## Why
- Greptile flagged that one bad server result could discard all valid results in a page
- Greptile also flagged that raw server errors were shown directly to Raycast users

## Validation
- `cd integrations/raycast && npm test`
- `cd integrations/raycast && npm run lint`
- `cd integrations/raycast && npm run build`
- `pnpm validate:raycast-feed`
- `git diff --check`