### PR TITLE
feat(growth): embeddable "Listed on HeyClaude" entry badges

### DIFF
--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -103,6 +103,58 @@ export function renderOgSvg(opts: {
 </svg>`;
 }
 
+/**
+ * Shield-style "Listed on HeyClaude" badge SVG, sized like shields.io badges so it
+ * drops cleanly into a README. Two segments: a dark left label and an accent-tinted
+ * right value (the entry's category). All caller-supplied text is escaped via esc()
+ * before it lands in the markup, so an entry-derived value can't break out of the SVG.
+ */
+export function renderBadgeSvg(opts: { label?: string; value: string; accent?: string }) {
+  const label = (opts.label ?? "Listed on HeyClaude").trim() || "Listed on HeyClaude";
+  const value = opts.value.trim() || "registry";
+  const accent = safeAccent(opts.accent);
+
+  // Approximate Verdana 11px advance width (≈6.4px/char) + horizontal padding per segment.
+  const charWidth = 6.4;
+  const pad = 12;
+  const height = 20;
+  const labelWidth = Math.ceil(label.length * charWidth) + pad * 2;
+  const valueWidth = Math.ceil(value.length * charWidth) + pad * 2;
+  const total = labelWidth + valueWidth;
+  // ×10 because text is rendered at scale(0.1) for crisp sub-pixel positioning (shields.io trick).
+  const labelMid = (labelWidth / 2) * 10;
+  const valueMid = (labelWidth + valueWidth / 2) * 10;
+  const labelTextLen = (labelWidth - pad * 2) * 10;
+  const valueTextLen = (valueWidth - pad * 2) * 10;
+  const safeLabel = esc(label);
+  const safeValue = esc(value);
+
+  // Escaped text only ever lands in element content (never an attribute), so esc()'s
+  // <, >, & coverage is sufficient — a raw quote can't break out of an attribute.
+  // The <title> element supplies the accessible name for role="img".
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="${height}" viewBox="0 0 ${total} ${height}" role="img">
+  <title>${safeLabel}: ${safeValue}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+    <stop offset=".9" stop-color="#000" stop-opacity=".3"/>
+    <stop offset="1" stop-color="#000" stop-opacity=".5"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${total}" height="${height}" rx="3"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="${height}" fill="#171614"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="${height}" fill="${accent}"/>
+    <rect width="${total}" height="${height}" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" transform="scale(.1)">
+    <text x="${labelMid}" y="150" fill="#000" fill-opacity=".25" textLength="${labelTextLen}">${safeLabel}</text>
+    <text x="${labelMid}" y="140" textLength="${labelTextLen}">${safeLabel}</text>
+    <text x="${valueMid}" y="150" fill="#000" fill-opacity=".25" textLength="${valueTextLen}">${safeValue}</text>
+    <text x="${valueMid}" y="140" fill="#171614" textLength="${valueTextLen}">${safeValue}</text>
+  </g>
+</svg>`;
+}
+
 /** OG card dimensions, exported so routes can advertise them in og:image:width/height. */
 export const OG_WIDTH = 1200;
 export const OG_HEIGHT = 630;

--- a/apps/web/src/routes/badge.$category.{$slug}[.]svg.ts
+++ b/apps/web/src/routes/badge.$category.{$slug}[.]svg.ts
@@ -1,0 +1,38 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { getEntry } from "@/data/search";
+import { categoryAccent, renderBadgeSvg } from "@/lib/og-image";
+
+/**
+ * Embeddable "Listed on HeyClaude" badge — a crawlable, shield-style SVG keyed by
+ * category + slug. Maintainers drop the markdown snippet (shown on the entry page)
+ * into their README, which links back to the entry page (a backlink driver).
+ *
+ * The right segment shows the entry's category. All entry-derived text is escaped
+ * inside renderBadgeSvg() before it reaches the SVG markup. Unknown entries get a
+ * neutral badge with a 404 status so the markup still renders but isn't cacheable
+ * as a real listing.
+ */
+export const Route = createFileRoute("/badge/$category/{$slug}.svg")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const entry = getEntry(params.category, params.slug);
+
+        const svg = entry
+          ? renderBadgeSvg({ value: entry.category, accent: categoryAccent(entry.category) })
+          : renderBadgeSvg({ value: "not found" });
+
+        return new Response(svg, {
+          status: entry ? 200 : 404,
+          headers: {
+            "content-type": "image/svg+xml; charset=utf-8",
+            // Long-lived for real entries (immutable per slug); short for the neutral 404.
+            "cache-control": entry
+              ? "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800"
+              : "public, max-age=300",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -270,6 +270,7 @@ function Dossier() {
     if (hasSchema) items.push({ id: "schema", label: "Schema details" });
     items.push({ id: "about", label: "About this resource" });
     items.push({ id: "citations", label: "Source citations" });
+    items.push({ id: "badge", label: "Add a badge" });
     if (rel.length > 0) items.push({ id: "related", label: "Related" });
     items.push({ id: "signals", label: "Signals" });
     return items;
@@ -626,6 +627,8 @@ function Dossier() {
             <SourceCitations entry={entry} />
           </DossierSection>
 
+          <BadgeSection category={entry.category} slug={entry.slug} title={entry.title} />
+
           {(relGroups.length > 0 || rel.length > 0) && (
             <DossierSection id="related" title="Related resources">
               {relGroups.length > 0 ? (
@@ -714,6 +717,45 @@ function Dossier() {
         </aside>
       </div>
     </div>
+  );
+}
+
+function BadgeSection({
+  category,
+  slug,
+  title,
+}: {
+  category: string;
+  slug: string;
+  title: string;
+}) {
+  const badgeUrl = absoluteUrl(`/badge/${category}/${slug}.svg`);
+  const entryUrl = absoluteUrl(`/entry/${category}/${slug}`);
+  const markdown = `[![Listed on HeyClaude](${badgeUrl})](${entryUrl})`;
+  return (
+    <DossierSection id="badge" icon={BadgeCheck} title="Add this badge to your README">
+      <p className="text-ink-muted">
+        Show that <span className="text-ink">{title}</span> is listed on HeyClaude. Paste this
+        Markdown into your README — it renders the badge and links back to this page.
+      </p>
+      <div className="mt-3 flex items-center gap-3">
+        <a href={entryUrl} target="_blank" rel="noreferrer">
+          <img src={badgeUrl} alt="Listed on HeyClaude" height={20} className="h-5 w-auto" />
+        </a>
+      </div>
+      <div className="mt-3 flex items-start gap-2">
+        <pre className="min-w-0 flex-1 overflow-auto rounded-md bg-surface-2 p-3 font-mono text-[12px] leading-relaxed text-ink">
+          <code>{markdown}</code>
+        </pre>
+        <CopyButton
+          value={markdown}
+          label="Copy"
+          iconOnly
+          size="md"
+          toastLabel="Badge Markdown copied"
+        />
+      </div>
+    </DossierSection>
   );
 }
 


### PR DESCRIPTION
Embeddable maintainer badges as a backlink driver.

## What
- New crawlable route `/badge/$category/{$slug}.svg` returning a shield-style SVG ("Listed on HeyClaude" + the entry's category, accent-colored), `Content-Type: image/svg+xml`, public `Cache-Control`. Unknown entries (`getEntry` miss) get a neutral badge with a 404 status.
- `renderBadgeSvg()` added to `apps/web/src/lib/og-image.ts` alongside `esc()`/`safeAccent()`. Filename uses the repo's bracket-escaped extension convention with the TanStack brace-suffix param: `badge.$category.{$slug}[.]svg.ts`.
- Entry detail page (`routes/entry.$category.$slug.tsx`) gains an "Add this badge to your README" section: a live badge preview plus a `CopyButton` with the markdown snippet `[![Listed on HeyClaude](<badge svg>)](<entry url>)`, both absolute via `absoluteUrl`. Added to the dossier TOC.

## Why
Gives listed maintainers a one-click README badge that links back to their HeyClaude entry, driving inbound backlinks (SEO/growth).

## Safety
All entry-derived text is escaped via `esc()` and only ever lands in SVG element content (never an attribute); the accent is clamped to a safe hex via `safeAccent()`, so entry-controlled values can't inject markup. Verified script/quote payloads are escaped and a bad accent falls back to the default.

## Validation
- `pnpm type-check` clean
- `pnpm --filter web build` OK (route bundles into a server SSR chunk)
- `wrangler dev`: badge route returns `image/svg+xml` — `200` for a real entry (category accent), `404` neutral badge for a miss; entry page renders the snippet and live preview
- `prettier --check` passes; `git diff --check` clean

Closes #2266