### PR TITLE
perf(runtime): precompute static registry derivations once

### DIFF
--- a/apps/web/src/components/harness-coverage.tsx
+++ b/apps/web/src/components/harness-coverage.tsx
@@ -1,22 +1,30 @@
 import { Link } from "@tanstack/react-router";
-import { HARNESSES, type Harness } from "@/types/registry";
+import { HARNESSES } from "@/types/registry";
 import { ENTRIES } from "@/data/entries";
 import { platformMark, IntegrationMark } from "@/components/integration-marks";
 import { cn } from "@/lib/utils";
 
-function coverageFor(h: Harness) {
-  // An entry "covers" a harness when it lists the harness in `harness[]`
-  // OR in its `platforms[]`. This matches how Browse filters.
-  const matches = ENTRIES.filter((e) => e.harness?.includes(h) || e.platforms.includes(h)).length;
-  const pct = ENTRIES.length ? Math.round((matches / ENTRIES.length) * 100) : 0;
-  return { count: matches, pct };
-}
+// An entry "covers" a harness when it lists the harness in `harness[]` OR in its
+// `platforms[]` (matches how Browse filters). Precomputed once at module load —
+// registry data is static, so this no longer runs a full ENTRIES.filter per
+// harness on every SSR render of /ecosystem.
+const HARNESS_COVERAGE: Record<string, { count: number; pct: number }> = Object.fromEntries(
+  HARNESSES.map((h) => {
+    const matches = ENTRIES.filter(
+      (e) => e.harness?.includes(h.id) || e.platforms.includes(h.id),
+    ).length;
+    return [
+      h.id,
+      { count: matches, pct: ENTRIES.length ? Math.round((matches / ENTRIES.length) * 100) : 0 },
+    ];
+  }),
+);
 
 export function HarnessCoverage() {
   return (
     <div className="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
       {HARNESSES.map((h) => {
-        const { count, pct } = coverageFor(h.id);
+        const { count, pct } = HARNESS_COVERAGE[h.id];
         const mark = platformMark(h.id);
         return (
           <Link

--- a/apps/web/src/routes/for.index.tsx
+++ b/apps/web/src/routes/for.index.tsx
@@ -1,11 +1,23 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PLATFORM_LABEL, type Platform } from "@/types/registry";
-import { search } from "@/data/search";
+import { ENTRIES } from "@/data/entries";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 
 const PLATFORMS = Object.keys(PLATFORM_LABEL) as Platform[];
+
+// Per-platform entry counts via a single pass over the static registry, computed
+// once at module load — was one full search() (filter+sort) per platform on
+// every SSR render of /for.
+const PLATFORM_COUNTS = new Map<string, number>(PLATFORMS.map((p) => [p, 0]));
+for (const entry of ENTRIES) {
+  for (const platform of entry.platforms ?? []) {
+    if (PLATFORM_COUNTS.has(platform)) {
+      PLATFORM_COUNTS.set(platform, (PLATFORM_COUNTS.get(platform) ?? 0) + 1);
+    }
+  }
+}
 
 export const Route = createFileRoute("/for/")({
   head: () => {
@@ -42,9 +54,7 @@ export const Route = createFileRoute("/for/")({
 });
 
 function PlatformsIndex() {
-  const counts = new Map<string, number>(
-    PLATFORMS.map((p) => [p, search({ platforms: [p] }).length]),
-  );
+  const counts = PLATFORM_COUNTS;
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
       <Breadcrumbs items={[{ label: "Directory", to: "/browse" }, { label: "Platforms" }]} home />

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -91,12 +91,39 @@ function scoreEntry(e: (typeof ENTRIES)[number]): QualityRow {
   return { entry: e, score: Math.max(0, score), recommendations: recs };
 }
 
+// Precomputed once at module load — the registry is static, so these no longer
+// re-run (927× scoreEntry + sort + per-category scans, ~28K iterations) on every
+// SSR render of /quality.
+const QUALITY_ROWS = ENTRIES.map(scoreEntry);
+const IMPROVEMENT_QUEUE = [...QUALITY_ROWS].sort((a, b) => a.score - b.score).slice(0, 8);
+const TRUST_QUEUE = QUALITY_ROWS.filter(
+  (r) => r.recommendations.length > 0 && r.score >= 60,
+).slice(0, 8);
+const CATEGORY_COVERAGE = new Map(
+  CATEGORIES.map((c) => {
+    const inCat = ENTRIES.filter((e) => e.category === c.id);
+    const len = inCat.length;
+    return [
+      c.id,
+      {
+        count: len,
+        trustedPct: len
+          ? Math.round((inCat.filter((e) => e.trust === "trusted").length / len) * 100)
+          : 0,
+        safetyPct: len ? Math.round((inCat.filter((e) => e.safetyNotes).length / len) * 100) : 0,
+        sourcedPct: len
+          ? Math.round((inCat.filter((e) => e.source !== "unverified").length / len) * 100)
+          : 0,
+      },
+    ];
+  }),
+);
+
 function QualityPage() {
   const total = QUALITY_STATS.totalEntries;
   const pct = (n: number) => Math.round((n / total) * 100);
-  const rows = ENTRIES.map(scoreEntry);
-  const improvementQueue = [...rows].sort((a, b) => a.score - b.score).slice(0, 8);
-  const trustQueue = rows.filter((r) => r.recommendations.length > 0 && r.score >= 60).slice(0, 8);
+  const improvementQueue = IMPROVEMENT_QUEUE;
+  const trustQueue = TRUST_QUEUE;
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
@@ -139,13 +166,7 @@ function QualityPage() {
       <h2 className="mt-12 h-display-2 text-ink text-balance">Coverage by category</h2>
       <div className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
         {CATEGORIES.map((c) => {
-          const inCat = ENTRIES.filter((e) => e.category === c.id);
-          const trusted = inCat.filter((e) => e.trust === "trusted").length;
-          const safety = inCat.filter((e) => e.safetyNotes).length;
-          const sourced = inCat.filter((e) => e.source !== "unverified").length;
-          const trustedPct = inCat.length ? Math.round((trusted / inCat.length) * 100) : 0;
-          const safetyPct = inCat.length ? Math.round((safety / inCat.length) * 100) : 0;
-          const sourcedPct = inCat.length ? Math.round((sourced / inCat.length) * 100) : 0;
+          const cov = CATEGORY_COVERAGE.get(c.id)!;
           return (
             <Link
               key={c.id}
@@ -155,10 +176,10 @@ function QualityPage() {
             >
               <div className="font-display font-semibold text-ink">{c.label}</div>
               <div className="hidden text-xs text-ink-muted md:block">{c.blurb}</div>
-              <Bar label="Source" pct={sourcedPct} />
-              <Bar label="Trusted" pct={trustedPct} />
-              <Bar label="Safety" pct={safetyPct} />
-              <div className="text-right font-mono text-xs text-ink-subtle">{inCat.length}</div>
+              <Bar label="Source" pct={cov.sourcedPct} />
+              <Bar label="Trusted" pct={cov.trustedPct} />
+              <Bar label="Safety" pct={cov.safetyPct} />
+              <div className="text-right font-mono text-xs text-ink-subtle">{cov.count}</div>
             </Link>
           );
         })}


### PR DESCRIPTION
Three SSR pages recomputed pure functions of the **static** registry on every request. Hoisted to module scope (computed once at worker init); registry data is immutable within a deployment, so rendered output is identical.

- **`components/harness-coverage.tsx`** (`/ecosystem`) — ran a full `ENTRIES.filter` per harness on every render. Precomputed `HARNESS_COVERAGE` once.
- **`routes/for.index.tsx`** (`/for`) — ran a full `search()` (filter+sort) per platform on every render. Replaced with a single pass over `ENTRIES` tallying platform membership, computed once.
- **`routes/quality.tsx`** (`/quality`) — ran `ENTRIES.map(scoreEntry)` + sort + per-category scans (~28K iterations) on every render. Precomputed the rows, the two queues, and per-category coverage once.

## Validation
- `pnpm type-check` — clean
- Pure refactor — same output, just computed once instead of per SSR request.

Part of the Round 6 audit follow-ups (alongside #2221).