### PR TITLE
fix(seo): /legal canonical + JobPosting pay-period unit

### DIFF
--- a/apps/web/src/routes/legal.tsx
+++ b/apps/web/src/routes/legal.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/legal")({
   head: () => ({
@@ -14,7 +15,9 @@ export const Route = createFileRoute("/legal")({
         property: "og:description",
         content: "Plain-English terms, privacy, content policy, and trademarks.",
       },
+      { property: "og:url", content: absoluteUrl("/legal") },
     ],
+    links: [{ rel: "canonical", href: absoluteUrl("/legal") }],
   }),
   component: LegalPage,
 });

--- a/packages/registry/src/seo.js
+++ b/packages/registry/src/seo.js
@@ -439,6 +439,18 @@ function parseJobCompensation(value) {
   // Reject inverted ranges so JSON-LD never advertises minValue > maxValue.
   if (!minValue || !maxValue || minValue > maxValue) return undefined;
 
+  // Infer the pay period so an hourly/day/week rate isn't advertised as an
+  // annual salary. Defaults to YEAR when the text gives no period hint.
+  const unitText = /per\s*hour|hourly|\/\s*h(ou)?r\b/i.test(text)
+    ? "HOUR"
+    : /per\s*day|daily|\/\s*day\b/i.test(text)
+      ? "DAY"
+      : /per\s*week|weekly|\/\s*wk\b/i.test(text)
+        ? "WEEK"
+        : /per\s*month|monthly|\/\s*mo\b/i.test(text)
+          ? "MONTH"
+          : "YEAR";
+
   return {
     "@type": "MonetaryAmount",
     currency,
@@ -446,7 +458,7 @@ function parseJobCompensation(value) {
       "@type": "QuantitativeValue",
       minValue,
       maxValue,
-      unitText: "YEAR",
+      unitText,
     },
   };
 }


### PR DESCRIPTION
Two SEO/structured-data correctness fixes from the Round 6 audit.

- **`routes/legal.tsx`** — `/legal` is advertised in `sitemap.xml` but its `head()` had no `rel=canonical` and no `og:url` (the only genuinely-indexed page with a `head()` missing them). Added both via `absoluteUrl("/legal")`.
- **`packages/registry/src/seo.js`** — `parseJobCompensation` hard-coded `unitText: "YEAR"`, so an hourly/day/week rate like `"$120 - $160 per hour"` was emitted as an **annual** salary in JobPosting JSON-LD. Now infers the period (HOUR/DAY/WEEK/MONTH) from the text, defaulting to YEAR. (Inverted/k-suffix malformed ranges are already rejected.)

## Validation
- `pnpm type-check` — clean
- `pnpm exec vitest run tests/seo-jsonld.test.ts` — 11 passed