### PR TITLE
refactor(ui): layout system rollout wave 3 — remaining hub pages

### DIFF
--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Rss, Plus, RefreshCw, Minus, Shield, FileText, Package } from "lucide-react";
 import { CHANGELOG, RELEASE_NOTES, type ReleaseStream } from "@/data/changelog";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
+import { PageContainer } from "@/components/page-container";
 import { cn } from "@/lib/utils";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
@@ -103,7 +104,7 @@ function ChangelogPage() {
   const items = RELEASE_NOTES.filter((n) => filter === "all" || n.stream === filter);
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-12 sm:px-6">
+    <PageContainer className="py-12">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="eyebrow">Changelog</div>
@@ -312,6 +313,6 @@ function ChangelogPage() {
           </div>
         </aside>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/ecosystem.tsx
+++ b/apps/web/src/routes/ecosystem.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import { ArrowRight, Rss } from "lucide-react";
 import { INTEGRATIONS } from "@/data/integrations";
 import { IntegrationCard } from "@/components/integration-card";
+import { PageContainer } from "@/components/page-container";
 import {
   CompatibilityMatrix,
   type MatrixRow,
@@ -227,7 +228,7 @@ function EcosystemPage() {
   const entries = ENTRIES.length;
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
+    <PageContainer>
       {/* Hero */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
@@ -338,7 +339,7 @@ function EcosystemPage() {
           </div>
         </div>
       </section>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/routes/integrations.index.tsx
+++ b/apps/web/src/routes/integrations.index.tsx
@@ -1,7 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { INTEGRATIONS } from "@/data/integrations";
 import { IntegrationCard } from "@/components/integration-card";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -50,20 +51,21 @@ export const Route = createFileRoute("/integrations/")({
 
 function IntegrationsPage() {
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Integrations" }]} />
-      <div className="mt-4 eyebrow">Integrations</div>
-      <h1 className="mt-2 max-w-3xl h-display-1 text-ink text-balance">
-        HeyClaude, where you already work
-      </h1>
-      <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
-        The registry ships as an extension, a server, an API, and a set of public feeds — so Claude,
-        Cursor, Windsurf, Codex, and Raycast can all read from the same source of truth.{" "}
-        <Link to="/ecosystem" className="text-ink underline">
-          See the ecosystem map
-        </Link>
-        .
-      </p>
+    <PageContainer>
+      <PageHeader
+        eyebrow="Integrations"
+        title="HeyClaude, where you already work"
+        description={
+          <>
+            The registry ships as an extension, a server, an API, and a set of public feeds — so
+            Claude, Cursor, Windsurf, Codex, and Raycast can all read from the same source of truth.{" "}
+            <Link to="/ecosystem" className="text-ink underline">
+              See the ecosystem map
+            </Link>
+            .
+          </>
+        }
+      />
       <div className="mt-10 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {INTEGRATIONS.map((i) => (
           <IntegrationCard key={i.slug} integration={i} />
@@ -87,6 +89,6 @@ function IntegrationsPage() {
           Open the API docs
         </Link>
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowUpRight, BadgeCheck } from "lucide-react";
 import { COMMERCIAL_TOOLS } from "@/data/tools";
-import { Breadcrumbs } from "@/components/breadcrumbs";
+import { PageContainer } from "@/components/page-container";
 import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -53,9 +53,8 @@ export const Route = createFileRoute("/tools")({
 
 function ToolsPage() {
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
-      <Breadcrumbs home items={[{ label: "Tools" }]} />
-      <div className="mt-4 flex flex-wrap items-end justify-between gap-4">
+    <PageContainer>
+      <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <div className="eyebrow">Commercial tools</div>
           <h1 className="mt-2 h-display-1 text-ink text-balance">
@@ -113,7 +112,7 @@ function ToolsPage() {
           </Link>
         ))}
       </div>
-    </div>
+    </PageContainer>
   );
 }
 

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router
 import { z } from "zod";
 import { ArrowRight, Clock, Flame, Info, Rss, Star, TrendingUp } from "lucide-react";
 import { BRIEF_ISSUES } from "@/data/entries";
+import { PageContainer } from "@/components/page-container";
 import { getEntry, search } from "@/data/search";
 import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { TrendingPodium } from "@/components/trending-podium";
@@ -229,7 +230,7 @@ function TrendingPage() {
   const shareUrl = `/trending${sp.category ? `?category=${sp.category}` : ""}`;
 
   return (
-    <div className="mx-auto max-w-[1280px] px-4 py-12 sm:px-6">
+    <PageContainer className="py-12">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
           <div className="flex items-center gap-2">
@@ -414,6 +415,6 @@ function TrendingPage() {
           </Link>
         </div>
       </div>
-    </div>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## What

Wave 3 of the layout standardization (after #2382, #2383). Brings the remaining **hub** pages onto the canonical `max-w-page` column via `PageContainer`, and removes the redundant lone breadcrumb where present.

**Migrated:**
- `integrations` (index) — `PageContainer` + `PageHeader` (breadcrumb dup removed)
- `tools` — `PageContainer`; kept its custom action-row header; dropped redundant breadcrumb
- `changelog`, `trending`, `ecosystem` — `PageContainer` (width normalization; custom headers untouched)

`trending` was the lone `max-w-[1280px]`; all hubs now share the 1400px token column.

## Intentionally NOT widened

Prose / form / doc pages keep their narrower reading or form widths (these are correct, not the hub drift): `about` (max-w-3xl), `feeds` (3xl), `advertise` (5xl), `legal` / `brief` (1100 with TOC sidebar). Forcing 1400 there would wreck readability.

## Still to come

Final wave: detail pages (`entry`, `compare`, `jobs`, `$slug`) — case-by-case since they mix wide tables, lists, and sidebar content. Plus the email/manifest/confirm token-drift guard.

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed
- Width normalization + breadcrumb removal only; custom headers preserved