### PR TITLE
feat(rum): report field Core Web Vitals (INP/LCP/CLS) to umami

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -81,6 +81,7 @@
     "tailwindcss": "4.3.0",
     "tw-animate-css": "1.4.0",
     "vaul": "1.1.2",
+    "web-vitals": "^5.3.0",
     "workers-og": "^0.0.27",
     "zod": "4.4.3"
   },

--- a/apps/web/src/components/web-vitals.tsx
+++ b/apps/web/src/components/web-vitals.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+declare global {
+  interface Window {
+    umami?: { track: (event: string, data?: Record<string, unknown>) => void };
+  }
+}
+
+interface ReportedMetric {
+  name: string;
+  value: number;
+  rating?: string;
+  id: string;
+}
+
+/**
+ * Field Core Web Vitals (RUM). Reports INP/LCP/CLS/TTFB/FCP for real sessions to
+ * the existing umami instance (umami.heyclau.de is already allowed by CSP, so no
+ * policy change). Renders nothing; the web-vitals library is dynamically imported
+ * inside the effect so it never enters the SSR path or the universal client chunk.
+ */
+export function WebVitals() {
+  React.useEffect(() => {
+    let cancelled = false;
+    void import("web-vitals").then(({ onCLS, onINP, onLCP, onTTFB, onFCP }) => {
+      if (cancelled) return;
+      const report = (metric: ReportedMetric) => {
+        // umami loads async; if it isn't ready yet, drop the sample rather than queue.
+        if (typeof window === "undefined" || !window.umami) return;
+        window.umami.track("web-vital", {
+          metric: metric.name,
+          // CLS is unitless (scale ×1000 to keep it an integer); the rest are ms.
+          value: metric.name === "CLS" ? Math.round(metric.value * 1000) : Math.round(metric.value),
+          rating: metric.rating,
+          id: metric.id,
+          path: window.location.pathname,
+        });
+      };
+      onCLS(report);
+      onINP(report);
+      onLCP(report);
+      onTTFB(report);
+      onFCP(report);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return null;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -22,6 +22,7 @@ import { ShortcutsProvider } from "@/components/shortcuts-dialog";
 import { SkipLink } from "@/components/skip-link";
 import { RouteProgress } from "@/components/route-progress";
 import { WebMcpProvider } from "@/components/webmcp-provider";
+import { WebVitals } from "@/components/web-vitals";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -236,6 +237,7 @@ function RootComponent() {
                 <CompareDrawer />
                 <BackToTop />
                 <WebMcpProvider />
+                <WebVitals />
                 <Toaster
                   position="bottom-right"
                   mobileOffset={{ bottom: "16px" }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       vaul:
         specifier: 1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      web-vitals:
+        specifier: ^5.3.0
+        version: 5.3.0
       workers-og:
         specifier: ^0.0.27
         version: 0.0.27
@@ -5278,6 +5281,9 @@ packages:
       jsdom:
         optional: true
 
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -10254,6 +10260,8 @@ snapshots:
       '@types/node': 25.9.1
     transitivePeerDependencies:
       - msw
+
+  web-vitals@5.3.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 


### PR DESCRIPTION
Implements #2258 (Round 7, Tier A — measurement).

## What
A client-only `WebVitals` reporter mounted in `__root` that captures **INP/LCP/CLS/TTFB/FCP** for real sessions and reports them through the **existing umami** (`umami.track('web-vital', …)`).

- `web-vitals` is **dynamically imported inside the effect** → never enters the SSR path or the universal client chunk (build confirms a separate `web-vitals-*.js` lazy chunk).
- Reports go to `umami.heyclau.de`, which is **already allowed by CSP** (script-src + connect-src) — no policy change, no new endpoint.
- CLS scaled ×1000 to stay an integer; samples dropped if umami hasn't loaded yet (LCP/INP/CLS fire late enough that it's loaded).

## Validation
- `pnpm type-check` clean; `pnpm --filter web build` succeeds; web-vitals confirmed in its own lazy chunk (not universal).

Closes #2258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Core Web Vitals performance metrics reporting to the application, enabling tracking of key performance indicators alongside existing analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->