### PR TITLE
fix(submissions): enforce auto-merge confidence floor

### DIFF
--- a/apps/submission-gate/src/review.ts
+++ b/apps/submission-gate/src/review.ts
@@ -3,7 +3,6 @@ import { DEFAULT_REVIEW_MARKER, LABELS } from "./constants";
 export const GATE_DECISION_SCHEMA_VERSION = 2;
 export const GATE_COMMENT_FORMATTER_VERSION = 5;
 export const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR = 0.85;
-const DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR = 0.75;
 const HEYCLAUDE_SITE_URL = "https://heyclau.de";
 const HEYCLAUDE_REPO_URL = "https://github.com/JSONbored/awesome-claude";
 const HEYCLAUDE_FORK_URL = "https://github.com/JSONbored/awesome-claude/fork";
@@ -474,63 +473,6 @@ function normalizedConfidenceFloor(value: number) {
     : DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR;
 }
 
-function hasFailedChecks(decision: GateDecision) {
-  return (decision.checks || []).some((check) =>
-    ["failed", "error", "cancelled"].includes(check.status),
-  );
-}
-
-function hasBlockingOrAmbiguousSections(decision: GateDecision) {
-  return (decision.sections || []).some((section) =>
-    ["fail", "warn"].includes(section.status),
-  );
-}
-
-function mergeSummarySignalsAcceptance(summary: string) {
-  const value = summary.toLowerCase();
-  return (
-    value.includes("no blocking") ||
-    value.includes("none blocking") ||
-    value.includes("recommend direct merge") ||
-    value.includes("direct merge is recommended") ||
-    value.includes("can be merged directly") ||
-    value.includes("meets all repository policies")
-  );
-}
-
-function mergeSummarySignalsAmbiguity(summary: string) {
-  const value = summary.toLowerCase();
-  const nonBlocking =
-    value.includes("non-blocking") ||
-    value.includes("not a blocker") ||
-    value.includes("not blocking");
-  if (nonBlocking) return false;
-  return (
-    value.includes("unresolved") ||
-    value.includes("ambiguous") ||
-    value.includes("could not verify") ||
-    value.includes("contradictory") ||
-    value.includes("manual review")
-  );
-}
-
-function isCleanStructuredMergeDecision(
-  decision: GateDecision,
-  cleanFloor = DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR,
-) {
-  return (
-    decision.verdict === "merge" &&
-    typeof decision.confidence === "number" &&
-    Number.isFinite(decision.confidence) &&
-    decision.confidence >= cleanFloor &&
-    !(decision.errors || []).length &&
-    !hasFailedChecks(decision) &&
-    !hasBlockingOrAmbiguousSections(decision) &&
-    mergeSummarySignalsAcceptance(decision.summary || "") &&
-    !mergeSummarySignalsAmbiguity(decision.summary || "")
-  );
-}
-
 function decisionConfidenceText(decision: GateDecision) {
   if (
     typeof decision.confidence === "number" &&
@@ -992,10 +934,6 @@ export function enforceAutoMergeConfidenceFloor(
   ) {
     return decision;
   }
-  if (isCleanStructuredMergeDecision(decision)) {
-    return decision;
-  }
-
   const confidenceSummary = [
     `Private reviewer confidence was ${confidenceText(decision.confidence)}; unattended merge floor is ${confidenceText(normalizedFloor)}.`,
     "Manual maintainer review is required before merge.",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -592,7 +592,7 @@ describe("Cloudflare submission gate helpers", () => {
     ).toContain("> ## ℹ️ Superseded gate report");
   });
 
-  it("keeps clean default-confidence merge verdicts on the merge path", () => {
+  it("routes clean below-floor private merge verdicts to manual review", () => {
     const decision = enforceAutoMergeConfidenceFloor({
       schemaVersion: 2,
       verdict: "merge",
@@ -611,11 +611,17 @@ describe("Cloudflare submission gate helpers", () => {
     });
 
     expect(decision).toMatchObject({
-      verdict: "merge",
+      verdict: "manual",
       confidence: 0.76,
-      labels: ["submission-merged-by-gate"],
+      labels: ["submission-manual-review"],
+      errors: [
+        {
+          code: "low_private_review_confidence",
+          retryable: false,
+        },
+      ],
     });
-    expect(decision.errors).toBeUndefined();
+    expect(decision.summary).toContain("unattended merge floor is 85%");
   });
 
   it("routes ambiguous low-confidence private merge verdicts to manual review", () => {


### PR DESCRIPTION
### Motivation
- A new "clean-merge" bypass allowed `merge` verdicts with confidence below the configured auto-merge floor to proceed, weakening the manual-review fallback and permitting low-confidence attacker-influenced decisions to auto-merge.
- The gate should uniformly enforce the configured unattended merge threshold (`AUTO_MERGE_CONFIDENCE_FLOOR`) for all private-review decisions to preserve repository and registry integrity.
- The change restores a single source of truth for the unattended merge threshold so maintainers' configured policy cannot be bypassed by textual heuristics.

### Description
- Removed the lower hard-coded clean-merge floor and related heuristics by deleting the `DEFAULT_CLEAN_MERGE_CONFIDENCE_FLOOR`, `isCleanStructuredMergeDecision()`, and the `mergeSummarySignals*` helpers from `apps/submission-gate/src/review.ts` so summary-text heuristics no longer bypass the configured floor.
- Updated `enforceAutoMergeConfidenceFloor()` in `apps/submission-gate/src/review.ts` to route any `merge` verdict whose `confidence` is below the normalized configured floor to `manual` with the existing `confidence_review` section and `low_private_review_confidence` error.
- Adjusted the regression test in `tests/submission-gate-worker.test.ts` to assert that a clean-looking `merge` decision at `confidence: 0.76` is converted to `manual` review rather than being kept on the merge path.

### Testing
- Ran the focused tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "routes clean below-floor private merge verdicts to manual review|routes ambiguous low-confidence private merge verdicts to manual review"` and the targeted cases passed.
- Ran the full submission-gate test file with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and all tests in that file passed.
- Verified repository lint/checks by running `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a228a9b8b348320993b56e4d9b13aaf)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enforced stricter confidence requirements for auto-merge verdicts. Submissions with confidence below the unattended merge floor (85%) now route to manual review instead of bypassing confidence checks. Low confidence submissions receive a "low private review confidence" error notification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->