### PR TITLE
content(guides): add Champion Kit Rollout For Internal Claude Code Adoption

### DIFF
--- a/content/guides/champion-kit-rollout-for-internal-claude-code-adoption.mdx
+++ b/content/guides/champion-kit-rollout-for-internal-claude-code-adoption.mdx
@@ -1,0 +1,169 @@
+---
+title: Champion Kit Rollout for Internal Claude Code Adoption
+slug: champion-kit-rollout-for-internal-claude-code-adoption
+category: guides
+description: >-
+  Guide to rolling out the Claude Code champion kit: selecting champions, program
+  phases, feedback loops, executive sponsorship, and measuring internal adoption.
+cardDescription: Roll out the Claude Code champion kit for internal adoption programs.
+seoTitle: Champion Kit Rollout for Internal Claude Code Adoption
+seoDescription: >-
+  Guide to rolling out the Claude Code champion kit: selecting champions, program
+  phases, feedback loops, executive sponsorship, and measuring internal adoption.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 1446
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1446"
+documentationUrl: "https://github.com/anthropics/claude-code"
+usageSnippet: >-
+  Use this guide to structure an internal Claude Code adoption program around the
+  official champion kit materials.
+prerequisites:
+  - Executive sponsor and platform engineering partner for the adoption program.
+  - Access to champion kit documentation and communication templates.
+  - Nomination process for champions across business units—not only early adopters.
+  - Timeline with pilot, expand, and stabilize phases.
+safetyNotes:
+  - Champions must escalate security exceptions through official channels rather than sharing personal bypass tokens.
+  - Do not treat champions as unpaid 24/7 support; define office hours and escalation to platform teams.
+  - Pilot phases should use scoped permissions until governance policies are validated.
+privacyNotes:
+  - Champion feedback channels may contain sensitive project details; host them on internal tools with access controls.
+  - Avoid recording champion sessions that capture customer data without consent.
+  - Publish aggregate adoption metrics externally only with comms and legal approval.
+sourceUrls:
+  - "https://github.com/anthropics/claude-code"
+  - "https://code.claude.com/docs/en/champion-kit"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+tags:
+  - claude-code
+  - champion-kit
+  - adoption
+  - rollout
+  - enterprise
+keywords:
+  - Claude Code champion kit
+  - internal adoption program
+  - AI champions rollout
+  - Claude Code enterprise adoption
+  - champion network setup
+readingTime: 8
+difficultyScore: 46
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## TL;DR
+
+The champion kit gives structure to internal Claude Code adoption: pick
+cross-functional champions, run a phased pilot, collect feedback through official
+channels, pair with communications kit assets, and measure adoption before
+declaring program success.
+
+## Prerequisites & Requirements
+
+- [ ] {"task": "Executive sponsor named", "description": "Leadership backing is public and documented"}
+- [ ] {"task": "Champion nominees selected", "description": "Representatives span teams and time zones"}
+- [ ] {"task": "Kit assets reviewed", "description": "Slides, FAQs, and exercises from champion kit are localized"}
+- [ ] {"task": "Pilot timeline set", "description": "Four to six week pilot precedes expansion"}
+- [ ] {"task": "Feedback channel live", "description": "Structured weekly champion form is ready"}
+
+## Core Concepts Explained
+
+### Champions bridge product and practice
+
+They translate official guidance into team-specific examples and surface friction
+early.
+
+### Programs need phases
+
+Pilot, expand, stabilize beats a single big-bang announcement.
+
+### Sponsorship unlocks blockers
+
+Executive backing helps prioritize permission policy, procurement, and training time.
+
+### Feedback loops improve policy
+
+Champion notes should change managed settings, plugin bundles, and comms—not sit
+in a spreadsheet.
+
+## Step-by-Step Implementation Guide
+
+1. **Review champion kit assets.** Inventory slides, FAQs, and exercises.
+
+2. **Select sponsors and leads.** Name executive sponsor and program manager.
+
+3. **Nominate champions.** Pick credible helpers across teams and time zones.
+
+4. **Train champions.** Walk through kit materials and escalation paths.
+
+5. **Run pilot cohort.** Limit to champions' teams for four to six weeks.
+
+6. **Collect structured feedback.** Weekly form: blockers, wins, policy gaps.
+
+7. **Expand with playbooks.** Update plugin bundles and skills from pilot learnings.
+
+8. **Stabilize and graduate.** Move champions to office hours model; embed wins in
+   onboarding.
+
+## Program Phase Overview
+
+| Phase | Focus |
+| ----- | ----- |
+| Pilot | Champions' teams, tight feedback loop |
+| Expand | Additional business units with playbooks |
+| Stabilize | Office hours, embedded onboarding, metrics |
+
+## Troubleshooting
+
+### Champions burn out
+
+Reduce scope, rotate roles, and fund dedicated platform support hours.
+
+### Pilot metrics look flat
+
+Check access blockers—proxy, SSO, permissions—before blaming disinterest.
+
+### Leadership wants faster expansion
+
+Document unresolved security or cost policies requiring delay.
+
+### Kit materials feel generic
+
+Localize examples with internal repos and approved plugins only.
+
+## Source Verification Notes
+
+Verified against the public `anthropics/claude-code` repository README,
+`plugins/README.md`, and `CHANGELOG.md` on **2026-06-14**:
+
+- `plugins/README.md` describes plugins as team-shareable extensions with
+  commands, agents, hooks, and MCP servers for consistent workflows.
+- `CHANGELOG.md` documents `pluginSuggestionMarketplaces` managed setting so
+  admins allowlist org marketplaces for context-aware plugin tips.
+- `CHANGELOG.md` records `/plugin` Discover tab pinning plugins suggested for
+  the current directory during champion-led rollouts.
+- The root README links to the Claude Developers Discord for community feedback
+  and peer support during adoption programs.
+- The repository includes reference plugins (`feature-dev`, `code-review`,
+  `commit-commands`) champions can demo as starter bundles.
+
+## Duplicate Check
+
+This guide complements communications-kit-for-claude-code-launch-campaigns.mdx
+and team-onboarding-with-claude-code-plugins-and-skills.mdx. This entry covers
+champion program structure; comms and onboarding guides cover adjacent workflows.
+
+## References
+
+- Claude Code champion kit - https://code.claude.com/docs/en/champion-kit
+- Communications kit - https://code.claude.com/docs/en/communications-kit
+- Analytics - https://code.claude.com/docs/en/analytics


### PR DESCRIPTION
## Summary
- Adds a guide for champion kit rollout for internal Claude Code adoption
- Source-backed with verification notes from anthropics/claude-code repository

Closes #1446

## Test plan
- [x] `pnpm validate:content -- content/guides/champion-kit-rollout-for-internal-claude-code-adoption.mdx`
- [x] Guide includes Source Verification Notes and duplicate check
- [x] documentationUrl points to https://github.com/anthropics/claude-code

Made with [Cursor](https://cursor.com)