### PR TITLE
fix(mcp): keep draft helpers local in stdio proxy

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -97,7 +97,11 @@ Workflow prompts are available for common client flows:
 
 ## Local Stdio
 
-The published package defaults to the live HeyClaude MCP endpoint:
+The published package defaults to the live HeyClaude MCP endpoint. In this
+remote-bridge mode, draft-content helpers that accept private submission fields
+(`validate_submission_draft`, `build_submission_urls`, `prepare_submission_draft`,
+and `review_submission_draft`) are intentionally not exposed or forwarded; use
+local artifact mode for those helpers before entering private draft content.
 
 ```json
 {
@@ -179,6 +183,9 @@ checks the HTTP guards used by the remote route.
   60 requests/minute/IP in production.
 - Submission tools prepare review drafts only; the MCP server does not perform
   GitHub writes or publish submitted content.
+- The npm stdio remote bridge does not forward local draft-helper calls that
+  carry submission fields; run local artifact mode before entering private draft
+  content.
 - Source-backed, content-only PRs may be merged automatically after content
   validation, Superagent, and private maintainer-agent review pass. Platform,
   workflow, package, and generated-artifact changes are never auto-merged by

--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -10,6 +10,7 @@ export type RegistryArtifactLoaders = {
 };
 
 export const READ_ONLY_TOOL_NAMES: string[];
+export const LOCAL_DRAFT_TOOL_NAMES: string[];
 export const TOOL_DEFINITIONS: Array<{
   name: string;
   description: string;

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -97,6 +97,13 @@ export const READ_ONLY_TOOL_NAMES = [
   "review_entry_safety",
 ];
 
+export const LOCAL_DRAFT_TOOL_NAMES = [
+  "validate_submission_draft",
+  "build_submission_urls",
+  "prepare_submission_draft",
+  "review_submission_draft",
+];
+
 export const TOOL_DEFINITIONS = [
   {
     name: "search_registry",

--- a/packages/mcp/src/remote-proxy.js
+++ b/packages/mcp/src/remote-proxy.js
@@ -14,7 +14,11 @@ import {
 
 import { normalizeEndpointUrl, normalizeTimeoutMs } from "./endpoint-url.js";
 import { packageVersion } from "./package-metadata.js";
-import { MCP_PUBLIC_POLICY, READ_ONLY_TOOL_NAMES } from "./registry.js";
+import {
+  LOCAL_DRAFT_TOOL_NAMES,
+  MCP_PUBLIC_POLICY,
+  READ_ONLY_TOOL_NAMES,
+} from "./registry.js";
 
 function toError(error) {
   if (error instanceof Error) return error;
@@ -53,12 +57,12 @@ function createTimeoutFetch(timeoutMs) {
   };
 }
 
-function invalidToolResult(name) {
+function toolErrorResult(code, message) {
   const structuredContent = {
     ok: false,
     error: {
-      code: "invalid_request",
-      message: `Unknown or unsupported HeyClaude MCP tool: ${name}`,
+      code,
+      message,
     },
     policy: MCP_PUBLIC_POLICY,
   };
@@ -72,6 +76,20 @@ function invalidToolResult(name) {
       },
     ],
   };
+}
+
+function invalidToolResult(name) {
+  return toolErrorResult(
+    "invalid_request",
+    `Unknown or unsupported HeyClaude MCP tool: ${name}`,
+  );
+}
+
+function localDraftToolResult(name) {
+  return toolErrorResult(
+    "local_only_tool",
+    `${name} handles submission draft content and is only available in local artifact mode. Run heyclaude-mcp with --local --data-dir, or set HEYCLAUDE_DATA_DIR, before sending private draft fields.`,
+  );
 }
 
 function errorToolResult(error) {
@@ -96,6 +114,7 @@ function errorToolResult(error) {
 }
 
 function readOnlyToolDefinition(tool) {
+  if (LOCAL_DRAFT_TOOL_NAMES.includes(tool?.name)) return null;
   if (!READ_ONLY_TOOL_NAMES.includes(tool?.name)) return null;
   return {
     ...tool,
@@ -188,6 +207,9 @@ export async function createRemoteMcpProxyServerFromClient(
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const name = request.params.name;
+    if (LOCAL_DRAFT_TOOL_NAMES.includes(name)) {
+      return localDraftToolResult(name);
+    }
     if (!supportedToolNames.has(name)) {
       return invalidToolResult(name);
     }

--- a/tests/mcp-remote-proxy.test.ts
+++ b/tests/mcp-remote-proxy.test.ts
@@ -1,0 +1,116 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { createRemoteMcpProxyServerFromClient } from "../packages/mcp/src/remote-proxy.js";
+import { LOCAL_DRAFT_TOOL_NAMES } from "../packages/mcp/src/registry.js";
+import { repoRoot } from "./helpers/registry-fixtures";
+
+const packageRequire = createRequire(
+  path.join(repoRoot, "packages/mcp/package.json"),
+);
+const { Client } = await import(
+  packageRequire.resolve("@modelcontextprotocol/sdk/client/index.js")
+);
+const { InMemoryTransport } = await import(
+  packageRequire.resolve("@modelcontextprotocol/sdk/inMemory.js")
+);
+
+async function withMcpClientForServer<T>(
+  server: any,
+  run: (client: any) => Promise<T>,
+) {
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client({
+    name: "heyclaude-remote-proxy-test",
+    version: "0.0.0",
+  });
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+  try {
+    return await run(client);
+  } finally {
+    await client.close().catch(() => {});
+    await server.close().catch(() => {});
+  }
+}
+
+describe("HeyClaude MCP remote proxy privacy boundary", () => {
+  it("does not expose or forward local draft tools through the remote proxy", async () => {
+    const forwardedCalls: Array<{ name: string; arguments?: unknown }> = [];
+    const remoteClient = {
+      getServerCapabilities() {
+        return { tools: {} };
+      },
+      async listTools() {
+        return {
+          tools: [
+            {
+              name: "search_registry",
+              description: "Remote search.",
+              inputSchema: { type: "object", additionalProperties: true },
+            },
+            ...LOCAL_DRAFT_TOOL_NAMES.map((name) => ({
+              name,
+              description: "Remote draft helper.",
+              inputSchema: { type: "object", additionalProperties: true },
+            })),
+          ],
+        };
+      },
+      async callTool(request: { name: string; arguments?: unknown }) {
+        forwardedCalls.push(request);
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ ok: true }),
+            },
+          ],
+        };
+      },
+    };
+    const { server } = await createRemoteMcpProxyServerFromClient(
+      remoteClient,
+      {
+        url: "https://example.com/api/mcp",
+        timeoutMs: 1000,
+      },
+    );
+
+    await withMcpClientForServer(server, async (client) => {
+      const tools = await client.listTools();
+      const toolNames = tools.tools.map((tool: { name: string }) => tool.name);
+      expect(toolNames).toContain("search_registry");
+      expect(toolNames).not.toContain("validate_submission_draft");
+      expect(toolNames).not.toContain("build_submission_urls");
+      expect(toolNames).not.toContain("prepare_submission_draft");
+      expect(toolNames).not.toContain("review_submission_draft");
+
+      const result = await client.callTool({
+        name: "validate_submission_draft",
+        arguments: {
+          fields: {
+            category: "mcp",
+            name: "Private Draft",
+            contact_email: "private@example.test",
+            full_copyable_content: "secret draft body",
+          },
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent).toMatchObject({
+        ok: false,
+        error: { code: "local_only_tool" },
+      });
+      expect(JSON.stringify(result.structuredContent)).toContain(
+        "local artifact mode",
+      );
+    });
+
+    expect(forwardedCalls).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- A remote-first change caused submission-draft helper tools that accept private fields to be proxied to the production MCP endpoint by default, creating a confidentiality regression.
- The intent of this change is to re-establish a clear privacy boundary so draft helpers that process private submission content remain local-only unless the user explicitly opts into local artifact mode.

### Description
- Add a new `LOCAL_DRAFT_TOOL_NAMES` list containing `validate_submission_draft`, `build_submission_urls`, `prepare_submission_draft`, and `review_submission_draft` in `packages/mcp/src/registry.js` and export it from `registry.d.ts`.
- Update the remote stdio proxy in `packages/mcp/src/remote-proxy.js` to filter local draft tools from advertised tool definitions and to return a `local_only_tool` error when a client attempts to call them through the remote proxy.
- Add a focused regression test `tests/mcp-remote-proxy.test.ts` that asserts draft helpers are not exposed, that direct calls return the `local_only_tool` error, and that no upstream calls are forwarded.
- Document the privacy boundary in `packages/mcp/README.md` to instruct npm stdio users to run the CLI in local artifact mode (`--local --data-dir` or `HEYCLAUDE_DATA_DIR`) before submitting private draft content.

### Testing
- Ran `pnpm exec vitest run tests/mcp-remote-proxy.test.ts tests/mcp-cli.test.ts` and both test files passed.
- Attempted `pnpm exec vitest run tests/mcp-server.test.ts tests/mcp-cli.test.ts` but the server-suite run is blocked in this workspace due to a missing generated fixture file `apps/web/public/data/directory-index.json` and therefore could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1db77158832a908bb58b045dff3c)