### PR TITLE
fix(hooks): catch prompt injection filler words

### DIFF
--- a/content/hooks/prompt-injection-content-scanner-hook.mdx
+++ b/content/hooks/prompt-injection-content-scanner-hook.mdx
@@ -121,8 +121,9 @@ scriptBody: |-
   fi
 
   normalized=$(printf '%s' "$content" | tr '\r\n\t' '    ' | tr '[:upper:]' '[:lower:]')
-  gap='[[:space:][:punct:]]{0,40}'
-  short_gap='[[:space:][:punct:]]{0,20}'
+  filler_words='(all|any|the|your|my|our|current|existing|original|following|these|those)'
+  gap="[[:space:][:punct:]]{0,40}(${filler_words}[[:space:][:punct:]]{1,40}){0,4}"
+  short_gap="[[:space:][:punct:]]{0,20}(${filler_words}[[:space:][:punct:]]{1,20}){0,2}"
 
   override_verbs='(ignore|disregard|forget|bypass|override|supersede)'
   instruction_refs='(previous|prior|above|earlier|system|developer|hidden)'


### PR DESCRIPTION
### Motivation
- The hook's original `gap`/`short_gap` only permitted whitespace and punctuation, which allowed common natural-language prompt-injection variants with filler words to bypass detection. 
- The goal is to close that bypass while preserving the hook's existing categories and local-only behavior.

### Description
- Add a constrained `filler_words` regex and expand `gap` and `short_gap` to allow common filler words (e.g. "all", "the", "your") between trigger terms while keeping the original whitespace/punctuation matching. 
- Existing pattern variables (`override_re`, `leak_re`, `role_re`, `conceal_re`, `tool_re`) now reuse the expanded gaps so detection categories are unchanged. 
- Change is limited to the script body in `content/hooks/prompt-injection-content-scanner-hook.mdx`.

### Testing
- Extracted the script and ran it against example phrases (baseline matches, bypass phrases, and a benign markdown sample) and verified the previously bypassed phrases now produce findings and exit with a non-zero status. 
- Ran `pnpm validate:content:strict` which passed. 
- Ran repository checks including `git diff --check` and confirmed no diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262381aa108320983ecb77c91afb4d)