### PR TITLE
fix(correctness): harden tag dedup, job date, and draft body guards

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -1017,7 +1017,8 @@ async function readJsonBodyWithLimit(request: Request) {
   }
 
   const reader = request.body?.getReader();
-  if (!reader) return JSON.parse("");
+  // No body stream → treat as an empty payload; the caller rejects non-objects.
+  if (!reader) return null;
 
   const chunks: Uint8Array[] = [];
   let total = 0;

--- a/apps/web/src/lib/jobs-utils.ts
+++ b/apps/web/src/lib/jobs-utils.ts
@@ -29,6 +29,7 @@ export function daysSince(iso: string, now = Date.now()): number {
 
 export function relativePosted(iso: string, now = Date.now()): string {
   const d = daysSince(iso, now);
+  if (!Number.isFinite(d)) return "—";
   if (d <= 0) return "today";
   if (d === 1) return "1d ago";
   if (d < 7) return `${d}d ago`;

--- a/apps/web/src/lib/tags.ts
+++ b/apps/web/src/lib/tags.ts
@@ -17,6 +17,9 @@ export function getAllTagGroups(): TagGroup[] {
   if (cache) return cache;
   const map = new Map<string, { entries: Entry[]; names: Map<string, number> }>();
   for (const entry of ENTRIES) {
+    // An entry can carry multiple raw tags that normalize to the same slug
+    // (e.g. "AI" and "ai"); count it once per slug so group sizes stay accurate.
+    const seenSlugs = new Set<string>();
     for (const tag of entry.tags ?? []) {
       const slug = tagSlug(tag);
       if (!slug) continue;
@@ -25,7 +28,10 @@ export function getAllTagGroups(): TagGroup[] {
         group = { entries: [], names: new Map() };
         map.set(slug, group);
       }
-      group.entries.push(entry);
+      if (!seenSlugs.has(slug)) {
+        group.entries.push(entry);
+        seenSlugs.add(slug);
+      }
       group.names.set(tag, (group.names.get(tag) ?? 0) + 1);
     }
   }


### PR DESCRIPTION
Three latent edge-case fixes from the Round 5 audit. None changes current observable output (no triggering data exists today), but each removes a latent footgun.

## Changes

- **`lib/tags.ts`** — an entry carrying multiple raw tags that normalize to the same slug (e.g. `AI` and `ai` → `ai`) was pushed into that tag group's `entries[]` once per raw tag, inflating the group size (and the indexable-threshold check). Now deduped per entry per slug; the raw-casing frequency map is untouched, so the canonical display name is unchanged.
- **`lib/jobs-utils.ts`** — `relativePosted()` returned `"Infinity y ago"` when `daysSince` yielded `Infinity` (unparseable date). Guarded with `Number.isFinite`, falling back to `"—"`.
- **`apps/submission-gate/src/index.ts`** — replaced `JSON.parse("")` (throws `SyntaxError` as control flow) with an explicit `return null` when a request has no body stream. The caller already rejects non-object payloads with a 400, so behavior is preserved and the intent is explicit.

## Validation

- `pnpm type-check` — clean
- `pnpm exec vitest run tests/submission-gate-worker.test.ts` — 96 passed

Closes #2202