### PR TITLE
fix(submissions): preserve catalog subpath duplicates

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -173,11 +173,17 @@ function normalizeUrl(value: unknown) {
     }
 
     if (parsed.hostname === "github.com") {
-      const [owner, repo] = parsed.pathname.split("/").filter(Boolean);
+      const [owner, repo, ...pathParts] = parsed.pathname
+        .split("/")
+        .filter(Boolean);
       if (owner && repo) {
-        return `https://github.com/${owner.toLowerCase()}/${repo
+        const repoRoot = `https://github.com/${owner.toLowerCase()}/${repo
           .replace(/\.git$/i, "")
           .toLowerCase()}`;
+        if (MULTI_ENTRY_CATALOG_URLS.has(repoRoot) && pathParts.length) {
+          return `${repoRoot}/${pathParts.join("/").replace(/\/+$/, "")}`;
+        }
+        return repoRoot;
       }
     }
 
@@ -244,8 +250,32 @@ function strictDuplicateUrls(sharedUrls: string[]) {
   return sharedUrls.filter((url) => !MULTI_ENTRY_CATALOG_URLS.has(url));
 }
 
-function sharedCatalogUrls(sharedUrls: string[]) {
-  return sharedUrls.filter((url) => MULTI_ENTRY_CATALOG_URLS.has(url));
+function multiEntryCatalogRoot(url: string) {
+  return [...MULTI_ENTRY_CATALOG_URLS].find(
+    (catalogUrl) => url === catalogUrl || url.startsWith(`${catalogUrl}/`),
+  );
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string";
+}
+
+function multiEntryCatalogSubpathUrls(sharedUrls: string[]) {
+  return sharedUrls.filter((url) => {
+    const catalogUrl = multiEntryCatalogRoot(url);
+    return catalogUrl && url !== catalogUrl;
+  });
+}
+
+function sharedCatalogUrls(leftUrls: string[], rightUrls: string[]) {
+  const leftCatalogUrls = leftUrls.map(multiEntryCatalogRoot).filter(isString);
+  const rightCatalogUrls = rightUrls
+    .map(multiEntryCatalogRoot)
+    .filter(isString);
+  return intersection(
+    [...new Set(leftCatalogUrls)],
+    [...new Set(rightCatalogUrls)],
+  );
 }
 
 function isCollectionBridge(
@@ -346,6 +376,16 @@ export function findStrictContentDuplicateMatch(
 
     const sharedUrls = intersection(candidate.urls, existing.urls);
     const blockingSharedUrls = strictDuplicateUrls(sharedUrls);
+    const catalogSubpathUrls = multiEntryCatalogSubpathUrls(blockingSharedUrls);
+    if (
+      catalogSubpathUrls.length &&
+      candidate.category &&
+      candidate.category === existing.category
+    ) {
+      reasons.push(
+        `same multi-entry catalog subpath URL ${catalogSubpathUrls[0]}`,
+      );
+    }
     if (
       blockingSharedUrls.length &&
       candidate.category &&
@@ -398,7 +438,7 @@ export function findRelatedContentMatches(
         `same canonical source URL ${sharedUrls[0]} in ${candidate.category}, but not a strict duplicate without the same title, slug, or purpose`,
       );
     }
-    const catalogUrls = sharedCatalogUrls(sharedUrls);
+    const catalogUrls = sharedCatalogUrls(candidate.urls, existing.urls);
     if (
       catalogUrls.length &&
       candidate.category &&

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2758,6 +2758,79 @@ documentationUrl: "https://code.claude.com/docs/en/mcp"
     );
   });
 
+  it("treats exact multi-entry MCP catalog subpaths as strict duplicates", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/mcp/postgres-mcp-server.mdx",
+      content: `---
+title: Postgres MCP Server
+slug: postgres-mcp-server
+category: mcp
+description: MCP server for PostgreSQL database workflows.
+repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres"
+---
+`,
+      label: "accepted entry content/mcp/postgres-mcp-server.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/postgresql-database-mcp.mdx",
+      content: `---
+title: PostgreSQL Database MCP
+slug: postgresql-database-mcp
+category: mcp
+description: Tooling that connects Claude to Postgres databases.
+repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres?utm_source=heyclaude"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(candidate, [existing]),
+    ).toMatchObject({
+      reasons: expect.arrayContaining([
+        "same multi-entry catalog subpath URL https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+      ]),
+    });
+  });
+
+  it("treats distinct multi-entry MCP catalog subpaths as related context", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/mcp/postgres-mcp-server.mdx",
+      content: `---
+title: Postgres MCP Server
+slug: postgres-mcp-server
+category: mcp
+description: MCP server for PostgreSQL database workflows.
+repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres"
+---
+`,
+      label: "accepted entry content/mcp/postgres-mcp-server.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/sqlite-mcp-server.mdx",
+      content: `---
+title: SQLite MCP Server
+slug: sqlite-mcp-server
+category: mcp
+description: MCP server for SQLite database workflows.
+repoUrl: "https://github.com/modelcontextprotocol/servers/tree/main/src/sqlite"
+---
+`,
+    });
+
+    expect(findStrictContentDuplicateMatch(candidate, [existing])).toBeNull();
+    expect(findRelatedContentMatches(candidate, [existing])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same multi-entry catalog source URL https://github.com/modelcontextprotocol/servers in mcp",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("treats shared multi-entry MCP catalogs as related context", () => {
     const existing = extractContentDuplicateSignals({
       filePath: "content/mcp/azure-mcp-server.mdx",


### PR DESCRIPTION
### Motivation
- Multi-entry catalog repository roots (MCP/Claude docs) were being normalized to owner/repo and thus collapsed away any distinguishing subpaths, which allowed submissions for the same exact catalog-hosted resource to evade strict duplicate detection. 
- The intent is to keep the existing behavior of treating shared catalog roots as related context while still detecting exact same-file/subpath duplicates inside those catalogs as strict duplicates.

### Description
- Preserve GitHub subpaths for known multi-entry catalog repositories in `apps/submission-gate/src/duplicates.ts` by returning the repo root plus path when the repo is in `MULTI_ENTRY_CATALOG_URLS` (update to `normalizeUrl`).
- Add `multiEntryCatalogRoot`, `multiEntryCatalogSubpathUrls`, and a refactored `sharedCatalogUrls` helper to distinguish catalog roots from their subpaths and to compare candidate vs existing URLs precisely.
- Make strict-duplicate logic in `findStrictContentDuplicateMatch` recognize exact catalog subpath overlaps and emit a `same multi-entry catalog subpath URL` strict reason when appropriate.
- Keep catalog-root overlap behavior: distinct subpaths in the same catalog remain `related` (handled by `findRelatedContentMatches`) while exact same subpaths become strict duplicate evidence.
- Add regression unit tests in `tests/submission-gate-worker.test.ts` that assert exact catalog subpaths are treated as strict duplicates and distinct subpaths as related context.

### Testing
- Ran the focused unit suite with `pnpm exec vitest run tests/submission-gate-worker.test.ts --reporter=verbose`, and the modified tests passed (all tests in that file passed).
- Ran repository type-check with `pnpm --filter @heyclaude/submission-gate exec tsc --noEmit`, which surfaced unrelated baseline TypeScript/environment errors (missing ambient Cloudflare worker types and other repo-wide type issues) and did not complete cleanly; these errors are pre-existing and outside the scope of the duplicate-detection fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5afc34832094bfc2d730eaf4b4)