### PR TITLE
fix(content): rewrite json-schema-validation-transformation SEO copy, add disclosure notes

### DIFF
--- a/content/skills/json-schema-validation-transformation.mdx
+++ b/content/skills/json-schema-validation-transformation.mdx
@@ -2,10 +2,10 @@
 title: JSON Schema Validate + Transform Skill
 slug: json-schema-validation-transformation
 category: skills
-description: "Validate JSON data against JSON Schema specifications (draft-07, 2019-09, 2020-12) and perform safe, lossless schema migrations and transformations using Ajv (fastest JSON Schema validator) and Zod (TypeScript-first validation)."
-cardDescription: "Validate JSON data against JSON Schema specifications (draft-07, 2019-09, 2020-12) and perform safe, lossless schema migrations and trans..."
-seoTitle: JSON Schema Validate + Transform Skill
-seoDescription: "Validate JSON data against JSON Schema specifications (draft-07, 2019-09, 2020-12) and perform safe, lossless schema migrations and transformations using Ajv..."
+description: "Validate JSON against Ajv-compiled schemas (draft-07, 2019-09, 2020-12) with errors reported by JSON path, then coerce types, apply defaults, migrate documents across schema versions, and generate TypeScript types from the same definitions."
+cardDescription: "Compile Ajv validators for JSON Schema draft-07/2019-09/2020-12, report errors by path, coerce, migrate, and emit TypeScript types."
+seoTitle: "Ajv JSON Schema: Validate, Migrate & Generate TS Types"
+seoDescription: "Validate JSON with Ajv-compiled schemas (draft-07, 2019-09, 2020-12), get path-keyed errors, coerce and default values, then emit TypeScript types."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"
@@ -45,6 +45,11 @@ prerequisites:
   - "json-schema-to-typescript (optional, for type generation)"
   - "File system read/write access for JSON schema files, data files, and generated TypeScript type definitions"
   - "JSON Schema specification knowledge or reference documentation for creating valid schemas (draft-07, 2019-09, or 2020-12)"
+safetyNotes:
+  - "This skill installs npm packages (ajv, zod, json-schema-to-typescript) and reads and writes local files — JSON schemas, data, migration output, and generated TypeScript definitions."
+  - "Type coercion and default-filling mutate the input data, and migration scripts overwrite documents; keep backups and validate each step, as the skill's troubleshooting notes recommend."
+privacyNotes:
+  - "Validation, transformation, and migration process your JSON data and schema files locally; nothing leaves the machine beyond the npm package downloads from the registry."
 tags:
   - json
   - schema


### PR DESCRIPTION
## What

Improves the `skills/json-schema-validation-transformation` entry, flagged by `pnpm report:thin-content` as low-uniqueness (unique-word ratio 0.37, below the 0.42 floor).

### Changes (single content file)
- **`description`, `cardDescription`, `seoDescription`** — were three near-identical copies of one sentence, with the card/seo ones carrying literal `...` truncation artifacts (`schema migrations and trans...`, `transformations using Ajv...`). Rewrote each to be distinct and information-dense.
- **`seoTitle`** — was a verbatim copy of `title`; now a distinct, keyword-bearing meta title.
- **`safetyNotes` / `privacyNotes`** — added. The skill installs npm packages, reads/writes local schema and data files, coerces/defaults (mutates input), and runs migrations that overwrite documents — flagged by the content-policy gate as `external_write_capability`, `local_or_personal_data_access`, and `destructive_actions`. The notes disclose the install/write, data-mutation, and local-only processing behavior accurately.

### Grounding
All new copy is grounded in the entry's protected `documentationUrl`, the official Ajv docs at https://ajv.js.org/ (compiles JSON Schema to optimized validators; supports draft-07 / 2019-09 / 2020-12; error objects with `instancePath`/JSON paths; type coercion and defaults) plus the entry's own body (migration, json-schema-to-typescript type generation).

### Validation
- `pnpm validate:content:strict` — passed
- content-policy gate — passed (exit 0; `community_local_download_request` is external-only and does not block this same-repo maintainer PR)
- `pnpm audit:content` — entry has 0 issues / 0 missing fields
- `pnpm report:thin-content` — entry no longer flagged
- `pnpm test:registry-artifacts` — 46 passed
- `git diff --check` — clean

No protected frontmatter changed (`documentationUrl`, `installCommand`, `downloadUrl`, `copySnippet`, etc. untouched); only the editable meta fields and the allowed-metadata `safetyNotes`/`privacyNotes`. No generated artifacts included.