### PR TITLE
fix(content): use safe chunkhound install command

### DIFF
--- a/content/mcp/chunkhound-mcp-server.mdx
+++ b/content/mcp/chunkhound-mcp-server.mdx
@@ -25,7 +25,7 @@ repoUrl: "https://github.com/chunkhound/chunkhound"
 documentationUrl: "https://raw.githubusercontent.com/chunkhound/chunkhound/main/site/src/pages/docs/cli-reference.md"
 packageUrl: "https://pypi.org/pypi/chunkhound/json"
 installable: true
-installCommand: "Install with `uv tool install chunkhound`, create `.chunkhound.json`, index the project, and run `chunkhound mcp` from the approved repository."
+installCommand: "uv tool install chunkhound"
 usageSnippet: "Run `chunkhound index`, start `chunkhound mcp`, then ask Claude to search or research the indexed codebase."
 copySnippet: |-
   {


### PR DESCRIPTION
### Motivation
- Prevent copy-paste command-substitution risk by removing Markdown backticks from the copyable `installCommand`, which could be executed by POSIX shells when users paste the Install payload.

### Description
- Replace the prose install payload in `content/mcp/chunkhound-mcp-server.mdx` with a single safe copyable command `uv tool install chunkhound` so the Install tab no longer contains backticked fragments that trigger shell substitutions.

### Testing
- Ran `pnpm validate:content:strict`, which passed, and `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262201d4f08320afb01ae752a2067f)