### PR TITLE
feat(seo): page-specific OG images for home + hubs

### DIFF
--- a/apps/web/src/routes/contributors.tsx
+++ b/apps/web/src/routes/contributors.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Monogram } from "@/components/monogram";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/contributors")({
   head: () => ({
@@ -14,6 +15,14 @@ export const Route = createFileRoute("/contributors")({
       { property: "og:title", content: "Contributors — HeyClaude" },
       { property: "og:description", content: "Provenance is preserved on every entry." },
       { property: "og:url", content: absoluteUrl("/contributors") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "Contributors", eyebrow: "HeyClaude" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "Contributors", eyebrow: "HeyClaude" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/contributors") }],
     scripts: [

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -31,6 +31,7 @@ import { CATEGORIES, type Category } from "@/types/registry";
 import { ENTRIES, BRIEF_ISSUES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { search } from "@/data/search";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 // Pre-computed counts at module scope so SSR + first paint show real numbers.
 const TRUSTED_COUNT = ENTRIES.filter((e) => e.trust === "trusted").length;
@@ -84,6 +85,14 @@ export const Route = createFileRoute("/")({
           "Source-backed registry of MCP servers, agents, skills, hooks, commands, and rules. Reviewed before installing.",
       },
       { property: "og:url", content: absoluteUrl("/") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "The directory for Claude workflows", eyebrow: "HeyClaude" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "The directory for Claude workflows", eyebrow: "HeyClaude" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/") }],
   }),

--- a/apps/web/src/routes/integrations.tsx
+++ b/apps/web/src/routes/integrations.tsx
@@ -4,6 +4,7 @@ import { IntegrationCard } from "@/components/integration-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/integrations")({
   head: () => ({
@@ -20,6 +21,14 @@ export const Route = createFileRoute("/integrations")({
         content: "Raycast extension, MCP server, Cursor adapter, REST API, and public feeds.",
       },
       { property: "og:url", content: absoluteUrl("/integrations") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "HeyClaude integrations", eyebrow: "Integrations" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "HeyClaude integrations", eyebrow: "Integrations" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/integrations") }],
     scripts: [

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -4,6 +4,7 @@ import { PLATFORM_LABEL, PLATFORM_SUPPORT_LABEL, type Platform } from "@/types/r
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/platforms")({
   head: () => ({
@@ -20,6 +21,14 @@ export const Route = createFileRoute("/platforms")({
           "Native skills, generated adapters, and manual-context fallbacks across every supported client.",
       },
       { property: "og:url", content: absoluteUrl("/platforms") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/platforms") }],
     scripts: [

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -4,6 +4,7 @@ import { COMMERCIAL_TOOLS } from "@/data/tools";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/tools")({
   head: () => ({
@@ -20,6 +21,14 @@ export const Route = createFileRoute("/tools")({
           "Editorial picks and disclosed partners. Free, open-source resources live in the directory.",
       },
       { property: "og:url", content: absoluteUrl("/tools") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/tools") }],
     scripts: [

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -12,6 +12,7 @@ import { CATEGORIES, type Entry } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl } from "@/lib/og-image";
 import { cn } from "@/lib/utils";
 
 const defaultSearch = {
@@ -71,6 +72,14 @@ export const Route = createFileRoute("/trending")({
           "Trending Claude Code MCP servers, agents, skills, hooks, and commands from live community and intent signals.",
       },
       { property: "og:url", content: absoluteUrl("/trending") },
+      {
+        property: "og:image",
+        content: ogImageUrl({ title: "Trending Claude workflows", eyebrow: "Trending" }),
+      },
+      {
+        name: "twitter:image",
+        content: ogImageUrl({ title: "Trending Claude workflows", eyebrow: "Trending" }),
+      },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/trending") }],
     scripts: [


### PR DESCRIPTION
Home and the tools / integrations / platforms / contributors / trending hubs now emit **page-specific** `og:image` + `twitter:image` via `ogImageUrl` (the crawlable `/og` generator), overriding the sitewide default brand card so each page shares with its own title. Reuses the existing OG generator — no new design.

`pnpm type-check` clean.

Closes #2179.