### PR TITLE
fix(content): update documentationUrl to hooks docs for database-migration-runner

### DIFF
--- a/content/hooks/database-migration-runner.mdx
+++ b/content/hooks/database-migration-runner.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://knexjs.org/guide/migrations.html"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch .claude/hooks/database-migration-runner.sh &&


### PR DESCRIPTION
Resubmit fixing the root cause of closes #2513, #2515: gate rejected because documentationUrl (knexjs.org) only covers Knex, not the full set of frameworks in the entry.

**Change:** Update `documentationUrl` from `https://knexjs.org/guide/migrations.html` to `https://code.claude.com/docs/en/hooks` — the only change in this PR.