### PR TITLE
fix(web): restore first-party umami origin

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -7,7 +7,7 @@
 
 /data/*
   Cache-Control: public, max-age=300, s-maxage=3600, stale-while-revalidate=86400
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://tasty.aethereal.dev https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://img.shields.io https://tasty.aethereal.dev https://challenges.cloudflare.com https://submission-gate.heyclau.de; frame-src https://challenges.cloudflare.com; form-action 'self' https://github.com; manifest-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' 'unsafe-inline' https://umami.heyclau.de https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://api.github.com https://img.shields.io https://umami.heyclau.de https://challenges.cloudflare.com https://submission-gate.heyclau.de; frame-src https://challenges.cloudflare.com; form-action 'self' https://github.com; manifest-src 'self'
 
 /assets/*
   Cache-Control: public, max-age=31536000, immutable

--- a/apps/web/src/components/web-vitals.tsx
+++ b/apps/web/src/components/web-vitals.tsx
@@ -15,7 +15,7 @@ interface ReportedMetric {
 
 /**
  * Field Core Web Vitals (RUM). Reports INP/LCP/CLS/TTFB/FCP for real sessions to
- * the existing umami instance (tasty.aethereal.dev is already allowed by CSP, so no
+ * the existing umami instance (umami.heyclau.de is already allowed by CSP, so no
  * policy change). Renders nothing; the web-vitals library is dynamically imported
  * inside the effect so it never enters the SSR path or the universal client chunk.
  */

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -12,7 +12,7 @@ function urlOrigin(value: string) {
 const scriptSrc = [
   "script-src 'self' 'unsafe-inline'",
   process.env.NODE_ENV === "production" ? "" : "'unsafe-eval'",
-  "https://tasty.aethereal.dev",
+  "https://umami.heyclau.de",
   "https://challenges.cloudflare.com",
 ]
   .filter(Boolean)
@@ -24,7 +24,7 @@ const connectSrc = Array.from(
       "connect-src 'self'",
       "https://api.github.com",
       "https://img.shields.io",
-      "https://tasty.aethereal.dev",
+      "https://umami.heyclau.de",
       "https://challenges.cloudflare.com",
       "https://submission-gate.heyclau.de",
       urlOrigin(siteConfig.submissionGateUrl),

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -47,7 +47,7 @@ export const siteConfig = {
   jobsEmail: "jobs@heyclau.de",
   twitterUrl: publicEnv("NEXT_PUBLIC_TWITTER_URL") || "https://x.com/jsonbored",
   discordUrl: publicEnv("NEXT_PUBLIC_DISCORD_URL") || "https://discord.com/invite/Ax3Py4YDrq",
-  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL") || "https://tasty.aethereal.dev/script.js",
+  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL") || "https://umami.heyclau.de/script.js",
   umamiWebsiteId: publicEnv("VITE_UMAMI_WEBSITE_ID") || "b734c138-2949-4527-9160-7fe5d0e81121",
   // Empty string intentionally disables the private gate and shows manual PR instructions.
   submissionGateUrl: publicHttpUrl(


### PR DESCRIPTION
### Motivation
- A recent change expanded runtime trust to `tasty.aethereal.dev`, allowing an unpinned third-party analytics script to execute in the site origin and exfiltrate data if compromised.
- Restoring the first-party analytics origin reduces the supply-chain risk by limiting executable script and network egress to the site-controlled Umami host.
- Keep analytics functionality intact while removing the unrelated external trust boundary introduced earlier.

### Description
- Restore the default Umami script URL in `apps/web/src/lib/site.ts` to `https://umami.heyclau.de/script.js` so the runtime loads the first-party analytics script.
- Replace `https://tasty.aethereal.dev` with `https://umami.heyclau.de` in `apps/web/src/lib/security-headers.ts` for both `script-src` and `connect-src` runtime CSP entries.
- Update the static `/data/*` CSP in `apps/web/public/_headers` to remove `tasty.aethereal.dev` and allow only `umami.heyclau.de` for scripts and connections.
- Fix a documentation/comment in `apps/web/src/components/web-vitals.tsx` to reference the restored `umami.heyclau.de` origin.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues and it passed.
- Verified with `rg` that `tasty.aethereal.dev` references were removed and `umami.heyclau.de` appears in `apps/web/src/lib/site.ts`, `apps/web/src/lib/security-headers.ts`, `apps/web/public/_headers`, and `apps/web/src/components/web-vitals.tsx`.
- Attempted `pnpm validate:openapi` but the run was blocked by repeated registry connectivity/supply-chain verification failures in this environment, so that validation could not complete before the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e9f4a6914832ab60f359e8dbb49ba)