### PR TITLE
fix(newsletter): harden confirmation flow defaults

### DIFF
--- a/apps/web/src/routes/api/newsletter/subscribe.ts
+++ b/apps/web/src/routes/api/newsletter/subscribe.ts
@@ -9,7 +9,8 @@ import { buildNewsletterConfirmEmail } from "@/lib/newsletter-emails";
 import { siteConfig } from "@/lib/site";
 
 const CONFIRM_TTL_MS = 48 * 60 * 60 * 1000;
-const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>";
+// mail.heyclau.de is the verified Resend sending domain; the apex domain is not.
+const DEFAULT_FROM = "HeyClaude <newsletter@mail.heyclau.de>";
 
 function envSegmentId(followId: string): string | undefined {
   const key = `RESEND_SEGMENT_${followId.toUpperCase().replace(/[^A-Z0-9]/g, "_")}`;

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -33,7 +33,7 @@ function resultPage(opts: {
       <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
       <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
       <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
-      ${opts.token ? `<form method="post" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
+      ${opts.token ? `<form method="post" action="/api/public/newsletter/confirm" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
     </main>
   </body>
 </html>`;

--- a/tests/codeql-regressions.test.ts
+++ b/tests/codeql-regressions.test.ts
@@ -92,10 +92,33 @@ describe("CodeQL regression coverage", () => {
     expect(confirmRoute).not.toContain("request.formData()");
     expect(confirmRoute).toContain("readRequestTextWithinLimit");
     expect(confirmRoute).toContain("BodyTooLargeError");
+    expect(confirmRoute).toContain('action="/api/public/newsletter/confirm"');
 
     expect(newsletterClient).toContain('fetch("/api/newsletter/subscribe"');
     expect(newsletterClient).not.toContain(
       'fetch("/api/public/newsletter/subscribe"',
     );
+  });
+  it("keeps newsletter confirmation defaults provider-safe", () => {
+    const repoRoot = new URL("..", import.meta.url);
+    const subscribeRoute = fs.readFileSync(
+      new URL("apps/web/src/routes/api/newsletter/subscribe.ts", repoRoot),
+      "utf8",
+    );
+    const confirmRoute = fs.readFileSync(
+      new URL("apps/web/src/routes/api/public/newsletter/confirm.ts", repoRoot),
+      "utf8",
+    );
+
+    expect(subscribeRoute).toContain(
+      'const DEFAULT_FROM = "HeyClaude <newsletter@mail.heyclau.de>"',
+    );
+    expect(subscribeRoute).not.toContain(
+      'const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>"',
+    );
+    expect(confirmRoute).toContain(
+      'method="post" action="/api/public/newsletter/confirm"',
+    );
+    expect(confirmRoute).not.toContain('<form method="post" style=');
   });
 });


### PR DESCRIPTION
### Motivation
- A recent revert changed the newsletter fallback sender to the unverified apex address and removed the explicit confirmation form action, causing Resend to reject confirmation emails when `RESEND_FROM` is unset and allowing the confirm token to remain in the POST URL.
- The intent is to restore a provider-safe default sender and ensure the confirmation POST does not retain the token-bearing query string.

### Description
- Restore the verified Resend subdomain as the fallback sender by changing `DEFAULT_FROM` to `"HeyClaude <newsletter@mail.heyclau.de>"` and add a comment explaining why the apex domain is not used. 
- Add an explicit `action="/api/public/newsletter/confirm"` attribute to the confirmation form so browsers POST to a clean URL rather than the token-bearing query URL. 
- Add regression coverage in `tests/codeql-regressions.test.ts` asserting the safe sender default and the explicit confirmation form action are present. 

### Testing
- Formatted changed files with `prettier` and ran the focused test via `node_modules/.bin/vitest run tests/codeql-regressions.test.ts`, and the test file passed. 
- Verified `prettier` formatting succeeded and `git diff --check` reported no problems in the workspace.
- The targeted regression assertions in `tests/codeql-regressions.test.ts` confirmed the new defaults and form action were present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee4746698832a9be703860a55c9d8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced newsletter confirmation form submission handling
  * Updated email sending configuration for newsletter delivery using verified domain

<!-- end of auto-generated comment: release notes by coderabbit.ai -->