### PR TITLE
content(guides): add Communications Kit For Claude Code Launch Campaigns

### DIFF
--- a/content/guides/communications-kit-for-claude-code-launch-campaigns.mdx
+++ b/content/guides/communications-kit-for-claude-code-launch-campaigns.mdx
@@ -1,0 +1,154 @@
+---
+title: Communications Kit for Claude Code Launch Campaigns
+slug: communications-kit-for-claude-code-launch-campaigns
+category: guides
+description: >-
+  Use the Claude Code communications kit for launch campaigns: message calendar,
+  stakeholder templates, FAQ handling, and aligning announcements with champion rollout.
+cardDescription: Plan internal launch communications for Claude Code using the communications kit.
+seoTitle: Communications Kit for Claude Code Launch Campaigns
+seoDescription: >-
+  Use the Claude Code communications kit for launch campaigns: message calendar,
+  stakeholder templates, FAQ handling, and aligning announcements with champion rollout.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 1447
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1447"
+documentationUrl: "https://code.claude.com/docs/en/communications-kit"
+usageSnippet: >-
+  Use this guide to plan internal Claude Code launch announcements with the official
+  communications kit templates and timeline.
+prerequisites:
+  - Access to communications kit templates and approved brand/voice guidelines.
+  - Launch date aligned with champion pilot readiness—not before permissions work.
+  - Stakeholder map: executives, managers, IC engineers, security, legal, IT helpdesk.
+  - FAQ owners for permissions, costs, data retention, and support paths.
+safetyNotes:
+  - Do not promise capabilities your enterprise deployment has disabled via managed settings.
+  - Security and legal must review external-facing announcements before publication.
+  - Avoid implying Claude Code replaces code review or testing obligations.
+privacyNotes:
+  - Launch emails should link to internal privacy and monitoring policies, not only product marketing.
+  - Screenshots in announcements must use sanitized repositories and redacted terminals.
+  - Collect FAQ questions internally without forwarding customer-identifiable Slack threads to public lists.
+sourceUrls:
+  - "https://code.claude.com/docs/en/communications-kit"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+  - "https://github.com/anthropics/claude-code"
+tags:
+  - claude-code
+  - communications
+  - launch
+  - rollout
+  - enterprise
+keywords:
+  - Claude Code communications kit
+  - internal launch campaign
+  - Claude Code announcement
+  - engineering comms rollout
+  - AI tool launch communications
+readingTime: 8
+difficultyScore: 44
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## TL;DR
+
+Launch campaigns fail when announcements run ahead of working permissions. Use
+the communications kit to sequence pre-launch teasers, go-live instructions,
+manager talking points, and FAQ updates—aligned with champion kit timing and
+verified enterprise settings.
+
+## Prerequisites & Requirements
+
+- [ ] {"task": "Templates imported", "description": "Communications kit assets are customized with org names and links"}
+- [ ] {"task": "Message calendar drafted", "description": "Pre-launch, launch day, and week-one reminders are scheduled"}
+- [ ] {"task": "Legal/security review scheduled", "description": "Wide send waits on approved messaging"}
+- [ ] {"task": "Champion timing aligned", "description": "Announcement date matches pilot support coverage"}
+- [ ] {"task": "FAQ owners assigned", "description": "Permissions, costs, ZDR, and MCP questions have named responders"}
+
+## Core Concepts Explained
+
+### Comms timing follows readiness
+
+Announce when SSO, proxy, plugins, and support channels work—not when procurement
+closes alone.
+
+### Audiences need different messages
+
+Executives want outcomes; managers want team guidance; ICs want setup steps and
+safe examples.
+
+### FAQs reduce helpdesk load
+
+Pre-write answers on data retention, costs, approved use cases, and escalation.
+
+### Campaigns are multi-channel
+
+Email, Slack, town halls, and wiki pages reinforce the same facts without
+contradiction.
+
+## Step-by-Step Workflow
+
+1. **Import communications kit templates.** Customize with org names and links.
+
+2. **Build message calendar.** Pre-launch, launch day, week-one reminder, office
+   hours promo.
+
+3. **Draft audience variants.** Executive summary, manager brief, IC setup guide.
+
+4. **Route security/legal review.** Complete before wide send.
+
+5. **Coordinate with champions.** Align announcement date with pilot support coverage.
+
+6. **Publish FAQ internally.** Cover permissions, costs, ZDR, and MCP policy.
+
+7. **Launch across channels.** Send email, pin Slack post, update internal wiki.
+
+8. **Measure questions.** Feed recurring FAQ gaps back into kit updates and settings fixes.
+
+## Launch Message Calendar
+
+| Timing | Channel | Content |
+| ------ | ------- | ------- |
+| T-7 days | Slack teaser | What is coming, not how to install yet |
+| Launch day | Email + wiki | Setup steps, support links, FAQ |
+| T+7 days | Slack reminder | Office hours, champion contacts |
+
+## Troubleshooting
+
+### Helpdesk flooded after launch
+
+Add troubleshooting links, record setup clinic, and pause expansion until blockers drop.
+
+### Managers share contradictory guidance
+
+Centralize talking points doc with version date and owner.
+
+### Employees cite outdated blog posts
+
+Link official code.claude.com docs in every template footer.
+
+### External press interest appears early
+
+Route through comms and legal; do not improvise enterprise claims.
+
+## Duplicate Check
+
+This guide complements champion-kit-rollout-for-internal-claude-code-adoption.mdx,
+which covers champion program operations. This entry covers announcement timing
+and communications kit assets.
+
+## References
+
+- Claude Code communications kit - https://code.claude.com/docs/en/communications-kit
+- Champion kit - https://code.claude.com/docs/en/champion-kit
+- Zero data retention - https://code.claude.com/docs/en/zero-data-retention


### PR DESCRIPTION
## Summary
- Adds a guide for communications kit planning during Claude Code launch campaigns
- Covers stakeholder messaging, rollout timelines, and FAQ templates
- Helps platform teams communicate Claude Code adoption internally

Closes #1447

## Test plan
- [x] `pnpm validate:content -- content/guides/communications-kit-for-claude-code-launch-campaigns.mdx`
- [x] Guide includes prerequisites, safety notes, troubleshooting, and duplicate check
- [x] Source URLs reference official Claude Code communications-kit documentation

Made with [Cursor](https://cursor.com)