### PR TITLE
feat(seo): footer categories, breadcrumb UI, entry→hub internal links

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import { ScrollProgress } from "./scroll-progress";
 import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { NewsletterInline } from "./newsletter-inline";
+import { CATEGORIES } from "@/types/registry";
 
 const NAV = [
   { to: "/browse", label: "Browse" },
@@ -149,6 +150,7 @@ export function Footer() {
             { to: "/tags", label: "Tags" },
             { to: "/for", label: "Platforms" },
             { to: "/best", label: "Best lists" },
+            { to: "/compare", label: "Compare" },
             { to: "/quality", label: "Quality" },
             { to: "/changelog", label: "Changelog" },
             { to: "/brief", label: "Weekly Brief" },
@@ -179,6 +181,23 @@ export function Footer() {
           ]}
           span={3}
         />
+      </div>
+      <div className="border-t border-border">
+        <div className="mx-auto max-w-[1400px] px-4 py-4 sm:px-6">
+          <div className="eyebrow mb-2">Categories</div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-ink-muted">
+            {CATEGORIES.map((c) => (
+              <Link
+                key={c.id}
+                to="/$category"
+                params={{ category: c.id }}
+                className="hover:text-ink"
+              >
+                {c.label}
+              </Link>
+            ))}
+          </div>
+        </div>
       </div>
       <div className="border-t border-border">
         <div className="mx-auto flex max-w-[1400px] flex-col items-start gap-3 px-4 py-5 text-xs text-ink-subtle sm:flex-row sm:items-center sm:justify-between sm:px-6">

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { ArrowLeft, CalendarDays, User } from "lucide-react";
+import { CalendarDays, User } from "lucide-react";
 import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entries";
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
+import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
@@ -84,12 +85,7 @@ function BestDetail() {
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
-      <Link
-        to="/best"
-        className="inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
-      >
-        <ArrowLeft className="h-4 w-4" /> All best lists
-      </Link>
+      <Breadcrumbs home items={[{ label: "Best lists", to: "/best" }, { label: list.title }]} />
 
       <div className="mt-6 eyebrow">
         {list.eyebrow} · {list.category} · {resolved.length} picks

--- a/apps/web/src/routes/best.tsx
+++ b/apps/web/src/routes/best.tsx
@@ -4,6 +4,7 @@ import { absoluteUrl } from "@/lib/seo";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { BEST_LISTS, ENTRIES } from "@/data/entries";
 import { ResourceCard } from "@/components/resource-card";
+import { Breadcrumbs } from "@/components/breadcrumbs";
 
 export const Route = createFileRoute("/best")({
   head: () => ({
@@ -47,7 +48,8 @@ function BestPage() {
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
-      <div className="eyebrow">Best lists · editorial</div>
+      <Breadcrumbs home items={[{ label: "Best lists" }]} />
+      <div className="mt-4 eyebrow">Best lists · editorial</div>
       <h1 className="mt-2 h-display-1 text-ink text-balance">Curated for real workflows</h1>
       <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
         Tightly scoped picks for specific jobs. Every list explains why each entry made the cut and

--- a/apps/web/src/routes/compare.tsx
+++ b/apps/web/src/routes/compare.tsx
@@ -6,6 +6,7 @@ import { X, ArrowRight, ExternalLink, Plus, Search as SearchIcon } from "lucide-
 import { ENTRIES } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { CategoryPill } from "@/components/badges";
+import { Breadcrumbs } from "@/components/breadcrumbs";
 import { CopyButton } from "@/components/copy-button";
 import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
@@ -143,7 +144,8 @@ function ComparePage() {
 
   return (
     <div className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
-      <div className="flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
+      <Breadcrumbs home items={[{ label: "Compare" }]} />
+      <div className="mt-4 flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
         <div>
           <div className="eyebrow">Compare</div>
           <h1 className="mt-1 h-display-2 text-ink text-balance">

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -257,7 +257,11 @@ function Dossier() {
       <Breadcrumbs
         items={[
           { label: "Directory", to: "/browse" },
-          { label: entry.category, to: "/browse", search: { category: entry.category } },
+          {
+            label: categoryLabels[entry.category] ?? entry.category,
+            to: "/$category",
+            params: { category: entry.category },
+          },
           { label: entry.title },
         ]}
       />
@@ -596,11 +600,11 @@ function Dossier() {
               </div>
               <div className="mt-3 text-right">
                 <Link
-                  to="/browse"
-                  search={{ category: entry.category }}
+                  to="/$category"
+                  params={{ category: entry.category }}
                   className="story-link text-xs font-medium text-ink"
                 >
-                  More in {entry.category} →
+                  More in {categoryLabels[entry.category] ?? entry.category} →
                 </Link>
               </div>
             </DossierSection>


### PR DESCRIPTION
Core internal-linking wins from the audit.

## Changes
- **Footer**: full-width **Categories** strip linking all 10 `/$category` hubs from every page + a **Compare** link in the Product column — site-wide PageRank to the indexable hubs.
- **Breadcrumb UI** added to `/best`, `/best/$slug` (replacing the bare back link), and `/compare` (they had BreadcrumbList JSON-LD but no visible trail).
- **Entry pages**: breadcrumb category crumb and the "More in {category}" link now point at the indexable `/$category` hub instead of canonical-deduped `/browse?category=`, consolidating link equity; labels via `categoryLabels`.

## Follow-up (tracked separately)
Deeper entry cross-linking — "Compared in"/"Featured in" backlinks, linkified platform chips, tag co-occurrence, related-group labeling — deferred to keep this PR focused/low-risk.

## Validation
- `pnpm type-check` clean.

Closes #2149.