### PR TITLE
feat(seo): contributor & integration page metadata + JSON-LD

### DIFF
--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -4,6 +4,9 @@ import { getContributor, CONTRIBUTORS } from "@/data/contributors";
 import { ENTRIES } from "@/data/entries";
 import { ResourceCard } from "@/components/resource-card";
 import { Monogram } from "@/components/monogram";
+import { absoluteUrl } from "@/lib/seo";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/contributors/$slug")({
   loader: ({ params }) => {
@@ -11,21 +14,63 @@ export const Route = createFileRoute("/contributors/$slug")({
     if (!contributor) throw notFound();
     return { contributor };
   },
-  head: ({ loaderData }) => ({
-    meta: loaderData
-      ? [
-          { title: `${loaderData.contributor.name} — HeyClaude contributor` },
-          {
-            name: "description",
-            content:
-              loaderData.contributor.bio ??
-              `Resources contributed by ${loaderData.contributor.name}.`,
-          },
-          { property: "og:title", content: `${loaderData.contributor.name} — HeyClaude` },
-          { property: "og:description", content: loaderData.contributor.bio ?? "" },
-        ]
-      : [],
-  }),
+  head: ({ params, loaderData }) => {
+    const c = loaderData?.contributor;
+    if (!c) return { meta: [{ title: "Contributor — HeyClaude" }] };
+    const url = absoluteUrl(`/contributors/${params.slug}`);
+    const name = c.name ?? c.handle ?? params.slug;
+    const description =
+      c.bio ?? `Resources contributed to the HeyClaude registry by ${name} (@${c.handle}).`;
+    const ogImage = ogImageUrl({ title: name, eyebrow: "Contributor", description });
+    const person = {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "@id": `${url}#person`,
+      name,
+      url,
+      ...(c.handle ? { alternateName: `@${c.handle}` } : {}),
+      ...(c.bio ? { description: c.bio } : {}),
+      ...(c.github ? { sameAs: [c.github] } : {}),
+    };
+    const profilePage = {
+      "@context": "https://schema.org",
+      "@type": "ProfilePage",
+      url,
+      mainEntity: { "@id": `${url}#person` },
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Contributors",
+          item: absoluteUrl("/contributors"),
+        },
+        { "@type": "ListItem", position: 2, name, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: `${name} — HeyClaude contributor` },
+        { name: "description", content: description },
+        { property: "og:title", content: `${name} — HeyClaude` },
+        { property: "og:description", content: description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
+        { property: "og:type", content: "profile" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(person) },
+        { type: "application/ld+json", children: stringifyJsonLd(profilePage) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
   component: ContributorPage,
 });
 

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -5,6 +5,9 @@ import { IntegrationMarkTile } from "@/components/integration-marks";
 import { IntegrationCard } from "@/components/integration-card";
 import { LiveVersionBadge } from "@/components/live-version-badge";
 import { CopyButton } from "@/components/copy-button";
+import { absoluteUrl } from "@/lib/seo";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/integrations/$slug")({
   loader: ({ params }) => {
@@ -12,16 +15,54 @@ export const Route = createFileRoute("/integrations/$slug")({
     if (!integration) throw notFound();
     return { integration };
   },
-  head: ({ loaderData }) => ({
-    meta: loaderData
-      ? [
-          { title: `${loaderData.integration.name} — HeyClaude integration` },
-          { name: "description", content: loaderData.integration.tagline },
-          { property: "og:title", content: `${loaderData.integration.name} — HeyClaude` },
-          { property: "og:description", content: loaderData.integration.tagline },
-        ]
-      : [],
-  }),
+  head: ({ params, loaderData }) => {
+    const it = loaderData?.integration;
+    if (!it) return { meta: [{ title: "Integration — HeyClaude" }] };
+    const url = absoluteUrl(`/integrations/${params.slug}`);
+    const description = it.tagline;
+    const ogImage = ogImageUrl({ title: it.name, eyebrow: "Integration", description });
+    const app = {
+      "@context": "https://schema.org",
+      "@type": "SoftwareApplication",
+      name: it.name,
+      description,
+      url,
+      applicationCategory: "DeveloperApplication",
+      ...(it.version ? { softwareVersion: it.version } : {}),
+      publisher: { "@type": "Organization", name: "HeyClaude", url: absoluteUrl("/") },
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Integrations",
+          item: absoluteUrl("/integrations"),
+        },
+        { "@type": "ListItem", position: 2, name: it.name, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: `${it.name} — HeyClaude integration` },
+        { name: "description", content: description },
+        { property: "og:title", content: `${it.name} — HeyClaude` },
+        { property: "og:description", content: description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
+        { property: "og:type", content: "website" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(app) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
   component: IntegrationDetail,
 });
 


### PR DESCRIPTION
Two crawlable, content-rich page types previously shipped only a bare title + description.

## Changes
- **`contributors/$slug`**: canonical, `og:url`, `og:image`, twitter card, and a **non-empty** `og:description` fallback. Emits `Person` + `ProfilePage` + `BreadcrumbList` JSON-LD (name, profile URL, `@handle`, bio, `sameAs:[github]`).
- **`integrations/$slug`**: canonical, `og:url`, `og:image`, twitter card. Emits a **ratings-free** `SoftwareApplication` (`DeveloperApplication`, optional `softwareVersion`, HeyClaude publisher) + `BreadcrumbList`.

## Validation
- `pnpm type-check` clean.

Closes #2152.