### PR TITLE
fix(submissions): fail neutral Superagent checks

### DIFF
--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -582,17 +582,6 @@ export async function getCommitValidationState(params: {
       });
       continue;
     }
-    if (
-      /^superagent security scan$/i.test(name) &&
-      run.conclusion === "neutral"
-    ) {
-      checkResults.push({
-        name,
-        status: "passed",
-        details: "concluded neutral",
-      });
-      continue;
-    }
     if (run.conclusion !== "success") {
       checkResults.push({
         name,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -343,7 +343,7 @@ describe("Cloudflare submission gate helpers", () => {
     });
   });
 
-  it("treats neutral Superagent scans as non-failing content gate signals", async () => {
+  it("treats neutral Superagent scans as failed validation for manual review", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({
         check_runs: [
@@ -372,12 +372,12 @@ describe("Cloudflare submission gate helpers", () => {
         requiredChecks: ["validate-content", "Superagent Security Scan"],
       }),
     ).resolves.toMatchObject({
-      state: "passed",
+      state: "failed",
       checks: [
         { name: "validate-content", status: "passed" },
         {
           name: "Superagent Security Scan",
-          status: "passed",
+          status: "failed",
           details: "concluded neutral",
         },
       ],


### PR DESCRIPTION
### Motivation
- Prevent a logic bypass that treated a `Superagent Security Scan` check run with conclusion `neutral` as passing, which could allow inconclusive security scans to proceed toward private review and merge.
- Ensure Superagent outcomes that are neutral/skipped/cancelled continue to trigger the existing manual-review path and do not weaken the required-validation contract.

### Description
- Removed the Superagent-specific `neutral` special-case in `getCommitValidationState` so completed checks only pass when `run.conclusion === "success"` in `apps/submission-gate/src/github.ts`.
- Adjusted the regression test in `tests/submission-gate-worker.test.ts` to assert a neutral `Superagent Security Scan` produces a failing validation check with `details: "concluded neutral"` and overall `state: "failed"`.
- Preserved existing behavior where neutral/inconclusive Superagent failures are handled by `validationGateDecision` and routed to manual review.

### Testing
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts --testNamePattern "neutral Superagent|validation"`, and the targeted tests passed.
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts`, and the full test file passed (`89/89` tests).
- Ran `pnpm test:submission-pr-first`, and the suite passed (`15/15` tests).
- Ran `git diff --check` to verify no whitespace/errors reported and found no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a262380a56c8320b3bd959a5c33d9d2)