### PR TITLE
fix(statuslines): sanitize kubectl statusline output

### DIFF
--- a/content/statuslines/kubectl-deployment-context-statusline.mdx
+++ b/content/statuslines/kubectl-deployment-context-statusline.mdx
@@ -42,19 +42,23 @@ scriptBody: |-
   #!/usr/bin/env bash
   set -u
 
+  sanitize_status_value() {
+    printf '%s' "$1" | LC_ALL=C tr -cd '\040-\176'
+  }
+
   main() {
   if ! command -v kubectl >/dev/null 2>&1; then
     echo "deploy: kubectl missing"
     exit 0
   fi
 
-  context=$(kubectl config current-context 2>/dev/null || true)
+  context=$(sanitize_status_value "$(kubectl config current-context 2>/dev/null || true)")
   if [ -z "$context" ]; then
     echo "deploy: no context"
     exit 0
   fi
 
-  namespace=$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null || true)
+  namespace=$(sanitize_status_value "$(kubectl config view --minify --output 'jsonpath={..namespace}' 2>/dev/null || true)")
   if [ -z "$namespace" ]; then
     namespace="default"
   fi
@@ -81,6 +85,7 @@ prerequisites:
   - Team naming conventions that distinguish production, staging, and development contexts.
 safetyNotes:
   - The script is read-only and does not contact workloads, apply manifests, or change namespaces.
+  - The displayed context and namespace are limited to printable ASCII before terminal output.
   - Risk labels are based on names; confirm the actual cluster and namespace before deployment commands.
   - Avoid running write-capable automation solely because the statusline says an environment looks like development.
 privacyNotes:


### PR DESCRIPTION
### Motivation
- Prevent terminal escape injection caused by printing untrusted `kubectl` context and namespace values directly to the Claude Code statusline by stripping control/non-printable characters before display.

### Description
- Add a `sanitize_status_value()` shell helper that limits input to printable ASCII via `tr -cd '\040-\176'`.
- Apply `sanitize_status_value` to the outputs of `kubectl config current-context` and the `jsonpath` namespace extraction before classification and printing.
- Preserve the existing risk-label logic and final `printf` format so visible behavior remains consistent except for sanitized values.
- Update the entry `safetyNotes` to document that displayed context and namespace are limited to printable ASCII.

### Testing
- Ran `pnpm validate:content:strict` and the content validation passed.
- Executed the extracted statusline script against a fake `kubectl` that emits ANSI/OSC/C1 control bytes and verified the final output contains only printable ASCII bytes.
- Ran `git diff --check` to ensure no formatting or whitespace issues were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1db8fad0832a81580d2101c030bb)