### PR TITLE
fix(submissions): refresh ignored PR review key

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -1796,6 +1796,7 @@ async function ignoreOutOfScopeReviewTarget(params: {
   message: QueueMessage;
   summary: string;
 }) {
+  const reviewScanKey = reviewScanKeyForTarget(params.target);
   await removeLabels({
     token: params.token,
     repo: params.repo,
@@ -1813,6 +1814,7 @@ async function ignoreOutOfScopeReviewTarget(params: {
     installationId: params.target.installationId,
     status: "ignored",
     deliveryId: String(params.message.payload.deliveryId || ""),
+    lastReviewKey: reviewScanKey || undefined,
     lastError: params.summary,
   });
   await insertAudit(params.env.SUBMISSION_GATE_DB, {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -502,6 +502,16 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).not.toContain("getRepositoryBlobText({");
     expect(source).not.toContain("getRepositoryTree({");
     expect(source).toContain("function ignoreOutOfScopeReviewTarget");
+    const ignoreOutOfScopeBlock = source.slice(
+      source.indexOf("async function ignoreOutOfScopeReviewTarget"),
+      source.indexOf("function isRetryableMergeError"),
+    );
+    expect(ignoreOutOfScopeBlock).toContain(
+      "const reviewScanKey = reviewScanKeyForTarget(params.target);",
+    );
+    expect(ignoreOutOfScopeBlock).toContain(
+      "lastReviewKey: reviewScanKey || undefined",
+    );
     expect(source).toContain(
       "Skipped because this PR no longer targets the configured content gate base.",
     );


### PR DESCRIPTION
### Motivation
- The out-of-scope ignore path previously recorded `status: "ignored"` without updating the deduplication key (`lastReviewKey`), allowing a retarget-to-other-branch-and-back timing race to suppress later reinspection of the same head SHA for the content gate.

### Description
- Compute the current review scan key with `reviewScanKeyForTarget(params.target)` inside `ignoreOutOfScopeReviewTarget` and persist it as `lastReviewKey` when calling `upsertPrState` so ignored states reflect the refreshed base/head combination.
- Add a regression assertion in `tests/submission-gate-worker.test.ts` that the ignore block contains the new `reviewScanKey` computation and the `lastReviewKey: reviewScanKey || undefined` write.
- Changes are limited to `apps/submission-gate/src/index.ts` and the associated unit test `tests/submission-gate-worker.test.ts` to avoid altering other gate behaviors.

### Testing
- Ran the focused unit test suite with `pnpm exec vitest run tests/submission-gate-worker.test.ts` which completed successfully with `89 passed (89)` tests.
- Ran `git diff --check` which reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26237f324c8320ac228a8beadd3344)