### PR TITLE
fix(content): repair react router agent fence nesting

### DIFF
--- a/content/agents/react-router-repository-contributor-agent.mdx
+++ b/content/agents/react-router-repository-contributor-agent.mdx
@@ -89,7 +89,7 @@ robotsFollow: true
 
 Create this file as `.claude/agents/react-router-repository-contributor.md`:
 
-```markdown
+````markdown
 ---
 name: react-router-repository-contributor
 description: Use when the user asks Claude to investigate, patch, test, or review work in the official remix-run/react-router repository from source-backed repository instructions.
@@ -247,7 +247,7 @@ Safety/privacy notes:
 Remaining risk:
 - ...
 ```
-```
+````
 
 ## Source Review
 


### PR DESCRIPTION
### Motivation
- The added agent MDX used nested triple-backtick fences which caused the inner example to close the outer code block and swallow the following content, breaking rendering for the `Source Review` section.
- This is a non-security content rendering bug that needs a minimal content-only fix so the output contract remains literal while the rest of the document renders normally.

### Description
- Change the outer agent-definition fence from triple backticks to four backticks in `content/agents/react-router-repository-contributor-agent.mdx` so the inner triple-backtick `Output Contract` block remains literal.
- Preserve the existing agent text, the inner triple-backtick example, and all surrounding content with a single-file, minimal edit.

### Testing
- Ran `pnpm validate:content:strict` which passed. 
- Ran `git diff --check` which produced no issues. 
- Ran a rendering check with `pnpm --filter web exec node --input-type=module ...` which confirmed `Source Review` renders as an `h2`, only one `<pre>` remains, and the `Output Contract` example is preserved as literal content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5ab4288320bdbffab08e08a5d5)