### PR TITLE
fix(content): add documentationUrl to dependency-security-audit-on-stop

### DIFF
--- a/content/hooks/dependency-security-audit-on-stop.mdx
+++ b/content/hooks/dependency-security-audit-on-stop.mdx
@@ -17,6 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
+documentationUrl: "https://docs.npmjs.com/cli/v10/commands/npm-audit"
 retrievalSources:
   - "https://docs.npmjs.com/cli/v10/commands/npm-audit"
   - "https://pypi.org/project/pip-audit/"


### PR DESCRIPTION
Previous attempt #2525 closed: documentationUrl pointed to the generic hooks reference page. This resubmit uses the primary tool's specific docs page.

**Change:** Add `documentationUrl: "https://docs.npmjs.com/cli/v10/commands/npm-audit"` — the primary audit tool this hook runs for Node.js projects. The entry already has `retrievalSources` (merged in #2516) covering npm-audit, pip-audit, bundler-audit, and safety.