### PR TITLE
content(guides): add Team Cost Governance For Claude Code Usage

### DIFF
--- a/content/guides/team-cost-governance-for-claude-code-usage.mdx
+++ b/content/guides/team-cost-governance-for-claude-code-usage.mdx
@@ -1,0 +1,172 @@
+---
+title: Team Cost Governance for Claude Code Usage
+slug: team-cost-governance-for-claude-code-usage
+category: guides
+description: >-
+  Team cost governance for Claude Code: budgets, model selection policy, prompt
+  caching awareness, anomaly review, and communicating spend with engineering leads.
+cardDescription: Establish cost governance policies for Claude Code team usage and budgets.
+seoTitle: Team Cost Governance for Claude Code Usage
+seoDescription: >-
+  Team cost governance for Claude Code: budgets, model selection policy, prompt
+  caching awareness, anomaly review, and communicating spend with engineering leads.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 1445
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1445"
+documentationUrl: "https://github.com/anthropics/claude-code"
+usageSnippet: >-
+  Use this guide to define Claude Code spend policies, review anomalies, and align
+  model selection with team budgets.
+prerequisites:
+  - Access to Claude Code cost or usage reporting for your organization.
+  - Baseline spend from a pilot cohort or pre-rollout month.
+  - Defined owners for finance review, platform engineering, and team lead escalation.
+  - Documented model tiers and when premium models are approved.
+safetyNotes:
+  - Cost caps should not push teams toward disabling security controls or skipping review to save tokens.
+  - Investigate anomalies before blaming individuals—misconfigured MCP loops can spike spend team-wide.
+  - Premium model access for incidents should have a documented break-glass path.
+privacyNotes:
+  - Cost reports may expose per-user usage; treat exports like HR-sensitive operational data.
+  - Do not paste customer content into prompts to debug cost spikes in shared tickets.
+  - Aggregate spend reviews in leadership meetings unless investigating a specific approved incident.
+sourceUrls:
+  - "https://github.com/anthropics/claude-code"
+  - "https://code.claude.com/docs/en/costs"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+tags:
+  - claude-code
+  - costs
+  - governance
+  - teams
+  - budgets
+keywords:
+  - Claude Code cost governance
+  - team usage budgets Claude Code
+  - Claude Code spend policy
+  - model selection cost policy
+  - Claude Code costs team
+readingTime: 8
+difficultyScore: 52
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## TL;DR
+
+Cost governance sets budgets, model policies, and review cadences before spend
+surprises arrive. Use official costs documentation, monitor anomalies, coach
+teams on prompt caching and scope discipline, and escalate structural
+issues—runaway MCP tools, missing compaction—not only individual overuse.
+
+## Prerequisites & Requirements
+
+- [ ] {"task": "Cost meters understood", "description": "Official costs documentation is reviewed for your plan"}
+- [ ] {"task": "Budget owners named", "description": "Finance and platform leads approve caps and alerts"}
+- [ ] {"task": "Model policy published", "description": "Default and premium model rules are written"}
+- [ ] {"task": "Baseline spend recorded", "description": "Pilot or pre-rollout month establishes comparison point"}
+- [ ] {"task": "Anomaly playbook ready", "description": "MCP loops and cache invalidation checks are documented"}
+
+## Core Concepts Explained
+
+### Spend is multi-dimensional
+
+Model choice, session length, MCP tool surface, and cache behavior all affect
+cost more than small wording tweaks.
+
+### Policy beats policing
+
+Clear defaults—when to use standard vs premium models—reduce ad-hoc expensive
+habits.
+
+### Anomalies have technical causes
+
+Infinite tool loops, huge pasted logs, and unbounded subagent fan-out show up as
+spikes before cultural issues do.
+
+### Finance and engineering share ownership
+
+Platform sets guardrails; team leads enforce task-scoping habits.
+
+## Step-by-Step Implementation Guide
+
+1. **Read costs documentation.** Understand meters available to your plan.
+
+2. **Set team budgets.** Monthly or quarterly caps with alert thresholds.
+
+3. **Publish model policy.** Define default model, premium approval path, and
+   incident exceptions.
+
+4. **Enable alerts.** Configure notifications before hard caps where supported.
+
+5. **Review weekly during rollout.** Flag teams exceeding baseline by agreed margin.
+
+6. **Coach on caching and scope.** Link to prompt caching troubleshooting when
+   prefixes churn unnecessarily.
+
+7. **Investigate anomalies.** Check MCP configs, hooks, and runaway sessions.
+
+8. **Report trends to leadership.** Show aggregate spend vs budget and drivers.
+
+## Cost Governance Policy Starters
+
+| Policy area | Example rule |
+| ----------- | ------------ |
+| Default model | Standard tier for daily coding |
+| Premium model | Requires incident ticket or lead approval |
+| MCP surface | Pre-approved servers only in production repos |
+| Log pastes | Paste stack traces, not full production logs |
+
+## Troubleshooting
+
+### One project dominates spend
+
+Look for CI automation, large log pastes, or always-on premium model defaults.
+
+### Budget alerts fire during legitimate incident
+
+Use documented break-glass premium access and post-incident review.
+
+### Teams cannot interpret cost dashboard
+
+Pair metrics review with champion office hours and written glossary.
+
+### Spend dropped after policy change
+
+Verify users did not disable Claude Code entirely due to confusing caps.
+
+## Source Verification Notes
+
+Verified against the public `anthropics/claude-code` repository README,
+`plugins/README.md`, and `CHANGELOG.md` on **2026-06-14**:
+
+- `CHANGELOG.md` documents `/usage` per-category breakdown of limits usage,
+  including skills, subagents, plugins, and per-MCP-server cost.
+- `CHANGELOG.md` records fast mode on Opus 4.8 at 2x the standard rate for 2.5x
+  speed, relevant for team cost forecasting.
+- `CHANGELOG.md` documents VSCode usage attribution showing cache misses, long
+  context, subagents, and plugin/MCP breakdowns.
+- The root README links to Commercial Terms of Service and data usage policies
+  governing billing and retention for enterprise accounts.
+- `CHANGELOG.md` records automatic compaction when 1M-context sessions exceed
+  credit limits, preventing runaway context-related spend.
+
+## Duplicate Check
+
+This guide complements prompt-caching-troubleshooting-in-claude-code.mdx and
+usage-analytics-for-claude-code-team-rollout.mdx by focusing on spend policy and
+governance.
+
+## References
+
+- Claude Code costs - https://code.claude.com/docs/en/costs
+- Prompt caching - https://code.claude.com/docs/en/prompt-caching
+- Analytics - https://code.claude.com/docs/en/analytics


### PR DESCRIPTION
## Summary
- Adds a guide for team cost governance for Claude Code usage
- Source-backed with verification notes from anthropics/claude-code repository

Closes #1445

## Test plan
- [x] `pnpm validate:content -- content/guides/team-cost-governance-for-claude-code-usage.mdx`
- [x] Guide includes Source Verification Notes and duplicate check
- [x] documentationUrl points to https://github.com/anthropics/claude-code

Made with [Cursor](https://cursor.com)