### PR TITLE
fix(content): update documentationUrl to hooks docs for api-endpoint-documentation-generator

### DIFF
--- a/content/hooks/api-endpoint-documentation-generator.mdx
+++ b/content/hooks/api-endpoint-documentation-generator.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
-documentationUrl: "https://swagger.io/docs/"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch


### PR DESCRIPTION
Resubmit fixing root cause of closes #2514, #2518: gate rejected because documentationUrl (swagger.io/docs/) is generic and does not verify the hook's behavior.

**Change:** Update `documentationUrl` from `https://swagger.io/docs/` to `https://code.claude.com/docs/en/hooks` — the only change in this PR.