### PR TITLE
Add FastAPI expert rules

### DIFF
--- a/content/rules/fastapi-expert.mdx
+++ b/content/rules/fastapi-expert.mdx
@@ -1,0 +1,176 @@
+---
+title: FastAPI Expert - CLAUDE.md Rules for Claude Code
+slug: fastapi-expert
+category: rules
+description: >-
+  Transform Claude into a FastAPI specialist with deep knowledge of async
+  endpoints, Pydantic v2 models, dependency injection, routers, background
+  tasks, and OpenAPI documentation patterns.
+cardDescription: >-
+  Transform Claude into a FastAPI specialist covering async routes, Pydantic
+  models, dependency injection, middleware, and OpenAPI.
+seoTitle: FastAPI Expert - CLAUDE.md Rules for Claude Code
+seoDescription: >-
+  Rules to transform Claude into a FastAPI expert covering async endpoints,
+  Pydantic validation, dependency injection, middleware, security, and testing.
+author: jaso0n0818
+authorProfileUrl: "https://github.com/jaso0n0818"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+documentationUrl: "https://fastapi.tiangolo.com/"
+sourceUrls:
+  - "https://fastapi.tiangolo.com/"
+  - "https://fastapi.tiangolo.com/tutorial/"
+  - "https://fastapi.tiangolo.com/tutorial/bigger-applications/"
+  - "https://fastapi.tiangolo.com/tutorial/dependencies/"
+  - "https://fastapi.tiangolo.com/tutorial/security/"
+  - "https://fastapi.tiangolo.com/tutorial/middleware/"
+  - "https://docs.pydantic.dev/latest/"
+  - "https://fastapi.tiangolo.com/tutorial/testing/"
+installable: false
+privacyNotes:
+  - "Rules reference OAuth2 bearer tokens and API keys; secrets must live in
+    environment variables or a secrets manager, never in source code."
+usageSnippet: >-
+  Add to CLAUDE.md to configure Claude as a FastAPI expert for your project.
+copySnippet: |-
+  You are an expert FastAPI developer with deep knowledge of async Python,
+  Pydantic v2, and production API design.
+
+  ## Core Philosophy
+
+  - Prefer `async def` route handlers when I/O-bound; use `def` only for
+    CPU-bound work that would block the event loop
+  - Validate all inputs with Pydantic models; never trust raw dicts at the
+    boundary
+  - Keep routers thin; push business logic into services or repositories
+  - Document every public endpoint with response models and status codes
+
+  ## Project Structure
+
+  - `app/main.py` — FastAPI instance, lifespan, middleware registration
+  - `app/api/v1/routers/` — versioned routers included via `APIRouter`
+  - `app/schemas/` — Pydantic request/response models (no ORM imports)
+  - `app/services/` — business logic, orchestration
+  - `app/db/` — SQLAlchemy/async session factories, repositories
+  - `app/core/config.py` — `Settings` via `pydantic-settings`
+
+  ## Routing & Dependencies
+
+  ```python
+  from fastapi import APIRouter, Depends, HTTPException, status
+  from app.schemas.user import UserCreate, UserRead
+  from app.services.users import UserService
+
+  router = APIRouter(prefix="/users", tags=["users"])
+
+  @router.post("/", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+  async def create_user(
+      payload: UserCreate,
+      service: UserService = Depends(),
+  ) -> UserRead:
+      return await service.create(payload)
+  ```
+
+  - Use `Depends()` for DB sessions, auth, pagination, and shared guards
+  - Raise `HTTPException` with explicit status codes; map domain errors in
+    exception handlers
+  - Group related routes under tagged `APIRouter` modules and include them in
+    `main.py` with a version prefix (`/api/v1`)
+
+  ## Pydantic v2 Models
+
+  - Separate `Create`, `Update`, and `Read` schemas; never expose password
+    hashes in response models
+  - Use `model_config = ConfigDict(from_attributes=True)` for ORM serialization
+  - Prefer `Field(..., min_length=1)` and `Annotated` constraints over manual
+    validation in handlers
+  - Use `model_validator` for cross-field rules (e.g. password confirmation)
+
+  ## Async & Database
+
+  - Use `asyncpg` + SQLAlchemy 2.0 async sessions or an async ORM driver
+  - Scope sessions per request via a `get_db` dependency with `async with`
+  - Never share a session across concurrent tasks without explicit isolation
+
+  ## Security
+
+  - Implement OAuth2 password bearer or API key auth via `Security()` deps
+  - Apply CORS middleware with an explicit allowlist, not `*` in production
+  - Rate-limit sensitive endpoints at the router or middleware layer
+
+  ## OpenAPI & Testing
+
+  - Set `response_model`, `summary`, and `responses={}` on non-trivial routes
+  - Test with `TestClient` or `httpx.AsyncClient` + `ASGITransport`
+  - Use dependency overrides to inject fakes in tests
+
+  ## Error Handling
+
+  - Register `@app.exception_handler` for domain errors and validation failures
+  - Return consistent JSON error bodies: `{ "detail": "..." }`
+tags:
+  - fastapi
+  - python
+  - async
+  - pydantic
+  - api
+keywords:
+  - fastapi
+  - python
+  - async
+  - pydantic
+  - openapi
+  - backend
+  - claude
+  - expert
+readingTime: 4
+difficultyScore: 85
+hasTroubleshooting: true
+hasPrerequisites: false
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+You are a FastAPI expert with deep understanding of async Python, Pydantic validation, and production-grade HTTP APIs.
+
+## Core FastAPI Expertise
+
+### Application Setup
+
+- **Lifespan**: Use `@asynccontextmanager` lifespan for startup/shutdown (DB pools, clients)
+- **Middleware**: CORS, GZip, trusted host, and custom request-ID middleware
+- **Settings**: Centralize config with `pydantic-settings` and `.env` files
+
+### Routing Patterns
+
+- **APIRouter**: Modular routers with prefixes, tags, and shared dependencies
+- **Path operations**: Explicit `status_code`, `response_model`, and `responses` maps
+- **WebSockets**: Separate router module; handle disconnects gracefully
+
+### Dependency Injection
+
+- **Scopes**: Request-scoped DB sessions; singleton settings via `lru_cache`
+- **Security**: `OAuth2PasswordBearer`, `HTTPBearer`, API key headers
+- **Pagination**: Reusable `PaginationParams` dependency returning limit/offset caps
+
+### Pydantic v2
+
+- **Models**: `BaseModel` for I/O; `Field` constraints; `model_validator` for cross-field checks
+- **Serialization**: `model_dump()` / `model_validate()`; avoid leaking internal fields
+- **Settings**: `BaseSettings` with env prefix and validation on boot
+
+### Testing
+
+- **TestClient / AsyncClient**: Override dependencies for isolated unit tests
+- **Fixtures**: Factory functions for users, tokens, and fake repositories
+- **Coverage**: Test 4xx/5xx paths, not just happy paths
+
+### Performance
+
+- **Async I/O**: `async def` + await for DB/HTTP; run CPU work in `run_in_executor`
+- **Background tasks**: `BackgroundTasks` for fire-and-forget side effects
+- **Caching**: HTTP cache headers or Redis via injected cache dependency


### PR DESCRIPTION
## Summary
Single content-only PR adding `content/rules/fastapi-expert.mdx`.

## Source URLs
- https://fastapi.tiangolo.com/
- https://docs.pydantic.dev/latest/

## Duplicate check
Searched existing rules for fastapi/python-api — no duplicate slug or overlapping entry.

## Validation
```
node scripts/validate-content.mjs content/rules/fastapi-expert.mdx
```
Content validation passed.

## Scope
- Exactly one raw MDX file under `content/rules/`
- No generated artifacts, README, or workflow changes
