### PR TITLE
feat(mcp): inline install commands in plan_workflow_toolbox

### DIFF
--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -121,7 +121,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: "plan_workflow_toolbox",
     description:
-      "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries with trust, install, and follow-up guidance.",
+      "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries. Each entry includes an inline install block (install command, config snippet, download URL) and the recommended stack is summarized as a copy-pasteable installPlan, alongside trust and follow-up guidance.",
     inputSchema: jsonSchemaForTool("plan_workflow_toolbox"),
     outputSchema: jsonSchemaForToolOutput("plan_workflow_toolbox"),
     annotations: {
@@ -1035,6 +1035,44 @@ function toolboxNextActions(entry) {
   ];
 }
 
+const TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT = 600;
+
+// Distills the ready-to-run install surface for a toolbox entry from its full
+// payload so the planner returns copy-pasteable commands instead of pointing at
+// more tool calls. Large config snippets are summarized rather than inlined to
+// preserve the lean response contract (callers use get_copyable_asset for them).
+function toolboxInstall(entry) {
+  if (!entry) return null;
+  const installCommand = String(
+    entry.installCommand || entry.commandSyntax || "",
+  ).trim();
+  const configSnippet = String(entry.configSnippet || "").trim();
+  const downloadUrl = String(entry.downloadUrl || "").trim();
+  const usageSnippet = String(entry.usageSnippet || "").trim();
+
+  const install = {
+    installable: Boolean(entry.installable),
+    primaryAssetType: categoryPrimaryAsset(entry)?.type || "",
+  };
+  if (installCommand) install.installCommand = installCommand;
+  if (downloadUrl) install.downloadUrl = downloadUrl;
+  if (usageSnippet) install.usageSnippet = usageSnippet;
+  if (configSnippet) {
+    if (configSnippet.length <= TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT) {
+      install.configSnippet = configSnippet;
+    } else {
+      install.configSnippetChars = configSnippet.length;
+      install.configHint =
+        "Config snippet is large; call get_copyable_asset for the full snippet.";
+    }
+  }
+  if (!installCommand && !downloadUrl && !configSnippet && !usageSnippet) {
+    install.note =
+      "No install command published; use the source or canonical URL.";
+  }
+  return install;
+}
+
 function toolboxCategoryMix(entries) {
   const counts = new Map();
   for (const entry of entries) {
@@ -1094,14 +1132,37 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
     );
   }
   const ranked = rankSearchEntries(matched, query);
-  const selected = selectDiverseRankedEntries(ranked, limit).map((item) => ({
-    ...toEntrySummary(item.entry),
-    searchScore: item.score,
-    searchReasons: item.reasons,
-    toolboxReasons: toolboxFitReasons(item.entry, item),
-    caveats: toolboxCaveats(item.entry),
-    nextActions: toolboxNextActions(item.entry),
-  }));
+  // Read the full payload for each selected entry so the planner can inline
+  // ready-to-run install commands; fall back to the search-index summary if a
+  // detail read fails so one bad entry never breaks the whole plan.
+  const selected = await Promise.all(
+    selectDiverseRankedEntries(ranked, limit).map(async (item) => {
+      const full = await readEntry(
+        item.entry.category,
+        item.entry.slug,
+        options,
+      ).catch(() => null);
+      return {
+        ...toEntrySummary(item.entry),
+        searchScore: item.score,
+        searchReasons: item.reasons,
+        toolboxReasons: toolboxFitReasons(item.entry, item),
+        caveats: toolboxCaveats(item.entry),
+        install: toolboxInstall(full || item.entry),
+        nextActions: toolboxNextActions(item.entry),
+      };
+    }),
+  );
+
+  // Consolidated, ordered install commands for the recommended stack.
+  const installPlan = selected
+    .filter((entry) => entry.install?.installCommand)
+    .map((entry) => ({
+      key: entry.key,
+      title: entry.title,
+      category: entry.category,
+      installCommand: entry.install.installCommand,
+    }));
 
   return {
     ok: true,
@@ -1110,6 +1171,7 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
     platform: platform || "",
     count: selected.length,
     entries: selected,
+    installPlan,
     categoryMix: toolboxCategoryMix(selected),
     trustSummary: toolboxTrustSummary(selected),
     recommendedNextTools: [
@@ -1120,6 +1182,7 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
     ],
     plannerNotes: [
       "This planner is metadata review only; it is not install approval or malware scanning, and it does not execute or install entries.",
+      "Each entry carries an inline install block and the recommended stack is summarized in installPlan; still review trust before running anything.",
       "Recommendations are bounded and category-diverse where matching entries allow it.",
       "Prefer source-backed entries with safety/privacy notes for risk-bearing MCP, hooks, skills, commands, and statuslines.",
       "Use get_entry_detail, explain_entry_trust, compare_entries, and get_copyable_asset before relying on any entry.",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -840,8 +840,21 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   it("returns trust-aware planner metadata with bounded category diversity", async () => {
+    const entryDetails: Record<string, { entry: Record<string, unknown> }> = {
+      "entries/mcp/workflow-audit-mcp.json": {
+        entry: {
+          category: "mcp",
+          slug: "workflow-audit-mcp",
+          installable: true,
+          installCommand: "npx -y workflow-audit-mcp",
+          configSnippet: '{"mcpServers":{"audit":{}}}',
+        },
+      },
+    };
     const readJsonArtifact = async (relativePath: string) => {
-      expect(relativePath).toBe("search-index.json");
+      if (relativePath !== "search-index.json") {
+        return entryDetails[relativePath] ?? null;
+      }
       return {
         entries: [
           {
@@ -949,11 +962,36 @@ describe("HeyClaude read-only MCP helpers", () => {
         expect.stringContaining("get_copyable_asset"),
       ]),
     );
+
+    // Inline install surface is pulled from the full entry payload...
+    const auditEntry = result.entries.find(
+      (entry: any) => entry.slug === "workflow-audit-mcp",
+    );
+    expect(auditEntry.install).toMatchObject({
+      installable: true,
+      installCommand: "npx -y workflow-audit-mcp",
+      configSnippet: '{"mcpServers":{"audit":{}}}',
+    });
+    // ...and surfaced in the consolidated install plan.
+    expect(result.installPlan).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: "mcp:workflow-audit-mcp",
+          installCommand: "npx -y workflow-audit-mcp",
+        }),
+      ]),
+    );
+    // Entries without a published install command fall back gracefully.
+    const sourceEntry = result.entries.find(
+      (entry: any) => entry.slug === "workflow-source-mcp",
+    );
+    expect(sourceEntry.install).toMatchObject({ installable: false });
+    expect(sourceEntry.install.installCommand).toBeUndefined();
   });
 
   it("does not fill planner results with unrelated trust-only matches", async () => {
     const readJsonArtifact = async (relativePath: string) => {
-      expect(relativePath).toBe("search-index.json");
+      if (relativePath !== "search-index.json") return null;
       return {
         entries: [
           {
@@ -994,7 +1032,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("matches a lowercase planner goal against mixed-case entry text", async () => {
     const readJsonArtifact = async (relativePath: string) => {
-      expect(relativePath).toBe("search-index.json");
+      if (relativePath !== "search-index.json") return null;
       return {
         entries: [
           {


### PR DESCRIPTION
## Summary

`plan_workflow_toolbox` recommends a category-diverse stack for a goal, but it returned only **prose `nextActions`** telling the model to call `get_entry_detail` / `get_copyable_asset` N more times to actually find install commands — because the `search-index.json` it reads carries only `hasInstallCommand` *booleans*, not the command strings. So "here are 6 entries" never became "here's your stack and how to install it."

This reads the full payload for each (already bounded, ≤10) selected entry and inlines the real install surface:

- **Per-entry `install` block**: `installCommand`, `configSnippet` (inlined when small, summarized with a `get_copyable_asset` hint when >600 chars to preserve the lean-response contract), `downloadUrl`, `usageSnippet`, `installable`, `primaryAssetType`.
- **Top-level `installPlan`**: the ordered, copy-pasteable install commands for the recommended stack — one call now yields the whole toolbox *and* how to install it.

A failed detail read falls back to the search-index summary, so one bad entry never breaks the plan.

## Example
```json
{
  "goal": "review pull requests",
  "installPlan": [
    { "key": "commands:review", "title": "Review", "installCommand": "/review [options] <file_or_directory>" }
  ],
  "entries": [ { "install": { "installable": true, "installCommand": "...", "configSnippet": "..." }, ... } ]
}
```

## Changes
- `packages/mcp/src/registry.js` — `toolboxInstall()` helper; `planWorkflowToolbox` now reads selected entries' full payloads, adds `install` per entry and a consolidated `installPlan`; updated tool description + planner notes.
- `tests/mcp-server.test.ts` — cover the inline install block, the consolidated plan, graceful fallback for entries without a published command, and updated the mocked planner tests to serve entry-detail reads.

## Validation
- `pnpm test:mcp` — 63 passed.
- Prettier clean; `git diff --check` clean.
- Builds on the merged lean `get_entry_detail` work (#2474): large config snippets are summarized, not inlined.