### PR TITLE
fix(web): harden umami collector proxy

### DIFF
--- a/apps/web/src/routes/u.api.send.ts
+++ b/apps/web/src/routes/u.api.send.ts
@@ -1,8 +1,31 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { apiError } from "@/lib/api/router";
+import {
+  BodyTooLargeError,
+  hasJsonContentType,
+  isAllowedOrigin,
+  isRateLimited,
+  readRequestTextWithinLimit,
+} from "@/lib/api-security";
+import { logApiWarn } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
 const DEFAULT_UPSTREAM = "https://tasty.aethereal.dev";
+const BODY_LIMIT_BYTES = 16 * 1024;
+const RATE_LIMIT = {
+  scope: "umami-collector",
+  limit: 60,
+  windowMs: 60_000,
+} as const;
+
+function getRequestId(request: Request) {
+  return (
+    request.headers.get("cf-ray") ||
+    request.headers.get("x-request-id") ||
+    crypto.randomUUID()
+  );
+}
 
 /**
  * First-party umami collector proxy. The tracker served from `/u/script.js`
@@ -12,43 +35,76 @@ const DEFAULT_UPSTREAM = "https://tasty.aethereal.dev";
  * `connect-src` to `'self'` — no third-party analytics origin in the CSP. Lives
  * under `/u/` (not `/api/`) since it's infra, not a product API.
  */
+export async function POST(request: Request): Promise<Response> {
+  const requestId = getRequestId(request);
+
+  if (!isAllowedOrigin(request)) {
+    logApiWarn(request, "umami.collector.forbidden_origin");
+    return apiError("forbidden_origin", 403, { requestId });
+  }
+
+  if (!hasJsonContentType(request)) {
+    logApiWarn(request, "umami.collector.invalid_content_type");
+    return apiError("invalid_content_type", 415, { requestId });
+  }
+
+  if (isRateLimited({ request, ...RATE_LIMIT })) {
+    logApiWarn(request, "umami.collector.rate_limited");
+    return apiError("rate_limited", 429, { requestId });
+  }
+
+  let body: string;
+  try {
+    body = await readRequestTextWithinLimit(request, BODY_LIMIT_BYTES);
+  } catch (error) {
+    if (error instanceof BodyTooLargeError) {
+      logApiWarn(request, "umami.collector.payload_too_large");
+      return apiError("payload_too_large", 413, { requestId });
+    }
+    throw error;
+  }
+
+  const upstream = getEnvString("UMAMI_UPSTREAM_URL") || DEFAULT_UPSTREAM;
+  const headers = new Headers({
+    "content-type": "application/json",
+    // umami drops requests without a User-Agent.
+    "user-agent":
+      request.headers.get("user-agent") || "Mozilla/5.0 (compatible; HeyClaude)",
+  });
+  const clientIp =
+    request.headers.get("cf-connecting-ip") || request.headers.get("x-forwarded-for");
+  if (clientIp) headers.set("x-forwarded-for", clientIp);
+
+  let response: Response;
+  try {
+    response = await fetch(`${upstream}/api/send`, {
+      method: "POST",
+      headers,
+      body,
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    return new Response("", {
+      status: 502,
+      headers: { "cache-control": "no-store" },
+    });
+  }
+
+  const text = await response.text();
+  return new Response(text, {
+    status: response.status,
+    headers: {
+      "content-type":
+        response.headers.get("content-type") || "text/plain; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
 export const Route = createFileRoute("/u/api/send")({
   server: {
     handlers: {
-      POST: async ({ request }) => {
-        const upstream = getEnvString("UMAMI_UPSTREAM_URL") || DEFAULT_UPSTREAM;
-        const body = await request.text();
-
-        const headers = new Headers({
-          "content-type": request.headers.get("content-type") || "application/json",
-          // umami drops requests without a User-Agent.
-          "user-agent": request.headers.get("user-agent") || "Mozilla/5.0 (compatible; HeyClaude)",
-        });
-        const clientIp =
-          request.headers.get("cf-connecting-ip") || request.headers.get("x-forwarded-for");
-        if (clientIp) headers.set("x-forwarded-for", clientIp);
-
-        let response: Response;
-        try {
-          response = await fetch(`${upstream}/api/send`, {
-            method: "POST",
-            headers,
-            body,
-            signal: AbortSignal.timeout(8000),
-          });
-        } catch {
-          return new Response("", { status: 502, headers: { "cache-control": "no-store" } });
-        }
-
-        const text = await response.text();
-        return new Response(text, {
-          status: response.status,
-          headers: {
-            "content-type": response.headers.get("content-type") || "text/plain; charset=utf-8",
-            "cache-control": "no-store",
-          },
-        });
-      },
+      POST: async ({ request }) => POST(request),
     },
   },
 });

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -708,3 +708,81 @@ describe("in-memory fallback rate limiter", () => {
     expect(__rateLimitTestHooks.size()).toBeLessThanOrEqual(cap);
   });
 });
+
+describe("umami collector proxy security", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.UMAMI_UPSTREAM_URL = "https://umami.example";
+    const { __rateLimitTestHooks } = await import("@/lib/api-security");
+    __rateLimitTestHooks.reset();
+  });
+
+  function analyticsRequest(body: string, headers: Record<string, string> = {}) {
+    return new Request("https://heyclau.de/u/api/send", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin: "https://heyclau.de",
+        "cf-connecting-ip": "198.51.100.80",
+        "user-agent": "Vitest/1.0",
+        ...headers,
+      },
+      body,
+    });
+  }
+
+  it("rejects cross-origin analytics posts before proxying", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(
+      analyticsRequest('{"payload":{}}', { origin: "https://attacker.example" }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-JSON analytics posts before proxying", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(
+      analyticsRequest("plain", { "content-type": "text/plain;charset=UTF-8" }),
+    );
+
+    expect(response.status).toBe(415);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized analytics posts before reading and proxying", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(
+      analyticsRequest("{}", { "content-length": String(17 * 1024) }),
+    );
+
+    expect(response.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rate-limits repeated analytics posts per client", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    let response = new Response(null, { status: 500 });
+    for (let i = 0; i < 61; i += 1) {
+      response = await POST(analyticsRequest('{"payload":{}}'));
+    }
+
+    expect(response.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(60);
+  });
+});


### PR DESCRIPTION
### Motivation
- The first-party collector at `/u/api/send` previously read the entire request body and proxied it upstream without origin checks, content-type validation, body-size limits, or rate limiting, allowing unauthenticated attackers to flood the service and poison analytics.

### Description
- Enforce same-origin checks, JSON `content-type` validation, a per-request body-size cap via `readRequestTextWithinLimit` (16 KiB), and a per-client fallback rate limit before proxying to the upstream Umami collector in `apps/web/src/routes/u.api.send.ts`.
- Refactor the POST handler into a standalone `POST(request)` function that returns appropriate `apiError(...)` responses for forbidden origin, invalid content type, rate limits, and oversized payloads while preserving User-Agent and client IP forwarding to the upstream collector.
- Keep the existing first-party proxy behavior and upstream fetch timeout, and wire the route to call the hardened `POST` handler via the existing `createFileRoute` wrapper.
- Add regression tests in `tests/api-router-security.test.ts` covering cross-origin rejection, content-type enforcement, payload size rejection, and per-client rate limiting.

### Testing
- Ran the focused test file with Vitest: `./node_modules/.bin/vitest run tests/api-router-security.test.ts`, and the suite passed for the modified tests (new analytics-proxy tests included). 
- Run `git diff --check` to confirm there are no whitespace or diff errors and it returned clean. 
- Type-checking with the local `tsc` binary was not executed in this environment because `tsc` was not present in `node_modules/.bin`, and `pnpm`-backed runs were blocked by registry network verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb25b3e64832ab54cf50134feed87)