### PR TITLE
fix(content): diversify borealhost-mcp-server SEO copy

### DIFF
--- a/content/mcp/borealhost-mcp-server.mdx
+++ b/content/mcp/borealhost-mcp-server.mdx
@@ -3,16 +3,17 @@ title: BorealHost MCP Server for Claude
 slug: borealhost-mcp-server
 category: mcp
 description: >-
-  BorealHost MCP server with 47 hosting tools available via remote HTTP at
-  borealhost.ai/mcp or local stdio through pip install borealhost-mcp, with
-  optional BOREALHOST_API_KEY.
+  Connect Claude to BorealHost's MCP server for hosting and infrastructure
+  management — 47 tools spanning servers, domains, DNS, SSL, and deployments.
+  Add it remotely with claude mcp add --transport http, or run it locally over
+  stdio via pip install borealhost-mcp with a BOREALHOST_API_KEY.
 cardDescription: >-
-  Connect Claude to BorealHost for 47 hosting management tools via remote HTTP
-  or local stdio with an optional API key.
-seoTitle: BorealHost MCP Server for Claude
+  47 BorealHost hosting tools (servers, DNS, SSL, deploys) in Claude over remote
+  HTTP or local stdio via pip install borealhost-mcp.
+seoTitle: "BorealHost MCP Server: 47 Hosting & DNS Tools for Claude"
 seoDescription: >-
-  Use BorealHost MCP with Claude to manage hosting through 47 tools on
-  borealhost.ai/mcp or pip install borealhost-mcp for local stdio transport.
+  Manage hosting from Claude with the BorealHost MCP server: 47 tools for
+  servers, domains, DNS, and SSL over remote HTTP or local stdio.
 author: BorealHost
 authorProfileUrl: "https://github.com/alainsvrd"
 submittedBy: kiannidev


### PR DESCRIPTION
Improves `mcp/borealhost-mcp-server` (low-uniqueness 0.40): rewrote `description`/`cardDescription`/`seoDescription` distinct (47 tools across servers/domains/DNS/SSL/deploys; remote HTTP via `claude mcp add --transport http`; local stdio via `pip install borealhost-mcp`) and a distinct `seoTitle`. Grounded in the repo (https://github.com/alainsvrd/borealhost-mcp) and body. Existing safety/privacy notes untouched. validate:content:strict + policy gate pass; thin-content cleared; no protected fields changed.