### PR TITLE
fix(submissions): harden review fallback docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,12 +13,22 @@ For direct content PRs:
 - [ ] `submittedBy` and `submittedByUrl` match the PR author.
 - [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
 - [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
+- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.
 
 For platform/code/docs PRs:
 
 - [ ] This is not a direct content submission.
 - [ ] Changed routes/components/endpoints/tools are listed below.
 - [ ] Screenshots or `No visual impact` are included when relevant.
+- [ ] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.
+
+For registry API endpoint PRs:
+
+- [ ] Route handler and central API contract changed together.
+- [ ] Origin-check and rate-limit posture is stated below.
+- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
+- [ ] API contract tests were added or updated.
+- [ ] Generator reproducibility was checked or the reason it was not checked is listed.
 
 ## Schema and Quality Checks
 
@@ -51,4 +61,5 @@ For platform/code/docs PRs:
 
 ## Notes
 
+- Linked issue or no-issue rationale:
 - Any caveats, follow-ups, or reviewer context.

--- a/docs/api-security-contract.md
+++ b/docs/api-security-contract.md
@@ -79,6 +79,41 @@ dynamic endpoints. Registry publishing is not exposed over the public API.
   by the token-protected D1 admin flow, which requires enriched reviewed listing
   content before active paid rows can publish.
 
+## Registry Endpoint Change Checklist
+
+Registry API PRs need a separate review path from content-only submission
+fallbacks. A clean CodeRabbit review or a skipped bot review is not enough for a
+new or changed registry endpoint. Review these surfaces together:
+
+- Route handler: add or update the thin handler under
+  `apps/web/src/routes/api/**` and keep request handling delegated through the
+  central API router.
+- Contract: add or update the matching route definition in
+  `apps/web/src/lib/api/contracts.ts`, including method, path, route id, tags,
+  response schema, error responses, origin-check setting, and rate-limit scope.
+- Runtime posture: state whether the endpoint is read-only or write-capable,
+  whether browser origin checks apply, which Cloudflare rate-limit binding is
+  used, and whether auth, webhook signatures, payload limits, or content-type
+  checks are required.
+- Source logic: keep registry aggregation or lookup behavior in the shared
+  content/server layer rather than duplicating registry traversal in the route
+  file.
+- Tests: update `tests/api-contracts.test.ts` and focused route/router tests so
+  route coverage, ids, paths, schemas, examples, and error envelopes stay
+  deterministic.
+- OpenAPI: run `pnpm validate:openapi` or document why it was not run. Generated
+  files such as `apps/web/public/openapi.{json,yaml}`,
+  `apps/web/src/data/openapi.ts`, and
+  `cloudflare/api-schema-heyclaude-openapi.yaml` must come from the generator;
+  do not hand-edit them.
+- Reproducibility: for maintainer/internal generation PRs, confirm generator
+  output is reproducible and generated diffs are limited to the endpoint change.
+  For external contributor PRs, prefer source route/contract/test changes and
+  leave generated artifact commits to maintainer automation.
+- Linked issue: link the issue being solved, or write an explicit
+  maintainer-lane no-issue rationale in the PR body so advisory bots do not
+  keep surfacing missing-link noise.
+
 ## Registry Trust Fields
 
 Registry feeds and entry detail payloads may include `trustSignals` derived from

--- a/docs/submission-queue-ops.md
+++ b/docs/submission-queue-ops.md
@@ -104,6 +104,46 @@ the gate later creates its own formal GitHub check run.
 - `manual` is rare and reserved for Superagent/private-review outages, merge
   failures after retries, or genuinely close high-risk calls.
 
+## Review Fallback Checklist
+
+Maintainer review must not depend on CodeRabbit being present. For content-only
+PRs, especially `content(mcp): ...` submissions where CodeRabbit is intentionally
+skipped by title policy, use the HeyClaude gate marker comment as the primary
+review surface and verify the remaining public signals before merging or
+closing.
+
+When CodeRabbit is skipped, rate-limited, unavailable, or clean-but-incomplete:
+
+- Read the stable `<!-- heyclaude-submission-gate -->` comment first. Trust
+  `gate-comment-v5` only when it names the changed file, category, validation
+  results, source reachability, duplicate review, safety/privacy coverage, and
+  deterministic source evidence or equivalent provenance.
+- Check required CI independently. A CodeRabbit skip or clean review does not
+  override a failed `validate-content`, Superagent, package scan, registry
+  contract test, or required PR gate.
+- Check Gittensory as advisory context for linked-issue/no-issue rationale,
+  duplicate/overlap clusters, review burden, and Gittensor contributor context.
+  Gittensory does not replace the HeyClaude content gate verdict.
+- Confirm linked-issue policy. Contributor-lane content PRs should close or
+  reference a concrete issue when one exists. Direct maintainer-lane additions
+  may be valid with an explicit no-issue rationale in the PR body.
+- Confirm focused diff scope. Accepted content submissions stay to one raw
+  `content/<category>/<slug>.mdx` file; generated artifacts, README, workflows,
+  scripts, package files, downloads, and multiple content entries remain out of
+  contributor PR scope.
+
+Gate comments should be concrete. For closures, the public comment must name the
+blocking validation or metadata gap, say whether a fresh clean PR is appropriate,
+and identify what evidence needs to change. Avoid generic resubmission loops
+that do not tell contributors whether the problem was CI, source truth,
+duplicate risk, generated-artifact scope, unsafe package/install behavior, or
+missing safety/privacy metadata.
+
+For accepted content-only MCP PRs with CodeRabbit skipped, preserve the review
+evidence that mattered in the gate comment or PR body: validation checks, source
+reachability, duplicate check, safety/privacy notes, deterministic source hash
+or equivalent provenance, and generated-artifact scope.
+
 ## Queue Debugging
 
 Maintainers can inspect non-secret queue state through `GET /queue` with the

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -165,6 +165,11 @@ describe("submission automation workflows", () => {
     expect(source).toContain("Important edge cases or invariants");
     expect(source).toContain("Backward compatibility notes");
     expect(source).toContain("Accessibility notes for UI changes");
+    expect(source).toMatch(/[Ll]inked issue/);
+    expect(source).toContain("no-issue rationale");
+    expect(source).toContain("For registry API endpoint PRs");
+    expect(source).toContain("Origin-check and rate-limit posture");
+    expect(source).toContain("Generator reproducibility");
   });
 
   it("keeps product feature issues scoped with screenshot expectations", () => {
@@ -1201,6 +1206,28 @@ diff --git a/README.md b/README.md
     expect(source).toContain("provenance");
     expect(source).toContain("duplicates");
     expect(source).toContain("generated-artifact");
+    expect(source).toContain("Review Fallback Checklist");
+    expect(source).toContain("CodeRabbit is skipped");
+    expect(source).toContain("gate-comment-v5");
+    expect(source).toContain("Gittensory as advisory context");
+    expect(source).toContain("no-issue rationale");
+    expect(source).toContain("deterministic source hash");
+  });
+
+  it("documents registry endpoint review as a separate contract checklist", () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, "docs/api-security-contract.md"),
+      "utf8",
+    );
+
+    expect(source).toContain("Registry Endpoint Change Checklist");
+    expect(source).toContain("apps/web/src/routes/api/**");
+    expect(source).toContain("apps/web/src/lib/api/contracts.ts");
+    expect(source).toContain("origin-check setting");
+    expect(source).toContain("rate-limit scope");
+    expect(source).toContain("tests/api-contracts.test.ts");
+    expect(source).toContain("pnpm validate:openapi");
+    expect(source).toContain("maintainer-lane no-issue rationale");
   });
 
   it("removes stale issue automation from public workflows", () => {


### PR DESCRIPTION
## Summary
This PR hardens maintainer review fallback paths when CodeRabbit is skipped, rate-limited, unavailable, or clean but incomplete.

It documents how maintainers should use the HeyClaude submission gate, Gittensory advisory signals, required CI, linked-issue/no-issue policy, generated artifact scope, and registry API contract checks together instead of relying on one review surface.

## Related issue
Closes: #1846 
## Change Type

- [x] Documentation
- [x] PR template update
- [x] Submission review policy
- [x] Registry API review checklist
- [x] Test coverage
- [ ] Runtime behavior change
- [ ] Content entry
- [ ] Generated artifact update

## Real Behavior Proof
- Direct content PRs now must state either:
  - linked issue, or
  - explicit no-issue rationale.
- Platform/code/docs PRs now must state either:
  - linked issue, or
  - maintainer-lane no-issue rationale.
- Registry API endpoint PRs now have an explicit checklist for:
  - route handler
  - central API contract
  - origin-check posture
  - rate-limit posture
  - OpenAPI/generated artifact impact
  - API contract tests
  - generator reproducibility
- Maintainer docs now explain that CodeRabbit is not required for content-only review when intentionally skipped.
- Maintainer docs now identify the HeyClaude gate comment as the primary review surface for content-only PRs.
- Gittensory is documented as advisory context for linked-issue/no-issue rationale, duplicate/overlap signals, and Gittensor contributor context.
- Gate closure advice now requires concrete failure reasons instead of generic resubmission loops.


## Issue Analysis
Issue #1846 asked to harden fallback review paths because recent PRs showed review could not depend on one bot or review surface.
Reviewed examples:
- #1669: CodeRabbit skipped because of `content(` title policy; HeyClaude gate closed due to failed `validate-content`.
- #1668: Registry endpoint PR touched route, contract, OpenAPI, generated artifacts, and tests; Gittensory flagged missing linked issue.
- #1666: CodeRabbit was rate-limited; Gittensory flagged no linked issue/no-issue rationale.
- #1972 and #1973: Content-only MCP PRs showed healthy fallback behavior where HeyClaude gate carried the useful review evidence while CodeRabbit skipped.

## Checklist
- [x] Added fallback review checklist for skipped/rate-limited CodeRabbit.
- [x] Documented HeyClaude gate comment as primary review surface for content-only PRs.
- [x] Documented Gittensory as advisory, not a replacement for the gate.
- [x] Clarified linked-issue vs no-issue maintainer-lane rationale.
- [x] Added registry API endpoint checklist.
- [x] Clarified generated OpenAPI artifacts must come from generators.
- [x] Added PR template prompts for linked issue/no-issue rationale.
- [x] Added PR template prompts for registry API endpoint changes.
- [x] Added regression tests to keep the docs and template requirements visible.
- [x] Did not edit generated artifacts.
- [x] Did not change runtime code.
- [x] Did not change package files.
## Validation
Passed:
```sh
pnpm validate:openapi
pnpm exec vitest run tests/api-contracts.test.ts tests/submission-workflows.test.ts
pnpm test:submission-pr-first
pnpm build
git diff --check
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a registry endpoint change checklist and a review fallback checklist to improve PR review guidance.
  * Updated the PR template to require a linked issue or a no-issue rationale in the Notes section.

* **Tests**
  * Strengthened tests to validate the new PR quality standards and the presence of the new documentation checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->