### PR TITLE
fix(registry): default source health freshness date

### DIFF
--- a/packages/registry/src/quality.js
+++ b/packages/registry/src/quality.js
@@ -322,7 +322,7 @@ function percentOf(count, total) {
   return total > 0 ? Math.round((count / total) * 100) : 0;
 }
 
-function deriveSourceFreshness(entry, referenceDate) {
+function deriveSourceFreshness(entry, referenceDate = new Date()) {
   const raw = clean(entry.repoUpdatedAt || entry.dateAdded);
   if (!raw) {
     return { freshness: "unknown", ageDays: null, lastActivityAt: "" };

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -1614,6 +1614,23 @@ describe("source health report", () => {
     expect(report.entries).toEqual([]);
   });
 
+  it("defaults direct entry freshness checks to the current date", () => {
+    const staleEntry = buildEntrySourceHealth(
+      healthEntry({
+        category: "tools",
+        slug: "old-tool",
+        dateAdded: "2000-01-01",
+        repoUpdatedAt: "2000-01-01",
+        repoUrl: "https://github.com/acme/old-tool",
+      }),
+    );
+
+    expect(staleEntry.freshness).toBe("dormant");
+    expect(staleEntry.ageDays).toEqual(expect.any(Number));
+    expect(staleEntry.needsAttention).toBe(true);
+    expect(staleEntry.attentionReasons).toContain("stale-source");
+  });
+
   it("returns unknown (not dormant) for unparsable entry or reference dates", () => {
     const base = healthEntry({
       category: "mcp",


### PR DESCRIPTION
### Motivation
- Fix a correctness bug where `buildEntrySourceHealth(entry)` callers that omit the optional `referenceDate` caused `deriveSourceFreshness` to evaluate `new Date(undefined)` and return `freshness: "unknown"` for otherwise valid entries.
- Ensure direct single-entry health checks classify stale/dormant sources and emit the `stale-source` attention reason the same way as the aggregate report path.

### Description
- Default the freshness reference date by changing `deriveSourceFreshness(entry, referenceDate)` to `deriveSourceFreshness(entry, referenceDate = new Date())` so omitted `referenceDate` uses the current date.
- Add a regression test in `tests/registry-artifacts.test.ts` that calls `buildEntrySourceHealth(entry)` without a `referenceDate` and asserts the entry is classified `dormant`, has an `ageDays` number, `needsAttention: true`, and includes `stale-source` in `attentionReasons`.
- Preserve existing unparsable-date handling so explicit invalid reference dates still produce `freshness: "unknown"` and `ageDays: null`.

### Testing
- Ran the focused source-health tests with `pnpm exec vitest run tests/registry-artifacts.test.ts --testNamePattern "source health report"` and the source-health assertions passed.
- Ran the single new test with `git diff --check && pnpm exec vitest run tests/registry-artifacts.test.ts --testNamePattern "defaults direct entry freshness checks"` and it passed.
- The broader `pnpm test:registry-artifacts` run showed two unrelated long-running aggregate artifact tests hit their per-test 60s timeout in this environment, but the source-health changes themselves did not fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1dbc45a8832a9b33728bbb63a741)