### PR TITLE
fix(mcp): align planner type exports

### DIFF
--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -29,6 +29,8 @@ import {
   validateSubmissionDraftFromSpec,
 } from "./submissions.js";
 
+export * from "./schemas.js";
+
 const safePathPartPattern = /^[a-z0-9-]+$/;
 const jsonMimeType = "application/json";
 const DISCOVERY_RESOURCE_LIMIT = 25;

--- a/packages/mcp/src/schemas.d.ts
+++ b/packages/mcp/src/schemas.d.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 
 export const SearchRegistryInputSchema: z.ZodType;
+export const PlanWorkflowToolboxInputSchema: z.ZodType;
 export const ServerInfoInputSchema: z.ZodType;
 export const ListCategoryEntriesInputSchema: z.ZodType;
 export const RecentUpdatesInputSchema: z.ZodType;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -5,6 +5,8 @@ import { describe, expect, it } from "vitest";
 
 import { createRemoteMcpProxyServerFromClient } from "../packages/mcp/src/remote-proxy.js";
 import { createHeyClaudeMcpServer } from "../packages/mcp/src/server.js";
+import * as registryModule from "../packages/mcp/src/registry.js";
+import * as schemaModule from "../packages/mcp/src/schemas.js";
 import {
   callRegistryTool,
   getClientSetup,
@@ -307,6 +309,26 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(packageJson.exports).toHaveProperty("./server");
     expect(packageJson.exports).toHaveProperty("./remote-proxy");
     expect(packageJson.exports).toHaveProperty("./submissions");
+  });
+
+  it("keeps MCP planner exports aligned across runtime and declarations", () => {
+    expect(registryModule.planWorkflowToolbox).toBe(planWorkflowToolbox);
+    expect(registryModule.PlanWorkflowToolboxInputSchema).toBe(
+      schemaModule.PlanWorkflowToolboxInputSchema,
+    );
+
+    const registryTypes = fs.readFileSync(
+      path.join(repoRoot, "packages/mcp/src/registry.d.ts"),
+      "utf8",
+    );
+    const schemaTypes = fs.readFileSync(
+      path.join(repoRoot, "packages/mcp/src/schemas.d.ts"),
+      "utf8",
+    );
+
+    expect(registryTypes).toContain("function planWorkflowToolbox");
+    expect(registryTypes).toContain("PlanWorkflowToolboxInputSchema");
+    expect(schemaTypes).toContain("PlanWorkflowToolboxInputSchema");
   });
 
   it("keeps npm package README branding, links, and release convention current", () => {


### PR DESCRIPTION
### Motivation
- A runtime MCP planner tool (`planWorkflowToolbox`) and its input schema (`PlanWorkflowToolboxInputSchema`) were added but the package declaration files did not expose them, causing TypeScript consumers to get import/type errors (TS2305). 
- The package `types`/exports point at `./src/registry.d.ts` and `./src/schemas.d.ts`, so declaration and runtime export surfaces must stay aligned. 
- The change ensures consumers can import the planner API and its Zod schema from both the package root and the `./schemas` subpath without type errors. 

### Description
- Re-export shared schemas from the runtime entrypoint by adding `export * from "./schemas.js";` to `packages/mcp/src/registry.js` so the package root export surface includes the planner schema. 
- Add the missing declaration `PlanWorkflowToolboxInputSchema` to `packages/mcp/src/schemas.d.ts` so `@heyclaude/mcp/schemas` is correctly typed. 
- Add regression coverage in `tests/mcp-server.test.ts` that asserts `planWorkflowToolbox` and `PlanWorkflowToolboxInputSchema` are present and consistent across runtime modules and declaration files. 

### Testing
- Ran a runtime smoke test with `node --input-type=module` that imported `planWorkflowToolbox` and the schema and verified the schema parses valid input, which succeeded. 
- Ran a TypeScript consumer check with `tsc` (local temporary project importing `@heyclaude/mcp` and `@heyclaude/mcp/schemas`) which type-checked successfully. 
- Ran `git diff --check` which reported no issues. 
- `pnpm exec vitest run tests/mcp-server.test.ts` could not be fully executed in this checkout because `apps/web/public/data/directory-index.json` is absent, so full test-suite assertion is blocked. 
- `pnpm --dir packages/mcp validate:package` is similarly blocked by the missing data artifact in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a264d59dfe08320bf8ebdee08b85fee)