### PR TITLE
fix(web): render detail pages for best/compare/contributor/integration routes

### DIFF
--- a/apps/web/src/routes/best.index.tsx
+++ b/apps/web/src/routes/best.index.tsx
@@ -6,7 +6,7 @@ import { BEST_LISTS, ENTRIES } from "@/data/entries";
 import { ResourceCard } from "@/components/resource-card";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 
-export const Route = createFileRoute("/best")({
+export const Route = createFileRoute("/best/")({
   head: () => ({
     meta: [
       { title: "Best of HeyClaude — curated Claude workflow lists" },
@@ -56,7 +56,7 @@ function BestPage() {
         what you'd reach for instead.
       </p>
 
-      <div className="mt-10 grid gap-4 sm:grid-cols-2">
+      <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
         {BEST_LISTS.map((b) => {
           const previewTitles = b.picks
             .slice(0, 3)
@@ -70,7 +70,7 @@ function BestPage() {
               key={b.slug}
               to="/best/$slug"
               params={{ slug: b.slug }}
-              className="group flex flex-col gap-3 rounded-xl border border-border bg-surface p-6 transition-colors duration-200 ease-out hover:bg-surface-2"
+              className="group flex min-w-0 flex-col gap-3 rounded-xl border border-border bg-surface p-6 transition-colors duration-200 ease-out hover:bg-surface-2"
             >
               <div className="eyebrow">
                 {b.picks.length} picks · {b.category}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -20,7 +20,7 @@ const searchSchema = z.object({
   ids: z.string().catch(defaultSearch.ids).default(defaultSearch.ids),
 });
 
-export const Route = createFileRoute("/compare")({
+export const Route = createFileRoute("/compare/")({
   validateSearch: searchSchema,
   search: {
     middlewares: [stripSearchParams(defaultSearch)],

--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -7,7 +7,7 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
-export const Route = createFileRoute("/contributors")({
+export const Route = createFileRoute("/contributors/")({
   head: () => ({
     meta: [
       { title: "Contributors — HeyClaude" },

--- a/apps/web/src/routes/integrations.index.tsx
+++ b/apps/web/src/routes/integrations.index.tsx
@@ -6,7 +6,7 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
-export const Route = createFileRoute("/integrations")({
+export const Route = createFileRoute("/integrations/")({
   head: () => ({
     meta: [
       { title: "Integrations — HeyClaude" },

--- a/tests/seo-metadata.test.ts
+++ b/tests/seo-metadata.test.ts
@@ -37,10 +37,14 @@ const staticMetadataPages = [
 
 function pageMetadataDescription(pagePath: string) {
   const routePath = pagePath.replaceAll("/", ".");
-  const source = fs.readFileSync(
+  // Index routes live as either `<path>.tsx` or `<path>.index.tsx` (the latter
+  // when the path also has a `<path>.$param` sibling, e.g. contributors).
+  const candidates = [
     path.join(repoRoot, `apps/web/src/routes/${routePath}.tsx`),
-    "utf8",
-  );
+    path.join(repoRoot, `apps/web/src/routes/${routePath}.index.tsx`),
+  ];
+  const routeFile = candidates.find((candidate) => fs.existsSync(candidate)) ?? candidates[0];
+  const source = fs.readFileSync(routeFile, "utf8");
   const inlineDescription = source.match(
     /\{\s*name:\s*"description",\s*content:\s*["`]([^"`]+)["`]/,
   )?.[1];


### PR DESCRIPTION
## Problem

`best.tsx`, `compare.tsx`, `contributors.tsx` and `integrations.tsx` each rendered their **index** UI but contained **no `<Outlet/>`**. In TanStack file-based routing, a flat `X.tsx` alongside `X.$slug.tsx` becomes the **layout parent** of the `$slug` child — without an `<Outlet/>` the child never renders.

Result: every `/best/*`, `/compare/*`, `/contributors/*` and `/integrations/*` URL rendered its **index page** instead of the detail. The per-route `head()` ran (so `<title>`/canonical/JSON-LD were correct), but the visible `<body>` was the index — ~50+ sitemap URLs served duplicate index content. Confirmed in production:

```
/best/mcp-servers        <title>MCP servers …</title>   <h1>Curated for real workflows</h1>  ← index body
/contributors/<x>        <h1>Contributors</h1>                                               ← index body
```

## Fix

Rename each parent to `*.index.tsx`, matching the **already-working** `for.index.tsx` / `tags.index.tsx` pattern. The index and `$slug` routes then become **siblings** under the root outlet and both render standalone. `tsr generate` syncs the route ids (`/best/`, `/compare/`, `/contributors/`, `/integrations/`); the generated `routeTree.gen.ts` is gitignored and rebuilt on `prebuild`.

Verified locally — detail pages now render their own content:

| URL | now renders |
|-----|-------------|
| `/best/claude-code-hooks` | h1 "Best Claude Code hooks for safer agent workflows" |
| `/compare/payment-mcp-servers` | h1 "Payment MCP servers compared" |
| `/contributors/<x>` | `<title>… — HeyClaude contributor` |
| `/integrations/web` | h1 "Web directory" |

All four index pages still return 200. The redirect-only `tools.$slug` / `$category.$slug` routes are unaffected (they `throw redirect()` in the loader, before render).

## Also

Mobile horizontal-overflow fix on the `/best` index: the card grid had no explicit mobile column, so a wide card pushed the page ~160px past the viewport. Added `grid-cols-1` (`minmax(0,1fr)`) + `min-w-0` on the card so cards shrink to fit (verified: scrollWidth 535 → 375 at 375px).

## Validation

- `pnpm --filter web build` ✓ (regenerates route tree, type-checks)
- Manual: all four detail groups render detail; indexes 200; mobile `/best` no overflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated URL routing structure across multiple pages for consistency

* **Style**
  * Enhanced responsive grid layout and card styling on the best-lists page, improving display on smaller screens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->