### PR TITLE
feat(seo): automate IndexNow — daily cron submits changed entry URLs

### DIFF
--- a/apps/web/plugins/indexnow-scheduled.ts
+++ b/apps/web/plugins/indexnow-scheduled.ts
@@ -24,6 +24,15 @@ type CloudflareScheduledPayload = {
   context: unknown;
 };
 
+/** Hostname of a URL, or null if it can't be parsed. */
+function urlHost(value: string): string | null {
+  try {
+    return new URL(value).host;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Daily IndexNow submission of recently changed entry URLs. Runs automatically
  * on the production host only (dev/preview never submit). Set INDEXNOW_DISABLED=1
@@ -62,9 +71,14 @@ export default definePlugin((nitroApp) => {
             const stamp = Date.parse(stampSource);
             if (!Number.isFinite(stamp) || stamp < cutoff || stamp > now) continue;
 
+            // IndexNow rejects a batch if any URL's host differs from the
+            // submitted `host`, so only trust canonicalUrl when it's HTTPS AND
+            // same-host; otherwise build a safe same-host URL.
+            const canonical = entry.canonicalUrl ?? "";
+            const canonicalHost = canonical.startsWith("https://") ? urlHost(canonical) : null;
             const url =
-              entry.canonicalUrl && entry.canonicalUrl.startsWith("https://")
-                ? entry.canonicalUrl
+              canonicalHost === host
+                ? canonical
                 : `${siteUrl}/entry/${entry.category}/${entry.slug}`;
             if (seen.has(url)) continue;
             seen.add(url);

--- a/apps/web/plugins/indexnow-scheduled.ts
+++ b/apps/web/plugins/indexnow-scheduled.ts
@@ -1,0 +1,103 @@
+import { definePlugin } from "nitro";
+
+import { getEnvString, runWithCloudflareRuntime } from "@/lib/cloudflare-env.server";
+import { getDirectoryEntries } from "@/lib/content.server";
+import { siteConfig } from "@/lib/site";
+
+// Daily 05:00 UTC. Must match the string in wrangler.jsonc triggers.crons
+// exactly (Cloudflare passes it through as controller.cron). The cron hook fires
+// for every trigger, so we gate on this exact string.
+const DAILY_CRON = "0 5 * * *";
+
+// IndexNow is a push-on-change protocol (Bing, Yandex, Seznam, Naver — Google
+// ignores it and uses sitemap lastmod instead). We submit ONLY the URLs that
+// changed recently, never the whole sitemap: resubmitting unchanged URLs gives
+// no benefit and reads as spam. The key file is served from the site root.
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+const INDEXNOW_KEY = "48486ebc7ddc47af875118345161ae70";
+const WINDOW_MS = 48 * 60 * 60 * 1000; // entries added/updated in the last 48h
+const MAX_URLS = 1000; // IndexNow per-request cap
+
+type CloudflareScheduledPayload = {
+  controller?: { cron?: string };
+  env: unknown;
+  context: unknown;
+};
+
+/**
+ * Daily IndexNow submission of recently changed entry URLs. Runs automatically
+ * on the production host only (dev/preview never submit). Set INDEXNOW_DISABLED=1
+ * to turn it off without a deploy. Best-effort — failures never throw.
+ */
+export default definePlugin((nitroApp) => {
+  nitroApp.hooks?.hook(
+    "cloudflare:scheduled",
+    async ({ controller, env, context }: CloudflareScheduledPayload) => {
+      if (controller?.cron !== DAILY_CRON) return;
+
+      const request = new Request("https://heyclau.de/__scheduled/indexnow");
+      await runWithCloudflareRuntime(request, env, context, async () => {
+        try {
+          const siteUrl = siteConfig.url.replace(/\/$/, "");
+          const host = new URL(siteUrl).host;
+
+          // IndexNow only makes sense for the live production host.
+          if (host !== "heyclau.de") {
+            console.log("[indexnow] skipped: non-production host", host);
+            return;
+          }
+          if (getEnvString("INDEXNOW_DISABLED") === "1") {
+            console.log("[indexnow] skipped: disabled via INDEXNOW_DISABLED");
+            return;
+          }
+
+          const now = Date.now();
+          const cutoff = now - WINDOW_MS;
+          const entries = await getDirectoryEntries();
+
+          const seen = new Set<string>();
+          const urls: string[] = [];
+          for (const entry of entries) {
+            const stampSource = entry.contentUpdatedAt ?? entry.dateAdded ?? "";
+            const stamp = Date.parse(stampSource);
+            if (!Number.isFinite(stamp) || stamp < cutoff || stamp > now) continue;
+
+            const url =
+              entry.canonicalUrl && entry.canonicalUrl.startsWith("https://")
+                ? entry.canonicalUrl
+                : `${siteUrl}/entry/${entry.category}/${entry.slug}`;
+            if (seen.has(url)) continue;
+            seen.add(url);
+            urls.push(url);
+          }
+
+          if (!urls.length) {
+            console.log("[indexnow] skipped: no URLs changed in the last 48h");
+            return;
+          }
+
+          const batch = urls.slice(0, MAX_URLS);
+          const response = await fetch(INDEXNOW_ENDPOINT, {
+            method: "POST",
+            headers: { "content-type": "application/json; charset=utf-8" },
+            body: JSON.stringify({
+              host,
+              key: INDEXNOW_KEY,
+              keyLocation: `${siteUrl}/${INDEXNOW_KEY}.txt`,
+              urlList: batch,
+            }),
+            signal: AbortSignal.timeout(10_000),
+          });
+
+          console.log(
+            `[indexnow] submitted ${batch.length} changed url(s)${
+              urls.length > batch.length ? ` (capped from ${urls.length})` : ""
+            } → HTTP ${response.status}`,
+          );
+        } catch (error) {
+          console.error("[indexnow] submission failed", error);
+        }
+      });
+    },
+  );
+});

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -21,9 +21,10 @@
     "mode": "smart",
   },
   "triggers": {
-    // 6-hourly: source-repo signals. Sundays 16:00 UTC: weekly newsletter digest.
+    // 6-hourly: source-repo signals. Daily 05:00 UTC: IndexNow changed-URL push.
+    // Sundays 16:00 UTC: weekly newsletter digest.
     // NB: Cloudflare day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN (not 0).
-    "crons": ["17 */6 * * *", "0 16 * * SUN"],
+    "crons": ["17 */6 * * *", "0 5 * * *", "0 16 * * SUN"],
   },
   "assets": {
     "directory": "dist/client",

--- a/docs/indexnow.md
+++ b/docs/indexnow.md
@@ -9,6 +9,23 @@ https://heyclau.de/48486ebc7ddc47af875118345161ae70.txt
 The key is intentionally public. It proves site ownership for IndexNow
 submissions and is not treated as a secret.
 
+IndexNow notifies **Bing, Yandex, Seznam, and Naver** (Bing shares onward).
+**Google ignores IndexNow** — it uses `sitemap.xml` `lastmod` + crawl, which the
+site already emits. So this is purely the Bing/everyone-else accelerator.
+
+## Automated daily submission (changed URLs only)
+
+A Cloudflare cron (`apps/web/plugins/indexnow-scheduled.ts`, daily 05:00 UTC —
+see `wrangler.jsonc` `triggers.crons`) submits **only the entry URLs added or
+updated in the last 48h**, derived from each entry's `contentUpdatedAt` /
+`dateAdded`. It deliberately does **not** resubmit the whole sitemap —
+resubmitting unchanged URLs gives no benefit and reads as spam.
+
+- Runs on the production host (`heyclau.de`) only; dev/preview never submit.
+- No secret required (the key is public). Set `INDEXNOW_DISABLED=1` to turn it
+  off without a deploy.
+- The manual script below remains for a one-off full-sitemap (re)submission.
+
 ## Local Dry Run
 
 ```bash

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -682,7 +682,7 @@ describe("registry artifacts", () => {
         ),
       ),
     ).toEqual(jsonLdSnapshotsPayload);
-  }, 60_000);
+  }, 180_000);
 
   it("publishes MCP harness targets only for validated config snippets", () => {
     const baseEntry = {
@@ -1101,7 +1101,7 @@ Use this hook after reviewing the notes.`,
     for (const contract of Object.values(manifest.artifactContracts)) {
       expect(contract.sha256).toMatch(/^[a-f0-9]{64}$/);
     }
-  }, 60_000);
+  }, 180_000);
 
   it("publishes category and platform sharded distribution feeds", () => {
     const feedIndex = readDataJson<{


### PR DESCRIPTION
## What

IndexNow was set up but **manual-only** (`pnpm indexnow:submit`). This automates it the right way: a daily Cloudflare cron that pushes **only the URLs that changed**, never the whole sitemap.

- New `apps/web/plugins/indexnow-scheduled.ts` (mirrors the newsletter-digest cron pattern), gated on a new daily cron `0 5 * * *` added to `wrangler.jsonc`.
- Submits entry URLs whose `contentUpdatedAt` / `dateAdded` falls in the last **48h** (deduped, capped at IndexNow's 1000/request). Resubmitting unchanged URLs gives no benefit and reads as spam, so we deliberately don't.
- **Production host only** (`heyclau.de`) — dev/preview never submit. No secret needed (the IndexNow key is public); `INDEXNOW_DISABLED=1` is an escape hatch. Best-effort — failures never throw.
- Docs updated (`docs/indexnow.md`): notes the automation + that IndexNow feeds Bing/Yandex/Seznam/Naver while **Google ignores it** (uses sitemap `lastmod`, already emitted).

The manual full-sitemap script stays for one-off (re)submissions.

## Why daily + changed-only

IndexNow is push-on-change, not a re-crawl ping. Daily is the right cadence for a directory that merges content through the day; changed-only keeps volume low and avoids spam signals.

## Validation

- `pnpm --filter web type-check` — passed
- `pnpm build` — passed
- `pnpm exec vitest run tests/indexnow.test.ts` — 4 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily IndexNow push at 05:00 UTC that submits only URLs updated/added in the last 48 hours (deduplicated, up to a fixed batch size).
  * IndexNow submissions now run only on production and can be disabled at runtime via an environment variable.
* **Documentation**
  * Updated IndexNow guidance to clarify supported search engines and explain the automated daily workflow, including how to disable it and when to use manual full resubmission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->