### PR TITLE
feat(brief): Stage 2+3 — review/approve link + scheduled send

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -3,10 +3,21 @@ import { definePlugin } from "nitro";
 import { buildWeeklyBrief } from "@heyclaude/registry/weekly-brief";
 import { getEnvString, runWithCloudflareRuntime } from "@/lib/cloudflare-env.server";
 import { getDirectoryEntries } from "@/lib/content.server";
-import { upsertBriefDraft } from "@/lib/brief-issues.server";
+import {
+  upsertBriefDraft,
+  getLatestDraft,
+  getDueApprovedBriefs,
+  markBriefSent,
+} from "@/lib/brief-issues.server";
+import { signBriefApproveToken } from "@/lib/brief-token.server";
+import { buildBriefEmail } from "@/lib/brief-email";
 import { selectDigestEntries, type DigestCandidate } from "@/lib/newsletter-digest";
 import { buildDigestEmail } from "@/lib/newsletter-emails";
-import { recordUmamiEvent, sendResendBroadcast } from "@/lib/newsletter-send.server";
+import {
+  recordUmamiEvent,
+  sendResendBroadcast,
+  sendResendEmail,
+} from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
 // Sundays 16:00 UTC. Must match the string in wrangler.jsonc triggers.crons
@@ -14,9 +25,15 @@ import { siteConfig } from "@/lib/site";
 // day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN, not 0.
 const WEEKLY_CRON = "0 16 * * SUN";
 
-// Fridays 14:00 UTC. Generates the next Weekly Brief draft and persists it to
-// D1 for maintainer review over the weekend (Stage 1 of the brief pipeline).
+// Fridays 14:00 UTC. Generates the next Weekly Brief draft + emails the
+// maintainer a preview with an approve link.
 const GENERATE_CRON = "0 14 * * FRI";
+
+// 6-hourly (the existing source-signals trigger). We piggyback to send any
+// approved brief whose scheduled send time has arrived — no new cron needed.
+const SEND_CRON = "17 */6 * * *";
+
+const APPROVE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
 const MONTHS = [
   "January",
@@ -79,8 +96,75 @@ export default definePlugin((nitroApp) => {
                 : "[brief-generate] draft skipped (already exists or D1 unavailable)",
               { periodThrough, newEntries: brief.summary?.newEntryCount },
             );
+
+            // Email the maintainer a preview + signed approve link. Inert unless
+            // the review address, signing secret, and Resend send creds exist.
+            const reviewEmail = getEnvString("BRIEF_REVIEW_EMAIL");
+            const secret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
+            const apiKey = getEnvString("RESEND_API_KEY");
+            const from = getEnvString("RESEND_FROM");
+            const draft = await getLatestDraft();
+            if (wrote && draft && reviewEmail && secret && apiKey && from) {
+              const token = await signBriefApproveToken(secret, {
+                n: draft.number,
+                p: draft.period_through,
+                exp: Date.now() + APPROVE_TOKEN_TTL_MS,
+              });
+              const approveUrl = `${siteConfig.url}/brief/approve?token=${encodeURIComponent(token)}`;
+              const { subject, html, text } = buildBriefEmail({
+                brief: draft.payload,
+                siteUrl: siteConfig.url,
+                dateLabel: periodThrough,
+                approveUrl,
+              });
+              await sendResendEmail({ apiKey, from, to: reviewEmail, subject, html, text });
+              console.log("[brief-generate] preview sent", { number: draft.number });
+            }
           } catch (error) {
             console.error("[brief-generate] generation failed", error);
+          }
+        });
+        return;
+      }
+
+      // 6-hourly: send any approved brief whose scheduled time has arrived.
+      if (controller?.cron === SEND_CRON) {
+        const sendRequest = new Request("https://heyclau.de/__scheduled/brief-send");
+        await runWithCloudflareRuntime(sendRequest, env, context, async () => {
+          try {
+            const apiKey = getEnvString("RESEND_API_KEY");
+            const segmentId = getEnvString("RESEND_SEGMENT_ID");
+            const from = getEnvString("RESEND_FROM");
+            if (!apiKey || !segmentId || !from) return;
+            const due = await getDueApprovedBriefs(new Date().toISOString());
+            for (const issue of due) {
+              const { subject, html, text } = buildBriefEmail({
+                brief: issue.payload,
+                siteUrl: siteConfig.url,
+                dateLabel: issue.period_through,
+              });
+              const result = await sendResendBroadcast({
+                apiKey,
+                segmentId,
+                from,
+                subject,
+                html,
+                text,
+                name: `Weekly Brief #${issue.number} — ${issue.period_through}`,
+              });
+              if (result.ok) {
+                await markBriefSent(issue.number);
+                console.log("[brief-send] sent", { number: issue.number });
+                await recordUmamiEvent("brief-sent", { number: issue.number });
+              } else {
+                console.error("[brief-send] send failed", {
+                  number: issue.number,
+                  status: result.status,
+                });
+              }
+            }
+          } catch (error) {
+            console.error("[brief-send] scheduled send failed", error);
           }
         });
         return;

--- a/apps/web/src/lib/brief-email.ts
+++ b/apps/web/src/lib/brief-email.ts
@@ -1,0 +1,112 @@
+// Renders a persisted Weekly Brief (buildWeeklyBrief payload) into newsletter
+// HTML/text. Used both for the maintainer review-preview (with an approve
+// button) and the audience send (no button).
+
+type BriefItem = {
+  title?: string;
+  url?: string;
+  description?: string;
+  reasons?: string[];
+};
+
+type BriefPayload = {
+  title?: string;
+  period?: { through?: string };
+  summary?: {
+    newEntryCount?: number;
+    sourceBackedCount?: number;
+    saferInstallCount?: number;
+    notableChangeCount?: number;
+  };
+  sections?: {
+    newEntries?: BriefItem[];
+    sourceBacked?: BriefItem[];
+    saferInstalls?: BriefItem[];
+    notableChanges?: BriefItem[];
+  };
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function absolute(url: string, siteUrl: string): string {
+  if (!url) return siteUrl;
+  return url.startsWith("http") ? url : `${siteUrl}${url.startsWith("/") ? "" : "/"}${url}`;
+}
+
+function sectionHtml(label: string, items: BriefItem[] | undefined, siteUrl: string): string {
+  const rows = (items ?? []).filter((item) => item?.title);
+  if (rows.length === 0) return "";
+  const list = rows
+    .map((item) => {
+      const href = escapeHtml(absolute(String(item.url ?? ""), siteUrl));
+      const title = escapeHtml(String(item.title ?? ""));
+      const reason = item.reasons?.[0] ?? item.description ?? "";
+      const sub = reason
+        ? `<div style="color:#6b675f;font-size:13px;margin-top:2px;">${escapeHtml(String(reason))}</div>`
+        : "";
+      return `<li style="margin:0 0 12px;"><a href="${href}" style="color:#171614;font-weight:600;text-decoration:none;">${title}</a>${sub}</li>`;
+    })
+    .join("");
+  return `<h3 style="font-size:15px;color:#171614;margin:24px 0 10px;">${escapeHtml(label)}</h3><ul style="list-style:none;padding:0;margin:0;">${list}</ul>`;
+}
+
+function sectionText(label: string, items: BriefItem[] | undefined, siteUrl: string): string {
+  const rows = (items ?? []).filter((item) => item?.title);
+  if (rows.length === 0) return "";
+  const list = rows
+    .map((item) => `- ${item.title} — ${absolute(String(item.url ?? ""), siteUrl)}`)
+    .join("\n");
+  return `\n${label}\n${list}\n`;
+}
+
+export function buildBriefEmail(options: {
+  brief: BriefPayload;
+  siteUrl: string;
+  dateLabel: string;
+  approveUrl?: string;
+}): { subject: string; html: string; text: string } {
+  const { brief, siteUrl, dateLabel, approveUrl } = options;
+  const sections = brief.sections ?? {};
+  const title = brief.title ?? `Weekly Claude workflow brief — ${dateLabel}`;
+  const subject = approveUrl
+    ? `[Review] Weekly Brief draft — ${dateLabel}`
+    : `Weekly Brief — ${dateLabel}`;
+
+  const approveBlock = approveUrl
+    ? `<div style="background:#f0ede4;border:1px solid #e3dfd3;border-radius:10px;padding:16px;margin:0 0 24px;">
+        <div style="font-size:13px;color:#6b675f;margin-bottom:10px;">Draft for review — nothing is sent to the audience until you approve.</div>
+        <a href="${escapeHtml(approveUrl)}" style="display:inline-block;background:#171614;color:#fff;text-decoration:none;font-weight:600;font-size:14px;padding:10px 18px;border-radius:8px;">Approve &amp; schedule send →</a>
+      </div>`
+    : "";
+
+  const body =
+    sectionHtml("New in the registry", sections.newEntries, siteUrl) +
+    sectionHtml("Source-backed picks", sections.sourceBacked, siteUrl) +
+    sectionHtml("Safer installs", sections.saferInstalls, siteUrl) +
+    sectionHtml("Notable changes", sections.notableChanges, siteUrl);
+
+  const html = `<!doctype html><html><body style="margin:0;background:#f7f5ef;font:400 16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#171614;">
+    <div style="max-width:600px;margin:0 auto;padding:28px 22px;">
+      <div style="font-size:12px;letter-spacing:0.08em;text-transform:uppercase;color:#6b675f;">HeyClaude Weekly Brief · ${escapeHtml(dateLabel)}</div>
+      <h1 style="font-size:22px;margin:6px 0 18px;">${escapeHtml(title)}</h1>
+      ${approveBlock}
+      ${body || '<p style="color:#6b675f;">No notable activity this week.</p>'}
+      <p style="margin-top:28px;font-size:12px;color:#9b968c;">Reviewed picks from <a href="${escapeHtml(siteUrl)}" style="color:#6b675f;">heyclau.de</a>. No hype, no listicle filler.</p>
+    </div></body></html>`;
+
+  const text =
+    `HeyClaude Weekly Brief — ${dateLabel}\n${title}\n` +
+    (approveUrl ? `\nApprove & schedule: ${approveUrl}\n` : "") +
+    sectionText("New in the registry", sections.newEntries, siteUrl) +
+    sectionText("Source-backed picks", sections.sourceBacked, siteUrl) +
+    sectionText("Safer installs", sections.saferInstalls, siteUrl) +
+    sectionText("Notable changes", sections.notableChanges, siteUrl);
+
+  return { subject, html, text };
+}

--- a/apps/web/src/lib/brief-issues.server.ts
+++ b/apps/web/src/lib/brief-issues.server.ts
@@ -123,3 +123,88 @@ export async function listPublishedBriefs(limit = 24): Promise<BriefIssue[]> {
     throw error;
   }
 }
+
+/** The most recent draft awaiting review (for the maintainer preview email). */
+export async function getLatestDraft(): Promise<BriefIssue | null> {
+  const db = getSiteDb();
+  if (!db) return null;
+  try {
+    const row = await db
+      .prepare(
+        `SELECT * FROM brief_issues
+         WHERE status = 'draft' ORDER BY period_through DESC LIMIT 1`,
+      )
+      .bind()
+      .first<BriefIssueRow>();
+    return parseRow(row);
+  } catch (error) {
+    if (isMissingInfra(error)) return null;
+    throw error;
+  }
+}
+
+/**
+ * Approve a draft and schedule its send. Only a `draft` can be approved (so a
+ * replayed approval link can't reschedule an already-sent issue). Returns true
+ * when a row transitioned to `approved`.
+ */
+export async function approveBrief(number: number, scheduledSendAt: string): Promise<boolean> {
+  const db = getSiteDb();
+  if (!db || !Number.isInteger(number)) return false;
+  try {
+    const result = await db
+      .prepare(
+        `UPDATE brief_issues
+         SET status = 'approved', scheduled_send_at = ?, approved_at = ?,
+             updated_at = CURRENT_TIMESTAMP
+         WHERE number = ? AND status = 'draft'`,
+      )
+      .bind(scheduledSendAt, new Date().toISOString(), number)
+      .run();
+    return Boolean(result?.meta?.changes);
+  } catch (error) {
+    if (isMissingInfra(error)) return false;
+    throw error;
+  }
+}
+
+/** Approved issues whose scheduled send time has arrived (for the send cron). */
+export async function getDueApprovedBriefs(nowIso: string): Promise<BriefIssue[]> {
+  const db = getSiteDb();
+  if (!db) return [];
+  try {
+    const { results } = await db
+      .prepare(
+        `SELECT * FROM brief_issues
+         WHERE status = 'approved' AND scheduled_send_at IS NOT NULL
+           AND scheduled_send_at <= ?
+         ORDER BY period_through ASC LIMIT 5`,
+      )
+      .bind(nowIso)
+      .all<BriefIssueRow>();
+    return (results ?? []).map(parseRow).filter((issue): issue is BriefIssue => issue !== null);
+  } catch (error) {
+    if (isMissingInfra(error)) return [];
+    throw error;
+  }
+}
+
+/** Mark an approved issue as sent. Guarded so a re-run cannot double-send. */
+export async function markBriefSent(number: number): Promise<boolean> {
+  const db = getSiteDb();
+  if (!db || !Number.isInteger(number)) return false;
+  try {
+    const result = await db
+      .prepare(
+        `UPDATE brief_issues
+         SET status = 'sent', sent_at = ?, updated_at = CURRENT_TIMESTAMP
+         WHERE number = ? AND status = 'approved'`,
+      )
+      .bind(new Date().toISOString(), number)
+      .run();
+    return Boolean(result?.meta?.changes);
+  } catch (error) {
+    if (isMissingInfra(error)) return false;
+    throw error;
+  }
+}

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -1,0 +1,19 @@
+// The recommended weekly send slot: Tuesday 15:00 UTC (mid-morning US /
+// afternoon EU — the strongest engagement window for developer newsletters).
+const SEND_DOW = 2; // 0=Sun..6=Sat; Tuesday
+const SEND_HOUR_UTC = 15;
+
+/**
+ * The next Tuesday 15:00 UTC strictly at or after `from` (today if it's Tuesday
+ * before 15:00, otherwise the following Tuesday). Returned as an ISO string for
+ * the scheduled_send_at column.
+ */
+export function nextSendSlot(from: Date): string {
+  const slot = new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), SEND_HOUR_UTC, 0, 0, 0),
+  );
+  let add = (SEND_DOW - slot.getUTCDay() + 7) % 7;
+  if (add === 0 && from.getTime() >= slot.getTime()) add = 7;
+  slot.setUTCDate(slot.getUTCDate() + add);
+  return slot.toISOString();
+}

--- a/apps/web/src/lib/brief-token.server.ts
+++ b/apps/web/src/lib/brief-token.server.ts
@@ -1,0 +1,95 @@
+// Self-contained HMAC-SHA256 signing for Weekly Brief approval links. The link
+// is emailed only to the maintainer, so a valid, unexpired signature is the
+// authorization to approve + schedule an issue. Uses Web Crypto so it runs in
+// the Cloudflare Worker runtime.
+
+export type BriefApprovePayload = {
+  /** issue number */
+  n: number;
+  /** period_through (binds the token to a specific issue snapshot) */
+  p: string;
+  /** unix-ms expiry */
+  exp: number;
+};
+
+const encoder = new TextEncoder();
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64urlDecode(value: string): Uint8Array {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function hmac(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign("HMAC", key, encoder.encode(message));
+  return new Uint8Array(sig);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+export async function signBriefApproveToken(
+  secret: string,
+  payload: BriefApprovePayload,
+): Promise<string> {
+  const body = base64urlEncode(encoder.encode(JSON.stringify(payload)));
+  const sig = base64urlEncode(await hmac(secret, body));
+  return `${body}.${sig}`;
+}
+
+export async function verifyBriefApproveToken(
+  secret: string,
+  token: string,
+  now: number,
+): Promise<BriefApprovePayload | null> {
+  if (!secret || typeof token !== "string") return null;
+  const dot = token.indexOf(".");
+  if (dot <= 0 || dot === token.length - 1) return null;
+  const body = token.slice(0, dot);
+  const providedSig = token.slice(dot + 1);
+
+  let expected: Uint8Array;
+  let provided: Uint8Array;
+  try {
+    expected = await hmac(secret, body);
+    provided = base64urlDecode(providedSig);
+  } catch {
+    return null;
+  }
+  if (!timingSafeEqual(expected, provided)) return null;
+
+  let payload: BriefApprovePayload;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(base64urlDecode(body)));
+  } catch {
+    return null;
+  }
+  if (
+    typeof payload?.n !== "number" ||
+    typeof payload?.p !== "string" ||
+    typeof payload?.exp !== "number" ||
+    payload.exp < now
+  ) {
+    return null;
+  }
+  return payload;
+}

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -1,0 +1,128 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { useState, type ReactNode } from "react";
+import { z } from "zod";
+
+const tokenInput = z.object({ token: z.string() });
+
+// Verify the signed link and return the draft it points at (read-only — the
+// approval itself is a separate POST so an email link-scanner can't auto-approve).
+const verifyApprove = createServerFn({ method: "GET" })
+  .inputValidator(tokenInput)
+  .handler(async ({ data }) => {
+    const { getEnvString } = await import("@/lib/cloudflare-env.server");
+    const { verifyBriefApproveToken } = await import("@/lib/brief-token.server");
+    const secret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
+    if (!secret) return { ok: false as const, reason: "unconfigured" as const };
+    const payload = await verifyBriefApproveToken(secret, data.token, Date.now());
+    if (!payload) return { ok: false as const, reason: "invalid" as const };
+    return { ok: true as const, number: payload.n, periodThrough: payload.p };
+  });
+
+const confirmApprove = createServerFn({ method: "POST" })
+  .inputValidator(tokenInput)
+  .handler(async ({ data }) => {
+    const { getEnvString } = await import("@/lib/cloudflare-env.server");
+    const { verifyBriefApproveToken } = await import("@/lib/brief-token.server");
+    const { approveBrief } = await import("@/lib/brief-issues.server");
+    const { nextSendSlot } = await import("@/lib/brief-schedule");
+    const secret = getEnvString("NEWSLETTER_CONFIRM_SECRET");
+    if (!secret) return { ok: false as const, reason: "unconfigured" as const };
+    const payload = await verifyBriefApproveToken(secret, data.token, Date.now());
+    if (!payload) return { ok: false as const, reason: "invalid" as const };
+    const scheduledSendAt = nextSendSlot(new Date());
+    const changed = await approveBrief(payload.n, scheduledSendAt);
+    return changed
+      ? { ok: true as const, scheduledSendAt }
+      : { ok: false as const, reason: "already" as const };
+  });
+
+export const Route = createFileRoute("/brief/approve")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: String(search.token ?? ""),
+  }),
+  loaderDeps: ({ search }) => ({ token: search.token }),
+  loader: ({ deps }) => verifyApprove({ data: { token: deps.token } }),
+  head: () => ({
+    meta: [{ title: "Approve Weekly Brief — HeyClaude" }, { name: "robots", content: "noindex" }],
+  }),
+  component: ApprovePage,
+});
+
+function ApprovePage() {
+  const result = Route.useLoaderData();
+  const { token } = Route.useSearch();
+  const [state, setState] = useState<
+    | { phase: "idle" }
+    | { phase: "working" }
+    | { phase: "done"; scheduledSendAt: string }
+    | { phase: "error"; reason: string }
+  >({ phase: "idle" });
+
+  if (!result.ok) {
+    return (
+      <Shell heading="Link not valid">
+        {result.reason === "unconfigured"
+          ? "Brief approval isn't configured right now."
+          : "This approval link is invalid or has expired. Generate a fresh draft and try again."}
+      </Shell>
+    );
+  }
+
+  if (state.phase === "done") {
+    const when = new Date(state.scheduledSendAt).toUTCString();
+    return (
+      <Shell heading="Approved — scheduled to send">
+        Weekly Brief #{result.number} (week of {result.periodThrough}) is approved and will be sent
+        to the newsletter audience at <strong>{when}</strong>.
+      </Shell>
+    );
+  }
+
+  return (
+    <Shell heading={`Approve Weekly Brief #${result.number}`}>
+      Approving the draft for the week of <strong>{result.periodThrough}</strong> schedules it to
+      send to the newsletter audience at the next Tuesday 15:00 UTC slot. Review the full draft in
+      your preview email first.
+      {state.phase === "error" && (
+        <p style={{ color: "#b4541f", marginTop: 12 }}>
+          {state.reason === "already"
+            ? "That issue was already approved or sent."
+            : "Could not approve — please try the link again."}
+        </p>
+      )}
+      <div style={{ marginTop: 20 }}>
+        <button
+          type="button"
+          disabled={state.phase === "working"}
+          onClick={async () => {
+            setState({ phase: "working" });
+            try {
+              const res = await confirmApprove({ data: { token } });
+              if (res.ok) setState({ phase: "done", scheduledSendAt: res.scheduledSendAt });
+              else setState({ phase: "error", reason: res.reason });
+            } catch {
+              setState({ phase: "error", reason: "error" });
+            }
+          }}
+          className="inline-flex h-10 items-center rounded-md bg-ink px-5 font-medium text-background hover:opacity-90 disabled:opacity-60"
+        >
+          {state.phase === "working" ? "Approving…" : "Approve & schedule send"}
+        </button>
+      </div>
+    </Shell>
+  );
+}
+
+function Shell({ heading, children }: { heading: string; children: ReactNode }) {
+  return (
+    <div className="mx-auto max-w-xl px-6 py-20">
+      <div className="eyebrow text-ink-subtle">Weekly Brief</div>
+      <h1 className="mt-2 h-display-2 text-ink">{heading}</h1>
+      <p className="mt-4 text-pretty text-ink-muted">{children}</p>
+      <Link to="/brief" className="mt-8 inline-block text-sm text-ink-muted hover:text-ink">
+        ← Back to the Weekly Brief
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Completes the **generate → review → approve → scheduled-send** Weekly Brief pipeline on top of Stage 1's persistence (#2519). This is exactly the flow you asked for: *fully automated generation, easy review, one-click approve, then a scheduled Resend send.*

Notably, it **sidesteps the API-contract/OpenAPI framework** by using a **page route** for approval instead of an `/api` route (which would have required contract + OpenAPI regen + ENDPOINTS docs + tags).

## The flow
1. **Friday 14:00 UTC** (existing Stage 1 cron): generate the draft → persist → **email you a preview with an "Approve & schedule send" link**.
2. **Approve** (`/brief/approve?token=…`, noindex): a signed-link page shows the draft; clicking the button sets `status=approved` + schedules the send. A separate POST does the mutation so an email link-scanner can't auto-approve.
3. **Send** (the existing **6-hourly** trigger — *no new cron*): any approved brief whose scheduled time has arrived is sent to the Resend audience and marked `sent`.

## Why it's safe to ship now
**Inert until configured + approved.** It needs `BRIEF_REVIEW_EMAIL` (your address) plus the existing `NEWSLETTER_CONFIRM_SECRET` + `RESEND_*` secrets, and **nothing reaches the audience without your explicit click**. The send is also guarded (`draft→approved→sent` transitions can't double-fire).

## Send timing
`nextSendSlot()` → **Tuesday 15:00 UTC** (the strongest dev-newsletter window). The 6-hourly trigger picks it up within a few hours of that slot.

## Files
- `lib/brief-token.server.ts` (new) — HMAC sign/verify, 14-day TTL, bound to issue+period
- `lib/brief-email.ts` (new) — brief → newsletter HTML/text (preview has the approve button; send doesn't)
- `lib/brief-schedule.ts` (new) — `nextSendSlot()`
- `routes/brief.approve.tsx` (new) — the approval page route
- `lib/brief-issues.server.ts` — `approveBrief` / `getDueApprovedBriefs` / `markBriefSent` / `getLatestDraft`
- `plugins/newsletter-digest-scheduled.ts` — preview email on Friday + send on the 6-hourly

## ⚙️ One new secret
Set **`BRIEF_REVIEW_EMAIL`** to your address (where the approve preview goes).

## Validation
- `tsc --noEmit` clean (verified against a regenerated route tree); Prettier clean.
- The email/approve/send paths can't be runtime-tested in CI (no live Resend/D1), but every path is fail-open and human-gated.

## Remaining follow-up
Public **`/brief` D1-render + `/brief/$number` archive + sitemap** (the on-site published view) — the last piece, purely additive.