### PR TITLE
fix(content): diversify SEO copy for dotnet-csharp-expert rules entry

### DIFF
--- a/content/rules/dotnet-csharp-expert.mdx
+++ b/content/rules/dotnet-csharp-expert.mdx
@@ -3,17 +3,17 @@ title: .NET and C# Expert - CLAUDE.md Rules for Claude Code
 slug: dotnet-csharp-expert
 category: rules
 description: >-
-  Transform Claude into a .NET and C# specialist with deep knowledge of
-  ASP.NET Core, Entity Framework Core, minimal APIs, async/await patterns,
-  and testing with xUnit and Testcontainers.
+  A CLAUDE.md rule set that turns Claude into a senior .NET reviewer aligned
+  with current Microsoft guidance across ASP.NET Core, Entity Framework Core,
+  asynchronous programming, typed options, and automated testing.
 cardDescription: >-
-  Transform Claude into a .NET and C# specialist covering ASP.NET Core,
-  Entity Framework Core, minimal APIs, async/await, and xUnit testing.
-seoTitle: .NET and C# Expert - CLAUDE.md Rules for Claude Code
+  Reviews C# idioms, Minimal API pipeline order, EF Core include and
+  no-tracking queries, deadlock-free await, and Testcontainers integration
+  suites.
+seoTitle: .NET & C# Code Review Rules for Claude Code
 seoDescription: >-
-  Rules to transform Claude into a .NET and C# expert covering ASP.NET Core
-  minimal APIs, Entity Framework Core, async patterns, configuration with
-  IOptions, and xUnit integration testing with Testcontainers.
+  Configure Claude to enforce IOptions binding, CancellationToken propagation,
+  policy-based authorization, and xUnit WebApplicationFactory tests for .NET.
 author: jaso0n0818
 authorProfileUrl: "https://github.com/jaso0n0818"
 submittedBy: jaso0n0818


### PR DESCRIPTION
## What

Diversifies the SEO copy for the `dotnet-csharp-expert` rules entry to clear the registry uniqueness floor. The entry was flagged by `report:thin-content` with a unique-word ratio of **0.40** (threshold is 0.42) because `description`, `cardDescription`, and `seoDescription` all opened with "Transform Claude into a .NET and C# specialist/expert" and repeated the same technology list, and `seoTitle` was byte-identical to `title`.

## Changes

Frontmatter SEO fields only — one file, no body or grounding changes:

- **`description`** — reframed to lead with the rule set's purpose (senior .NET reviewer aligned with current Microsoft guidance).
- **`cardDescription`** — now describes concrete review behavior (C# idioms, Minimal API pipeline order, EF Core include/no-tracking queries, deadlock-free await, Testcontainers suites).
- **`seoTitle`** — now distinct from `title` (".NET & C# Code Review Rules for Claude Code").
- **`seoDescription`** — rewritten with long-tail, distinct keywords (IOptions binding, CancellationToken propagation, policy-based authorization, xUnit WebApplicationFactory). Length is 152 chars, inside the 120–160 window so it renders clean (no boilerplate suffix, no truncation `…`).

`documentationUrl`, `sourceUrls`, `author`, dates, `copySnippet`, and the body are unchanged.

## Grounding

Every claim in the new copy maps to a line in the existing `copySnippet`, which is itself grounded in the entry's live sources:

- `documentationUrl`: https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-9/overview → 200
- ASP.NET Core, EF Core, C# async, ASP.NET security, .NET testing docs (`sourceUrls`) → all 200

## Validation

- `pnpm validate:content:strict` → passed (1010 files)
- `report:thin-content` → unique-word ratio **0.40 → 0.76**; entry removed from the flagged list (51 → 50)
- `git diff --check` → clean

Refs the low-uniqueness content backlog.
