### PR TITLE
content(skills): add Claude Code Communications Kit Capability Pack

### DIFF
--- a/content/skills/claude-code-communications-kit-capability-pack.mdx
+++ b/content/skills/claude-code-communications-kit-capability-pack.mdx
@@ -1,0 +1,221 @@
+---
+title: Claude Code Communications Kit Capability Pack Skill
+slug: claude-code-communications-kit-capability-pack
+category: skills
+description: >-
+  Expert Claude Code communications kit capability pack for planning internal
+  launch campaigns, message calendars, manager talking points, and FAQ updates
+  aligned to official communications kit documentation.
+cardDescription: >-
+  Plan Claude Code launch communications using the communications kit with message
+  calendars, talking points, and FAQ update checklists.
+seoTitle: Claude Code Communications Kit Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack for Claude Code communications kit campaigns:
+  pre-launch teasers, go-live instructions, manager talking points, and FAQ updates
+  aligned to official docs.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-15"
+submittedAt: "2026-06-15"
+sourceSubmissionNumber: 1548
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1548"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://github.com/anthropics/claude-code"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when planning an internal Claude Code launch campaign with the
+  communications kit templates, timelines, and stakeholder messaging.
+copySnippet: |-
+  # Trigger
+  "Apply the Claude Code communications kit capability pack for this launch campaign."
+
+  # Required output
+  1) Campaign scope and audience map
+  2) Message calendar with owners and channels
+  3) Manager talking points and FAQ draft
+  4) Champion kit alignment notes
+  5) Privacy-safe launch summary for leadership
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-15"
+retrievalSources:
+  - "https://code.claude.com/docs/en/communications-kit"
+  - "https://code.claude.com/docs/en/champion-kit"
+  - "https://code.claude.com/docs/en/admin-setup"
+  - "https://code.claude.com/docs/en/security"
+  - "https://code.claude.com/docs/en/zero-data-retention"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude
+  - Claude Code
+  - Codex
+  - Cursor
+  - Windsurf
+  - Generic AGENTS
+prerequisites:
+  - "Access to Claude Code communications kit templates and approved org brand or voice guidelines."
+  - "Named launch owner, champion contacts, and target audience segments (engineering, managers, security)."
+  - "Admin clarity on plan features, ZDR status, and approved plugin or MCP policies for accurate FAQ answers."
+  - "Launch timeline coordinated with champion kit rollout and admin enablement steps."
+safetyNotes:
+  - "This skill plans communications; it must not enable Claude Code org settings or install apps without admin approval."
+  - "Avoid productivity guarantees or compensation claims in launch messaging; stick to documented capabilities."
+  - "Do not share embargoed security findings or unreleased product details in pre-launch teasers."
+  - "Manager talking points should not pressure individual leaderboard rankings without HR alignment."
+privacyNotes:
+  - "Launch plans may reference internal team names, adoption targets, and security exceptions; redact for external audiences."
+  - "FAQ drafts can expose ZDR limitations, proxy requirements, and data handling policies sensitive outside the org."
+  - "Communications calendars may include executive quotes or customer examples requiring approval before send."
+  - "Analytics mentions in launch copy should avoid naming individual contributors unless policy allows."
+tags:
+  - claude-code
+  - communications
+  - launch
+  - enablement
+  - capability-pack
+keywords:
+  - Claude Code communications kit capability pack
+  - Claude Code launch campaign planning
+  - internal Claude Code rollout messaging
+  - Claude Code manager talking points
+  - Claude Code FAQ launch communications
+readingTime: 9
+difficultyScore: 76
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+This capability pack is grounded in Claude Code communications kit, champion kit,
+admin setup, security, and zero data retention documentation verified on
+**2026-06-15**. Template assets and policy constraints can change; prefer live
+official docs over cached assumptions.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/communications-kit
+- https://code.claude.com/docs/en/champion-kit
+- https://code.claude.com/docs/en/admin-setup
+- https://code.claude.com/docs/en/security
+- https://code.claude.com/docs/en/zero-data-retention
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified against public Claude Code communications and rollout docs on **2026-06-15**:
+
+- Communications kit docs provide launch templates, message sequencing, and FAQ
+  patterns for internal Claude Code campaigns.
+- Champion kit materials define advocate roles that communications campaigns should
+  reference for support routing and office hours.
+- Admin setup and ZDR docs supply accurate constraints for FAQ answers about analytics,
+  GitHub metrics, and data handling.
+
+## Scope Note
+
+This pack operationalizes the communications kit as a reusable Skill workflow. It
+complements the `communications-kit-for-claude-code-launch-campaigns` guide with
+checklist steps, review matrix, and output contract.
+
+## Core Workflow
+
+1. Define campaign scope, audiences, launch date, and success signals.
+2. Import and customize communications kit templates with org names and links.
+3. Build a message calendar across pre-launch, go-live, and post-launch windows.
+4. Draft manager talking points and FAQ updates aligned to admin and ZDR policy.
+5. Coordinate timing with champion kit activities and admin enablement milestones.
+6. Review security, privacy, and HR-sensitive wording with stakeholders.
+7. Deliver privacy-safe leadership summary and channel-ready message drafts.
+
+## Capability Scope
+
+- Launch audience and channel planning.
+- Message calendar and owner assignment.
+- Manager talking points and FAQ drafting.
+- Champion kit alignment checks.
+- Privacy-safe leadership summary output.
+
+## Compatibility
+
+### Native
+
+- **Claude Code / Claude**: use as an Agent Skill when planning internal Claude Code
+  launch communications with platform or enablement teams.
+
+### Manual Adaptation
+
+- **Codex, Cursor, Windsurf, Generic AGENTS**: apply the checklist using public
+  communications kit documentation for any enterprise rollout.
+
+## Required Inputs
+
+- Communications kit template access and brand guidelines.
+- Launch timeline, audiences, and champion roster.
+- Admin answers on plan features, ZDR, plugins, and MCP policy.
+- Approved internal links and support escalation paths.
+
+## Production Rules
+
+- Customize templates; do not ship generic vendor copy unchanged.
+- Align FAQ answers with current admin setup and security docs.
+- Pair go-live messages with concrete getting-started steps and support contacts.
+- Avoid individual performance comparisons unless HR approves wording.
+- Keep embargoed roadmap items out of pre-launch teasers.
+- Document message owners and rollback plan for incorrect sends.
+
+## Review Matrix
+
+| Topic | Signal | Action |
+| --- | --- | --- |
+| FAQ | ZDR org mentioned GitHub metrics | Correct to usage-only analytics per docs |
+| Timeline | Go-live before admin setup | Resequence messages after enablement |
+| Voice | Productivity guarantee language | Rewrite to capability-focused copy |
+| Champions | No support path in emails | Add champion office hours and links |
+| Security | Vague data handling claims | Cite official security and ZDR docs |
+| Privacy | Customer names in examples | Remove or anonymize before send |
+
+## Output Contract
+
+1. Campaign scope and audience map.
+2. Message calendar with owners and channels.
+3. Manager talking points and FAQ draft.
+4. Champion kit alignment notes.
+5. Privacy-safe leadership launch summary.
+
+## Troubleshooting
+
+**Issue:** Template links point to generic Anthropic pages
+**Fix:** Replace with org-specific admin docs, internal wiki, and support routes.
+
+**Issue:** Managers ask for ROI numbers not yet available
+**Fix:** Reference analytics adoption timeline; avoid inventing metrics.
+
+**Issue:** Security blocks mention of GitHub app
+**Fix:** Align FAQ with approved integration list and ZDR constraints.
+
+**Issue:** Launch email volume overwhelms champions
+**Fix:** Stagger segments and add self-serve links from communications kit assets.
+
+## Duplicate Check
+
+Checked `content/skills/`, `content/guides/`, open PRs, and the live catalog.
+`communications-kit-for-claude-code-launch-campaigns` exists as a guide. No `skills`
+entry provides this communications kit capability pack with review matrix and
+output contract.
+
+## Editorial Disclosure
+
+Submitted as an independent source-backed HeyClaude content entry by `kiannidev`.
+It is based on public Claude Code documentation and the public Anthropic `claude-code`
+repository. No paid placement, referral link, affiliate link, or vendor sponsorship is used.


### PR DESCRIPTION
Closes #1548

## Summary
Adds one source-backed Skills capability pack for planning internal Claude Code launch communications using the communications kit templates, message calendar, and FAQ updates.

## Duplicate check
Distinct from `communications-kit-for-claude-code-launch-campaigns` guide; no skills entry provides this capability pack workflow.

## URL preflight
- `repoUrl` https://github.com/anthropics/claude-code → HTTP 200
- `documentationUrl` https://github.com/anthropics/claude-code → HTTP 200
- `downloadUrl` https://github.com/anthropics/claude-code/archive/refs/heads/main.zip → HTTP 200

## Validation
- `node scripts/validate-content.mjs --strict-recommended --category skills`

## Test plan
- [x] Single-file PR only
- [x] Source URLs verified reachable before PR creation
- [x] Local content validation passed

Made with [Cursor](https://cursor.com)