### PR TITLE
fix(content): diversify SEO copy for mobile-app-development-expert rules entry

### DIFF
--- a/content/rules/mobile-app-development-expert.mdx
+++ b/content/rules/mobile-app-development-expert.mdx
@@ -7,18 +7,21 @@ description: >-
   concurrency isolation, app lifecycle, and App Store review and privacy
   requirements — grounded in Apple's developer documentation
 cardDescription: >-
-  iOS and Apple-platform architecture reviewer covering SwiftUI state, Swift
-  concurrency isolation, app lifecycle, and App Store review and privacy
-  requirements — grounded in Apple's developer documentation
-seoTitle: iOS & Apple Platform Architecture Reviewer - CLAUDE.md Rules
+  CLAUDE.md rule for iOS/iPadOS code review: flags SwiftUI state issues,
+  Swift concurrency actor isolation errors, and App Store privacy gaps.
+seoTitle: iOS SwiftUI Architecture Reviewer CLAUDE.md Rule
 seoDescription: >-
-  iOS and Apple-platform architecture reviewer covering SwiftUI state, Swift
-  concurrency isolation, app lifecycle, and App Store review and privacy
-  requirements. Discover tools for AI development.
+  Claude Code rule for iOS and Apple-platform development: reviews SwiftUI
+  state management, Swift concurrency isolation, app lifecycle, and App Store
+  privacy requirements before you ship.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://developer.apple.com/documentation/"
+documentationUrl: "https://developer.apple.com/documentation/swiftui"
+retrievalSources:
+  - "https://developer.apple.com/documentation/swiftui"
+  - "https://developer.apple.com/documentation/swift/concurrency"
+  - "https://developer.apple.com/app-store/review/guidelines/"
 installable: false
 usageSnippet: >-
   You are an iOS and Apple-platform architecture reviewer. Check SwiftUI state,


### PR DESCRIPTION
Diversifies cardDescription and seoDescription (previously copies of description). Changes documentationUrl from generic developer.apple.com/documentation to the SwiftUI docs. Adds retrievalSources: SwiftUI, Swift Concurrency, App Store Review Guidelines.