### PR TITLE
fix(newsletter): verified-domain sender default + confirm token in body (WAF)

### DIFF
--- a/apps/web/src/routes/api/newsletter/subscribe.ts
+++ b/apps/web/src/routes/api/newsletter/subscribe.ts
@@ -9,7 +9,9 @@ import { buildNewsletterConfirmEmail } from "@/lib/newsletter-emails";
 import { siteConfig } from "@/lib/site";
 
 const CONFIRM_TTL_MS = 48 * 60 * 60 * 1000;
-const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>";
+// Fallback sender when RESEND_FROM isn't set. Must be on a Resend-verified
+// domain — mail.heyclau.de is verified (the apex heyclau.de is not).
+const DEFAULT_FROM = "HeyClaude <newsletter@mail.heyclau.de>";
 
 function envSegmentId(followId: string): string | undefined {
   const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -33,7 +33,7 @@ function resultPage(opts: {
       <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
       <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
       <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
-      ${opts.token ? `<form method="post" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
+      ${opts.token ? `<form method="post" action="${siteConfig.url}/api/public/newsletter/confirm" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
     </main>
   </body>
 </html>`;


### PR DESCRIPTION
The `RESEND_FROM` fallback was `newsletter@heyclau.de` (apex), which isn't Resend-verified — a cleared/missing secret would 502 every confirm send (exactly what we hit while testing). The verified sending domain is `mail.heyclau.de`; point the committed default there. Prod sets `RESEND_FROM` explicitly, so this only hardens the fallback. Verified end-to-end: a confirm send to a single test address now returns `{ok:true,pending:true}`.