### PR TITLE
fix(leads): harden Discord notifications

### DIFF
--- a/apps/web/src/lib/notify.server.ts
+++ b/apps/web/src/lib/notify.server.ts
@@ -1,14 +1,25 @@
 // Server-only outbound notifications (Discord). Best-effort by design: a failure
 // here must never block or fail the request that triggered it.
 
+/** Escape attacker-controlled text before interpolating it into Discord markdown. */
+export function escapeDiscordMarkdown(value: string): string {
+  return value
+    .replace(/[\u0000-\u001f\u007f]/g, " ")
+    .replace(/@/g, "@\u200b")
+    .replace(/[\\`*_{}[\]()#+\-.!|>~<>]/g, "\\$&");
+}
+
 /** Post a plain message to a Discord webhook. No-ops without a URL; never throws. */
-export async function sendDiscordMessage(webhookUrl: string, content: string): Promise<boolean> {
+export async function sendDiscordMessage(
+  webhookUrl: string,
+  content: string,
+): Promise<boolean> {
   if (!webhookUrl) return false;
   try {
     const response = await fetch(webhookUrl, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ content }),
+      body: JSON.stringify({ content, allowed_mentions: { parse: [] } }),
       signal: AbortSignal.timeout(8000),
     });
     return response.ok;

--- a/apps/web/src/routes/api/listing-leads.ts
+++ b/apps/web/src/routes/api/listing-leads.ts
@@ -9,7 +9,7 @@ import { getSiteDb } from "@/lib/db";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 import { buildListingLeadAckEmail } from "@/lib/newsletter-emails";
 import { sendResendEmail } from "@/lib/newsletter-send.server";
-import { sendDiscordMessage } from "@/lib/notify.server";
+import { escapeDiscordMarkdown, sendDiscordMessage } from "@/lib/notify.server";
 import { siteConfig } from "@/lib/site";
 
 const DEFAULT_FROM = "HeyClaude <newsletter@heyclau.de>";
@@ -109,10 +109,13 @@ export const POST = createApiHandler(
 
       if (discordWebhookUrl) {
         const tier = data.tierInterest ? ` (${data.tierInterest})` : "";
+        const listingTitle = escapeDiscordMarkdown(data.listingTitle);
+        const companyName = escapeDiscordMarkdown(data.companyName);
+        const contactEmail = escapeDiscordMarkdown(data.contactEmail);
         notifications.push(
           sendDiscordMessage(
             discordWebhookUrl,
-            `New ${data.kind} lead${tier}: **${data.listingTitle}** — ${data.companyName} <${data.contactEmail}>`,
+            `New ${data.kind} lead${tier}: **${listingTitle}** — ${companyName} <${contactEmail}>`,
           ),
         );
       }

--- a/tests/notify-server.test.ts
+++ b/tests/notify-server.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  escapeDiscordMarkdown,
+  sendDiscordMessage,
+} from "@/lib/notify.server";
+
+describe("Discord notifications", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("disables Discord mention parsing on webhook messages", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      sendDiscordMessage(
+        "https://discord.example/webhook",
+        "@everyone hello <@&123>",
+      ),
+    ).resolves.toBe(true);
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).toEqual({
+      content: "@everyone hello <@&123>",
+      allowed_mentions: { parse: [] },
+    });
+  });
+
+  it("escapes untrusted text before Discord markdown interpolation", () => {
+    expect(escapeDiscordMarkdown("@everyone **urgent** <@&123>")).toBe(
+      "@\u200beveryone \\*\\*urgent\\*\\* \\<@\u200b&123\\>",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated listing-lead submissions from causing maintainer Discord pings or rendering attacker-controlled Discord markdown/mention syntax. 
- Preserve the existing best-effort, non-blocking notification behavior while making webhook payloads safe to post.

### Description
- Add `escapeDiscordMarkdown()` in `apps/web/src/lib/notify.server.ts` to neutralize control characters, markdown, and raw `@` mention syntax before interpolation. 
- Include `allowed_mentions: { parse: [] }` in the JSON webhook body in `sendDiscordMessage()` to disable `@everyone`, `@here`, user, and role pings. 
- Escape `listingTitle`, `companyName`, and `contactEmail` in `apps/web/src/routes/api/listing-leads.ts` before formatting the Discord notification. 
- Add regression tests in `tests/notify-server.test.ts` covering mention suppression and markdown-escaping and keep notifications best-effort/no-throw behavior.

### Testing
- Ran `./node_modules/.bin/vitest run tests/notify-server.test.ts` and all tests passed (2 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eeb368ea8832ab5e8d06eda2401e6)