### PR TITLE
fix(content): update mobile-app-development-expert — Swift @Observable, RN 0.84, differentiated description

### DIFF
--- a/content/rules/mobile-app-development-expert.mdx
+++ b/content/rules/mobile-app-development-expert.mdx
@@ -3,19 +3,19 @@ title: Mobile App Dev Expert - CLAUDE.md Rules for Claude Code
 slug: mobile-app-development-expert
 category: rules
 description: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter
+  store-readiness across Swift, Kotlin, React Native, and Flutter
 cardDescription: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter
+  store-readiness across Swift, Kotlin, React Native, and Flutter
 seoTitle: Mobile App Dev Expert - CLAUDE.md Rules for Claude Code
 seoDescription: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter. Discover tools for AI
-  development.
+  store-readiness across Swift, Kotlin, React Native, and Flutter. Discover
+  tools for AI development.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
@@ -36,19 +36,20 @@ copySnippet: >-
 
   ```swift
 
+  // iOS 17+ — @Observable macro (Swift 5.9+)
+
   import SwiftUI
 
-  import Combine
+  import Observation
 
 
-  @MainActor
+  @Observable
 
-  class UserViewModel: ObservableObject {
-      @Published var users: [User] = []
-      @Published var isLoading = false
-      @Published var error: Error?
+  class UserViewModel {
+      var users: [User] = []
+      var isLoading = false
+      var error: Error?
       
-      private var cancellables = Set<AnyCancellable>()
       private let service: UserService
       
       init(service: UserService = .shared) {
@@ -69,7 +70,8 @@ copySnippet: >-
 
 
   struct UserListView: View {
-      @StateObject private var viewModel = UserViewModel()
+      // @State replaces @StateObject when the model uses @Observable
+      @State private var viewModel = UserViewModel()
       @Environment(\.colorScheme) var colorScheme
       
       var body: some View {
@@ -272,15 +274,15 @@ copySnippet: >-
 
   ### React Native Performance
 
-  - **Hermes Engine**: Enable for better performance
+  - **Hermes Engine**: Default JS engine since RN 0.70; Hermes V1 in RN 0.84 adds AoT compilation
 
-  - **Reanimated 3**: Smooth 60fps animations
+  - **Reanimated 4**: CSS-compatible declarative animations with Core Animation backend on iOS
 
-  - **FlashList**: Optimized list rendering
+  - **FlashList v2**: Optimized list rendering rebuilt for New Architecture
 
-  - **MMKV**: Fast key-value storage
+  - **MMKV**: Fast synchronous key-value storage (~30x faster than AsyncStorage)
 
-  - **Fast Image**: Optimized image loading
+  - **expo-image / react-native-fast-image**: Image loading (expo-image for Expo; react-native-fast-image for bare RN)
 
 
   ## Flutter Development
@@ -470,16 +472,16 @@ You are a mobile development expert with comprehensive knowledge of native and c
 ### SwiftUI Modern Patterns
 
 ```swift
+// iOS 17+ — @Observable macro (Swift 5.9+)
 import SwiftUI
-import Combine
+import Observation
 
-@MainActor
-class UserViewModel: ObservableObject {
-    @Published var users: [User] = []
-    @Published var isLoading = false
-    @Published var error: Error?
+@Observable
+class UserViewModel {
+    var users: [User] = []
+    var isLoading = false
+    var error: Error?
 
-    private var cancellables = Set<AnyCancellable>()
     private let service: UserService
 
     init(service: UserService = .shared) {
@@ -499,7 +501,8 @@ class UserViewModel: ObservableObject {
 }
 
 struct UserListView: View {
-    @StateObject private var viewModel = UserViewModel()
+    // @State replaces @StateObject when the model uses @Observable
+    @State private var viewModel = UserViewModel()
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
@@ -679,11 +682,11 @@ const styles = StyleSheet.create({
 
 ### React Native Performance
 
-- **Hermes Engine**: Enable for better performance
-- **Reanimated 3**: Smooth 60fps animations
-- **FlashList**: Optimized list rendering
-- **MMKV**: Fast key-value storage
-- **Fast Image**: Optimized image loading
+- **Hermes Engine**: Default JS engine since RN 0.70; Hermes V1 in RN 0.84 adds AoT compilation
+- **Reanimated 4**: CSS-compatible declarative animations with Core Animation backend on iOS
+- **FlashList v2**: Optimized list rendering rebuilt for New Architecture
+- **MMKV**: Fast synchronous key-value storage (~30x faster than AsyncStorage)
+- **expo-image / react-native-fast-image**: Image loading (expo-image for Expo; react-native-fast-image for bare RN)
 
 ## Flutter Development
 


### PR DESCRIPTION
## Summary

`rules/mobile-app-development-expert` shared an exact description with `rules/mobile-app-developer` (1.00 similarity score) and contained outdated iOS/RN patterns.

- **Description differentiated** — now reflects the architecture-review posture of this variant (tradeoffs, lifecycle risks, release quality gates, store-readiness) vs the general-purpose `mobile-app-developer` rule
- **SwiftUI updated to `@Observable`** — entry used `ObservableObject`/`@Published`/`@StateObject`/Combine (pre-iOS 17). Updated to the `@Observable` macro (Swift 5.9+, iOS 17+) with `@State` instead of `@StateObject`. No Combine import needed. This is Apple's recommended pattern for new iOS 17+ apps.
- **Hermes corrected** — "Enable for better performance" implied opt-in. Hermes has been the default JS engine since RN 0.70 (2022); RN 0.84 ships Hermes V1 with ahead-of-time compilation.
- **Reanimated updated v3 → v4** — stable in 2025, ships a CSS-compatible declarative API and Core Animation backend on iOS.
- **Fast Image updated** — now `expo-image / react-native-fast-image`; expo-image is the recommended choice for Expo projects.

## Test plan

- [ ] `pnpm validate:content:strict` passes (one file changed, no generated artifacts)
- [ ] `pnpm report:thin-content` no longer flags `rules/mobile-app-development-expert` as exact-duplicate with `rules/mobile-app-developer`