### PR TITLE
feat(web): data-dense ranking table + lead stats on category hubs

### DIFF
--- a/apps/web/src/components/category-ranking-table.tsx
+++ b/apps/web/src/components/category-ranking-table.tsx
@@ -1,0 +1,89 @@
+import { Link } from "@tanstack/react-router";
+import { PlatformChip, InstallRiskBadge, NotesPresenceChips } from "@/components/badges";
+import type { Entry } from "@/types/registry";
+
+/**
+ * Scannable, rows-as-entries data table for a category hub. Every cell is
+ * rendered from the entry's own reviewed metadata (source provenance, install
+ * risk, install availability, platform support, safety/privacy disclosure) so
+ * the page is a dense, citeable comparison rather than a card wall. Ordering is
+ * the hub's existing metadata-review ranking — never repo popularity.
+ */
+export function CategoryRankingTable({ entries, label }: { entries: Entry[]; label: string }) {
+  if (entries.length < 3) return null;
+
+  return (
+    <section className="mt-12">
+      <h2 className="h-display-2 text-ink">Top {label}, compared</h2>
+      <p className="mt-2 max-w-3xl text-sm text-ink-muted">
+        The leading {label.toLowerCase()} side by side on the signals that matter before you install
+        — source provenance, install risk, setup, and disclosed safety notes. Ordered by
+        HeyClaude&apos;s metadata review, not by repo popularity.
+      </p>
+      <div className="mt-5 overflow-x-auto rounded-xl border border-border">
+        <table className="w-full min-w-[44rem] border-collapse text-left">
+          <caption className="sr-only">
+            Top Claude {label} compared by source, install risk, setup, platform support, and
+            disclosed notes.
+          </caption>
+          <thead className="bg-surface">
+            <tr>
+              {["Resource", "Source", "Install risk", "Setup", "Platforms", "Notes"].map((head) => (
+                <th
+                  key={head}
+                  scope="col"
+                  className="border-b border-border px-3 py-2.5 text-xs font-semibold text-ink-muted"
+                >
+                  {head}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e, i) => (
+              <tr key={`${e.category}/${e.slug}`} className={i % 2 === 1 ? "bg-surface-2/30" : ""}>
+                <th scope="row" className="px-3 py-2.5 align-top">
+                  <Link
+                    to="/entry/$category/$slug"
+                    params={{ category: e.category, slug: e.slug }}
+                    className="story-link text-sm font-medium text-ink"
+                  >
+                    {e.title}
+                  </Link>
+                  <div className="mt-0.5 text-xs text-ink-subtle">{e.author}</div>
+                </th>
+                <td className="px-3 py-2.5 align-top text-sm capitalize text-ink">{e.source}</td>
+                <td className="px-3 py-2.5 align-top">
+                  <InstallRiskBadge entry={e} />
+                </td>
+                <td className="px-3 py-2.5 align-top">
+                  {e.installCommand ? (
+                    <span className="text-xs text-ink">
+                      <span className="mr-1 text-trust-trusted">✓</span>
+                      one-line install
+                    </span>
+                  ) : (
+                    <span className="text-xs text-ink-subtle">—</span>
+                  )}
+                </td>
+                <td className="px-3 py-2.5 align-top">
+                  <div className="flex flex-wrap gap-1">
+                    {e.platforms.slice(0, 3).map((p) => (
+                      <PlatformChip key={p} id={p} />
+                    ))}
+                    {e.platforms.length > 3 ? (
+                      <span className="text-xs text-ink-subtle">+{e.platforms.length - 3}</span>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="px-3 py-2.5 align-top">
+                  <NotesPresenceChips entry={e} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -15,6 +15,7 @@ import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
+import { CategoryRankingTable } from "@/components/category-ranking-table";
 import { hubHighlights, hubStats } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
@@ -161,6 +162,10 @@ function CategoryHub() {
   // Data-derived signals computed across the full category set.
   const highlights = hubHighlights(entries);
   const stats = hubStats(entries);
+  // Extractable, citeable lead facts computed from the reviewed metadata.
+  const sourcedPct = stats.find((s) => s.key === "sourced")?.pct;
+  const safetyPct = stats.find((s) => s.key === "safety")?.pct;
+  const installableCount = entries.filter((e) => Boolean(e.installCommand)).length;
 
   return (
     <PageContainer>
@@ -196,6 +201,16 @@ function CategoryHub() {
         )}
       </div>
 
+      {sourcedPct !== undefined && (
+        <p className="mt-6 max-w-3xl text-pretty text-sm text-ink-muted">
+          Of {entries.length} Claude {label.toLowerCase()} in the directory,{" "}
+          <strong className="font-medium text-ink">{sourcedPct}% are source-backed</strong>
+          {safetyPct !== undefined ? <>, {safetyPct}% disclose safety notes</> : null}, and{" "}
+          <strong className="font-medium text-ink">{installableCount}</strong> ship a one-line
+          install command.
+        </p>
+      )}
+
       <HubHighlights
         highlights={highlights}
         caption={`Standout Claude ${label}, picked from their own metadata — trust tier, provenance, documentation, and recency.`}
@@ -220,6 +235,8 @@ function CategoryHub() {
           </div>
         )}
       </section>
+
+      <CategoryRankingTable entries={entries.slice(0, 12)} label={label} />
 
       <HubSignalStats stats={stats} total={entries.length} />
 


### PR DESCRIPTION
## Summary

The first move in the **data-density GEO strategy**: turn the existing category hubs into citeable data pages — **no new URLs**, enriching pages that already rank.

AI answer engines preferentially cite **comparison tables (+55%)** and **hard statistics (+62%)** (per the GEO research we grounded), and this site's unique, hard-to-replicate asset is its reviewed registry metadata. So each `/<category>` hub now carries:

1. **`CategoryRankingTable`** — a scannable, rows-as-entries table comparing the top entries on the signals that matter *before install*: source provenance, install risk, one-line-install availability, platform support, and disclosed safety/privacy notes. Built entirely from existing reviewed metadata, ordered by the hub's existing ranking — **explicitly not repo popularity** (consistent with the project's no-popularity-metrics stance; `stars` is `@deprecated`). Reuses the shared badge components (`InstallRiskBadge`, `NotesPresenceChips`, `PlatformChip`).

2. **An extractable lead statistic sentence** — e.g. *"Of 332 Claude MCP servers, 41% are source-backed, 28% disclose safety notes, and 190 ship a one-line install command"* — the answer-first factual statement LLMs quote verbatim. Computed from the existing `hubStats`.

## Why this and not "alternatives to X" pages
I measured that approach first: **801 of 980 entries** would qualify → ~800 near-duplicate pages, which the research flags as counterproductive (thin-content risk). This instead adds **zero new pages** and makes existing indexed, ranking pages denser and more citeable — same intent capture, no thin-content downside.

## Changes
- `apps/web/src/components/category-ranking-table.tsx` (new) — the data table.
- `apps/web/src/routes/$category.tsx` — lead stats sentence + table, both from existing helpers.

## Validation
- `tsc --noEmit` clean (0 errors); Prettier clean.
- No new routes or JSON-LD churn; the existing `ItemList`/`BreadcrumbList` already cover the entries.
- Applies to all 10 category hubs (`/mcp`, `/skills`, `/agents`, …) from one component.