### PR TITLE
fix(submissions): require maintainer approval for tools listings

### DIFF
--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -120,6 +120,8 @@ function isToolsRouteError(message: string) {
   const normalized = message.toLowerCase();
   return (
     normalized.includes("tools/app lead form") ||
+    normalized.includes("tools/app listing flow") ||
+    normalized.includes("free resource queue without maintainer approval") ||
     normalized.includes("change the category to tools")
   );
 }

--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -4,6 +4,7 @@ import {
   looksLikeToolAppListing,
   missingToolListingReviewFields,
   TOOLS_CATEGORY,
+  toolListingApprovalMessage,
   toolListingRoutingMessage,
 } from "./submission-classification.js";
 import { buildSubmissionFieldModel } from "./submission-spec.js";
@@ -768,6 +769,26 @@ const TOOL_DISCLOSURES = new Set([
   "claimed",
 ]);
 
+const PROTECTED_SUBMISSION_LABELS = new Set(["accepted"]);
+
+function labelName(label) {
+  if (typeof label === "string") return label;
+  if (label && typeof label === "object") return label.name;
+  return "";
+}
+
+function hasProtectedSubmissionLabel(draft = {}) {
+  return Array.isArray(draft.labels)
+    ? draft.labels.some((label) =>
+        PROTECTED_SUBMISSION_LABELS.has(
+          String(labelName(label) || "")
+            .trim()
+            .toLowerCase(),
+        ),
+      )
+    : false;
+}
+
 export function validateSubmission(draft) {
   const fields = parseSubmissionPrBody(draft.body ?? "");
   const categoryFromField = normalizeCategory(fields.category);
@@ -890,6 +911,10 @@ export function validateSubmission(draft) {
   }
 
   if (category === TOOLS_CATEGORY) {
+    if (!hasProtectedSubmissionLabel(draft)) {
+      errors.push(toolListingApprovalMessage());
+    }
+
     const missingToolFields = missingToolListingReviewFields(fields);
     for (const field of missingToolFields) {
       errors.push(`Tools listings require ${field}`);

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -144,6 +144,36 @@ describe("website submission preflight API", () => {
     expect(body.routeSuggestion).toBe("route_away");
   });
 
+  it("routes tools listings without maintainer approval away from public PR submission", async () => {
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest({
+        fields: validFields({
+          category: "tools",
+          name: "Paid Hosted Claude Platform",
+          slug: "paid-hosted-claude-platform",
+          description:
+            "Paid SaaS platform with sponsored placement and enterprise pricing for Claude workflow teams.",
+          card_description: "Paid Claude workflow platform.",
+          website_url: "https://example.com/product",
+          docs_url: "https://example.com/docs",
+          pricing_model: "paid",
+          disclosure: "sponsored",
+          application_category: "Hosted platform",
+          operating_system: "Web",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.routeSuggestion).toBe("route_away");
+    expect(body.valid).toBe(false);
+    expect(body.schema.errors.join("\n")).toContain(
+      "not merged from the free resource queue without maintainer approval",
+    );
+  });
+
   it("routes risky but potentially valid submissions to manual review", async () => {
     const { POST } = await import("@/routes/api/submissions/preflight");
     const response = await POST(

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -148,6 +148,55 @@ Native macOS MCP server.`);
     expect(buildSubmissionFieldModel("prompts")).toBeNull();
   });
 
+  it("requires maintainer approval before tools listings enter the PR-first queue", () => {
+    const draft = buildSubmissionPrDraft({
+      name: "Acme Sponsored Claude Platform",
+      slug: "acme-sponsored-claude-platform",
+      category: "tools",
+      description:
+        "Paid SaaS platform with sponsored placement for Claude workflow teams.",
+      card_description: "Paid Claude workflow platform.",
+      website_url: "https://example.com/product",
+      docs_url: "https://example.com/docs",
+      pricing_model: "paid",
+      disclosure: "sponsored",
+      application_category: "Hosted platform",
+      operating_system: "Web",
+    });
+
+    const validation = validateSubmission(draft);
+
+    expect(validation.ok).toBe(false);
+    expect(validation.errors.join("\n")).toContain(
+      "not merged from the free resource queue without maintainer approval",
+    );
+  });
+
+  it("allows maintainer-accepted tools listings to keep existing metadata validation", () => {
+    const draft = {
+      ...buildSubmissionPrDraft({
+        name: "Maintainer Reviewed Claude Tool",
+        slug: "maintainer-reviewed-claude-tool",
+        category: "tools",
+        description:
+          "Editorially reviewed Claude tool with complete listing metadata.",
+        card_description: "Reviewed Claude tool listing.",
+        website_url: "https://example.com/product",
+        docs_url: "https://example.com/docs",
+        pricing_model: "free",
+        disclosure: "editorial",
+        application_category: "Developer tool",
+        operating_system: "Web",
+      }),
+      labels: [{ name: "accepted" }],
+    };
+
+    const validation = validateSubmission(draft);
+
+    expect(validation.ok).toBe(true);
+    expect(validation.errors).toEqual([]);
+  });
+
   it("blocks affiliate, referral, and unsafe source signals during draft risk review", () => {
     const draft = buildSubmissionPrDraft({
       ...validMcpFields,


### PR DESCRIPTION
### Motivation
- A recent refactor removed the protected maintainer-approval gate for `tools` submissions, allowing commercial/sponsored/affiliate tool listings to route into the public PR-first intake when they should require maintainer review. 
- Restore policy enforcement so product-like `tools` entries cannot bypass the tools/app listing flow and maintainer approval.

### Description
- Reinstates the maintainer-approval gate by importing `toolListingApprovalMessage`, adding `PROTECTED_SUBMISSION_LABELS` and `hasProtectedSubmissionLabel`, and rejecting `tools`-category drafts that lack the protected label inside `validateSubmission` in `packages/registry/src/submission.js`.
- Treats approval-related validation messages as tools-route errors in `apps/web/src/lib/submission-preflight.ts` by expanding `isToolsRouteError` so preflight routes unapproved tools to `route_away` instead of `submit_pr`.
- Adds regression tests to `tests/submission-pr-first.test.ts` and `tests/submission-api.test.ts` that assert unapproved `tools` listings are blocked while maintainer-accepted (labelled) listings continue to validate normally.

### Testing
- Ran formatter and linters with `pnpm exec prettier --write ...` and verified no formatting errors (applied to changed files). 
- Ran unit tests with `pnpm exec vitest run tests/submission-pr-first.test.ts tests/submission-api.test.ts` and observed all tests passed. 
- Ran API contract check with `pnpm validate:openapi` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2623809030832091756138cd751870)