### PR TITLE
fix(a11y): announce form errors, label fields, add combobox + mobile nav

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
-import { Moon, Sun, Send, Github, Rss } from "lucide-react";
+import { Moon, Sun, Send, Github, Rss, Menu } from "lucide-react";
 import { CommandBar, useGlobalCommandKey } from "./command-bar";
 import { AlertsDropdown } from "./alerts-dropdown";
 import { useShortcuts } from "./shortcuts-dialog";
@@ -8,6 +8,13 @@ import { ScrollProgress } from "./scroll-progress";
 import { useTheme } from "@/lib/theme";
 import { cn } from "@/lib/utils";
 import { NewsletterInline } from "./newsletter-inline";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
 import { CATEGORIES } from "@/types/registry";
 
 const NAV = [
@@ -26,6 +33,7 @@ export function TopBar() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isHome = pathname === "/";
   const [elevated, setElevated] = React.useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = React.useState(false);
   React.useEffect(() => {
     const onScroll = () => setElevated(window.scrollY > 8);
     onScroll();
@@ -45,6 +53,15 @@ export function TopBar() {
     >
       <ScrollProgress />
       <div className="mx-auto flex h-14 max-w-[1400px] items-center gap-4 px-4 sm:px-6">
+        <button
+          type="button"
+          onClick={() => setMobileNavOpen(true)}
+          aria-label="Open menu"
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink md:hidden"
+        >
+          <Menu className="h-4 w-4" />
+        </button>
+
         <Link to="/" className="flex items-center gap-2">
           <span className="flex h-7 w-7 items-center justify-center rounded-md bg-ink text-background">
             <span className="font-display text-sm font-bold">hc</span>
@@ -61,6 +78,7 @@ export function TopBar() {
               <Link
                 key={item.to}
                 to={item.to}
+                aria-current={active ? "page" : undefined}
                 className={cn(
                   "relative rounded-md px-2.5 py-1.5 text-sm transition-colors duration-200 ease-out",
                   active ? "text-ink" : "text-ink-muted hover:bg-surface-2 hover:text-ink",
@@ -111,6 +129,38 @@ export function TopBar() {
           </Link>
         </div>
       </div>
+
+      <Sheet open={mobileNavOpen} onOpenChange={setMobileNavOpen}>
+        <SheetContent side="left" className="w-72">
+          <SheetHeader>
+            <SheetTitle className="font-display text-base font-semibold text-ink">
+              Menu
+            </SheetTitle>
+            <SheetDescription className="sr-only">
+              Primary site navigation links.
+            </SheetDescription>
+          </SheetHeader>
+          <nav className="mt-6 flex flex-col gap-1">
+            {NAV.map((item) => {
+              const active = pathname.startsWith(item.to);
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  onClick={() => setMobileNavOpen(false)}
+                  aria-current={active ? "page" : undefined}
+                  className={cn(
+                    "rounded-md px-3 py-2 text-sm transition-colors duration-200 ease-out",
+                    active ? "bg-surface-2 text-ink" : "text-ink-muted hover:bg-surface-2 hover:text-ink",
+                  )}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+        </SheetContent>
+      </Sheet>
     </header>
   );
 }

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -2,7 +2,13 @@ import * as React from "react";
 import { Link } from "@tanstack/react-router";
 import { X, ExternalLink, ArrowRight, Shield, Lock } from "lucide-react";
 import { toast } from "sonner";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
 import { useCompare } from "@/lib/compare";
 import { CategoryPill, PlatformChip, NotesPresenceChips } from "@/components/badges";
 import { HarnessBadgeRow } from "@/components/harness-badge";
@@ -193,6 +199,9 @@ export function CompareDrawer() {
             <SheetTitle className="font-display text-base font-semibold text-ink">
               Comparing {items.length} {items.length === 1 ? "resource" : "resources"}
             </SheetTitle>
+            <SheetDescription className="sr-only">
+              Side-by-side comparison of the selected resources.
+            </SheetDescription>
             <div className="flex flex-wrap items-center gap-2">
               {items.length > 0 && (
                 <div className="hidden items-center gap-1.5 sm:flex">

--- a/apps/web/src/components/dossier-toc.tsx
+++ b/apps/web/src/components/dossier-toc.tsx
@@ -26,6 +26,7 @@ export function DossierTOC({ items, className }: { items: TocItem[]; className?:
             <li key={item.id}>
               <a
                 href={`#${item.id}`}
+                aria-current={isActive ? "true" : undefined}
                 className={cn(
                   "group flex items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
                   isActive

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -28,7 +28,7 @@ function SourceRepoStars({ entry, compact = false }: { entry: Entry; compact?: b
       className="inline-flex items-center gap-1 font-mono text-[11px] text-ink-subtle"
       title="Source repository stars"
     >
-      <Star className="h-3 w-3" /> {fmtNum(entry.repoStats.stars)}
+      <Star className="h-3 w-3" aria-hidden /> {fmtNum(entry.repoStats.stars)}
       {!compact && <span className="hidden sm:inline"> repo</span>}
     </span>
   );
@@ -242,7 +242,7 @@ export function ResourceCard({
           {entry.repoStats?.stars !== undefined ? (
             <>
               <div className="flex items-center gap-1 font-mono">
-                <Star className="h-3 w-3" /> {fmtNum(entry.repoStats.stars)}
+                <Star className="h-3 w-3" aria-hidden /> {fmtNum(entry.repoStats.stars)}
               </div>
               <div className="font-mono text-ink-subtle">repo stars</div>
             </>

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -402,6 +402,7 @@ function Browse() {
 
   return (
     <div className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+      <h1 className="sr-only">Browse the directory</h1>
       <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
         {/* Filter sidebar */}
         <aside className="hidden lg:block">

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, ShieldCheck, ListChecks } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
 import { cn } from "@/lib/utils";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { absoluteUrl } from "@/lib/seo";
 
 type ClaimType = "maintain" | "transfer" | "correct" | "remove";
@@ -85,6 +86,9 @@ function ClaimPage() {
   const [proof, setProof] = React.useState<Record<string, string>>({});
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState("");
+  const [activeIndex, setActiveIndex] = React.useState(-1);
+
+  const listboxId = React.useId();
 
   const matches = React.useMemo(() => {
     if (!query || picked) return [];
@@ -96,6 +100,55 @@ function ClaimPage() {
         e.author.toLowerCase().includes(q),
     ).slice(0, 6);
   }, [query, picked]);
+
+  // Reset the active option whenever the result set changes so the highlight
+  // never points at a stale index.
+  React.useEffect(() => {
+    setActiveIndex(-1);
+  }, [query, picked]);
+
+  const optionId = (index: number) => `${listboxId}-option-${index}`;
+
+  const choose = (entry: (typeof ENTRIES)[number]) => {
+    setPicked(entry);
+    setActiveIndex(-1);
+  };
+
+  const onSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (matches.length === 0) {
+      if (e.key === "Escape" && query) {
+        e.preventDefault();
+        setQuery("");
+      }
+      return;
+    }
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((i) => (i + 1) % matches.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((i) => (i <= 0 ? matches.length - 1 : i - 1));
+        break;
+      case "Enter":
+        if (activeIndex >= 0 && activeIndex < matches.length) {
+          e.preventDefault();
+          choose(matches[activeIndex]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        if (activeIndex >= 0) {
+          setActiveIndex(-1);
+        } else {
+          setQuery("");
+        }
+        break;
+      default:
+        break;
+    }
+  };
 
   const filled = PROOF_FIELDS.filter((f) => (proof[f.id] ?? "").trim().length > 0);
   const contactEmail = (proof.email ?? "").trim();
@@ -209,17 +262,39 @@ function ClaimPage() {
                   <input
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
+                    onKeyDown={onSearchKeyDown}
                     placeholder="Search by title, slug, or author"
+                    role="combobox"
+                    aria-expanded={matches.length > 0}
+                    aria-controls={listboxId}
+                    aria-autocomplete="list"
+                    aria-activedescendant={
+                      activeIndex >= 0 ? optionId(activeIndex) : undefined
+                    }
                     className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-subtle focus:border-ink focus:outline-none"
                   />
                   {matches.length > 0 && (
-                    <ul className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-auto rounded-md border border-border bg-surface shadow-sm">
-                      {matches.map((m) => (
-                        <li key={`${m.category}/${m.slug}`}>
+                    <ul
+                      id={listboxId}
+                      role="listbox"
+                      aria-label="Listing search results"
+                      className="absolute left-0 right-0 top-full z-10 mt-1 max-h-64 overflow-auto rounded-md border border-border bg-surface shadow-sm"
+                    >
+                      {matches.map((m, i) => (
+                        <li
+                          key={`${m.category}/${m.slug}`}
+                          id={optionId(i)}
+                          role="option"
+                          aria-selected={activeIndex === i}
+                        >
                           <button
                             type="button"
-                            onClick={() => setPicked(m)}
-                            className="block w-full px-3 py-2 text-left hover:bg-surface-2"
+                            onClick={() => choose(m)}
+                            onMouseEnter={() => setActiveIndex(i)}
+                            className={cn(
+                              "block w-full px-3 py-2 text-left hover:bg-surface-2",
+                              activeIndex === i && "bg-surface-2",
+                            )}
                           >
                             <div className="text-sm text-ink">{m.title}</div>
                             <div className="font-mono text-[11px] text-ink-subtle">
@@ -286,8 +361,13 @@ function ClaimPage() {
             <span className="text-xs text-ink-subtle">
               {filled.length} of {PROOF_FIELDS.length} proof fields filled
             </span>
-            {error && <span className="text-xs text-trust-blocked">{error}</span>}
           </div>
+
+          {error && (
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
         </div>
 
         <aside className="space-y-4">

--- a/apps/web/src/routes/jobs.post.tsx
+++ b/apps/web/src/routes/jobs.post.tsx
@@ -3,6 +3,7 @@ import { useState, type FormEvent } from "react";
 import { absoluteUrl } from "@/lib/seo";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { JobTier } from "@/types/registry";
 
 export const Route = createFileRoute("/jobs/post")({
@@ -199,7 +200,11 @@ function PostJobPage() {
             {submitting ? "Submitting…" : "Submit for review"}
           </button>
         </div>
-        {error && <p className="text-sm text-trust-blocked">{error}</p>}
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
       </form>
     </div>
   );

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import {
   AlertTriangle,
   ArrowRight,
@@ -20,6 +20,7 @@ import {
 import { logClientError } from "@/lib/client-logs";
 import { siteConfig } from "@/lib/site";
 import { CopyButton } from "@/components/copy-button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 import { absoluteUrl } from "@/lib/seo";
 
@@ -505,9 +506,9 @@ function SubmitPage() {
             </div>
 
             {submitError && (
-              <div className="rounded-md border border-trust-blocked/40 bg-trust-blocked/10 px-3 py-2 text-sm text-ink">
-                {submitError}
-              </div>
+              <Alert variant="destructive">
+                <AlertDescription>{submitError}</AlertDescription>
+              </Alert>
             )}
           </div>
         )}
@@ -566,12 +567,14 @@ function ServerPreflightBlock({
   }
   if (error) {
     return (
-      <div className="rounded-md border border-trust-blocked/40 bg-trust-blocked/10 px-3 py-2 text-sm text-ink">
-        {error}{" "}
-        <button type="button" onClick={onRun} className="font-medium underline">
-          Retry
-        </button>
-      </div>
+      <Alert variant="destructive">
+        <AlertDescription>
+          {error}{" "}
+          <button type="button" onClick={onRun} className="font-medium underline">
+            Retry
+          </button>
+        </AlertDescription>
+      </Alert>
     );
   }
   if (!result) {
@@ -732,10 +735,14 @@ function TextArea({
   onChange: (v: string) => void;
   examples?: string[];
 }) {
+  const id = useId();
   return (
     <div>
-      <div className="eyebrow mb-1.5">{label}</div>
+      <label htmlFor={id} className="eyebrow mb-1.5 block">
+        {label}
+      </label>
       <textarea
+        id={id}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         rows={4}


### PR DESCRIPTION
Round 5 accessibility pass across forms and navigation. Resolves **#2198** and **#2205**. All changes are additive ARIA/semantics — form submission, validation, filtering, and visual layout are preserved.

## Forms (#2198)
- **Error announcements** — `submit.tsx`, `claim.tsx`, `jobs.post.tsx` rendered submit errors as plain text. They now use the existing `Alert` primitive (`role="alert"`, `variant="destructive"`) so screen readers announce them when they appear. (`--color-destructive` is a defined red token, so styling is intact.)
- **Field labels** — `submit.tsx` safety/privacy textareas were unlabeled; they now get `<label htmlFor>`/`id` via `useId()`, mirroring the existing `FieldRender` pattern.

## Components (#2198)
- `compare-drawer.tsx` — added an `sr-only` `SheetDescription` (Radix Dialog warns without one).
- `browse.tsx` — added an `sr-only` `<h1>` so the page has a proper document heading without disturbing the tool layout.
- `resource-card.tsx` — decorative `Star` icons marked `aria-hidden` (numeric value + "repo stars" text remain).
- `app-shell.tsx` + `dossier-toc.tsx` — `aria-current` on the active nav link / TOC anchor.

## Larger a11y (#2205)
- **Combobox** — `claim.tsx` listing search is now a real combobox: `role=combobox` input with `aria-expanded`/`aria-controls`/`aria-autocomplete`/`aria-activedescendant`, a `role=listbox` results container, `role=option` items, and ArrowUp/Down/Enter/Escape keyboard navigation. Existing filter/selection logic unchanged (manual ARIA chosen over a cmdk refactor to avoid disturbing the controlled-query model).
- **Mobile nav** — `app-shell.tsx` adds a Radix `Sheet` mobile menu (hamburger, `md:hidden`, `aria-label="Open menu"`) reusing the same `NAV` array, so desktop and mobile stay in sync; links close the sheet on click and set `aria-current`.

## Validation
- `pnpm type-check` — clean
- Additive ARIA only; full `validate-web` suite runs in CI.

Closes #2198
Closes #2205