### PR TITLE
fix(content): add retrievalSources to api-endpoint-documentation-generator (resubmit)

### DIFF
--- a/content/hooks/api-endpoint-documentation-generator.mdx
+++ b/content/hooks/api-endpoint-documentation-generator.mdx
@@ -3,30 +3,42 @@ title: API Doc Generator
 slug: api-endpoint-documentation-generator
 category: hooks
 description: >-
-  Automatically generates or updates API documentation when endpoint files are
-  modified, supporting OpenAPI 3.1.0, Swagger 2.0, and AsyncAPI 2.0
-  specifications.
+  A PostToolUse hook that watches for writes to API endpoint, route, and
+  controller files, then generates or refreshes OpenAPI 3.1.0, Swagger 2.0,
+  and AsyncAPI 2.0 documentation without a manual build step.
 cardDescription: >-
-  Automatically generates or updates API documentation when endpoint files are
-  modified, supporting OpenAPI 3.1.0, Swagger 2.0, and AsyncAP...
-seoTitle: API Doc Generator
+  PostToolUse hook that watches API route and controller files, then
+  regenerates OpenAPI 3.1.0 or Swagger 2.0 docs automatically on write.
+seoTitle: "Claude Code Hook: Auto-Regenerate OpenAPI Docs on Endpoint Edit"
 seoDescription: >-
-  Automatically generates or updates API documentation when endpoint files are
-  modified, supporting OpenAPI 3.1.0, Swagger 2.0, and AsyncAPI 2.0
-  specifications...
+  Trigger on route or controller file writes and regenerate OpenAPI 3.1.0,
+  Swagger 2.0, or AsyncAPI 2.0 documentation automatically on every Claude
+  Code edit.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
 documentationUrl: "https://swagger.io/docs/"
+retrievalSources:
+  - "https://swagger.io/docs/open-source-tools/swagger-jsdoc/"
+  - "https://jsdoc.app/about-getting-started.html"
+  - "https://docs.python.org/3/library/pydoc.html"
+  - "https://swagger.io/specification/"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch
   .claude/hooks/api-endpoint-documentation-generator.sh && chmod +x
   .claude/hooks/api-endpoint-documentation-generator.sh
 usageSnippet: >-
-  mkdir -p .claude/hooks && touch
-  .claude/hooks/api-endpoint-documentation-generator.sh && chmod +x
-  .claude/hooks/api-endpoint-documentation-generator.sh
+  Wire to PostToolUse write/edit matchers for routes and controllers;
+  the hook reads the modified file path, detects OpenAPI or Swagger
+  annotations, and writes updated documentation to your spec file.
+safetyNotes:
+  - "Runs automatically after every write or edit tool call matching routes/, controllers/, or api/ file paths."
+  - "Writes updated documentation files to ./docs/api/ or ./docs/api.json; confirm the output path is correct before enabling."
+  - "Invokes local swagger-jsdoc, jsdoc, or pydoc executables when available; verify these tools are trusted before the hook is active."
+privacyNotes:
+  - "Reads API source files (routes, controllers) to extract documentation; those files may contain endpoint logic, parameter names, or internal path structures."
+  - "Generated documentation files may expose API structure, endpoint names, and parameter schemas; treat them with the same access controls as your source code."
 copySnippet: |-
   {
     "hooks": {


### PR DESCRIPTION
Resubmit of #2514, which was closed: "Source is generic Swagger docs and does not back the specific hook implementation described."

- **retrievalSources added** for the actual tools called in the scriptBody: swagger-jsdoc (swagger.io/docs/open-source-tools/swagger-jsdoc/), JSDoc (jsdoc.app), Python pydoc (docs.python.org), and the OpenAPI specification (swagger.io/specification/).
- **cardDescription/seoTitle/seoDescription/usageSnippet** rewritten distinct from description.
- **safetyNotes/privacyNotes added** for hook file write behavior and API source file reading.

\`validate:content:strict\` + policy gate pass; thin-content cleared; no protected fields changed.