### PR TITLE
feat(seo): entry cross-links + related tags

### DIFF
--- a/apps/web/src/components/badges.tsx
+++ b/apps/web/src/components/badges.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Link } from "@tanstack/react-router";
 import { cn } from "@/lib/utils";
 import {
   TRUST_LABEL,
@@ -84,14 +85,29 @@ export function SourceBadge({ status, className }: { status: SourceStatus; class
   );
 }
 
-export function PlatformChip({ id }: { id: Platform }) {
+export function PlatformChip({ id, asLink = false }: { id: Platform; asLink?: boolean }) {
   const mark = platformMark(id);
-  return (
-    <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border px-2 py-0.5 font-mono text-[10px] leading-none text-ink-muted">
+  const base =
+    "inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-border px-2 py-0.5 font-mono text-[10px] leading-none text-ink-muted";
+  const content = (
+    <>
       {mark && <IntegrationMark name={mark} size={10} className="opacity-80" />}
       {PLATFORM_LABEL[id]}
-    </span>
+    </>
   );
+  // asLink is opt-in: never used inside card <Link>s (would nest anchors); only on detail pages.
+  if (asLink) {
+    return (
+      <Link
+        to="/for/$platform"
+        params={{ platform: id }}
+        className={cn(base, "transition-colors hover:border-ink/20 hover:text-ink")}
+      >
+        {content}
+      </Link>
+    );
+  }
+  return <span className={base}>{content}</span>;
 }
 
 export function CategoryPill({

--- a/apps/web/src/lib/tags.ts
+++ b/apps/web/src/lib/tags.ts
@@ -48,3 +48,23 @@ export function getTagGroup(slug: string): TagGroup | undefined {
 export function getIndexableTagGroups(): TagGroup[] {
   return getAllTagGroups().filter((group) => group.entries.length >= 2);
 }
+
+// Tags that most co-occur with this one across its entries — for "related topics" interlinking.
+// Only returns indexable (>=2 entry) groups so we never link to thin/noindex tag pages.
+export function relatedTags(slug: string, limit = 8): TagGroup[] {
+  const group = getTagGroup(slug);
+  if (!group) return [];
+  const counts = new Map<string, number>();
+  for (const entry of group.entries) {
+    for (const tag of entry.tags ?? []) {
+      const s = tagSlug(tag);
+      if (s === group.slug) continue;
+      counts.set(s, (counts.get(s) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([s]) => getTagGroup(s))
+    .filter((g): g is TagGroup => Boolean(g) && (g as TagGroup).entries.length >= 2)
+    .slice(0, limit);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -21,6 +21,9 @@ import {
   Globe2,
 } from "lucide-react";
 import { getEntry, related } from "@/data/search";
+import { BEST_LISTS } from "@/data/entries";
+import { COMPARISONS } from "@/data/comparisons";
+import { CONTRIBUTORS } from "@/data/contributors";
 import {
   CategoryPill,
   PlatformChip,
@@ -211,6 +214,12 @@ function Dossier() {
   const data = Route.useLoaderData() as { entry: Entry };
   const entry = data.entry;
   const rel = related(entry);
+  const entryRef = `${entry.category}/${entry.slug}`;
+  const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
+  const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
+  const authorContributor = CONTRIBUTORS.find(
+    (c) => c.handle === entry.author || c.handle === entry.submittedBy || c.name === entry.author,
+  );
   const recents = useRecents();
   useEffect(() => {
     recents.pushEntry({ category: entry.category, slug: entry.slug, title: entry.title });
@@ -303,7 +312,18 @@ function Dossier() {
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-ink-muted">
             <span>
-              by <span className="text-ink">{entry.author}</span>
+              by{" "}
+              {authorContributor ? (
+                <Link
+                  to="/contributors/$slug"
+                  params={{ slug: authorContributor.slug }}
+                  className="text-ink hover:underline"
+                >
+                  {entry.author}
+                </Link>
+              ) : (
+                <span className="text-ink">{entry.author}</span>
+              )}
             </span>
             <span>·</span>
             <span>added {entry.dateAdded}</span>
@@ -319,7 +339,7 @@ function Dossier() {
             <span>·</span>
             <div className="flex flex-wrap gap-1">
               {entry.platforms.map((p) => (
-                <PlatformChip key={p} id={p} />
+                <PlatformChip key={p} id={p} asLink />
               ))}
             </div>
           </div>
@@ -607,6 +627,35 @@ function Dossier() {
                   More in {categoryLabels[entry.category] ?? entry.category} →
                 </Link>
               </div>
+            </DossierSection>
+          )}
+
+          {(featuredIn.length > 0 || comparedIn.length > 0) && (
+            <DossierSection id="featured-in" title="Featured in">
+              <ul className="flex flex-col gap-2 text-sm">
+                {featuredIn.map((l) => (
+                  <li key={`best-${l.slug}`}>
+                    <Link
+                      to="/best/$slug"
+                      params={{ slug: l.slug }}
+                      className="story-link text-ink"
+                    >
+                      Best list: {l.title}
+                    </Link>
+                  </li>
+                ))}
+                {comparedIn.map((c) => (
+                  <li key={`cmp-${c.slug}`}>
+                    <Link
+                      to="/compare/$slug"
+                      params={{ slug: c.slug }}
+                      className="story-link text-ink"
+                    >
+                      Comparison: {c.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
             </DossierSection>
           )}
 

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -6,7 +6,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
-import { getTagGroup } from "@/lib/tags";
+import { getTagGroup, relatedTags } from "@/lib/tags";
 
 export const Route = createFileRoute("/tags/$tag")({
   loader: ({ params }) => {
@@ -83,6 +83,7 @@ function TagHub() {
   const group = getTagGroup(tag);
   if (!group) return null;
   const entries = group.entries;
+  const related = relatedTags(group.slug);
 
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
@@ -98,6 +99,22 @@ function TagHub() {
           the HeyClaude directory — across MCP servers, agents, skills, hooks, commands, and more.
         </p>
       </header>
+
+      {related.length > 0 && (
+        <div className="mt-6 flex flex-wrap items-center gap-2">
+          <span className="eyebrow mr-1">Related topics</span>
+          {related.map((g) => (
+            <Link
+              key={g.slug}
+              to="/tags/$tag"
+              params={{ tag: g.slug }}
+              className="rounded-md border border-border bg-surface px-2 py-0.5 text-xs text-ink-muted transition-colors hover:border-ink/20 hover:text-ink"
+            >
+              {g.name}
+            </Link>
+          ))}
+        </div>
+      )}
 
       <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {entries.map((e) => (


### PR DESCRIPTION
Deeper internal linking — the follow-up to #2149, tracked in #2165.

## Changes
- **Entry pages**:
  - **"Featured in"** section linking the Best lists + comparisons that include the entry (resolved from `BEST_LISTS` picks and `COMPARISONS` refs) — rescues the otherwise near-orphan comparison/best pages with contextual links from every member entry.
  - **Author → `/contributors/$slug`** when the author/`submittedBy` maps to a known contributor.
  - **Platform chips link to `/for/$platform`** via a new opt-in `asLink` prop on `PlatformChip` (the 4 in-card usages stay plain `<span>`s — no nested anchors).
- **Tag pages**: a **"Related topics"** row of the most co-occurring tags (new `relatedTags()` in `lib/tags.ts`), limited to indexable (≥2-entry) groups so it never links to thin/noindex tag pages.

## Validation
- `pnpm type-check` clean.

Refs #2165 — remaining: grouping the Related-resources section by typed `relation` (works-with / alternative / prerequisite), which needs a `related()` API change; deferred as lower-value polish since the section already works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Platform names on entry pages are now clickable links to platform-specific content
  * Tag pages now display related topics based on tag relationships
  * Entry pages show "Featured in" sections linking to relevant best lists and comparisons
  * Author names on entry pages now link to contributor profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->