### PR TITLE
fix(content): harden pdf reader mcp config

### DIFF
--- a/content/mcp/pdf-reader-mcp.mdx
+++ b/content/mcp/pdf-reader-mcp.mdx
@@ -42,9 +42,9 @@ configSnippet: |-
         "args": ["-y", "@sylphx/pdf-reader-mcp"],
         "env": {
           "MCP_TRANSPORT": "stdio",
-          "MCP_PDF_ALLOWED_DIRS": "",
-          "MCP_PDF_ALLOWED_HOSTS": "",
-          "MCP_PDF_ALLOW_HTTP": "true"
+          "MCP_PDF_ALLOWED_DIRS": "/Users/you/Documents/approved-pdfs",
+          "MCP_PDF_ALLOWED_HOSTS": "trusted.example.com",
+          "MCP_PDF_ALLOW_HTTP": "false"
         }
       }
     }
@@ -146,9 +146,12 @@ Configure the stdio server in your MCP client:
 }
 ```
 
-After restarting the MCP client, ask Claude to read only approved PDF paths or
-URLs and specify whether you need full text, metadata, page counts, images,
-tables, or particular page ranges.
+Replace the example directory and host with locations you trust before use.
+Keep `MCP_PDF_ALLOW_HTTP` set to `false` unless you have a specific, trusted
+plaintext HTTP source and understand the tampering risk. After restarting the
+MCP client, ask Claude to read only approved PDF paths or URLs and specify
+whether you need full text, metadata, page counts, images, tables, or particular
+page ranges.
 
 ## Use Cases
 


### PR DESCRIPTION
### Motivation
- The published MCP config snippet for `PDF Reader MCP` exposed an unsafe default by leaving directory and host allowlists empty and enabling plaintext HTTP fetching, which users could copy verbatim and thereby enable unrestricted local file reads or HTTP-fetched PDFs.
- The change aims to bring the copyable example into a safer, explicit state that encourages maintainers to replace placeholders and keeps risky features disabled by default.

### Description
- Replaced empty `MCP_PDF_ALLOWED_DIRS` and `MCP_PDF_ALLOWED_HOSTS` values in the entry `content/mcp/pdf-reader-mcp.mdx` with explicit example placeholders (`/Users/you/Documents/approved-pdfs` and `trusted.example.com`).
- Set `MCP_PDF_ALLOW_HTTP` to `false` in the copyable `configSnippet` to avoid enabling plaintext HTTP PDF fetching by default.
- Added installation guidance instructing users to replace example placeholders with trusted locations and to only enable HTTP when they explicitly trust the source and understand tampering risk.

### Testing
- Ran `pnpm validate:content:strict` which completed and reported content validation passed for the repository.
- Ran `git diff --check` which reported no issues for the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f23c0832088e0145f5f6df7c3)