### PR TITLE
fix(submissions): narrow cross-category duplicate URL signals

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -6,6 +6,7 @@ export type ContentDuplicateSignals = {
   normalizedTitle: string;
   normalizedDescription: string;
   urls: string[];
+  strictDuplicateUrls: string[];
   domains: string[];
   label?: string;
   url?: string;
@@ -73,6 +74,21 @@ const URL_FIELDS = new Set([
   "repository_url",
   "source_url",
   "website_url",
+]);
+
+const CROSS_CATEGORY_STRICT_URL_FIELDS = new Set([
+  "downloadUrl",
+  "githubUrl",
+  "packageUrl",
+  "repoUrl",
+  "repositoryUrl",
+  "sourceUrl",
+  "download_url",
+  "github_url",
+  "package_url",
+  "repo_url",
+  "repository_url",
+  "source_url",
 ]);
 const DOMAIN_ONLY_EXCLUSIONS = new Set([
   "github.com",
@@ -218,12 +234,19 @@ export function extractContentDuplicateSignals(params: {
 }): ContentDuplicateSignals {
   const fields = parseSimpleFrontmatter(params.content);
   const parts = pathParts(params.filePath);
-  const urls = [
+  const urlEntries = Object.entries(fields)
+    .filter(([key]) => URL_FIELDS.has(key))
+    .map(([key, value]) => ({
+      key,
+      url: normalizeUrl(value),
+    }))
+    .filter((entry) => entry.url);
+  const urls = [...new Set(urlEntries.map((entry) => entry.url))];
+  const strictDuplicateUrls = [
     ...new Set(
-      Object.entries(fields)
-        .filter(([key]) => URL_FIELDS.has(key))
-        .map(([, value]) => normalizeUrl(value))
-        .filter(Boolean),
+      urlEntries
+        .filter((entry) => CROSS_CATEGORY_STRICT_URL_FIELDS.has(entry.key))
+        .map((entry) => entry.url),
     ),
   ];
 
@@ -235,6 +258,7 @@ export function extractContentDuplicateSignals(params: {
     normalizedTitle: normalizeText(fields.title),
     normalizedDescription: normalizeText(fields.description),
     urls,
+    strictDuplicateUrls,
     domains: [...new Set(urls.map(domainFromUrl).filter(Boolean))],
     label: params.label,
     url: params.url,
@@ -376,6 +400,9 @@ export function findStrictContentDuplicateMatch(
 
     const sharedUrls = intersection(candidate.urls, existing.urls);
     const blockingSharedUrls = strictDuplicateUrls(sharedUrls);
+    const crossCategoryBlockingSharedUrls = strictDuplicateUrls(
+      intersection(candidate.strictDuplicateUrls, existing.strictDuplicateUrls),
+    );
     const catalogSubpathUrls = multiEntryCatalogSubpathUrls(blockingSharedUrls);
     if (
       catalogSubpathUrls.length &&
@@ -387,14 +414,14 @@ export function findStrictContentDuplicateMatch(
       );
     }
     if (
-      blockingSharedUrls.length &&
+      crossCategoryBlockingSharedUrls.length &&
       candidate.category &&
       existing.category &&
       candidate.category !== existing.category &&
       !isCollectionBridge(candidate, existing)
     ) {
       reasons.push(
-        `same canonical source URL ${blockingSharedUrls[0]} across ${candidate.category}/${existing.category}`,
+        `same canonical source URL ${crossCategoryBlockingSharedUrls[0]} across ${candidate.category}/${existing.category}`,
       );
     }
     if (

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2676,6 +2676,46 @@ docsUrl: "https://developers.cloudflare.com/ai-gateway/get-started/"
     );
   });
 
+  it("treats shared official docs across categories as related, not strict duplicate", () => {
+    const existingGuide = extractContentDuplicateSignals({
+      filePath: "content/guides/claude-code-security-review.mdx",
+      content: `---
+title: Claude Code Security Review
+slug: claude-code-security-review
+category: guides
+description: Guide for reviewing Claude Code security posture.
+docsUrl: "https://docs.anthropic.com/en/docs/claude-code/security"
+---
+`,
+    });
+    const candidateHook = extractContentDuplicateSignals({
+      filePath: "content/hooks/security-event-logger.mdx",
+      content: `---
+title: Security Event Logger Hook
+slug: security-event-logger
+category: hooks
+description: Hook that logs sensitive Claude Code security events.
+docsUrl: "https://docs.anthropic.com/en/docs/claude-code/security#events"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(candidateHook, [existingGuide]),
+    ).toBeNull();
+    expect(findRelatedContentMatches(candidateHook, [existingGuide])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://docs.anthropic.com/en/docs/claude-code/security across hooks/guides",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("treats same canonical project across different categories as a strict duplicate", () => {
     const existingMcp = extractContentDuplicateSignals({
       filePath: "content/mcp/langchain-mcp-server.mdx",


### PR DESCRIPTION
### Motivation
- The deterministic submission gate treated any shared URL-like frontmatter (including broad `docsUrl`/`websiteUrl`) as a cross-category blocking duplicate, causing false-positive automatic closures that contradict the policy which treats shared official docs as related context.
- The change narrows the set of URL fields that may trigger cross-category strict-duplicate decisions so shared documentation pages cannot be abused to auto-close unrelated submissions.

### Description
- Add a new `CROSS_CATEGORY_STRICT_URL_FIELDS` set and a `strictDuplicateUrls` field on `ContentDuplicateSignals` to separate canonical/actionable source signals from broad documentation/website signals in `apps/submission-gate/src/duplicates.ts`.
- Change `extractContentDuplicateSignals` to build `urlEntries`, preserve all normalized `urls` for related-content checks, and populate `strictDuplicateUrls` using only fields from `CROSS_CATEGORY_STRICT_URL_FIELDS`.
- Update `findStrictContentDuplicateMatch` to use the intersection of `candidate.strictDuplicateUrls` and `existing.strictDuplicateUrls` for cross-category blocking, while leaving same-category and catalog-subpath logic intact.
- Add a regression test in `tests/submission-gate-worker.test.ts` asserting that shared official docs across `guides`/`hooks` are treated as related context (not a strict duplicate) while preserving strict duplicate behavior for canonical repositories and other actionable sources.

### Testing
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts` and the test file completed successfully; the suite reports all tests passed for that file.
- Ran `git diff --check` to ensure there is no whitespace/formatting issue and it passed.
- Attempted `pnpm exec tsc --noEmit --pretty false`, which surfaced existing repository-level type/environment errors unrelated to this patch (Cloudflare worker globals and generated artifacts); these pre-existing issues were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cf7807f4c832a92933f32b83331de)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined duplicate detection to apply stricter URL matching criteria across content categories, reducing false positive duplicate classifications.

* **Tests**
  * Added test coverage for cross-category content with shared URLs, ensuring they are correctly identified as related rather than duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->