### PR TITLE
fix(web): escape JSON-LD head scripts

### DIFF
--- a/apps/web/src/lib/json-ld.ts
+++ b/apps/web/src/lib/json-ld.ts
@@ -1,0 +1,15 @@
+const SCRIPT_JSON_ESCAPE_PATTERN = /[<>&\u2028\u2029]/g;
+const SCRIPT_JSON_ESCAPES: Record<string, string> = {
+  "<": "\\u003c",
+  ">": "\\u003e",
+  "&": "\\u0026",
+  "\u2028": "\\u2028",
+  "\u2029": "\\u2029",
+};
+
+export function stringifyJsonLd(value: unknown) {
+  return JSON.stringify(value).replace(
+    SCRIPT_JSON_ESCAPE_PATTERN,
+    (character) => SCRIPT_JSON_ESCAPES[character] ?? character,
+  );
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -4,6 +4,7 @@ import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entrie
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 export const Route = createFileRoute("/best/$slug")({
   loader: ({ params }) => {
@@ -37,7 +38,7 @@ export const Route = createFileRoute("/best/$slug")({
         { property: "og:type", content: "article" },
       ],
       links: [{ rel: "canonical", href: url }],
-      scripts: [{ type: "application/ld+json", children: JSON.stringify(ld) }],
+      scripts: [{ type: "application/ld+json", children: stringifyJsonLd(ld) }],
     };
   },
   notFoundComponent: () => (

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -4,6 +4,7 @@ import { Rss, Plus, RefreshCw, Minus, Shield, FileText, Package } from "lucide-r
 import { CHANGELOG, RELEASE_NOTES, type ReleaseStream } from "@/data/changelog";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { cn } from "@/lib/utils";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 export const Route = createFileRoute("/changelog")({
   head: () => ({
@@ -40,7 +41,7 @@ export const Route = createFileRoute("/changelog")({
     scripts: [
       {
         type: "application/ld+json",
-        children: JSON.stringify({
+        children: stringifyJsonLd({
           "@context": "https://schema.org",
           "@type": "ItemList",
           name: "HeyClaude registry changelog",

--- a/apps/web/src/routes/ecosystem.tsx
+++ b/apps/web/src/routes/ecosystem.tsx
@@ -17,6 +17,7 @@ import { HARNESSES } from "@/types/registry";
 import { CopyButton } from "@/components/copy-button";
 import { CountUp } from "@/components/count-up";
 import { cn } from "@/lib/utils";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 const CLIENTS = [
   { id: "claude-code", label: "Claude Code" },
@@ -213,7 +214,7 @@ export const Route = createFileRoute("/ecosystem")({
         { property: "og:url", content: "/ecosystem" },
       ],
       links: [{ rel: "canonical", href: "/ecosystem" }],
-      scripts: [{ type: "application/ld+json", children: JSON.stringify(ld) }],
+      scripts: [{ type: "application/ld+json", children: stringifyJsonLd(ld) }],
     };
   },
   component: EcosystemPage,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -32,6 +32,7 @@ import { TrustDrilldown } from "@/components/trust-drilldown";
 import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
+import { stringifyJsonLd } from "@/lib/json-ld";
 // (HoverChevrons removed — related uses static grid)
 import { ShareMenu } from "@/components/share-menu";
 import { DossierTOC, type TocItem } from "@/components/dossier-toc";
@@ -131,8 +132,8 @@ export const Route = createFileRoute("/entry/$category/$slug")({
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [
-        { type: "application/ld+json", children: JSON.stringify(ld) },
-        { type: "application/ld+json", children: JSON.stringify(breadcrumbs) },
+        { type: "application/ld+json", children: stringifyJsonLd(ld) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
       ],
     };
   },

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -30,6 +30,7 @@ import { useRecents } from "@/lib/recents";
 import { CATEGORIES, type Category } from "@/types/registry";
 import { ENTRIES, BRIEF_ISSUES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { search } from "@/data/search";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 // Pre-computed counts at module scope so SSR + first paint show real numbers.
 const TRUSTED_COUNT = ENTRIES.filter((e) => e.trust === "trusted").length;
@@ -88,7 +89,7 @@ export const Route = createFileRoute("/")({
     scripts: [
       {
         type: "application/ld+json",
-        children: JSON.stringify({
+        children: stringifyJsonLd({
           "@context": "https://schema.org",
           "@type": "WebSite",
           name: "HeyClaude",

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/data/validators";
 import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
+import { stringifyJsonLd } from "@/lib/json-ld";
 
 export const Route = createFileRoute("/validators")({
   head: () => ({
@@ -33,7 +34,7 @@ export const Route = createFileRoute("/validators")({
     scripts: [
       {
         type: "application/ld+json",
-        children: JSON.stringify({
+        children: stringifyJsonLd({
           "@context": "https://schema.org",
           "@type": "Dataset",
           name: "HeyClaude maintainer review coverage",

--- a/tests/json-ld-script-safety.test.ts
+++ b/tests/json-ld-script-safety.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { stringifyJsonLd } from "@/lib/json-ld";
+
+describe("stringifyJsonLd", () => {
+  it("escapes script-breakout characters while preserving JSON-LD values", () => {
+    const payload = {
+      "@context": "https://schema.org",
+      name: "</script><script>globalThis.__xss = true</script>",
+      description: "Tom & Jerry > Road Runner\u2028next line\u2029final line",
+    };
+
+    const serialized = stringifyJsonLd(payload);
+
+    expect(serialized).not.toContain("<");
+    expect(serialized).not.toContain(">");
+    expect(serialized).not.toContain("&");
+    expect(serialized).not.toContain("</script>");
+    expect(serialized).toContain("\\u003c/script\\u003e");
+    expect(serialized).toContain("\\u0026");
+    expect(serialized).toContain("\\u2028");
+    expect(serialized).toContain("\\u2029");
+    expect(JSON.parse(serialized)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
### Motivation
- Route head scripts used `JSON.stringify` to emit `application/ld+json` with registry-controlled fields, which allowed literal `</script>` sequences to break out of the JSON-LD context and enable stored XSS. 
- The change restores safe JSON-LD serialization to prevent contributor-controlled titles/descriptions from injecting executable script elements.

### Description
- Add `apps/web/src/lib/json-ld.ts` exporting `stringifyJsonLd`, a JSON-LD serializer that escapes `<`, `>`, `&`, `\u2028`, and `\u2029` to their `\u` escapes before embedding in inline scripts. 
- Replace direct `JSON.stringify(...)` usages for `application/ld+json` script children with `stringifyJsonLd(...)` in the main route files including the entry page and other pages that emit JSON-LD. 
- Add `tests/json-ld-script-safety.test.ts` to verify that script-breakout characters are escaped and that `JSON.parse` round-trips the serialized payload. 
- Commit message: `fix(web): escape JSON-LD head scripts` to follow Conventional Commit style.

### Testing
- Ran the new unit test via `pnpm exec vitest run tests/json-ld-script-safety.test.ts`, which passed. 
- Ran type checking via the repository `pnpm type-check` (which runs `tsc --noEmit` and site generation steps) and it completed successfully. 
- Ran repository checks `git diff --check` and `git diff --cached --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27169cfe14832aae33cb696fe9adac)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON-LD serialization to safely escape HTML and script-breaking characters in structured data across pages.

* **Tests**
  * Added test suite validating JSON-LD serialization safety and proper character escaping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->