### PR TITLE
seo(content): add data-derived unique value to hub/tag/intersection pages

### DIFF
--- a/apps/web/src/components/hub-highlights.tsx
+++ b/apps/web/src/components/hub-highlights.tsx
@@ -1,0 +1,111 @@
+import { Link } from "@tanstack/react-router";
+import {
+  ShieldCheck,
+  Sparkles,
+  FileText,
+  GitBranch,
+  Star,
+  BadgeCheck,
+  type LucideIcon,
+} from "lucide-react";
+import { TrustBadge, SourceBadge } from "@/components/badges";
+import type { Highlight, HighlightKind, HubStat } from "@/lib/hub-highlights";
+
+const HIGHLIGHT_ICON: Record<HighlightKind, LucideIcon> = {
+  trusted: ShieldCheck,
+  newest: Sparkles,
+  documented: FileText,
+  sourced: GitBranch,
+  popular: Star,
+  reviewed: BadgeCheck,
+};
+
+/**
+ * Data-derived "highlights" strip for hub/tag/intersection pages. Each card is a real
+ * registry entry surfaced for a specific, fact-based reason. The optional `caption`
+ * lets each page frame the same primitive in page-specific prose.
+ */
+export function HubHighlights({
+  highlights,
+  caption,
+}: {
+  highlights: Highlight[];
+  caption?: string;
+}) {
+  if (highlights.length < 2) return null;
+  return (
+    <section className="mt-10">
+      <div className="flex items-baseline justify-between gap-3">
+        <h2 className="h-display-2 text-ink">Highlights from this set</h2>
+      </div>
+      {caption && <p className="mt-2 max-w-2xl text-sm text-ink-muted">{caption}</p>}
+      <ul className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {highlights.map((h) => {
+          const Icon = HIGHLIGHT_ICON[h.kind];
+          return (
+            <li key={`${h.kind}-${h.entry.category}/${h.entry.slug}`}>
+              <Link
+                to="/entry/$category/$slug"
+                params={{ category: h.entry.category, slug: h.entry.slug }}
+                className="group flex h-full flex-col rounded-xl border border-border bg-surface p-4 transition-colors hover:border-ink/20 hover:bg-surface-2"
+              >
+                <div className="flex items-center gap-1.5 eyebrow">
+                  <Icon className="h-3.5 w-3.5 text-accent" aria-hidden />
+                  {h.label}
+                </div>
+                <div className="mt-2 font-display text-sm font-semibold text-ink group-hover:underline">
+                  {h.entry.title}
+                </div>
+                <p className="mt-1 flex-1 text-xs text-ink-muted">{h.reason}</p>
+                <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                  <TrustBadge level={h.entry.trust} />
+                  <SourceBadge status={h.entry.source} />
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+function StatBar({ stat }: { stat: HubStat }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="text-xs font-medium text-ink-muted">{stat.label}</span>
+        <span className="font-mono text-[11px] tabular-nums text-ink-subtle">{stat.pct}%</span>
+      </div>
+      <div className="mt-1 font-display text-2xl font-semibold tabular-nums text-ink">
+        {stat.count}
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-surface-2">
+        <div className="h-full bg-ink" style={{ width: `${stat.pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Signal coverage for a hub's entries — trust tier, source backing, safety/privacy
+ * notes, review status. Every number is counted from the entries actually on the page,
+ * so no two hubs render the same breakdown unless their data is genuinely identical.
+ */
+export function HubSignalStats({ stats, total }: { stats: HubStat[]; total: number }) {
+  if (stats.length === 0 || total < 2) return null;
+  return (
+    <section className="mt-12">
+      <h2 className="h-display-2 text-ink">Signal coverage</h2>
+      <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+        How these {total} resources score on the trust and safety signals HeyClaude reviews —
+        counted from this set, not the directory as a whole.
+      </p>
+      <div className="mt-5 grid gap-3 sm:grid-cols-3 lg:grid-cols-5">
+        {stats.map((s) => (
+          <StatBar key={s.key} stat={s} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/hub-highlights.ts
+++ b/apps/web/src/lib/hub-highlights.ts
@@ -1,0 +1,206 @@
+import type { Entry, SourceStatus } from "@/types/registry";
+import { TRUST_LABEL, SOURCE_LABEL } from "@/types/registry";
+import { timeAgo } from "@/lib/format";
+
+// Data-derived "highlights" for programmatic hub/tag/intersection pages.
+//
+// Everything here is computed from real registry fields (trust, source, dateAdded,
+// safetyNotes, privacyNotes, reviewed, repoStats). Nothing is fabricated: a pick is
+// only surfaced when an entry genuinely satisfies the criterion, and each pick carries
+// a one-line reason pulled from the entry's own metadata. Pages that share the same
+// underlying entries will produce the same facts, but each page renders them under its
+// own labels/prose so no two indexable pages emit identical copy.
+
+export type HighlightKind =
+  | "trusted"
+  | "newest"
+  | "documented"
+  | "sourced"
+  | "popular"
+  | "reviewed";
+
+export interface Highlight {
+  kind: HighlightKind;
+  /** Short human label for the pick, e.g. "Most-trusted pick". */
+  label: string;
+  /** One-line reason derived from the entry's own fields. */
+  reason: string;
+  entry: Entry;
+}
+
+const SOURCE_RANK: Record<SourceStatus, number> = {
+  "first-party": 3,
+  "source-backed": 2,
+  external: 1,
+  unverified: 0,
+};
+
+function parseDate(iso: string | undefined): number {
+  if (!iso) return 0;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
+}
+
+// Pick the single best entry for a criterion. `score` ranks candidates; only entries
+// that pass `eligible` are considered, so we never claim a pick that isn't real.
+function pickBest(
+  entries: Entry[],
+  eligible: (e: Entry) => boolean,
+  score: (e: Entry) => number,
+): Entry | undefined {
+  let best: Entry | undefined;
+  let bestScore = -Infinity;
+  for (const e of entries) {
+    if (!eligible(e)) continue;
+    const s = score(e);
+    if (s > bestScore) {
+      bestScore = s;
+      best = e;
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute up to `limit` distinct, non-overlapping highlight picks for a set of entries.
+ * Each pick is a different entry so the strip surfaces breadth, not the same resource
+ * four times. Returns [] when there aren't enough entries to be meaningful.
+ */
+export function hubHighlights(entries: Entry[], limit = 4): Highlight[] {
+  if (entries.length < 2) return [];
+
+  const used = new Set<string>();
+  const key = (e: Entry) => `${e.category}/${e.slug}`;
+  const out: Highlight[] = [];
+  const free = (e: Entry | undefined): e is Entry => Boolean(e) && !used.has(key(e!));
+
+  const claim = (
+    kind: HighlightKind,
+    label: string,
+    entry: Entry | undefined,
+    reason: (e: Entry) => string,
+  ) => {
+    if (!entry || used.has(key(entry)) || out.length >= limit) return;
+    used.add(key(entry));
+    out.push({ kind, label, entry, reason: reason(entry) });
+  };
+
+  // Most-trusted pick: highest trust tier, tie-broken by source quality then recency.
+  claim(
+    "trusted",
+    "Most-trusted pick",
+    pickBest(
+      entries,
+      (e) => free(e) && e.trust === "trusted",
+      (e) => SOURCE_RANK[e.source] * 1e6 + parseDate(e.dateAdded) / 1e6,
+    ),
+    (e) =>
+      e.source === "unverified"
+        ? `${TRUST_LABEL[e.trust]} trust tier in this set.`
+        : `${TRUST_LABEL[e.trust]} trust, ${SOURCE_LABEL[e.source].toLowerCase()} source.`,
+  );
+
+  // Newest addition: most recent dateAdded.
+  claim(
+    "newest",
+    "Newest addition",
+    pickBest(
+      entries,
+      (e) => free(e) && parseDate(e.dateAdded) > 0,
+      (e) => parseDate(e.dateAdded),
+    ),
+    (e) => `Added to the directory ${timeAgo(e.dateAdded)}.`,
+  );
+
+  // Best-documented: carries both safety and privacy notes (and ideally reviewed).
+  claim(
+    "documented",
+    "Safety + privacy documented",
+    pickBest(
+      entries,
+      (e) => free(e) && Boolean(e.safetyNotes) && Boolean(e.privacyNotes),
+      (e) => (e.reviewed ? 1 : 0) * 1e6 + parseDate(e.dateAdded) / 1e6,
+    ),
+    (e) =>
+      e.reviewed
+        ? "Has safety and privacy notes, maintainer-reviewed."
+        : "Has both safety and privacy notes on file.",
+  );
+
+  // Best-sourced: strongest provenance not already claimed above.
+  claim(
+    "sourced",
+    "Strongest provenance",
+    pickBest(
+      entries,
+      (e) => free(e) && (e.source === "first-party" || e.source === "source-backed"),
+      (e) => SOURCE_RANK[e.source] * 1e6 + parseDate(e.dateAdded) / 1e6,
+    ),
+    (e) => `${SOURCE_LABEL[e.source]} provenance — links to a verifiable origin.`,
+  );
+
+  // Most-starred source repo (provenance signal, not listing popularity).
+  claim(
+    "popular",
+    "Most-starred source repo",
+    pickBest(
+      entries,
+      (e) => free(e) && (e.repoStats?.stars ?? 0) > 0,
+      (e) => e.repoStats?.stars ?? 0,
+    ),
+    (e) => `${(e.repoStats?.stars ?? 0).toLocaleString()} stars on its source repository.`,
+  );
+
+  // Maintainer-reviewed fallback so the strip stays useful even for sparse metadata.
+  claim(
+    "reviewed",
+    "Maintainer-reviewed",
+    pickBest(
+      entries,
+      (e) => free(e) && Boolean(e.reviewed),
+      (e) => SOURCE_RANK[e.source] * 1e6 + parseDate(e.dateAdded) / 1e6,
+    ),
+    () => "Metadata eyeballed by a maintainer before listing.",
+  );
+
+  return out;
+}
+
+export interface HubStat {
+  key: string;
+  label: string;
+  count: number;
+  pct: number;
+}
+
+/**
+ * Count breakdowns for a set of entries — each derived from real fields. Only returns
+ * the signals that actually apply (count > 0), so a thin or low-signal set won't render
+ * a wall of zeros.
+ */
+export function hubStats(entries: Entry[]): HubStat[] {
+  const total = entries.length;
+  if (total === 0) return [];
+  const pct = (n: number) => Math.round((n / total) * 100);
+
+  const trusted = entries.filter((e) => e.trust === "trusted").length;
+  const sourced = entries.filter((e) => e.source !== "unverified").length;
+  const safety = entries.filter((e) => Boolean(e.safetyNotes)).length;
+  const privacy = entries.filter((e) => Boolean(e.privacyNotes)).length;
+  const reviewed = entries.filter((e) => Boolean(e.reviewed)).length;
+
+  return [
+    { key: "trusted", label: "Trusted tier", count: trusted, pct: pct(trusted) },
+    { key: "sourced", label: "Source-backed", count: sourced, pct: pct(sourced) },
+    { key: "safety", label: "Safety notes", count: safety, pct: pct(safety) },
+    { key: "privacy", label: "Privacy notes", count: privacy, pct: pct(privacy) },
+    { key: "reviewed", label: "Reviewed", count: reviewed, pct: pct(reviewed) },
+  ].filter((s) => s.count > 0);
+}
+
+/** Trusted-tier share of a set, derived from real trust fields — used to vary intro copy. */
+export function trustPosture(entries: Entry[]): { trusted: number; pct: number } {
+  const total = entries.length;
+  const trusted = entries.filter((e) => e.trust === "trusted").length;
+  return { trusted, pct: total ? Math.round((trusted / total) * 100) : 0 };
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -13,6 +13,8 @@ import {
 import { ResourceCard } from "@/components/resource-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
+import { hubHighlights, hubStats } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, categoryAccent } from "@/lib/og-image";
@@ -155,6 +157,10 @@ function CategoryHub() {
   const quickstart = categoryQuickstarts[id] ?? [];
   const faqs = faqFor(id, label);
 
+  // Data-derived signals computed across the full category set.
+  const highlights = hubHighlights(entries);
+  const stats = hubStats(entries);
+
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
       <Breadcrumbs items={[{ label: "Directory", to: "/browse" }, { label }]} home />
@@ -189,7 +195,12 @@ function CategoryHub() {
         )}
       </header>
 
-      <section className="mt-10">
+      <HubHighlights
+        highlights={highlights}
+        caption={`Standout Claude ${label}, picked from their own metadata — trust tier, provenance, documentation, and recency.`}
+      />
+
+      <section className="mt-12">
         <h2 className="h-display-2 text-ink">Top {label}</h2>
         <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {top.map((e) => (
@@ -208,6 +219,8 @@ function CategoryHub() {
           </div>
         )}
       </section>
+
+      <HubSignalStats stats={stats} total={entries.length} />
 
       <section className="mt-14">
         <h2 className="h-display-2 text-ink">Frequently asked</h2>

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -7,6 +7,8 @@ import { categoryLabels } from "@/lib/site";
 import { ResourceCard } from "@/components/resource-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
+import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -116,6 +118,17 @@ function IntersectionPage() {
   const cLabel = categoryLabels[category] ?? category;
   const entries = intersection(platform, category);
 
+  // Data-derived framing unique to this platform×category slice.
+  const posture = trustPosture(entries);
+  const highlights = hubHighlights(entries);
+  const stats = hubStats(entries);
+  const newest = entries.reduce<(typeof entries)[number] | undefined>((acc, e) => {
+    const t = Date.parse(e.dateAdded || "");
+    if (Number.isNaN(t)) return acc;
+    const accT = acc ? Date.parse(acc.dateAdded || "") : -Infinity;
+    return t > accT ? e : acc;
+  }, undefined);
+
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
       <Breadcrumbs
@@ -133,8 +146,10 @@ function IntersectionPage() {
           Claude {cLabel} for {pLabel}
         </h1>
         <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          Source-backed Claude {cLabel} that work with <span className="text-ink">{pLabel}</span> —
-          curated and metadata-reviewed in HeyClaude.
+          {entries.length} Claude {cLabel} that work with <span className="text-ink">{pLabel}</span>
+          , curated and metadata-reviewed in HeyClaude.
+          {posture.trusted > 0 ? <> {posture.pct}% sit in the trusted tier.</> : null}
+          {newest ? <> Most recent addition: {newest.title}.</> : null}
         </p>
         <div className="mt-6 flex flex-wrap items-center gap-2 text-sm">
           <Link
@@ -153,11 +168,21 @@ function IntersectionPage() {
         </div>
       </header>
 
-      <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <HubHighlights
+        highlights={highlights}
+        caption={`Standout ${cLabel} for ${pLabel}, picked from this slice's own metadata — trust tier, provenance, documentation, and recency.`}
+      />
+
+      <h2 className="mt-12 h-display-2 text-ink">
+        All {cLabel} for {pLabel}
+      </h2>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {entries.map((e) => (
           <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
         ))}
       </div>
+
+      <HubSignalStats stats={stats} total={entries.length} />
 
       <NewsletterInline
         variant="quiet"

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -7,6 +7,8 @@ import { categoryLabels } from "@/lib/site";
 import { ResourceCard } from "@/components/resource-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
+import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -111,6 +113,12 @@ function PlatformPage() {
     entries: all.filter((e) => e.category === c.id).slice(0, 6),
   })).filter((s) => s.entries.length > 0);
 
+  // Data-derived framing unique to this platform's catalog.
+  const posture = trustPosture(all);
+  const highlights = hubHighlights(all);
+  const stats = hubStats(all);
+  const categoryCount = new Set(all.map((e) => e.category)).size;
+
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
       <Breadcrumbs
@@ -125,8 +133,11 @@ function PlatformPage() {
         <div className="eyebrow">{all.length} compatible resources</div>
         <h1 className="mt-2 h-display-1 text-ink text-balance">Claude resources for {label}</h1>
         <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          Source-backed MCP servers, agents, skills, hooks, commands, and rules that work with{" "}
-          <span className="text-ink">{label}</span> — curated and metadata-reviewed in HeyClaude.
+          {all.length} source-backed Claude resources that work with{" "}
+          <span className="text-ink">{label}</span>, spanning {categoryCount}{" "}
+          {categoryCount === 1 ? "category" : "categories"} — curated and metadata-reviewed in
+          HeyClaude.
+          {posture.trusted > 0 ? <> {posture.pct}% sit in the trusted tier.</> : null}
         </p>
         <div className="mt-6">
           <Link
@@ -138,6 +149,13 @@ function PlatformPage() {
           </Link>
         </div>
       </header>
+
+      <HubHighlights
+        highlights={highlights}
+        caption={`Standout ${label}-compatible resources, picked from their own metadata — trust tier, provenance, documentation, and recency.`}
+      />
+
+      <HubSignalStats stats={stats} total={all.length} />
 
       {sections.map((section) => (
         <section key={section.category.id} className="mt-12">

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -3,10 +3,31 @@ import { ArrowRight } from "lucide-react";
 import { ResourceCard } from "@/components/resource-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
+import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
+import { categoryLabels } from "@/lib/site";
+import { CATEGORIES, type Entry } from "@/types/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getTagGroup, relatedTags } from "@/lib/tags";
+
+// The categories a tag's entries actually span — used to vary intro copy per tag so no
+// two indexable tag pages emit the same boilerplate sentence.
+function categorySpread(entries: Entry[], limit = 3): string[] {
+  const counts = new Map<string, number>();
+  for (const e of entries) counts.set(e.category, (counts.get(e.category) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => categoryLabels[id] ?? CATEGORIES.find((c) => c.id === id)?.label ?? id);
+}
+
+function joinList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}
 
 export const Route = createFileRoute("/tags/$tag")({
   loader: ({ params }) => {
@@ -88,6 +109,13 @@ function TagHub() {
   const entries = group.entries;
   const related = relatedTags(group.slug);
 
+  // Distinct, data-derived intro: name the categories this tag actually spans and its
+  // trusted-tier share, so each indexable tag page reads differently from the next.
+  const spread = categorySpread(entries);
+  const posture = trustPosture(entries);
+  const highlights = hubHighlights(entries);
+  const stats = hubStats(entries);
+
   return (
     <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
       <Breadcrumbs
@@ -104,9 +132,17 @@ function TagHub() {
           Claude resources tagged “{group.name}”
         </h1>
         <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          Every source-backed Claude Code resource tagged{" "}
-          <span className="text-ink">{group.name}</span> in the HeyClaude directory — across MCP
-          servers, agents, skills, hooks, commands, and more.
+          {entries.length} curated Claude Code {entries.length === 1 ? "resource" : "resources"}{" "}
+          tagged <span className="text-ink">{group.name}</span> in the HeyClaude directory
+          {spread.length > 0 ? <> — mostly {joinList(spread.map((s) => s.toLowerCase()))}</> : null}
+          .
+          {posture.trusted > 0 ? (
+            <>
+              {" "}
+              {posture.trusted} of them {posture.trusted === 1 ? "sits" : "sit"} in the trusted
+              tier.
+            </>
+          ) : null}
         </p>
       </header>
 
@@ -126,11 +162,19 @@ function TagHub() {
         </div>
       )}
 
-      <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <HubHighlights
+        highlights={highlights}
+        caption={`Standout entries tagged ${group.name}, picked by their own metadata — trust tier, provenance, documentation, and recency.`}
+      />
+
+      <h2 className="mt-12 h-display-2 text-ink">All {group.name} resources</h2>
+      <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {entries.map((e) => (
           <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
         ))}
       </div>
+
+      <HubSignalStats stats={stats} total={entries.length} />
 
       <NewsletterInline
         variant="quiet"


### PR DESCRIPTION
## What

Adds genuinely unique, **data-derived** on-page value to the programmatic hub routes so they read as distinct pages, not templated boilerplate — `routes/$category.tsx`, `routes/for.$platform.tsx`, `routes/for.$platform.$category.tsx`, and `routes/tags.$tag.tsx` (the tag + intersection pages being the most templated and highest-risk).

Two new shared primitives keep the logic DRY across all four routes:

- **`apps/web/src/lib/hub-highlights.ts`**
  - `hubHighlights(entries)` — picks up to 4 *distinct, real* entries for fact-based reasons (most-trusted pick, newest addition, safety+privacy documented, strongest provenance, most-starred source repo, maintainer-reviewed). Each carries a one-line reason pulled straight from real fields (`trust`, `source`, `dateAdded`, `safetyNotes`/`privacyNotes`, `reviewed`, `repoStats`). A pick is only surfaced when an entry genuinely satisfies the criterion — nothing fabricated.
  - `hubStats(entries)` — count breakdowns (trusted tier / source-backed / safety notes / privacy notes / reviewed), counted from the page's own set; zero-count signals are dropped.
  - `trustPosture(entries)` — trusted-tier share, used to vary intro copy.
- **`apps/web/src/components/hub-highlights.tsx`** — `HubHighlights` strip + `HubSignalStats` bars, reusing the existing `TrustBadge`/`SourceBadge` and the `Bar`/`Stat` pattern from `routes/quality.tsx`, plus `Breadcrumbs`/`ResourceCard`-style cards.

Each route now renders the highlights strip + signal coverage and **varies its intro text by the page's own data** (category spread for tags, trusted-tier share, newest entry title, category count for platforms) so no two indexable pages emit the same sentence.

## Why

Reduces thin/templated-page (helpful-content) risk on the programmatic hubs by giving every indexable page unique, source-backed substance derived from the registry — not copy duplicated across pages.

## Safety

- Highlights and stats render only for **≥2-entry** sets.
- The existing `noindex, follow` for **<2-entry** intersections/tags is preserved unchanged.
- Every number/claim derives from real registry data; no fabricated prose or numbers.
- No `content/*.mdx` touched. No generated artifacts changed (`git status` stays clean after build).

## Validation

- `pnpm type-check` — clean
- `pnpm --filter web build` — green
- `pnpm exec vitest run` — full suite **752 passed**, including `seo-metadata`, `crawler-policy`, `sitemap-policy`
- `pnpm exec prettier --check` on changed files — clean
- `git diff --check` — clean

Closes #2261