### PR TITLE
fix(content): update python-data-science-expert for 2026 stack accuracy

### DIFF
--- a/content/rules/python-data-science-expert.mdx
+++ b/content/rules/python-data-science-expert.mdx
@@ -4,18 +4,18 @@ slug: python-data-science-expert
 category: rules
 description: >-
   End-to-end data science rule that challenges dataset assumptions, model
-  evaluation, reproducibility, leakage risk, and explainability for
-  defensible analysis plans beyond notebook snippets
+  evaluation, reproducibility, leakage risk, and explainability — producing
+  defensible analysis plans with Pandas 3, Polars, and PyMC
 cardDescription: >-
   End-to-end data science rule that challenges dataset assumptions, model
-  evaluation, reproducibility, leakage risk, and explainability for
-  defensible analysis plans beyond notebook snippets
+  evaluation, reproducibility, leakage risk, and explainability — producing
+  defensible analysis plans with Pandas 3, Polars, and PyMC
 seoTitle: Python Data Science Expert - CLAUDE.md Rules for Claude Code
 seoDescription: >-
   End-to-end data science rule that challenges dataset assumptions, model
-  evaluation, reproducibility, leakage risk, and explainability for
-  defensible analysis plans beyond notebook snippets. Discover tools for AI
-  development.
+  evaluation, reproducibility, leakage risk, and explainability — producing
+  defensible analysis plans with Pandas 3, Polars, and PyMC. Discover tools
+  for AI development.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
@@ -34,7 +34,7 @@ copySnippet: >-
 
   ### Data Analysis Stack
 
-  - **Pandas 2.2+**: DataFrames, Series, MultiIndex, time series analysis
+  - **Pandas 3.x** (3.0 released Jan 2026): DataFrames, Series, MultiIndex, time series analysis
 
   - **NumPy**: Array operations, broadcasting, linear algebra
 
@@ -42,7 +42,7 @@ copySnippet: >-
 
   - **DuckDB**: SQL analytics on DataFrames
 
-  - **Vaex**: Out-of-core DataFrames for big data
+  - **Polars (lazy/streaming)**: Out-of-core and larger-than-memory DataFrames
 
 
   ### Visualization
@@ -142,11 +142,11 @@ You are a Python data science expert with deep knowledge of modern data analysis
 
 ### Data Analysis Stack
 
-- **Pandas 2.2+**: DataFrames, Series, MultiIndex, time series analysis
+- **Pandas 3.x** (3.0 released Jan 2026): DataFrames, Series, MultiIndex, time series analysis
 - **NumPy**: Array operations, broadcasting, linear algebra
 - **Polars**: High-performance DataFrame operations
 - **DuckDB**: SQL analytics on DataFrames
-- **Vaex**: Out-of-core DataFrames for big data
+- **Polars (lazy/streaming)**: Out-of-core and larger-than-memory DataFrames
 
 ### Visualization
 


### PR DESCRIPTION
## Summary

- Updates **Pandas 2.2+** to **Pandas 3.x** with release context (3.0 released January 2026)
- Replaces **Vaex** (project is effectively unmaintained, last meaningful release 2022) with **Polars lazy/streaming** — the current community recommendation for out-of-core and larger-than-memory DataFrame work
- Refines description/cardDescription/seoDescription to name the key tools (Pandas 3, Polars, PyMC) so this entry is distinct from the base `python-data-science.mdx` and surfaces clearly in search

## Changes

- `content/rules/python-data-science-expert.mdx` only — no generated artifacts

## Validation

```
pnpm validate:content:strict  # passes (951 files)
```