### PR TITLE
feat(brief): public archive — /brief/N pages, archive list, sitemap

### DIFF
--- a/apps/web/src/components/brief-sections.tsx
+++ b/apps/web/src/components/brief-sections.tsx
@@ -1,0 +1,60 @@
+// Renders a persisted Weekly Brief (the buildWeeklyBrief payload shape) for the
+// /brief/$number archive pages. Tolerant of partial payloads.
+
+export type BriefSectionItem = {
+  title?: string;
+  url?: string;
+  description?: string;
+  reasons?: string[];
+};
+
+export type BriefSectionsData = {
+  newEntries?: BriefSectionItem[];
+  sourceBacked?: BriefSectionItem[];
+  saferInstalls?: BriefSectionItem[];
+  notableChanges?: BriefSectionItem[];
+};
+
+const SECTION_ORDER: Array<{ key: keyof BriefSectionsData; label: string }> = [
+  { key: "newEntries", label: "New in the registry" },
+  { key: "sourceBacked", label: "Source-backed picks" },
+  { key: "saferInstalls", label: "Safer installs" },
+  { key: "notableChanges", label: "Notable changes" },
+];
+
+function BriefSectionList({ label, items }: { label: string; items: BriefSectionItem[] }) {
+  const rows = items.filter((item) => item?.title);
+  if (rows.length === 0) return null;
+  return (
+    <section className="rounded-xl border border-border bg-surface p-5">
+      <h2 className="font-display text-base font-semibold text-ink">{label}</h2>
+      <ul className="mt-3 space-y-3 text-sm">
+        {rows.map((item, index) => {
+          const sub = item.reasons?.[0] ?? item.description ?? "";
+          return (
+            <li key={`${item.url ?? item.title}-${index}`}>
+              <a href={item.url || "#"} className="font-medium text-ink hover:underline">
+                {item.title}
+              </a>
+              {sub && <p className="mt-1 text-xs text-ink-muted">{sub}</p>}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}
+
+export function BriefSections({ sections }: { sections: BriefSectionsData }) {
+  const present = SECTION_ORDER.filter((s) => (sections[s.key] ?? []).length > 0);
+  if (present.length === 0) {
+    return <p className="text-sm text-ink-muted">No notable activity in this issue.</p>;
+  }
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {present.map((s) => (
+        <BriefSectionList key={s.key} label={s.label} items={sections[s.key] ?? []} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/routes/brief.$number.tsx
+++ b/apps/web/src/routes/brief.$number.tsx
@@ -1,0 +1,82 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { BriefSections, type BriefSectionsData } from "@/components/brief-sections";
+import { absoluteUrl } from "@/lib/seo";
+
+const loadBriefIssue = createServerFn({ method: "GET" })
+  .inputValidator(z.object({ number: z.number().int() }))
+  .handler(async ({ data }) => {
+    const { getBriefByNumber } = await import("@/lib/brief-issues.server");
+    const issue = await getBriefByNumber(data.number);
+    if (!issue) return { found: false as const };
+    const payload = issue.payload as { title?: string; sections?: BriefSectionsData };
+    return {
+      found: true as const,
+      number: issue.number,
+      periodThrough: issue.period_through,
+      title: typeof payload.title === "string" ? payload.title : `Weekly Brief #${issue.number}`,
+      sections: payload.sections ?? {},
+    };
+  });
+
+function parseNumber(value: string): number {
+  return /^\d+$/.test(value) ? Number(value) : NaN;
+}
+
+export const Route = createFileRoute("/brief/$number")({
+  loader: async ({ params }) => {
+    const number = parseNumber(params.number);
+    if (!Number.isInteger(number)) throw notFound();
+    const issue = await loadBriefIssue({ data: { number } });
+    if (!issue.found) throw notFound();
+    return issue;
+  },
+  head: ({ loaderData }) => {
+    if (!loaderData || !loaderData.found) return { meta: [] };
+    const url = absoluteUrl(`/brief/${loaderData.number}`);
+    const description = `Weekly Brief #${loaderData.number} — reviewed Claude workflow picks and registry changes for the week of ${loaderData.periodThrough}.`;
+    return {
+      meta: [
+        { title: `${loaderData.title} — HeyClaude Weekly Brief` },
+        { name: "description", content: description },
+        { property: "og:title", content: loaderData.title },
+        { property: "og:description", content: description },
+        { property: "og:url", content: url },
+        { property: "og:type", content: "article" },
+      ],
+      links: [{ rel: "canonical", href: url }],
+    };
+  },
+  component: BriefIssuePage,
+  notFoundComponent: () => (
+    <div className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <h1 className="h-display-2 text-ink">Issue not found</h1>
+      <Link to="/brief" className="mt-4 inline-block text-ink-muted hover:text-ink">
+        ← All Weekly Brief issues
+      </Link>
+    </div>
+  ),
+});
+
+function BriefIssuePage() {
+  const issue = Route.useLoaderData();
+  return (
+    <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
+      <Breadcrumbs
+        home
+        items={[{ label: "Weekly Brief", to: "/brief" }, { label: `Issue #${issue.number}` }]}
+      />
+      <header className="mt-6 max-w-3xl">
+        <div className="eyebrow text-ink-subtle">
+          Issue #{String(issue.number).padStart(2, "0")} · Week of {issue.periodThrough}
+        </div>
+        <h1 className="mt-2 h-display-1 text-ink text-balance">{issue.title}</h1>
+      </header>
+      <div className="mt-8">
+        <BriefSections sections={issue.found ? issue.sections : {}} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/brief.tsx
+++ b/apps/web/src/routes/brief.tsx
@@ -1,11 +1,32 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { createServerFn } from "@tanstack/react-start";
 import { Calendar } from "lucide-react";
 import { BRIEF_ISSUES, WEEKLY_BRIEF } from "@/data/entries";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { absoluteUrl } from "@/lib/seo";
 
+type PublishedBriefSummary = { number: number; periodThrough: string; title: string };
+
+// Published (approved/sent) issues from D1. Empty until the first brief is
+// approved, at which point the archive lists real persisted issues.
+const loadPublishedBriefs = createServerFn({ method: "GET" }).handler(
+  async (): Promise<PublishedBriefSummary[]> => {
+    const { listPublishedBriefs } = await import("@/lib/brief-issues.server");
+    const issues = await listPublishedBriefs(24);
+    return issues.map((issue) => {
+      const payload = issue.payload as { title?: string };
+      return {
+        number: issue.number,
+        periodThrough: issue.period_through,
+        title: typeof payload.title === "string" ? payload.title : `Weekly Brief #${issue.number}`,
+      };
+    });
+  },
+);
+
 export const Route = createFileRoute("/brief")({
+  loader: () => loadPublishedBriefs(),
   head: () => ({
     meta: [
       { title: "Weekly Brief — HeyClaude" },
@@ -28,6 +49,7 @@ export const Route = createFileRoute("/brief")({
 const latest = BRIEF_ISSUES[0];
 
 function BriefPage() {
+  const published = Route.useLoaderData();
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-10 sm:px-6">
       <Breadcrumbs home items={[{ label: "Weekly Brief" }]} />
@@ -94,36 +116,63 @@ function BriefPage() {
           <div className="mt-12 flex items-end justify-between border-b border-border pb-3">
             <h2 className="font-display text-xl font-semibold tracking-tight text-ink">Archive</h2>
             <span className="font-mono text-[11px] text-ink-subtle">
-              {BRIEF_ISSUES.length - 1} past issues
+              {published.length > 0 ? published.length : BRIEF_ISSUES.length - 1} past issues
             </span>
           </div>
-          <ol className="mt-4 space-y-3 stagger-children">
-            {BRIEF_ISSUES.slice(1).map((b) => (
-              <li
-                key={b.slug}
-                className="group hover-lift rounded-xl border border-border bg-surface p-5 transition-[border-color,background-color] duration-200 ease-out hover:border-ink/20 hover:bg-surface-2"
-              >
-                <div className="flex items-center justify-between text-xs text-ink-subtle">
-                  <span className="font-mono">Issue #{String(b.number).padStart(2, "0")}</span>
-                  <span>{b.date}</span>
-                </div>
-                <h3 className="mt-2 font-display text-lg font-semibold text-ink transition-colors duration-200 ease-out group-hover:text-ink-hover">
-                  {b.title}
-                </h3>
-                <p className="mt-1 text-pretty text-sm text-ink-muted">{b.summary}</p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {b.tags.map((t) => (
-                    <span
-                      key={t}
-                      className="inline-flex rounded-md border border-border bg-background px-2 py-0.5 text-[11px] text-ink-muted"
-                    >
-                      #{t}
-                    </span>
-                  ))}
-                </div>
-              </li>
-            ))}
-          </ol>
+          {published.length > 0 ? (
+            <ol className="mt-4 space-y-3 stagger-children">
+              {published.map((issue: PublishedBriefSummary) => (
+                <li
+                  key={issue.number}
+                  className="group hover-lift rounded-xl border border-border bg-surface p-5 transition-[border-color,background-color] duration-200 ease-out hover:border-ink/20 hover:bg-surface-2"
+                >
+                  <Link
+                    to="/brief/$number"
+                    params={{ number: String(issue.number) }}
+                    className="block"
+                  >
+                    <div className="flex items-center justify-between text-xs text-ink-subtle">
+                      <span className="font-mono">
+                        Issue #{String(issue.number).padStart(2, "0")}
+                      </span>
+                      <span>{issue.periodThrough}</span>
+                    </div>
+                    <h3 className="mt-2 font-display text-lg font-semibold text-ink transition-colors duration-200 ease-out group-hover:text-ink-hover">
+                      {issue.title}
+                    </h3>
+                  </Link>
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <ol className="mt-4 space-y-3 stagger-children">
+              {BRIEF_ISSUES.slice(1).map((b) => (
+                <li
+                  key={b.slug}
+                  className="group hover-lift rounded-xl border border-border bg-surface p-5 transition-[border-color,background-color] duration-200 ease-out hover:border-ink/20 hover:bg-surface-2"
+                >
+                  <div className="flex items-center justify-between text-xs text-ink-subtle">
+                    <span className="font-mono">Issue #{String(b.number).padStart(2, "0")}</span>
+                    <span>{b.date}</span>
+                  </div>
+                  <h3 className="mt-2 font-display text-lg font-semibold text-ink transition-colors duration-200 ease-out group-hover:text-ink-hover">
+                    {b.title}
+                  </h3>
+                  <p className="mt-1 text-pretty text-sm text-ink-muted">{b.summary}</p>
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {b.tags.map((t) => (
+                      <span
+                        key={t}
+                        className="inline-flex rounded-md border border-border bg-background px-2 py-0.5 text-[11px] text-ink-muted"
+                      >
+                        #{t}
+                      </span>
+                    ))}
+                  </div>
+                </li>
+              ))}
+            </ol>
+          )}
         </div>
 
         <aside className="lg:sticky lg:top-20 lg:self-start">

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -108,9 +108,17 @@ async function renderSitemap() {
     }
   }
 
+  // Published Weekly Brief archive issues (fail-open: empty in dev/preview or
+  // before the first brief is approved).
+  const { listPublishedBriefs } = await import("@/lib/brief-issues.server");
+  const briefPaths = (await listPublishedBriefs(100)).map((issue) =>
+    urlItem(`/brief/${issue.number}`, "0.5", "monthly", issue.period_through),
+  );
+
   const rows = [
     ...staticPaths.map((pathname) => urlItem(pathname, pathname === "" ? "1" : "0.7")),
     ...feedPaths.map((pathname) => urlItem(pathname, "0.4")),
+    ...briefPaths,
     // `tools` has no /$category hub — its URL is the static commercial /tools page,
     // already emitted in staticPaths above. Exclude it here to avoid a duplicate.
     ...CATEGORIES.filter((category) => category.id !== "tools").map((category) =>


### PR DESCRIPTION
## Summary

The **final piece** of the Weekly Brief pipeline — the public on-site view of approved/sent issues, reading from D1. (Generation #2519 + review/approve/send #2521 are already merged.)

- **`BriefSections` component** renders a persisted brief payload (new entries, source-backed, safer installs, notable changes), tolerant of partial data.
- **`/brief/$number` archive route** — loads a published issue by number (server fn, 404 when missing), with canonical + OG.
- **`/brief`** now lists published D1 issues in the Archive (linked to `/brief/N`), **falling back to the build-time issues until the first brief is approved**. The hero/lists are unchanged → no regression before any issue exists.
- **`sitemap.xml`** includes published `/brief/N` issues (fail-open — empty in dev/preview or before the first approval).

Static `/brief/approve` (from #2521) and dynamic `/brief/$number` coexist cleanly (TanStack prioritizes the static route).

## Validation
- `tsc --noEmit` clean (verified against a regenerated route tree); Prettier clean.
- All read paths fail open against a missing binding/table.

## Pipeline status — complete
generate (Fri) → preview email + approve link → scheduled Tue-15:00-UTC send → **public `/brief` + `/brief/N` archive**. The `brief_issues` table is already migrated on prod; the only remaining config is the `BRIEF_REVIEW_EMAIL` secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated pages for individual weekly brief issues with SEO metadata and breadcrumb navigation
  * Updated brief archive section to display published weekly briefs with issue numbers and dates
  * Added weekly brief issue pages to sitemap for improved search engine visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->