### PR TITLE
content(skills): add Claude Code Champion Kit Rollout Capability Pack

### DIFF
--- a/content/skills/claude-code-champion-kit-rollout-capability-pack.mdx
+++ b/content/skills/claude-code-champion-kit-rollout-capability-pack.mdx
@@ -1,0 +1,219 @@
+---
+title: Claude Code Champion Kit Rollout Capability Pack Skill
+slug: claude-code-champion-kit-rollout-capability-pack
+category: skills
+description: >-
+  Expert Claude Code champion kit rollout capability pack for selecting advocates,
+  localizing kit assets, running enablement sessions, and measuring adoption with
+  source-backed rollout checklists aligned to official champion kit docs.
+cardDescription: >-
+  Roll out the Claude Code champion kit with advocate selection, localized assets,
+  enablement sessions, and adoption measurement checklists.
+seoTitle: Claude Code Champion Kit Rollout Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack for Claude Code champion kit rollout: advocate
+  selection, program structure, enablement sessions, communications alignment, and
+  adoption measurement aligned to official docs.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-15"
+submittedAt: "2026-06-15"
+sourceSubmissionNumber: 1547
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1547"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://github.com/anthropics/claude-code"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when rolling out the Claude Code champion kit to select advocates,
+  localize assets, run enablement, and measure internal adoption responsibly.
+copySnippet: |-
+  # Trigger
+  "Apply the Claude Code champion kit rollout capability pack for this adoption program."
+
+  # Required output
+  1) Champion selection criteria and roster draft
+  2) Localized kit asset inventory and gaps
+  3) Enablement session plan with exercises
+  4) Communications kit alignment checklist
+  5) Privacy-safe adoption measurement plan
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-15"
+retrievalSources:
+  - "https://code.claude.com/docs/en/champion-kit"
+  - "https://code.claude.com/docs/en/communications-kit"
+  - "https://code.claude.com/docs/en/analytics"
+  - "https://code.claude.com/docs/en/admin-setup"
+  - "https://code.claude.com/docs/en/security"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude
+  - Claude Code
+  - Codex
+  - Cursor
+  - Windsurf
+  - Generic AGENTS
+prerequisites:
+  - "Access to champion kit slides, FAQs, exercises, and communication templates."
+  - "Executive sponsor and admin owner for Claude Code enablement and policy questions."
+  - "Candidate champions across teams with time allocated for office hours and feedback loops."
+  - "Analytics or admin access appropriate to the org plan for adoption measurement."
+safetyNotes:
+  - "This skill plans champion programs; it must not change admin settings or install integrations without owner approval."
+  - "Champion programs can create informal performance pressure; align incentives and messaging with HR policy."
+  - "Do not task champions with bypassing security, MCP, or managed policy controls."
+  - "Pilot exercises should use non-production repos unless explicitly approved."
+privacyNotes:
+  - "Champion rosters and adoption metrics can expose team structure and individual usage patterns."
+  - "Office hours notes may contain unreleased product feedback and internal project details."
+  - "Analytics dashboards differ by plan; avoid sharing per-user stats broadly without admin approval."
+  - "Localized kit assets may include internal wiki links that should not leave the organization."
+tags:
+  - claude-code
+  - champion-kit
+  - enablement
+  - adoption
+  - capability-pack
+keywords:
+  - Claude Code champion kit rollout capability pack
+  - Claude Code internal adoption program
+  - Claude Code champion selection checklist
+  - Claude Code enablement session plan
+  - Claude Code advocate rollout workflow
+readingTime: 9
+difficultyScore: 77
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+This capability pack is grounded in Claude Code champion kit, communications kit,
+analytics, admin setup, and security documentation verified on **2026-06-15**.
+Kit assets and analytics surfaces evolve; prefer live official docs over cached assumptions.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/champion-kit
+- https://code.claude.com/docs/en/communications-kit
+- https://code.claude.com/docs/en/analytics
+- https://code.claude.com/docs/en/admin-setup
+- https://code.claude.com/docs/en/security
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified against public Claude Code champion and rollout docs on **2026-06-15**:
+
+- Champion kit docs define advocate responsibilities, exercises, FAQs, and program
+  structure for internal Claude Code adoption.
+- Communications kit materials pair with champion timing for launch and sustainment waves.
+- Analytics and admin setup docs clarify which adoption signals are available by plan,
+  including ZDR limitations on GitHub contribution metrics.
+
+## Scope Note
+
+This pack operationalizes champion kit rollout as a reusable Skill workflow. It
+complements the `champion-kit-rollout-for-internal-claude-code-adoption` guide with
+checklist steps, review matrix, and output contract.
+
+## Core Workflow
+
+1. Confirm executive sponsor, admin owner, and rollout goals.
+2. Select champions using cross-team coverage, communication skills, and time availability.
+3. Inventory and localize champion kit slides, FAQs, and exercises.
+4. Plan enablement sessions, office hours, and feedback channels.
+5. Align message timing with communications kit campaigns and admin milestones.
+6. Define adoption metrics appropriate to the org plan and privacy policy.
+7. Deliver privacy-safe program summary with owners and review cadence.
+
+## Capability Scope
+
+- Champion selection and roster planning.
+- Kit asset localization and gap tracking.
+- Enablement session and office hours design.
+- Communications kit alignment checks.
+- Privacy-safe adoption measurement planning.
+
+## Compatibility
+
+### Native
+
+- **Claude Code / Claude**: use as an Agent Skill when standing up or refreshing an
+  internal Claude Code champion program.
+
+### Manual Adaptation
+
+- **Codex, Cursor, Windsurf, Generic AGENTS**: apply the rollout checklist using public
+  champion kit documentation for enterprise enablement teams.
+
+## Required Inputs
+
+- Champion kit asset access and localization requirements.
+- Sponsor, admin owner, and candidate champion list.
+- Org plan details affecting analytics and GitHub metrics availability.
+- Communications calendar and launch milestones.
+
+## Production Rules
+
+- Select champions for coverage and judgment, not only highest usage scores.
+- Localize examples to approved internal repos and policies.
+- Pair champion training with explicit escalation paths to admins and security.
+- Measure adoption with plan-appropriate metrics; avoid punitive leaderboard use.
+- Refresh kit assets when Claude Code releases change core workflows.
+- Document program retrospectives without naming individuals in public summaries.
+
+## Review Matrix
+
+| Topic | Signal | Action |
+| --- | --- | --- |
+| Roster | Single-team champions only | Recruit cross-functional advocates |
+| Assets | Generic vendor slides only | Localize exercises and internal links |
+| Enablement | No hands-on exercises | Add kit exercises with approved repos |
+| Comms | Launch emails without champions | Align calendar with communications kit |
+| Metrics | ZDR org tracking GitHub metrics | Switch to usage analytics per docs |
+| Privacy | Public leaderboard planned | Replace with team-level trends |
+
+## Output Contract
+
+1. Champion selection criteria and roster draft.
+2. Localized asset inventory and gaps.
+3. Enablement session and office hours plan.
+4. Communications alignment checklist status.
+5. Privacy-safe adoption measurement plan.
+
+## Troubleshooting
+
+**Issue:** Champions burn out answering repeat questions
+**Fix:** Publish FAQ updates from kit materials and rotate office hour topics.
+
+**Issue:** Low attendance at enablement sessions
+**Fix:** Schedule with team leads, record sessions, and tie exercises to real tickets.
+
+**Issue:** Analytics unavailable for desired KPI
+**Fix:** Map goals to plan-supported metrics in analytics docs; avoid proxy scores.
+
+**Issue:** Security blocks champion-suggested plugins
+**Fix:** Maintain approved plugin list and route exceptions through admin review.
+
+## Duplicate Check
+
+Checked `content/skills/`, `content/guides/`, open PRs, and the live catalog.
+`champion-kit-rollout-for-internal-claude-code-adoption` exists as a guide. No `skills`
+entry provides this champion kit rollout capability pack with review matrix and
+output contract.
+
+## Editorial Disclosure
+
+Submitted as an independent source-backed HeyClaude content entry by `kiannidev`.
+It is based on public Claude Code documentation and the public Anthropic `claude-code`
+repository. No paid placement, referral link, affiliate link, or vendor sponsorship is used.


### PR DESCRIPTION
Closes #1547

## Summary
Adds one source-backed Skills capability pack for rolling out the Claude Code champion kit with advocate selection, localized assets, enablement sessions, and adoption measurement.

## Duplicate check
Distinct from `champion-kit-rollout-for-internal-claude-code-adoption` guide; no skills entry provides this capability pack workflow.

## URL preflight
- `repoUrl` https://github.com/anthropics/claude-code → HTTP 200
- `documentationUrl` https://github.com/anthropics/claude-code → HTTP 200
- `downloadUrl` https://github.com/anthropics/claude-code/archive/refs/heads/main.zip → HTTP 200

## Validation
- `node scripts/validate-content.mjs --strict-recommended --category skills`

## Test plan
- [x] Single-file PR only
- [x] Source URLs verified reachable before PR creation
- [x] Local content validation passed

Made with [Cursor](https://cursor.com)