### PR TITLE
fix(hooks): harden checksum guard comment parsing

### DIFF
--- a/content/hooks/package-download-checksum-guard-hook.mdx
+++ b/content/hooks/package-download-checksum-guard-hook.mdx
@@ -57,9 +57,82 @@ installCommand: |-
     fi
   fi
 
-  # Remove unquoted shell comments before matching policy tokens. This keeps a
-  # comment such as `# sha256sum -c` from being treated as verification.
-  command_without_comments=$(printf '%s\n' "$command_text" | sed -E 's/(^|[[:space:]])#.*$/\1/')
+  strip_shell_comments() {
+    local text=$1
+    local out=""
+    local char=""
+    local in_single=0
+    local in_double=0
+    local escaped=0
+    local at_word_start=1
+    local i=0
+
+    while [ "$i" -lt "${#text}" ]; do
+      char=${text:i:1}
+
+      if [ "$escaped" -eq 1 ]; then
+        out+="$char"
+        at_word_start=0
+        escaped=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "\\" ] && [ "$in_single" -eq 0 ]; then
+        out+="$char"
+        at_word_start=0
+        escaped=1
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "'" ] && [ "$in_double" -eq 0 ]; then
+        if [ "$in_single" -eq 1 ]; then
+          in_single=0
+        else
+          in_single=1
+        fi
+        out+="$char"
+        at_word_start=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = '"' ] && [ "$in_single" -eq 0 ]; then
+        if [ "$in_double" -eq 1 ]; then
+          in_double=0
+        else
+          in_double=1
+        fi
+        out+="$char"
+        at_word_start=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "#" ] && [ "$in_single" -eq 0 ] && [ "$in_double" -eq 0 ] && [ "$at_word_start" -eq 1 ]; then
+        break
+      fi
+
+      out+="$char"
+
+      if [ "$in_single" -eq 0 ] && [ "$in_double" -eq 0 ]; then
+        case "$char" in
+          [[:space:]]|";"|"&"|"|"|"("|")") at_word_start=1 ;;
+          *) at_word_start=0 ;;
+        esac
+      fi
+
+      i=$((i + 1))
+    done
+
+    printf '%s\n' "$out"
+  }
+
+  # Remove only real shell comments before matching policy tokens. This keeps a
+  # comment such as `# sha256sum -c` from being treated as verification without
+  # truncating quoted or escaped # characters that are part of the command.
+  command_without_comments=$(strip_shell_comments "$command_text")
 
   downloader_a='curl'
   downloader_b='wget'
@@ -190,9 +263,82 @@ scriptBody: |-
     fi
   fi
 
-  # Remove unquoted shell comments before matching policy tokens. This keeps a
-  # comment such as `# sha256sum -c` from being treated as verification.
-  command_without_comments=$(printf '%s\n' "$command_text" | sed -E 's/(^|[[:space:]])#.*$/\1/')
+  strip_shell_comments() {
+    local text=$1
+    local out=""
+    local char=""
+    local in_single=0
+    local in_double=0
+    local escaped=0
+    local at_word_start=1
+    local i=0
+
+    while [ "$i" -lt "${#text}" ]; do
+      char=${text:i:1}
+
+      if [ "$escaped" -eq 1 ]; then
+        out+="$char"
+        at_word_start=0
+        escaped=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "\\" ] && [ "$in_single" -eq 0 ]; then
+        out+="$char"
+        at_word_start=0
+        escaped=1
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "'" ] && [ "$in_double" -eq 0 ]; then
+        if [ "$in_single" -eq 1 ]; then
+          in_single=0
+        else
+          in_single=1
+        fi
+        out+="$char"
+        at_word_start=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = '"' ] && [ "$in_single" -eq 0 ]; then
+        if [ "$in_double" -eq 1 ]; then
+          in_double=0
+        else
+          in_double=1
+        fi
+        out+="$char"
+        at_word_start=0
+        i=$((i + 1))
+        continue
+      fi
+
+      if [ "$char" = "#" ] && [ "$in_single" -eq 0 ] && [ "$in_double" -eq 0 ] && [ "$at_word_start" -eq 1 ]; then
+        break
+      fi
+
+      out+="$char"
+
+      if [ "$in_single" -eq 0 ] && [ "$in_double" -eq 0 ]; then
+        case "$char" in
+          [[:space:]]|";"|"&"|"|"|"("|")") at_word_start=1 ;;
+          *) at_word_start=0 ;;
+        esac
+      fi
+
+      i=$((i + 1))
+    done
+
+    printf '%s\n' "$out"
+  }
+
+  # Remove only real shell comments before matching policy tokens. This keeps a
+  # comment such as `# sha256sum -c` from being treated as verification without
+  # truncating quoted or escaped # characters that are part of the command.
+  command_without_comments=$(strip_shell_comments "$command_text")
 
   downloader_a='curl'
   downloader_b='wget'


### PR DESCRIPTION
### Motivation
- The hook used `sed -E 's/(^|[[:space:]])#.*$/\1/'` to strip comments which was not shell-quote-aware and allowed a quoted or escaped `#` earlier on the same command line to truncate the command and bypass downstream downloader/archive/install checks.

### Description
- Replace the non-quote-aware `sed` truncation with a `strip_shell_comments()` Bash function that tracks single quotes, double quotes, backslash escapes, and shell word boundaries and returns a safe `command_without_comments`.
- Apply the same `strip_shell_comments()` implementation to both the `installCommand` and the published `scriptBody` in `content/hooks/package-download-checksum-guard-hook.mdx` so installed and copy/paste consumers have identical, hardened behavior.
- Preserve the existing downloader/archive/pipe-installer and verification regex checks and only change how comment detection/truncation is performed so that quoted/escaped `#` characters no longer create a bypass.

### Testing
- Extracted the `scriptBody`, ran `bash -n` for a syntax check, and executed focused PoC cases that covered baseline unsafe archive, quoted/single-quoted/escaped `#` before archive, installer-pipe pipeline, commented verifier, verified archive acceptance, and non-archive acceptance, all of which produced the expected exit codes.
- Ran `pnpm validate:content:strict` which passed, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b191933c8832aafc8e27ae18798c7)