### PR TITLE
refactor(submission-gate): extract decision/retry helpers from index.ts

### DIFF
--- a/apps/submission-gate/src/decisions.ts
+++ b/apps/submission-gate/src/decisions.ts
@@ -1,0 +1,656 @@
+import { LABELS } from "./constants";
+import { type ContentDuplicateReview } from "./duplicates";
+import {
+  GitHubApiError,
+  githubRetryDelaySeconds,
+  isGitHubRateLimitError,
+} from "./github";
+import {
+  duplicateEvidenceContractExhaustedDecision,
+  GATE_COMMENT_FORMATTER_VERSION,
+  privateReviewErrorDecision,
+  type GateDecision,
+  type GateDecisionEvidence,
+  type GateVerdict,
+} from "./review";
+import {
+  sourceEvidenceSummary,
+  type SourceEvidenceReport,
+} from "./source-evidence";
+
+export type ReviewTarget = {
+  repoFullName: string;
+  number: number;
+  baseRef: string;
+  headRepo?: string;
+  headRef?: string;
+  headSha?: string;
+  installationId?: number;
+};
+
+export type DirectContentScope = {
+  filePath: string;
+  category: string;
+  slug: string;
+  status: string;
+  rawUrl?: string;
+};
+
+export const VALIDATION_REQUEUE_SECONDS = 90;
+export const MERGE_RETRY_SECONDS = 30;
+export const RETRYABLE_ERROR_SECONDS = 60;
+export const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
+export const RETRY_BACKOFF_SECONDS = [60, 120, 300, 600, 1_200, 1_800] as const;
+export const RETRY_BUDGETS: Record<string, number> = {
+  source_evidence_timeout: 6,
+  private_reviewer_unavailable: 5,
+  invalid_private_response: 5,
+  github_rate_limited: 6,
+  github_api_unavailable: 5,
+  source_evidence_conflict: 2,
+  duplicate_evidence_conflict: 2,
+};
+
+export class SourceEvidenceRetryableError extends Error {
+  sourceEvidence: SourceEvidenceReport;
+
+  constructor(message: string, sourceEvidence: SourceEvidenceReport) {
+    super(message);
+    this.name = "SourceEvidenceRetryableError";
+    this.sourceEvidence = sourceEvidence;
+  }
+}
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+export function isoAfter(seconds: number) {
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+export function isoBefore(seconds: number) {
+  return new Date(Date.now() - seconds * 1000).toISOString();
+}
+
+export function truncateForQueue(value: unknown, maxLength = 500) {
+  const text = String(value || "").trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength - 3)}...`;
+}
+
+export function decisionStatus(verdict: GateVerdict) {
+  if (verdict === "merge") return "merge_pending";
+  if (verdict === "manual") return "manual";
+  if (verdict === "ignore") return "ignored";
+  return "closed";
+}
+
+export function gateCheckStatus(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === "missing") return "pending" as const;
+  if (
+    ["passed", "pending", "failed", "neutral", "skipped", "unknown"].includes(
+      normalized,
+    )
+  ) {
+    return normalized as NonNullable<GateDecision["checks"]>[number]["status"];
+  }
+  return "unknown" as const;
+}
+
+export function checksForDecision(
+  validation:
+    | {
+        checks?: Array<{ name: string; status: string; details?: string }>;
+      }
+    | null
+    | undefined,
+) {
+  return (validation?.checks || []).map((check) => ({
+    name: check.name,
+    status: gateCheckStatus(check.status),
+    details: check.details,
+  }));
+}
+
+export function decisionWithReviewContext(
+  decision: GateDecision,
+  params: {
+    scope?: DirectContentScope | null;
+    validation?: {
+      checks?: Array<{ name: string; status: string; details?: string }>;
+    } | null;
+  } = {},
+): GateDecision {
+  return {
+    ...decision,
+    scope:
+      decision.scope ||
+      (params.scope
+        ? {
+            filePath: params.scope.filePath,
+            category: params.scope.category,
+            slug: params.scope.slug,
+            status: params.scope.status,
+          }
+        : undefined),
+    checks: decision.checks?.length
+      ? decision.checks
+      : checksForDecision(params.validation),
+  };
+}
+
+export function decisionMetadata(
+  decision: GateDecision,
+  comment?: { id?: number; url?: string },
+  review?: { id?: number },
+) {
+  return {
+    commentId: comment?.id ?? null,
+    commentUrl: comment?.url || null,
+    reviewId: review?.id ?? null,
+    schemaVersion: decision.schemaVersion ?? 1,
+    formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
+    decisionId: decision.decisionId || crypto.randomUUID(),
+    confidence: decision.confidence ?? null,
+    sourceEvidenceHash: decision.sourceEvidenceHash ?? null,
+  };
+}
+
+export function nextReviewForStatus(status: string) {
+  if (status === "validation_pending") {
+    return isoAfter(VALIDATION_REQUEUE_SECONDS);
+  }
+  if (status === "merge_pending") {
+    return isoAfter(MERGE_RETRY_SECONDS);
+  }
+  if (status === "error_retryable") {
+    return isoAfter(RETRY_BACKOFF_SECONDS[0]);
+  }
+  return null;
+}
+
+export function retryDelayForError(error: unknown) {
+  if (isGitHubRateLimitError(error)) {
+    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
+  }
+  return RETRYABLE_ERROR_SECONDS;
+}
+
+export function retryDelayForMergeError(error: unknown) {
+  if (
+    isGitHubRateLimitError(error) ||
+    (error instanceof GitHubApiError && error.status === 429)
+  ) {
+    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
+  }
+  return MERGE_RETRY_SECONDS;
+}
+
+export function nextReviewForError(error: unknown) {
+  return isoAfter(retryDelayForError(error));
+}
+
+export function isTimeoutError(error: unknown) {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.name === "AbortError" ||
+    error.name === "TimeoutError" ||
+    /(?:operation was aborted due to timeout|aborted due to timeout|timed out|timeout)/i.test(
+      error.message,
+    )
+  );
+}
+
+export function retryablePrecheckDecision(error: unknown) {
+  if (error instanceof SourceEvidenceRetryableError) {
+    return {
+      ...privateReviewErrorDecision(error.message, "source_evidence_timeout"),
+      sourceEvidenceHash: error.sourceEvidence.hash,
+      sections: [
+        {
+          id: "source_review",
+          title: "Source Review",
+          status: "warn" as const,
+          bullets: [
+            "Deterministic source evidence could not conclusively verify all canonical source URLs.",
+            sourceEvidenceSummary(error.sourceEvidence),
+          ],
+        },
+      ],
+    };
+  }
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate deterministic duplicate/edit review hit a GitHub rate limit.",
+      "github_rate_limited",
+    );
+  }
+  if (isTimeoutError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate deterministic duplicate/edit review timed out while reading source or duplicate evidence.",
+      "source_evidence_timeout",
+    );
+  }
+  return null;
+}
+
+export function retryableTargetErrorDecision(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate hit a GitHub rate limit while inspecting the pull request.",
+      "github_rate_limited",
+    );
+  }
+  if (isTimeoutError(error)) {
+    return privateReviewErrorDecision(
+      `Submission gate timed out while inspecting the pull request: ${message}`,
+      "github_api_unavailable",
+    );
+  }
+  return privateReviewErrorDecision(
+    `Submission gate could not inspect the pull request: ${message}`,
+    "github_api_unavailable",
+  );
+}
+
+export function retryableValidationReadDecision(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isGitHubRateLimitError(error)) {
+    return privateReviewErrorDecision(
+      "Submission gate hit a GitHub rate limit while reading public validation checks.",
+      "github_rate_limited",
+    );
+  }
+  return privateReviewErrorDecision(
+    `Submission gate could not read public validation checks: ${message}`,
+    "github_api_unavailable",
+  );
+}
+
+export function normalizeOneShotDecision(decision: GateDecision): GateDecision {
+  if (decision.verdict === "close" && !decision.close) {
+    return {
+      ...decision,
+      close: true,
+      labels: decision.labels.length ? decision.labels : [LABELS.close],
+    };
+  }
+  if (decision.verdict !== "request_changes") return decision;
+  return {
+    ...decision,
+    verdict: "close",
+    labels: [LABELS.close],
+    close: true,
+    summary: [
+      decision.summary.trim(),
+      "",
+      "One-shot Review:",
+      "- This submission needs changes, so the maintainer agent is closing it instead of keeping an iterative review open.",
+      "- Please resubmit a new focused one-file content PR after fixing the issue.",
+    ].join("\n"),
+  };
+}
+
+export function hasPrivateReviewErrorCode(
+  decision: GateDecision,
+  code: string,
+) {
+  return Boolean(decision.errors?.some((error) => error.code === code));
+}
+
+export function retryErrorCode(decision: GateDecision) {
+  const retryableError = decision.errors?.find(
+    (error) => error.retryable || error.code,
+  );
+  return retryableError?.code || "private_reviewer_unavailable";
+}
+
+export function retryBudgetForCode(code: string) {
+  return RETRY_BUDGETS[code] ?? 3;
+}
+
+export function retryBackoffSecondsForCount(count: number) {
+  const index = Math.max(
+    0,
+    Math.min(count - 1, RETRY_BACKOFF_SECONDS.length - 1),
+  );
+  return RETRY_BACKOFF_SECONDS[index];
+}
+
+export function normalizeRetryFingerprintPart(value: unknown, maxLength = 220) {
+  return String(value || "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
+export function retryFingerprintForDecision(decision: GateDecision) {
+  const code = retryErrorCode(decision);
+  const sourceHash = decision.sourceEvidenceHash
+    ? `source:${decision.sourceEvidenceHash}`
+    : "";
+  const errorText =
+    decision.errors
+      ?.map((error) => `${error.code}:${error.message || ""}`)
+      .join("|") || "";
+  return [
+    code,
+    sourceHash,
+    normalizeRetryFingerprintPart(errorText || decision.summary),
+  ]
+    .filter(Boolean)
+    .join(":");
+}
+
+export function retryStateForDecision(
+  existing: Record<string, unknown> | null,
+  target: ReviewTarget,
+  decision: GateDecision,
+) {
+  const code = retryErrorCode(decision);
+  const fingerprint = retryFingerprintForDecision(decision);
+  const previousSameFingerprint =
+    String(existing?.headSha || "") === String(target.headSha || "") &&
+    String(existing?.lastErrorCode || "") === code &&
+    String(existing?.lastRetryFingerprint || "") === fingerprint;
+  const previousCount = previousSameFingerprint
+    ? Number(existing?.retryFingerprintCount || 0)
+    : 0;
+  const count =
+    Number.isFinite(previousCount) && previousCount > 0 ? previousCount + 1 : 1;
+  const maxAttempts = retryBudgetForCode(code);
+  const nextReviewAt = isoAfter(retryBackoffSecondsForCount(count));
+  return {
+    code,
+    fingerprint,
+    count,
+    maxAttempts,
+    nextReviewAt,
+    exhausted: count > maxAttempts,
+  };
+}
+
+export function retryExhaustedDecision(
+  decision: GateDecision,
+  retryState: ReturnType<typeof retryStateForDecision>,
+): GateDecision {
+  const exhaustedSummary = [
+    "Summary:",
+    `- Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
+    "- This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
+    `- Last retry reason: ${decision.summary.trim()}`,
+    "",
+    "Recommended Action:",
+    "- A maintainer can recheck after the external service recovers, merge manually if review confirms no blocker, or close if review finds a real content issue.",
+  ].join("\n");
+  return {
+    verdict: "manual",
+    labels: [LABELS.manual],
+    confidence: decision.confidence,
+    sourceEvidenceHash: decision.sourceEvidenceHash,
+    summary: exhaustedSummary,
+    errors: [
+      {
+        code: retryState.code,
+        retryable: false,
+        message: `Retry budget exhausted after ${retryState.maxAttempts} automatic attempt(s).`,
+      },
+    ],
+    sections: [
+      {
+        id: "summary",
+        title: "Summary",
+        status: "warn",
+        bullets: [
+          `Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
+          "This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
+          `Last retry reason: ${decision.summary.trim()}`,
+        ],
+      },
+      {
+        id: "recommended_action",
+        title: "Recommended Action",
+        status: "warn",
+        bullets: [
+          "Recheck after the external service recovers.",
+          "Merge manually if maintainer review confirms no blocker.",
+          "Close only if manual review finds a real content issue.",
+        ],
+      },
+      ...(decision.sections || []),
+    ],
+    retryState,
+  } as GateDecision & { retryState: ReturnType<typeof retryStateForDecision> };
+}
+
+export function retryExhaustedStorageMetadata(decision: GateDecision) {
+  const retryState = (
+    decision as GateDecision & {
+      retryState?: ReturnType<typeof retryStateForDecision>;
+    }
+  ).retryState;
+  if (!retryState?.exhausted) return {};
+  return {
+    lastError: truncateForQueue(decision.summary),
+    lastErrorCode: retryState.code,
+    lastRetryFingerprint: retryState.fingerprint,
+    retryFingerprintCount: retryState.maxAttempts,
+    retryExhaustedAt: nowIso(),
+    retryExhaustedReason: truncateForQueue(decision.summary),
+  };
+}
+
+export function sourceEvidenceConflictDecision(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport,
+) {
+  const conflict = privateReviewErrorDecision(
+    "Private review claimed source_hard_failure, but deterministic source evidence found the submitted source URLs reachable.",
+    "source_evidence_conflict",
+  );
+  return {
+    ...conflict,
+    confidence: decision.confidence,
+    sourceEvidenceHash: sourceEvidence.hash,
+    sections: [
+      {
+        id: "source_review",
+        title: "Source Review",
+        status: "warn" as const,
+        bullets: [
+          "Private review reported a source URL reachability failure that conflicts with deterministic source evidence.",
+          sourceEvidenceSummary(sourceEvidence),
+          "The gate will retry with the deterministic source artifact before requiring manual review if the conflict persists.",
+        ],
+      },
+    ],
+  };
+}
+
+export function sourceEvidenceConflictExhaustedDecision(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport,
+): GateDecision {
+  return {
+    schemaVersion: 2,
+    verdict: "manual",
+    confidence: decision.confidence,
+    sourceEvidenceHash: sourceEvidence.hash,
+    labels: [LABELS.manual],
+    summary: [
+      "Summary:",
+      "- Public validation and deterministic source evidence passed.",
+      "- Private review repeatedly returned a source_hard_failure for URL reachability that conflicts with deterministic source evidence.",
+      "- Automation will not override the private close into a merge; a maintainer must review the source evidence conflict.",
+      "",
+      "Source Review:",
+      `- ${sourceEvidenceSummary(sourceEvidence)}`,
+      "",
+      "Recommended Action:",
+      "- Review this source evidence conflict manually before deciding whether to merge or close the PR.",
+    ].join("\n"),
+    sections: [
+      {
+        id: "source_review",
+        title: "Source Review",
+        status: "warn",
+        bullets: [
+          "Deterministic source evidence found submitted source URLs reachable, but private review repeatedly reported a source reachability hard failure.",
+          sourceEvidenceSummary(sourceEvidence),
+        ],
+      },
+      {
+        id: "recommended_action",
+        title: "Recommended Action",
+        status: "info",
+        bullets: [
+          "Review this source evidence conflict manually before deciding whether to merge or close the PR.",
+        ],
+      },
+    ],
+  };
+}
+
+export function duplicateReviewSummaryLine(
+  duplicateReview: ContentDuplicateReview,
+) {
+  const relatedCount = duplicateReview.relatedCandidates.length;
+  return duplicateReview.strictDuplicate
+    ? `strict duplicate: ${
+        duplicateReview.strictDuplicate.existing.label ||
+        duplicateReview.strictDuplicate.existing.filePath
+      }`
+    : `no strict duplicate${
+        relatedCount ? `; ${relatedCount} related candidate(s)` : ""
+      }`;
+}
+
+export function duplicateEvidenceConflictDecision(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview,
+) {
+  const conflict = privateReviewErrorDecision(
+    "Private review claimed strict_duplicate, but deterministic duplicate review found no strict duplicate.",
+    "duplicate_evidence_conflict",
+  );
+  return {
+    ...conflict,
+    confidence: decision.confidence,
+    sections: [
+      {
+        id: "duplicate_history",
+        title: "Duplicate and History Review",
+        status: "warn" as const,
+        bullets: [
+          "Private review reported a strict duplicate that conflicts with deterministic duplicate review.",
+          duplicateReviewSummaryLine(duplicateReview),
+          "The gate will retry with the deterministic duplicate artifact before falling back to manual review.",
+        ],
+      },
+    ],
+  };
+}
+
+export function duplicateEvidenceConflictExhaustedDecision(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview,
+  sourceEvidence: SourceEvidenceReport | null,
+): GateDecision {
+  return duplicateEvidenceContractExhaustedDecision({
+    decision,
+    duplicateSummary: duplicateReviewSummaryLine(duplicateReview),
+    sourceSummary: sourceEvidence
+      ? sourceEvidenceSummary(sourceEvidence)
+      : null,
+  });
+}
+
+export function sourceEvidenceUrlCandidates(evidence: GateDecisionEvidence) {
+  return [
+    evidence.url,
+    evidence.matchedUrl,
+    evidence.finalUrl,
+    evidence.source,
+  ].filter((value): value is string => Boolean(value));
+}
+
+export function privateEvidenceClaimsDeadSourceUrl(
+  evidence: GateDecisionEvidence,
+) {
+  const httpStatus = Number(evidence.httpStatus || evidence.status || 0);
+  if ([404, 410].includes(httpStatus)) return true;
+  const text = [
+    evidence.ruleId,
+    evidence.outcome,
+    evidence.status,
+    evidence.behavior,
+    evidence.policy,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return (
+    text.includes("source_url_reachability") ||
+    /\b(?:404|410)\b/.test(text) ||
+    /\b(?:dead|broken|unreachable|not found|hard[-_ ]failure)\b/.test(text)
+  );
+}
+
+export function privateEvidenceMatchesReachableSourceUrl(
+  evidence: GateDecisionEvidence,
+  sourceEvidence: SourceEvidenceReport,
+) {
+  const candidates = sourceEvidenceUrlCandidates(evidence);
+  if (!candidates.length) return false;
+  return sourceEvidence.urls.some((item) => {
+    if (item.status !== "passed" || item.outcome !== "reachable") return false;
+    return candidates.some(
+      (url) => url === item.url || (item.finalUrl && url === item.finalUrl),
+    );
+  });
+}
+
+export function privateSourceHardFailureContradicted(
+  decision: GateDecision,
+  sourceEvidence: SourceEvidenceReport | null,
+) {
+  if (
+    decision.verdict !== "close" ||
+    decision.reasonCode !== "source_hard_failure" ||
+    sourceEvidence?.status !== "passed" ||
+    !sourceEvidence.urls.length
+  ) {
+    return false;
+  }
+  return (decision.evidence || []).some(
+    (item) =>
+      privateEvidenceClaimsDeadSourceUrl(item) &&
+      privateEvidenceMatchesReachableSourceUrl(item, sourceEvidence),
+  );
+}
+
+export function privateStrictDuplicateContradicted(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview | null,
+) {
+  return (
+    decision.verdict === "close" &&
+    decision.reasonCode === "strict_duplicate" &&
+    Boolean(duplicateReview) &&
+    !duplicateReview?.strictDuplicate
+  );
+}
+
+export function duplicateConflictRetryableContradicted(
+  decision: GateDecision,
+  duplicateReview: ContentDuplicateReview | null,
+) {
+  return (
+    hasPrivateReviewErrorCode(decision, "duplicate_evidence_conflict") &&
+    Boolean(duplicateReview) &&
+    !duplicateReview?.strictDuplicate
+  );
+}

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -29,7 +29,6 @@ import {
   exchangeGitHubUserCode,
   getCommitValidationState,
   GitHubApiError,
-  githubRetryDelaySeconds,
   getInstallationToken,
   getPullRequest,
   getRepositoryInstallationId,
@@ -48,7 +47,6 @@ import {
   approvalReviewBody,
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
   defaultManualDecision,
-  duplicateEvidenceContractExhaustedDecision,
   enforceAutoMergeConfidenceFloor,
   GATE_COMMENT_FORMATTER_VERSION,
   isRetryableGateDecision,
@@ -92,6 +90,40 @@ import {
   upsertPrState,
   verifyDraftState,
 } from "./storage";
+import {
+  checksForDecision,
+  decisionMetadata,
+  decisionStatus,
+  decisionWithReviewContext,
+  duplicateConflictRetryableContradicted,
+  duplicateEvidenceConflictDecision,
+  duplicateEvidenceConflictExhaustedDecision,
+  isoAfter,
+  isoBefore,
+  isTimeoutError,
+  MERGE_RETRY_SECONDS,
+  nextReviewForError,
+  nextReviewForStatus,
+  normalizeOneShotDecision,
+  nowIso,
+  privateSourceHardFailureContradicted,
+  privateStrictDuplicateContradicted,
+  retryableTargetErrorDecision,
+  retryablePrecheckDecision,
+  retryableValidationReadDecision,
+  retryDelayForError,
+  retryDelayForMergeError,
+  retryExhaustedDecision,
+  retryExhaustedStorageMetadata,
+  retryStateForDecision,
+  sourceEvidenceConflictDecision,
+  sourceEvidenceConflictExhaustedDecision,
+  SourceEvidenceRetryableError,
+  truncateForQueue,
+  VALIDATION_REQUEUE_SECONDS,
+  type DirectContentScope,
+  type ReviewTarget,
+} from "./decisions";
 
 type Env = {
   PUBLIC_SITE_URL: string;
@@ -164,38 +196,14 @@ class SubmissionMergePendingError extends Error {
   }
 }
 
-class SourceEvidenceRetryableError extends Error {
-  sourceEvidence: SourceEvidenceReport;
-
-  constructor(message: string, sourceEvidence: SourceEvidenceReport) {
-    super(message);
-    this.name = "SourceEvidenceRetryableError";
-    this.sourceEvidence = sourceEvidence;
-  }
-}
-
 const TERMINAL_GATE_VERDICTS = new Set(["close", "manual", "ignore"]);
 const TERMINAL_PR_STATUSES = new Set(["merged", "closed", "manual", "ignored"]);
 const GITHUB_TERMINAL_VERIFICATION_ERROR = "GitHub terminal state verified.";
-const VALIDATION_REQUEUE_SECONDS = 90;
 const VALIDATION_PENDING_STALE_SECONDS = 30 * 60;
 const VALIDATION_PENDING_STALE_ATTEMPTS = 20;
 const QUEUED_STALE_SECONDS = 60;
 const REVIEWING_STALE_SECONDS = 180;
-const MERGE_RETRY_SECONDS = 30;
-const RETRYABLE_ERROR_SECONDS = 60;
-const GITHUB_RATE_LIMIT_FALLBACK_SECONDS = 15 * 60;
 const PRIVATE_REVIEW_TIMEOUT_MS = 45_000;
-const RETRY_BACKOFF_SECONDS = [60, 120, 300, 600, 1_200, 1_800] as const;
-const RETRY_BUDGETS: Record<string, number> = {
-  source_evidence_timeout: 6,
-  private_reviewer_unavailable: 5,
-  invalid_private_response: 5,
-  github_rate_limited: 6,
-  github_api_unavailable: 5,
-  source_evidence_conflict: 2,
-  duplicate_evidence_conflict: 2,
-};
 const DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR_TEXT = String(
   DEFAULT_AUTO_MERGE_CONFIDENCE_FLOOR,
 );
@@ -318,16 +326,6 @@ const CONTENT_CATEGORY_LABELS = [
 ].map(categoryLabel);
 const RECONCILED_GATE_LABELS = [...DECISION_LABELS, ...CONTENT_CATEGORY_LABELS];
 
-type ReviewTarget = {
-  repoFullName: string;
-  number: number;
-  baseRef: string;
-  headRepo?: string;
-  headRef?: string;
-  headSha?: string;
-  installationId?: number;
-};
-
 type PrQueueState = Record<string, unknown> & {
   repo?: string;
   number?: number;
@@ -342,14 +340,6 @@ type PrQueueState = Record<string, unknown> & {
   attemptCount?: number;
   createdAt?: string;
   updatedAt?: string;
-};
-
-type DirectContentScope = {
-  filePath: string;
-  category: string;
-  slug: string;
-  status: string;
-  rawUrl?: string;
 };
 
 type DirectContentReviewability =
@@ -374,592 +364,8 @@ function json(payload: unknown, init: ResponseInit = {}) {
   return Response.json(payload, { ...init, headers });
 }
 
-function nowIso() {
-  return new Date().toISOString();
-}
-
-function isoAfter(seconds: number) {
-  return new Date(Date.now() + seconds * 1000).toISOString();
-}
-
-function isoBefore(seconds: number) {
-  return new Date(Date.now() - seconds * 1000).toISOString();
-}
-
 function contentGateBaseRef(env: Env) {
   return env.CONTENT_GATE_BASE_REF || "main";
-}
-
-function truncateForQueue(value: unknown, maxLength = 500) {
-  const text = String(value || "").trim();
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength - 3)}...`;
-}
-
-function decisionStatus(verdict: GateVerdict) {
-  if (verdict === "merge") return "merge_pending";
-  if (verdict === "manual") return "manual";
-  if (verdict === "ignore") return "ignored";
-  return "closed";
-}
-
-function gateCheckStatus(status: string) {
-  const normalized = status.toLowerCase();
-  if (normalized === "missing") return "pending" as const;
-  if (
-    ["passed", "pending", "failed", "neutral", "skipped", "unknown"].includes(
-      normalized,
-    )
-  ) {
-    return normalized as NonNullable<GateDecision["checks"]>[number]["status"];
-  }
-  return "unknown" as const;
-}
-
-function checksForDecision(
-  validation:
-    | {
-        checks?: Array<{ name: string; status: string; details?: string }>;
-      }
-    | null
-    | undefined,
-) {
-  return (validation?.checks || []).map((check) => ({
-    name: check.name,
-    status: gateCheckStatus(check.status),
-    details: check.details,
-  }));
-}
-
-function decisionWithReviewContext(
-  decision: GateDecision,
-  params: {
-    scope?: DirectContentScope | null;
-    validation?: {
-      checks?: Array<{ name: string; status: string; details?: string }>;
-    } | null;
-  } = {},
-): GateDecision {
-  return {
-    ...decision,
-    scope:
-      decision.scope ||
-      (params.scope
-        ? {
-            filePath: params.scope.filePath,
-            category: params.scope.category,
-            slug: params.scope.slug,
-            status: params.scope.status,
-          }
-        : undefined),
-    checks: decision.checks?.length
-      ? decision.checks
-      : checksForDecision(params.validation),
-  };
-}
-
-function decisionMetadata(
-  decision: GateDecision,
-  comment?: { id?: number; url?: string },
-  review?: { id?: number },
-) {
-  return {
-    commentId: comment?.id ?? null,
-    commentUrl: comment?.url || null,
-    reviewId: review?.id ?? null,
-    schemaVersion: decision.schemaVersion ?? 1,
-    formatterVersion: GATE_COMMENT_FORMATTER_VERSION,
-    decisionId: decision.decisionId || crypto.randomUUID(),
-    confidence: decision.confidence ?? null,
-    sourceEvidenceHash: decision.sourceEvidenceHash ?? null,
-  };
-}
-
-function nextReviewForStatus(status: string) {
-  if (status === "validation_pending") {
-    return isoAfter(VALIDATION_REQUEUE_SECONDS);
-  }
-  if (status === "merge_pending") {
-    return isoAfter(MERGE_RETRY_SECONDS);
-  }
-  if (status === "error_retryable") {
-    return isoAfter(RETRY_BACKOFF_SECONDS[0]);
-  }
-  return null;
-}
-
-function retryDelayForError(error: unknown) {
-  if (isGitHubRateLimitError(error)) {
-    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
-  }
-  return RETRYABLE_ERROR_SECONDS;
-}
-
-function retryDelayForMergeError(error: unknown) {
-  if (
-    isGitHubRateLimitError(error) ||
-    (error instanceof GitHubApiError && error.status === 429)
-  ) {
-    return githubRetryDelaySeconds(error, GITHUB_RATE_LIMIT_FALLBACK_SECONDS);
-  }
-  return MERGE_RETRY_SECONDS;
-}
-
-function nextReviewForError(error: unknown) {
-  return isoAfter(retryDelayForError(error));
-}
-
-function isTimeoutError(error: unknown) {
-  if (!(error instanceof Error)) return false;
-  return (
-    error.name === "AbortError" ||
-    error.name === "TimeoutError" ||
-    /(?:operation was aborted due to timeout|aborted due to timeout|timed out|timeout)/i.test(
-      error.message,
-    )
-  );
-}
-
-function retryablePrecheckDecision(error: unknown) {
-  if (error instanceof SourceEvidenceRetryableError) {
-    return {
-      ...privateReviewErrorDecision(error.message, "source_evidence_timeout"),
-      sourceEvidenceHash: error.sourceEvidence.hash,
-      sections: [
-        {
-          id: "source_review",
-          title: "Source Review",
-          status: "warn" as const,
-          bullets: [
-            "Deterministic source evidence could not conclusively verify all canonical source URLs.",
-            sourceEvidenceSummary(error.sourceEvidence),
-          ],
-        },
-      ],
-    };
-  }
-  if (isGitHubRateLimitError(error)) {
-    return privateReviewErrorDecision(
-      "Submission gate deterministic duplicate/edit review hit a GitHub rate limit.",
-      "github_rate_limited",
-    );
-  }
-  if (isTimeoutError(error)) {
-    return privateReviewErrorDecision(
-      "Submission gate deterministic duplicate/edit review timed out while reading source or duplicate evidence.",
-      "source_evidence_timeout",
-    );
-  }
-  return null;
-}
-
-function retryableTargetErrorDecision(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  if (isGitHubRateLimitError(error)) {
-    return privateReviewErrorDecision(
-      "Submission gate hit a GitHub rate limit while inspecting the pull request.",
-      "github_rate_limited",
-    );
-  }
-  if (isTimeoutError(error)) {
-    return privateReviewErrorDecision(
-      `Submission gate timed out while inspecting the pull request: ${message}`,
-      "github_api_unavailable",
-    );
-  }
-  return privateReviewErrorDecision(
-    `Submission gate could not inspect the pull request: ${message}`,
-    "github_api_unavailable",
-  );
-}
-
-function retryableValidationReadDecision(error: unknown) {
-  const message = error instanceof Error ? error.message : String(error);
-  if (isGitHubRateLimitError(error)) {
-    return privateReviewErrorDecision(
-      "Submission gate hit a GitHub rate limit while reading public validation checks.",
-      "github_rate_limited",
-    );
-  }
-  return privateReviewErrorDecision(
-    `Submission gate could not read public validation checks: ${message}`,
-    "github_api_unavailable",
-  );
-}
-
-function normalizeOneShotDecision(decision: GateDecision): GateDecision {
-  if (decision.verdict === "close" && !decision.close) {
-    return {
-      ...decision,
-      close: true,
-      labels: decision.labels.length ? decision.labels : [LABELS.close],
-    };
-  }
-  if (decision.verdict !== "request_changes") return decision;
-  return {
-    ...decision,
-    verdict: "close",
-    labels: [LABELS.close],
-    close: true,
-    summary: [
-      decision.summary.trim(),
-      "",
-      "One-shot Review:",
-      "- This submission needs changes, so the maintainer agent is closing it instead of keeping an iterative review open.",
-      "- Please resubmit a new focused one-file content PR after fixing the issue.",
-    ].join("\n"),
-  };
-}
-
-function hasPrivateReviewErrorCode(decision: GateDecision, code: string) {
-  return Boolean(decision.errors?.some((error) => error.code === code));
-}
-
-function retryErrorCode(decision: GateDecision) {
-  const retryableError = decision.errors?.find(
-    (error) => error.retryable || error.code,
-  );
-  return retryableError?.code || "private_reviewer_unavailable";
-}
-
-function retryBudgetForCode(code: string) {
-  return RETRY_BUDGETS[code] ?? 3;
-}
-
-function retryBackoffSecondsForCount(count: number) {
-  const index = Math.max(0, Math.min(count - 1, RETRY_BACKOFF_SECONDS.length - 1));
-  return RETRY_BACKOFF_SECONDS[index];
-}
-
-function normalizeRetryFingerprintPart(value: unknown, maxLength = 220) {
-  return String(value || "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .slice(0, maxLength);
-}
-
-function retryFingerprintForDecision(decision: GateDecision) {
-  const code = retryErrorCode(decision);
-  const sourceHash = decision.sourceEvidenceHash
-    ? `source:${decision.sourceEvidenceHash}`
-    : "";
-  const errorText =
-    decision.errors
-      ?.map((error) => `${error.code}:${error.message || ""}`)
-      .join("|") || "";
-  return [
-    code,
-    sourceHash,
-    normalizeRetryFingerprintPart(errorText || decision.summary),
-  ]
-    .filter(Boolean)
-    .join(":");
-}
-
-function retryStateForDecision(
-  existing: Record<string, unknown> | null,
-  target: ReviewTarget,
-  decision: GateDecision,
-) {
-  const code = retryErrorCode(decision);
-  const fingerprint = retryFingerprintForDecision(decision);
-  const previousSameFingerprint =
-    String(existing?.headSha || "") === String(target.headSha || "") &&
-    String(existing?.lastErrorCode || "") === code &&
-    String(existing?.lastRetryFingerprint || "") === fingerprint;
-  const previousCount = previousSameFingerprint
-    ? Number(existing?.retryFingerprintCount || 0)
-    : 0;
-  const count =
-    Number.isFinite(previousCount) && previousCount > 0
-      ? previousCount + 1
-      : 1;
-  const maxAttempts = retryBudgetForCode(code);
-  const nextReviewAt = isoAfter(retryBackoffSecondsForCount(count));
-  return {
-    code,
-    fingerprint,
-    count,
-    maxAttempts,
-    nextReviewAt,
-    exhausted: count > maxAttempts,
-  };
-}
-
-function retryExhaustedDecision(
-  decision: GateDecision,
-  retryState: ReturnType<typeof retryStateForDecision>,
-): GateDecision {
-  const exhaustedSummary = [
-    "Summary:",
-    `- Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
-    "- This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
-    `- Last retry reason: ${decision.summary.trim()}`,
-    "",
-    "Recommended Action:",
-    "- A maintainer can recheck after the external service recovers, merge manually if review confirms no blocker, or close if review finds a real content issue.",
-  ].join("\n");
-  return {
-    verdict: "manual",
-    labels: [LABELS.manual],
-    confidence: decision.confidence,
-    sourceEvidenceHash: decision.sourceEvidenceHash,
-    summary: exhaustedSummary,
-    errors: [
-      {
-        code: retryState.code,
-        retryable: false,
-        message: `Retry budget exhausted after ${retryState.maxAttempts} automatic attempt(s).`,
-      },
-    ],
-    sections: [
-      {
-        id: "summary",
-        title: "Summary",
-        status: "warn",
-        bullets: [
-          `Automation stopped after ${retryState.maxAttempts} retry attempt(s) for \`${retryState.code}\`.`,
-          "This is not a content rejection; the gate could not complete an infrastructure-dependent check.",
-          `Last retry reason: ${decision.summary.trim()}`,
-        ],
-      },
-      {
-        id: "recommended_action",
-        title: "Recommended Action",
-        status: "warn",
-        bullets: [
-          "Recheck after the external service recovers.",
-          "Merge manually if maintainer review confirms no blocker.",
-          "Close only if manual review finds a real content issue.",
-        ],
-      },
-      ...(decision.sections || []),
-    ],
-    retryState,
-  } as GateDecision & { retryState: ReturnType<typeof retryStateForDecision> };
-}
-
-function retryExhaustedStorageMetadata(decision: GateDecision) {
-  const retryState = (
-    decision as GateDecision & {
-      retryState?: ReturnType<typeof retryStateForDecision>;
-    }
-  ).retryState;
-  if (!retryState?.exhausted) return {};
-  return {
-    lastError: truncateForQueue(decision.summary),
-    lastErrorCode: retryState.code,
-    lastRetryFingerprint: retryState.fingerprint,
-    retryFingerprintCount: retryState.maxAttempts,
-    retryExhaustedAt: nowIso(),
-    retryExhaustedReason: truncateForQueue(decision.summary),
-  };
-}
-
-function sourceEvidenceConflictDecision(
-  decision: GateDecision,
-  sourceEvidence: SourceEvidenceReport,
-) {
-  const conflict = privateReviewErrorDecision(
-    "Private review claimed source_hard_failure, but deterministic source evidence found the submitted source URLs reachable.",
-    "source_evidence_conflict",
-  );
-  return {
-    ...conflict,
-    confidence: decision.confidence,
-    sourceEvidenceHash: sourceEvidence.hash,
-    sections: [
-      {
-        id: "source_review",
-        title: "Source Review",
-        status: "warn" as const,
-        bullets: [
-          "Private review reported a source URL reachability failure that conflicts with deterministic source evidence.",
-          sourceEvidenceSummary(sourceEvidence),
-          "The gate will retry with the deterministic source artifact before requiring manual review if the conflict persists.",
-        ],
-      },
-    ],
-  };
-}
-
-function sourceEvidenceConflictExhaustedDecision(
-  decision: GateDecision,
-  sourceEvidence: SourceEvidenceReport,
-): GateDecision {
-  return {
-    schemaVersion: 2,
-    verdict: "manual",
-    confidence: decision.confidence,
-    sourceEvidenceHash: sourceEvidence.hash,
-    labels: [LABELS.manual],
-    summary: [
-      "Summary:",
-      "- Public validation and deterministic source evidence passed.",
-      "- Private review repeatedly returned a source_hard_failure for URL reachability that conflicts with deterministic source evidence.",
-      "- Automation will not override the private close into a merge; a maintainer must review the source evidence conflict.",
-      "",
-      "Source Review:",
-      `- ${sourceEvidenceSummary(sourceEvidence)}`,
-      "",
-      "Recommended Action:",
-      "- Review this source evidence conflict manually before deciding whether to merge or close the PR.",
-    ].join("\n"),
-    sections: [
-      {
-        id: "source_review",
-        title: "Source Review",
-        status: "warn",
-        bullets: [
-          "Deterministic source evidence found submitted source URLs reachable, but private review repeatedly reported a source reachability hard failure.",
-          sourceEvidenceSummary(sourceEvidence),
-        ],
-      },
-      {
-        id: "recommended_action",
-        title: "Recommended Action",
-        status: "info",
-        bullets: [
-          "Review this source evidence conflict manually before deciding whether to merge or close the PR.",
-        ],
-      },
-    ],
-  };
-}
-
-function duplicateReviewSummaryLine(duplicateReview: ContentDuplicateReview) {
-  const relatedCount = duplicateReview.relatedCandidates.length;
-  return duplicateReview.strictDuplicate
-    ? `strict duplicate: ${
-        duplicateReview.strictDuplicate.existing.label ||
-        duplicateReview.strictDuplicate.existing.filePath
-      }`
-    : `no strict duplicate${
-        relatedCount ? `; ${relatedCount} related candidate(s)` : ""
-      }`;
-}
-
-function duplicateEvidenceConflictDecision(
-  decision: GateDecision,
-  duplicateReview: ContentDuplicateReview,
-) {
-  const conflict = privateReviewErrorDecision(
-    "Private review claimed strict_duplicate, but deterministic duplicate review found no strict duplicate.",
-    "duplicate_evidence_conflict",
-  );
-  return {
-    ...conflict,
-    confidence: decision.confidence,
-    sections: [
-      {
-        id: "duplicate_history",
-        title: "Duplicate and History Review",
-        status: "warn" as const,
-        bullets: [
-          "Private review reported a strict duplicate that conflicts with deterministic duplicate review.",
-          duplicateReviewSummaryLine(duplicateReview),
-          "The gate will retry with the deterministic duplicate artifact before falling back to manual review.",
-        ],
-      },
-    ],
-  };
-}
-
-function duplicateEvidenceConflictExhaustedDecision(
-  decision: GateDecision,
-  duplicateReview: ContentDuplicateReview,
-  sourceEvidence: SourceEvidenceReport | null,
-): GateDecision {
-  return duplicateEvidenceContractExhaustedDecision({
-    decision,
-    duplicateSummary: duplicateReviewSummaryLine(duplicateReview),
-    sourceSummary: sourceEvidence ? sourceEvidenceSummary(sourceEvidence) : null,
-  });
-}
-
-function sourceEvidenceUrlCandidates(evidence: GateDecisionEvidence) {
-  return [
-    evidence.url,
-    evidence.matchedUrl,
-    evidence.finalUrl,
-    evidence.source,
-  ].filter((value): value is string => Boolean(value));
-}
-
-function privateEvidenceClaimsDeadSourceUrl(evidence: GateDecisionEvidence) {
-  const httpStatus = Number(evidence.httpStatus || evidence.status || 0);
-  if ([404, 410].includes(httpStatus)) return true;
-  const text = [
-    evidence.ruleId,
-    evidence.outcome,
-    evidence.status,
-    evidence.behavior,
-    evidence.policy,
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return (
-    text.includes("source_url_reachability") ||
-    /\b(?:404|410)\b/.test(text) ||
-    /\b(?:dead|broken|unreachable|not found|hard[-_ ]failure)\b/.test(text)
-  );
-}
-
-function privateEvidenceMatchesReachableSourceUrl(
-  evidence: GateDecisionEvidence,
-  sourceEvidence: SourceEvidenceReport,
-) {
-  const candidates = sourceEvidenceUrlCandidates(evidence);
-  if (!candidates.length) return false;
-  return sourceEvidence.urls.some((item) => {
-    if (item.status !== "passed" || item.outcome !== "reachable") return false;
-    return candidates.some(
-      (url) => url === item.url || (item.finalUrl && url === item.finalUrl),
-    );
-  });
-}
-
-function privateSourceHardFailureContradicted(
-  decision: GateDecision,
-  sourceEvidence: SourceEvidenceReport | null,
-) {
-  if (
-    decision.verdict !== "close" ||
-    decision.reasonCode !== "source_hard_failure" ||
-    sourceEvidence?.status !== "passed" ||
-    !sourceEvidence.urls.length
-  ) {
-    return false;
-  }
-  return (decision.evidence || []).some(
-    (item) =>
-      privateEvidenceClaimsDeadSourceUrl(item) &&
-      privateEvidenceMatchesReachableSourceUrl(item, sourceEvidence),
-  );
-}
-
-function privateStrictDuplicateContradicted(
-  decision: GateDecision,
-  duplicateReview: ContentDuplicateReview | null,
-) {
-  return (
-    decision.verdict === "close" &&
-    decision.reasonCode === "strict_duplicate" &&
-    Boolean(duplicateReview) &&
-    !duplicateReview?.strictDuplicate
-  );
-}
-
-function duplicateConflictRetryableContradicted(
-  decision: GateDecision,
-  duplicateReview: ContentDuplicateReview | null,
-) {
-  return (
-    hasPrivateReviewErrorCode(decision, "duplicate_evidence_conflict") &&
-    Boolean(duplicateReview) &&
-    !duplicateReview?.strictDuplicate
-  );
 }
 
 function allowedCorsOrigins(env: Env) {
@@ -1782,9 +1188,7 @@ async function issueLabelNames(params: {
   try {
     const labels = await listIssueLabels(params);
     return new Set(
-      labels
-        .map((label) => String(label.name || "").trim())
-        .filter(Boolean),
+      labels.map((label) => String(label.name || "").trim()).filter(Boolean),
     );
   } catch (error) {
     console.warn("submission gate could not read issue labels", {
@@ -1900,10 +1304,7 @@ async function ignoreOutOfScopeReviewTarget(params: {
 function isRetryableMergeError(error: unknown) {
   if (isTimeoutError(error) || isGitHubRateLimitError(error)) return true;
   if (error instanceof GitHubApiError) {
-    return (
-      error.status === 429 ||
-      (error.status >= 500 && error.status <= 599)
-    );
+    return error.status === 429 || (error.status >= 500 && error.status <= 599);
   }
   const message = error instanceof Error ? error.message : String(error || "");
   return /required status check|required approving review|not mergeable|merge conflict|base branch was modified|head branch was modified|sha does not match|review_required|status check/i.test(

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -53,10 +53,20 @@ import {
 import { repoRoot } from "./helpers/registry-fixtures";
 
 function readWorkerSource() {
-  return fs.readFileSync(
-    path.join(repoRoot, "apps/submission-gate/src/index.ts"),
-    "utf8",
-  );
+  // The orchestrator was split: pure decision/retry helpers now live in
+  // decisions.ts and are re-imported into index.ts. Concatenate both files so
+  // source-pinned assertions keep matching regardless of which file a symbol
+  // (function, constant, or call site) now lives in.
+  return [
+    fs.readFileSync(
+      path.join(repoRoot, "apps/submission-gate/src/index.ts"),
+      "utf8",
+    ),
+    fs.readFileSync(
+      path.join(repoRoot, "apps/submission-gate/src/decisions.ts"),
+      "utf8",
+    ),
+  ].join("\n");
 }
 
 function readReviewSource() {
@@ -480,7 +490,9 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("privateStrictDuplicateContradicted(");
     expect(source).toContain("duplicateEvidenceConflictExhaustedDecision(");
     expect(source).toContain("duplicateEvidenceContractExhaustedDecision(");
-    expect(readReviewSource()).toContain("duplicate_evidence_contract_exhausted");
+    expect(readReviewSource()).toContain(
+      "duplicate_evidence_contract_exhausted",
+    );
     expect(source).not.toContain("duplicateEvidenceConflictMergeDecision(");
     expect(source).toContain("privateEvidenceClaimsDeadSourceUrl(");
     expect(source).toContain("privateEvidenceMatchesReachableSourceUrl(");
@@ -846,14 +858,12 @@ documentationUrl: "https://example.com/docs"
 packageUrl: "https://hub.docker.com/r/example/project"
 ---
 `,
-      vi
-        .fn<typeof fetch>()
-        .mockImplementation(async (url) => {
-          const hostname = new URL(String(url)).hostname;
-          return new Response(null, {
-            status: hostname === "hub.docker.com" ? 429 : 200,
-          });
-        }),
+      vi.fn<typeof fetch>().mockImplementation(async (url) => {
+        const hostname = new URL(String(url)).hostname;
+        return new Response(null, {
+          status: hostname === "hub.docker.com" ? 429 : 200,
+        });
+      }),
     );
 
     expect(report.status).toBe("passed");


### PR DESCRIPTION
## What

Extracts the cohesive cluster of **pure decision/retry helper functions** out of the 5,137-line `apps/submission-gate/src/index.ts` into a new leaf module `apps/submission-gate/src/decisions.ts`, then imports them back. `index.ts` shrinks from **5,137 → 4,543 lines** (-594) with **no behavior change**.

Moved (pure, side-effect-free only):
- Decision shaping: `decisionStatus`, `gateCheckStatus`, `checksForDecision`, `decisionWithReviewContext`, `decisionMetadata`
- Scheduling/retry: `nextReviewForStatus`, `nextReviewForError`, `retryDelayForError`, `retryDelayForMergeError`, `isTimeoutError`, `retryablePrecheckDecision`, `retryableTargetErrorDecision`, `retryableValidationReadDecision`, `normalizeOneShotDecision`
- Retry bookkeeping: `retryErrorCode`, `retryBudgetForCode`, `retryBackoffSecondsForCount`, `normalizeRetryFingerprintPart`, `retryFingerprintForDecision`, `retryStateForDecision`, `retryExhaustedDecision`, `retryExhaustedStorageMetadata`, `hasPrivateReviewErrorCode`
- Evidence-conflict / contradiction: `sourceEvidenceConflictDecision`, `sourceEvidenceConflictExhaustedDecision`, `duplicateReviewSummaryLine`, `duplicateEvidenceConflictDecision`, `duplicateEvidenceConflictExhaustedDecision`, `sourceEvidenceUrlCandidates`, `privateEvidenceClaimsDeadSourceUrl`, `privateEvidenceMatchesReachableSourceUrl`, `privateSourceHardFailureContradicted`, `privateStrictDuplicateContradicted`, `duplicateConflictRetryableContradicted`
- Supporting `RETRY_BACKOFF_SECONDS` / `RETRY_BUDGETS` + timing constants, the `SourceEvidenceRetryableError` data class, the `isoAfter`/`isoBefore`/`nowIso`/`truncateForQueue` pure helpers, and the `ReviewTarget` / `DirectContentScope` types they share.

All route handlers, the `fetch` handler, the queue consumer, the scheduled sweep, and **everything that reads `env`/bindings stay in `index.ts`**.

## Why

`index.ts` is the largest file in the gate; #2262 asks to reduce it without behavior change by extracting one well-bounded cluster. `decisions.ts` is a leaf module — it imports only from sibling leaf modules (`constants`/`review`/`github`/`duplicates`/`source-evidence`) and **never from `index.ts`**, so there is no import cycle. As a side effect this fixes a latent unimported-type reference: the moved evidence helpers now correctly import `GateDecisionEvidence` from `./review` (previously used unqualified in `index.ts`).

## Source-pinned tests

`tests/submission-gate-worker.test.ts`, `private-reviewer-boundary`, `classify-pr-changes`, and `cleanup-policy` read `index.ts` and assert `source.toContain(...)` on these symbols. To keep every pin valid after the move, `readWorkerSource()` now returns the **concatenation of `index.ts` + `decisions.ts`**, so each existing assertion still matches regardless of which file the symbol lives in. No assertion was deleted or weakened. (The other three suites pin only symbols that stayed in `index.ts`, so they were already green.)

## Validation

- `pnpm type-check` — clean. Direct `tsc` over the gate shows a strictly smaller error set than `main` (only the pre-existing latent `GateDecisionEvidence` error is now gone; all other diagnostics are pre-existing lib-config noise, identical on both sides).
- `pnpm exec vitest run tests/submission-gate-worker.test.ts tests/private-reviewer-boundary.test.ts tests/classify-pr-changes.test.ts tests/cleanup-policy.test.ts tests/api-router-security.test.ts` — **139 passed** (same as baseline).
- `pnpm exec vitest run tests/submission-pr-first.test.ts` — 25 passed.
- `prettier --check` — clean. `git diff --check` — clean.

Pure, behavior-preserving refactor.

Closes #2262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry orchestration with configurable budgets and backoff strategies for submission processing.
  * Implemented conflict detection for source and duplicate evidence scenarios.
  * Enhanced decision metadata generation with timestamp tracking.

* **Refactor**
  * Consolidated decision-making utilities into a dedicated module for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->