### PR TITLE
content(mcp): add ai.auxen/auxen MCP Server

### DIFF
--- a/content/mcp/ai-auxen-auxen-mcp-server.mdx
+++ b/content/mcp/ai-auxen-auxen-mcp-server.mdx
@@ -1,0 +1,197 @@
+---
+title: Auxen MCP Server for Claude
+slug: ai-auxen-auxen-mcp-server
+category: mcp
+description: >-
+  Official Auxen.ai remote MCP server for listing GPU models and instances,
+  checking account balance, and provisioning or destroying inference instances
+  from Claude via OAuth 2.1 or API keys.
+cardDescription: >-
+  Connect Claude to Auxen.ai to list models, manage GPU instances, and check
+  balance through a hosted remote MCP server.
+seoTitle: Auxen MCP Server for Claude
+seoDescription: >-
+  Use the Auxen.ai MCP server with Claude to list models and instances, check
+  balance, and provision or destroy GPU inference workloads via OAuth or API key.
+author: Auxen AI
+authorProfileUrl: "https://github.com/auxen-ai"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 1475
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1475"
+repoUrl: "https://github.com/auxen-ai/auxen-mcp"
+documentationUrl: "https://github.com/auxen-ai/auxen-mcp"
+websiteUrl: "https://auxen.ai"
+installable: true
+installCommand: >-
+  claude mcp add --transport http auxen https://api.auxen.ai/mcp
+usageSnippet: >-
+  Add a custom connector in Claude with https://api.auxen.ai/mcp, then complete
+  OAuth 2.1 + PKCE or configure a Bearer token with an auxen_live_* or
+  auxen_test_* API key.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "auxen": {
+        "url": "https://api.auxen.ai/mcp",
+        "type": "http"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "auxen": {
+        "url": "https://api.auxen.ai/mcp",
+        "type": "http",
+        "headers": {
+          "Authorization": "Bearer auxen_live_YOUR_KEY"
+        }
+      }
+    }
+  }
+estimatedSetupTime: 10 minutes
+difficulty: intermediate
+prerequisites:
+  - "Auxen.ai account with billing enabled for production instance provisioning."
+  - "Claude Pro, Team, or Enterprise with Connectors support, or another MCP client with remote HTTP connectors."
+  - "OAuth 2.1 + PKCE flow support in your MCP client, or an Auxen API key prefixed with auxen_live_ or auxen_test_."
+  - "Understanding that provision_model and destroy_instance are destructive and may incur GPU charges."
+safetyNotes:
+  - "provision_model creates billable GPU instances; confirm model, region, and cost before approving tool calls."
+  - "destroy_instance permanently removes running instances and cannot be undone through MCP."
+  - "API keys prefixed auxen_live_* operate on production resources; use auxen_test_* keys in development."
+  - "OAuth tokens grant persistent account access until revoked in Auxen or the MCP client."
+privacyNotes:
+  - "MCP tool results can expose account balance, instance IDs, model names, and deployment metadata."
+  - "Provisioning requests are processed by Auxen.ai under its own data-handling and billing terms."
+  - "Do not paste live API keys or OAuth tokens into public issues or shared chat logs."
+tags:
+  - gpu
+  - inference
+  - cloud
+  - remote-mcp
+  - oauth
+keywords:
+  - auxen mcp
+  - auxen.ai claude connector
+  - gpu inference mcp
+  - provision model mcp
+  - remote mcp oauth
+readingTime: 4
+difficultyScore: 40
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Auxen.ai provides a hosted Model Context Protocol server that lets Claude and other MCP clients manage GPU inference workloads. After OAuth 2.1 + PKCE authorisation or Bearer token setup, assistants can list available models and running instances, check account balance, provision new models, and destroy instances without leaving chat.
+
+The public manifest lives in the [auxen-ai/auxen-mcp](https://github.com/auxen-ai/auxen-mcp) repository. The server is hosted at `https://api.auxen.ai/mcp`.
+
+## Features
+
+- List available GPU models, running instances, and account balance.
+- Provision new inference instances with `provision_model`.
+- Tear down instances with `destroy_instance`.
+- OAuth 2.1 + PKCE or Bearer token auth with `auxen_live_*` and `auxen_test_*` keys.
+- Hosted remote HTTP transport compatible with Claude Connectors and Claude Code.
+
+## Use Cases
+
+- Check GPU availability and pricing before launching a fine-tuning job.
+- List running instances and idle spend during a cost review.
+- Provision a test instance with an `auxen_test_*` key before promoting to production.
+- Destroy orphaned instances after an experiment completes.
+- Ask natural-language questions about current balance and active deployments.
+
+## Installation
+
+### Claude (Connectors)
+
+1. Add a custom connector under **Settings → Connectors**.
+2. Enter the MCP URL: `https://api.auxen.ai/mcp`.
+3. Complete OAuth 2.1 + PKCE sign-in, or configure a Bearer token with your API key.
+4. Enable the connector in your next conversation.
+
+### Claude Code
+
+```bash
+claude mcp add --transport http auxen https://api.auxen.ai/mcp
+claude mcp list
+```
+
+For API key auth, add the `Authorization: Bearer auxen_live_YOUR_KEY` header in your MCP config.
+
+### Other MCP clients
+
+Add a custom remote connector pointing at `https://api.auxen.ai/mcp` and complete OAuth or Bearer token setup supported by your client.
+
+## Configuration
+
+```json
+{
+  "mcpServers": {
+    "auxen": {
+      "url": "https://api.auxen.ai/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer auxen_live_YOUR_KEY"
+      }
+    }
+  }
+}
+```
+
+Omit the `headers` block when using OAuth through a connector UI. Use `auxen_test_*` keys for non-production environments.
+
+## Examples
+
+### List available models
+
+```text
+List the GPU models available on my Auxen account and summariseVRAM and pricing tiers.
+```
+
+### Check balance and instances
+
+```text
+What is my Auxen account balance and how many instances are currently running?
+```
+
+### Provision a test instance
+
+```text
+Provision a small test inference instance using the cheapest available model in my Auxen test environment.
+```
+
+## Security
+
+- Treat `provision_model` and `destroy_instance` as destructive; review tool arguments before approving.
+- Revoke OAuth tokens and rotate API keys when offboarding users or connectors.
+- Use `auxen_test_*` keys in development to avoid accidental production charges.
+- Instance metadata may contain deployment details; avoid pasting raw output into public channels.
+
+## Troubleshooting
+
+### OAuth or 401 errors
+
+Re-authorise the connector and confirm your Auxen account is active. For Bearer auth, verify the key prefix matches your environment (`auxen_live_*` vs `auxen_test_*`).
+
+### Provision failures
+
+Check account balance and model availability in the Auxen dashboard. Some models require elevated quotas or billing setup.
+
+### Empty instance list
+
+Confirm you are authenticated against the correct Auxen environment. Test keys only see test resources.
+
+### Unexpected charges
+
+Review recent `provision_model` tool calls in your MCP client audit log and destroy unused instances promptly.


### PR DESCRIPTION
Closes #1475

## Summary
Adds one source-backed MCP entry for the Auxen remote MCP server for provisioning private GPU model endpoints with OAuth or API key auth.

## Duplicate check
Searched `content/mcp/`, open PRs, and the live catalog. No duplicate found.

## Source verification
- Manifest repo: https://github.com/auxen-ai/auxen-mcp
- Remote endpoint: https://api.auxen.ai/mcp
- Registry name: `ai.auxen/auxen`

## Validation
- `pnpm validate:content -- content/mcp/ai-auxen-auxen-mcp-server.mdx`

## Test plan
- [x] Single-file PR only
- [x] `submittedBy` matches PR author (`kiannidev`)
- [x] Local content validation passed


Made with [Cursor](https://cursor.com)