### PR TITLE
fix(submissions): honor GitHub merge retry backoff

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -151,9 +151,12 @@ class SubmissionLockBusyError extends Error {
 }
 
 class SubmissionMergePendingError extends Error {
-  constructor(message: string) {
+  retryDelaySeconds: number;
+
+  constructor(message: string, retryDelaySeconds = MERGE_RETRY_SECONDS) {
     super(message);
     this.name = "SubmissionMergePendingError";
+    this.retryDelaySeconds = retryDelaySeconds;
   }
 }
 
@@ -483,8 +486,22 @@ function retryDelayForError(error: unknown) {
   return RETRYABLE_ERROR_SECONDS;
 }
 
+function retryDelayForMergeError(error: unknown) {
+  if (isGitHubRateLimitError(error)) {
+    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
+  }
+  if (error instanceof GitHubApiError && error.status === 429) {
+    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
+  }
+  return MERGE_RETRY_SECONDS;
+}
+
 function nextReviewForError(error: unknown) {
   return isoAfter(retryDelayForError(error));
+}
+
+function nextReviewForMergeError(error: unknown) {
+  return isoAfter(retryDelayForMergeError(error));
 }
 
 function isTimeoutError(error: unknown) {
@@ -4182,6 +4199,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           });
         } catch (error) {
           if (isRetryableMergeError(error)) {
+            const retryDelaySeconds = retryDelayForMergeError(error);
             const pendingSummary = [
               decision.summary.trim(),
               "",
@@ -4202,7 +4220,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               status: "merge_pending",
               verdict: "merge",
               verdictSummary: pendingSummary,
-              nextReviewAt: nextReviewForStatus("merge_pending"),
+              nextReviewAt: nextReviewForMergeError(error),
               lastError: error instanceof Error ? error.message : "unknown",
               ...decisionMetadata(acceptedDecision, acceptedReport),
             });
@@ -4213,7 +4231,10 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               decision: "merge_pending",
               summary: pendingSummary,
             });
-            throw new SubmissionMergePendingError(pendingSummary);
+            throw new SubmissionMergePendingError(
+              pendingSummary,
+              retryDelaySeconds,
+            );
           }
           const manualDecision = defaultManualDecision(
             `Private review accepted this PR, but direct merge failed: ${
@@ -4968,7 +4989,7 @@ export default {
           console.debug("submission merge pending, retrying", {
             targetKey: body.targetKey,
           });
-          message.retry({ delaySeconds: 30 });
+          message.retry({ delaySeconds: error.retryDelaySeconds });
         } else {
           await recordRetryableQueueError(env, body, error);
           console.error("submission gate queue failure", error);

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1894,7 +1894,9 @@ ${urls}
     expect(source).toContain("SubmissionMergePendingError");
     expect(source).toContain('status: "merge_pending"');
     expect(source).toContain('decision: "merge_pending"');
-    expect(source).toContain("message.retry({ delaySeconds: 30 })");
+    expect(source).toContain(
+      "message.retry({ delaySeconds: error.retryDelaySeconds })",
+    );
     expect(source).toContain("AUTO_MERGE_CONFIDENCE_FLOOR");
     expect(source).toContain("enforceAutoMergeConfidenceFloor(");
     expect(source.indexOf("normalizeOneShotDecision(decision)")).toBeLessThan(
@@ -1913,7 +1915,7 @@ ${urls}
       )?.[0] || "";
     const retryBranch =
       source.match(
-        /if \(isRetryableMergeError\(error\)\) \{[\s\S]*?throw new SubmissionMergePendingError\(pendingSummary\);/,
+        /if \(isRetryableMergeError\(error\)\) \{[\s\S]*?throw new SubmissionMergePendingError\([\s\S]*?retryDelaySeconds,[\s\S]*?\);/,
       )?.[0] || "";
 
     expect(classifier).toContain("isTimeoutError(error)");
@@ -1927,6 +1929,8 @@ ${urls}
     expect(retryBranch).toContain('status: "merge_pending"');
     expect(retryBranch).toContain('decision: "merge_pending"');
     expect(retryBranch).toContain("merge retry pending");
+    expect(retryBranch).toContain("retryDelayForMergeError(error)");
+    expect(retryBranch).toContain("nextReviewForMergeError(error)");
     expect(retryBranch).toContain(
       "The gate will retry after transient GitHub merge state settles.",
     );
@@ -2143,9 +2147,14 @@ ${urls}
     expect(source).toContain("function retryDelayForError");
     expect(source).toContain("isGitHubRateLimitError(error)");
     expect(source).toContain("githubRetryDelaySeconds(error");
+    expect(source).toContain("retryDelayForMergeError(error)");
     expect(source).toContain("nextReviewForError(error)");
+    expect(source).toContain("nextReviewForMergeError(error)");
     expect(source).toContain(
       "message.retry({ delaySeconds: retryDelayForError(error) })",
+    );
+    expect(source).toContain(
+      "message.retry({ delaySeconds: error.retryDelaySeconds })",
     );
     expect(source).toContain("scheduled(_controller, env, ctx)");
     expect(source).toContain("ctx.waitUntil(sweepSubmissionQueue(env))");


### PR DESCRIPTION
### Motivation
- Retryable accepted-merge failures were being routed to a `merge_pending` path that always scheduled retries after a fixed 30 seconds, which ignored GitHub `Retry-After` and `x-ratelimit-reset` metadata and risked repeatedly re-running the expensive merge flow under 429/secondary rate-limit conditions. 
- The change preserves the existing retryable-merge behavior but must respect GitHub-provided backoff so the worker and GitHub API quota are not overconsumed.

### Description
- Add `retryDelaySeconds` to `SubmissionMergePendingError` and compute a merge-specific delay via `retryDelayForMergeError` that uses `githubRetryDelaySeconds` for `isGitHubRateLimitError` and `429` `GitHubApiError` responses. 
- Persist `nextReviewAt` for `merge_pending` using `nextReviewForMergeError(error)` (GitHub-aware delay) instead of the fixed `MERGE_RETRY_SECONDS` and throw `SubmissionMergePendingError` with the computed delay. 
- Make the queue handler retry `SubmissionMergePendingError` using the error’s `retryDelaySeconds` rather than a hard-coded 30 seconds. 
- Update `tests/submission-gate-worker.test.ts` assertions to cover the new merge retry helpers and the queue retry behavior.

### Testing
- Ran unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and all tests passed (`89 passed`).
- Ran `git diff --check` and `pnpm validate:openapi` (openapi generation check) with no errors. 
- Ran `pnpm validate:packages` and package validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a251c419874832c87d5b05202adcf6f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced merge operation retry logic with dynamic delay calculation based on error conditions, including specialized handling for GitHub rate-limiting responses.

* **Tests**
  * Updated test assertions to validate new retry delay calculations and error metadata propagation through the worker and queue systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->