### PR TITLE
fix(submissions): recover stalled gate reviews

### DIFF
--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -582,6 +582,14 @@ export async function getCommitValidationState(params: {
       });
       continue;
     }
+    if (/superagent/i.test(name) && run.conclusion === "neutral") {
+      checkResults.push({
+        name,
+        status: "passed",
+        details: "concluded neutral",
+      });
+      continue;
+    }
     if (run.conclusion !== "success") {
       checkResults.push({
         name,

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -177,6 +177,8 @@ const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
 const TERMINAL_PR_STATUSES = new Set(["merged", "closed", "manual", "ignored"]);
 const GITHUB_TERMINAL_VERIFICATION_ERROR = "GitHub terminal state verified.";
 const VALIDATION_REQUEUE_SECONDS = 90;
+const VALIDATION_PENDING_STALE_SECONDS = 30 * 60;
+const VALIDATION_PENDING_STALE_ATTEMPTS = 20;
 const QUEUED_STALE_SECONDS = 60;
 const REVIEWING_STALE_SECONDS = 180;
 const MERGE_RETRY_SECONDS = 30;
@@ -336,6 +338,8 @@ type PrQueueState = Record<string, unknown> & {
   status?: string;
   verdict?: string;
   lastReviewKey?: string;
+  attemptCount?: number;
+  createdAt?: string;
   updatedAt?: string;
 };
 
@@ -400,6 +404,7 @@ function decisionStatus(verdict: GateVerdict) {
 
 function gateCheckStatus(status: string) {
   const normalized = status.toLowerCase();
+  if (normalized === "missing") return "pending" as const;
   if (
     ["passed", "pending", "failed", "neutral", "skipped", "unknown"].includes(
       normalized,
@@ -2180,6 +2185,65 @@ function validationGateDecision(validation: {
   };
 }
 
+function staleValidationPendingAgeSeconds(existing?: PrQueueState | null) {
+  const createdAt = Date.parse(
+    String(existing?.createdAt || existing?.updatedAt || ""),
+  );
+  if (!Number.isFinite(createdAt)) return 0;
+  return Math.max(0, Math.floor((Date.now() - createdAt) / 1000));
+}
+
+function staleValidationPendingDecision(
+  existing: PrQueueState | null | undefined,
+  validation: {
+    summary: string;
+    checks: Array<{ name: string; status: string; details?: string }>;
+  },
+): GateDecision | null {
+  const missingChecks = validation.checks.filter(
+    (check) => check.status === "missing",
+  );
+  if (!missingChecks.length) return null;
+  const attempts = Number(existing?.attemptCount || 0);
+  const ageSeconds = staleValidationPendingAgeSeconds(existing);
+  if (
+    attempts < VALIDATION_PENDING_STALE_ATTEMPTS &&
+    ageSeconds < VALIDATION_PENDING_STALE_SECONDS
+  ) {
+    return null;
+  }
+  const ageMinutes = ageSeconds
+    ? `${Math.max(1, Math.round(ageSeconds / 60))} minutes`
+    : "an extended period";
+  return {
+    verdict: "manual",
+    reasonCode: "validation_failure",
+    confidence: 1,
+    summary: [
+      "Summary:",
+      `- Required public validation has not started after ${attempts} gate attempts over ${ageMinutes}.`,
+      `- ${validation.summary}`,
+      "",
+      "Validation Review:",
+      "- The submission gate cannot auto-merge until every required public check reports on the current head SHA.",
+      "- Missing check runs usually mean GitHub is waiting for maintainer approval on a first-time contributor workflow, or a required workflow did not create its check run.",
+      "",
+      "Recommended Action:",
+      "- Approve or rerun the missing required workflow checks, then comment `/recheck` or wait for the next check event.",
+    ].join("\n"),
+    labels: [LABELS.manual],
+    close: false,
+    checks: checksForDecision(validation),
+    errors: [
+      {
+        code: "public_validation_not_started",
+        retryable: false,
+        message: validation.summary,
+      },
+    ],
+  };
+}
+
 function validationSummaryForNotification(
   validation:
     | {
@@ -3774,54 +3838,62 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
         });
         validationForNotification = validation;
         if (!decision && validation.state === "pending") {
-          await upsertPrState(env.SUBMISSION_GATE_DB, {
-            repo: target.repoFullName,
-            number: target.number,
-            headRepo: target.headRepo,
-            headRef: target.headRef,
-            headSha: target.headSha,
-            baseRef: target.baseRef || contentGateBaseRef(env),
-            installationId: target.installationId,
-            status: "validation_pending",
-            deliveryId: String(message.payload.deliveryId || ""),
-            nextReviewAt: nextReviewForStatus("validation_pending"),
-            lastCheckSummary: validation.summary,
-          });
-          const pendingComment = await upsertMarkerComment({
-            token,
-            repo,
-            issueNumber: target.number,
-            marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-            body: markerComment(
-              undefined,
-              env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
-            ),
-            apiVersion: env.GITHUB_API_VERSION,
-          });
-          await upsertPrState(env.SUBMISSION_GATE_DB, {
-            repo: target.repoFullName,
-            number: target.number,
-            headRepo: target.headRepo,
-            headRef: target.headRef,
-            headSha: target.headSha,
-            baseRef: target.baseRef || contentGateBaseRef(env),
-            installationId: target.installationId,
-            status: "validation_pending",
-            deliveryId: String(message.payload.deliveryId || ""),
-            nextReviewAt: nextReviewForStatus("validation_pending"),
-            lastCheckSummary: validation.summary,
-            commentId: pendingComment.id,
-            commentUrl: pendingComment.url,
-            formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
-          });
-          await insertAudit(env.SUBMISSION_GATE_DB, {
-            id: crypto.randomUUID(),
-            targetKey: message.targetKey,
-            eventType: message.kind,
-            decision: "validation_pending",
-            summary: validation.summary,
-          });
-          return;
+          const staleDecision = staleValidationPendingDecision(
+            existing,
+            validation,
+          );
+          if (staleDecision) {
+            decision = staleDecision;
+          } else {
+            await upsertPrState(env.SUBMISSION_GATE_DB, {
+              repo: target.repoFullName,
+              number: target.number,
+              headRepo: target.headRepo,
+              headRef: target.headRef,
+              headSha: target.headSha,
+              baseRef: target.baseRef || contentGateBaseRef(env),
+              installationId: target.installationId,
+              status: "validation_pending",
+              deliveryId: String(message.payload.deliveryId || ""),
+              nextReviewAt: nextReviewForStatus("validation_pending"),
+              lastCheckSummary: validation.summary,
+            });
+            const pendingComment = await upsertMarkerComment({
+              token,
+              repo,
+              issueNumber: target.number,
+              marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+              body: markerComment(
+                undefined,
+                env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+              ),
+              apiVersion: env.GITHUB_API_VERSION,
+            });
+            await upsertPrState(env.SUBMISSION_GATE_DB, {
+              repo: target.repoFullName,
+              number: target.number,
+              headRepo: target.headRepo,
+              headRef: target.headRef,
+              headSha: target.headSha,
+              baseRef: target.baseRef || contentGateBaseRef(env),
+              installationId: target.installationId,
+              status: "validation_pending",
+              deliveryId: String(message.payload.deliveryId || ""),
+              nextReviewAt: nextReviewForStatus("validation_pending"),
+              lastCheckSummary: validation.summary,
+              commentId: pendingComment.id,
+              commentUrl: pendingComment.url,
+              formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
+            });
+            await insertAudit(env.SUBMISSION_GATE_DB, {
+              id: crypto.randomUUID(),
+              targetKey: message.targetKey,
+              eventType: message.kind,
+              decision: "validation_pending",
+              summary: validation.summary,
+            });
+            return;
+          }
         }
         if (!decision && validation.state === "failed") {
           decision = validationGateDecision(validation);

--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -70,6 +70,7 @@ const TRUSTED_SOURCE_HOSTS = new Set([
   "github.com",
   "gitlab.com",
   "jsr.io",
+  "codeload.github.com",
   "marketplace.visualstudio.com",
   "npmjs.com",
   "pkg.go.dev",
@@ -397,9 +398,16 @@ function hasVerifiableCanonicalSource(urls: SourceEvidenceItem[]) {
 }
 
 function isDowngradableInconclusiveSource(item: SourceEvidenceItem) {
-  return (
+  if (
     item.status === "retryable" &&
     !PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field)
+  ) {
+    return true;
+  }
+  return (
+    item.status === "hard_failure" &&
+    item.role === "distribution" &&
+    item.outcome === "source_host_not_checked"
   );
 }
 

--- a/apps/submission-gate/src/storage.ts
+++ b/apps/submission-gate/src/storage.ts
@@ -476,10 +476,13 @@ export async function listDuePrStates(
        )
        OR (
          terminal_at IS NOT NULL
-         AND status = 'closed'
+         AND status IN ('merged', 'closed', 'manual', 'ignored')
          AND COALESCE(last_error, '') != 'GitHub terminal state verified.'
        )
-       ORDER BY COALESCE(next_review_at, updated_at) ASC, updated_at ASC
+       ORDER BY
+        CASE WHEN terminal_at IS NULL THEN 0 ELSE 1 END ASC,
+        COALESCE(next_review_at, updated_at) ASC,
+        updated_at ASC
        LIMIT ?`,
     )
     .bind(

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -343,7 +343,7 @@ describe("Cloudflare submission gate helpers", () => {
     });
   });
 
-  it("treats neutral Superagent scans as failed validation for manual review", async () => {
+  it("treats neutral Superagent scans as a non-blocking validation pass", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({
         check_runs: [
@@ -372,12 +372,12 @@ describe("Cloudflare submission gate helpers", () => {
         requiredChecks: ["validate-content", "Superagent Security Scan"],
       }),
     ).resolves.toMatchObject({
-      state: "failed",
+      state: "passed",
       checks: [
         { name: "validate-content", status: "passed" },
         {
           name: "Superagent Security Scan",
-          status: "failed",
+          status: "passed",
           details: "concluded neutral",
         },
       ],
@@ -414,6 +414,10 @@ describe("Cloudflare submission gate helpers", () => {
     expect(readConstantsSource()).toContain('"edited"');
     expect(source).toContain('status: "validation_pending"');
     expect(source).toContain('nextReviewForStatus("validation_pending")');
+    expect(source).toContain("VALIDATION_PENDING_STALE_SECONDS");
+    expect(source).toContain("VALIDATION_PENDING_STALE_ATTEMPTS");
+    expect(source).toContain("staleValidationPendingDecision(");
+    expect(source).toContain('"public_validation_not_started"');
     expect(source).toContain("REVIEWING_STALE_SECONDS");
     expect(source).toContain("QUEUED_STALE_SECONDS");
     expect(source).toContain("PRIVATE_REVIEW_TIMEOUT_MS = 45_000");
@@ -853,6 +857,74 @@ packageUrl: "https://hub.docker.com/r/example/project"
       role: "distribution",
       blocking: false,
       httpStatus: 429,
+    });
+    expect(sourceEvidenceCloseDecision(report)).toBeNull();
+  });
+
+  it("follows GitHub archive redirects to codeload for download evidence", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: GitHub Archive Fixture
+repoUrl: "https://github.com/example/project"
+downloadUrl: "https://github.com/example/project/archive/refs/heads/main.zip"
+---
+`,
+      vi.fn<typeof fetch>().mockImplementation(async (url) => {
+        const href = String(url);
+        if (href.includes("/archive/refs/heads/main.zip")) {
+          return new Response(null, {
+            status: 302,
+            headers: {
+              location:
+                "https://codeload.github.com/example/project/zip/refs/heads/main",
+            },
+          });
+        }
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.urls).toContainEqual(
+      expect.objectContaining({
+        field: "downloadUrl",
+        status: "passed",
+        role: "distribution",
+        finalUrl:
+          "https://codeload.github.com/example/project/zip/refs/heads/main",
+      }),
+    );
+    expect(sourceEvidenceCloseDecision(report)).toBeNull();
+  });
+
+  it("treats distribution-only untrusted redirects as warnings when canonical evidence passes", async () => {
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Distribution Redirect Warning Fixture
+repoUrl: "https://github.com/example/project"
+downloadUrl: "https://github.com/example/project/archive/refs/heads/main.zip"
+---
+`,
+      vi.fn<typeof fetch>().mockImplementation(async (url) => {
+        const href = String(url);
+        if (href.includes("/archive/refs/heads/main.zip")) {
+          return new Response(null, {
+            status: 302,
+            headers: { location: "https://download.example/project.zip" },
+          });
+        }
+        return new Response(null, { status: 200 });
+      }),
+    );
+
+    expect(report.status).toBe("passed");
+    expect(report.warnings).toHaveLength(1);
+    expect(report.warnings[0]).toMatchObject({
+      field: "downloadUrl",
+      status: "hard_failure",
+      role: "distribution",
+      outcome: "source_host_not_checked",
+      blocking: false,
     });
     expect(sourceEvidenceCloseDecision(report)).toBeNull();
   });
@@ -2095,7 +2167,12 @@ ${urls}
       "COALESCE(last_error, '') != 'GitHub terminal state verified.'",
     );
     expect(storageSource).toContain("terminal_at IS NOT NULL");
-    expect(storageSource).toContain("status = 'closed'");
+    expect(storageSource).toContain(
+      "status IN ('merged', 'closed', 'manual', 'ignored')",
+    );
+    expect(storageSource).toContain(
+      "CASE WHEN terminal_at IS NULL THEN 0 ELSE 1 END ASC",
+    );
     expect(storageSource).toContain("listTerminalPrStatesForReconciliation");
     expect(storageSource).toContain(
       "WHERE status IN ('merged', 'closed', 'manual', 'ignored')",


### PR DESCRIPTION
## Summary
- recover stalled submission-gate reviews without leaving PRs in endless validation retries

## What changed
- bounds missing required-check retries and emits a specific manual decision when public validation never starts
- treats neutral Superagent Marketplace results as non-blocking while preserving real failures
- trusts GitHub codeload archive redirects and downgrades distribution-only untrusted redirects when canonical source evidence passes
- lets scheduled terminal reconciliation clean stale labels without starving active queue retries

## Why
- direct content PRs were sitting in validation_pending for hours when GitHub Actions never created the required validate-content check
- GitHub archive download URLs were being routed to manual review after redirecting to GitHub codeload
- terminal label cleanup could occupy the scheduled sweep before active stuck PRs were retried

## Validation
- pnpm exec vitest run tests/submission-gate-worker.test.ts
- pnpm exec vitest run tests/submission-api.test.ts tests/api-contracts.test.ts tests/api-router-security.test.ts tests/submission-gate-worker.test.ts
- pnpm test:submission-pr-first
- pnpm validate:openapi
- pnpm type-check
- pnpm build
- git diff --check
- pnpm submission-gate:dry-run:prod
- pnpm submission-gate:deploy:prod

## Notes
- Deployed the submission gate Worker after validation.
- PR #2065 now exits the endless retry path with an explicit missing validate-content workflow decision.
- PR #2063 is still a draft, so it cannot auto-merge until the contributor marks it ready.