### PR TITLE
fix(registry): honor explicit rules copy snippets

### DIFF
--- a/packages/registry/src/content-schema.js
+++ b/packages/registry/src/content-schema.js
@@ -523,10 +523,10 @@ export function inferStructuredFields(data, body, category) {
   const copySnippet =
     category === "guides" || category === "collections"
       ? ""
-      : category === "agents" || category === "rules"
-        ? String(body || "").trim()
-        : data.copySnippet
-          ? String(data.copySnippet)
+      : data.copySnippet
+        ? String(data.copySnippet)
+        : category === "agents" || category === "rules"
+          ? String(body || "").trim()
           : firstCodeBlock?.code?.trim() || usageSnippet || "";
 
   const scriptLanguage = data.scriptLanguage

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { inferStructuredFields } from "../packages/registry/src/content-schema.js";
+
+describe("inferStructuredFields", () => {
+  it("prefers explicit copySnippet frontmatter for rules entries", () => {
+    const inferred = inferStructuredFields(
+      {
+        copySnippet: "Full rule payload\n\n## Rule Details",
+        usageSnippet: "Short usage summary",
+      },
+      "## Usage\n\nShort public description.",
+      "rules",
+    );
+
+    expect(inferred.copySnippet).toBe("Full rule payload\n\n## Rule Details");
+  });
+
+  it("falls back to the body as copySnippet for rules entries without frontmatter copy", () => {
+    const inferred = inferStructuredFields(
+      {
+        usageSnippet: "Short usage summary",
+      },
+      "## Rule Body\n\nUse these rules.",
+      "rules",
+    );
+
+    expect(inferred.copySnippet).toBe("## Rule Body\n\nUse these rules.");
+  });
+});


### PR DESCRIPTION
### Motivation

- Content entries in `agents` and `rules` categories ignored explicit `copySnippet` frontmatter and instead published the MDX body as the public copy, which caused rule assets placed in frontmatter (e.g., `content/rules/nestjs-expert.mdx`) to be omitted from the published `fullCopy` payload.

### Description

- Change `inferStructuredFields` in `packages/registry/src/content-schema.js` to prefer an explicit `data.copySnippet` before falling back to the MDX body for `agents` and `rules` entries.
- Add regression tests in `tests/content-schema.test.ts` that assert explicit frontmatter `copySnippet` is honored and that the body is used when no frontmatter copy exists.

### Testing

- Ran unit tests with `pnpm exec vitest run tests/content-schema.test.ts` and the two new tests passed.
- Ran content validation with `pnpm validate:content:strict` which completed successfully.
- Ran registry generation with `pnpm generate:registry` (`node scripts/build-content-index.mjs`) which produced entry detail artifacts and updated the `nestjs-expert` entry `copySnippet` to include the full rule asset.
- Ran the full registry artifacts test suite with `pnpm test:registry-artifacts` and `pnpm exec vitest run tests/registry-artifacts.test.ts --testTimeout=180000`; 44/46 tests passed and two long-running tests timed out in this environment (per-test 60s limits), unrelated to the change in `copySnippet` preference.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e44deea98832aaa6f9983d42e53bb)