### PR TITLE
fix(content): diversify claude-plugin-marketplace-reviewer-agent SEO copy

### DIFF
--- a/content/agents/claude-plugin-marketplace-reviewer-agent.mdx
+++ b/content/agents/claude-plugin-marketplace-reviewer-agent.mdx
@@ -3,17 +3,18 @@ title: Claude Plugin Marketplace Reviewer Agent
 slug: claude-plugin-marketplace-reviewer-agent
 category: agents
 description: >-
-  Source-backed agent that reviews a Claude Code plugin or marketplace before a
-  team installs it, checking source trust, bundled components, context cost,
-  what the plugin will install, version pinning, and managed-scope controls,
-  grounded in the official discover-plugins docs.
+  A reusable agent prompt that vets a Claude Code plugin or marketplace before a
+  team installs it. It walks source trust, the plugin's Will-install list and
+  bundled components (skills, agents, hooks, MCP servers, commands), the
+  context-window cost, version pinning, and the user/project/local/managed
+  install scope.
 cardDescription: >-
-  Review a Claude Code plugin or marketplace before install: source trust,
-  bundled components, context cost, version pinning, and managed scope.
-seoTitle: Claude Plugin Marketplace Reviewer Agent
+  Vet a Claude Code plugin before install: source trust, the Will-install list,
+  bundled components, context cost, version pinning, and scope.
+seoTitle: "Claude Code Plugin Review Agent: Trust, Cost & Scope"
 seoDescription: >-
-  Reusable agent prompt that reviews a Claude Code plugin or marketplace before
-  a team installs it: source trust, bundled components, context cost, the will-
+  An agent prompt that vets a Claude Code plugin before install: source trust,
+  the Will-install list, bundled components, context cost, and install scope.
   install list, version pinning, and managed-scope restrictions.
 author: JPette1783
 authorProfileUrl: "https://github.com/JPette1783"


### PR DESCRIPTION
Improves `agents/claude-plugin-marketplace-reviewer-agent` (low-uniqueness 0.39): rewrote `description`/`cardDescription`/`seoDescription` distinct (source trust, the Will-install list + bundled components, context-window cost, version pinning, user/project/local/managed scope) and a distinct `seoTitle`. Grounded in the protected `documentationUrl` (https://code.claude.com/docs/en/discover-plugins) and the agent body. validate:content:strict + policy gate pass; thin-content cleared; no protected fields changed.