### PR TITLE
fix(content): diversify building-a-claude-code-plugin-marketplace SEO copy

### DIFF
--- a/content/guides/building-a-claude-code-plugin-marketplace.mdx
+++ b/content/guides/building-a-claude-code-plugin-marketplace.mdx
@@ -3,18 +3,18 @@ title: Building a Claude Code Plugin Marketplace
 slug: building-a-claude-code-plugin-marketplace
 category: guides
 description: >-
-  A practical walkthrough of creating and distributing a Claude Code plugin
-  marketplace: the marketplace.json catalog, hosting on a git repository, adding
-  it with /plugin marketplace add, private repositories, and how users install
-  and update plugins.
+  A practical walkthrough of building and distributing a Claude Code plugin
+  marketplace. Define a marketplace.json catalog, host it on a git repository,
+  and let users add it with /plugin marketplace add, install with /plugin
+  install, and refresh with /plugin marketplace update — plus private-repo
+  hosting and a version-vs-commit-SHA update strategy.
 cardDescription: >-
-  Create and distribute a Claude Code plugin marketplace with marketplace.json,
-  git hosting, private repos, and /plugin marketplace add.
-seoTitle: Building a Claude Code Plugin Marketplace
+  Publish a marketplace.json catalog on a git repo so users can /plugin
+  marketplace add and /plugin install — including private-repo hosting.
+seoTitle: "Build a Claude Code Plugin Marketplace: marketplace.json"
 seoDescription: >-
-  How to build and distribute a Claude Code plugin marketplace: define a
-  marketplace.json catalog, host it on a git repository, add it with /plugin
-  marketplace add, support private repos, and let users install and update.
+  Distribute Claude Code plugins from a marketplace.json catalog on git: /plugin
+  marketplace add, install/update commands, private repos, and versioning.
 author: JPette1783
 authorProfileUrl: "https://github.com/JPette1783"
 submittedBy: JPette1783


### PR DESCRIPTION
## What
Improves the `guides/building-a-claude-code-plugin-marketplace` entry, flagged by `pnpm report:thin-content` as low-uniqueness (ratio 0.39) — `description`, `cardDescription`, `seoDescription`, and `usageSnippet` repeated the same "create/distribute a Claude Code plugin marketplace… marketplace.json… git hosting… /plugin marketplace add… private repos" phrasing.

## Changes (single content file, meta only)
- **`description` / `cardDescription` / `seoDescription`** — rewritten distinct, naming the concrete commands (`/plugin marketplace add`, `/plugin install`, `/plugin marketplace update`), private-repo hosting, and the version-vs-commit-SHA update strategy.
- **`seoTitle`** — was a verbatim copy of `title`; now distinct.

## Grounding
All claims map to the protected `documentationUrl` (https://code.claude.com/docs/en/plugin-marketplaces) and the body: defining a `marketplace.json` catalog, hosting on a git repo, `/plugin marketplace add`, `/plugin install plugin@marketplace`, `/plugin marketplace update`, private-repo distribution, and explicit-version vs commit-SHA updates.

## Validation
- `pnpm validate:content:strict` — passed · content-policy gate — exit 0
- `pnpm report:thin-content` — entry no longer flagged · `git diff --check` — clean
- No protected frontmatter changed; existing `safetyNotes`/`privacyNotes` untouched.