### PR TITLE
fix(submissions): preserve accepted duplicate URL signals

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2606,6 +2606,18 @@ function yamlScalar(value: unknown) {
   return JSON.stringify(String(value || ""));
 }
 
+const DIRECTORY_ENTRY_URL_SIGNAL_FIELDS = [
+  "documentationUrl",
+  "docsUrl",
+  "downloadUrl",
+  "githubUrl",
+  "packageUrl",
+  "repoUrl",
+  "repositoryUrl",
+  "sourceUrl",
+  "websiteUrl",
+] as const;
+
 function contentSignalSourceFromDirectoryEntry(entry: Record<string, unknown>) {
   const lines = [
     "---",
@@ -2614,12 +2626,8 @@ function contentSignalSourceFromDirectoryEntry(entry: Record<string, unknown>) {
     `category: ${yamlScalar(entry.category)}`,
     `slug: ${yamlScalar(entry.slug)}`,
   ];
-  for (const [field, value] of [
-    ["documentationUrl", entry.documentationUrl],
-    ["downloadUrl", entry.downloadUrl],
-    ["repoUrl", entry.repoUrl],
-    ["websiteUrl", entry.websiteUrl],
-  ] as const) {
+  for (const field of DIRECTORY_ENTRY_URL_SIGNAL_FIELDS) {
+    const value = entry[field];
     if (value) lines.push(`${field}: ${yamlScalar(value)}`);
   }
   lines.push("---", "");

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -259,6 +259,15 @@ export function buildDirectoryEntries(entries) {
       tags: entry.tags ?? [],
       keywords: entry.keywords ?? [],
       documentationUrl: entry.documentationUrl || "",
+      docsUrl: entry.docsUrl || undefined,
+      sourceUrl: entry.sourceUrl || undefined,
+      sourceUrls:
+        Array.isArray(entry.sourceUrls) && entry.sourceUrls.length
+          ? entry.sourceUrls
+          : undefined,
+      packageUrl: entry.packageUrl || undefined,
+      repositoryUrl: entry.repositoryUrl || undefined,
+      websiteUrl: entry.websiteUrl || undefined,
       ...buildEntryProvenanceFields(entry),
       ...buildEntryBrandFields(entry),
       repoUrl: entry.repoUrl || "",
@@ -381,9 +390,15 @@ export function buildSkillPlatformCompatibility(entry) {
 function sourceUrlsForEntry(entry) {
   return [
     entry.documentationUrl,
+    entry.docsUrl,
+    entry.downloadUrl,
     entry.repoUrl,
     entry.githubUrl,
+    entry.packageUrl,
+    entry.repositoryUrl,
+    entry.sourceUrl,
     entry.websiteUrl,
+    ...(Array.isArray(entry.sourceUrls) ? entry.sourceUrls : []),
     ...(Array.isArray(entry.retrievalSources) ? entry.retrievalSources : []),
   ]
     .map((value) => String(value || "").trim())

--- a/packages/registry/src/content-builder.js
+++ b/packages/registry/src/content-builder.js
@@ -279,6 +279,16 @@ export function buildContentEntryFromMdx(params) {
     documentationUrl: data.documentationUrl
       ? String(data.documentationUrl)
       : undefined,
+    docsUrl: data.docsUrl ? String(data.docsUrl) : undefined,
+    sourceUrl: data.sourceUrl ? String(data.sourceUrl) : undefined,
+    packageUrl: data.packageUrl ? String(data.packageUrl) : undefined,
+    repositoryUrl: data.repositoryUrl ? String(data.repositoryUrl) : undefined,
+    sourceUrls: Array.isArray(data.sourceUrls)
+      ? data.sourceUrls
+          .map(String)
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : undefined,
     websiteUrl: data.websiteUrl ? String(data.websiteUrl) : undefined,
     ...brandAssets,
     affiliateUrl:

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -243,6 +243,11 @@ export type ContentEntry = {
   readingTime?: number;
   difficultyScore?: number;
   documentationUrl?: string;
+  docsUrl?: string;
+  sourceUrl?: string;
+  sourceUrls?: string[];
+  packageUrl?: string;
+  repositoryUrl?: string;
   websiteUrl?: string;
   brandName?: string;
   brandDomain?: string;

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -199,6 +199,53 @@ describe("registry artifacts", () => {
     expect(searchEntries.length).toBe(contentEntries.length);
   });
 
+  it("keeps duplicate-detection source URL fields in directory entries", () => {
+    const [directoryEntry] = buildDirectoryEntries([
+      {
+        category: "tools",
+        slug: "source-backed-tool",
+        title: "Source Backed Tool",
+        description: "Tool with every accepted source URL alias.",
+        tags: [],
+        keywords: [],
+        documentationUrl: "https://example.com/docs",
+        docsUrl: "https://example.com/docs-alias",
+        downloadUrl: "https://example.com/download.zip",
+        packageUrl: "https://www.npmjs.com/package/source-backed-tool",
+        repoUrl: "https://github.com/example/source-backed-tool",
+        repositoryUrl: "https://gitlab.com/example/source-backed-tool",
+        sourceUrl: "https://example.com/source",
+        sourceUrls: ["https://example.com/extra-source"],
+        websiteUrl: "https://example.com",
+      },
+    ]);
+
+    expect(directoryEntry).toMatchObject({
+      documentationUrl: "https://example.com/docs",
+      docsUrl: "https://example.com/docs-alias",
+      downloadUrl: "https://example.com/download.zip",
+      packageUrl: "https://www.npmjs.com/package/source-backed-tool",
+      repoUrl: "https://github.com/example/source-backed-tool",
+      repositoryUrl: "https://gitlab.com/example/source-backed-tool",
+      sourceUrl: "https://example.com/source",
+      sourceUrls: ["https://example.com/extra-source"],
+      websiteUrl: "https://example.com",
+    });
+    expect(directoryEntry.trustSignals.sourceUrls).toEqual(
+      expect.arrayContaining([
+        "https://example.com/docs",
+        "https://example.com/docs-alias",
+        "https://example.com/download.zip",
+        "https://www.npmjs.com/package/source-backed-tool",
+        "https://github.com/example/source-backed-tool",
+        "https://gitlab.com/example/source-backed-tool",
+        "https://example.com/source",
+        "https://example.com/extra-source",
+        "https://example.com",
+      ]),
+    );
+  });
+
   it("keeps public registry payloads within reviewable byte budgets", () => {
     const entryCount = contentEntries.length;
     // These budgets are growth guards, not fixed caps. The public registry

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2360,6 +2360,30 @@ ${urls}
     expect(source).toContain("secret: env.GITHUB_WEBHOOK_SECRET,");
   });
 
+  it("reconstructs all directory URL signal fields for accepted duplicate scans", () => {
+    const source = readWorkerSource();
+    const helperSource =
+      source.match(
+        /const DIRECTORY_ENTRY_URL_SIGNAL_FIELDS[\s\S]*?async function acceptedContentSignals/,
+      )?.[0] || "";
+
+    for (const field of [
+      "documentationUrl",
+      "docsUrl",
+      "downloadUrl",
+      "githubUrl",
+      "packageUrl",
+      "repoUrl",
+      "repositoryUrl",
+      "sourceUrl",
+      "websiteUrl",
+    ]) {
+      expect(helperSource).toContain(`"${field}"`);
+    }
+    expect(helperSource).toContain("DIRECTORY_ENTRY_URL_SIGNAL_FIELDS");
+    expect(helperSource).toContain("entry[field]");
+  });
+
   it("detects neutral duplicate submissions from canonical source URLs", () => {
     const existing = extractContentDuplicateSignals({
       filePath: "content/tools/ccusage.mdx",


### PR DESCRIPTION
### Motivation
- The duplicate-detection precheck was reconstructed from the public `directory-index.json`, but the public artifact omitted several source URL aliases (e.g. `sourceUrl`, `packageUrl`, `docsUrl`, `repositoryUrl`, `sourceUrls`), allowing same-source duplicates to bypass the deterministic close path.
- Restore the full set of URL signals used by the duplicate classifier so accepted entries keep comparable canonical/source signals during the deterministic precheck.

### Description
- Reconstruct accepted-entry frontmatter from directory entries using a full URL-signal set via `DIRECTORY_ENTRY_URL_SIGNAL_FIELDS` and updated `contentSignalSourceFromDirectoryEntry` in `apps/submission-gate/src/index.ts` to include `documentationUrl`, `docsUrl`, `downloadUrl`, `githubUrl`, `packageUrl`, `repoUrl`, `repositoryUrl`, `sourceUrl`, and `websiteUrl`.
- Preserve those URL aliases in registry parsing by adding `docsUrl`, `sourceUrl`, `sourceUrls`, `packageUrl`, and `repositoryUrl` to `buildContentEntryFromMdx` in `packages/registry/src/content-builder.js` and expose them in the compact directory artifact in `packages/registry/src/artifacts.js`.
- Include the expanded fields in `sourceUrlsForEntry` so `trustSignals.sourceUrls` aggregates all URL aliases used for duplicate detection.
- Add/update type declarations in `packages/registry/src/index.d.ts` to reflect new optional fields (`docsUrl`, `sourceUrl`, `sourceUrls`, `packageUrl`, `repositoryUrl`).
- Add regression tests: `tests/registry-artifacts.test.ts` verifies directory entries preserve duplicate-detection URL fields, and `tests/submission-gate-worker.test.ts` asserts the worker reconstructs those fields for accepted duplicate scans.

### Testing
- Ran the registry prebuild and targeted tests: `pnpm --filter web run prebuild`, `pnpm exec vitest run tests/registry-artifacts.test.ts -t "keeps duplicate-detection source URL fields|keeps public registry payloads"`, and `pnpm exec vitest run tests/submission-gate-worker.test.ts`; the targeted tests passed.
- Executed the full `tests/submission-gate-worker.test.ts` suite and the worker tests completed successfully (`90 passed`).
- Also ran `git diff --check` as part of validation to ensure no whitespace/format issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f35e08320a6bafaf5b9d5c3c7)