### PR TITLE
fix(submissions): block explicit credential stealing claims

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -59,6 +59,8 @@ const RESOURCE_THEFT_CAPABILITY_PATTERN =
   /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
 const CREDENTIAL_THEFT_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
+const EXPLICIT_CREDENTIAL_STEALING_PATTERN =
+  /\b(?:credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\bsteals?\b|\bsteals?\b[\s\S]{0,80}\b(?:credential|password|cookie|session|token|wallet)s?\b|\b(?:credential|password|cookie) stealer|keylogger\b/i;
 const ABUSE_ENABLEMENT_PATTERN =
   /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 
@@ -117,6 +119,7 @@ function hasDefensiveSecuritySafeHarbor(text) {
   return (
     DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
     !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
+    !EXPLICIT_CREDENTIAL_STEALING_PATTERN.test(text) &&
     !ABUSE_ENABLEMENT_PATTERN.test(text)
   );
 }

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -62,6 +62,8 @@ const RESOURCE_THEFT_CAPABILITY_PATTERN =
   /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
 const CREDENTIAL_THEFT_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
+const EXPLICIT_CREDENTIAL_STEALING_PATTERN =
+  /\b(?:credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\bsteals?\b|\bsteals?\b[\s\S]{0,80}\b(?:credential|password|cookie|session|token|wallet)s?\b|\b(?:credential|password|cookie) stealer|keylogger\b/i;
 const ABUSE_ENABLEMENT_PATTERN =
   /\b(build|create|generate|run|deploy|use|ship)\b[\s\S]{0,80}\b(credential stealer|password stealer|cookie stealer|keylogger|steal credentials|exfiltrat(?:e|ion)|harvest cookies|dump tokens?)\b/i;
 const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/i;
@@ -105,6 +107,7 @@ function hasDefensiveSecuritySafeHarbor(text) {
   return (
     DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
     !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
+    !EXPLICIT_CREDENTIAL_STEALING_PATTERN.test(text) &&
     !ABUSE_ENABLEMENT_PATTERN.test(text)
   );
 }

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -560,6 +560,43 @@ This audit hook can steal tokens and harvest credentials from shell output for r
     );
   });
 
+  it("does not let defensive words bypass explicit token stealing claims", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Credential Audit Notes
+category: hooks
+description: Prevent errors with audit notes; steal tokens from browser sessions.
+sourceUrl: https://github.com/example/credential-audit-notes
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Reviews browser session behavior before commands run.
+privacyNotes:
+  - Reads token material from user browser sessions.
+---
+
+Prevent errors during review; steal tokens from browser sessions for audit notes.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/hooks/credential-audit-notes.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "malicious_data_theft_capability" }),
+      ]),
+    );
+  });
+
   it("routes commercial API relay submissions out of the free content queue", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -398,7 +398,9 @@ Native macOS MCP server.`);
               "Prevent errors with audit notes; steal tokens from browser sessions.",
             repoUrl: "https://github.com/example/credential-audit-notes",
             docsUrl: "https://example.com/credential-audit-notes",
-            safetyNotes: ["Reviews browser session behavior before commands run."],
+            safetyNotes: [
+              "Reviews browser session behavior before commands run.",
+            ],
             privacyNotes: ["Reads token material from user browser sessions."],
           }),
           "content/hooks/credential-audit-notes.mdx",

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -379,6 +379,41 @@ Native macOS MCP server.`);
     );
   });
 
+  it("keeps credential-theft request changes for explicit stealing claims with defensive wording", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 131,
+        title: "content(hooks): add credential audit notes",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Credential Audit Notes",
+            slug: "credential-audit-notes",
+            category: "hooks",
+            description:
+              "Prevent errors with audit notes; steal tokens from browser sessions.",
+            repoUrl: "https://github.com/example/credential-audit-notes",
+            docsUrl: "https://example.com/credential-audit-notes",
+            safetyNotes: ["Reviews browser session behavior before commands run."],
+            privacyNotes: ["Reads token material from user browser sessions."],
+          }),
+          "content/hooks/credential-audit-notes.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(directContentRequestChangesReasons(report).join("\n")).toContain(
+      "credential, token, session, or wallet theft",
+    );
+  });
+
   it("routes commercial API relays to the listing flow", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
### Motivation
- Defensive-keyword safe-harbor was too broad and could suppress deterministic credential/theft blocking when benign words like "prevent" or "audit" appeared anywhere in the submission text.
- The intent is to allow legitimate defensive security content while still deterministically flagging submissions that explicitly advertise credential/token/session/wallet theft.

### Description
- Add an `EXPLICIT_CREDENTIAL_STEALING_PATTERN` regex to detect explicit stealing language and ensure the defensive safe-harbor does not apply when those explicit phrases are present. (updated `packages/registry/src/submission-risk.js` and `scripts/ci/validate-content-policy.mjs`).
- Update `hasDefensiveSecuritySafeHarbor(text)` to reject the safe-harbor when the new explicit-stealing pattern matches, preserving defensive exemptions for benign wording but not for explicit theft claims.
- Add regression tests that ensure explicit stealing claims are still flagged even when defensive wording is present (`tests/content-policy-validation.test.ts`, `tests/submission-pr-first.test.ts`).

### Testing
- Ran the focused test suite with `pnpm exec vitest run tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts` and all tests passed.
- Ran targeted analyzer checks by exercising `analyzeSubmissionDraftRisk`/`analyzeDirectContentRisk` on sample texts to confirm explicit theft phrases trigger `malicious_data_theft_capability` while purely defensive wording does not.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2623801b2c8320b48e500ef5c72172)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened detection of explicit credential/theft language (credential, token, session, wallet, keylogger, etc.) so defensive-sounding wording no longer allows policy bypass; such submissions are now correctly flagged for credential-theft risk.

* **Tests**
  * Added tests to ensure content policy validation and submission risk assessment flag explicit credential-theft claims even when defensive language is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->