### PR TITLE
fix(web): mobile table overflow, jobs a11y labels, footer privacy anchor

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -258,7 +258,7 @@ export function Footer() {
             <span aria-hidden className="text-ink-subtle/60">
               ·
             </span>
-            <Link to="/legal" className="hover:text-ink">
+            <Link to="/legal" hash="privacy" className="hover:text-ink">
               Privacy
             </Link>
             <span aria-hidden className="text-ink-subtle/60">

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -859,7 +859,7 @@ function SchemaDetails({ entry }: { entry: Entry }) {
             <PillList label="Retrieval sources" values={entry.retrievalSources} />
             <PillList label="Tested platforms" values={entry.testedPlatforms} />
             {entry.platformCompatibility?.length ? (
-              <div className="mt-3 overflow-hidden rounded-lg border border-border">
+              <div className="mt-3 overflow-x-auto rounded-lg border border-border">
                 <table className="w-full text-left text-xs">
                   <thead className="bg-surface-2 text-ink-subtle">
                     <tr>

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -207,6 +207,7 @@ function JobsPage() {
               value={q}
               onChange={(e) => setQ(e.target.value)}
               placeholder="Search title, company, stack…"
+              aria-label="Search jobs by title, company, or stack"
               className="h-9 w-full rounded-md border border-border bg-background pl-8 pr-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
             />
           </div>
@@ -232,6 +233,7 @@ function JobsPage() {
           <select
             value={type}
             onChange={(e) => setType(e.target.value)}
+            aria-label="Filter by job type"
             className="h-9 rounded-md border border-border bg-background px-2 text-xs text-ink-muted focus:outline-none focus:ring-2 focus:ring-accent/40"
           >
             <option value="all">Any type</option>

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -164,7 +164,7 @@ function QualityPage() {
       </div>
 
       <h2 className="mt-12 h-display-2 text-ink text-balance">Coverage by category</h2>
-      <div className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="mt-4 overflow-x-auto rounded-xl border border-border bg-surface">
         {CATEGORIES.map((c) => {
           const cov = CATEGORY_COVERAGE.get(c.id)!;
           return (
@@ -216,7 +216,7 @@ function QualityPage() {
         </code>
         .
       </p>
-      <div className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
+      <div className="mt-4 overflow-x-auto rounded-xl border border-border bg-surface">
         <div className="grid grid-cols-[1fr_120px_180px_180px] gap-4 border-b border-border bg-surface-2 px-5 py-2 text-[11px] uppercase tracking-wider text-ink-subtle">
           <span>Path</span>
           <span className="text-right">Size</span>


### PR DESCRIPTION
Findings from a route-quality audit (parallel finders across all 59 route files + shared components, each adversarially verified). 10 raw findings → **5 real bugs** here; 3 verified false positives were dropped (implicit `<label>` wrapping already labels the job-post inputs; the comparison tray scrolls by design; the state-of-tooling table fits the viewport).

## Fixes

**Mobile data-table clipping (overflow)** — `/quality` Coverage + Artifact-contracts grids and the entry platform-compatibility table used fixed-px column tracks inside `overflow-hidden`. At 375px the content is ~576–610px, so right-hand columns (trust bars, SHA-256, Built, install paths) were **silently clipped** — no page scroll, just missing data (which is why a `scrollWidth` page check doesn't catch it). Switched to `overflow-x-auto`.
Verified headless at 375px: **0 clipped tables, no page overflow**, all columns reachable by scroll.

**a11y** — `/jobs` search input and job-type `<select>` had no accessible name (placeholder/bare options only). Added `aria-label` to both (WCAG 4.1.2), matching the browse/subscribe pattern.

**Footer link** — the footer "Privacy" link pointed at `/legal` with no hash (identical to "Legal", landing at page top). Added `hash="privacy"` → jumps to the existing `#privacy` section.

## Validation

- `pnpm --filter web type-check` ✓ (`hash` is valid TanStack `Link` API)
- Headless 375px: quality tables now scroll (`overflowX: auto`), 0 clipped, no page overflow
- `legal.tsx` confirmed to have `Section id="privacy"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enabled horizontal scrolling for platform compatibility table and quality metrics panels to better handle overflow content
  * Added accessibility labels to job search and filter controls

* **Bug Fixes**
  * Fixed footer Legal link to properly navigate to privacy section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->