### PR TITLE
fix(content): clear claude-plugin-marketplace-reviewer-agent uniqueness floor

### DIFF
--- a/content/agents/claude-plugin-marketplace-reviewer-agent.mdx
+++ b/content/agents/claude-plugin-marketplace-reviewer-agent.mdx
@@ -15,7 +15,6 @@ seoTitle: "Claude Code Plugin Review Agent: Trust, Cost & Scope"
 seoDescription: >-
   An agent prompt that vets a Claude Code plugin before install: source trust,
   the Will-install list, bundled components, context cost, and install scope.
-  install list, version pinning, and managed-scope restrictions.
 author: JPette1783
 authorProfileUrl: "https://github.com/JPette1783"
 submittedBy: JPette1783
@@ -24,7 +23,7 @@ dateAdded: "2026-06-05"
 submittedAt: "2026-06-05"
 documentationUrl: "https://code.claude.com/docs/en/discover-plugins"
 installable: false
-usageSnippet: "Use this agent to review a Claude Code plugin or marketplace before a team installs it, checking source trust, bundled components, context cost, and version pinning."
+usageSnippet: "Point this agent at a plugin or marketplace you are weighing, and it returns a go/no-go with a recommended scope and which bundled pieces to disable."
 prerequisites:
   - "The plugin or marketplace under review (name, source repo or URL, and what it bundles)."
   - "Knowledge of the team's trust policy and which scope (user, project, local, managed) is intended."


### PR DESCRIPTION
Follow-up to #2504: the meta rewrite landed but the entry stayed just under the low-uniqueness floor (0.405 < 0.42) because the `usageSnippet` still duplicated the description's phrasing. This rewrites `usageSnippet` with distinct wording (a go/no-go verdict + recommended scope + components to disable), which clears the ratio. Still grounded in the protected `documentationUrl` (https://code.claude.com/docs/en/discover-plugins). validate:content:strict + thin-content pass; no protected fields changed.