### PR TITLE
feat(agents): llms.txt discovery links, MCP resources, category RSS, feed map

### DIFF
--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -34,6 +34,23 @@ export function buildLlmsTxt(origin: string): string {
     }
     lines.push("");
   }
+
+  // Optional section (llmstxt.org): supplementary machine-readable surfaces agents can pull.
+  lines.push("## Optional");
+  lines.push("");
+  lines.push(
+    `- [Full corpus](${origin}/llms-full.txt): every entry with descriptions, metadata, and install/config snippets`,
+  );
+  lines.push(`- [OpenAPI spec](${origin}/openapi.json): machine-readable REST API`);
+  lines.push(`- [API feed](${origin}/api/registry/feed): endpoint map and distribution feeds`);
+  lines.push(
+    `- [Directory index](${origin}/data/directory-index.json): flat per-entry JSON with tags and keywords`,
+  );
+  lines.push(
+    `- [MCP server card](${origin}/.well-known/mcp/server-card.json): MCP tools and resources`,
+  );
+  lines.push(`- [Agent skills index](${origin}/.well-known/agent-skills/index.json)`);
+  lines.push("");
   return lines.join("\n");
 }
 

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -111,7 +111,15 @@ export const Route = createFileRoute("/$category")({
         { name: "twitter:card", content: "summary_large_image" },
         { name: "twitter:image", content: ogImage },
       ],
-      links: [{ rel: "canonical", href: url }],
+      links: [
+        { rel: "canonical", href: url },
+        {
+          rel: "alternate",
+          type: "application/rss+xml",
+          href: absoluteUrl(`/feeds/${id}.xml`),
+          title: `Claude ${label} — HeyClaude`,
+        },
+      ],
       scripts: [
         { type: "application/ld+json", children: stringifyJsonLd(itemList) },
         { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },

--- a/apps/web/src/routes/[.]well-known.mcp.server-card[.]json.ts
+++ b/apps/web/src/routes/[.]well-known.mcp.server-card[.]json.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { TOOL_DEFINITIONS } from "@heyclaude/mcp/registry";
+import { TOOL_DEFINITIONS, RESOURCE_TEMPLATES } from "@heyclaude/mcp/registry";
 import { siteConfig } from "@/lib/site";
 import { getIntegration } from "@/data/integrations";
 import { applySecurityHeaders } from "@/lib/security-headers";
@@ -16,8 +16,14 @@ function serverCard() {
     description:
       "Search and inspect the HeyClaude directory of Claude Code MCP servers, agents, skills, hooks, commands, rules, collections, and tools.",
     transport: { type: "streamable-http", endpoint: `${base}/api/mcp` },
-    capabilities: { tools: {} },
+    capabilities: { tools: {}, resources: {} },
     tools: TOOL_DEFINITIONS.map((tool) => ({ name: tool.name, description: tool.description })),
+    resourceTemplates: RESOURCE_TEMPLATES.map((resource) => ({
+      uriTemplate: resource.uriTemplate,
+      name: resource.name,
+      description: resource.description,
+      mimeType: resource.mimeType,
+    })),
     documentation: `${base}/api-docs`,
     homepage: base,
   };

--- a/apps/web/src/routes/api/registry/feed.ts
+++ b/apps/web/src/routes/api/registry/feed.ts
@@ -26,6 +26,8 @@ export const GET = createApiHandler("registry.feed", async ({ request }) => {
       integrity: "/api/registry/integrity?artifact={artifact}&hash={sha256}",
       entry: "/api/registry/entries/{category}/{slug}",
       entryLlms: "/api/registry/entries/{category}/{slug}/llms",
+      directoryIndex: "/data/directory-index.json",
+      searchIndex: "/data/search-index.json",
       jobs: "/api/jobs?limit=100",
       ecosystemFeed: "/data/ecosystem-feed.json",
       mcpRegistryFeed: "/data/mcp-registry-feed.json",


### PR DESCRIPTION
AI-agent-readiness wins from the audit (additive, no behavior regressions).

## Changes
- **llms.txt** gains an `## Optional` section (per llmstxt.org) linking llms-full.txt, openapi.json, the API feed, the directory index, the MCP server card, and the agent-skills index — closes the discovery loop to the surfaces already shipped.
- **MCP server card** now advertises `capabilities.resources` + a `resourceTemplates` summary from `@heyclaude/mcp/registry` `RESOURCE_TEMPLATES` (the server implements resources; the card only listed tools).
- **`$category` hubs** emit `<link rel="alternate" type="application/rss+xml">` for `/feeds/{category}.xml` autodiscovery.
- **`/api/registry/feed`** endpoint map adds `directoryIndex` + `searchIndex` (the richest flat per-entry indexes, previously undiscoverable from the API).

## Deliberately deferred
Unifying `/llms-full.txt` onto the registry `renderCorpusLlms` generator was evaluated and **not** done: `renderEntryLlms` renders `body` content but omits the install/config/`fullCopy` code blocks the current generator emits, so the swap would *regress* AI-ingestion content. The richer per-entry citation format is already served at `/api/registry/.../llms`.

## Validation
- `pnpm type-check` clean; `crawler-policy` + `mcp-server` (56) tests pass.

Closes #2151.