### PR TITLE
fix(seo): bound OG image text inputs

### DIFF
--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -15,6 +15,13 @@ const PALETTE: Record<string, string> = {
 
 const DEFAULT_ACCENT = "#c5e84e";
 
+export const OG_TEXT_LIMITS = {
+  eyebrow: 40,
+  title: 140,
+  description: 240,
+  author: 80,
+} as const;
+
 export function categoryAccent(category?: string) {
   return PALETTE[category ?? ""] ?? DEFAULT_ACCENT;
 }
@@ -37,19 +44,44 @@ export function esc(value: string) {
   return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
+/**
+ * Bound user-visible OG text before expensive SVG/PNG rendering. This keeps public
+ * query-string driven cards from feeding URL-sized strings into Satori/resvg.
+ */
+export function clampOgText(value: string, maxChars: number) {
+  return value.replace(/\s+/g, " ").trim().slice(0, maxChars);
+}
+
 /** Greedy word-wrap into at most `maxLines` lines of ~`perLine` chars. Exported for the PNG renderer. */
 export function wrap(value: string, perLine: number, maxLines: number) {
-  const words = value.split(/\s+/);
+  const words = value.replace(/\s+/g, " ").trim().split(" ").filter(Boolean);
   const lines: string[] = [];
   let cur = "";
+
   for (const word of words) {
-    if ((cur + " " + word).trim().length > perLine) {
-      if (cur) lines.push(cur);
-      cur = word;
-    } else cur = (cur ? cur + " " : "") + word;
+    let remaining = word;
+    while (remaining) {
+      const candidate = (cur ? cur + " " : "") + remaining;
+      if (candidate.length <= perLine) {
+        cur = candidate;
+        break;
+      }
+
+      if (cur) {
+        lines.push(cur);
+        cur = "";
+        if (lines.length >= maxLines) return lines;
+        continue;
+      }
+
+      lines.push(remaining.slice(0, perLine));
+      remaining = remaining.slice(perLine);
+      if (lines.length >= maxLines) return lines;
+    }
   }
-  if (cur) lines.push(cur);
-  return lines.slice(0, maxLines);
+
+  if (cur && lines.length < maxLines) lines.push(cur);
+  return lines;
 }
 
 /** Deterministic 1200×630 OG card SVG. Shared by /og/$category/$slug and the generic /og route. */
@@ -61,9 +93,13 @@ export function renderOgSvg(opts: {
   accent?: string;
 }) {
   const accent = safeAccent(opts.accent);
-  const eyebrow = esc((opts.eyebrow || "HeyClaude").toUpperCase());
-  const titleLines = wrap(opts.title, 22, 2);
-  const descLines = opts.description ? wrap(opts.description, 60, 2) : [];
+  const eyebrow = esc(
+    clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),
+  );
+  const titleLines = wrap(clampOgText(opts.title, OG_TEXT_LIMITS.title), 22, 2);
+  const descLines = opts.description
+    ? wrap(clampOgText(opts.description, OG_TEXT_LIMITS.description), 60, 2)
+    : [];
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -1,7 +1,7 @@
 import { ImageResponse } from "workers-og";
 
 import { getOgFonts } from "@/lib/og-fonts";
-import { OG_HEIGHT, OG_WIDTH, safeAccent, wrap } from "@/lib/og-image";
+import { OG_HEIGHT, OG_TEXT_LIMITS, OG_WIDTH, clampOgText, safeAccent, wrap } from "@/lib/og-image";
 
 /**
  * Sanitize a text value for the Satori HTML template.
@@ -39,9 +39,13 @@ export function renderOgPng(opts: {
   accent?: string;
 }): ImageResponse {
   const accent = safeAccent(opts.accent);
-  const eyebrow = escForSatori((opts.eyebrow || "HeyClaude").toUpperCase());
-  const titleLines = wrap(opts.title, 22, 2);
-  const descLines = opts.description ? wrap(opts.description, 60, 2) : [];
+  const eyebrow = escForSatori(
+    clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),
+  );
+  const titleLines = wrap(clampOgText(opts.title, OG_TEXT_LIMITS.title), 22, 2);
+  const descLines = opts.description
+    ? wrap(clampOgText(opts.description, OG_TEXT_LIMITS.description), 60, 2)
+    : [];
 
   const titleHtml = titleLines
     .map(
@@ -67,7 +71,7 @@ export function renderOgPng(opts: {
   // HTMLRewriter, which does not decode entities, so "&nbsp;" would render verbatim.
   const authorHtml = opts.author
     ? `<div style="display:flex;margin-top:32px;font-family:'Space Grotesk';font-weight:500;font-size:22px;color:#6b6a64;">by <span style="font-weight:700;color:#171614;">${escForSatori(
-        opts.author,
+        clampOgText(opts.author, OG_TEXT_LIMITS.author),
       )}</span></div>`
     : "";
 

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { safeAccent } from "@/lib/og-image";
+import { OG_TEXT_LIMITS, clampOgText, safeAccent } from "@/lib/og-image";
 import { renderOgPng } from "@/lib/og-render.server";
 
 /**
@@ -13,10 +13,19 @@ export const Route = createFileRoute("/og/")({
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url);
-        const title = url.searchParams.get("title") ?? "HeyClaude";
-        const description =
+        const title = clampOgText(
+          url.searchParams.get("title") ?? "HeyClaude",
+          OG_TEXT_LIMITS.title,
+        );
+        const rawDescription =
           url.searchParams.get("description") ?? url.searchParams.get("subtitle") ?? undefined;
-        const eyebrow = url.searchParams.get("eyebrow") ?? "HeyClaude";
+        const description = rawDescription
+          ? clampOgText(rawDescription, OG_TEXT_LIMITS.description)
+          : undefined;
+        const eyebrow = clampOgText(
+          url.searchParams.get("eyebrow") ?? "HeyClaude",
+          OG_TEXT_LIMITS.eyebrow,
+        );
         // accent is user-controlled; clamp to a safe hex before it reaches the card markup.
         const accent = safeAccent(url.searchParams.get("accent"));
 

--- a/tests/og-image.test.ts
+++ b/tests/og-image.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { categoryAccent, renderOgSvg, safeAccent } from "@/lib/og-image";
+import {
+  OG_TEXT_LIMITS,
+  categoryAccent,
+  clampOgText,
+  renderOgSvg,
+  safeAccent,
+  wrap,
+} from "@/lib/og-image";
 
 describe("og image accent sanitization", () => {
   it("passes through valid hex colors", () => {
@@ -24,5 +31,23 @@ describe("og image accent sanitization", () => {
     const svg = renderOgSvg({ title: "Hello", accent: payload });
     expect(svg).not.toContain("<script>");
     expect(svg).toContain('fill="#c5e84e"');
+  });
+});
+
+describe("og image text bounds", () => {
+  it("clamps query-controlled text before rendering", () => {
+    expect(
+      clampOgText("a".repeat(OG_TEXT_LIMITS.title + 1), OG_TEXT_LIMITS.title),
+    ).toHaveLength(OG_TEXT_LIMITS.title);
+    expect(clampOgText("  hello\n\tworld  ", OG_TEXT_LIMITS.title)).toBe(
+      "hello world",
+    );
+  });
+
+  it("does not pass overlong single words through wrapping", () => {
+    const lines = wrap("a".repeat(200), 22, 2);
+
+    expect(lines).toHaveLength(2);
+    expect(lines.every((line) => line.length <= 22)).toBe(true);
   });
 });


### PR DESCRIPTION
### Motivation
- Public `/og` PNG rendering accepted unbounded query parameters and fed them into Satori/resvg rendering, enabling high CPU/cost abuse via attacker-controlled long query strings. 
- The existing `wrap` helper preserved overlong single words, allowing URL-sized tokens to reach the expensive renderer.

### Description
- Add `OG_TEXT_LIMITS` and a `clampOgText` helper to bound eyebrow/title/description/author lengths before rendering. 
- Harden `wrap` to normalize whitespace and break long single words into chunks so produced lines never exceed the per-line limit and `maxLines` is respected. 
- Apply clamping in both SVG (`renderOgSvg`) and PNG (`renderOgPng`) render paths and clamp query parameters in the generic `/og` route before invoking the renderer. 
- Add unit tests (`tests/og-image.test.ts`) covering text clamping and overlong-word wrapping.

### Testing
- Ran formatting with `prettier` on modified files and the formatter completed successfully. 
- Ran the unit tests with `vitest` (`tests/og-image.test.ts`) and all tests passed. 
- Ran `git diff --check` (whitespace/checks) which reported no issues. 
- Note: repository-level pnpm supply-chain/attestation checks attempted by the commit hook could not complete due to repeated registry attestation fetch failures in the environment, so those wider automated checks were blocked in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e6ab42084832aa7d6b8acfe1d2844)