### PR TITLE
feat(newsletter): double opt-in confirmation flow

### DIFF
--- a/apps/web/src/components/newsletter-inline.tsx
+++ b/apps/web/src/components/newsletter-inline.tsx
@@ -30,8 +30,12 @@ export function NewsletterInline({
 }: Props) {
   const [email, setEmail] = useState("");
   const [done, setDone] = useState(false);
+  const [pending, setPending] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+
+  // Double opt-in: a confirmation email was sent; the user must click to finish.
+  const successMessage = pending ? "Check your inbox to confirm." : "You're subscribed.";
 
   async function onSubmit(e: FormEvent) {
     e.preventDefault();
@@ -42,6 +46,11 @@ export function NewsletterInline({
     setBusy(false);
     if (result.ok) {
       setDone(true);
+      setPending(result.pending);
+      // First-party site analytics (umami) — not an email tracking pixel.
+      (
+        window as unknown as { umami?: { track?: (e: string, d?: Record<string, unknown>) => void } }
+      ).umami?.track?.("newsletter-subscribe", { source });
       return;
     }
     setError(result.error);
@@ -82,10 +91,14 @@ export function NewsletterInline({
               )}
             </button>
           </form>
-          {error && (
-            <p role="alert" className="text-xs text-trust-blocked">
-              {error}
-            </p>
+          {done ? (
+            <p className="text-xs text-ink-muted">{successMessage}</p>
+          ) : (
+            error && (
+              <p role="alert" className="text-xs text-trust-blocked">
+                {error}
+              </p>
+            )
           )}
         </div>
       </div>
@@ -135,7 +148,9 @@ export function NewsletterInline({
           </button>
         </form>
         <p className="mt-3 text-[11px] text-ink-subtle">
-          {error || "Unsubscribe any time. No tracking pixels. No partner blasts."}
+          {done
+            ? successMessage
+            : error || "Unsubscribe any time. No tracking pixels. No partner blasts."}
         </p>
       </section>
     );
@@ -182,10 +197,14 @@ export function NewsletterInline({
           </button>
         </form>
       </div>
-      {error && (
-        <p role="alert" className="mt-2 text-xs text-trust-blocked">
-          {error}
-        </p>
+      {done ? (
+        <p className="mt-2 text-xs text-ink-muted">{successMessage}</p>
+      ) : (
+        error && (
+          <p role="alert" className="mt-2 text-xs text-trust-blocked">
+            {error}
+          </p>
+        )
       )}
     </section>
   );

--- a/apps/web/src/lib/api/newsletter.ts
+++ b/apps/web/src/lib/api/newsletter.ts
@@ -22,7 +22,7 @@ function responseErrorMessage(data: unknown, fallback: string) {
 
 export async function subscribeToNewsletter(
   input: SubscribeInput,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true; pending: boolean } | { ok: false; error: string }> {
   try {
     const res = await fetch("/api/newsletter/subscribe", {
       method: "POST",
@@ -33,7 +33,10 @@ export async function subscribeToNewsletter(
     if (!res.ok) {
       return { ok: false, error: responseErrorMessage(data, `Subscribe failed (${res.status}).`) };
     }
-    return { ok: true };
+    // `pending` is true under double opt-in: a confirmation email was sent and
+    // the contact is added only after the user clicks the link.
+    const pending = Boolean((data as { pending?: unknown })?.pending);
+    return { ok: true, pending };
   } catch {
     return { ok: false, error: "Network error. Try again in a moment." };
   }

--- a/apps/web/src/lib/newsletter-emails.ts
+++ b/apps/web/src/lib/newsletter-emails.ts
@@ -1,0 +1,67 @@
+// Minimal, on-brand confirmation email for double opt-in. Built as an inline
+// string (not React Email) so it renders in the Worker without a runtime React
+// dependency. Light theme to match heyclau.de; no tracking pixel.
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function buildNewsletterConfirmEmail(opts: { confirmUrl: string; siteUrl: string }): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const confirmUrl = escapeHtml(opts.confirmUrl);
+  const siteHost = escapeHtml(opts.siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, ""));
+  const subject = "Confirm your HeyClaude subscription";
+
+  const html = `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#f7f5ef;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">Tap the button to confirm your subscription to the HeyClaude weekly brief.</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f7f5ef;padding:40px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:480px;background:#ffffff;border:1px solid #e7e3d8;border-radius:14px;">
+            <tr>
+              <td style="padding:32px 32px 8px;">
+                <div style="font:600 13px/1.4 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude</div>
+                <h1 style="margin:14px 0 0;font:700 24px/1.25 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#171614;">Confirm your subscription</h1>
+                <p style="margin:14px 0 0;font:400 15px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#4d4c47;">One calm read on Claude workflows. Confirm your email and you're in &mdash; you can unsubscribe any time.</p>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:24px 32px 8px;">
+                <a href="${confirmUrl}" style="display:inline-block;background:#171614;color:#ffffff;text-decoration:none;font:600 15px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;padding:14px 22px;border-radius:10px;">Confirm subscription</a>
+              </td>
+            </tr>
+            <tr>
+              <td style="padding:8px 32px 32px;">
+                <p style="margin:0;font:400 12px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#8a8980;">If the button doesn't work, paste this link into your browser:<br><a href="${confirmUrl}" style="color:#6b6a64;word-break:break-all;">${confirmUrl}</a></p>
+                <p style="margin:16px 0 0;font:400 12px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#8a8980;">Didn't request this? Ignore this email &mdash; nothing was added. &middot; ${siteHost}</p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  const text = [
+    "Confirm your HeyClaude subscription",
+    "",
+    "One calm read on Claude workflows. Confirm your email and you're in — unsubscribe any time.",
+    "",
+    `Confirm: ${opts.confirmUrl}`,
+    "",
+    "Didn't request this? Ignore this email — nothing was added.",
+    siteHost,
+  ].join("\n");
+
+  return { subject, html, text };
+}

--- a/apps/web/src/lib/newsletter-token.server.ts
+++ b/apps/web/src/lib/newsletter-token.server.ts
@@ -1,0 +1,114 @@
+// Stateless double-opt-in confirmation tokens.
+//
+// A confirmation link must prove "this email asked to subscribe" without a
+// database row, so we sign the pending payload with HMAC-SHA256 (Web Crypto,
+// available in both the Cloudflare Worker runtime and Node test env). The token
+// is `base64url(payload).base64url(hmac)`; verification recomputes the HMAC,
+// compares in constant time, and enforces the embedded expiry.
+//
+// Server-only (the `.server` suffix keeps the signing secret out of the client
+// bundle via the serverOnlyClientStubs vite plugin).
+
+const encoder = new TextEncoder();
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecode(value: string): Uint8Array {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/") + "===".slice((value.length + 3) % 4);
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function hmacSha256(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return new Uint8Array(signature);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+export type NewsletterConfirmPayload = {
+  /** Lowercased subscriber email. */
+  email: string;
+  /** Follow/segment ids to add on confirm (besides the default audience). */
+  segments: string[];
+  /** Where the signup happened, for attribution. */
+  source: string;
+  /** Expiry as a unix-ms timestamp. */
+  exp: number;
+};
+
+/** Sign a pending-subscription payload into a self-verifying confirm token. */
+export async function signConfirmToken(
+  secret: string,
+  payload: NewsletterConfirmPayload,
+): Promise<string> {
+  const body = base64urlEncode(encoder.encode(JSON.stringify(payload)));
+  const signature = base64urlEncode(await hmacSha256(secret, body));
+  return `${body}.${signature}`;
+}
+
+/**
+ * Verify a confirm token and return its payload, or null if the signature is
+ * invalid, the token is malformed, or it has expired (`now` is unix-ms).
+ */
+export async function verifyConfirmToken(
+  secret: string,
+  token: string,
+  now: number,
+): Promise<NewsletterConfirmPayload | null> {
+  if (!secret || typeof token !== "string") return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return null;
+
+  const body = token.slice(0, dot);
+  const providedSig = token.slice(dot + 1);
+
+  let expectedSig: Uint8Array;
+  let providedBytes: Uint8Array;
+  try {
+    expectedSig = await hmacSha256(secret, body);
+    providedBytes = base64urlDecode(providedSig);
+  } catch {
+    return null;
+  }
+  if (!timingSafeEqual(expectedSig, providedBytes)) return null;
+
+  let payload: NewsletterConfirmPayload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(base64urlDecode(body))) as NewsletterConfirmPayload;
+  } catch {
+    return null;
+  }
+
+  if (
+    !payload ||
+    typeof payload.email !== "string" ||
+    !payload.email ||
+    typeof payload.exp !== "number" ||
+    !Array.isArray(payload.segments)
+  ) {
+    return null;
+  }
+  if (typeof payload.source !== "string") payload.source = "newsletter";
+  if (now > payload.exp) return null;
+
+  return payload;
+}

--- a/apps/web/src/routes/api/newsletter/subscribe.ts
+++ b/apps/web/src/routes/api/newsletter/subscribe.ts
@@ -4,19 +4,98 @@ import { newsletterSubscribeBodySchema } from "@/lib/api/contracts";
 import { apiError, apiJson, createApiHandler, type InferApiBody } from "@/lib/api/router";
 import { logApiError, logApiInfo, redactEmail } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env.server";
+import { signConfirmToken } from "@/lib/newsletter-token.server";
+import { buildNewsletterConfirmEmail } from "@/lib/newsletter-emails";
+import { siteConfig } from "@/lib/site";
+
+const CONFIRM_TTL_MS = 48 * 60 * 60 * 1000;
+const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>";
 
 function envSegmentId(followId: string): string | undefined {
   const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;
   return getEnvString(key) || undefined;
 }
 
+/**
+ * Add (or upsert) a CONFIRMED contact in the Resend audience. Shared by the
+ * single-opt-in fallback below and the double-opt-in confirm route. Returns a
+ * status the caller maps to an HTTP response. 409 (already a contact) is a
+ * success from the user's perspective and avoids account enumeration.
+ */
+export async function addNewsletterContact(params: {
+  email: string;
+  segments: string[];
+  source: string;
+  resendApiKey: string;
+  resendSegmentId: string;
+}): Promise<"ok" | "duplicate" | "error"> {
+  const segmentIds = new Set<string>([params.resendSegmentId]);
+  for (const segment of params.segments) {
+    const segmentId = envSegmentId(segment);
+    if (segmentId) segmentIds.add(segmentId);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch("https://api.resend.com/contacts", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        email: params.email,
+        unsubscribed: false,
+        first_name: "",
+        last_name: "",
+        metadata: { source: params.source },
+        segments: [...segmentIds].map((id) => ({ id })),
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    return "error";
+  }
+
+  if (response.ok) return "ok";
+  if (response.status === 409) return "duplicate";
+  return "error";
+}
+
+async function sendConfirmEmail(params: {
+  email: string;
+  token: string;
+  resendApiKey: string;
+  from: string;
+}): Promise<boolean> {
+  const confirmUrl = `${siteConfig.url}/api/public/newsletter/confirm?token=${encodeURIComponent(
+    params.token,
+  )}`;
+  const { subject, html, text } = buildNewsletterConfirmEmail({
+    confirmUrl,
+    siteUrl: siteConfig.url,
+  });
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.resendApiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ from: params.from, to: params.email, subject, html, text }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export const POST = createApiHandler(
   "newsletter.subscribe",
   async ({ request, body, requestId }) => {
     const payload = body as InferApiBody<typeof newsletterSubscribeBodySchema>;
-    const email = payload.email;
-    const segments = payload.segments;
-    const source = payload.source;
+    const { email, segments, source } = payload;
 
     const resendApiKey = getEnvString("RESEND_API_KEY");
     const resendSegmentId = getEnvString("RESEND_SEGMENT_ID");
@@ -26,50 +105,42 @@ export const POST = createApiHandler(
       return apiError("newsletter_not_configured", 503, { requestId });
     }
 
-    const segmentIds = new Set<string>([resendSegmentId]);
-    for (const segment of segments) {
-      const segmentId = envSegmentId(segment);
-      if (segmentId) segmentIds.add(segmentId);
-    }
-
-    const requestBody: Record<string, unknown> = {
-      email,
-      unsubscribed: false,
-      first_name: "",
-      last_name: "",
-      metadata: {
+    // Double opt-in when a confirm secret is configured: email a signed confirm
+    // link and add the contact only after they click it. Without the secret we
+    // fall back to single opt-in (direct add) to preserve prior behavior.
+    const confirmSecret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
+    if (confirmSecret) {
+      const from = getEnvString("RESEND_FROM") || DEFAULT_FROM;
+      const token = await signConfirmToken(confirmSecret, {
+        email,
+        segments,
         source,
-      },
-      segments: [...segmentIds].map((id) => ({ id })),
-    };
-
-    let response: Response;
-    try {
-      response = await fetch("https://api.resend.com/contacts", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${resendApiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(requestBody),
-        signal: AbortSignal.timeout(8000),
+        exp: Date.now() + CONFIRM_TTL_MS,
       });
-    } catch {
-      logApiError(request, "newsletter.subscribe.provider_unavailable");
-      return apiError("provider_unavailable", 502, { requestId });
-    }
-
-    if (response.ok) {
-      logApiInfo(request, "newsletter.subscribe.success", {
+      const sent = await sendConfirmEmail({ email, token, resendApiKey, from });
+      if (!sent) {
+        logApiError(request, "newsletter.subscribe.confirm_send_failed", {
+          email: redactEmail(email),
+          source,
+        });
+        return apiError("provider_error", 502, { requestId });
+      }
+      logApiInfo(request, "newsletter.subscribe.confirm_sent", {
         email: redactEmail(email),
         source,
       });
-      return apiJson({ ok: true }, { headers: { "cache-control": "no-store" } });
+      return apiJson({ ok: true, pending: true }, { headers: { "cache-control": "no-store" } });
     }
 
-    if (response.status === 409) {
-      // Treat duplicate as success to keep UX simple and avoid account enumeration.
-      logApiInfo(request, "newsletter.subscribe.duplicate", {
+    const result = await addNewsletterContact({
+      email,
+      segments,
+      source,
+      resendApiKey,
+      resendSegmentId,
+    });
+    if (result === "ok" || result === "duplicate") {
+      logApiInfo(request, `newsletter.subscribe.${result === "ok" ? "success" : "duplicate"}`, {
         email: redactEmail(email),
         source,
       });
@@ -77,7 +148,6 @@ export const POST = createApiHandler(
     }
 
     logApiError(request, "newsletter.subscribe.provider_error", {
-      status: response.status,
       email: redactEmail(email),
       source,
     });

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -1,0 +1,84 @@
+import { createApiFileRoute } from "@/lib/api/file-route";
+
+import { getEnvString } from "@/lib/cloudflare-env.server";
+import { verifyConfirmToken } from "@/lib/newsletter-token.server";
+import { addNewsletterContact } from "@/routes/api/newsletter/subscribe";
+import { siteConfig } from "@/lib/site";
+
+// Minimal, on-brand confirmation landing page (light theme, matches the site).
+function resultPage(opts: { ok: boolean; heading: string; body: string }): Response {
+  const accent = opts.ok ? "#2f8f5b" : "#b4541f";
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>${opts.heading} — HeyClaude</title>
+  </head>
+  <body style="margin:0;background:#f7f5ef;font:400 16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#171614;">
+    <main style="max-width:480px;margin:0 auto;padding:80px 20px;text-align:center;">
+      <div style="font:600 13px/1.4 sans-serif;letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude</div>
+      <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
+      <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
+      <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
+      <a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>
+    </main>
+  </body>
+</html>`;
+  return new Response(html, {
+    status: opts.ok ? 200 : 400,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+export const Route = createApiFileRoute("/api/public/newsletter/confirm")({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const token = new URL(request.url).searchParams.get("token") ?? "";
+        const confirmSecret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
+        const resendApiKey = getEnvString("RESEND_API_KEY");
+        const resendSegmentId = getEnvString("RESEND_SEGMENT_ID");
+
+        if (!confirmSecret || !resendApiKey || !resendSegmentId) {
+          return resultPage({
+            ok: false,
+            heading: "Not available",
+            body: "Newsletter confirmation isn't configured right now.",
+          });
+        }
+
+        const payload = await verifyConfirmToken(confirmSecret, token, Date.now());
+        if (!payload) {
+          return resultPage({
+            ok: false,
+            heading: "Link expired",
+            body: "This confirmation link is invalid or has expired. Please subscribe again.",
+          });
+        }
+
+        const result = await addNewsletterContact({
+          email: payload.email,
+          segments: payload.segments,
+          source: payload.source,
+          resendApiKey,
+          resendSegmentId,
+        });
+        if (result === "error") {
+          return resultPage({
+            ok: false,
+            heading: "Something went wrong",
+            body: "We couldn't confirm your subscription just now. Please try again shortly.",
+          });
+        }
+
+        return resultPage({
+          ok: true,
+          heading: "You're subscribed",
+          body: "Thanks for confirming. The weekly brief lands on Sundays — unsubscribe any time.",
+        });
+      },
+    },
+  },
+});

--- a/tests/newsletter-token.test.ts
+++ b/tests/newsletter-token.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  signConfirmToken,
+  verifyConfirmToken,
+  type NewsletterConfirmPayload,
+} from "../apps/web/src/lib/newsletter-token.server";
+
+const SECRET = "test-confirm-secret-please-rotate";
+const NOW = 1_750_000_000_000;
+
+function payload(overrides: Partial<NewsletterConfirmPayload> = {}): NewsletterConfirmPayload {
+  return {
+    email: "reader@example.com",
+    segments: ["mcp", "agents"],
+    source: "inline",
+    exp: NOW + 60_000,
+    ...overrides,
+  };
+}
+
+describe("newsletter confirm tokens", () => {
+  it("round-trips a signed payload", async () => {
+    const token = await signConfirmToken(SECRET, payload());
+    const verified = await verifyConfirmToken(SECRET, token, NOW);
+    expect(verified).toMatchObject({
+      email: "reader@example.com",
+      segments: ["mcp", "agents"],
+      source: "inline",
+    });
+  });
+
+  it("rejects an expired token", async () => {
+    const token = await signConfirmToken(SECRET, payload({ exp: NOW - 1 }));
+    expect(await verifyConfirmToken(SECRET, token, NOW)).toBeNull();
+  });
+
+  it("rejects a token signed with a different secret", async () => {
+    const token = await signConfirmToken(SECRET, payload());
+    expect(await verifyConfirmToken("a-different-secret", token, NOW)).toBeNull();
+  });
+
+  it("rejects a tampered payload body", async () => {
+    const token = await signConfirmToken(SECRET, payload());
+    const [, sig] = token.split(".");
+    const forged = Buffer.from(JSON.stringify(payload({ email: "attacker@evil.com" })))
+      .toString("base64url");
+    expect(await verifyConfirmToken(SECRET, `${forged}.${sig}`, NOW)).toBeNull();
+  });
+
+  it("rejects a tampered signature", async () => {
+    const token = await signConfirmToken(SECRET, payload());
+    const [body] = token.split(".");
+    expect(await verifyConfirmToken(SECRET, `${body}.AAAA`, NOW)).toBeNull();
+  });
+
+  it("rejects malformed tokens", async () => {
+    expect(await verifyConfirmToken(SECRET, "not-a-token", NOW)).toBeNull();
+    expect(await verifyConfirmToken(SECRET, "", NOW)).toBeNull();
+    expect(await verifyConfirmToken(SECRET, ".", NOW)).toBeNull();
+    expect(await verifyConfirmToken("", "a.b", NOW)).toBeNull();
+  });
+});


### PR DESCRIPTION
First piece of the automated newsletter (per the confirmed plan: weekly digest + double opt-in + privacy-respecting analytics). This adds **double opt-in** so the Resend sending audience only contains confirmed subscribers.

## Flow
1. Signup → if `NEWSLETTER_CONFIRM_SECRET` is set, we email a **signed confirm link** and add nothing yet; the form shows "Check your inbox to confirm."
2. Confirm click → `/api/public/newsletter/confirm?token=…` verifies the token and adds the contact to the Resend audience, then shows an on-brand confirmation page.
3. Without the secret, it falls back to the prior single-opt-in direct add (no behavior change).

## Pieces
- `lib/newsletter-token.server.ts` — **stateless** HMAC-SHA256 confirm tokens (Web Crypto, no DB) carrying `{email, segments, source, exp}`, constant-time verified with embedded 48h expiry. Server-only.
- `lib/newsletter-emails.ts` — minimal light-theme confirm email, **no tracking pixel**.
- `api/newsletter/subscribe.ts` — double-opt-in path + shared `addNewsletterContact()` (reused by confirm).
- `api/public/newsletter/confirm.ts` — token verify → add contact → confirmation page.
- Client: subscribe helper surfaces `pending`; form shows confirm copy + fires a first-party umami `newsletter-subscribe` event (site analytics, **not** an email pixel — keeps the "No tracking pixels" promise).

## Safety
Fully **inert without config**: returns the existing `not_configured` 503 until `RESEND_API_KEY` + `RESEND_SEGMENT_ID` exist, and only switches to double opt-in once `NEWSLETTER_CONFIRM_SECRET` (+ a verified `RESEND_FROM`) are set. No emails sent until you configure secrets.

## Config to go live (your Cloudflare Worker secrets)
`RESEND_API_KEY`, `RESEND_SEGMENT_ID` (audience), `NEWSLETTER_CONFIRM_SECRET` (random 32+ chars), and `RESEND_FROM` (e.g. `HeyClaude <newsletter@heyclau.de>`, a verified Resend domain).

## Validation
- `tests/newsletter-token.test.ts` ✓ (round-trip, expiry, wrong secret, tampered body/signature, malformed)
- `pnpm --filter web type-check` ✓, `pnpm --filter web build` ✓ (confirm route registered)
- `tests/newsletter-client.test.ts`, `tests/api-contracts.test.ts` ✓

Next (separate PRs): weekly digest cron (skip thin weeks) → send via Resend Broadcasts API; webhook→umami for clicks/delivered/bounced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented double opt-in newsletter flow. Users now receive a confirmation email to verify their subscription. Success messaging updates to "Check your inbox to confirm" during verification and changes to "You're subscribed" once confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->