### PR TITLE
fix(security): resolve 2 CodeQL high alerts (incomplete sanitization + ReDoS)

### DIFF
--- a/packages/registry/src/source-repo.js
+++ b/packages/registry/src/source-repo.js
@@ -39,15 +39,15 @@ const RESERVED_OWNERS = new Set([
 // Strip a single leading "www." so the www alias resolves to the bare host,
 // while other subdomains (gist., api., raw.) stay distinct and get rejected.
 function normalizeHost(host) {
-  return String(host).toLowerCase().replace(/^www\./, "");
+  return String(host)
+    .toLowerCase()
+    .replace(/^www\./, "");
 }
 
 // Pull "owner" and "repo" from the first two non-empty path segments, dropping a
 // trailing ".git". Deep paths (tree/blob/issues) keep their owner/repo prefix.
 function ownerRepoFromPath(pathname) {
-  const parts = String(pathname)
-    .split("/")
-    .filter(Boolean);
+  const parts = String(pathname).split("/").filter(Boolean);
   if (parts.length < 2) return null;
   return { owner: parts[0], repo: parts[1].replace(/\.git$/i, "") };
 }

--- a/packages/registry/src/source-repo.js
+++ b/packages/registry/src/source-repo.js
@@ -57,8 +57,10 @@ function ownerRepoFromPath(pathname) {
 function fromScpLike(value) {
   const match = /^[^/@\s]+@([^:/\s]+):(.+)$/.exec(value);
   if (!match) return null;
-  const rest = match[2].replace(/\/+$/, "");
-  const segments = rest.split("/").filter(Boolean);
+  // No trailing-slash regex: split("/").filter(Boolean) already drops empty
+  // segments from trailing slashes, so we avoid the polynomial /\/+$/ scan
+  // (CodeQL js/polynomial-redos) entirely.
+  const segments = match[2].split("/").filter(Boolean);
   if (segments.length < 2) return null;
   return {
     host: normalizeHost(match[1]),

--- a/scripts/report-thin-content.mjs
+++ b/scripts/report-thin-content.mjs
@@ -397,7 +397,8 @@ const summary = {
 const limit = (list) => (top > 0 ? list.slice(0, top) : list);
 // Escape backslashes first, then pipes, so a literal "\" in the text can't
 // combine with the inserted escape (CodeQL js/incomplete-sanitization).
-const escapePipes = (text) => String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+const escapePipes = (text) =>
+  String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 const truncate = (text, max = 140) => {
   const value = collapseWhitespace(text);
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;

--- a/scripts/report-thin-content.mjs
+++ b/scripts/report-thin-content.mjs
@@ -395,7 +395,9 @@ const summary = {
 // --- output ---
 
 const limit = (list) => (top > 0 ? list.slice(0, top) : list);
-const escapePipes = (text) => String(text).replace(/\|/g, "\\|");
+// Escape backslashes first, then pipes, so a literal "\" in the text can't
+// combine with the inserted escape (CodeQL js/incomplete-sanitization).
+const escapePipes = (text) => String(text).replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 const truncate = (text, max = 140) => {
   const value = collapseWhitespace(text);
   return value.length > max ? `${value.slice(0, max - 1)}…` : value;


### PR DESCRIPTION
Resolves the 2 open CodeQL **high** code-scanning alerts.

### #343 `js/incomplete-sanitization` — `scripts/report-thin-content.mjs:398`
`escapePipes` escaped `|` → `\|` but did not escape backslashes first, so a literal `\` in the input could combine with the inserted escape. Now escapes `\` → `\\` first, then `|`.

### #339 `js/polynomial-redos` — `packages/registry/src/source-repo.js:60`
`fromScpLike` stripped trailing slashes with `/\/+$/` — unanchored start + quantifier + end-anchor → **O(n²)** on strings with many `/`. **Removed the regex**: the next line's `split("/").filter(Boolean)` already drops empty trailing segments, so the change is behavior-preserving.

## Validation
- `tests/source-repo.test.ts` + `tests/source-repo-signals.test.ts` pass; scp/trailing-slash parsing unchanged.
- `escapePipes('a|b\\c')` → `a\|b\\\\c` (complete escaping); thin-content markdown renders fine.
- `pnpm type-check` clean; prettier clean.

CodeQL will re-scan on this PR and should clear both alerts.