### PR TITLE
chore(mcp): enforce trust coverage gate

### DIFF
--- a/content/mcp/airtable-mcp-server.mdx
+++ b/content/mcp/airtable-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Airtable MCP Server for Claude
 slug: airtable-mcp-server
+safetyNotes:
+  - Restrict the Airtable API key to the bases and write scopes Claude is allowed to use before enabling record or schema changes.
+privacyNotes:
+  - Airtable records, field values, attachments, and base metadata may be sent through the MCP client and model context.
 category: mcp
 description: >-
   Read and write records, manage bases and tables in Airtable directly from
@@ -13,6 +17,7 @@ seoDescription: >-
   Read and write records, manage bases and tables in Airtable directly from
   Claude. Discover tools for AI development.
 author: domdomegg
+authorProfileUrl: "https://github.com/domdomegg"
 dateAdded: "2025-09-18"
 repoUrl: "https://github.com/domdomegg/airtable-mcp-server"
 documentationUrl: "https://github.com/domdomegg/airtable-mcp-server"

--- a/content/mcp/asana-mcp-server.mdx
+++ b/content/mcp/asana-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Asana MCP Server for Claude
 slug: asana-mcp-server
+safetyNotes:
+  - Use a least-privilege Asana token and test task or project writes in a non-critical workspace before connecting production workflows.
+privacyNotes:
+  - Asana task text, project metadata, comments, assignees, due dates, and workspace details may be sent through model context.
 category: mcp
 description: Interact with Asana workspaces to manage projects and tasks
 cardDescription: Interact with Asana workspaces to manage projects and tasks
@@ -9,6 +13,7 @@ seoDescription: >-
   Interact with Asana workspaces to manage projects and tasks Discover tools for
   AI development.
 author: Asana
+authorProfileUrl: "https://asana.com/"
 dateAdded: "2025-09-18"
 brandName: Asana
 brandDomain: asana.com

--- a/content/mcp/aws-services-mcp-server.mdx
+++ b/content/mcp/aws-services-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: AWS Services MCP Server - MCP Servers
 slug: aws-services-mcp-server
+safetyNotes:
+  - Scope AWS credentials to the intended accounts, regions, and services because infrastructure actions can affect production resources.
+privacyNotes:
+  - AWS resource names, configuration, metrics, logs, ARNs, and account metadata may be exposed through tool calls and responses.
 category: mcp
 description: >-
   Comprehensive AWS cloud services integration for infrastructure management,
@@ -13,6 +17,7 @@ seoDescription: >-
   Comprehensive AWS cloud services integration for infrastructure management,
   deployment, and monitoring Discover tools for AI development.
 author: AWS Labs
+authorProfileUrl: "https://github.com/awslabs"
 dateAdded: "2025-09-16"
 repoUrl: "https://github.com/awslabs/mcp"
 documentationUrl: "https://github.com/awslabs/mcp"

--- a/content/mcp/box-mcp-server.mdx
+++ b/content/mcp/box-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Box MCP Server for Claude
 slug: box-mcp-server
+safetyNotes:
+  - Restrict Box app permissions and shared folders, and review write or sharing actions before using the server with sensitive content.
+privacyNotes:
+  - Box file contents, names, comments, folder metadata, and user or workspace details may be sent through model context.
 category: mcp
 description: "Access enterprise content, analyze unstructured data, and automate workflows"
 cardDescription: "Access enterprise content, analyze unstructured data, and automate workflows"
@@ -9,6 +13,7 @@ seoDescription: >-
   Access enterprise content, analyze unstructured data, and automate workflows
   Discover tools for AI development.
 author: Box
+authorProfileUrl: "https://www.box.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://box.dev/guides/box-mcp/remote/"
 downloadUrl: /downloads/mcp/box-mcp-server.mcpb

--- a/content/mcp/canva-mcp-server.mdx
+++ b/content/mcp/canva-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Canva MCP Server for Claude
 slug: canva-mcp-server
+safetyNotes:
+  - Limit access to the intended Canva team or projects and review generated or modified designs before publishing or sharing them.
+privacyNotes:
+  - Design contents, uploaded media, brand assets, templates, and Canva account metadata may be sent to the MCP client and model.
 category: mcp
 description: "Browse, summarize, and generate Canva designs directly from Claude"
 cardDescription: "Browse, summarize, and generate Canva designs directly from Claude"
@@ -9,6 +13,7 @@ seoDescription: >-
   Browse, summarize, and generate Canva designs directly from Claude Discover
   tools for AI development.
 author: Canva
+authorProfileUrl: "https://www.canva.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://www.canva.dev/docs/connect/canva-mcp-server-setup/"
 downloadUrl: /downloads/mcp/canva-mcp-server.mcpb

--- a/content/mcp/clickup-mcp-server.mdx
+++ b/content/mcp/clickup-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Clickup MCP Server for Claude
 slug: clickup-mcp-server
+safetyNotes:
+  - Scope the ClickUp API key to the intended team and review task, status, or project mutations before using it on active workspaces.
+privacyNotes:
+  - Tasks, comments, custom fields, assignees, due dates, and workspace metadata may be exposed through tool calls.
 category: mcp
 description: Task management and project tracking with ClickUp integration
 cardDescription: Task management and project tracking with ClickUp integration
@@ -9,6 +13,7 @@ seoDescription: >-
   Task management and project tracking with ClickUp integration Discover tools
   for AI development.
 author: hauptsacheNet
+authorProfileUrl: "https://github.com/hauptsacheNet"
 dateAdded: "2025-09-18"
 repoUrl: "https://github.com/hauptsacheNet/clickup-mcp"
 documentationUrl: "https://github.com/hauptsacheNet/clickup-mcp"

--- a/content/mcp/cloudflare-mcp-server.mdx
+++ b/content/mcp/cloudflare-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Cloudflare MCP Server - MCP Servers
 slug: cloudflare-mcp-server
+safetyNotes:
+  - Use a least-privilege Cloudflare token because DNS, security, Worker, and deployment actions can affect production services.
+privacyNotes:
+  - Zone settings, analytics, logs, account identifiers, deployment metadata, and security configuration may be sent through model context.
 category: mcp
 description: >-
   Build applications, analyze traffic, and manage security settings through
@@ -13,6 +17,7 @@ seoDescription: >-
   Build applications, analyze traffic, and manage security settings through
   Cloudflare Discover tools for AI development.
 author: Cloudflare
+authorProfileUrl: "https://www.cloudflare.com/"
 dateAdded: "2025-09-18"
 documentationUrl: >-
   https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/

--- a/content/mcp/cloudinary-mcp-server.mdx
+++ b/content/mcp/cloudinary-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Cloudinary MCP Server - MCP Servers
 slug: cloudinary-mcp-server
+safetyNotes:
+  - Use constrained Cloudinary credentials and review destructive or bulk asset operations before enabling media management actions.
+privacyNotes:
+  - Media assets, filenames, metadata, transformations, tags, delivery URLs, and account details may be sent through tool calls.
 category: mcp
 description: "Upload, manage, transform, and analyze media assets in the cloud"
 cardDescription: "Upload, manage, transform, and analyze media assets in the cloud"
@@ -9,6 +13,7 @@ seoDescription: >-
   Upload, manage, transform, and analyze media assets in the cloud Discover
   tools for AI development.
 author: Cloudinary
+authorProfileUrl: "https://cloudinary.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://cloudinary.com/documentation/cloudinary_llm_mcp#mcp_servers"
 downloadUrl: /downloads/mcp/cloudinary-mcp-server.mcpb

--- a/content/mcp/contrastapi-mcp-server.mdx
+++ b/content/mcp/contrastapi-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: ContrastAPI Security Tools
 slug: contrastapi-mcp-server
+safetyNotes:
+  - Treat CVE, EPSS, KEV, IOC, and OSINT enrichment as advisory input that still needs security review before acting on it.
+privacyNotes:
+  - Queried domains, IPs, dependencies, vulnerabilities, and indicators can reveal investigation targets and may enter model context.
 category: mcp
 description: "49 remote MCP security tools for CVE/KEV/CWE/EPSS lookup, composite CVSS+EPSS+KEV+PoC risk scoring, CVSS v3.x vector parsing, domain/IP/IOC enrichment, dependency and web intelligence checks, MITRE ATLAS AI/ML attacks, and MITRE D3FEND defenses. Anonymous tier available; Pro tier uses an API key."
 cardDescription: "49 remote security tools for CVE risk scoring, MITRE ATLAS/D3FEND, domain audit, IP threat intel, IOC enrichment, web intelligence, and dependency scanning."

--- a/content/mcp/daloopa-mcp-server.mdx
+++ b/content/mcp/daloopa-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Daloopa MCP Server for Claude
 slug: daloopa-mcp-server
+safetyNotes:
+  - Treat financial data as informational research and verify figures before using them for investment, accounting, or reporting decisions.
+privacyNotes:
+  - Company queries, filing references, financial models, and research topics may be sent through the MCP client and model.
 category: mcp
 description: >-
   Access high-quality fundamental financial data from SEC filings and investor
@@ -13,6 +17,7 @@ seoDescription: >-
   Access high-quality fundamental financial data from SEC filings and investor
   presentations Discover tools for AI development.
 author: Daloopa
+authorProfileUrl: "https://www.daloopa.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.daloopa.com/docs/daloopa-mcp"
 downloadUrl: /downloads/mcp/daloopa-mcp-server.mcpb

--- a/content/mcp/desktop-mcp-setup.mdx
+++ b/content/mcp/desktop-mcp-setup.mdx
@@ -1,6 +1,10 @@
 ---
 title: Claude Desktop MCP Setup
 slug: desktop-mcp-setup
+safetyNotes:
+  - Only add trusted MCP servers and restrict configured filesystem paths or app permissions to the minimum needed for the workflow.
+privacyNotes:
+  - Configured servers may expose local files, prompts, app data, or account metadata depending on the tools and paths enabled.
 category: mcp
 description: >-
   Master Claude Desktop MCP server setup in 20 minutes. Complete config JSON

--- a/content/mcp/discord-mcp-server.mdx
+++ b/content/mcp/discord-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Discord MCP Server for Claude
 slug: discord-mcp-server
+safetyNotes:
+  - Use least-privilege bot permissions and test moderation or message-writing actions in a non-critical server first.
+privacyNotes:
+  - Discord messages, channel names, user IDs, member metadata, and server configuration may be sent through model context.
 category: mcp
 description: >-
   Discord bot integration for community management, moderation, and server
@@ -13,6 +17,7 @@ seoDescription: >-
   Discord bot integration for community management, moderation, and server
   automation Discover tools for AI development.
 author: saseq
+authorProfileUrl: "https://github.com/saseq"
 dateAdded: "2025-09-20"
 repoUrl: "https://github.com/saseq/discord-mcp"
 documentationUrl: "https://github.com/saseq/discord-mcp"

--- a/content/mcp/docker-mcp-server.mdx
+++ b/content/mcp/docker-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Docker MCP Server for Claude
 slug: docker-mcp-server
+safetyNotes:
+  - Restrict Docker daemon access because container operations can start, stop, delete, or expose workloads and host-mounted paths.
+privacyNotes:
+  - Image names, container logs, environment variables, volume paths, compose files, and registry metadata may be exposed through tool calls.
 category: mcp
 description: >-
   Manage Docker containers, images, and services directly through Claude with

--- a/content/mcp/figma-mcp-server.mdx
+++ b/content/mcp/figma-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Figma MCP Server for Claude
 slug: figma-mcp-server
+safetyNotes:
+  - Use a scoped Figma token and review export or edit permissions before granting access to shared design files.
+privacyNotes:
+  - Figma designs, comments, components, prototypes, team names, and file metadata may be sent through model context.
 category: mcp
 description: "Access designs, export assets, and interact with Figma files through Claude"
 cardDescription: "Access designs, export assets, and interact with Figma files through Claude"
@@ -9,6 +13,7 @@ seoDescription: >-
   Access designs, export assets, and interact with Figma files through Claude
   Discover tools for AI development.
 author: Figma
+authorProfileUrl: "https://www.figma.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://help.figma.com/hc/en-us/articles/32132100833559"
 downloadUrl: /downloads/mcp/figma-mcp-server.mcpb

--- a/content/mcp/filesystem-mcp-server.mdx
+++ b/content/mcp/filesystem-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Filesystem MCP Server - MCP Servers
 slug: filesystem-mcp-server
+safetyNotes:
+  - Limit allowed roots to the specific folders Claude needs because file operations can read, write, overwrite, or delete local data.
+privacyNotes:
+  - Local file contents, filenames, directory structure, and system paths may be sent through the MCP client and model context.
 category: mcp
 description: >-
   Official MCP server providing secure file system operations for Claude Desktop
@@ -13,6 +17,7 @@ seoDescription: >-
   Official MCP server providing secure file system operations for Claude Desktop
   and Claude Code Discover tools for AI development.
 author: Anthropic
+authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-15"
 documentationUrl: "https://modelcontextprotocol.io/examples"
 downloadUrl: /downloads/mcp/filesystem-mcp-server.mcpb

--- a/content/mcp/fireflies-mcp-server.mdx
+++ b/content/mcp/fireflies-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Fireflies MCP Server for Claude
 slug: fireflies-mcp-server
+safetyNotes:
+  - Connect only meetings and workspaces intended for AI review, especially when transcripts include customers or internal discussions.
+privacyNotes:
+  - Meeting transcripts, summaries, speaker names, attendee metadata, and conversation details may be sent through model context.
 category: mcp
 description: Extract valuable insights from meeting transcripts and summaries
 cardDescription: Extract valuable insights from meeting transcripts and summaries
@@ -9,6 +13,7 @@ seoDescription: >-
   Extract valuable insights from meeting transcripts and summaries Discover
   tools for AI development.
 author: Fireflies
+authorProfileUrl: "https://fireflies.ai/"
 dateAdded: "2025-09-18"
 documentationUrl: >-
   https://guide.fireflies.ai/articles/8272956938-learn-about-the-fireflies-mcp-server-model-context-protocol

--- a/content/mcp/git-mcp-server.mdx
+++ b/content/mcp/git-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Git MCP Server for Claude
 slug: git-mcp-server
+safetyNotes:
+  - Restrict access to intended repositories and review write operations because commands can alter branches, commits, and working trees.
+privacyNotes:
+  - Source code, commit history, author metadata, file paths, and repository configuration may be sent through tool calls.
 category: mcp
 description: >-
   Official MCP server providing Git repository tools for reading, searching, and
@@ -13,6 +17,7 @@ seoDescription: >-
   Official MCP server providing Git repository tools for reading, searching, and
   manipulating Git repositories Discover tools for AI development.
 author: Anthropic
+authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"
 documentationUrl: "https://modelcontextprotocol.io/examples"
 downloadUrl: /downloads/mcp/git-mcp-server.mcpb

--- a/content/mcp/github-mcp-server.mdx
+++ b/content/mcp/github-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: GitHub MCP Server for Claude
 slug: github-mcp-server
+safetyNotes:
+  - Use a least-privilege GitHub token because repository, issue, pull request, and file operations can modify public or private projects.
+privacyNotes:
+  - Repository contents, issues, pull requests, comments, org metadata, and user details may be sent through model context.
 category: mcp
 description: >-
   Official GitHub MCP server providing comprehensive GitHub API access for
@@ -14,6 +18,7 @@ seoDescription: >-
   repository management, file operations, and search functionality Discover
   tools for ...
 author: GitHub
+authorProfileUrl: "https://github.com/github"
 dateAdded: "2025-09-18"
 documentationUrl: "https://www.npmjs.com/package/@modelcontextprotocol/server-github"
 downloadUrl: /downloads/mcp/github-mcp-server.mcpb

--- a/content/mcp/hubspot-mcp-server.mdx
+++ b/content/mcp/hubspot-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Hubspot MCP Server for Claude
 slug: hubspot-mcp-server
+safetyNotes:
+  - Scope HubSpot CRM permissions and test writes against non-critical objects before enabling contact, company, or deal updates.
+privacyNotes:
+  - Contacts, companies, deals, tickets, communication history, and CRM metadata may be exposed through tool calls.
 category: mcp
 description: "Access and manage HubSpot CRM data including contacts, companies, and deals"
 cardDescription: "Access and manage HubSpot CRM data including contacts, companies, and deals"
@@ -9,6 +13,7 @@ seoDescription: >-
   Access and manage HubSpot CRM data including contacts, companies, and deals
   Discover tools for AI development.
 author: HubSpot
+authorProfileUrl: "https://www.hubspot.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developers.hubspot.com/mcp"
 downloadUrl: /downloads/mcp/hubspot-mcp-server.mcpb

--- a/content/mcp/hugging-face-mcp-server.mdx
+++ b/content/mcp/hugging-face-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Hugging Face MCP Server - MCP Servers
 slug: hugging-face-mcp-server
+safetyNotes:
+  - Review Hub token permissions and hosted app behavior because model, dataset, and Space actions may use remote execution paths.
+privacyNotes:
+  - Prompts, model queries, dataset names, Space inputs, and Hugging Face account metadata may be sent through the integration.
 category: mcp
 description: Access Hugging Face Hub and Gradio AI applications
 cardDescription: Access Hugging Face Hub and Gradio AI applications
@@ -9,6 +13,7 @@ seoDescription: >-
   Access Hugging Face Hub and Gradio AI applications Discover tools for AI
   development.
 author: Hugging Face
+authorProfileUrl: "https://huggingface.co/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://huggingface.co/settings/mcp"
 downloadUrl: /downloads/mcp/hugging-face-mcp-server.mcpb

--- a/content/mcp/intercom-mcp-server.mdx
+++ b/content/mcp/intercom-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Intercom MCP Server for Claude
 slug: intercom-mcp-server
+safetyNotes:
+  - Restrict Intercom workspace access and review outbound message or ticket changes before using it on live customer support data.
+privacyNotes:
+  - Customer conversations, emails, user profiles, tickets, company records, and support metadata may be sent through model context.
 category: mcp
 description: "Access customer conversations, tickets, and user data in real-time"
 cardDescription: "Access customer conversations, tickets, and user data in real-time"
@@ -9,6 +13,7 @@ seoDescription: >-
   Access customer conversations, tickets, and user data in real-time Discover
   tools for AI development.
 author: Intercom
+authorProfileUrl: "https://www.intercom.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developers.intercom.com/docs/guides/mcp"
 downloadUrl: /downloads/mcp/intercom-mcp-server.mcpb

--- a/content/mcp/invideo-mcp-server.mdx
+++ b/content/mcp/invideo-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Invideo MCP Server for Claude
 slug: invideo-mcp-server
+safetyNotes:
+  - Review generated video scripts, visuals, and exports before publishing or sharing them from production brand accounts.
+privacyNotes:
+  - Prompts, uploaded media, brand assets, project metadata, and generated video content may be sent through tool calls.
 category: mcp
 description: Build video creation capabilities into your applications
 cardDescription: Build video creation capabilities into your applications
@@ -9,6 +13,7 @@ seoDescription: >-
   Build video creation capabilities into your applications Discover tools for AI
   development.
 author: invideo
+authorProfileUrl: "https://invideo.io/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://invideo.io/ai/mcp"
 downloadUrl: /downloads/mcp/invideo-mcp-server.mcpb

--- a/content/mcp/jam-mcp-server.mdx
+++ b/content/mcp/jam-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Jam MCP Server for Claude
 slug: jam-mcp-server
+safetyNotes:
+  - Share only Jam recordings and debugging captures that are intended for AI review, especially when they include production sessions.
+privacyNotes:
+  - Screen recordings, console logs, network requests, URLs, cookies, and user-visible data may be exposed through model context.
 category: mcp
 description: >-
   Debug faster with AI agents that access video recordings, console logs, and
@@ -13,6 +17,7 @@ seoDescription: >-
   Debug faster with AI agents that access video recordings, console logs, and
   network requests Discover tools for AI development.
 author: Jam
+authorProfileUrl: "https://jam.dev/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://jam.dev/docs/debug-a-jam/mcp"
 downloadUrl: /downloads/mcp/jam-mcp-server.mcpb

--- a/content/mcp/jira-mcp-server.mdx
+++ b/content/mcp/jira-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Jira MCP Server for Claude
 slug: jira-mcp-server
+safetyNotes:
+  - Scope Atlassian access and review issue or page writes because updates can notify teams and change project records.
+privacyNotes:
+  - Jira tickets, Confluence pages, comments, attachments, user metadata, and organization details may be sent through tool calls.
 category: mcp
 description: Manage Jira tickets and Confluence documentation
 cardDescription: Manage Jira tickets and Confluence documentation
@@ -9,6 +13,7 @@ seoDescription: >-
   Manage Jira tickets and Confluence documentation Discover tools for AI
   development.
 author: Atlassian
+authorProfileUrl: "https://www.atlassian.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://www.atlassian.com/platform/remote-mcp-server"
 downloadUrl: /downloads/mcp/jira-mcp-server.mcpb

--- a/content/mcp/kubernetes-mcp-server.mdx
+++ b/content/mcp/kubernetes-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Kubernetes MCP Server - MCP Servers
 slug: kubernetes-mcp-server
+safetyNotes:
+  - Use a least-privilege kubeconfig and selected context because cluster operations can affect production workloads and infrastructure.
+privacyNotes:
+  - Resource specs, pod logs, namespaces, environment variables, secret names or values, and cluster metadata may be exposed.
 category: mcp
 description: >-
   Kubernetes cluster management and container orchestration through MCP
@@ -13,6 +17,7 @@ seoDescription: >-
   Kubernetes cluster management and container orchestration through MCP
   integration Discover tools for AI development.
 author: feiskyer
+authorProfileUrl: "https://github.com/feiskyer"
 dateAdded: "2025-09-20"
 repoUrl: "https://github.com/feiskyer/mcp-kubernetes-server"
 documentationUrl: "https://github.com/feiskyer/mcp-kubernetes-server"

--- a/content/mcp/legal-fournier-spain-legal-mcp.mdx
+++ b/content/mcp/legal-fournier-spain-legal-mcp.mdx
@@ -1,6 +1,10 @@
 ---
 title: Spain Legal by Legal Fournier
 slug: legal-fournier-spain-legal-mcp
+safetyNotes:
+  - Use this as a screening aid only and verify immigration, tax, or legal conclusions with qualified counsel before acting.
+privacyNotes:
+  - Personal eligibility facts, residency details, citizenship information, and legal questions may be sent through model context.
 category: mcp
 description: Spain Legal by Legal Fournier is a public, read-only MCP server for Spain legal route screening. It helps AI assistants explore visa options, Beckham Law eligibility, NIE/TIE steps, residency/nationality paths, EU family routes, and when to prepare a human Legal Fournier handoff.
 cardDescription: Read-only Spain legal MCP for visa screening, Beckham eligibility, NIE/TIE, residency, nationality, EU family routes, and handoff preparation.

--- a/content/mcp/linear-mcp-server.mdx
+++ b/content/mcp/linear-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Linear MCP Server for Claude
 slug: linear-mcp-server
+safetyNotes:
+  - Scope the Linear token to the intended workspace and review issue or project writes before changing active roadmaps.
+privacyNotes:
+  - Issue text, comments, assignees, labels, project context, customer references, and workspace metadata may be sent through tool calls.
 category: mcp
 description: Integrate with Linear's issue tracking and project management system
 cardDescription: Integrate with Linear's issue tracking and project management system
@@ -9,6 +13,7 @@ seoDescription: >-
   Integrate with Linear's issue tracking and project management system Discover
   tools for AI development.
 author: Linear
+authorProfileUrl: "https://linear.app/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://linear.app/docs/mcp"
 downloadUrl: /downloads/mcp/linear-mcp-server.mcpb

--- a/content/mcp/memesio-mcp-server.mdx
+++ b/content/mcp/memesio-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Memesio MCP Server
 slug: memesio-mcp-server
+safetyNotes:
+  - Review generated memes and share links before publishing, and avoid uploading sensitive images or private text.
+privacyNotes:
+  - Prompts, source images, captions, API keys, generated outputs, and shared asset URLs may be sent through the integration.
 category: mcp
 description: Memesio MCP Server is a hosted MCP endpoint for meme template discovery, captioned meme creation, share links, and AI-assisted meme generation. Public tools support anonymous/rate-limited usage, while optional developer or agent keys unlock higher-rate, premium, and AI-powered actions.
 cardDescription: Hosted MCP server for meme template search, captioned meme rendering, share links, and optional keyed AI meme generation.

--- a/content/mcp/monday-mcp-server.mdx
+++ b/content/mcp/monday-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Monday MCP Server for Claude
 slug: monday-mcp-server
+safetyNotes:
+  - Scope the Monday API token to intended boards and review item, CRM, or automation changes before using live workflows.
+privacyNotes:
+  - Board items, CRM records, comments, custom fields, users, and workspace automation metadata may be sent through tool calls.
 category: mcp
 description: "Manage monday.com boards, items, and CRM activities"
 cardDescription: "Manage monday.com boards, items, and CRM activities"
@@ -9,6 +13,7 @@ seoDescription: >-
   Manage monday.com boards, items, and CRM activities Discover tools for AI
   development.
 author: Monday.com
+authorProfileUrl: "https://monday.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developer.monday.com/apps/docs/mondaycom-mcp-integration"
 downloadUrl: /downloads/mcp/monday-mcp-server.mcpb

--- a/content/mcp/netlify-mcp-server.mdx
+++ b/content/mcp/netlify-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Netlify MCP Server for Claude
 slug: netlify-mcp-server
+safetyNotes:
+  - Scope Netlify team and site permissions because deploy, environment, and domain changes can affect production websites.
+privacyNotes:
+  - Build logs, deployment history, site metadata, environment variable names, domains, and team details may be exposed.
 category: mcp
 description: "Create, deploy, and manage websites on Netlify platform"
 cardDescription: "Create, deploy, and manage websites on Netlify platform"
@@ -9,6 +13,7 @@ seoDescription: >-
   Create, deploy, and manage websites on Netlify platform Discover tools for AI
   development.
 author: Netlify
+authorProfileUrl: "https://www.netlify.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.netlify.com/build/build-with-ai/netlify-mcp-server/"
 downloadUrl: /downloads/mcp/netlify-mcp-server.mcpb

--- a/content/mcp/notion-mcp-server.mdx
+++ b/content/mcp/notion-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Notion MCP Server for Claude
 slug: notion-mcp-server
+safetyNotes:
+  - Share only intended Notion pages or databases and review writes that alter docs, tasks, or workspace records.
+privacyNotes:
+  - Page contents, database rows, comments, attachments, user names, and workspace metadata may be sent through model context.
 category: mcp
 description: "Read docs, update pages, and manage tasks in Notion workspaces"
 cardDescription: "Read docs, update pages, and manage tasks in Notion workspaces"
@@ -9,6 +13,7 @@ seoDescription: >-
   Read docs, update pages, and manage tasks in Notion workspaces Discover tools
   for AI development.
 author: Notion
+authorProfileUrl: "https://www.notion.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developers.notion.com/docs/mcp"
 downloadUrl: /downloads/mcp/notion-mcp-server.mcpb

--- a/content/mcp/packrift-mcp-server.mdx
+++ b/content/mcp/packrift-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Packrift MCP Server
 slug: packrift-mcp-server
+safetyNotes:
+  - Verify pricing, inventory, packaging, and cart output before purchasing or using it in customer-facing commerce workflows.
+privacyNotes:
+  - Product searches, pricing context, cart URLs, packaging requirements, and merchant interaction details may be sent through tool calls.
 category: mcp
 description: Packrift MCP Server exposes Packrift's packaging-supplies catalog through a remote MCP endpoint. It lets AI agents search packaging products, retrieve pricing and inventory context, and create cart URLs for ecommerce packaging workflows. Use it when an agent needs packaging-supply discovery, carton or mailer selection, or cart-building support.
 cardDescription: Remote MCP server for Packrift packaging catalog search, pricing and inventory context, and ecommerce cart URL creation.

--- a/content/mcp/paypal-mcp-server.mdx
+++ b/content/mcp/paypal-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Paypal MCP Server for Claude
 slug: paypal-mcp-server
+safetyNotes:
+  - Use sandbox or least-privilege credentials because payment, order, and commerce actions can affect real money flows.
+privacyNotes:
+  - Transaction details, buyer and seller information, order metadata, account identifiers, and payment context may be exposed.
 category: mcp
 description: >-
   Integrate PayPal commerce capabilities, payment processing, and transaction
@@ -13,6 +17,7 @@ seoDescription: >-
   Integrate PayPal commerce capabilities, payment processing, and transaction
   management Discover tools for AI development.
 author: PayPal
+authorProfileUrl: "https://www.paypal.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://www.paypal.ai/"
 downloadUrl: /downloads/mcp/paypal-mcp-server.mcpb

--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Plaid MCP Server for Claude
 slug: plaid-mcp-server
+safetyNotes:
+  - Use sandbox or restricted Plaid credentials and avoid exposing production banking tokens outside the required workflow.
+privacyNotes:
+  - Account-linking data, balances, transactions, institution identifiers, and financial metadata may be sent through model context.
 category: mcp
 description: >-
   Analyze, troubleshoot, and optimize Plaid integrations for banking data and
@@ -13,6 +17,7 @@ seoDescription: >-
   Analyze, troubleshoot, and optimize Plaid integrations for banking data and
   financial account linking Discover tools for AI development.
 author: Plaid
+authorProfileUrl: "https://plaid.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://plaid.com/blog/plaid-mcp-ai-assistant-claude/"
 downloadUrl: /downloads/mcp/plaid-mcp-server.mcpb

--- a/content/mcp/postgresql-mcp-server.mdx
+++ b/content/mcp/postgresql-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Postgresql MCP Server - MCP Servers
 slug: postgresql-mcp-server
+safetyNotes:
+  - Use a read-only database user with restricted schemas unless write access is explicitly needed and reviewed.
+privacyNotes:
+  - Queried schemas, table names, rows, connection details, and application data may be exposed through tool calls.
 category: mcp
 description: >-
   Official MCP server providing read-only access to PostgreSQL databases with
@@ -13,6 +17,7 @@ seoDescription: >-
   Official MCP server providing read-only access to PostgreSQL databases with
   schema inspection and query capabilities Discover tools for AI development.
 author: Anthropic
+authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"
 documentationUrl: "https://modelcontextprotocol.io/examples"
 downloadUrl: /downloads/mcp/postgresql-mcp-server.mcpb

--- a/content/mcp/prompt-to-asset.mdx
+++ b/content/mcp/prompt-to-asset.mdx
@@ -1,6 +1,10 @@
 ---
 title: Prompt-to-asset
 slug: prompt-to-asset
+safetyNotes:
+  - Review generated assets, licensing, and usage rights before publication, and avoid sending confidential brand or source material.
+privacyNotes:
+  - Prompts, uploaded or reference images, brand specifications, and generated assets may be sent to external model providers.
 category: mcp
 description: MCP server that generates production-ready visual assets by routing requests across 30+ image generation models. Handles app icons, favicons, OG images, logos, and wordmarks. Validates output for WCAG contrast and palette consistency. Zero API key required for first run via Pollinations and Stable Horde free tiers.
 cardDescription: Generate app icons, favicons, OG images, and logos via 30+ image models. No API key required for first run.

--- a/content/mcp/reddit-mcp-buddy.mdx
+++ b/content/mcp/reddit-mcp-buddy.mdx
@@ -1,6 +1,10 @@
 ---
 title: Reddit MCP Buddy for Claude
 slug: reddit-mcp-buddy
+safetyNotes:
+  - Respect Reddit rules and avoid automating harassment, brigading, doxxing, or other abusive community analysis workflows.
+privacyNotes:
+  - Searched posts, usernames, communities, activity patterns, and analysis prompts may be sent through model context.
 category: mcp
 description: >-
   Browse Reddit, search posts, and analyze user activity directly from Claude -

--- a/content/mcp/redis-mcp-server.mdx
+++ b/content/mcp/redis-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Redis MCP Server for Claude
 slug: redis-mcp-server
+safetyNotes:
+  - Use a restricted Redis user or database because commands can expose, mutate, or delete cache, queue, and session data.
+privacyNotes:
+  - Keys, values, connection URLs, database metadata, and application data stored in Redis may be exposed through tool calls.
 category: mcp
 description: >-
   Official Redis MCP server providing natural language interface for Redis data

--- a/content/mcp/sentry-mcp-server.mdx
+++ b/content/mcp/sentry-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Sentry MCP Server for Claude
 slug: sentry-mcp-server
+safetyNotes:
+  - Scope Sentry org and project access, and review issue updates or alert changes before using it on production monitoring.
+privacyNotes:
+  - Stack traces, logs, release data, user context, event payloads, and project metadata may be sent through model context.
 category: mcp
 description: "Monitor errors, debug production issues, and track application health"
 cardDescription: "Monitor errors, debug production issues, and track application health"

--- a/content/mcp/socket-mcp-server.mdx
+++ b/content/mcp/socket-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Socket MCP Server for Claude
 slug: socket-mcp-server
+safetyNotes:
+  - Treat dependency risk findings as triage input and verify impact before blocking releases or changing package policy.
+privacyNotes:
+  - Package names, manifests, dependency graphs, repository context, and security findings may be sent through tool calls.
 category: mcp
 description: Security analysis and vulnerability scanning for dependencies
 cardDescription: Security analysis and vulnerability scanning for dependencies
@@ -9,6 +13,7 @@ seoDescription: >-
   Security analysis and vulnerability scanning for dependencies Discover tools
   for AI development.
 author: Socket
+authorProfileUrl: "https://github.com/SocketDev"
 dateAdded: "2025-09-18"
 repoUrl: "https://github.com/SocketDev/socket-mcp"
 documentationUrl: "https://github.com/SocketDev/socket-mcp"

--- a/content/mcp/square-mcp-server.mdx
+++ b/content/mcp/square-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Square MCP Server for Claude
 slug: square-mcp-server
+safetyNotes:
+  - Use sandbox or least-privilege credentials because payment, order, inventory, and customer actions can affect real commerce.
+privacyNotes:
+  - Buyer, seller, payment, order, inventory, location, and customer metadata may be exposed through the integration.
 category: mcp
 description: "Build on Square APIs for payments, inventory, and order management"
 cardDescription: "Build on Square APIs for payments, inventory, and order management"
@@ -9,6 +13,7 @@ seoDescription: >-
   Build on Square APIs for payments, inventory, and order management Discover
   tools for AI development.
 author: Square
+authorProfileUrl: "https://squareup.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developer.squareup.com/docs/mcp"
 downloadUrl: /downloads/mcp/square-mcp-server.mcpb

--- a/content/mcp/stripe-mcp-server.mdx
+++ b/content/mcp/stripe-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Stripe MCP Server for Claude
 slug: stripe-mcp-server
+safetyNotes:
+  - Use restricted or sandbox Stripe keys because customer, payment, invoice, and subscription actions can affect billing.
+privacyNotes:
+  - Customer records, invoices, subscriptions, payment metadata, account identifiers, and transaction details may be sent through model context.
 category: mcp
 description: >-
   Payment processing, subscription management, and financial transaction
@@ -13,6 +17,7 @@ seoDescription: >-
   Payment processing, subscription management, and financial transaction
   handling Discover tools for AI development.
 author: Stripe
+authorProfileUrl: "https://stripe.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.stripe.com/mcp"
 downloadUrl: /downloads/mcp/stripe-mcp-server.mcpb

--- a/content/mcp/stytch-mcp-server.mdx
+++ b/content/mcp/stytch-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Stytch MCP Server for Claude
 slug: stytch-mcp-server
+safetyNotes:
+  - Restrict Stytch workspace and admin permissions because auth configuration changes can affect sign-in and account security.
+privacyNotes:
+  - User identities, authentication logs, session details, workspace settings, and security configuration may be sent through tool calls.
 category: mcp
 description: Configure and manage Stytch authentication services and workspace settings
 cardDescription: Configure and manage Stytch authentication services and workspace settings
@@ -9,6 +13,7 @@ seoDescription: >-
   Configure and manage Stytch authentication services and workspace settings
   Discover tools for AI development.
 author: Stytch
+authorProfileUrl: "https://stytch.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://stytch.com/docs/workspace-management/stytch-mcp"
 downloadUrl: /downloads/mcp/stytch-mcp-server.mcpb

--- a/content/mcp/vercel-mcp-server.mdx
+++ b/content/mcp/vercel-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Vercel MCP Server for Claude
 slug: vercel-mcp-server
+safetyNotes:
+  - Scope Vercel team and project permissions because deployments, environment variables, and domain changes can affect production apps.
+privacyNotes:
+  - Deployment logs, project metadata, environment variable names, domains, team details, and runtime errors may be exposed.
 category: mcp
 description: "Manage deployments, analyze logs, and control Vercel projects"
 cardDescription: "Manage deployments, analyze logs, and control Vercel projects"
@@ -9,6 +13,7 @@ seoDescription: >-
   Manage deployments, analyze logs, and control Vercel projects Discover tools
   for AI development.
 author: Vercel
+authorProfileUrl: "https://vercel.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://vercel.com/docs/mcp/vercel-mcp"
 downloadUrl: /downloads/mcp/vercel-mcp-server.mcpb

--- a/content/mcp/workato-mcp-server.mdx
+++ b/content/mcp/workato-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Workato MCP Server for Claude
 slug: workato-mcp-server
+safetyNotes:
+  - Restrict recipe and connection access because automations can trigger reads or writes across many connected business systems.
+privacyNotes:
+  - Connected app data, workflow payloads, account metadata, and integration connection details may be sent through tool calls.
 category: mcp
 description: "Access any application, workflows, or data via Workato's integration platform"
 cardDescription: "Access any application, workflows, or data via Workato's integration platform"
@@ -9,6 +13,7 @@ seoDescription: >-
   Access any application, workflows, or data via Workato's integration platform
   Discover tools for AI development.
 author: Workato
+authorProfileUrl: "https://www.workato.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.workato.com/mcp.html"
 downloadUrl: /downloads/mcp/workato-mcp-server.mcpb

--- a/content/mcp/xquik-mcp-server.mdx
+++ b/content/mcp/xquik-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Xquik MCP Server
 slug: xquik-mcp-server
+safetyNotes:
+  - Use API keys with write confirmations enabled because posting, follower exports, media actions, and webhooks can affect public accounts.
+privacyNotes:
+  - Timelines, profile data, follower exports, media, webhook details, and API credentials may be sent through model context.
 category: mcp
 description: "Remote MCP server for X and Twitter automation: tweet search, profile timelines, follower export, media workflows, webhooks, and confirmation-gated write actions."
 cardDescription: "Remote X and Twitter MCP server for tweet search, follower export, media, webhooks, and confirmation-gated write workflows."

--- a/content/mcp/zapier-mcp-server.mdx
+++ b/content/mcp/zapier-mcp-server.mdx
@@ -1,6 +1,10 @@
 ---
 title: Zapier MCP Server for Claude
 slug: zapier-mcp-server
+safetyNotes:
+  - Restrict the generated Zapier MCP URL and enabled actions because automations can write across many connected apps.
+privacyNotes:
+  - Connected app data, workflow payloads, account metadata, and action inputs or outputs may be sent through model context.
 category: mcp
 description: "Connect to nearly 8,000 apps through Zapier's automation platform"
 cardDescription: "Connect to nearly 8,000 apps through Zapier's automation platform"
@@ -9,6 +13,7 @@ seoDescription: >-
   Connect to nearly 8,000 apps through Zapier's automation platform Discover
   tools for AI development.
 author: Zapier
+authorProfileUrl: "https://zapier.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://help.zapier.com/hc/en-us/articles/36265392843917"
 downloadUrl: /downloads/mcp/zapier-mcp-server.mcpb

--- a/content/mcp/zyntra-mail.mdx
+++ b/content/mcp/zyntra-mail.mdx
@@ -1,6 +1,10 @@
 ---
 title: Zyntra - Temp e-mails MCP
 slug: zyntra-mail
+safetyNotes:
+  - Use disposable inboxes only for test or low-risk flows and avoid receiving real user, password-reset, or secret-bearing email.
+privacyNotes:
+  - Email addresses, message contents, delivery links, extracted fields, and API credentials may be sent through tool calls.
 category: mcp
 description: |-
   MCP server for e-mail testing: create disposable inboxes, wait for delivery, and extract e-mail content or links - all from your AI agent or test automation workflow.

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "validate:readme": "node scripts/generate-readme.mjs --check",
     "audit:content": "node scripts/audit-content.mjs",
     "report:trust-coverage": "node scripts/report-trust-coverage.mjs",
+    "validate:mcp-trust": "node scripts/report-trust-coverage.mjs --category mcp --check --min-risk-coverage 100 --min-attribution-coverage 100",
     "sync:votes:d1": "node scripts/sync-votes-to-d1.mjs --mode=both",
     "verify:votes:d1": "node scripts/verify-d1-votes.mjs --mode=both",
     "jobs:admin": "node scripts/manage-d1-jobs.mjs",

--- a/scripts/report-trust-coverage.mjs
+++ b/scripts/report-trust-coverage.mjs
@@ -23,7 +23,12 @@ import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
  */
 
 const repoRoot = process.cwd();
-const contentRoot = path.join(repoRoot, "content");
+let configuredRepoRoot = repoRoot;
+let outputPath = "";
+let check = false;
+let minRiskCoverage = null;
+let minAttributionCoverage = null;
+let outputFormat = "text";
 
 const RISK_BEARING = new Set([
   "hooks",
@@ -57,17 +62,69 @@ for (let index = 2; index < process.argv.length; index += 1) {
       const normalized = category.trim();
       if (normalized) selectedCategories.add(normalized);
     }
+  } else if (arg === "--repo-root") {
+    configuredRepoRoot = path.resolve(process.argv[index + 1] || "");
+    index += 1;
+  } else if (arg.startsWith("--repo-root=")) {
+    configuredRepoRoot = path.resolve(arg.slice("--repo-root=".length));
+  } else if (arg === "--output") {
+    outputPath = process.argv[index + 1] || "";
+    index += 1;
+  } else if (arg.startsWith("--output=")) {
+    outputPath = arg.slice("--output=".length);
+  } else if (arg === "--check") {
+    check = true;
+  } else if (arg === "--min-risk-coverage") {
+    minRiskCoverage = Number(process.argv[index + 1]);
+    index += 1;
+  } else if (arg.startsWith("--min-risk-coverage=")) {
+    minRiskCoverage = Number(arg.slice("--min-risk-coverage=".length));
+  } else if (arg === "--min-attribution-coverage") {
+    minAttributionCoverage = Number(process.argv[index + 1]);
+    index += 1;
+  } else if (arg.startsWith("--min-attribution-coverage=")) {
+    minAttributionCoverage = Number(
+      arg.slice("--min-attribution-coverage=".length),
+    );
+  } else if (arg === "--format") {
+    outputFormat = process.argv[index + 1] || "text";
+    index += 1;
+  } else if (arg.startsWith("--format=")) {
+    outputFormat = arg.slice("--format=".length);
   }
 }
 
-const reportPath =
+const validatePercent = (value, flag) => {
+  if (value !== null && (!Number.isFinite(value) || value < 0 || value > 100)) {
+    console.error(`${flag} must be a number from 0 to 100.`);
+    process.exit(2);
+  }
+};
+
+if (minRiskCoverage !== null || minAttributionCoverage !== null) {
+  validatePercent(minRiskCoverage, "--min-risk-coverage");
+  validatePercent(minAttributionCoverage, "--min-attribution-coverage");
+}
+
+if (!["json", "text"].includes(outputFormat)) {
+  console.error("--format must be either json or text.");
+  process.exit(2);
+}
+
+const contentRoot = path.join(configuredRepoRoot, "content");
+
+const defaultReportPath =
   selectedCategories.size > 0
     ? path.join(
-        repoRoot,
+        configuredRepoRoot,
         "reports/trust-coverage",
         `${[...selectedCategories].sort().join("-")}.json`,
       )
-    : path.join(repoRoot, "content/data/trust-coverage.json");
+    : path.join(configuredRepoRoot, "content/data/trust-coverage.json");
+const explicitReportPath = outputPath
+  ? path.resolve(process.cwd(), outputPath)
+  : "";
+const reportPath = explicitReportPath || (check ? "" : defaultReportPath);
 
 const has = (value) =>
   Array.isArray(value)
@@ -112,7 +169,7 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
     entries.push({
       category,
       slug: String(data.slug ?? fileName.replace(/\.mdx$/, "")),
-      filePath: path.relative(repoRoot, filePath),
+      filePath: path.relative(configuredRepoRoot, filePath),
       riskBearing,
       trust,
       trustGaps,
@@ -239,36 +296,83 @@ const summary = {
 
 const out = { summary, gaps, entries };
 
-fs.mkdirSync(path.dirname(reportPath), { recursive: true });
-fs.writeFileSync(
-  reportPath,
-  await prettier.format(JSON.stringify(out), { parser: "json" }),
-);
-
-// --- console summary ---
-console.log(`Wrote ${path.relative(repoRoot, reportPath)}`);
-if (selectedCategories.size > 0) {
-  console.log(`Selected categories: ${[...selectedCategories].join(", ")}`);
-}
-console.log(`Entries scanned: ${entries.length}`);
-console.log(
-  `Risk-bearing entries (${riskCategories.join(", ")}): ${risk.length}`,
-);
-console.log(
-  `  with safety + privacy notes: ${riskWithBoth} (${summary.riskBearing.coveragePct}%), missing ${summary.riskBearing.missing}`,
-);
-console.log("By risk-bearing category (lowest coverage first):");
-for (const [category, value] of Object.entries(riskByCategory).sort(
-  (a, b) => a[1].coveragePct - b[1].coveragePct,
-)) {
-  console.log(
-    `  ${category.padEnd(12)} ${String(value.covered).padStart(3)}/${String(
-      value.entries,
-    ).padEnd(
-      4,
-    )} (${String(value.coveragePct).padStart(3)}%)  missing ${value.missing}`,
+if (reportPath) {
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(
+    reportPath,
+    await prettier.format(JSON.stringify(out), { parser: "json" }),
   );
 }
-console.log(
-  `Provenance (all ${entries.length}): source-backed ${summary.coverage.sourceBacked}%, attributed ${summary.coverage.attributed}%`,
-);
+
+const thresholdFailures = [];
+if (
+  minRiskCoverage !== null &&
+  summary.riskBearing.coveragePct < minRiskCoverage
+) {
+  thresholdFailures.push(
+    `Risk-bearing safety/privacy coverage ${summary.riskBearing.coveragePct}% is below required ${minRiskCoverage}%.`,
+  );
+}
+if (
+  minAttributionCoverage !== null &&
+  summary.coverage.attributed < minAttributionCoverage
+) {
+  thresholdFailures.push(
+    `Attribution coverage ${summary.coverage.attributed}% is below required ${minAttributionCoverage}%.`,
+  );
+}
+
+function printTextSummary() {
+  if (reportPath) {
+    console.log(`Wrote ${path.relative(process.cwd(), reportPath)}`);
+  } else if (check) {
+    console.log("Check mode: no report file written.");
+  }
+  if (selectedCategories.size > 0) {
+    console.log(`Selected categories: ${[...selectedCategories].join(", ")}`);
+  }
+  console.log(`Entries scanned: ${entries.length}`);
+  console.log(
+    `Risk-bearing entries (${riskCategories.join(", ")}): ${risk.length}`,
+  );
+  console.log(
+    `  with safety + privacy notes: ${riskWithBoth} (${summary.riskBearing.coveragePct}%), missing ${summary.riskBearing.missing}`,
+  );
+  console.log("By risk-bearing category (lowest coverage first):");
+  for (const [category, value] of Object.entries(riskByCategory).sort(
+    (a, b) => a[1].coveragePct - b[1].coveragePct,
+  )) {
+    console.log(
+      `  ${category.padEnd(12)} ${String(value.covered).padStart(3)}/${String(
+        value.entries,
+      ).padEnd(
+        4,
+      )} (${String(value.coveragePct).padStart(3)}%)  missing ${value.missing}`,
+    );
+  }
+  console.log(
+    `Provenance (all ${entries.length}): source-backed ${summary.coverage.sourceBacked}%, attributed ${summary.coverage.attributed}%`,
+  );
+  for (const failure of thresholdFailures) {
+    console.error(failure);
+  }
+}
+
+// --- console summary ---
+if (outputFormat === "json") {
+  console.log(
+    JSON.stringify({
+      ok: thresholdFailures.length === 0,
+      check,
+      reportPath: reportPath || null,
+      summary,
+      failures: thresholdFailures,
+    }),
+  );
+} else {
+  printTextSummary();
+}
+
+if (thresholdFailures.length) {
+  process.exit(1);
+}

--- a/tests/trust-coverage-script.test.ts
+++ b/tests/trust-coverage-script.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const scriptPath = path.join(repoRoot, "scripts/report-trust-coverage.mjs");
+
+function writeMcpEntry(
+  root: string,
+  slug: string,
+  options: { safety?: boolean; privacy?: boolean; attributed?: boolean } = {},
+) {
+  const dir = path.join(root, "content/mcp");
+  fs.mkdirSync(dir, { recursive: true });
+  const notes = [
+    options.attributed ? `authorProfileUrl: https://github.com/example` : "",
+    options.safety
+      ? `safetyNotes:\n  - Runs as a local MCP server and should be granted only the account permissions required for testing.`
+      : "",
+    options.privacy
+      ? `privacyNotes:\n  - Can pass selected user prompts and account data through the connected MCP client.`
+      : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  fs.writeFileSync(
+    path.join(dir, `${slug}.mdx`),
+    `---
+title: ${slug}
+slug: ${slug}
+category: mcp
+description: Test MCP entry.
+sourceUrl: https://github.com/example/${slug}
+${notes}
+---
+
+Test MCP body.
+`,
+    "utf8",
+  );
+}
+
+function runTrustCoverage(args: string[]) {
+  return spawnSync(process.execPath, [scriptPath, ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+describe("trust coverage report script", () => {
+  it("honors an explicit output path", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-output-"),
+    );
+    writeMcpEntry(tmpDir, "covered-mcp", { safety: true, privacy: true });
+    const outputPath = path.join(tmpDir, "mcp-trust.json");
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--output",
+      outputPath,
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(outputPath)).toBe(true);
+    expect(JSON.parse(fs.readFileSync(outputPath, "utf8"))).toMatchObject({
+      summary: {
+        riskBearing: {
+          withSafetyAndPrivacy: 1,
+          missing: 0,
+          coveragePct: 100,
+        },
+      },
+    });
+  });
+
+  it("fails check mode when risk coverage is below the threshold", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-check-"),
+    );
+    writeMcpEntry(tmpDir, "missing-notes");
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--check",
+      "--min-risk-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("below required 100%");
+    expect(
+      fs.existsSync(path.join(tmpDir, "reports/trust-coverage/mcp.json")),
+    ).toBe(false);
+  });
+
+  it("fails check mode when attribution coverage is below the threshold", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-attribution-"),
+    );
+    writeMcpEntry(tmpDir, "safe-but-unattributed", {
+      safety: true,
+      privacy: true,
+    });
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--check",
+      "--min-attribution-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Attribution coverage 0% is below required 100%",
+    );
+    expect(
+      fs.existsSync(path.join(tmpDir, "reports/trust-coverage/mcp.json")),
+    ).toBe(false);
+  });
+
+  it("does not write the default report in successful check mode", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-clean-check-"),
+    );
+    writeMcpEntry(tmpDir, "covered-mcp", { safety: true, privacy: true });
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--check",
+      "--min-risk-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Check mode: no report file written.");
+    expect(
+      fs.existsSync(path.join(tmpDir, "reports/trust-coverage/mcp.json")),
+    ).toBe(false);
+  });
+
+  it("keeps live MCP content at full trust coverage", () => {
+    const result = runTrustCoverage([
+      "--category",
+      "mcp",
+      "--check",
+      "--min-risk-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("with safety + privacy notes: 318 (100%)");
+    expect(result.stdout).toContain(
+      "Provenance (all 318): source-backed 100%, attributed 100%",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add check-mode trust coverage thresholds for MCP safety/privacy coverage and attribution coverage.
- Add `validate:mcp-trust` so MCP content must stay at 100% safety/privacy trust coverage and 100% attribution.
- Fill the current MCP metadata gaps with factual `safetyNotes`, `privacyNotes`, and source-backed `authorProfileUrl` values.
- Add focused regression coverage for output handling, check-mode behavior, threshold failures, and live MCP coverage.

## Validation

- `pnpm validate:mcp-trust`
- `pnpm validate:content:strict -- --category mcp`
- `pnpm exec vitest run tests/trust-coverage-script.test.ts tests/content-policy-validation.test.ts tests/registry-artifacts.test.ts`
- `git diff --check`

No generated artifacts are included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new validation script with configurable trust coverage thresholds and reporting capabilities for MCP content verification.

* **Tests**
  * Added comprehensive test suite validating trust-coverage report generation, threshold enforcement, and output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->