### PR TITLE
feat(raycast): add cross-harness MCP installer

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -86,6 +86,7 @@
           "downloadTrust": { "type": ["string", "null"] },
           "verificationStatus": { "type": "string" },
           "platforms": { "type": "array", "items": { "type": "string" }, "maxItems": 12 },
+          "mcpInstallTargets": { "type": "array", "items": { "type": "string" }, "maxItems": 4 },
           "supportLevels": { "type": "array", "items": { "type": "string" }, "maxItems": 12 },
           "documentationUrl": { "type": "string" },
           "repoUrl": { "type": "string" },
@@ -737,6 +738,12 @@
           {
             "schema": { "type": "string", "enum": ["all", "true", "false"], "default": "all" },
             "required": false,
+            "name": "installable",
+            "in": "query"
+          },
+          {
+            "schema": { "type": "string", "enum": ["all", "true", "false"], "default": "all" },
+            "required": false,
             "name": "hasSafetyNotes",
             "in": "query"
           },
@@ -804,6 +811,7 @@
                     "filters": {
                       "type": "object",
                       "properties": {
+                        "installable": { "type": "string" },
                         "hasSafetyNotes": { "type": "string" },
                         "hasPrivacyNotes": { "type": "string" },
                         "downloadTrust": { "type": "string" },
@@ -811,6 +819,7 @@
                         "sourceStatus": { "type": "string" }
                       },
                       "required": [
+                        "installable",
                         "hasSafetyNotes",
                         "hasPrivacyNotes",
                         "downloadTrust",
@@ -891,6 +900,11 @@
                             "type": "array",
                             "items": { "type": "string" },
                             "maxItems": 12
+                          },
+                          "mcpInstallTargets": {
+                            "type": "array",
+                            "items": { "type": "string" },
+                            "maxItems": 4
                           },
                           "supportLevels": {
                             "type": "array",
@@ -974,6 +988,10 @@
                           "type": "object",
                           "additionalProperties": { "type": "integer", "minimum": 0 }
                         },
+                        "installable": {
+                          "type": "object",
+                          "additionalProperties": { "type": "integer", "minimum": 0 }
+                        },
                         "hasSafetyNotes": {
                           "type": "object",
                           "additionalProperties": { "type": "integer", "minimum": 0 }
@@ -998,6 +1016,7 @@
                       "required": [
                         "categories",
                         "platforms",
+                        "installable",
                         "hasSafetyNotes",
                         "hasPrivacyNotes",
                         "downloadTrust",

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -165,6 +165,11 @@ components:
           items:
             type: string
           maxItems: 12
+        mcpInstallTargets:
+          type: array
+          items:
+            type: string
+          maxItems: 4
         supportLevels:
           type: array
           items:
@@ -956,6 +961,16 @@ paths:
               - "false"
             default: all
           required: false
+          name: installable
+          in: query
+        - schema:
+            type: string
+            enum:
+              - all
+              - "true"
+              - "false"
+            default: all
+          required: false
           name: hasSafetyNotes
           in: query
         - schema:
@@ -1037,6 +1052,8 @@ paths:
                   filters:
                     type: object
                     properties:
+                      installable:
+                        type: string
                       hasSafetyNotes:
                         type: string
                       hasPrivacyNotes:
@@ -1048,6 +1065,7 @@ paths:
                       sourceStatus:
                         type: string
                     required:
+                      - installable
                       - hasSafetyNotes
                       - hasPrivacyNotes
                       - downloadTrust
@@ -1186,6 +1204,11 @@ paths:
                           items:
                             type: string
                           maxItems: 12
+                        mcpInstallTargets:
+                          type: array
+                          items:
+                            type: string
+                          maxItems: 4
                         supportLevels:
                           type: array
                           items:
@@ -1288,6 +1311,11 @@ paths:
                         additionalProperties:
                           type: integer
                           minimum: 0
+                      installable:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
                       hasSafetyNotes:
                         type: object
                         additionalProperties:
@@ -1316,6 +1344,7 @@ paths:
                     required:
                       - categories
                       - platforms
+                      - installable
                       - hasSafetyNotes
                       - hasPrivacyNotes
                       - downloadTrust

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -287,6 +287,7 @@ export const registrySearchResultSchema = registryBrandAssetSchema
     downloadTrust: z.string().nullable().optional(),
     verificationStatus: z.string(),
     platforms: z.array(z.string()).max(12).optional(),
+    mcpInstallTargets: z.array(z.string()).max(4).optional(),
     supportLevels: z.array(z.string()).max(12).optional(),
     documentationUrl: z.string(),
     repoUrl: z.string(),
@@ -306,6 +307,7 @@ export const registrySearchFacetBucketsSchema = z.record(
 export const registrySearchFacetsSchema = z.object({
   categories: registrySearchFacetBucketsSchema,
   platforms: registrySearchFacetBucketsSchema,
+  installable: registrySearchFacetBucketsSchema,
   hasSafetyNotes: registrySearchFacetBucketsSchema,
   hasPrivacyNotes: registrySearchFacetBucketsSchema,
   downloadTrust: registrySearchFacetBucketsSchema,
@@ -320,6 +322,7 @@ export const registrySearchResponseSchema = z.object({
   platform: z.string(),
   filters: z
     .object({
+      installable: z.string(),
       hasSafetyNotes: z.string(),
       hasPrivacyNotes: z.string(),
       downloadTrust: z.string(),
@@ -367,6 +370,7 @@ export const registrySearchQuerySchema = z.object({
   q: z.string().trim().toLowerCase().max(120).optional().default(""),
   category: categorySchema,
   platform: platformSchema,
+  installable: z.enum(["all", "true", "false"]).optional().default("all"),
   hasSafetyNotes: z.enum(["all", "true", "false"]).optional().default("all"),
   hasPrivacyNotes: z.enum(["all", "true", "false"]).optional().default("all"),
   downloadTrust: z.enum(["all", "first-party", "external", "none"]).optional().default("all"),

--- a/apps/web/src/lib/api/registry-search-facets.ts
+++ b/apps/web/src/lib/api/registry-search-facets.ts
@@ -5,6 +5,7 @@ import {
   entryMatchesFilters,
   hasPrivacyNotes,
   hasSafetyNotes,
+  isInstallable,
   packageTrustValue,
   sourceStatusValue,
   type RegistrySearchFilterDimension,
@@ -16,6 +17,7 @@ export type RegistrySearchFacetBuckets = Record<string, number>;
 export type RegistrySearchFacets = {
   categories: RegistrySearchFacetBuckets;
   platforms: RegistrySearchFacetBuckets;
+  installable: RegistrySearchFacetBuckets;
   hasSafetyNotes: RegistrySearchFacetBuckets;
   hasPrivacyNotes: RegistrySearchFacetBuckets;
   downloadTrust: RegistrySearchFacetBuckets;
@@ -80,11 +82,9 @@ export function computeRegistrySearchFacets(
   const categories = tally(entries, filters, "category", (entry) =>
     entry.category ? entry.category : "",
   );
-  const platforms = tally(
-    entries,
-    filters,
-    "platform",
-    (entry) => normalizedPlatforms(entry),
+  const platforms = tally(entries, filters, "platform", (entry) => normalizedPlatforms(entry));
+  const installable = tally(entries, filters, "installable", (entry) =>
+    isInstallable(entry) ? "true" : "false",
   );
   const safety = tally(entries, filters, "hasSafetyNotes", (entry) =>
     hasSafetyNotes(entry) ? "true" : "false",
@@ -95,16 +95,13 @@ export function computeRegistrySearchFacets(
   const downloadTrust = tally(entries, filters, "downloadTrust", (entry) =>
     packageTrustValue(entry),
   );
-  const claimStatus = tally(entries, filters, "claimStatus", (entry) =>
-    claimStatusValue(entry),
-  );
-  const sourceStatus = tally(entries, filters, "sourceStatus", (entry) =>
-    sourceStatusValue(entry),
-  );
+  const claimStatus = tally(entries, filters, "claimStatus", (entry) => claimStatusValue(entry));
+  const sourceStatus = tally(entries, filters, "sourceStatus", (entry) => sourceStatusValue(entry));
 
   return {
     categories: sortBuckets(categories, MAX_CATEGORY_BUCKETS),
     platforms: sortBuckets(platforms, MAX_PLATFORM_BUCKETS),
+    installable: sortBuckets(installable),
     hasSafetyNotes: sortBuckets(safety),
     hasPrivacyNotes: sortBuckets(privacy),
     downloadTrust: sortBuckets(downloadTrust),

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -12,6 +12,7 @@ export type RegistrySearchFilterState = {
   query: string;
   category: string;
   platform: string;
+  installable: BooleanFilterValue;
   hasSafetyNotes: BooleanFilterValue;
   hasPrivacyNotes: BooleanFilterValue;
   downloadTrust: DownloadTrustFilterValue;
@@ -23,6 +24,7 @@ export type RegistrySearchFilterDimension =
   | "query"
   | "category"
   | "platform"
+  | "installable"
   | "hasSafetyNotes"
   | "hasPrivacyNotes"
   | "downloadTrust"
@@ -30,6 +32,15 @@ export type RegistrySearchFilterDimension =
   | "sourceStatus";
 
 const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+const QUERY_ALIASES: Record<string, string[]> = {
+  cc: ["claude", "claude-code"],
+  claude: ["claude-code"],
+  gh: ["github"],
+  ms: ["microsoft"],
+  msteams: ["teams", "microsoft-teams"],
+  repo: ["repository", "github"],
+  repos: ["repository", "github"],
+};
 
 function tokenizeSearchQuery(query: string) {
   return query
@@ -39,9 +50,14 @@ function tokenizeSearchQuery(query: string) {
     .slice(0, 12);
 }
 
+function expandedTokenCandidates(token: string) {
+  return [token, ...(QUERY_ALIASES[token] ?? [])];
+}
+
 function normalizedSearchText(entry: SearchDocument) {
   return [
     entry.category,
+    entry.slug,
     entry.title,
     entry.description,
     entry.author,
@@ -58,11 +74,41 @@ function normalizedSearchText(entry: SearchDocument) {
     .toLowerCase();
 }
 
+function entryWordSet(entry: SearchDocument) {
+  return new Set(
+    normalizedSearchText(entry)
+      .split(TOKEN_SPLIT_PATTERN)
+      .map((token) => token.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function candidateMatchesText(candidate: string, haystack: string, words: ReadonlySet<string>) {
+  if (candidate.length <= 2) {
+    return [...words].some((word) => word === candidate || word.startsWith(candidate));
+  }
+  return haystack.includes(candidate) || [...words].some((word) => word.startsWith(candidate));
+}
+
 export function matchesQuery(entry: SearchDocument, query: string) {
   const normalizedQuery = query.trim().toLowerCase();
   if (!normalizedQuery) return true;
   const haystack = normalizedSearchText(entry);
-  return haystack.includes(normalizedQuery);
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (!tokens.length) return false;
+  const words = entryWordSet(entry);
+  if (
+    normalizedQuery.length > 2
+      ? haystack.includes(normalizedQuery)
+      : candidateMatchesText(normalizedQuery, haystack, words)
+  ) {
+    return true;
+  }
+  return tokens.every((token) =>
+    expandedTokenCandidates(token).some((candidate) =>
+      candidateMatchesText(candidate, haystack, words),
+    ),
+  );
 }
 
 export function matchesPlatform(entry: SearchDocument, platform: string) {
@@ -81,6 +127,10 @@ export function hasSafetyNotes(entry: SearchDocument) {
 
 export function hasPrivacyNotes(entry: SearchDocument) {
   return Boolean(entry.trustSignals?.hasPrivacyNotes || entry.privacyNotes?.length);
+}
+
+export function isInstallable(entry: SearchDocument) {
+  return Boolean(entry.installable || entry.downloadUrl);
 }
 
 export function packageTrustValue(entry: SearchDocument) {
@@ -106,6 +156,9 @@ export function entryMatchesFilters(
     return false;
   }
   if (!skip("platform") && !matchesPlatform(entry, filters.platform)) {
+    return false;
+  }
+  if (!skip("installable") && !matchesBooleanFilter(isInstallable(entry), filters.installable)) {
     return false;
   }
   if (
@@ -169,10 +222,12 @@ export function scoreSearchEntry(
   if (!tokens.length) return { score: 0, reasons: [] };
 
   const title = entry.title.toLowerCase();
+  const slug = entry.slug.toLowerCase();
   const category = entry.category.toLowerCase();
   const tags = new Set((entry.tags ?? []).map((tag) => tag.toLowerCase()));
   const keywords = new Set((entry.keywords ?? []).map((keyword) => keyword.toLowerCase()));
   const haystack = normalizedSearchText(entry);
+  const words = entryWordSet(entry);
   let score = 0;
   const reasons = new Set<string>();
 
@@ -180,33 +235,64 @@ export function scoreSearchEntry(
     score += 90;
     reasons.add("title phrase");
   }
+  if (slug.includes(normalizedQuery)) {
+    score += 65;
+    reasons.add("slug phrase");
+  }
   if (category === normalizedQuery) {
     score += 45;
     reasons.add("category match");
   }
 
   for (const token of tokens) {
-    if (title.includes(token)) {
+    const candidates = expandedTokenCandidates(token);
+    const hasCandidate = (value: string) =>
+      candidates.some((candidate) =>
+        candidateMatchesText(
+          candidate,
+          value,
+          new Set(
+            value
+              .split(TOKEN_SPLIT_PATTERN)
+              .map((word) => word.trim().toLowerCase())
+              .filter(Boolean),
+          ),
+        ),
+      );
+    const hasPrefixCandidate = [...words].some((word) =>
+      candidates.some((candidate) => word.startsWith(candidate)),
+    );
+
+    if (hasCandidate(title)) {
       score += 35;
       reasons.add("title term");
     }
-    if (tags.has(token)) {
+    if (hasCandidate(slug)) {
+      score += 28;
+      reasons.add("slug term");
+    }
+    if (candidates.some((candidate) => tags.has(candidate))) {
       score += 24;
       reasons.add("tag match");
     }
-    if (keywords.has(token)) {
+    if (candidates.some((candidate) => keywords.has(candidate))) {
       score += 18;
       reasons.add("keyword match");
     }
-    if (category.includes(token)) {
+    if (hasCandidate(category)) {
       score += 12;
       reasons.add("category term");
     }
-    if (haystack.includes(token)) {
+    if (candidates.some((candidate) => candidateMatchesText(candidate, haystack, words))) {
       score += 4;
     }
+    if (hasPrefixCandidate) score += 2;
   }
 
+  if (isInstallable(entry)) {
+    score += 4;
+    reasons.add("installable");
+  }
   if (entry.trustSignals?.sourceStatus === "available") {
     score += 8;
     reasons.add("source-backed");

--- a/apps/web/src/routes/api/registry/search.ts
+++ b/apps/web/src/routes/api/registry/search.ts
@@ -18,6 +18,7 @@ export const GET = createApiHandler("registry.search", async ({ request, query: 
     q: query,
     category,
     platform,
+    installable,
     hasSafetyNotes,
     hasPrivacyNotes,
     downloadTrust,
@@ -31,6 +32,7 @@ export const GET = createApiHandler("registry.search", async ({ request, query: 
     query,
     category,
     platform,
+    installable,
     hasSafetyNotes,
     hasPrivacyNotes,
     downloadTrust,
@@ -58,6 +60,7 @@ export const GET = createApiHandler("registry.search", async ({ request, query: 
       category: category || "all",
       platform: platform || "all",
       filters: {
+        installable,
         hasSafetyNotes,
         hasPrivacyNotes,
         downloadTrust,

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -166,6 +166,11 @@ components:
           items:
             type: string
           maxItems: 12
+        mcpInstallTargets:
+          type: array
+          items:
+            type: string
+          maxItems: 4
         supportLevels:
           type: array
           items:
@@ -957,6 +962,16 @@ paths:
               - "false"
             default: all
           required: false
+          name: installable
+          in: query
+        - schema:
+            type: string
+            enum:
+              - all
+              - "true"
+              - "false"
+            default: all
+          required: false
           name: hasSafetyNotes
           in: query
         - schema:
@@ -1038,6 +1053,8 @@ paths:
                   filters:
                     type: object
                     properties:
+                      installable:
+                        type: string
                       hasSafetyNotes:
                         type: string
                       hasPrivacyNotes:
@@ -1049,6 +1066,7 @@ paths:
                       sourceStatus:
                         type: string
                     required:
+                      - installable
                       - hasSafetyNotes
                       - hasPrivacyNotes
                       - downloadTrust
@@ -1187,6 +1205,11 @@ paths:
                           items:
                             type: string
                           maxItems: 12
+                        mcpInstallTargets:
+                          type: array
+                          items:
+                            type: string
+                          maxItems: 4
                         supportLevels:
                           type: array
                           items:
@@ -1289,6 +1312,11 @@ paths:
                         additionalProperties:
                           type: integer
                           minimum: 0
+                      installable:
+                        type: object
+                        additionalProperties:
+                          type: integer
+                          minimum: 0
                       hasSafetyNotes:
                         type: object
                         additionalProperties:
@@ -1317,6 +1345,7 @@ paths:
                     required:
                       - categories
                       - platforms
+                      - installable
                       - hasSafetyNotes
                       - hasPrivacyNotes
                       - downloadTrust

--- a/content/mcp/after-effects-mcp-server.mdx
+++ b/content/mcp/after-effects-mcp-server.mdx
@@ -36,6 +36,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   npm run build && npm run install-bridge
 estimatedSetupTime: 20 minutes
 difficulty: advanced

--- a/content/mcp/ai-game-developer-unity-mcp-server.mdx
+++ b/content/mcp/ai-game-developer-unity-mcp-server.mdx
@@ -35,6 +35,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   npm install -g unity-mcp-cli
   unity-mcp-cli install-plugin ./MyUnityProject
   unity-mcp-cli open ./MyUnityProject

--- a/content/mcp/airtable-mcp-server.mdx
+++ b/content/mcp/airtable-mcp-server.mdx
@@ -45,15 +45,18 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "airtable": {
-      "env": {
-        "AIRTABLE_API_KEY": "${AIRTABLE_API_KEY}"
-      },
-      "args": [
-        "-y",
-        "airtable-mcp-server"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "airtable": {
+        "env": {
+          "AIRTABLE_API_KEY": "${AIRTABLE_API_KEY}"
+        },
+        "args": [
+          "-y",
+          "airtable-mcp-server"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/algolia-mcp-server.mdx
+++ b/content/mcp/algolia-mcp-server.mdx
@@ -37,8 +37,8 @@ configSnippet: |-
   {
     "mcpServers": {
       "algolia": {
-        "transport": "http",
-        "url": "https://mcp.algolia.com/mcp"
+        "url": "https://mcp.algolia.com/mcp",
+        "type": "http"
       }
     }
   }

--- a/content/mcp/alpaca-mcp-server.mdx
+++ b/content/mcp/alpaca-mcp-server.mdx
@@ -43,6 +43,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add alpaca --scope user --transport stdio uvx alpaca-mcp-server --env ALPACA_API_KEY=YOUR_ALPACA_API_KEY --env ALPACA_SECRET_KEY=YOUR_ALPACA_SECRET_KEY
 estimatedSetupTime: 15 minutes
 difficulty: advanced

--- a/content/mcp/anki-mcp-server.mdx
+++ b/content/mcp/anki-mcp-server.mdx
@@ -37,7 +37,19 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx -y @ankimcp/anki-mcp-server --stdio --read-only
+  {
+    "mcpServers": {
+      "anki": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@ankimcp/anki-mcp-server",
+          "--stdio"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/apple-docs-mcp-server.mdx
+++ b/content/mcp/apple-docs-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add apple-docs -- npx -y @kimsungwhee/apple-docs-mcp@latest
+  {
+    "mcpServers": {
+      "apple-docs": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@kimsungwhee/apple-docs-mcp@latest"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 5 minutes
 difficulty: beginner
 prerequisites:

--- a/content/mcp/asana-mcp-server.mdx
+++ b/content/mcp/asana-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "asana": {
-      "url": "https://mcp.asana.com/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "asana": {
+        "url": "https://mcp.asana.com/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/aws-services-mcp-server.mdx
+++ b/content/mcp/aws-services-mcp-server.mdx
@@ -42,16 +42,19 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "aws": {
-      "env": {
-        "AWS_REGION": "${AWS_REGION:-us-east-1}",
-        "AWS_PROFILE": "${AWS_PROFILE}",
-        "FASTMCP_LOG_LEVEL": "${FASTMCP_LOG_LEVEL:-ERROR}"
-      },
-      "args": [
-        "awslabs.core-mcp-server@latest"
-      ],
-      "command": "uvx"
+    "mcpServers": {
+      "aws": {
+        "env": {
+          "AWS_REGION": "${AWS_REGION:-us-east-1}",
+          "AWS_PROFILE": "${AWS_PROFILE}",
+          "FASTMCP_LOG_LEVEL": "${FASTMCP_LOG_LEVEL:-ERROR}"
+        },
+        "args": [
+          "awslabs.core-mcp-server@latest"
+        ],
+        "command": "uvx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/azure-devops-mcp-server.mdx
+++ b/content/mcp/azure-devops-mcp-server.mdx
@@ -45,6 +45,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "servers": {
       "ado-remote-mcp": {

--- a/content/mcp/bethington-ghidra-mcp-server.mdx
+++ b/content/mcp/bethington-ghidra-mcp-server.mdx
@@ -37,6 +37,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   python -m tools.setup preflight --ghidra-path GHIDRA_INSTALL_DIR
   python -m tools.setup ensure-prereqs --ghidra-path GHIDRA_INSTALL_DIR
   python -m tools.setup build

--- a/content/mcp/bifrost-mcp-gateway.mdx
+++ b/content/mcp/bifrost-mcp-gateway.mdx
@@ -41,19 +41,14 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "mcp": {
-      "client_configs": [
-        {
-          "name": "web_search",
-          "connection_type": "http",
-          "connection_string": "env.WEB_SEARCH_MCP_URL",
-          "auth_type": "headers",
-          "tools_to_execute": [
-            "search",
-            "fetch_url"
-          ]
-        }
-      ]
+    "mcpServers": {
+      "bifrost": {
+        "url": "BIFROST_MCP_URL",
+        "headers": {
+          "Authorization": "Bearer ${BIFROST_VIRTUAL_KEY}"
+        },
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 25 minutes

--- a/content/mcp/bigquery-mcp-server.mdx
+++ b/content/mcp/bigquery-mcp-server.mdx
@@ -32,9 +32,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "bigquery": {
-      "type": "http",
-      "url": "https://bigquery.googleapis.com/mcp"
+    "mcpServers": {
+      "bigquery": {
+        "type": "http",
+        "url": "https://bigquery.googleapis.com/mcp"
+      }
     }
   }
 estimatedSetupTime: 10 minutes

--- a/content/mcp/box-mcp-server.mdx
+++ b/content/mcp/box-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "box": {
-      "url": "https://mcp.box.com/",
-      "transport": "http"
+    "mcpServers": {
+      "box": {
+        "url": "https://mcp.box.com/",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/browserstack-mcp-server.mdx
+++ b/content/mcp/browserstack-mcp-server.mdx
@@ -41,6 +41,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "browserstack": {
       "command": "npx",

--- a/content/mcp/burp-suite-mcp-server.mdx
+++ b/content/mcp/burp-suite-mcp-server.mdx
@@ -41,6 +41,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   ./gradlew embedProxyJar
 estimatedSetupTime: 20 minutes
 difficulty: advanced

--- a/content/mcp/canva-mcp-server.mdx
+++ b/content/mcp/canva-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "canva": {
-      "url": "https://mcp.canva.com/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "canva": {
+        "url": "https://mcp.canva.com/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/chrome-devtools-mcp-server.mdx
+++ b/content/mcp/chrome-devtools-mcp-server.mdx
@@ -32,9 +32,14 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
+    "mcpServers": {
+      "chrome-devtools": {
+        "command": "npx",
+        "args": [
+          "chrome-devtools-mcp@latest"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/clickhouse-mcp-server.mdx
+++ b/content/mcp/clickhouse-mcp-server.mdx
@@ -50,6 +50,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "clickhouse": {
       "command": "uv",

--- a/content/mcp/clickup-mcp-server.mdx
+++ b/content/mcp/clickup-mcp-server.mdx
@@ -44,16 +44,19 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "clickup": {
-      "env": {
-        "CLICKUP_API_KEY": "${CLICKUP_API_KEY}",
-        "CLICKUP_TEAM_ID": "${CLICKUP_TEAM_ID}"
-      },
-      "args": [
-        "-y",
-        "@hauptsache.net/clickup-mcp"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "clickup": {
+        "env": {
+          "CLICKUP_API_KEY": "${CLICKUP_API_KEY}",
+          "CLICKUP_TEAM_ID": "${CLICKUP_TEAM_ID}"
+        },
+        "args": [
+          "-y",
+          "@hauptsache.net/clickup-mcp"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/cloudflare-mcp-server.mdx
+++ b/content/mcp/cloudflare-mcp-server.mdx
@@ -46,16 +46,19 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "cloudflare": {
-      "env": {
-        "CLOUDFLARE_API_TOKEN": "${CLOUDFLARE_API_TOKEN}",
-        "CLOUDFLARE_ACCOUNT_ID": "${CLOUDFLARE_ACCOUNT_ID}"
-      },
-      "args": [
-        "-y",
-        "@cloudflare/mcp-server-cloudflare"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "cloudflare": {
+        "env": {
+          "CLOUDFLARE_API_TOKEN": "${CLOUDFLARE_API_TOKEN}",
+          "CLOUDFLARE_ACCOUNT_ID": "${CLOUDFLARE_ACCOUNT_ID}"
+        },
+        "args": [
+          "-y",
+          "@cloudflare/mcp-server-cloudflare"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/cloudinary-mcp-server.mdx
+++ b/content/mcp/cloudinary-mcp-server.mdx
@@ -39,14 +39,16 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "cloudinary": {
-      "env": {
-        "CLOUDINARY_API_KEY": "${CLOUDINARY_API_KEY}",
-        "CLOUDINARY_API_SECRET": "${CLOUDINARY_API_SECRET}",
-        "CLOUDINARY_CLOUD_NAME": "${CLOUDINARY_CLOUD_NAME}"
-      },
-      "url": "https://mcp.cloudinary.com/",
-      "transport": "http"
+    "mcpServers": {
+      "cloudinary": {
+        "env": {
+          "CLOUDINARY_API_KEY": "${CLOUDINARY_API_KEY}",
+          "CLOUDINARY_API_SECRET": "${CLOUDINARY_API_SECRET}",
+          "CLOUDINARY_CLOUD_NAME": "${CLOUDINARY_CLOUD_NAME}"
+        },
+        "url": "https://mcp.cloudinary.com/",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/code-index-mcp-server.mdx
+++ b/content/mcp/code-index-mcp-server.mdx
@@ -40,6 +40,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   uvx code-index-mcp --project-path ABSOLUTE_PATH_TO_REPOSITORY
 estimatedSetupTime: 10 minutes
 difficulty: intermediate

--- a/content/mcp/codedb-mcp-server.mdx
+++ b/content/mcp/codedb-mcp-server.mdx
@@ -37,7 +37,19 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add codedb -- npx -y codedeebee mcp
+  {
+    "mcpServers": {
+      "codedb": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "codedeebee",
+          "mcp"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/context7-mcp-server.mdx
+++ b/content/mcp/context7-mcp-server.mdx
@@ -33,9 +33,15 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "context7": {
-      "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp"]
+    "mcpServers": {
+      "context7": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@upstash/context7-mcp"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/contrastapi-mcp-server.mdx
+++ b/content/mcp/contrastapi-mcp-server.mdx
@@ -32,9 +32,11 @@ usageSnippet: |-
   claude mcp list
 configSnippet: |-
   {
-    "contrastapi": {
-      "url": "https://api.contrastcyber.com/mcp/",
-      "transport": "http"
+    "mcpServers": {
+      "contrastapi": {
+        "url": "https://api.contrastcyber.com/mcp/",
+        "type": "http"
+      }
     }
   }
 tags:

--- a/content/mcp/coolify-mcp-server.mdx
+++ b/content/mcp/coolify-mcp-server.mdx
@@ -41,7 +41,22 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add coolify -e COOLIFY_BASE_URL=https://your-coolify-instance.example -e COOLIFY_ACCESS_TOKEN=your-token -- npx @masonator/coolify-mcp@latest
+  {
+    "mcpServers": {
+      "coolify": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@masonator/coolify-mcp"
+        ],
+        "env": {
+          "COOLIFY_BASE_URL": "https://your-coolify-instance.example",
+          "COOLIFY_ACCESS_TOKEN": "your-api-token"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/cupertino-mcp-server.mdx
+++ b/content/mcp/cupertino-mcp-server.mdx
@@ -38,10 +38,17 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add cupertino --scope user -- $(which cupertino)
-
-  # Codex users should keep --no-reap enabled.
-  codex mcp add cupertino -- $(which cupertino) serve --no-reap
+  {
+    "mcpServers": {
+      "cupertino": {
+        "command": "/opt/homebrew/bin/cupertino",
+        "args": [
+          "serve"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/daloopa-mcp-server.mdx
+++ b/content/mcp/daloopa-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "daloopa": {
-      "url": "https://mcp.daloopa.com/server/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "daloopa": {
+        "url": "https://mcp.daloopa.com/server/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/data-api-builder-mcp-tools.mdx
+++ b/content/mcp/data-api-builder-mcp-tools.mdx
@@ -33,6 +33,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   "mcp": {
     "enabled": true,
     "path": "/mcp"

--- a/content/mcp/datagouv-mcp-server.mdx
+++ b/content/mcp/datagouv-mcp-server.mdx
@@ -37,7 +37,14 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add --transport http datagouv https://mcp.data.gouv.fr/mcp
+  {
+    "mcpServers": {
+      "datagouv": {
+        "url": "https://mcp.data.gouv.fr/mcp",
+        "type": "http"
+      }
+    }
+  }
 estimatedSetupTime: 5 minutes
 difficulty: beginner
 prerequisites:

--- a/content/mcp/davinci-resolve-mcp-server.mdx
+++ b/content/mcp/davinci-resolve-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx davinci-resolve-mcp setup
+  {
+    "mcpServers": {
+      "davinci-resolve": {
+        "command": "npx",
+        "args": [
+          "davinci-resolve-mcp",
+          "server"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 25 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/desktop-mcp-setup.mdx
+++ b/content/mcp/desktop-mcp-setup.mdx
@@ -37,6 +37,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "mcpServers": {
       "filesystem": {

--- a/content/mcp/discord-mcp-server.mdx
+++ b/content/mcp/discord-mcp-server.mdx
@@ -45,6 +45,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "discord-mcp": {
       "env": {

--- a/content/mcp/django-mcp-server.mdx
+++ b/content/mcp/django-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  python manage.py mcp_inspect
+  {
+    "mcpServers": {
+      "django": {
+        "command": "python",
+        "args": [
+          "manage.py",
+          "stdio_server"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 25 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/docker-mcp-server.mdx
+++ b/content/mcp/docker-mcp-server.mdx
@@ -41,16 +41,19 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "docker": {
-      "env": {
-        "DOCKER_HOST": "${DOCKER_HOST:-unix:///var/run/docker.sock}",
-        "DOCKER_API_VERSION": "${DOCKER_API_VERSION:-1.43}"
-      },
-      "args": [
-        "-y",
-        "@docker/mcp-server"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "docker": {
+        "env": {
+          "DOCKER_HOST": "${DOCKER_HOST:-unix:///var/run/docker.sock}",
+          "DOCKER_API_VERSION": "${DOCKER_API_VERSION:-1.43}"
+        },
+        "args": [
+          "-y",
+          "@docker/mcp-server"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/drawio-mcp-server.mdx
+++ b/content/mcp/drawio-mcp-server.mdx
@@ -40,7 +40,22 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add-json drawio '{"type":"stdio","command":"npx","args":["-y","drawio-mcp-server","--editor"]}'
+  {
+    "mcpServers": {
+      "drawio": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "drawio-mcp-server",
+          "--editor"
+        ],
+        "env": {
+          "NPM_CONFIG_IGNORE_SCRIPTS": "true"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/dreamlit-mcp-server.mdx
+++ b/content/mcp/dreamlit-mcp-server.mdx
@@ -40,7 +40,7 @@ configSnippet: |-
     "mcpServers": {
       "dreamlit": {
         "url": "https://mcp.dreamlit.ai/mcp",
-        "transport": "http"
+        "type": "http"
       }
     }
   }

--- a/content/mcp/elevenlabs-mcp-server.mdx
+++ b/content/mcp/elevenlabs-mcp-server.mdx
@@ -42,6 +42,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add elevenlabs --env ELEVENLABS_API_KEY=YOUR_ELEVENLABS_API_KEY -- uvx elevenlabs-mcp
 estimatedSetupTime: 10 minutes
 difficulty: intermediate

--- a/content/mcp/expo-mcp-server.mdx
+++ b/content/mcp/expo-mcp-server.mdx
@@ -41,7 +41,7 @@ configSnippet: |-
     "mcpServers": {
       "expo": {
         "url": "https://mcp.expo.dev/mcp",
-        "transport": "http"
+        "type": "http"
       }
     }
   }

--- a/content/mcp/fastapi-mcp.mdx
+++ b/content/mcp/fastapi-mcp.mdx
@@ -26,7 +26,7 @@ documentationUrl: "https://fastapi-mcp.tadata.com/"
 packageUrl: "https://pypi.org/project/fastapi-mcp/"
 installable: true
 installCommand: "uv add fastapi-mcp"
-usageSnippet: "Install `fastapi-mcp`, mount `FastApiMCP(app)` into a reviewed FastAPI app, and expose only endpoints that are safe for agent tool use."
+usageSnippet: "Install `fastapi-mcp`, mount `FastApiMCP(app)` with HTTP transport, run the FastAPI app, then connect the MCP client to `http://localhost:8000/mcp`."
 copySnippet: |-
   from fastapi import FastAPI
   from fastapi_mcp import FastApiMCP
@@ -34,15 +34,16 @@ copySnippet: |-
   app = FastAPI()
 
   mcp = FastApiMCP(app)
-  mcp.mount()
+  mcp.mount_http()
 configSnippet: |-
-  from fastapi import FastAPI
-  from fastapi_mcp import FastApiMCP
-
-  app = FastAPI()
-
-  mcp = FastApiMCP(app)
-  mcp.mount()
+  {
+    "mcpServers": {
+      "fastapi-mcp": {
+        "url": "http://localhost:8000/mcp",
+        "type": "http"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:
@@ -63,6 +64,7 @@ privacyNotes:
 sourceUrls:
   - "https://github.com/tadata-org/fastapi_mcp"
   - "https://fastapi-mcp.tadata.com/"
+  - "https://fastapi-mcp.tadata.com/advanced/transport"
   - "https://pypi.org/project/fastapi-mcp/"
 tags:
   - fastapi
@@ -87,16 +89,18 @@ tools. It preserves request and response schemas, endpoint documentation, and
 FastAPI dependency-based authentication patterns instead of treating an API only
 as a generic OpenAPI document.
 
-The simplest documented pattern mounts an MCP server directly into a FastAPI app
-so the MCP endpoint becomes available from the application.
+The simplest documented pattern mounts an HTTP MCP server directly into a
+FastAPI app so the MCP endpoint becomes available from the application at
+`/mcp`.
 
 ## Source Review
 
 - https://github.com/tadata-org/fastapi_mcp
 - https://fastapi-mcp.tadata.com/
+- https://fastapi-mcp.tadata.com/advanced/transport
 - https://pypi.org/project/fastapi-mcp/
 
-These sources were reviewed on **2026-06-05**. Prefer live documentation for
+These sources were reviewed on **2026-06-07**. Prefer live documentation for
 current installation, mounting, deployment, authentication, and endpoint
 selection options.
 
@@ -132,11 +136,23 @@ from fastapi_mcp import FastApiMCP
 app = FastAPI()
 
 mcp = FastApiMCP(app)
-mcp.mount()
+mcp.mount_http()
 ```
 
-The generated MCP endpoint is available from the mounted application path
-documented by the package.
+When the app runs on port 8000, the generated Streamable HTTP MCP endpoint is
+available at `http://localhost:8000/mcp`.
+
+Client configuration:
+
+```json
+{
+  "mcpServers": {
+    "fastapi-mcp": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
 
 ## Use Cases
 
@@ -159,5 +175,6 @@ when experimenting.
 ## Duplicate Check
 
 Existing entries include generic OpenAPI and API tooling, but no
-`tadata-org/fastapi_mcp` entry was found in `content/mcp`. This entry is for the
-FastAPI-native MCP package and belongs in `content/mcp`.
+`tadata-org/fastapi_mcp` entry was found in `content/mcp`. This entry is for
+the FastAPI-native MCP framework package and uses the documented local
+Streamable HTTP endpoint.

--- a/content/mcp/figma-mcp-server.mdx
+++ b/content/mcp/figma-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "figma": {
-      "url": "http://127.0.0.1:3845/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "figma": {
+        "url": "http://127.0.0.1:3845/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/filesystem-mcp-server.mdx
+++ b/content/mcp/filesystem-mcp-server.mdx
@@ -37,6 +37,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "filesystem": {
       "args": [

--- a/content/mcp/fireflies-mcp-server.mdx
+++ b/content/mcp/fireflies-mcp-server.mdx
@@ -31,9 +31,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "fireflies": {
-      "url": "https://api.fireflies.ai/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "fireflies": {
+        "url": "https://api.fireflies.ai/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/flexprice-mcp-server.mdx
+++ b/content/mcp/flexprice-mcp-server.mdx
@@ -40,12 +40,21 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "flexprice": {
-      "command": "npx",
-      "args": ["-y", "@flexprice/mcp-server", "start", "--scope", "read"],
-      "env": {
-        "API_KEY_APIKEYAUTH": "${FLEXPRICE_API_KEY}",
-        "BASE_URL": "https://us.api.flexprice.io/v1"
+    "mcpServers": {
+      "flexprice": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@flexprice/mcp-server",
+          "start",
+          "--scope",
+          "read"
+        ],
+        "env": {
+          "API_KEY_APIKEYAUTH": "${FLEXPRICE_API_KEY}",
+          "BASE_URL": "https://us.api.flexprice.io/v1"
+        },
+        "type": "stdio"
       }
     }
   }

--- a/content/mcp/fli-google-flights-mcp-server.mdx
+++ b/content/mcp/fli-google-flights-mcp-server.mdx
@@ -37,7 +37,15 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add fli -- fli-mcp
+  {
+    "mcpServers": {
+      "fli": {
+        "command": "fli-mcp",
+        "args": [],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/freee-mcp-server.mdx
+++ b/content/mcp/freee-mcp-server.mdx
@@ -35,7 +35,14 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx freee-mcp configure
+  {
+    "mcpServers": {
+      "freee": {
+        "url": "https://mcp.freee.co.jp/mcp",
+        "type": "http"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/funasr-mcp-server.mdx
+++ b/content/mcp/funasr-mcp-server.mdx
@@ -38,6 +38,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   pip install funasr
 estimatedSetupTime: 20 minutes
 difficulty: intermediate

--- a/content/mcp/gcloud-mcp-server.mdx
+++ b/content/mcp/gcloud-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add gcloud -- npx -y @google-cloud/gcloud-mcp
+  {
+    "mcpServers": {
+      "gcloud": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@google-cloud/gcloud-mcp"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/git-mcp-server.mdx
+++ b/content/mcp/git-mcp-server.mdx
@@ -37,12 +37,15 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "git": {
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-git"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "git": {
+        "args": [
+          "-y",
+          "@modelcontextprotocol/server-git"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/gitbook-published-docs-mcp-server.mdx
+++ b/content/mcp/gitbook-published-docs-mcp-server.mdx
@@ -31,9 +31,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "gitbook": {
-      "url": "https://gitbook.com/docs/~gitbook/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "gitbook": {
+        "url": "https://gitbook.com/docs/~gitbook/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/github-mcp-server.mdx
+++ b/content/mcp/github-mcp-server.mdx
@@ -45,15 +45,18 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "github": {
-      "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
-      },
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-github"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "github": {
+        "env": {
+          "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
+        },
+        "args": [
+          "-y",
+          "@modelcontextprotocol/server-github"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/gittensory-mcp.mdx
+++ b/content/mcp/gittensory-mcp.mdx
@@ -33,9 +33,16 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "gittensory": {
-      "command": "npx",
-      "args": ["-y", "@jsonbored/gittensory-mcp@latest", "--stdio"]
+    "mcpServers": {
+      "gittensory": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@jsonbored/gittensory-mcp@latest",
+          "--stdio"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 5 minutes

--- a/content/mcp/google-search-console-mcp-server.mdx
+++ b/content/mcp/google-search-console-mcp-server.mdx
@@ -38,6 +38,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   GSC_OAUTH_CLIENT_SECRETS_FILE=<absolute-path-to-client-secrets-json>
   GSC_CREDENTIALS_PATH=<absolute-path-to-service-account-json>
   GSC_SKIP_OAUTH=true

--- a/content/mcp/gpt-researcher-mcp-server.mdx
+++ b/content/mcp/gpt-researcher-mcp-server.mdx
@@ -40,6 +40,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   python server.py
 estimatedSetupTime: 20 minutes
 difficulty: advanced

--- a/content/mcp/grafana-mcp-server.mdx
+++ b/content/mcp/grafana-mcp-server.mdx
@@ -39,6 +39,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "grafana": {
       "command": "uvx",

--- a/content/mcp/graphlit-mcp-server.mdx
+++ b/content/mcp/graphlit-mcp-server.mdx
@@ -42,7 +42,23 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add graphlit -- npx -y graphlit-mcp-server
+  {
+    "mcpServers": {
+      "graphlit": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "graphlit-mcp-server"
+        ],
+        "env": {
+          "GRAPHLIT_ORGANIZATION_ID": "your-organization-id",
+          "GRAPHLIT_ENVIRONMENT_ID": "your-environment-id",
+          "GRAPHLIT_JWT_SECRET": "your-jwt-secret"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/httprunner-uixt-mcp-server.mdx
+++ b/content/mcp/httprunner-uixt-mcp-server.mdx
@@ -36,7 +36,17 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  hrp mcp-server
+  {
+    "mcpServers": {
+      "httprunner-uixt": {
+        "command": "hrp",
+        "args": [
+          "mcp-server"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 30 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/hubspot-mcp-server.mdx
+++ b/content/mcp/hubspot-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "hubspot": {
-      "url": "https://mcp.hubspot.com/anthropic",
-      "transport": "http"
+    "mcpServers": {
+      "hubspot": {
+        "url": "https://mcp.hubspot.com/anthropic",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/hugging-face-mcp-server.mdx
+++ b/content/mcp/hugging-face-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "huggingface": {
-      "url": "https://huggingface.co/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "huggingface": {
+        "url": "https://huggingface.co/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/intercom-mcp-server.mdx
+++ b/content/mcp/intercom-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "intercom": {
-      "url": "https://mcp.intercom.com/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "intercom": {
+        "url": "https://mcp.intercom.com/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/invideo-mcp-server.mdx
+++ b/content/mcp/invideo-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "invideo": {
-      "url": "https://mcp.invideo.io/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "invideo": {
+        "url": "https://mcp.invideo.io/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/jam-mcp-server.mdx
+++ b/content/mcp/jam-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "jam": {
-      "url": "https://mcp.jam.dev/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "jam": {
+        "url": "https://mcp.jam.dev/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/jira-mcp-server.mdx
+++ b/content/mcp/jira-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "atlassian": {
-      "url": "https://mcp.atlassian.com/v1/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "atlassian": {
+        "url": "https://mcp.atlassian.com/v1/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 4 minutes

--- a/content/mcp/jscpd-mcp-server.mdx
+++ b/content/mcp/jscpd-mcp-server.mdx
@@ -32,6 +32,7 @@ copySnippet: |-
   npm install -g jscpd-server
   jscpd-server PROJECT_DIR
 configSnippet: |-
+  Manual-only setup:
   {
     "mcpServers": {
       "jscpd": {

--- a/content/mcp/jupyter-mcp-server.mdx
+++ b/content/mcp/jupyter-mcp-server.mdx
@@ -41,6 +41,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add jupyter --env JUPYTER_URL=YOUR_JUPYTER_SERVER_URL --env JUPYTER_TOKEN=YOUR_JUPYTER_TOKEN -- uvx jupyter-mcp-server@latest
 estimatedSetupTime: 20 minutes
 difficulty: advanced

--- a/content/mcp/kagi-mcp-server.mdx
+++ b/content/mcp/kagi-mcp-server.mdx
@@ -38,6 +38,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   uvx kagimcp
 estimatedSetupTime: 10 minutes
 difficulty: beginner

--- a/content/mcp/keeper-sh-mcp-server.mdx
+++ b/content/mcp/keeper-sh-mcp-server.mdx
@@ -37,6 +37,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   BETTER_AUTH_URL=https://<keeper-host>
   MCP_PUBLIC_URL=https://<keeper-host>/mcp
   MCP_PORT=3002

--- a/content/mcp/kordoc-mcp-server.mdx
+++ b/content/mcp/kordoc-mcp-server.mdx
@@ -37,7 +37,19 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx -y kordoc setup
+  {
+    "mcpServers": {
+      "kordoc": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "kordoc",
+          "mcp"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/kubernetes-mcp-server.mdx
+++ b/content/mcp/kubernetes-mcp-server.mdx
@@ -44,14 +44,17 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "kubernetes": {
-      "env": {
-        "KUBECONFIG": "${KUBECONFIG:-~/.kube/config}"
-      },
-      "args": [
-        "mcp-kubernetes-server"
-      ],
-      "command": "uvx"
+    "mcpServers": {
+      "kubernetes": {
+        "env": {
+          "KUBECONFIG": "${KUBECONFIG:-~/.kube/config}"
+        },
+        "args": [
+          "mcp-kubernetes-server"
+        ],
+        "command": "uvx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/line-bot-mcp-server.mdx
+++ b/content/mcp/line-bot-mcp-server.mdx
@@ -42,6 +42,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add line-bot --env CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN -- npx -y @line/line-bot-mcp-server
 estimatedSetupTime: 15 minutes
 difficulty: intermediate

--- a/content/mcp/linear-mcp-server.mdx
+++ b/content/mcp/linear-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "linear": {
-      "url": "https://mcp.linear.app/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "linear": {
+        "url": "https://mcp.linear.app/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/mac-messages-mcp-server.mdx
+++ b/content/mcp/mac-messages-mcp-server.mdx
@@ -37,7 +37,17 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  uvx mac-messages-mcp
+  {
+    "mcpServers": {
+      "messages": {
+        "command": "uvx",
+        "args": [
+          "mac-messages-mcp"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/macos-automator-mcp.mdx
+++ b/content/mcp/macos-automator-mcp.mdx
@@ -42,7 +42,20 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add macos-automator -- npx -y --package @steipete/macos-automator-mcp macos-automator-mcp
+  {
+    "mcpServers": {
+      "macos_automator": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "--package",
+          "@steipete/macos-automator-mcp",
+          "macos-automator-mcp"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/magic-mcp-server.mdx
+++ b/content/mcp/magic-mcp-server.mdx
@@ -36,11 +36,17 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "magic": {
-      "command": "npx",
-      "args": ["-y", "@21st-dev/magic@latest"],
-      "env": {
-        "API_KEY": "${API_KEY}"
+    "mcpServers": {
+      "magic": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@21st-dev/magic@latest"
+        ],
+        "env": {
+          "API_KEY": "${API_KEY}"
+        },
+        "type": "stdio"
       }
     }
   }

--- a/content/mcp/mapbox-mcp-server.mdx
+++ b/content/mcp/mapbox-mcp-server.mdx
@@ -39,6 +39,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   npx -y @mapbox/mcp-server --disable-tools static_map_image_tool
 estimatedSetupTime: 10 minutes
 difficulty: intermediate

--- a/content/mcp/maxkb-mcp-server.mdx
+++ b/content/mcp/maxkb-mcp-server.mdx
@@ -36,6 +36,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   Default route:
   - chat path: /chat
   - chat API prefix: /chat/api/

--- a/content/mcp/mcp-brasil.mdx
+++ b/content/mcp/mcp-brasil.mdx
@@ -43,6 +43,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add mcp-brasil -- uvx --from mcp-brasil python -m mcp_brasil.server
 estimatedSetupTime: 15 minutes
 difficulty: advanced

--- a/content/mcp/mcp-proxy-transport-bridge.mdx
+++ b/content/mcp/mcp-proxy-transport-bridge.mdx
@@ -39,6 +39,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   mcp-proxy https://example.com/sse
 estimatedSetupTime: 10 minutes
 difficulty: intermediate

--- a/content/mcp/mcp-registry-server-mcp-server.mdx
+++ b/content/mcp/mcp-registry-server-mcp-server.mdx
@@ -1,187 +1,173 @@
 ---
-title: MCP Registry Server
+title: MCP Registry MCP Server
 slug: mcp-registry-server-mcp-server
 category: mcp
 description: >-
-  Community-driven MCP registry service that lets clients discover published MCP
-  server metadata and lets publishers submit server.json records through a
-  documented API and publisher CLI.
+  MCP server that lets Claude and other MCP clients search and page through the
+  official MCP Registry from a local stdio server.
 cardDescription: >-
-  Run or integrate with the official MCP Registry service for server discovery,
-  publishing workflows, namespace verification, metadata validation, and
-  registry aggregator use cases.
-seoTitle: MCP Registry Server for Claude
+  Discover available MCP servers from the official registry through an
+  installable npm stdio MCP server.
+seoTitle: MCP Registry MCP Server for Claude
 seoDescription: >-
-  Use the MCP Registry Server with Claude, MCP clients, publishers, and
-  aggregators to discover MCP server metadata, validate server.json records,
-  publish verified listings, and run a local registry development server.
-author: Model Context Protocol
-authorProfileUrl: "https://github.com/modelcontextprotocol"
+  Install the MCP Registry MCP server for Claude, Cursor, Codex, and other MCP
+  clients to list and search registry.modelcontextprotocol.io server records
+  with pagination and custom registry URL support.
+author: Jun Han
+authorProfileUrl: "https://github.com/formulahendry"
 submittedBy: oktofeesh1
 submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-06"
-brandName: MCP Registry
-brandDomain: modelcontextprotocol.io
-repoUrl: "https://github.com/modelcontextprotocol/registry"
-documentationUrl: "https://registry.modelcontextprotocol.io/docs"
-packageUrl: "https://github.com/modelcontextprotocol/registry/pkgs/container/registry"
+brandName: MCP Registry MCP Server
+brandDomain: github.com
+repoUrl: "https://github.com/formulahendry/mcp-server-mcp-registry"
+documentationUrl: "https://github.com/formulahendry/mcp-server-mcp-registry#readme"
+packageUrl: "https://www.npmjs.com/package/mcp-server-mcp-registry"
 installable: true
-installCommand: "make dev-compose"
-usageSnippet: "Run `make dev-compose` from a cloned registry repository to start the local registry service with PostgreSQL-backed development data."
+installCommand: "npx -y mcp-server-mcp-registry@latest"
+usageSnippet: "Install the npm stdio MCP server with `npx -y mcp-server-mcp-registry@latest`, then call `list_mcp_servers` to browse or search registry records."
 copySnippet: |-
-  make dev-compose
+  {
+    "mcpServers": {
+      "mcp-registry": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "mcp-server-mcp-registry@latest"
+        ]
+      }
+    }
+  }
 configSnippet: |-
-  MCP_REGISTRY_DATABASE_URL=postgres://registry:registry@postgres:5432/registry
-  MCP_REGISTRY_SEED_FROM=data/seed.json
-  MCP_REGISTRY_ENABLE_REGISTRY_VALIDATION=true
-estimatedSetupTime: 20 minutes
-difficulty: advanced
+  {
+    "mcpServers": {
+      "mcp-registry": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "mcp-server-mcp-registry@latest"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
+estimatedSetupTime: 3 minutes
+difficulty: beginner
 prerequisites:
-  - Docker for the local development environment documented by the registry project.
-  - Go 1.24.x, ko, and golangci-lint when building or validating the registry from source.
-  - PostgreSQL available when running the prebuilt registry container outside the bundled development compose setup.
-  - Understanding of MCP server.json metadata, registry namespaces, and the difference between a registry API and an MCP tool server.
-  - GitHub OAuth, GitHub OIDC, DNS verification, or HTTP verification prepared before publishing under an owned namespace.
+  - Node.js 20 or newer.
+  - Network access to the MCP Registry API, or a custom registry URL supplied when calling the tool.
+  - Understanding that registry results are discovery metadata, not security approval for listed servers.
 safetyNotes:
-  - The registry service stores and serves MCP server metadata; inaccurate metadata can mislead clients about server packages, remotes, versions, auth requirements, or publisher identity.
-  - Publishing uses namespace ownership checks. Keep GitHub, DNS, HTTP verification, and OIDC configuration limited to namespaces you control.
-  - Local development seeding can mirror production registry behavior or load local seed data; review seed sources before using them in tests or demonstrations.
-  - Do not treat registry inclusion as a security audit of listed MCP servers. Review each referenced server, package, transport, and permission model independently.
-  - Running the prebuilt container outside the compose setup requires a correctly configured database connection, deployment controls, and registry validation enabled before exposure.
+  - Registry search results can point to arbitrary third-party MCP servers, packages, remotes, and repositories; review each result before installing anything it recommends.
+  - The server shells through `npx`, so pin a package version if you need reproducible installs instead of `@latest`.
+  - A custom `registry_url` can point the server at a private registry; only use trusted registry endpoints.
 privacyNotes:
-  - Published server metadata can include repository URLs, package URLs, remote endpoints, website URLs, organization names, namespaces, versions, and server descriptions.
-  - Publisher authentication and namespace verification can involve GitHub identities, GitHub Actions OIDC claims, DNS records, or HTTP challenge material.
-  - Registry logs, database rows, API requests, publisher CLI output, and validation errors may expose submitted metadata and namespace ownership details.
-  - Aggregators and clients that consume the registry may cache metadata and present it to users or models, so remove secrets and private endpoints before publishing.
+  - Search terms, pagination cursors, custom registry URLs, registry responses, package names, repository URLs, and server metadata may be visible to the MCP client and model provider.
+  - Private registry URLs or internal server metadata can be exposed in prompts, logs, transcripts, and client config if used directly.
 sourceUrls:
-  - "https://github.com/modelcontextprotocol/registry"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/README.md"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/docker-compose.yml"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/.env.example"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/about.mdx"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx"
-  - "https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx"
+  - "https://github.com/formulahendry/mcp-server-mcp-registry"
+  - "https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/README.md"
+  - "https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/server.json"
+  - "https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/package.json"
+  - "https://www.npmjs.com/package/mcp-server-mcp-registry"
   - "https://registry.modelcontextprotocol.io/docs"
-  - "https://github.com/modelcontextprotocol/registry/pkgs/container/registry"
 tags:
   - registry
   - discovery
-  - publishing
-  - metadata
-  - aggregator
+  - search
+  - npm
+  - stdio
 keywords:
-  - MCP Registry
-  - MCP Registry Server
-  - modelcontextprotocol registry
-  - MCP server.json
-  - MCP publisher CLI
+  - MCP Registry MCP Server
+  - mcp-server-mcp-registry
+  - registry.modelcontextprotocol.io MCP
+  - MCP server discovery
+  - list_mcp_servers
 robotsIndex: true
 robotsFollow: true
 ---
 
 ## Content
 
-MCP Registry Server is the community-driven registry service for Model Context
-Protocol server metadata. It gives MCP clients, directories, and aggregators a
-standard API for discovering published server records, and gives publishers a
-documented path for submitting validated `server.json` metadata under verified
-namespaces.
+MCP Registry MCP Server is an installable npm MCP server for discovering and
+searching the MCP Registry from an MCP client. It exposes a `list_mcp_servers`
+tool that can browse registry records, page through large result sets, and use a
+custom registry URL when needed.
 
-The project is not a general MCP tool executor. Its job is registry
-infrastructure: store, validate, serve, and publish metadata about MCP servers.
-That makes it useful when building MCP discovery flows, registry aggregators,
-publisher automation, or local registry development environments.
+This entry is intentionally pointed at `formulahendry/mcp-server-mcp-registry`,
+not the official `modelcontextprotocol/registry` service repository. The
+official registry project is a REST registry and publisher service. This package
+is the client-installed MCP server that wraps registry discovery as an MCP tool.
 
 ## Source Review
 
-- https://github.com/modelcontextprotocol/registry
-- https://github.com/modelcontextprotocol/registry/blob/main/README.md
-- https://github.com/modelcontextprotocol/registry/blob/main/docker-compose.yml
-- https://github.com/modelcontextprotocol/registry/blob/main/.env.example
-- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/about.mdx
-- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx
-- https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/registry-aggregators.mdx
+- https://github.com/formulahendry/mcp-server-mcp-registry
+- https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/README.md
+- https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/server.json
+- https://github.com/formulahendry/mcp-server-mcp-registry/blob/main/package.json
+- https://www.npmjs.com/package/mcp-server-mcp-registry
 - https://registry.modelcontextprotocol.io/docs
-- https://github.com/modelcontextprotocol/registry/pkgs/container/registry
 
-These sources were reviewed on **2026-06-06**. Prefer the live repository,
-official API docs, publisher quickstart, and aggregator guide for current API
-versions, namespace verification rules, publisher CLI behavior, development
-commands, and container deployment notes.
+These sources were reviewed on **2026-06-07**. Prefer the live README,
+`server.json`, package metadata, and official registry API docs for current
+package version, transport, tool parameters, and default registry endpoint.
 
 ## Features
 
-- Registry API for MCP server metadata discovery.
-- Publisher workflow for submitting MCP `server.json` records.
-- Namespace verification through GitHub OAuth, GitHub OIDC, DNS, or HTTP
-  challenges.
-- Validation for submitted server metadata.
-- Local development environment through `make dev-compose`.
-- PostgreSQL-backed registry service implementation in Go.
-- Prebuilt GitHub Container Registry images for registry deployments.
-- Documentation for registry aggregators and third-party directory builders.
-- Production API docs for testing registry endpoints.
+- Search and list MCP Registry server records from an MCP client.
+- Support cursor-based pagination through registry results.
+- Accept an optional custom registry API URL.
+- Return raw server metadata that can be reviewed or analyzed by the client.
+- Install through npm with stdio transport.
+- Publish an official `server.json` manifest for registry metadata.
 
 ## Installation
 
-Clone the registry repository and run the documented development environment:
+Add the stdio server to an MCP client:
 
-```bash
-make dev-compose
+```json
+{
+  "mcpServers": {
+    "mcp-registry": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-server-mcp-registry@latest"
+      ]
+    }
+  }
+}
 ```
 
-The development compose setup builds the registry image, starts PostgreSQL, and
-seeds the service with registry data for local testing.
-
-When using the prebuilt container image, provide your own PostgreSQL database,
-configure the registry database URL, and keep registry validation enabled before
-exposing the service.
-
-## Publisher Workflow
-
-Build the publisher CLI from the repository:
-
-```bash
-make publisher
-```
-
-Then inspect available publishing commands:
-
-```bash
-./bin/mcp-publisher --help
-```
-
-Use the official quickstart before publishing. Namespace ownership checks are a
-core part of the registry trust model.
+After installation, use the `list_mcp_servers` tool. The default registry URL is
+`https://registry.modelcontextprotocol.io/v0/servers`, and callers can override
+it with the tool's `registry_url` parameter.
 
 ## Use Cases
 
-- Build MCP client discovery flows backed by a standard registry API.
-- Run a local registry service while developing registry integrations.
-- Test server metadata validation before publishing.
-- Publish MCP server records under verified namespaces.
-- Build registry aggregators, mirrors, or directory sync jobs.
-- Review server package, remote, version, repository, and website metadata in a
-  consistent schema.
+- Search for available MCP servers without leaving the MCP client.
+- Page through registry results while comparing candidate servers.
+- Query a private registry by passing a custom registry URL.
+- Build discovery and triage workflows that start from official registry
+  metadata.
+- Inspect package, repository, and transport metadata before installing a
+  separate MCP server.
 
 ## Safety and Privacy
 
-Treat registry records as discovery metadata, not endorsement. Registry entries
-can help users find MCP servers, but each server still needs its own security,
-privacy, package, and source review before installation.
+Treat registry results as leads, not approvals. A listed package still needs its
+own source, package, permission, privacy, and trust review before installation.
+Do not install or run a returned MCP server just because it appears in registry
+metadata.
 
-Keep namespace verification credentials and challenge material under tight
-control. Publishing from GitHub Actions should use the least privilege needed
-for OIDC-based namespace proof, and DNS or HTTP challenges should be scoped to
-domains you control.
-
-Before publishing metadata, remove private endpoints, internal package URLs,
-temporary repository links, secrets, tokens, personal contact details, and
-anything that should not be cached by clients, aggregators, or model contexts.
+Private registry URLs and search results can reveal internal server names,
+package locations, repository URLs, and operational metadata. Keep private
+registry usage out of shared transcripts and logs unless it has been reviewed.
 
 ## Duplicate Check
 
-No dedicated `modelcontextprotocol/registry` entry, MCP Registry Server entry,
-or matching registry source URL was found in `content/mcp`. The registry repo
-appears only as a supporting source URL in the Windows MCP entry, not as its own
-catalog entry.
+The previous content pointed at the official `modelcontextprotocol/registry`
+service, which is registry infrastructure rather than a client-installed MCP
+server. This entry now targets the installable
+`formulahendry/mcp-server-mcp-registry` MCP server package and keeps the
+official registry only as the queried data source.

--- a/content/mcp/mcphub-server-manager.mdx
+++ b/content/mcp/mcphub-server-manager.mdx
@@ -39,6 +39,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "mcpServers": {
       "time": {

--- a/content/mcp/mcpjungle-gateway.mdx
+++ b/content/mcp/mcpjungle-gateway.mdx
@@ -38,10 +38,14 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "name": "context7",
-    "transport": "streamable_http",
-    "description": "Context7 MCP Server",
-    "url": "https://mcp.context7.com/mcp"
+    "mcpServers": {
+      "mcpjungle-gateway": {
+        "name": "context7",
+        "description": "Context7 MCP Server",
+        "url": "https://mcp.context7.com/mcp",
+        "type": "http"
+      }
+    }
   }
 estimatedSetupTime: 20 minutes
 difficulty: advanced

--- a/content/mcp/memory-bank-mcp-server.mdx
+++ b/content/mcp/memory-bank-mcp-server.mdx
@@ -38,6 +38,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   MEMORY_BANK_ROOT=ABSOLUTE_PATH_TO_MEMORY_BANK npx -y @allpepper/memory-bank-mcp@latest
 estimatedSetupTime: 10 minutes
 difficulty: beginner

--- a/content/mcp/memory-mcp-server.mdx
+++ b/content/mcp/memory-mcp-server.mdx
@@ -31,9 +31,15 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "memory": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    "mcpServers": {
+      "memory": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@modelcontextprotocol/server-memory"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/microsoft-mcp-gateway.mdx
+++ b/content/mcp/microsoft-mcp-gateway.mdx
@@ -32,12 +32,12 @@ copySnippet: |-
   kubectl port-forward -n adapter svc/mcpgateway-service 8000:8000
 configSnippet: |-
   {
-    "name": "sample-adapter",
-    "imageName": "mcp-example",
-    "imageVersion": "1.0.0",
-    "requiredRoles": [
-      "mcp.engineer"
-    ]
+    "mcpServers": {
+      "microsoft-mcp-gateway": {
+        "url": "http://localhost:8000/mcp",
+        "type": "http"
+      }
+    }
   }
 estimatedSetupTime: 45 minutes
 difficulty: advanced
@@ -104,7 +104,7 @@ tools when Azure AI Foundry settings are configured.
 - https://github.com/microsoft/mcp-gateway/blob/main/openapi/mcp-gateway.openapi.json
 - https://github.com/microsoft/mcp-gateway/blob/main/dotnet/Microsoft.McpGateway.Service/src/Session/AdapterSessionRoutingHandler.cs
 
-These sources were reviewed on **2026-06-06**. Prefer the live repository,
+These sources were reviewed on **2026-06-07**. Prefer the live repository,
 README, Entra app-role guide, MCP proxy sample, OpenAPI contract, session
 routing source, and license file for current deployment, authorization, adapter
 management, tool registration, and routing behavior.
@@ -151,6 +151,12 @@ required role values:
 }
 ```
 
+The README documents two client-facing Streamable HTTP paths after the gateway
+is running. Direct adapter access uses `/adapters/{name}/mcp`, such as
+`http://localhost:8000/adapters/mcp-example/mcp`. The dynamic tool gateway
+router uses the stable `http://localhost:8000/mcp` endpoint and routes calls to
+registered tool servers.
+
 ## Use Cases
 
 - Put a Kubernetes-native reverse proxy in front of multiple MCP server deployments.
@@ -185,4 +191,5 @@ network policy, image provenance, and log retention before production use.
 
 No `microsoft/mcp-gateway` source entry, Microsoft MCP Gateway entry, or
 matching source URL was found in `content/mcp` or the broader content
-directories.
+directories. This entry uses the documented Streamable HTTP gateway endpoint
+and still requires the gateway deployment plus registered adapters or tools.

--- a/content/mcp/minimax-mcp-server.mdx
+++ b/content/mcp/minimax-mcp-server.mdx
@@ -42,11 +42,22 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add minimax \
-    --env MINIMAX_API_KEY=insert-your-api-key-here \
-    --env MINIMAX_API_HOST=https://api.minimax.io \
-    --env MINIMAX_API_RESOURCE_MODE=url \
-    -- uvx minimax-mcp
+  {
+    "mcpServers": {
+      "minimax": {
+        "command": "uvx",
+        "args": [
+          "minimax-mcp"
+        ],
+        "env": {
+          "MINIMAX_API_KEY": "insert-your-api-key-here",
+          "MINIMAX_API_HOST": "https://api.minimax.io",
+          "MINIMAX_API_RESOURCE_MODE": "url"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/monday-mcp-server.mdx
+++ b/content/mcp/monday-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "monday": {
-      "url": "https://mcp.monday.com/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "monday": {
+        "url": "https://mcp.monday.com/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/netlify-mcp-server.mdx
+++ b/content/mcp/netlify-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "netlify": {
-      "url": "https://netlify-mcp.netlify.app/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "netlify": {
+        "url": "https://netlify-mcp.netlify.app/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/new-relic-mcp-server.mdx
+++ b/content/mcp/new-relic-mcp-server.mdx
@@ -38,9 +38,17 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  [mcp_servers.new-relic]
-  url = "https://mcp.newrelic.com/mcp/"
-  env_http_headers = { "api-key" = "NEW_RELIC_API_KEY" }
+  {
+    "mcpServers": {
+      "newrelic": {
+        "type": "http",
+        "url": "https://mcp.newrelic.com/mcp/",
+        "headers": {
+          "include-tags": "discovery,alerting"
+        }
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/nginx-ui-mcp-module.mdx
+++ b/content/mcp/nginx-ui-mcp-module.mdx
@@ -33,6 +33,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   Use the Nginx UI /mcp endpoint with the node_secret query parameter from the target Nginx UI node.
 estimatedSetupTime: 20 minutes
 difficulty: intermediate

--- a/content/mcp/nocturne-memory-mcp-server.mdx
+++ b/content/mcp/nocturne-memory-mcp-server.mdx
@@ -33,6 +33,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "host": "127.0.0.1",
     "web_port": 8233,

--- a/content/mcp/notion-mcp-server.mdx
+++ b/content/mcp/notion-mcp-server.mdx
@@ -30,9 +30,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "notion": {
-      "url": "https://mcp.notion.com/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "notion": {
+        "url": "https://mcp.notion.com/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/nuclear-mcp-server.mdx
+++ b/content/mcp/nuclear-mcp-server.mdx
@@ -34,6 +34,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add nuclear --transport http <copy-url-from-nuclear-settings>
 estimatedSetupTime: 10 minutes
 difficulty: beginner

--- a/content/mcp/odoo-mcp-server.mdx
+++ b/content/mcp/odoo-mcp-server.mdx
@@ -44,7 +44,24 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  uvx odoo-mcp --health
+  {
+    "mcpServers": {
+      "odoo": {
+        "command": "uvx",
+        "args": [
+          "odoo-mcp"
+        ],
+        "env": {
+          "ODOO_URL": "https://your-odoo-instance.example",
+          "ODOO_DB": "your-database",
+          "ODOO_USERNAME": "your-user",
+          "ODOO_PASSWORD": "your-password-or-api-key",
+          "ODOO_TRANSPORT": "xmlrpc"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/omnisearch-mcp-server.mdx
+++ b/content/mcp/omnisearch-mcp-server.mdx
@@ -47,7 +47,26 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx mcp-omnisearch
+  {
+    "mcpServers": {
+      "omnisearch": {
+        "command": "npx",
+        "args": [
+          "mcp-omnisearch"
+        ],
+        "env": {
+          "TAVILY_API_KEY": "your-tavily-key",
+          "KAGI_API_KEY": "your-kagi-key",
+          "BRAVE_API_KEY": "your-brave-key",
+          "GITHUB_API_KEY": "your-github-token",
+          "EXA_API_KEY": "your-exa-key",
+          "LINKUP_API_KEY": "your-linkup-key",
+          "FIRECRAWL_API_KEY": "your-firecrawl-key"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/open-websearch-mcp-server.mdx
+++ b/content/mcp/open-websearch-mcp-server.mdx
@@ -43,7 +43,24 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add open-websearch --env MODE=stdio --env DEFAULT_SEARCH_ENGINE=duckduckgo -- npx -y open-websearch@latest
+  {
+    "mcpServers": {
+      "open-websearch": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "open-websearch@latest"
+        ],
+        "env": {
+          "MODE": "stdio",
+          "DEFAULT_SEARCH_ENGINE": "duckduckgo",
+          "ALLOWED_SEARCH_ENGINES": "duckduckgo,startpage,bing",
+          "NPM_CONFIG_IGNORE_SCRIPTS": "true"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 5 minutes
 difficulty: beginner
 prerequisites:

--- a/content/mcp/openapi-mcp-server.mdx
+++ b/content/mcp/openapi-mcp-server.mdx
@@ -38,8 +38,8 @@ configSnippet: |-
   {
     "mcpServers": {
       "openapi": {
-        "transport": "http",
-        "url": "https://openapi-mcp.openapisearch.com/mcp"
+        "url": "https://openapi-mcp.openapisearch.com/mcp",
+        "type": "http"
       }
     }
   }

--- a/content/mcp/openmetadata-mcp-server.mdx
+++ b/content/mcp/openmetadata-mcp-server.mdx
@@ -33,6 +33,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   Configure OpenMetadata MCP settings with a production baseUrl, explicit allowedOrigins, and enabled=true before connecting clients.
 estimatedSetupTime: 45 minutes
 difficulty: advanced

--- a/content/mcp/pagerduty-mcp-server.mdx
+++ b/content/mcp/pagerduty-mcp-server.mdx
@@ -39,13 +39,14 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  [mcp_servers.pagerduty-mcp-server]
-  command = "uvx"
-  args = ["pagerduty-mcp==0.17.0"]
-
-  [mcp_servers.pagerduty-mcp-server.env]
-  PAGERDUTY_USER_API_KEY = "<PAGERDUTY_USER_API_KEY>"
-  PAGERDUTY_API_HOST = "https://api.pagerduty.com"
+  {
+    "mcpServers": {
+      "pagerduty": {
+        "type": "http",
+        "url": "https://mcp.pagerduty.com/mcp"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/paper-search-mcp-server.mdx
+++ b/content/mcp/paper-search-mcp-server.mdx
@@ -42,6 +42,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   uv tool install paper-search-mcp
   uv tool run paper-search-mcp
 estimatedSetupTime: 15 minutes

--- a/content/mcp/paperbanana-mcp-server.mdx
+++ b/content/mcp/paperbanana-mcp-server.mdx
@@ -40,6 +40,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   uvx --from "paperbanana[mcp]" paperbanana-mcp
 estimatedSetupTime: 15 minutes
 difficulty: intermediate

--- a/content/mcp/paypal-mcp-server.mdx
+++ b/content/mcp/paypal-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "paypal": {
-      "url": "https://mcp.paypal.com/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "paypal": {
+        "url": "https://mcp.paypal.com/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/perplexity-mcp-server.mdx
+++ b/content/mcp/perplexity-mcp-server.mdx
@@ -36,11 +36,17 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "perplexity-ask": {
-      "command": "npx",
-      "args": ["-y", "server-perplexity-ask"],
-      "env": {
-        "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
+    "mcpServers": {
+      "perplexity-ask": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "server-perplexity-ask"
+        ],
+        "env": {
+          "PERPLEXITY_API_KEY": "${PERPLEXITY_API_KEY}"
+        },
+        "type": "stdio"
       }
     }
   }

--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "plaid": {
-      "url": "https://api.dashboard.plaid.com/mcp/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "plaid": {
+        "url": "https://api.dashboard.plaid.com/mcp/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/planetscale-mcp-server.mdx
+++ b/content/mcp/planetscale-mcp-server.mdx
@@ -38,8 +38,8 @@ configSnippet: |-
   {
     "mcpServers": {
       "planetscale": {
-        "transport": "http",
-        "url": "https://mcp.pscale.dev/mcp/planetscale"
+        "url": "https://mcp.pscale.dev/mcp/planetscale",
+        "type": "http"
       }
     }
   }

--- a/content/mcp/playwright-mcp-server.mdx
+++ b/content/mcp/playwright-mcp-server.mdx
@@ -32,9 +32,14 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
+    "mcpServers": {
+      "playwright": {
+        "command": "npx",
+        "args": [
+          "@playwright/mcp@latest"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 3 minutes

--- a/content/mcp/postgres-mcp-pro.mdx
+++ b/content/mcp/postgres-mcp-pro.mdx
@@ -40,6 +40,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add postgres-pro \
     --env DATABASE_URI=postgresql://username:password@localhost:5432/dbname \
     -- uvx postgres-mcp --access-mode=restricted

--- a/content/mcp/postgresql-mcp-server.mdx
+++ b/content/mcp/postgresql-mcp-server.mdx
@@ -37,6 +37,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "postgres": {
       "args": [

--- a/content/mcp/postman-mcp-server.mdx
+++ b/content/mcp/postman-mcp-server.mdx
@@ -37,12 +37,14 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  [mcp_servers.postman-mcp-server]
-  command = "npx"
-  args = ["-y", "@postman/postman-mcp-server@2.8.9", "--minimal"]
-
-  [mcp_servers.postman-mcp-server.env]
-  POSTMAN_API_KEY = "<POSTMAN_API_KEY>"
+  {
+    "mcpServers": {
+      "postman": {
+        "type": "http",
+        "url": "https://mcp.postman.com/minimal"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/prometheus-mcp-server.mdx
+++ b/content/mcp/prometheus-mcp-server.mdx
@@ -45,7 +45,25 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  docker run -i --rm -e PROMETHEUS_URL="https://prometheus.example.com" ghcr.io/pab1it0/prometheus-mcp-server:latest
+  {
+    "mcpServers": {
+      "prometheus": {
+        "command": "docker",
+        "args": [
+          "run",
+          "-i",
+          "--rm",
+          "-e",
+          "PROMETHEUS_URL",
+          "ghcr.io/pab1it0/prometheus-mcp-server:latest"
+        ],
+        "env": {
+          "PROMETHEUS_URL": "https://prometheus.example.com"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/pulumi-mcp-server.mdx
+++ b/content/mcp/pulumi-mcp-server.mdx
@@ -38,8 +38,8 @@ configSnippet: |-
   {
     "mcpServers": {
       "pulumi": {
-        "transport": "http",
-        "url": "https://mcp.ai.pulumi.com/mcp"
+        "url": "https://mcp.ai.pulumi.com/mcp",
+        "type": "http"
       }
     }
   }

--- a/content/mcp/rails-mcp-server.mdx
+++ b/content/mcp/rails-mcp-server.mdx
@@ -36,7 +36,14 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  rails-mcp-config
+  {
+    "mcpServers": {
+      "railsMcpServer": {
+        "command": "rails-mcp-server",
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/reddit-mcp-buddy.mdx
+++ b/content/mcp/reddit-mcp-buddy.mdx
@@ -37,11 +37,14 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "reddit": {
-      "args": [
-        "reddit-mcp-buddy"
-      ],
-      "command": "npx"
+    "mcpServers": {
+      "reddit": {
+        "args": [
+          "reddit-mcp-buddy"
+        ],
+        "command": "npx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/redis-mcp-server.mdx
+++ b/content/mcp/redis-mcp-server.mdx
@@ -45,15 +45,18 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "redis": {
-      "args": [
-        "--from",
-        "git+https://github.com/redis/mcp-redis.git",
-        "redis-mcp-server",
-        "--url",
-        "redis://localhost:6379/0"
-      ],
-      "command": "uvx"
+    "mcpServers": {
+      "redis": {
+        "args": [
+          "--from",
+          "git+https://github.com/redis/mcp-redis.git",
+          "redis-mcp-server",
+          "--url",
+          "redis://localhost:6379/0"
+        ],
+        "command": "uvx",
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/ros-mcp-server.mdx
+++ b/content/mcp/ros-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add ros-mcp -- uvx ros-mcp --transport=stdio
+  {
+    "mcpServers": {
+      "ros-mcp": {
+        "command": "uvx",
+        "args": [
+          "ros-mcp",
+          "--transport=stdio"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 30 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/ruflo-mcp-server.mdx
+++ b/content/mcp/ruflo-mcp-server.mdx
@@ -37,7 +37,20 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add ruflo -- npx -y ruflo@latest mcp start
+  {
+    "mcpServers": {
+      "ruflo": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "ruflo@latest",
+          "mcp",
+          "start"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/sentry-mcp-server.mdx
+++ b/content/mcp/sentry-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "sentry": {
-      "url": "https://mcp.sentry.dev/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "sentry": {
+        "url": "https://mcp.sentry.dev/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/sequential-thinking-mcp-server.mdx
+++ b/content/mcp/sequential-thinking-mcp-server.mdx
@@ -32,9 +32,15 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "sequential-thinking": {
-      "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+    "mcpServers": {
+      "sequential-thinking": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@modelcontextprotocol/server-sequential-thinking"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 2 minutes

--- a/content/mcp/serena-mcp-server.mdx
+++ b/content/mcp/serena-mcp-server.mdx
@@ -39,16 +39,19 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "serena": {
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena",
-        "start-mcp-server",
-        "--context",
-        "ide-assistant"
-      ]
+    "mcpServers": {
+      "serena": {
+        "command": "uvx",
+        "args": [
+          "--from",
+          "git+https://github.com/oraios/serena",
+          "serena",
+          "start-mcp-server",
+          "--context",
+          "ide-assistant"
+        ],
+        "type": "stdio"
+      }
     }
   }
 estimatedSetupTime: 5 minutes

--- a/content/mcp/slack-mcp-server.mdx
+++ b/content/mcp/slack-mcp-server.mdx
@@ -35,7 +35,7 @@ configSnippet: |-
     "mcpServers": {
       "slack": {
         "url": "https://mcp.slack.com/mcp",
-        "transport": "http"
+        "type": "http"
       }
     }
   }

--- a/content/mcp/snyk-mcp-server.mdx
+++ b/content/mcp/snyk-mcp-server.mdx
@@ -38,9 +38,23 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  [mcp_servers.snyk-security]
-  command = "npx"
-  args = ["-y", "snyk@1.1305.1", "mcp", "-t", "stdio", "--profile=lite"]
+  {
+    "mcpServers": {
+      "Snyk": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "snyk@1.1305.1",
+          "mcp",
+          "-t",
+          "stdio",
+          "--profile=lite"
+        ],
+        "env": {},
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/socket-mcp-server.mdx
+++ b/content/mcp/socket-mcp-server.mdx
@@ -35,9 +35,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "socket": {
-      "url": "https://mcp.socket.dev/",
-      "transport": "http"
+    "mcpServers": {
+      "socket": {
+        "url": "https://mcp.socket.dev/",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/softeria-ms-365-graph-mcp-server.mdx
+++ b/content/mcp/softeria-ms-365-graph-mcp-server.mdx
@@ -42,7 +42,21 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx -y @softeria/ms-365-mcp-server --read-only --preset outlook
+  {
+    "mcpServers": {
+      "ms365-graph": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@softeria/ms-365-mcp-server",
+          "--read-only",
+          "--preset",
+          "outlook"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 25 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/sonarqube-mcp-server.mdx
+++ b/content/mcp/sonarqube-mcp-server.mdx
@@ -52,6 +52,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add sonarqube \
     --env SONARQUBE_TOKEN=$SONAR_TOKEN \
     --env SONARQUBE_ORG=$SONAR_ORG \

--- a/content/mcp/square-mcp-server.mdx
+++ b/content/mcp/square-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "square": {
-      "url": "https://mcp.squareup.com/sse",
-      "transport": "sse"
+    "mcpServers": {
+      "square": {
+        "url": "https://mcp.squareup.com/sse",
+        "type": "sse"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/stripe-mcp-server.mdx
+++ b/content/mcp/stripe-mcp-server.mdx
@@ -38,9 +38,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "stripe": {
-      "url": "https://mcp.stripe.com",
-      "transport": "http"
+    "mcpServers": {
+      "stripe": {
+        "url": "https://mcp.stripe.com",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/stytch-mcp-server.mdx
+++ b/content/mcp/stytch-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "stytch": {
-      "url": "http://mcp.stytch.dev/mcp",
-      "transport": "http"
+    "mcpServers": {
+      "stytch": {
+        "url": "http://mcp.stytch.dev/mcp",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/supabase-mcp-server.mdx
+++ b/content/mcp/supabase-mcp-server.mdx
@@ -35,6 +35,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "supabase": {
       "type": "http",

--- a/content/mcp/tavily-mcp-server.mdx
+++ b/content/mcp/tavily-mcp-server.mdx
@@ -36,11 +36,17 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "tavily": {
-      "command": "npx",
-      "args": ["-y", "tavily-mcp@latest"],
-      "env": {
-        "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+    "mcpServers": {
+      "tavily": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "tavily-mcp@latest"
+        ],
+        "env": {
+          "TAVILY_API_KEY": "${TAVILY_API_KEY}"
+        },
+        "type": "stdio"
       }
     }
   }

--- a/content/mcp/telegram-mcp-server.mdx
+++ b/content/mcp/telegram-mcp-server.mdx
@@ -42,6 +42,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add telegram-mcp --env TELEGRAM_API_ID=YOUR_TELEGRAM_API_ID --env TELEGRAM_API_HASH=YOUR_TELEGRAM_API_HASH --env TELEGRAM_SESSION_STRING=YOUR_TELEGRAM_SESSION_STRING --env TELEGRAM_EXPOSED_TOOLS=read-only -- uv --directory PATH_TO_TELEGRAM_MCP_CHECKOUT run main.py
 estimatedSetupTime: 30 minutes
 difficulty: advanced

--- a/content/mcp/todoist-mcp-server.mdx
+++ b/content/mcp/todoist-mcp-server.mdx
@@ -42,7 +42,22 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add todoist -e TODOIST_API_TOKEN=your-token -- npx @greirson/mcp-todoist
+  {
+    "mcpServers": {
+      "todoist": {
+        "command": "npx",
+        "args": [
+          "@greirson/mcp-todoist"
+        ],
+        "env": {
+          "TODOIST_API_TOKEN": "your-api-token",
+          "DRYRUN": "true",
+          "TODOIST_UNIFIED_TOOLS": "true"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: beginner
 prerequisites:

--- a/content/mcp/toolhive-mcp-platform.mdx
+++ b/content/mcp/toolhive-mcp-platform.mdx
@@ -28,20 +28,24 @@ packageUrl: "https://github.com/stacklok/toolhive/releases"
 websiteUrl: "https://stacklok.com/download/"
 installable: true
 installCommand: "brew tap stacklok/tap && brew install thv"
-usageSnippet: "Install the `thv` CLI, list trusted registry entries, run an approved MCP server, and use `thv client setup` to connect supported local MCP clients."
+usageSnippet: "Install the `thv` CLI, start `thv mcp serve`, then connect MCP clients to the local ToolHive control server at `http://localhost:4483/mcp`."
 copySnippet: |-
-  thv registry list
-  thv registry info toolhive-doc-mcp
-  thv run toolhive-doc-mcp
-  thv client setup
+  thv mcp serve
 configSnippet: |-
-  thv run --proxy-port 8081 toolhive-doc-mcp
+  {
+    "mcpServers": {
+      "toolhive": {
+        "url": "http://localhost:4483/mcp",
+        "type": "http"
+      }
+    }
+  }
 estimatedSetupTime: 20 minutes
 difficulty: advanced
 prerequisites:
   - Docker or Podman available for local containerized MCP server runtime.
   - ToolHive CLI installed through Homebrew, winget, release archive, or source build.
-  - MCP client configuration reviewed before running `thv client setup`.
+  - MCP client configuration reviewed before connecting to `thv mcp serve` or running `thv client setup`.
   - Registry entries, server images, permissions, secrets, and network access reviewed before running MCP servers.
   - Kubernetes cluster, operator permissions, ingress, identity provider, and observability stack planned before cluster deployment.
 safetyNotes:
@@ -50,6 +54,7 @@ safetyNotes:
   - Registry, gateway, and operator features can centralize access to many MCP servers; enforce least privilege, approval workflows, and audit review before broad rollout.
   - OIDC/OAuth, authorization policy, remote MCP authentication, and Kubernetes operator controls should be configured before exposing shared endpoints.
   - Built-in client setup can modify local MCP client configuration; review generated changes before connecting sensitive workspaces.
+  - The `thv mcp serve` control server is experimental and can expose tools that search the registry, run servers, stop servers, remove servers, inspect logs, and manage secrets.
 privacyNotes:
   - ToolHive may handle MCP server configs, registry metadata, container images, permission files, secrets, client config paths, prompts, tool arguments, tool outputs, traces, metrics, audit logs, and identity claims.
   - Local configuration, keyring entries, runtime logs, OpenTelemetry traces, Prometheus metrics, Kubernetes custom resources, and registry contents can reveal private server names, endpoints, credentials, and tool schemas.
@@ -66,6 +71,9 @@ sourceUrls:
   - "https://github.com/stacklok/toolhive/blob/main/docs/remote-mcp-authentication.md"
   - "https://github.com/stacklok/toolhive/blob/main/docs/arch/04-secrets-management.md"
   - "https://github.com/stacklok/toolhive/blob/main/docs/arch/05-runconfig-and-permissions.md"
+  - "https://github.com/stacklok/toolhive/blob/main/docs/cli/thv_mcp_serve.md"
+  - "https://github.com/stacklok/toolhive/blob/main/cmd/thv/app/mcp_serve.go"
+  - "https://github.com/stacklok/toolhive/blob/main/pkg/mcp/server/server.go"
   - "https://github.com/stacklok/toolhive/blob/main/deploy/charts/operator/values.yaml"
   - "https://github.com/stacklok/toolhive/releases"
   - "https://docs.stacklok.com/toolhive"
@@ -118,6 +126,9 @@ deployment patterns.
 - https://github.com/stacklok/toolhive/blob/main/docs/remote-mcp-authentication.md
 - https://github.com/stacklok/toolhive/blob/main/docs/arch/04-secrets-management.md
 - https://github.com/stacklok/toolhive/blob/main/docs/arch/05-runconfig-and-permissions.md
+- https://github.com/stacklok/toolhive/blob/main/docs/cli/thv_mcp_serve.md
+- https://github.com/stacklok/toolhive/blob/main/cmd/thv/app/mcp_serve.go
+- https://github.com/stacklok/toolhive/blob/main/pkg/mcp/server/server.go
 - https://github.com/stacklok/toolhive/blob/main/deploy/charts/operator/values.yaml
 - https://github.com/stacklok/toolhive/releases
 - https://docs.stacklok.com/toolhive
@@ -129,15 +140,17 @@ deployment patterns.
 - https://docs.stacklok.com/toolhive/guides-mcp
 - https://stacklok.com/download/
 
-These sources were reviewed on **2026-06-05**. Prefer the live repository,
+These sources were reviewed on **2026-06-07**. Prefer the live repository,
 README, license, security policy, architecture notes, authorization notes,
 observability notes, remote MCP authentication notes, secrets and permissions
-docs, operator values, release page, CLI docs, UI docs, Kubernetes docs, MCP
-guides, and download page for current installation and operating guidance.
+docs, MCP serve docs and source, operator values, release page, CLI docs, UI
+docs, Kubernetes docs, MCP guides, and download page for current installation
+and operating guidance.
 
 ## Features
 
 - Run MCP servers locally through the `thv` CLI.
+- Expose an experimental local ToolHive control MCP server through `thv mcp serve`.
 - Use Docker or Podman-backed container isolation for MCP servers.
 - Discover approved servers through registries.
 - Set up supported local MCP clients from the CLI.
@@ -170,6 +183,17 @@ thv client setup
 Review the registry entry, server image, permissions, and generated client
 configuration before connecting the server to a sensitive workspace.
 
+To expose ToolHive itself as an MCP control server, run:
+
+```bash
+thv mcp serve
+```
+
+The CLI reference documents this as an experimental MCP server for controlling
+ToolHive. The source sets the default host to `localhost`, the default port to
+`4483`, and the Streamable HTTP endpoint path to `/mcp`, so the default client
+URL is `http://localhost:4483/mcp`.
+
 ## Use Cases
 
 - Run MCP servers locally without giving each server direct host-level access.
@@ -194,7 +218,14 @@ secret stores, permission files, and generated client configs can reveal private
 tooling, endpoints, credentials, prompts, arguments, responses, and identity
 claims.
 
+The ToolHive MCP control server is stronger than a passive status endpoint. It
+can expose tools for running and removing servers and for interacting with the
+local ToolHive secret store, so keep it bound to localhost and only connect
+trusted clients.
+
 ## Duplicate Check
 
 No `stacklok/toolhive` entry, ToolHive MCP Platform entry, or matching source
-URL was found in `content/mcp`.
+URL was found in `content/mcp`. This entry now uses the documented
+`thv mcp serve` local Streamable HTTP endpoint for the installable ToolHive
+control server.

--- a/content/mcp/trello-mcp-server.mdx
+++ b/content/mcp/trello-mcp-server.mdx
@@ -42,7 +42,22 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add trello -- npx @delorenj/mcp-server-trello
+  {
+    "mcpServers": {
+      "trello": {
+        "command": "npx",
+        "args": [
+          "@delorenj/mcp-server-trello"
+        ],
+        "env": {
+          "TRELLO_API_KEY": "your-api-key",
+          "TRELLO_TOKEN": "your-token",
+          "TRELLO_ALLOWED_WORKSPACES": "workspace-id-1,workspace-id-2"
+        },
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/twilio-mcp-server.mdx
+++ b/content/mcp/twilio-mcp-server.mdx
@@ -41,8 +41,8 @@ configSnippet: |-
   {
     "mcpServers": {
       "twilio-docs": {
-        "transport": "http",
-        "url": "https://mcp.twilio.com/docs"
+        "url": "https://mcp.twilio.com/docs",
+        "type": "http"
       }
     }
   }

--- a/content/mcp/unreal-engine-mcp-server.mdx
+++ b/content/mcp/unreal-engine-mcp-server.mdx
@@ -40,6 +40,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   claude mcp add unreal-engine -- npx unreal-engine-mcp-server
 estimatedSetupTime: 30 minutes
 difficulty: advanced

--- a/content/mcp/vercel-mcp-server.mdx
+++ b/content/mcp/vercel-mcp-server.mdx
@@ -34,9 +34,11 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "vercel": {
-      "url": "https://mcp.vercel.com",
-      "transport": "http"
+    "mcpServers": {
+      "vercel": {
+        "url": "https://mcp.vercel.com",
+        "type": "http"
+      }
     }
   }
 estimatedSetupTime: 1 minute

--- a/content/mcp/wassette-mcp-server.mdx
+++ b/content/mcp/wassette-mcp-server.mdx
@@ -34,12 +34,17 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  # Optional config.toml
-  component_dir = "./wassette-components"
-  secrets_dir = "./wassette-secrets"
-
-  [environment_vars]
-  LOG_LEVEL = "info"
+  {
+    "mcpServers": {
+      "wassette": {
+        "command": "wassette",
+        "args": [
+          "run"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/webclaw-mcp-server.mdx
+++ b/content/mcp/webclaw-mcp-server.mdx
@@ -39,6 +39,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   npx create-webclaw
 estimatedSetupTime: 15 minutes
 difficulty: intermediate

--- a/content/mcp/webdriverio-mcp-server.mdx
+++ b/content/mcp/webdriverio-mcp-server.mdx
@@ -37,7 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  claude mcp add wdio-mcp -- npx -y @wdio/mcp@latest
+  {
+    "mcpServers": {
+      "wdio-mcp": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@wdio/mcp@latest"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 15 minutes
 difficulty: advanced
 prerequisites:

--- a/content/mcp/webiny-mcp-server.mdx
+++ b/content/mcp/webiny-mcp-server.mdx
@@ -37,10 +37,18 @@ copySnippet: |-
     }
   }
 configSnippet: |-
-  npx @webiny/mcp configure claude
-
-  # Or configure manually:
-  claude mcp add webiny -- npx @webiny/mcp serve
+  {
+    "mcpServers": {
+      "webiny": {
+        "command": "npx",
+        "args": [
+          "@webiny/mcp",
+          "serve"
+        ],
+        "type": "stdio"
+      }
+    }
+  }
 estimatedSetupTime: 10 minutes
 difficulty: intermediate
 prerequisites:

--- a/content/mcp/workato-mcp-server.mdx
+++ b/content/mcp/workato-mcp-server.mdx
@@ -33,6 +33,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "workato": {
       "url": "https://your-workspace.workato.com/mcp",

--- a/content/mcp/xquik-mcp-server.mdx
+++ b/content/mcp/xquik-mcp-server.mdx
@@ -46,6 +46,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "mcpServers": {
       "xquik": {

--- a/content/mcp/yield-intelligence-mcp.mdx
+++ b/content/mcp/yield-intelligence-mcp.mdx
@@ -44,7 +44,7 @@ configSnippet: |-
     "mcpServers": {
       "yield-intelligence": {
         "url": "https://api.intuitek.ai/yield/mcp",
-        "transport": "sse"
+        "type": "sse"
       }
     }
   }

--- a/content/mcp/zapier-mcp-server.mdx
+++ b/content/mcp/zapier-mcp-server.mdx
@@ -29,6 +29,7 @@ copySnippet: |-
     }
   }
 configSnippet: |-
+  Manual-only setup:
   {
     "zapier": {
       "url": "https://mcp.zapier.com/YOUR_GENERATED_URL",

--- a/content/mcp/zeplin-mcp-server.mdx
+++ b/content/mcp/zeplin-mcp-server.mdx
@@ -43,11 +43,17 @@ copySnippet: |-
   }
 configSnippet: |-
   {
-    "zeplin": {
-      "command": "npx",
-      "args": ["-y", "@zeplin/mcp-server@latest"],
-      "env": {
-        "ZEPLIN_ACCESS_TOKEN": "${ZEPLIN_ACCESS_TOKEN}"
+    "mcpServers": {
+      "zeplin": {
+        "command": "npx",
+        "args": [
+          "-y",
+          "@zeplin/mcp-server@latest"
+        ],
+        "env": {
+          "ZEPLIN_ACCESS_TOKEN": "${ZEPLIN_ACCESS_TOKEN}"
+        },
+        "type": "stdio"
       }
     }
   }

--- a/integrations/raycast/CHANGELOG.md
+++ b/integrations/raycast/CHANGELOG.md
@@ -1,5 +1,16 @@
 # HeyClaude Changelog
 
+## [Search and Claude Code MCP Install] - {PR_MERGE_DATE}
+
+- Add a confirmed `Install in Claude Code` action for MCP entries with
+  machine-readable config metadata.
+- Improve server-backed search with installable/source/platform/trust filters
+  and token-aware matching.
+- Show compact visual signals for installability, source backing, trust, and
+  safety/privacy notes.
+- Use richer detail metadata and sectioned search results for easier scanning.
+- Improve icon fallback coverage for entries without explicit brand icons.
+
 ## [Initial Store Release] - {PR_MERGE_DATE}
 
 - Add the `Search HeyClaude` command.

--- a/integrations/raycast/package-lock.json
+++ b/integrations/raycast/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@raycast/eslint-config": "2.1.1",
+        "@types/node": "^22.19.20",
         "tsx": "4.22.3",
         "typescript": "6.0.3"
       }
@@ -1074,6 +1075,15 @@
         }
       }
     },
+    "node_modules/@raycast/api/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@raycast/eslint-config": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@raycast/eslint-config/-/eslint-config-2.1.1.tgz",
@@ -1149,9 +1159,10 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.19.17",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
-      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"

--- a/integrations/raycast/package.json
+++ b/integrations/raycast/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "title": "HeyClaude",
-  "description": "Search and copy Claude agents, MCP servers, skills, hooks, rules, commands, guides, and statuslines from HeyClaude.",
+  "description": "Search, copy, and install Claude agents, MCP servers, skills, hooks, rules, commands, guides, and statuslines from HeyClaude.",
   "icon": "icon.png",
   "author": "jsonbored",
   "platforms": [
@@ -19,7 +19,7 @@
     {
       "name": "search",
       "title": "Search HeyClaude",
-      "description": "Browse HeyClaude entries and copy install commands, configs, or full usable assets.",
+      "description": "Browse HeyClaude entries, install MCP servers in Claude Code, Codex, Cursor, or Antigravity, and copy configs or full usable assets.",
       "mode": "view",
       "keywords": [
         "claude",
@@ -44,7 +44,7 @@
     {
       "name": "search-mcp",
       "title": "Search MCP Servers",
-      "description": "Browse HeyClaude MCP servers and copy install or config details.",
+      "description": "Browse HeyClaude MCP servers, install them in major AI coding harnesses, and copy install or config details.",
       "mode": "view",
       "keywords": [
         "mcp",
@@ -204,6 +204,15 @@
       ]
     }
   ],
+  "preferences": [
+    {
+      "name": "feedUrlOverride",
+      "title": "Feed URL Override",
+      "description": "Optional advanced feed URL for preview deployments or local ray develop smoke tests. Must end with /data/raycast-index.json.",
+      "type": "textfield",
+      "required": false
+    }
+  ],
   "scripts": {
     "dev": "ray develop",
     "test": "node --import tsx --test test/feed.test.ts",
@@ -218,6 +227,7 @@
   },
   "devDependencies": {
     "@raycast/eslint-config": "2.1.1",
+    "@types/node": "^22.19.20",
     "tsx": "4.22.3",
     "typescript": "6.0.3"
   },

--- a/integrations/raycast/raycast-env.d.ts
+++ b/integrations/raycast/raycast-env.d.ts
@@ -7,7 +7,10 @@
 
 /* eslint-disable @typescript-eslint/ban-types */
 
-type ExtensionPreferences = {}
+type ExtensionPreferences = {
+  /** Feed URL Override - Optional advanced feed URL for preview deployments or local ray develop smoke tests. Must end with /data/raycast-index.json. */
+  "feedUrlOverride"?: string
+}
 
 /** Preferences accessible in all the extension's commands */
 declare type Preferences = ExtensionPreferences

--- a/integrations/raycast/src/discovery-command.tsx
+++ b/integrations/raycast/src/discovery-command.tsx
@@ -9,13 +9,13 @@ import {
   LocalStorage,
   PopToRootType,
   Toast,
+  getPreferenceValues,
   showHUD,
   showToast,
 } from "@raycast/api";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   FAVORITES_KEY,
-  FEED_URL,
   absoluteDataUrl,
   attachDiscoveryEntries,
   buildContributeEntryUrl,
@@ -25,6 +25,7 @@ import {
   entryKey,
   filterDiscoveryEntries,
   parseFavoriteKeys,
+  resolveConfiguredFeedUrl,
   serializeFavoriteKeys,
   sortedCategoryOptions,
   type RaycastDiscoveryEntry,
@@ -66,7 +67,11 @@ const categoryIcons: Record<string, Icon> = {
 };
 
 function getConfiguredFeed() {
-  return { feedUrl: FEED_URL };
+  return {
+    feedUrl: resolveConfiguredFeedUrl(
+      getPreferenceValues<{ feedUrlOverride?: string }>(),
+    ),
+  };
 }
 
 function loadCachedFeed(feedUrl: string) {

--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -9,6 +9,7 @@ import {
 } from "./utils";
 
 export const FEED_URL = "https://heyclau.de/data/raycast-index.json";
+export const RAYCAST_FEED_OVERRIDE_ENV = "HEYCLAUDE_RAYCAST_FEED_URL";
 export const REGISTRY_SEARCH_URL = "https://heyclau.de/api/registry/search";
 export const SUBMIT_URL = "https://heyclau.de/submit";
 export const CACHE_KEY = "heyclaude-raycast-index";
@@ -22,8 +23,21 @@ const REGISTRY_MANIFEST_PATH = "/data/registry-manifest.json";
 const REGISTRY_TRENDING_PATH = "/api/registry/trending";
 const REGISTRY_DIFF_PATH = "/api/registry/diff";
 const DEFAULT_DISCOVERY_LIMIT = 25;
+const localFeedHostnames = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 
 export type DownloadTrust = "first-party" | "external" | null;
+export type McpInstallTargetId =
+  | "claude-code"
+  | "codex"
+  | "cursor"
+  | "antigravity";
+
+const mcpInstallTargetIds = new Set<McpInstallTargetId>([
+  "claude-code",
+  "codex",
+  "cursor",
+  "antigravity",
+]);
 
 export type RaycastEntry = {
   category: string;
@@ -39,6 +53,10 @@ export type RaycastEntry = {
   brandAssetSource?: string;
   brandVerifiedAt?: string;
   platformCompatibility?: string[];
+  installable: boolean;
+  hasInstallCommand: boolean;
+  hasConfigSnippet: boolean;
+  mcpInstallTargets?: McpInstallTargetId[];
   installCommand: string;
   configSnippet: string;
   copyText: string;
@@ -56,6 +74,36 @@ export type RaycastEntry = {
   documentationUrl: string;
   downloadTrust: DownloadTrust;
   verificationStatus: string;
+  packageVerified?: boolean;
+  safetyNotes?: string[];
+  privacyNotes?: string[];
+  trustSignals?: RaycastTrustSignals;
+  searchScore?: number;
+  searchReasons?: string[];
+};
+
+export type RaycastTrustSignals = {
+  firstPartyEditorial?: boolean;
+  packageVerified?: boolean;
+  sourceStatus?: string;
+  lastVerifiedAt?: string;
+  hasSafetyNotes?: boolean;
+  hasPrivacyNotes?: boolean;
+  platforms?: string[];
+  supportLevels?: string[];
+};
+
+export type RegistrySearchFacetBuckets = Record<string, number>;
+
+export type RegistrySearchFacets = {
+  categories: RegistrySearchFacetBuckets;
+  platforms: RegistrySearchFacetBuckets;
+  installable: RegistrySearchFacetBuckets;
+  hasSafetyNotes: RegistrySearchFacetBuckets;
+  hasPrivacyNotes: RegistrySearchFacetBuckets;
+  downloadTrust: RegistrySearchFacetBuckets;
+  claimStatus: RegistrySearchFacetBuckets;
+  sourceStatus: RegistrySearchFacetBuckets;
 };
 
 export type RaycastDiscoveryReference = {
@@ -118,6 +166,63 @@ function normalizePlatformCompatibility(value: unknown) {
   );
 }
 
+function normalizeMcpInstallTargets(value: unknown): McpInstallTargetId[] {
+  return uniqueStrings(
+    normalizeStringArray(value).filter((item): item is McpInstallTargetId =>
+      mcpInstallTargetIds.has(item as McpInstallTargetId),
+    ),
+  ) as McpInstallTargetId[];
+}
+
+function normalizeTrustSignals(
+  value: unknown,
+): RaycastTrustSignals | undefined {
+  if (!isRecord(value)) return undefined;
+  const trustSignals: RaycastTrustSignals = {
+    firstPartyEditorial: optionalBoolean(value.firstPartyEditorial),
+    packageVerified: optionalBoolean(value.packageVerified),
+    sourceStatus: optionalString(value.sourceStatus) || undefined,
+    lastVerifiedAt: optionalString(value.lastVerifiedAt) || undefined,
+    hasSafetyNotes: optionalBoolean(value.hasSafetyNotes),
+    hasPrivacyNotes: optionalBoolean(value.hasPrivacyNotes),
+    platforms: normalizeStringArray(value.platforms),
+    supportLevels: normalizeStringArray(value.supportLevels),
+  };
+  const compact = Object.fromEntries(
+    Object.entries(trustSignals).filter(([, item]) =>
+      Array.isArray(item) ? item.length > 0 : item !== undefined,
+    ),
+  ) as RaycastTrustSignals;
+  return Object.keys(compact).length > 0 ? compact : undefined;
+}
+
+function normalizeFacetBuckets(value: unknown): RegistrySearchFacetBuckets {
+  if (!isRecord(value)) return {};
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(
+        ([, count]) => typeof count === "number" && Number.isFinite(count),
+      )
+      .map(([key, count]) => [key, Math.max(0, Math.trunc(count as number))]),
+  );
+}
+
+function normalizeRegistrySearchFacets(
+  value: unknown,
+): RegistrySearchFacets | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    categories: normalizeFacetBuckets(value.categories),
+    platforms: normalizeFacetBuckets(value.platforms),
+    installable: normalizeFacetBuckets(value.installable),
+    hasSafetyNotes: normalizeFacetBuckets(value.hasSafetyNotes),
+    hasPrivacyNotes: normalizeFacetBuckets(value.hasPrivacyNotes),
+    downloadTrust: normalizeFacetBuckets(value.downloadTrust),
+    claimStatus: normalizeFacetBuckets(value.claimStatus),
+    sourceStatus: normalizeFacetBuckets(value.sourceStatus),
+  };
+}
+
 export function buildEntrySummary(entry: RaycastEntry) {
   return [
     `${entry.title} — ${categoryLabel(entry.category)}`,
@@ -133,6 +238,16 @@ export type RaycastDetail = {
   copyText?: string;
   detailMarkdown: string;
   llmsUrl?: string;
+  installable?: boolean;
+  hasInstallCommand?: boolean;
+  hasConfigSnippet?: boolean;
+  mcpInstallTargets?: McpInstallTargetId[];
+  installCommand?: string;
+  configSnippet?: string;
+  safetyNotes?: string[];
+  privacyNotes?: string[];
+  sourceUrl?: string;
+  trustSignals?: RaycastTrustSignals;
 };
 
 export type ParsedFeed = {
@@ -151,15 +266,26 @@ export type ParsedRegistrySearch = {
   limit: number;
   offset: number;
   nextOffset: number | null;
+  facets?: RegistrySearchFacets;
   skippedMalformedEntries?: number;
 };
 
 export type RegistrySearchUrlOptions = {
   query: string;
   category?: string;
+  platform?: string;
+  installable?: string;
+  hasSafetyNotes?: string;
+  hasPrivacyNotes?: string;
+  downloadTrust?: string;
+  sourceStatus?: string;
   limit?: number;
   offset?: number;
   searchUrl?: string;
+};
+
+export type RaycastFeedPreferences = {
+  feedUrlOverride?: string;
 };
 
 export type FeedSnapshotMetadata = {
@@ -221,8 +347,10 @@ export function resolveFeedUrl(value?: string | null) {
     throw new Error("Feed override must be a valid URL");
   }
 
-  if (url.protocol !== "https:") {
-    throw new Error("Feed override must use HTTPS");
+  const isLocalHttp =
+    url.protocol === "http:" && localFeedHostnames.has(url.hostname);
+  if (url.protocol !== "https:" && !isLocalHttp) {
+    throw new Error("Feed override must use HTTPS unless it targets localhost");
   }
   if (!url.pathname.endsWith(RAYCAST_FEED_PATH)) {
     throw new Error(`Feed override must end with ${RAYCAST_FEED_PATH}`);
@@ -230,6 +358,15 @@ export function resolveFeedUrl(value?: string | null) {
 
   url.hash = "";
   return url.toString();
+}
+
+export function resolveConfiguredFeedUrl(
+  preferences: RaycastFeedPreferences = {},
+  env: Record<string, string | undefined> = process.env,
+) {
+  return resolveFeedUrl(
+    env[RAYCAST_FEED_OVERRIDE_ENV] || preferences.feedUrlOverride,
+  );
 }
 
 export function scopedCacheKey(baseKey: string, feedUrl = FEED_URL) {
@@ -282,6 +419,22 @@ export function registrySearchUrl(options: RegistrySearchUrlOptions) {
   const url = new URL(options.searchUrl || REGISTRY_SEARCH_URL);
   url.searchParams.set("q", options.query.trim());
   if (options.category) url.searchParams.set("category", options.category);
+  if (options.platform) url.searchParams.set("platform", options.platform);
+  if (options.installable) {
+    url.searchParams.set("installable", options.installable);
+  }
+  if (options.hasSafetyNotes) {
+    url.searchParams.set("hasSafetyNotes", options.hasSafetyNotes);
+  }
+  if (options.hasPrivacyNotes) {
+    url.searchParams.set("hasPrivacyNotes", options.hasPrivacyNotes);
+  }
+  if (options.downloadTrust) {
+    url.searchParams.set("downloadTrust", options.downloadTrust);
+  }
+  if (options.sourceStatus) {
+    url.searchParams.set("sourceStatus", options.sourceStatus);
+  }
   if (options.limit !== undefined) {
     url.searchParams.set("limit", String(options.limit));
   }
@@ -428,6 +581,10 @@ export function normalizeRaycastEntry(value: unknown): RaycastEntry | null {
     platformCompatibility: normalizePlatformCompatibility(
       value.platformCompatibility,
     ),
+    installable: optionalBoolean(value.installable) ?? false,
+    hasInstallCommand: optionalBoolean(value.hasInstallCommand) ?? false,
+    hasConfigSnippet: optionalBoolean(value.hasConfigSnippet) ?? false,
+    mcpInstallTargets: normalizeMcpInstallTargets(value.mcpInstallTargets),
     installCommand: optionalRawString(value.installCommand),
     configSnippet: optionalRawString(value.configSnippet),
     copyText,
@@ -445,6 +602,12 @@ export function normalizeRaycastEntry(value: unknown): RaycastEntry | null {
     documentationUrl: optionalString(value.documentationUrl),
     downloadTrust: normalizeDownloadTrust(value.downloadTrust),
     verificationStatus: optionalString(value.verificationStatus),
+    packageVerified: optionalBoolean(value.packageVerified),
+    safetyNotes: normalizeStringArray(value.safetyNotes),
+    privacyNotes: normalizeStringArray(value.privacyNotes),
+    trustSignals: normalizeTrustSignals(value.trustSignals),
+    searchScore: optionalNumber(value.searchScore),
+    searchReasons: normalizeStringArray(value.searchReasons),
   };
 
   if (!entry.copyText.trim()) {
@@ -517,6 +680,10 @@ export function normalizeRegistrySearchEntry(
     brandAssetSource: optionalString(value.brandAssetSource) || undefined,
     brandVerifiedAt: optionalString(value.brandVerifiedAt) || undefined,
     platformCompatibility: normalizeStringArray(value.platforms),
+    installable: optionalBoolean(value.installable) ?? false,
+    hasInstallCommand: optionalBoolean(value.hasInstallCommand) ?? false,
+    hasConfigSnippet: optionalBoolean(value.hasConfigSnippet) ?? false,
+    mcpInstallTargets: normalizeMcpInstallTargets(value.mcpInstallTargets),
     installCommand: "",
     configSnippet: "",
     copyText: "",
@@ -532,6 +699,14 @@ export function normalizeRegistrySearchEntry(
     documentationUrl: optionalString(value.documentationUrl),
     downloadTrust: normalizeDownloadTrust(value.downloadTrust),
     verificationStatus: optionalString(value.verificationStatus),
+    packageVerified:
+      optionalBoolean(value.packageVerified) ??
+      normalizeTrustSignals(value.trustSignals)?.packageVerified,
+    safetyNotes: normalizeStringArray(value.safetyNotes),
+    privacyNotes: normalizeStringArray(value.privacyNotes),
+    trustSignals: normalizeTrustSignals(value.trustSignals),
+    searchScore: optionalNumber(value.searchScore),
+    searchReasons: normalizeStringArray(value.searchReasons),
   };
 
   entry.copyText = buildSearchResultCopyText(entry);
@@ -583,6 +758,7 @@ export function parseRegistrySearch(value: string): ParsedRegistrySearch {
     limit,
     offset,
     nextOffset,
+    facets: normalizeRegistrySearchFacets(parsed.facets),
     skippedMalformedEntries: skippedMalformedEntries || undefined,
   };
 }
@@ -712,6 +888,9 @@ function discoveryFallbackEntry(
     title,
     description: reference.description,
     tags: [],
+    installable: false,
+    hasInstallCommand: false,
+    hasConfigSnippet: false,
     installCommand: "",
     configSnippet: "",
     copyText,
@@ -833,19 +1012,45 @@ export function isRaycastDetail(value: unknown): value is RaycastDetail {
     Boolean(detail) &&
     typeof detail.detailMarkdown === "string" &&
     (detail.copyText === undefined || typeof detail.copyText === "string") &&
-    (detail.llmsUrl === undefined || typeof detail.llmsUrl === "string")
+    (detail.llmsUrl === undefined || typeof detail.llmsUrl === "string") &&
+    (detail.installable === undefined ||
+      typeof detail.installable === "boolean") &&
+    (detail.hasInstallCommand === undefined ||
+      typeof detail.hasInstallCommand === "boolean") &&
+    (detail.hasConfigSnippet === undefined ||
+      typeof detail.hasConfigSnippet === "boolean") &&
+    (detail.mcpInstallTargets === undefined ||
+      (Array.isArray(detail.mcpInstallTargets) &&
+        detail.mcpInstallTargets.every((item) => typeof item === "string"))) &&
+    (detail.installCommand === undefined ||
+      typeof detail.installCommand === "string") &&
+    (detail.configSnippet === undefined ||
+      typeof detail.configSnippet === "string")
   );
 }
 
 export function parseDetail(value: string): RaycastDetail | null {
   const parsed = JSON.parse(value) as unknown;
-  return isRaycastDetail(parsed) ? parsed : null;
+  if (!isRaycastDetail(parsed)) return null;
+  return {
+    ...parsed,
+    mcpInstallTargets: normalizeMcpInstallTargets(parsed.mcpInstallTargets),
+  };
 }
 
 export function fallbackDetail(entry: RaycastEntry): RaycastDetail {
   return {
     copyText: entry.copyText,
     detailMarkdown: entry.detailMarkdown,
+    installable: entry.installable,
+    hasInstallCommand: entry.hasInstallCommand,
+    hasConfigSnippet: entry.hasConfigSnippet,
+    mcpInstallTargets: entry.mcpInstallTargets,
+    installCommand: entry.installCommand,
+    configSnippet: entry.configSnippet,
+    safetyNotes: entry.safetyNotes,
+    privacyNotes: entry.privacyNotes,
+    trustSignals: entry.trustSignals,
   };
 }
 

--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -1,0 +1,758 @@
+import { execFile } from "node:child_process";
+import {
+  access,
+  copyFile,
+  mkdir,
+  readFile,
+  rename,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { isRecord } from "./utils";
+import type { RaycastDetail, RaycastEntry } from "./feed";
+
+const execFileAsync = promisify(execFile);
+const SAFE_SERVER_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const SAFE_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const ENV_EXPANSION_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}/g;
+const LITERAL_PLACEHOLDER_PATTERN =
+  /<[^>\n]{2,}>|\b(?:YOUR|REPLACE|TODO|INSERT)_[A-Z0-9_]+\b|(?:YOUR|REPLACE|INSERT)[ _-]?(?:KEY|TOKEN|SECRET|ID)/i;
+
+export type McpInstallTargetId =
+  | "claude-code"
+  | "codex"
+  | "cursor"
+  | "antigravity";
+
+export type McpInstallKind = "cli" | "json-config";
+
+export type McpInstallTarget = {
+  id: McpInstallTargetId;
+  label: string;
+  installKind: McpInstallKind;
+  scopeLabel: string;
+  actionTitle: string;
+};
+
+export type McpServerConfig = Record<string, unknown>;
+
+export type McpInstallPlan = {
+  target: McpInstallTargetId;
+  targetLabel: string;
+  installKind: McpInstallKind;
+  name: string;
+  scopeLabel: string;
+  config: McpServerConfig;
+  configJson: string;
+  addArgs?: string[];
+  getArgs?: string[];
+  removeArgs?: string[];
+  configPath?: string;
+  warnings: string[];
+  envPlaceholders: string[];
+  sourceUrl?: string;
+};
+
+export type McpInstallResult = {
+  name: string;
+  target: McpInstallTargetId;
+  targetLabel: string;
+  replacedExisting: boolean;
+  configPath?: string;
+  backupPath?: string;
+  cliPath?: string;
+};
+
+export type ExecFileLike = (
+  file: string,
+  args: string[],
+) => Promise<{ stdout?: string; stderr?: string }>;
+
+type CliInstallTargetId = Extract<McpInstallTargetId, "claude-code" | "codex">;
+
+export type InstallMcpServerOptions = {
+  replaceExisting?: boolean;
+  execFileFn?: ExecFileLike;
+  cliPath?: string;
+  configPath?: string;
+  now?: Date;
+};
+
+export const MCP_INSTALL_TARGETS: readonly McpInstallTarget[] = [
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    installKind: "cli",
+    scopeLabel: "user",
+    actionTitle: "Install in Claude Code",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    installKind: "cli",
+    scopeLabel: "user",
+    actionTitle: "Install in Codex",
+  },
+  {
+    id: "cursor",
+    label: "Cursor",
+    installKind: "json-config",
+    scopeLabel: "global",
+    actionTitle: "Install in Cursor",
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity",
+    installKind: "json-config",
+    scopeLabel: "global",
+    actionTitle: "Install in Antigravity",
+  },
+] as const;
+
+export const MCP_INSTALL_TARGET_BY_ID = Object.fromEntries(
+  MCP_INSTALL_TARGETS.map((target) => [target.id, target]),
+) as Record<McpInstallTargetId, McpInstallTarget>;
+
+function homeDir() {
+  return process.env.HOME || process.env.USERPROFILE || os.homedir() || "";
+}
+
+export function defaultMcpConfigPath(
+  target: Extract<McpInstallTargetId, "cursor" | "antigravity">,
+  home = homeDir(),
+) {
+  return mcpJsonConfigPathCandidates(target, home)[0];
+}
+
+export function mcpJsonConfigPathCandidates(
+  target: Extract<McpInstallTargetId, "cursor" | "antigravity">,
+  home = homeDir(),
+) {
+  if (target === "cursor") return [path.join(home, ".cursor", "mcp.json")];
+  return [
+    path.join(home, ".gemini", "antigravity", "mcp_config.json"),
+    path.join(home, ".gemini", "config", "mcp_config.json"),
+  ];
+}
+
+export async function resolveMcpJsonConfigPath(
+  target: Extract<McpInstallTargetId, "cursor" | "antigravity">,
+  home = homeDir(),
+) {
+  const candidates = mcpJsonConfigPathCandidates(target, home);
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      // Keep looking for an existing config before falling back to the default.
+    }
+  }
+  return candidates[0];
+}
+
+export function mcpCliCandidates(target: CliInstallTargetId) {
+  const home = homeDir();
+  if (target === "codex") {
+    return [
+      "codex",
+      home ? `${home}/.local/bin/codex` : "",
+      home ? `${home}/.npm-global/bin/codex` : "",
+      home ? `${home}/.bun/bin/codex` : "",
+      "/Applications/Codex.app/Contents/Resources/codex",
+      "/opt/homebrew/bin/codex",
+      "/usr/local/bin/codex",
+    ].filter(Boolean);
+  }
+
+  return [
+    "claude",
+    home ? `${home}/.local/bin/claude` : "",
+    home ? `${home}/.npm-global/bin/claude` : "",
+    home ? `${home}/.bun/bin/claude` : "",
+    "/opt/homebrew/bin/claude",
+    "/usr/local/bin/claude",
+  ].filter(Boolean);
+}
+
+export function claudeCliCandidates() {
+  return mcpCliCandidates("claude-code");
+}
+
+function slugifyServerName(value: string) {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[^a-z0-9]+/, "")
+    .replace(/[^a-z0-9]+$/, "")
+    .slice(0, 64);
+  return slug || "heyclaude-mcp";
+}
+
+function safeServerName(value: string, fallback: string) {
+  const candidate = slugifyServerName(value);
+  return SAFE_SERVER_NAME_PATTERN.test(candidate)
+    ? candidate
+    : slugifyServerName(fallback);
+}
+
+function stableJson(value: unknown) {
+  return JSON.stringify(value);
+}
+
+function cloneConfig(config: McpServerConfig) {
+  return JSON.parse(JSON.stringify(config)) as McpServerConfig;
+}
+
+function looksLikeServerConfig(value: Record<string, unknown>) {
+  return (
+    typeof value.command === "string" ||
+    typeof value.url === "string" ||
+    typeof value.serverUrl === "string" ||
+    value.type === "stdio" ||
+    value.type === "sse" ||
+    value.type === "http" ||
+    value.type === "streamable-http"
+  );
+}
+
+export function extractMcpServerConfig(configSnippet: string): {
+  name?: string;
+  config: McpServerConfig;
+} {
+  const trimmed = configSnippet.trim();
+  if (!trimmed) {
+    throw new Error("No MCP config snippet is available for this entry.");
+  }
+
+  const parsed = JSON.parse(trimmed) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("MCP config must be a JSON object.");
+  }
+
+  if (isRecord(parsed.mcpServers)) {
+    const servers = Object.entries(parsed.mcpServers).filter(([, value]) =>
+      isRecord(value),
+    );
+    if (servers.length !== 1) {
+      throw new Error(
+        "MCP install currently supports one MCP server per entry.",
+      );
+    }
+    const [name, config] = servers[0];
+    return { name, config: config as McpServerConfig };
+  }
+
+  if (looksLikeServerConfig(parsed)) return { config: parsed };
+
+  throw new Error("MCP config did not contain a compatible server.");
+}
+
+export const extractClaudeMcpServerConfig = extractMcpServerConfig;
+
+function collectStringValues(value: unknown, output: string[] = []) {
+  if (typeof value === "string") {
+    output.push(value);
+    return output;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStringValues(item, output);
+    return output;
+  }
+  if (isRecord(value)) {
+    for (const item of Object.values(value)) collectStringValues(item, output);
+  }
+  return output;
+}
+
+function collectEnvPlaceholders(config: McpServerConfig) {
+  const placeholders = new Set<string>();
+  for (const value of collectStringValues(config)) {
+    ENV_EXPANSION_PATTERN.lastIndex = 0;
+    for (const match of value.matchAll(ENV_EXPANSION_PATTERN)) {
+      const variableName = match[1];
+      const hasDefault = match[2] !== undefined;
+      if (!hasDefault && !process.env[variableName]) {
+        placeholders.add(`\${${variableName}}`);
+      }
+    }
+    if (LITERAL_PLACEHOLDER_PATTERN.test(value)) placeholders.add(value);
+  }
+  return [...placeholders].sort();
+}
+
+function sourceUrlFor(entry: RaycastEntry, detail: RaycastDetail) {
+  return (
+    detail.sourceUrl ||
+    entry.repoUrl ||
+    entry.documentationUrl ||
+    entry.webUrl ||
+    undefined
+  );
+}
+
+function normalizeConfigForTarget(
+  target: McpInstallTargetId,
+  config: McpServerConfig,
+) {
+  const next = cloneConfig(config);
+  if (!next.type && typeof next.command === "string") next.type = "stdio";
+  if (!next.type && typeof next.url === "string") next.type = "http";
+  if (
+    target === "antigravity" &&
+    typeof next.url === "string" &&
+    typeof next.serverUrl !== "string"
+  ) {
+    next.serverUrl = next.url;
+    delete next.url;
+  }
+  if (next.type === "streamable-http") next.type = "http";
+  return next;
+}
+
+function normalizedConfigType(config: McpServerConfig) {
+  if (typeof config.type === "string") {
+    const type = config.type.toLowerCase();
+    if (type === "streamable-http") return "http";
+    if (type === "stdio" || type === "http" || type === "sse") return type;
+  }
+  if (typeof config.command === "string" && config.command.trim()) {
+    return "stdio";
+  }
+  if (getServerUrl(config)) return "http";
+  return "";
+}
+
+function getServerUrl(config: McpServerConfig) {
+  if (typeof config.url === "string" && config.url.trim()) return config.url;
+  if (typeof config.serverUrl === "string" && config.serverUrl.trim()) {
+    return config.serverUrl;
+  }
+  return "";
+}
+
+function normalizeServerArgs(config: McpServerConfig, targetLabel: string) {
+  if (config.args === undefined) return [];
+  if (!Array.isArray(config.args)) {
+    throw new Error(`${targetLabel} install requires MCP args to be an array.`);
+  }
+  return config.args.map((arg) => {
+    if (typeof arg !== "string") {
+      throw new Error(
+        `${targetLabel} install requires MCP args to be strings.`,
+      );
+    }
+    return arg;
+  });
+}
+
+function normalizeServerEnv(config: McpServerConfig, targetLabel: string) {
+  if (config.env === undefined) return [];
+  if (!isRecord(config.env)) {
+    throw new Error(`${targetLabel} install requires MCP env to be an object.`);
+  }
+  return Object.entries(config.env)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => {
+      if (!SAFE_ENV_KEY_PATTERN.test(key)) {
+        throw new Error(`${targetLabel} install found an invalid env key.`);
+      }
+      if (
+        typeof value !== "string" &&
+        typeof value !== "number" &&
+        typeof value !== "boolean"
+      ) {
+        throw new Error(
+          `${targetLabel} install requires MCP env values to be scalar.`,
+        );
+      }
+      return `${key}=${String(value)}`;
+    });
+}
+
+function bearerTokenEnvVar(config: McpServerConfig) {
+  return (
+    (typeof config.bearerTokenEnvVar === "string" &&
+      config.bearerTokenEnvVar.trim()) ||
+    (typeof config.bearer_token_env_var === "string" &&
+      config.bearer_token_env_var.trim()) ||
+    ""
+  );
+}
+
+function hasStaticOrEnvHttpHeaders(config: McpServerConfig) {
+  return (
+    (isRecord(config.headers) && Object.keys(config.headers).length > 0) ||
+    (isRecord(config.http_headers) &&
+      Object.keys(config.http_headers).length > 0) ||
+    (isRecord(config.env_http_headers) &&
+      Object.keys(config.env_http_headers).length > 0)
+  );
+}
+
+export function mcpConfigSupportsTarget(
+  config: McpServerConfig,
+  target: McpInstallTargetId,
+) {
+  const type = normalizedConfigType(config);
+  if (!MCP_INSTALL_TARGET_BY_ID[target]) return false;
+  if (target === "codex") {
+    if (type === "sse") return false;
+    if (type === "http" && hasStaticOrEnvHttpHeaders(config)) {
+      return Boolean(bearerTokenEnvVar(config));
+    }
+  }
+  return Boolean(type);
+}
+
+export function mcpInstallTargetsForConfig(config: McpServerConfig) {
+  return MCP_INSTALL_TARGETS.map((target) => target.id).filter((target) =>
+    mcpConfigSupportsTarget(config, target),
+  );
+}
+
+function buildCliArgs(
+  target: CliInstallTargetId,
+  name: string,
+  config: McpServerConfig,
+  configJson: string,
+) {
+  if (target === "claude-code") {
+    return {
+      addArgs: ["mcp", "add-json", name, configJson, "--scope", "user"],
+      getArgs: ["mcp", "get", name],
+      removeArgs: ["mcp", "remove", name],
+    };
+  }
+
+  const url = getServerUrl(config);
+  if (url) {
+    if (config.type === "sse") {
+      throw new Error(
+        "Codex install supports stdio and streamable HTTP MCP configs; this entry uses SSE.",
+      );
+    }
+    if (hasStaticOrEnvHttpHeaders(config) && !bearerTokenEnvVar(config)) {
+      throw new Error(
+        "Codex install cannot preserve this MCP config's HTTP headers.",
+      );
+    }
+    const addArgs = ["mcp", "add", name, "--url", url];
+    const tokenEnvVar = bearerTokenEnvVar(config);
+    if (tokenEnvVar) {
+      addArgs.push("--bearer-token-env-var", tokenEnvVar);
+    }
+    return {
+      addArgs,
+      getArgs: ["mcp", "get", name, "--json"],
+      removeArgs: ["mcp", "remove", name],
+    };
+  }
+
+  if (typeof config.command !== "string" || !config.command.trim()) {
+    throw new Error(
+      "Codex install supports MCP configs with a stdio command or HTTP URL.",
+    );
+  }
+  const envArgs = normalizeServerEnv(config, "Codex").flatMap((env) => [
+    "--env",
+    env,
+  ]);
+  const addArgs = [
+    "mcp",
+    "add",
+    name,
+    ...envArgs,
+    "--",
+    config.command,
+    ...normalizeServerArgs(config, "Codex"),
+  ];
+  return {
+    addArgs,
+    getArgs: ["mcp", "get", name, "--json"],
+    removeArgs: ["mcp", "remove", name],
+  };
+}
+
+export function buildMcpInstallPlan(
+  targetId: McpInstallTargetId,
+  entry: RaycastEntry,
+  detail: RaycastDetail,
+): McpInstallPlan {
+  if (entry.category !== "mcp") {
+    throw new Error("Harness install is currently available for MCP entries.");
+  }
+
+  const target = MCP_INSTALL_TARGET_BY_ID[targetId];
+  const advertisedTargets = detail.mcpInstallTargets?.length
+    ? detail.mcpInstallTargets
+    : entry.mcpInstallTargets || [];
+  if (advertisedTargets.length && !advertisedTargets.includes(targetId)) {
+    throw new Error(
+      `${target.label} install is not available for this MCP config.`,
+    );
+  }
+  const configSnippet = detail.configSnippet || entry.configSnippet;
+  const extracted = extractMcpServerConfig(configSnippet || "");
+  const name = safeServerName(extracted.name || entry.slug, entry.slug);
+  if (!mcpConfigSupportsTarget(extracted.config, targetId)) {
+    throw new Error(
+      `${target.label} install is not available for this MCP config.`,
+    );
+  }
+  const config = normalizeConfigForTarget(targetId, extracted.config);
+  const configJson = stableJson(config);
+  const envPlaceholders = collectEnvPlaceholders(config);
+  const warnings = [
+    ...(envPlaceholders.length
+      ? [
+          "This server has environment placeholders. Install can proceed, but the server may not run until those values are configured.",
+        ]
+      : []),
+    ...(targetId === "antigravity" && typeof config.serverUrl === "string"
+      ? ["Antigravity uses serverUrl for remote MCP servers."]
+      : []),
+    ...(detail.safetyNotes || entry.safetyNotes || []),
+  ];
+  const cliArgs =
+    target.installKind === "cli"
+      ? buildCliArgs(targetId as CliInstallTargetId, name, config, configJson)
+      : {};
+
+  return {
+    target: targetId,
+    targetLabel: target.label,
+    installKind: target.installKind,
+    name,
+    scopeLabel: target.scopeLabel,
+    config,
+    configJson,
+    configPath:
+      target.installKind === "json-config"
+        ? defaultMcpConfigPath(targetId as "cursor" | "antigravity")
+        : undefined,
+    warnings,
+    envPlaceholders,
+    sourceUrl: sourceUrlFor(entry, detail),
+    ...cliArgs,
+  };
+}
+
+export function buildClaudeMcpInstallPlan(
+  entry: RaycastEntry,
+  detail: RaycastDetail,
+) {
+  return buildMcpInstallPlan("claude-code", entry, detail);
+}
+
+async function defaultExecFile(file: string, args: string[]) {
+  const result = await execFileAsync(file, args, {
+    timeout: 30_000,
+    maxBuffer: 1024 * 1024,
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+export async function resolveMcpCli(
+  target: CliInstallTargetId,
+  execFileFn: ExecFileLike = defaultExecFile,
+) {
+  const label = MCP_INSTALL_TARGET_BY_ID[target].label;
+  for (const candidate of mcpCliCandidates(target)) {
+    try {
+      await execFileFn(candidate, ["--version"]);
+      return candidate;
+    } catch (error) {
+      void error;
+    }
+  }
+
+  throw new Error(
+    `${label} CLI was not found. Install or reinstall ${label}, or repair the launcher so Raycast can run it from PATH or a common local install path.`,
+  );
+}
+
+export function resolveClaudeCli(execFileFn: ExecFileLike = defaultExecFile) {
+  return resolveMcpCli("claude-code", execFileFn);
+}
+
+function nodeErrorCode(error: unknown) {
+  return isRecord(error) && typeof error.code === "string" ? error.code : "";
+}
+
+async function readMcpJsonConfig(configPath: string) {
+  try {
+    const raw = await readFile(configPath, "utf8");
+    const trimmed = raw.trim();
+    if (!trimmed) return { raw, config: {}, exists: true };
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!isRecord(parsed)) {
+      throw new Error("MCP config file must contain a JSON object.");
+    }
+    return { raw, config: parsed as Record<string, unknown>, exists: true };
+  } catch (error) {
+    if (nodeErrorCode(error) === "ENOENT") {
+      return { raw: "", config: {}, exists: false };
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error("Existing MCP config is not valid JSON.");
+    }
+    throw error;
+  }
+}
+
+function getMcpServers(config: Record<string, unknown>) {
+  if (config.mcpServers === undefined) {
+    config.mcpServers = {};
+  }
+  if (!isRecord(config.mcpServers)) {
+    throw new Error("Existing MCP config has a non-object mcpServers field.");
+  }
+  return config.mcpServers as Record<string, unknown>;
+}
+
+function backupTimestamp(now: Date) {
+  return now
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+async function writeMcpJsonConfig(
+  plan: McpInstallPlan,
+  options: InstallMcpServerOptions,
+) {
+  const configPath =
+    options.configPath ||
+    (plan.installKind === "json-config"
+      ? await resolveMcpJsonConfigPath(plan.target as "cursor" | "antigravity")
+      : plan.configPath);
+  if (!configPath) {
+    throw new Error(`${plan.targetLabel} install does not have a config path.`);
+  }
+
+  const current = await readMcpJsonConfig(configPath);
+  const servers = getMcpServers(current.config);
+  const existed = servers[plan.name] !== undefined;
+  if (existed && !options.replaceExisting) {
+    throw new Error(
+      `${plan.targetLabel} MCP server "${plan.name}" already exists.`,
+    );
+  }
+
+  servers[plan.name] = plan.config;
+  await mkdir(path.dirname(configPath), { recursive: true });
+
+  let backupPath: string | undefined;
+  if (current.exists && current.raw.trim()) {
+    backupPath = `${configPath}.bak.heyclaude-${backupTimestamp(
+      options.now || new Date(),
+    )}`;
+    await copyFile(configPath, backupPath);
+  }
+
+  const tempPath = `${configPath}.heyclaude-${process.pid}-${Date.now()}.tmp`;
+  await writeFile(tempPath, `${JSON.stringify(current.config, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await rename(tempPath, configPath);
+
+  return {
+    name: plan.name,
+    target: plan.target,
+    targetLabel: plan.targetLabel,
+    replacedExisting: existed,
+    configPath,
+    backupPath,
+  } satisfies McpInstallResult;
+}
+
+export async function mcpServerExists(
+  plan: McpInstallPlan,
+  options: Pick<
+    InstallMcpServerOptions,
+    "execFileFn" | "cliPath" | "configPath"
+  > = {},
+) {
+  if (plan.installKind === "json-config") {
+    const configPath =
+      options.configPath ||
+      (await resolveMcpJsonConfigPath(plan.target as "cursor" | "antigravity"));
+    if (!configPath) return false;
+    const current = await readMcpJsonConfig(configPath);
+    const servers = getMcpServers(current.config);
+    return servers[plan.name] !== undefined;
+  }
+
+  const execFileFn = options.execFileFn ?? defaultExecFile;
+  const cliPath =
+    options.cliPath ??
+    (await resolveMcpCli(plan.target as CliInstallTargetId, execFileFn));
+  try {
+    await execFileFn(cliPath, plan.getArgs || []);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function installMcpServer(
+  plan: McpInstallPlan,
+  options: InstallMcpServerOptions = {},
+) {
+  if (plan.installKind === "json-config") {
+    return writeMcpJsonConfig(plan, options);
+  }
+
+  const execFileFn = options.execFileFn ?? defaultExecFile;
+  const cliPath =
+    options.cliPath ??
+    (await resolveMcpCli(plan.target as CliInstallTargetId, execFileFn));
+  const exists = await mcpServerExists(plan, { execFileFn, cliPath });
+  if (exists && !options.replaceExisting) {
+    throw new Error(
+      `${plan.targetLabel} MCP server "${plan.name}" already exists.`,
+    );
+  }
+  if (exists && options.replaceExisting) {
+    await execFileFn(cliPath, plan.removeArgs || []);
+  }
+
+  await execFileFn(cliPath, plan.addArgs || []);
+  await execFileFn(cliPath, plan.getArgs || []);
+
+  return {
+    name: plan.name,
+    target: plan.target,
+    targetLabel: plan.targetLabel,
+    replacedExisting: exists,
+    cliPath,
+  } satisfies McpInstallResult;
+}
+
+export async function claudeMcpServerExists(
+  plan: McpInstallPlan,
+  execFileFn: ExecFileLike = defaultExecFile,
+  claudeCli = "claude",
+) {
+  return mcpServerExists(plan, { execFileFn, cliPath: claudeCli });
+}
+
+export async function installClaudeMcpServer(
+  plan: McpInstallPlan,
+  options: {
+    replaceExisting?: boolean;
+    execFileFn?: ExecFileLike;
+    claudeCli?: string;
+  } = {},
+) {
+  return installMcpServer(plan, {
+    replaceExisting: options.replaceExisting,
+    execFileFn: options.execFileFn,
+    cliPath: options.claudeCli,
+  });
+}

--- a/integrations/raycast/src/raycast-ui.tsx
+++ b/integrations/raycast/src/raycast-ui.tsx
@@ -19,6 +19,14 @@ function trustLabel(value: RaycastEntry["downloadTrust"]) {
   return "";
 }
 
+function sourceLabel(entry: RaycastEntry) {
+  if (entry.trustSignals?.sourceStatus === "available" || entry.repoUrl) {
+    return "Source-backed";
+  }
+  if (entry.documentationUrl) return "Documentation-backed";
+  return "";
+}
+
 export function entrySnippetKeyword(entry: RaycastEntry) {
   return `hc-${entry.slug}`.slice(0, 40);
 }
@@ -72,6 +80,28 @@ export function entryDetailMetadata(entry: RaycastEntry, generatedAt = "") {
         />
       ) : null}
       <List.Item.Detail.Metadata.Separator />
+      {entry.installable ||
+      entry.hasInstallCommand ||
+      entry.hasConfigSnippet ? (
+        <List.Item.Detail.Metadata.Label
+          title="Install"
+          text={[
+            entry.hasInstallCommand ? "command" : "",
+            entry.hasConfigSnippet ? "config" : "",
+            entry.installable ? "installable" : "",
+          ]
+            .filter(Boolean)
+            .join(", ")}
+          icon={Icon.Download}
+        />
+      ) : null}
+      {sourceLabel(entry) ? (
+        <List.Item.Detail.Metadata.Label
+          title="Source status"
+          text={sourceLabel(entry)}
+          icon={Icon.Shield}
+        />
+      ) : null}
       {trustLabel(entry.downloadTrust) ? (
         <List.Item.Detail.Metadata.Label
           title="Download trust"
@@ -84,6 +114,13 @@ export function entryDetailMetadata(entry: RaycastEntry, generatedAt = "") {
           title="Verification"
           text={entry.verificationStatus}
           icon={Icon.CheckRosette}
+        />
+      ) : null}
+      {typeof entry.searchScore === "number" ? (
+        <List.Item.Detail.Metadata.Label
+          title="Search score"
+          text={String(entry.searchScore)}
+          icon={Icon.MagnifyingGlass}
         />
       ) : null}
       {entry.copyTextTruncated ? (
@@ -109,6 +146,20 @@ export function entryDetailMetadata(entry: RaycastEntry, generatedAt = "") {
                 key={platform}
                 text={platform}
                 color={Color.Blue}
+              />
+            ))}
+          </List.Item.Detail.Metadata.TagList>
+        </>
+      ) : null}
+      {entry.searchReasons?.length ? (
+        <>
+          <List.Item.Detail.Metadata.Separator />
+          <List.Item.Detail.Metadata.TagList title="Why this matched">
+            {entry.searchReasons.slice(0, 8).map((reason) => (
+              <List.Item.Detail.Metadata.TagList.Item
+                key={reason}
+                text={reason}
+                color={Color.Green}
               />
             ))}
           </List.Item.Detail.Metadata.TagList>

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -1,6 +1,7 @@
 import {
   Action,
   ActionPanel,
+  Alert,
   Cache,
   Clipboard,
   Color,
@@ -9,6 +10,8 @@ import {
   LocalStorage,
   PopToRootType,
   Toast,
+  confirmAlert,
+  getPreferenceValues,
   showHUD,
   showToast,
 } from "@raycast/api";
@@ -16,16 +19,15 @@ import { useFrecencySorting } from "@raycast/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   FAVORITES_KEY,
-  FEED_URL,
   absoluteDataUrl,
   buildEntrySummary,
   buildContributeEntryUrl,
   buildSuggestChangeUrl,
   categoryLabel,
   entryKey,
-  filterEntriesByCategory,
   filterEntriesBySearchText,
   parseFavoriteKeys,
+  resolveConfiguredFeedUrl,
   serializeFavoriteKeys,
   sortedCategoryOptions,
   type RaycastEntry,
@@ -38,11 +40,29 @@ import {
 } from "./runtime";
 import { markdownLink, withRaycastUtm } from "./links";
 import { entryDetailMetadata, entrySnippetKeyword } from "./raycast-ui";
+import {
+  MCP_INSTALL_TARGETS,
+  buildMcpInstallPlan,
+  installMcpServer,
+  mcpServerExists,
+  resolveMcpCli,
+  type McpInstallTargetId,
+} from "./mcp-installer";
 
 const cache = new Cache();
 const SEARCH_PAGE_SIZE = 20;
 const SERVER_SEARCH_UNAVAILABLE_MESSAGE =
   "Search is temporarily unavailable. Try again shortly.";
+type CliMcpInstallTargetId = Extract<
+  McpInstallTargetId,
+  "claude-code" | "codex"
+>;
+
+function isCliMcpInstallTargetId(
+  targetId: McpInstallTargetId,
+): targetId is CliMcpInstallTargetId {
+  return targetId === "claude-code" || targetId === "codex";
+}
 
 type RegistryCommandOptions = {
   fixedCategory?: string;
@@ -53,6 +73,7 @@ type ServerSearchState = {
   status: "idle" | "loading" | "ready" | "failed";
   query: string;
   category: string;
+  filterKey: string;
   entries: RaycastEntry[];
   total: number;
   nextOffset: number | null;
@@ -73,15 +94,77 @@ const categoryIcons: Record<string, Icon> = {
   statuslines: Icon.BarChart,
 };
 
+type RegistrySearchFilters = {
+  category?: string;
+  platform?: string;
+  installable?: "true" | "false";
+  hasSafetyNotes?: "true" | "false";
+  hasPrivacyNotes?: "true" | "false";
+  downloadTrust?: "first-party" | "external" | "none";
+  sourceStatus?: "available" | "missing";
+};
+
+type ResolvedRegistryFilter = {
+  favorites: boolean;
+  localCategory?: string;
+  search: RegistrySearchFilters;
+};
+
+const advancedFilterOptions = [
+  { value: "installable", title: "Installable" },
+  { value: "source:available", title: "Source-backed" },
+  { value: "platform:claude-code", title: "Claude Code" },
+  { value: "trust:first-party", title: "First-party Packages" },
+  { value: "trust:external", title: "External Packages" },
+  { value: "safety:true", title: "Has Safety Notes" },
+  { value: "privacy:true", title: "Has Privacy Notes" },
+];
+
+function hostFromUrl(value?: string) {
+  const trimmed = String(value || "").trim();
+  if (!trimmed) return "";
+  try {
+    return new URL(trimmed).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
 function raycastEntryIcon(entry: RaycastEntry, feedUrl: string) {
   const brandIconUrl = String(entry.brandIconUrl || "").trim();
-  return brandIconUrl
-    ? { source: absoluteDataUrl(brandIconUrl, feedUrl) }
-    : (categoryIcons[entry.category] ?? Icon.Document);
+  if (brandIconUrl) return { source: absoluteDataUrl(brandIconUrl, feedUrl) };
+
+  const fallbackDomain =
+    entry.brandDomain ||
+    hostFromUrl(entry.repoUrl) ||
+    hostFromUrl(entry.documentationUrl);
+  if (fallbackDomain) {
+    return {
+      source: absoluteDataUrl(
+        `/api/brand-assets/icon/${fallbackDomain}`,
+        feedUrl,
+      ),
+    };
+  }
+
+  const fallbackIcon = categoryIcons[entry.category] ?? Icon.Document;
+  const fallbackColor =
+    entry.category === "mcp"
+      ? Color.Blue
+      : entry.category === "skills"
+        ? Color.Green
+        : entry.category === "hooks"
+          ? Color.Orange
+          : Color.SecondaryText;
+  return { source: fallbackIcon, tintColor: fallbackColor };
 }
 
 function getConfiguredFeed() {
-  return { feedUrl: FEED_URL };
+  return {
+    feedUrl: resolveConfiguredFeedUrl(
+      getPreferenceValues<{ feedUrlOverride?: string }>(),
+    ),
+  };
 }
 
 function loadCachedFeed(feedUrl: string) {
@@ -117,6 +200,26 @@ function metadataAccessories(entry: RaycastEntry, isFavorite: boolean) {
       icon: { source: Icon.CheckCircle, tintColor: Color.Green },
     });
   }
+  if (entry.installable || entry.hasConfigSnippet || entry.hasInstallCommand) {
+    accessories.push({
+      icon: { source: Icon.Download, tintColor: Color.Blue },
+    });
+  }
+  if (entry.trustSignals?.sourceStatus === "available" || entry.repoUrl) {
+    accessories.push({
+      icon: { source: Icon.Shield, tintColor: Color.Green },
+    });
+  }
+  if (
+    entry.trustSignals?.hasSafetyNotes ||
+    entry.trustSignals?.hasPrivacyNotes ||
+    entry.safetyNotes?.length ||
+    entry.privacyNotes?.length
+  ) {
+    accessories.push({
+      icon: { source: Icon.ExclamationMark, tintColor: Color.Orange },
+    });
+  }
 
   return accessories;
 }
@@ -125,7 +228,104 @@ function fixedCategoryOptions(category: string) {
   return [
     { value: "all", title: `All ${categoryLabel(category)}` },
     { value: "favorites", title: "Favorites" },
+    ...advancedFilterOptions,
   ];
+}
+
+function resolveRegistryFilter(
+  filter: string,
+  fixedCategory?: string,
+): ResolvedRegistryFilter {
+  const resolved: ResolvedRegistryFilter = {
+    favorites: filter === "favorites",
+    localCategory: fixedCategory,
+    search: {},
+  };
+  if (fixedCategory) resolved.search.category = fixedCategory;
+
+  if (!fixedCategory && filter !== "all" && filter !== "favorites") {
+    resolved.localCategory = filter.includes(":") ? undefined : filter;
+    if (!filter.includes(":")) resolved.search.category = filter;
+  }
+
+  if (filter === "installable") resolved.search.installable = "true";
+  if (filter === "source:available") resolved.search.sourceStatus = "available";
+  if (filter === "platform:claude-code")
+    resolved.search.platform = "claude-code";
+  if (filter === "trust:first-party")
+    resolved.search.downloadTrust = "first-party";
+  if (filter === "trust:external") resolved.search.downloadTrust = "external";
+  if (filter === "safety:true") resolved.search.hasSafetyNotes = "true";
+  if (filter === "privacy:true") resolved.search.hasPrivacyNotes = "true";
+
+  return resolved;
+}
+
+function registryFilterKey(filters: RegistrySearchFilters) {
+  return [
+    filters.category || "",
+    filters.platform || "",
+    filters.installable || "",
+    filters.hasSafetyNotes || "",
+    filters.hasPrivacyNotes || "",
+    filters.downloadTrust || "",
+    filters.sourceStatus || "",
+  ].join("|");
+}
+
+function entryMatchesResolvedFilter(
+  entry: RaycastEntry,
+  resolved: ResolvedRegistryFilter,
+  favorites: Set<string>,
+) {
+  if (resolved.favorites && !favorites.has(entryKey(entry))) return false;
+  if (resolved.localCategory && entry.category !== resolved.localCategory) {
+    return false;
+  }
+  if (
+    resolved.search.platform &&
+    !(entry.platformCompatibility || []).some((platform) =>
+      platform.toLowerCase().includes(resolved.search.platform || ""),
+    )
+  ) {
+    return false;
+  }
+  if (
+    resolved.search.installable === "true" &&
+    !entry.installable &&
+    !entry.hasConfigSnippet &&
+    !entry.hasInstallCommand
+  ) {
+    return false;
+  }
+  if (
+    resolved.search.sourceStatus === "available" &&
+    entry.trustSignals?.sourceStatus !== "available" &&
+    !entry.repoUrl
+  ) {
+    return false;
+  }
+  if (
+    resolved.search.downloadTrust &&
+    entry.downloadTrust !== resolved.search.downloadTrust
+  ) {
+    return false;
+  }
+  if (
+    resolved.search.hasSafetyNotes === "true" &&
+    !entry.trustSignals?.hasSafetyNotes &&
+    !entry.safetyNotes?.length
+  ) {
+    return false;
+  }
+  if (
+    resolved.search.hasPrivacyNotes === "true" &&
+    !entry.trustSignals?.hasPrivacyNotes &&
+    !entry.privacyNotes?.length
+  ) {
+    return false;
+  }
+  return true;
 }
 
 function filterRegistryEntries(
@@ -134,21 +334,10 @@ function filterRegistryEntries(
   favorites: Set<string>,
   fixedCategory?: string,
 ) {
-  if (!fixedCategory)
-    return filterEntriesByCategory(entries, filter, favorites);
-
-  const categoryEntries = entries.filter(
-    (entry) => entry.category === fixedCategory,
+  const resolved = resolveRegistryFilter(filter, fixedCategory);
+  return entries.filter((entry) =>
+    entryMatchesResolvedFilter(entry, resolved, favorites),
   );
-  if (filter === "favorites") {
-    return categoryEntries.filter((entry) => favorites.has(entryKey(entry)));
-  }
-  return categoryEntries;
-}
-
-function serverSearchCategory(filter: string, fixedCategory?: string) {
-  if (fixedCategory) return fixedCategory;
-  return filter !== "all" && filter !== "favorites" ? filter : "";
 }
 
 function createEmptyServerSearchState(): ServerSearchState {
@@ -156,6 +345,7 @@ function createEmptyServerSearchState(): ServerSearchState {
     status: "idle",
     query: "",
     category: "",
+    filterKey: "",
     entries: [],
     total: 0,
     nextOffset: null,
@@ -248,7 +438,12 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
     }, []);
 
     const normalizedSearchText = searchText.trim();
-    const searchCategory = serverSearchCategory(filter, options.fixedCategory);
+    const resolvedFilter = useMemo(
+      () => resolveRegistryFilter(filter, options.fixedCategory),
+      [filter, options.fixedCategory],
+    );
+    const searchCategory = resolvedFilter.search.category || "";
+    const searchFilterKey = registryFilterKey(resolvedFilter.search);
     const canUseServerSearch =
       normalizedSearchText.length > 0 && filter !== "favorites";
 
@@ -265,6 +460,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           status: "loading",
           query: normalizedSearchText,
           category: searchCategory,
+          filterKey: searchFilterKey,
           entries: [],
           total: 0,
           nextOffset: null,
@@ -274,7 +470,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
 
         fetchRegistrySearch({
           query: normalizedSearchText,
-          category: searchCategory || undefined,
+          ...resolvedFilter.search,
           limit: SEARCH_PAGE_SIZE,
         })
           .then((result) => {
@@ -283,6 +479,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
               status: "ready",
               query: normalizedSearchText,
               category: searchCategory,
+              filterKey: searchFilterKey,
               entries: result.entries,
               total: result.total,
               nextOffset: result.nextOffset,
@@ -295,6 +492,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
               status: "failed",
               query: normalizedSearchText,
               category: searchCategory,
+              filterKey: searchFilterKey,
               entries: [],
               total: 0,
               nextOffset: null,
@@ -308,7 +506,13 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
         cancelled = true;
         clearTimeout(timeout);
       };
-    }, [canUseServerSearch, normalizedSearchText, searchCategory]);
+    }, [
+      canUseServerSearch,
+      normalizedSearchText,
+      resolvedFilter.search,
+      searchCategory,
+      searchFilterKey,
+    ]);
 
     async function loadMoreSearchResults() {
       if (
@@ -321,9 +525,12 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
 
       const requestQuery = normalizedSearchText;
       const requestCategory = searchCategory;
+      const requestFilterKey = searchFilterKey;
       const requestOffset = serverSearch.nextOffset;
       const isStaleResponse = (state: ServerSearchState) =>
-        state.query !== requestQuery || state.category !== requestCategory;
+        state.query !== requestQuery ||
+        state.category !== requestCategory ||
+        state.filterKey !== requestFilterKey;
 
       setServerSearch((previous) => ({
         ...previous,
@@ -333,7 +540,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
       try {
         const result = await fetchRegistrySearch({
           query: requestQuery,
-          category: requestCategory || undefined,
+          ...resolvedFilter.search,
           limit: SEARCH_PAGE_SIZE,
           offset: requestOffset,
         });
@@ -363,13 +570,15 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
       }
     }
 
-    const categoryOptions = useMemo(
-      () =>
-        options.fixedCategory
-          ? fixedCategoryOptions(options.fixedCategory)
-          : sortedCategoryOptions(entries),
-      [entries, options.fixedCategory],
-    );
+    const categoryOptions = useMemo(() => {
+      if (options.fixedCategory)
+        return fixedCategoryOptions(options.fixedCategory);
+      const categories = sortedCategoryOptions(entries);
+      const [all, favorites, ...rest] = categories;
+      return [all, favorites, ...advancedFilterOptions, ...rest].filter(
+        Boolean,
+      );
+    }, [entries, options.fixedCategory]);
     const localEntries = useMemo(
       () =>
         filterRegistryEntries(
@@ -388,6 +597,7 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
       canUseServerSearch &&
       serverSearch.query === normalizedSearchText &&
       serverSearch.category === searchCategory &&
+      serverSearch.filterKey === searchFilterKey &&
       serverSearch.status === "ready" &&
       !serverSearch.error;
     const displayedEntries = isCurrentServerSearch
@@ -404,6 +614,22 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
     const visibleEntries = isCurrentServerSearch
       ? displayedEntries
       : rankedEntries;
+    const visibleSections = isCurrentServerSearch
+      ? [
+          { title: "Best Matches", entries: visibleEntries.slice(0, 5) },
+          { title: "More Matches", entries: visibleEntries.slice(5) },
+        ].filter((section) => section.entries.length > 0)
+      : [
+          {
+            title:
+              filter === "favorites"
+                ? "Favorites"
+                : options.fixedCategory
+                  ? categoryLabel(options.fixedCategory)
+                  : "Entries",
+            entries: visibleEntries,
+          },
+        ];
 
     async function copyFullAsset(entry: RaycastEntry) {
       try {
@@ -444,6 +670,133 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           title: "Could not paste full asset",
           message: error instanceof Error ? error.message : "Unknown error",
         });
+      }
+    }
+
+    async function copyInstallCommand(entry: RaycastEntry) {
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const installCommand = detail.installCommand || entry.installCommand;
+        if (!installCommand.trim()) {
+          throw new Error("No install command is available for this entry.");
+        }
+        await Clipboard.copy(installCommand);
+        await visitItem(entry);
+        await showHUD(`Copied ${entry.title} install command`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Could not copy install command",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    async function copyConfigSnippet(entry: RaycastEntry) {
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const configSnippet = detail.configSnippet || entry.configSnippet;
+        if (!configSnippet.trim()) {
+          throw new Error("No config snippet is available for this entry.");
+        }
+        await Clipboard.copy(configSnippet);
+        await visitItem(entry);
+        await showHUD(`Copied ${entry.title} config`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Could not copy config",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    async function installMcp(
+      entry: RaycastEntry,
+      targetId: McpInstallTargetId,
+    ) {
+      const target = MCP_INSTALL_TARGETS.find(({ id }) => id === targetId);
+      if (!target) return;
+      const toast = await showToast({
+        style: Toast.Style.Animated,
+        title: `Preparing ${target.label} install`,
+        message: entry.title,
+      });
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const plan = buildMcpInstallPlan(targetId, entry, detail);
+        const warningSummary = plan.envPlaceholders.length
+          ? `\n\nEnvironment placeholders: ${plan.envPlaceholders
+              .slice(0, 4)
+              .join(", ")}${plan.envPlaceholders.length > 4 ? ", ..." : ""}`
+          : "";
+        const installSummary =
+          plan.installKind === "cli"
+            ? `This will add a ${plan.scopeLabel}-scoped MCP server through the ${target.label} CLI.`
+            : `This will update your ${plan.scopeLabel} ${target.label} MCP config and create a backup before replacing an existing server.`;
+        const confirmed = await confirmAlert({
+          title: `Install ${plan.name} in ${target.label}?`,
+          message: `${installSummary}${warningSummary}`,
+          primaryAction: { title: "Install" },
+          dismissAction: { title: "Cancel" },
+        });
+        if (!confirmed) {
+          toast.style = Toast.Style.Success;
+          toast.title = "Install cancelled";
+          toast.message = entry.title;
+          return;
+        }
+
+        const cliPath =
+          plan.installKind === "cli" && isCliMcpInstallTargetId(targetId)
+            ? await resolveMcpCli(targetId)
+            : undefined;
+        const exists = await mcpServerExists(plan, { cliPath });
+        let replaceExisting = false;
+        if (exists) {
+          replaceExisting = await confirmAlert({
+            title: `Replace existing ${plan.name}?`,
+            message: `${target.label} already has an MCP server with this name. Replace it with the HeyClaude config?`,
+            primaryAction: {
+              title: "Replace",
+              style: Alert.ActionStyle.Destructive,
+            },
+            dismissAction: { title: "Cancel" },
+          });
+          if (!replaceExisting) {
+            toast.style = Toast.Style.Success;
+            toast.title = "Install cancelled";
+            toast.message = `${plan.name} already exists`;
+            return;
+          }
+        }
+
+        await installMcpServer(plan, { replaceExisting, cliPath });
+        await visitItem(entry);
+        toast.style = Toast.Style.Success;
+        toast.title = `Installed in ${target.label}`;
+        toast.message = plan.name;
+      } catch (error) {
+        toast.style = Toast.Style.Failure;
+        toast.title = `${target.label} install failed`;
+        toast.message =
+          error instanceof Error ? error.message : "Unknown install error";
       }
     }
 
@@ -511,212 +864,246 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           </List.Dropdown>
         }
       >
-        {visibleEntries.map((entry) => {
-          const isFavorite = favorites.has(entryKey(entry));
-          const hasInstallCommand = Boolean(entry.installCommand.trim());
-          const hasConfig = Boolean(entry.configSnippet.trim());
-          const sourceUrl = entry.repoUrl || entry.documentationUrl;
-          const webUrl = withRaycastUtm(entry.webUrl, "registry-entry");
+        {visibleSections.map((section) => (
+          <List.Section key={section.title} title={section.title}>
+            {section.entries.map((entry) => {
+              const isFavorite = favorites.has(entryKey(entry));
+              const hasInstallCommand =
+                entry.hasInstallCommand || Boolean(entry.installCommand.trim());
+              const hasConfig =
+                entry.hasConfigSnippet || Boolean(entry.configSnippet.trim());
+              const installTargets =
+                entry.category === "mcp"
+                  ? MCP_INSTALL_TARGETS.filter((target) =>
+                      entry.mcpInstallTargets?.includes(target.id),
+                    )
+                  : [];
+              const canInstallMcp = installTargets.length > 0;
+              const sourceUrl = entry.repoUrl || entry.documentationUrl;
+              const webUrl = withRaycastUtm(entry.webUrl, "registry-entry");
 
-          return (
-            <List.Item
-              key={entryKey(entry)}
-              title={entry.title}
-              subtitle={categoryLabel(entry.category)}
-              keywords={[
-                entry.category,
-                categoryLabel(entry.category),
-                entry.brandName || "",
-                entry.brandDomain || "",
-                ...entry.tags,
-              ].filter(Boolean)}
-              icon={raycastEntryIcon(entry, configuredFeed.feedUrl)}
-              accessories={metadataAccessories(entry, isFavorite)}
-              detail={
-                <List.Item.Detail
-                  markdown={entry.detailMarkdown}
-                  metadata={entryDetailMetadata(entry, generatedAt)}
+              return (
+                <List.Item
+                  key={entryKey(entry)}
+                  title={entry.title}
+                  subtitle={categoryLabel(entry.category)}
+                  keywords={[
+                    entry.category,
+                    categoryLabel(entry.category),
+                    entry.brandName || "",
+                    entry.brandDomain || "",
+                    ...(entry.searchReasons || []),
+                    ...entry.tags,
+                  ].filter(Boolean)}
+                  icon={raycastEntryIcon(entry, configuredFeed.feedUrl)}
+                  accessories={metadataAccessories(entry, isFavorite)}
+                  detail={
+                    <List.Item.Detail
+                      markdown={entry.detailMarkdown}
+                      metadata={entryDetailMetadata(entry, generatedAt)}
+                    />
+                  }
+                  actions={
+                    <ActionPanel>
+                      <ActionPanel.Section title="Use">
+                        {canInstallMcp
+                          ? installTargets.map((target, index) => (
+                              <Action
+                                key={target.id}
+                                title={target.actionTitle}
+                                icon={Icon.Download}
+                                shortcut={
+                                  index === 0
+                                    ? { modifiers: ["cmd"], key: "return" }
+                                    : undefined
+                                }
+                                onAction={() =>
+                                  void installMcp(entry, target.id)
+                                }
+                              />
+                            ))
+                          : null}
+                        <Action
+                          title="Copy Full Asset"
+                          icon={Icon.Clipboard}
+                          shortcut={{ modifiers: ["cmd"], key: "c" }}
+                          onAction={() => void copyFullAsset(entry)}
+                        />
+                        <Action
+                          title="Paste Full Asset"
+                          icon={Icon.TextCursor}
+                          shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
+                          onAction={() => void pasteFullAsset(entry)}
+                        />
+                        {hasInstallCommand ? (
+                          <Action
+                            title="Copy Install Command"
+                            icon={Icon.Terminal}
+                            shortcut={{ modifiers: ["cmd"], key: "i" }}
+                            onAction={() => void copyInstallCommand(entry)}
+                          />
+                        ) : null}
+                        {hasConfig ? (
+                          <Action
+                            title="Copy Config"
+                            icon={Icon.Code}
+                            shortcut={{ modifiers: ["cmd"], key: "." }}
+                            onAction={() => void copyConfigSnippet(entry)}
+                          />
+                        ) : null}
+                        <Action.OpenInBrowser
+                          title="Open on HeyClaude"
+                          url={webUrl}
+                          shortcut={{ modifiers: ["cmd"], key: "o" }}
+                          onOpen={() => void visitItem(entry)}
+                        />
+                        {entry.documentationUrl ? (
+                          <Action.OpenInBrowser
+                            title="Open Documentation"
+                            url={entry.documentationUrl}
+                            onOpen={() => void visitItem(entry)}
+                          />
+                        ) : null}
+                        {sourceUrl ? (
+                          <Action.OpenInBrowser
+                            title="Open Source"
+                            url={sourceUrl}
+                            onOpen={() => void visitItem(entry)}
+                          />
+                        ) : null}
+                      </ActionPanel.Section>
+                      <ActionPanel.Section title="Share">
+                        <Action.CopyToClipboard
+                          title="Copy Canonical URL"
+                          content={entry.webUrl}
+                          onCopy={() => void visitItem(entry)}
+                        />
+                        <Action.CopyToClipboard
+                          title="Copy Markdown Link"
+                          content={markdownLink(entry.title, entry.webUrl)}
+                          onCopy={() => void visitItem(entry)}
+                        />
+                        <Action.CopyToClipboard
+                          title="Copy Summary"
+                          content={buildEntrySummary(entry)}
+                          onCopy={() => void visitItem(entry)}
+                        />
+                        {entry.brandDomain ? (
+                          <Action.CopyToClipboard
+                            title="Copy Brand Domain"
+                            content={entry.brandDomain}
+                            onCopy={() => void visitItem(entry)}
+                          />
+                        ) : null}
+                      </ActionPanel.Section>
+                      <ActionPanel.Section title="Create">
+                        <Action.CreateQuicklink
+                          title="Create Entry Quicklink"
+                          quicklink={{
+                            name: `HeyClaude: ${entry.title}`,
+                            link: webUrl,
+                            icon: Icon.Link,
+                          }}
+                        />
+                        <Action.CreateQuicklink
+                          title="Create Category Quicklink"
+                          quicklink={{
+                            name: `HeyClaude ${categoryLabel(entry.category)}`,
+                            link: withRaycastUtm(
+                              `https://heyclau.de/${entry.category}`,
+                              "category-quicklink",
+                            ),
+                            icon: categoryIcons[entry.category] ?? Icon.Link,
+                          }}
+                        />
+                        {entry.installCommand.trim() ? (
+                          <Action.CreateSnippet
+                            title="Create Install Snippet"
+                            snippet={{
+                              name: `${entry.title} install`,
+                              text: entry.installCommand,
+                              keyword: entrySnippetKeyword(entry),
+                            }}
+                          />
+                        ) : null}
+                        {entry.configSnippet.trim() ? (
+                          <Action.CreateSnippet
+                            title="Create Config Snippet"
+                            snippet={{
+                              name: `${entry.title} config`,
+                              text: entry.configSnippet,
+                              keyword:
+                                `${entrySnippetKeyword(entry)}-config`.slice(
+                                  0,
+                                  40,
+                                ),
+                            }}
+                          />
+                        ) : null}
+                      </ActionPanel.Section>
+                      <ActionPanel.Section title="Save">
+                        <Action
+                          title={
+                            isFavorite ? "Remove Favorite" : "Add Favorite"
+                          }
+                          icon={isFavorite ? Icon.StarDisabled : Icon.Star}
+                          shortcut={{ modifiers: ["cmd"], key: "f" }}
+                          onAction={() => void toggleFavorite(entry)}
+                        />
+                        <Action
+                          title="Reset Ranking"
+                          icon={Icon.ArrowCounterClockwise}
+                          onAction={() => void resetRanking(entry)}
+                        />
+                      </ActionPanel.Section>
+                      <ActionPanel.Section title="Contribute">
+                        <Action.OpenInBrowser
+                          title="Submit Similar Entry"
+                          url={buildContributeEntryUrl({
+                            category: entry.category,
+                            brandName: entry.brandName,
+                            brandDomain: entry.brandDomain,
+                            tags: entry.tags,
+                          })}
+                          icon={Icon.Plus}
+                        />
+                        <Action.OpenInBrowser
+                          title="Suggest Change"
+                          url={buildSuggestChangeUrl(entry)}
+                          icon={Icon.Pencil}
+                        />
+                        <Action.OpenInBrowser
+                          title="Claim or Update Listing"
+                          url={withRaycastUtm(
+                            `https://heyclau.de/claim?category=${encodeURIComponent(entry.category)}&slug=${encodeURIComponent(entry.slug)}`,
+                            "entry-claim",
+                          )}
+                          icon={Icon.Person}
+                        />
+                      </ActionPanel.Section>
+                      <ActionPanel.Section title="Refresh">
+                        {isCurrentServerSearch &&
+                        serverSearch.nextOffset !== null ? (
+                          <Action
+                            title="Load More Search Results"
+                            icon={Icon.Plus}
+                            onAction={() => void loadMoreSearchResults()}
+                          />
+                        ) : null}
+                        <Action
+                          title="Refresh Feed"
+                          icon={Icon.ArrowClockwise}
+                          shortcut={{ modifiers: ["cmd"], key: "r" }}
+                          onAction={() => void refreshEntries(true)}
+                        />
+                      </ActionPanel.Section>
+                    </ActionPanel>
+                  }
                 />
-              }
-              actions={
-                <ActionPanel>
-                  <ActionPanel.Section title="Use">
-                    <Action
-                      title="Copy Full Asset"
-                      icon={Icon.Clipboard}
-                      shortcut={{ modifiers: ["cmd"], key: "c" }}
-                      onAction={() => void copyFullAsset(entry)}
-                    />
-                    <Action
-                      title="Paste Full Asset"
-                      icon={Icon.TextCursor}
-                      shortcut={{ modifiers: ["cmd", "shift"], key: "v" }}
-                      onAction={() => void pasteFullAsset(entry)}
-                    />
-                    {hasInstallCommand ? (
-                      <Action.CopyToClipboard
-                        title="Copy Install Command"
-                        content={entry.installCommand}
-                        shortcut={{ modifiers: ["cmd"], key: "i" }}
-                        onCopy={() => void visitItem(entry)}
-                      />
-                    ) : null}
-                    {hasConfig ? (
-                      <Action.CopyToClipboard
-                        title="Copy Config"
-                        content={entry.configSnippet}
-                        shortcut={{ modifiers: ["cmd"], key: "." }}
-                        onCopy={() => void visitItem(entry)}
-                      />
-                    ) : null}
-                    <Action.OpenInBrowser
-                      title="Open on HeyClaude"
-                      url={webUrl}
-                      shortcut={{ modifiers: ["cmd"], key: "o" }}
-                      onOpen={() => void visitItem(entry)}
-                    />
-                    {entry.documentationUrl ? (
-                      <Action.OpenInBrowser
-                        title="Open Documentation"
-                        url={entry.documentationUrl}
-                        onOpen={() => void visitItem(entry)}
-                      />
-                    ) : null}
-                    {sourceUrl ? (
-                      <Action.OpenInBrowser
-                        title="Open Source"
-                        url={sourceUrl}
-                        onOpen={() => void visitItem(entry)}
-                      />
-                    ) : null}
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Share">
-                    <Action.CopyToClipboard
-                      title="Copy Canonical URL"
-                      content={entry.webUrl}
-                      onCopy={() => void visitItem(entry)}
-                    />
-                    <Action.CopyToClipboard
-                      title="Copy Markdown Link"
-                      content={markdownLink(entry.title, entry.webUrl)}
-                      onCopy={() => void visitItem(entry)}
-                    />
-                    <Action.CopyToClipboard
-                      title="Copy Summary"
-                      content={buildEntrySummary(entry)}
-                      onCopy={() => void visitItem(entry)}
-                    />
-                    {entry.brandDomain ? (
-                      <Action.CopyToClipboard
-                        title="Copy Brand Domain"
-                        content={entry.brandDomain}
-                        onCopy={() => void visitItem(entry)}
-                      />
-                    ) : null}
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Create">
-                    <Action.CreateQuicklink
-                      title="Create Entry Quicklink"
-                      quicklink={{
-                        name: `HeyClaude: ${entry.title}`,
-                        link: webUrl,
-                        icon: Icon.Link,
-                      }}
-                    />
-                    <Action.CreateQuicklink
-                      title="Create Category Quicklink"
-                      quicklink={{
-                        name: `HeyClaude ${categoryLabel(entry.category)}`,
-                        link: withRaycastUtm(
-                          `https://heyclau.de/${entry.category}`,
-                          "category-quicklink",
-                        ),
-                        icon: categoryIcons[entry.category] ?? Icon.Link,
-                      }}
-                    />
-                    {hasInstallCommand ? (
-                      <Action.CreateSnippet
-                        title="Create Install Snippet"
-                        snippet={{
-                          name: `${entry.title} install`,
-                          text: entry.installCommand,
-                          keyword: entrySnippetKeyword(entry),
-                        }}
-                      />
-                    ) : null}
-                    {hasConfig ? (
-                      <Action.CreateSnippet
-                        title="Create Config Snippet"
-                        snippet={{
-                          name: `${entry.title} config`,
-                          text: entry.configSnippet,
-                          keyword: `${entrySnippetKeyword(entry)}-config`.slice(
-                            0,
-                            40,
-                          ),
-                        }}
-                      />
-                    ) : null}
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Save">
-                    <Action
-                      title={isFavorite ? "Remove Favorite" : "Add Favorite"}
-                      icon={isFavorite ? Icon.StarDisabled : Icon.Star}
-                      shortcut={{ modifiers: ["cmd"], key: "f" }}
-                      onAction={() => void toggleFavorite(entry)}
-                    />
-                    <Action
-                      title="Reset Ranking"
-                      icon={Icon.ArrowCounterClockwise}
-                      onAction={() => void resetRanking(entry)}
-                    />
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Contribute">
-                    <Action.OpenInBrowser
-                      title="Submit Similar Entry"
-                      url={buildContributeEntryUrl({
-                        category: entry.category,
-                        brandName: entry.brandName,
-                        brandDomain: entry.brandDomain,
-                        tags: entry.tags,
-                      })}
-                      icon={Icon.Plus}
-                    />
-                    <Action.OpenInBrowser
-                      title="Suggest Change"
-                      url={buildSuggestChangeUrl(entry)}
-                      icon={Icon.Pencil}
-                    />
-                    <Action.OpenInBrowser
-                      title="Claim or Update Listing"
-                      url={withRaycastUtm(
-                        `https://heyclau.de/claim?category=${encodeURIComponent(entry.category)}&slug=${encodeURIComponent(entry.slug)}`,
-                        "entry-claim",
-                      )}
-                      icon={Icon.Person}
-                    />
-                  </ActionPanel.Section>
-                  <ActionPanel.Section title="Refresh">
-                    {isCurrentServerSearch &&
-                    serverSearch.nextOffset !== null ? (
-                      <Action
-                        title="Load More Search Results"
-                        icon={Icon.Plus}
-                        onAction={() => void loadMoreSearchResults()}
-                      />
-                    ) : null}
-                    <Action
-                      title="Refresh Feed"
-                      icon={Icon.ArrowClockwise}
-                      shortcut={{ modifiers: ["cmd"], key: "r" }}
-                      onAction={() => void refreshEntries(true)}
-                    />
-                  </ActionPanel.Section>
-                </ActionPanel>
-              }
-            />
-          );
-        })}
+              );
+            })}
+          </List.Section>
+        ))}
         {!isLoading &&
         !serverSearch.isLoading &&
         displayedEntries.length === 0 ? (

--- a/integrations/raycast/src/runtime.ts
+++ b/integrations/raycast/src/runtime.ts
@@ -394,6 +394,12 @@ export async function fetchFreshFeed(options: {
 export async function fetchRegistrySearch(options: {
   query: string;
   category?: string;
+  platform?: string;
+  installable?: string;
+  hasSafetyNotes?: string;
+  hasPrivacyNotes?: string;
+  downloadTrust?: string;
+  sourceStatus?: string;
   limit?: number;
   offset?: number;
   searchUrl?: string;
@@ -403,6 +409,12 @@ export async function fetchRegistrySearch(options: {
   const requestUrl = registrySearchUrl({
     query: options.query,
     category: options.category,
+    platform: options.platform,
+    installable: options.installable,
+    hasSafetyNotes: options.hasSafetyNotes,
+    hasPrivacyNotes: options.hasPrivacyNotes,
+    downloadTrust: options.downloadTrust,
+    sourceStatus: options.sourceStatus,
     limit: options.limit,
     offset: options.offset,
     searchUrl: options.searchUrl,

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -9,6 +9,7 @@ import {
   DETAIL_CACHE_PREFIX,
   REGISTRY_SEARCH_URL,
   RECENT_UPDATES_CACHE_KEY,
+  RAYCAST_FEED_OVERRIDE_ENV,
   TRENDING_CACHE_KEY,
   absoluteDataUrl,
   attachDiscoveryEntries,
@@ -38,6 +39,7 @@ import {
   recentUpdatesFeedUrl,
   registryManifestUrl,
   registrySearchUrl,
+  resolveConfiguredFeedUrl,
   resolveFeedUrl,
   serializeFavoriteKeys,
   sortedCategoryOptions,
@@ -83,6 +85,23 @@ import {
   normalizeSubmissionDraft,
   slugify,
 } from "../src/submission";
+import {
+  MCP_INSTALL_TARGETS,
+  buildMcpInstallPlan,
+  buildClaudeMcpInstallPlan,
+  defaultMcpConfigPath,
+  extractMcpServerConfig,
+  extractClaudeMcpServerConfig,
+  installMcpServer,
+  installClaudeMcpServer,
+  mcpConfigSupportsTarget,
+  mcpInstallTargetsForConfig,
+  mcpJsonConfigPathCandidates,
+  mcpServerExists,
+  resolveMcpJsonConfigPath,
+  resolveMcpCli,
+  resolveClaudeCli,
+} from "../src/mcp-installer";
 
 const sampleEntry: RaycastEntry = {
   category: "mcp",
@@ -95,6 +114,10 @@ const sampleEntry: RaycastEntry = {
   brandIconUrl:
     "https://cdn.brandfetch.io/domain/upstash.com/w/128/h/128/icon.png?c=test-client",
   brandAssetSource: "brandfetch",
+  installable: true,
+  hasInstallCommand: true,
+  hasConfigSnippet: false,
+  mcpInstallTargets: ["claude-code", "codex", "cursor", "antigravity"],
   installCommand: "claude mcp add context7",
   configSnippet: "",
   copyText: "complete asset",
@@ -107,6 +130,12 @@ const sampleEntry: RaycastEntry = {
   documentationUrl: "https://context7.com",
   downloadTrust: "external",
   verificationStatus: "validated",
+  trustSignals: {
+    sourceStatus: "available",
+    hasSafetyNotes: true,
+    hasPrivacyNotes: false,
+    platforms: ["claude-code"],
+  },
 };
 
 function sampleSearchResult(overrides: Record<string, unknown> = {}) {
@@ -128,6 +157,16 @@ function sampleSearchResult(overrides: Record<string, unknown> = {}) {
     downloadTrust: sampleEntry.downloadTrust,
     verificationStatus: sampleEntry.verificationStatus,
     platforms: ["claude-code"],
+    installable: true,
+    hasInstallCommand: true,
+    hasConfigSnippet: true,
+    mcpInstallTargets: ["claude-code", "codex", "cursor", "antigravity"],
+    trustSignals: {
+      sourceStatus: "available",
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
+      platforms: ["claude-code"],
+    },
     searchScore: 137,
     searchReasons: ["title phrase", "source-backed"],
     ...overrides,
@@ -202,12 +241,16 @@ async function captureConsoleWarnings<T>(callback: () => T | Promise<T>) {
   }
 }
 
-function readSourceFiles(dir: string): string[] {
+function readSourceFiles(
+  dir: string,
+): Array<{ filePath: string; source: string }> {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const entryPath = path.join(dir, entry.name);
     if (entry.isDirectory()) return readSourceFiles(entryPath);
     if (!/\.(ts|tsx)$/.test(entry.name)) return [];
-    return fs.readFileSync(entryPath, "utf8");
+    return [
+      { filePath: entryPath, source: fs.readFileSync(entryPath, "utf8") },
+    ];
   });
 }
 
@@ -243,6 +286,12 @@ describe("Raycast feed helpers", () => {
     assert.equal(parsed.generatedAt, "2026-04-27T00:00:00.000Z");
     assert.equal(parsed.entries[0].slug, sampleEntry.slug);
     assert.deepEqual(parsed.entries[0].tags, sampleEntry.tags);
+    assert.deepEqual(parsed.entries[0].mcpInstallTargets, [
+      "claude-code",
+      "codex",
+      "cursor",
+      "antigravity",
+    ]);
     assert.equal(parsed.entries[0].brandDomain, sampleEntry.brandDomain);
     assert.deepEqual(parsed.entries[1].platformCompatibility, [
       "Claude: native-skill",
@@ -316,6 +365,16 @@ describe("Raycast feed helpers", () => {
         offset: 0,
         nextOffset: 1,
         results: [sampleSearchResult()],
+        facets: {
+          categories: { mcp: 2 },
+          platforms: { "claude-code": 2 },
+          installable: { true: 2 },
+          hasSafetyNotes: { true: 1, false: 1 },
+          hasPrivacyNotes: { true: 1, false: 1 },
+          downloadTrust: { external: 2 },
+          claimStatus: { unclaimed: 2 },
+          sourceStatus: { available: 2 },
+        },
       }),
     );
 
@@ -331,6 +390,21 @@ describe("Raycast feed helpers", () => {
     assert.match(parsed.entries[0].copyText, /https:\/\/heyclau.de\/mcp/);
     assert.match(parsed.entries[0].detailMarkdown, /## Source/);
     assert.deepEqual(parsed.entries[0].platformCompatibility, ["claude-code"]);
+    assert.deepEqual(parsed.entries[0].mcpInstallTargets, [
+      "claude-code",
+      "codex",
+      "cursor",
+      "antigravity",
+    ]);
+    assert.equal(parsed.entries[0].installable, true);
+    assert.equal(parsed.entries[0].hasConfigSnippet, true);
+    assert.equal(parsed.entries[0].searchScore, 137);
+    assert.deepEqual(parsed.entries[0].searchReasons, [
+      "title phrase",
+      "source-backed",
+    ]);
+    assert.equal(parsed.entries[0].trustSignals?.sourceStatus, "available");
+    assert.deepEqual(parsed.facets?.installable, { true: 2 });
     assert.equal(parsed.skippedMalformedEntries, undefined);
   });
 
@@ -516,6 +590,9 @@ describe("Raycast feed helpers", () => {
     const devFeed = resolveFeedUrl(
       " https://preview.example.com/data/raycast-index.json#ignored ",
     );
+    const localFeed = resolveFeedUrl(
+      "http://127.0.0.1:4173/data/raycast-index.json",
+    );
 
     assert.equal(
       devFeed,
@@ -524,6 +601,21 @@ describe("Raycast feed helpers", () => {
     assert.equal(
       resolveFeedUrl(""),
       "https://heyclau.de/data/raycast-index.json",
+    );
+    assert.equal(
+      localFeed,
+      "http://127.0.0.1:4173/data/raycast-index.json",
+    );
+    assert.equal(
+      resolveConfiguredFeedUrl(
+        { feedUrlOverride: devFeed },
+        { [RAYCAST_FEED_OVERRIDE_ENV]: localFeed },
+      ),
+      localFeed,
+    );
+    assert.equal(
+      resolveConfiguredFeedUrl({ feedUrlOverride: devFeed }, {}),
+      devFeed,
     );
     assert.throws(
       () =>
@@ -576,6 +668,10 @@ describe("Raycast feed helpers", () => {
       registrySearchUrl({
         query: " context server ",
         category: "mcp",
+        platform: "claude-code",
+        installable: "true",
+        sourceStatus: "available",
+        downloadTrust: "first-party",
         limit: 20,
         offset: 40,
       }),
@@ -584,6 +680,10 @@ describe("Raycast feed helpers", () => {
     assert.equal(url.origin + url.pathname, REGISTRY_SEARCH_URL);
     assert.equal(url.searchParams.get("q"), "context server");
     assert.equal(url.searchParams.get("category"), "mcp");
+    assert.equal(url.searchParams.get("platform"), "claude-code");
+    assert.equal(url.searchParams.get("installable"), "true");
+    assert.equal(url.searchParams.get("sourceStatus"), "available");
+    assert.equal(url.searchParams.get("downloadTrust"), "first-party");
     assert.equal(url.searchParams.get("limit"), "20");
     assert.equal(url.searchParams.get("offset"), "40");
 
@@ -596,6 +696,406 @@ describe("Raycast feed helpers", () => {
     const omitted = new URL(registrySearchUrl({ query: "context" }));
     assert.equal(omitted.searchParams.has("limit"), false);
     assert.equal(omitted.searchParams.has("offset"), false);
+  });
+
+  it("builds Claude Code MCP add-json plans from single-server configs", () => {
+    const detail = {
+      detailMarkdown: "# Context7",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp"],
+            env: { API_KEY: "${CONTEXT7_API_KEY}" },
+          },
+        },
+      }),
+      safetyNotes: ["Runs a local MCP server command."],
+    };
+    const extracted = extractClaudeMcpServerConfig(detail.configSnippet);
+    const plan = buildClaudeMcpInstallPlan(sampleEntry, detail);
+
+    assert.equal(extracted.name, "context7");
+    assert.deepEqual(plan.addArgs.slice(0, 3), ["mcp", "add-json", "context7"]);
+    assert.deepEqual(plan.addArgs.slice(-2), ["--scope", "user"]);
+    assert.equal(plan.getArgs.join(" "), "mcp get context7");
+    assert.equal(plan.removeArgs.join(" "), "mcp remove context7");
+    assert.match(plan.configJson, /@upstash\/context7-mcp/);
+    assert.deepEqual(plan.envPlaceholders, ["${CONTEXT7_API_KEY}"]);
+    assert.match(plan.warnings.join(" "), /environment placeholders/i);
+  });
+
+  it("builds MCP install plans for Claude Code, Codex, Cursor, and Antigravity", () => {
+    const detail = {
+      detailMarkdown: "# Context7",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp"],
+            env: { API_KEY: "${CONTEXT7_API_KEY}" },
+          },
+        },
+      }),
+    };
+    const plans = Object.fromEntries(
+      MCP_INSTALL_TARGETS.map((target) => [
+        target.id,
+        buildMcpInstallPlan(target.id, sampleEntry, detail),
+      ]),
+    );
+
+    assert.deepEqual(plans["claude-code"].addArgs?.slice(0, 3), [
+      "mcp",
+      "add-json",
+      "context7",
+    ]);
+    assert.deepEqual(plans.codex.addArgs?.slice(0, 3), [
+      "mcp",
+      "add",
+      "context7",
+    ]);
+    assert.deepEqual(plans.codex.addArgs?.slice(-3), [
+      "npx",
+      "-y",
+      "@upstash/context7-mcp",
+    ]);
+    assert.equal(plans.cursor.configPath, defaultMcpConfigPath("cursor"));
+    assert.equal(
+      plans.antigravity.configPath,
+      defaultMcpConfigPath("antigravity"),
+    );
+  });
+
+  it("normalizes remote MCP configs for target-specific install formats", () => {
+    const detail = {
+      detailMarkdown: "# Docs MCP",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          docs: {
+            type: "streamable-http",
+            url: "https://example.com/mcp",
+          },
+        },
+      }),
+    };
+
+    const codexPlan = buildMcpInstallPlan("codex", sampleEntry, detail);
+    const antigravityPlan = buildMcpInstallPlan(
+      "antigravity",
+      sampleEntry,
+      detail,
+    );
+
+    assert.deepEqual(codexPlan.addArgs, [
+      "mcp",
+      "add",
+      "docs",
+      "--url",
+      "https://example.com/mcp",
+    ]);
+    assert.equal(antigravityPlan.config.serverUrl, "https://example.com/mcp");
+    assert.equal("url" in antigravityPlan.config, false);
+    assert.equal(antigravityPlan.config.type, "http");
+  });
+
+  it("rejects ambiguous or malformed MCP configs", () => {
+    assert.throws(
+      () =>
+        extractMcpServerConfig(
+          JSON.stringify({
+            mcpServers: {
+              first: { command: "npx" },
+              second: { command: "uvx" },
+            },
+          }),
+        ),
+      /one MCP server/,
+    );
+    assert.throws(
+      () => extractMcpServerConfig(JSON.stringify({ nope: true })),
+      /compatible/,
+    );
+    assert.throws(
+      () =>
+        buildMcpInstallPlan("codex", sampleEntry, {
+          detailMarkdown: "# SSE",
+          configSnippet: JSON.stringify({
+            mcpServers: {
+              remote: { type: "sse", url: "https://example.com/sse" },
+            },
+          }),
+        }),
+      /not available/,
+    );
+    const sseConfig = { type: "sse", url: "https://example.com/sse" };
+    assert.equal(mcpConfigSupportsTarget(sseConfig, "codex"), false);
+    assert.deepEqual(mcpInstallTargetsForConfig(sseConfig), [
+      "claude-code",
+      "cursor",
+      "antigravity",
+    ]);
+    assert.throws(
+      () =>
+        buildMcpInstallPlan("codex", sampleEntry, {
+          detailMarkdown: "# SSE",
+          mcpInstallTargets: ["claude-code", "cursor", "antigravity"],
+          configSnippet: JSON.stringify({
+            mcpServers: {
+              remote: sseConfig,
+            },
+          }),
+        }),
+      /not available/,
+    );
+    assert.equal(
+      mcpConfigSupportsTarget(
+        {
+          type: "http",
+          url: "https://example.com/mcp",
+          headers: { Authorization: "Bearer ${MCP_TOKEN}" },
+        },
+        "codex",
+      ),
+      false,
+    );
+    assert.throws(
+      () =>
+        buildMcpInstallPlan("codex", sampleEntry, {
+          detailMarkdown: "# Headers",
+          configSnippet: JSON.stringify({
+            mcpServers: {
+              remote: {
+                type: "http",
+                url: "https://example.com/mcp",
+                headers: { Authorization: "Bearer ${MCP_TOKEN}" },
+              },
+            },
+          }),
+        }),
+      /not available/,
+    );
+  });
+
+  it("runs Claude Code installs through non-shell argv and verifies the server", async () => {
+    const detail = {
+      detailMarkdown: "# Context7",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          context7: { command: "npx", args: ["-y", "@upstash/context7-mcp"] },
+        },
+      }),
+    };
+    const plan = buildClaudeMcpInstallPlan(sampleEntry, detail);
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const execFileFn = async (file: string, args: string[]) => {
+      calls.push({ file, args });
+      if (args.join(" ") === "mcp get context7" && calls.length === 2) {
+        throw new Error("not installed yet");
+      }
+      return {};
+    };
+
+    await installClaudeMcpServer(plan, { execFileFn });
+
+    assert.deepEqual(
+      calls.map((call) => [call.file, call.args[0], call.args[1]]),
+      [
+        ["claude", "--version", undefined],
+        ["claude", "mcp", "get"],
+        ["claude", "mcp", "add-json"],
+        ["claude", "mcp", "get"],
+      ],
+    );
+    assert.equal(calls[2].args[3], plan.configJson);
+  });
+
+  it("runs Codex installs through non-shell argv and verifies the server", async () => {
+    const detail = {
+      detailMarkdown: "# Context7",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          context7: {
+            command: "npx",
+            args: ["-y", "@upstash/context7-mcp"],
+          },
+        },
+      }),
+    };
+    const plan = buildMcpInstallPlan("codex", sampleEntry, detail);
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const execFileFn = async (file: string, args: string[]) => {
+      calls.push({ file, args });
+      if (args.join(" ") === "mcp get context7 --json" && calls.length === 2) {
+        throw new Error("not installed yet");
+      }
+      return {};
+    };
+
+    await installMcpServer(plan, { execFileFn });
+
+    assert.deepEqual(
+      calls.map((call) => [call.file, call.args[0], call.args[1]]),
+      [
+        ["codex", "--version", undefined],
+        ["codex", "mcp", "get"],
+        ["codex", "mcp", "add"],
+        ["codex", "mcp", "get"],
+      ],
+    );
+    assert.deepEqual(calls[2].args.slice(-3), [
+      "npx",
+      "-y",
+      "@upstash/context7-mcp",
+    ]);
+  });
+
+  it("writes Cursor and Antigravity MCP configs with explicit replacement", async () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(process.env.TMPDIR || "/tmp", "heyclaude-raycast-"),
+    );
+    try {
+      const detail = {
+        detailMarkdown: "# Context7",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            context7: {
+              command: "npx",
+              args: ["-y", "@upstash/context7-mcp"],
+            },
+          },
+        }),
+      };
+      const cursorPath = path.join(tmpDir, "cursor", "mcp.json");
+      const cursorPlan = buildMcpInstallPlan("cursor", sampleEntry, detail);
+
+      assert.equal(
+        await mcpServerExists(cursorPlan, { configPath: cursorPath }),
+        false,
+      );
+      const firstInstall = await installMcpServer(cursorPlan, {
+        configPath: cursorPath,
+      });
+      assert.equal(firstInstall.replacedExisting, false);
+      assert.equal(
+        await mcpServerExists(cursorPlan, { configPath: cursorPath }),
+        true,
+      );
+      assert.deepEqual(
+        JSON.parse(fs.readFileSync(cursorPath, "utf8")).mcpServers.context7
+          .args,
+        ["-y", "@upstash/context7-mcp"],
+      );
+      await assert.rejects(
+        installMcpServer(cursorPlan, { configPath: cursorPath }),
+        /already exists/,
+      );
+
+      const replacement = await installMcpServer(cursorPlan, {
+        configPath: cursorPath,
+        replaceExisting: true,
+        now: new Date("2026-06-07T01:02:03.000Z"),
+      });
+      assert.equal(replacement.replacedExisting, true);
+      assert.match(
+        replacement.backupPath || "",
+        /mcp\.json\.bak\.heyclaude-20260607T010203Z$/,
+      );
+      assert.equal(fs.existsSync(replacement.backupPath || ""), true);
+
+      const antigravityCandidates = mcpJsonConfigPathCandidates(
+        "antigravity",
+        tmpDir,
+      );
+      assert.deepEqual(antigravityCandidates, [
+        path.join(tmpDir, ".gemini", "antigravity", "mcp_config.json"),
+        path.join(tmpDir, ".gemini", "config", "mcp_config.json"),
+      ]);
+      assert.equal(
+        await resolveMcpJsonConfigPath("antigravity", tmpDir),
+        antigravityCandidates[0],
+      );
+      const antigravityPath = antigravityCandidates[1];
+      fs.mkdirSync(path.dirname(antigravityPath), { recursive: true });
+      fs.writeFileSync(antigravityPath, "", "utf8");
+      assert.equal(
+        await resolveMcpJsonConfigPath("antigravity", tmpDir),
+        antigravityPath,
+      );
+      const antigravityPlan = buildMcpInstallPlan("antigravity", sampleEntry, {
+        detailMarkdown: "# Docs",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            docs: { url: "https://example.com/mcp" },
+          },
+        }),
+      });
+
+      await installMcpServer(antigravityPlan, {
+        configPath: antigravityPath,
+      });
+      assert.deepEqual(
+        JSON.parse(fs.readFileSync(antigravityPath, "utf8")).mcpServers.docs,
+        { type: "http", serverUrl: "https://example.com/mcp" },
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves Claude Code from common local install paths when PATH misses it", async () => {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const execFileFn = async (file: string, args: string[]) => {
+      calls.push({ file, args });
+      if (file === "claude") throw new Error("not on PATH");
+      return {};
+    };
+
+    const resolved = await resolveClaudeCli(execFileFn);
+
+    assert.notEqual(resolved, "claude");
+    assert.match(resolved, /\/claude$/);
+    assert.deepEqual(calls[0], { file: "claude", args: ["--version"] });
+  });
+
+  it("resolves Codex from common local install paths when PATH misses it", async () => {
+    const calls: Array<{ file: string; args: string[] }> = [];
+    const execFileFn = async (file: string, args: string[]) => {
+      calls.push({ file, args });
+      if (file === "codex") throw new Error("not on PATH");
+      return {};
+    };
+
+    const resolved = await resolveMcpCli("codex", execFileFn);
+
+    assert.notEqual(resolved, "codex");
+    assert.match(resolved, /\/codex$/);
+    assert.deepEqual(calls[0], { file: "codex", args: ["--version"] });
+  });
+
+  it("reports a user-facing error when the Claude Code CLI cannot be resolved", async () => {
+    await assert.rejects(
+      resolveClaudeCli(async () => {
+        throw new Error("missing");
+      }),
+      /Install or reinstall Claude Code/,
+    );
+  });
+
+  it("requires explicit replacement before removing an existing Claude MCP server", async () => {
+    const detail = {
+      detailMarkdown: "# Context7",
+      configSnippet: JSON.stringify({
+        mcpServers: { context7: { command: "npx" } },
+      }),
+    };
+    const plan = buildClaudeMcpInstallPlan(sampleEntry, detail);
+    const execFileFn = async () => ({});
+
+    await assert.rejects(
+      installClaudeMcpServer(plan, { execFileFn }),
+      /already exists/,
+    );
   });
 
   it("resolves jobs feeds from the production HeyClaude host", () => {
@@ -690,19 +1190,39 @@ describe("Raycast feed helpers", () => {
   });
 
   it("validates and parses full detail payloads", () => {
-    const detail = { copyText: "full text", detailMarkdown: "# Detail" };
+    const detail = {
+      copyText: "full text",
+      detailMarkdown: "# Detail",
+      mcpInstallTargets: ["claude-code", "not-real", "codex"],
+    };
     const lazyDetail = {
       detailMarkdown: "# Detail",
       llmsUrl: "/data/llms/mcp/context7.txt",
     };
     assert.equal(isRaycastDetail(detail), true);
     assert.equal(isRaycastDetail(lazyDetail), true);
-    assert.deepEqual(parseDetail(JSON.stringify(detail)), detail);
-    assert.equal(parseDetail(JSON.stringify({ copyText: "missing md" })), null);
-    assert.deepEqual(fallbackDetail(sampleEntry), {
-      copyText: sampleEntry.copyText,
-      detailMarkdown: sampleEntry.detailMarkdown,
+    assert.deepEqual(parseDetail(JSON.stringify(detail)), {
+      copyText: "full text",
+      detailMarkdown: "# Detail",
+      mcpInstallTargets: ["claude-code", "codex"],
     });
+    assert.equal(parseDetail(JSON.stringify({ copyText: "missing md" })), null);
+    assert.deepEqual(
+      {
+        copyText: fallbackDetail(sampleEntry).copyText,
+        detailMarkdown: fallbackDetail(sampleEntry).detailMarkdown,
+        installable: fallbackDetail(sampleEntry).installable,
+        hasInstallCommand: fallbackDetail(sampleEntry).hasInstallCommand,
+        mcpInstallTargets: fallbackDetail(sampleEntry).mcpInstallTargets,
+      },
+      {
+        copyText: sampleEntry.copyText,
+        detailMarkdown: sampleEntry.detailMarkdown,
+        installable: true,
+        hasInstallCommand: true,
+        mcpInstallTargets: ["claude-code", "codex", "cursor", "antigravity"],
+      },
+    );
   });
 
   it("parses, filters, and summarizes Raycast jobs", () => {
@@ -810,12 +1330,20 @@ describe("Raycast feed helpers", () => {
     assert.deepEqual(filterEntriesBySearchText(entries, "@@@ ///"), []);
   });
 
-  it("keeps the v1 extension read-only and non-mutating", () => {
-    const source = readSourceFiles(path.join(process.cwd(), "src")).join("\n");
+  it("keeps local mutation scoped to the MCP installer", () => {
+    const sourceDir = path.join(process.cwd(), "src");
+    const sourceFiles = readSourceFiles(sourceDir);
+    const installerPath = path.join(sourceDir, "mcp-installer.ts");
+    const installerSource =
+      sourceFiles.find(({ filePath }) => filePath === installerPath)?.source ||
+      "";
+    const browseSource = sourceFiles
+      .filter(({ filePath }) => filePath !== installerPath)
+      .map(({ source }) => source)
+      .join("\n");
     const forbiddenPatterns = [
       /\bfrom\s+["'](?:node:)?fs(?:\/promises)?["']/,
       /\brequire\(["'](?:node:)?fs(?:\/promises)?["']\)/,
-      /\bfrom\s+["'](?:node:)?child_process["']/,
       /\brequire\(["'](?:node:)?child_process["']\)/,
       /\bwriteFile(?:Sync)?\b/,
       /\bappendFile(?:Sync)?\b/,
@@ -833,8 +1361,18 @@ describe("Raycast feed helpers", () => {
     ];
 
     for (const pattern of forbiddenPatterns) {
-      assert.doesNotMatch(source, pattern);
+      assert.doesNotMatch(browseSource, pattern);
     }
+    assert.doesNotMatch(
+      browseSource,
+      /\bfrom\s+["'](?:node:)?child_process["']/,
+    );
+    assert.match(installerSource, /\bfrom\s+["']node:child_process["']/);
+    assert.match(installerSource, /\bfrom\s+["']node:fs\/promises["']/);
+    assert.match(installerSource, /\bexecFile\b/);
+    assert.match(installerSource, /\bwriteFile\b/);
+    assert.match(installerSource, /\brename\b/);
+    assert.doesNotMatch(installerSource, /\bexec\(/);
   });
 
   it("keeps Raycast list rows compact enough for split-pane scanning", () => {
@@ -904,9 +1442,21 @@ describe("Raycast feed helpers", () => {
   it("keeps the production Raycast manifest fixed to HeyClaude endpoints", () => {
     const manifest = JSON.parse(
       fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
-    ) as { preferences?: unknown; commands?: { name?: string }[] };
+    ) as {
+      preferences?: unknown;
+      commands?: { name?: string }[];
+    };
 
-    assert.equal(manifest.preferences, undefined);
+    assert.deepEqual(manifest.preferences, [
+      {
+        name: "feedUrlOverride",
+        title: "Feed URL Override",
+        description:
+          "Optional advanced feed URL for preview deployments or local ray develop smoke tests. Must end with /data/raycast-index.json.",
+        type: "textfield",
+        required: false,
+      },
+    ]);
     assert.deepEqual(
       (manifest.commands || []).map((command) => command.name),
       [

--- a/integrations/raycast/tsconfig.json
+++ b/integrations/raycast/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "ES2023",
     "jsx": "react-jsx",
     "strict": true,
+    "types": ["node"],
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -54,6 +54,10 @@
       "types": "./src/index.d.ts",
       "default": "./src/llms.js"
     },
+    "./mcp-install-config": {
+      "types": "./src/mcp-install-config.d.ts",
+      "default": "./src/mcp-install-config.js"
+    },
     "./weekly-brief": {
       "types": "./src/weekly-brief.d.ts",
       "default": "./src/weekly-brief.js"

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -10,6 +10,7 @@ import {
 import { renderCorpusLlms, renderEntryLlms } from "./llms.js";
 import { buildEntryJsonLdSnapshot } from "./seo.js";
 import { buildSubmissionSpecs } from "./submission-spec.js";
+import { resolveMcpInstallConfig } from "./mcp-install-config.js";
 import {
   buildRegistryRelationGraph,
   relationLookupFromGraph,
@@ -165,6 +166,12 @@ function compactDefinedObject(value) {
 
 export function buildRaycastDetailMarkdown(entry) {
   const lines = [`# ${entry.title}`, "", entry.description];
+  const mcpInstallConfig =
+    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+  const configSnippet =
+    entry.category === "mcp"
+      ? mcpInstallConfig?.configSnippet
+      : entry.configSnippet;
 
   pushRaycastTrustSection(lines, entry);
   pushNoteSection(lines, "Safety notes", entry.safetyNotes);
@@ -178,8 +185,8 @@ export function buildRaycastDetailMarkdown(entry) {
     );
   }
 
-  if (entry.configSnippet) {
-    lines.push("", "## Config", codeBlock("json", entry.configSnippet));
+  if (configSnippet) {
+    lines.push("", "## Config", codeBlock("json", configSnippet));
   }
 
   if (entry.usageSnippet) {
@@ -307,15 +314,11 @@ export function buildSearchEntries(entries) {
       ...buildEntryProvenanceFields(entry),
       ...buildEntryBrandFields(entry),
       dateAdded: entry.dateAdded || "",
-      installable: Boolean(
-        entry.installable || entry.installCommand || entry.downloadUrl,
-      ),
+      ...buildCompactInstallFields(entry),
       downloadUrl: entry.downloadUrl || "",
       downloadTrust: entry.downloadTrust ?? null,
       verificationStatus: entry.verificationStatus || "",
-      platforms: buildSkillPlatformCompatibility(entry).map(
-        (item) => item.platform,
-      ),
+      platforms: buildEntryPlatformNames(entry),
       supportLevels: buildSkillPlatformCompatibility(entry).map(
         (item) => item.supportLevel,
       ),
@@ -387,6 +390,47 @@ export function buildSkillPlatformCompatibility(entry) {
   ];
 }
 
+function buildEntryPlatformNames(entry) {
+  const platforms = new Set(
+    buildSkillPlatformCompatibility(entry)
+      .map((item) => item.platform)
+      .filter(Boolean),
+  );
+  const tokens = new Set(
+    [entry.category, ...(entry.tags ?? []), ...(entry.keywords ?? [])].map(
+      (item) => String(item || "").toLowerCase(),
+    ),
+  );
+
+  if (entry.category === "mcp") {
+    const mcpInstallConfig = resolveMcpInstallConfig(entry);
+    for (const target of mcpInstallConfig?.targets ?? []) {
+      platforms.add(target);
+    }
+  }
+  if (
+    ["agents", "commands", "hooks", "rules", "statuslines"].includes(
+      entry.category,
+    )
+  ) {
+    platforms.add("claude-code");
+  }
+  for (const platform of [
+    "cursor",
+    "codex",
+    "gemini",
+    "windsurf",
+    "raycast",
+    "aider",
+    "zed",
+    "continue",
+  ]) {
+    if (tokens.has(platform)) platforms.add(platform);
+  }
+
+  return [...platforms];
+}
+
 function sourceUrlsForEntry(entry) {
   return [
     entry.documentationUrl,
@@ -446,7 +490,7 @@ export function buildEntryTrustSignals(entry) {
     adapterGenerated,
     hasSafetyNotes,
     hasPrivacyNotes,
-    platforms: platformCompatibility.map((item) => item.platform),
+    platforms: buildEntryPlatformNames(entry),
     supportLevels: platformCompatibility.map((item) => item.supportLevel),
   };
 }
@@ -463,6 +507,56 @@ function buildListTrustSignals(entry) {
     platforms: trustSignals.platforms,
     supportLevels: trustSignals.supportLevels,
   };
+}
+
+function buildCompactInstallFields(entry) {
+  const mcpInstallConfig =
+    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+  if (entry.category === "mcp") {
+    return compactDefinedObject({
+      installable: Boolean(
+        entry.installable ||
+          entry.installCommand ||
+          entry.commandSyntax ||
+          entry.downloadUrl ||
+          mcpInstallConfig,
+      ),
+      hasInstallCommand: Boolean(entry.installCommand || entry.commandSyntax),
+      hasConfigSnippet: Boolean(mcpInstallConfig),
+      mcpInstallTargets: mcpInstallConfig?.targets,
+    });
+  }
+
+  return {
+    installable: Boolean(
+      entry.installable ||
+      entry.installCommand ||
+      entry.commandSyntax ||
+      entry.downloadUrl ||
+      entry.configSnippet,
+    ),
+    hasInstallCommand: Boolean(entry.installCommand || entry.commandSyntax),
+    hasConfigSnippet: Boolean(entry.configSnippet),
+  };
+}
+
+function buildRaycastInstallDetailFields(entry) {
+  const mcpInstallConfig =
+    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+  if (entry.category === "mcp") {
+    return compactDefinedObject({
+      ...buildCompactInstallFields(entry),
+      installCommand: entry.installCommand || entry.commandSyntax || "",
+      configSnippet: mcpInstallConfig?.configSnippet || "",
+      mcpInstallTargets: mcpInstallConfig?.targets,
+    });
+  }
+
+  return compactDefinedObject({
+    ...buildCompactInstallFields(entry),
+    installCommand: entry.installCommand || entry.commandSyntax || "",
+    configSnippet: entry.configSnippet || "",
+  });
 }
 
 function verificationAgeDays(entry, generatedAt) {
@@ -776,7 +870,11 @@ export function buildRaycastEntries(entries) {
       documentationUrl: entry.documentationUrl || "",
       downloadTrust: entry.downloadTrust,
       verificationStatus: entry.verificationStatus || "",
-      platformCompatibility: buildSkillPlatformCompatibility(entry),
+      ...buildCompactInstallFields(entry),
+      platformCompatibility:
+        entry.category === "skills"
+          ? buildSkillPlatformCompatibility(entry)
+          : buildEntryPlatformNames(entry),
     });
   });
 }
@@ -832,6 +930,8 @@ export function buildRaycastDetail(entry) {
     downloadTrust: entry.downloadTrust ?? null,
     verificationStatus: entry.verificationStatus || "",
     packageVerified: Boolean(entry.packageVerified),
+    trustSignals: buildEntryTrustSignals(entry),
+    ...buildRaycastInstallDetailFields(entry),
   };
 }
 

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -125,6 +125,21 @@ export type RegistryRelationGraph = {
   entries: RegistryRelationGraphEntry[];
 };
 
+export type McpInstallTargetId =
+  | "claude-code"
+  | "codex"
+  | "cursor"
+  | "antigravity";
+
+export type McpServerConfig = Record<string, unknown>;
+
+export type ResolvedMcpInstallConfig = {
+  name: string;
+  config: McpServerConfig;
+  configSnippet: string;
+  targets: McpInstallTargetId[];
+};
+
 export type RegistryTrustReportEntry = {
   key: string;
   category: string;
@@ -493,6 +508,27 @@ export declare function buildBrandAssetMetadata(
   brandVerifiedAt?: string;
   brandColors?: string[];
 };
+export declare const MCP_INSTALL_TARGET_IDS: readonly McpInstallTargetId[];
+export declare function normalizeMcpServerConfig(
+  value: unknown,
+): McpServerConfig | null;
+export declare function extractMcpServerConfig(
+  value: unknown,
+): { name?: string; config: McpServerConfig } | null;
+export declare function mcpConfigSupportsTarget(
+  config: unknown,
+  target: McpInstallTargetId,
+): boolean;
+export declare function mcpInstallTargetsForConfig(
+  config: unknown,
+): McpInstallTargetId[];
+export declare function formatMcpConfigSnippet(
+  name: string,
+  config: McpServerConfig,
+): string;
+export declare function resolveMcpInstallConfig(
+  entry: Record<string, unknown>,
+): ResolvedMcpInstallConfig | null;
 export type ToolListing = DirectoryEntry & {
   websiteUrl?: string;
   pricingModel?: string;

--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -15,4 +15,5 @@ export * from "./submission.js";
 export * from "./submission-risk.js";
 export * from "./submission-spec.js";
 export * from "./llms.js";
+export * from "./mcp-install-config.js";
 export * from "./weekly-brief.js";

--- a/packages/registry/src/mcp-install-config.d.ts
+++ b/packages/registry/src/mcp-install-config.d.ts
@@ -1,0 +1,42 @@
+export type McpInstallTargetId =
+  | "claude-code"
+  | "codex"
+  | "cursor"
+  | "antigravity";
+
+export type McpServerConfig = Record<string, unknown>;
+
+export type ResolvedMcpInstallConfig = {
+  name: string;
+  config: McpServerConfig;
+  configSnippet: string;
+  targets: McpInstallTargetId[];
+};
+
+export declare const MCP_INSTALL_TARGET_IDS: readonly McpInstallTargetId[];
+
+export declare function normalizeMcpServerConfig(
+  value: unknown,
+): McpServerConfig | null;
+
+export declare function extractMcpServerConfig(
+  value: unknown,
+): { name?: string; config: McpServerConfig } | null;
+
+export declare function mcpConfigSupportsTarget(
+  config: unknown,
+  target: McpInstallTargetId,
+): boolean;
+
+export declare function mcpInstallTargetsForConfig(
+  config: unknown,
+): McpInstallTargetId[];
+
+export declare function formatMcpConfigSnippet(
+  name: string,
+  config: McpServerConfig,
+): string;
+
+export declare function resolveMcpInstallConfig(
+  entry: Record<string, unknown>,
+): ResolvedMcpInstallConfig | null;

--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -1,0 +1,184 @@
+export const MCP_INSTALL_TARGET_IDS = [
+  "claude-code",
+  "codex",
+  "cursor",
+  "antigravity",
+];
+
+const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function scalarRecordIsValid(value) {
+  return (
+    value === undefined ||
+    (isRecord(value) &&
+      Object.values(value).every(
+        (item) =>
+          typeof item === "string" ||
+          typeof item === "number" ||
+          typeof item === "boolean",
+      ))
+  );
+}
+
+function normalizeType(value) {
+  const normalized = String(value || "").trim().toLowerCase();
+  if (normalized === "streamable-http") return "http";
+  if (normalized === "http" || normalized === "sse" || normalized === "stdio") {
+    return normalized;
+  }
+  return "";
+}
+
+function normalizeArgs(value) {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) return null;
+  if (
+    !value.every(
+      (item) =>
+        typeof item === "string" ||
+        typeof item === "number" ||
+        typeof item === "boolean",
+    )
+  ) {
+    return null;
+  }
+  return value.map(String);
+}
+
+export function normalizeMcpServerConfig(value) {
+  if (!isRecord(value)) return null;
+  const config = cloneJson(value);
+
+  if (config.transport !== undefined) return null;
+
+  if (config.serverUrl !== undefined) {
+    if (typeof config.serverUrl !== "string" || !config.serverUrl.trim()) {
+      return null;
+    }
+    if (config.url === undefined) config.url = config.serverUrl;
+    delete config.serverUrl;
+  }
+
+  const type = normalizeType(config.type);
+  const hasCommand = typeof config.command === "string" && config.command.trim();
+  const hasUrl = typeof config.url === "string" && config.url.trim();
+
+  if (!type && hasCommand) config.type = "stdio";
+  else if (!type && hasUrl) config.type = "http";
+  else if (type) config.type = type;
+
+  const normalizedType = normalizeType(config.type);
+  if (!SERVER_CONFIG_TYPES.has(normalizedType)) return null;
+  if (normalizedType === "stdio" && !hasCommand) return null;
+  if ((normalizedType === "http" || normalizedType === "sse") && !hasUrl) {
+    return null;
+  }
+
+  const args = normalizeArgs(config.args);
+  if (args === null) return null;
+  if (args !== undefined) config.args = args;
+  if (!scalarRecordIsValid(config.env)) return null;
+  if (!scalarRecordIsValid(config.headers)) return null;
+  if (!scalarRecordIsValid(config.http_headers)) return null;
+  if (!scalarRecordIsValid(config.env_http_headers)) return null;
+
+  return config;
+}
+
+function singleServerFromMap(value) {
+  if (!isRecord(value)) return null;
+  const servers = Object.entries(value).filter(([, config]) =>
+    isRecord(config),
+  );
+  if (servers.length !== 1) return null;
+  const [name, config] = servers[0];
+  const normalized = normalizeMcpServerConfig(config);
+  return normalized ? { name, config: normalized } : null;
+}
+
+export function extractMcpServerConfig(value) {
+  const parsed = typeof value === "string" ? JSON.parse(value.trim()) : value;
+  if (!isRecord(parsed)) return null;
+
+  return singleServerFromMap(parsed.mcpServers);
+}
+
+function bearerTokenEnvVar(config) {
+  return (
+    (typeof config.bearerTokenEnvVar === "string" &&
+      config.bearerTokenEnvVar.trim()) ||
+    (typeof config.bearer_token_env_var === "string" &&
+      config.bearer_token_env_var.trim()) ||
+    ""
+  );
+}
+
+function hasStaticOrEnvHttpHeaders(config) {
+  return (
+    (isRecord(config.headers) && Object.keys(config.headers).length > 0) ||
+    (isRecord(config.http_headers) &&
+      Object.keys(config.http_headers).length > 0) ||
+    (isRecord(config.env_http_headers) &&
+      Object.keys(config.env_http_headers).length > 0)
+  );
+}
+
+export function mcpConfigSupportsTarget(config, target) {
+  const normalized = normalizeMcpServerConfig(config);
+  if (!normalized) return false;
+  const type = normalizeType(normalized.type);
+
+  if (target === "codex") {
+    if (type === "sse") return false;
+    if (type === "http" && hasStaticOrEnvHttpHeaders(normalized)) {
+      return Boolean(bearerTokenEnvVar(normalized));
+    }
+  }
+
+  return MCP_INSTALL_TARGET_IDS.includes(target);
+}
+
+export function mcpInstallTargetsForConfig(config) {
+  return MCP_INSTALL_TARGET_IDS.filter((target) =>
+    mcpConfigSupportsTarget(config, target),
+  );
+}
+
+export function formatMcpConfigSnippet(name, config) {
+  const serverName = String(name || "heyclaude-mcp").trim() || "heyclaude-mcp";
+  return `${JSON.stringify(
+    { mcpServers: { [serverName]: config } },
+    null,
+    2,
+  )}\n`;
+}
+
+export function resolveMcpInstallConfig(entry) {
+  if (!entry || entry.category !== "mcp") return null;
+  const snippet = String(entry.configSnippet || "").trim();
+  if (!snippet) return null;
+  try {
+    const extracted = extractMcpServerConfig(snippet);
+    if (!extracted) return null;
+    const name = extracted.name || entry.slug || "heyclaude-mcp";
+    const targets = mcpInstallTargetsForConfig(extracted.config);
+    if (!targets.length) return null;
+    return {
+      name,
+      config: extracted.config,
+      configSnippet: formatMcpConfigSnippet(name, extracted.config),
+      targets,
+    };
+  } catch {
+    // Non-JSON shell commands and prose are intentionally manual-only.
+  }
+  return null;
+}

--- a/scripts/validate-raycast-feed.mjs
+++ b/scripts/validate-raycast-feed.mjs
@@ -3,6 +3,11 @@ import path from "node:path";
 
 import { RAYCAST_COPY_PREVIEW_LIMIT } from "@heyclaude/registry";
 import { isAllowedBrandAssetUrl } from "@heyclaude/registry/brand-assets";
+import {
+  MCP_INSTALL_TARGET_IDS,
+  extractMcpServerConfig,
+  mcpConfigSupportsTarget,
+} from "@heyclaude/registry/mcp-install-config";
 
 const repoRoot = process.cwd();
 const feedPath = path.join(repoRoot, "apps/web/public/data/raycast-index.json");
@@ -34,6 +39,7 @@ const forbiddenEntryFields = [
   "codeBlocks",
   "scriptBody",
 ];
+const allowedMcpInstallTargets = new Set(MCP_INSTALL_TARGET_IDS);
 
 function fail(message) {
   console.error(message);
@@ -107,6 +113,36 @@ function objectDefinesKey(block, key) {
   return new RegExp(
     `(^|\\n)\\s*(?:${escapedKey}|["']${escapedKey}["'])\\s*:`,
   ).test(block);
+}
+
+function normalizeMcpInstallTargets(value, label) {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    fail(`${label}: mcpInstallTargets must be an array`);
+    return [];
+  }
+  const targets = [];
+  const seenTargets = new Set();
+  for (const item of value) {
+    if (typeof item !== "string" || !allowedMcpInstallTargets.has(item)) {
+      fail(`${label}: invalid MCP install target ${String(item)}`);
+      continue;
+    }
+    if (seenTargets.has(item)) {
+      fail(`${label}: duplicate MCP install target ${item}`);
+      continue;
+    }
+    seenTargets.add(item);
+    targets.push(item);
+  }
+  return targets;
+}
+
+function equalStringArrays(left, right) {
+  return (
+    left.length === right.length &&
+    left.every((item, index) => item === right[index])
+  );
 }
 
 if (!fs.existsSync(feedPath)) {
@@ -226,6 +262,14 @@ for (const entry of payload.entries) {
   }
 
   const detail = JSON.parse(fs.readFileSync(detailPath, "utf8"));
+  const entryMcpTargets = normalizeMcpInstallTargets(
+    entry.mcpInstallTargets,
+    `${key} entry`,
+  );
+  const detailMcpTargets = normalizeMcpInstallTargets(
+    detail.mcpInstallTargets,
+    `${key} detail`,
+  );
   assertNoLoneSurrogates(detail, `${key} detail`);
   if (detail.schemaVersion !== 2)
     fail(`${key}: detail schemaVersion must be 2`);
@@ -260,6 +304,51 @@ for (const entry of payload.entries) {
   ]) {
     if (entry[field] && entry[field] !== detail[field]) {
       fail(`${key}: detail ${field} must match feed ${field}`);
+    }
+  }
+
+  if (!equalStringArrays(entryMcpTargets, detailMcpTargets)) {
+    fail(`${key}: detail mcpInstallTargets must match feed entry`);
+  }
+  if (entry.category !== "mcp") {
+    if (entryMcpTargets.length || detailMcpTargets.length) {
+      fail(`${key}: non-MCP entry must not advertise MCP install targets`);
+    }
+    continue;
+  }
+
+  const detailConfigSnippet = String(detail.configSnippet || "").trim();
+  const advertisesMcpInstall =
+    entry.hasConfigSnippet ||
+    detail.hasConfigSnippet ||
+    entryMcpTargets.length ||
+    detailMcpTargets.length;
+  if (!advertisesMcpInstall) {
+    if (detailConfigSnippet) {
+      fail(`${key}: manual MCP entry must not publish Raycast configSnippet`);
+    }
+    continue;
+  }
+
+  if (!entry.hasConfigSnippet || !detail.hasConfigSnippet) {
+    fail(`${key}: MCP install target requires hasConfigSnippet in feed/detail`);
+  }
+  if (!entryMcpTargets.length) {
+    fail(`${key}: MCP install target list must not be empty`);
+  }
+  let extractedMcpConfig = null;
+  try {
+    extractedMcpConfig = extractMcpServerConfig(detailConfigSnippet);
+  } catch {
+    extractedMcpConfig = null;
+  }
+  if (!extractedMcpConfig) {
+    fail(`${key}: advertised MCP install target requires valid detail config`);
+    continue;
+  }
+  for (const target of entryMcpTargets) {
+    if (!mcpConfigSupportsTarget(extractedMcpConfig.config, target)) {
+      fail(`${key}: unsupported MCP install target ${target}`);
     }
   }
 }

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MCP_INSTALL_TARGET_IDS,
+  extractMcpServerConfig,
+  mcpInstallTargetsForConfig,
+  normalizeMcpServerConfig,
+  resolveMcpInstallConfig,
+  type McpInstallTargetId,
+  type ResolvedMcpInstallConfig,
+} from "@heyclaude/registry";
+
+describe("MCP install config helpers", () => {
+  it("exports the install-config surface from the registry package root", () => {
+    const targets: McpInstallTargetId[] = [...MCP_INSTALL_TARGET_IDS];
+
+    expect(targets).toEqual([
+      "claude-code",
+      "codex",
+      "cursor",
+      "antigravity",
+    ]);
+    expect(
+      mcpInstallTargetsForConfig({
+        command: "npx",
+        args: ["-y", "@example/mcp"],
+      }),
+    ).toEqual(targets);
+  });
+
+  it("normalizes streamable HTTP and serverUrl configs for artifact metadata", () => {
+    expect(
+      normalizeMcpServerConfig({
+        type: "streamable-http",
+        serverUrl: "https://example.com/mcp",
+      }),
+    ).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+    });
+
+    const resolved: ResolvedMcpInstallConfig | null = resolveMcpInstallConfig({
+      category: "mcp",
+      slug: "remote-docs",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          docs: {
+            type: "streamable-http",
+            serverUrl: "https://example.com/mcp",
+          },
+        },
+      }),
+    });
+
+    expect(resolved).toMatchObject({
+      name: "docs",
+      targets: ["claude-code", "codex", "cursor", "antigravity"],
+      config: {
+        type: "http",
+        url: "https://example.com/mcp",
+      },
+    });
+    expect(extractMcpServerConfig(resolved?.configSnippet)?.config).toEqual({
+      type: "http",
+      url: "https://example.com/mcp",
+    });
+  });
+
+  it("keeps legacy transport snippets out of machine-install metadata", () => {
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "legacy-sse",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            legacy: {
+              transport: "sse",
+              url: "https://example.com/sse",
+            },
+          },
+        }),
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -25,6 +25,7 @@ import {
   SOURCE_HEALTH_REPORT_SCHEMA_VERSION,
   buildReadOnlyEcosystemFeed,
   buildRaycastEnvelope,
+  buildRaycastDetail,
   buildRaycastDetailMarkdown,
   parseAbbreviatedCount,
   renderEntryLlms,
@@ -37,6 +38,7 @@ import {
   isAllowedBrandAssetUrl,
   truncateText,
 } from "@heyclaude/registry";
+import { extractMcpServerConfig } from "@heyclaude/registry/mcp-install-config";
 import {
   buildContentEntryFromMdx,
   parseGitHubRepo,
@@ -681,6 +683,96 @@ describe("registry artifacts", () => {
       ),
     ).toEqual(jsonLdSnapshotsPayload);
   }, 60_000);
+
+  it("publishes MCP harness targets only for validated config snippets", () => {
+    const baseEntry = {
+      category: "mcp",
+      title: "MCP Harness Fixture",
+      description: "Fixture entry for MCP installer metadata.",
+      cardDescription: "Fixture entry for MCP installer metadata.",
+      author: "Fixture",
+      dateAdded: "2026-06-07",
+      tags: ["mcp"],
+      keywords: [],
+      body: "",
+      sections: [],
+      headings: [],
+      codeBlocks: [],
+    };
+    const stdioEntry = {
+      ...baseEntry,
+      slug: "stdio-fixture",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          fixture: {
+            command: "npx",
+            args: ["-y", "fixture-mcp"],
+          },
+        },
+      }),
+    };
+    const sseEntry = {
+      ...baseEntry,
+      slug: "sse-fixture",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          remote: {
+            type: "sse",
+            url: "https://example.com/sse",
+          },
+        },
+      }),
+    };
+    const manualEntry = {
+      ...baseEntry,
+      slug: "manual-fixture",
+      installCommand: "thv run fixture-mcp",
+      configSnippet: "thv run fixture-mcp",
+    };
+
+    const raycastEntries = buildRaycastEnvelope([
+      stdioEntry,
+      sseEntry,
+      manualEntry,
+    ] as any).entries;
+    const stdioFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "stdio-fixture",
+    );
+    const sseFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "sse-fixture",
+    );
+    const manualFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "manual-fixture",
+    );
+    const stdioDetail = buildRaycastDetail(stdioEntry as any);
+    const manualDetail = buildRaycastDetail(manualEntry as any);
+
+    expect(stdioFeedEntry).toMatchObject({
+      hasConfigSnippet: true,
+      mcpInstallTargets: [
+        "claude-code",
+        "codex",
+        "cursor",
+        "antigravity",
+      ],
+    });
+    expect(extractMcpServerConfig(stdioDetail.configSnippet)?.name).toBe(
+      "fixture",
+    );
+    expect(sseFeedEntry?.mcpInstallTargets).toEqual([
+      "claude-code",
+      "cursor",
+      "antigravity",
+    ]);
+    expect(manualFeedEntry).toMatchObject({
+      installable: true,
+      hasInstallCommand: true,
+      hasConfigSnippet: false,
+    });
+    expect(manualFeedEntry).not.toHaveProperty("mcpInstallTargets");
+    expect(manualDetail.configSnippet).toBe("");
+    expect(String(manualDetail.detailMarkdown)).not.toContain("## Config");
+  });
 
   it("does not derive comparative safety relations from safety notes alone", () => {
     const target = {

--- a/tests/registry-search-api.test.ts
+++ b/tests/registry-search-api.test.ts
@@ -122,6 +122,66 @@ describe("/api/registry/search", () => {
     expect(body.results[0].searchReasons).toContain("source-backed");
   });
 
+  it("matches multi-token and aliased category searches without requiring an exact phrase", async () => {
+    searchIndexMock.entries = [
+      {
+        ...makeEntry("microsoft-teams"),
+        title: "MCP Teams Server",
+        description: "Connect Microsoft Teams through Claude Code.",
+        tags: ["teams", "mcp"],
+        keywords: ["microsoft-teams", "msteams"],
+        installable: true,
+      },
+      {
+        ...makeEntry("claude-hook"),
+        category: "hooks",
+        title: "Auto Formatter Hook",
+        description: "Format files before Claude Code completes a task.",
+        tags: ["hooks", "formatter"],
+        keywords: ["claude-code"],
+      },
+      {
+        ...makeEntry("github-server"),
+        title: "GitHub MCP Server",
+        description: "Search repositories and issues.",
+        tags: ["github"],
+        keywords: ["repository"],
+      },
+    ];
+
+    const { GET } = await import("../apps/web/src/routes/api/registry/search");
+    const teams = await GET(
+      new Request(
+        "https://heyclau.de/api/registry/search?q=ms%20teams&installable=true",
+        { headers: { origin: "https://heyclau.de" } },
+      ),
+    );
+    const hooks = await GET(
+      new Request(
+        "https://heyclau.de/api/registry/search?q=claude%20code%20hooks",
+        { headers: { origin: "https://heyclau.de" } },
+      ),
+    );
+    const github = await GET(
+      new Request("https://heyclau.de/api/registry/search?q=gh", {
+        headers: { origin: "https://heyclau.de" },
+      }),
+    );
+
+    await expect(teams.json()).resolves.toMatchObject({
+      total: 1,
+      results: [expect.objectContaining({ slug: "microsoft-teams" })],
+    });
+    await expect(hooks.json()).resolves.toMatchObject({
+      total: 1,
+      results: [expect.objectContaining({ slug: "claude-hook" })],
+    });
+    await expect(github.json()).resolves.toMatchObject({
+      total: 1,
+      results: [expect.objectContaining({ slug: "github-server" })],
+    });
+  });
+
   it("does not advertise an offset beyond the documented maximum", async () => {
     searchIndexMock.entries = Array.from({ length: 10_001 }, (_, index) =>
       makeEntry(`fixture-${index}`),

--- a/tests/registry-search-facets.test.ts
+++ b/tests/registry-search-facets.test.ts
@@ -51,6 +51,7 @@ const defaultFilters: RegistrySearchFilterState = {
   query: "",
   category: "",
   platform: "",
+  installable: "all",
   hasSafetyNotes: "all",
   hasPrivacyNotes: "all",
   downloadTrust: "all",
@@ -119,6 +120,7 @@ describe("computeRegistrySearchFacets", () => {
 
     expect(facets.categories).toEqual({ mcp: 2, hooks: 1, skills: 1 });
     expect(facets.platforms).toEqual({ "claude-code": 3, cursor: 2 });
+    expect(facets.installable).toEqual({ false: 4 });
     expect(facets.hasSafetyNotes).toEqual({ false: 2, true: 2 });
     expect(facets.hasPrivacyNotes).toEqual({ false: 2, true: 2 });
     expect(facets.downloadTrust).toEqual({
@@ -198,6 +200,27 @@ describe("computeRegistrySearchFacets", () => {
 
     expect(matched).toHaveLength(2);
     expect(facets.hasSafetyNotes.true).toBe(2);
+  });
+
+  it("counts installable entries and preserves the active installable selection", () => {
+    const installable = makeEntry({
+      slug: "installable-mcp",
+      installable: true,
+      category: "mcp",
+    });
+    const entries = [...fixtures, installable];
+    const filters: RegistrySearchFilterState = {
+      ...defaultFilters,
+      installable: "true",
+    };
+
+    expect(filterEntries(entries, filters).map((entry) => entry.slug)).toEqual([
+      "installable-mcp",
+    ]);
+    expect(computeRegistrySearchFacets(entries, filters).installable).toEqual({
+      false: 4,
+      true: 1,
+    });
   });
 
   it("uses compact trust-signal booleans when full note text is omitted", () => {


### PR DESCRIPTION
## Summary

Adds cross-harness MCP install support to the Raycast extension and registry artifacts so valid MCP config snippets can be installed into Claude Code, Codex, Cursor, and Antigravity.

## What changed

- Added Raycast MCP installer planning and install execution for Claude Code, Codex, Cursor, and Antigravity.
- Added registry MCP install-config helpers and exported them through `@heyclaude/registry` root and subpath types.
- Published normalized `mcpInstallTargets` into Raycast/search artifacts and added an installable search filter/facet.
- Normalized modified MCP entries so placeholder-backed configs stay manual-only while valid `mcpServers` JSON advertises harness targets.
- Expanded Raycast, registry artifact, search API, and trust coverage tests for the new install path.

## Why

Raycast can only safely offer one-click harness installs when the entry has a concrete single-server MCP config. Placeholder paths, generated URLs, sample credentials, or setup-only snippets would otherwise write broken config into local harness files.

## Validation

- `pnpm validate:content:strict`
- `pnpm validate:raycast-feed`
- `pnpm validate:openapi`
- `pnpm validate:mcp-trust`
- `pnpm exec vitest run tests/mcp-install-config.test.ts tests/registry-artifacts.test.ts tests/registry-search-api.test.ts tests/registry-search-facets.test.ts`
- `pnpm exec vitest run tests/trust-coverage-script.test.ts`
- `pnpm exec tsc --noEmit --pretty false --target ES2022 --module ESNext --moduleResolution Bundler --strict --skipLibCheck tests/mcp-install-config.test.ts`
- `(cd integrations/raycast && npm test)`
- `(cd integrations/raycast && npm run build)`
- `(cd integrations/raycast && npm run lint)`
- `git diff --check`

## Notes

- Remote preview validation was not run.
- Manual Raycast UI smoke and screenshot evidence are still needed before release packaging.