### PR TITLE
fix(content): rewrite react-19-concurrent-features-specialist SEO copy, add disclosure notes

### DIFF
--- a/content/rules/react-19-concurrent-features-specialist.mdx
+++ b/content/rules/react-19-concurrent-features-specialist.mdx
@@ -3,16 +3,17 @@ title: React 19 Concurrent Features Specialist for Claude
 slug: react-19-concurrent-features-specialist
 category: rules
 description: >-
-  React 19 concurrent features specialist with useTransition, useDeferredValue,
-  Suspense boundaries, streaming SSR, and selective hydration patterns
+  A coding rule that turns Claude into a React 19 concurrent-rendering
+  specialist. It applies the documented React hooks — useTransition,
+  useDeferredValue, useOptimistic, and Suspense — to keep interfaces responsive
+  during heavy updates, stream server-rendered UI, and hydrate it selectively.
 cardDescription: >-
-  React 19 concurrent features specialist with useTransition, useDeferredValue,
-  Suspense boundaries, streaming SSR, and selective hydration...
-seoTitle: React 19 Concurrent Features Specialist for Claude
+  Keep React 19 UIs responsive: defer non-urgent renders, mark pending
+  transitions, show optimistic updates, and stream UI behind Suspense.
+seoTitle: "React 19 Concurrent Rendering Rule — Transitions & Suspense"
 seoDescription: >-
-  React 19 concurrent features specialist with useTransition, useDeferredValue,
-  Suspense boundaries, streaming SSR, and selective hydration patterns Discover
-  t...
+  Guide Claude through React 19 concurrent rendering: useTransition,
+  useDeferredValue, useOptimistic, Suspense streaming, and selective hydration.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -895,6 +896,11 @@ scriptBody: >-
   Always use useTransition for non-blocking updates, useDeferredValue for
   expensive renders, Suspense boundaries for parallel data fetching, streaming
   SSR for instant page loads, and selective hydration for optimal interactivity.
+safetyNotes:
+  - "This rule is prompt guidance, not executable code, but its examples use Server Actions with useActionState and useFormStatus to perform server-side writes such as form submissions and optimistic mutations; review and authorize generated mutations before running them."
+  - "The optimistic-update examples call crypto.randomUUID() only to generate temporary client-side keys — it is the standard Web Crypto UUID API and involves no payments, wallets, or identity data."
+privacyNotes:
+  - "The patterns render user-submitted form data and fetch user-specific records on the server through Suspense data sources; validate inputs and keep server-only data off the client, never exposing sensitive fields as props to Client Components."
 tags:
   - react-19
   - concurrent


### PR DESCRIPTION
## What

Improves the `rules/react-19-concurrent-features-specialist` entry, flagged by `pnpm report:thin-content` as low-uniqueness (unique-word ratio 0.39, below the 0.42 floor — repetitive, keyword-stuffed SEO copy).

### Changes (single content file)
- **`description`, `cardDescription`, `seoDescription`** — were three near-identical copies of one sentence, and the card/seo ones still carried literal `...` truncation artifacts (`selective hydration...`, `selective hydration patterns Discover t...`). Rewrote each to be distinct and information-dense, each covering a different facet (overview / practical outcomes / search meta).
- **`seoTitle`** — was a verbatim copy of `title`; now a distinct, keyword-bearing meta title.
- **`safetyNotes` / `privacyNotes`** — added. The rule body uses Server Actions with `useActionState`/`useFormStatus` (server-side writes) and renders user form data, which the content-policy gate flags as `external_write_capability` and `local_or_personal_data_access`. The notes disclose that behavior, and one safety note clarifies that the `crypto.randomUUID()` in the optimistic-update examples is the standard Web Crypto UUID API (temporary client keys) — not payment/identity behavior — which the gate otherwise heuristically flags as `financial_or_identity_sensitive`.

### Grounding
All new copy stays within React APIs documented under the entry's protected `documentationUrl`, the official React reference at https://react.dev/reference/react — `useTransition`, `useDeferredValue`, `useOptimistic`, `Suspense`, and selective hydration / streaming SSR.

### Validation
- `pnpm validate:content:strict` — passed
- content-policy gate (`scripts/ci/validate-content-policy.mjs`) — passed (was blocking on missing safety/privacy notes; now satisfied)
- `pnpm audit:content` — entry has 0 issues / 0 missing fields
- `pnpm report:thin-content` — entry no longer flagged
- `pnpm test:registry-artifacts` — 46 passed
- `git diff --check` — clean

No protected frontmatter changed: `description`/`seoDescription` edits are within `>-` block scalars; `seoTitle` and the added `safetyNotes`/`privacyNotes` are editable/allowed-metadata fields. No generated artifacts included.