### PR TITLE
fix(web): eliminate mobile horizontal overflow on entry pages

### DIFF
--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -295,7 +295,7 @@ function Dossier() {
       />
 
       {/* Header */}
-      <header className="mt-6 grid gap-6 border-b border-border pb-8 lg:grid-cols-[minmax(0,1fr)_320px]">
+      <header className="mt-6 grid grid-cols-[minmax(0,1fr)] gap-6 border-b border-border pb-8 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <CategoryPill>{entry.category}</CategoryPill>
@@ -374,7 +374,7 @@ function Dossier() {
         </div>
 
         {/* Sticky install panel */}
-        <aside className="lg:sticky lg:top-20 lg:self-start">
+        <aside className="min-w-0 lg:sticky lg:top-20 lg:self-start">
           <div className="overflow-hidden rounded-xl border border-border bg-surface">
             <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
               <div className="eyebrow">Install</div>
@@ -500,7 +500,7 @@ function Dossier() {
       <div id="dossier-header-sentinel" aria-hidden className="h-px w-full" />
 
       {/* Body */}
-      <div className="grid gap-8 py-8 lg:grid-cols-[minmax(0,1fr)_280px]">
+      <div className="grid grid-cols-[minmax(0,1fr)] gap-8 py-8 lg:grid-cols-[minmax(0,1fr)_280px]">
         <div className="min-w-0 space-y-8">
           {risk !== "low" && (
             <section


### PR DESCRIPTION
## Problem

The entry header and body grids used `lg:grid-cols-[minmax(0,1fr)_NNNpx]` with **no explicit mobile column**, so on phones they collapsed to a single implicit `auto` grid track sized to the **widest child's content**. The install card's code `<pre>` has long unbreakable lines, so that track grew to **~613px on a 375px viewport** — the title, description and badge row were all clipped off-screen and the page scrolled horizontally.

## Fix

- Add an explicit `grid-cols-[minmax(0,1fr)]` mobile column to both grids so the single column floors at width 0.
- Add `min-w-0` to the install `<aside>` (the one header child lacking it) so it can shrink below content width.

The code block then scrolls **internally** instead of stretching the page.

Verified at 375px: document scrollWidth **613 → 375**; title/description/badges wrap; install code scrolls within its card. Affects every `/entry/*` page (~948 resources).

## Validation

- `pnpm --filter web build` ✓
- Manual (headless 375px): no horizontal overflow; install card scrolls internally