### PR TITLE
feat(mcp): add assetType selector to get_copyable_asset

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -49,7 +49,8 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
   available via `get_copyable_asset`.
 - `get_copyable_asset` - fetch the category-aware copy/install asset for an
   entry, such as full prompt text, config snippets, commands, scripts, or
-  collection items.
+  collection items. Pass `assetType` (e.g. `install_command`) to return only
+  that asset and skip the large `full_content`/`script` payloads.
 - `compare_entries` - compare 2-5 entries by fit, category, platform support,
   install complexity, and source metadata.
 - `get_registry_stats` - fetch aggregate counts, freshness metadata, and real

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -178,7 +178,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: "get_copyable_asset",
     description:
-      "Fetch the category-aware copy/install asset for a HeyClaude entry without writing local files.",
+      "Fetch the category-aware copy/install asset for a HeyClaude entry without writing local files. Pass assetType (e.g. 'install_command', 'config_snippet') to return only that asset and avoid the full_content/script payloads when you do not need them.",
     inputSchema: jsonSchemaForTool("get_copyable_asset"),
   },
   {
@@ -1641,8 +1641,8 @@ export async function getCopyableAsset(args = {}, options = {}) {
     return notFound(`No HeyClaude entry found for ${category}/${slug}.`);
   }
 
-  const primary = categoryPrimaryAsset(entry);
-  const assets = [
+  const requestedType = normalizeText(args.assetType);
+  const allAssets = [
     contentAsset(
       "full_content",
       "Full usable entry content",
@@ -1670,6 +1670,15 @@ export async function getCopyableAsset(args = {}, options = {}) {
     contentAsset("usage", "Usage snippet", entry.usageSnippet, "markdown"),
     contentAsset("items", "Collection items", entry.items, "json"),
   ].filter(Boolean);
+  // When a specific assetType is requested, return only that asset so the
+  // caller does not pay for the (potentially tens-of-KB) full_content/script
+  // payloads it did not ask for.
+  const assets = requestedType
+    ? allAssets.filter((asset) => asset.type === requestedType)
+    : allAssets;
+  const primary = requestedType
+    ? assets[0] || null
+    : categoryPrimaryAsset(entry);
   const compatibility = buildSkillPlatformCompatibility(entry);
 
   return {
@@ -1680,6 +1689,7 @@ export async function getCopyableAsset(args = {}, options = {}) {
     title: entry.title,
     canonicalUrl: entryCanonicalUrl(entry),
     platform: platform || "",
+    requestedAssetType: requestedType || "",
     primaryAsset: primary,
     assets,
     installCommand: entry.installCommand || "",

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -188,6 +188,20 @@ export const CopyableAssetInputSchema = z
     category: pathPart,
     slug: pathPart,
     platform: platform.optional(),
+    assetType: z
+      .enum([
+        "full_content",
+        "install_command",
+        "config_snippet",
+        "script",
+        "command_syntax",
+        "usage",
+        "items",
+      ])
+      .optional()
+      .describe(
+        "Return only this asset type instead of every asset. Use it to avoid paying for the full_content or script payload (up to tens of KB) when you only need, e.g., the install_command or config_snippet.",
+      ),
   })
   .strict();
 

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1406,6 +1406,54 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
+  it("filters get_copyable_asset to a single requested assetType", async () => {
+    const full = await callRegistryTool(
+      "get_copyable_asset",
+      { category: skill.category, slug: skill.slug },
+      { dataDir },
+    );
+    expect(full.requestedAssetType).toBe("");
+    expect(full.assets.length).toBeGreaterThan(0);
+
+    const wantType = full.assets[0].type;
+    const filtered = await callRegistryTool(
+      "get_copyable_asset",
+      { category: skill.category, slug: skill.slug, assetType: wantType },
+      { dataDir },
+    );
+    expect(filtered.ok).toBe(true);
+    expect(filtered.requestedAssetType).toBe(wantType);
+    expect(filtered.assets.every((a: any) => a.type === wantType)).toBe(true);
+    expect(filtered.assets.length).toBeLessThanOrEqual(full.assets.length);
+    expect(filtered.primaryAsset?.type).toBe(wantType);
+
+    // Requesting an assetType the entry lacks returns an empty list, not an error.
+    const absent = await callRegistryTool(
+      "get_copyable_asset",
+      { category: skill.category, slug: skill.slug, assetType: "items" },
+      { dataDir },
+    );
+    expect(absent.ok).toBe(true);
+    expect(absent.assets.every((a: any) => a.type === "items")).toBe(true);
+
+    // Unknown assetType is rejected by the schema.
+    await expect(
+      callRegistryTool(
+        "get_copyable_asset",
+        { category: skill.category, slug: skill.slug, assetType: "nope" },
+        { dataDir },
+      ),
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: "invalid_request",
+        details: expect.arrayContaining([
+          expect.objectContaining({ path: "assetType" }),
+        ]),
+      },
+    });
+  });
+
   it("returns category-aware copyable assets and comparison metadata", async () => {
     const asset = await callRegistryTool(
       "get_copyable_asset",


### PR DESCRIPTION
## Summary

`get_copyable_asset` always returned **every** asset — including `full_content` (the entry body, up to ~40 KB) and `script` — even when the caller only wanted the install command. On the heaviest entries the response is **~44 KB**.

Add an optional **`assetType`** input (`full_content | install_command | config_snippet | script | command_syntax | usage | items`). When set, the response returns only that asset (and `primaryAsset` points at it), reporting `requestedAssetType`. Requesting an absent type yields an empty list rather than an error. Omitting it preserves the existing full payload — **fully backwards compatible.**

**Worst-case response: ~44 KB → ~1.9 KB (96% smaller)** when asking for just the install command.

## Changes
- `packages/mcp/src/schemas.js` — optional `assetType` enum on `CopyableAssetInputSchema` with a described purpose.
- `packages/mcp/src/registry.js` — filter assets by `requestedType`; add `requestedAssetType` to the response; updated tool description.
- `packages/mcp/README.md` — document it.
- `tests/mcp-server.test.ts` — cover filtering, absent-type (empty list, not error), and schema rejection of unknown types.

## Validation
- `pnpm test:mcp` — 66 passed.
- Prettier + `git diff --check` clean.
- Completes the MCP token-efficiency thread alongside the merged lean-view (#2474), toolbox-install (#2479), and recommend_for_task (#2481) work.