### PR TITLE
fix(llms): use raw registry entries for citation facts

### DIFF
--- a/apps/web/src/data/entries.ts
+++ b/apps/web/src/data/entries.ts
@@ -11,12 +11,12 @@ type RegistryChangelogEntry = {
   type?: string;
 };
 
-const registryEntries = (atlasRegistry.entries ?? []) as RegistryEntry[];
+export const REGISTRY_ENTRIES = (atlasRegistry.entries ?? []) as RegistryEntry[];
 const registryChangelog = (atlasRegistry.changelog ?? []) as RegistryChangelogEntry[];
 const generatedAt = atlasRegistry.generatedAt;
 export const REGISTRY_GENERATED_AT = generatedAt;
 
-export const ENTRIES: Entry[] = registryEntries.map(buildEntry);
+export const ENTRIES: Entry[] = REGISTRY_ENTRIES.map(buildEntry);
 
 export const BRIEF_ISSUES = registryChangelog.slice(0, 6).map((item, index) => ({
   slug: `registry-brief-${String(index + 1).padStart(3, "0")}`,

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -7,7 +7,7 @@
  *
  * Both are deterministic for a given registry snapshot so ETags are stable.
  */
-import { ENTRIES } from "@/data/entries";
+import { ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { CATEGORIES } from "@/types/registry";
 import { etagFor } from "@/lib/feeds";
 import { applySecurityHeaders } from "@/lib/security-headers";
@@ -56,6 +56,9 @@ export function buildLlmsTxt(origin: string): string {
 }
 
 export function buildLlmsFullTxt(origin: string): string {
+  const rawEntriesByKey = new Map(
+    REGISTRY_ENTRIES.map((entry) => [`${entry.category}/${entry.slug}`, entry] as const),
+  );
   const out: string[] = [];
   out.push("# HeyClaude registry — full export");
   out.push("");
@@ -80,9 +83,12 @@ export function buildLlmsFullTxt(origin: string): string {
       out.push("");
       out.push(e.description);
       out.push("");
-      const facts = buildEntryCitationFacts(e as Parameters<typeof buildEntryCitationFacts>[0], {
-        siteUrl: origin,
-      });
+      const citationEntry = rawEntriesByKey.get(`${e.category}/${e.slug}`);
+      const facts = citationEntry
+        ? buildEntryCitationFacts(citationEntry as Parameters<typeof buildEntryCitationFacts>[0], {
+            siteUrl: origin,
+          })
+        : "";
       if (facts) {
         out.push("Citation facts:");
         out.push(facts);

--- a/tests/llms-full-citation-facts.test.ts
+++ b/tests/llms-full-citation-facts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/feeds", () => ({ etagFor: vi.fn(async () => "test-etag") }));
+vi.mock("@/lib/security-headers", () => ({ applySecurityHeaders: (headers: Headers) => headers }));
+
+vi.mock("@/data/entries", () => ({
+  REGISTRY_ENTRIES: [
+    {
+      category: "agents",
+      slug: "citation-shape-fixture",
+      title: "Citation Shape Fixture",
+      description: "Raw entry used for citation facts.",
+      author: "Registry Author",
+      documentationUrl: "https://example.com/docs",
+      repoUrl: "https://github.com/example/citation-shape-fixture",
+      safetyNotes: ["Runs local checks before writing files."],
+      privacyNotes: ["Reads only files selected by the user."],
+      platformCompatibility: [{ platform: "claude-code", supportLevel: "native-skill" }],
+      dateAdded: "2026-06-14",
+    },
+  ],
+  ENTRIES: [
+    {
+      category: "agents",
+      slug: "citation-shape-fixture",
+      title: "Citation Shape Fixture",
+      description: "Normalized entry used for the web export.",
+      author: "Registry Author",
+      trust: "trusted",
+      source: "github",
+      sourceUrl: "https://github.com/example/citation-shape-fixture",
+      docsUrl: "https://example.com/docs",
+      platforms: ["claude-code"],
+      safetyNotes: "Runs local checks before writing files.",
+      safetyNotesList: ["Runs local checks before writing files."],
+      privacyNotes: "Reads only files selected by the user.",
+      privacyNotesList: ["Reads only files selected by the user."],
+      platformCompatibility: [{ platform: "claude-code", support: "native-skill" }],
+    },
+  ],
+}));
+
+describe("buildLlmsFullTxt", () => {
+  it("builds citation facts from raw registry entries, not normalized web entries", async () => {
+    const { buildLlmsFullTxt } = await import("@/lib/llms");
+
+    const output = buildLlmsFullTxt("https://heyclau.de");
+
+    expect(output).toContain("Citation facts:\n");
+    expect(output).toContain("- Source URLs: https://example.com/docs, https://github.com/example/citation-shape-fixture");
+    expect(output).toContain("- Safety notes: Runs local checks before writing files.");
+    expect(output).toContain("- Privacy notes: Reads only files selected by the user.");
+    expect(output).toContain("- Platform compatibility: claude-code (native-skill)");
+    expect(output).not.toContain("(undefined)");
+  });
+});


### PR DESCRIPTION
### Motivation

- The `/llms-full.txt` generator passed normalized web `Entry` objects into `buildEntryCitationFacts`, which expects raw registry `ContentEntry` fields and produced incomplete/misleading citation facts.

### Description

- Export the raw registry snapshot as `REGISTRY_ENTRIES` while preserving the existing normalized `ENTRIES` export in `apps/web/src/data/entries.ts`.
- Use `REGISTRY_ENTRIES` to build a lookup keyed by `category/slug` and pass the raw registry entry into `buildEntryCitationFacts` when generating `/llms-full.txt` in `apps/web/src/lib/llms.ts`.
- Add a regression test `tests/llms-full-citation-facts.test.ts` that verifies Source URLs, Safety/Privacy notes, and platform support levels are emitted from the raw entry shape and that no `(undefined)` support levels appear.

### Testing

- Ran `pnpm --filter web run type-check` and it succeeded.
- Ran `pnpm exec vitest run tests/llms-full-citation-facts.test.ts` and the new test passed.
- Ran `git diff --check` and there were no whitespace or formatting errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e47eeb440832a9e1ee49ca7e750ae)