### PR TITLE
fix(content): remove all cost-multiplier claims from haiku-45-speed-optimizer-agent

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -3,24 +3,31 @@ title: Claude Haiku 45 Speed Optimizer Agent - Agents
 slug: claude-haiku-45-speed-optimizer-agent
 category: agents
 description: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
+  Claude Haiku 4.5 agent configuration for cost-efficient, high-speed
+  automation — lower per-token cost than Sonnet with 200k context and the
+  fastest comparative latency in the current Claude lineup.
 cardDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid...
-seoTitle: Claude Haiku 45 Speed Optimizer Agent - Agents
+  Haiku 4.5 agent config: fastest Claude model with 200k context — ideal
+  for batch tasks and cost-sensitive automation.
+seoTitle: Claude Haiku 4.5 Agent — Fastest, Cost-Efficient Model Config
 seoDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
-  Discover...
+  Claude Haiku 4.5 agent config — Anthropic's fastest model with 200k context.
+  Lower cost per token than Sonnet 4.5; optimized for batch and agentic tasks.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://docs.anthropic.com/en/docs/about-claude/models"
+documentationUrl: "https://platform.claude.com/docs/en/about-claude/models/overview"
+retrievalSources:
+  - "https://platform.claude.com/docs/en/about-claude/models/overview"
+  - "https://www.anthropic.com/claude/haiku"
 installable: false
+privacyNotes:
+  - Requires an Anthropic API key (ANTHROPIC_API_KEY); prompts and responses are processed by Anthropic's API under their standard privacy policy.
 usageSnippet: >-
-  You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
-  for rapid iteration and cost-effective automation.
+  You are a cost-efficient coding agent built on Claude Haiku 4.5
+  (claude-haiku-4-5). Focus on well-scoped repeatable tasks — linting,
+  formatting, import corrections, boilerplate, and simple bug fixes — where
+  fastest throughput and low per-token cost matter.
 copySnippet: >-
   You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
   for rapid iteration and cost-effective automation.
@@ -46,7 +53,7 @@ copySnippet: >-
   ## Optimal Use Cases for Haiku 4.5
 
 
-  ### 1. Rapid Iteration Tasks (2x Speed Advantage)
+  ### 1. Rapid Iteration Tasks (Fastest Comparative Latency)
 
 
   **Quick Code Fixes**
@@ -152,7 +159,7 @@ copySnippet: >-
 
   - Reserve Sonnet 4.5 for complex architecture work
 
-  - Achieve 3x cost reduction on aggregate workflows
+  - Achieve meaningful cost savings on aggregate workflows vs Sonnet 4.5
 
   - Monitor token usage and optimize for Haiku's strengths
 
@@ -160,17 +167,19 @@ copySnippet: >-
   ## Performance Comparison
 
 
-  | Metric | Haiku 4.5 | Sonnet 4.5 | Advantage |
+  | Metric      | Haiku 4.5      | Sonnet 4.5     | Advantage         |
 
-  |--------|-----------|------------|----------|
+  |-------------|----------------|----------------|-------------------|
 
-  | Speed | 2x faster | Baseline | Haiku wins |
+  | Latency     | Fastest        | Fast           | Haiku wins        |
 
-  | Cost | $1/$5 | $3/$15 | 3x cheaper |
+  | Input cost  | Lower          | Higher         | See anthropic.com |
 
-  | Agentic Performance | 90% | 100% | Close enough |
+  | Output cost | Lower          | Higher         | See anthropic.com |
 
-  | Best For | Speed tasks | Complex tasks | Context-dependent |
+  | Context     | 200k tokens    | 200k tokens    | Same              |
+
+  | Best For    | Speed tasks    | Complex tasks  | Context-dependent |
 
 
   ## Smart Task Routing
@@ -256,9 +265,9 @@ copySnippet: >-
 
   # Track costs across models
 
-  Input tokens:  Haiku $1/M vs Sonnet $3/M (3x savings)
+  Input tokens:  Haiku lower cost vs Sonnet (see anthropic.com/claude/haiku)
 
-  Output tokens: Haiku $5/M vs Sonnet $15/M (3x savings)
+  Output tokens: Haiku lower cost vs Sonnet (see anthropic.com/claude/haiku)
 
   ```
 
@@ -269,7 +278,7 @@ copySnippet: >-
 
   - Reserve Sonnet 4.5 for 20-30% complex work
 
-  - Achieve ~2.5x overall cost reduction
+  - Achieve meaningful overall cost reduction vs Sonnet-only workflows
 
   - Maintain high quality with smart routing
 
@@ -279,13 +288,13 @@ copySnippet: >-
 
   1. **Profile Your Tasks**: Track which tasks benefit most from speed
 
-  2. **Measure Quality**: Verify Haiku 4.5's 90% performance meets needs
+  2. **Measure Quality**: Verify output quality on a sample of tasks before scaling
 
   3. **Automate Routing**: Create scripts that choose model based on task type
 
   4. **Monitor Costs**: Use token tracking to validate savings
 
-  5. **Iterate Fast**: Leverage 2x speed for rapid prototyping
+  5. **Iterate Fast**: Use Haiku 4.5's lower latency for rapid prototyping loops
 
 
   ## Integration Examples
@@ -363,7 +372,7 @@ model: haiku
 
 ## Optimal Use Cases for Haiku 4.5
 
-### 1. Rapid Iteration Tasks (2x Speed Advantage)
+### 1. Rapid Iteration Tasks (Fastest Comparative Latency)
 
 **Quick Code Fixes**
 
@@ -431,17 +440,18 @@ model: haiku
 
 - Use Haiku 4.5 for 80% of routine tasks
 - Reserve Sonnet 4.5 for complex architecture work
-- Achieve 3x cost reduction on aggregate workflows
+- Achieve meaningful cost savings on aggregate workflows vs Sonnet 4.5
 - Monitor token usage and optimize for Haiku's strengths
 
 ## Performance Comparison
 
-| Metric              | Haiku 4.5   | Sonnet 4.5    | Advantage         |
-| ------------------- | ----------- | ------------- | ----------------- |
-| Speed               | 2x faster   | Baseline      | Haiku wins        |
-| Cost                | $1/$5       | $3/$15        | 3x cheaper        |
-| Agentic Performance | 90%         | 100%          | Close enough      |
-| Best For            | Speed tasks | Complex tasks | Context-dependent |
+| Metric      | Haiku 4.5     | Sonnet 4.5    | Advantage         |
+| ----------- | ------------- | ------------- | ----------------- |
+| Latency     | Fastest       | Fast          | Haiku wins        |
+| Input cost  | Lower         | Higher        | See anthropic.com |
+| Output cost | Lower         | Higher        | See anthropic.com |
+| Context     | 200k tokens   | 200k tokens   | Same              |
+| Best For    | Speed tasks   | Complex tasks | Context-dependent |
 
 ## Smart Task Routing
 
@@ -497,25 +507,25 @@ done
 ### Token Usage Monitoring
 
 ```bash
-# Track costs across models
-Input tokens:  Haiku $1/M vs Sonnet $3/M (3x savings)
-Output tokens: Haiku $5/M vs Sonnet $15/M (3x savings)
+# Track costs across models (see anthropic.com/claude/haiku for current pricing)
+# Haiku 4.5: lower input and output cost per token than Sonnet 4.5
+# Route routine tasks to Haiku to reduce token spend on aggregate workflows
 ```
 
 ### Monthly Budget Planning
 
 - Estimate 70-80% of tasks suitable for Haiku 4.5
 - Reserve Sonnet 4.5 for 20-30% complex work
-- Achieve ~2.5x overall cost reduction
+- Achieve meaningful overall cost reduction vs Sonnet-only workflows
 - Maintain high quality with smart routing
 
 ## Best Practices
 
 1. **Profile Your Tasks**: Track which tasks benefit most from speed
-2. **Measure Quality**: Verify Haiku 4.5's 90% performance meets needs
+2. **Measure Quality**: Verify output quality on a sample of tasks before scaling
 3. **Automate Routing**: Create scripts that choose model based on task type
 4. **Monitor Costs**: Use token tracking to validate savings
-5. **Iterate Fast**: Leverage 2x speed for rapid prototyping
+5. **Iterate Fast**: Use Haiku 4.5's lower latency for rapid prototyping loops
 
 ## Integration Examples
 


### PR DESCRIPTION
Re-submission (previous #2537, #2534 closed — grounding failures).

**Root cause of #2537 closure:** Gate still saw `3x cost reduction` and `~2.5x overall cost reduction` in the MDX body section. The v4 fix only replaced the YAML copySnippet versions (indented), not the unindented body versions.

**This PR:** Removes ALL specific cost-multiplier claims from both copySnippet and body:
- Body line `- Achieve 3x cost reduction on aggregate workflows` → qualitative
- Body line `- Achieve ~2.5x overall cost reduction` → qualitative

Combined with v4's changes (already included here):
- No dollar amounts ($1/$5, $3/MTok etc.)  
- No "2x faster" or "90% performance" language
- Qualitative comparison table (Lower/Higher/See anthropic.com)
- No consumer pricing URL in retrievalSources