### PR TITLE
fix(content): ground haiku-45-speed-optimizer-agent claims and fix SEO

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -3,24 +3,32 @@ title: Claude Haiku 45 Speed Optimizer Agent - Agents
 slug: claude-haiku-45-speed-optimizer-agent
 category: agents
 description: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
+  Claude Haiku 4.5 agent configuration for cost-efficient, high-speed
+  automation — $1 input / $5 output per MTok with 200k token context and the
+  fastest comparative latency in the current Claude lineup.
 cardDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid...
-seoTitle: Claude Haiku 45 Speed Optimizer Agent - Agents
+  Haiku 4.5 agent config: fastest Claude at $1/$5 per MTok with 200k context
+  — ideal for batch tasks and cost-sensitive automation.
+seoTitle: Claude Haiku 4.5 Agent — Fastest, Cost-Efficient Model Config
 seoDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
-  Discover...
+  Claude Haiku 4.5 agent config — Anthropic's fastest model at $1/$5 per MTok
+  with 200k context. Optimized for batch tasks and rapid agentic iteration.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://docs.anthropic.com/en/docs/about-claude/models"
+documentationUrl: "https://platform.claude.com/docs/en/about-claude/models/overview"
+retrievalSources:
+  - "https://platform.claude.com/docs/en/about-claude/models/overview"
+  - "https://www.anthropic.com/claude/haiku"
+  - "https://www.anthropic.com/pricing"
 installable: false
+privacyNotes:
+  - Requires an Anthropic API key (ANTHROPIC_API_KEY); prompts and responses are processed by Anthropic's API under their standard privacy policy.
 usageSnippet: >-
-  You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
-  for rapid iteration and cost-effective automation.
+  You are a cost-efficient coding agent built on Claude Haiku 4.5
+  (claude-haiku-4-5, $1/$5 per MTok). Focus on well-scoped repeatable tasks —
+  linting, formatting, import corrections, boilerplate, and simple bug fixes —
+  where fastest throughput and low per-token cost matter.
 copySnippet: >-
   You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
   for rapid iteration and cost-effective automation.
@@ -46,7 +54,7 @@ copySnippet: >-
   ## Optimal Use Cases for Haiku 4.5
 
 
-  ### 1. Rapid Iteration Tasks (2x Speed Advantage)
+  ### 1. Rapid Iteration Tasks (Fastest Comparative Latency)
 
 
   **Quick Code Fixes**
@@ -160,17 +168,19 @@ copySnippet: >-
   ## Performance Comparison
 
 
-  | Metric | Haiku 4.5 | Sonnet 4.5 | Advantage |
+  | Metric      | Haiku 4.5      | Sonnet 4.5     | Advantage         |
 
-  |--------|-----------|------------|----------|
+  |-------------|----------------|----------------|-------------------|
 
-  | Speed | 2x faster | Baseline | Haiku wins |
+  | Latency     | Fastest        | Fast           | Haiku wins        |
 
-  | Cost | $1/$5 | $3/$15 | 3x cheaper |
+  | Input cost  | $1/MTok        | $3/MTok        | 3x cheaper        |
 
-  | Agentic Performance | 90% | 100% | Close enough |
+  | Output cost | $5/MTok        | $15/MTok       | 3x cheaper        |
 
-  | Best For | Speed tasks | Complex tasks | Context-dependent |
+  | Context     | 200k tokens    | 200k tokens    | Same              |
+
+  | Best For    | Speed tasks    | Complex tasks  | Context-dependent |
 
 
   ## Smart Task Routing
@@ -279,13 +289,13 @@ copySnippet: >-
 
   1. **Profile Your Tasks**: Track which tasks benefit most from speed
 
-  2. **Measure Quality**: Verify Haiku 4.5's 90% performance meets needs
+  2. **Measure Quality**: Verify output quality on a sample of tasks before scaling
 
   3. **Automate Routing**: Create scripts that choose model based on task type
 
   4. **Monitor Costs**: Use token tracking to validate savings
 
-  5. **Iterate Fast**: Leverage 2x speed for rapid prototyping
+  5. **Iterate Fast**: Use Haiku 4.5's lower latency for rapid prototyping loops
 
 
   ## Integration Examples
@@ -363,7 +373,7 @@ model: haiku
 
 ## Optimal Use Cases for Haiku 4.5
 
-### 1. Rapid Iteration Tasks (2x Speed Advantage)
+### 1. Rapid Iteration Tasks (Fastest Comparative Latency)
 
 **Quick Code Fixes**
 
@@ -436,12 +446,13 @@ model: haiku
 
 ## Performance Comparison
 
-| Metric              | Haiku 4.5   | Sonnet 4.5    | Advantage         |
-| ------------------- | ----------- | ------------- | ----------------- |
-| Speed               | 2x faster   | Baseline      | Haiku wins        |
-| Cost                | $1/$5       | $3/$15        | 3x cheaper        |
-| Agentic Performance | 90%         | 100%          | Close enough      |
-| Best For            | Speed tasks | Complex tasks | Context-dependent |
+| Metric      | Haiku 4.5     | Sonnet 4.5    | Advantage         |
+| ----------- | ------------- | ------------- | ----------------- |
+| Latency     | Fastest       | Fast          | Haiku wins        |
+| Input cost  | $1/MTok       | $3/MTok       | 3x cheaper        |
+| Output cost | $5/MTok       | $15/MTok      | 3x cheaper        |
+| Context     | 200k tokens   | 200k tokens   | Same              |
+| Best For    | Speed tasks   | Complex tasks | Context-dependent |
 
 ## Smart Task Routing
 
@@ -512,10 +523,10 @@ Output tokens: Haiku $5/M vs Sonnet $15/M (3x savings)
 ## Best Practices
 
 1. **Profile Your Tasks**: Track which tasks benefit most from speed
-2. **Measure Quality**: Verify Haiku 4.5's 90% performance meets needs
+2. **Measure Quality**: Verify output quality on a sample of tasks before scaling
 3. **Automate Routing**: Create scripts that choose model based on task type
 4. **Monitor Costs**: Use token tracking to validate savings
-5. **Iterate Fast**: Leverage 2x speed for rapid prototyping
+5. **Iterate Fast**: Use Haiku 4.5's lower latency for rapid prototyping loops
 
 ## Integration Examples
 


### PR DESCRIPTION
Fixes grounding and SEO uniqueness for `claude-haiku-45-speed-optimizer-agent`.

**Changes:**
- `documentationUrl`: dead 307-redirect → `https://platform.claude.com/docs/en/about-claude/models/overview` (live)
- `retrievalSources`: added `anthropic.com/claude/haiku` and `anthropic.com/pricing` (non-JS-rendered grounding pages)
- Removed unverifiable "90% performance" and "2x speed" claims from body Best Practices section
- `description`: rewritten to state factual model specs ($1/$5 per MTok, 200k context)
- `cardDescription`: distinct concise one-liner
- `seoTitle`/`seoDescription`: distinct from description, SEO-optimized
- `privacyNotes`: added (API key / Anthropic privacy policy)

Closes: previous attempts #2517, #2520, #2528 (all closed).