### PR TITLE
fix(content): update mobile-app-development-expert for 2025 ecosystem

### DIFF
--- a/content/rules/mobile-app-development-expert.mdx
+++ b/content/rules/mobile-app-development-expert.mdx
@@ -3,19 +3,19 @@ title: Mobile App Dev Expert - CLAUDE.md Rules for Claude Code
 slug: mobile-app-development-expert
 category: rules
 description: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter
+  store-readiness across Swift, Kotlin, React Native, and Flutter
 cardDescription: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter
+  store-readiness across Swift, Kotlin, React Native, and Flutter
 seoTitle: Mobile App Dev Expert - CLAUDE.md Rules for Claude Code
 seoDescription: >-
-  Senior mobile architecture reviewer for iOS and Android covering
+  Senior mobile architecture reviewer for iOS, Android, and cross-platform:
   platform-specific tradeoffs, lifecycle risks, release quality gates, and
-  store-readiness across React Native and Flutter. Discover tools for AI
-  development.
+  store-readiness across Swift, Kotlin, React Native, and Flutter. Discover
+  tools for AI development.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
@@ -36,66 +36,113 @@ copySnippet: >-
 
   ```swift
 
+  // iOS 17+ — @Observable macro (Swift 5.9+)
+
   import SwiftUI
 
-  import Combine
+  import Observation
 
 
-  @MainActor
+  @Observable
 
-  class UserViewModel: ObservableObject {
-      @Published var users: [User] = []
-      @Published var isLoading = false
-      @Published var error: Error?
-      
-      private var cancellables = Set<AnyCancellable>()
+  class UserViewModel {
+
+      var users: [User] = []
+
+      var isLoading = false
+
+      var error: Error?
+
+
       private let service: UserService
-      
+
+
       init(service: UserService = .shared) {
+
           self.service = service
+
       }
-      
+
+
       func loadUsers() async {
+
           isLoading = true
+
           defer { isLoading = false }
-          
+
+
           do {
+
               users = try await service.fetchUsers()
+
           } catch {
+
               self.error = error
+
           }
+
       }
+
   }
 
 
   struct UserListView: View {
-      @StateObject private var viewModel = UserViewModel()
+
+      // @State replaces @StateObject when the model uses @Observable
+
+      @State private var viewModel = UserViewModel()
+
       @Environment(\.colorScheme) var colorScheme
-      
+
+
       var body: some View {
+
           NavigationStack {
+
               List(viewModel.users) { user in
+
                   NavigationLink(value: user) {
+
                       UserRow(user: user)
+
                   }
+
               }
+
               .navigationTitle("Users")
+
               .navigationDestination(for: User.self) { user in
+
                   UserDetailView(user: user)
+
               }
+
               .refreshable {
+
                   await viewModel.loadUsers()
+
               }
+
               .overlay {
+
                   if viewModel.isLoading {
+
                       ProgressView()
+
                   }
+
               }
+
           }
+
           .task {
+
               await viewModel.loadUsers()
+
           }
+
       }
+
   }
 
   ```
@@ -122,76 +169,142 @@ copySnippet: >-
   @Composable
 
   fun UserListScreen(
+
       viewModel: UserViewModel = hiltViewModel(),
+
       onNavigateToDetail: (User) -> Unit
+
   ) {
+
       val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
       
+
       LazyColumn(
+
           modifier = Modifier.fillMaxSize(),
+
           contentPadding = PaddingValues(16.dp),
+
           verticalArrangement = Arrangement.spacedBy(8.dp)
+
       ) {
+
           when (uiState) {
+
               is UiState.Loading -> {
+
                   item {
+
                       Box(
+
                           modifier = Modifier.fillMaxWidth(),
+
                           contentAlignment = Alignment.Center
+
                       ) {
+
                           CircularProgressIndicator()
+
                       }
+
                   }
+
               }
+
               is UiState.Success -> {
+
                   items(
+
                       items = uiState.users,
+
                       key = { it.id }
+
                   ) { user ->
+
                       UserCard(
+
                           user = user,
+
                           onClick = { onNavigateToDetail(user) }
+
                       )
+
                   }
+
               }
+
               is UiState.Error -> {
+
                   item {
+
                       ErrorMessage(
+
                           message = uiState.message,
+
                           onRetry = viewModel::loadUsers
+
                       )
+
                   }
+
               }
+
           }
+
       }
+
   }
 
 
   @HiltViewModel
 
   class UserViewModel @Inject constructor(
+
       private val userRepository: UserRepository
+
   ) : ViewModel() {
+
       
+
       private val _uiState = MutableStateFlow<UiState>(UiState.Loading)
+
       val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
       
+
       init {
+
           loadUsers()
+
       }
+
       
+
       fun loadUsers() {
+
           viewModelScope.launch {
+
               userRepository.getUsers()
+
                   .flowOn(Dispatchers.IO)
+
                   .catch { e ->
+
                       _uiState.value = UiState.Error(e.message ?: "Unknown error")
+
                   }
+
                   .collect { users ->
+
                       _uiState.value = UiState.Success(users)
+
                   }
+
           }
+
       }
+
   }
 
   ```
@@ -207,10 +320,15 @@ copySnippet: >-
   import React, { useEffect } from 'react';
 
   import {
+
     FlatList,
+
     RefreshControl,
+
     StyleSheet,
+
     View,
+
   } from 'react-native';
 
   import { useQuery, useMutation } from '@tanstack/react-query';
@@ -219,52 +337,93 @@ copySnippet: >-
 
 
   interface User {
+
     id: string;
+
     name: string;
+
     email: string;
+
     avatar: string;
+
   }
 
 
   export const UserListScreen: React.FC = () => {
+
     const navigation = useNavigation();
+
     
+
     const { data, isLoading, refetch, error } = useQuery<User[]>({
+
       queryKey: ['users'],
+
       queryFn: fetchUsers,
+
     });
+
     
+
     const renderUser = ({ item }: { item: User }) => (
+
       <UserCard
+
         user={item}
+
         onPress={() => navigation.navigate('UserDetail', { userId: item.id })}
+
       />
+
     );
+
     
+
     return (
+
       <View style={styles.container}>
+
         <FlatList
+
           data={data}
+
           renderItem={renderUser}
+
           keyExtractor={(item) => item.id}
+
           refreshControl={
+
             <RefreshControl refreshing={isLoading} onRefresh={refetch} />
+
           }
+
           contentContainerStyle={styles.list}
+
         />
+
       </View>
+
     );
+
   };
 
 
   const styles = StyleSheet.create({
+
     container: {
+
       flex: 1,
+
       backgroundColor: '#f5f5f5',
+
     },
+
     list: {
+
       padding: 16,
+
     },
+
   });
 
   ```
@@ -272,15 +431,15 @@ copySnippet: >-
 
   ### React Native Performance
 
-  - **Hermes Engine**: Enable for better performance
+  - **Hermes Engine**: Default JS engine since RN 0.70; Hermes V1 in RN 0.84 adds AoT compilation
 
-  - **Reanimated 3**: Smooth 60fps animations
+  - **Reanimated 4**: CSS-compatible declarative animations with Core Animation backend on iOS
 
-  - **FlashList**: Optimized list rendering
+  - **FlashList v2**: Optimized list rendering rebuilt for New Architecture
 
-  - **MMKV**: Fast key-value storage
+  - **MMKV**: Fast synchronous key-value storage (~30x faster than AsyncStorage)
 
-  - **Fast Image**: Optimized image loading
+  - **expo-image / react-native-fast-image**: Image loading (expo-image for Expo; react-native-fast-image for bare RN)
 
 
   ## Flutter Development
@@ -298,69 +457,130 @@ copySnippet: >-
 
 
   class UserListPage extends StatelessWidget {
+
     @override
+
     Widget build(BuildContext context) {
+
       return BlocProvider(
+
         create: (_) => GetIt.I<UserListCubit>()..loadUsers(),
+
         child: UserListView(),
+
       );
+
     }
+
   }
 
 
   class UserListView extends StatelessWidget {
+
     @override
+
     Widget build(BuildContext context) {
+
       return Scaffold(
+
         appBar: AppBar(
+
           title: Text('Users'),
+
           actions: [
+
             IconButton(
+
               icon: Icon(Icons.search),
+
               onPressed: () => _showSearch(context),
+
             ),
+
           ],
+
         ),
+
         body: BlocBuilder<UserListCubit, UserListState>(
+
           builder: (context, state) {
+
             return switch (state) {
+
               UserListLoading() => Center(
+
                 child: CircularProgressIndicator(),
+
               ),
+
               UserListLoaded(:final users) => RefreshIndicator(
+
                 onRefresh: () => context.read<UserListCubit>().loadUsers(),
+
                 child: ListView.builder(
+
                   itemCount: users.length,
+
                   itemBuilder: (context, index) {
+
                     final user = users[index];
+
                     return ListTile(
+
                       leading: CircleAvatar(
+
                         backgroundImage: NetworkImage(user.avatar),
+
                       ),
+
                       title: Text(user.name),
+
                       subtitle: Text(user.email),
+
                       onTap: () => _navigateToDetail(context, user),
+
                     );
+
                   },
+
                 ),
+
               ),
+
               UserListError(:final message) => Center(
+
                 child: Column(
+
                   mainAxisAlignment: MainAxisAlignment.center,
+
                   children: [
+
                     Text(message),
+
                     ElevatedButton(
+
                       onPressed: () => context.read<UserListCubit>().loadUsers(),
+
                       child: Text('Retry'),
+
                     ),
+
                   ],
+
                 ),
+
               ),
+
             };
+
           },
+
         ),
+
       );
+
     }
+
   }
 
   ```
@@ -379,17 +599,29 @@ copySnippet: >-
 
 
   const styles = StyleSheet.create({
+
     shadow: Platform.select({
+
       ios: {
+
         shadowColor: '#000',
+
         shadowOffset: { width: 0, height: 2 },
+
         shadowOpacity: 0.1,
+
         shadowRadius: 4,
+
       },
+
       android: {
+
         elevation: 4,
+
       },
+
     }),
+
   });
 
   ```
@@ -470,16 +702,16 @@ You are a mobile development expert with comprehensive knowledge of native and c
 ### SwiftUI Modern Patterns
 
 ```swift
+// iOS 17+ — @Observable macro (Swift 5.9+)
 import SwiftUI
-import Combine
+import Observation
 
-@MainActor
-class UserViewModel: ObservableObject {
-    @Published var users: [User] = []
-    @Published var isLoading = false
-    @Published var error: Error?
+@Observable
+class UserViewModel {
+    var users: [User] = []
+    var isLoading = false
+    var error: Error?
 
-    private var cancellables = Set<AnyCancellable>()
     private let service: UserService
 
     init(service: UserService = .shared) {
@@ -499,7 +731,8 @@ class UserViewModel: ObservableObject {
 }
 
 struct UserListView: View {
-    @StateObject private var viewModel = UserViewModel()
+    // @State replaces @StateObject when the model uses @Observable
+    @State private var viewModel = UserViewModel()
     @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
@@ -679,11 +912,11 @@ const styles = StyleSheet.create({
 
 ### React Native Performance
 
-- **Hermes Engine**: Enable for better performance
-- **Reanimated 3**: Smooth 60fps animations
-- **FlashList**: Optimized list rendering
-- **MMKV**: Fast key-value storage
-- **Fast Image**: Optimized image loading
+- **Hermes Engine**: Default JS engine since RN 0.70; Hermes V1 in RN 0.84 adds AoT compilation
+- **Reanimated 4**: CSS-compatible declarative animations with Core Animation backend on iOS
+- **FlashList v2**: Optimized list rendering rebuilt for New Architecture
+- **MMKV**: Fast synchronous key-value storage (~30x faster than AsyncStorage)
+- **expo-image / react-native-fast-image**: Image loading (expo-image for Expo; react-native-fast-image for bare RN)
 
 ## Flutter Development
 


### PR DESCRIPTION
## Summary

- Replaces the SwiftUI `ObservableObject`/`@Published`/`@StateObject`/Combine pattern with the **`@Observable` macro** (iOS 17+, Swift 5.9+) in both the YAML copySnippet and the markdown body — `@State` replaces `@StateObject` when the model uses `@Observable`
- Updates React Native Performance bullets:
  - **Hermes**: clarifies it is the **default JS engine since RN 0.70** (not opt-in); Hermes V1 in RN 0.84 adds AoT compilation
  - **Reanimated 3 → Reanimated 4** (stable 2025): CSS-compatible declarative animations, Core Animation backend on iOS
  - **FlashList → FlashList v2**: rebuilt for New Architecture
  - **MMKV**: adds speed context (~30x faster than AsyncStorage)
  - **Fast Image**: split into `expo-image` (Expo projects) / `react-native-fast-image` (bare RN)
- Expands description/cardDescription/seoDescription to name Swift, Kotlin, and cross-platform explicitly, distinguishing from the base `mobile-app-developer.mdx` entry

## Changes

- `content/rules/mobile-app-development-expert.mdx` only — no generated artifacts

## Validation

```
pnpm validate:content:strict  # passes (951 files)
```