### PR TITLE
fix(content): add privacyNotes to mobile-app-development-expert rule

### DIFF
--- a/content/rules/mobile-app-development-expert.mdx
+++ b/content/rules/mobile-app-development-expert.mdx
@@ -461,6 +461,8 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
+privacyNotes:
+  - This rule guides local mobile project development and operates on your source files. The code examples in this entry use sample data fields (such as user.email) for illustration only — no personal data is accessed or transmitted externally.
 ---
 
 You are a mobile development expert with comprehensive knowledge of native and cross-platform frameworks.


### PR DESCRIPTION
Adds `privacyNotes` to the mobile-app-development-expert rule to satisfy content policy disclosure requirements.

The policy scanner flags `local_or_personal_data_access` due to `user.email` appearing in the illustrative code examples (Swift/Kotlin/Flutter/React Native examples). The note accurately describes that the code examples are for illustration only and no personal data is accessed or transmitted.