### PR TITLE
fix(newsletter): require action for confirmation

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -3968,6 +3968,236 @@
         }
       }
     },
+    "/api/public/newsletter/confirm": {
+      "post": {
+        "tags": ["Newsletter"],
+        "summary": "Confirm a newsletter subscription",
+        "responses": {
+          "200": {
+            "description": "Request accepted.",
+            "content": {
+              "application/json": { "schema": { "type": "object", "additionalProperties": {} } }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid query, invalid payload, or invalid status transition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin token or invalid webhook signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden origin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Invalid content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Route-level or Cloudflare-native rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Site DB not configured, provider not configured, or endpoint unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/newsletter/webhook": {
       "post": {
         "tags": ["Newsletter"],

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -4606,6 +4606,262 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/newsletter/confirm:
+    post:
+      tags:
+        - Newsletter
+      summary: Confirm a newsletter subscription
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/newsletter/webhook:
     post:
       tags:

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -1045,6 +1045,19 @@ export const apiRouteDefinitions = {
       binding: "API_STRICT_RATE_LIMIT",
     },
   }),
+  "newsletter.confirm": route({
+    id: "newsletter.confirm",
+    method: "POST",
+    path: "/api/public/newsletter/confirm",
+    summary: "Confirm a newsletter subscription",
+    tags: ["Newsletter"],
+    rateLimit: {
+      scope: "newsletter-confirm",
+      limit: 15,
+      windowMs: 60_000,
+      binding: "API_STRICT_RATE_LIMIT",
+    },
+  }),
   "newsletter.webhook": route({
     id: "newsletter.webhook",
     method: "POST",

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -1,4 +1,6 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
+import { enforceApiRateLimit, getApiRequestId } from "@/lib/api/router";
+import { getApiRouteDefinition } from "@/lib/api/contracts";
 
 import { getEnvString } from "@/lib/cloudflare-env.server";
 import { verifyConfirmToken } from "@/lib/newsletter-token.server";
@@ -8,7 +10,7 @@ import { sendResendEmail } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
 // Minimal, on-brand confirmation landing page (light theme, matches the site).
-function resultPage(opts: { ok: boolean; heading: string; body: string }): Response {
+function resultPage(opts: { ok: boolean; heading: string; body: string; token?: string }): Response {
   const accent = opts.ok ? "#2f8f5b" : "#b4541f";
   const html = `<!doctype html>
 <html lang="en">
@@ -24,7 +26,7 @@ function resultPage(opts: { ok: boolean; heading: string; body: string }): Respo
       <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
       <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
       <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
-      <a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>
+      ${opts.token ? `<form method="post" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
     </main>
   </body>
 </html>`;
@@ -34,11 +36,63 @@ function resultPage(opts: { ok: boolean; heading: string; body: string }): Respo
   });
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+const consumedConfirmTokens = new Map<string, number>();
+const MAX_CONSUMED_CONFIRM_TOKENS = 10_000;
+
+function pruneConsumedConfirmTokens(now: number) {
+  for (const [token, expiresAt] of consumedConfirmTokens) {
+    if (expiresAt <= now) consumedConfirmTokens.delete(token);
+  }
+  while (consumedConfirmTokens.size > MAX_CONSUMED_CONFIRM_TOKENS) {
+    const oldest = consumedConfirmTokens.keys().next().value;
+    if (!oldest) break;
+    consumedConfirmTokens.delete(oldest);
+  }
+}
+
+async function readConfirmToken(request: Request) {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    const body = (await request.json().catch(() => null)) as { token?: unknown } | null;
+    return typeof body?.token === "string" ? body.token : "";
+  }
+  const form = await request.formData().catch(() => null);
+  const token = form?.get("token");
+  return typeof token === "string" ? token : "";
+}
+
 export const Route = createApiFileRoute("/api/public/newsletter/confirm")({
   server: {
     handlers: {
       GET: async ({ request }) => {
         const token = new URL(request.url).searchParams.get("token") ?? "";
+        return resultPage({
+          ok: true,
+          heading: "Confirm your subscription",
+          body: "One more step: press the button below to confirm you want the weekly brief.",
+          token,
+        });
+      },
+      POST: async ({ request }) => {
+        const requestId = getApiRequestId(request);
+        const route = getApiRouteDefinition("newsletter.confirm");
+        if (await enforceApiRateLimit(route, request)) {
+          return resultPage({
+            ok: false,
+            heading: "Too many attempts",
+            body: `Please wait a minute before trying again. Request ID: ${requestId}`,
+          });
+        }
+
+        const token = await readConfirmToken(request);
         const confirmSecret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
         const resendApiKey = getEnvString("RESEND_API_KEY");
         const resendSegmentId = getEnvString("RESEND_SEGMENT_ID");
@@ -51,12 +105,23 @@ export const Route = createApiFileRoute("/api/public/newsletter/confirm")({
           });
         }
 
-        const payload = await verifyConfirmToken(confirmSecret, token, Date.now());
+        const now = Date.now();
+        pruneConsumedConfirmTokens(now);
+
+        const payload = await verifyConfirmToken(confirmSecret, token, now);
         if (!payload) {
           return resultPage({
             ok: false,
             heading: "Link expired",
             body: "This confirmation link is invalid or has expired. Please subscribe again.",
+          });
+        }
+
+        if (consumedConfirmTokens.has(token)) {
+          return resultPage({
+            ok: true,
+            heading: "Already confirmed",
+            body: "This confirmation link has already been used. You're all set.",
           });
         }
 
@@ -74,6 +139,8 @@ export const Route = createApiFileRoute("/api/public/newsletter/confirm")({
             body: "We couldn't confirm your subscription just now. Please try again shortly.",
           });
         }
+
+        consumedConfirmTokens.set(token, payload.exp);
 
         // Send the welcome email on first-time confirm (best-effort; never block
         // or fail the confirmation on a welcome-send hiccup). Skip duplicates.

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -4609,6 +4609,262 @@ paths:
                 required:
                   - ok
                   - error
+  /api/public/newsletter/confirm:
+    post:
+      tags:
+        - Newsletter
+      summary: Confirm a newsletter subscription
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/newsletter/webhook:
     post:
       tags:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -31,6 +31,7 @@ const apiRoutes = [
   "/api/votes/toggle",
   "/api/newsletter/subscribe",
   "/api/newsletter/webhook",
+  "/api/public/newsletter/confirm",
   "/api/og",
   "/api/submissions/preflight",
   "/api/download",


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated replay and automated confirmation side effects by requiring an explicit user action before performing the Resend contact write. 
- Bring the confirmation flow under the central API rate-limits and origin checks used by other endpoints.

### Description

- Change the public confirmation `GET` to render a small confirmation form instead of performing the subscription write directly. 
- Add a `POST` handler that parses the token (JSON/form), enforces the `newsletter.confirm` rate limit via `enforceApiRateLimit`, verifies the signed token, and performs `addNewsletterContact` only on explicit POST. 
- Add an in-process `consumedConfirmTokens` cache with pruning so a valid token becomes effectively single-use until its expiry to short-circuit replays. 
- Register a `newsletter.confirm` route in `apps/web/src/lib/api/contracts.ts` with the strict rate-limit binding and add small helpers (`readConfirmToken`, `escapeHtml`) and form support in `apps/web/src/routes/api/public/newsletter/confirm.ts`.

### Testing

- Ran `node_modules/.bin/vitest run tests/newsletter-token.test.ts` and the newsletter token unit tests all passed. 
- Ran `git diff --check` and there were no whitespace/format errors. 
- Attempted `pnpm exec tsc --noEmit`, but the package-manager supply-chain verification retried registry requests and could not complete in this environment, so a full typecheck was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb4263c74832a84f0bccf57cf7784)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added newsletter confirmation endpoint with token-based verification and rate limiting (15 requests per 60 seconds).
  * Supports both form and JSON submission formats.
  * Prevents duplicate confirmations through token tracking.

* **Documentation**
  * Updated API schema and specifications to document the new confirmation endpoint with comprehensive error response definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->