### PR TITLE
feat(mcp): add recommend_for_task answer-shaped tool

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -30,6 +30,10 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
 
 - `search_registry` - search public registry entries by query, category, and
   platform.
+- `recommend_for_task` - answer "what should I use to do X" in one call: returns
+  the best-match entries for a plain-language task, each with why it fits, a
+  trust summary, safety/privacy notes, and an inline install block, plus a
+  `topPick` and consolidated `installPlan`.
 - `server_info` - fetch package version, registry generation, tool list, public
   access policy, and rate-limit metadata.
 - `list_category_entries` - browse entries with bounded pagination and optional

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -71,6 +71,7 @@ const platformAliases = new Map([
 export const READ_ONLY_TOOL_NAMES = [
   "search_registry",
   "plan_workflow_toolbox",
+  "recommend_for_task",
   "server_info",
   "list_category_entries",
   "get_recent_updates",
@@ -124,6 +125,19 @@ export const TOOL_DEFINITIONS = [
       "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries. Each entry includes an inline install block (install command, config snippet, download URL) and the recommended stack is summarized as a copy-pasteable installPlan, alongside trust and follow-up guidance.",
     inputSchema: jsonSchemaForTool("plan_workflow_toolbox"),
     outputSchema: jsonSchemaForToolOutput("plan_workflow_toolbox"),
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  {
+    name: "recommend_for_task",
+    description:
+      "Answer 'what should I use to do X' in one call. Given a plain-language task (and optional platform/category), returns the best-match HeyClaude entries ranked by fit — each with why it fits, trust summary, disclosed safety/privacy notes, and an inline install block — plus a topPick and a consolidated installPlan. Unlike plan_workflow_toolbox it does not force category diversity; it returns the genuinely best matches. Collapses the search → compare → detail → asset loop into a single answer-shaped response.",
+    inputSchema: jsonSchemaForTool("recommend_for_task"),
+    outputSchema: jsonSchemaForToolOutput("recommend_for_task"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -1186,6 +1200,76 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
       "Recommendations are bounded and category-diverse where matching entries allow it.",
       "Prefer source-backed entries with safety/privacy notes for risk-bearing MCP, hooks, skills, commands, and statuslines.",
       "Use get_entry_detail, explain_entry_trust, compare_entries, and get_copyable_asset before relying on any entry.",
+    ],
+  };
+}
+
+export async function recommendForTask(args = {}, options = {}) {
+  const task = String(args.task || "").trim();
+  if (task.length < 2) {
+    return invalid("Task description must be at least 2 characters.");
+  }
+  const query = normalizeText(task);
+  const category = normalizeText(args.category);
+  const platform = normalizePlatform(args.platform);
+  const limit = Math.min(5, normalizeLimit(args.limit, 3));
+  const searchIndex = unwrapEntries(
+    await readJsonArtifact("search-index.json", options),
+  );
+  const scoped = searchIndex
+    .filter((entry) => !category || entry.category === category)
+    .filter((entry) => entryMatchesPlatform(entry, platform));
+  let matched = scoped.filter((entry) => entryMatchesQuery(entry, query));
+  const queryTokens = searchTokens(query);
+  if (!matched.length && queryTokens.length) {
+    matched = scoped.filter((entry) =>
+      queryTokens.some((token) => entrySearchText(entry).includes(token)),
+    );
+  }
+  // Best-match ranking, top-N — unlike the toolbox planner this does NOT force
+  // category diversity; it returns the genuinely closest entries for the task.
+  const ranked = rankSearchEntries(matched, query).slice(0, limit);
+  const recommendations = await Promise.all(
+    ranked.map(async (item) => {
+      const full = await readEntry(
+        item.entry.category,
+        item.entry.slug,
+        options,
+      ).catch(() => null);
+      return {
+        ...toEntrySummary(item.entry),
+        searchScore: item.score,
+        searchReasons: item.reasons,
+        why: toolboxFitReasons(item.entry, item),
+        caveats: toolboxCaveats(item.entry),
+        install: toolboxInstall(full || item.entry),
+      };
+    }),
+  );
+
+  const installPlan = recommendations
+    .filter((entry) => entry.install?.installCommand)
+    .map((entry) => ({
+      key: entry.key,
+      title: entry.title,
+      category: entry.category,
+      installCommand: entry.install.installCommand,
+    }));
+
+  return {
+    ok: true,
+    task,
+    category: category || "",
+    platform: platform || "",
+    count: recommendations.length,
+    topPick: recommendations[0]?.key || "",
+    recommendations,
+    installPlan,
+    trustSummary: toolboxTrustSummary(recommendations),
+    notes: [
+      "Best-match recommendations for the task; unlike plan_workflow_toolbox they are not forced to span categories.",
+      "This is metadata review only — it does not execute, install, or scan entries. Review trust before running anything.",
+      "Use compare_entries to weigh the top picks and explain_entry_trust before relying on any entry.",
     ],
   };
 }
@@ -2699,6 +2783,9 @@ export async function callRegistryTool(name, args = {}, options = {}) {
       break;
     case "plan_workflow_toolbox":
       result = await planWorkflowToolbox(parsedArgs, options);
+      break;
+    case "recommend_for_task":
+      result = await recommendForTask(parsedArgs, options);
       break;
     case "server_info":
       result = await getServerInfo(parsedArgs, options);

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -115,6 +115,32 @@ export const PlanWorkflowToolboxInputSchema = z
   })
   .strict();
 
+export const RecommendForTaskInputSchema = z
+  .object({
+    task: z
+      .string()
+      .trim()
+      .min(2)
+      .max(240)
+      .describe(
+        "Plain-language description of what you want to accomplish, e.g. 'review pull requests in Claude Code' or 'connect to a Postgres database'.",
+      ),
+    category: pathPart
+      .optional()
+      .describe("Restrict recommendations to a single category."),
+    platform: platform
+      .optional()
+      .describe("Restrict to entries compatible with this platform."),
+    limit: z
+      .number()
+      .int()
+      .min(1)
+      .max(5)
+      .optional()
+      .describe("Maximum recommendations to return (default 3)."),
+  })
+  .strict();
+
 export const ServerInfoInputSchema = z.object({}).strict();
 
 export const ListCategoryEntriesInputSchema = z
@@ -300,6 +326,7 @@ export const ReviewEntrySafetyInputSchema = z
 export const TOOL_INPUT_SCHEMAS = {
   search_registry: SearchRegistryInputSchema,
   plan_workflow_toolbox: PlanWorkflowToolboxInputSchema,
+  recommend_for_task: RecommendForTaskInputSchema,
   server_info: ServerInfoInputSchema,
   list_category_entries: ListCategoryEntriesInputSchema,
   get_recent_updates: RecentUpdatesInputSchema,

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -86,6 +86,7 @@ function validToolArguments(name: string) {
   const argsByTool: Record<string, unknown> = {
     search_registry: { query: "mcp", limit: 1 },
     plan_workflow_toolbox: { goal: "code review automation", limit: 2 },
+    recommend_for_task: { task: "code review automation", limit: 2 },
     server_info: {},
     list_category_entries: { category: "mcp", limit: 1 },
     get_recent_updates: { limit: 1 },
@@ -788,6 +789,51 @@ describe("HeyClaude read-only MCP helpers", () => {
           expect.objectContaining({ path: "bodyMode" }),
         ]),
       },
+    });
+  });
+
+  it("recommends best-match entries for a task with inline install", async () => {
+    const result = await callRegistryTool(
+      "recommend_for_task",
+      { task: "review pull requests", limit: 3 },
+      { dataDir },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      task: "review pull requests",
+      count: expect.any(Number),
+      topPick: expect.any(String),
+      recommendations: expect.any(Array),
+      installPlan: expect.any(Array),
+      trustSummary: expect.any(Object),
+      notes: expect.any(Array),
+    });
+    expect(result.recommendations.length).toBeGreaterThan(0);
+    expect(result.recommendations.length).toBeLessThanOrEqual(3);
+    expect(result.topPick).toBe(result.recommendations[0].key);
+
+    const pick = result.recommendations[0];
+    expect(pick).toMatchObject({
+      key: expect.any(String),
+      category: expect.any(String),
+      slug: expect.any(String),
+      why: expect.any(Array),
+      install: expect.objectContaining({ installable: expect.any(Boolean) }),
+    });
+    // installPlan only lists entries that actually publish a command.
+    for (const planned of result.installPlan) {
+      expect(typeof planned.installCommand).toBe("string");
+      expect(planned.installCommand.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects an empty recommend_for_task task", async () => {
+    await expect(
+      callRegistryTool("recommend_for_task", { task: " " }, { dataDir }),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { code: "invalid_request" },
     });
   });
 


### PR DESCRIPTION
## Summary

Finding the right entry today takes a multi-call loop: `search_registry` → `compare_entries` → `get_entry_detail` → `get_copyable_asset`. Most MCP callers just want **one authoritative answer** to "what should I use to do X."

`recommend_for_task` collapses that loop into a single answer-shaped response. Given a plain-language task (and optional `platform`/`category`), it ranks the best-match entries and returns each with:
- **why** it fits (top ranking reasons)
- a **trust** summary + disclosed **safety/privacy notes**
- an inline **install** block (command, config snippet, download URL)

…plus a **`topPick`** and a consolidated **`installPlan`**.

### How it differs from `plan_workflow_toolbox`
The planner deliberately builds a **category-diverse stack**. `recommend_for_task` does **not** force diversity — it returns the genuinely closest matches for the task. Example — `task: "connect to a postgres database"`:

| key | why | install? |
|-----|-----|----------|
| `skills:supabase-realtime-database` | tag match | ✓ |
| `mcp:postgres-mcp-pro` | title term | ✓ |
| `hooks:database-connection-cleanup` | title term | ✓ |

## Changes
- `packages/mcp/src/schemas.js` — `RecommendForTaskInputSchema` (described fields) + registration in `TOOL_INPUT_SCHEMAS`.
- `packages/mcp/src/registry.js` — `recommendForTask()` handler (reuses the existing ranking, trust, and `toolboxInstall` helpers); registered in `READ_ONLY_TOOL_NAMES`, `TOOL_DEFINITIONS` (with annotations), and the dispatch switch.
- `packages/mcp/README.md` — document the tool.
- `tests/mcp-server.test.ts` — recommendation shape, `topPick`, `installPlan` filtering, empty-task rejection, and all-tools smoke args.

## Validation
- `pnpm test:mcp` — 65 passed (2 new tests; the strict `TOOL_INPUT_SCHEMAS === READ_ONLY_TOOL_NAMES` ordering check passes).
- Prettier + `git diff --check` clean.
- Builds on the merged lean-view (#2474) and toolbox-install (#2479) work — large config snippets are summarized, not inlined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a new recommendation tool that identifies best-match solutions for user tasks with installation guidance, trust assessments, and safety/privacy information in a single consolidated response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->