### PR TITLE
fix(content): sanitize lockfile hook diagnostics

### DIFF
--- a/content/hooks/lockfile-provenance-checker.mdx
+++ b/content/hooks/lockfile-provenance-checker.mdx
@@ -91,13 +91,16 @@ scriptBody: |-
   jq -e 'has("packages")' "$FILE" >/dev/null 2>&1 || exit 0
 
   found=0
+  sanitize_output() {
+    LC_ALL=C tr -d '\000-\010\013-\037\177'
+  }
   report() {
     local lines
-    lines=$(jq -r "$2" "$FILE" 2>/dev/null | sed '/^$/d' | head -10)
+    lines=$(jq -r "$2" "$FILE" 2>/dev/null | sanitize_output | sed '/^$/d' | head -10)
     if [ -n "$lines" ]; then
       echo "$1" >&2
       printf '%s\n' "$lines" | while IFS= read -r l; do
-        [ -n "$l" ] && echo "   - $l" >&2
+        [ -n "$l" ] && printf '   - %s\n' "$l" >&2
       done
       found=1
     fi
@@ -107,10 +110,10 @@ scriptBody: |-
   # provenance signal: git sources, alternate registries, and insecure
   # transports all fail this test.
   report "Dependencies resolved from outside the public npm registry (supply-chain risk):" \
-    '.packages | to_entries[] | select(.value.resolved) | select(.value.resolved | test("^https://registry\\.npmjs\\.org/") | not) | "\(.key): \(.value.resolved)"'
+    'def clean: gsub("[\u0000-\u001F\u007F]"; ""); .packages | to_entries[] | select(.value.resolved) | select(.value.resolved | test("^https://registry\\.npmjs\\.org/") | not) | "\(.key | clean): \(.value.resolved | clean)"'
 
   report "Registry tarballs missing an integrity hash:" \
-    '.packages | to_entries[] | select(.value.resolved) | select(.value.resolved | test("^https://registry\\.npmjs\\.org/")) | select((.value.integrity // "") == "") | .key'
+    'def clean: gsub("[\u0000-\u001F\u007F]"; ""); .packages | to_entries[] | select(.value.resolved) | select(.value.resolved | test("^https://registry\\.npmjs\\.org/")) | select((.value.integrity // "") == "") | (.key | clean)'
 
   if [ "$found" -ne 0 ]; then
     echo "Confirm these sources are expected; run lockfile-lint for the full check set and an allowlist." >&2


### PR DESCRIPTION
### Motivation
- The lockfile hook emitted copyable shell advice containing raw file paths and printed jq-derived values directly to stderr, which could lead to accidental command execution or terminal-control-sequence injection when paths or lockfile fields contain control characters or shell metacharacters.
- The change aims to ensure diagnostic output is safe to view and copy while preserving the original advisory checks and behavior.

### Description
- Added a `sanitize_output()` helper that strips ASCII control characters via `tr` and applied it to all jq-derived report lines.
- Switched diagnostic line emission to `printf '   - %s\n'` to avoid `echo`-related interpretation issues when printing values.
- Sanitized package keys and resolved URLs at the `jq` filter level by adding a `def clean: gsub("[\u0000-\u001F\u007F]"; "")` wrapper so reported strings are cleaned before formatting.
- Preserved existing safe escaping for suggested Yarn/`pnpm` command paths using `printf -v SAFE_FILE '%q'` so the one-line reminder remains shell-escaped for copy/paste.

### Testing
- Ran `pnpm validate:content:strict` and validation passed.
- Ran `git diff --check` and it produced no issues.
- Executed extracted-hook smoke tests that simulated a malicious Yarn/pnpm path and a package-lock containing ESC/BEL/control bytes; tests verified the suggested command remains shell-escaped and that control characters were removed from hook stderr output (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f29d88320946b9cf506db4eaf)