### PR TITLE
feat(brief): Stage 1 — automated weekly brief generation + persistence

### DIFF
--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -63,6 +63,7 @@ Current migrations include:
 - `0007_jobs_admin_indexes.sql` for reviewed job admin queues, expiry checks, and paid placement windows
 - `0008_jobs_compensation_metadata.sql` for dedicated salary, equity, bonus, and benefits/perks job metadata
 - `0009_source_repo_signals.sql` for cached source repository stars, forks, upstream update timestamps, and refresh errors
+- `0010_brief_issues.sql` for persisted Weekly Brief issues (draft/approved/sent status, JSON payload, scheduled send time)
 
 The jobs board renders active reviewed D1 rows only. Curated, employer-submitted,
 claimed, featured, and sponsored jobs all go through the same private D1-backed

--- a/apps/web/migrations/0010_brief_issues.sql
+++ b/apps/web/migrations/0010_brief_issues.sql
@@ -1,0 +1,25 @@
+-- Weekly Brief issues: one persisted row per generated weekly brief.
+-- The Friday generation cron writes a `draft`; a signed maintainer approval
+-- moves it to `approved` with a scheduled send time; the send cron marks it
+-- `sent`. `payload` is the JSON.stringify of buildWeeklyBrief()'s output.
+CREATE TABLE IF NOT EXISTS brief_issues (
+  number INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug TEXT NOT NULL UNIQUE,
+  period_through TEXT NOT NULL UNIQUE,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'approved', 'sent')),
+  generated_at TEXT NOT NULL,
+  scheduled_send_at TEXT,
+  approved_at TEXT,
+  sent_at TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Send cron scans for approved issues due to go out.
+CREATE INDEX IF NOT EXISTS idx_brief_issues_status_send
+  ON brief_issues (status, scheduled_send_at);
+
+-- Public /brief reads the most recent published (sent/approved) issues.
+CREATE INDEX IF NOT EXISTS idx_brief_issues_period
+  ON brief_issues (period_through DESC);

--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -73,11 +73,12 @@ export default definePlugin((nitroApp) => {
               payload: brief,
               generatedAt,
             });
-            console.log("[brief-generate] draft persisted", {
-              wrote,
-              periodThrough,
-              newEntries: brief.summary?.newEntryCount,
-            });
+            console.log(
+              wrote
+                ? "[brief-generate] draft persisted"
+                : "[brief-generate] draft skipped (already exists or D1 unavailable)",
+              { periodThrough, newEntries: brief.summary?.newEntryCount },
+            );
           } catch (error) {
             console.error("[brief-generate] generation failed", error);
           }

--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -1,7 +1,9 @@
 import { definePlugin } from "nitro";
 
+import { buildWeeklyBrief } from "@heyclaude/registry/weekly-brief";
 import { getEnvString, runWithCloudflareRuntime } from "@/lib/cloudflare-env.server";
 import { getDirectoryEntries } from "@/lib/content.server";
+import { upsertBriefDraft } from "@/lib/brief-issues.server";
 import { selectDigestEntries, type DigestCandidate } from "@/lib/newsletter-digest";
 import { buildDigestEmail } from "@/lib/newsletter-emails";
 import { recordUmamiEvent, sendResendBroadcast } from "@/lib/newsletter-send.server";
@@ -12,9 +14,23 @@ import { siteConfig } from "@/lib/site";
 // day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN, not 0.
 const WEEKLY_CRON = "0 16 * * SUN";
 
+// Fridays 14:00 UTC. Generates the next Weekly Brief draft and persists it to
+// D1 for maintainer review over the weekend (Stage 1 of the brief pipeline).
+const GENERATE_CRON = "0 14 * * FRI";
+
 const MONTHS = [
-  "January", "February", "March", "April", "May", "June",
-  "July", "August", "September", "October", "November", "December",
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
 ];
 
 type CloudflareScheduledPayload = {
@@ -38,6 +54,37 @@ export default definePlugin((nitroApp) => {
   nitroApp.hooks?.hook(
     "cloudflare:scheduled",
     async ({ controller, env, context }: CloudflareScheduledPayload) => {
+      // Friday: generate + persist the next brief draft for maintainer review.
+      if (controller?.cron === GENERATE_CRON) {
+        const generateRequest = new Request("https://heyclau.de/__scheduled/brief-generate");
+        await runWithCloudflareRuntime(generateRequest, env, context, async () => {
+          try {
+            const generatedAt = new Date().toISOString();
+            const entries = await getDirectoryEntries();
+            const brief = buildWeeklyBrief(entries as Parameters<typeof buildWeeklyBrief>[0], {
+              generatedAt,
+              days: 7,
+              siteUrl: siteConfig.url,
+            });
+            const periodThrough = brief.period?.through ?? generatedAt.slice(0, 10);
+            const wrote = await upsertBriefDraft({
+              slug: `weekly-brief-${periodThrough}`,
+              periodThrough,
+              payload: brief,
+              generatedAt,
+            });
+            console.log("[brief-generate] draft persisted", {
+              wrote,
+              periodThrough,
+              newEntries: brief.summary?.newEntryCount,
+            });
+          } catch (error) {
+            console.error("[brief-generate] generation failed", error);
+          }
+        });
+        return;
+      }
+
       if (controller?.cron !== WEEKLY_CRON) return;
 
       const request = new Request("https://heyclau.de/__scheduled/newsletter-digest");

--- a/apps/web/src/lib/brief-issues.server.ts
+++ b/apps/web/src/lib/brief-issues.server.ts
@@ -18,11 +18,13 @@ export type BriefIssue = Omit<BriefIssueRow, "payload"> & {
   payload: Record<string, unknown>;
 };
 
-// Every D1 access fails open: a missing SITE_DB binding (dev/preview) or a
-// not-yet-applied migration must never break the brief pages or the cron.
+// Fail open only for a not-yet-applied migration (the absent-binding case is
+// already short-circuited by the getSiteDb() null guards before any query
+// runs). Real D1 faults — constraint violations, syntax errors, timeouts — must
+// still surface, so this matcher is deliberately narrow to "table not present".
 function isMissingInfra(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error ?? "");
-  return /no such table|SITE_DB|D1_ERROR|not a function/i.test(message);
+  return /no such table: brief_issues|no such table/i.test(message);
 }
 
 function parseRow(row: BriefIssueRow | null): BriefIssue | null {

--- a/apps/web/src/lib/brief-issues.server.ts
+++ b/apps/web/src/lib/brief-issues.server.ts
@@ -1,0 +1,123 @@
+import { getSiteDb } from "@/lib/db";
+
+export type BriefIssueStatus = "draft" | "approved" | "sent";
+
+export type BriefIssueRow = {
+  number: number;
+  slug: string;
+  period_through: string;
+  payload: string;
+  status: BriefIssueStatus;
+  generated_at: string;
+  scheduled_send_at: string | null;
+  approved_at: string | null;
+  sent_at: string | null;
+};
+
+export type BriefIssue = Omit<BriefIssueRow, "payload"> & {
+  payload: Record<string, unknown>;
+};
+
+// Every D1 access fails open: a missing SITE_DB binding (dev/preview) or a
+// not-yet-applied migration must never break the brief pages or the cron.
+function isMissingInfra(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return /no such table|SITE_DB|D1_ERROR|not a function/i.test(message);
+}
+
+function parseRow(row: BriefIssueRow | null): BriefIssue | null {
+  if (!row) return null;
+  let payload: Record<string, unknown> = {};
+  try {
+    payload = JSON.parse(row.payload) as Record<string, unknown>;
+  } catch {
+    payload = {};
+  }
+  return { ...row, payload };
+}
+
+/**
+ * Persist a freshly generated weekly brief as a draft. Idempotent on the
+ * period (a re-fired generation cron will not burn a second issue number or
+ * overwrite an already-reviewed issue). Returns true when a row was written.
+ */
+export async function upsertBriefDraft(input: {
+  slug: string;
+  periodThrough: string;
+  payload: unknown;
+  generatedAt: string;
+}): Promise<boolean> {
+  const db = getSiteDb();
+  if (!db) return false;
+  try {
+    const result = await db
+      .prepare(
+        `INSERT INTO brief_issues (slug, period_through, payload, status, generated_at)
+         VALUES (?, ?, ?, 'draft', ?)
+         ON CONFLICT(period_through) DO NOTHING`,
+      )
+      .bind(input.slug, input.periodThrough, JSON.stringify(input.payload), input.generatedAt)
+      .run();
+    return Boolean(result?.meta?.changes);
+  } catch (error) {
+    if (isMissingInfra(error)) return false;
+    throw error;
+  }
+}
+
+export async function getLatestPublishedBrief(): Promise<BriefIssue | null> {
+  const db = getSiteDb();
+  if (!db) return null;
+  try {
+    const row = await db
+      .prepare(
+        `SELECT * FROM brief_issues
+         WHERE status IN ('approved', 'sent')
+         ORDER BY period_through DESC LIMIT 1`,
+      )
+      .bind()
+      .first<BriefIssueRow>();
+    return parseRow(row);
+  } catch (error) {
+    if (isMissingInfra(error)) return null;
+    throw error;
+  }
+}
+
+export async function getBriefByNumber(number: number): Promise<BriefIssue | null> {
+  const db = getSiteDb();
+  if (!db || !Number.isInteger(number)) return null;
+  try {
+    const row = await db
+      .prepare(
+        `SELECT * FROM brief_issues
+         WHERE number = ? AND status IN ('approved', 'sent') LIMIT 1`,
+      )
+      .bind(number)
+      .first<BriefIssueRow>();
+    return parseRow(row);
+  } catch (error) {
+    if (isMissingInfra(error)) return null;
+    throw error;
+  }
+}
+
+/** Published issues for the /brief archive list + sitemap. */
+export async function listPublishedBriefs(limit = 24): Promise<BriefIssue[]> {
+  const db = getSiteDb();
+  if (!db) return [];
+  try {
+    const { results } = await db
+      .prepare(
+        `SELECT * FROM brief_issues
+         WHERE status IN ('approved', 'sent')
+         ORDER BY period_through DESC LIMIT ?`,
+      )
+      .bind(Math.max(1, Math.min(limit, 100)))
+      .all<BriefIssueRow>();
+    return (results ?? []).map(parseRow).filter((issue): issue is BriefIssue => issue !== null);
+  } catch (error) {
+    if (isMissingInfra(error)) return [];
+    throw error;
+  }
+}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -22,9 +22,10 @@
   },
   "triggers": {
     // 6-hourly: source-repo signals. Daily 05:00 UTC: IndexNow changed-URL push.
+    // Fridays 14:00 UTC: generate the next Weekly Brief draft for review.
     // Sundays 16:00 UTC: weekly newsletter digest.
     // NB: Cloudflare day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN (not 0).
-    "crons": ["17 */6 * * *", "0 5 * * *", "0 16 * * SUN"],
+    "crons": ["17 */6 * * *", "0 5 * * *", "0 14 * * FRI", "0 16 * * SUN"],
   },
   "assets": {
     "directory": "dist/client",


### PR DESCRIPTION
## Summary

Stage 1 of the **generate → review → approve → scheduled-send** Weekly Brief pipeline. This is the foundation: automated generation + D1 persistence. It's architecture-agnostic (works whether review ends up inbox-link or dashboard) and **changes zero live behavior**.

## What it does
- **`migrations/0010_brief_issues.sql`** — `brief_issues` table: autoincrement `number`, `UNIQUE(period_through)` for idempotency, `status` (draft/approved/sent), `payload` JSON, plus `scheduled_send_at`/`approved_at`/`sent_at` for the later stages.
- **`lib/brief-issues.server.ts`** — **fail-open** D1 helpers. Every call no-ops when `SITE_DB` is absent or the migration is unapplied, so this ships safely *before* the migration runs.
- **`newsletter-digest-scheduled.ts`** — a **Friday 14:00 UTC** branch generates the next brief via the existing `buildWeeklyBrief()` engine and upserts it as a `draft`. Added to the **same** plugin (gated on cron string) to avoid the duplicate-plugin hazard flagged in `vite.config.ts`; the existing Sunday digest is **untouched**.
- **`wrangler.jsonc`** — adds the `0 14 * * FRI` trigger.

## Verified
- `tsc --noEmit` clean; Prettier clean.
- Generation smoke-tested against **real registry data**: *Weekly brief 2026-06-15 — 8 new entries, 6 source-backed, 6 safer-installs, 8 notable changes* (17 KB payload). `buildWeeklyBrief` stamps `manualReviewRequired: true` — honored by Stages 2/3.

## ⚠️ Maintainer step (required for it to persist)
Run **`pnpm --filter web db:migrate:remote`** to create `brief_issues` in prod D1. Until then the Friday cron generates and *harmlessly no-ops* the write (fail-open) — nothing breaks.

## Next (separate PRs)
- **Stage 2:** Friday generation also emails *you* the draft preview + a signed "Approve & schedule" link → marks `approved`, sets send time.
- **Stage 3:** a send cron (recommended **Tue 15:00 UTC**) delivers approved-and-due issues via Resend, marks `sent`, and `/brief` + `/brief/$number` render the published archive (+ sitemap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistence for Weekly Brief outputs, tracking lifecycle status (draft/approved/sent) and scheduled send timing.
  * Introduced a Friday 14:00 UTC automated job that generates the next Weekly Brief draft for maintainer review.
  * Added support for retrieving and browsing published Weekly Briefs (including latest and paginated lookups).
* **Documentation**
  * Documented the new database migration powering Weekly Brief storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->