### PR TITLE
fix(content): remove unsafe imcp install backticks

### DIFF
--- a/content/mcp/imcp-mcp-server.mdx
+++ b/content/mcp/imcp-mcp-server.mdx
@@ -25,7 +25,7 @@ brandDomain: imcp.app
 repoUrl: "https://github.com/mattt/iMCP"
 documentationUrl: "https://raw.githubusercontent.com/mattt/iMCP/main/README.md"
 installable: true
-installCommand: "Install the iMCP macOS app, enable only the services you need, then configure the bundled `imcp-server` from the app menu or your MCP client."
+installCommand: "Install the iMCP macOS app, enable only the services you need, then configure the bundled imcp-server from the app menu or your MCP client."
 usageSnippet: "Open iMCP, approve the specific macOS services Claude should use, then connect an MCP client to the bundled `imcp-server` command."
 copySnippet: |-
   {


### PR DESCRIPTION
### Motivation
- Prevent accidental POSIX shell command-substitution when users copy the entry's install payload by removing inline backticks from the copyable `installCommand` text.

### Description
- Remove Markdown-style backticks around `imcp-server` in `content/mcp/imcp-mcp-server.mdx` while preserving the original guidance and other metadata.

### Testing
- Ran `pnpm validate:content:strict` which passed.
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d59e4e08320ba6ca4aa6426ef16)