### PR TITLE
fix(content): rewrite monorepo-workspace-manager SEO copy

### DIFF
--- a/content/rules/monorepo-workspace-manager.mdx
+++ b/content/rules/monorepo-workspace-manager.mdx
@@ -3,17 +3,18 @@ title: Monorepo Workspace Manager - CLAUDE.md Rules for Claude Code
 slug: monorepo-workspace-manager
 category: rules
 description: >-
-  Monorepo workspace management expert with Turborepo, pnpm workspaces, Nx
-  integration, package coordination, and cross-package dependency optimization
-  for scalable multi-package repositories.
+  A CLAUDE.md rule for managing JavaScript and TypeScript monorepos. It applies
+  Turborepo task pipelines, local and remote caching, and workspace dependency
+  protocols — across pnpm and Nx setups — to keep cross-package builds fast and
+  dependencies coordinated as the repository scales.
 cardDescription: >-
-  Monorepo workspace management expert with Turborepo, pnpm workspaces, Nx
-  integration, package coordination, and cross-package dependency...
-seoTitle: Monorepo Workspace Manager - CLAUDE.md Rules for Claude Code
+  Scale JS/TS monorepos: Turborepo task pipelines, local and remote caching,
+  workspace dependency protocols, and a clean apps/packages layout.
+seoTitle: "Monorepo Rule: Turborepo Pipelines, Caching & Workspaces"
 seoDescription: >-
-  Monorepo workspace management expert with Turborepo, pnpm workspaces, Nx
-  integration, package coordination, and cross-package dependency optimization
-  for sca...
+  Guide Claude through monorepo workspace management: Turborepo pipelines and
+  remote caching, pnpm and Nx workspaces, and cross-package dependency
+  coordination.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"


### PR DESCRIPTION
## What

Improves the `rules/monorepo-workspace-manager` entry, flagged by `pnpm report:thin-content` as low-uniqueness (unique-word ratio 0.40, below the 0.42 floor — repetitive, keyword-stuffed SEO copy).

### Changes (single content file, meta fields only)
- **`description`, `cardDescription`, `seoDescription`** — were three near-identical copies of one sentence, with the card/seo ones carrying literal `...` truncation artifacts (`cross-package dependency...`, `for sca...`). Rewrote each to be distinct and information-dense, covering different facets (overview / practical layout / search meta).
- **`seoTitle`** — was a verbatim copy of `title`; now a distinct, keyword-bearing meta title.

No `safetyNotes`/`privacyNotes` were needed — the content-policy gate raises zero risk flags for this entry.

### Grounding
All new copy is grounded in the entry's protected `documentationUrl`, the official Turborepo docs at https://turbo.build/repo/docs (301 → live docs that describe Turborepo as "a high-performance build system… designed for scaling monorepos," covering task pipelines, workspaces, and local/remote caching). The body's `turbo.json` pipeline, caching, and `workspace:*` dependency examples map directly to that source.

### Validation
- `pnpm validate:content:strict` — passed
- content-policy gate (`scripts/ci/validate-content-policy.mjs`) — passed (exit 0, no flags)
- `pnpm audit:content` — entry has 0 issues / 0 missing fields
- `pnpm report:thin-content` — entry no longer flagged
- `pnpm test:registry-artifacts` — 46 passed
- `git diff --check` — clean

No protected frontmatter changed: `description`/`seoDescription` edits are within `>-` block scalars; `seoTitle` is editable. No generated artifacts included.