### PR TITLE
fix(submissions): honor merge rate-limit backoff

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -151,9 +151,15 @@ class SubmissionLockBusyError extends Error {
 }
 
 class SubmissionMergePendingError extends Error {
-  constructor(message: string) {
+  retryDelaySeconds: number;
+
+  constructor(
+    message: string,
+    retryDelaySeconds: number = MERGE_RETRY_SECONDS,
+  ) {
     super(message);
     this.name = "SubmissionMergePendingError";
+    this.retryDelaySeconds = retryDelaySeconds;
   }
 }
 
@@ -481,6 +487,16 @@ function retryDelayForError(error: unknown) {
     return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
   }
   return RETRYABLE_ERROR_SECONDS;
+}
+
+function retryDelayForMergeError(error: unknown) {
+  if (
+    isGitHubRateLimitError(error) ||
+    (error instanceof GitHubApiError && error.status === 429)
+  ) {
+    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
+  }
+  return MERGE_RETRY_SECONDS;
 }
 
 function nextReviewForError(error: unknown) {
@@ -4182,6 +4198,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
           });
         } catch (error) {
           if (isRetryableMergeError(error)) {
+            const retryDelaySeconds = retryDelayForMergeError(error);
             const pendingSummary = [
               decision.summary.trim(),
               "",
@@ -4202,7 +4219,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               status: "merge_pending",
               verdict: "merge",
               verdictSummary: pendingSummary,
-              nextReviewAt: nextReviewForStatus("merge_pending"),
+              nextReviewAt: isoAfter(retryDelaySeconds),
               lastError: error instanceof Error ? error.message : "unknown",
               ...decisionMetadata(acceptedDecision, acceptedReport),
             });
@@ -4213,7 +4230,10 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               decision: "merge_pending",
               summary: pendingSummary,
             });
-            throw new SubmissionMergePendingError(pendingSummary);
+            throw new SubmissionMergePendingError(
+              pendingSummary,
+              retryDelaySeconds,
+            );
           }
           const manualDecision = defaultManualDecision(
             `Private review accepted this PR, but direct merge failed: ${
@@ -4968,7 +4988,7 @@ export default {
           console.debug("submission merge pending, retrying", {
             targetKey: body.targetKey,
           });
-          message.retry({ delaySeconds: 30 });
+          message.retry({ delaySeconds: error.retryDelaySeconds });
         } else {
           await recordRetryableQueueError(env, body, error);
           console.error("submission gate queue failure", error);

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1894,7 +1894,9 @@ ${urls}
     expect(source).toContain("SubmissionMergePendingError");
     expect(source).toContain('status: "merge_pending"');
     expect(source).toContain('decision: "merge_pending"');
-    expect(source).toContain("message.retry({ delaySeconds: 30 })");
+    expect(source).toContain(
+      "message.retry({ delaySeconds: error.retryDelaySeconds })",
+    );
     expect(source).toContain("AUTO_MERGE_CONFIDENCE_FLOOR");
     expect(source).toContain("enforceAutoMergeConfidenceFloor(");
     expect(source.indexOf("normalizeOneShotDecision(decision)")).toBeLessThan(
@@ -1913,7 +1915,7 @@ ${urls}
       )?.[0] || "";
     const retryBranch =
       source.match(
-        /if \(isRetryableMergeError\(error\)\) \{[\s\S]*?throw new SubmissionMergePendingError\(pendingSummary\);/,
+        /if \(isRetryableMergeError\(error\)\) \{[\s\S]*?throw new SubmissionMergePendingError\([\s\S]*?retryDelaySeconds,[\s\S]*?\);/,
       )?.[0] || "";
 
     expect(classifier).toContain("isTimeoutError(error)");
@@ -1924,9 +1926,18 @@ ${urls}
     expect(classifier).toContain("error.status <= 599");
     expect(classifier).toContain("required approving review");
     expect(classifier).toContain("merge conflict");
+    expect(source).toContain("function retryDelayForMergeError");
+    expect(source).toContain("error.status === 429");
+    expect(source).toContain("githubRetryDelaySeconds(error");
+    expect(source).toContain("GITHUB_RATE_LIMIT_FALLBACK_SECONDS");
+    expect(retryBranch).toContain(
+      "const retryDelaySeconds = retryDelayForMergeError(error)",
+    );
     expect(retryBranch).toContain('status: "merge_pending"');
     expect(retryBranch).toContain('decision: "merge_pending"');
     expect(retryBranch).toContain("merge retry pending");
+    expect(retryBranch).toContain("nextReviewAt: isoAfter(retryDelaySeconds)");
+    expect(retryBranch).toContain("retryDelaySeconds");
     expect(retryBranch).toContain(
       "The gate will retry after transient GitHub merge state settles.",
     );
@@ -2144,8 +2155,12 @@ ${urls}
     expect(source).toContain("isGitHubRateLimitError(error)");
     expect(source).toContain("githubRetryDelaySeconds(error");
     expect(source).toContain("nextReviewForError(error)");
+    expect(source).toContain("function retryDelayForMergeError");
     expect(source).toContain(
       "message.retry({ delaySeconds: retryDelayForError(error) })",
+    );
+    expect(source).toContain(
+      "message.retry({ delaySeconds: error.retryDelaySeconds })",
     );
     expect(source).toContain("scheduled(_controller, env, ctx)");
     expect(source).toContain("ctx.waitUntil(sweepSubmissionQueue(env))");


### PR DESCRIPTION
### Motivation
- The merge-pending path converted GitHub rate-limit (403/429) and timeout errors into a fixed 30s `merge_pending` retry, which discards provider backoff metadata and can amplify GitHub rate limits and exhaust quota.

### Description
- Add a `retryDelaySeconds` field to `SubmissionMergePendingError` so a computed delay can be carried through the queue.
- Add `retryDelayForMergeError(error)` that uses `githubRetryDelaySeconds` (with the existing `GITHUB_RATE_LIMIT_FALLBACK_SECONDS`) for rate-limit/429 merge failures and falls back to the existing 30s for other transient merge errors.
- Persist `merge_pending.nextReviewAt` using the computed provider-aware delay (via `isoAfter(retryDelaySeconds)`) and throw `SubmissionMergePendingError` with that delay.
- Update queue handling to call `message.retry({ delaySeconds: error.retryDelaySeconds })` for `SubmissionMergePendingError` and adjust tests to assert the new behavior.

### Testing
- Ran unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and the test file passed (`89` tests passed). 
- Ensured formatting with `prettier --check` and fixed style issues with `prettier --write` so style checks succeed. 
- Built the project with `pnpm build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5ae4648320be37d8571172174c)