### PR TITLE
fix(content): diversify cost-tracking-for-claude-agent-sdk-applications SEO copy

### DIFF
--- a/content/guides/cost-tracking-for-claude-agent-sdk-applications.mdx
+++ b/content/guides/cost-tracking-for-claude-agent-sdk-applications.mdx
@@ -3,17 +3,18 @@ title: Cost Tracking for Claude Agent SDK Applications
 slug: cost-tracking-for-claude-agent-sdk-applications
 category: guides
 description: >-
-  A practical walkthrough of tracking token usage and cost in the Claude Agent
-  SDK: the result message total_cost_usd estimate, per-step and per-model usage,
-  deduplicating parallel tool calls, accumulating across calls, and cache tokens.
+  A practical walkthrough of token and spend accounting in the Claude Agent SDK.
+  Read total_cost_usd from the result message, deduplicate parallel tool calls
+  that share an assistant id, break spend down per model with modelUsage, sum
+  cost across query() calls yourself, and read cache_creation/cache_read tokens.
 cardDescription: >-
-  Track token usage and cost in the Claude Agent SDK via the result message
-  estimate, per-step/per-model usage, and cache tokens.
-seoTitle: Cost Tracking for Claude Agent SDK Applications
+  Read total_cost_usd from the result message, dedupe parallel tool calls by id,
+  split spend per model, and track cache token fields.
+seoTitle: "Claude Agent SDK Cost Tracking: total_cost_usd & Usage"
 seoDescription: >-
-  How to track token usage and cost in the Claude Agent SDK: read total_cost_usd
-  and usage from the result message, per-step and per-model breakdowns,
-  deduplicate parallel tool calls, accumulate across calls, and read cache tokens.
+  Account for Agent SDK spend: read total_cost_usd from the result message,
+  dedupe parallel tool calls by id, break it down per model, and read cache
+  tokens.
 author: JPette1783
 authorProfileUrl: "https://github.com/JPette1783"
 submittedBy: JPette1783


### PR DESCRIPTION
## What
Improves the `guides/cost-tracking-for-claude-agent-sdk-applications` entry, flagged by `pnpm report:thin-content` as low-uniqueness (ratio 0.40) — `description`, `cardDescription`, `seoDescription`, and `usageSnippet` all paraphrased the same "track token usage and cost… result message… per-step/per-model… cache tokens" sentence.

## Changes (single content file, meta only)
- **`description` / `cardDescription` / `seoDescription`** — rewritten to be lexically distinct (total_cost_usd, dedupe parallel tool calls by assistant id, modelUsage per-model split, summing across query() calls, cache_creation/cache_read tokens).
- **`seoTitle`** — was a verbatim copy of `title`; now distinct.

## Grounding
All claims map to the protected `documentationUrl` (https://code.claude.com/docs/en/agent-sdk/cost-tracking) and the body: `total_cost_usd` on the `result` message (client-side estimate), deduplicating parallel tool calls that share an assistant `id`, `modelUsage`/`model_usage` per-model breakdown, and `cache_creation_input_tokens`/`cache_read_input_tokens`.

## Validation
- `pnpm validate:content:strict` — passed · content-policy gate — exit 0
- `pnpm report:thin-content` — entry no longer flagged · `git diff --check` — clean
- No protected frontmatter changed; existing `safetyNotes`/`privacyNotes` untouched.