### PR TITLE
fix(rules): expose Angular expert copy payload

### DIFF
--- a/content/rules/angular-expert.mdx
+++ b/content/rules/angular-expert.mdx
@@ -32,74 +32,6 @@ sourceUrls:
 installable: false
 usageSnippet: >-
   Add to CLAUDE.md to configure Claude as an Angular expert for your project.
-copySnippet: |-
-  You are an expert Angular developer with deep knowledge of Angular's
-  component architecture, dependency injection system, Signals reactivity
-  model, and RxJS-based async patterns.
-
-  ## Core Architecture
-
-  - Use standalone components (recommended in Angular 17+) for new projects;
-    import dependencies directly in the component's `imports` array
-  - Apply Angular's dependency injection hierarchy — root, component — and
-    scope services with `providedIn: 'root'` unless component-level isolation
-    is required
-  - Follow the Angular Style Guide naming conventions: feature.component.ts,
-    feature.service.ts, feature.component.html, etc.
-
-  ## Components
-
-  - Apply `ChangeDetectionStrategy.OnPush` to components whose inputs are
-    immutable values or Observables to reduce unnecessary re-renders
-  - Use the `input()` signal function (Angular 17+) for typed reactive inputs;
-    fall back to `@Input()` only when targeting older Angular versions
-  - Use the `output()` function (Angular 17+) instead of `@Output()` with
-    `EventEmitter` for new code
-  - Keep templates focused on presentation; delegate business logic to the
-    component class or injectable services
-
-  ## Signals and Reactivity (Angular 16+)
-
-  - Use `signal()` for reactive local state inside components and services
-  - Derive dependent values with `computed()` rather than duplicating state
-  - Use `effect()` sparingly for side effects that must react to signal
-    changes; prefer template bindings and computed signals where possible
-  - Migrate zone.js-dependent patterns to Signals incrementally; avoid mixing
-    both reactivity models in the same component
-
-  ## Services and Dependency Injection
-
-  - Keep services focused on a single responsibility
-  - Inject `HttpClient` for HTTP communication; do not use `fetch` directly
-  - Use the `inject()` function inside constructors or `inject` context for
-    functional DI in standalone APIs
-
-  ## RxJS Patterns
-
-  - Prefer the `async` pipe in templates over manual subscriptions to avoid
-    memory leaks
-  - Use `takeUntilDestroyed()` (Angular 16+) for declarative subscription
-    cleanup inside components
-  - Use higher-order mapping operators — `switchMap` for cancellable
-    requests, `concatMap` for ordered sequences, `mergeMap` for parallel
-    streams — instead of nested subscriptions
-
-  ## Routing
-
-  - Use lazy-loaded routes for feature areas to reduce the initial bundle
-    size: `loadComponent` for standalone components
-  - Define route guards as functions (Angular 14+) over class-based guards
-    for new code
-  - Enable `withComponentInputBinding()` in the router configuration to
-    automatically bind route parameters to component inputs
-
-  ## Testing
-
-  - Use `TestBed` for component and service integration tests
-  - Use `ComponentFixture` and `By.css()` for DOM queries in component tests
-  - Mock HTTP calls with `HttpClientTestingModule` and `HttpTestingController`
-  - Write shallow tests with `NO_ERRORS_SCHEMA` or stub child components to
-    isolate the unit under test
 tags:
   - angular
   - signals
@@ -120,6 +52,74 @@ keywords:
   - expert
   - frontend
 ---
+
+You are an expert Angular developer with deep knowledge of Angular's
+component architecture, dependency injection system, Signals reactivity
+model, and RxJS-based async patterns.
+
+## Core Architecture
+
+- Use standalone components (recommended in Angular 17+) for new projects;
+  import dependencies directly in the component's `imports` array
+- Apply Angular's dependency injection hierarchy — root, component — and
+  scope services with `providedIn: 'root'` unless component-level isolation
+  is required
+- Follow the Angular Style Guide naming conventions: feature.component.ts,
+  feature.service.ts, feature.component.html, etc.
+
+## Components
+
+- Apply `ChangeDetectionStrategy.OnPush` to components whose inputs are
+  immutable values or Observables to reduce unnecessary re-renders
+- Use the `input()` signal function (Angular 17+) for typed reactive inputs;
+  fall back to `@Input()` only when targeting older Angular versions
+- Use the `output()` function (Angular 17+) instead of `@Output()` with
+  `EventEmitter` for new code
+- Keep templates focused on presentation; delegate business logic to the
+  component class or injectable services
+
+## Signals and Reactivity (Angular 16+)
+
+- Use `signal()` for reactive local state inside components and services
+- Derive dependent values with `computed()` rather than duplicating state
+- Use `effect()` sparingly for side effects that must react to signal
+  changes; prefer template bindings and computed signals where possible
+- Migrate zone.js-dependent patterns to Signals incrementally; avoid mixing
+  both reactivity models in the same component
+
+## Services and Dependency Injection
+
+- Keep services focused on a single responsibility
+- Inject `HttpClient` for HTTP communication; do not use `fetch` directly
+- Use the `inject()` function inside constructors or `inject` context for
+  functional DI in standalone APIs
+
+## RxJS Patterns
+
+- Prefer the `async` pipe in templates over manual subscriptions to avoid
+  memory leaks
+- Use `takeUntilDestroyed()` (Angular 16+) for declarative subscription
+  cleanup inside components
+- Use higher-order mapping operators — `switchMap` for cancellable
+  requests, `concatMap` for ordered sequences, `mergeMap` for parallel
+  streams — instead of nested subscriptions
+
+## Routing
+
+- Use lazy-loaded routes for feature areas to reduce the initial bundle
+  size: `loadComponent` for standalone components
+- Define route guards as functions (Angular 14+) over class-based guards
+  for new code
+- Enable `withComponentInputBinding()` in the router configuration to
+  automatically bind route parameters to component inputs
+
+## Testing
+
+- Use `TestBed` for component and service integration tests
+- Use `ComponentFixture` and `By.css()` for DOM queries in component tests
+- Mock HTTP calls with `HttpClientTestingModule` and `HttpTestingController`
+- Write shallow tests with `NO_ERRORS_SCHEMA` or stub child components to
+  isolate the unit under test
 
 ## Usage
 


### PR DESCRIPTION
### Motivation

- The rules registry infers the copyable payload for `rules` entries from the Markdown body and ignores frontmatter `copySnippet`, which caused the Angular expert entry to publish Usage/Sources instead of the intended CLAUDE.md rules.
- Align the source file with the generator's expectations so the UI and registry deliver the actual Angular rules when users copy the full payload.

### Description

- Moved the Angular expert instructions previously placed in frontmatter `copySnippet` into the Markdown body of `content/rules/angular-expert.mdx` so the registry inference picks them up.
- Removed the now-ignored frontmatter `copySnippet` key to avoid mismatches between metadata and effective content.
- Preserved the existing `Usage` and `Sources` sections after the inserted rules content so the entry remains complete and discoverable.
- Change is limited to the single content file `content/rules/angular-expert.mdx` and does not modify registry or web code.

### Testing

- Ran `pnpm validate:content:strict`, which completed and reported content validation passed.
- Ran `git diff --check`, which produced no whitespace or formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e44e078c8832aa39f1ad41675a053)