### PR TITLE
test(trust): cover install-risk verdict + RSS/Atom feed behavior

### DIFF
--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySavedSearch,
+  buildAtom,
+  buildRss,
+  categoryItems,
+  etagFor,
+  type FeedItem,
+  respondFeed,
+  siteWideItems,
+} from "@/lib/feeds";
+
+const ITEMS: FeedItem[] = [
+  {
+    title: 'Tom & Jerry <"best">',
+    link: "/entry/skills/a",
+    guid: "entry:skills/a",
+    pubDate: "2026-01-02T03:04:05.000Z",
+    description: "A & B < C",
+    category: "skills",
+  },
+  {
+    title: "Older",
+    link: "/entry/skills/b",
+    guid: "entry:skills/b",
+    pubDate: "2025-06-01T00:00:00.000Z",
+    description: "older item",
+  },
+];
+
+const rssOpts = {
+  title: "Feed & Title",
+  description: "desc <x>",
+  link: "https://heyclau.de",
+  selfLink: "https://heyclau.de/feed.xml",
+  items: ITEMS,
+};
+
+describe("buildRss", () => {
+  it("produces a well-formed RSS 2.0 envelope", () => {
+    const xml = buildRss(rssOpts);
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain('<rss version="2.0"');
+    expect(xml).toContain("<channel>");
+    expect(xml).toContain("<item>");
+    expect(xml).toContain("<guid isPermaLink=\"false\">entry:skills/a</guid>");
+    // rfc822 pubDate
+    expect(xml).toContain("<pubDate>Fri, 02 Jan 2026 03:04:05 GMT</pubDate>");
+  });
+
+  it("escapes XML metacharacters in titles and descriptions", () => {
+    const xml = buildRss(rssOpts);
+    expect(xml).toContain("Tom &amp; Jerry &lt;&quot;best&quot;&gt;");
+    expect(xml).toContain("<description>A &amp; B &lt; C</description>");
+    // No raw unescaped angle bracket from the data leaks into the body.
+    expect(xml).not.toContain('<"best">');
+  });
+
+  it("emits a <category> only when the item has one", () => {
+    const xml = buildRss(rssOpts);
+    expect(xml).toContain("<category>skills</category>");
+    // second item has no category -> exactly one category element
+    expect(xml.match(/<category>/g)?.length).toBe(1);
+  });
+
+  it("is deterministic for the same input (stable ETag source)", () => {
+    expect(buildRss(rssOpts)).toBe(buildRss(rssOpts));
+  });
+
+  it("defaults lastBuildDate to the newest item pubDate", () => {
+    const xml = buildRss(rssOpts);
+    expect(xml).toContain("<lastBuildDate>Fri, 02 Jan 2026 03:04:05 GMT</lastBuildDate>");
+  });
+});
+
+describe("buildAtom", () => {
+  it("produces a well-formed Atom 1.0 envelope with ISO timestamps", () => {
+    const xml = buildAtom(rssOpts);
+    expect(xml).toContain('<feed xmlns="http://www.w3.org/2005/Atom">');
+    expect(xml).toContain("<id>entry:skills/a</id>");
+    expect(xml).toContain("<updated>2026-01-02T03:04:05.000Z</updated>");
+    expect(xml).toContain("Tom &amp; Jerry &lt;&quot;best&quot;&gt;");
+  });
+
+  it("is deterministic for the same input", () => {
+    expect(buildAtom(rssOpts)).toBe(buildAtom(rssOpts));
+  });
+});
+
+describe("etagFor", () => {
+  it("is stable for identical bodies", async () => {
+    const a = await etagFor("hello");
+    const b = await etagFor("hello");
+    expect(a).toBe(b);
+  });
+
+  it("differs for different bodies and is a quoted 16-hex string", async () => {
+    const a = await etagFor("hello");
+    const b = await etagFor("world");
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^"[0-9a-f]{16}"$/);
+  });
+});
+
+describe("respondFeed conditional GET", () => {
+  const body = buildRss(rssOpts);
+  const lastBuilt = "2026-01-02T03:04:05.000Z";
+
+  it("returns 200 with cache + validator headers when unconditional", async () => {
+    const res = await respondFeed(new Request("https://heyclau.de/feed.xml"), body, lastBuilt);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("ETag")).toMatch(/^"[0-9a-f]{16}"$/);
+    expect(res.headers.get("Cache-Control")).toContain("max-age=300");
+    expect(res.headers.get("Last-Modified")).toBe(new Date(lastBuilt).toUTCString());
+    expect(await res.text()).toBe(body);
+  });
+
+  it("returns 304 with an empty body when If-None-Match matches", async () => {
+    const etag = await etagFor(body);
+    const res = await respondFeed(
+      new Request("https://heyclau.de/feed.xml", { headers: { "if-none-match": etag } }),
+      body,
+      lastBuilt,
+    );
+    expect(res.status).toBe(304);
+    expect(res.headers.get("ETag")).toBe(etag);
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 200 when If-None-Match does not match", async () => {
+    const res = await respondFeed(
+      new Request("https://heyclau.de/feed.xml", { headers: { "if-none-match": '"deadbeef"' } }),
+      body,
+      lastBuilt,
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it("honors a custom content type (atom)", async () => {
+    const res = await respondFeed(
+      new Request("https://heyclau.de/atom.xml"),
+      buildAtom(rssOpts),
+      lastBuilt,
+      "application/atom+xml; charset=utf-8",
+    );
+    expect(res.headers.get("Content-Type")).toContain("application/atom+xml");
+  });
+});
+
+describe("item builders over the real registry", () => {
+  it("categoryItems returns only that category, newest first, capped at 100", () => {
+    const items = categoryItems("skills");
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.length).toBeLessThanOrEqual(100);
+    for (const i of items) {
+      expect(i.category).toBe("skills");
+      expect(i.link.startsWith("/entry/skills/")).toBe(true);
+    }
+    // sorted descending by pubDate
+    for (let n = 1; n < items.length; n++) {
+      expect(items[n - 1].pubDate >= items[n].pubDate).toBe(true);
+    }
+  });
+
+  it("applySavedSearch filters by category and caps at 50", () => {
+    const items = applySavedSearch({ category: "mcp" });
+    expect(items.length).toBeLessThanOrEqual(50);
+    for (const i of items) expect(i.link.startsWith("/entry/mcp/")).toBe(true);
+  });
+
+  it("applySavedSearch with no filters returns the newest slice", () => {
+    const items = applySavedSearch({});
+    expect(items.length).toBeLessThanOrEqual(50);
+    for (let n = 1; n < items.length; n++) {
+      expect(items[n - 1].pubDate >= items[n].pubDate).toBe(true);
+    }
+  });
+
+  it("siteWideItems is capped at 100 and newest-first", () => {
+    const items = siteWideItems();
+    expect(items.length).toBeLessThanOrEqual(100);
+    for (let n = 1; n < items.length; n++) {
+      expect(items[n - 1].pubDate >= items[n].pubDate).toBe(true);
+    }
+  });
+});

--- a/tests/trust.test.ts
+++ b/tests/trust.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getTrustReasons,
+  installRiskLevel,
+  INSTALL_RISK_LABEL,
+  summarizeTrust,
+} from "@/lib/trust";
+import type { Entry } from "@/types/registry";
+
+// Minimal entry factory — only the fields trust.ts reads matter; the cast keeps
+// the table-driven cases terse without reconstructing the whole Entry shape.
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "demo",
+    title: "Demo",
+    description: "d",
+    trust: "trusted",
+    source: "first-party",
+    platforms: [],
+    tags: [],
+    ...overrides,
+  } as Entry;
+}
+
+const byId = (reasons: ReturnType<typeof getTrustReasons>, id: string) =>
+  reasons.find((r) => r.id === id);
+
+describe("getTrustReasons", () => {
+  it("always emits the six core reasons", () => {
+    const reasons = getTrustReasons(entry());
+    for (const id of ["trust-level", "source", "claim", "reviewed", "safety", "privacy"]) {
+      expect(byId(reasons, id), `missing ${id}`).toBeDefined();
+    }
+  });
+
+  it("maps trust posture to severity", () => {
+    expect(byId(getTrustReasons(entry({ trust: "trusted" })), "trust-level")?.severity).toBe("ok");
+    expect(byId(getTrustReasons(entry({ trust: "review" })), "trust-level")?.severity).toBe(
+      "warning",
+    );
+    expect(byId(getTrustReasons(entry({ trust: "limited" })), "trust-level")?.severity).toBe(
+      "warning",
+    );
+    expect(byId(getTrustReasons(entry({ trust: "blocked" })), "trust-level")?.severity).toBe(
+      "blocker",
+    );
+  });
+
+  it("maps source provenance to severity", () => {
+    expect(byId(getTrustReasons(entry({ source: "first-party" })), "source")?.severity).toBe("ok");
+    expect(byId(getTrustReasons(entry({ source: "source-backed" })), "source")?.severity).toBe(
+      "ok",
+    );
+    expect(byId(getTrustReasons(entry({ source: "external" })), "source")?.severity).toBe("info");
+    // An unknown / missing provenance is a warning.
+    expect(
+      byId(getTrustReasons(entry({ source: "community" as Entry["source"] })), "source")?.severity,
+    ).toBe("warning");
+  });
+
+  it("treats safetyNotesList as equivalent to safetyNotes", () => {
+    expect(byId(getTrustReasons(entry({ safetyNotes: "runs a worker" })), "safety")?.severity).toBe(
+      "ok",
+    );
+    expect(
+      byId(getTrustReasons(entry({ safetyNotesList: ["touches ~/.ssh"] })), "safety")?.severity,
+    ).toBe("ok");
+    expect(byId(getTrustReasons(entry()), "safety")?.severity).toBe("warning");
+  });
+
+  it("only emits checksum reason when a download is present", () => {
+    expect(byId(getTrustReasons(entry()), "checksum")).toBeUndefined();
+    expect(
+      byId(getTrustReasons(entry({ downloadUrl: "https://x/y.zip" })), "checksum")?.severity,
+    ).toBe("warning");
+    expect(
+      byId(getTrustReasons(entry({ downloadSha256: "abcdef0123456789" })), "checksum")?.severity,
+    ).toBe("ok");
+  });
+
+  it("only emits package-verified reason when the flag is defined", () => {
+    expect(byId(getTrustReasons(entry()), "package-verified")).toBeUndefined();
+    expect(
+      byId(getTrustReasons(entry({ packageVerified: true })), "package-verified")?.severity,
+    ).toBe("ok");
+    expect(
+      byId(getTrustReasons(entry({ packageVerified: false })), "package-verified")?.severity,
+    ).toBe("warning");
+  });
+
+  it("emits prerequisites reason only when present", () => {
+    expect(byId(getTrustReasons(entry()), "prereqs")).toBeUndefined();
+    expect(
+      byId(getTrustReasons(entry({ prerequisites: ["Node 20", "an API key"] })), "prereqs")?.label,
+    ).toContain("2 prerequisites");
+    expect(
+      byId(getTrustReasons(entry({ prerequisites: ["one"] })), "prereqs")?.label,
+    ).toContain("1 prerequisite");
+  });
+});
+
+describe("summarizeTrust", () => {
+  it("counts every reason exactly once across severities", () => {
+    const reasons = getTrustReasons(
+      entry({ trust: "blocked", source: "external", packageVerified: false }),
+    );
+    const counts = summarizeTrust(reasons);
+    expect(counts.ok + counts.info + counts.warning + counts.blocker).toBe(reasons.length);
+    expect(counts.blocker).toBeGreaterThan(0);
+  });
+});
+
+describe("installRiskLevel", () => {
+  // A fully clean, trusted entry with no freshness timestamp -> no warnings.
+  const lowEntry = () =>
+    entry({
+      trust: "trusted",
+      source: "first-party",
+      claimed: true,
+      reviewed: true,
+      safetyNotes: "runs read-only",
+      privacyNotes: "no telemetry",
+      packageVerified: true,
+    });
+
+  it("returns low for a clean trusted entry", () => {
+    expect(installRiskLevel(lowEntry())).toBe("low");
+  });
+
+  it("returns high when blocked", () => {
+    expect(installRiskLevel(entry({ trust: "blocked" }))).toBe("high");
+  });
+
+  it("returns review when trust is not trusted (no blocker)", () => {
+    expect(installRiskLevel({ ...lowEntry(), trust: "review" } as Entry)).toBe("review");
+    expect(installRiskLevel({ ...lowEntry(), trust: "limited" } as Entry)).toBe("review");
+  });
+
+  it("downgrades a trusted entry to review on any warning", () => {
+    expect(installRiskLevel({ ...lowEntry(), reviewed: false } as Entry)).toBe("review");
+    expect(
+      installRiskLevel({ ...lowEntry(), safetyNotes: undefined, safetyNotesList: [] } as Entry),
+    ).toBe("review");
+    expect(installRiskLevel({ ...lowEntry(), packageVerified: false } as Entry)).toBe("review");
+  });
+
+  it("exposes a label for every risk level", () => {
+    expect(INSTALL_RISK_LABEL.low).toBeTruthy();
+    expect(INSTALL_RISK_LABEL.review).toBeTruthy();
+    expect(INSTALL_RISK_LABEL.high).toBeTruthy();
+  });
+});
+
+describe("freshness 60-day boundary", () => {
+  const NOW = new Date("2026-06-13T00:00:00.000Z");
+  const daysAgo = (n: number) => new Date(NOW.getTime() - n * 86_400_000).toISOString();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("treats verification under 60 days old as fresh", () => {
+    const reasons = getTrustReasons(entry({ reviewedAt: daysAgo(59) }));
+    const freshness = byId(reasons, "freshness");
+    expect(freshness?.severity).toBe("ok");
+    expect(freshness?.label).toBe("Recently verified");
+  });
+
+  it("treats verification at/after 60 days as stale", () => {
+    expect(byId(getTrustReasons(entry({ reviewedAt: daysAgo(60) })), "freshness")?.severity).toBe(
+      "warning",
+    );
+    expect(byId(getTrustReasons(entry({ reviewedAt: daysAgo(120) })), "freshness")?.severity).toBe(
+      "warning",
+    );
+  });
+
+  it("prefers brandVerifiedAt over reviewedAt/submittedAt for freshness", () => {
+    const reasons = getTrustReasons(
+      entry({ brandVerifiedAt: daysAgo(1), reviewedAt: daysAgo(900) }),
+    );
+    expect(byId(reasons, "freshness")?.severity).toBe("ok");
+  });
+
+  it("a stale verification pushes an otherwise-clean entry to review risk", () => {
+    const stale = entry({
+      trust: "trusted",
+      source: "first-party",
+      claimed: true,
+      reviewed: true,
+      safetyNotes: "x",
+      privacyNotes: "y",
+      packageVerified: true,
+      reviewedAt: daysAgo(90),
+    });
+    expect(installRiskLevel(stale)).toBe("review");
+  });
+});


### PR DESCRIPTION
Adds executable test coverage for two previously-untested modules. Resolves **#2204**.

## `lib/trust.ts` — the user-facing safety verdict (was zero-coverage)
A silent refactor here could downgrade risk badges without anyone noticing.
- `getTrustReasons` — the six always-present reasons; severity mapping for trust posture and source provenance; `safetyNotesList` treated like `safetyNotes`; checksum/package-verified/prerequisites reasons emitted only when their data is present.
- `summarizeTrust` — severity counts always sum to the reason count.
- `installRiskLevel` — the full `low`/`review`/`high` matrix (clean trusted ⇒ low; blocked ⇒ high; non-trusted or any warning ⇒ review).
- **60-day freshness boundary** via `vi.setSystemTime`: 59 days ⇒ fresh, 60+ days ⇒ stale, `brandVerifiedAt` preferred, and a stale verification demoting an otherwise-clean entry to `review`.

## `lib/feeds.ts`
- `buildRss`/`buildAtom` — envelope structure, **XML escaping** of `& < > " '`, conditional `<category>`, ISO/rfc822 timestamps, and **determinism** (stable body ⇒ stable ETag).
- `etagFor` — stable for identical bodies, distinct for different bodies, quoted 16-hex.
- `respondFeed` — 200 with `ETag`/`Cache-Control`/`Last-Modified`, **304** on matching `If-None-Match` (empty body), 200 on mismatch, custom content type.
- `categoryItems`/`applySavedSearch`/`siteWideItems` — category filtering, newest-first ordering, and slice caps over the real registry.

## Note on sitemap
`renderSitemap` is a route handler backed by D1-dependent `getJobs()`, so it can't be unit-executed without env. The sitemap-indexable policy remains covered by `tests/sitemap-policy.test.ts` (strengthened in #2213).

## Validation
- `pnpm exec vitest run tests/trust.test.ts tests/feeds.test.ts` — 34 passed
- `pnpm type-check` — clean

Closes #2204