### PR TITLE
feat(seo): SEO round 2 — sitewide schema, OG images, comparison pages, agent-readiness polish

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -13,6 +13,8 @@ const NAV = [
   { to: "/browse", label: "Browse" },
   { to: "/trending", label: "Trending" },
   { to: "/best", label: "Best" },
+  { to: "/tags", label: "Tags" },
+  { to: "/for", label: "Platforms" },
   { to: "/ecosystem", label: "Ecosystem" },
   { to: "/jobs", label: "Jobs" },
   { to: "/quality", label: "Quality" },
@@ -144,6 +146,8 @@ export function Footer() {
           links={[
             { to: "/browse", label: "Browse" },
             { to: "/trending", label: "Trending" },
+            { to: "/tags", label: "Tags" },
+            { to: "/for", label: "Platforms" },
             { to: "/best", label: "Best lists" },
             { to: "/quality", label: "Quality" },
             { to: "/changelog", label: "Changelog" },

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -1,0 +1,196 @@
+import * as React from "react";
+import { Link } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import {
+  CategoryPill,
+  PlatformChip,
+  InstallRiskBadge,
+  NotesPresenceChips,
+} from "@/components/badges";
+import { TrustDrilldown } from "@/components/trust-drilldown";
+import { CopyButton } from "@/components/copy-button";
+import { SourceCitations } from "@/components/source-citations";
+import { formatCompact } from "@/lib/format";
+import type { Entry } from "@/types/registry";
+
+export interface RowDef {
+  label: string;
+  render: (e: Entry) => React.ReactNode;
+}
+
+/** Shared comparison field definitions — used by the interactive /compare page and curated pages. */
+export const COMPARISON_ROWS: RowDef[] = [
+  { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
+  { label: "Install risk", render: (e) => <InstallRiskBadge entry={e} /> },
+  { label: "Notes", render: (e) => <NotesPresenceChips entry={e} /> },
+  { label: "Category", render: (e) => <CategoryPill>{e.category}</CategoryPill> },
+  {
+    label: "Source",
+    render: (e) => <span className="text-sm capitalize text-ink">{e.source}</span>,
+  },
+  { label: "Author", render: (e) => <span className="text-sm text-ink">{e.author}</span> },
+  {
+    label: "Added",
+    render: (e) => <span className="font-mono text-xs text-ink-muted">{e.dateAdded}</span>,
+  },
+  {
+    label: "Platforms",
+    render: (e) => (
+      <div className="flex flex-wrap gap-1">
+        {e.platforms.map((p) => (
+          <PlatformChip key={p} id={p} />
+        ))}
+      </div>
+    ),
+  },
+  {
+    label: "Source repo",
+    render: (e) => (
+      <span className="font-mono text-sm tabular-nums text-ink">
+        {e.repoStats?.stars !== undefined ? `${formatCompact(e.repoStats.stars)} repo stars` : "—"}
+      </span>
+    ),
+  },
+  {
+    label: "Safety notes",
+    render: (e) =>
+      e.safetyNotes ? (
+        <span className="text-xs text-ink">
+          <span className="mr-1 text-trust-trusted">✓</span>
+          <span className="line-clamp-3">{e.safetyNotes}</span>
+        </span>
+      ) : (
+        <span className="text-xs text-ink-subtle">— missing</span>
+      ),
+  },
+  {
+    label: "Privacy notes",
+    render: (e) =>
+      e.privacyNotes ? (
+        <span className="text-xs text-ink">
+          <span className="mr-1 text-trust-trusted">✓</span>
+          <span className="line-clamp-3">{e.privacyNotes}</span>
+        </span>
+      ) : (
+        <span className="text-xs text-ink-subtle">— missing</span>
+      ),
+  },
+  {
+    label: "Prerequisites",
+    render: (e) =>
+      e.prerequisites && e.prerequisites.length > 0 ? (
+        <ul className="list-disc space-y-0.5 pl-4 text-xs text-ink-muted">
+          {e.prerequisites.slice(0, 4).map((p) => (
+            <li key={p}>{p}</li>
+          ))}
+        </ul>
+      ) : (
+        <span className="text-xs text-ink-subtle">— none listed</span>
+      ),
+  },
+  {
+    label: "Install",
+    render: (e) =>
+      e.installCommand ? (
+        <div className="space-y-1.5">
+          <pre className="max-h-24 overflow-auto rounded-md bg-background p-2 font-mono text-[11px] text-ink">
+            <code>{e.installCommand}</code>
+          </pre>
+          <CopyButton value={e.installCommand} label="Copy install" />
+        </div>
+      ) : (
+        <span className="text-xs text-ink-subtle">—</span>
+      ),
+  },
+  {
+    label: "Config",
+    render: (e) =>
+      e.configSnippet ? (
+        <div className="space-y-1.5">
+          <pre className="max-h-24 overflow-auto rounded-md bg-background p-2 font-mono text-[11px] text-ink">
+            <code>{e.configSnippet}</code>
+          </pre>
+          <CopyButton value={e.configSnippet} label="Copy config" />
+        </div>
+      ) : (
+        <span className="text-xs text-ink-subtle">—</span>
+      ),
+  },
+  {
+    label: "Citations",
+    render: (e) => (
+      <div className="text-xs">
+        <SourceCitations entry={e} />
+      </div>
+    ),
+  },
+  {
+    label: "Claim",
+    render: (e) => (
+      <span className="text-xs text-ink-muted">{e.claimed ? "Claimed" : "Unclaimed"}</span>
+    ),
+  },
+];
+
+/** Static side-by-side comparison table (no add/remove controls) for curated comparison pages. */
+export function ComparisonTable({ entries }: { entries: Entry[] }) {
+  return (
+    <div className="overflow-auto rounded-xl border border-border">
+      <table className="w-full border-collapse text-sm">
+        <thead className="bg-surface">
+          <tr>
+            <th
+              scope="col"
+              className="sticky left-0 z-10 w-[150px] border-b border-r border-border bg-surface p-3 text-left text-xs uppercase tracking-wider text-ink-subtle"
+            >
+              Field
+            </th>
+            {entries.map((e) => (
+              <th
+                scope="col"
+                key={`${e.category}/${e.slug}`}
+                className="min-w-[260px] max-w-[320px] border-b border-r border-border bg-surface p-3 text-left align-top"
+              >
+                <Link
+                  to="/entry/$category/$slug"
+                  params={{ category: e.category, slug: e.slug }}
+                  className="font-display text-sm font-semibold text-ink hover:underline"
+                >
+                  {e.title}
+                </Link>
+                <p className="mt-1 line-clamp-2 text-xs text-ink-muted">{e.description}</p>
+                <Link
+                  to="/entry/$category/$slug"
+                  params={{ category: e.category, slug: e.slug }}
+                  className="mt-2 inline-flex items-center gap-1 text-[11px] text-ink-muted hover:text-ink"
+                >
+                  Open dossier <ArrowRight className="h-3 w-3" />
+                </Link>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {COMPARISON_ROWS.map((row, i) => (
+            <tr key={row.label} className={i % 2 === 0 ? "bg-surface-2/30" : ""}>
+              <th
+                scope="row"
+                className="sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted"
+              >
+                {row.label}
+              </th>
+              {entries.map((e) => (
+                <td
+                  key={`${e.category}/${e.slug}`}
+                  className="min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top"
+                >
+                  {row.render(e)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/data/comparisons.ts
+++ b/apps/web/src/data/comparisons.ts
@@ -1,0 +1,74 @@
+// Curated, bounded set of head-to-head comparison pages. Each `refs` is "category/slug"; the
+// route drops missing refs and 404s if fewer than 2 resolve, so a renamed entry can't ship an
+// empty page. Keep this list hand-maintained (high-intent pairings only) to avoid thin pages.
+export type Comparison = {
+  slug: string;
+  title: string;
+  heading: string;
+  seoDescription: string;
+  intro: string;
+  refs: string[];
+};
+
+export const COMPARISONS: Comparison[] = [
+  {
+    slug: "payment-mcp-servers",
+    title: "Stripe vs PayPal vs Square MCP servers for Claude",
+    heading: "Payment MCP servers compared",
+    seoDescription:
+      "Compare the Stripe, PayPal, and Square MCP servers for Claude Code — trust, install, safety notes, and config, side by side.",
+    intro:
+      "Three payment MCP servers for Claude Code, side by side — so you can pick the one that matches your stack and risk tolerance.",
+    refs: ["mcp/stripe-mcp-server", "mcp/paypal-mcp-server", "mcp/square-mcp-server"],
+  },
+  {
+    slug: "database-mcp-servers",
+    title: "PostgreSQL vs Redis vs MongoDB vs Supabase MCP servers for Claude",
+    heading: "Database MCP servers compared",
+    seoDescription:
+      "Compare PostgreSQL, Redis, MongoDB, and Supabase MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro: "The most-used database MCP servers for Claude Code, compared on trust, install, and safety signals.",
+    refs: [
+      "mcp/postgresql-mcp-server",
+      "mcp/redis-mcp-server",
+      "mcp/mongodb-mcp-server",
+      "mcp/supabase-mcp-server",
+    ],
+  },
+  {
+    slug: "devops-mcp-servers",
+    title: "GitHub vs GitLab vs Cloudflare vs Netlify MCP servers for Claude",
+    heading: "DevOps MCP servers compared",
+    seoDescription:
+      "Compare GitHub, GitLab, Cloudflare, and Netlify MCP servers for Claude Code side by side.",
+    intro: "Ship-and-deploy MCP servers for Claude Code, compared on trust, platforms, and setup.",
+    refs: [
+      "mcp/github-mcp-server",
+      "mcp/gitlab-mcp-server",
+      "mcp/cloudflare-mcp-server",
+      "mcp/netlify-mcp-server",
+    ],
+  },
+  {
+    slug: "ai-coding-agents",
+    title: "Cursor vs Aider vs Cline vs Continue for Claude",
+    heading: "AI coding agents compared",
+    seoDescription:
+      "Compare Cursor, Aider, Cline, and Continue — AI coding tools that work with Claude — side by side.",
+    intro: "The leading AI coding tools that pair with Claude, compared on platforms, source, and setup.",
+    refs: ["tools/cursor", "tools/aider", "tools/cline", "tools/continue"],
+  },
+  {
+    slug: "llm-observability-tools",
+    title: "Langfuse vs LangSmith vs Helicone vs Braintrust",
+    heading: "LLM observability tools compared",
+    seoDescription:
+      "Compare Langfuse, LangSmith, Helicone, and Braintrust — LLM observability and eval tools — side by side.",
+    intro: "Observability and eval platforms for LLM apps, compared on trust, source, and setup.",
+    refs: ["tools/langfuse", "tools/langsmith", "tools/helicone", "tools/braintrust"],
+  },
+];
+
+export function getComparison(slug: string) {
+  return COMPARISONS.find((comparison) => comparison.slug === slug);
+}

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -13,8 +13,23 @@ const PALETTE: Record<string, string> = {
   statuslines: "#9bd6f0",
 };
 
+const DEFAULT_ACCENT = "#c5e84e";
+
 export function categoryAccent(category?: string) {
-  return PALETTE[category ?? ""] ?? "#c5e84e";
+  return PALETTE[category ?? ""] ?? DEFAULT_ACCENT;
+}
+
+/**
+ * Clamp an accent to a strict hex color before it lands in an SVG attribute.
+ * The generic /og route accepts a user-controlled `accent` query param; without
+ * this, a value like `"><script>…` could break out of the `fill="…"` attribute
+ * and inject markup into the SVG response. Anything that isn't a #rgb/#rrggbb/
+ * #rrggbbaa hex falls back to the default.
+ */
+export function safeAccent(value?: string | null) {
+  return value && /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(value)
+    ? value
+    : DEFAULT_ACCENT;
 }
 
 function esc(value: string) {
@@ -43,7 +58,7 @@ export function renderOgSvg(opts: {
   author?: string;
   accent?: string;
 }) {
-  const accent = opts.accent || "#c5e84e";
+  const accent = safeAccent(opts.accent);
   const eyebrow = esc((opts.eyebrow || "HeyClaude").toUpperCase());
   const titleLines = wrap(opts.title, 22, 2);
   const descLines = opts.description ? wrap(opts.description, 60, 2) : [];

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -1,0 +1,101 @@
+import { absoluteUrl } from "@/lib/seo";
+
+// Per-category accent colors (shared by the entry OG route and generic OG route).
+const PALETTE: Record<string, string> = {
+  mcp: "#7cd17c",
+  agents: "#f3b85a",
+  skills: "#8aa9ff",
+  rules: "#d4a5ff",
+  commands: "#ff9a7a",
+  hooks: "#76d7c4",
+  guides: "#ffcf72",
+  collections: "#b8a4ff",
+  statuslines: "#9bd6f0",
+};
+
+export function categoryAccent(category?: string) {
+  return PALETTE[category ?? ""] ?? "#c5e84e";
+}
+
+function esc(value: string) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function wrap(value: string, perLine: number, maxLines: number) {
+  const words = value.split(/\s+/);
+  const lines: string[] = [];
+  let cur = "";
+  for (const word of words) {
+    if ((cur + " " + word).trim().length > perLine) {
+      if (cur) lines.push(cur);
+      cur = word;
+    } else cur = (cur ? cur + " " : "") + word;
+  }
+  if (cur) lines.push(cur);
+  return lines.slice(0, maxLines);
+}
+
+/** Deterministic 1200×630 OG card SVG. Shared by /og/$category/$slug and the generic /og route. */
+export function renderOgSvg(opts: {
+  eyebrow?: string;
+  title: string;
+  description?: string;
+  author?: string;
+  accent?: string;
+}) {
+  const accent = opts.accent || "#c5e84e";
+  const eyebrow = esc((opts.eyebrow || "HeyClaude").toUpperCase());
+  const titleLines = wrap(opts.title, 22, 2);
+  const descLines = opts.description ? wrap(opts.description, 60, 2) : [];
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f7f5ef"/>
+      <stop offset="1" stop-color="#ece8df"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="0" y="0" width="14" height="630" fill="${accent}"/>
+  <g transform="translate(80,90)">
+    <text x="0" y="0" font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64" letter-spacing="2">
+      ${eyebrow}
+    </text>
+    ${titleLines
+      .map(
+        (l, i) =>
+          `<text x="0" y="${110 + i * 88}" font-family="Space Grotesk, system-ui, sans-serif" font-weight="700" font-size="78" fill="#171614">${esc(l)}</text>`,
+      )
+      .join("")}
+    ${descLines
+      .map(
+        (l, i) =>
+          `<text x="0" y="${340 + i * 38}" font-family="DM Sans, system-ui, sans-serif" font-size="28" fill="#4d4c47">${esc(l)}</text>`,
+      )
+      .join("")}
+    ${
+      opts.author
+        ? `<text x="0" y="460" font-family="DM Sans, system-ui, sans-serif" font-size="22" fill="#6b6a64">by <tspan font-weight="600" fill="#171614">${esc(opts.author)}</tspan></text>`
+        : ""
+    }
+  </g>
+  <g transform="translate(80,540)">
+    <text font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64">heyclau.de</text>
+  </g>
+</svg>`;
+}
+
+/** Absolute og:image URL pointing at the crawlable /og generator (NOT /api/og, which is disallowed). */
+export function ogImageUrl(opts: {
+  title: string;
+  eyebrow?: string;
+  description?: string;
+  accent?: string;
+}) {
+  const params = new URLSearchParams({ title: opts.title });
+  if (opts.eyebrow) params.set("eyebrow", opts.eyebrow);
+  if (opts.description) params.set("description", opts.description);
+  if (opts.accent) params.set("accent", opts.accent);
+  return absoluteUrl(`/og?${params.toString()}`);
+}

--- a/apps/web/src/lib/seo-jsonld.ts
+++ b/apps/web/src/lib/seo-jsonld.ts
@@ -1,0 +1,32 @@
+import { buildBreadcrumbJsonLd, buildItemListJsonLd } from "@heyclaude/registry/seo";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { absoluteUrl } from "@/lib/seo";
+
+type Crumb = { name: string; path: string };
+type ListItem = { name: string; path: string };
+
+/** A `<script type="application/ld+json">` head entry for a BreadcrumbList (absolute URLs). */
+export function breadcrumbScript(crumbs: Crumb[]) {
+  return {
+    type: "application/ld+json" as const,
+    children: stringifyJsonLd(
+      buildBreadcrumbJsonLd(crumbs.map((c) => ({ name: c.name, url: absoluteUrl(c.path) }))),
+    ),
+  };
+}
+
+/** A `<script type="application/ld+json">` head entry for an ItemList (absolute URLs). */
+export function itemListScript(
+  items: ListItem[],
+  meta: { name: string; description?: string },
+) {
+  return {
+    type: "application/ld+json" as const,
+    children: stringifyJsonLd(
+      buildItemListJsonLd(
+        items.map((item) => ({ name: item.name, url: absoluteUrl(item.path) })),
+        meta,
+      ),
+    ),
+  };
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -14,6 +14,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, categoryAccent } from "@/lib/og-image";
 
 const categoryIds = new Set(CATEGORIES.map((c) => c.id));
 
@@ -60,6 +61,12 @@ export const Route = createFileRoute("/$category")({
       categorySeoDescriptions[id] ??
       categoryDescriptions[id] ??
       `Browse ${entries.length} source-backed Claude ${label} in the HeyClaude directory.`;
+    const ogImage = ogImageUrl({
+      title: `Claude ${label}`,
+      eyebrow: label,
+      description,
+      accent: categoryAccent(id),
+    });
 
     const itemList = {
       "@context": "https://schema.org",
@@ -99,8 +106,10 @@ export const Route = createFileRoute("/$category")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
         { property: "og:type", content: "website" },
         { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/[.]well-known.mcp.server-card[.]json.ts
+++ b/apps/web/src/routes/[.]well-known.mcp.server-card[.]json.ts
@@ -1,34 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { TOOL_DEFINITIONS } from "@heyclaude/mcp/registry";
 import { siteConfig } from "@/lib/site";
 import { getIntegration } from "@/data/integrations";
 import { applySecurityHeaders } from "@/lib/security-headers";
 
 // MCP Server Card (SEP-1649) for agent discovery of the hosted HeyClaude MCP server.
-// Version is sourced from the mcp-server integration metadata, which is kept in sync with
-// packages/mcp/package.json (enforced by tests/atlas-production-data.test.ts).
-const MCP_TOOLS = [
-  "search_registry",
-  "search_duplicate_entries",
-  "list_category_entries",
-  "get_entry_detail",
-  "get_related_entries",
-  "get_recent_updates",
-  "compare_entries",
-  "get_copyable_asset",
-  "get_install_guidance",
-  "get_client_setup",
-  "get_compatibility",
-  "get_platform_adapter",
-  "get_registry_stats",
-  "list_distribution_feeds",
-  "plan_workflow_toolbox",
-  "server_info",
-  "get_submission_schema",
-  "get_submission_policy",
-  "get_submission_examples",
-  "get_category_submission_guidance",
-  "validate_submission_draft",
-];
+// Tools come from @heyclaude/mcp/registry (TOOL_DEFINITIONS) and the version from the mcp-server
+// integration metadata (synced to packages/mcp) — neither can drift from the real server.
 
 function serverCard() {
   const base = siteConfig.url;
@@ -39,7 +17,7 @@ function serverCard() {
       "Search and inspect the HeyClaude directory of Claude Code MCP servers, agents, skills, hooks, commands, rules, collections, and tools.",
     transport: { type: "streamable-http", endpoint: `${base}/api/mcp` },
     capabilities: { tools: {} },
-    tools: MCP_TOOLS.map((name) => ({ name })),
+    tools: TOOL_DEFINITIONS.map((tool) => ({ name: tool.name, description: tool.description })),
     documentation: `${base}/api-docs`,
     homepage: base,
   };

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,6 +23,8 @@ import { SkipLink } from "@/components/skip-link";
 import { RouteProgress } from "@/components/route-progress";
 import { WebMcpProvider } from "@/components/webmcp-provider";
 import { siteConfig } from "@/lib/site";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { buildOrganizationJsonLd, buildWebsiteJsonLd } from "@heyclaude/registry/seo";
 
 function NotFoundComponent() {
   return (
@@ -121,6 +123,31 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
       {
         rel: "stylesheet",
         href: "https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap",
+      },
+    ],
+    scripts: [
+      {
+        type: "application/ld+json",
+        children: stringifyJsonLd(
+          buildOrganizationJsonLd({
+            siteUrl: siteConfig.url,
+            name: siteConfig.name,
+            githubUrl: siteConfig.githubUrl,
+            twitterUrl: siteConfig.twitterUrl,
+            discordUrl: siteConfig.discordUrl,
+            logo: `${siteConfig.url}/apple-touch-icon.png`,
+          }),
+        ),
+      },
+      {
+        type: "application/ld+json",
+        children: stringifyJsonLd(
+          buildWebsiteJsonLd({
+            siteUrl: siteConfig.url,
+            name: siteConfig.name,
+            description: siteConfig.description,
+          }),
+        ),
       },
     ],
   }),

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ShieldCheck, GitBranch, Users, Sparkles } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/about")({
   head: () => ({
@@ -17,6 +18,12 @@ export const Route = createFileRoute("/about")({
         property: "og:description",
         content: "The decision layer for Claude Code and AI agent workflows.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "HeyClaude", path: "/" },
+        { name: "About", path: "/about" },
+      ]),
     ],
   }),
   component: AboutPage,

--- a/apps/web/src/routes/api-docs.tsx
+++ b/apps/web/src/routes/api-docs.tsx
@@ -4,6 +4,7 @@ import { Search } from "lucide-react";
 import { ENDPOINTS, OPENAPI_TAGS } from "@/data/openapi";
 import { OpenApiEndpointCard, MethodPill } from "@/components/openapi";
 import { cn } from "@/lib/utils";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/api-docs")({
   head: () => ({
@@ -19,6 +20,12 @@ export const Route = createFileRoute("/api-docs")({
         content:
           "Search, trending, manifest, integrity, diff, submissions, and generated OpenAPI specs.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "HeyClaude", path: "/" },
+        { name: "API docs", path: "/api-docs" },
+      ]),
     ],
   }),
   component: ApiDocsPage,

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -6,6 +6,8 @@ import { ResourceCard } from "@/components/resource-card";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/best/$slug")({
   loader: ({ params }) => {
@@ -17,6 +19,7 @@ export const Route = createFileRoute("/best/$slug")({
     if (!loaderData) return { meta: [] };
     const l = loaderData.list;
     const url = absoluteUrl(`/best/${params.slug}`);
+    const ogImage = ogImageUrl({ title: l.title, eyebrow: "Best", description: l.seoDescription });
     const ld = {
       "@context": "https://schema.org",
       "@type": "ItemList",
@@ -36,10 +39,20 @@ export const Route = createFileRoute("/best/$slug")({
         { property: "og:title", content: l.title },
         { property: "og:description", content: l.seoDescription },
         { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
         { property: "og:type", content: "article" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
       ],
       links: [{ rel: "canonical", href: url }],
-      scripts: [{ type: "application/ld+json", children: stringifyJsonLd(ld) }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(ld) },
+        breadcrumbScript([
+          { name: "Directory", path: "/browse" },
+          { name: "Best", path: "/best" },
+          { name: l.title, path: `/best/${params.slug}` },
+        ]),
+      ],
     };
   },
   notFoundComponent: () => (

--- a/apps/web/src/routes/best.tsx
+++ b/apps/web/src/routes/best.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { BEST_LISTS, ENTRIES } from "@/data/entries";
 import { ResourceCard } from "@/components/resource-card";
 
@@ -21,6 +22,16 @@ export const Route = createFileRoute("/best")({
       { property: "og:url", content: absoluteUrl("/best") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/best") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Best", path: "/best" },
+      ]),
+      itemListScript(
+        BEST_LISTS.map((list) => ({ name: list.title, path: `/best/${list.slug}` })),
+        { name: "Best of HeyClaude" },
+      ),
+    ],
   }),
   component: BestPage,
 });

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -1,0 +1,129 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { ArrowLeft } from "lucide-react";
+import { ENTRIES } from "@/data/entries";
+import type { Entry } from "@/types/registry";
+import { ComparisonTable } from "@/components/comparison-table";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
+import { getComparison } from "@/data/comparisons";
+
+function resolveRefs(refs: string[]): Entry[] {
+  const out: Entry[] = [];
+  for (const ref of refs) {
+    const [category, slug] = ref.split("/");
+    const entry = ENTRIES.find((e) => e.category === category && e.slug === slug);
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+export const Route = createFileRoute("/compare/$slug")({
+  loader: ({ params }) => {
+    const comparison = getComparison(params.slug);
+    if (!comparison || resolveRefs(comparison.refs).length < 2) throw notFound();
+    return {};
+  },
+  head: ({ params }) => {
+    const comparison = getComparison(params.slug);
+    if (!comparison) return { meta: [] };
+    const entries = resolveRefs(comparison.refs);
+    const url = absoluteUrl(`/compare/${comparison.slug}`);
+    const ogImage = ogImageUrl({
+      title: comparison.heading,
+      eyebrow: "Compare",
+      description: comparison.seoDescription,
+    });
+    const itemList = {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: comparison.heading,
+      description: comparison.seoDescription,
+      numberOfItems: entries.length,
+      itemListElement: entries.map((e, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: e.title,
+        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
+      })),
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
+        { "@type": "ListItem", position: 2, name: "Compare", item: absoluteUrl("/compare") },
+        { "@type": "ListItem", position: 3, name: comparison.heading, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: `${comparison.title} — HeyClaude` },
+        { name: "description", content: comparison.seoDescription },
+        { property: "og:title", content: comparison.title },
+        { property: "og:description", content: comparison.seoDescription },
+        { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
+        { property: "og:type", content: "article" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(itemList) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: ComparisonPage,
+  notFoundComponent: () => (
+    <div className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <h1 className="h-display-2 text-ink">Comparison not found</h1>
+      <Link to="/compare" className="mt-4 inline-block text-ink-muted hover:text-ink">
+        ← Build your own comparison
+      </Link>
+    </div>
+  ),
+});
+
+function ComparisonPage() {
+  const { slug } = Route.useParams();
+  const comparison = getComparison(slug);
+  if (!comparison) return null;
+  const entries = resolveRefs(comparison.refs);
+
+  return (
+    <div className="mx-auto max-w-[1400px] px-4 py-10 sm:px-6">
+      <Breadcrumbs
+        items={[{ label: "Directory", to: "/browse" }, { label: "Compare", to: "/compare" }, { label: comparison.heading }]}
+        home
+      />
+      <header className="mt-6 max-w-3xl">
+        <div className="eyebrow">{entries.length} compared</div>
+        <h1 className="mt-2 h-display-1 text-ink text-balance">{comparison.heading}</h1>
+        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">{comparison.intro}</p>
+        <Link
+          to="/compare"
+          search={{ ids: entries.map((e) => `${e.category}/${e.slug}`).join(",") }}
+          className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+        >
+          <ArrowLeft className="h-4 w-4" /> Open in the interactive comparison tool
+        </Link>
+      </header>
+
+      <div className="mt-8">
+        <ComparisonTable entries={entries} />
+      </div>
+
+      <NewsletterInline
+        variant="quiet"
+        title="More comparisons, weekly"
+        description="A short, calm digest of reviewed Claude resources. Unsubscribe any time."
+        source={`compare:${comparison.slug}`}
+        className="mt-14"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/compare.tsx
+++ b/apps/web/src/routes/compare.tsx
@@ -4,18 +4,12 @@ import { absoluteUrl } from "@/lib/seo";
 import { z } from "zod";
 import { X, ArrowRight, ExternalLink, Plus, Search as SearchIcon } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
-import {
-  CategoryPill,
-  PlatformChip,
-  InstallRiskBadge,
-  NotesPresenceChips,
-} from "@/components/badges";
-import { TrustDrilldown } from "@/components/trust-drilldown";
+import { COMPARISONS } from "@/data/comparisons";
+import { CategoryPill } from "@/components/badges";
 import { CopyButton } from "@/components/copy-button";
-import { SourceCitations } from "@/components/source-citations";
+import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
 import { search } from "@/data/search";
-import { formatCompact } from "@/lib/format";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 
@@ -64,124 +58,6 @@ function resolveIds(ids: string): Entry[] {
   }
   return out;
 }
-
-interface RowDef {
-  label: string;
-  render: (e: Entry) => React.ReactNode;
-}
-
-const ROWS: RowDef[] = [
-  { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
-  { label: "Install risk", render: (e) => <InstallRiskBadge entry={e} /> },
-  { label: "Notes", render: (e) => <NotesPresenceChips entry={e} /> },
-  { label: "Category", render: (e) => <CategoryPill>{e.category}</CategoryPill> },
-  {
-    label: "Source",
-    render: (e) => <span className="text-sm capitalize text-ink">{e.source}</span>,
-  },
-  { label: "Author", render: (e) => <span className="text-sm text-ink">{e.author}</span> },
-  {
-    label: "Added",
-    render: (e) => <span className="font-mono text-xs text-ink-muted">{e.dateAdded}</span>,
-  },
-  {
-    label: "Platforms",
-    render: (e) => (
-      <div className="flex flex-wrap gap-1">
-        {e.platforms.map((p) => (
-          <PlatformChip key={p} id={p} />
-        ))}
-      </div>
-    ),
-  },
-  {
-    label: "Source repo",
-    render: (e) => (
-      <span className="font-mono text-sm tabular-nums text-ink">
-        {e.repoStats?.stars !== undefined ? `${formatCompact(e.repoStats.stars)} repo stars` : "—"}
-      </span>
-    ),
-  },
-  {
-    label: "Safety notes",
-    render: (e) =>
-      e.safetyNotes ? (
-        <span className="text-xs text-ink">
-          <span className="mr-1 text-trust-trusted">✓</span>
-          <span className="line-clamp-3">{e.safetyNotes}</span>
-        </span>
-      ) : (
-        <span className="text-xs text-ink-subtle">— missing</span>
-      ),
-  },
-  {
-    label: "Privacy notes",
-    render: (e) =>
-      e.privacyNotes ? (
-        <span className="text-xs text-ink">
-          <span className="mr-1 text-trust-trusted">✓</span>
-          <span className="line-clamp-3">{e.privacyNotes}</span>
-        </span>
-      ) : (
-        <span className="text-xs text-ink-subtle">— missing</span>
-      ),
-  },
-  {
-    label: "Prerequisites",
-    render: (e) =>
-      e.prerequisites && e.prerequisites.length > 0 ? (
-        <ul className="list-disc space-y-0.5 pl-4 text-xs text-ink-muted">
-          {e.prerequisites.slice(0, 4).map((p) => (
-            <li key={p}>{p}</li>
-          ))}
-        </ul>
-      ) : (
-        <span className="text-xs text-ink-subtle">— none listed</span>
-      ),
-  },
-  {
-    label: "Install",
-    render: (e) =>
-      e.installCommand ? (
-        <div className="space-y-1.5">
-          <pre className="max-h-24 overflow-auto rounded-md bg-background p-2 font-mono text-[11px] text-ink">
-            <code>{e.installCommand}</code>
-          </pre>
-          <CopyButton value={e.installCommand} label="Copy install" />
-        </div>
-      ) : (
-        <span className="text-xs text-ink-subtle">—</span>
-      ),
-  },
-  {
-    label: "Config",
-    render: (e) =>
-      e.configSnippet ? (
-        <div className="space-y-1.5">
-          <pre className="max-h-24 overflow-auto rounded-md bg-background p-2 font-mono text-[11px] text-ink">
-            <code>{e.configSnippet}</code>
-          </pre>
-          <CopyButton value={e.configSnippet} label="Copy config" />
-        </div>
-      ) : (
-        <span className="text-xs text-ink-subtle">—</span>
-      ),
-  },
-  {
-    label: "Citations",
-    render: (e) => (
-      <div className="text-xs">
-        <SourceCitations entry={e} />
-      </div>
-    ),
-  },
-  {
-    label: "Claim",
-    render: (e) => (
-      <span className="text-xs text-ink-muted">{e.claimed ? "Claimed" : "Unclaimed"}</span>
-    ),
-  },
-];
 
 function ComparePage() {
   const sp = Route.useSearch();
@@ -244,6 +120,21 @@ function ComparePage() {
             >
               Browse the directory
             </Link>
+          </div>
+          <div className="mt-6">
+            <div className="eyebrow mb-2">Popular comparisons</div>
+            <div className="flex flex-wrap justify-center gap-2">
+              {COMPARISONS.map((c) => (
+                <Link
+                  key={c.slug}
+                  to="/compare/$slug"
+                  params={{ slug: c.slug }}
+                  className="inline-flex items-center rounded-full border border-border bg-background px-3 py-1.5 text-xs text-ink-muted hover:text-ink"
+                >
+                  {c.heading}
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/routes/contributors.tsx
+++ b/apps/web/src/routes/contributors.tsx
@@ -3,6 +3,7 @@ import { Github } from "lucide-react";
 import { CONTRIBUTORS } from "@/data/contributors";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Monogram } from "@/components/monogram";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/contributors")({
   head: () => ({
@@ -11,6 +12,19 @@ export const Route = createFileRoute("/contributors")({
       { name: "description", content: "People whose submissions power the HeyClaude registry." },
       { property: "og:title", content: "Contributors — HeyClaude" },
       { property: "og:description", content: "Provenance is preserved on every entry." },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Contributors", path: "/contributors" },
+      ]),
+      itemListScript(
+        CONTRIBUTORS.map((c) => ({
+          name: c.name ?? c.slug,
+          path: `/contributors/${c.slug}`,
+        })),
+        { name: "HeyClaude contributors" },
+      ),
     ],
   }),
   component: ContributorsPage,

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -8,6 +8,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
 
@@ -27,6 +28,7 @@ export const Route = createFileRoute("/for/$platform")({
     const url = absoluteUrl(`/for/${params.platform}`);
     const title = `Claude resources for ${label} — HeyClaude`;
     const description = `${entries.length} source-backed Claude resources that work with ${label}: MCP servers, agents, skills, hooks, commands, and rules, curated in HeyClaude.`;
+    const ogImage = ogImageUrl({ title: `Claude for ${label}`, eyebrow: "Platform", description });
     const itemList = {
       "@context": "https://schema.org",
       "@type": "ItemList",
@@ -70,7 +72,9 @@ export const Route = createFileRoute("/for/$platform")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
         { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -30,7 +30,6 @@ import { useRecents } from "@/lib/recents";
 import { CATEGORIES, type Category } from "@/types/registry";
 import { ENTRIES, BRIEF_ISSUES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { search } from "@/data/search";
-import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 
 // Pre-computed counts at module scope so SSR + first paint show real numbers.
@@ -87,22 +86,6 @@ export const Route = createFileRoute("/")({
       { property: "og:url", content: absoluteUrl("/") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/") }],
-    scripts: [
-      {
-        type: "application/ld+json",
-        children: stringifyJsonLd({
-          "@context": "https://schema.org",
-          "@type": "WebSite",
-          name: "HeyClaude",
-          url: "https://heyclau.de/",
-          potentialAction: {
-            "@type": "SearchAction",
-            target: "https://heyclau.de/browse?q={search_term_string}",
-            "query-input": "required name=search_term_string",
-          },
-        }),
-      },
-    ],
   }),
   component: Home,
 });

--- a/apps/web/src/routes/integrations.tsx
+++ b/apps/web/src/routes/integrations.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { INTEGRATIONS } from "@/data/integrations";
 import { IntegrationCard } from "@/components/integration-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/integrations")({
   head: () => ({
@@ -17,6 +18,16 @@ export const Route = createFileRoute("/integrations")({
         property: "og:description",
         content: "Raycast extension, MCP server, Cursor adapter, REST API, and public feeds.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Integrations", path: "/integrations" },
+      ]),
+      itemListScript(
+        INTEGRATIONS.map((it) => ({ name: it.name, path: `/integrations/${it.slug}` })),
+        { name: "HeyClaude integrations" },
+      ),
     ],
   }),
   component: IntegrationsPage,

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { getEntry } from "@/data/search";
+import { renderOgSvg, categoryAccent } from "@/lib/og-image";
 
 /**
  * Lightweight OG image — deterministic SVG keyed by category + slug.
@@ -12,80 +13,18 @@ export const Route = createFileRoute("/og/$category/$slug")({
       GET: async ({ params }) => {
         const entry = getEntry(params.category, params.slug);
         const title = entry?.title ?? params.slug;
-        const desc =
+        const description =
           entry?.cardDescription ?? entry?.description ?? "Curated in the HeyClaude registry.";
         const author = entry?.author ?? "HeyClaude";
         const category = entry?.category ?? params.category;
 
-        // category color seed
-        const palette: Record<string, string> = {
-          mcp: "#7cd17c",
-          agents: "#f3b85a",
-          skills: "#8aa9ff",
-          rules: "#d4a5ff",
-          commands: "#ff9a7a",
-          hooks: "#76d7c4",
-          guides: "#ffcf72",
-          collections: "#b8a4ff",
-          statuslines: "#9bd6f0",
-        };
-        const accent = palette[category] ?? "#c5e84e";
-
-        const esc = (s: string) =>
-          s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-
-        // Word-wrap title to ~20 chars per line, 2 lines max
-        const wrap = (s: string, n: number) => {
-          const words = s.split(/\s+/);
-          const lines: string[] = [];
-          let cur = "";
-          for (const w of words) {
-            if ((cur + " " + w).trim().length > n) {
-              if (cur) lines.push(cur);
-              cur = w;
-            } else cur = (cur ? cur + " " : "") + w;
-          }
-          if (cur) lines.push(cur);
-          return lines.slice(0, 2);
-        };
-
-        const titleLines = wrap(title, 22);
-        const descLines = wrap(desc, 60).slice(0, 2);
-
-        const svg = `<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#f7f5ef"/>
-      <stop offset="1" stop-color="#ece8df"/>
-    </linearGradient>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
-  <rect x="0" y="0" width="14" height="630" fill="${accent}"/>
-  <g transform="translate(80,90)">
-    <text x="0" y="0" font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64" letter-spacing="2">
-      ${esc(category.toUpperCase())} · HEYCLAUDE
-    </text>
-    ${titleLines
-      .map(
-        (l, i) =>
-          `<text x="0" y="${110 + i * 88}" font-family="Space Grotesk, system-ui, sans-serif" font-weight="700" font-size="78" fill="#171614">${esc(l)}</text>`,
-      )
-      .join("")}
-    ${descLines
-      .map(
-        (l, i) =>
-          `<text x="0" y="${340 + i * 38}" font-family="DM Sans, system-ui, sans-serif" font-size="28" fill="#4d4c47">${esc(l)}</text>`,
-      )
-      .join("")}
-    <text x="0" y="460" font-family="DM Sans, system-ui, sans-serif" font-size="22" fill="#6b6a64">
-      by <tspan font-weight="600" fill="#171614">${esc(author)}</tspan>
-    </text>
-  </g>
-  <g transform="translate(80,540)">
-    <text font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64">heyclau.de</text>
-  </g>
-</svg>`;
+        const svg = renderOgSvg({
+          eyebrow: `${category} · HeyClaude`,
+          title,
+          description,
+          author,
+          accent: categoryAccent(category),
+        });
 
         return new Response(svg, {
           status: 200,

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,0 +1,37 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { renderOgSvg } from "@/lib/og-image";
+
+/**
+ * Generic OG image generator (query params) for hub/list pages that aren't a single entry.
+ * Lives on the crawlable /og namespace (NOT /api/og, which robots disallows) so social
+ * scrapers and Google can fetch the card.
+ */
+export const Route = createFileRoute("/og/")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const url = new URL(request.url);
+        const title = url.searchParams.get("title") ?? "HeyClaude";
+        const description =
+          url.searchParams.get("description") ?? url.searchParams.get("subtitle") ?? undefined;
+        const eyebrow = url.searchParams.get("eyebrow") ?? "HeyClaude";
+        const accent = url.searchParams.get("accent") ?? undefined;
+
+        const svg = renderOgSvg({
+          eyebrow,
+          title,
+          description: description ?? undefined,
+          accent: accent ?? undefined,
+        });
+
+        return new Response(svg, {
+          status: 200,
+          headers: {
+            "Content-Type": "image/svg+xml; charset=utf-8",
+            "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { renderOgSvg } from "@/lib/og-image";
+import { renderOgSvg, safeAccent } from "@/lib/og-image";
 
 /**
  * Generic OG image generator (query params) for hub/list pages that aren't a single entry.
@@ -15,13 +15,14 @@ export const Route = createFileRoute("/og/")({
         const description =
           url.searchParams.get("description") ?? url.searchParams.get("subtitle") ?? undefined;
         const eyebrow = url.searchParams.get("eyebrow") ?? "HeyClaude";
-        const accent = url.searchParams.get("accent") ?? undefined;
+        // accent is user-controlled; clamp to a safe hex before it reaches the SVG attribute.
+        const accent = safeAccent(url.searchParams.get("accent"));
 
         const svg = renderOgSvg({
           eyebrow,
           title,
           description: description ?? undefined,
-          accent: accent ?? undefined,
+          accent,
         });
 
         return new Response(svg, {

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { SUPPORTED_PLATFORMS, PLATFORM_MATRIX } from "@/data/platforms";
-import { PLATFORM_LABEL, PLATFORM_SUPPORT_LABEL } from "@/types/registry";
+import { PLATFORM_LABEL, PLATFORM_SUPPORT_LABEL, type Platform } from "@/types/registry";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/platforms")({
   head: () => ({
@@ -17,6 +18,19 @@ export const Route = createFileRoute("/platforms")({
         content:
           "Native skills, generated adapters, and manual-context fallbacks across every supported client.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Platforms", path: "/platforms" },
+      ]),
+      itemListScript(
+        (Object.keys(PLATFORM_LABEL) as Platform[]).map((id) => ({
+          name: PLATFORM_LABEL[id],
+          path: `/for/${id}`,
+        })),
+        { name: "Claude platforms" },
+      ),
     ],
   }),
   component: PlatformsPage,

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 import {
   ShieldCheck,
   GitBranch,
@@ -35,6 +36,12 @@ export const Route = createFileRoute("/quality")({
       { property: "og:url", content: absoluteUrl("/quality") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/quality") }],
+    scripts: [
+      breadcrumbScript([
+        { name: "HeyClaude", path: "/" },
+        { name: "Quality", path: "/quality" },
+      ]),
+    ],
   }),
   component: QualityPage,
 });

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -8,6 +8,7 @@ import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
 import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
+import { COMPARISONS } from "@/data/comparisons";
 
 function escapeXml(value: string) {
   return value
@@ -94,6 +95,7 @@ async function renderSitemap() {
     ),
     ...getIndexableTagGroups().map((group) => urlItem(`/tags/${group.slug}`, "0.5")),
     ...Object.keys(PLATFORM_LABEL).map((platform) => urlItem(`/for/${platform}`, "0.6")),
+    ...COMPARISONS.map((comparison) => urlItem(`/compare/${comparison.slug}`, "0.6")),
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),
     ...ENTRIES.map((entry) =>
       urlItem(

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 import { getTagGroup } from "@/lib/tags";
 
 export const Route = createFileRoute("/tags/$tag")({
@@ -18,6 +19,7 @@ export const Route = createFileRoute("/tags/$tag")({
     const url = absoluteUrl(`/tags/${params.tag}`);
     const title = `Claude ${group.name} resources — HeyClaude`;
     const description = `${group.entries.length} Claude Code resources tagged "${group.name}" — MCP servers, agents, skills, hooks, commands, rules, and more, curated in HeyClaude.`;
+    const ogImage = ogImageUrl({ title: `Tagged "${group.name}"`, eyebrow: "Tag", description });
     const itemList = {
       "@context": "https://schema.org",
       "@type": "ItemList",
@@ -47,7 +49,9 @@ export const Route = createFileRoute("/tags/$tag")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
         { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowUpRight, BadgeCheck } from "lucide-react";
 import { COMMERCIAL_TOOLS } from "@/data/tools";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 
 export const Route = createFileRoute("/tools")({
   head: () => ({
@@ -17,6 +18,19 @@ export const Route = createFileRoute("/tools")({
         content:
           "Editorial picks and disclosed partners. Free, open-source resources live in the directory.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Tools", path: "/tools" },
+      ]),
+      itemListScript(
+        COMMERCIAL_TOOLS.slice(0, 30).map((t) => ({
+          name: t.name,
+          path: `/entry/tools/${t.slug}`,
+        })),
+        { name: "Claude tools" },
+      ),
     ],
   }),
   component: ToolsPage,

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -10,6 +10,7 @@ import { ShareMenu } from "@/components/share-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CATEGORIES, type Entry } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { cn } from "@/lib/utils";
 
 const defaultSearch = {
@@ -68,6 +69,12 @@ export const Route = createFileRoute("/trending")({
         content:
           "Trending Claude Code MCP servers, agents, skills, hooks, and commands from live community and intent signals.",
       },
+    ],
+    scripts: [
+      breadcrumbScript([
+        { name: "Directory", path: "/browse" },
+        { name: "Trending", path: "/trending" },
+      ]),
     ],
   }),
   component: TrendingPage,

--- a/packages/registry/src/seo.js
+++ b/packages/registry/src/seo.js
@@ -25,6 +25,7 @@ export function buildOrganizationJsonLd(params = {}) {
     "@id": `${siteUrl.replace(/\/$/, "")}/#organization`,
     name: params.name || "HeyClaude",
     url: siteUrl,
+    ...(params.logo ? { logo: { "@type": "ImageObject", url: params.logo } } : {}),
     sameAs: uniqueValues([
       params.githubUrl,
       params.twitterUrl,

--- a/packages/registry/src/seo.js
+++ b/packages/registry/src/seo.js
@@ -25,7 +25,9 @@ export function buildOrganizationJsonLd(params = {}) {
     "@id": `${siteUrl.replace(/\/$/, "")}/#organization`,
     name: params.name || "HeyClaude",
     url: siteUrl,
-    ...(params.logo ? { logo: { "@type": "ImageObject", url: params.logo } } : {}),
+    ...(params.logo
+      ? { logo: { "@type": "ImageObject", url: absoluteSiteUrl(siteUrl, params.logo) } }
+      : {}),
     sameAs: uniqueValues([
       params.githubUrl,
       params.twitterUrl,

--- a/tests/og-image.test.ts
+++ b/tests/og-image.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { categoryAccent, renderOgSvg, safeAccent } from "@/lib/og-image";
+
+describe("og image accent sanitization", () => {
+  it("passes through valid hex colors", () => {
+    expect(safeAccent("#c5e84e")).toBe("#c5e84e");
+    expect(safeAccent("#FFF")).toBe("#FFF");
+    expect(safeAccent("#aabbccdd")).toBe("#aabbccdd");
+    expect(safeAccent(categoryAccent("mcp"))).toBe(categoryAccent("mcp"));
+  });
+
+  it("falls back to the default accent for missing or non-hex values", () => {
+    expect(safeAccent(undefined)).toBe("#c5e84e");
+    expect(safeAccent(null)).toBe("#c5e84e");
+    expect(safeAccent("red")).toBe("#c5e84e");
+    expect(safeAccent("#ggg")).toBe("#c5e84e");
+  });
+
+  it("rejects attribute-breakout payloads so the SVG cannot be injected", () => {
+    const payload = '"><script>alert(1)</script>';
+    expect(safeAccent(payload)).toBe("#c5e84e");
+
+    const svg = renderOgSvg({ title: "Hello", accent: payload });
+    expect(svg).not.toContain("<script>");
+    expect(svg).toContain('fill="#c5e84e"');
+  });
+});


### PR DESCRIPTION
## Summary

Follow-on SEO + agent-readiness improvements after #2135 (merged). Closes the remaining requested items and the additional opportunities surfaced in review.

### Structured data
- **Sitewide Organization + WebSite/SearchAction** JSON-LD (canonical registry builders) with logo + sameAs; removed the homepage's duplicate WebSite block.
- New `lib/seo-jsonld` helper; **ItemList + BreadcrumbList** on the best/tools/integrations/trending/contributors/platforms hubs and breadcrumb backing on about/quality/api-docs.

### OG images
- Shared `renderOgSvg` extracted; **generic crawlable `/og` generator** (query params) — deliberately not `/api/og` (robots-disallowed → scrapers can't fetch).
- Real `og:image` + `twitter:image` on category, tag, platform, best-list, and comparison pages.

### Curated comparison pages
- `ComparisonTable` extracted from `/compare` and **reused** (existing design primitives only).
- `data/comparisons.ts` curated set + `/compare/:slug` with ItemList/Breadcrumb JSON-LD + OG; 404s if a curated pairing can't resolve ≥2 entries. Listed on the `/compare` empty state and in the sitemap.

### Agent readiness
- MCP server-card tools now sourced from `@heyclaude/mcp/registry` (`TOOL_DEFINITIONS`) — no more hardcoded drift.

### Internal linking
- `/tags` and `/for` added to top nav + footer.

### Validation
`pnpm type-check`, `pnpm test` (703), `pnpm validate:raycast-feed` (922), `pnpm validate:openapi`, `pnpm build`, `git diff --check` — all green.

> Thin-entry content is handled as separate one-entry PRs (#2137, #2140, #2141, #2142, #2143, #2144).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Tags" and "Platforms" navigation links in header and footer menus.
  * Launched curated comparison pages to compare tools side-by-side.
  * Improved social media sharing with auto-generated Open Graph images.
  * Enhanced SEO with structured metadata for better search visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->