### PR TITLE
fix(web): avoid tools category route collision

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -9,6 +9,7 @@ import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { NewsletterInline } from "./newsletter-inline";
 import { CATEGORIES } from "@/types/registry";
+import { CategoryHubLink } from "@/components/category-hub-link";
 
 const NAV = [
   { to: "/browse", label: "Browse" },
@@ -187,14 +188,9 @@ export function Footer() {
           <div className="eyebrow mb-2">Categories</div>
           <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-ink-muted">
             {CATEGORIES.map((c) => (
-              <Link
-                key={c.id}
-                to="/$category"
-                params={{ category: c.id }}
-                className="hover:text-ink"
-              >
+              <CategoryHubLink key={c.id} category={c.id} className="hover:text-ink">
                 {c.label}
-              </Link>
+              </CategoryHubLink>
             ))}
           </div>
         </div>

--- a/apps/web/src/components/category-hub-link.tsx
+++ b/apps/web/src/components/category-hub-link.tsx
@@ -1,0 +1,25 @@
+import { Link } from "@tanstack/react-router";
+import type { ReactNode } from "react";
+import type { Category } from "@/types/registry";
+
+type CategoryHubLinkProps = {
+  category: Category;
+  children: ReactNode;
+  className?: string;
+};
+
+export function CategoryHubLink({ category, children, className }: CategoryHubLinkProps) {
+  if (category === "tools") {
+    return (
+      <Link to="/browse" search={{ category }} className={className}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <Link to="/$category" params={{ category }} className={className}>
+      {children}
+    </Link>
+  );
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -45,6 +45,7 @@ import { DossierTOC, type TocItem } from "@/components/dossier-toc";
 import { EntryFacets } from "@/components/entry-facets";
 import { HarnessBadge } from "@/components/harness-badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { CategoryHubLink } from "@/components/category-hub-link";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { SourceCitations } from "@/components/source-citations";
 import { ProvenanceBlock } from "@/components/provenance-block";
@@ -266,11 +267,17 @@ function Dossier() {
       <Breadcrumbs
         items={[
           { label: "Directory", to: "/browse" },
-          {
-            label: categoryLabels[entry.category] ?? entry.category,
-            to: "/$category",
-            params: { category: entry.category },
-          },
+          entry.category === "tools"
+            ? {
+                label: categoryLabels[entry.category] ?? entry.category,
+                to: "/browse",
+                search: { category: entry.category },
+              }
+            : {
+                label: categoryLabels[entry.category] ?? entry.category,
+                to: "/$category",
+                params: { category: entry.category },
+              },
           { label: entry.title },
         ]}
       />
@@ -619,13 +626,12 @@ function Dossier() {
                 ))}
               </div>
               <div className="mt-3 text-right">
-                <Link
-                  to="/$category"
-                  params={{ category: entry.category }}
+                <CategoryHubLink
+                  category={entry.category}
                   className="story-link text-xs font-medium text-ink"
                 >
                   More in {categoryLabels[entry.category] ?? entry.category} →
-                </Link>
+                </CategoryHubLink>
               </div>
             </DossierSection>
           )}

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -4,6 +4,7 @@ import { CATEGORIES, PLATFORM_LABEL, type Platform } from "@/types/registry";
 import { search } from "@/data/search";
 import { categoryLabels } from "@/lib/site";
 import { ResourceCard } from "@/components/resource-card";
+import { CategoryHubLink } from "@/components/category-hub-link";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -111,7 +112,11 @@ function PlatformPage() {
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
       <Breadcrumbs
-        items={[{ label: "Directory", to: "/browse" }, { label: "Platforms", to: "/for" }, { label }]}
+        items={[
+          { label: "Directory", to: "/browse" },
+          { label: "Platforms", to: "/for" },
+          { label },
+        ]}
         home
       />
       <header className="mt-6 max-w-3xl">
@@ -138,13 +143,12 @@ function PlatformPage() {
             <h2 className="h-display-2 text-ink">
               {categoryLabels[section.category.id] ?? section.category.label}
             </h2>
-            <Link
-              to="/$category"
-              params={{ category: section.category.id }}
+            <CategoryHubLink
+              category={section.category.id}
               className="story-link text-sm font-medium text-ink"
             >
               All {categoryLabels[section.category.id] ?? section.category.label} →
-            </Link>
+            </CategoryHubLink>
           </div>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {section.entries.map((e) => (

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -31,6 +31,7 @@ import { CATEGORIES, type Category } from "@/types/registry";
 import { ENTRIES, BRIEF_ISSUES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { search } from "@/data/search";
 import { absoluteUrl } from "@/lib/seo";
+import { CategoryHubLink } from "@/components/category-hub-link";
 
 // Pre-computed counts at module scope so SSR + first paint show real numbers.
 const TRUSTED_COUNT = ENTRIES.filter((e) => e.trust === "trusted").length;
@@ -244,10 +245,9 @@ function Home() {
             const count = ENTRIES.filter((e) => e.category === c.id).length;
             const Icon = CATEGORY_ICONS[c.id] ?? Sparkles;
             return (
-              <Link
+              <CategoryHubLink
                 key={c.id}
-                to="/$category"
-                params={{ category: c.id }}
+                category={c.id}
                 className="group hover-lift relative flex flex-col gap-1 bg-surface p-4 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60"
               >
                 <div className="flex items-center justify-between">
@@ -260,7 +260,7 @@ function Home() {
                   aria-hidden
                   className="absolute inset-y-0 left-0 w-px origin-bottom scale-y-0 bg-accent transition-transform duration-200 group-hover:scale-y-100"
                 />
-              </Link>
+              </CategoryHubLink>
             );
           })}
         </div>


### PR DESCRIPTION
### Motivation
- Recent changes switched category links to the dynamic `/$category` route, but the `tools` category produces `/tools` which collides with an existing static `/tools` route and causes navigation/SEO regressions.
- The intent is to preserve the dynamic category hub behaviour for normal categories while avoiding the shadowing of the static `/tools` page.

### Description
- Add a shared `CategoryHubLink` component that links to `/$category` for normal categories and routes `tools` to the filtered directory at `/browse?category=tools` to avoid the static route collision (`apps/web/src/components/category-hub-link.tsx`).
- Replace direct `/$category` links in the footer with `CategoryHubLink` to prevent emitting `/tools` from the footer (`apps/web/src/components/app-shell.tsx`).
- Replace homepage category shortcut links and platform section links to use `CategoryHubLink`, preserving correct hub navigation for all categories (`apps/web/src/routes/index.tsx`, `apps/web/src/routes/for.$platform.tsx`).
- Update entry page breadcrumbs and the "More in …" related-resources link to use `CategoryHubLink` (or an explicit `/browse?category=tools` breadcrumb) so tools entries do not link to the shadowed `/tools` path (`apps/web/src/routes/entry.$category.$slug.tsx`).

### Testing
- Ran `pnpm --filter web type-check`, which executes artifact/registry/route generation and `tsc --noEmit`, and the type-check and generation steps completed successfully. 
- Ran `git diff --check` and the repository sanity checks reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df96bfb18832aa6b1ad2a598c9f5b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Tools category navigation routing.

* **Refactor**
  * Introduced a unified category link component across the application for consistent navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->