### PR TITLE
fix(deploy): isolate preview version uploads

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,7 +26,7 @@
     "deploy": "pnpm run deploy:prod",
     "deploy:dev": "vite build && wrangler deploy --config wrangler.jsonc --env dev",
     "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\"",
-    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env \"\""
+    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
   },
   "dependencies": {
     "@heyclaude/mcp": "workspace:*",


### PR DESCRIPTION
### Motivation
- Prevent preview/version uploads from targeting the top-level production Cloudflare Worker environment and thereby exposing production D1/datastore bindings and secrets.

### Description
- Update `apps/web/package.json` so the `versions:upload` script uses `wrangler versions upload --config wrangler.jsonc --env dev` (targeting the existing `dev` environment) instead of the empty top-level environment, while leaving `deploy:prod` behavior unchanged.

### Testing
- Ran `node -e "const p=require('./apps/web/package.json'); if(!p.scripts['versions:upload'].includes('--env dev')) process.exit(1); console.log(p.scripts['versions:upload'])"` which succeeded and ran `git diff --check` which passed, and an attempted `pnpm --filter web run versions:upload -- --dry-run` was blocked by pnpm supply-chain/attestation network retries in this environment so the `wrangler` dry-run could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e808762bc832a8e347ca360126aa2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration settings for the deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->