### PR TITLE
fix(web): preserve detail trust signals

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -2,6 +2,7 @@ import type {
   Category,
   Entry,
   EntryRelation,
+  EntryTrustSignals,
   HookTrigger,
   InstallType,
   Platform,
@@ -73,13 +74,7 @@ export type RegistryEntry = Record<string, unknown> & {
     appliesTo?: "listing_source_repo" | "upstream_reference" | "directory_repo" | "none";
     label?: string;
   };
-  trustSignals?: {
-    firstPartyEditorial?: boolean;
-    sourceStatus?: string;
-    lastVerifiedAt?: string;
-    platforms?: string[];
-    supportLevels?: string[];
-  };
+  trustSignals?: EntryTrustSignals;
   relatedEntries?: Array<{
     key?: string;
     category?: string;
@@ -419,6 +414,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     websiteUrl: entry.websiteUrl,
     trust: inferTrust(entry, source),
     source,
+    trustSignals: entry.trustSignals,
     repoStats: normalizeRepoStats(entry),
     relatedEntries: normalizeRelatedEntries(entry.relatedEntries),
     dateAdded: entry.dateAdded ?? entry.contentUpdatedAt?.slice(0, 10) ?? "2026-01-01",

--- a/apps/web/src/lib/content.server.ts
+++ b/apps/web/src/lib/content.server.ts
@@ -27,6 +27,19 @@ const MAX_ENTRY_DETAIL_CACHE_SIZE = 512;
 let directoryIndexPromise: Promise<DirectoryEntry[]> | null = null;
 const entryDetailPromises = new Map<string, Promise<ContentEntry | null>>();
 
+type EntryDetailPayload = {
+  schemaVersion?: number;
+  entry?: ContentEntry;
+  trustSignals?: ContentEntry["trustSignals"];
+};
+
+export function normalizeEntryDetailPayload(payload: EntryDetailPayload): ContentEntry | null {
+  const entry = payload.entry ?? null;
+  if (!entry) return null;
+  if (!payload.trustSignals || entry.trustSignals) return entry;
+  return { ...entry, trustSignals: payload.trustSignals };
+}
+
 function localDataFilePaths(fileName: string) {
   return [
     path.join(process.cwd(), "public", "data", fileName),
@@ -130,12 +143,9 @@ async function loadEntryDetail(category: string, slug: string) {
   const key = `${category}:${slug}`;
   let promise = entryDetailPromises.get(key);
   if (!promise) {
-    promise = loadJsonDataFile<{
-      schemaVersion?: number;
-      entry?: ContentEntry;
-    }>(`entries/${category}/${slug}.json`)
+    promise = loadJsonDataFile<EntryDetailPayload>(`entries/${category}/${slug}.json`)
       .then((payload) => {
-        const entry = payload.entry ?? null;
+        const entry = normalizeEntryDetailPayload(payload);
         if (!entry) entryDetailPromises.delete(key);
         return entry;
       })

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -44,6 +44,24 @@ export type SkillType = "general" | "capability-pack";
 export type VerificationStatus = "draft" | "validated" | "production";
 export type PlatformSupport = "native-skill" | "adapter" | "manual-context" | "unsupported";
 
+export interface EntryTrustSignals {
+  firstPartyEditorial?: boolean;
+  packageVerified?: boolean;
+  packageTrust?: string | null;
+  packageChecksum?: string;
+  checksumPresent?: boolean;
+  sourceUrlCount?: number;
+  sourceUrls?: string[];
+  sourceStatus?: string;
+  lastVerifiedAt?: string;
+  adapterGenerated?: boolean;
+  platforms?: string[];
+  supportLevels?: string[];
+  hasProvenance?: boolean;
+  hasSafetyNotes?: boolean;
+  hasPrivacyNotes?: boolean;
+}
+
 export interface Provenance {
   submittedBy?: string;
   submittedByUrl?: string;
@@ -156,6 +174,7 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
   repoUrl?: string;
   trust: TrustLevel;
   source: SourceStatus;
+  trustSignals?: EntryTrustSignals;
   repoStats?: RepoStats;
   relatedEntries?: EntryRelation[];
   /** @deprecated Repo stars are source metadata, not listing popularity. */

--- a/tests/content-detail-loader.test.ts
+++ b/tests/content-detail-loader.test.ts
@@ -1,0 +1,63 @@
+import type { ContentEntry } from "@heyclaude/registry";
+import { describe, expect, it } from "vitest";
+import { normalizeEntryDetailPayload } from "../apps/web/src/lib/content.server";
+import {
+  buildEntry,
+  type RegistryEntry,
+} from "../apps/web/src/data/entry-normalize";
+
+const trustSignals = {
+  firstPartyEditorial: false,
+  packageVerified: false,
+  packageTrust: null,
+  packageChecksum: "",
+  checksumPresent: false,
+  sourceUrlCount: 1,
+  sourceUrls: ["https://github.com/example/source-backed-entry"],
+  sourceStatus: "available",
+  lastVerifiedAt: "2026-06-01T00:00:00.000Z",
+  adapterGenerated: false,
+  platforms: ["claude-code"],
+  supportLevels: [],
+};
+
+describe("entry detail loading", () => {
+  it("preserves trust signals from the detail artifact envelope", () => {
+    const entry = normalizeEntryDetailPayload({
+      schemaVersion: 2,
+      entry: {
+        category: "agents",
+        slug: "source-backed-entry",
+        title: "Source Backed Entry",
+        description: "Fixture entry with top-level trust signals.",
+        author: "Fixture",
+        dateAdded: "2026-06-01",
+        tags: [],
+        body: "",
+        sections: [],
+        headings: [],
+        codeBlocks: [],
+      } as ContentEntry,
+      trustSignals,
+    });
+
+    expect(entry?.trustSignals).toEqual(trustSignals);
+  });
+
+  it("keeps detail trust signals available after web entry normalization", () => {
+    const entry = buildEntry({
+      category: "agents",
+      slug: "source-backed-entry",
+      title: "Source Backed Entry",
+      description: "Fixture entry with source-only trust signals.",
+      author: "Fixture",
+      dateAdded: "2026-06-01",
+      tags: [],
+      trustSignals,
+    } satisfies RegistryEntry);
+
+    expect(entry.source).toBe("source-backed");
+    expect(entry.trustSignals?.sourceStatus).toBe("available");
+    expect(entry.trustSignals?.sourceUrlCount).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Entry detail artifacts expose `trustSignals` at the top-level alongside `entry`, but the web loader previously returned only `payload.entry`, dropping the sibling `trustSignals` and causing detail pages to show `Source missing` incorrectly.

### Description
- Add `EntryDetailPayload` and `normalizeEntryDetailPayload` in `apps/web/src/lib/content.server.ts` and use it in `loadEntryDetail` so top-level `trustSignals` are merged into the returned `ContentEntry` when needed.
- Add `EntryTrustSignals` type in `apps/web/src/types/registry.ts` and add `trustSignals` to the web `Entry` shape so UI consumers can access structured trust metadata.
- Preserve `trustSignals` through web normalization by carrying `trustSignals: entry.trustSignals` in `apps/web/src/data/entry-normalize.ts` so `buildEntry` consumers see the source status and counts.
- Add regression test `tests/content-detail-loader.test.ts` that verifies envelope `trustSignals` are preserved and survive web entry normalization.

### Testing
- Ran `pnpm exec vitest run tests/content-detail-loader.test.ts` and the new test passed.
- Ran `pnpm --filter web type-check` (which runs the generate step and `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1e1722c0832a924ec67bbedafcbc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Registry entries now include trust signal metadata tracking editorial verification status, package authenticity checks, source verification details, supported platforms, and provenance information.

* **Improvements**
  - Enhanced entry processing pipeline to preserve and propagate trust signal metadata consistently across loading and normalization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->