### PR TITLE
fix(reliability): external-fetch timeouts + npm/admin hardening

### DIFF
--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -33,6 +33,18 @@ export function getAdminTokens() {
   return getScopedAdminTokens(PRIMARY_ADMIN_TOKEN_NAMES);
 }
 
+// Constant-time string compare so admin-token checks don't leak via early-exit timing
+// (consistent with the timing-safe comparisons used elsewhere in the codebase).
+function timingSafeEqual(a: string, b: string): boolean {
+  const enc = new TextEncoder();
+  const aBytes = enc.encode(a);
+  const bBytes = enc.encode(b);
+  const len = Math.max(aBytes.length, bBytes.length);
+  let mismatch = aBytes.length ^ bBytes.length;
+  for (let i = 0; i < len; i++) mismatch |= (aBytes[i] ?? 0) ^ (bBytes[i] ?? 0);
+  return mismatch === 0;
+}
+
 function hasAdminToken(request: Request, tokens: readonly string[]) {
   if (tokens.length === 0) return false;
 
@@ -41,7 +53,11 @@ function hasAdminToken(request: Request, tokens: readonly string[]) {
     ?.replace(/^Bearer\s+/i, "")
     .trim();
   const headerToken = request.headers.get("x-admin-token")?.trim();
-  return tokens.some((token) => bearer === token || headerToken === token);
+  return tokens.some(
+    (token) =>
+      (bearer !== undefined && timingSafeEqual(bearer, token)) ||
+      (headerToken !== undefined && timingSafeEqual(headerToken, token)),
+  );
 }
 
 export function isAdminAuthorized(request: Request) {

--- a/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
+++ b/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
@@ -33,6 +33,7 @@ async function resolveBrandIconUrl(domain: string, clientId: string) {
 
   const searchResponse = await fetch(searchUrl, {
     headers: { accept: "application/json" },
+    signal: AbortSignal.timeout(6000),
   });
   if (!searchResponse.ok) return "";
 

--- a/apps/web/src/routes/api/public/npm/$.ts
+++ b/apps/web/src/routes/api/public/npm/$.ts
@@ -30,9 +30,11 @@ async function fetchMeta(pkg: string): Promise<NpmMeta> {
   const [latestRes, dlRes] = await Promise.allSettled([
     fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg)}/latest`, {
       headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
     }),
     fetch(`https://api.npmjs.org/downloads/point/last-week/${encodeURIComponent(pkg)}`, {
       headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(5000),
     }),
   ]);
 
@@ -52,6 +54,7 @@ async function fetchMeta(pkg: string): Promise<NpmMeta> {
   try {
     const packumentRes = await fetch(`https://registry.npmjs.org/${encodeURIComponent(pkg)}`, {
       headers: { accept: "application/vnd.npm.install-v1+json" },
+      signal: AbortSignal.timeout(5000),
     });
     if (packumentRes.ok) {
       const p = (await packumentRes.json()) as { time?: Record<string, string> };
@@ -104,7 +107,8 @@ export const Route = createApiFileRoute("/api/public/npm/$")({
             },
           });
         } catch (err) {
-          return new Response(JSON.stringify({ error: (err as Error).message }), {
+          console.error("npm proxy error", err);
+          return new Response(JSON.stringify({ error: "Upstream metadata unavailable" }), {
             status: 502,
             headers: { "Content-Type": "application/json" },
           });


### PR DESCRIPTION
From the deep audit (#2199).

- **npm proxy** (`api/public/npm/$`): `AbortSignal.timeout(5000)` on all three registry/downloads fetches — a hung npm registry previously held the Worker request open with no timeout (every sibling route already has one). Also stop reflecting the internal error message (static `"Upstream metadata unavailable"` + server log).
- **brand-assets**: 6s timeout on the Brandfetch **search** fetch (the asset fetch already had one).
- **admin-auth**: constant-time token compare instead of `===`, matching the timing-safe comparisons used elsewhere.

`pnpm type-check` + `api-router-security` tests pass. Closes #2199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced admin authentication security through implementation of timing-safe token comparison.
  * Added automatic request timeouts to brand assets and npm proxy endpoints—6 seconds and 5 seconds respectively—to prevent requests from hanging indefinitely.
  * Improved npm proxy error handling with enhanced logging and standardized error responses for upstream service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->