### PR TITLE
fix(content): diversify claude-haiku-45-speed-optimizer-agent SEO copy

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -3,24 +3,26 @@ title: Claude Haiku 45 Speed Optimizer Agent - Agents
 slug: claude-haiku-45-speed-optimizer-agent
 category: agents
 description: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
+  An agent prompt that targets Claude Haiku 4.5 for high-speed, cost-efficient
+  tasks: rapid code iteration, batch processing, and agentic workflows where
+  latency and token cost matter more than maximum reasoning depth.
 cardDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid...
-seoTitle: Claude Haiku 45 Speed Optimizer Agent - Agents
+  Use Claude Haiku 4.5 for fast, affordable agentic tasks — rapid iteration,
+  batch jobs, and workflows where speed outweighs deep reasoning.
+seoTitle: "Claude Haiku 4.5 Speed Optimizer Agent Prompt"
 seoDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
-  Discover...
+  Agent prompt targeting Claude Haiku 4.5 for rapid code iteration, batch
+  processing, and cost-sensitive workflows — high throughput at lower
+  per-token cost.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
 documentationUrl: "https://docs.anthropic.com/en/docs/about-claude/models"
 installable: false
 usageSnippet: >-
-  You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
-  for rapid iteration and cost-effective automation.
+  Specify claude-haiku-4-5 as the model when you call this agent; use it for
+  fast sub-tasks inside a larger orchestration — file scanning, log parsing,
+  or rapid code suggestions — where Haiku's lower latency matters most.
 copySnippet: >-
   You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
   for rapid iteration and cost-effective automation.
@@ -319,6 +321,9 @@ copySnippet: >-
   Prioritize speed over perfection. Fix syntax, imports, and obvious bugs.
 
   ```
+privacyNotes:
+  - "This agent prompt includes example API key configuration for the Anthropic API; store credentials in environment variables or a secrets manager, not in version-controlled files."
+  - "The code and context you send to this agent is processed by Anthropic's Claude Haiku 4.5 model; review Anthropic's privacy policy before using it with sensitive or proprietary code."
 tags:
   - haiku-4.5
   - speed


### PR DESCRIPTION
Improves \`agents/claude-haiku-45-speed-optimizer-agent\` (low-uniqueness 0.376).

- **description/cardDescription/seoTitle/seoDescription/usageSnippet** rewritten to be distinct. Previous meta was near-identical across all fields with literal \`...\` truncation artifacts; seoTitle duplicated the title verbatim.
- **privacyNotes added** for API key examples in the copySnippet body and Anthropic model data processing (requires_credentials + third-party data behavior).

\`validate:content:strict\` + policy gate pass; thin-content cleared (ratio was 0.376, now above 0.42); no protected fields changed.