### PR TITLE
feat(tags): redesign the tag index — searchable + popular grid + weighted cloud

### DIFF
--- a/apps/web/src/routes/tags.index.tsx
+++ b/apps/web/src/routes/tags.index.tsx
@@ -1,9 +1,14 @@
+import * as React from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { Search } from "lucide-react";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
+import { CategoryPill } from "@/components/badges";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { getIndexableTagGroups } from "@/lib/tags";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/tags/")({
   head: () => {
@@ -39,29 +44,145 @@ export const Route = createFileRoute("/tags/")({
   component: TagsIndex,
 });
 
+type TagView = {
+  slug: string;
+  name: string;
+  count: number;
+  topCategory: string;
+  categoryCount: number;
+};
+
+// Derive a lightweight, sorted view-model (by entry count desc) with the category
+// each tag mostly spans — enough context to make the index scannable.
+function buildTagViews(): TagView[] {
+  return getIndexableTagGroups().map((group) => {
+    const catCounts = new Map<string, number>();
+    for (const entry of group.entries) {
+      catCounts.set(entry.category, (catCounts.get(entry.category) ?? 0) + 1);
+    }
+    const sorted = [...catCounts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    return {
+      slug: group.slug,
+      name: group.name,
+      count: group.entries.length,
+      topCategory: sorted[0]?.[0] ?? "",
+      categoryCount: sorted.length,
+    };
+  });
+}
+
+function FeaturedTagCard({ tag }: { tag: TagView }) {
+  return (
+    <Link
+      to="/tags/$tag"
+      params={{ tag: tag.slug }}
+      className="group flex flex-col rounded-xl border border-border bg-surface p-4 transition-colors duration-200 ease-out hover:border-border-strong hover:bg-surface-2"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="min-w-0 truncate font-display text-base font-semibold text-ink group-hover:underline">
+          {tag.name}
+        </span>
+        <span className="shrink-0 font-mono text-xs text-ink-subtle">{tag.count}</span>
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-1.5">
+        {tag.topCategory && <CategoryPill>{tag.topCategory}</CategoryPill>}
+        {tag.categoryCount > 1 && (
+          <span className="text-xs text-ink-subtle">+{tag.categoryCount - 1} more</span>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function TagPill({ tag, strong }: { tag: TagView; strong?: boolean }) {
+  return (
+    <Link
+      to="/tags/$tag"
+      params={{ tag: tag.slug }}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm transition-colors duration-200 ease-out",
+        strong
+          ? "border-border-strong bg-surface-2 font-medium text-ink hover:border-ink/30"
+          : "border-border bg-surface text-ink hover:bg-surface-2",
+      )}
+    >
+      {tag.name}
+      <span className="font-mono text-xs text-ink-subtle">{tag.count}</span>
+    </Link>
+  );
+}
+
 function TagsIndex() {
-  const groups = getIndexableTagGroups();
+  const all = React.useMemo(buildTagViews, []);
+  const [query, setQuery] = React.useState("");
+  const q = query.trim().toLowerCase();
+
+  const filtered = React.useMemo(
+    () => (q ? all.filter((t) => t.name.toLowerCase().includes(q) || t.slug.includes(q)) : all),
+    [all, q],
+  );
+
+  const featured = all.slice(0, 8);
+  // Subtle weighting: tags at/above the featured cutoff read as "strong" pills.
+  const strongCutoff = featured[featured.length - 1]?.count ?? 0;
+
   return (
     <PageContainer>
       <PageHeader
         breadcrumbs={[{ label: "Directory", to: "/browse" }]}
-        eyebrow={`${groups.length} topics`}
+        eyebrow={`${all.length} topics`}
         title="Browse by tag"
         description="Jump to a topic to see every Claude Code resource tagged with it across the directory."
       />
-      <div className="mt-8 flex flex-wrap gap-2">
-        {groups.map((group) => (
-          <Link
-            key={group.slug}
-            to="/tags/$tag"
-            params={{ tag: group.slug }}
-            className="inline-flex items-center gap-1.5 rounded-full border border-border bg-surface px-3 py-1.5 text-sm text-ink hover:bg-surface-2"
-          >
-            {group.name}
-            <span className="font-mono text-xs text-ink-subtle">{group.entries.length}</span>
-          </Link>
-        ))}
+
+      <div className="relative mt-8 max-w-md">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-subtle"
+          aria-hidden
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => {
+            const next = e.target.value;
+            setQuery(next);
+            if (next.trim().length >= 2) trackEvent("tag-filter", { q: next.trim().slice(0, 64) });
+          }}
+          placeholder="Filter topics…"
+          aria-label="Filter topics"
+          className="h-10 w-full rounded-md border border-border bg-surface pl-9 pr-3 text-sm text-ink placeholder:text-ink-subtle focus-visible:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+        />
       </div>
+
+      {!q && (
+        <section className="mt-10">
+          <div className="eyebrow">Popular topics</div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            {featured.map((tag) => (
+              <FeaturedTagCard key={tag.slug} tag={tag} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="mt-10">
+        <div className="eyebrow">{q ? `${filtered.length} matching` : "All topics"}</div>
+        {filtered.length > 0 ? (
+          <div className="mt-4 flex flex-wrap gap-2">
+            {filtered.map((tag) => (
+              <TagPill key={tag.slug} tag={tag} strong={tag.count >= strongCutoff} />
+            ))}
+          </div>
+        ) : (
+          <p className="mt-4 text-sm text-ink-muted">
+            No topics match “{query}”. Try a broader term, or{" "}
+            <Link to="/browse" className="text-ink underline">
+              browse the full directory
+            </Link>
+            .
+          </p>
+        )}
+      </section>
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Why

The tag index (`/tags`) was a flat `flex-wrap` of identical pills — every tag the same size regardless of whether it had 48 entries or 2, no search, no sense of what's inside each topic. It didn't live up to the (already rich) per-tag pages.

## What

Rebuilt `tags.index.tsx` on the new `PageContainer`/`PageHeader` system, fully within the existing design language (pills, `eyebrow`, citron accent, tokens):

- **Filter box** — instant client-side search over topics (no full dataset shipped; operates on a lightweight derived view-model).
- **"Popular topics" grid** — the top 8 tags as cards showing entry count + the category each tag mostly spans (`+N more`), so the index is scannable at a glance.
- **Weighted pill cloud** — all topics as count-badged pills, with the top tier visually emphasized (subtle weighting, not font-size soup). Filters live as you type; graceful empty state.

Derives category context per tag from existing data (`getIndexableTagGroups`) — no new data sources. Adds one bounded `tag-filter` umami event (fires at ≥2 chars).

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed
- Visual preview reviewed (representative data)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tag browsing with integrated search functionality for faster discovery.
  * Featured tags now prominently displayed when browsing without an active search.
  * Search results include tag popularity metrics to help identify relevant tags.
  * Improved navigation with "no matches" messaging and links to full directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->