### PR TITLE
fix(content): correct /refactor-code metadata and differentiate description from /refactor

### DIFF
--- a/content/commands/refactor-code.mdx
+++ b/content/commands/refactor-code.mdx
@@ -3,27 +3,26 @@ title: /refactor-code - Specialized Refactor Commands for Claude
 slug: refactor-code
 category: commands
 description: >-
-  Targeted refactor command for specific code selections, functions, or
-  components — stays within narrow ownership boundaries for focused,
-  pull-request-sized changes without repository-wide modernization
+  Targeted Claude Code custom command for scoped, pull-request-sized refactors
+  on a specific file, function, or selection — stays within a narrow ownership
+  boundary rather than sweeping the whole repository
 cardDescription: >-
-  Targeted refactor command for specific code selections, functions, or
-  components — stays within narrow ownership boundaries for focused,
-  pull-request-sized changes without repository-wide modernization
+  Targeted Claude Code custom command for scoped, pull-request-sized refactors
+  on a specific file, function, or selection — stays within a narrow ownership
+  boundary rather than sweeping the whole repository
 seoTitle: /refactor-code - Specialized Refactor Commands for Claude
 seoDescription: >-
-  Targeted refactor command for specific code selections, functions, or
-  components — stays within narrow ownership boundaries for focused,
-  pull-request-sized changes without repository-wide modernization. Discover
-  tools for AI development.
+  Targeted Claude Code custom command for scoped, pull-request-sized refactors
+  on a specific file, function, or selection — stays within a narrow ownership
+  boundary rather than sweeping the whole repository. Discover tools for AI
+  development.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/refactor"
-installable: true
-installCommand: "/refactor [options] <file_or_selection>"
-usageSnippet: "/refactor [options] <file_or_selection>"
-copySnippet: "/refactor [options] <file_or_selection>"
+documentationUrl: "https://docs.anthropic.com/en/docs/claude-code/slash-commands"
+installable: false
+usageSnippet: "/refactor-code src/utils.js"
+copySnippet: "/refactor-code src/utils.js"
 tags:
   - refactoring
   - code-quality
@@ -49,18 +48,22 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
-commandSyntax: "/refactor [options] <file_or_selection>"
+commandSyntax: "/refactor-code <file_or_selection>"
 ---
 
-The `/refactor` command provides intelligent code refactoring capabilities with multiple strategies and safety checks.
+The `/refactor-code` command provides targeted refactoring for a specific file, function, or code selection. Copy the contents of this file to `.claude/commands/refactor-code.md` in your project (or `~/.claude/commands/refactor-code.md` for global use) to install it as a slash command.
 
 ## Usage
 
 ```
-/refactor [options] <file_or_selection>
+/refactor-code <file_or_selection>
+/refactor-code --dry-run src/utils.js
+/refactor-code --extract-function src/utils.js
 ```
 
-## Options
+> **Note:** These are not parsed CLI flags. Claude Code passes the entire string after `/refactor-code` as `$ARGUMENTS` to the command prompt. Claude interprets tokens like `--dry-run` and `--extract-function` as natural language instructions from the text. Behavior depends on how the prompt body handles them.
+
+## Argument Tokens
 
 ### Refactoring Types
 
@@ -73,14 +76,14 @@ The `/refactor` command provides intelligent code refactoring capabilities with 
 - `--modernize` - Update to modern language features
 - `--performance` - Apply performance optimizations
 
-### Safety Options
+### Safety Tokens
 
 - `--dry-run` - Show proposed changes without applying
 - `--interactive` - Prompt for each change
 - `--backup` - Create backup before refactoring
 - `--test-first` - Run tests before and after changes
 
-### Language-Specific Options
+### Language Tokens
 
 - `--javascript` - Apply JS/TS specific refactoring
 - `--python` - Apply Python-specific refactoring
@@ -238,22 +241,6 @@ refactor needs to stay inside a narrow ownership boundary.
 - GitLab CI pipeline
 - Jenkins job integration
 
-## Configuration
+## Installation
 
-Create a `.refactor.json` file in your project root:
-
-```json
-{
-  "rules": {
-    "maxFunctionLength": 20,
-    "maxParameterCount": 4,
-    "enforceConstantExtraction": true,
-    "modernizeFeatures": true
-  },
-  "exclude": ["node_modules/**", "dist/**", "*.test.js"],
-  "backup": {
-    "enabled": true,
-    "directory": ".refactor-backups"
-  }
-}
-```
+Copy this file to your project's `.claude/commands/refactor-code.md` for project-scoped use, or to `~/.claude/commands/refactor-code.md` to make it available across all your projects. After saving, the `/refactor-code` command appears in Claude Code automatically.


### PR DESCRIPTION
## Summary

`commands/refactor-code` had five accuracy issues and shared an exact description with `commands/refactor`, producing a 1.00 similarity score in the thin-content report.

- **Description differentiated** — now reflects the scoped, single-file, pull-request-sized posture vs the repo-wide `/refactor` command
- **`documentationUrl` corrected** — was pointing to `docs.claude.ai/commands/refactor` (nonexistent); updated to the real Claude Code slash commands reference
- **`installable: false`** + `installCommand` removed — there is no remote package endpoint; users install by copying the file to `.claude/commands/`
- **"Options" → "Argument Tokens"** — added note that `--dry-run`, `--extract-function`, etc. are natural-language tokens passed as `$ARGUMENTS`, not parsed CLI flags
- **Invented `.refactor.json` config schema removed** — no such config format exists in Claude Code; replaced with an accurate Installation section

## Test plan

- [ ] `pnpm validate:content:strict` passes (one file changed, no generated artifacts)
- [ ] `pnpm report:thin-content` no longer flags `commands/refactor-code` as exact-duplicate with `commands/refactor`