### PR TITLE
feat(seo): add six curated MCP comparison pages

### DIFF
--- a/apps/web/src/data/comparisons.ts
+++ b/apps/web/src/data/comparisons.ts
@@ -67,6 +67,75 @@ export const COMPARISONS: Comparison[] = [
     intro: "Observability and eval platforms for LLM apps, compared on trust, source, and setup.",
     refs: ["tools/langfuse", "tools/langsmith", "tools/helicone", "tools/braintrust"],
   },
+  {
+    slug: "search-mcp-servers",
+    title: "Brave Search vs Exa vs Perplexity MCP servers for Claude",
+    heading: "Web search MCP servers compared",
+    seoDescription:
+      "Compare the Brave Search, Exa, and Perplexity MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Web-search MCP servers that give Claude live retrieval, compared on trust, setup, and safety signals.",
+    refs: ["mcp/brave-search-mcp-server", "mcp/exa-mcp-server", "mcp/perplexity-mcp-server"],
+  },
+  {
+    slug: "vector-database-mcp-servers",
+    title: "Pinecone vs Chroma vs Qdrant MCP servers for Claude",
+    heading: "Vector database MCP servers compared",
+    seoDescription:
+      "Compare the Pinecone, Chroma, and Qdrant MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Vector-store MCP servers for retrieval-augmented Claude workflows, compared on trust, setup, and platforms.",
+    refs: ["mcp/pinecone-developer-mcp-server", "mcp/chroma-mcp-server", "mcp/qdrant-mcp-server"],
+  },
+  {
+    slug: "browser-automation-mcp-servers",
+    title: "Playwright vs Browserbase MCP servers for Claude",
+    heading: "Browser automation MCP servers compared",
+    seoDescription:
+      "Compare the Playwright and Browserbase MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Browser-automation MCP servers that let Claude drive a real browser, compared on trust, setup, and safety.",
+    refs: ["mcp/playwright-mcp-server", "mcp/browserbase-mcp-server"],
+  },
+  {
+    slug: "project-management-mcp-servers",
+    title: "Linear vs Jira vs Notion vs Asana MCP servers for Claude",
+    heading: "Project management MCP servers compared",
+    seoDescription:
+      "Compare the Linear, Jira, Notion, and Asana MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Project- and issue-tracking MCP servers for Claude Code, compared on trust, platforms, and setup.",
+    refs: [
+      "mcp/linear-mcp-server",
+      "mcp/jira-mcp-server",
+      "mcp/notion-mcp-server",
+      "mcp/asana-mcp-server",
+    ],
+  },
+  {
+    slug: "observability-mcp-servers",
+    title: "Datadog vs Grafana vs Sentry MCP servers for Claude",
+    heading: "Observability MCP servers compared",
+    seoDescription:
+      "Compare the Datadog, Grafana, and Sentry MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Monitoring and observability MCP servers that bring metrics and errors into Claude, compared on trust and setup.",
+    refs: ["mcp/datadog-mcp-server", "mcp/grafana-mcp-server", "mcp/sentry-mcp-server"],
+  },
+  {
+    slug: "memory-mcp-servers",
+    title: "Memory vs Basic Memory vs Codebase Memory MCP servers for Claude",
+    heading: "Memory MCP servers compared",
+    seoDescription:
+      "Compare the Memory, Basic Memory, and Codebase Memory MCP servers for Claude Code — trust, install, safety, and config side by side.",
+    intro:
+      "Persistent-memory MCP servers that give Claude recall across sessions, compared on trust, setup, and safety.",
+    refs: [
+      "mcp/memory-mcp-server",
+      "mcp/basic-memory-mcp-server",
+      "mcp/codebase-memory-mcp-server",
+    ],
+  },
 ];
 
 export function getComparison(slug: string) {


### PR DESCRIPTION
Expands the curated comparison set **5 → 11** with high-intent "X vs Y" MCP-server landing pages — pure data, source-backed against existing entries (all 17 refs verified). The `/compare/$slug` route, `ComparisonTable`, sitemap, and the `/compare` popular-comparisons rail pick these up automatically; **no new UI** (reuses existing primitives).

New pages:
- `/compare/search-mcp-servers` — Brave Search vs Exa vs Perplexity
- `/compare/vector-database-mcp-servers` — Pinecone vs Chroma vs Qdrant
- `/compare/browser-automation-mcp-servers` — Playwright vs Browserbase
- `/compare/project-management-mcp-servers` — Linear vs Jira vs Notion vs Asana
- `/compare/observability-mcp-servers` — Datadog vs Grafana vs Sentry
- `/compare/memory-mcp-servers` — Memory vs Basic Memory vs Codebase Memory

## Validation
`pnpm type-check` clean; every ref verified to exist as a content entry.

Refs #2175 (the "alternatives to X" half remains).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new comparison pages: web search (Brave Search vs Exa vs Perplexity), vector databases (Pinecone vs Chroma vs Qdrant), browser automation (Playwright vs Browserbase), project management (Linear vs Jira vs Notion vs Asana), observability (Datadog vs Grafana vs Sentry), and memory systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->