### PR TITLE
fix(content): diversify SEO copy for zod-schema-validator skill

### DIFF
--- a/content/skills/zod-schema-validator.mdx
+++ b/content/skills/zod-schema-validator.mdx
@@ -2,10 +2,10 @@
 title: Zod Schema Validation Skill
 slug: zod-schema-validator
 category: skills
-description: "Build type-safe runtime validation with Zod for APIs, forms, and data pipelines with TypeScript 5.5+ integration and automatic type inference."
-cardDescription: "Build type-safe runtime validation with Zod for APIs, forms, and data pipelines with TypeScript 5.5+ integration and automatic type infer..."
-seoTitle: Zod Schema Validation Skill
-seoDescription: "Build type-safe runtime validation with Zod for APIs, forms, and data pipelines with TypeScript 5.5+ integration and automatic type inference. Zod is a TypeS..."
+description: "TypeScript-first validation skill using Zod — define schemas once, get runtime checks and inferred types for APIs, forms, and data pipelines."
+cardDescription: "Zod skill: define a schema, get runtime validation and inferred TypeScript types with no duplication — works with APIs, forms, and config."
+seoTitle: Zod Runtime Validation Skill for TypeScript Projects
+seoDescription: "Zod skill for Claude Code: parse and validate API payloads, form inputs, and config at runtime with automatic TypeScript inference and zero schema duplication."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
Diversifies description, cardDescription, seoTitle, and seoDescription so each field has distinct copy. All previously identical. No functional changes.