### PR TITLE
feat(seo): canonical defaults, OG/Twitter completeness, description clamp, article tags

### DIFF
--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -9,3 +9,15 @@ export function absoluteUrl(path: string) {
   const normalized = normalizePath(path);
   return new URL(normalized, siteConfig.url).toString();
 }
+
+/**
+ * Clamp a meta/OG description to a search-display-safe length (~155 chars; Google
+ * truncates around 160). Collapses whitespace and cuts on a word boundary.
+ */
+export function clampDescription(value: string, max = 155) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= max) return normalized;
+  const slice = normalized.slice(0, max - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  return `${(lastSpace > 40 ? slice.slice(0, lastSpace) : slice).trimEnd()}…`;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,8 +23,21 @@ import { SkipLink } from "@/components/skip-link";
 import { RouteProgress } from "@/components/route-progress";
 import { WebMcpProvider } from "@/components/webmcp-provider";
 import { siteConfig } from "@/lib/site";
+import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { buildOrganizationJsonLd, buildWebsiteJsonLd } from "@heyclaude/registry/seo";
+
+const twitterHandle = (() => {
+  try {
+    const handle = new URL(siteConfig.twitterUrl).pathname.split("/").filter(Boolean)[0];
+    return handle ? `@${handle.replace(/^@/, "")}` : undefined;
+  } catch {
+    return undefined;
+  }
+})();
+
+// Sitewide default OG/Twitter card. Routes that render a page-specific card override og:image.
+const defaultOgImage = absoluteUrl("/og-image.png");
 
 function NotFoundComponent() {
   return (
@@ -109,7 +122,17 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
           "Search, compare, and inspect trust on Claude Code MCP servers, skills, hooks, commands, agents, and tools.",
       },
       { property: "og:type", content: "website" },
+      { property: "og:site_name", content: siteConfig.name },
+      { property: "og:locale", content: "en_US" },
+      { property: "og:image", content: defaultOgImage },
       { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:image", content: defaultOgImage },
+      ...(twitterHandle
+        ? [
+            { name: "twitter:site", content: twitterHandle },
+            { name: "twitter:creator", content: twitterHandle },
+          ]
+        : []),
     ],
     links: [
       { rel: "stylesheet", href: appCss },

--- a/apps/web/src/routes/about.tsx
+++ b/apps/web/src/routes/about.tsx
@@ -3,6 +3,7 @@ import { ShieldCheck, GitBranch, Users, Sparkles } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/about")({
   head: () => ({
@@ -18,7 +19,9 @@ export const Route = createFileRoute("/about")({
         property: "og:description",
         content: "The decision layer for Claude Code and AI agent workflows.",
       },
+      { property: "og:url", content: absoluteUrl("/about") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/about") }],
     scripts: [
       breadcrumbScript([
         { name: "HeyClaude", path: "/" },

--- a/apps/web/src/routes/advertise.tsx
+++ b/apps/web/src/routes/advertise.tsx
@@ -1,13 +1,16 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 import { Check } from "lucide-react";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/advertise")({
   head: () => ({
     meta: [
       { title: "Advertise on HeyClaude" },
       { name: "description", content: "Sponsorship and paid listings on HeyClaude." },
+      { property: "og:url", content: absoluteUrl("/advertise") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/advertise") }],
   }),
   component: AdvertisePage,
 });

--- a/apps/web/src/routes/api-docs.tsx
+++ b/apps/web/src/routes/api-docs.tsx
@@ -5,6 +5,7 @@ import { ENDPOINTS, OPENAPI_TAGS } from "@/data/openapi";
 import { OpenApiEndpointCard, MethodPill } from "@/components/openapi";
 import { cn } from "@/lib/utils";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/api-docs")({
   head: () => ({
@@ -20,7 +21,9 @@ export const Route = createFileRoute("/api-docs")({
         content:
           "Search, trending, manifest, integrity, diff, submissions, and generated OpenAPI specs.",
       },
+      { property: "og:url", content: absoluteUrl("/api-docs") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/api-docs") }],
     scripts: [
       breadcrumbScript([
         { name: "HeyClaude", path: "/" },

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -26,11 +26,15 @@ export const Route = createFileRoute("/best/$slug")({
       name: l.title,
       description: l.subtitle,
       numberOfItems: l.picks.length,
-      itemListElement: l.picks.map((p, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        url: absoluteUrl(`/entry/${p.ref}`),
-      })),
+      itemListElement: l.picks.map((p, i) => {
+        const entry = ENTRIES.find((e) => `${e.category}/${e.slug}` === p.ref);
+        return {
+          "@type": "ListItem",
+          position: i + 1,
+          name: entry?.title ?? p.ref,
+          url: absoluteUrl(`/entry/${p.ref}`),
+        };
+      }),
     };
     return {
       meta: [

--- a/apps/web/src/routes/brief.tsx
+++ b/apps/web/src/routes/brief.tsx
@@ -3,6 +3,7 @@ import { Calendar } from "lucide-react";
 import { BRIEF_ISSUES, WEEKLY_BRIEF } from "@/data/entries";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/brief")({
   head: () => ({
@@ -17,7 +18,9 @@ export const Route = createFileRoute("/brief")({
         property: "og:description",
         content: "Reviewed picks, what shipped, and what to watch. No hype.",
       },
+      { property: "og:url", content: absoluteUrl("/brief") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/brief") }],
   }),
   component: BriefPage,
 });

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, ShieldCheck, ListChecks } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
 import { cn } from "@/lib/utils";
+import { absoluteUrl } from "@/lib/seo";
 
 type ClaimType = "maintain" | "transfer" | "correct" | "remove";
 
@@ -21,7 +22,9 @@ export const Route = createFileRoute("/claim")({
         name: "description",
         content: "Claim a HeyClaude listing, attach proof of ownership, and track claim status.",
       },
+      { property: "og:url", content: absoluteUrl("/claim") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/claim") }],
   }),
   component: ClaimPage,
 });

--- a/apps/web/src/routes/contributors.tsx
+++ b/apps/web/src/routes/contributors.tsx
@@ -4,6 +4,7 @@ import { CONTRIBUTORS } from "@/data/contributors";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Monogram } from "@/components/monogram";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/contributors")({
   head: () => ({
@@ -12,7 +13,9 @@ export const Route = createFileRoute("/contributors")({
       { name: "description", content: "People whose submissions power the HeyClaude registry." },
       { property: "og:title", content: "Contributors — HeyClaude" },
       { property: "og:description", content: "Provenance is preserved on every entry." },
+      { property: "og:url", content: absoluteUrl("/contributors") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/contributors") }],
     scripts: [
       breadcrumbScript([
         { name: "Directory", path: "/browse" },

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -33,7 +33,7 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { stringifyJsonLd } from "@/lib/json-ld";
-import { absoluteUrl } from "@/lib/seo";
+import { absoluteUrl, clampDescription } from "@/lib/seo";
 import { categoryLabels, categoryUsageHints } from "@/lib/site";
 import { tagSlug } from "@/lib/tags";
 // (HoverChevrons removed — related uses static grid)
@@ -172,18 +172,25 @@ export const Route = createFileRoute("/entry/$category/$slug")({
       ],
     };
     const ogUrl = absoluteUrl(`/og/${params.category}/${params.slug}`);
+    const ogTitle = `${e.title} — HeyClaude`;
+    const metaDescription = clampDescription(e.seoDescription ?? e.description);
     return {
       meta: [
-        { title: e.seoTitle ? `${e.seoTitle} — HeyClaude` : `${e.title} — HeyClaude` },
-        { name: "description", content: e.seoDescription ?? e.description },
-        { property: "og:title", content: `${e.title} — HeyClaude` },
-        { property: "og:description", content: e.seoDescription ?? e.description },
+        { title: e.seoTitle ? `${e.seoTitle} — HeyClaude` : ogTitle },
+        { name: "description", content: metaDescription },
+        { property: "og:title", content: ogTitle },
+        { property: "og:description", content: metaDescription },
         { property: "og:url", content: url },
         { property: "og:type", content: "article" },
         { property: "og:image", content: ogUrl },
+        { property: "article:published_time", content: e.dateAdded },
+        { property: "article:modified_time", content: e.reviewedAt ?? e.dateAdded },
+        ...(e.author ? [{ property: "article:author", content: e.author }] : []),
+        { property: "article:section", content: e.category },
+        ...(e.tags ?? []).map((tag) => ({ property: "article:tag", content: tag })),
         { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:title", content: e.title },
-        { name: "twitter:description", content: e.description },
+        { name: "twitter:title", content: ogTitle },
+        { name: "twitter:description", content: metaDescription },
         { name: "twitter:image", content: ogUrl },
       ],
       links: [{ rel: "canonical", href: url }],

--- a/apps/web/src/routes/integrations.tsx
+++ b/apps/web/src/routes/integrations.tsx
@@ -3,6 +3,7 @@ import { INTEGRATIONS } from "@/data/integrations";
 import { IntegrationCard } from "@/components/integration-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/integrations")({
   head: () => ({
@@ -18,7 +19,9 @@ export const Route = createFileRoute("/integrations")({
         property: "og:description",
         content: "Raycast extension, MCP server, Cursor adapter, REST API, and public feeds.",
       },
+      { property: "og:url", content: absoluteUrl("/integrations") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/integrations") }],
     scripts: [
       breadcrumbScript([
         { name: "Directory", path: "/browse" },

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -3,6 +3,7 @@ import { SUPPORTED_PLATFORMS, PLATFORM_MATRIX } from "@/data/platforms";
 import { PLATFORM_LABEL, PLATFORM_SUPPORT_LABEL, type Platform } from "@/types/registry";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/platforms")({
   head: () => ({
@@ -18,7 +19,9 @@ export const Route = createFileRoute("/platforms")({
         content:
           "Native skills, generated adapters, and manual-context fallbacks across every supported client.",
       },
+      { property: "og:url", content: absoluteUrl("/platforms") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/platforms") }],
     scripts: [
       breadcrumbScript([
         { name: "Directory", path: "/browse" },

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -21,6 +21,7 @@ import { logClientError } from "@/lib/client-logs";
 import { siteConfig } from "@/lib/site";
 import { CopyButton } from "@/components/copy-button";
 import { cn } from "@/lib/utils";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/submit")({
   head: () => ({
@@ -35,7 +36,9 @@ export const Route = createFileRoute("/submit")({
         property: "og:description",
         content: "Free, source-backed, useful. Paid tools route to the commercial intake.",
       },
+      { property: "og:url", content: absoluteUrl("/submit") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/submit") }],
   }),
   component: SubmitPage,
 });

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/tools/submit")({
   head: () => ({
@@ -11,7 +12,9 @@ export const Route = createFileRoute("/tools/submit")({
         content:
           "Route commercial Claude tools, sponsorships, listing claims, and paid review interest through HeyClaude lead capture.",
       },
+      { property: "og:url", content: absoluteUrl("/tools/submit") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/tools/submit") }],
   }),
   component: SubmitTool,
 });

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight, BadgeCheck } from "lucide-react";
 import { COMMERCIAL_TOOLS } from "@/data/tools";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/tools")({
   head: () => ({
@@ -18,7 +19,9 @@ export const Route = createFileRoute("/tools")({
         content:
           "Editorial picks and disclosed partners. Free, open-source resources live in the directory.",
       },
+      { property: "og:url", content: absoluteUrl("/tools") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/tools") }],
     scripts: [
       breadcrumbScript([
         { name: "Directory", path: "/browse" },

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -11,6 +11,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { CATEGORIES, type Entry } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { absoluteUrl } from "@/lib/seo";
 import { cn } from "@/lib/utils";
 
 const defaultSearch = {
@@ -69,7 +70,9 @@ export const Route = createFileRoute("/trending")({
         content:
           "Trending Claude Code MCP servers, agents, skills, hooks, and commands from live community and intent signals.",
       },
+      { property: "og:url", content: absoluteUrl("/trending") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/trending") }],
     scripts: [
       breadcrumbScript([
         { name: "Directory", path: "/browse" },

--- a/tests/clamp-description.test.ts
+++ b/tests/clamp-description.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { clampDescription } from "@/lib/seo";
+
+describe("clampDescription", () => {
+  it("returns short descriptions unchanged (whitespace collapsed)", () => {
+    expect(clampDescription("A concise description.")).toBe("A concise description.");
+    expect(clampDescription("multi   space\ntext")).toBe("multi space text");
+  });
+
+  it("clamps long descriptions to <= max and cuts on a word boundary", () => {
+    const long =
+      "This is a deliberately long meta description that comfortably exceeds the configured " +
+      "maximum length so that the clamp has to trim it down to a search-display-safe size.";
+    const out = clampDescription(long);
+    expect(out.length).toBeLessThanOrEqual(155);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toMatch(/\s…$/); // no dangling space before the ellipsis
+  });
+
+  it("respects a custom max", () => {
+    expect(clampDescription("one two three four five six", 10).length).toBeLessThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
Closes the on-page metadata gaps from the audit.

## Changes
- **Canonical + `og:url`** added to 12 indexable routes that lacked them: tools, integrations, platforms, contributors, trending, about, api-docs, advertise, claim, brief, submit, tools/submit. `/trending` canonical folds its `?category` facets onto the bare hub.
- **`__root` sitewide defaults**: `og:site_name`, `og:locale`, a default `og:image` + `twitter:image`, and `twitter:site`/`twitter:creator` derived from `siteConfig.twitterUrl`. Page-specific routes still override `og:image`.
- **Entry pages**: clamp meta/`og`/`twitter` description to ~155 chars (457 entries exceeded Google's display limit), align `twitter:title`/`twitter:description` with the `og` values, and emit `article:published_time`/`modified_time`/`author`/`section`/`tag`.
- **`best/$slug`** ItemList items now include resolved entry `name`.
- New `clampDescription()` helper in `lib/seo.ts`.

## Validation
- `pnpm type-check` clean; `seo-metadata`, `seo-jsonld`, and new `clamp-description` tests pass.

Closes #2148.