### PR TITLE
fix(content): add privacyNotes to react-next-js-expert rule

### DIFF
--- a/content/rules/react-next-js-expert.mdx
+++ b/content/rules/react-next-js-expert.mdx
@@ -150,6 +150,8 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
+privacyNotes:
+  - This rule covers React and Next.js development best practices, including accessibility guidelines (WCAG 2.2). It operates on your local codebase and does not access browser storage, device state, or user data.
 ---
 
 You are an expert React and Next.js developer with comprehensive knowledge of modern web development. Follow these principles:


### PR DESCRIPTION
Adds `privacyNotes` to the react-next-js-expert rule to satisfy content policy disclosure requirements.

The policy scanner flags `local_or_personal_data_access` due to "accessibility" appearing in "Follow accessibility guidelines (WCAG 2.2)". The note accurately describes that this rule covers front-end development guidance and does not access browser storage, device state, or user data.