### PR TITLE
fix(web): defer workers-og import so vite dev SSR works

### DIFF
--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -1,4 +1,4 @@
-import { ImageResponse } from "workers-og";
+import type { ImageResponse } from "workers-og";
 
 import { getOgFonts } from "@/lib/og-fonts";
 import { OG_HEIGHT, OG_TEXT_LIMITS, OG_WIDTH, clampOgText, safeAccent, wrap } from "@/lib/og-image";
@@ -27,17 +27,25 @@ function escForSatori(value: string) {
  * yoga `.wasm` modules, which must not be pulled into the browser bundle. The Vite
  * `serverOnlyClientStubs` plugin stubs `*.server` imports for the client build.
  *
+ * workers-og is imported lazily (dynamic `import()` below) rather than at module top
+ * level: TanStack's dev SSR eagerly evaluates the whole route tree, so a static import
+ * here would pull workers-og's `.wasm` into Node's ESM loader for EVERY page and 500 the
+ * entire site under `vite dev` (Node can't resolve the bundled `.wasm`). Deferring it
+ * keeps `pnpm dev` working for all routes; only an actual request to `/og*` loads it
+ * (still server-only — the Cloudflare/Workers runtime resolves the WASM in prod).
+ *
  * workers-og initializes the WASM lazily on first render, so no manual WASM handling is
  * required here. Satori needs real font bytes (it cannot resolve CSS font-family names),
  * which getOgFonts() supplies from a bundled, base64-embedded Space Grotesk subset.
  */
-export function renderOgPng(opts: {
+export async function renderOgPng(opts: {
   eyebrow?: string;
   title: string;
   description?: string;
   author?: string;
   accent?: string;
-}): ImageResponse {
+}): Promise<ImageResponse> {
+  const { ImageResponse } = await import("workers-og");
   const accent = safeAccent(opts.accent);
   const eyebrow = escForSatori(
     clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/og/$category/$slug")({
         const author = entry?.author ?? "HeyClaude";
         const category = entry?.category ?? params.category;
 
-        const image = renderOgPng({
+        const image = await renderOgPng({
           eyebrow: `${category} · HeyClaude`,
           title,
           description,

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -29,7 +29,7 @@ export const Route = createFileRoute("/og/")({
         // accent is user-controlled; clamp to a safe hex before it reaches the card markup.
         const accent = safeAccent(url.searchParams.get("accent"));
 
-        const image = renderOgPng({
+        const image = await renderOgPng({
           eyebrow,
           title,
           description: description ?? undefined,


### PR DESCRIPTION
## Problem

`og-render.server.ts` statically imported `workers-og`, whose package entry pulls in a yoga `.wasm`. TanStack Start's dev SSR **eagerly evaluates the whole route tree**, so that static import dragged the wasm into Node's ESM loader on *every* request. Node can't resolve the bundled `.wasm`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'a' imported from
  …/workers-og/dist/yoga-ZMNYPE6Z.wasm
Error: h3 swallowed SSR error: {"status":500,…}
```

So `pnpm dev` returned **500 on every page**, not just `/og` — the dev server was effectively unusable for any contributor.

## Fix

Move the import to a dynamic `import("workers-og")` inside `renderOgPng` (now `async`), keeping only a **type-only** import at module scope (erased at runtime). The route tree no longer evaluates `workers-og`; it loads only when an `/og*` route actually handles a request.

- Production is unchanged — the Cloudflare/Workers runtime resolves the wasm, and the module stays server-only (out of the client bundle via the existing `serverOnlyClientStubs` plugin).
- The two callers (`og.index`, `og.$category.$slug`) already run in async handlers and now `await renderOgPng(...)`.

## Validation

- `pnpm --filter web type-check` ✓
- `pnpm --filter web build` ✓
- `pnpm dev` → home and all pages now return 200 (previously 500); `/og*` still renders PNGs in production