### PR TITLE
fix(a11y): compatibility-matrix labels + newsletter error announcements

### DIFF
--- a/apps/web/src/components/compatibility-matrix.tsx
+++ b/apps/web/src/components/compatibility-matrix.tsx
@@ -93,6 +93,7 @@ export function CompatibilityMatrix({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Filter capabilities…"
+            aria-label="Filter capabilities"
             className="h-9 w-full rounded-md border border-border bg-background pl-8 pr-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
           />
         </div>
@@ -186,7 +187,8 @@ export function CompatibilityMatrix({
                               )}
                               title={`${meta.label} · click for details`}
                             >
-                              {meta.glyph}
+                              <span aria-hidden>{meta.glyph}</span>
+                              <span className="sr-only">{meta.label}</span>
                             </button>
                           </PopoverTrigger>
                           <PopoverContent align="center" className="w-[320px] p-0">
@@ -203,7 +205,8 @@ export function CompatibilityMatrix({
                           title={meta.label}
                           className={cn("inline-block font-mono text-base leading-none", meta.tone)}
                         >
-                          {meta.glyph}
+                          <span aria-hidden>{meta.glyph}</span>
+                          <span className="sr-only">{meta.label}</span>
                         </span>
                       )}
                     </td>

--- a/apps/web/src/components/newsletter-inline.tsx
+++ b/apps/web/src/components/newsletter-inline.tsx
@@ -82,7 +82,11 @@ export function NewsletterInline({
               )}
             </button>
           </form>
-          {error && <p className="text-xs text-trust-blocked">{error}</p>}
+          {error && (
+            <p role="alert" className="text-xs text-trust-blocked">
+              {error}
+            </p>
+          )}
         </div>
       </div>
     );
@@ -178,7 +182,11 @@ export function NewsletterInline({
           </button>
         </form>
       </div>
-      {error && <p className="mt-2 text-xs text-trust-blocked">{error}</p>}
+      {error && (
+        <p role="alert" className="mt-2 text-xs text-trust-blocked">
+          {error}
+        </p>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
Two a11y defects from the Round 6 audit.

## compatibility-matrix.tsx (`/ecosystem`)
- **Support cells** conveyed level by glyph + color only (`●` Native / `◐` Adapter / `○` Manual / `—` Unsupported), with the label only in a `title` attribute (unreliable for screen readers). Added an `sr-only` label and `aria-hidden` on the glyph in both the popover-trigger and plain-span branches, so SR users hear the actual support level (WCAG 1.1.1 / 1.4.1).
- **Filter input** had only a placeholder — added `aria-label="Filter capabilities"`.

## newsletter-inline.tsx
Submit errors rendered as a plain `<p>`; wrapped in `role="alert"` so they're announced. (The inline newsletter widget, which appears on many pages, wasn't covered by the earlier role=alert form pass.) `subscribe-form.tsx` has no error render, so no change there.

## Validation
- `pnpm type-check` — clean
- Additive ARIA only.