### PR TITLE
fix(content): normalize escaped MCP URLs

### DIFF
--- a/content/hooks/mcp-server-url-allowlist-hook.mdx
+++ b/content/hooks/mcp-server-url-allowlist-hook.mdx
@@ -43,7 +43,7 @@ installCommand: |-
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$text" | sed 's#\\/#/#g' | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
   allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')
@@ -117,7 +117,7 @@ scriptBody: |-
     *) exit 0 ;;
   esac
 
-  hosts=$(printf '%s' "$text" | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
+  hosts=$(printf '%s' "$text" | sed 's#\\/#/#g' | grep -Eo 'https?://[^"[:space:]]+' | awk -F/ '{print $3}' | sort -u)
   [ -z "$hosts" ] && exit 0
 
   allowlist=$(printf '%s' "${ALLOWED_MCP_HOSTS:-}" | tr ',' ' ')


### PR DESCRIPTION
### Motivation
- A recent change stopped normalizing escaped JSON slashes (`\/`) before extracting hosts, which allowed Edit/MultiEdit JSON fragments like `"url": "https:\/\/evil.example\/sse"` to bypass the allowlist check. 
- The hook is intended to block unreviewed remote MCP hosts in pending config edits, so normalization must be restored to preserve that security control.

### Description
- Restore global escaped-slash normalization by piping the candidate text through `sed 's#\\/#/#g'` before URL extraction in the generated `installCommand`. 
- Apply the same `sed` normalization to the standalone `scriptBody` so both code paths treat escaped fragments consistently. 
- Preserve the existing `jq`-based decoded-string extraction and allowlist logic without changing behavior beyond the normalization step.

### Testing
- Ran `pnpm validate:content:strict` and content validation passed. 
- Ran `git diff --check` and formatting checks passed. 
- Executed manual hook payload tests with three cases and observed expected behavior: escaped-slash fragment is now blocked (exit code 2), plain `https://` fragment is blocked (exit code 2), and an escaped-slash fragment with the host in `ALLOWED_MCP_HOSTS` is allowed (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26536609348320912c7a99894c0365)