### PR TITLE
fix(validators): redact root mcp config secrets

### DIFF
--- a/apps/web/src/lib/mcp-config-validator.ts
+++ b/apps/web/src/lib/mcp-config-validator.ts
@@ -508,12 +508,24 @@ export function validateMcpConfigText(input: string): McpConfigValidation {
   const reports = Object.entries(extracted.servers).map(([name, value]) =>
     validateServer(name, value),
   );
+  let rootRedactedSecretCount = 0;
+  const sanitizedRootConfig = Object.fromEntries(
+    isRecord(parsed) && !extracted.wrapped
+      ? Object.entries(parsed)
+          .filter(([key]) => key !== "mcpServers")
+          .map(([key, value]) => {
+            const sanitized = sanitizeConfigValue(key, value);
+            rootRedactedSecretCount += sanitized.redactedCount;
+            return [key, sanitized.value];
+          })
+      : [],
+  );
   const redactedSecretCount = reports.reduce(
     (count, report) => count + report.redactedSecretCount,
-    0,
+    rootRedactedSecretCount,
   );
   const sanitizedConfig = {
-    ...(isRecord(parsed) && !extracted.wrapped ? parsed : {}),
+    ...sanitizedRootConfig,
     mcpServers: Object.fromEntries(
       reports.map((report) => [report.name, report.sanitized]),
     ),

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -150,6 +150,37 @@ describe("MCP config validator", () => {
     expect(result.reportText).toContain("${URL}");
   });
 
+  it("redacts root-level secrets outside mcpServers from fixed snippets", () => {
+    const result = validateMcpConfigText(
+      JSON.stringify({
+        globalToken: "root-token-SECRET-333",
+        headers: {
+          Authorization: "Bearer abcdefghijklmnopqrstuvwxyz123456",
+        },
+        metadata: {
+          owner: "docs",
+        },
+        mcpServers: {
+          remote: {
+            url: "https://example.com/mcp",
+          },
+        },
+      }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.redactedSecretCount).toBe(2);
+    expect(result.fixedConfigText).not.toContain("root-token-SECRET-333");
+    expect(result.fixedConfigText).not.toContain(
+      "Bearer abcdefghijklmnopqrstuvwxyz123456",
+    );
+    expect(result.fixedConfigText).toContain("${GLOBALTOKEN}");
+    expect(result.fixedConfigText).toContain("${AUTHORIZATION}");
+    expect(JSON.parse(result.fixedConfigText).metadata).toEqual({
+      owner: "docs",
+    });
+  });
+
   it("redacts values after sensitive split CLI flags", () => {
     const result = validateMcpConfigText(
       JSON.stringify({


### PR DESCRIPTION
### Motivation
- The MCP config validator previously only redacted environment-variable-style secrets, which left secrets in other top-level fields (headers, oauthToken, apiKey, args, etc.) present in the copyable "fixed snippet" and created a data-leak risk.
- The change aims to ensure any root-level non-`mcpServers` fields are sanitized before producing the fixed snippet and that root-level redactions are reflected in the redaction count.

### Description
- Sanitize all non-`mcpServers` root keys with `sanitizeConfigValue` and collect `rootRedactedSecretCount` before composing the copyable `fixedConfigText` (`apps/web/src/lib/mcp-config-validator.ts`).
- Include `rootRedactedSecretCount` when computing the overall `redactedSecretCount` and merge the sanitized root into the serialized `sanitizedConfig` instead of spreading the original parsed root.
- Preserve existing per-server sanitization behavior and reporting while preventing retained secrets in other top-level properties.
- Add regression test coverage that verifies redaction of a `globalToken` and `headers.Authorization` while preserving non-sensitive metadata (`tests/mcp-config-validator.test.ts`).

### Testing
- Ran unit tests with `pnpm exec vitest run tests/mcp-config-validator.test.ts` and all tests passed (16/16).
- Executed a runtime redaction check with `pnpm exec tsx /tmp/mcp-config-secret-leak-check.mjs` which confirmed no leaked secrets and reported an increased `redactedSecretCount` for root and server secrets.
- Performed a full site build with `pnpm build` and validated output formatting with `git diff --check`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b1dbc4194832a93211a61ca61d047)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced secret redaction in configuration files to detect and protect sensitive information at the root level of configuration objects, ensuring comprehensive security coverage beyond nested server entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->