### PR TITLE
fix(content): sanitize windbg install command

### DIFF
--- a/content/mcp/windbg-mcp-server.mdx
+++ b/content/mcp/windbg-mcp-server.mdx
@@ -25,7 +25,7 @@ repoUrl: "https://github.com/svnscha/mcp-windbg"
 documentationUrl: "https://raw.githubusercontent.com/svnscha/mcp-windbg/main/README.md"
 packageUrl: "https://pypi.org/pypi/mcp-windbg/json"
 installable: true
-installCommand: "Install with `pip install mcp-windbg` or run the PyPI package with uvx, then configure an MCP client to launch `mcp-windbg` over stdio."
+installCommand: "pip install mcp-windbg"
 usageSnippet: "Install Windows Debugging Tools, configure `mcp-windbg`, then ask Claude to list dumps, open a dump, or run reviewed WinDbg commands."
 copySnippet: |-
   {


### PR DESCRIPTION
### Motivation
- Prevent accidental command execution when a user copies the Install tab payload by removing Markdown backticks from the copyable `installCommand` so POSIX shells cannot perform command substitution.

### Description
- Replace the prose `installCommand` value with the literal `pip install mcp-windbg` in `content/mcp/windbg-mcp-server.mdx` and keep the explanatory guidance inside `usageSnippet`.

### Testing
- Ran `pnpm validate:content:strict` and it passed. 
- Ran `git diff --check` and there were no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b186de318832ab19a65dc1fce060d)