### PR TITLE
fix(statuslines): harden context pressure validation

### DIFF
--- a/content/statuslines/context-pressure-statusline.mdx
+++ b/content/statuslines/context-pressure-statusline.mdx
@@ -47,12 +47,12 @@ scriptBody: |-
   limit="${CLAUDE_CONTEXT_LIMIT:-200000}"
   used=$(printf '%s' "$input" | jq -r '.session.totalTokens // .usage.input_tokens // .cost.total_tokens // 0')
 
-  if ! printf '%s' "$limit" | grep -Eq '^[0-9]+$'; then
-    limit=200000
-  fi
-  if ! printf '%s' "$used" | grep -Eq '^[0-9]+$'; then
-    used=0
-  fi
+  case "$limit" in
+    "" | *[!0-9]*) limit=200000 ;;
+  esac
+  case "$used" in
+    "" | *[!0-9]*) used=0 ;;
+  esac
 
   if [ "$limit" -le 0 ]; then
     limit=200000

--- a/tests/statusline-scripts.test.ts
+++ b/tests/statusline-scripts.test.ts
@@ -1,0 +1,45 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function readScriptBody(relativePath: string) {
+  const source = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+  const { data } = parseSafeFrontmatter(source);
+  return String(data.scriptBody ?? "");
+}
+
+function writeExecutableTempScript(scriptBody: string) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "heyclaude-statusline-"));
+  const scriptPath = path.join(tmpDir, "statusline.sh");
+  fs.writeFileSync(scriptPath, scriptBody, { encoding: "utf8", mode: 0o700 });
+  return { scriptPath, tmpDir };
+}
+
+describe("statusline scripts", () => {
+  it("rejects multiline token counters before Bash arithmetic evaluation", () => {
+    const scriptBody = readScriptBody(
+      "content/statuslines/context-pressure-statusline.mdx",
+    );
+    const { scriptPath, tmpDir } = writeExecutableTempScript(scriptBody);
+    const markerPath = path.join(tmpDir, "marker");
+    const payload = JSON.stringify({
+      session: {
+        totalTokens: `123\n+limit[$(printf pwned > ${markerPath})]`,
+      },
+    });
+
+    const output = execFileSync("bash", [scriptPath], {
+      input: `${payload}\n`,
+      encoding: "utf8",
+    });
+
+    expect(output).toBe("context: 0/200000 | 0% | ok\n");
+    expect(fs.existsSync(markerPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent command injection from crafted multiline token fields in the context-pressure statusline by ensuring numeric values cannot contain newlines or shell metacharacters before Bash arithmetic expansion.

### Description

- Replace line-oriented `grep -Eq '^[0-9]+$'` checks with shell `case` pattern validation that rejects empty or non-digit (including multiline) `limit` and `used` values before performing arithmetic.
- Update `content/statuslines/context-pressure-statusline.mdx` to use the safer `case "$var" in "" | *[!0-9]*) ... ;; esac` pattern for both `limit` and `used`.
- Add a regression test `tests/statusline-scripts.test.ts` that extracts the MDX `scriptBody`, runs it with a malicious multiline `totalTokens` payload, and verifies the script resets `used` to `0` and does not create the command-substitution marker file.

### Testing

- Ran `pnpm validate:content:strict` which completed successfully and reported content validation passed.  
- Ran the new unit test with `pnpm exec vitest run tests/statusline-scripts.test.ts` and the test passed.  
- Ran `git diff --check` (whitespace/format checks) which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262380de248320a34fd8c51d87d5ac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for statusline scripts with enhanced validation coverage to ensure robust handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->