### PR TITLE
fix(content): update react-next-js-expert for Next.js 16 accuracy

### DIFF
--- a/content/rules/react-next-js-expert.mdx
+++ b/content/rules/react-next-js-expert.mdx
@@ -3,18 +3,19 @@ title: React Next.js Expert - CLAUDE.md Rules for Claude Code
 slug: react-next-js-expert
 category: rules
 description: >-
-  React and Next.js App Router specialist covering server/client boundaries,
-  caching, metadata, route handlers, edge runtime tradeoffs, and deploy
-  behavior for production architecture
+  React and Next.js 16 App Router specialist covering server/client boundaries,
+  stable Partial Prerendering, Turbopack-default builds, and production
+  architecture for edge and serverless deployments
 cardDescription: >-
-  React and Next.js App Router specialist covering server/client boundaries,
-  caching, metadata, route handlers, edge runtime tradeoffs, and deploy
-  behavior for production architecture
+  React and Next.js 16 App Router specialist covering server/client boundaries,
+  stable Partial Prerendering, Turbopack-default builds, and production
+  architecture for edge and serverless deployments
 seoTitle: React Next.js Expert - CLAUDE.md Rules for Claude Code
 seoDescription: >-
-  React and Next.js App Router specialist covering server/client boundaries,
-  caching, metadata, route handlers, edge runtime tradeoffs, and deploy
-  behavior for production architecture. Discover tools for AI development.
+  React and Next.js 16 App Router specialist covering server/client boundaries,
+  stable Partial Prerendering, Turbopack-default builds, and production
+  architecture for edge and serverless deployments. Discover tools for AI
+  development.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
@@ -33,7 +34,7 @@ copySnippet: >-
 
   ### React 19+ Patterns
 
-  - Use React Server Components by default in Next.js 15+
+  - Use React Server Components by default in Next.js 16+
 
   - Implement proper Suspense boundaries with streaming SSR
 
@@ -44,17 +45,17 @@ copySnippet: >-
   - Use Actions for form handling and mutations
 
 
-  ### Next.js 15+ Best Practices
+  ### Next.js 16+ Best Practices
 
   - App Router with nested layouts and parallel routes
 
-  - Partial Prerendering (PPR) for optimal performance
+  - Partial Prerendering (PPR) — stable in Next.js 16, no experimental flag required
 
   - Server Actions for secure data mutations
 
   - Middleware for authentication and redirects
 
-  - Turbopack for faster development builds
+  - Turbopack — default bundler in Next.js 16 for both dev and production builds
 
 
   ### Performance Optimization
@@ -158,19 +159,19 @@ You are an expert React and Next.js developer with comprehensive knowledge of mo
 
 ### React 19+ Patterns
 
-- Use React Server Components by default in Next.js 15+
+- Use React Server Components by default in Next.js 16+
 - Implement proper Suspense boundaries with streaming SSR
 - Utilize the new use() hook for data fetching
 - Apply React Compiler optimizations automatically
 - Use Actions for form handling and mutations
 
-### Next.js 15+ Best Practices
+### Next.js 16+ Best Practices
 
 - App Router with nested layouts and parallel routes
-- Partial Prerendering (PPR) for optimal performance
+- Partial Prerendering (PPR) — stable in Next.js 16, no experimental flag required
 - Server Actions for secure data mutations
 - Middleware for authentication and redirects
-- Turbopack for faster development builds
+- Turbopack — default bundler in Next.js 16 for both dev and production builds
 
 ### Performance Optimization
 


### PR DESCRIPTION
## Summary

- Updates all `Next.js 15+` references to `Next.js 16+` (Next.js 16 shipped October 2025)
- Notes Partial Prerendering (PPR) as **stable in Next.js 16** — no `experimental.ppr` flag required
- Updates Turbopack description: it is now the **default bundler in Next.js 16** for both dev and production, not just for development builds
- Differentiates description/cardDescription/seoDescription from the base `react-expert.mdx` entry to reflect the App Router, server/client boundaries, and production architecture focus

## Changes

- `content/rules/react-next-js-expert.mdx` only — no generated artifacts

## Validation

```
pnpm validate:content:strict  # passes (951 files)
```