### PR TITLE
fix(seo): de-duplicate /tools in the sitemap

### DIFF
--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -110,7 +110,9 @@ async function renderSitemap() {
   const rows = [
     ...staticPaths.map((pathname) => urlItem(pathname, pathname === "" ? "1" : "0.7")),
     ...feedPaths.map((pathname) => urlItem(pathname, "0.4")),
-    ...CATEGORIES.map((category) =>
+    // `tools` has no /$category hub — its URL is the static commercial /tools page,
+    // already emitted in staticPaths above. Exclude it here to avoid a duplicate.
+    ...CATEGORIES.filter((category) => category.id !== "tools").map((category) =>
       urlItem(`/${category.id}`, "0.8", "weekly", categoryLastmod.get(category.id)),
     ),
     ...getIndexableTagGroups().map((group) => urlItem(`/tags/${group.slug}`, "0.5")),


### PR DESCRIPTION
`/tools` was listed **twice** in `sitemap.xml`:
- `staticPaths` (the static commercial `/tools` page), and
- the category-hub loop `CATEGORIES.map(c => /${c.id})`, because `tools` is a member of `CATEGORIES`.

`tools` has no reachable `/$category` hub — TanStack Router's static-route precedence resolves `/tools` to the dedicated static commercial page. So the category-hub entry was a pure duplicate. Excluded `tools` from the hub loop; `/tools` is now emitted once (from `staticPaths`). Consistent with the tools-are-commercial sitemap policy wired in #2213.

This is the one objective defect in the area #2192 targets (see that PR's review note).

## Validation
- `pnpm type-check` — clean
- `pnpm exec vitest run tests/sitemap-policy.test.ts` — 3 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate sitemap entries for the tools category, improving site search engine optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->