### PR TITLE
fix(seo): apply sitemap-indexable policy (drop commercial tools listings)

### DIFF
--- a/apps/web/src/lib/sitemap-policy.ts
+++ b/apps/web/src/lib/sitemap-policy.ts
@@ -6,7 +6,19 @@ export function safeSitemapDate(value?: string | null) {
   return Number.isNaN(date.getTime()) ? undefined : date;
 }
 
-export function isSitemapIndexableEntry(entry: DirectoryEntry) {
+/**
+ * Whether an entry's detail page should be advertised in the sitemap.
+ *
+ * `tools` entries are commercial listings (routed to the website lead flows per
+ * AGENTS.md) and are thin-by-design, so we keep them crawlable via internal links
+ * but do not advertise them in the sitemap. Anything explicitly `robotsIndex:false`
+ * is excluded too. Accepts any entry-shaped object so both the server
+ * `DirectoryEntry` and the client registry `Entry` satisfy it.
+ */
+export function isSitemapIndexableEntry(entry: {
+  category: string;
+  robotsIndex?: boolean;
+}) {
   return entry.category !== "tools" && entry.robotsIndex !== false;
 }
 

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -8,6 +8,7 @@ import { siteConfig } from "@/lib/site";
 import { applySecurityHeaders } from "@/lib/security-headers";
 import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
+import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
 
 function escapeXml(value: string) {
@@ -117,7 +118,10 @@ async function renderSitemap() {
     ...intersectionPaths.map((pathname) => urlItem(pathname, "0.55")),
     ...COMPARISONS.map((comparison) => urlItem(`/compare/${comparison.slug}`, "0.6")),
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),
-    ...ENTRIES.map((entry) =>
+    // Advertise only indexable entry pages. `tools` entries are commercial,
+    // thin-by-design listings (see isSitemapIndexableEntry / AGENTS.md): still
+    // crawlable via internal links, just not advertised in the sitemap.
+    ...ENTRIES.filter(isSitemapIndexableEntry).map((entry) =>
       urlItem(
         `/entry/${entry.category}/${entry.slug}`,
         "0.8",

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -55,7 +55,9 @@ describe("sitemap policy", () => {
     expect(source).not.toContain('"/validators/mcp-config"');
     expect(source).not.toContain('"/validators/skill-package"');
     expect(source).not.toContain("lastModified: new Date()");
-    expect(source).toContain("ENTRIES.map");
+    // Entry pages are filtered through the sitemap-indexable policy (drops
+    // commercial `tools` listings + any robotsIndex:false entries).
+    expect(source).toContain("ENTRIES.filter(isSitemapIndexableEntry)");
     // Category hub landing pages with per-category + per-entry lastmod.
     expect(source).toContain("categoryLastmod");
     expect(source).toContain("entry.reviewedAt ?? entry.dateAdded");


### PR DESCRIPTION
Resolves the open decision in #2206.

## Decision: apply the policy (drop `tools` entry pages from the sitemap)

The sitemap route emitted `/entry/<category>/<slug>` for **all 923 entries**, including **128 `tools` entries** — even though a **tested** `isSitemapIndexableEntry` policy already existed in `lib/sitemap-policy.ts` but was **never wired into the route**.

I applied the policy rather than deleting the helper, because:
- **AGENTS.md** treats `tools` as commercial listings routed to the website lead flows — second-class for the directory.
- `tools` entries are **thin-by-design** (link-out + metadata, no body); advertising 128 thin pages dilutes crawl budget and invites "crawled – not indexed" in GSC.
- The behavior is intentional enough that someone wrote **and tested** the helper (`tests/sitemap-policy.test.ts`).

> ⚠️ **This is the reversible half of the #2206 decision.** Tools pages are **not** noindexed — they stay fully crawlable via internal links; they're just no longer *advertised* in the sitemap. If you'd rather keep them advertised, revert this PR (the alternative resolution was to delete the unused helper instead).

## Changes
- `routes/sitemap[.]xml.ts` — filter entry rows through `isSitemapIndexableEntry` (also drops any `robotsIndex:false` entry).
- `lib/sitemap-policy.ts` — relax the helper param to a minimal `{ category; robotsIndex? }` shape so both the server `DirectoryEntry` and the client `Entry` satisfy it; add a doc comment.
- `tests/sitemap-policy.test.ts` — update the source-pinning assertion to require the policy is wired (`ENTRIES.filter(isSitemapIndexableEntry)`).

## Validation
- `pnpm type-check` — clean
- `pnpm exec vitest run tests/sitemap-policy.test.ts tests/indexnow.test.ts tests/crawler-policy.test.ts tests/atlas-production-data.test.ts` — 18 passed

Closes #2206

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated sitemap generation to exclude certain tool entries and pages marked as non-indexable from search engine discovery, while keeping them accessible via direct links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->