### PR TITLE
fix(content): diversify SEO copy for model-switch-history-tracker statusline

### DIFF
--- a/content/statuslines/model-switch-history-tracker.mdx
+++ b/content/statuslines/model-switch-history-tracker.mdx
@@ -3,21 +3,23 @@ title: Model Switch History Tracker - Statuslines
 slug: model-switch-history-tracker
 category: statuslines
 description: >-
-  Claude Code model switch detector tracking transitions between
-  Opus/Sonnet/Haiku with switch count, current model indicator, and cost impact
-  visualization.
+  Claude Code statusline that detects model switches between Opus, Sonnet, and
+  Haiku — shows current tier, total session switch count, and the last few
+  model transitions inline.
 cardDescription: >-
-  Claude Code model switch detector tracking transitions between
-  Opus/Sonnet/Haiku with switch count, current model indicator, and cost imp...
-seoTitle: Model Switch History Tracker - Statuslines
+  Statusline showing current Claude tier, session switch count, and recent
+  Opus/Sonnet/Haiku transitions — know when Claude auto-switched models.
+seoTitle: Claude Model Switch History Statusline for Claude Code
 seoDescription: >-
-  Claude Code model switch detector tracking transitions between
-  Opus/Sonnet/Haiku with switch count, current model indicator, and cost impact
-  visualization.
+  Claude Code statusline that tracks model-tier changes per session. Displays
+  the current Opus/Sonnet/Haiku indicator, total switch count, and a short
+  transition log directly in your statusline.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://docs.claude.com/en/docs/claude-code/statusline"
+retrievalSources:
+  - "https://docs.claude.com/en/docs/claude-code/statusline"
 installable: true
 usageSnippet: "\U0001F3B5 SONNET | 2 switches | Opus→Sonnet Haiku→Sonnet"
 copySnippet: |-
@@ -53,6 +55,9 @@ prerequisites:
   - >-
     Write access to home directory (~/.claude-code-model-history) for persistent
     model history files
+safetyNotes:
+  - Creates and writes to ~/.claude-code-model-history/ to persist model switch history across Claude Code invocations.
+  - Runs as a background statusline command on every Claude Code refresh (every 1000ms by default).
 tags:
   - model-switching
   - opus-sonnet-haiku


### PR DESCRIPTION
Diversifies description, cardDescription, seoTitle, seoDescription (previously nearly identical). Adds retrievalSources pointing to Claude Code statusline documentation. Adds safetyNotes for home-directory writes and background execution.