### PR TITLE
chore(web): migrate umami analytics domain to tasty.aethereal.dev

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -7,7 +7,7 @@
 
 /data/*
   Cache-Control: public, max-age=300, s-maxage=3600, stale-while-revalidate=86400
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://umami.heyclau.de https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://img.shields.io https://umami.heyclau.de https://challenges.cloudflare.com https://submission-gate.heyclau.de; frame-src https://challenges.cloudflare.com; form-action 'self' https://github.com; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://tasty.aethereal.dev https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://img.shields.io https://tasty.aethereal.dev https://challenges.cloudflare.com https://submission-gate.heyclau.de; frame-src https://challenges.cloudflare.com; form-action 'self' https://github.com; manifest-src 'self'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/apps/web/src/components/web-vitals.tsx
+++ b/apps/web/src/components/web-vitals.tsx
@@ -15,7 +15,7 @@ interface ReportedMetric {
 
 /**
  * Field Core Web Vitals (RUM). Reports INP/LCP/CLS/TTFB/FCP for real sessions to
- * the existing umami instance (umami.heyclau.de is already allowed by CSP, so no
+ * the existing umami instance (tasty.aethereal.dev is already allowed by CSP, so no
  * policy change). Renders nothing; the web-vitals library is dynamically imported
  * inside the effect so it never enters the SSR path or the universal client chunk.
  */

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -12,7 +12,7 @@ function urlOrigin(value: string) {
 const scriptSrc = [
   "script-src 'self' 'unsafe-inline'",
   process.env.NODE_ENV === "production" ? "" : "'unsafe-eval'",
-  "https://umami.heyclau.de",
+  "https://tasty.aethereal.dev",
   "https://challenges.cloudflare.com",
 ]
   .filter(Boolean)
@@ -24,7 +24,7 @@ const connectSrc = Array.from(
       "connect-src 'self'",
       "https://api.github.com",
       "https://img.shields.io",
-      "https://umami.heyclau.de",
+      "https://tasty.aethereal.dev",
       "https://challenges.cloudflare.com",
       "https://submission-gate.heyclau.de",
       urlOrigin(siteConfig.submissionGateUrl),

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -47,7 +47,7 @@ export const siteConfig = {
   jobsEmail: "jobs@heyclau.de",
   twitterUrl: publicEnv("NEXT_PUBLIC_TWITTER_URL") || "https://x.com/jsonbored",
   discordUrl: publicEnv("NEXT_PUBLIC_DISCORD_URL") || "https://discord.com/invite/Ax3Py4YDrq",
-  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL") || "https://umami.heyclau.de/script.js",
+  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL") || "https://tasty.aethereal.dev/script.js",
   umamiWebsiteId: publicEnv("VITE_UMAMI_WEBSITE_ID") || "b734c138-2949-4527-9160-7fe5d0e81121",
   // Empty string intentionally disables the private gate and shows manual PR instructions.
   submissionGateUrl: publicHttpUrl(


### PR DESCRIPTION
The umami tracker moved from `umami.heyclau.de` → `tasty.aethereal.dev` (same self-hosted instance, **same website id** `b734c138-...`).

## Changes
- `lib/site.ts` — default `umamiScriptUrl` → `https://tasty.aethereal.dev/script.js` (the `VITE_UMAMI_SCRIPT_URL` / `VITE_UMAMI_WEBSITE_ID` overrides still work)
- `lib/security-headers.ts` — allow the new origin in runtime CSP `script-src` + `connect-src`
- `public/_headers` — same swap in the static `/data/*` edge CSP
- `web-vitals.tsx` — comment reference

The `<script defer src=… data-website-id=…>` tag in `__root.tsx` already reads from `siteConfig`, so no change there. Website id and web-vitals RUM (`window.umami.track`) are unaffected.

## Validation
- `pnpm exec vitest run tests/edge-cache.test.ts tests/crawler-policy.test.ts` ✓
- No `umami.heyclau.de` references remain anywhere in the tree

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics endpoints configuration across security headers and default settings. No changes to application features or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->