### PR TITLE
ci(seo): on-publish IndexNow ping for newly merged entries

### DIFF
--- a/.github/workflows/indexnow-on-publish.yml
+++ b/.github/workflows/indexnow-on-publish.yml
@@ -1,0 +1,78 @@
+name: IndexNow on publish
+
+# Fire an IndexNow submission the moment content lands on main, for near-instant
+# Bing/Yandex/Seznam/Naver pickup. Complements the daily Worker cron
+# (apps/web/plugins/indexnow-scheduled.ts), which is the catch-all safety net —
+# IndexNow dedupes, so overlap is harmless. No secrets: the IndexNow key is
+# public (served from the site root + committed), so this runs on the runner and
+# POSTs straight to api.indexnow.org.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "content/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: indexnow-on-publish
+  cancel-in-progress: false
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Collect changed entry URLs (live only)
+        id: urls
+        run: |
+          set -euo pipefail
+          base="${{ github.event.before }}"
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            base="HEAD~1"
+          fi
+
+          # Added or modified content entries (deletes are skipped — we don't
+          # ping URLs that no longer exist).
+          changed="$(git diff --name-only --diff-filter=AM "$base" "${{ github.sha }}" -- 'content/**/*.mdx' || true)"
+
+          : > indexnow-urls.txt
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            rel="${file#content/}"          # <category>/<slug>.mdx
+            category="${rel%%/*}"
+            slug="${rel#*/}"; slug="${slug%.mdx}"
+            # Skip anything that isn't a flat <category>/<slug> entry (e.g. archive/).
+            case "$slug" in */*) continue;; esac
+            url="https://heyclau.de/entry/${category}/${slug}"
+            # Only submit URLs that are actually live (filters non-entry paths and
+            # entries whose deploy hasn't propagated yet — the daily cron re-catches those).
+            code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo 000)"
+            if [ "$code" = "200" ]; then
+              echo "$url" >> indexnow-urls.txt
+              echo "live   $url"
+            else
+              echo "skip   $url (HTTP $code)"
+            fi
+          done <<< "$changed"
+
+          count="$(grep -c . indexnow-urls.txt || true)"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "Submitting $count live entry URL(s)."
+
+      - name: Submit to IndexNow
+        if: steps.urls.outputs.count != '0'
+        env:
+          INDEXNOW_SUBMIT: "1"
+        run: node scripts/submit-indexnow.mjs --urls-file indexnow-urls.txt

--- a/.github/workflows/indexnow-on-publish.yml
+++ b/.github/workflows/indexnow-on-publish.yml
@@ -26,11 +26,12 @@ jobs:
   submit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
+          persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "22"
 

--- a/.github/workflows/indexnow-on-publish.yml
+++ b/.github/workflows/indexnow-on-publish.yml
@@ -36,16 +36,20 @@ jobs:
 
       - name: Collect changed entry URLs (live only)
         id: urls
+        env:
+          # Passed via env (not inlined into the shell) to avoid script injection.
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          base="${{ github.event.before }}"
+          base="$BEFORE_SHA"
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             base="HEAD~1"
           fi
 
           # Added or modified content entries (deletes are skipped — we don't
           # ping URLs that no longer exist).
-          changed="$(git diff --name-only --diff-filter=AM "$base" "${{ github.sha }}" -- 'content/**/*.mdx' || true)"
+          changed="$(git diff --name-only --diff-filter=AM "$base" "$HEAD_SHA" -- 'content/**/*.mdx' || true)"
 
           : > indexnow-urls.txt
           while IFS= read -r file; do


### PR DESCRIPTION
## What

Fires an IndexNow submission the moment content merges to `main`, for near-instant Bing/Yandex/Seznam/Naver pickup — instead of waiting up to a day for the Worker cron.

- New workflow `.github/workflows/indexnow-on-publish.yml`, triggered on `push: main` + `paths: content/**` (same model as `readme-refresh-pr.yml`).
- Diffs the push for added/modified `content/<category>/<slug>.mdx`, maps each to `https://heyclau.de/entry/<category>/<slug>`, **HEAD-checks each is live (200)**, and submits the survivors via the committed `scripts/submit-indexnow.mjs`.
- **No secrets / no Cloudflare** — the IndexNow key is public, so this runs entirely on the runner. `permissions: contents: read` only.

## How it fits the existing automation

This complements the daily Worker cron (`apps/web/plugins/indexnow-scheduled.ts`): on-publish handles instant pickup, the cron is the catch-all safety net for anything missed (e.g. a workflow failure, or a page that hadn't finished deploying when the 200-check ran). IndexNow dedupes, so the overlap is harmless. Deletes are skipped (we don't ping URLs that no longer exist).

## Validation

- YAML parses; `submit-indexnow.mjs --urls-file` dry-run produces a valid payload
- `vitest run tests/generated-churn-policy.test.ts tests/submission-workflows.test.ts` — 77 passed (the new workflow commits nothing, so it passes the churn policy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated IndexNow-on-publish workflow that detects changes to Markdown entries under `content/**`, builds the corresponding entry URLs, verifies each URL is live (HTTP 200), and submits the verified URLs for improved search engine indexing.  
  * Includes manual triggering support and runs on pushes to `main` affecting content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->