### PR TITLE
fix(web): use Cloudflare-valid Sunday cron for the weekly digest

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -7,8 +7,10 @@ import { buildDigestEmail } from "@/lib/newsletter-emails";
 import { recordUmamiEvent, sendResendBroadcast } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
-// Sundays 16:00 UTC. Must also be present in wrangler.jsonc triggers.crons.
-const WEEKLY_CRON = "0 16 * * 0";
+// Sundays 16:00 UTC. Must match the string in wrangler.jsonc triggers.crons
+// exactly (Cloudflare passes it through as controller.cron). NB: Cloudflare's
+// day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN, not 0.
+const WEEKLY_CRON = "0 16 * * SUN";
 
 const MONTHS = [
   "January", "February", "March", "April", "May", "June",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -22,7 +22,8 @@
   },
   "triggers": {
     // 6-hourly: source-repo signals. Sundays 16:00 UTC: weekly newsletter digest.
-    "crons": ["17 */6 * * *", "0 16 * * 0"],
+    // NB: Cloudflare day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN (not 0).
+    "crons": ["17 */6 * * *", "0 16 * * SUN"],
   },
   "assets": {
     "directory": "dist/client",


### PR DESCRIPTION
The weekly-digest cron `0 16 * * 0` (from #2331) failed the prod deploy: `invalid cron string: 0 16 * * 0 [code: 10100]`. Cloudflare's day-of-week field is **1=Sunday..7=Saturday** (not the usual 0=Sunday), so `0` is out of range and **all prod deploys were blocked**.

Fix: use `SUN` (Sundays 16:00 UTC) in both `wrangler.jsonc` triggers and the plugin's `WEEKLY_CRON` guard (which must match `controller.cron` exactly). Unblocks deploys; digest cadence unchanged.

Ref: Cloudflare cron docs — "Days of the week go from 1 = Sunday to 7 = Saturday".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cloudflare scheduler configuration to align with the required day-of-week format for weekly newsletter digest scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->