### PR TITLE
refactor(ui): page layout system — PageContainer/PageHeader + max-w-page token

### DIFF
--- a/apps/web/src/components/agent-native-strip.tsx
+++ b/apps/web/src/components/agent-native-strip.tsx
@@ -44,7 +44,7 @@ const CARDS: Card[] = [
 
 export function AgentNativeStrip() {
   return (
-    <section className="mx-auto max-w-[1400px] px-4 py-12 sm:px-6">
+    <section className="mx-auto max-w-page px-4 py-12 sm:px-6">
       <div className="flex items-end justify-between gap-4">
         <div>
           <div className="eyebrow">Agent-native</div>

--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -52,7 +52,7 @@ export function TopBar() {
       )}
     >
       <ScrollProgress />
-      <div className="mx-auto flex h-14 max-w-[1400px] items-center gap-4 px-4 sm:px-6">
+      <div className="mx-auto flex h-14 max-w-page items-center gap-4 px-4 sm:px-6">
         <button
           type="button"
           onClick={() => setMobileNavOpen(true)}
@@ -171,7 +171,7 @@ export function Footer() {
         source="footer"
         className="border-0 border-b border-border bg-background"
       />
-      <div className="mx-auto grid max-w-[1400px] gap-10 px-4 py-12 sm:grid-cols-2 sm:px-6 md:grid-cols-12">
+      <div className="mx-auto grid max-w-page gap-10 px-4 py-12 sm:grid-cols-2 sm:px-6 md:grid-cols-12">
         <div className="sm:col-span-2 md:col-span-3">
           <div className="flex items-center gap-2">
             <span className="flex h-7 w-7 items-center justify-center rounded-md bg-ink text-background">
@@ -232,7 +232,7 @@ export function Footer() {
         />
       </div>
       <div className="border-t border-border">
-        <div className="mx-auto max-w-[1400px] px-4 py-4 sm:px-6">
+        <div className="mx-auto max-w-page px-4 py-4 sm:px-6">
           <div className="eyebrow mb-2">Categories</div>
           <div className="flex flex-wrap gap-x-4 gap-y-1.5 text-sm text-ink-muted">
             {CATEGORIES.map((c) => (
@@ -249,7 +249,7 @@ export function Footer() {
         </div>
       </div>
       <div className="border-t border-border">
-        <div className="mx-auto flex max-w-[1400px] flex-col items-start gap-3 px-4 py-5 text-xs text-ink-subtle sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="mx-auto flex max-w-page flex-col items-start gap-3 px-4 py-5 text-xs text-ink-subtle sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <span>© {new Date().getFullYear()} HeyClaude · heyclau.de</span>
           <nav className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Link to="/legal" className="hover:text-ink">

--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -10,7 +10,7 @@ export function ComparisonTray() {
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface/95 backdrop-blur">
-      <div className="mx-auto flex max-w-[1400px] items-center gap-3 px-4 py-3 sm:px-6">
+      <div className="mx-auto flex max-w-page items-center gap-3 px-4 py-3 sm:px-6">
         <div className="flex items-center gap-2 text-sm font-medium text-ink">
           <GitCompare className="h-4 w-4" />
           Compare

--- a/apps/web/src/components/how-it-works.tsx
+++ b/apps/web/src/components/how-it-works.tsx
@@ -23,7 +23,7 @@ const STEPS = [
 
 export function HowItWorks() {
   return (
-    <section className="mx-auto max-w-[1400px] px-4 py-12 sm:px-6">
+    <section className="mx-auto max-w-page px-4 py-12 sm:px-6">
       <div className="flex items-end justify-between gap-4">
         <div>
           <div className="eyebrow">How it works</div>

--- a/apps/web/src/components/newsletter-inline.tsx
+++ b/apps/web/src/components/newsletter-inline.tsx
@@ -59,7 +59,7 @@ export function NewsletterInline({
   if (variant === "footer-strip") {
     return (
       <div className={cn("border-t border-border bg-surface", className)}>
-        <div className="mx-auto flex max-w-[1400px] flex-col items-start gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+        <div className="mx-auto flex max-w-page flex-col items-start gap-3 px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <div className="flex items-center gap-2 text-sm text-ink-muted">
             <Mail className="h-4 w-4 text-ink" aria-hidden />
             <span>

--- a/apps/web/src/components/page-container.tsx
+++ b/apps/web/src/components/page-container.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The canonical page frame. Matches the app shell's column (`max-w-page`,
+ * `px-4 sm:px-6`) so every route lines up with the header and footer instead of
+ * drifting to hand-picked widths. Vertical rhythm defaults to `py-10`; override
+ * via `className` for the rare page that needs more or less.
+ *
+ * Width is intentionally fixed to the design-token column — long-form reading
+ * width is handled by capping the inner content (e.g. `prose-editorial`), not by
+ * shrinking the frame, so page gutters stay consistent everywhere.
+ */
+export function PageContainer({
+  children,
+  className,
+  as: Tag = "div",
+}: {
+  children: React.ReactNode;
+  className?: string;
+  as?: React.ElementType;
+}) {
+  return (
+    <Tag className={cn("mx-auto w-full max-w-page px-4 py-10 sm:px-6", className)}>{children}</Tag>
+  );
+}

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { Breadcrumbs, type Crumb } from "@/components/breadcrumbs";
+import { SectionHeader } from "@/components/section-header";
+import { cn } from "@/lib/utils";
+
+/**
+ * Standard page header: ancestor breadcrumbs + eyebrow + h1 + description.
+ *
+ * `breadcrumbs` lists ANCESTORS ONLY — never the current page. The `<h1>` is the
+ * "you are here", so repeating it as the last crumb directly above itself is the
+ * redundancy this component removes. The route's `head()` still emits the full
+ * `BreadcrumbList` JSON-LD (including the current page) for SEO, independent of
+ * this visual trail. Top-level pages (whose only ancestor is Home) omit
+ * `breadcrumbs` entirely and just show the heading.
+ */
+export function PageHeader({
+  breadcrumbs,
+  eyebrow,
+  title,
+  description,
+  actions,
+  className,
+}: {
+  /** Ancestor crumbs only (Home is added automatically). Omit for top-level pages. */
+  breadcrumbs?: Crumb[];
+  eyebrow?: React.ReactNode;
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn(className)}>
+      {breadcrumbs && breadcrumbs.length > 0 && (
+        <Breadcrumbs home items={breadcrumbs} className="mb-6" />
+      )}
+      <SectionHeader
+        as="h1"
+        size="lg"
+        eyebrow={eyebrow}
+        title={title}
+        description={description}
+        action={actions}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -11,7 +11,8 @@ import {
   categoryQuickstarts,
 } from "@/lib/site";
 import { ResourceCard } from "@/components/resource-card";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats } from "@/lib/hub-highlights";
@@ -162,16 +163,16 @@ function CategoryHub() {
   const stats = hubStats(entries);
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
-      <Breadcrumbs items={[{ label: "Directory", to: "/browse" }, { label }]} home />
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[{ label: "Directory", to: "/browse" }]}
+        eyebrow={`${entries.length} entries`}
+        title={`Claude ${label}`}
+        description={categorySeoDescriptions[id] ?? categoryDescriptions[id]}
+      />
 
-      <header className="mt-6 max-w-3xl">
-        <div className="eyebrow">{entries.length} entries</div>
-        <h1 className="mt-2 h-display-1 text-ink text-balance">Claude {label}</h1>
-        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          {categorySeoDescriptions[id] ?? categoryDescriptions[id]}
-        </p>
-        <div className="mt-6 flex flex-wrap items-center gap-2 text-sm">
+      <div className="mt-6 max-w-3xl">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
           <Link
             to="/browse"
             search={{ category: id }}
@@ -193,7 +194,7 @@ function CategoryHub() {
             </ul>
           </div>
         )}
-      </header>
+      </div>
 
       <HubHighlights
         highlights={highlights}
@@ -241,6 +242,6 @@ function CategoryHub() {
         source={`category:${id}`}
         className="mt-14"
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/api-docs.tsx
+++ b/apps/web/src/routes/api-docs.tsx
@@ -48,7 +48,7 @@ function ApiDocsPage() {
   );
 
   return (
-    <div className="mx-auto max-w-[1400px] px-4 py-8 sm:px-6">
+    <div className="mx-auto max-w-page px-4 py-8 sm:px-6">
       <div className="grid gap-8 lg:grid-cols-[260px_1fr]">
         <aside className="lg:sticky lg:top-20 lg:self-start">
           <div className="eyebrow">API · v1</div>

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -425,7 +425,7 @@ function Browse() {
   }, [sp, results.length]);
 
   return (
-    <div className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+    <div className="mx-auto max-w-page px-4 py-6 sm:px-6">
       <h1 className="sr-only">Browse the directory</h1>
       <div className="grid gap-6 lg:grid-cols-[260px_1fr]">
         {/* Filter sidebar */}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -98,7 +98,7 @@ function ComparisonPage() {
   const entries = resolveRefs(comparison.refs);
 
   return (
-    <div className="mx-auto max-w-[1400px] px-4 py-10 sm:px-6">
+    <div className="mx-auto max-w-page px-4 py-10 sm:px-6">
       <Breadcrumbs
         items={[
           { label: "Directory", to: "/browse" },

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -143,7 +143,7 @@ function ComparePage() {
   }
 
   return (
-    <div className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+    <div className="mx-auto max-w-page px-4 py-6 sm:px-6">
       <Breadcrumbs home items={[{ label: "Compare" }]} />
       <div className="mt-4 flex flex-wrap items-end justify-between gap-3 border-b border-border pb-4">
         <div>

--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Github } from "lucide-react";
 import { CONTRIBUTORS } from "@/data/contributors";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { Monogram } from "@/components/monogram";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
@@ -52,16 +53,19 @@ function ContributorsPage() {
   const total = sorted.reduce((s, c) => s + c.acceptedCount, 0);
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Contributors" }]} />
-      <div className="mt-4 eyebrow">People</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">Contributors</h1>
-      <p className="mt-2 max-w-2xl text-ink-muted">
-        Derived from accepted submissions. Provenance is preserved on every entry.{" "}
-        <span className="text-ink-subtle">
-          {sorted.length} contributors · {total} accepted entries.
-        </span>
-      </p>
+    <PageContainer>
+      <PageHeader
+        eyebrow="People"
+        title="Contributors"
+        description={
+          <>
+            Derived from accepted submissions. Provenance is preserved on every entry.{" "}
+            <span className="text-ink-subtle">
+              {sorted.length} contributors · {total} accepted entries.
+            </span>
+          </>
+        }
+      />
 
       {top && (
         <div className="mt-8 surface-raised rounded-xl border border-accent/30 bg-gradient-to-br from-surface to-accent/[0.06] p-6">
@@ -137,6 +141,6 @@ function ContributorsPage() {
           Submit a resource
         </Link>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -247,7 +247,7 @@ function Home() {
       </section>
 
       {/* Trust strip — moved up under hero */}
-      <section className="mx-auto max-w-[1400px] px-4 py-8 sm:px-6">
+      <section className="mx-auto max-w-page px-4 py-8 sm:px-6">
         <div className="grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-2 lg:grid-cols-5">
           <TrustStat
             icon={ShieldCheck}
@@ -294,7 +294,7 @@ function Home() {
       <HowItWorks />
 
       {/* Category shortcuts — Claude-native primary */}
-      <section className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+      <section className="mx-auto max-w-page px-4 py-6 sm:px-6">
         <RailHeader
           eyebrow="Categories"
           title="Browse by surface"
@@ -329,7 +329,7 @@ function Home() {
       </section>
 
       {recentEntries.length > 0 && (
-        <section className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+        <section className="mx-auto max-w-page px-4 py-6 sm:px-6">
           <div className="mb-3 flex items-baseline justify-between gap-3">
             <div className="eyebrow">Recently viewed</div>
             <Link to="/browse" className="text-xs text-ink-muted hover:text-ink">
@@ -345,7 +345,7 @@ function Home() {
       )}
 
       {/* Popular */}
-      <section className="mx-auto max-w-[1400px] px-4 py-6 sm:px-6">
+      <section className="mx-auto max-w-page px-4 py-6 sm:px-6">
         <RailHeader
           eyebrow="Popular starting points"
           title="What developers inspect first"
@@ -373,7 +373,7 @@ function Home() {
       </section>
 
       {/* Compare-ready rail (was: source-backed dup) */}
-      <section className="mx-auto max-w-[1400px] px-4 py-12 sm:px-6">
+      <section className="mx-auto max-w-page px-4 py-12 sm:px-6">
         <div className="overflow-hidden rounded-xl border border-border bg-surface">
           <div className="flex items-center justify-between gap-4 border-b border-border px-5 py-4">
             <div className="flex items-start gap-2">
@@ -411,7 +411,7 @@ function Home() {
       <AgentNativeStrip />
 
       {/* Two-up: new + pulse */}
-      <section className="mx-auto grid max-w-[1400px] gap-8 px-4 py-6 sm:px-6 lg:grid-cols-3">
+      <section className="mx-auto grid max-w-page gap-8 px-4 py-6 sm:px-6 lg:grid-cols-3">
         <div className="lg:col-span-2">
           <RailHeader
             eyebrow="New this week"
@@ -451,7 +451,7 @@ function Home() {
       </section>
 
       {/* CTA */}
-      <section className="mx-auto max-w-[1400px] px-4 py-16 sm:px-6">
+      <section className="mx-auto max-w-page px-4 py-16 sm:px-6">
         <div className="relative overflow-hidden rounded-xl border border-border bg-ink p-8 text-background">
           <span aria-hidden className="absolute inset-x-0 top-0 h-px bg-accent/60" />
           <div className="flex flex-col items-start gap-6 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
 import { ResourceCard } from "@/components/resource-card";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
@@ -117,34 +118,32 @@ function TagHub() {
   const stats = hubStats(entries);
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
-      <Breadcrumbs
-        items={[
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[
           { label: "Directory", to: "/browse" },
           { label: "Tags", to: "/tags" },
-          { label: group.name },
         ]}
-        home
+        eyebrow={`${entries.length} entries`}
+        title={<>Claude resources tagged “{group.name}”</>}
+        description={
+          <>
+            {entries.length} curated Claude Code {entries.length === 1 ? "resource" : "resources"}{" "}
+            tagged <span className="text-ink">{group.name}</span> in the HeyClaude directory
+            {spread.length > 0 ? (
+              <> — mostly {joinList(spread.map((s) => s.toLowerCase()))}</>
+            ) : null}
+            .
+            {posture.trusted > 0 ? (
+              <>
+                {" "}
+                {posture.trusted} of them {posture.trusted === 1 ? "sits" : "sit"} in the trusted
+                tier.
+              </>
+            ) : null}
+          </>
+        }
       />
-      <header className="mt-6 max-w-3xl">
-        <div className="eyebrow">{entries.length} entries</div>
-        <h1 className="mt-2 h-display-1 text-ink text-balance">
-          Claude resources tagged “{group.name}”
-        </h1>
-        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          {entries.length} curated Claude Code {entries.length === 1 ? "resource" : "resources"}{" "}
-          tagged <span className="text-ink">{group.name}</span> in the HeyClaude directory
-          {spread.length > 0 ? <> — mostly {joinList(spread.map((s) => s.toLowerCase()))}</> : null}
-          .
-          {posture.trusted > 0 ? (
-            <>
-              {" "}
-              {posture.trusted} of them {posture.trusted === 1 ? "sits" : "sit"} in the trusted
-              tier.
-            </>
-          ) : null}
-        </p>
-      </header>
 
       {related.length > 0 && (
         <div className="mt-6 flex flex-wrap items-center gap-2">
@@ -183,6 +182,6 @@ function TagHub() {
         source={`tag:${group.slug}`}
         className="mt-14"
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/tags.index.tsx
+++ b/apps/web/src/routes/tags.index.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { getIndexableTagGroups } from "@/lib/tags";
@@ -41,15 +42,13 @@ export const Route = createFileRoute("/tags/")({
 function TagsIndex() {
   const groups = getIndexableTagGroups();
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs items={[{ label: "Directory", to: "/browse" }, { label: "Tags" }]} home />
-      <header className="mt-6 max-w-3xl">
-        <div className="eyebrow">{groups.length} topics</div>
-        <h1 className="mt-2 h-display-1 text-ink text-balance">Browse by tag</h1>
-        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          Jump to a topic to see every Claude Code resource tagged with it across the directory.
-        </p>
-      </header>
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[{ label: "Directory", to: "/browse" }]}
+        eyebrow={`${groups.length} topics`}
+        title="Browse by tag"
+        description="Jump to a topic to see every Claude Code resource tagged with it across the directory."
+      />
       <div className="mt-8 flex flex-wrap gap-2">
         {groups.map((group) => (
           <Link
@@ -63,6 +62,6 @@ function TagsIndex() {
           </Link>
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -22,6 +22,10 @@
   --radius-xl: 14px;
   --radius-2xl: 20px;
 
+  /* Canonical page column — matches the app shell. Use via `max-w-page` so every
+   * route lines up with the header/footer instead of hand-picked widths. */
+  --container-page: 1400px;
+
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-surface: var(--surface);


### PR DESCRIPTION
## Why

Page widths had drifted to hand-picked values (`max-w-[1100px]`, `[1200px]`, `[1280px]`, `max-w-3xl`, …) instead of the canonical Lovable column the app shell uses (`max-w-[1400px]`). Separately, every page hand-rolled `Breadcrumbs + <header>(eyebrow/h1/description)`, and the terminal breadcrumb repeated the `<h1>` right below it.

This introduces a small layout system to fix both at the source — **non-breaking**, reproducing the existing classes.

## What

- **`--container-page` design token** (`= 1400px`) → `max-w-page` utility. The canonical column is now token-driven, not a magic number.
- **Tokenized every existing `max-w-[1400px]`** (app shell, home, browse, compare, api-docs, …) → `max-w-page`. Zero visual change — same width, now one source of truth.
- **`PageContainer`** — the canonical frame (`mx-auto w-full max-w-page px-4 py-10 sm:px-6`), matching the shell so pages line up with the header/footer.
- **`PageHeader`** — ancestor breadcrumbs + eyebrow + h1 + description, built on the existing `SectionHeader`. **Breadcrumbs list ancestors only** — the current page is no longer repeated as the last crumb directly above its own `<h1>`. The route `head()` still emits the full `BreadcrumbList` JSON-LD, so SEO is unchanged.
- **Adopted on the highest-traffic hubs:** contributors, tags index, tag detail, category pages — fixing their width drift + breadcrumb duplication.

## Rollout

This is step 1 of the layout standardization. Follow-ups adopt `PageContainer`/`PageHeader` on the remaining hub/info/profile pages, then the detail/form pages (entry, compare, jobs, forms) with per-page visual checks. The tag-index redesign and an email/manifest token-drift guard are separate PRs.

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed; confirmed `.max-w-page{max-width:1400px}` compiles
- Visual diff to confirm on the Cloudflare preview before merge (same classes; only width normalization + breadcrumb-trail change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized maximum page container widths across the application for improved layout consistency.
  * Introduced new shared layout components to ensure uniform styling and spacing across all pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->