### PR TITLE
fix(content): diversify oh-my-zsh-robbyrussell SEO copy, add privacy note

### DIFF
--- a/content/statuslines/oh-my-zsh-robbyrussell.mdx
+++ b/content/statuslines/oh-my-zsh-robbyrussell.mdx
@@ -3,16 +3,17 @@ title: Oh My Zsh Robbyrussell - Statuslines
 slug: oh-my-zsh-robbyrussell
 category: statuslines
 description: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell integration.
+  A Claude Code statusline that recreates the Oh My Zsh robbyrussell theme: the
+  cyan ➜ arrow, the working-directory basename, and git:(branch) with a red ✗
+  when the tree is dirty, plus the active model name. A bash script parses the
+  status JSON with jq.
 cardDescription: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell i...
-seoTitle: Oh My Zsh Robbyrussell - Statuslines
+  Recreate the Oh My Zsh robbyrussell prompt in Claude Code: cyan ➜ arrow,
+  directory basename, git:(branch), and a ✗ dirty marker.
+seoTitle: "Oh My Zsh robbyrussell Statusline for Claude Code"
 seoDescription: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell integration.
-  Discover...
+  A Claude Code statusline replicating the Oh My Zsh robbyrussell prompt: the ➜
+  arrow, directory basename, git:(branch) branch, and a ✗ dirty indicator.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
@@ -125,6 +126,8 @@ prerequisites:
   - >-
     Terminal with ANSI color code support (256-color mode recommended for
     authentic robbyrussell colors)
+privacyNotes:
+  - "The script reads the workspace path, git branch, and dirty state from the Claude Code status JSON and your local repository to render the prompt; it only prints to your terminal and sends nothing over the network."
 tags:
   - oh-my-zsh
   - robbyrussell


### PR DESCRIPTION
## What
Improves the `statuslines/oh-my-zsh-robbyrussell` entry, flagged by `pnpm report:thin-content` as low-uniqueness (ratio 0.39) — `description`, `cardDescription`, and `seoDescription` were copies of one sentence (with `...` truncation artifacts).

## Changes (single content file)
- **`description` / `cardDescription` / `seoDescription`** — rewritten distinct, naming the concrete prompt elements (cyan `➜` arrow, working-directory basename, `git:(branch)`, red `✗` dirty marker, model name) and the bash+jq mechanism.
- **`seoTitle`** — was a generic `… - Statuslines`; now distinct.
- **`privacyNotes`** — added: the script reads workspace path, git branch, and dirty state to render the prompt and prints only to the terminal (`local_or_personal_data_access`).

## Grounding
Maps to the protected `documentationUrl` (https://github.com/ohmyzsh/ohmyzsh/wiki/Themes#robbyrussell) — the robbyrussell theme's `➜  %c git:(branch) ✗` format — and the entry's own `scriptBody`.

## Validation
- `pnpm validate:content:strict` — passed · content-policy gate — exit 0
- `pnpm report:thin-content` — entry no longer flagged · `git diff --check` — clean
- No protected frontmatter changed.