### PR TITLE
fix(submissions): retry transient merge failures

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -28,6 +28,7 @@ import {
   createUserForkContentPr,
   exchangeGitHubUserCode,
   getCommitValidationState,
+  GitHubApiError,
   githubRetryDelaySeconds,
   getInstallationToken,
   getPullRequest,
@@ -1824,6 +1825,13 @@ async function ignoreOutOfScopeReviewTarget(params: {
 }
 
 function isRetryableMergeError(error: unknown) {
+  if (isTimeoutError(error) || isGitHubRateLimitError(error)) return true;
+  if (error instanceof GitHubApiError) {
+    return (
+      error.status === 429 ||
+      (error.status >= 500 && error.status <= 599)
+    );
+  }
   const message = error instanceof Error ? error.message : String(error || "");
   return /required status check|required approving review|not mergeable|merge conflict|base branch was modified|head branch was modified|sha does not match|review_required|status check/i.test(
     message,
@@ -4178,10 +4186,10 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               decision.summary.trim(),
               "",
               "Merge Result:",
-              `- Accepted by private review, but GitHub is not merge-ready yet: ${
+              `- Accepted by private review; merge retry pending after GitHub returned: ${
                 error instanceof Error ? error.message : "unknown merge state"
               }`,
-              "- The gate will retry after branch protection and required review state settle.",
+              "- The gate will retry after transient GitHub merge state settles.",
             ].join("\n");
             await upsertPrState(env.SUBMISSION_GATE_DB, {
               repo: target.repoFullName,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1905,6 +1905,35 @@ ${urls}
     );
   });
 
+  it("keeps transient accepted-merge failures pending for retry", () => {
+    const source = readWorkerSource();
+    const classifier =
+      source.match(
+        /function isRetryableMergeError[\s\S]*?\nfunction importContentPathParts/,
+      )?.[0] || "";
+    const retryBranch =
+      source.match(
+        /if \(isRetryableMergeError\(error\)\) \{[\s\S]*?throw new SubmissionMergePendingError\(pendingSummary\);/,
+      )?.[0] || "";
+
+    expect(classifier).toContain("isTimeoutError(error)");
+    expect(classifier).toContain("isGitHubRateLimitError(error)");
+    expect(classifier).toContain("error instanceof GitHubApiError");
+    expect(classifier).toContain("error.status === 429");
+    expect(classifier).toContain("error.status >= 500");
+    expect(classifier).toContain("error.status <= 599");
+    expect(classifier).toContain("required approving review");
+    expect(classifier).toContain("merge conflict");
+    expect(retryBranch).toContain('status: "merge_pending"');
+    expect(retryBranch).toContain('decision: "merge_pending"');
+    expect(retryBranch).toContain("merge retry pending");
+    expect(retryBranch).toContain(
+      "The gate will retry after transient GitHub merge state settles.",
+    );
+    expect(retryBranch).not.toContain('status: "manual"');
+    expect(retryBranch).not.toContain("submission-manual-review");
+  });
+
   it("closes direct content PRs when required validation fails", () => {
     const source = readWorkerSource();
     const validationBlock =


### PR DESCRIPTION
## Summary
- classify direct merge timeout/abort failures as retryable merge-pending state
- keep GitHub rate limits, 429s, and GitHub 5xx merge failures out of terminal manual review
- update the accepted-but-not-merged comment wording to say merge retry is pending

## What changed
- expands `isRetryableMergeError` to use the existing timeout helper and GitHub API error metadata
- preserves existing branch-protection/review/conflict retry behavior
- adds regression coverage that transient accepted-merge failures stay `merge_pending`

## Why
- accepted content PRs should not land in `submission-manual-review` when GitHub merge/review APIs time out or return transient service/rate-limit errors

## Validation
- `pnpm exec vitest run tests/submission-gate-worker.test.ts`
- `pnpm test:submission-pr-first`
- `pnpm validate:packages`
- `pnpm build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of transient merge failures caused by network timeouts, rate limiting, and temporary GitHub service issues
  * Enhanced retry logic to properly recognize temporary GitHub API errors and server issues as retryable conditions that trigger automatic retries
  * Updated retry messaging to provide clearer descriptions of transient merge states and automatic retry behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->