### PR TITLE
fix(mcp): reject cleartext remote install urls

### DIFF
--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -334,6 +334,26 @@ function getServerUrl(config: McpServerConfig) {
   return "";
 }
 
+function isLoopbackHostname(hostname: string) {
+  const host = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "::1") return true;
+  const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  return Boolean(ipv4 && Number(ipv4[1]) === 127);
+}
+
+function isSafeRemoteMcpUrl(value: string) {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol === "https:") return true;
+    return url.protocol === "http:" && isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
 function normalizeServerArgs(config: McpServerConfig, targetLabel: string) {
   if (config.args === undefined) return [];
   if (!Array.isArray(config.args)) {
@@ -399,6 +419,10 @@ export function mcpConfigSupportsTarget(
 ) {
   const type = normalizedConfigType(config);
   if (!MCP_INSTALL_TARGET_BY_ID[target]) return false;
+  if (type === "http" || type === "sse") {
+    const url = getServerUrl(config);
+    if (!url || !isSafeRemoteMcpUrl(url)) return false;
+  }
   if (target === "codex") {
     if (type === "sse") return false;
     if (type === "http" && hasStaticOrEnvHttpHeaders(config)) {

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -602,10 +602,7 @@ describe("Raycast feed helpers", () => {
       resolveFeedUrl(""),
       "https://heyclau.de/data/raycast-index.json",
     );
-    assert.equal(
-      localFeed,
-      "http://127.0.0.1:4173/data/raycast-index.json",
-    );
+    assert.equal(localFeed, "http://127.0.0.1:4173/data/raycast-index.json");
     assert.equal(
       resolveConfiguredFeedUrl(
         { feedUrlOverride: devFeed },
@@ -828,6 +825,33 @@ describe("Raycast feed helpers", () => {
         }),
       /not available/,
     );
+    const remoteHttpConfig = {
+      type: "http",
+      url: "http://mcp.example.com/mcp",
+    };
+    assert.equal(
+      mcpConfigSupportsTarget(remoteHttpConfig, "claude-code"),
+      false,
+    );
+    assert.deepEqual(mcpInstallTargetsForConfig(remoteHttpConfig), []);
+    assert.deepEqual(
+      mcpInstallTargetsForConfig({
+        type: "http",
+        url: "http://127.0.0.1:3000/mcp",
+      }),
+      ["claude-code", "codex", "cursor", "antigravity"],
+    );
+    assert.throws(
+      () =>
+        buildMcpInstallPlan("claude-code", sampleEntry, {
+          detailMarkdown: "# Remote HTTP",
+          configSnippet: JSON.stringify({
+            mcpServers: { remote: remoteHttpConfig },
+          }),
+        }),
+      /not available/,
+    );
+
     const sseConfig = { type: "sse", url: "https://example.com/sse" };
     assert.equal(mcpConfigSupportsTarget(sseConfig, "codex"), false);
     assert.deepEqual(mcpInstallTargetsForConfig(sseConfig), [

--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -29,12 +29,34 @@ function scalarRecordIsValid(value) {
 }
 
 function normalizeType(value) {
-  const normalized = String(value || "").trim().toLowerCase();
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
   if (normalized === "streamable-http") return "http";
   if (normalized === "http" || normalized === "sse" || normalized === "stdio") {
     return normalized;
   }
   return "";
+}
+
+function isLoopbackHostname(hostname) {
+  const host = String(hostname || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "::1") return true;
+  const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  return Boolean(ipv4 && Number(ipv4[1]) === 127);
+}
+
+function isSafeRemoteMcpUrl(value) {
+  try {
+    const url = new URL(String(value).trim());
+    if (url.protocol === "https:") return true;
+    return url.protocol === "http:" && isLoopbackHostname(url.hostname);
+  } catch {
+    return false;
+  }
 }
 
 function normalizeArgs(value) {
@@ -68,7 +90,8 @@ export function normalizeMcpServerConfig(value) {
   }
 
   const type = normalizeType(config.type);
-  const hasCommand = typeof config.command === "string" && config.command.trim();
+  const hasCommand =
+    typeof config.command === "string" && config.command.trim();
   const hasUrl = typeof config.url === "string" && config.url.trim();
 
   if (!type && hasCommand) config.type = "stdio";
@@ -78,8 +101,8 @@ export function normalizeMcpServerConfig(value) {
   const normalizedType = normalizeType(config.type);
   if (!SERVER_CONFIG_TYPES.has(normalizedType)) return null;
   if (normalizedType === "stdio" && !hasCommand) return null;
-  if ((normalizedType === "http" || normalizedType === "sse") && !hasUrl) {
-    return null;
+  if (normalizedType === "http" || normalizedType === "sse") {
+    if (!hasUrl || !isSafeRemoteMcpUrl(config.url)) return null;
   }
 
   const args = normalizeArgs(config.args);

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -14,12 +14,7 @@ describe("MCP install config helpers", () => {
   it("exports the install-config surface from the registry package root", () => {
     const targets: McpInstallTargetId[] = [...MCP_INSTALL_TARGET_IDS];
 
-    expect(targets).toEqual([
-      "claude-code",
-      "codex",
-      "cursor",
-      "antigravity",
-    ]);
+    expect(targets).toEqual(["claude-code", "codex", "cursor", "antigravity"]);
     expect(
       mcpInstallTargetsForConfig({
         command: "npx",
@@ -64,6 +59,38 @@ describe("MCP install config helpers", () => {
       type: "http",
       url: "https://example.com/mcp",
     });
+  });
+
+  it("keeps cleartext remote HTTP MCP URLs out of machine-install metadata", () => {
+    const targets: McpInstallTargetId[] = [...MCP_INSTALL_TARGET_IDS];
+
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "remote-http",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            remote: {
+              type: "http",
+              url: "http://mcp.example.com/mcp",
+            },
+          },
+        }),
+      }),
+    ).toBeNull();
+
+    expect(
+      mcpInstallTargetsForConfig({
+        type: "http",
+        url: "http://127.0.0.1:3000/mcp",
+      }),
+    ).toEqual(targets);
+    expect(
+      mcpInstallTargetsForConfig({
+        type: "sse",
+        url: "http://[::1]:3000/sse",
+      }),
+    ).toEqual(["claude-code", "cursor", "antigravity"]);
   });
 
   it("keeps legacy transport snippets out of machine-install metadata", () => {


### PR DESCRIPTION
### Motivation

- Prevent advertising and one-click installation of non-local cleartext HTTP MCP endpoints because they can expose sensitive auth-management traffic and credentials in transit.
- Preserve developer convenience for local loopback HTTP endpoints while enforcing HTTPS for remote MCP servers to reduce on-path tampering and disclosure risk.

### Description

- Add URL safety helpers `isLoopbackHostname` and `isSafeRemoteMcpUrl` and enforce them in `packages/registry/src/mcp-install-config.js` so `http`/`sse` configs are only accepted when `url` is HTTPS or localhost/loopback HTTP.
- Apply the same safety gate in `integrations/raycast/src/mcp-installer.ts` so Raycast install plans cannot pass non-local cleartext HTTP URLs through to CLI (`claude`, `codex`) or JSON-config targets (`cursor`, `antigravity`).
- Update tests to cover rejected remote HTTP MCP URLs and allowed loopback HTTP endpoints by modifying `tests/mcp-install-config.test.ts` and `integrations/raycast/test/feed.test.ts` accordingly.

### Testing

- Ran `pnpm exec vitest run tests/mcp-install-config.test.ts` and the updated tests passed.
- Ran the targeted registry artifact test (`pnpm exec vitest run tests/registry-artifacts.test.ts -t "publishes MCP harness targets only for validated config snippets"`) and it passed, while the full `tests/registry-artifacts.test.ts` run timed out in two long-running deterministic-artifact cases in this environment.
- Ran Raycast integration tests (`cd integrations/raycast && npm test -- --runInBand`) and they passed, and `cd integrations/raycast && npm run build` succeeded, but `cd integrations/raycast && npm run lint` failed due to external DNS lookups to `www.raycast.com` (`EAI_AGAIN`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b19161e04832ab94bd6999b1a8097)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for MCP server configuration URLs.
  * Remote HTTP connections are no longer supported; only HTTPS is permitted for remote servers.
  * Localhost HTTP connections remain supported for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->