### PR TITLE
feat(analytics): track high-signal conversion events in umami

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -21,6 +21,7 @@ import { CategoryPill, Kbd, TrustBadge } from "./badges";
 import { useTheme } from "@/lib/theme";
 import { useShortcuts } from "./shortcuts-dialog";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
 
 const EXAMPLES = [
   "postgres MCP",
@@ -188,7 +189,10 @@ export function CommandBar({
   }, [q]);
 
   const submit = () => {
-    if (q.trim()) navigate({ to: "/browse", search: { q } });
+    const query = q.trim();
+    if (!query) return;
+    trackEvent("search", { q: query.slice(0, 64) });
+    navigate({ to: "/browse", search: { q } });
   };
 
   const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {

--- a/apps/web/src/components/copy-button.tsx
+++ b/apps/web/src/components/copy-button.tsx
@@ -3,6 +3,7 @@ import { Check, Copy } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 import { useReducedMotion } from "@/lib/motion";
+import { trackEvent } from "@/lib/analytics";
 
 export function CopyButton({
   value,
@@ -12,6 +13,8 @@ export function CopyButton({
   disabled = false,
   toastLabel,
   iconOnly = false,
+  event,
+  eventData,
 }: {
   value: string;
   label?: string;
@@ -22,6 +25,10 @@ export function CopyButton({
   toastLabel?: string;
   /** When true, hide the visible label and render an icon-only square button. */
   iconOnly?: boolean;
+  /** Optional umami event name to emit on a successful copy (opt-in). */
+  event?: string;
+  /** Optional umami event data sent alongside `event`. */
+  eventData?: Record<string, unknown>;
 }) {
   const [copied, setCopied] = React.useState(false);
   const reduced = useReducedMotion();
@@ -38,6 +45,7 @@ export function CopyButton({
         try {
           await navigator.clipboard.writeText(value);
           setCopied(true);
+          if (event) trackEvent(event, eventData);
           toast.success(toastLabel ?? "Copied to clipboard", {
             description: value.length > 60 ? value.slice(0, 60) + "…" : value,
             duration: 1800,

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -17,6 +17,7 @@ import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-bu
 import { PeekHint } from "./peek-hint";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
+import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
 
 import { formatCompact, timeAgo } from "@/lib/format";
 const fmtNum = (n?: number) => formatCompact(n);
@@ -171,6 +172,8 @@ function ResourceCardInner({
                 value={installPayload}
                 label="Copy install"
                 toastLabel={`Copied install — ${entry.title}`}
+                event="copy-install"
+                eventData={{ entry: entryEventKey(entry.category, entry.slug) }}
               />
             </div>
           )}
@@ -258,6 +261,8 @@ function ResourceCardInner({
                 value={installPayload}
                 label="Install"
                 className="w-full justify-center"
+                event="copy-install"
+                eventData={{ entry: entryEventKey(entry.category, entry.slug) }}
               />
             ) : (
               <span aria-hidden className="block h-7 w-full" />
@@ -283,6 +288,12 @@ function ResourceCardInner({
                 href={entry.sourceUrl}
                 target="_blank"
                 rel="noreferrer"
+                onClick={() =>
+                  trackEvent("source-click", {
+                    entry: entryEventKey(entry.category, entry.slug),
+                    host: outboundHost(entry.sourceUrl!),
+                  })
+                }
                 className="inline-flex h-7 w-full items-center justify-center gap-1 rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
               >
                 Source <ArrowUpRight className="h-3 w-3" />

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,33 @@
+// Client-side, cookieless umami custom-event helper. SSR-safe and best-effort:
+// if the tracker hasn't loaded yet (or is blocked) the call is a silent no-op.
+//
+// We only emit events that map to a real product action worth measuring —
+// conversions and high-signal engagement. Pageviews are recorded automatically
+// by the tracker, so we never re-emit those, and event data never carries PII
+// (no emails, no raw form fields, queries truncated). This keeps the umami
+// dashboard accurate and quiet rather than noisy.
+
+type UmamiTracker = {
+  track?: (event: string, data?: Record<string, unknown>) => void;
+};
+
+/** Emit a named umami event. No-ops on the server or before the tracker loads. */
+export function trackEvent(name: string, data?: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  const umami = (window as unknown as { umami?: UmamiTracker }).umami;
+  umami?.track?.(name, data);
+}
+
+/** An entry's stable `category/slug` key, for grouping events by resource. */
+export function entryEventKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+/** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
+export function outboundHost(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "unknown";
+  }
+}

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -23,6 +23,7 @@ import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 import { absoluteUrl } from "@/lib/seo";
+import { trackEvent } from "@/lib/analytics";
 
 export const Route = createFileRoute("/submit")({
   head: () => ({
@@ -215,8 +216,10 @@ function SubmitPage() {
     if (!category || submitBusy) return;
     setSubmitBusy(true);
     setSubmitError("");
+    trackEvent("submit-start", { category });
     try {
       if (!siteConfig.submissionGateUrl) {
+        trackEvent("submit-success", { category, path: "manual" });
         setDone({
           manualPr: {
             targetPath: prTarget,
@@ -247,6 +250,7 @@ function SubmitPage() {
       if (!response.ok || !payload?.ok) {
         throw new Error(payload?.error || "The private submission gate rejected the draft.");
       }
+      trackEvent("submit-success", { category, path: "gate" });
       const authUrl = payload.authUrl ? safeGitHubAuthUrl(payload.authUrl) : "";
       if (payload.authUrl && !authUrl) {
         throw new Error("The submission gate returned an invalid GitHub auth URL.");


### PR DESCRIPTION
## What

Adds a tight, opt-in set of umami custom events for the actions that actually signal growth, on top of the existing cookieless first-party umami setup (which already records pageviews automatically + `web-vital`, `newsletter-subscribe`, and server-side digest sends). The goal is an accurate, quiet dashboard — not noise.

New `apps/web/src/lib/analytics.ts` exposes an SSR-safe, best-effort `trackEvent(name, data?)` (no-ops on the server or when the tracker is blocked) plus small `entryEventKey` / `outboundHost` helpers.

## Events added

| Event | Where | Data |
|---|---|---|
| `search` | global command-bar search | `{ q }` — query truncated to 64 chars |
| `copy-install` | copying an entry's install/config snippet (grid + row cards) | `{ entry: "category/slug" }` |
| `source-click` | outbound click to an entry's source | `{ entry, host }` |
| `submit-start` | submission flow begins | `{ category }` |
| `submit-success` | submission reaches the gate / manual PR | `{ category, path }` |

## Privacy / accuracy

- Cookieless (umami), no PII: no emails, no raw form fields; search queries truncated; outbound tracked by host only (not full URL).
- Pageviews are **not** re-emitted (the tracker does those).
- `CopyButton` gains opt-in `event` / `eventData` props — no behavior change unless passed.
- No CSP change: events post same-origin to the existing `/u/api/send` proxy.

These map cleanly to umami Goals/Funnels (e.g. search → entry → copy/source-click; submit-start → submit-success).

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed
- `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking across the application to capture insights into user search behavior, resource interactions, content copying, and submission workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->