### PR TITLE
fix(web): align mcp-server integration version with 0.3.1

### DIFF
--- a/apps/web/src/data/integrations.ts
+++ b/apps/web/src/data/integrations.ts
@@ -79,7 +79,7 @@ export const INTEGRATIONS: Integration[] = [
       label: "Source",
       href: "https://github.com/jsonbored/awesome-claude/tree/main/packages/mcp",
     },
-    version: "0.3.0",
+    version: "0.3.1",
     updatedAt: REGISTRY_UPDATED_DATE,
     install: [
       {


### PR DESCRIPTION
Completes the @heyclaude/mcp 0.3.1 release: `apps/web/src/data/integrations.ts` still listed the `mcp-server` integration at `0.3.0`, which trips `tests/atlas-production-data.test.ts` ("keeps first-party MCP integration metadata aligned with the package"). That test runs only under `validate-web`, which was skipped on the mcp-only release PR #2325, so the mismatch surfaced on the next web PR. Bumps it to `0.3.1`.

Validation: `pnpm exec vitest run tests/atlas-production-data.test.ts` ✓ (7 passed).