### PR TITLE
fix(content): harden MCP privacy hook edit scanning

### DIFF
--- a/content/hooks/mcp-config-privacy-scanner-hook.mdx
+++ b/content/hooks/mcp-config-privacy-scanner-hook.mdx
@@ -91,6 +91,13 @@ scriptBody: |-
       (.toolInput.edits[]?.new_string) ]
     | map(select(. != null)) | join("\n")
   ')
+  edit_new_content=$(printf '%s' "$input" | jq -r '
+    [ .tool_input.new_string,
+      .toolInput.new_string,
+      (.tool_input.edits[]?.new_string),
+      (.toolInput.edits[]?.new_string) ]
+    | map(select(. != null)) | join("\n")
+  ')
 
   if [ -z "$content" ]; then
     exit 0
@@ -167,6 +174,18 @@ scriptBody: |-
   literal_secret_re="\"[A-Za-z0-9_ -]*${secret_name_re}[A-Za-z0-9_ -]*\"[[:space:]]*:[[:space:]]*\"(Bearer[[:space:]]+)?[^\"\\$<{][^\"]{8,}\""
   default_expansion_secret_re="\"[A-Za-z0-9_ -]*${secret_name_re}[A-Za-z0-9_ -]*\"[[:space:]]*:[[:space:]]*\"(Bearer[[:space:]]+)?\\$\{[A-Za-z_][A-Za-z0-9_]*:-[^}\"]{8,}\}\""
   credential_url_re='https?://[^[:space:]"<>]+[?&](access_token|api_key|token|password|client_secret)='
+  bare_secret_value_re='^"?(Bearer[[:space:]]+)?(sk-[A-Za-z0-9_-]{12,}|[A-Za-z0-9_./+=-]{24,})"?$'
+  broad_root_value_re='^"?(~|/|/Users|/home|/root|[A-Za-z]:\\Users)/?"?$'
+
+  if [ -n "$edit_new_content" ]; then
+    if printf '%s\n' "$edit_new_content" | grep -Eq -- "$bare_secret_value_re"; then
+      add_finding "inline credential value in env or headers"
+    fi
+
+    if printf '%s\n' "$edit_new_content" | grep -Eq -- "$broad_root_value_re"; then
+      add_finding "broad filesystem root exposed to filesystem MCP server"
+    fi
+  fi
 
   if printf '%s\n' "$content" | grep -Eiq -- "$literal_secret_re"; then
     add_finding "inline credential value in env or headers"
@@ -211,7 +230,7 @@ prerequisites:
   - "bash, jq, grep, sort, and a reviewed `.claude/settings.json` or user-level hook configuration."
   - "A team MCP policy for approved servers, credential storage, filesystem scopes, and remote transports."
 safetyNotes:
-  - "Runs before Write, Edit, and MultiEdit tool calls and reads only the pending file path plus proposed new text."
+  - "Runs before Write, Edit, and MultiEdit tool calls and reads only the pending file path plus proposed new text, including replacement fragments for partial edits."
   - "Blocks matching MCP configuration edits with exit code 2 when it finds inline credential values, credential-bearing URLs, or broad filesystem roots for filesystem MCP servers."
   - "Does not start MCP servers, contact remote MCP endpoints, edit files, delete files, or inspect existing config beyond the proposed tool input."
   - "Text and JSON heuristics can miss unusual config shapes or flag reviewed local setups; use `MCP_CONFIG_PRIVACY_ALLOWLIST` only for documented exceptions."


### PR DESCRIPTION
### Motivation
- The embedded MCP Config Privacy Scanner could be bypassed for Edit/MultiEdit operations that replace only a bare token or path because the hook scanned only the replacement fragment as content and relied on surrounding JSON keys to detect secrets or broad roots. 
- The change aims to ensure value-only replacements (e.g. replacing `${MCP_API_KEY}` with a real token) and single-edit MultiEdit fragments are inspected with focused high-confidence checks so the scanner enforces the advertised privacy guard.

### Description
- Extract `edit_new_content` separately from the incoming tool payload so replacement fragments from `Edit` and `MultiEdit` are available for targeted scanning. The new extraction is implemented with a `jq` expression that joins `new_string` fields into `edit_new_content`.
- Add high-confidence value-only regexes `bare_secret_value_re` and `broad_root_value_re` and run them against `edit_new_content` to detect quoted or bare secret tokens and broad filesystem root replacements before falling back to existing JSON and regex heuristics.
- Preserve all existing JSON-structure checks and fallback regexes so full snippet and structural detections remain unchanged.
- Update the hook `safetyNotes` text to explicitly state that replacement fragments for partial edits are inspected.

### Testing
- Ran an extracted copy of the embedded hook (`awk ... > /tmp/mcp-config-privacy-scanner.sh && chmod +x`) and executed targeted `Edit`/`MultiEdit` payloads; value-only and root replacement cases were flagged (non-zero exit) while safe placeholder and non-MCP edits remained allowed (zero exit). 
- Verified `pnpm validate:content:strict` against the repository content and the validation passed. 
- Ran `git diff --check` to ensure no whitespace/check errors were introduced and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2623806cd8832092713962d3b26a40)