### PR TITLE
fix(statuslines): avoid OSV report symlink clobber

### DIFF
--- a/content/statuslines/osv-dependency-risk-statusline.mdx
+++ b/content/statuslines/osv-dependency-risk-statusline.mdx
@@ -47,7 +47,19 @@ scriptBody: |-
   report="${OSV_STATUSLINE_JSON:-osv-report.json}"
 
   if [ "${OSV_STATUSLINE_SCAN:-0}" = "1" ] && command -v osv-scanner >/dev/null 2>&1; then
-    osv-scanner --format json . > "$report" 2>/dev/null || true
+    if [ -L "$report" ]; then
+      echo "deps: unsafe report path"
+      exit 0
+    fi
+
+    report_dir=$(dirname "$report")
+    tmp_report=$(mktemp "$report_dir/.osv-report.XXXXXX") || exit 0
+    trap 'rm -f "$tmp_report"' EXIT
+
+    if osv-scanner --format json . > "$tmp_report" 2>/dev/null; then
+      mv -f "$tmp_report" "$report"
+      trap - EXIT
+    fi
   fi
 
   if [ ! -f "$report" ]; then
@@ -79,6 +91,7 @@ prerequisites:
   - Optional OSV-Scanner CLI installed if OSV_STATUSLINE_SCAN is set to 1.
 safetyNotes:
   - Prefer reading a precomputed report; scanning dependencies during every statusline refresh can be slow.
+  - Auto-scan mode refuses symlinked report paths and writes through a temporary file before replacing the report.
   - Vulnerability counts need human triage for reachability, exploitability, and acceptable remediation timing.
   - Do not let a zero count replace lockfile review, provenance checks, or package-manager audit policy.
 privacyNotes:


### PR DESCRIPTION
### Motivation
- The statusline's auto-scan mode wrote OSV scanner output directly to a configurable/default report path with shell redirection, which follows symlinks and can clobber arbitrary user-writable files.
- The documented `OSV_STATUSLINE_SCAN=1` and `OSV_STATUSLINE_JSON` options create the preconditions for this local file truncate/replace risk, so the auto-scan write path needed hardening.

### Description
- Reject symlinked report paths before running the scanner by checking `-L "$report"` and aborting when the report is a symlink.
- Write scanner output to a safely-created temporary file in the report directory using `mktemp`, and atomically replace the target with `mv -f` only after a successful scan, with a `trap` to clean up on error.
- Update `safetyNotes` to document that auto-scan mode refuses symlinked report paths and uses a temp-file replacement strategy.
- The single modified file is `content/statuslines/osv-dependency-risk-statusline.mdx`.

### Testing
- Ran `pnpm validate:content:strict` and it passed.
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f5c748320b15ac4f264002c98)