### PR TITLE
perf(web): lazy-load registry dataset off the universal bundle + load intended fonts

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -17,7 +17,6 @@ import {
   Shield,
   Lock,
 } from "lucide-react";
-import { search } from "@/data/search";
 import { CategoryPill, Kbd, TrustBadge } from "./badges";
 import { useTheme } from "@/lib/theme";
 import { useShortcuts } from "./shortcuts-dialog";
@@ -64,6 +63,22 @@ export function CommandBar({
   const { toggle: toggleTheme } = useTheme();
   const shortcuts = useShortcuts();
 
+  // Lazy-load the in-memory search index (and the registry dataset it pulls in) only when the
+  // bar is opened or typed into, so the ~1 MB dataset stays out of the universal client bundle.
+  const [searchFn, setSearchFn] = React.useState<
+    (typeof import("@/data/search"))["search"] | null
+  >(null);
+  React.useEffect(() => {
+    if ((!open && !q) || searchFn) return;
+    let cancelled = false;
+    void import("@/data/search").then((m) => {
+      if (!cancelled) setSearchFn(() => m.search);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, q, searchFn]);
+
   React.useEffect(() => {
     const id = setInterval(() => setPlaceholderIdx((i) => (i + 1) % EXAMPLES.length), 2800);
     return () => clearInterval(id);
@@ -71,12 +86,12 @@ export function CommandBar({
 
   const results = React.useMemo(
     () =>
-      q.trim()
-        ? search({ q, sort: "popular" })
+      q.trim() && searchFn
+        ? searchFn({ q, sort: "popular" })
             .slice(0, 6)
             .filter((r) => !quickCat || r.category === quickCat)
         : [],
-    [q, quickCat],
+    [q, quickCat, searchFn],
   );
 
   const actions = React.useMemo<ActionItem[]>(() => {

--- a/apps/web/src/components/webmcp-provider.tsx
+++ b/apps/web/src/components/webmcp-provider.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "react";
-import { search } from "@/data/search";
 import { absoluteUrl } from "@/lib/seo";
 
 // WebMCP (navigator.modelContext) — exposes directory search to in-browser AI agents.
@@ -42,6 +41,8 @@ export function WebMcpProvider() {
             async execute(args) {
               const query = String(args.query ?? "");
               const category = typeof args.category === "string" ? args.category : "";
+              // Lazy-load the dataset only when an agent actually calls the tool.
+              const { search } = await import("@/data/search");
               const results = search({ q: query })
                 .filter((e) => !category || e.category === category)
                 .slice(0, 10)

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import type { Entry } from "@/types/registry";
-import { ENTRIES } from "@/data/entries";
 
 interface CompareCtx {
   items: Entry[];
@@ -19,7 +18,7 @@ interface CompareCtx {
 
 const Ctx = React.createContext<CompareCtx | null>(null);
 
-function resolve(param: string): Entry[] {
+function resolve(entries: Entry[], param: string): Entry[] {
   if (!param) return [];
   const refs = param
     .split(",")
@@ -31,7 +30,7 @@ function resolve(param: string): Entry[] {
   for (const ref of refs) {
     const [cat, slug] = ref.split("/");
     if (!cat || !slug || seen.has(ref)) continue;
-    const e = ENTRIES.find((x) => x.category === cat && x.slug === slug);
+    const e = entries.find((x) => x.category === cat && x.slug === slug);
     if (e) {
       out.push(e);
       seen.add(ref);
@@ -63,11 +62,19 @@ export function CompareProvider({ children }: { children: React.ReactNode }) {
       },
       has: (slug) => items.some((x) => x.slug === slug),
       hydrate: (param) => {
-        const next = resolve(param);
-        // Only update if changed to avoid render loops
-        const sig = next.map((e) => `${e.category}/${e.slug}`).join(",");
-        const curSig = items.map((e) => `${e.category}/${e.slug}`).join(",");
-        if (sig !== curSig) setItems(next);
+        if (!param) {
+          if (items.length) setItems([]);
+          return;
+        }
+        // Lazy-load the dataset only when a compare selection is hydrated from the URL,
+        // keeping the registry dataset out of the universal client bundle.
+        void import("@/data/entries").then(({ ENTRIES }) => {
+          const next = resolve(ENTRIES, param);
+          // Only update if changed to avoid render loops
+          const sig = next.map((e) => `${e.category}/${e.slug}`).join(",");
+          const curSig = items.map((e) => `${e.category}/${e.slug}`).join(",");
+          if (sig !== curSig) setItems(next);
+        });
       },
       serialize: () => items.map((e) => `${e.category}/${e.slug}`).join(","),
       getShareUrl: () => {

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -39,9 +39,11 @@ const SECURITY_HEADERS = {
     "object-src 'none'",
     "frame-ancestors 'none'",
     scriptSrc,
-    "style-src 'self' 'unsafe-inline'",
+    // Allow the Google Fonts stylesheet + font files the app already links in __root.tsx
+    // (previously CSP-blocked, so the intended typography silently fell back to system fonts).
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "img-src 'self' data: blob: https:",
-    "font-src 'self' data:",
+    "font-src 'self' data: https://fonts.gstatic.com",
     connectSrc,
     "frame-src https://challenges.cloudflare.com",
     "form-action 'self' https://github.com",


### PR DESCRIPTION
The headline audit finding: the **3.68 MB** atlas-registry dataset was in the universal client chunk (loaded on **every** page) via three always-mounted modules — the command bar, the WebMCP provider, and the `CompareProvider`.

## Changes
- **command-bar**: dynamic-import `@/data/search` on open/first-input (results fill in once loaded).
- **webmcp-provider**: dynamic-import `@/data/search` inside the async tool handler.
- **lib/compare**: dynamic-import `@/data/entries` inside `hydrate()` (URL-driven, not render path).
- **Fonts**: `__root.tsx` links Google Fonts but the CSP omitted the font origins, so the intended typography was silently blocked and fell back to system fonts. Allow `fonts.googleapis.com` (style-src) + `fonts.gstatic.com` (font-src).

## Verified via build
The dataset chunk is now **route-scoped** (home + pages that use it) instead of universal — the most-referenced/every-page chunks are all <5 KB gzip. Entry, profile, about, and guide pages no longer ship ~1 MB of data. `pnpm type-check` + `pnpm --filter web build` pass.

## Deliberately skipped
`manualChunks` vendor splitting — the build uses a wrapped `@lovable.dev` TanStack/nitro preset; injecting rollup output config risks the SSR build and isn't worth it now that the dataset (the real weight) is off the critical path. The home route still imports the dataset directly (it renders featured entries) — a loader-based version is a possible follow-up.

Closes #2153.