### PR TITLE
fix(newsletter): one weekly send — retire auto-digest, brief sends Sunday

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -11,19 +11,12 @@ import {
 } from "@/lib/brief-issues.server";
 import { signBriefApproveToken } from "@/lib/brief-token.server";
 import { buildBriefEmail } from "@/lib/brief-email";
-import { selectDigestEntries, type DigestCandidate } from "@/lib/newsletter-digest";
-import { buildDigestEmail } from "@/lib/newsletter-emails";
 import {
   recordUmamiEvent,
   sendResendBroadcast,
   sendResendEmail,
 } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
-
-// Sundays 16:00 UTC. Must match the string in wrangler.jsonc triggers.crons
-// exactly (Cloudflare passes it through as controller.cron). NB: Cloudflare's
-// day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN, not 0.
-const WEEKLY_CRON = "0 16 * * SUN";
 
 // Fridays 14:00 UTC. Generates the next Weekly Brief draft + emails the
 // maintainer a preview with an approve link.
@@ -35,37 +28,19 @@ const SEND_CRON = "17 */6 * * *";
 
 const APPROVE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
-const MONTHS = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
-
 type CloudflareScheduledPayload = {
   controller?: { cron?: string };
   env: unknown;
   context: unknown;
 };
 
-function formatDateLabel(ms: number): string {
-  const date = new Date(ms);
-  return `${MONTHS[date.getUTCMonth()]} ${date.getUTCDate()}, ${date.getUTCFullYear()}`;
-}
-
 /**
- * Weekly "new & notable" newsletter digest. Fully automated: picks entries
- * added in the last 7 days, skips thin weeks (<5), and sends a Resend broadcast
- * to the audience. Inert until RESEND_* secrets are configured. The cron hook
- * fires for every trigger, so we gate on the weekly cron string.
+ * The Weekly Brief pipeline — the single weekly newsletter send. Friday:
+ * generate a draft + email the maintainer an approve link. 6-hourly: send any
+ * approved-and-due brief to the Resend audience (scheduled for Sunday 16:00 UTC
+ * on approval). The cron hook fires for every trigger, so each branch gates on
+ * its cron string. Inert until configured + a brief is approved — nothing
+ * reaches the audience automatically. (Replaced the old auto-send Sunday digest.)
  */
 export default definePlugin((nitroApp) => {
   nitroApp.hooks?.hook(
@@ -169,56 +144,6 @@ export default definePlugin((nitroApp) => {
         });
         return;
       }
-
-      if (controller?.cron !== WEEKLY_CRON) return;
-
-      const request = new Request("https://heyclau.de/__scheduled/newsletter-digest");
-      await runWithCloudflareRuntime(request, env, context, async () => {
-        try {
-          const apiKey = getEnvString("RESEND_API_KEY");
-          const segmentId = getEnvString("RESEND_SEGMENT_ID");
-          const from = getEnvString("RESEND_FROM");
-          if (!apiKey || !segmentId || !from) {
-            console.log("[newsletter-digest] skipped: not configured");
-            return;
-          }
-
-          const now = Date.now();
-          const entries = (await getDirectoryEntries()) as readonly DigestCandidate[];
-          const items = selectDigestEntries(entries, now, { windowDays: 7, min: 5, max: 6 });
-          if (!items) {
-            console.log("[newsletter-digest] skipped: not enough new entries this week");
-            return;
-          }
-
-          const dateLabel = formatDateLabel(now);
-          const { subject, html, text } = buildDigestEmail({
-            siteUrl: siteConfig.url,
-            items,
-            dateLabel,
-          });
-          const result = await sendResendBroadcast({
-            apiKey,
-            segmentId,
-            from,
-            subject,
-            html,
-            text,
-            name: `Weekly digest — ${dateLabel}`,
-          });
-          console.log("[newsletter-digest] broadcast sent", {
-            ok: result.ok,
-            status: result.status,
-            count: items.length,
-          });
-          await recordUmamiEvent("newsletter-digest-sent", {
-            count: items.length,
-            ok: result.ok,
-          });
-        } catch (error) {
-          console.error("[newsletter-digest] scheduled send failed", error);
-        }
-      });
     },
   );
 });

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -1,11 +1,12 @@
-// The recommended weekly send slot: Tuesday 15:00 UTC (mid-morning US /
-// afternoon EU — the strongest engagement window for developer newsletters).
-const SEND_DOW = 2; // 0=Sun..6=Sat; Tuesday
-const SEND_HOUR_UTC = 15;
+// The weekly send slot: Sunday 16:00 UTC — the cadence subscribers signed up
+// for ("Weekly · Sundays"). Generation runs Friday, leaving the weekend for
+// review before the Sunday send.
+const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
+const SEND_HOUR_UTC = 16;
 
 /**
- * The next Tuesday 15:00 UTC strictly at or after `from` (today if it's Tuesday
- * before 15:00, otherwise the following Tuesday). Returned as an ISO string for
+ * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
+ * before 16:00, otherwise the following Sunday). Returned as an ISO string for
  * the scheduled_send_at column.
  */
 export function nextSendSlot(from: Date): string {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -21,11 +21,12 @@
     "mode": "smart",
   },
   "triggers": {
-    // 6-hourly: source-repo signals. Daily 05:00 UTC: IndexNow changed-URL push.
+    // 6-hourly: source-repo signals + send any approved Weekly Brief that is due.
+    // Daily 05:00 UTC: IndexNow changed-URL push.
     // Fridays 14:00 UTC: generate the next Weekly Brief draft for review.
-    // Sundays 16:00 UTC: weekly newsletter digest.
-    // NB: Cloudflare day-of-week is 1=Sunday..7=Saturday, so Sunday is SUN (not 0).
-    "crons": ["17 */6 * * *", "0 5 * * *", "0 14 * * FRI", "0 16 * * SUN"],
+    // (The Weekly Brief is the single weekly send — approved issues go out
+    //  Sunday 16:00 UTC via the 6-hourly check; no separate Sunday cron.)
+    "crons": ["17 */6 * * *", "0 5 * * *", "0 14 * * FRI"],
   },
   "assets": {
     "directory": "dist/client",


### PR DESCRIPTION
## Summary

We briefly had **two weekly emails** — the old fully-automated **Sunday digest** *and* the new (reviewed) **Weekly Brief** I'd scheduled for **Tuesday**. Same job, same Resend audience → double-sending. My mistake for adding the second without flagging it. Consolidating to **one: the Weekly Brief, on Sunday.**

## Why the brief (not the digest), and why Sunday
- The **brief is the better product**: richer multi-section content, human-reviewed (the approve step you asked for), and it has the on-site `/brief/N` archive. The digest was a flat auto-sent 5–6 item list.
- **Sunday** because that's the cadence subscribers actually signed up for ("Weekly · Sundays" in the signup copy). My Tuesday pick would've silently broken that promise for a marginal open-rate stat.

## Changes
- Removed the auto-send Sunday digest branch + its now-unused imports/helpers (`selectDigestEntries`, `buildDigestEmail`, `formatDateLabel`, `WEEKLY_CRON`).
- Removed the `0 16 * * SUN` cron — the brief sends via the existing 6-hourly check, so no dedicated Sunday trigger is needed (**one fewer cron**).
- `brief-schedule.ts`: send slot is now **Sunday 16:00 UTC**. Flow: generate Friday → review over the weekend → send Sunday.

## Net behavior
The Weekly Brief is the **single** weekly newsletter, and it only goes out when you approve that week's draft (no approve click = no send). `tsc` + Prettier clean.