### PR TITLE
fix(content): repair allways nested markdown fence

### DIFF
--- a/content/agents/allways-agent-quickstart.mdx
+++ b/content/agents/allways-agent-quickstart.mdx
@@ -86,7 +86,7 @@ robotsFollow: true
 
 Create this file as `.claude/agents/allways-agent-quickstart.md`:
 
-```markdown
+````markdown
 ---
 name: allways-agent-quickstart
 description: Use when the user asks Claude to inspect, explain, preflight, or monitor Allways protocol workflows from source-backed public docs and live state.
@@ -198,7 +198,7 @@ Next step:
 Keep the answer concise. If the user asks for a live-funds plan, pause after the
 read-only preflight and make the required approvals, fresh checks, and remaining
 uncertainties explicit before any action.
-```
+````
 
 ## Source Scope
 


### PR DESCRIPTION
### Motivation
- The Allways agent MDX nested a three-backtick fenced `markdown` block inside another three-backtick fence which caused the outer block to terminate early and subsequent sections to be rendered or copied inside a code block. 
- The goal is to fix the content rendering/copying bug without changing any agent text, metadata, or behavior.

### Description
- Replace the outer triple-backtick fence with a four-backtick fence in `content/agents/allways-agent-quickstart.mdx` so the nested three-backtick output template does not close the outer block. 
- Preserve all existing agent content, frontmatter, and surrounding sections (Source Scope / Use Cases / Duplicate Check) unchanged. 
- Commit message: `fix(content): repair allways nested markdown fence`.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully. 
- Verified rendering with a repo-local `marked` parse using `pnpm --dir apps/web exec node --input-type=module` which confirmed a single code block and that the `Source Scope` heading is rendered outside code, and this check passed. 
- Ran `git diff --check` to ensure no linting/diff errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5a9d5483209b78f2581157f225)