### PR TITLE
perf(web): edge-cache SSR HTML and /data/* assets

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -6,6 +6,7 @@
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 
 /data/*
+  Cache-Control: public, max-age=300, s-maxage=3600, stale-while-revalidate=86400
   Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://umami.heyclau.de https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://img.shields.io https://umami.heyclau.de https://challenges.cloudflare.com https://submission-gate.heyclau.de; frame-src https://challenges.cloudflare.com; form-action 'self' https://github.com; manifest-src 'self'
 
 /assets/*

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -97,6 +97,21 @@ export function applySecurityHeaders(headers: Headers, request?: Request) {
   return headers;
 }
 
+// SSR HTML that no route opted out of is safe to cache at the edge so repeat hits
+// skip re-rendering. Personalized/dynamic routes already set their own `Cache-Control`
+// (typically `no-store`), which is preserved; a `Set-Cookie` (session/personalization)
+// also disables caching as a backstop. CDN-only (`s-maxage`) — no browser `max-age`, so
+// a deploy invalidates immediately for users.
+const HTML_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=86400";
+
+export function applyEdgeCacheHeaders(headers: Headers, status: number, method: string) {
+  if (method !== "GET" || status !== 200) return headers;
+  if (headers.has("cache-control") || headers.has("set-cookie")) return headers;
+  if (!(headers.get("content-type") ?? "").includes("text/html")) return headers;
+  headers.set("cache-control", HTML_CACHE_CONTROL);
+  return headers;
+}
+
 export function getSecurityHeaders() {
   return Object.entries(SECURITY_HEADERS).map(([key, value]) => ({
     key,

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -3,7 +3,7 @@ import "./lib/error-capture";
 import { runWithCloudflareRuntime } from "./lib/cloudflare-env.server";
 import { consumeLastCapturedError } from "./lib/error-capture";
 import { renderErrorPage } from "./lib/error-page";
-import { applySecurityHeaders } from "./lib/security-headers";
+import { applyEdgeCacheHeaders, applySecurityHeaders } from "./lib/security-headers";
 
 type ServerEntry = {
   fetch: (request: Request, env: unknown, ctx: unknown) => Promise<Response> | Response;
@@ -24,6 +24,7 @@ async function getServerEntry(): Promise<ServerEntry> {
 // {"unhandled":true,"message":"HTTPError"} — try/catch alone never fires for those.
 function withSecurityHeaders(response: Response, request: Request): Response {
   const headers = applySecurityHeaders(new Headers(response.headers), request);
+  applyEdgeCacheHeaders(headers, response.status, request.method);
   return new Response(response.body, {
     status: response.status,
     statusText: response.statusText,

--- a/tests/crawler-policy.test.ts
+++ b/tests/crawler-policy.test.ts
@@ -14,7 +14,7 @@ describe("crawler and AI citation policy", () => {
     );
 
     expect(serverSource).toContain(
-      'import { applySecurityHeaders } from "./lib/security-headers"',
+      'import { applyEdgeCacheHeaders, applySecurityHeaders } from "./lib/security-headers"',
     );
     expect(serverSource).toContain(
       "function withSecurityHeaders(response: Response, request: Request): Response",

--- a/tests/edge-cache.test.ts
+++ b/tests/edge-cache.test.ts
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { applyEdgeCacheHeaders } from "@/lib/security-headers";
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function htmlHeaders(extra: Record<string, string> = {}) {
+  return new Headers({ "content-type": "text/html; charset=utf-8", ...extra });
+}
+
+describe("edge cache policy", () => {
+  it("caches a plain 200 text/html GET response at the edge", () => {
+    const headers = applyEdgeCacheHeaders(htmlHeaders(), 200, "GET");
+    expect(headers.get("cache-control")).toContain("s-maxage=300");
+    expect(headers.get("cache-control")).toContain("stale-while-revalidate");
+  });
+
+  it("never overrides a route's own Cache-Control (e.g. no-store)", () => {
+    const headers = applyEdgeCacheHeaders(
+      htmlHeaders({ "cache-control": "no-store" }),
+      200,
+      "GET",
+    );
+    expect(headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("does not cache personalized responses that set a cookie", () => {
+    const headers = applyEdgeCacheHeaders(
+      htmlHeaders({ "set-cookie": "session=abc" }),
+      200,
+      "GET",
+    );
+    expect(headers.has("cache-control")).toBe(false);
+  });
+
+  it("does not cache non-GET, non-200, or non-HTML responses", () => {
+    expect(applyEdgeCacheHeaders(htmlHeaders(), 200, "POST").has("cache-control")).toBe(false);
+    expect(applyEdgeCacheHeaders(htmlHeaders(), 404, "GET").has("cache-control")).toBe(false);
+    expect(applyEdgeCacheHeaders(htmlHeaders(), 500, "GET").has("cache-control")).toBe(false);
+    const json = new Headers({ "content-type": "application/json" });
+    expect(applyEdgeCacheHeaders(json, 200, "GET").has("cache-control")).toBe(false);
+  });
+
+  it("sets Cache-Control on the /data/* static-asset rule", () => {
+    const headersFile = fs.readFileSync(
+      path.join(repoRoot, "apps/web/public/_headers"),
+      "utf8",
+    );
+    const dataBlock = headersFile.split("/data/*")[1]?.split(/\n\/\S/)[0] ?? "";
+    expect(dataBlock).toContain("Cache-Control: public");
+    expect(dataBlock).toContain("stale-while-revalidate");
+  });
+});


### PR DESCRIPTION
Caches rendered HTML and the public `/data/*` JSON at the edge so repeat hits skip SSR and large data files stop re-downloading.

## Changes
- `applyEdgeCacheHeaders()` in `lib/security-headers.ts`, called from `server.ts`: caches **200 `text/html` GET** responses that set neither `Cache-Control` nor `Set-Cookie` → `public, s-maxage=300, stale-while-revalidate=86400`. Routes that opt out via their own `Cache-Control` (e.g. `no-store` on dynamic/auth/vote/submission routes) are preserved untouched; the `Set-Cookie` guard is a personalization backstop. CDN-only (no browser `max-age`) so a deploy invalidates immediately.
- `/data/*` `Cache-Control` rule in `public/_headers` (`max-age=300, s-maxage=3600, stale-while-revalidate=86400`), matching the 6h regeneration cron. `/assets/*` already had immutable caching; `/data/*` was the gap (~36 MB of JSON).

## Validation
- New `tests/edge-cache.test.ts` (caches plain HTML; never overrides existing `Cache-Control`; skips `Set-Cookie`/non-GET/non-200/non-HTML; `_headers` rule present).
- Updated the `crawler-policy` test that pins the `server.ts` import line.

Impact: TTFB + bytes. Closes #2146.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved edge caching for API endpoints with enhanced cache control policies.
  * Implemented server-side caching for HTML responses while intelligently preserving personalized content and session data.
  * Cache optimization reduces server load and improves overall application performance.

* **Tests**
  * Added comprehensive test coverage validating caching behavior across different request types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->