### PR TITLE
docs(content): reformat /debug command body into proper markdown

### DIFF
--- a/content/commands/debug.mdx
+++ b/content/commands/debug.mdx
@@ -48,4 +48,49 @@ robotsFollow: true
 commandSyntax: /debug
 ---
 
-The `/debug` command provides intelligent debugging assistance with root cause analysis, systematic troubleshooting, performance profiling, and automated fix generation for various programming languages and frameworks.\n\n## Usage\n\n`\n/debug [options] <error_or_file>\n`\n\n## Options\n\n### Debug Modes\n- `--interactive` - Step-by-step guided debugging\n- `--automated` - Automatic issue detection and fixes\n- `--analysis` - Deep code analysis without fixes\n- `--performance` - Performance bottleneck identification\n\n### Error Types\n- `--runtime` - Runtime errors and exceptions\n- `--logic` - Logic errors and unexpected behavior\n- `--memory` - Memory leaks and allocation issues\n- `--network` - Network and API related problems\n- `--database` - Database connection and query issues\n\n### Scope Options\n- `--function` - Debug specific function\n- `--class` - Debug entire class\n- `--module` - Debug module/file\n- `--system` - System-wide debugging\n\n### Output Formats\n- `--format=detailed` - Comprehensive analysis (default)\n- `--format=quick` - Quick diagnosis and fix\n- `--format=checklist` - Debugging checklist\n- `--format=trace` - Execution trace analysis\n\n## Examples\n\n### Runtime Error Debugging\n\n`javascript\n// Problematic code with multiple issues\nconst UserManager = {\n  users: [],\n  \n  async addUser(userData) {\n    // 🐛 Bug 1: No input validation\n    const user = {\n      id: this.users.length + 1, // 🐛 Bug 2: Race condition possible\n      name: userData.name,\n      email: userData.email,\n      createdAt: new Date()\n    };\n    \n    // 🐛 Bug 3: Async operation without proper error handling\n    const result = await fetch('/api/users', {\n      method: 'POST',\n      body: JSON.stringify(user) // 🐛 Bug 4: Missing Content-Type header\n    });\n    \n    // 🐛 Bug 5: No response status check\n    const savedUser = await result.json();\n    \n    this.users.push(savedUser);\n    return savedUser;\n  },\n  \n  findUserByEmail(email) {\n    // 🐛 Bug 6: Case-sensitive search\n    return this.users.find(user => user.email === email);\n  },\n  \n  deleteUser(userId) {\n    // 🐛 Bug 7: Modifying array while iterating\n    for (let i = 0; i < this.users.length; i++) {\n      if (this.users[i].id === userId) {\n        this.users.splice(i, 1);\n        break;\n      }\n    }\n  }\n};\n\n// Error scenario\nUserManager.addUser({ name: \"John\" }) // Missing email\n  .then(user => console.log('Added:', user))\n  .catch(error => console.error('Error:', error)); // 🐛 Error not properly caught\n`\n\n**Debug Analysis Output:**\n\n``markdown\n# 🐛 Debug Analysis: UserManager\n\n## 🚨 Critical Issues Found (7)\n\n### Issue 1: Missing Input Validation\n**Location:** Line 5 - `addUser` method\n**Severity:** High\n**Type:** Runtime Error\n\n**Problem:**\n``javascript\n// Current code (vulnerable)\nconst user = {\n id: this.users.length + 1,\n name: userData.name, // ❌ Could be undefined\n email: userData.email, // ❌ Could be undefined\n createdAt: new Date()\n};\n``\n\n**Error Symptoms:**\n- `TypeError: Cannot read property 'name' of undefined`\n- Silent failures with incomplete data\n- Database constraint violations\n\n**Root Cause:**\nNo validation of input parameters allows undefined/null values to propagate through the system.\n\n**Fix:**\n``javascript\nasync addUser(userData) {\n // Input validation\n if (!userData || typeof userData !== 'object') {\n throw new Error('Invalid user data: expected object');\n }\n \n const required = ['name', 'email'];\n const missing = required.filter(field => !userData[field]);\n \n if (missing.length > 0) {\n throw new Error(`Missing required fields: ${missing.join(', ')}`);\n }\n \n // Email format validation\n const emailRegex = /^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$/;\n if (!emailRegex.test(userData.email)) {\n throw new Error('Invalid email format');\n }\n \n // Continue with validated data...\n}\n`\n\n### Issue 2: Race Condition in ID Generation\n**Location:** Line 6\n**Severity:** High\n**Type:** Logic Error\n\n**Problem:**\n`javascript\nid: this.users.length + 1, // ❌ Not thread-safe\n`\n\n**Race Condition Scenario:**\n`\nThread A: reads length = 5, calculates id = 6\nThread B: reads length = 5, calculates id = 6\nThread A: adds user with id = 6\nThread B: adds user with id = 6 (DUPLICATE!)\n`\n\n**Fix Options:**\n\n**Option 1: UUID (Recommended)**\n`javascript\nconst { v4: uuidv4 } = require('uuid');\n\nconst user = {\n id: uuidv4(), // ✅ Guaranteed unique\n name: userData.name,\n email: userData.email,\n createdAt: new Date()\n};\n`\n\n**Option 2: Atomic Counter**\n`javascript\nclass UserManager {\n constructor() {\n this.users = [];\n this.nextId = 1;\n }\n \n generateId() {\n return this.nextId++; // ✅ Atomic increment\n }\n}\n```\n\nThis debugging analysis demonstrates systematic problem identification, root cause analysis, and comprehensive solution implementation with prevention strategies.
+The `/debug` command provides intelligent debugging assistance with root cause analysis, systematic troubleshooting, performance profiling, and automated fix generation across common languages and frameworks.
+
+## Usage
+
+```
+/debug [options] <error_or_file>
+```
+
+## Options
+
+### Debug modes
+
+- `--interactive` — step-by-step guided debugging
+- `--automated` — automatic issue detection and fixes
+- `--analysis` — deep code analysis without applying fixes
+- `--performance` — performance bottleneck identification
+
+### Error types
+
+- `--runtime` — runtime errors and exceptions
+- `--logic` — logic errors and unexpected behavior
+- `--memory` — memory leaks and allocation issues
+- `--network` — network and API problems
+- `--database` — database connection and query issues
+
+### Scope
+
+- `--function` — debug a specific function
+- `--class` — debug an entire class
+- `--module` — debug a module or file
+- `--system` — system-wide debugging
+
+### Output formats
+
+- `--format=detailed` — comprehensive analysis (default)
+- `--format=quick` — quick diagnosis and fix
+- `--format=checklist` — debugging checklist
+- `--format=trace` — execution-trace analysis
+
+## Example
+
+```
+/debug --runtime --format=detailed src/user-manager.js
+```
+
+For each issue it finds — missing input validation, race conditions in ID generation, unhandled async errors, case-sensitive lookups, or mutating an array while iterating — the assistant reports the location and severity, explains the root cause, and proposes a concrete fix with a prevention strategy.


### PR DESCRIPTION
## What

The `commands/debug` entry's body was stored as a single physical line containing literal `\n` escape sequences (and single-backtick fences), so on the live page it rendered as one unbroken, unreadable blob.

## Change

Reformats the body into proper Markdown — **Usage**, **Options** grouped by Debug modes / Error types / Scope / Output formats, and a concise **Example** — preserving the documented options and the original example's intent. Frontmatter is unchanged.

## Why

Fixes a rendering bug that made the page effectively thin/low-quality (it was among the *crawled – currently not indexed* URLs in Search Console). Content-only; one source entry per the contribution policy.

## Validation

`pnpm validate:content:strict` — 922 content files pass.