### PR TITLE
content(commands): add prompt/eval runbook slash command

### DIFF
--- a/content/commands/prompt-eval-runbook.mdx
+++ b/content/commands/prompt-eval-runbook.mdx
@@ -1,0 +1,121 @@
+---
+title: /prompt-eval-runbook - Prompt Eval Runbook Command for Claude Code
+slug: prompt-eval-runbook
+category: commands
+description: >-
+  Slash command that runs a prompt evaluation runbook for a prompt file or
+  template: quality rubric scoring, token cost estimate, safety/refusal checks,
+  regression cases, and a ship-or-revise verdict before production use.
+cardDescription: >-
+  Run a prompt eval runbook for quality, cost, safety, and regression checks.
+seoTitle: /prompt-eval-runbook - Prompt Eval Runbook Command for Claude Code
+seoDescription: >-
+  Claude Code slash command to evaluate prompts for quality, token cost, safety
+  refusals, and regression cases before production deployment.
+author: kiannidev
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 757
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/757"
+documentationUrl: "https://github.com/anthropics/claude-code"
+repoUrl: "https://github.com/anthropics/claude-code"
+sourceUrls:
+  - "https://github.com/anthropics/claude-code"
+  - "https://docs.anthropic.com/en/docs/test-and-evaluate/develop-tests"
+  - "https://code.claude.com/docs/en/skills"
+installable: true
+installCommand: "/prompt-eval-runbook [prompt-file]"
+commandSyntax: "/prompt-eval-runbook [prompt-file]"
+usageSnippet: "/prompt-eval-runbook prompts/support-triage.md"
+copySnippet: "/prompt-eval-runbook [prompt-file]"
+prerequisites:
+  - "Prompt file, skill template, or command MDX body to evaluate."
+  - "Representative test inputs including edge cases and known regression prompts."
+  - "Target model and deployment context (Claude Code command, skill, or API prompt)."
+safetyNotes:
+  - "Evaluation may send test inputs to the model; use synthetic data, not production customer content."
+  - "Do not disable safety refusals to improve scores; fix prompt scope instead."
+  - "Cost estimates are approximate; confirm with real usage metrics before budgeting."
+privacyNotes:
+  - "Prompt files and eval transcripts may contain system instructions or confidential business logic."
+  - "Redact proprietary prompts and customer examples from shared eval reports."
+tags:
+  - prompts
+  - evaluation
+  - safety
+  - cost
+  - quality
+keywords:
+  - prompt eval runbook command
+  - prompt quality evaluation
+  - claude code prompt testing
+  - prompt cost safety eval
+---
+
+The `/prompt-eval-runbook` command applies a **repeatable evaluation pass** to a prompt before it ships in Claude Code commands, skills, or API templates — covering quality, cost, safety, and regressions.
+
+## Usage
+
+```
+/prompt-eval-runbook [prompt-file]
+```
+
+- With a `prompt-file`: evaluate that prompt or template file.
+- Without an argument: evaluate the prompt in the active command, skill, or user-selected buffer.
+
+## What it does
+
+When you invoke this command, follow these steps:
+
+1. **Load the prompt artifact.** Read the file (Markdown, MDX, YAML template, or plain text). Separate system instructions, tool policies, output contracts, and user-facing examples.
+2. **Define eval cases.** Build a small matrix: happy path, ambiguous input, empty input, adversarial injection, policy-edge request, and one known historical regression if available.
+3. **Score quality.** Rate instruction clarity, output contract completeness, tool-scope boundaries, and failure-mode guidance on a simple 1–5 rubric with evidence quotes.
+4. **Estimate cost.** Count prompt tokens, list always-on context (tools, examples), and flag sections that should move to retrieval or on-demand skills.
+5. **Run safety checks.** Verify refusals for disallowed tasks, secret exfil patterns, role-breaking instructions, and missing human-approval gates for destructive actions.
+6. **Check regressions.** Compare outputs on regression cases to the prior prompt version when git history or a saved baseline exists.
+7. **Deliver verdict.** Return ship, revise, or block with prioritized edits, eval case table, and suggested A/B validation steps.
+
+## Output format
+
+- **Prompt:** file path, intended surface (command/skill/API).
+- **Eval matrix:** case, expected behavior, observed result, pass/fail.
+- **Quality rubric:** dimension scores with cited prompt lines.
+- **Cost notes:** token drivers and trimming suggestions.
+- **Safety findings:** severity and required guardrail edits.
+- **Verdict:** ship / revise / block.
+
+## Requirements
+
+- Readable prompt file or active editor content.
+- Synthetic or approved test inputs (no live customer data).
+- Optional git history for regression comparison.
+
+## Safety notes
+
+Use synthetic eval inputs. Do not weaken refusals to improve task completion scores. Cost estimates are directional; validate against production telemetry before financial commitments.
+
+## Privacy notes
+
+Prompts may encode confidential system behavior. Eval transcripts enter model context; redact proprietary instructions before external sharing.
+
+## Source Verification Notes
+
+Verified against the public Anthropic `claude-code` repository and Anthropic evaluation docs on **2026-06-14**:
+
+- Anthropic documents test-and-evaluate workflows for developing and scoring prompts.
+- Claude Code skills docs describe packaging reusable prompt assets with explicit output contracts.
+- `claude-code` README and plugins guidance cover distributing evaluated commands to teams.
+- CHANGELOG records prompt, skills, and context-management features relevant to eval loops.
+- Evaluation runbooks align with documented Claude Code emphasis on reviewable, minimal prompt changes.
+
+## Duplicate Check
+
+Checked `content/commands` and `content/skills`. No command runs a structured prompt eval runbook across quality, cost, safety, and regression dimensions. `context-analyzer` focuses on session context usage, not pre-ship prompt scoring. Complements capability-pack skills without duplicating their domain checklists.
+
+## References
+
+- Claude Code repository: https://github.com/anthropics/claude-code
+- Anthropic develop tests guide: https://docs.anthropic.com/en/docs/test-and-evaluate/develop-tests
+- Claude Code skills documentation: https://code.claude.com/docs/en/skills


### PR DESCRIPTION
## Summary
Adds the prompt/eval runbook slash command to the commands catalog.

Closes #757