### PR TITLE
fix(content): pin clerk skill download archive

### DIFF
--- a/content/skills/clerk-nextjs-authentication.mdx
+++ b/content/skills/clerk-nextjs-authentication.mdx
@@ -22,7 +22,7 @@ dateAdded: "2026-06-04"
 submittedAt: "2026-06-04"
 repoUrl: "https://github.com/clerk/javascript"
 documentationUrl: "https://clerk.com/docs/nextjs/getting-started/quickstart"
-downloadUrl: "https://github.com/clerk/javascript/archive/refs/heads/main.zip"
+downloadUrl: "https://github.com/clerk/javascript/archive/refs/tags/@clerk/nextjs@7.4.3.zip"
 installable: true
 installCommand: "pnpm add @clerk/nextjs"
 usageSnippet: >-
@@ -60,7 +60,7 @@ prerequisites:
   - "Decision on whether to use Clerk hosted Account Portal pages, custom sign-in/sign-up pages, or both."
   - "Production domain, redirect URL, callback URL, and allowed origin plan."
 safetyNotes:
-  - "The download URL is Clerk's external JavaScript SDK source archive, not a HeyClaude-packaged skill archive; review source provenance before using it in automated workflows."
+  - "The download URL is Clerk's external JavaScript SDK source archive pinned to the `@clerk/nextjs@7.4.3` tag, not a HeyClaude-packaged skill archive; review source provenance before using it in automated workflows."
   - "Clerk middleware does not protect routes by default; require an explicit protected-route matcher before assuming a page, API route, or tRPC endpoint is private."
   - "Do not commit `CLERK_SECRET_KEY`, webhook signing secrets, OAuth provider secrets, or copied dashboard values to source control, issue comments, screenshots, or chat transcripts."
   - "Review middleware matchers carefully. A broad matcher can affect static assets and public routes, while a narrow matcher can leave sensitive routes unauthenticated."


### PR DESCRIPTION
### Motivation
- The skill entry exposed a mutable GitHub branch archive (`refs/heads/main.zip`) as `downloadUrl`, which can change after validation and create an integrity risk for users and automation.
- Pin the downloadable archive to an immutable tag to ensure the reviewed registry entry continues to reference the same bytes.

### Description
- Update `content/skills/clerk-nextjs-authentication.mdx` to replace the `downloadUrl` from the mutable `refs/heads/main.zip` URL to the tagged archive `https://github.com/clerk/javascript/archive/refs/tags/@clerk/nextjs@7.4.3.zip`.
- Update the `safetyNotes` text to indicate the archive is pinned to the `@clerk/nextjs@7.4.3` tag while preserving the warning that this is an external SDK archive and not a HeyClaude-packaged skill.
- Commit changes with the PR title `fix(content): pin clerk skill download archive` so the validated entry no longer points at a mutable branch archive.

### Testing
- Ran `pnpm validate:content:strict` and the content validation passed successfully.
- Ran `pnpm validate:packages` and `node scripts/validate-download-packages.mjs` (package download validation) and both passed successfully.
- Ran `pnpm scan:packages` (package artifact scan) and `git diff --check`, and both checks completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f1ae48320bff471404034014e)