### PR TITLE
fix(seo): jobs soft-404 + JobPosting, tag noindex, robots cleanup

### DIFF
--- a/apps/web/src/lib/robots-policy.ts
+++ b/apps/web/src/lib/robots-policy.ts
@@ -2,7 +2,9 @@ import { siteConfig } from "@/lib/site";
 
 // Machine endpoints and generated artifacts should not be crawled: they waste crawl budget
 // and surface as "crawled - not indexed" / 404 noise in Search Console.
-const DISALLOW_PATHS = ["/api/", "/data/", "/downloads/", "/_next/"];
+// /_next/ was a Next.js artifact; this app is TanStack Start on Workers and never serves it.
+// Hashed build assets live under /assets/* and stay crawlable (Google needs JS/CSS to render).
+const DISALLOW_PATHS = ["/api/", "/data/", "/downloads/"];
 
 // AI content-usage preferences (contentsignals.org / draft-romm-aipref-contentsignals).
 // Fully open: appear in search + AI answers and allow training.

--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -1,5 +1,6 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { absoluteUrl } from "@/lib/seo";
+import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { NewsletterInline } from "@/components/newsletter-inline";
@@ -16,9 +17,18 @@ const loadJobDetailData = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     const { buildPublicJobsIndex, getJobBySlug, getJobs, toPublicJobListing } =
       await import("@/lib/jobs");
+    const { buildJobPostingJsonLd } = await import("@heyclaude/registry/seo");
+    const { stringifyJsonLd } = await import("@/lib/json-ld");
     const [job, jobs] = await Promise.all([getJobBySlug(data.slug), getJobs()]);
+    // Built from the raw job (has expiresAt/status); the builder returns null for missing
+    // fields or non-active roles, so stale listings never get JobPosting markup. Stringified
+    // here so the server fn returns a plain serializable string.
+    const jobPostingLd = job
+      ? buildJobPostingJsonLd(job as unknown as Record<string, unknown>)
+      : null;
     return {
       job: job ? toPublicJobListing(job) : null,
+      jobPostingLd: jobPostingLd ? stringifyJsonLd(jobPostingLd) : null,
       related: buildPublicJobsIndex(jobs.filter((item) => item.slug !== data.slug)).entries.slice(
         0,
         4,
@@ -29,43 +39,47 @@ const loadJobDetailData = createServerFn({ method: "GET" })
 export const Route = createFileRoute("/jobs/$slug")({
   loader: async ({ params }) => {
     const data = await loadJobDetailData({ data: { slug: params.slug } });
+    // Unknown/filled/removed slugs return a real 404 (was a soft-404 at HTTP 200, wasting
+    // crawl budget and emitting a self-canonical for a dead URL).
+    if (!data.job) throw notFound();
     return {
       slug: params.slug,
-      job: data.job ? normalizeJobListing(data.job) : null,
+      job: normalizeJobListing(data.job),
       related: data.related
         .map(normalizeJobListing)
         .filter((item) => item.slug)
         .slice(0, 4),
+      jobPostingLd: data.jobPostingLd,
     };
   },
   head: ({ params, loaderData }) => {
     const job = loaderData?.job;
+    if (!job) {
+      // Not-found path: no canonical for a dead URL.
+      return { meta: [{ title: "Role not found — HeyClaude jobs" }] };
+    }
     const url = absoluteUrl(`/jobs/${params.slug}`);
+    const title = `${job.title} at ${job.company}`;
+    const description = job.description || "Source-verified role from the HeyClaude jobs board.";
     return {
       meta: [
-        {
-          title: job
-            ? `${job.title} at ${job.company} — HeyClaude jobs`
-            : "Claude workflow role — HeyClaude",
-        },
-        {
-          name: "description",
-          content:
-            job?.description ||
-            "Source-verified roles building Claude Code, MCP servers, and agent workflows.",
-        },
-        {
-          property: "og:title",
-          content: job ? `${job.title} at ${job.company}` : "Claude workflow role — HeyClaude",
-        },
-        {
-          property: "og:description",
-          content: job?.description || "Source-verified role from the HeyClaude jobs board.",
-        },
+        { title: `${title} — HeyClaude jobs` },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
         { property: "og:url", content: url },
         { property: "og:type", content: "article" },
       ],
       links: [{ rel: "canonical", href: url }],
+      scripts: [
+        breadcrumbScript([
+          { name: "Jobs", path: "/jobs" },
+          { name: title, path: `/jobs/${params.slug}` },
+        ]),
+        ...(loaderData?.jobPostingLd
+          ? [{ type: "application/ld+json", children: loaderData.jobPostingLd }]
+          : []),
+      ],
     };
   },
   errorComponent: ({ error, reset }: ErrorComponentProps) => (

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -52,6 +52,9 @@ export const Route = createFileRoute("/tags/$tag")({
         { property: "og:image", content: ogImage },
         { name: "twitter:card", content: "summary_large_image" },
         { name: "twitter:image", content: ogImage },
+        // Single-entry tag pages are thin and excluded from the sitemap; keep them usable for
+        // in-page tag links but out of the index to match the sitemap policy.
+        ...(group.entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [


### PR DESCRIPTION
Crawl-hygiene fixes from the audit.

## Changes
- **`jobs/$slug` soft-404 → real 404**: unknown/filled/expired slugs now `throw notFound()` (was HTTP 200 with a self-canonical for a dead URL — crawl-budget waste). The existing `notFoundComponent` now actually fires.
- **JobPosting + BreadcrumbList JSON-LD** for valid roles. The JobPosting is built from the **raw** job (which carries `expiresAt`/`status`) inside the server fn and returned as a serializable string; the registry builder returns `null` for missing-field or non-active roles, so stale/closed listings never get markup. Unlocks Google Jobs eligibility.
- **`tags/$tag`**: single-entry tag pages get `robots: noindex, follow` — they’re excluded from the sitemap but still linked from entry tag chips, so they stay usable yet out of the index.
- **robots**: drop the dead `/_next/` Disallow (Next.js artifact; this is TanStack Start on Workers, and hashed `/assets/*` stay crawlable so Google can render).

## Validation
- `pnpm type-check` clean; `crawler-policy` + `sitemap-policy` tests pass.

Closes #2150.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **SEO & Indexing Updates**
  * Updated site crawling rules to expand search engine access.
  * Job posting pages now include structured data for improved discoverability.
  * Single-entry tag pages excluded from search indexing while remaining accessible through site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->