### PR TITLE
fix(seo): avoid rescaling explicit salary bounds

### DIFF
--- a/packages/registry/src/seo.js
+++ b/packages/registry/src/seo.js
@@ -422,9 +422,9 @@ function parseJobCompensation(value) {
     const numericText = hasK ? amount.slice(0, -1) : amount;
     const numeric = Number(String(numericText).replaceAll(",", ""));
     if (!Number.isFinite(numeric)) return null;
-    return Math.round(
-      numeric * (hasK || fallbackSuffix.toLowerCase() === "k" ? 1000 : 1),
-    );
+    const shouldUseFallbackK =
+      !hasK && fallbackSuffix.toLowerCase() === "k" && numeric < 1000;
+    return Math.round(numeric * (hasK || shouldUseFallbackK ? 1000 : 1));
   };
 
   const minHasK = amounts[0].toLowerCase().endsWith("k");

--- a/tests/seo-jsonld.test.ts
+++ b/tests/seo-jsonld.test.ts
@@ -357,6 +357,14 @@ describe("SEO JSON-LD policy", () => {
       value: { minValue: 150000, maxValue: 190000 },
     });
 
+    // Explicit values are not scaled again when paired with a shorthand bound.
+    expect(baseSalaryFor("$150,000 - $190k")).toMatchObject({
+      value: { minValue: 150000, maxValue: 190000 },
+    });
+    expect(baseSalaryFor("$150000-$190k")).toMatchObject({
+      value: { minValue: 150000, maxValue: 190000 },
+    });
+
     // Inverted ranges are rejected rather than emitting minValue > maxValue.
     expect(baseSalaryFor("$190-150k")).toBeUndefined();
     expect(baseSalaryFor("$190k-150k")).toBeUndefined();


### PR DESCRIPTION
### Motivation
- A recent change shared a `k` suffix across salary range endpoints which caused already-explicit bounds like `$150,000` in `$150,000 - $190k` to be rescaled (to 150,000,000), producing an inverted range and omitting `baseSalary` from JSON-LD, so the parser must preserve explicit values while keeping shorthand support.

### Description
- Modify the `parseAmount` logic in `packages/registry/src/seo.js` so the fallback `"k"` multiplier is only applied when the amount is unsuffixed and its numeric value is less than `1000`, preventing rescaling of explicit values.
- Preserve the existing shared-suffix inference so shorthand ranges like `$150-190k` and `$80–120k` still scale both endpoints as intended.
- Add regression coverage in `tests/seo-jsonld.test.ts` asserting that mixed explicit/shorthand ranges such as `$150,000 - $190k` and `$150000-$190k` produce the expected `minValue`/`maxValue`.

### Testing
- Ran `pnpm exec vitest run tests/seo-jsonld.test.ts` and the test suite passed (all tests succeeded, 11 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d59e3148320bc02034a4c444f14)