### PR TITLE
feat(agents): citation-facts block in /llms-full.txt

### DIFF
--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -11,6 +11,7 @@ import { ENTRIES } from "@/data/entries";
 import { CATEGORIES } from "@/types/registry";
 import { etagFor } from "@/lib/feeds";
 import { applySecurityHeaders } from "@/lib/security-headers";
+import { buildEntryCitationFacts } from "@heyclaude/registry";
 
 export function buildLlmsTxt(origin: string): string {
   const lines: string[] = [];
@@ -79,6 +80,14 @@ export function buildLlmsFullTxt(origin: string): string {
       out.push("");
       out.push(e.description);
       out.push("");
+      const facts = buildEntryCitationFacts(e as Parameters<typeof buildEntryCitationFacts>[0], {
+        siteUrl: origin,
+      });
+      if (facts) {
+        out.push("Citation facts:");
+        out.push(facts);
+        out.push("");
+      }
       if (e.safetyNotes) {
         out.push(`Safety: ${e.safetyNotes}`);
         out.push("");


### PR DESCRIPTION
Adds a per-entry **Citation Facts** block to `/llms-full.txt` via the registry's `buildEntryCitationFacts` (canonical URL, source URLs, brand, package + SHA256, safety/privacy notes, platform compatibility, provenance, license, last-verified) — the structured fact set AI crawlers cite when answering.

Additive: keeps the existing install/config/fullCopy code blocks (no lossy generator swap, which would have dropped them).

`pnpm type-check` + crawler-policy tests pass.

Closes #2181.