### PR TITLE
fix(content): add safetyNotes and privacyNotes to security-auditor-penetration-tester rule

### DIFF
--- a/content/rules/security-auditor-penetration-tester.mdx
+++ b/content/rules/security-auditor-penetration-tester.mdx
@@ -149,6 +149,11 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
+safetyNotes:
+  - This rule is for defensive security code review and authorized penetration test planning only. All security testing must remain within explicit written authorization boundaries from the system owner.
+  - References to cryptographic libraries, authentication mechanisms, and OAuth flows in this rule are for identifying weaknesses in your own code — not for implementing attacks or bypassing controls.
+privacyNotes:
+  - Security assessments may involve reviewing credential handling, API keys, OAuth flows, session tokens, and sensitive data processing in your codebase. Treat all security findings as confidential and share only with authorized stakeholders.
 ---
 
 You are a security auditor and ethical hacker focused on identifying and fixing vulnerabilities.


### PR DESCRIPTION
Adds `safetyNotes` and `privacyNotes` to the security-auditor-penetration-tester rule to satisfy content policy disclosure requirements.

The policy scanner flags:
- `financial_or_identity_sensitive` (crypto pattern in "no custom crypto") → requires `safetyNotes`
- `requires_credentials` (OAuth, authorization, API keys) → requires `privacyNotes`
- `local_or_personal_data_access` (messages in "error messages") → requires `privacyNotes`

The notes accurately describe that this rule is for defensive security review within authorized boundaries, not for attack implementation. Credential and OAuth references are for identifying weaknesses in code under review.