### PR TITLE
ci(content): exempt content/** from prettier

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -23,6 +23,11 @@ lint:
     - linters: [prettier]
       paths:
         - integrations/raycast/raycast-env.d.ts
+        # Author-submitted content (.mdx) is not prettier-governed — markdownlint
+        # still covers it. This stops pre-existing content formatting from failing
+        # the code `ci` lane (e.g. when a code PR's diff includes content changes)
+        # without bulk-reformatting community submissions.
+        - content/**
   enabled:
     - actionlint@1.7.12
     - checkov@3.2.525


### PR DESCRIPTION
Implements #2264 (Round 7, Tier B — CI hygiene).

**Problem:** content PRs bypass the Trunk `ci` lane, so ~96 `content/*.mdx` files are prettier-unformatted on main. Any code PR whose diff includes content (e.g. after a main merge) fails `validate-ci` on Trunk's prettier step — and adding content to a code PR to fix it gets the PR auto-closed by the submission gate (that closed #2244).

**Fix:** exempt `content/**` from prettier in `.trunk/trunk.yaml`. Content is author-submitted UGC that **markdownlint still covers**; prettier's cosmetic formatting (e.g. table alignment) shouldn't gate the code lane. This removes the friction definitively without bulk-reformatting 96 community files (which would risk a gate auto-close on a large content PR) and pairs with the existing "keep platform/code changes separate from content" rule.

> Alternative considered: *enforce* prettier on content + backfill-format the 96 files. Rejected for now — it reformats UGC and the bulk content PR risks the gate. Easy to switch to later if you'd prefer enforced content formatting.

## Validation
- `pnpm exec prettier --check .trunk/trunk.yaml` clean.

Closes #2264