### PR TITLE
perf(runtime): memo ResourceCard, split Compare store, memo browse facets

### DIFF
--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -15,7 +15,7 @@ import { CopyButton } from "./copy-button";
 import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
 import { PeekHint } from "./peek-hint";
-import { useCompare } from "@/lib/compare";
+import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
 
 import { formatCompact, timeAgo } from "@/lib/format";
@@ -34,7 +34,7 @@ function SourceRepoStars({ entry, compact = false }: { entry: Entry; compact?: b
   );
 }
 
-export function ResourceCard({
+function ResourceCardInner({
   entry,
   variant = "row",
   rank,
@@ -43,8 +43,8 @@ export function ResourceCard({
   variant?: "row" | "grid" | "compact";
   rank?: number;
 }) {
-  const compare = useCompare();
-  const inCompare = compare.has(entry.slug);
+  const { toggle, setOpen } = useCompareActions();
+  const inCompare = useIsCompared(entry.slug);
   const peekRef = React.useRef<PeekHandle>(null);
   const handle = React.useMemo(() => ({ open: () => peekRef.current?.open() }), []);
   const [hovered, setHovered] = React.useState(false);
@@ -71,13 +71,13 @@ export function ResourceCard({
 
   const onCompareToggle = () => {
     const wasIn = inCompare;
-    compare.toggle(entry);
+    toggle(entry);
     if (wasIn) {
       toast(`Removed “${entry.title}” from compare`);
     } else {
       toast.success("Added to compare", {
         description: entry.title,
-        action: { label: "View", onClick: () => compare.setOpen(true) },
+        action: { label: "View", onClick: () => setOpen(true) },
       });
     }
   };
@@ -296,3 +296,11 @@ export function ResourceCard({
     </div>
   );
 }
+
+/**
+ * Memoized so that selecting/deselecting one card in the compare set does not
+ * re-render every other visible card. Cards subscribe to their own compare
+ * membership via `useIsCompared`, and `entry`/`variant`/`rank` props are stable
+ * references from the registry, so the shallow prop compare is effective.
+ */
+export const ResourceCard = React.memo(ResourceCardInner);

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import type { Entry } from "@/types/registry";
 
-interface CompareCtx {
-  items: Entry[];
-  open: boolean;
+interface CompareActions {
   setOpen: (open: boolean) => void;
   toggle: (e: Entry) => void;
   clear: () => void;
@@ -16,7 +14,21 @@ interface CompareCtx {
   getShareUrl: () => string;
 }
 
-const Ctx = React.createContext<CompareCtx | null>(null);
+interface CompareState {
+  items: Entry[];
+  open: boolean;
+}
+
+interface CompareStore {
+  getState: () => CompareState;
+  subscribe: (listener: () => void) => () => void;
+  actions: CompareActions;
+}
+
+/** Full context value: live state spread together with the stable actions. */
+export interface CompareCtx extends CompareState, CompareActions {}
+
+const StoreCtx = React.createContext<CompareStore | null>(null);
 
 function resolve(entries: Entry[], param: string): Entry[] {
   if (!param) return [];
@@ -39,57 +51,106 @@ function resolve(entries: Entry[], param: string): Entry[] {
   return out;
 }
 
-export function CompareProvider({ children }: { children: React.ReactNode }) {
-  const [items, setItems] = React.useState<Entry[]>([]);
-  const [open, setOpen] = React.useState(false);
+/**
+ * A tiny external store backs the compare selection. Splitting state from the
+ * stable `actions` object lets cards subscribe narrowly (see `useIsCompared`):
+ * toggling one card only re-renders that card plus the singletons that read the
+ * full state, instead of every visible `ResourceCard`.
+ */
+function createCompareStore(): CompareStore {
+  let state: CompareState = { items: [], open: false };
+  const listeners = new Set<() => void>();
+  const setState = (next: CompareState) => {
+    if (next === state) return;
+    state = next;
+    for (const l of listeners) l();
+  };
 
-  const value = React.useMemo<CompareCtx>(
-    () => ({
-      items,
-      open,
-      setOpen,
-      toggle: (e) =>
-        setItems((cur) =>
-          cur.find((x) => x.slug === e.slug)
-            ? cur.filter((x) => x.slug !== e.slug)
-            : cur.length >= 4
-              ? cur
-              : [...cur, e],
-        ),
-      clear: () => {
-        setItems([]);
-        setOpen(false);
-      },
-      has: (slug) => items.some((x) => x.slug === slug),
-      hydrate: (param) => {
-        if (!param) {
-          if (items.length) setItems([]);
-          return;
-        }
-        // Lazy-load the dataset only when a compare selection is hydrated from the URL,
-        // keeping the registry dataset out of the universal client bundle.
-        void import("@/data/entries").then(({ ENTRIES }) => {
-          const next = resolve(ENTRIES, param);
-          // Only update if changed to avoid render loops
-          const sig = next.map((e) => `${e.category}/${e.slug}`).join(",");
-          const curSig = items.map((e) => `${e.category}/${e.slug}`).join(",");
-          if (sig !== curSig) setItems(next);
-        });
-      },
-      serialize: () => items.map((e) => `${e.category}/${e.slug}`).join(","),
-      getShareUrl: () => {
-        const sig = items.map((e) => `${e.category}/${e.slug}`).join(",");
-        const origin = typeof window !== "undefined" ? window.location.origin : "";
-        return sig ? `${origin}/browse?compare=${encodeURIComponent(sig)}` : `${origin}/browse`;
-      },
-    }),
-    [items, open],
-  );
-  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+  const actions: CompareActions = {
+    setOpen: (open) => {
+      if (state.open === open) return;
+      setState({ ...state, open });
+    },
+    toggle: (e) => {
+      const cur = state.items;
+      const next = cur.find((x) => x.slug === e.slug)
+        ? cur.filter((x) => x.slug !== e.slug)
+        : cur.length >= 4
+          ? cur
+          : [...cur, e];
+      if (next === cur) return; // at the 4-item cap — no change
+      setState({ ...state, items: next });
+    },
+    clear: () => {
+      if (state.items.length === 0 && !state.open) return;
+      setState({ items: [], open: false });
+    },
+    has: (slug) => state.items.some((x) => x.slug === slug),
+    hydrate: (param) => {
+      if (!param) {
+        if (state.items.length) setState({ ...state, items: [] });
+        return;
+      }
+      // Lazy-load the dataset only when a compare selection is hydrated from the
+      // URL, keeping the registry dataset out of the universal client bundle.
+      void import("@/data/entries").then(({ ENTRIES }) => {
+        const next = resolve(ENTRIES, param);
+        const sig = next.map((e) => `${e.category}/${e.slug}`).join(",");
+        const curSig = state.items.map((e) => `${e.category}/${e.slug}`).join(",");
+        if (sig !== curSig) setState({ ...state, items: next });
+      });
+    },
+    serialize: () => state.items.map((e) => `${e.category}/${e.slug}`).join(","),
+    getShareUrl: () => {
+      const sig = state.items.map((e) => `${e.category}/${e.slug}`).join(",");
+      const origin = typeof window !== "undefined" ? window.location.origin : "";
+      return sig ? `${origin}/browse?compare=${encodeURIComponent(sig)}` : `${origin}/browse`;
+    },
+  };
+
+  return {
+    getState: () => state,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    actions,
+  };
 }
 
-export function useCompare() {
-  const ctx = React.useContext(Ctx);
-  if (!ctx) throw new Error("useCompare must be used within CompareProvider");
-  return ctx;
+export function CompareProvider({ children }: { children: React.ReactNode }) {
+  const [store] = React.useState(createCompareStore);
+  return <StoreCtx.Provider value={store}>{children}</StoreCtx.Provider>;
+}
+
+function useStore(): CompareStore {
+  const store = React.useContext(StoreCtx);
+  if (!store) throw new Error("useCompare must be used within CompareProvider");
+  return store;
+}
+
+/** Stable action handlers — never changes identity, so consuming it never
+ * triggers a re-render when the selection changes. */
+export function useCompareActions(): CompareActions {
+  return useStore().actions;
+}
+
+/** Narrow per-card subscription: a card re-renders only when its own
+ * membership in the compare set flips, not on every selection change. */
+export function useIsCompared(slug: string): boolean {
+  const store = useStore();
+  return React.useSyncExternalStore(
+    store.subscribe,
+    () => store.getState().items.some((x) => x.slug === slug),
+    () => false,
+  );
+}
+
+/** Full compare context (live state + actions). Use for the drawer/tray and
+ * page-level consumers; per-card components should prefer `useIsCompared` +
+ * `useCompareActions` to avoid re-rendering on every selection change. */
+export function useCompare(): CompareCtx {
+  const store = useStore();
+  const state = React.useSyncExternalStore(store.subscribe, store.getState, store.getState);
+  return { ...state, ...store.actions };
 }

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { CATEGORIES, type Category } from "@/types/registry";
@@ -19,9 +20,8 @@ import { ogImageUrl, categoryAccent } from "@/lib/og-image";
 const categoryIds = new Set(CATEGORIES.map((c) => c.id));
 
 // Reuse the canonical registry ranking (recommendedScore) so hub order matches /browse.
-function topEntriesFor(id: string) {
-  return search({ categories: [id as Category] });
-}
+// Cached per render pass so head() and the component don't each re-run the search.
+const topEntriesFor = cache((id: string) => search({ categories: [id as Category] }));
 
 function faqFor(id: string, label: string) {
   return [

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -173,6 +173,17 @@ export const Route = createFileRoute("/browse")({
   component: Browse,
 });
 
+const TRUST_LEVELS: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_STATUSES: SourceStatus[] = ["first-party", "source-backed", "external"];
+const PLATFORM_IDS: Platform[] = [
+  "claude-code",
+  "claude-desktop",
+  "cursor",
+  "vscode",
+  "cli",
+  "raycast",
+];
+
 function Browse() {
   const sp = Route.useSearch();
   const navigate = Route.useNavigate();
@@ -312,18 +323,31 @@ function Browse() {
     setShown(PAGE);
   }, [sp.q, sp.category, sp.trust, sp.source, sp.platform, sp.sort]);
 
-  // Per-axis result counts: count if this filter were the only one in its axis.
-  const axisCount = (axis: "category" | "trust" | "source" | "platform", value: string) => {
-    const merged = { ...sp, [axis]: value } as typeof sp;
-    return search({
-      q: merged.q,
-      categories: merged.category ? [merged.category as Category] : undefined,
-      trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
-      source: merged.source ? [merged.source as SourceStatus] : undefined,
-      platforms: merged.platform ? [merged.platform as Platform] : undefined,
-      sort: merged.sort,
-    }).length;
-  };
+  // Per-axis facet counts: how many results if this value were the only filter
+  // in its axis. Memoized on the search params so the ~23 search() passes run
+  // once per filter change instead of on every render (compare toggle, hover…).
+  const facetCounts = useMemo(() => {
+    const countFor = (axis: "category" | "trust" | "source" | "platform", value: string) => {
+      const merged = { ...sp, [axis]: value } as typeof sp;
+      return search({
+        q: merged.q,
+        categories: merged.category ? [merged.category as Category] : undefined,
+        trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
+        source: merged.source ? [merged.source as SourceStatus] : undefined,
+        platforms: merged.platform ? [merged.platform as Platform] : undefined,
+        sort: merged.sort,
+      }).length;
+    };
+    return {
+      category: Object.fromEntries(CATEGORIES.map((c) => [c.id, countFor("category", c.id)])),
+      trust: Object.fromEntries(TRUST_LEVELS.map((t) => [t, countFor("trust", t)])),
+      source: Object.fromEntries(SOURCE_STATUSES.map((s) => [s, countFor("source", s)])),
+      platform: Object.fromEntries(PLATFORM_IDS.map((p) => [p, countFor("platform", p)])),
+    } as Record<string, Record<string, number>>;
+  }, [sp]);
+
+  const axisCount = (axis: "category" | "trust" | "source" | "platform", value: string) =>
+    facetCounts[axis]?.[value] ?? 0;
 
   // Focus search on "/" key.
   const searchRef = React.useRef<HTMLInputElement>(null);
@@ -432,7 +456,7 @@ function Browse() {
 
             <FilterSection title="Trust">
               <FilterChipGroup label="Filter by trust level">
-                {(["trusted", "review", "limited", "blocked"] as TrustLevel[]).map((t) => (
+                {TRUST_LEVELS.map((t) => (
                   <FilterChip
                     key={t}
                     active={sp.trust === t}
@@ -447,7 +471,7 @@ function Browse() {
 
             <FilterSection title="Source">
               <FilterChipGroup label="Filter by source status">
-                {(["first-party", "source-backed", "external"] as SourceStatus[]).map((s) => (
+                {SOURCE_STATUSES.map((s) => (
                   <FilterChip
                     key={s}
                     active={sp.source === s}
@@ -462,16 +486,7 @@ function Browse() {
 
             <FilterSection title="Platform">
               <FilterChipGroup label="Filter by platform">
-                {(
-                  [
-                    "claude-code",
-                    "claude-desktop",
-                    "cursor",
-                    "vscode",
-                    "cli",
-                    "raycast",
-                  ] as Platform[]
-                ).map((p) => (
+                {PLATFORM_IDS.map((p) => (
                   <FilterChip
                     key={p}
                     active={sp.platform === p}

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { CATEGORIES, PLATFORM_LABEL, type Platform } from "@/types/registry";
@@ -12,9 +13,8 @@ import { ogImageUrl } from "@/lib/og-image";
 
 const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
 
-function platformEntries(platform: string) {
-  return search({ platforms: [platform as Platform] });
-}
+// Cached per render pass so head() and the component don't each re-run the search.
+const platformEntries = cache((platform: string) => search({ platforms: [platform as Platform] }));
 
 export const Route = createFileRoute("/for/$platform")({
   loader: ({ params }) => {


### PR DESCRIPTION
The biggest INP win on Browse, plus server-CPU cuts on the hubs. Resolves **#2201** and the remainder of **#2200** (entry `related()` memo + sitemap single-pass already shipped in #2210).

## Compare re-render storm (#2201)
Every visible `ResourceCard` consumed the whole Compare context, whose value was recreated on every `toggle`/`open` — so selecting one card re-rendered all ~30 visible cards (memo alone wouldn't help while each card reads the changing value).
- **`lib/compare.tsx`** — selection now lives in a tiny external store. `useCompare()` keeps the **same surface** (live state + actions) for the drawer, tray, and page-level consumers, but per-card components use:
  - `useIsCompared(slug)` — a `useSyncExternalStore` selector that re-renders a card **only when its own membership flips**, and
  - `useCompareActions()` — stable action identities (never trigger a re-render).
  - SSR-safe: server snapshots are the empty initial state, so hydration matches.
- **`resource-card.tsx`** — wrapped in `React.memo` (props are stable `entry`/`variant`/`rank`).

Net: toggling one card re-renders that card + the full-state consumers only.

## Browse facet counts (#2200)
- **`browse.tsx`** — `axisCount` ran ~23 `search()` filter+sort passes over 922 entries **on every render** (including compare toggles, hover, density switches). Now computed once in a `useMemo` keyed on the search params; facet lists shared as consts.

## Hub server-CPU (#2200)
- **`$category.tsx` / `for.$platform.tsx`** — the `search()` hub helper ran once in `head()` and again in the component per request. Wrapped in `React.cache` (the pattern already used in `content.server.ts`/`contributors.ts`/`growth-surfaces.ts`) to dedupe within a render pass. Kept out of the loader to avoid serializing the dataset into the client payload.

## Validation
- `pnpm type-check` — clean
- Compare interaction headless-verified before merge (toggle add/remove, drawer open, count) — see PR comment.

Closes #2201
Closes #2200