### PR TITLE
fix(submissions): block cross-category website duplicates

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -83,12 +83,14 @@ const CROSS_CATEGORY_STRICT_URL_FIELDS = new Set([
   "repoUrl",
   "repositoryUrl",
   "sourceUrl",
+  "websiteUrl",
   "download_url",
   "github_url",
   "package_url",
   "repo_url",
   "repository_url",
   "source_url",
+  "website_url",
 ]);
 const DOMAIN_ONLY_EXCLUSIONS = new Set([
   "github.com",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2762,6 +2762,52 @@ repoUrl: "https://github.com/langchain-ai/langchain.git"
     );
   });
 
+  it("treats same canonical website across different categories as a strict duplicate", () => {
+    const existingTool = extractContentDuplicateSignals({
+      filePath: "content/tools/acme-claude.mdx",
+      content: `---
+title: Acme Claude
+slug: acme-claude
+category: tools
+description: Tooling for Acme Claude workflows.
+websiteUrl: "https://acme-claude.example/product"
+---
+`,
+    });
+    const candidateMcp = extractContentDuplicateSignals({
+      filePath: "content/mcp/acme-claude-server.mdx",
+      content: `---
+title: Acme Claude MCP Server
+slug: acme-claude-server
+category: mcp
+description: MCP server for Acme Claude workflows.
+websiteUrl: "https://acme-claude.example/product?utm_source=submission"
+---
+`,
+    });
+
+    expect(
+      findStrictContentDuplicateMatch(candidateMcp, [existingTool]),
+    ).toMatchObject({
+      reasons: expect.arrayContaining([
+        expect.stringContaining(
+          "same canonical source URL https://acme-claude.example/product across mcp/tools",
+        ),
+      ]),
+    });
+    expect(findRelatedContentMatches(candidateMcp, [existingTool])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            expect.stringContaining(
+              "same canonical source URL https://acme-claude.example/product across mcp/tools",
+            ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it("treats collection member overlap as related context, not a strict duplicate", () => {
     const existingTool = extractContentDuplicateSignals({
       filePath: "content/tools/storybook-a11y.mdx",


### PR DESCRIPTION
### Motivation

- A recent change narrowed the set of URL fields used for strict cross-category duplicate detection and inadvertently omitted `websiteUrl`/`website_url`, which allowed canonical website collisions to avoid deterministic strict-duplicate closure.
- The intent is to restore deterministic blocking for submissions that share the same canonical website URL across non-collection categories while preserving related/collection behaviors.

### Description

- Added `websiteUrl` and `website_url` to `CROSS_CATEGORY_STRICT_URL_FIELDS` in `apps/submission-gate/src/duplicates.ts` so canonical website signals are included in cross-category strict duplicate checks.
- Added a regression test `it("treats same canonical website across different categories as a strict duplicate")` to `tests/submission-gate-worker.test.ts` that validates a `tools`/`mcp` pair with the same normalized `websiteUrl` is treated as a strict duplicate and appears in related matches.
- No other behavioral changes were made to `URL_FIELDS`, `strictDuplicateUrls` filtering, or multi-entry catalog logic.

### Testing

- Ran the focused test subset with `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "canonical website|canonical project|shared official docs|neutral duplicate submissions" --reporter=dot`, which reported the test file passed and the selected tests succeeded (1 file passed, 4 tests passed, 92 skipped).
- Ran `git diff --check` to ensure there are no formatting or whitespace issues and it succeeded.
- The modified files are `apps/submission-gate/src/duplicates.ts` and `tests/submission-gate-worker.test.ts` and the added tests exercise the fixed behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0b77d1a0832a8793e5e4581b3fe4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced duplicate detection by expanding website URL comparison to work across different submission categories, preventing duplicate content.

* **Tests**
  * Added test cases validating cross-category duplicate detection accuracy using website URL matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->