### PR TITLE
fix(content): clarify ORT hook install scope

### DIFF
--- a/content/hooks/ort-dependency-license-checker-hook.mdx
+++ b/content/hooks/ort-dependency-license-checker-hook.mdx
@@ -154,6 +154,7 @@ prerequisites:
   - "A repository-level license policy or review process for interpreting ORT analyzer output, evaluator rules, reports, and exceptions."
 safetyNotes:
   - "Runs after Write, Edit, and MultiEdit and inspects only the edited file path to decide whether a dependency manifest or lockfile changed."
+  - "Install this project-relative command only in the trusted project's `.claude/settings.json`; user/global hooks must point to a trusted absolute path outside project directories."
   - "Default mode is advisory, prints the ORT command to run, and always exits 0 without reading dependency contents, creating reports, or contacting registries."
   - "When `ORT_LICENSE_HOOK_RUN=1` is set, it runs `ort analyze` in the project root and writes reports under `.claude/ort-license-checks/` by default."
   - "An opted-in ORT run may invoke package managers, inspect dependency graphs, read project configuration, fetch package metadata, and take several minutes on large repositories."
@@ -218,10 +219,12 @@ The output is intentionally analyzer-focused. ORT's own documentation describes 
 1. Create the hooks directory: `mkdir -p .claude/hooks`
 2. Create the hook file: `touch .claude/hooks/ort-dependency-license-checker.sh`
 3. Paste the script body into that file and make it executable: `chmod +x .claude/hooks/ort-dependency-license-checker.sh`
-4. Add the configuration below to `.claude/settings.json` for a project hook or `~/.claude/settings.json` for a user hook.
+4. Add the configuration below only to this trusted project's `.claude/settings.json`. Do not put this `$CLAUDE_PROJECT_DIR/.claude/hooks/...` command in `~/.claude/settings.json`; a global hook must point to a trusted user-owned absolute path outside project directories.
 5. Install and configure ORT only if you want the hook to run analysis locally.
 
 ## Hook configuration
+
+Use this project-local configuration only in the trusted repository that contains the script.
 
 ```json
 {


### PR DESCRIPTION
### Motivation

- The hook documentation allowed installing a project-relative command into a user/global Claude settings file, which lets any opened repository supply an executable at `$CLAUDE_PROJECT_DIR/.claude/hooks/...` and results in arbitrary code execution when hooks run.
- The change aims to close that policy gap by making the intended safe installation pattern explicit and preventing unsafe global usage of a project-relative hook path.

### Description

- Updated `content/hooks/ort-dependency-license-checker-hook.mdx` to add an explicit `safetyNotes` warning that the project-relative command must only be installed in the trusted project's ` .claude/settings.json` and that user/global hooks must point to a trusted absolute path outside project directories. 
- Modified the `Installation` section to instruct maintainers to add the sample configuration only to the trusted project's `.claude/settings.json` and to avoid placing the `$CLAUDE_PROJECT_DIR/.claude/hooks/...` command in `~/.claude/settings.json`.
- Added a short note before the sample `Hook configuration` making clear the sample is project-local only.
- Changes are limited to documentation content in `content/hooks/ort-dependency-license-checker-hook.mdx` and preserve the hook script and behavior unchanged.

### Testing

- Ran `pnpm validate:content:strict` and validation passed. 
- Ran `git diff --check` and no whitespace or formatting issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2717230be8832a955c712fd3c6a6a3)