### PR TITLE
fix(a11y): darken --ink-subtle to meet WCAG AA 4.5:1

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -69,7 +69,8 @@
   --surface-2: oklch(0.945 0.012 95); /* hover/zebra */
   --ink: oklch(0.18 0.01 90); /* near-black */
   --ink-muted: oklch(0.45 0.012 90);
-  --ink-subtle: oklch(0.62 0.012 90);
+  /* L tuned to clear WCAG AA 4.5:1 on background/surface/surface-2 (was 0.62 → ~3.1:1). */
+  --ink-subtle: oklch(0.525 0.012 90);
   --border: oklch(0.88 0.012 90);
   --border-strong: oklch(0.78 0.012 90);
   --foreground: var(--ink);
@@ -101,7 +102,8 @@
   --surface-2: oklch(0.23 0 0); /* #262626 */
   --ink: oklch(0.96 0.005 90);
   --ink-muted: oklch(0.72 0.008 90);
-  --ink-subtle: oklch(0.55 0.008 90);
+  /* L tuned to clear WCAG AA 4.5:1 on background/surface/surface-2 (was 0.55 → ~3.5:1). */
+  --ink-subtle: oklch(0.615 0.008 90);
   --border: oklch(0.28 0 0);
   --border-strong: oklch(0.38 0 0);
   --foreground: var(--ink);


### PR DESCRIPTION
From the audit (#2197). `--ink-subtle` styles real text in ~204 places but measured only **~3.1:1 (light) / ~3.5:1 (dark)** on background/surface/surface-2 — below the 4.5:1 WCAG AA floor for normal-size text.

Retuned the lightness (computed via oklch→linear-sRGB→WCAG relative luminance, against the worst-case surface):
- light `0.62 → 0.525` (now **4.59–5.17:1**)
- dark `0.55 → 0.615` (now **4.55–5.36:1**)

One token, ~204 call sites fixed. `--ink-muted` was already compliant and is unchanged. Closes #2197.