### PR TITLE
fix(metrics): show real @heyclaude/mcp npm stats, not the upstream SDK's

### DIFF
--- a/apps/web/src/components/hero-status-row.tsx
+++ b/apps/web/src/components/hero-status-row.tsx
@@ -4,7 +4,7 @@ import { LiveVersionBadge } from "./live-version-badge";
 /**
  * Hero status row: live-ish signals stitched together as a single line.
  * - Indexed timestamp from the generated registry manifest
- * - MCP SDK version (live from npm)
+ * - @heyclaude/mcp version (live from npm)
  * - Latest weekly brief
  */
 export function HeroStatusRow({
@@ -36,8 +36,8 @@ export function HeroStatusRow({
         className="hidden sm:inline-flex"
       >
         <LiveVersionBadge
-          pkg="@modelcontextprotocol/sdk"
-          fallbackVersion="1.0.0"
+          pkg="@heyclaude/mcp"
+          fallbackVersion="0.3.1"
           showDownloads={false}
         />
       </Link>

--- a/apps/web/src/data/integrations.ts
+++ b/apps/web/src/data/integrations.ts
@@ -67,7 +67,9 @@ export const INTEGRATIONS: Integration[] = [
     tier: "First-party server",
     status: "live",
     mark: "mcp",
-    npmPackage: "@modelcontextprotocol/sdk",
+    // Our own published package — the live badge must reflect @heyclaude/mcp's
+    // real version + weekly downloads, NOT the upstream MCP SDK's (which has ~39M/wk).
+    npmPackage: "@heyclaude/mcp",
     githubRepo: "jsonbored/awesome-claude",
     bullets: [
       "20+ tools: search, trending, compare, get_entry_detail, prepare_submission_draft, explain_entry_trust",


### PR DESCRIPTION
## The bug

The MCP integration page and the homepage hero showed **v1.29.0 · 39.1M/wk** for `@heyclaude/mcp` — numbers that are real but belong to a **different package**.

Root cause: the live badge (`LiveVersionBadge` → `/api/public/npm` proxy) was pointed at **`@modelcontextprotocol/sdk`** (the upstream MCP SDK: v1.x, ~39M downloads/wk) instead of our own **`@heyclaude/mcp`** (v0.3.1, ~199/wk, verified live from npm). So it rendered the SDK's genuine npm stats, mislabeled as ours.

## Fix

- `data/integrations.ts` — MCP integration `npmPackage`: `@modelcontextprotocol/sdk` → `@heyclaude/mcp` (fixes the integration card + detail page badge).
- `components/hero-status-row.tsx` — hero `LiveVersionBadge` pkg → `@heyclaude/mcp`, fallback `0.3.1` (fixes the homepage hero version).

All counters stay **live from the npm proxy** — this only corrects which package is queried. After this, both surfaces show `@heyclaude/mcp`'s real version and weekly downloads.

## Audit

Only that one integration had an (incorrect) `npmPackage`; all other integrations have none. Other homepage counters (resource/reviewed counts, brief number, indexed timestamp) are already computed from real registry data, and the MCP server-card version is derived from the package. This was the only mislabeled metric.

## Validation

- `pnpm --filter web type-check` — passed
- npm data verified: `@heyclaude/mcp` = v0.3.1 / 199/wk; `@modelcontextprotocol/sdk` = 39,092,172/wk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated MCP integration version display source for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->