### PR TITLE
fix(content): harden checksum guard verification matching

### DIFF
--- a/content/hooks/package-download-checksum-guard-hook.mdx
+++ b/content/hooks/package-download-checksum-guard-hook.mdx
@@ -77,6 +77,41 @@ installCommand: |-
   signature_re='(cosign[[:space:]]+verify-blob|gpg[[:space:]][^;&|#]*--verify|minisign[[:space:]][^;&|#]*-V)'
   verification_command_re="(${verify_re})[[:space:]]*(${checksum_re}|${signature_re})([[:space:]]|$)"
 
+  escape_ere() {
+    printf '%s' "$1" | sed -E 's/[][(){}.^$*+?|\]/\\&/g'
+  }
+
+  has_verification_for_download() {
+    urls=$(printf '%s\n' "$command_without_comments" | grep -Eo -- "$archive_re" || true)
+    [ -n "$urls" ] || return 1
+
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+      clean_url=$(printf '%s\n' "$url" | sed -E 's/[?#].*$//')
+      artifact=${clean_url##*/}
+      [ -n "$artifact" ] || continue
+      artifact_re=$(escape_ere "$artifact")
+      after_url=$(printf '%s\n' "$command_without_comments" | awk -v u="$url" '
+        found { print }
+        !found {
+          index_at = index($0, u)
+          if (index_at > 0) {
+            print substr($0, index_at + length(u))
+            found = 1
+          }
+        }
+      ')
+      artifact_verification_re="(${artifact_re}[^;&#]*${verification_command_re}|${verification_command_re}[^;&#]*${artifact_re})"
+      if printf '%s\n' "$after_url" | grep -Eq -- "$artifact_verification_re"; then
+        return 0
+      fi
+    done <<EOF
+  $urls
+  EOF
+
+    return 1
+  }
+
   if ! printf '%s\n' "$command_without_comments" | grep -Eq -- "$downloader_re"; then
     exit 0
   fi
@@ -106,7 +141,7 @@ installCommand: |-
     exit 2
   fi
 
-  if printf '%s\n' "$command_without_comments" | grep -Eq -- "$verification_command_re"; then
+  if has_verification_for_download; then
     exit 0
   fi
 
@@ -210,6 +245,41 @@ scriptBody: |-
   signature_re='(cosign[[:space:]]+verify-blob|gpg[[:space:]][^;&|#]*--verify|minisign[[:space:]][^;&|#]*-V)'
   verification_command_re="(${verify_re})[[:space:]]*(${checksum_re}|${signature_re})([[:space:]]|$)"
 
+  escape_ere() {
+    printf '%s' "$1" | sed -E 's/[][(){}.^$*+?|\]/\\&/g'
+  }
+
+  has_verification_for_download() {
+    urls=$(printf '%s\n' "$command_without_comments" | grep -Eo -- "$archive_re" || true)
+    [ -n "$urls" ] || return 1
+
+    while IFS= read -r url; do
+      [ -n "$url" ] || continue
+      clean_url=$(printf '%s\n' "$url" | sed -E 's/[?#].*$//')
+      artifact=${clean_url##*/}
+      [ -n "$artifact" ] || continue
+      artifact_re=$(escape_ere "$artifact")
+      after_url=$(printf '%s\n' "$command_without_comments" | awk -v u="$url" '
+        found { print }
+        !found {
+          index_at = index($0, u)
+          if (index_at > 0) {
+            print substr($0, index_at + length(u))
+            found = 1
+          }
+        }
+      ')
+      artifact_verification_re="(${artifact_re}[^;&#]*${verification_command_re}|${verification_command_re}[^;&#]*${artifact_re})"
+      if printf '%s\n' "$after_url" | grep -Eq -- "$artifact_verification_re"; then
+        return 0
+      fi
+    done <<EOF
+  $urls
+  EOF
+
+    return 1
+  }
+
   if ! printf '%s\n' "$command_without_comments" | grep -Eq -- "$downloader_re"; then
     exit 0
   fi
@@ -239,7 +309,7 @@ scriptBody: |-
     exit 2
   fi
 
-  if printf '%s\n' "$command_without_comments" | grep -Eq -- "$verification_command_re"; then
+  if has_verification_for_download; then
     exit 0
   fi
 
@@ -261,7 +331,7 @@ prerequisites:
   - "A team policy for when package, installer, or archive downloads require checksums, signatures, pinned releases, or manual source review."
 safetyNotes:
   - "Runs before Bash tool calls and reads only the proposed command string from Claude Code hook input."
-  - "Blocks matching curl/wget package or archive downloads with exit code 2 unless the command includes an executable verification step such as `sha256sum -c`, `shasum -a 256 -c`, `cosign verify-blob`, `gpg --verify`, or `minisign -V`; downloader-to-shell installer pipelines are blocked unless allowlisted."
+  - "Blocks matching curl/wget package or archive downloads with exit code 2 unless a later executable verification step references the downloaded artifact name. Downloader-to-shell installer pipelines are blocked unless allowlisted."
   - "Does not download, execute, hash, delete, install, or modify files; it is a pre-execution guard around the proposed command text."
   - "Regex matching can miss unusual shell constructs or flag legitimate internal download workflows; comments and digest-print-only commands are not accepted as verification, and `PACKAGE_DOWNLOAD_GUARD_ALLOWLIST` is available for reviewed patterns."
   - "Set `PACKAGE_DOWNLOAD_GUARD_MODE=advisory` to warn without blocking while a team tunes the policy."
@@ -327,13 +397,14 @@ as `sha256sum -c`, `shasum -a 256 -c`, `cosign verify-blob`,
 Claude Code passes the pending Bash tool call to the hook on stdin. The script
 extracts `.tool_input.command`, checks for `curl` or `wget`, and then looks for
 package/archive URL shapes or installer pipes. If a risky download is found, it
-requires an executable checksum-check or signature-verification command in the
-same proposed command. Without that command, it exits `2`, which tells Claude
-Code to block the Bash call.
+requires a later executable checksum-check or signature-verification command in
+the same proposed command that references the downloaded artifact name. Without
+that command, it exits `2`, which tells Claude Code to block the Bash call.
 
 The guard is intentionally text-based. It strips shell comments before looking
 for verification commands and blocks downloader-to-shell installer pipelines so
-comment-only or digest-print-only snippets do not count as verification. It does
+comment-only, unrelated, out-of-order, or digest-print-only snippets do not
+count as verification. It does
 not claim to verify the checksum itself; its job is to stop the session long
 enough for a human or agent to add the reviewed verification step before using
 the downloaded artifact.
@@ -394,8 +465,10 @@ the downloaded artifact.
   instead of manual archive checks. Tune the allowlist for those workflows.
 - Verification commands can be present but wrong. Review the expected digest,
   signing identity, release source, and pinned version before trusting the
-  artifact. Digest-print-only commands such as `openssl dgst -sha256 file` do
-  not satisfy the guard because they do not compare against a trusted value.
+  artifact. Digest-print-only commands such as `openssl dgst -sha256 file`,
+  unrelated checks, or checks that do not reference the downloaded artifact name
+  do not satisfy the guard because they do not compare that artifact against a
+  trusted value.
 
 ## Duplicate And History Check
 


### PR DESCRIPTION
### Motivation
- The original Bash PreToolUse hook treated any verification-looking text anywhere in the proposed command as proof of verification, allowing inert or unrelated tokens to bypass the guard and permit risky downloads.
- The intent is to ensure a checksum/signature verification step actually references the downloaded artifact so the guard cannot be trivially bypassed.

### Description
- Replaced the broad inline `grep` allow-path with a targeted `has_verification_for_download()` routine that extracts archive URLs, derives the downloaded artifact name, and requires a later verification command that references that artifact name in the same proposed command. (changed file: `content/hooks/package-download-checksum-guard-hook.mdx`)
- Added `escape_ere()` helper and artifact-scoped regex construction to avoid accidental matches and to scope verification to the artifact name. (changed file: `content/hooks/package-download-checksum-guard-hook.mdx`)
- Swapped the original `if printf ... | grep -Eq -- "$verification_command_re"; then` check to `if has_verification_for_download; then` so unrelated, out-of-order, inert `echo` tokens, and digest-print-only commands no longer satisfy the guard. (changed file: `content/hooks/package-download-checksum-guard-hook.mdx`)
- Updated documentation and `safetyNotes`/`Limitations` text to describe the stricter requirement that verification must reference the downloaded artifact name. (changed file: `content/hooks/package-download-checksum-guard-hook.mdx`)

### Testing
- Ran content validation with `pnpm validate:content:strict` and it passed. 
- Ran package validations with `pnpm validate:packages` and they passed. 
- Extracted the embedded hook script and ran `bash -n` for syntax checking and executed test cases that confirmed blocking of unverified downloads and bypass attempts (inert `echo`, digest-only `openssl dgst`, out-of-order unrelated checks) and allowing of valid artifact-referencing checks (stdin `sha256sum -c -`, `gpg --verify`); all behaved as expected. 
- Ran `git diff --check` and `validate` checks; no remaining validation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1915cff0832aa36d9512486e492c)