### PR TITLE
fix(test): add recommend_for_task to mcp-http-route tool-list assertion

### DIFF
--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -85,6 +85,7 @@ describe("HeyClaude remote MCP route", () => {
     expect(toolNames).toEqual([
       "search_registry",
       "plan_workflow_toolbox",
+      "recommend_for_task",
       "server_info",
       "list_category_entries",
       "get_recent_updates",


### PR DESCRIPTION
## Summary

`tests/mcp-http-route.test.ts` asserts the Streamable-HTTP route exposes an exact ordered tool list, but `recommend_for_task` (added in [#2481](https://github.com/JSONbored/awesome-claude/pull/2481)) was never added to it — so the assertion expected 25 tools while the route now serves 26.

**Why it wasn't caught earlier:** `validate-mcp` only runs `test:mcp` (`mcp-server` + `mcp-cli`); the http-route test imports web routes and only runs under `validate-web`. The PRs merged after #2481 (#2484 Raycast, #2489 MCP package) both *skipped* `validate-web`, so main went red on this the moment a web-touching PR ([#2495](https://github.com/JSONbored/awesome-claude/pull/2495)) re-ran the full suite.

## Fix
Add `recommend_for_task` to the expected list (position 3, matching `READ_ONLY_TOOL_NAMES`). Verified the test list is now byte-identical in order/count to `READ_ONLY_TOOL_NAMES`.

Test-only change; unblocks `validate-web` on main and on #2495.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `recommend_for_task` read-only tool is now available in HTTP-based integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->