### PR TITLE
fix(content): decode MCP allowlist hook JSON strings

### DIFF
--- a/content/hooks/mcp-server-url-allowlist-hook.mdx
+++ b/content/hooks/mcp-server-url-allowlist-hook.mdx
@@ -30,15 +30,20 @@ installCommand: |-
 
   input=$(cat)
   file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
-  text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
-  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
+  text=$(printf '%s' "$input" | jq -r '
+    def decoded_config_strings:
+      try (fromjson | .. | strings) catch empty;
+    [.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
+    | map(select(. != null))[]
+    | ., decoded_config_strings
+  ')
 
   case "$file" in
     *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
   allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
@@ -99,15 +104,20 @@ scriptBody: |-
 
   input=$(cat)
   file=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .tool_input.path // ""')
-  text=$(printf '%s' "$input" | jq -r '[.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)] | map(select(. != null)) | join(" ")')
-  normalized_text=$(printf '%s' "$text" | sed 's#\\/#/#g')
+  text=$(printf '%s' "$input" | jq -r '
+    def decoded_config_strings:
+      try (fromjson | .. | strings) catch empty;
+    [.tool_input.content, .tool_input.new_string, (.tool_input.edits[]?.new_string)]
+    | map(select(. != null))[]
+    | ., decoded_config_strings
+  ')
 
   case "$file" in
     *mcp*.json|*.mcp.json|*.claude/settings.json|*/settings.json) ;;
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$normalized_text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
   allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
@@ -125,7 +135,7 @@ scriptBody: |-
 trigger: PreToolUse
 prerequisites:
   - Claude Code CLI with hooks enabled.
-  - bash, jq, grep, awk, and sed available locally.
+  - bash, jq, grep, and awk available locally.
   - ALLOWED_MCP_HOSTS set to a comma-separated list of reviewed remote MCP hosts.
 safetyNotes:
   - "This hook blocks unreviewed remote hosts in MCP-related config edits; it does not prove an allowed host is safe."


### PR DESCRIPTION
### Motivation
- The installed `mcp-server-url-allowlist` hook only scanned raw pending text (with only `\/` normalization), so JSON Unicode-escaped URLs (e.g. `https:\u002f\u002fevil.example` or `h\u0074tps://...`) could bypass the allowlist and persist unreviewed remote MCP endpoints.
- This change prevents that security bypass by ensuring the hook inspects decoded JSON string values before extracting hosts for allowlist comparison.

### Description
- Update `content/hooks/mcp-server-url-allowlist-hook.mdx` to decode JSON string values in both the `installCommand` and `scriptBody` by using a `jq` snippet that extracts decoded strings (`fromjson | .. | strings`) alongside the raw pending snippets, and use that combined `text` for URL extraction with `grep`/`awk`.
- Replace the prior `sed`-based slash normalization approach and switch host extraction to run on the decoded `text` variable instead of `normalized_text`.
- Remove `sed` from the hook `prerequisites` since it is no longer required.
- Commit message: `fix(content): decode MCP allowlist hook JSON strings`.

### Testing
- Ran `pnpm validate:content:strict` which reported `Content validation passed`.
- Ran `git diff --check` with no issues reported.
- Performed a manual regression test by extracting the `installCommand`, installing the hook locally, and feeding payloads with literal and Unicode-escaped slash and scheme URLs; the hook now blocks both escaped and literal URLs (blocked exit code `rc=2`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262381db008320baee034c721df64c)