### PR TITLE
fix(correctness): category/slug React keys in cross-category lists

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -262,7 +262,7 @@ export function CompareDrawer() {
                     {items.map((e) => (
                       <th
                         scope="col"
-                        key={e.slug}
+                        key={`${e.category}/${e.slug}`}
                         className="min-w-[260px] max-w-[320px] border-b border-r border-border bg-surface p-3 text-left align-top last:border-r-0"
                       >
                         <div className="flex items-start justify-between gap-2">
@@ -304,7 +304,7 @@ export function CompareDrawer() {
                       </th>
                       {items.map((e) => (
                         <td
-                          key={e.slug}
+                          key={`${e.category}/${e.slug}`}
                           className="min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top last:border-r-0"
                         >
                           {row.render(e)}

--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -21,7 +21,7 @@ export function ComparisonTray() {
         <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
           {items.map((e) => (
             <span
-              key={e.slug}
+              key={`${e.category}/${e.slug}`}
               className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs"
             >
               <ReadinessDot entry={e} />

--- a/apps/web/src/routes/best.tsx
+++ b/apps/web/src/routes/best.tsx
@@ -106,7 +106,7 @@ function BestPage() {
       <h2 className="mt-16 h-display-2 text-ink text-balance">Editor's pick · {featured.title}</h2>
       <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {featuredPicks.map((e) => (
-          <ResourceCard key={e.slug} entry={e} variant="grid" />
+          <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
         ))}
       </div>
     </div>

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -813,19 +813,19 @@ function Browse() {
               {sp.view === "grid" ? (
                 <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                   {results.slice(0, shown).map((e) => (
-                    <ResourceCard key={e.slug} entry={e} variant="grid" />
+                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
                   ))}
                 </div>
               ) : sp.view === "compact" ? (
                 <div className="mt-2 overflow-hidden rounded-lg border border-border bg-surface">
                   {results.slice(0, shown).map((e, i) => (
-                    <ResourceCard key={e.slug} entry={e} variant="compact" rank={i + 1} />
+                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="compact" rank={i + 1} />
                   ))}
                 </div>
               ) : (
                 <div className="mt-2 overflow-hidden rounded-lg border border-border bg-surface">
                   {results.slice(0, shown).map((e) => (
-                    <ResourceCard key={e.slug} entry={e} />
+                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} />
                   ))}
                 </div>
               )}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -364,7 +364,7 @@ function Home() {
         </div>
         <div className="mt-4 grid gap-4 stagger-children sm:grid-cols-2 lg:grid-cols-3">
           {popular.map((e) => (
-            <ResourceCard key={e.slug} entry={e} variant="grid" />
+            <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
           ))}
         </div>
       </section>
@@ -392,7 +392,7 @@ function Home() {
           </div>
           <div className="divide-y divide-border">
             {sourceBacked.map((e) => (
-              <ResourceCard key={e.slug} entry={e} />
+              <ResourceCard key={`${e.category}/${e.slug}`} entry={e} />
             ))}
           </div>
           <div className="flex items-center justify-between border-t border-border bg-surface-2 px-5 py-3 text-xs text-ink-muted">
@@ -419,7 +419,7 @@ function Home() {
           />
           <div className="mt-4 grid gap-4 sm:grid-cols-2">
             {newest.map((e) => (
-              <ResourceCard key={e.slug} entry={e} variant="grid" />
+              <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
             ))}
           </div>
           {latestBrief && (


### PR DESCRIPTION
From the bug audit (Refs #2202). Lists spanning categories (browse results, home popular/newest/source-backed, best featured picks, compare drawer columns, comparison tray) keyed rows on `entry.slug` alone. Slugs are only unique **per-category**, so a future cross-category slug collision would cause duplicate React keys (state bleed / wrong DOM reuse). Switched to the canonical `${category}/${slug}` identity — matching the entry route and `$category` hub.

Latent today (all 923 slugs are globally unique), but cheap correctness hardening. `pnpm type-check` clean (confirms every `e` has `.category`).

The minor guards from #2202 (tags-slug dedup, jobs-utils Infinity, submission-gate JSON.parse) remain tracked.