### PR TITLE
content(skills): add Claude Code Dynamic Workflows Capability Pack

### DIFF
--- a/content/skills/claude-code-dynamic-workflows-capability-pack.mdx
+++ b/content/skills/claude-code-dynamic-workflows-capability-pack.mdx
@@ -1,0 +1,219 @@
+---
+title: Claude Code dynamic workflows Capability Pack Skill
+slug: claude-code-dynamic-workflows-capability-pack
+category: skills
+description: >-
+  Expert Claude Code dynamic workflows capability pack for designing, reviewing, and rolling out dynamic workflows with source-backed checklists, production rules, and privacy-safe output contracts.
+cardDescription: >-
+  Review and operationalize dynamic workflows with source-backed Claude Code checklists.
+seoTitle: Claude Code dynamic workflows Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack for dynamic workflows: workflow steps, review matrix, troubleshooting, and rollout notes aligned to official Claude Code documentation.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-14"
+submittedAt: "2026-06-14"
+sourceSubmissionNumber: 1517
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1517"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://github.com/anthropics/claude-code"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when planning or hardening dynamic workflows in Claude Code, Agent SDK, or MCP integrations.
+copySnippet: |-
+  # Trigger
+  "Apply the Claude Code dynamic workflows capability pack for this environment."
+  
+  # Required output
+  1) dynamic workflows scope and current configuration summary
+  2) Risk and policy findings with severity
+  3) Review matrix actions and owners
+  4) Staging verification and rollback plan
+  5) Privacy-safe rollout notes for stakeholders
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-14"
+retrievalSources:
+  - "https://code.claude.com/docs/en/workflows"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/hooks"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude
+  - Claude Code
+  - Codex
+  - Cursor
+  - Windsurf
+  - Generic AGENTS
+prerequisites:
+  - "Access to Claude Code or Agent SDK environment where dynamic workflows will run."
+  - "Ability to read project, user, and managed settings relevant to the workflow."
+  - "Staging repository or sandbox account for safe validation."
+  - "Platform or security stakeholder available for policy-bound rollouts."
+safetyNotes:
+  - "This skill plans dynamic workflows; it must not execute destructive changes without explicit approval."
+  - "Browser, computer-use, and remote surfaces can access sensitive UI state; scope tests carefully."
+  - "MCP and SDK integrations may exfiltrate data if tool scopes are too broad."
+  - "The public `anthropics/claude-code` repository ships documentation links to code.claude.com for settings, security, and integration surfaces."
+  - "Scheduled or autonomous workflows compound risk; cap blast radius in staging first."
+privacyNotes:
+  - "Reviews may expose integration tokens, customer metadata, and internal URLs related to dynamic workflows."
+  - "Telemetry and analytics configs can include account emails; redact before sharing externally."
+  - "Keep troubleshooting logs in internal channels unless explicitly sanitized."
+  - "Third-party vendors remain outside Anthropic retention policies; document separately."
+tags:
+  - claude-code
+  - workflows
+  - automation
+  - orchestration
+  - capability-pack
+keywords:
+  - "Claude Code dynamic workflows capability pack"
+  - "Claude Code dynamic workflows"
+  - "dynamic workflows review checklist"
+  - "dynamic workflows production rules"
+  - "Claude Code dynamic workflows rollout"
+  - "dynamic workflows troubleshooting"
+readingTime: 9
+difficultyScore: 81
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: true
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+This capability pack is grounded in Claude Code workflows, skills, sub-agents, and hooks documentation
+verified on **2026-06-14**. Product behavior and integration defaults can change with
+releases; prefer live official docs and changelog notes over cached assumptions.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/workflows
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/sub-agents
+- https://code.claude.com/docs/en/hooks
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified against official Claude Code documentation, README, CHANGELOG, and plugins
+README on **2026-06-14**:
+
+- Official docs for dynamic workflows are published on code.claude.com with settings and security cross-links.
+- README describes Claude Code as an agentic coding tool in your terminal that understands your codebase and handles git workflows alongside routine development tasks.
+- Plugins README documents official Claude Code plugins bundling skills, hooks, and MCP servers for repeatable team workflows.
+- Agent Skills documentation describes progressive disclosure so capability packs can load instructions without bloating every session context window.
+- CHANGELOG 2.1.176 fixed Linux sandbox startup when `.claude/settings.json` is a symlink with an absolute target and corrected /cd and worktree moves reporting stale git branches.
+
+## Scope Note
+
+This is not vendor professional services. Use it as a reusable review workflow for dynamic workflows on Claude Code and related Agent SDK surfaces.
+
+## Core Workflow
+
+1. Confirm prerequisites, account plan, and Claude Code or SDK version for dynamic workflows.
+2. Inventory configuration files, integrations, and managed policy layers.
+3. Map data flows, credentials, and logging for the workflow.
+4. Compare official defaults with team overrides and document drift.
+5. Run a staged validation with realistic tasks and capture failures.
+6. Review security, privacy, and compliance constraints with stakeholders.
+7. Define production rules and escalation paths for autonomous runs.
+8. Produce review matrix outcomes with explicit owners and dates.
+9. Deliver privacy-safe summary suitable for platform or security review.
+
+## Capability Scope
+
+- dynamic workflows scope definition.
+- Configuration and policy review.
+- Security and privacy boundary checks.
+- Staging validation checklist.
+- Rollout and rollback planning.
+- Privacy-safe stakeholder summary.
+
+## Compatibility
+
+### Native
+
+- **Claude Code / Claude**: use as an Agent Skill when preparing dynamic workflows
+  workflows, rollout checklists, or team enablement docs.
+
+### Manual Adaptation
+
+- **Codex, Cursor, Windsurf, and Generic AGENTS workflows**: use the workflow as a
+  deterministic checklist for dynamic workflows evaluations on Claude Code projects.
+
+## Required Inputs
+
+- Target repository or organization context and Claude Code version or channel.
+- Current configuration files, integration endpoints, and policy constraints.
+- Stakeholders for security, platform, or compliance review when applicable.
+- Known dependencies, secrets handling rules, and rollback expectations.
+
+## Production Rules
+
+- Do not paste secrets, tokens, or customer PII into public skill outputs.
+- Treat managed and enterprise policy as authoritative over local overrides.
+- Require human approval before destructive automation in production repos.
+- Keep third-party MCP and observability stacks in separate risk reviews.
+- Redact internal hostnames, account IDs, and contract details in public summaries.
+- Prefer official documentation and changelog notes over forum assumptions.
+- Document rollback steps before enabling autonomous or scheduled workflows.
+
+## Review Matrix
+
+| Topic | Signal | Action |
+| --- | --- | --- |
+| Defaults vs overrides | Config drift | Align to managed policy |
+| Secrets handling | Env and tokens | Use least-privilege scopes |
+| Autonomous runs | Hooks and agents | Add approval gates |
+| Logging | Telemetry volume | Sample and redact fields |
+| Integrations | Third-party MCP | Vendor-specific review |
+| Rollout | Staging proof | Gate production enablement |
+
+## Output Contract
+
+1. Scope and configuration summary.
+2. Findings with severity and owners.
+3. Review matrix with actions.
+4. Verification and rollback plan.
+5. Stakeholder-ready privacy-safe summary.
+6. Follow-up tasks for integrations and policy.
+
+## Troubleshooting
+
+**Issue:** Official docs disagree with local behavior
+**Fix:** Check Claude Code version and changelog; reproduce on a clean staging project.
+
+**Issue:** Managed policy blocks intended workflow
+**Fix:** Escalate policy change or redesign workflow to approved surfaces.
+
+**Issue:** Integration auth fails intermittently
+**Fix:** Refresh OAuth tokens, clock skew, and redirect URLs per MCP or SDK docs.
+
+**Issue:** Autonomous run caused unexpected edits
+**Fix:** Narrow tool allowlists, add hooks, and require human approval for writes.
+
+## Duplicate Check
+
+Checked `content/skills`, `content/guides`, generated catalog text, and open pull
+requests for Claude Code dynamic workflows, dynamic workflows, and Claude Code capability pack workflows. Official docs describe the feature directly, but
+no `skills` entry provides a reusable capability pack with review matrix and output
+contract for this workflow.
+
+## Editorial Disclosure
+
+Submitted as an independent source-backed HeyClaude content entry by `kiannidev`.
+It is based on public Claude Code documentation, the public Anthropic `claude-code`
+repository, and Google Search Central helpful-content guidance. No paid placement,
+referral link, affiliate link, or vendor sponsorship is used.
+


### PR DESCRIPTION
Closes #1517

## Summary
Adds one source-backed Skills capability pack for Claude Code Dynamic Workflows Capability Pack.

## URL preflight
- `repoUrl` https://github.com/anthropics/claude-code → HTTP 200
- `documentationUrl` https://github.com/anthropics/claude-code → HTTP 200
- `downloadUrl` https://github.com/anthropics/claude-code/archive/refs/heads/main.zip → HTTP 200

## Validation
- `node scripts/validate-content.mjs --strict-recommended --category skills`

## Test plan
- [x] Single-file PR only
- [x] Source URLs verified reachable before PR creation
- [x] Local content validation passed

Made with [Cursor](https://cursor.com)