### PR TITLE
docs(content): expand Cursor tool listing

### DIFF
--- a/content/tools/cursor.mdx
+++ b/content/tools/cursor.mdx
@@ -24,7 +24,11 @@ keywords:
 
 ## Editorial notes
 
-Cursor is a strong fit for teams that want codebase-aware AI workflows inside an editor rather than a separate chat surface.
+Cursor is an AI-native code editor (a fork of VS Code) built around codebase-aware chat and agent-assisted edits. It indexes your project so the model can answer questions and make multi-file changes with whole-repo context, and its agent mode can plan and apply edits across files while you review the diffs.
+
+It is model-flexible and supports Claude models for chat and agent edits, so teams standardized on Claude can keep it as the reasoning engine inside the editor. Because it is a full editor rather than a terminal tool or a separate chat surface, the AI sits next to your code, tests, and terminal.
+
+Reach for Cursor when you want codebase-aware AI inside the editor and an agent that can carry out larger, multi-file changes. If you prefer a terminal-first workflow where each change lands as a Git commit, Aider is a leaner alternative.
 
 ## Disclosure
 

--- a/content/tools/cursor.mdx
+++ b/content/tools/cursor.mdx
@@ -14,6 +14,8 @@ pricingModel: freemium
 disclosure: heyclaude_pick
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Windows, Linux
+privacyNotes:
+  - Cursor indexes your project and sends code and prompts to the configured model provider (including Claude) for chat and agent edits.
 tags:
   - ai-coding
   - code-editor


### PR DESCRIPTION
## What
The `tools/cursor` listing had a one-sentence body, which read thin on the live page.

## Change
Expands the editorial notes with accurate detail: Cursor as an AI-native, codebase-aware editor (VS Code fork) with whole-repo indexing, an agent mode for multi-file changes, support for Claude models as the reasoning engine, and trade-offs vs a terminal-first tool like Aider.

## Notes
Editorial listing — no paid placement or affiliate link; disclosure unchanged. One source entry per the contribution policy.

## Validation
`pnpm validate:content:strict` — 922 content files pass.
