### PR TITLE
fix(mcp): enforce exact trust coverage thresholds

### DIFF
--- a/scripts/report-trust-coverage.mjs
+++ b/scripts/report-trust-coverage.mjs
@@ -180,6 +180,7 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
 // --- aggregate ---
 const pct = (count, total) =>
   total === 0 ? 0 : Math.round((count / total) * 100);
+const exactPct = (count, total) => (total === 0 ? 0 : (count / total) * 100);
 const countWhere = (list, fn) => list.filter(fn).length;
 
 const presentCategories = [...new Set(entries.map((e) => e.category))].sort();
@@ -305,20 +306,20 @@ if (reportPath) {
 }
 
 const thresholdFailures = [];
-if (
-  minRiskCoverage !== null &&
-  summary.riskBearing.coveragePct < minRiskCoverage
-) {
+const riskCoverageExact = exactPct(riskWithBoth, risk.length);
+const attributedCount = countWhere(entries, (e) => e.trust.attributed);
+const attributionCoverageExact = exactPct(attributedCount, entries.length);
+if (minRiskCoverage !== null && riskCoverageExact < minRiskCoverage) {
   thresholdFailures.push(
-    `Risk-bearing safety/privacy coverage ${summary.riskBearing.coveragePct}% is below required ${minRiskCoverage}%.`,
+    `Risk-bearing safety/privacy coverage ${riskCoverageExact.toFixed(2)}% (${riskWithBoth}/${risk.length}) is below required ${minRiskCoverage}%.`,
   );
 }
 if (
   minAttributionCoverage !== null &&
-  summary.coverage.attributed < minAttributionCoverage
+  attributionCoverageExact < minAttributionCoverage
 ) {
   thresholdFailures.push(
-    `Attribution coverage ${summary.coverage.attributed}% is below required ${minAttributionCoverage}%.`,
+    `Attribution coverage ${attributionCoverageExact.toFixed(2)}% (${attributedCount}/${entries.length}) is below required ${minAttributionCoverage}%.`,
   );
 }
 

--- a/tests/trust-coverage-script.test.ts
+++ b/tests/trust-coverage-script.test.ts
@@ -124,11 +124,77 @@ describe("trust coverage report script", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain(
-      "Attribution coverage 0% is below required 100%",
+      "Attribution coverage 0.00% (0/1) is below required 100%",
     );
     expect(
       fs.existsSync(path.join(tmpDir, "reports/trust-coverage/mcp.json")),
     ).toBe(false);
+  });
+
+  it("uses exact risk coverage for threshold checks instead of rounded display percentages", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-rounded-risk-"),
+    );
+    for (let index = 0; index < 199; index += 1) {
+      writeMcpEntry(tmpDir, `covered-mcp-${index}`, {
+        safety: true,
+        privacy: true,
+      });
+    }
+    writeMcpEntry(tmpDir, "almost-covered-mcp", { privacy: true });
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--check",
+      "--min-risk-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "with safety + privacy notes: 199 (100%), missing 1",
+    );
+    expect(result.stderr).toContain(
+      "Risk-bearing safety/privacy coverage 99.50% (199/200) is below required 100%",
+    );
+  });
+
+  it("uses exact attribution coverage for threshold checks instead of rounded display percentages", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-trust-rounded-attribution-"),
+    );
+    for (let index = 0; index < 199; index += 1) {
+      writeMcpEntry(tmpDir, `attributed-mcp-${index}`, {
+        safety: true,
+        privacy: true,
+        attributed: true,
+      });
+    }
+    writeMcpEntry(tmpDir, "unattributed-mcp", {
+      safety: true,
+      privacy: true,
+    });
+
+    const result = runTrustCoverage([
+      "--repo-root",
+      tmpDir,
+      "--category",
+      "mcp",
+      "--check",
+      "--min-attribution-coverage",
+      "100",
+    ]);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain(
+      "Provenance (all 200): source-backed 100%, attributed 100%",
+    );
+    expect(result.stderr).toContain(
+      "Attribution coverage 99.50% (199/200) is below required 100%",
+    );
   });
 
   it("does not write the default report in successful check mode", () => {


### PR DESCRIPTION
### Motivation
- The trust-coverage report used rounded display percentages (`Math.round`) for both reporting and threshold enforcement, allowing cases like 317/318 (99.69%) to round to `100%` and falsely pass a `--min-*-coverage 100` gate. 
- The intent is to ensure the MCP trust/provenance quality gate fails if any required entries are missing rather than relying on rounded display values.

### Description
- Compute exact percentage ratios with an `exactPct` helper and use those exact values for threshold comparisons instead of the rounded `coveragePct` used for display. 
- Compute and check exact attribution counts and percentages (`attributedCount` / `attributionCoverageExact`) and exact risk coverage (`riskCoverageExact`) against the configured minimums. 
- Update threshold failure messages to include the exact percentage with two decimals and the covered/total counts for clarity. 
- Add regression tests that create edge cases where display percentages round to `100%` (e.g., 199/200) but exact percentages are below `100%`, and update an existing attribution assertion to match the new message format.

### Testing
- Ran `pnpm exec vitest run tests/trust-coverage-script.test.ts` and all tests in that file passed. 
- Ran the MCP validation command `node scripts/report-trust-coverage.mjs --category mcp --check --min-risk-coverage 100 --min-attribution-coverage 100` as part of `pnpm validate:mcp-trust` and it behaved correctly. 
- Ran `git diff --check` to ensure no whitespace/check issues and verified the changes are staged in a single focused commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d59f8cc832080327e65926abf5c)