### PR TITLE
feat(seo): group entry Related-resources by typed relation

### DIFF
--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -1,5 +1,12 @@
 import { ENTRIES } from "./entries";
-import type { Category, Entry, Platform, SourceStatus, TrustLevel } from "@/types/registry";
+import type {
+  Category,
+  Entry,
+  EntryRelationType,
+  Platform,
+  SourceStatus,
+  TrustLevel,
+} from "@/types/registry";
 
 export interface SearchFilters {
   q?: string;
@@ -89,4 +96,45 @@ export function related(entry: Entry, limit = 4): Entry[] {
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
     .map((x) => x.e);
+}
+
+// Order for surfacing relation groups (most decision-relevant first). "duplicate" is excluded.
+const RELATION_ORDER: EntryRelationType[] = [
+  "alternative",
+  "works-with",
+  "complementary",
+  "extends",
+  "prerequisite",
+  "same-project",
+  "same-ecosystem",
+  "collection-member",
+  "related",
+];
+
+// Group an entry's graph relations by their typed relation, so the entry page can render labeled
+// "Works with" / "Alternatives" / "Prerequisites" sections. Returns [] when there's no graph
+// relation data (the caller falls back to the flat related() grid).
+export function relatedGroups(
+  entry: Entry,
+  perGroup = 6,
+): { relation: EntryRelationType; entries: Entry[] }[] {
+  const byRelation = new Map<EntryRelationType, Entry[]>();
+  for (const rel of entry.relatedEntries ?? []) {
+    if (rel.relation === "duplicate") continue;
+    const candidate = ENTRIES.find((e) => e.category === rel.category && e.slug === rel.slug);
+    if (!candidate) continue;
+    if (candidate.category === entry.category && candidate.slug === entry.slug) continue;
+    const list = byRelation.get(rel.relation) ?? [];
+    if (!byRelation.has(rel.relation)) byRelation.set(rel.relation, list);
+    if (
+      list.length < perGroup &&
+      !list.some((e) => e.category === candidate.category && e.slug === candidate.slug)
+    ) {
+      list.push(candidate);
+    }
+  }
+  return RELATION_ORDER.map((relation) => ({
+    relation,
+    entries: byRelation.get(relation) ?? [],
+  })).filter((g) => g.entries.length > 0);
 }

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -20,7 +20,7 @@ import {
   BadgeCheck,
   Globe2,
 } from "lucide-react";
-import { getEntry, related } from "@/data/search";
+import { getEntry, related, relatedGroups } from "@/data/search";
 import { BEST_LISTS } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { CONTRIBUTORS } from "@/data/contributors";
@@ -210,10 +210,23 @@ export const Route = createFileRoute("/entry/$category/$slug")({
   component: Dossier,
 });
 
+const RELATION_LABELS: Record<string, string> = {
+  alternative: "Alternatives",
+  "works-with": "Works with",
+  complementary: "Complementary",
+  extends: "Extends",
+  prerequisite: "Prerequisites",
+  "same-project": "Same project",
+  "same-ecosystem": "Same ecosystem",
+  "collection-member": "In the same collection",
+  related: "Related",
+};
+
 function Dossier() {
   const data = Route.useLoaderData() as { entry: Entry };
   const entry = data.entry;
   const rel = related(entry);
+  const relGroups = relatedGroups(entry);
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
@@ -611,13 +624,28 @@ function Dossier() {
             <SourceCitations entry={entry} />
           </DossierSection>
 
-          {rel.length > 0 && (
+          {(relGroups.length > 0 || rel.length > 0) && (
             <DossierSection id="related" title="Related resources">
-              <div className="grid gap-3 sm:grid-cols-2">
-                {rel.slice(0, 4).map((e) => (
-                  <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
-                ))}
-              </div>
+              {relGroups.length > 0 ? (
+                <div className="flex flex-col gap-6">
+                  {relGroups.map((g) => (
+                    <div key={g.relation}>
+                      <div className="eyebrow mb-2">{RELATION_LABELS[g.relation] ?? "Related"}</div>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {g.entries.map((e) => (
+                          <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
+                        ))}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {rel.slice(0, 4).map((e) => (
+                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
+                  ))}
+                </div>
+              )}
               <div className="mt-3 text-right">
                 <Link
                   to="/$category"


### PR DESCRIPTION
Closes the carried-over follow-up #2165. The entry "Related resources" section now groups entries by their typed `relation` — **Alternatives / Works with / Complementary / Extends / Prerequisites / Same project / Same ecosystem / In the same collection / Related** — instead of one undifferentiated grid, giving readers and crawlers semantic context.

- New `relatedGroups()` in `data/search.ts` (excludes `duplicate`; ordered most-decision-relevant first).
- Entry page renders labeled sub-sections, **falling back** to the flat tag-based grid when an entry has no graph-relation data. Reuses `ResourceCard`.

`pnpm type-check` clean. Closes #2165.