### PR TITLE
fix(reliability): timing-safe internal bearer + exact duplicate-body detection

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -72,6 +72,7 @@ import {
   encryptText,
   randomToken,
   signInternalPayload,
+  timingSafeEqual,
   verifyGitHubWebhookSignature,
 } from "./security";
 import {
@@ -4661,9 +4662,11 @@ async function discoverOpenContentPullRequests(
 
 function hasInternalBearer(request: Request, env: Env) {
   const authorization = request.headers.get("authorization") || "";
+  // Constant-time compare to match the timing-safe standard used elsewhere in
+  // this worker (security.ts), instead of a short-circuiting === on the secret.
   return (
     Boolean(env.INTERNAL_SHARED_SECRET) &&
-    authorization === `Bearer ${env.INTERNAL_SHARED_SECRET}`
+    timingSafeEqual(authorization, `Bearer ${env.INTERNAL_SHARED_SECRET}`)
   );
 }
 

--- a/packages/registry/src/quality.js
+++ b/packages/registry/src/quality.js
@@ -33,15 +33,6 @@ function normalizeBodyForDuplicateCheck(entry) {
     .trim();
 }
 
-function hashString(value) {
-  let hash = 0;
-  for (let index = 0; index < value.length; index += 1) {
-    hash = (hash << 5) - hash + value.charCodeAt(index);
-    hash |= 0;
-  }
-  return Math.abs(hash).toString(36);
-}
-
 export function buildSourceProvenance(entry) {
   const sourceUrls = [
     entry.documentationUrl,
@@ -196,7 +187,9 @@ export function findDuplicateBodyGroups(entries) {
   for (const entry of entries) {
     const normalized = normalizeBodyForDuplicateCheck(entry);
     if (normalized.length < 180) continue;
-    const key = hashString(normalized);
+    // Key by the exact normalized body so two distinct bodies can't be reported
+    // as duplicates via a hash collision.
+    const key = normalized;
     const existing = buckets.get(key) ?? [];
     existing.push({
       key: `${entry.category}:${entry.slug}`,


### PR DESCRIPTION
Two small hardening fixes from the Round 6 audit (no behavior change for valid inputs).

- **`apps/submission-gate/src/index.ts`** — `hasInternalBearer` compared the internal shared secret with a plain `===` (short-circuits on the first mismatched byte), inconsistent with the `timingSafeEqual` used everywhere else in the worker (`security.ts`). Switched to `timingSafeEqual` for the `/queue` + `/queue/reconcile` admin endpoints. (Practical risk is low for a high-entropy server-to-server secret; this aligns with the project's own standard.)
- **`packages/registry/src/quality.js`** — `findDuplicateBodyGroups` bucketed by a 32-bit hash of the normalized body, so two **distinct** bodies could be reported as duplicates on a hash collision (a maintainer-facing content-quality report false positive). Key by the exact normalized body; removed the now-unused `hashString` helper.

## Validation
- `pnpm type-check` — clean
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/quality-dashboard.test.ts` — 110 passed