### PR TITLE
fix(content): fix documentationUrl for claude-haiku-45-speed-optimizer-agent

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://docs.anthropic.com/en/docs/about-claude/models"
+documentationUrl: "https://platform.claude.com/docs/en/about-claude/models/overview"
 installable: false
 usageSnippet: >-
   You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed


### PR DESCRIPTION
Resubmit fixing root cause of closes #2517, #2520: documentationUrl was returning HTTP 307 redirect chain (source_unfetchable).

**Change:** Update `documentationUrl` from `https://docs.anthropic.com/en/docs/about-claude/models` (307 chain) to `https://platform.claude.com/docs/en/about-claude/models/overview` (HTTP 200) — the only change in this PR.