### PR TITLE
feat(leads): acknowledge listing inquiries by email + ping Discord

### DIFF
--- a/apps/web/src/lib/newsletter-emails.ts
+++ b/apps/web/src/lib/newsletter-emails.ts
@@ -182,6 +182,63 @@ export function buildWelcomeEmail(opts: { siteUrl: string }): {
   return { subject, html: emailShell({ preheader: "Welcome — your weekly Claude brief lands Sundays.", inner }), text };
 }
 
+/**
+ * Acknowledgment email (transactional) sent to someone who submits a commercial
+ * listing / job / sponsorship inquiry, confirming we received it and what happens
+ * next. Low volume, expected by the recipient — not marketing.
+ */
+export function buildListingLeadAckEmail(opts: {
+  siteUrl: string;
+  contactName: string;
+  listingTitle: string;
+  kind: string;
+}): { subject: string; html: string; text: string } {
+  const base = trimUrl(opts.siteUrl);
+  const host = escapeHtml(siteHostOf(opts.siteUrl));
+  const name = escapeHtml(opts.contactName.trim().split(/\s+/)[0] || "there");
+  const title = escapeHtml(opts.listingTitle.trim() || "your submission");
+  const kindLabel =
+    opts.kind === "job"
+      ? "job listing"
+      : opts.kind === "claim"
+        ? "listing claim"
+        : opts.kind === "tool"
+          ? "tool listing"
+          : "listing";
+  const ctaHref = opts.kind === "job" ? `${base}/jobs/post` : `${base}/advertise`;
+  const ctaLabel = opts.kind === "job" ? "See job listing options" : "See listing options";
+  const subject = "We got your HeyClaude inquiry";
+
+  const inner = `<tr><td style="padding:32px 30px 8px;">
+            ${eyebrow("HeyClaude")}
+            <h1 style="margin:14px 0 0;font-family:${DISPLAY};font-weight:600;font-size:26px;letter-spacing:-0.02em;line-height:1.1;color:${THEME.ink};">Thanks, ${name} &mdash; we've <span style="background:${THEME.accent};padding:0 6px;border-radius:2px;">got it</span>.</h1>
+            <p style="margin:14px 0 0;font-family:${BODY};font-size:15px;line-height:1.6;color:${THEME.muted};">We received your ${kindLabel} inquiry for <strong style="color:${THEME.ink};">${title}</strong>. A maintainer reviews every submission by hand &mdash; usually within a couple of days &mdash; and we'll reply straight to this email with next steps.</p>
+          </td></tr>
+          <tr><td style="padding:20px 30px 4px;">${primaryButton(ctaHref, ctaLabel)}</td></tr>
+          <tr><td style="padding:12px 30px 28px;">
+            <p style="margin:0;font-family:${BODY};font-size:13px;line-height:1.7;color:${THEME.subtle};">In the meantime, browse the directory at <a href="${base}/browse" style="color:${THEME.ink};">${host}/browse</a>.</p>
+            <p style="margin:14px 0 0;font-family:${BODY};font-size:12px;line-height:1.6;color:${THEME.subtle};">Didn't submit this? You can ignore this email. &middot; ${host}</p>
+          </td></tr>`;
+
+  const text = [
+    "Thanks — we got your HeyClaude inquiry",
+    "",
+    `We received your ${kindLabel} inquiry for ${opts.listingTitle.trim() || "your submission"}. A maintainer reviews every submission by hand — usually within a couple of days — and we'll reply straight to this email with next steps.`,
+    "",
+    `${ctaLabel}: ${ctaHref}`,
+    `Browse the directory: ${base}/browse`,
+    "",
+    "Didn't submit this? You can ignore this email.",
+    host,
+  ].join("\n");
+
+  return {
+    subject,
+    html: emailShell({ preheader: "We received your inquiry — a maintainer will be in touch.", inner }),
+    text,
+  };
+}
+
 /** Weekly "new & notable" digest, sent as a Resend broadcast. */
 export function buildDigestEmail(opts: {
   siteUrl: string;

--- a/apps/web/src/lib/notify.server.ts
+++ b/apps/web/src/lib/notify.server.ts
@@ -1,0 +1,18 @@
+// Server-only outbound notifications (Discord). Best-effort by design: a failure
+// here must never block or fail the request that triggered it.
+
+/** Post a plain message to a Discord webhook. No-ops without a URL; never throws. */
+export async function sendDiscordMessage(webhookUrl: string, content: string): Promise<boolean> {
+  if (!webhookUrl) return false;
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content }),
+      signal: AbortSignal.timeout(8000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/routes/api/listing-leads.ts
+++ b/apps/web/src/routes/api/listing-leads.ts
@@ -6,6 +6,13 @@ import { listingLeadBodySchema } from "@/lib/api/contracts";
 import { apiError, apiJson, createApiHandler, type InferApiBody } from "@/lib/api/router";
 import { logApiError, logApiInfo, logApiWarn, redactEmail } from "@/lib/api-logs";
 import { getSiteDb } from "@/lib/db";
+import { getEnvString } from "@/lib/cloudflare-env.server";
+import { buildListingLeadAckEmail } from "@/lib/newsletter-emails";
+import { sendResendEmail } from "@/lib/newsletter-send.server";
+import { sendDiscordMessage } from "@/lib/notify.server";
+import { siteConfig } from "@/lib/site";
+
+const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>";
 
 export const POST = createApiHandler(
   "listingLeads.create",
@@ -73,6 +80,45 @@ export const POST = createApiHandler(
         tier: data.tierInterest,
         email: redactEmail(data.contactEmail),
       });
+
+      // Best-effort notifications: the lead is already stored, so neither the
+      // acknowledgment email nor the maintainer ping can fail the request. Run
+      // them concurrently to keep the form response snappy.
+      const resendApiKey = getEnvString("RESEND_API_KEY");
+      const discordWebhookUrl = getEnvString("DISCORD_WEBHOOK_URL");
+      const notifications: Promise<unknown>[] = [];
+
+      if (resendApiKey) {
+        const ack = buildListingLeadAckEmail({
+          siteUrl: siteConfig.url,
+          contactName: data.contactName,
+          listingTitle: data.listingTitle,
+          kind: data.kind,
+        });
+        notifications.push(
+          sendResendEmail({
+            apiKey: resendApiKey,
+            from: getEnvString("RESEND_FROM") || DEFAULT_FROM,
+            to: data.contactEmail,
+            subject: ack.subject,
+            html: ack.html,
+            text: ack.text,
+          }),
+        );
+      }
+
+      if (discordWebhookUrl) {
+        const tier = data.tierInterest ? ` (${data.tierInterest})` : "";
+        notifications.push(
+          sendDiscordMessage(
+            discordWebhookUrl,
+            `New ${data.kind} lead${tier}: **${data.listingTitle}** — ${data.companyName} <${data.contactEmail}>`,
+          ),
+        );
+      }
+
+      if (notifications.length) await Promise.allSettled(notifications);
+
       return apiJson({ ok: true }, { headers: { "cache-control": "no-store" } });
     } catch {
       logApiError(request, "listing_leads.insert_failed", {


### PR DESCRIPTION
## What

`/api/listing-leads` (the `advertise` and `jobs/post` forms) stored each lead in D1 and logged it — but sent the submitter **nothing** and gave maintainers no real-time signal. For a commercial inquiry, that silence is a UX and conversion gap. This closes it with two best-effort notifications.

## Changes

- **Acknowledgment email** — new `buildListingLeadAckEmail()` in `newsletter-emails.ts`: an on-brand transactional "we got it, a maintainer will reply to this email" message, reusing the shared email shell, tailored per lead kind (tool / job / claim) with the right CTA (`/advertise` vs `/jobs/post`).
- **Maintainer Discord ping** — new `lib/notify.server.ts` `sendDiscordMessage()`; on a new lead we post `New <kind> lead (<tier>): **<title>** — <company> <email>` to `DISCORD_WEBHOOK_URL`.
- Both fire **after** the row is persisted and run **concurrently + best-effort** (`Promise.allSettled`): the lead is already stored, so neither can fail or block the form response. Each is gated on its env (`RESEND_API_KEY` / `DISCORD_WEBHOOK_URL`) and no-ops without it.

This is purely additive — no contract or response change. It's the one transactional template that made sense (the submit flow already gets GitHub's PR emails; unsubscribe is handled by Resend).

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm validate:clean` — passed
- `pnpm build` — passed
- `pnpm exec vitest run tests/api-contracts.test.ts tests/api-router-security.test.ts tests/commercial-intake.test.ts` — 51 passed
- Email rendered + visually verified (transactional ack, light theme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Acknowledgment emails now sent to users upon submission of listings, jobs, tools, or claims
  * Discord notifications added for new submissions when configured

<!-- end of auto-generated comment: release notes by coderabbit.ai -->