### PR TITLE
refactor(ui): layout system rollout wave 2 — hub/info pages

### DIFF
--- a/apps/web/src/routes/best.index.tsx
+++ b/apps/web/src/routes/best.index.tsx
@@ -4,7 +4,8 @@ import { absoluteUrl } from "@/lib/seo";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { BEST_LISTS, ENTRIES } from "@/data/entries";
 import { ResourceCard } from "@/components/resource-card";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 
 export const Route = createFileRoute("/best/")({
   head: () => ({
@@ -47,14 +48,12 @@ function BestPage() {
     .filter((e): e is NonNullable<typeof e> => e !== undefined);
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Best lists" }]} />
-      <div className="mt-4 eyebrow">Best lists · editorial</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">Curated for real workflows</h1>
-      <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
-        Tightly scoped picks for specific jobs. Every list explains why each entry made the cut and
-        what you'd reach for instead.
-      </p>
+    <PageContainer className="py-12">
+      <PageHeader
+        eyebrow="Best lists · editorial"
+        title="Curated for real workflows"
+        description="Tightly scoped picks for specific jobs. Every list explains why each entry made the cut and what you'd reach for instead."
+      />
 
       <div className="mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2">
         {BEST_LISTS.map((b) => {
@@ -109,6 +108,6 @@ function BestPage() {
           <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/for.index.tsx
+++ b/apps/web/src/routes/for.index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { PLATFORM_LABEL, type Platform } from "@/types/registry";
 import { ENTRIES } from "@/data/entries";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 
@@ -56,15 +57,13 @@ export const Route = createFileRoute("/for/")({
 function PlatformsIndex() {
   const counts = PLATFORM_COUNTS;
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs items={[{ label: "Directory", to: "/browse" }, { label: "Platforms" }]} home />
-      <header className="mt-6 max-w-3xl">
-        <div className="eyebrow">{PLATFORMS.length} platforms</div>
-        <h1 className="mt-2 h-display-1 text-ink text-balance">Claude resources by platform</h1>
-        <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">
-          Pick your editor or runtime to see every compatible Claude resource in the directory.
-        </p>
-      </header>
+    <PageContainer>
+      <PageHeader
+        breadcrumbs={[{ label: "Directory", to: "/browse" }]}
+        eyebrow={`${PLATFORMS.length} platforms`}
+        title="Claude resources by platform"
+        description="Pick your editor or runtime to see every compatible Claude resource in the directory."
+      />
       <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {PLATFORMS.map((p) => (
           <Link
@@ -80,6 +79,6 @@ function PlatformsIndex() {
           </Link>
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { SUPPORTED_PLATFORMS, PLATFORM_MATRIX } from "@/data/platforms";
 import { PLATFORM_LABEL, PLATFORM_SUPPORT_LABEL, type Platform } from "@/types/registry";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -53,14 +54,12 @@ export const Route = createFileRoute("/platforms")({
 
 function PlatformsPage() {
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Platforms" }]} />
-      <div className="mt-4 eyebrow">Compatibility</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">Platform support matrix</h1>
-      <p className="mt-2 max-w-2xl text-ink-muted">
-        Native skills, generated adapters, and manual-context fallbacks across every supported
-        client.
-      </p>
+    <PageContainer>
+      <PageHeader
+        eyebrow="Compatibility"
+        title="Platform support matrix"
+        description="Native skills, generated adapters, and manual-context fallbacks across every supported client."
+      />
 
       <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {SUPPORTED_PLATFORMS.map((p) => {
@@ -96,6 +95,6 @@ function PlatformsPage() {
           );
         })}
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -16,7 +16,8 @@ import { ENTRIES, QUALITY_STATS } from "@/data/entries";
 import { ARTIFACT_CONTRACTS, CHANGELOG } from "@/data/changelog";
 import { FeedHealthPanel } from "@/components/feed-health-panel";
 import { CountUp } from "@/components/count-up";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { cn } from "@/lib/utils";
 
@@ -126,16 +127,12 @@ function QualityPage() {
   const trustQueue = TRUST_QUEUE;
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Quality" }]} />
-      <div className="mt-4 eyebrow">Registry quality</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">Our quality pledge</h1>
-      <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
-        Every entry is reviewed for source-backed identity and metadata completeness before it
-        lands. We surface the trust signals you'd look for yourself — not malware verdicts. Always
-        read the source before installing anything that touches your filesystem, network, or
-        credentials.
-      </p>
+    <PageContainer>
+      <PageHeader
+        eyebrow="Registry quality"
+        title="Our quality pledge"
+        description="Every entry is reviewed for source-backed identity and metadata completeness before it lands. We surface the trust signals you'd look for yourself — not malware verdicts. Always read the source before installing anything that touches your filesystem, network, or credentials."
+      />
       <p className="mt-2 text-xs text-ink-subtle">
         Last rebuilt{" "}
         {new Date(ARTIFACT_CONTRACTS[0].builtAt).toISOString().slice(0, 16).replace("T", " ")} UTC
@@ -350,7 +347,7 @@ function QualityPage() {
           source="quality"
         />
       </div>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -15,7 +15,8 @@ import { ENTRIES, QUALITY_STATS, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { CountUp } from "@/components/count-up";
 import { NewsletterInline } from "@/components/newsletter-inline";
 
@@ -150,15 +151,12 @@ function StateOfClaudeToolingPage() {
   });
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: TITLE }]} />
-      <div className="mt-4 eyebrow">Data report</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">State of Claude Tooling</h1>
-      <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
-        A snapshot of the Claude and AI agent tooling ecosystem, derived directly from the HeyClaude
-        registry. Every number below is computed from the live, source-backed catalog — no
-        estimates, no projections.
-      </p>
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title="State of Claude Tooling"
+        description="A snapshot of the Claude and AI agent tooling ecosystem, derived directly from the HeyClaude registry. Every number below is computed from the live, source-backed catalog — no estimates, no projections."
+      />
       <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
 
       <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
@@ -288,7 +286,7 @@ function StateOfClaudeToolingPage() {
           source="state-of-claude-tooling"
         />
       </div>
-    </div>
+    </PageContainer>
   );
 
   function DistTable({ rows, linkCategory = false }: { rows: DistRow[]; linkCategory?: boolean }) {

--- a/apps/web/src/routes/validators.tsx
+++ b/apps/web/src/routes/validators.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { FileJson, ShieldCheck, Terminal } from "lucide-react";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import {
   EXPERTISE_OPTIONS,
   RECENT_REVIEWED,
@@ -76,16 +78,12 @@ function ValidatorsPage() {
   const list = REVIEW_COVERAGE.filter((coverage) => active === "all" || coverage.id === active);
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
-      <div className="eyebrow">Review coverage</div>
-      <h1 className="mt-2 h-display-1 text-ink text-balance">
-        What has been checked, and what still needs maintainer attention.
-      </h1>
-      <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
-        HeyClaude does not publish a named validator roster yet. This page exposes the real registry
-        coverage we can stand behind today: source status, maintainer review flags, and
-        safety/privacy metadata completeness.
-      </p>
+    <PageContainer className="py-12">
+      <PageHeader
+        eyebrow="Review coverage"
+        title="What has been checked, and what still needs maintainer attention."
+        description="HeyClaude does not publish a named validator roster yet. This page exposes the real registry coverage we can stand behind today: source status, maintainer review flags, and safety/privacy metadata completeness."
+      />
 
       <div className="mt-8 grid gap-px overflow-hidden rounded-xl border border-border bg-border sm:grid-cols-4">
         <SummaryStat label="Entries" value={REVIEW_SUMMARY.total} />
@@ -256,7 +254,7 @@ function ValidatorsPage() {
         Want to improve coverage? Open a focused PR that adds source-backed safety, privacy, or
         provenance metadata for specific entries.
       </p>
-    </div>
+    </PageContainer>
   );
 }
 


### PR DESCRIPTION
## What

Wave 2 of the page-layout standardization started in #2382. Adopts `PageContainer` + `PageHeader` on the next set of hub/info pages, normalizing them to the canonical `max-w-page` column and removing the breadcrumb-duplicates-the-h1 pattern.

**Migrated:** platforms, best (index), for (index), state-of-claude-tooling, quality, validators.

Each:
- container → `PageContainer` (canonical 1400px column; `py-12` preserved where it was)
- breadcrumbs + eyebrow/h1/description → `PageHeader` (ancestor-only breadcrumbs; full `BreadcrumbList` JSON-LD still emitted in `head()`)

## Deferred (Wave 3, intentionally)

Prose / 2-column / form / detail pages where 1400px would hurt readability or the header isn't the standard pattern — these need per-page care + visual checks: about, legal, brief, advertise, feeds, changelog, trending, ecosystem, integrations, tools, entry detail, compare, jobs, and the `$slug` detail pages. The tag-index redesign and the email/manifest token-drift guard remain separate PRs.

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed
- Same primitives/classes as #2382; width normalization + breadcrumb-trail change only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized page layout structure across multiple routes using shared components for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->