### PR TITLE
perf(runtime): memoize entry related() + single-pass sitemap

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -225,8 +225,10 @@ const RELATION_LABELS: Record<string, string> = {
 function Dossier() {
   const data = Route.useLoaderData() as { entry: Entry };
   const entry = data.entry;
-  const rel = related(entry);
-  const relGroups = relatedGroups(entry);
+  // Memoized: related() scans all entries (tag-overlap fallback); recomputing on every harness/tab
+  // toggle was wasted work. entry is stable per page.
+  const rel = useMemo(() => related(entry), [entry]);
+  const relGroups = useMemo(() => relatedGroups(entry), [entry]);
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -6,7 +6,7 @@ import atlasRegistry from "@/generated/atlas-registry.json";
 import { getJobs } from "@/lib/jobs";
 import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
-import { CATEGORIES, PLATFORM_LABEL, type Platform } from "@/types/registry";
+import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
 import { COMPARISONS } from "@/data/comparisons";
 
@@ -88,14 +88,21 @@ async function renderSitemap() {
   const jobPaths = (await getJobs()).map((job) => `/jobs/${job.slug}`);
   // category × platform intersection hubs — only those with >=2 entries (the route noindexes
   // thinner ones), so the sitemap never advertises a thin page.
+  // One pass over ENTRIES building a `${category}/${platform}` -> count map (was platforms ×
+  // categories × ENTRIES.filter ≈ 83K iterations per request).
+  const intersectionCounts = new Map<string, number>();
+  for (const entry of ENTRIES) {
+    for (const platform of entry.platforms ?? []) {
+      const key = `${entry.category}/${platform}`;
+      intersectionCounts.set(key, (intersectionCounts.get(key) ?? 0) + 1);
+    }
+  }
   const intersectionPaths: string[] = [];
   for (const platform of Object.keys(PLATFORM_LABEL)) {
     for (const category of CATEGORIES) {
-      const count = ENTRIES.filter(
-        (entry) =>
-          entry.category === category.id && (entry.platforms ?? []).includes(platform as Platform),
-      ).length;
-      if (count >= 2) intersectionPaths.push(`/for/${platform}/${category.id}`);
+      if ((intersectionCounts.get(`${category.id}/${platform}`) ?? 0) >= 2) {
+        intersectionPaths.push(`/for/${platform}/${category.id}`);
+      }
     }
   }
 


### PR DESCRIPTION
From the runtime-perf audit (Refs #2200).

- **entry/$category/$slug**: `related()` / `relatedGroups()` wrapped in `useMemo([entry])`. `related()` scans all ~922 entries via the tag-overlap fallback (the live path today — no entry has graph relations yet) and was recomputed on every harness/copy-tab re-render. entry is stable per page.
- **sitemap**: compute the category×platform intersection counts in **one pass** over ENTRIES + Map lookups, replacing `platforms × categories × ENTRIES.filter` (~83K iterations/request). Output identical.

`pnpm type-check` clean. The browse `axisCount` memo and hub `search()` dedupe from #2200 are tracked for a follow-up (they share files with the keys PR).