### PR TITLE
fix(content): repair material ui agent fences

### DIFF
--- a/content/agents/material-ui-repository-contributor-agent.mdx
+++ b/content/agents/material-ui-repository-contributor-agent.mdx
@@ -89,7 +89,7 @@ robotsFollow: true
 
 Create this file as `.claude/agents/material-ui-repository-contributor.md`:
 
-```markdown
+````markdown
 ---
 name: material-ui-repository-contributor
 description: Use when the user asks Claude to investigate, patch, test, or review work in the official mui/material-ui monorepo from source-backed repository instructions.
@@ -245,7 +245,7 @@ Safety/privacy notes:
 Remaining risk:
 - ...
 ```
-```
+````
 
 ## Source Review
 


### PR DESCRIPTION
### Motivation
- Fix a malformed nested triple-backtick fence in `content/agents/material-ui-repository-contributor-agent.mdx` that caused the agent output example to prematurely close the outer block and render subsequent prose sections as code in common Markdown parsers and the repo's regex extractor.

### Description
- Change the outer agent-definition fence from triple backticks to a matching four-backtick fence so the nested ```markdown``` example remains inside the intended block; the edit is confined to `content/agents/material-ui-repository-contributor-agent.mdx` and committed as `fix(content): repair material ui agent fences`.

### Testing
- Ran `node scripts/validate-content.mjs --category=agents`, `git diff --check`, and a Marked-based render smoke check using the web app's `marked` dependency, and all checks passed while confirming the affected headings render as normal `h2` elements and only the intended code block remains.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1d3ab3e0832aac05d229885ef785)