### PR TITLE
feat(newsletter): automated weekly digest + welcome email

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -1,0 +1,90 @@
+import { definePlugin } from "nitro";
+
+import { getEnvString, runWithCloudflareRuntime } from "@/lib/cloudflare-env.server";
+import { getDirectoryEntries } from "@/lib/content.server";
+import { selectDigestEntries, type DigestCandidate } from "@/lib/newsletter-digest";
+import { buildDigestEmail } from "@/lib/newsletter-emails";
+import { recordUmamiEvent, sendResendBroadcast } from "@/lib/newsletter-send.server";
+import { siteConfig } from "@/lib/site";
+
+// Sundays 16:00 UTC. Must also be present in wrangler.jsonc triggers.crons.
+const WEEKLY_CRON = "0 16 * * 0";
+
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+type CloudflareScheduledPayload = {
+  controller?: { cron?: string };
+  env: unknown;
+  context: unknown;
+};
+
+function formatDateLabel(ms: number): string {
+  const date = new Date(ms);
+  return `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
+}
+
+/**
+ * Weekly "new & notable" newsletter digest. Fully automated: picks entries
+ * added in the last 7 days, skips thin weeks (<5), and sends a Resend broadcast
+ * to the audience. Inert until RESEND_* secrets are configured. The cron hook
+ * fires for every trigger, so we gate on the weekly cron string.
+ */
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks?.hook(
+    "cloudflare:scheduled",
+    async ({ controller, env, context }: CloudflareScheduledPayload) => {
+      if (controller?.cron !== WEEKLY_CRON) return;
+
+      const request = new Request("https://heyclau.de/__scheduled/newsletter-digest");
+      await runWithCloudflareRuntime(request, env, context, async () => {
+        try {
+          const apiKey = getEnvString("RESEND_API_KEY");
+          const segmentId = getEnvString("RESEND_SEGMENT_ID");
+          const from = getEnvString("RESEND_FROM");
+          if (!apiKey || !segmentId || !from) {
+            console.log("[newsletter-digest] skipped: not configured");
+            return;
+          }
+
+          const now = Date.now();
+          const entries = (await getDirectoryEntries()) as readonly DigestCandidate[];
+          const items = selectDigestEntries(entries, now, { windowDays: 7, min: 5, max: 6 });
+          if (!items) {
+            console.log("[newsletter-digest] skipped: not enough new entries this week");
+            return;
+          }
+
+          const dateLabel = formatDateLabel(now);
+          const { subject, html, text } = buildDigestEmail({
+            siteUrl: siteConfig.url,
+            items,
+            dateLabel,
+          });
+          const result = await sendResendBroadcast({
+            apiKey,
+            segmentId,
+            from,
+            subject,
+            html,
+            text,
+            name: `Weekly digest — ${dateLabel}`,
+          });
+          console.log("[newsletter-digest] broadcast sent", {
+            ok: result.ok,
+            status: result.status,
+            count: items.length,
+          });
+          await recordUmamiEvent("newsletter-digest-sent", {
+            count: items.length,
+            ok: result.ok,
+          });
+        } catch (error) {
+          console.error("[newsletter-digest] scheduled send failed", error);
+        }
+      });
+    },
+  );
+});

--- a/apps/web/src/lib/newsletter-digest.ts
+++ b/apps/web/src/lib/newsletter-digest.ts
@@ -1,0 +1,59 @@
+// Selection logic for the weekly "new & notable" digest. Pure (no I/O) so it's
+// unit-testable; the scheduled job feeds it getDirectoryEntries() + Date.now().
+
+export type DigestCandidate = {
+  title: string;
+  category: string;
+  slug: string;
+  description?: string;
+  cardDescription?: string;
+  dateAdded?: string;
+};
+
+export type DigestItem = {
+  title: string;
+  category: string;
+  slug: string;
+  summary: string;
+};
+
+export type DigestSelectionOptions = {
+  /** How far back to look for "new" entries. */
+  windowDays?: number;
+  /** Don't send a digest with fewer than this many items (skip thin weeks). */
+  min?: number;
+  /** Cap the digest to this many items. */
+  max?: number;
+};
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Pick the entries added within the last `windowDays`, newest first. Returns
+ * null when there are fewer than `min` (the caller skips the send that week) so
+ * the newsletter never goes out thin or empty.
+ */
+export function selectDigestEntries(
+  entries: readonly DigestCandidate[],
+  nowMs: number,
+  options: DigestSelectionOptions = {},
+): DigestItem[] | null {
+  const windowDays = options.windowDays ?? 7;
+  const min = options.min ?? 5;
+  const max = options.max ?? 6;
+  const cutoff = nowMs - windowDays * DAY_MS;
+
+  const recent = entries
+    .map((entry) => ({ entry, added: entry.dateAdded ? Date.parse(entry.dateAdded) : NaN }))
+    .filter(({ added }) => Number.isFinite(added) && added >= cutoff && added <= nowMs)
+    .sort((a, b) => b.added - a.added);
+
+  if (recent.length < min) return null;
+
+  return recent.slice(0, max).map(({ entry }) => ({
+    title: entry.title,
+    category: entry.category,
+    slug: entry.slug,
+    summary: (entry.cardDescription || entry.description || "").trim(),
+  }));
+}

--- a/apps/web/src/lib/newsletter-emails.ts
+++ b/apps/web/src/lib/newsletter-emails.ts
@@ -1,6 +1,10 @@
-// Minimal, on-brand confirmation email for double opt-in. Built as an inline
-// string (not React Email) so it renders in the Worker without a runtime React
-// dependency. Light theme to match heyclau.de; no tracking pixel.
+// On-brand (light) newsletter emails, built as inline strings (not React Email)
+// so they render in the Worker without a runtime React dependency. No tracking
+// pixels. Confirm + welcome are transactional; the digest is a Resend broadcast.
+
+import type { DigestItem } from "@/lib/newsletter-digest";
+
+const FONT = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
 
 function escapeHtml(value: string): string {
   return value
@@ -61,6 +65,153 @@ export function buildNewsletterConfirmEmail(opts: { confirmUrl: string; siteUrl:
     "",
     "Didn't request this? Ignore this email — nothing was added.",
     siteHost,
+  ].join("\n");
+
+  return { subject, html, text };
+}
+
+function trimUrl(siteUrl: string): string {
+  return siteUrl.replace(/\/$/, "");
+}
+
+function siteHostOf(siteUrl: string): string {
+  return siteUrl.replace(/^https?:\/\//, "").replace(/\/$/, "");
+}
+
+function emailShell(opts: { preheader: string; inner: string }): string {
+  return `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#f7f5ef;">
+    <div style="display:none;max-height:0;overflow:hidden;opacity:0;">${escapeHtml(opts.preheader)}</div>
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f7f5ef;padding:40px 16px;">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:520px;background:#ffffff;border:1px solid #e7e3d8;border-radius:14px;">
+          ${opts.inner}
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+}
+
+// Standing growth/revenue CTAs (submissions, paid jobs, sponsorship) shown in
+// the welcome + digest footers. Deliberately subtle — one quiet line.
+function standingCtasHtml(siteUrl: string): string {
+  const base = trimUrl(siteUrl);
+  const link = (href: string, label: string) =>
+    `<a href="${base}${href}" style="color:#4d4c47;text-decoration:underline;">${label}</a>`;
+  return `<tr><td style="padding:18px 32px 6px;border-top:1px solid #efece3;">
+            <p style="margin:0;font:400 13px/1.7 ${FONT};color:#6b6a64;">${link("/submit", "Built something? Submit it")} &middot; ${link("/jobs/post", "Hiring? Post a role")} &middot; ${link("/advertise", "List or sponsor your tool")}</p>
+            <p style="margin:8px 0 0;font:400 12px/1.6 ${FONT};color:#8a8980;">Enjoying this? Forward it to a teammate.</p>
+          </td></tr>`;
+}
+
+function standingCtasText(siteUrl: string): string {
+  const base = trimUrl(siteUrl);
+  return [
+    "—",
+    `Built something? Submit it: ${base}/submit`,
+    `Hiring? Post a role: ${base}/jobs/post`,
+    `List or sponsor your tool: ${base}/advertise`,
+    "Enjoying this? Forward it to a teammate.",
+  ].join("\n");
+}
+
+/** Welcome email sent (transactional) right after a subscriber confirms. */
+export function buildWelcomeEmail(opts: { siteUrl: string }): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const base = trimUrl(opts.siteUrl);
+  const host = escapeHtml(siteHostOf(opts.siteUrl));
+  const subject = "You're in — welcome to HeyClaude";
+  const inner = `<tr><td style="padding:32px 32px 8px;">
+            <div style="font:600 13px/1.4 ${FONT};letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude</div>
+            <h1 style="margin:14px 0 0;font:700 24px/1.25 ${FONT};color:#171614;">You're in.</h1>
+            <p style="margin:14px 0 0;font:400 15px/1.6 ${FONT};color:#4d4c47;">Thanks for confirming. Every Sunday you'll get one calm read: the best new Claude Code agents, MCP servers, skills, and workflows reviewed that week. No hype, no tracking pixels.</p>
+          </td></tr>
+          <tr><td style="padding:18px 32px 4px;">
+            <a href="${base}/best" style="display:inline-block;background:#171614;color:#ffffff;text-decoration:none;font:600 15px/1 ${FONT};padding:13px 20px;border-radius:10px;">Start with the best of HeyClaude</a>
+          </td></tr>
+          <tr><td style="padding:12px 32px 4px;">
+            <p style="margin:0;font:400 14px/1.7 ${FONT};color:#4d4c47;">While you wait for Sunday:<br>&bull; <a href="${base}/state-of-claude-tooling" style="color:#171614;">The state of Claude tooling</a><br>&bull; <a href="${base}/browse" style="color:#171614;">Browse the full directory</a></p>
+          </td></tr>
+          ${standingCtasHtml(opts.siteUrl)}
+          <tr><td style="padding:2px 32px 28px;">
+            <p style="margin:8px 0 0;font:400 12px/1.6 ${FONT};color:#8a8980;">Manage your subscription at <a href="${base}/subscriptions" style="color:#6b6a64;">${host}/subscriptions</a>.</p>
+          </td></tr>`;
+  const html = emailShell({ preheader: "Welcome — your weekly Claude brief lands Sundays.", inner });
+  const text = [
+    "You're in — welcome to HeyClaude",
+    "",
+    "Thanks for confirming. Every Sunday: one calm read on the best new Claude tools reviewed that week. No hype, no tracking pixels.",
+    "",
+    `Start with the best of HeyClaude: ${base}/best`,
+    `The state of Claude tooling: ${base}/state-of-claude-tooling`,
+    `Browse the directory: ${base}/browse`,
+    "",
+    standingCtasText(opts.siteUrl),
+    "",
+    `Manage your subscription: ${base}/subscriptions`,
+  ].join("\n");
+  return { subject, html, text };
+}
+
+/** Weekly "new & notable" digest, sent as a Resend broadcast. */
+export function buildDigestEmail(opts: {
+  siteUrl: string;
+  items: DigestItem[];
+  dateLabel: string;
+}): { subject: string; html: string; text: string } {
+  const base = trimUrl(opts.siteUrl);
+  const subject = `New on HeyClaude — ${opts.dateLabel}`;
+
+  const itemsHtml = opts.items
+    .map((item) => {
+      const url = `${base}/entry/${encodeURIComponent(item.category)}/${encodeURIComponent(item.slug)}`;
+      const summary = item.summary
+        ? `<p style="margin:4px 0 0;font:400 14px/1.6 ${FONT};color:#4d4c47;">${escapeHtml(item.summary)}</p>`
+        : "";
+      return `<tr><td style="padding:14px 32px;border-top:1px solid #efece3;">
+            <div style="font:600 11px/1.4 ${FONT};letter-spacing:1px;text-transform:uppercase;color:#8a8980;">${escapeHtml(item.category)}</div>
+            <a href="${url}" style="display:block;margin:4px 0 0;font:700 17px/1.35 ${FONT};color:#171614;text-decoration:none;">${escapeHtml(item.title)}</a>
+            ${summary}
+          </td></tr>`;
+    })
+    .join("");
+
+  const inner = `<tr><td style="padding:32px 32px 4px;">
+            <div style="font:600 13px/1.4 ${FONT};letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude &middot; ${escapeHtml(opts.dateLabel)}</div>
+            <h1 style="margin:12px 0 0;font:700 23px/1.25 ${FONT};color:#171614;">New &amp; notable this week</h1>
+            <p style="margin:10px 0 0;font:400 14px/1.6 ${FONT};color:#4d4c47;">Reviewed Claude tools that landed in the directory this week.</p>
+          </td></tr>
+          ${itemsHtml}
+          <tr><td style="padding:20px 32px 4px;border-top:1px solid #efece3;">
+            <a href="${base}/browse" style="display:inline-block;background:#171614;color:#ffffff;text-decoration:none;font:600 15px/1 ${FONT};padding:13px 20px;border-radius:10px;">Browse all on HeyClaude</a>
+          </td></tr>
+          ${standingCtasHtml(opts.siteUrl)}
+          <tr><td style="padding:2px 32px 28px;">
+            <p style="margin:8px 0 0;font:400 12px/1.6 ${FONT};color:#8a8980;"><a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#8a8980;">Unsubscribe</a></p>
+          </td></tr>`;
+  const html = emailShell({
+    preheader: `${opts.items.length} new Claude tools worth a look.`,
+    inner,
+  });
+
+  const text = [
+    `New on HeyClaude — ${opts.dateLabel}`,
+    "",
+    ...opts.items.map(
+      (item) =>
+        `• [${item.category}] ${item.title}\n  ${base}/entry/${item.category}/${item.slug}${item.summary ? `\n  ${item.summary}` : ""}`,
+    ),
+    "",
+    `Browse all: ${base}/browse`,
+    "",
+    standingCtasText(opts.siteUrl),
+    "",
+    "Unsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}",
   ].join("\n");
 
   return { subject, html, text };

--- a/apps/web/src/lib/newsletter-send.server.ts
+++ b/apps/web/src/lib/newsletter-send.server.ts
@@ -1,0 +1,114 @@
+// Server-only Resend + umami helpers for newsletter sending. Used by the confirm
+// route (welcome email) and the weekly-digest scheduled job (broadcast).
+
+import { getEnvString } from "@/lib/cloudflare-env.server";
+
+const RESEND_BASE = "https://api.resend.com";
+const DEFAULT_UMAMI_UPSTREAM = "https://tasty.aethereal.dev";
+const DEFAULT_UMAMI_WEBSITE_ID = "b734c138-2949-4527-9160-7fe5d0e81121";
+
+/** Send a transactional email via Resend (/emails). Returns success. */
+export async function sendResendEmail(params: {
+  apiKey: string;
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+}): Promise<boolean> {
+  try {
+    const response = await fetch(`${RESEND_BASE}/emails`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: params.from,
+        to: params.to,
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+      }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create AND send a Resend broadcast to a segment in one call (`send: true`).
+ * Broadcasts can only be sent via the API if they were also created via the API,
+ * which is exactly this flow.
+ */
+export async function sendResendBroadcast(params: {
+  apiKey: string;
+  segmentId: string;
+  from: string;
+  subject: string;
+  html: string;
+  text: string;
+  name: string;
+}): Promise<{ ok: boolean; status?: number; id?: string }> {
+  try {
+    const response = await fetch(`${RESEND_BASE}/broadcasts`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${params.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        segment_id: params.segmentId,
+        from: params.from,
+        subject: params.subject,
+        html: params.html,
+        text: params.text,
+        name: params.name,
+        send: true,
+      }),
+      signal: AbortSignal.timeout(10000),
+    });
+    let body: { id?: string; data?: { id?: string } } = {};
+    try {
+      body = (await response.json()) as typeof body;
+    } catch {
+      /* non-JSON body */
+    }
+    return { ok: response.ok, status: response.status, id: body.id ?? body.data?.id };
+  } catch {
+    return { ok: false };
+  }
+}
+
+/**
+ * Record a server-side umami event (best-effort) so newsletter sends show up in
+ * the same dashboard as web traffic. No-op on failure — analytics never blocks.
+ */
+export async function recordUmamiEvent(name: string, data?: Record<string, unknown>): Promise<void> {
+  const upstream = getEnvString("UMAMI_UPSTREAM_URL") || DEFAULT_UMAMI_UPSTREAM;
+  const websiteId = getEnvString("UMAMI_WEBSITE_ID") || DEFAULT_UMAMI_WEBSITE_ID;
+  try {
+    await fetch(`${upstream}/api/send`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "Mozilla/5.0 (compatible; HeyClaude-newsletter)",
+      },
+      body: JSON.stringify({
+        type: "event",
+        payload: {
+          website: websiteId,
+          hostname: "heyclau.de",
+          url: "/__cron/newsletter",
+          name,
+          data,
+        },
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
+  } catch {
+    /* best-effort */
+  }
+}

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -3,6 +3,8 @@ import { createApiFileRoute } from "@/lib/api/file-route";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 import { verifyConfirmToken } from "@/lib/newsletter-token.server";
 import { addNewsletterContact } from "@/routes/api/newsletter/subscribe";
+import { buildWelcomeEmail } from "@/lib/newsletter-emails";
+import { sendResendEmail } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
 // Minimal, on-brand confirmation landing page (light theme, matches the site).
@@ -71,6 +73,23 @@ export const Route = createApiFileRoute("/api/public/newsletter/confirm")({
             heading: "Something went wrong",
             body: "We couldn't confirm your subscription just now. Please try again shortly.",
           });
+        }
+
+        // Send the welcome email on first-time confirm (best-effort; never block
+        // or fail the confirmation on a welcome-send hiccup). Skip duplicates.
+        if (result === "ok") {
+          const from = getEnvString("RESEND_FROM");
+          if (from) {
+            const welcome = buildWelcomeEmail({ siteUrl: siteConfig.url });
+            await sendResendEmail({
+              apiKey: resendApiKey,
+              from,
+              to: payload.email,
+              subject: welcome.subject,
+              html: welcome.html,
+              text: welcome.text,
+            }).catch(() => false);
+          }
         }
 
         return resultPage({

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -21,7 +21,8 @@
     "mode": "smart",
   },
   "triggers": {
-    "crons": ["17 */6 * * *"],
+    // 6-hourly: source-repo signals. Sundays 16:00 UTC: weekly newsletter digest.
+    "crons": ["17 */6 * * *", "0 16 * * 0"],
   },
   "assets": {
     "directory": "dist/client",

--- a/tests/newsletter-digest.test.ts
+++ b/tests/newsletter-digest.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { selectDigestEntries, type DigestCandidate } from "../apps/web/src/lib/newsletter-digest";
+
+const NOW = Date.parse("2026-06-14T16:00:00Z");
+
+function entry(daysAgo: number, overrides: Partial<DigestCandidate> = {}): DigestCandidate {
+  const d = new Date(NOW - daysAgo * 86_400_000).toISOString().slice(0, 10);
+  return {
+    title: `Entry ${daysAgo}d`,
+    category: "mcp",
+    slug: `entry-${daysAgo}`,
+    description: `Description ${daysAgo}`,
+    dateAdded: d,
+    ...overrides,
+  };
+}
+
+describe("selectDigestEntries", () => {
+  it("returns null (skip thin week) below the minimum", () => {
+    const entries = [entry(1), entry(2), entry(3)]; // 3 < min 5
+    expect(selectDigestEntries(entries, NOW, { min: 5 })).toBeNull();
+  });
+
+  it("includes only entries within the window, newest first", () => {
+    const entries = [entry(10), entry(1), entry(8), entry(3), entry(0), entry(6), entry(2)];
+    const result = selectDigestEntries(entries, NOW, { windowDays: 7, min: 1, max: 10 });
+    expect(result).not.toBeNull();
+    // 0,1,2,3,6 days ago are within 7 days; 8 and 10 are excluded.
+    expect(result!.map((r) => r.slug)).toEqual([
+      "entry-0",
+      "entry-1",
+      "entry-2",
+      "entry-3",
+      "entry-6",
+    ]);
+  });
+
+  it("caps the digest at max", () => {
+    const entries = Array.from({ length: 12 }, (_, i) => entry(i % 6));
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 6 });
+    expect(result).toHaveLength(6);
+  });
+
+  it("excludes future-dated and unparseable entries", () => {
+    const entries = [
+      entry(-2, { slug: "future" }),
+      entry(1),
+      entry(2),
+      entry(3),
+      entry(4),
+      entry(5, { dateAdded: "not-a-date", slug: "bad-date" }),
+    ];
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 10 });
+    const slugs = result!.map((r) => r.slug);
+    expect(slugs).not.toContain("future");
+    expect(slugs).not.toContain("bad-date");
+  });
+
+  it("prefers cardDescription over description for the summary", () => {
+    const entries = [
+      entry(1, { cardDescription: "Card copy", description: "Long copy" }),
+      entry(2),
+      entry(3),
+      entry(4),
+      entry(5),
+    ];
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 1 });
+    expect(result![0].summary).toBe("Card copy");
+  });
+});


### PR DESCRIPTION
Completes the automated newsletter (confirmed plan: weekly, skip thin weeks; double opt-in already merged in #2328). Fully hands-off; **inert until the Resend secrets are set**.

## What ships
- **Weekly digest cron** — `plugins/newsletter-digest-scheduled.ts`, Cloudflare cron **Sundays 16:00 UTC** (added to `wrangler.jsonc`). The hook fires for every trigger so it gates on the weekly cron string, then sends a **Resend broadcast** to the audience. Records a best-effort umami `newsletter-digest-sent` event.
- **Digest selection** — `newsletter-digest.ts` `selectDigestEntries()`: entries added in the last 7 days, newest first, **returns null below 5 → skips thin weeks** (never sends empty/sparse). Unit-tested (5 cases).
- **Welcome email** — sent on first-time confirm (best-effort) from the confirm route.
- **Templates** — `newsletter-emails.ts` gains a shared light-theme shell + a **standing CTA footer** (the growth/revenue engine, kept to one quiet line): *Submit* (content), *Post a role* (paid jobs), *Sponsor* (revenue), forward-to-a-teammate. `buildWelcomeEmail` + `buildDigestEmail`. **No tracking pixels**; the digest uses Resend's `{{{RESEND_UNSUBSCRIBE_URL}}}` merge tag.
- **Send helpers** — `newsletter-send.server.ts`: `sendResendEmail` (transactional), `sendResendBroadcast` (create+send in one call), `recordUmamiEvent` (server-side).

## Safety / anti-spam
- No-op until `RESEND_API_KEY` + `RESEND_SEGMENT_ID` + `RESEND_FROM` exist (the cron logs "not configured" and returns).
- Weekly cadence + thin-week skip + one purpose per email.

## To go live + test
Set the secrets (see double-opt-in PR), then a safe self-test: temporarily point `RESEND_SEGMENT_ID` at a test segment containing only your address and trigger a send, or call `sendResendBroadcast` against a test segment. Real cron fires Sundays.

## Validation
- `tests/newsletter-digest.test.ts` ✓ (5)
- `pnpm --filter web type-check` ✓, `pnpm --filter web build` ✓ (cron plugin + routes compile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly automated newsletter digest that curates and sends "new & notable" content to subscribers.
  * Welcome email now automatically sent when users confirm their newsletter subscription.

* **Tests**
  * Added test coverage for newsletter digest selection and filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->