### PR TITLE
feat(raycast): badge tooltips, copy LLM context URL, per-harness MCP config

### DIFF
--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -195,21 +195,25 @@ function metadataAccessories(entry: RaycastEntry, isFavorite: boolean) {
   if (isFavorite) {
     accessories.push({
       icon: { source: Icon.Star, tintColor: Color.Yellow },
+      tooltip: "Favorite",
     });
   }
   if (entry.downloadTrust === "first-party") {
     accessories.push({
       icon: { source: Icon.CheckCircle, tintColor: Color.Green },
+      tooltip: "First-party package",
     });
   }
   if (entry.installable || entry.hasConfigSnippet || entry.hasInstallCommand) {
     accessories.push({
       icon: { source: Icon.Download, tintColor: Color.Blue },
+      tooltip: "Installable — has an install command or config snippet",
     });
   }
   if (entry.trustSignals?.sourceStatus === "available" || entry.repoUrl) {
     accessories.push({
       icon: { source: Icon.Shield, tintColor: Color.Green },
+      tooltip: "Source-backed",
     });
   }
   if (
@@ -220,6 +224,7 @@ function metadataAccessories(entry: RaycastEntry, isFavorite: boolean) {
   ) {
     accessories.push({
       icon: { source: Icon.ExclamationMark, tintColor: Color.Orange },
+      tooltip: "Has safety / privacy notes — review before installing",
     });
   }
 
@@ -725,6 +730,58 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
       }
     }
 
+    async function copyLlmsUrl(entry: RaycastEntry) {
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const llmsUrl = (detail.llmsUrl || "").trim();
+        if (!llmsUrl) {
+          throw new Error("No LLM context URL is available for this entry.");
+        }
+        await Clipboard.copy(absoluteDataUrl(llmsUrl, configuredFeed.feedUrl));
+        await visitItem(entry);
+        await showHUD(`Copied ${entry.title} LLM context URL`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: "Could not copy LLM context URL",
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
+    async function copyTargetConfig(
+      entry: RaycastEntry,
+      targetId: McpInstallTargetId,
+    ) {
+      const target = MCP_INSTALL_TARGETS.find(({ id }) => id === targetId);
+      if (!target) return;
+      try {
+        const detail = await loadEntryDetail({
+          entry,
+          cache,
+          feedUrl: configuredFeed.feedUrl,
+        });
+        const plan = buildMcpInstallPlan(targetId, entry, detail);
+        await Clipboard.copy(plan.configJson);
+        await visitItem(entry);
+        await showHUD(`Copied ${target.label} config for ${entry.title}`, {
+          popToRootType: PopToRootType.Immediate,
+        });
+      } catch (error) {
+        await showToast({
+          style: Toast.Style.Failure,
+          title: `Could not copy ${target.label} config`,
+          message: error instanceof Error ? error.message : "Unknown error",
+        });
+      }
+    }
+
     async function installMcp(
       entry: RaycastEntry,
       targetId: McpInstallTargetId,
@@ -963,6 +1020,22 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
                             onAction={() => void copyConfigSnippet(entry)}
                           />
                         ) : null}
+                        {canInstallMcp ? (
+                          <ActionPanel.Submenu
+                            title="Copy MCP Config for…"
+                            icon={Icon.Code}
+                          >
+                            {installTargets.map((target) => (
+                              <Action
+                                key={target.id}
+                                title={target.label}
+                                onAction={() =>
+                                  void copyTargetConfig(entry, target.id)
+                                }
+                              />
+                            ))}
+                          </ActionPanel.Submenu>
+                        ) : null}
                         <Action.OpenInBrowser
                           title="Open on HeyClaude"
                           url={webUrl}
@@ -999,6 +1072,11 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
                           title="Copy Summary"
                           content={buildEntrySummary(entry)}
                           onCopy={() => void visitItem(entry)}
+                        />
+                        <Action
+                          title="Copy LLM Context URL"
+                          icon={Icon.Snippets}
+                          onAction={() => void copyLlmsUrl(entry)}
                         />
                         {entry.brandDomain ? (
                           <Action.CopyToClipboard


### PR DESCRIPTION
## Summary

Three install/discovery polish improvements to the Raycast extension:

1. **Badge tooltips** — list accessory badges were icon-only and ambiguous. Added tooltips so the first-party check, blue download, green source shield, and orange safety badges explain themselves on hover ("First-party package", "Source-backed", "Installable…", "Has safety / privacy notes — review before installing").

2. **Copy LLM Context URL** — a new Share action that resolves the entry's `llms.txt` endpoint (from the detail payload) to an absolute URL. Useful for feeding an entry's context to Claude. The `llmsUrl` was carried in the feed but **never surfaced by any action** before.

3. **Copy MCP Config for… submenu** — copies the **per-target rendered config JSON** (via the existing `buildMcpInstallPlan`) for each harness an MCP entry supports, so manual-paste users get the right shape for Cursor / Codex / Antigravity instead of the generic snippet.

## Changes
- `integrations/raycast/src/registry-command.tsx`:
  - `metadataAccessories` — add `tooltip` to each badge.
  - `copyLlmsUrl` + `copyTargetConfig` handlers (mirror the existing `copyConfigSnippet` async-detail-load + failure-toast pattern).
  - "Copy LLM Context URL" action in the Share section; "Copy MCP Config for…" `ActionPanel.Submenu` gated to MCP entries with supported targets.

## Validation
- `tsc --noEmit` clean; Prettier clean.
- `node --import tsx --test test/feed.test.ts` — 51 passed.
- All additive and read-only — respects the extension's no-silent-write contract (the new actions only copy to clipboard).