### PR TITLE
fix(content): rewrite test-driven-development-enforcer SEO copy, add disclosure notes

### DIFF
--- a/content/rules/test-driven-development-enforcer.mdx
+++ b/content/rules/test-driven-development-enforcer.mdx
@@ -3,17 +3,18 @@ title: Test-Driven Development Enforcer - CLAUDE.md Rules for Claude Code
 slug: test-driven-development-enforcer
 category: rules
 description: >-
-  Test-driven development expert enforcing red-green-refactor cycles,
-  Vitest/Jest configuration, test coverage requirements, mocking strategies, and
-  test-first coding discipline for robust software development.
+  A CLAUDE.md rule that holds Claude to strict test-driven development: write a
+  failing Vitest test first, add the minimum code to make it pass, then refactor.
+  It covers vitest.config setup, expect assertions, vi mocks and fake timers, the
+  arrange-act-assert pattern, and running suites in watch mode or once in CI.
 cardDescription: >-
-  Test-driven development expert enforcing red-green-refactor cycles,
-  Vitest/Jest configuration, test coverage requirements, mocking strate...
-seoTitle: Test-Driven Development Enforcer - CLAUDE.md Rules for Claude Code
+  Hold Claude to red-green-refactor TDD with Vitest: failing test first, minimal
+  code to pass, then refactor — with vi mocks and AAA tests.
+seoTitle: "TDD Enforcer Rule: Red-Green-Refactor With Vitest"
 seoDescription: >-
-  Test-driven development expert enforcing red-green-refactor cycles,
-  Vitest/Jest configuration, test coverage requirements, mocking strategies, and
-  test-first...
+  Make Claude practice TDD with Vitest: write failing tests first, then code.
+  Covers red-green-refactor, vi mocks, fake timers, and arrange-act-assert
+  structure.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
@@ -1541,6 +1542,11 @@ scriptBody: >-
   Always write tests before implementation, follow red-green-refactor cycle
   strictly, maintain minimum 80% coverage with focus on quality, mock external
   dependencies to isolate units, and use AAA pattern for clear test structure.
+safetyNotes:
+  - "Guidance only — this rule adds no executable code, but its examples install dependencies (npm ci), run the Vitest CLI, and execute generated test suites locally and in CI; review and run them yourself rather than auto-executing."
+  - "The CI sample runs tests on every push and pull request via GitHub Actions and uploads coverage to a third-party service (Codecov), which you must configure before use."
+privacyNotes:
+  - "The async examples mock the global fetch against endpoints like /api/users and write coverage reports (lcov, html) to a local coverage/ directory; the CI sample additionally uploads lcov coverage to Codecov."
 tags:
   - tdd
   - testing


### PR DESCRIPTION
## What

Improves the `rules/test-driven-development-enforcer` entry, flagged by `pnpm report:thin-content` as low-uniqueness (unique-word ratio 0.39, below the 0.42 floor — repetitive, keyword-stuffed SEO copy).

### Changes (single content file)
- **`description`, `cardDescription`, `seoDescription`** — were three near-identical copies of one sentence, with the card/seo ones carrying literal `...` truncation artifacts (`mocking strate...`, `test-first...`). Rewrote each to be distinct and information-dense, covering different facets (overview / practical loop / search meta).
- **`seoTitle`** — was a verbatim copy of `title`; now a distinct, keyword-bearing meta title.
- **`safetyNotes` / `privacyNotes`** — added. The rule body installs deps (`npm ci`), runs the Vitest CLI / generated suites, ships a GitHub Actions CI sample that uploads coverage to Codecov, and mocks `global.fetch` against `/api/users`. The content-policy gate flags this as `external_write_capability` / `local_or_personal_data_access`, so these notes disclose the install/CI/coverage-upload and local-data behavior accurately.

### Grounding
All new copy is grounded in the entry's protected `documentationUrl`, the official Vitest guide at https://vitest.dev/guide/ ("a next generation testing framework powered by Vite"; `.test`/`.spec` discovery; watch mode vs `vitest run`; `expect()` assertions; `vitest.config`/`vite.config`; `--coverage`) plus the entry's own red-green-refactor body. I deliberately kept claims to what the Vitest guide and body support (e.g. omitted "mutation testing", which the guide does not document).

### Validation
- `pnpm validate:content:strict` — passed
- content-policy gate (`scripts/ci/validate-content-policy.mjs`) — passed (exit 0)
- `pnpm audit:content` — entry has 0 issues / 0 missing fields
- `pnpm report:thin-content` — entry no longer flagged
- `pnpm test:registry-artifacts` — 46 passed
- `git diff --check` — clean

No protected frontmatter changed: `description`/`seoDescription` edits are within `>-` block scalars; `seoTitle` and the added `safetyNotes`/`privacyNotes` are editable/allowed-metadata fields. No generated artifacts included.