### PR TITLE
feat(seo): category × platform intersection hub pages

### DIFF
--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -1,0 +1,169 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { ArrowRight } from "lucide-react";
+import { CATEGORIES, PLATFORM_LABEL, type Platform, type Category } from "@/types/registry";
+import { search } from "@/data/search";
+import { categoryLabels } from "@/lib/site";
+import { ResourceCard } from "@/components/resource-card";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
+
+const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
+const CATEGORY_IDS = new Set(CATEGORIES.map((c) => c.id));
+
+function intersection(platform: string, category: string) {
+  return search({ platforms: [platform as Platform], categories: [category as Category] });
+}
+
+export const Route = createFileRoute("/for/$platform/$category")({
+  loader: ({ params }) => {
+    if (!PLATFORM_IDS.has(params.platform) || !CATEGORY_IDS.has(params.category as Category)) {
+      throw notFound();
+    }
+    // Never generate a page for an empty (platform × category) intersection.
+    if (intersection(params.platform, params.category).length === 0) throw notFound();
+    return {};
+  },
+  head: ({ params }) => {
+    if (!PLATFORM_IDS.has(params.platform) || !CATEGORY_IDS.has(params.category as Category)) {
+      return { meta: [] };
+    }
+    const pLabel = PLATFORM_LABEL[params.platform as Platform];
+    const cLabel = categoryLabels[params.category] ?? params.category;
+    const entries = intersection(params.platform, params.category);
+    if (entries.length === 0) return { meta: [] };
+    const url = absoluteUrl(`/for/${params.platform}/${params.category}`);
+    const title = `Claude ${cLabel} for ${pLabel} — HeyClaude`;
+    const description = `${entries.length} source-backed Claude ${cLabel} that work with ${pLabel}, curated and metadata-reviewed in HeyClaude.`;
+    const ogImage = ogImageUrl({ title: `${cLabel} for ${pLabel}`, eyebrow: pLabel, description });
+    const itemList = {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: `Claude ${cLabel} for ${pLabel}`,
+      description,
+      numberOfItems: entries.length,
+      itemListElement: entries.slice(0, 30).map((e, i) => ({
+        "@type": "ListItem",
+        position: i + 1,
+        name: e.title,
+        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
+      })),
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
+        { "@type": "ListItem", position: 2, name: "Platforms", item: absoluteUrl("/for") },
+        {
+          "@type": "ListItem",
+          position: 3,
+          name: pLabel,
+          item: absoluteUrl(`/for/${params.platform}`),
+        },
+        { "@type": "ListItem", position: 4, name: cLabel, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title },
+        { name: "description", content: description },
+        { property: "og:title", content: title },
+        { property: "og:description", content: description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: ogImage },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:image", content: ogImage },
+        // Single-entry intersections render (linked from the platform hub) but stay out of the
+        // index to avoid thin pages — matches the sitemap policy below.
+        ...(entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(itemList) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: IntersectionPage,
+  notFoundComponent: () => (
+    <div className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <h1 className="h-display-2 text-ink">Nothing here yet</h1>
+      <p className="mt-3 text-sm text-ink-muted">
+        No resources match that platform and category combination.
+      </p>
+      <Link
+        to="/for"
+        className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
+      >
+        All platforms <ArrowRight className="h-4 w-4" />
+      </Link>
+    </div>
+  ),
+});
+
+function IntersectionPage() {
+  const { platform, category } = Route.useParams();
+  const pLabel = PLATFORM_LABEL[platform as Platform] ?? platform;
+  const cLabel = categoryLabels[category] ?? category;
+  const entries = intersection(platform, category);
+
+  return (
+    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
+      <Breadcrumbs
+        items={[
+          { label: "Directory", to: "/browse" },
+          { label: "Platforms", to: "/for" },
+          { label: pLabel, to: "/for/$platform", params: { platform } },
+          { label: cLabel },
+        ]}
+        home
+      />
+      <header className="mt-6 max-w-3xl">
+        <div className="eyebrow">{entries.length} compatible resources</div>
+        <h1 className="mt-2 h-display-1 text-ink text-balance">
+          Claude {cLabel} for {pLabel}
+        </h1>
+        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
+          Source-backed Claude {cLabel} that work with <span className="text-ink">{pLabel}</span> —
+          curated and metadata-reviewed in HeyClaude.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center gap-2 text-sm">
+          <Link
+            to="/for/$platform"
+            params={{ platform }}
+            className="story-link font-medium text-ink"
+          >
+            All {pLabel} resources →
+          </Link>
+          <span aria-hidden className="text-ink-subtle">
+            ·
+          </span>
+          <Link
+            to="/$category"
+            params={{ category }}
+            className="story-link font-medium text-ink"
+          >
+            All Claude {cLabel} →
+          </Link>
+        </div>
+      </header>
+
+      <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {entries.map((e) => (
+          <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
+        ))}
+      </div>
+
+      <NewsletterInline
+        variant="quiet"
+        title={`New ${pLabel} resources, weekly`}
+        description="A short, calm digest of reviewed Claude resources. Unsubscribe any time."
+        source={`for:${platform}:${category}`}
+        className="mt-14"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -139,11 +139,11 @@ function PlatformPage() {
               {categoryLabels[section.category.id] ?? section.category.label}
             </h2>
             <Link
-              to="/$category"
-              params={{ category: section.category.id }}
+              to="/for/$platform/$category"
+              params={{ platform, category: section.category.id }}
               className="story-link text-sm font-medium text-ink"
             >
-              All {categoryLabels[section.category.id] ?? section.category.label} →
+              All {categoryLabels[section.category.id] ?? section.category.label} for {label} →
             </Link>
           </div>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -6,7 +6,7 @@ import atlasRegistry from "@/generated/atlas-registry.json";
 import { getJobs } from "@/lib/jobs";
 import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
-import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
+import { CATEGORIES, PLATFORM_LABEL, type Platform } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
 import { COMPARISONS } from "@/data/comparisons";
 
@@ -86,6 +86,18 @@ async function renderSitemap() {
   const contributorPaths = CONTRIBUTORS.map((contributor) => `/contributors/${contributor.slug}`);
   const integrationPaths = INTEGRATIONS.map((integration) => `/integrations/${integration.slug}`);
   const jobPaths = (await getJobs()).map((job) => `/jobs/${job.slug}`);
+  // category × platform intersection hubs — only those with >=2 entries (the route noindexes
+  // thinner ones), so the sitemap never advertises a thin page.
+  const intersectionPaths: string[] = [];
+  for (const platform of Object.keys(PLATFORM_LABEL)) {
+    for (const category of CATEGORIES) {
+      const count = ENTRIES.filter(
+        (entry) =>
+          entry.category === category.id && (entry.platforms ?? []).includes(platform as Platform),
+      ).length;
+      if (count >= 2) intersectionPaths.push(`/for/${platform}/${category.id}`);
+    }
+  }
 
   const rows = [
     ...staticPaths.map((pathname) => urlItem(pathname, pathname === "" ? "1" : "0.7")),
@@ -95,6 +107,7 @@ async function renderSitemap() {
     ),
     ...getIndexableTagGroups().map((group) => urlItem(`/tags/${group.slug}`, "0.5")),
     ...Object.keys(PLATFORM_LABEL).map((platform) => urlItem(`/for/${platform}`, "0.6")),
+    ...intersectionPaths.map((pathname) => urlItem(pathname, "0.55")),
     ...COMPARISONS.map((comparison) => urlItem(`/compare/${comparison.slug}`, "0.6")),
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),
     ...ENTRIES.map((entry) =>


### PR DESCRIPTION
New crawlable **`/for/$platform/$category`** landing pages (e.g. "Claude MCP servers for Cursor") for high-intent long-tail queries. Reuses the existing platform-hub layout + `ResourceCard` + `Breadcrumbs` + `ogImageUrl` + ItemList/Breadcrumb JSON-LD — **no new design**.

## Behavior
- Empty intersections **404**; single-entry ones still render (linked from the platform hub) but carry `robots noindex` — no thin pages enter the index.
- **Sitemap** lists only ≥2-entry intersections (matches the noindex policy).
- The platform hub's per-category "All X →" links now point at these intersection pages, so they're internally linked.

## Validation
`pnpm type-check` clean (route tree regenerated); reuses the proven `/for/$platform` pattern.

Closes #2176.