### PR TITLE
fix(content): rewrite react-server-components-expert SEO copy, add disclosure notes

### DIFF
--- a/content/rules/react-server-components-expert.mdx
+++ b/content/rules/react-server-components-expert.mdx
@@ -3,17 +3,17 @@ title: React Server Components Expert for Claude
 slug: react-server-components-expert
 category: rules
 description: >-
-  Expert in React Server Components (RSC) with React 19 and Next.js 15,
-  specializing in server-first rendering patterns, data fetching strategies, and
-  streaming architectures
+  A coding rule that makes Claude fluent in React Server Components — the React
+  19 component type that renders ahead of bundling, on a server or at build time.
+  It guides async server components, the use client boundary, Suspense
+  streaming, and Server Functions through the Next.js 15 App Router.
 cardDescription: >-
-  Expert in React Server Components (RSC) with React 19 and Next.js 15,
-  specializing in server-first rendering patterns, data fetching stra...
-seoTitle: React Server Components Expert for Claude
+  Server-first React 19: async data fetching, isolating interactivity in client
+  components, and Suspense streaming without fetch waterfalls.
+seoTitle: "React Server Components (RSC) Rule for React 19 & Claude"
 seoDescription: >-
-  Expert in React Server Components (RSC) with React 19 and Next.js 15,
-  specializing in server-first rendering patterns, data fetching strategies, and
-  streamin...
+  Teach Claude React Server Components: the render-before-bundle model, direct
+  database access, the use client boundary, and Suspense streaming in React 19.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -906,6 +906,12 @@ scriptBody: >-
 
   Always prioritize server-first architecture, minimize client JavaScript, and
   leverage RSC's full potential for performance and developer experience.
+safetyNotes:
+  - "This rule is prompt guidance, not executable code, but it directs Claude to generate React Server Functions and Server Actions that perform server-side writes such as database mutations and cache revalidation; review and authorize generated mutations before running them."
+  - "Server Actions execute on the server with full backend access, so validate every action input (for example with Zod) and add CSRF protection before exposing a mutation, as the rule itself recommends."
+privacyNotes:
+  - "The recommended patterns fetch user data directly on the server through database queries and session or auth lookups and read server environment variables; keep secrets server-only and never pass sensitive data as props to Client Components."
+  - "Treat NEXT_PUBLIC_ environment variables as client-exposed and keep credentials, tokens, and personal records on the server, matching the rule's security guidance."
 tags:
   - react
   - rsc


### PR DESCRIPTION
## What

Improves the `rules/react-server-components-expert` entry, flagged by `pnpm report:thin-content` as low-uniqueness (unique-word ratio 0.38, below the 0.42 floor — bottom-decile, keyword-stuffed SEO copy).

### Changes (single content file)
- **`description`, `cardDescription`, `seoDescription`** — were three near-identical copies of one sentence (the card/seo ones still carried literal `...` truncation artifacts: `data fetching stra...`, `streamin...`). Rewrote each to be distinct and information-dense, grounded in the official source.
- **`seoTitle`** — was a verbatim copy of `title`; now a distinct, keyword-bearing meta title.
- **`safetyNotes` / `privacyNotes`** — added. The rule body teaches Server Actions (server-side writes/mutations), auth/session lookups, direct database access, and environment-variable handling, which the content-policy gate flags as `external_write_capability` and `local_or_personal_data_access`. These notes disclose that behavior accurately, per `AGENTS.md` safety/privacy metadata guidance.

### Grounding
All new copy is grounded in the entry's protected `documentationUrl` — the official React docs at https://react.dev/reference/rsc/server-components — including the render-before-bundling model, async Server Components, the `use client` boundary, Suspense streaming, and Server Functions.

### Validation
- `pnpm validate:content:strict` — passed (982 files)
- content-policy gate (`scripts/ci/validate-content-policy.mjs`) — passed (was blocking on missing safety/privacy notes; now satisfied)
- `pnpm audit:content` — entry has 0 issues / 0 missing fields
- `pnpm report:thin-content` — entry no longer flagged (low-uniqueness cohort 74 → 73)
- `pnpm test:registry-artifacts` — 46 passed
- `git diff --check` — clean

No protected frontmatter fields changed: `description`/`seoDescription` edits are within `>-` block scalars, `seoTitle` and the added `safetyNotes`/`privacyNotes` are editable/allowed-metadata fields. No generated artifacts included.