### PR TITLE
ci(deploy): versions:upload script to fix CF preview builds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "predeploy": "pnpm run generate:artifacts",
     "predeploy:dev": "pnpm run generate:artifacts",
     "predeploy:prod": "pnpm run generate:artifacts",
+    "preversions:upload": "pnpm run generate:artifacts",
     "dev": "vite dev",
     "build": "vite build",
     "type-check": "tsc --noEmit",
@@ -24,7 +25,8 @@
     "preview": "vite build && wrangler dev --config wrangler.jsonc",
     "deploy": "pnpm run deploy:prod",
     "deploy:dev": "vite build && wrangler deploy --config wrangler.jsonc --env dev",
-    "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\""
+    "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\"",
+    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env \"\""
   },
   "dependencies": {
     "@heyclaude/mcp": "workspace:*",


### PR DESCRIPTION
Fixes the failing Cloudflare Workers Builds **preview** builds (non-production branches).

## Root cause
CF Workers Builds runs two commands:
- **Deploy command** (main): `pnpm --filter web run deploy:prod` ✅ correct — prod is current (verified `/state-of-claude-tooling`, OG PNG, badge route all live).
- **Version command** (preview branches): `npx wrangler versions upload` ❌ — runs from repo root, **no build**, no `--config`, so `dist/` doesn't exist and there's no `wrangler.jsonc` at root → "Missing entry-point". Even from `apps/web` the Nitro redirect config rejects the `env.dev` block; `--config wrangler.jsonc` bypasses it (dry-run verified).

## This PR
Adds a version-controlled `versions:upload` script (apps/web) that mirrors the working `deploy:prod` — `vite build && wrangler versions upload --config wrangler.jsonc --env ""` plus a `preversions:upload` artifact-gen hook.

## Action required (dashboard — I can't change CF settings)
In **Workers Builds → Build configuration**, change the **Version command** from `npx wrangler versions upload` to:
```
pnpm --filter web run versions:upload
```
Leave Build command = None and Deploy command = `pnpm --filter web run deploy:prod` (both already correct). Then retry a preview build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added npm lifecycle scripts to support Cloudflare Wrangler version uploads during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->