### PR TITLE
refactor(ui): layout wave 4 — hub/list detail pages to max-w-page

### DIFF
--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { PageContainer } from "@/components/page-container";
 import { CalendarDays, User } from "lucide-react";
 import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entries";
 import type { Entry } from "@/types/registry";
@@ -87,7 +88,7 @@ function BestDetail() {
     .filter((p): p is Resolved => p !== null);
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
+    <PageContainer className="py-12">
       <Breadcrumbs home items={[{ label: "Best lists", to: "/best" }, { label: list.title }]} />
 
       <div className="mt-6 eyebrow">
@@ -153,6 +154,6 @@ function BestDetail() {
       <div className="mt-12">
         <NewsletterInline variant="card" source={`best:${list.slug}`} />
       </div>
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { PageContainer } from "@/components/page-container";
 import { ArrowRight } from "lucide-react";
 import { CATEGORIES, PLATFORM_LABEL, type Platform, type Category } from "@/types/registry";
 import { search } from "@/data/search";
@@ -130,7 +131,7 @@ function IntersectionPage() {
   }, undefined);
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
+    <PageContainer>
       <Breadcrumbs
         items={[
           { label: "Directory", to: "/browse" },
@@ -191,6 +192,6 @@ function IntersectionPage() {
         source={`for:${platform}:${category}`}
         className="mt-14"
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -1,5 +1,6 @@
 import { cache } from "react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { PageContainer } from "@/components/page-container";
 import { ArrowRight } from "lucide-react";
 import { CATEGORIES, PLATFORM_LABEL, type Platform } from "@/types/registry";
 import { search } from "@/data/search";
@@ -120,7 +121,7 @@ function PlatformPage() {
   const categoryCount = new Set(all.map((e) => e.category)).size;
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
+    <PageContainer>
       <Breadcrumbs
         items={[
           { label: "Directory", to: "/browse" },
@@ -186,6 +187,6 @@ function PlatformPage() {
         source={`platform:${platform}`}
         className="mt-14"
       />
-    </div>
+    </PageContainer>
   );
 }

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { PageContainer } from "@/components/page-container";
 import { absoluteUrl } from "@/lib/seo";
 import { createServerFn } from "@tanstack/react-start";
 import { useEffect, useMemo, useState } from "react";
@@ -177,7 +178,7 @@ function JobsPage() {
     q || tier !== "all" || remote !== "all" || type !== "all" || freshOnly || featuredOnly;
 
   return (
-    <div className="mx-auto max-w-[1200px] px-4 py-10 sm:px-6">
+    <PageContainer>
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div className="min-w-0">
           <div className="eyebrow">Hiring</div>
@@ -374,7 +375,7 @@ function JobsPage() {
           </div>
         </aside>
       </div>
-    </div>
+    </PageContainer>
   );
 }
 


### PR DESCRIPTION
## What

Final width-standardization wave. Brings the remaining **hub/list** detail pages onto the canonical `max-w-page` column via `PageContainer`:

- `jobs` (index) — 1200 → `max-w-page`
- `for/$platform` and `for/$platform/$category` — 1200 → `max-w-page`
- `best/$slug` (best-list detail) — 1100 → `max-w-page`

Width-only swaps (custom headers/breadcrumbs preserved). Early-return / not-found states left untouched.

## Intentionally kept narrower (per the 2-width decision)

Reading/profile detail pages keep their reading widths: `entry/$category/$slug`, `jobs/$slug`, `contributors/$slug`, `integrations/$slug`. Confirmed with the user — hubs/lists = 1400, reading/detail = narrower.

## Result

Every hub/list surface across the site now shares the single `max-w-page` (1400px) Lovable column. The width standardization is complete.

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized page layout structure across multiple routes by implementing a shared `PageContainer` component. Updated several route pages to use the unified container instead of individual fixed-width layout definitions, improving code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->