### PR TITLE
fix(content): harden secret scanner hook path

### DIFF
--- a/content/hooks/pre-write-secret-scanner.mdx
+++ b/content/hooks/pre-write-secret-scanner.mdx
@@ -24,9 +24,9 @@ documentationUrl: "https://docs.anthropic.com/en/docs/claude-code/hooks"
 repoUrl: "https://github.com/gitleaks/gitleaks"
 installable: true
 installCommand: >-
-  mkdir -p .claude/hooks && touch
-  .claude/hooks/pre-write-secret-scanner.sh && chmod +x
-  .claude/hooks/pre-write-secret-scanner.sh
+  mkdir -p "$HOME/.claude/hooks" && touch
+  "$HOME/.claude/hooks/pre-write-secret-scanner.sh" && chmod +x
+  "$HOME/.claude/hooks/pre-write-secret-scanner.sh"
 usageSnippet: "🔒 Secret blocked: possible GitHub personal access token in src/config.ts."
 copySnippet: |-
   {
@@ -37,7 +37,7 @@ copySnippet: |-
           "hooks": [
             {
               "type": "command",
-              "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+              "command": "$HOME/.claude/hooks/pre-write-secret-scanner.sh"
             }
           ]
         }
@@ -53,7 +53,7 @@ configSnippet: |-
           "hooks": [
             {
               "type": "command",
-              "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+              "command": "$HOME/.claude/hooks/pre-write-secret-scanner.sh"
             }
           ]
         }
@@ -127,6 +127,7 @@ safetyNotes:
   - Blocks the write with exit code 2 when a high-confidence secret pattern matches; no files are created, deleted, or modified by the hook itself.
   - Uses regex heuristics, so it can produce false positives (block a non-secret) or false negatives (miss an obfuscated secret); treat it as a guardrail, not proof of safety.
   - Makes no network calls and runs entirely locally.
+  - Safe for user-level settings only when the command points to a trusted script you installed under your home directory; do not configure global hooks to execute scripts from `$CLAUDE_PROJECT_DIR`.
 privacyNotes:
   - Reads the text about to be written but never prints the matched secret value; only the detected secret type and the target file path are written to stderr.
   - Writes nothing to disk and retains no logs.
@@ -174,10 +175,10 @@ Claude Code passes the pending tool call to the hook as JSON on stdin. The hook 
 
 ## Installation
 
-1. Create the hooks directory: `mkdir -p .claude/hooks`
-2. Create the hook file: `touch .claude/hooks/pre-write-secret-scanner.sh`
-3. Paste the script body into that file and make it executable: `chmod +x .claude/hooks/pre-write-secret-scanner.sh`
-4. Add the configuration below to `.claude/settings.json` (project) or `~/.claude/settings.json` (user).
+1. Create a trusted user hooks directory: `mkdir -p "$HOME/.claude/hooks"`
+2. Create the hook file: `touch "$HOME/.claude/hooks/pre-write-secret-scanner.sh"`
+3. Paste the script body into that file and make it executable: `chmod +x "$HOME/.claude/hooks/pre-write-secret-scanner.sh"`
+4. Add the configuration below to `~/.claude/settings.json` (user) or `.claude/settings.json` (project). Keep user-level hooks pointed at this trusted `$HOME` script; do not use `$CLAUDE_PROJECT_DIR` in global settings because untrusted projects can control that path.
 
 ## Requirements
 
@@ -186,6 +187,8 @@ Claude Code passes the pending tool call to the hook as JSON on stdin. The hook 
 - jq (for parsing the tool input)
 
 ## Hook configuration
+
+This configuration references the trusted script installed under your home directory, so it is safe to use from user-level settings across projects. If you instead keep a project-local copy under `.claude/hooks`, only reference that project-local path from that same project's `.claude/settings.json`, never from `~/.claude/settings.json`.
 
 ```json
 {
@@ -196,7 +199,7 @@ Claude Code passes the pending tool call to the hook as JSON on stdin. The hook 
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/pre-write-secret-scanner.sh"
+            "command": "$HOME/.claude/hooks/pre-write-secret-scanner.sh"
           }
         ]
       }


### PR DESCRIPTION
### Motivation

- Close a documented security issue where the copyable hook configuration allowed user-level settings to execute a project-controlled script at `$CLAUDE_PROJECT_DIR`, enabling arbitrary code execution via attacker-supplied repositories.

### Description

- Change the install command and copy/config snippets to reference a trusted user-owned path under `"$HOME/.claude/hooks/pre-write-secret-scanner.sh"` instead of `$CLAUDE_PROJECT_DIR/.claude/hooks/...`.
- Update the `copySnippet` and `configSnippet` JSON examples to use `"$HOME/.claude/hooks/pre-write-secret-scanner.sh"` so user-level/global settings point to a trusted script.
- Add an explicit safety note and installation guidance advising to install the trusted script under `$HOME` and to never reference `$CLAUDE_PROJECT_DIR` from user/global settings. 
- Clarify that project-local hook paths are OK only when kept and referenced in that same project's `.claude/settings.json`.

### Testing

- Verified no remaining copyable snippets point at `$CLAUDE_PROJECT_DIR` using `rg` searches against the modified file. 
- Ran `git diff --check` to ensure no whitespace or formatting errors were introduced. 
- Ran content validation with `pnpm validate:content:strict` (and `node scripts/validate-content.mjs --strict-recommended`) and the content validation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2717268c84832a8ceb08ff9e2e638e)