### PR TITLE
perf(runtime): O(1) entry lookup index + cache intersection hub

### DIFF
--- a/apps/web/src/data/entries.ts
+++ b/apps/web/src/data/entries.ts
@@ -18,6 +18,17 @@ export const REGISTRY_GENERATED_AT = generatedAt;
 
 export const ENTRIES: Entry[] = registryEntries.map(buildEntry);
 
+// O(1) lookup by `category/slug`. Hot SSR paths (entry loader, /og route, the
+// /$category/$slug redirect, related()/relatedGroups(), trending) previously did
+// O(n) ENTRIES.find per lookup — and trending does ~50 lookups per request.
+const ENTRY_BY_REF: Map<string, Entry> = new Map(
+  ENTRIES.map((entry) => [`${entry.category}/${entry.slug}`, entry]),
+);
+
+export function entryByRef(category: string, slug: string): Entry | undefined {
+  return ENTRY_BY_REF.get(`${category}/${slug}`);
+}
+
 export const BRIEF_ISSUES = registryChangelog.slice(0, 6).map((item, index) => ({
   slug: `registry-brief-${String(index + 1).padStart(3, "0")}`,
   number: registryChangelog.length - index,

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -1,4 +1,4 @@
-import { ENTRIES } from "./entries";
+import { ENTRIES, entryByRef } from "./entries";
 import type {
   Category,
   Entry,
@@ -69,16 +69,12 @@ function recommendedScore(entry: Entry) {
 }
 
 export function getEntry(category: string, slug: string): Entry | undefined {
-  return ENTRIES.find((e) => e.category === category && e.slug === slug);
+  return entryByRef(category, slug);
 }
 
 export function related(entry: Entry, limit = 4): Entry[] {
   const graphEntries = (entry.relatedEntries ?? [])
-    .map((relation) =>
-      ENTRIES.find(
-        (candidate) => candidate.category === relation.category && candidate.slug === relation.slug,
-      ),
-    )
+    .map((relation) => entryByRef(relation.category, relation.slug))
     .filter((candidate): candidate is Entry => Boolean(candidate))
     .filter((candidate) => candidate.category !== entry.category || candidate.slug !== entry.slug)
     .slice(0, limit);
@@ -121,7 +117,7 @@ export function relatedGroups(
   const byRelation = new Map<EntryRelationType, Entry[]>();
   for (const rel of entry.relatedEntries ?? []) {
     if (rel.relation === "duplicate") continue;
-    const candidate = ENTRIES.find((e) => e.category === rel.category && e.slug === rel.slug);
+    const candidate = entryByRef(rel.category, rel.slug);
     if (!candidate) continue;
     if (candidate.category === entry.category && candidate.slug === entry.slug) continue;
     const list = byRelation.get(rel.relation) ?? [];

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { CATEGORIES, PLATFORM_LABEL, type Platform, type Category } from "@/types/registry";
@@ -13,9 +14,11 @@ import { ogImageUrl } from "@/lib/og-image";
 const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
 const CATEGORY_IDS = new Set(CATEGORIES.map((c) => c.id));
 
-function intersection(platform: string, category: string) {
-  return search({ platforms: [platform as Platform], categories: [category as Category] });
-}
+// Cached per render pass so loader + head() + the component don't each re-run the
+// full search() scan (matches the React.cache pattern on the sibling hub routes).
+const intersection = cache((platform: string, category: string) =>
+  search({ platforms: [platform as Platform], categories: [category as Category] }),
+);
 
 export const Route = createFileRoute("/for/$platform/$category")({
   loader: ({ params }) => {


### PR DESCRIPTION
Two server-CPU wins found in a fresh audit.

## O(1) entry lookup index
`getEntry`, `related()`'s graph branch, and `relatedGroups()` each did `ENTRIES.find` (O(927)) per lookup. These are on hot SSR paths — the entry-detail loader fallback, the `/og` image route, the `/$category/$slug` → `/entry/…` redirect, and **trending**, which calls `getEntry` in a ~50-item loop (~46K iterations per request).

Added `ENTRY_BY_REF` (a `Map` keyed by `category/slug`) in `data/entries.ts` with an `entryByRef()` helper, and routed all three through it. O(n) → O(1) per lookup.

## Cache the intersection hub search
`for.$platform.$category.tsx`'s `intersection()` ran a full `search()` filter+sort in the loader, again in `head()`, and again in the component — 3 full scans per request. Wrapped it in `React.cache`, exactly like the sibling hub routes (`$category.tsx`, `for.$platform.tsx`) already do; this one was missed.

## Validation
- `pnpm type-check` — clean
- `pnpm exec vitest run tests/registry-search-api.test.ts tests/registry-search-facets.test.ts` — 14 passed (related/search behavior unchanged)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance for platform and category filtering through optimized entry indexing and search result caching across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->