### PR TITLE
fix(content): ground oh-my-zsh-robbyrussell statusline (resubmit)

### DIFF
--- a/content/statuslines/oh-my-zsh-robbyrussell.mdx
+++ b/content/statuslines/oh-my-zsh-robbyrussell.mdx
@@ -18,6 +18,9 @@ author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
 documentationUrl: "https://github.com/ohmyzsh/ohmyzsh/wiki/Themes#robbyrussell"
+retrievalSources:
+  - "https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme"
+  - "https://docs.claude.com/en/docs/claude-code/statusline"
 installable: true
 usageSnippet: "➜  my-project git:(main) ✗ [claude-sonnet-4.5]"
 copySnippet: |-

--- a/content/statuslines/oh-my-zsh-robbyrussell.mdx
+++ b/content/statuslines/oh-my-zsh-robbyrussell.mdx
@@ -3,16 +3,17 @@ title: Oh My Zsh Robbyrussell - Statuslines
 slug: oh-my-zsh-robbyrussell
 category: statuslines
 description: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell integration.
+  A Claude Code statusline that recreates the Oh My Zsh robbyrussell theme: the
+  cyan ➜ arrow, the working-directory basename, and git:(branch) with a red ✗
+  when the tree is dirty, plus the active model name. A bash script parses the
+  status JSON with jq.
 cardDescription: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell i...
-seoTitle: Oh My Zsh Robbyrussell - Statuslines
+  Recreate the Oh My Zsh robbyrussell prompt in Claude Code: cyan ➜ arrow,
+  directory basename, git:(branch), and a ✗ dirty marker.
+seoTitle: "Oh My Zsh robbyrussell Statusline for Claude Code"
 seoDescription: >-
-  Oh-My-Zsh robbyrussell theme replica with iconic arrow prompt, Git status
-  indicators, and directory path for seamless Claude Code shell integration.
-  Discover...
+  A Claude Code statusline replicating the Oh My Zsh robbyrussell prompt: the ➜
+  arrow, directory basename, git:(branch) branch, and a ✗ dirty indicator.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
@@ -125,6 +126,8 @@ prerequisites:
   - >-
     Terminal with ANSI color code support (256-color mode recommended for
     authentic robbyrussell colors)
+privacyNotes:
+  - "The script reads the workspace path, git branch, and dirty state from the Claude Code status JSON and your local repository to render the prompt; it only prints to your terminal and sends nothing over the network."
 tags:
   - oh-my-zsh
   - robbyrussell


### PR DESCRIPTION
Resubmit of #2494 (closed `dual_review_declined`). Reviewer A (94% close): the documentationUrl "documents the theme but does not back the statusline script"; reviewer B voted merge (95%). This adds source breadth so both the visual replica and the statusline mechanism are backed.

## Changes (single content file, vs main)
- **`description` / `cardDescription` / `seoDescription`** — distinct, grounded in the robbyrussell prompt format and the entry's `scriptBody`.
- **`seoTitle`** — distinct.
- **`retrievalSources`** (editable) — added the actual robbyrussell theme file (https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme) and the Claude Code statusline reference (https://docs.claude.com/en/docs/claude-code/statusline), so the `➜  %c git:(branch) ✗` replica and the `statusLine`/`command` script mechanism are both sourced.
- **`privacyNotes`** — the script reads workspace path + git state and prints to the terminal only.

## Validation
- `pnpm validate:content:strict` — passed · content-policy gate — exit 0
- `pnpm report:thin-content` — entry no longer flagged · `git diff --check` — clean
- No protected frontmatter changed (`retrievalSources` is not a protected field).