### PR TITLE
fix(content): remove executable MCP package placeholder

### DIFF
--- a/content/guides/claude-code-subagent-mcp-scope-guide.mdx
+++ b/content/guides/claude-code-subagent-mcp-scope-guide.mdx
@@ -110,8 +110,8 @@ description: Review source-backed docs claims and cite official URLs before cont
 tools: Read, Glob, Grep
 mcpServers:
   docs-search:
-    command: npx
-    args: ["-y", "@example/docs-mcp"]
+    command: <reviewed-docs-mcp-command>
+    args: ["<reviewed-docs-mcp-arg>"]
 model: sonnet
 isolation: worktree
 ---


### PR DESCRIPTION
### Motivation
- The guide contained a copyable YAML that ran `npx -y @example/docs-mcp`, an unvetted and unpinned npm invocation that could execute attacker-controlled code on users' machines and thus represents a registry content supply-chain risk.

### Description
- Replaced the executable example in `content/guides/claude-code-subagent-mcp-scope-guide.mdx` by changing the MCP server `command` and `args` to non-executable placeholders (`<reviewed-docs-mcp-command>`, `<reviewed-docs-mcp-arg>`) while preserving the example structure.

### Testing
- Ran `pnpm validate:content -- content/guides/claude-code-subagent-mcp-scope-guide.mdx` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f72648320ab53ce35df6a118e)