### PR TITLE
feat(mcp): token-efficient get_entry_detail with bodyMode

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -39,6 +39,10 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
 - `get_related_entries` - find related entries based on category, tags,
   platforms, keywords, and source metadata.
 - `get_entry_detail` - fetch an entry detail payload by category and slug.
+  Defaults to a token-efficient body excerpt (reporting `bodyChars`,
+  `bodyTruncated`, and any `omittedFields`); pass `bodyMode: "full"` for the
+  complete content or `"none"` to drop the body. Omitted copyable fields are
+  available via `get_copyable_asset`.
 - `get_copyable_asset` - fetch the category-aware copy/install asset for an
   entry, such as full prompt text, config snippets, commands, scripts, or
   collection items.

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -158,7 +158,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: "get_entry_detail",
     description:
-      "Fetch a read-only HeyClaude registry entry detail payload by category and slug.",
+      "Fetch a read-only HeyClaude registry entry detail payload by category and slug. By default (bodyMode='excerpt') the body markdown is trimmed to a short lead and large copyable fields are omitted to conserve context, with bodyChars/bodyTruncated/omittedFields describing what was dropped; pass bodyMode='full' for the complete content or 'none' to drop the body entirely. Use get_copyable_asset to retrieve omitted install/script content.",
     inputSchema: jsonSchemaForTool("get_entry_detail"),
   },
   {
@@ -1344,6 +1344,111 @@ export async function getRelatedEntries(args = {}, options = {}) {
   };
 }
 
+const ENTRY_BODY_EXCERPT_CHARS = 1200;
+
+// Large copyable-content fields that largely duplicate the body or the install
+// asset. In non-full modes they are omitted (and surfaced via omittedFields)
+// because the caller should pull them from get_copyable_asset when needed,
+// rather than paying for tens of kilobytes on every detail lookup.
+const ENTRY_ASSET_FIELDS = ["scriptBody", "fullCopyableContent", "copySnippet"];
+
+function excerptText(text, limit) {
+  if (text.length <= limit) {
+    return text;
+  }
+  const slice = text.slice(0, limit);
+  // Back off to the last paragraph/sentence/word boundary so the excerpt does
+  // not end mid-word; fall back to the hard cut if no decent boundary exists.
+  const boundary = Math.max(
+    slice.lastIndexOf("\n\n"),
+    slice.lastIndexOf("\n"),
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf(" "),
+  );
+  const cut = boundary > limit * 0.6 ? slice.slice(0, boundary) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+// Projects an entry's heavy content to the requested verbosity so the default
+// get_entry_detail response stays token-efficient. Returns the (possibly
+// trimmed) entry plus body metadata describing exactly what was returned.
+function projectEntryBody(entry, requestedMode) {
+  const mode =
+    requestedMode === "none" || requestedMode === "full"
+      ? requestedMode
+      : "excerpt";
+  const body = typeof entry.body === "string" ? entry.body : "";
+  const bodyChars = body.length;
+
+  if (mode === "full") {
+    return {
+      entry,
+      bodyMeta: {
+        bodyMode: "full",
+        bodyChars,
+        bodyTruncated: false,
+        omittedFields: [],
+      },
+    };
+  }
+
+  // Lean modes: drop large copyable asset fields, keep small useful ones.
+  const projected = { ...entry };
+  const omittedFields = [];
+  for (const field of ENTRY_ASSET_FIELDS) {
+    const value = projected[field];
+    const size = typeof value === "string" ? value.length : 0;
+    if (size > ENTRY_BODY_EXCERPT_CHARS) {
+      delete projected[field];
+      omittedFields.push({ field, chars: size });
+    }
+  }
+
+  if (mode === "none") {
+    delete projected.body;
+    return {
+      entry: projected,
+      bodyMeta: withAssetHint({
+        bodyMode: "none",
+        bodyChars,
+        bodyTruncated: bodyChars > 0,
+        omittedFields,
+      }),
+    };
+  }
+
+  if (bodyChars > ENTRY_BODY_EXCERPT_CHARS) {
+    projected.body = excerptText(body, ENTRY_BODY_EXCERPT_CHARS);
+    return {
+      entry: projected,
+      bodyMeta: withAssetHint({
+        bodyMode: "excerpt",
+        bodyChars,
+        bodyTruncated: true,
+        omittedFields,
+      }),
+    };
+  }
+
+  return {
+    entry: projected,
+    bodyMeta: withAssetHint({
+      bodyMode: "excerpt",
+      bodyChars,
+      bodyTruncated: false,
+      omittedFields,
+    }),
+  };
+}
+
+function withAssetHint(bodyMeta) {
+  if (bodyMeta.omittedFields.length > 0) {
+    bodyMeta.assetHint =
+      "Large copyable fields were omitted to save context; call get_copyable_asset for the full script or snippet.";
+  }
+  return bodyMeta;
+}
+
 export async function getEntryDetail(args = {}, options = {}) {
   const category = normalizeText(args.category);
   const slug = normalizeText(args.slug);
@@ -1356,15 +1461,22 @@ export async function getEntryDetail(args = {}, options = {}) {
     return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
   }
 
+  const normalizedEntry = {
+    ...entry,
+    safetyNotes: notes(entry.safetyNotes),
+    privacyNotes: notes(entry.privacyNotes),
+  };
+  const { entry: projectedEntry, bodyMeta } = projectEntryBody(
+    normalizedEntry,
+    args.bodyMode,
+  );
+
   return {
     ok: true,
     key: `${entry.category}:${entry.slug}`,
     canonicalUrl: entryCanonicalUrl(entry),
-    entry: {
-      ...entry,
-      safetyNotes: notes(entry.safetyNotes),
-      privacyNotes: notes(entry.privacyNotes),
-    },
+    ...bodyMeta,
+    entry: projectedEntry,
     trust: entryTrustSummary(entry),
   };
 }
@@ -2123,7 +2235,12 @@ export async function readRegistryResource(args = {}, options = {}) {
     };
   } else if (parsed.hostname === "entry" && parts.length === 2) {
     const [category, slug] = parts.map(normalizeText);
-    const detail = await getEntryDetail({ category, slug }, options);
+    // Resource reads return the full document; only the tool defaults to a
+    // token-efficient excerpt.
+    const detail = await getEntryDetail(
+      { category, slug, bodyMode: "full" },
+      options,
+    );
     payload = detail;
   } else if (
     parsed.hostname === "registry" &&

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -148,6 +148,12 @@ export const EntryDetailInputSchema = z
   .object({
     category: pathPart,
     slug: pathPart,
+    bodyMode: z
+      .enum(["none", "excerpt", "full"])
+      .describe(
+        "How much entry content to return. 'excerpt' (default) trims the body markdown to a short lead and omits large copyable fields (scriptBody, fullCopyableContent, copySnippet), reporting what was dropped via bodyChars/bodyTruncated/omittedFields; 'none' also drops the body; 'full' returns everything. Use get_copyable_asset for omitted install/script content, and request 'full' only when you truly need the complete inline content — it can be tens of kilobytes.",
+      )
+      .optional(),
   })
   .strict();
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -674,6 +674,123 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
+  it("returns a token-efficient body excerpt by default and honors bodyMode", async () => {
+    const full = await callRegistryTool(
+      "get_entry_detail",
+      { category: skill.category, slug: skill.slug, bodyMode: "full" },
+      { dataDir },
+    );
+    expect(full).toMatchObject({
+      ok: true,
+      bodyMode: "full",
+      bodyTruncated: false,
+      bodyChars: expect.any(Number),
+      omittedFields: [],
+    });
+    expect(full.entry.body.length).toBe(full.bodyChars);
+
+    const excerpt = await callRegistryTool(
+      "get_entry_detail",
+      { category: skill.category, slug: skill.slug },
+      { dataDir },
+    );
+    expect(excerpt.bodyMode).toBe("excerpt");
+    expect(excerpt.bodyChars).toBe(full.bodyChars);
+    expect(Array.isArray(excerpt.omittedFields)).toBe(true);
+    if (full.bodyChars > 1200) {
+      expect(excerpt.bodyTruncated).toBe(true);
+      expect(excerpt.entry.body.length).toBeLessThan(full.bodyChars);
+      expect(excerpt.entry.body.endsWith("…")).toBe(true);
+    } else {
+      expect(excerpt.bodyTruncated).toBe(false);
+      expect(excerpt.entry.body).toBe(full.entry.body);
+    }
+
+    const omitted = await callRegistryTool(
+      "get_entry_detail",
+      { category: skill.category, slug: skill.slug, bodyMode: "none" },
+      { dataDir },
+    );
+    expect(omitted.bodyMode).toBe("none");
+    expect(omitted.entry).not.toHaveProperty("body");
+    // Non-body fields survive the projection.
+    expect(omitted.entry.slug).toBe(skill.slug);
+    expect(omitted.trust).toEqual(full.trust);
+  });
+
+  it("omits large copyable asset fields in lean modes and points to get_copyable_asset", async () => {
+    const directory = JSON.parse(
+      fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
+    ) as { entries: Array<{ category: string; slug: string }> };
+
+    // Find an entry whose scriptBody/fullCopyableContent exceeds the excerpt
+    // threshold so we exercise the asset-omission path deterministically.
+    let heavy: { category: string; slug: string } | null = null;
+    for (const candidate of directory.entries) {
+      const file = path.join(
+        dataDir,
+        "entries",
+        candidate.category,
+        `${candidate.slug}.json`,
+      );
+      if (!fs.existsSync(file)) continue;
+      const entry = JSON.parse(fs.readFileSync(file, "utf8")).entry as Record<
+        string,
+        unknown
+      >;
+      const big = ["scriptBody", "fullCopyableContent", "copySnippet"].some(
+        (field) =>
+          typeof entry[field] === "string" &&
+          (entry[field] as string).length > 1200,
+      );
+      if (big) {
+        heavy = { category: candidate.category, slug: candidate.slug };
+        break;
+      }
+    }
+    if (!heavy) return; // No heavy-asset entry in this dataset; nothing to assert.
+
+    const full = await callRegistryTool(
+      "get_entry_detail",
+      { ...heavy, bodyMode: "full" },
+      { dataDir },
+    );
+    expect(full.omittedFields).toEqual([]);
+
+    const lean = await callRegistryTool("get_entry_detail", heavy, { dataDir });
+    expect(lean.omittedFields.length).toBeGreaterThan(0);
+    const omittedNames = lean.omittedFields.map(
+      (item: { field: string }) => item.field,
+    );
+    for (const field of omittedNames) {
+      expect(lean.entry).not.toHaveProperty(field);
+    }
+    expect(lean.assetHint).toContain("get_copyable_asset");
+    // The full content is still retrievable via the dedicated asset tool.
+    const asset = await callRegistryTool("get_copyable_asset", heavy, {
+      dataDir,
+    });
+    expect(asset.ok).toBe(true);
+  });
+
+  it("rejects an unknown bodyMode for get_entry_detail", async () => {
+    await expect(
+      callRegistryTool(
+        "get_entry_detail",
+        { category: skill.category, slug: skill.slug, bodyMode: "summary" },
+        { dataDir },
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_request",
+        details: expect.arrayContaining([
+          expect.objectContaining({ path: "bodyMode" }),
+        ]),
+      },
+    });
+  });
+
   it("plans a ranked read-only workflow toolbox", async () => {
     const result = await callRegistryTool(
       "plan_workflow_toolbox",
@@ -922,7 +1039,9 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("rejects blank planner goals when called directly", async () => {
     const readJsonArtifact = async () => {
-      throw new Error("Expected direct planner validation before artifact read.");
+      throw new Error(
+        "Expected direct planner validation before artifact read.",
+      );
     };
 
     await expect(
@@ -938,7 +1057,9 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("rejects 1-character planner goals when called directly", async () => {
     const readJsonArtifact = async () => {
-      throw new Error("Expected direct planner validation before artifact read.");
+      throw new Error(
+        "Expected direct planner validation before artifact read.",
+      );
     };
 
     await expect(


### PR DESCRIPTION
## Summary

`get_entry_detail` is the most frequently called read tool, but it spread the entire entry verbatim — the full body markdown **plus** duplicate copyable fields (`scriptBody`/`fullCopyableContent`/`copySnippet`). A single entry could return **~88 KB**, rapidly exhausting a model's context budget.

This adds a `bodyMode` input — `none | excerpt | full`, default `excerpt`:

| Mode | Behavior |
|------|----------|
| `excerpt` (default) | Body trimmed to a ~1200-char, boundary-aware lead; large copyable asset fields omitted. Reports `bodyChars`, `bodyTruncated`, `omittedFields`, and an `assetHint` pointing to `get_copyable_asset`. |
| `none` | Also drops the body. |
| `full` | Unchanged legacy payload. |

**Worst-case detail response drops from ~88 KB → ~5 KB (94% smaller)** while preserving trust/safety/privacy metadata and all small fields. The model can still retrieve omitted install/script content via `get_copyable_asset`, and request `bodyMode: "full"` when it genuinely needs the complete inline content.

Resource reads (`heyclaude://entry/...`) explicitly pass `bodyMode: "full"` so documents stay complete — only the *tool* defaults to lean.

## Changes
- `packages/mcp/src/schemas.js` — add optional `bodyMode` enum to `EntryDetailInputSchema` with a model-facing description.
- `packages/mcp/src/registry.js` — `projectEntryBody` helper + boundary-aware `excerptText`; updated tool description; resource handler pinned to full.
- `packages/mcp/README.md` — document the new behavior.
- `tests/mcp-server.test.ts` — cover excerpt/full/none, asset-field omission + `assetHint`, and invalid-`bodyMode` rejection.

## Validation
- `pnpm test:mcp` — 63 passed (2 new behavioral tests + 1 asset-omission test).
- Prettier clean on all changed files.
- Backwards compatible: `bodyMode` is optional; existing callers that omit it now get the leaner default, with full content one explicit flag away.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bodyMode` parameter to entry detail queries, allowing users to control body content retrieval (excerpt, full, or none), with token-efficient excerpts as the default.

* **Documentation**
  * Updated documentation clarifying default entry body response behavior and available content options.

* **Tests**
  * Added test coverage for body content mode selection and field omission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->