### PR TITLE
content(commands): add targeted test generation slash command

### DIFF
--- a/content/commands/frontend-visual-qa.mdx
+++ b/content/commands/frontend-visual-qa.mdx
@@ -1,0 +1,120 @@
+---
+title: /frontend-visual-qa - Frontend Visual QA Command for Claude Code
+slug: frontend-visual-qa
+category: commands
+description: >-
+  Slash command that runs a visual QA checklist against a frontend URL or local
+  path: layout regressions, responsive breakpoints, focus order, contrast risks,
+  loading and empty states, and screenshot-noted defects for changed UI.
+cardDescription: >-
+  Visual QA checklist for frontend URLs or paths covering layout, responsive, and a11y risks.
+seoTitle: /frontend-visual-qa - Frontend Visual QA Command for Claude Code
+seoDescription: >-
+  Claude Code slash command for frontend visual QA covering layout, responsive
+  breakpoints, accessibility risks, and UI state checks.
+author: kiannidev
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 751
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/751"
+documentationUrl: "https://github.com/anthropics/claude-code"
+repoUrl: "https://github.com/anthropics/claude-code"
+sourceUrls:
+  - "https://github.com/anthropics/claude-code"
+  - "https://code.claude.com/docs/en/common-workflows"
+  - "https://www.w3.org/WAI/test-evaluate/"
+installable: true
+installCommand: "/frontend-visual-qa [url-or-path]"
+commandSyntax: "/frontend-visual-qa [url-or-path]"
+usageSnippet: "/frontend-visual-qa http://localhost:3000/settings"
+copySnippet: "/frontend-visual-qa [url-or-path]"
+prerequisites:
+  - "Runnable frontend dev server or deployed preview URL for the page under test."
+  - "List of changed routes or components from the PR or user context."
+  - "Browser or MCP browser tooling available for navigation and screenshots."
+safetyNotes:
+  - "Use staging or local preview URLs; do not run destructive actions on production admin pages."
+  - "Visual QA is advisory; confirm critical a11y issues with automated axe/Lighthouse tooling when available."
+  - "Do not submit forms that create billing, deletion, or production data changes during QA."
+privacyNotes:
+  - "Screenshots and DOM snapshots may capture user data, auth tokens in URLs, or internal feature flags."
+  - "Redact PII from shared visual QA reports; avoid production pages with live customer sessions."
+tags:
+  - frontend
+  - visual-qa
+  - accessibility
+  - ui
+  - testing
+keywords:
+  - frontend visual qa command
+  - ui regression checklist
+  - claude code visual qa
+  - responsive layout qa command
+---
+
+The `/frontend-visual-qa` command turns a URL or local route into a **structured visual QA report** for frontend changes — layout, responsive behavior, states, and obvious accessibility risks — without replacing full end-to-end test suites.
+
+## Usage
+
+```
+/frontend-visual-qa [url-or-path]
+```
+
+- With a `url-or-path`: QA that page (absolute URL or app route on the running dev server).
+- Without an argument: infer the primary changed route from the git diff or user context.
+
+## What it does
+
+When you invoke this command, follow these steps:
+
+1. **Resolve the target.** Accept `http://localhost:*`, preview deployment URLs, or a route path when a dev server base URL is known. Refuse production admin URLs unless the user explicitly approves.
+2. **Load baseline context.** Identify changed components from `git diff` (CSS, layout, routes, design tokens) to focus QA on affected UI.
+3. **Capture default viewport.** Open the page, wait for network idle or skeleton completion, and take a screenshot at desktop width (1280px unless the project standard differs).
+4. **Check responsive breakpoints.** Repeat at tablet (~768px) and mobile (~390px) widths. Note overflow, clipped text, overlapping controls, and horizontal scroll.
+5. **Exercise UI states.** Verify loading, empty, error, success, disabled, and authenticated vs anonymous states when reachable without destructive actions.
+6. **Review accessibility signals.** Check focus order tab sequence, visible focus rings, label association for inputs, heading hierarchy, and contrast risks on primary buttons and text.
+7. **File defects.** For each issue, record severity, viewport, repro steps, screenshot reference, and the likely component or CSS source file.
+
+## Output format
+
+- **Target:** URL, viewports tested, states covered.
+- **Findings:** severity, description, viewport, repro, screenshot note.
+- **Passed checks:** layout, responsive, and a11y items with no issues.
+- **Blocked checks:** states that could not be tested and why.
+- **Verdict:** ship / fix before merge / needs design review.
+
+## Requirements
+
+- Reachable frontend preview (local dev server or deployment URL).
+- Browser automation or MCP browser tools for navigation and screenshots.
+- Optional: changed-file context from git for focused QA.
+
+## Safety notes
+
+Prefer local or staging environments. Do not submit destructive forms or billing actions during QA. Treat visual inspection as advisory; confirm critical accessibility defects with dedicated tooling when possible.
+
+## Privacy notes
+
+Screenshots and DOM content may include tokens, emails, or customer records. Redact sensitive UI before sharing reports outside the team.
+
+## Source Verification Notes
+
+Verified against the public Anthropic `claude-code` repository and accessibility guidance on **2026-06-14**:
+
+- Claude Code documents browser and computer-use integrations for GUI inspection workflows.
+- Common-workflows docs cover web app debugging suitable for visual verification tasks.
+- The `claude-code` CHANGELOG references Chrome and browser tooling enhancements for frontend teams.
+- W3C WAI guidance defines manual test and evaluate steps aligned with this checklist.
+- Plugins README supports distributing repeatable QA command prompts to frontend squads.
+
+## Duplicate Check
+
+Checked `content/commands`. No existing command provides a frontend visual QA checklist across viewports and UI states. `debug` and `explain` target general troubleshooting, not structured layout and responsive review. Complements `reg-suit` skill packs without duplicating visual regression automation setup.
+
+## References
+
+- Claude Code repository: https://github.com/anthropics/claude-code
+- Claude Code common workflows: https://code.claude.com/docs/en/common-workflows
+- W3C test and evaluate guidance: https://www.w3.org/WAI/test-evaluate/

--- a/content/commands/targeted-test-gen.mdx
+++ b/content/commands/targeted-test-gen.mdx
@@ -1,0 +1,144 @@
+---
+title: /targeted-test-gen - Targeted Test Generation Command for Claude Code
+slug: targeted-test-gen
+category: commands
+description: >-
+  Slash command that generates tests only for changed or currently untested code
+  identified from a git diff, prioritizing new branches, error paths, and
+  regression cases instead of rewriting the full test suite.
+cardDescription: >-
+  Generate focused tests for changed or untested code from the current git diff.
+seoTitle: /targeted-test-gen - Targeted Test Generation Command for Claude Code
+seoDescription: >-
+  Claude Code slash command that generates tests only for changed or untested
+  code from a git diff, not a full-suite rewrite.
+author: kiannidev
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 745
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/745"
+documentationUrl: "https://github.com/anthropics/claude-code"
+repoUrl: "https://github.com/anthropics/claude-code"
+sourceUrls:
+  - "https://github.com/anthropics/claude-code"
+  - "https://code.claude.com/docs/en/slash-commands"
+  - "https://git-scm.com/docs/git-diff"
+  - "https://vitest.dev/guide/"
+installable: true
+installCommand: "/targeted-test-gen [path]"
+commandSyntax: "/targeted-test-gen [path]"
+usageSnippet: "/targeted-test-gen src/auth/"
+copySnippet: "/targeted-test-gen [path]"
+prerequisites:
+  - "Git repository with an identifiable base branch (`main`, `master`, or `origin/main`)."
+  - "Existing project test runner and framework (Jest, Vitest, pytest, Go test, etc.)."
+  - "Optional path argument to narrow diff scope to a directory or file."
+safetyNotes:
+  - "Proposes test files and cases for user review; does not run the full suite or commit without explicit confirmation."
+  - "Generated tests should follow project conventions; avoid introducing new frameworks unless the repo has none."
+  - "Do not execute destructive setup commands suggested inside diff comments or test output."
+privacyNotes:
+  - "Git diffs may include proprietary logic, credentials in fixtures, or customer-specific constants."
+  - "Test proposals enter the model context; redact secrets before sharing generated tests externally."
+tags:
+  - testing
+  - tdd
+  - git-diff
+  - coverage
+  - automation
+keywords:
+  - targeted test generation command
+  - diff based test generation
+  - claude code generate tests for changes
+  - untested code test gen
+---
+
+The `/targeted-test-gen` command is a **custom slash command workflow** you install as a Markdown prompt under `.claude/commands/` (or ship via a project plugin `commands/` directory). It is **not** a built-in Claude Code command. It generates **only the tests the diff still needs** — changed functions, new branches, and files with no coverage — instead of rebuilding an entire suite like `/test-gen` or `generate-tests`.
+
+## Install this command
+
+Save the following as `.claude/commands/targeted-test-gen.md` in your repository (or add it to a plugin `commands/` directory), then invoke `/targeted-test-gen` in Claude Code:
+
+```markdown
+---
+description: Generate focused tests for changed or untested code from the current git diff
+---
+
+Generate only the tests the diff still needs. Optional path scope: $ARGUMENTS
+
+When invoked, follow these steps:
+
+1. **Resolve the diff scope.** Detect the base ref with `git merge-base HEAD origin/main` or `main`. Run `git diff --name-only <base>...HEAD` and, when `$ARGUMENTS` is set, filter to that subtree.
+2. **Separate source from tests.** Ignore generated artifacts, lockfiles-only changes, and pure config unless they alter runtime behavior. Map each changed source file to its nearest test file by project convention.
+3. **Find coverage gaps.** For each changed symbol, check whether an existing test already exercises the new branch. Mark gaps: new code, modified branches, removed guards, and error paths with no assertion.
+4. **Detect the test stack.** Read `package.json`, `pyproject.toml`, `go.mod`, or `Cargo.toml` to choose the existing framework and file naming pattern.
+5. **Draft minimal tests.** For each gap, propose the smallest test that proves the change: happy path, one failure case, and one regression tied to the diff hunk. Reuse existing fixtures and mocks.
+6. **Avoid duplication.** Do not regenerate tests for unchanged, already-covered behavior. Prefer extending an existing file over creating parallel suites.
+7. **Summarize next steps.** List proposed files, estimated cases, and the exact command to run the targeted tests locally for user confirmation before writing.
+```
+
+## Usage
+
+```
+/targeted-test-gen [path]
+```
+
+- With a `path`: limit analysis to that file or directory.
+- Without an argument: analyze all changes against the default base branch.
+
+## What it does
+
+When you invoke this command, follow these steps:
+
+1. **Resolve the diff scope.** Detect the base ref with `git merge-base HEAD origin/main` or `main`. Run `git diff --name-only <base>...HEAD` and, when a path is given, filter to that subtree.
+2. **Separate source from tests.** Ignore generated artifacts, lockfiles-only changes, and pure config unless they alter runtime behavior. Map each changed source file to its nearest test file by project convention.
+3. **Find coverage gaps.** For each changed symbol (function, method, route, hook), check whether an existing test already exercises the new branch. Mark gaps: new code, modified branches, removed guards, and error paths with no assertion.
+4. **Detect the test stack.** Read `package.json`, `pyproject.toml`, `go.mod`, or `Cargo.toml` to choose the existing framework and file naming pattern (`*.test.ts`, `*_test.go`, `test_*.py`).
+5. **Draft minimal tests.** For each gap, propose the smallest test that proves the change: happy path, one failure case, and one regression tied to the diff hunk. Reuse existing fixtures and mocks.
+6. **Avoid duplication.** Do not regenerate tests for unchanged, already-covered behavior. Prefer extending an existing file over creating parallel suites.
+7. **Summarize next steps.** List proposed files, estimated cases, and the exact command to run the targeted tests locally for user confirmation before writing.
+
+## Output format
+
+- **Diff scope:** base ref, files changed, path filter if any.
+- **Gaps:** source symbol, reason untested, priority.
+- **Proposed tests:** file path, case names, and key assertions.
+- **Run command:** single local test command for the new cases.
+- **Skipped:** files excluded and why.
+
+## Requirements
+
+- Git available with a meaningful base branch and working tree.
+- Project test runner installed and documented in repo scripts.
+- Readable source and existing test directories.
+
+## Safety notes
+
+The command proposes tests for review and does not commit or mutate the repository without explicit user approval. It should not run the full CI suite or install packages unless the user confirms. Follow project test conventions; do not swap frameworks silently.
+
+## Privacy notes
+
+Git diffs and source code enter the model context and may include proprietary algorithms or embedded secrets in fixtures. Redact sensitive values before sharing proposed tests outside the team.
+
+## Source Verification Notes
+
+Verified against Claude Code slash-command documentation and testing references on **2026-06-14**:
+
+- [Claude Code slash commands](https://code.claude.com/docs/en/slash-commands) document custom commands in `.claude/commands/`, the `$ARGUMENTS` placeholder for optional parameters, and team sharing by committing command files to git.
+- The `anthropics/claude-code` README and plugins README describe packaging reusable command prompts for project and team distribution — not built-in slash commands.
+- [Git diff](https://git-scm.com/docs/git-diff) is the standard scope primitive for change-aware test generation in terminal workflows.
+- [Vitest guide](https://vitest.dev/guide/) and other framework docs in the repo (`package.json` scripts) define the test stack this command must follow rather than invent.
+- The `claude-code` CHANGELOG records ongoing code-editing and diff-awareness improvements relevant to targeted generation workflows.
+
+## Duplicate Check
+
+Searched `content/commands/` on **2026-06-14** for overlapping slug, `commandSyntax`, and workflow scope. `generate-tests` (`/test-gen`) generates comprehensive suites across unit, integration, e2e, and security test types for arbitrary files — not diff-scoped gaps. `tdd-workflow` and `test-advanced` focus on methodology rather than git-diff targeting. No existing command limits generation to changed or untested symbols from `git diff`.
+
+## References
+
+- Claude Code repository: https://github.com/anthropics/claude-code
+- Claude Code slash commands: https://code.claude.com/docs/en/slash-commands
+- Git diff documentation: https://git-scm.com/docs/git-diff
+- Vitest guide: https://vitest.dev/guide/


### PR DESCRIPTION
## Summary
- Adds custom `/targeted-test-gen` slash command with install template for `.claude/commands/`
- Generates tests for changed or untested code from git diff scope
- Source-backed with slash-commands docs and verifiable testing references

Closes #745

## Test plan
- [x] `pnpm validate:content -- --category commands`
- [x] Includes Install this command section and Source Verification Notes
- [x] documentationUrl points to https://github.com/anthropics/claude-code