### PR TITLE
feat(raycast): surface safety and privacy notes before MCP install

### DIFF
--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -234,6 +234,28 @@ export function buildEntrySummary(entry: RaycastEntry) {
     .join("\n");
 }
 
+/**
+ * Formats disclosed safety/privacy notes for an install confirmation dialog so
+ * the user sees risk disclosures (config writes, process execution, network or
+ * credential access) before an MCP server is installed. Shows up to three notes
+ * per category; returns "" when there is nothing to disclose.
+ */
+export function buildInstallNotesSummary(
+  safetyNotes?: string[],
+  privacyNotes?: string[],
+): string {
+  const section = (label: string, notes?: string[]) => {
+    const items = (notes ?? []).map((note) => note.trim()).filter(Boolean);
+    if (items.length === 0) return "";
+    const lines = items.slice(0, 3).map((note) => `• ${note}`);
+    if (items.length > 3) {
+      lines.push(`• …and ${items.length - 3} more`);
+    }
+    return `\n\n${label}:\n${lines.join("\n")}`;
+  };
+  return `${section("⚠️ Safety", safetyNotes)}${section("🔒 Privacy", privacyNotes)}`;
+}
+
 export type RaycastDetail = {
   copyText?: string;
   detailMarkdown: string;

--- a/integrations/raycast/src/feed.ts
+++ b/integrations/raycast/src/feed.ts
@@ -240,12 +240,23 @@ export function buildEntrySummary(entry: RaycastEntry) {
  * credential access) before an MCP server is installed. Shows up to three notes
  * per category; returns "" when there is nothing to disclose.
  */
+/**
+ * Coerces a notes value into a clean list of non-empty trimmed strings,
+ * tolerating malformed payloads (non-array values or non-string items) that can
+ * reach the UI since detail payloads are not strictly validated.
+ */
+export function normalizeNotes(notes?: string[]): string[] {
+  return (Array.isArray(notes) ? notes : [])
+    .map((note) => String(note).trim())
+    .filter(Boolean);
+}
+
 export function buildInstallNotesSummary(
   safetyNotes?: string[],
   privacyNotes?: string[],
 ): string {
   const section = (label: string, notes?: string[]) => {
-    const items = (notes ?? []).map((note) => note.trim()).filter(Boolean);
+    const items = normalizeNotes(notes);
     if (items.length === 0) return "";
     const lines = items.slice(0, 3).map((note) => `• ${note}`);
     if (items.length > 3) {

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -22,6 +22,7 @@ import {
   absoluteDataUrl,
   buildEntrySummary,
   buildInstallNotesSummary,
+  normalizeNotes,
   buildContributeEntryUrl,
   buildSuggestChangeUrl,
   categoryLabel,
@@ -749,12 +750,13 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           : "";
         // Surface the entry's disclosed safety/privacy notes before the user
         // commits to writing config or running a server process. Prefer the
-        // richer detail payload, falling back to the compact list entry.
+        // richer detail payload, but only when it has meaningful (non-blank)
+        // notes — otherwise fall back to the compact list entry.
+        const pickNotes = (primary?: string[], fallback?: string[]) =>
+          normalizeNotes(primary).length ? primary : fallback;
         const notesSummary = buildInstallNotesSummary(
-          detail.safetyNotes?.length ? detail.safetyNotes : entry.safetyNotes,
-          detail.privacyNotes?.length
-            ? detail.privacyNotes
-            : entry.privacyNotes,
+          pickNotes(detail.safetyNotes, entry.safetyNotes),
+          pickNotes(detail.privacyNotes, entry.privacyNotes),
         );
         const installSummary =
           plan.installKind === "cli"

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -21,6 +21,7 @@ import {
   FAVORITES_KEY,
   absoluteDataUrl,
   buildEntrySummary,
+  buildInstallNotesSummary,
   buildContributeEntryUrl,
   buildSuggestChangeUrl,
   categoryLabel,
@@ -746,13 +747,22 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
               .slice(0, 4)
               .join(", ")}${plan.envPlaceholders.length > 4 ? ", ..." : ""}`
           : "";
+        // Surface the entry's disclosed safety/privacy notes before the user
+        // commits to writing config or running a server process. Prefer the
+        // richer detail payload, falling back to the compact list entry.
+        const notesSummary = buildInstallNotesSummary(
+          detail.safetyNotes?.length ? detail.safetyNotes : entry.safetyNotes,
+          detail.privacyNotes?.length
+            ? detail.privacyNotes
+            : entry.privacyNotes,
+        );
         const installSummary =
           plan.installKind === "cli"
             ? `This will add a ${plan.scopeLabel}-scoped MCP server through the ${target.label} CLI.`
             : `This will update your ${plan.scopeLabel} ${target.label} MCP config and create a backup before replacing an existing server.`;
         const confirmed = await confirmAlert({
           title: `Install ${plan.name} in ${target.label}?`,
-          message: `${installSummary}${warningSummary}`,
+          message: `${installSummary}${notesSummary}${warningSummary}`,
           primaryAction: { title: "Install" },
           dismissAction: { title: "Cancel" },
         });

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -17,6 +17,7 @@ import {
   buildContributeEntryUrl,
   buildEntrySummary,
   buildInstallNotesSummary,
+  normalizeNotes,
   buildSuggestChangeUrl,
   buildSubmitPrUrl,
   categoryLabel,
@@ -1234,6 +1235,28 @@ describe("Raycast feed helpers", () => {
     assert.match(capped, /• …and 2 more/);
     assert.equal(/• one|• two|• three/.test(capped), true);
     assert.equal(capped.includes("• four"), false);
+
+    // Tolerates malformed payloads without throwing (non-array / non-string).
+    assert.equal(
+      buildInstallNotesSummary(
+        "not-an-array" as unknown as string[],
+        [42, "  "] as unknown as string[],
+      ),
+      "\n\n🔒 Privacy:\n• 42",
+    );
+  });
+
+  it("normalizes notes and drops blank/malformed values", () => {
+    assert.deepEqual(normalizeNotes(undefined), []);
+    assert.deepEqual(normalizeNotes("nope" as unknown as string[]), []);
+    assert.deepEqual(normalizeNotes(["  ", "", " keep "]), ["keep"]);
+    // A whitespace-only "detail" list must not suppress a real entry fallback.
+    const detailNotes = ["   "];
+    const entryNotes = ["Real disclosure"];
+    const chosen = normalizeNotes(detailNotes).length
+      ? detailNotes
+      : entryNotes;
+    assert.deepEqual(chosen, entryNotes);
   });
 
   it("validates and parses full detail payloads", () => {

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -16,6 +16,7 @@ import {
   buildFeedSnapshotMetadata,
   buildContributeEntryUrl,
   buildEntrySummary,
+  buildInstallNotesSummary,
   buildSuggestChangeUrl,
   buildSubmitPrUrl,
   categoryLabel,
@@ -1211,6 +1212,28 @@ describe("Raycast feed helpers", () => {
       "[Context7](https://heyclau.de/mcp/context7)",
     );
     assert.match(buildEntrySummary(sampleEntry), /Fetch up-to-date docs/);
+  });
+
+  it("summarizes safety and privacy notes for install confirmation", () => {
+    assert.equal(buildInstallNotesSummary(undefined, undefined), "");
+    assert.equal(buildInstallNotesSummary([], ["   "]), "");
+
+    const summary = buildInstallNotesSummary(
+      ["Runs a server process", "Writes to your MCP config"],
+      ["Reads local credentials"],
+    );
+    assert.match(summary, /⚠️ Safety:/);
+    assert.match(summary, /• Runs a server process/);
+    assert.match(summary, /🔒 Privacy:/);
+    assert.match(summary, /• Reads local credentials/);
+
+    const capped = buildInstallNotesSummary(
+      ["one", "two", "three", "four", "five"],
+      undefined,
+    );
+    assert.match(capped, /• …and 2 more/);
+    assert.equal(/• one|• two|• three/.test(capped), true);
+    assert.equal(capped.includes("• four"), false);
   });
 
   it("validates and parses full detail payloads", () => {


### PR DESCRIPTION
## Summary

The Raycast extension's one-click MCP install is the only category with a real "install" action — it writes a config file or runs a server process via the CLI. But the confirm dialog only warned about **environment-variable placeholders**; it never surfaced the entry's disclosed `safetyNotes`/`privacyNotes`, even though the feed carries them end-to-end (both the compact list entry and the detail payload). Users were one-click-installing config-writing / network-accessing servers without seeing the disclosed risk — the single highest-trust gap in the extension.

This injects those notes into the install confirmation so the user sees them **before** committing.

### Before
> This will update your global Cursor MCP config and create a backup before replacing an existing server.
>
> Environment placeholders: API_KEY

### After
> This will update your global Cursor MCP config and create a backup before replacing an existing server.
>
> ⚠️ Safety:
> • Runs a server process on your machine
> • Writes to your MCP client config
>
> 🔒 Privacy:
> • Reads local credentials from the environment
>
> Environment placeholders: API_KEY

## Changes
- `integrations/raycast/src/feed.ts` — add `buildInstallNotesSummary(safetyNotes, privacyNotes)`: a pure, unit-tested helper that formats up to three notes per category with a `…and N more` overflow and returns `""` when there is nothing to disclose.
- `integrations/raycast/src/registry-command.tsx` — call it in `installMcp` and prepend the summary to the `confirmAlert` message, preferring the richer `detail` payload and falling back to the list `entry`.
- `integrations/raycast/test/feed.test.ts` — cover empty/whitespace input, safety+privacy formatting, and the three-note cap.

## Validation
- `node --import tsx --test test/feed.test.ts` — 50 passed (1 new test).
- `tsc --noEmit` clean; Prettier clean.
- Respects the extension's read-only/opt-in contract: this only adds disclosure to an existing user-confirmed flow; no new write behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation confirmations now display aggregated safety and privacy notes with automatic formatting and truncation for improved readability.

* **Tests**
  * Added unit tests for notes formatting and summary generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->