### PR TITLE
fix(registry): sanitize weekly brief terminal controls

### DIFF
--- a/packages/registry/src/weekly-brief.js
+++ b/packages/registry/src/weekly-brief.js
@@ -82,8 +82,12 @@ function normalizeDays(value) {
   return Number.isFinite(numeric) ? Math.max(1, Math.min(31, numeric)) : 7;
 }
 
+const TERMINAL_CONTROL_PATTERN =
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/g;
+
 function markdownText(value) {
   return text(value)
+    .replace(TERMINAL_CONTROL_PATTERN, "")
     .replace(/\s+/g, " ")
     .replace(/[\\[\]()`<>]/g, "\\$&");
 }

--- a/tests/weekly-brief.test.ts
+++ b/tests/weekly-brief.test.ts
@@ -189,6 +189,43 @@ describe("weekly brief generation", () => {
     expect(brief.period.through).toBe("2026-05-29");
   });
 
+  it("strips terminal controls from rendered markdown fields", () => {
+    const brief = buildWeeklyBrief(
+      [
+        entry("control-chars", {
+          title: "Trusted\u001b7SPOOFED\u001b8\u0007 Title",
+          description:
+            "Description with backspace ABC\b\bZ and reset\u001bc end",
+          dateAdded: "2026-05-29",
+        }),
+      ],
+      {
+        generatedAt: "2026-05-30T00:00:00.000Z",
+        days: 7,
+        changelogEntries: [
+          {
+            category: "mcp\u009b31m",
+            slug: "control-chars",
+            title: "Changed\u001b[31m title",
+            type: "added\u0007",
+            dateAdded: "2026-05-29",
+          },
+        ],
+      },
+    );
+    const markdown = renderWeeklyBriefMarkdown(brief);
+
+    expect(markdown).not.toMatch(
+      /[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F-\u009F]/,
+    );
+    expect(markdown).toContain("Trusted7SPOOFED8 Title");
+    expect(markdown).toContain(
+      "Description with backspace ABCZ and resetc end",
+    );
+    expect(markdown).toContain("Changed\\[31m title");
+    expect(markdown).toContain("(mcp31m) - added on 2026-05-29");
+  });
+
   it("escapes markdown text and drops unsafe canonical URLs", () => {
     const brief = buildWeeklyBrief(
       [


### PR DESCRIPTION
### Motivation

- The weekly brief renderer previously escaped Markdown metacharacters but did not remove C0/C1 terminal control bytes, allowing attacker-controlled artifact fields to inject terminal controls into maintainer-facing CLI output.

### Description

- Strip non-printing terminal control characters using a `TERMINAL_CONTROL_PATTERN` regex and remove them in `markdownText()` before whitespace normalization and Markdown escaping in `packages/registry/src/weekly-brief.js`.
- Preserve existing behavior for Markdown escaping and URLs by performing control-stripping prior to the existing `.replace()` calls in `markdownText()`.
- Add a regression test `strips terminal controls from rendered markdown fields` to `tests/weekly-brief.test.ts` that injects ESC, BEL, backspace, and C1 controls and asserts the rendered Markdown contains no control bytes while still showing the sanitized visible text.

### Testing

- Ran `pnpm exec vitest run tests/weekly-brief.test.ts` and all tests passed (`8 passed`).
- Ran `git diff --check` to ensure no whitespace or diff issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1dbc38e0832a998a503b653d5f96)