### PR TITLE
fix(content): use HexStrike virtualenv commands

### DIFF
--- a/content/mcp/hexstrike-ai-mcp-server.mdx
+++ b/content/mcp/hexstrike-ai-mcp-server.mdx
@@ -25,13 +25,13 @@ repoUrl: "https://github.com/0x4m4/hexstrike-ai"
 documentationUrl: "https://github.com/0x4m4/hexstrike-ai"
 websiteUrl: "https://www.hexstrike.com/"
 installable: true
-installCommand: "git clone https://github.com/0x4m4/hexstrike-ai.git && cd hexstrike-ai && python3 -m venv hexstrike-env && pip3 install -r requirements.txt"
-usageSnippet: "Start `python3 hexstrike_server.py`, then configure your MCP client to run `hexstrike_mcp.py` with the server argument documented in the repository."
+installCommand: "git clone https://github.com/0x4m4/hexstrike-ai.git && cd hexstrike-ai && python3 -m venv hexstrike-env && hexstrike-env/bin/pip install -r requirements.txt"
+usageSnippet: "Start `hexstrike-env/bin/python hexstrike_server.py`, then configure your MCP client to run `hexstrike_mcp.py` with the server argument documented in the repository."
 copySnippet: |-
   {
     "mcpServers": {
       "hexstrike-ai": {
-        "command": "python3",
+        "command": "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike-env/bin/python",
         "args": [
           "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike_mcp.py",
           "--server",
@@ -44,7 +44,7 @@ configSnippet: |-
   {
     "mcpServers": {
       "hexstrike-ai": {
-        "command": "python3",
+        "command": "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike-env/bin/python",
         "args": [
           "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike_mcp.py",
           "--server",
@@ -133,24 +133,25 @@ Clone the repository and install the Python dependencies:
 git clone https://github.com/0x4m4/hexstrike-ai.git
 cd hexstrike-ai
 python3 -m venv hexstrike-env
-pip3 install -r requirements.txt
+hexstrike-env/bin/pip install -r requirements.txt
 ```
 
 Install only the security tools needed for your authorized workflow, then start
 the server:
 
 ```sh
-python3 hexstrike_server.py
+hexstrike-env/bin/python hexstrike_server.py
 ```
 
-Configure your MCP client to run the repository's `hexstrike_mcp.py` bridge and
-provide the server argument documented in the README.
+Configure your MCP client to run the repository's `hexstrike_mcp.py` bridge with
+the virtual environment's Python interpreter and provide the server argument
+documented in the README.
 
 ```json
 {
   "mcpServers": {
     "hexstrike-ai": {
-      "command": "python3",
+      "command": "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike-env/bin/python",
       "args": [
         "/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike_mcp.py",
         "--server",


### PR DESCRIPTION
### Motivation
- The MDX entry created a Python virtual environment with `python3 -m venv hexstrike-env` but then used bare `pip3` and `python3`, which can install dependencies into the global environment and break the intended isolation.
- Correcting the copyable install and run commands preserves the documented isolation guidance and prevents misleading instructions.

### Description
- Updated `content/mcp/hexstrike-ai-mcp-server.mdx` frontmatter `installCommand` to use `hexstrike-env/bin/pip install -r requirements.txt` instead of a bare `pip3`.
- Updated `usageSnippet`, `copySnippet`, and `configSnippet` to run the server and MCP bridge with the virtual environment interpreter at `/ABSOLUTE_PATH_TO/hexstrike-ai/hexstrike-env/bin/python`.
- Updated the installation section and server start snippet to use `hexstrike-env/bin/pip` and `hexstrike-env/bin/python` so the created venv is actually used.
- Changes applied to `content/mcp/hexstrike-ai-mcp-server.mdx` and committed with the message `fix(content): use HexStrike virtualenv commands`.

### Testing
- Ran `pnpm validate:content:strict`, which reported `Validated 920 content files.` and exited successfully.
- Ran `git diff --check`, which reported no whitespace or formatting errors and exited successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1db99318832abf8ae0337cfbe1f9)