### PR TITLE
fix(ci): restore superagent pull request scan

### DIFF
--- a/.github/workflows/superagent-security.yml
+++ b/.github/workflows/superagent-security.yml
@@ -1,6 +1,7 @@
 name: Superagent Repo Scan
 
 on:
+  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -272,13 +272,13 @@ describe("submission automation workflows", () => {
     ).toBe(false);
   });
 
-  it("keeps advisory Superagent scanning manual, read-only, and secret-gated", () => {
+  it("keeps advisory Superagent scanning pull-request scoped, read-only, and secret-gated", () => {
     const source = fs.readFileSync(
       path.join(repoRoot, ".github/workflows/superagent-security.yml"),
       "utf8",
     );
 
-    expect(source).not.toContain("pull_request:");
+    expect(source).toContain("pull_request:");
     expect(source).toContain("workflow_dispatch:");
     expect(source).not.toContain("pull_request_target");
     expect(source).toContain("contents: read");


### PR DESCRIPTION
### Motivation
- Restore automatic pre-merge scanning by adding the `pull_request` trigger back to the Superagent security workflow so PR branches are scanned again while preserving the manual `workflow_dispatch` option.

### Description
- Reinserted `pull_request:` under `on:` in `.github/workflows/superagent-security.yml` so the workflow triggers on PRs as well as manual dispatch.

### Testing
- Ran the validation script `node -e "const fs=require('fs'); const s=fs.readFileSync('.github/workflows/superagent-security.yml','utf8'); if (!/^on:\n  pull_request:\n  workflow_dispatch:/m.test(s)) process.exit(1); console.log('superagent workflow has pull_request and workflow_dispatch triggers');"`, which succeeded.
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5a1b988320b41a1991362ef13e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow updated to also run on pull request events.
* **Tests**
  * Updated workflow tests to expect the pull-request trigger and reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->