### PR TITLE
fix(content): narrow db-migration-runner to Knex + Django with targeted sources

### DIFF
--- a/content/hooks/database-migration-runner.mdx
+++ b/content/hooks/database-migration-runner.mdx
@@ -3,21 +3,26 @@ title: Database Migration Runner - Hooks
 slug: database-migration-runner
 category: hooks
 description: >-
-  Automated database migration management with rollback capabilities,
-  validation, and multi-environment support using Knex 3.x, Sequelize 6.x/7.x,
-  TypeORM 0.3.x, Django 5.x, and Rails 7.x.
+  PostToolUse hook that detects writes to migration, schema, and SQL files then
+  runs framework-specific status checks — runs knex migrate:status for Node.js
+  projects and python manage.py showmigrations for Django projects.
 cardDescription: >-
-  Automated database migration management with rollback capabilities,
-  validation, and multi-environment support using Knex 3.x, Sequelize 6...
-seoTitle: Database Migration Runner - Hooks
+  PostToolUse hook for Knex and Django projects: detects migration file changes,
+  runs knex migrate:status or python manage.py showmigrations, and warns on
+  destructive SQL statements.
+seoTitle: Database Migration Runner Hook for Knex and Django - Claude Code
 seoDescription: >-
-  Automated database migration management with rollback capabilities,
-  validation, and multi-environment support using Knex 3.x, Sequelize 6.x/7.x,
-  TypeORM 0.3....
+  Claude Code PostToolUse hook that watches migration and schema files, checks
+  migration status via knex migrate:status or Django showmigrations, and flags
+  destructive SQL operations before they run.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
 documentationUrl: "https://knexjs.org/guide/migrations.html"
+retrievalSources:
+  - "https://docs.claude.com/en/docs/claude-code/hooks"
+  - "https://knexjs.org/guide/migrations.html"
+  - "https://docs.djangoproject.com/en/5.0/ref/django-admin/#showmigrations"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch .claude/hooks/database-migration-runner.sh &&
@@ -54,7 +59,7 @@ scriptBody: "#!/usr/bin/env bash\n\n# Read the tool input from stdin\nINPUT=$(ca
 trigger: PostToolUse
 safetyNotes:
   - Runs automatically after write or edit activity on migration, schema, and SQL files.
-  - Invokes local framework status commands such as knex migrate status, Django showmigrations, and Rails migrate status when available.
+  - Invokes local migration status commands: knex migrate:status for Node.js projects and python manage.py showmigrations for Django projects.
   - Scans raw SQL for destructive statements and reports warnings but does not apply migrations itself.
 privacyNotes:
   - Reads migration, schema, SQL, package, and framework configuration files to infer migration state.
@@ -87,23 +92,19 @@ robotsFollow: true
 
 ## Features
 
-- Automated database migration detection and execution with intelligent framework detection (Knex 3.x, Sequelize 6.x/7.x, TypeORM 0.3.x, Django 5.x, Rails 7.x)
-- Support for multiple database systems (PostgreSQL, MySQL, SQLite, SQL Server) across all major migration frameworks with automatic database type detection
-- Safe rollback capabilities with validation and transaction support ensuring migrations can be safely reverted when needed
-- Migration file integrity checking with checksums and validation preventing corrupted or incomplete migrations from executing
-- Environment-specific migration configurations for development, staging, and production with separate migration paths
-- CI/CD pipeline integration with automated migration execution and status reporting for deployment workflows
-- Destructive operation detection warning about DROP/DELETE/TRUNCATE statements with recommendations for safe migration practices
-- Migration best practices reminders including backup recommendations, testing guidelines, and reversible migration patterns
+- Detects writes to migration, schema, and `.sql` files via PostToolUse and triggers status checks automatically
+- Runs `npx knex migrate:status` for Node.js projects that include Knex in `package.json`
+- Runs `python manage.py showmigrations --plan` for Django projects when `manage.py` is present
+- Flags pending Knex migrations and prompts the developer to run `npx knex migrate:latest`
+- Scans raw SQL files for destructive statements (DROP, DELETE, TRUNCATE) and issues warnings before execution
+- Prints migration best-practice reminders (backup, test on staging, reversible migrations, use transactions)
 
 ## Use Cases
 
-- Automated database schema evolution in development workflows detecting and validating migrations as they are created
-- CI/CD pipeline integration for deployment migrations automatically running migrations during deployment processes
-- Multi-environment database synchronization ensuring consistent schema across development, staging, and production environments
-- Migration validation and rollback safety checking migration files for potential issues before execution
-- Database versioning and change tracking maintaining a complete history of database schema changes
-- Development workflow optimization providing immediate feedback on migration files and framework-specific guidance
+- Catching unapplied Knex migrations immediately after a schema file is written during development
+- Verifying Django migration state after editing a models.py or migrations file without leaving Claude Code
+- Flagging accidental DROP or TRUNCATE statements in hand-written SQL before they run in a CI pipeline
+- Keeping development, staging, and production schemas in sync by surfacing pending migrations early
 
 ## Installation
 
@@ -125,8 +126,8 @@ robotsFollow: true
 - Project directory initialized
 - Bash shell available
 - jq command-line JSON processor
-- Migration framework: Knex 3.x, Sequelize 6.x/7.x, TypeORM 0.3.x, Django 5.x, or Rails 7.x
-- Database connection configured (connection string, credentials, or environment variables) and appropriate runtime environment (Node.js for Knex/Sequelize/TypeORM, Python for Django, Ruby for Rails)
+- Knex 3.x (Node.js) or Django 5.x (Python) installed in the project
+- Node.js and npx available for Knex projects; Python and manage.py present for Django projects
 
 ## Hook Configuration
 
@@ -327,54 +328,25 @@ fi
 exit 0
 ```
 
-### Rails Migration Detection
-
-Enhanced hook script for Rails migration detection and status checking
-
-```bash
-#!/usr/bin/env bash
-INPUT=$(cat)
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // ""')
-if [[ "$FILE_PATH" == *migration* ]] && [ -f "Gemfile" ] && grep -q "rails" Gemfile; then
-  echo "Rails project detected" >&2
-  if command -v bundle &> /dev/null; then
-    echo "Checking Rails migration status..." >&2
-    bundle exec rails db:migrate:status 2>/dev/null | tail -5 || echo "Run 'rails db:migrate:status' to check status" >&2
-  fi
-fi
-exit 0
-```
 
 ## Troubleshooting
 
-### Hook detects migration file but framework check fails
+### Hook detects migration file but Knex check fails
 
-Verify package.json contains knex, sequelize, or typeorm dependency. Run npm install to ensure frameworks are installed. Check npx command availability and node_modules/.bin in PATH. Verify framework versions: Knex 3.x, Sequelize 6.x/7.x, TypeORM 0.3.x.
+Verify `package.json` contains a `knex` dependency and run `npm install`. Check that `npx knex --version` succeeds. Ensure `knexfile.js` is present and points to the correct migrations directory.
 
 ### Knex migration status shows no pending despite new files
 
-Run npx knex migrate:list to verify migration discovery. Check migration file naming follows timestamp pattern. Ensure knexfile.js configuration points to correct migrations directory. Verify Knex version 3.x compatibility.
+Run `npx knex migrate:list` to verify migration discovery. Check that migration filenames follow the timestamp pattern Knex expects (e.g. `20240101_create_users.js`). Confirm `knexfile.js` migrations path is correct.
 
 ### PostToolUse hook triggers on non-migration SQL files
 
-Refine file path pattern matching to exclude seed/query files. Add migration directory check: [[$FILE_PATH == *migrations/*]]. Update matchers to prevent false positives. Consider adding file extension checks.
+Tighten path matching by adding a directory check: `[[ "$FILE_PATH" == *migrations/* ]]`. Adjust or remove the `*.sql` pattern if raw SQL files in other directories are causing false positives.
 
 ### Destructive operation warning for safe rollback scripts
 
-Hook warns on DROP/DELETE/TRUNCATE in any context. Add migration safety comments to suppress warnings. Consider splitting destructive down migrations into separate reviewed files. Verify rollback scripts are properly tested.
+The hook warns on DROP/DELETE/TRUNCATE in any SQL context. Split destructive down-migrations into separately reviewed files, or add a comment like `# rollback-safe` and update the grep pattern to skip flagged files.
 
-### Django migration detection fails in virtual environment
+### Django migration detection fails in a virtual environment
 
-Activate virtualenv before hook runs: source venv/bin/activate in shell config. Use absolute python path from which python. Ensure manage.py is executable and in project root. Verify Django 5.x compatibility.
-
-### TypeORM migration status check fails with datasource error
-
-Verify TypeORM datasource configuration file exists and is properly configured. Check datasource path in migration:run command. Ensure TypeORM 0.3.x compatibility. Test manually: npx typeorm migration:show -d path-to-datasource-config.
-
-### Sequelize migration detection fails with sequelize-cli not found
-
-Install sequelize-cli globally: npm install -g sequelize-cli or locally: npm install --save-dev sequelize-cli. Verify Sequelize 6.x/7.x compatibility. Check npx sequelize-cli --version. Ensure sequelize-cli is in node_modules/.bin.
-
-### Rails migration detection fails with bundle exec error
-
-Verify bundle is installed and Gemfile contains rails gem. Run bundle install to ensure dependencies are installed. Check Rails 7.x compatibility. Test manually: bundle exec rails db:migrate:status. Ensure bundle exec is in PATH.
+Use the absolute Python path from `which python` or `which python3` instead of relying on the shell PATH inside the hook. Ensure `manage.py` is present in the project root and the virtualenv is activated before Claude Code starts.

--- a/content/hooks/database-migration-runner.mdx
+++ b/content/hooks/database-migration-runner.mdx
@@ -59,7 +59,7 @@ scriptBody: "#!/usr/bin/env bash\n\n# Read the tool input from stdin\nINPUT=$(ca
 trigger: PostToolUse
 safetyNotes:
   - Runs automatically after write or edit activity on migration, schema, and SQL files.
-  - Invokes local migration status commands: knex migrate:status for Node.js projects and python manage.py showmigrations for Django projects.
+  - Invokes knex migrate:status for Knex projects and python manage.py showmigrations for Django projects when the respective framework CLI is available.
   - Scans raw SQL for destructive statements and reports warnings but does not apply migrations itself.
 privacyNotes:
   - Reads migration, schema, SQL, package, and framework configuration files to infer migration state.


### PR DESCRIPTION
Resubmission of #2551 (closed: safetyNotes YAML validation failure).

**Root cause of #2551 failure:** One `safetyNotes` item contained `commands: knex` — a
colon-space pattern that YAML interprets as a key-value mapping instead of a plain string.
The CI validator saw the element as a non-string and rejected it.

**Fix:** Reworded the safetyNote to remove the colon-space pattern
(`Invokes knex migrate:status for Knex projects and python manage.py showmigrations...`).

**Scope change (from #2542):**
- Narrowed from 5 frameworks to Knex + Django only — gate previously only substantiated Knex
- Added `https://docs.djangoproject.com/en/5.0/ref/django-admin/#showmigrations` as a targeted
  source that puts the `showmigrations` command near the top of the fetched content
- Rewrote description, features, requirements, and troubleshooting to Knex + Django only

Refs #2542, #2551