### PR TITLE
docs(content): expand n8n tool listing

### DIFF
--- a/content/tools/n8n.mdx
+++ b/content/tools/n8n.mdx
@@ -25,7 +25,11 @@ keywords:
 
 ## Editorial notes
 
-n8n is valuable for teams that want workflow automation with self-hosting options and AI integration steps.
+n8n is a source-available workflow automation platform you can self-host or run in the cloud. You build workflows visually from nodes — triggers, integrations, logic, and AI steps — to connect APIs, move data, and automate operations without writing glue code for every integration.
+
+For Claude workflows, n8n's AI nodes let you call models as steps inside a larger automation: pull data from a trigger, run it through Claude for classification or drafting, and route the result to another system. Self-hosting keeps data and credentials on your own infrastructure, which matters for sensitive pipelines.
+
+Reach for n8n when you want automation that mixes AI steps with hundreds of integrations and you value self-hosting and data control. If you only need an agent editing code, this is the wrong layer — it is an operations and automation tool, not a coding assistant.
 
 ## Disclosure
 


### PR DESCRIPTION
## What
The `tools/n8n` listing had a one-sentence body, which read thin on the live page.

## Change
Expands the editorial notes with accurate detail: n8n as a source-available, self-hostable visual automation platform; its AI nodes calling models (including Claude) as steps inside a larger workflow; the data-control benefit of self-hosting; and the boundary that it's an operations/automation tool, not a coding assistant.

## Notes
Editorial listing — no paid placement or affiliate link; disclosure unchanged. One source entry per the contribution policy.

## Validation
`pnpm validate:content:strict` — 922 content files pass.
