### PR TITLE
content(skills): Rarefriend Skills

### DIFF
--- a/content/skills/rarefriend-skills.mdx
+++ b/content/skills/rarefriend-skills.mdx
@@ -1,0 +1,143 @@
+---
+title: Rarefriend Skills
+slug: rarefriend-skills
+category: skills
+description: "Cross-agent personal network manager skills for Rarefriend — six Agent Skills for contacts, notes, LinkedIn, Google Calendar/Contacts, and Microsoft Outlook email and calendar. Requires Rarefriend MCP."
+cardDescription: "Personal network manager skills for Rarefriend — contacts, calendar, LinkedIn, Outlook."
+seoTitle: Rarefriend Skills — Cross-Agent Personal Network Manager
+seoDescription: "Install Rarefriend Agent Skills for contacts, LinkedIn, Google Calendar, Google Contacts, and Microsoft Outlook via npx. Works with Claude Code, Cursor, Codex, OpenClaw, and Gemini CLI."
+author: Rarefriend
+authorProfileUrl: "https://github.com/Whitefield-Labs"
+submittedBy: rarefriendai
+submittedByUrl: "https://github.com/rarefriendai"
+dateAdded: "2026-06-08"
+repoUrl: "https://github.com/Whitefield-Labs/rarefriend-skills"
+documentationUrl: "https://rarefriend.com"
+downloadUrl: "https://github.com/Whitefield-Labs/rarefriend-skills/archive/refs/heads/main.zip"
+installable: true
+installCommand: "npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y"
+usageSnippet: "npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y"
+copySnippet: |-
+  # Trigger
+  "Use Rarefriend skills to search my network, schedule meetings, or find Outlook emails."
+
+  # Install
+  npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y
+
+  # MCP (required)
+  npx -y @rarefriend-ai/mcp
+  # OAuth credentials: rarefriend.com → Settings → Integrations → MCP
+skillType: general
+skillLevel: advanced
+verificationStatus: validated
+verifiedAt: "2026-06-08"
+retrievalSources:
+  - "https://github.com/Whitefield-Labs/rarefriend-skills"
+  - "https://raw.githubusercontent.com/Whitefield-Labs/rarefriend-skills/main/README.md"
+testedPlatforms:
+  - Claude
+  - Cursor
+  - Codex
+  - OpenClaw
+  - Gemini
+prerequisites:
+  - Rarefriend account with MCP OAuth credentials (rarefriend.com → Settings → Integrations → MCP)
+  - Agent client with Agent Skills support (SKILL.md + MCP)
+  - Node.js for `npx skills add` and `npx -y @rarefriend-ai/mcp`
+safetyNotes:
+  - Skills call Rarefriend MCP with OAuth credentials; store client ID/secret in env or client config, never in chat logs or committed files.
+  - Contact, calendar, and email tools mutate user CRM data; confirm destructive actions (delete, bulk update) before executing.
+  - LinkedIn and Google/Microsoft integrations depend on connected accounts; verify workspace scope before sharing output externally.
+privacyNotes:
+  - MCP calls send contact names, emails, notes, calendar events, and email metadata to Rarefriend servers for the authenticated user only.
+  - Do not paste OAuth client secrets, refresh tokens, or full contact exports into public issues, PRs, or shared transcripts.
+  - Per-skill setup in `skills/<name>/references/SETUP.md` describes required scopes and data access for each integration.
+tags:
+  - rarefriend
+  - personal-crm
+  - contacts
+  - calendar
+  - linkedin
+  - outlook
+keywords:
+  - rarefriend-skills
+  - network-manager
+  - google-contacts
+  - google-calendar
+  - outlook
+  - linkedin
+readingTime: 5
+packageVerified: true
+difficultyScore: 55
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+# Rarefriend Skills
+
+Cross-agent skills for [Rarefriend](https://rarefriend.com) — your personal CRM.
+
+Works with **Claude Code**, **Cursor**, **Codex**, **OpenClaw**, **Gemini CLI**, and any client that supports the [Agent Skills](https://agentskills.io/specification) format (`SKILL.md` + MCP).
+
+Each skill is a focused `SKILL.md` that teaches your AI assistant a specific Rarefriend capability. Install only what you need, or install all six.
+
+## Available skills
+
+| Skill                              | What it does                                       |
+| ---------------------------------- | -------------------------------------------------- |
+| `network-and-relationship-manager` | Full CRM — contacts, notes, tags, all integrations |
+| `manage-linkedin-network`          | Search and manage LinkedIn-synced connections      |
+| `schedule-with-google-calendar`    | Google Calendar scheduling and availability        |
+| `organize-google-contacts`         | Google Contacts sync and management                |
+| `schedule-with-outlook`            | Microsoft Outlook contacts and calendar            |
+| `find-outlook-emails`              | Microsoft email search and management              |
+
+## Install skills
+
+Use the [skills CLI](https://skills.sh) (works across supported agents):
+
+**All skills:**
+
+```bash
+npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y
+npx skills add Whitefield-Labs/rarefriend-skills --skill manage-linkedin-network -y
+npx skills add Whitefield-Labs/rarefriend-skills --skill schedule-with-google-calendar -y
+npx skills add Whitefield-Labs/rarefriend-skills --skill organize-google-contacts -y
+npx skills add Whitefield-Labs/rarefriend-skills --skill schedule-with-outlook -y
+npx skills add Whitefield-Labs/rarefriend-skills --skill find-outlook-emails -y
+```
+
+**Just the main skill (recommended starting point):**
+
+```bash
+npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y
+```
+
+> **Note:** The `--all` flag installs only the first skill due to a known CLI bug ([#1015](https://github.com/anthropics/claude-code/issues/1015)). Use `--skill <name>` for each one until the bug is fixed.
+
+**Cursor:** skills install into `.cursor/skills/` or `~/.cursor/skills/` depending on scope.
+
+**Claude Code / Codex:** global install via `npx skills add …` (same command).
+
+**OpenClaw:** skills include `metadata.openclaw` blocks for ClawHub; install via ClawHub or copy from this repo.
+
+## Requirements — Rarefriend MCP
+
+Skills call Rarefriend via MCP. Connect once per client:
+
+| Client                             | Setup                                                                                                                            |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| **Claude Code / Codex**            | `claude mcp add rarefriend -e RAREFRIEND_CLIENT_ID=your-id -e RAREFRIEND_CLIENT_SECRET=your-secret -- npx -y @rarefriend-ai/mcp` |
+| **Cursor**                         | Add to `~/.cursor/mcp.json` — see [MCP repo](https://github.com/Whitefield-Labs/rarefriend-mcp)                                  |
+| **Claude Desktop**                 | Add to `claude_desktop_config.json` — see [MCP repo](https://github.com/Whitefield-Labs/rarefriend-mcp)                          |
+| **OpenClaw / Gemini CLI / others** | Run `npx -y @rarefriend-ai/mcp` with `RAREFRIEND_CLIENT_ID` and `RAREFRIEND_CLIENT_SECRET` in env                                |
+
+Get credentials at [rarefriend.com](https://rarefriend.com) → Settings → Integrations → MCP.
+
+Per-skill setup details: `skills/<name>/references/SETUP.md`.
+
+## License
+
+MIT

--- a/content/skills/rarefriend-skills.mdx
+++ b/content/skills/rarefriend-skills.mdx
@@ -67,7 +67,6 @@ keywords:
   - outlook
   - linkedin
 readingTime: 5
-packageVerified: true
 difficultyScore: 55
 hasTroubleshooting: true
 hasPrerequisites: true


### PR DESCRIPTION
## Summary
Adds cross-agent personal network manager skills for [Rarefriend](https://rarefriend.com) — contacts, LinkedIn, Google Calendar/Contacts, and Microsoft Outlook via Rarefriend MCP.

- **Repo:** https://github.com/Whitefield-Labs/rarefriend-skills
- **Install:** `npx skills add Whitefield-Labs/rarefriend-skills --skill network-and-relationship-manager -y`
- **MCP:** `npx -y @rarefriend-ai/mcp` (OAuth from rarefriend.com → Settings → Integrations → MCP)
- **Contact:** developer@rarefriend.ai
- **Tested:** Claude Code, Cursor, Codex, OpenClaw, Gemini CLI

## Test plan
- [x] Single content entry (`content/skills/rarefriend-skills.mdx`)
- [x] Body copied verbatim from upstream `README.md`
- [x] Registry frontmatter only (HeyClaude listing requirements)
- [x] Safety and privacy notes included