### PR TITLE
fix(content): add documentationUrl to dependency-security-audit-on-stop

### DIFF
--- a/content/hooks/dependency-security-audit-on-stop.mdx
+++ b/content/hooks/dependency-security-audit-on-stop.mdx
@@ -17,6 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch


### PR DESCRIPTION
Resubmit fixing the root cause of closes #2512, #2516: gate Source Review showed "No source URLs were declared" because this entry had no documentationUrl field.

**Change:** Add `documentationUrl: "https://code.claude.com/docs/en/hooks"` — the only change in this PR.