### PR TITLE
fix(test): assert full MCP trust coverage instead of a hardcoded count

### DIFF
--- a/tests/trust-coverage-script.test.ts
+++ b/tests/trust-coverage-script.test.ts
@@ -230,9 +230,13 @@ describe("trust coverage report script", () => {
     ]);
 
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("with safety + privacy notes: 318 (100%)");
-    expect(result.stdout).toContain(
-      "Provenance (all 318): source-backed 100%, attributed 100%",
+    // Assert FULL trust coverage rather than a hardcoded total: the live MCP entry count drifts
+    // every time content is added/removed, which otherwise fails this (unrelated) web test on every
+    // such change. What matters is that ALL live MCP entries are 100% covered, 0 missing, and fully
+    // provenanced — the count is incidental.
+    expect(result.stdout).toMatch(/with safety \+ privacy notes: \d+ \(100%\), missing 0/);
+    expect(result.stdout).toMatch(
+      /Provenance \(all \d+\): source-backed 100%, attributed 100%/,
     );
   });
 });


### PR DESCRIPTION
The `keeps live MCP content at full trust coverage` test hardcoded **318** live MCP entries, so it failed `validate-web` on every PR once the corpus count drifted (it's **322** now — still 100% covered, 0 missing). That blocked otherwise-good web PRs (#2092, #2101, #2118, #2120) on an unrelated content-count change. Now it asserts *full coverage* (100% safety+privacy notes, 0 missing, fully provenanced) count-agnostically; a genuine coverage gap still fails via the `missing 0` check. Verified locally: 7/7 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to use dynamic pattern matching instead of hardcoded values, improving test robustness for validating coverage metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->