### PR TITLE
fix(content): diversify SEO copy and add sources for api-first-development-architect rule

### DIFF
--- a/content/rules/api-first-development-architect.mdx
+++ b/content/rules/api-first-development-architect.mdx
@@ -3,21 +3,26 @@ title: API First Dev Expert - CLAUDE.md Rules for Claude Code
 slug: api-first-development-architect
 category: rules
 description: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and
-  contract-driven development for scalable backend architectures.
+  A CLAUDE.md rule set for contract-first backend work: define OpenAPI, tRPC,
+  and GraphQL schemas before code, generate typed clients, and enforce request
+  and response validation.
 cardDescription: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and...
-seoTitle: API First Dev Expert - CLAUDE.md Rules for Claude Code
+  Guides schema-first API design, URL-based versioning, generated SDK clients,
+  and Swagger UI documentation across REST, tRPC, and GraphQL services.
+seoTitle: Contract-First API Design Rules for Claude Code
 seoDescription: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and
-  contract-driven deve...
+  CLAUDE.md rules for API-first development: OpenAPI 3.1 contracts, tRPC
+  type-safe procedures, GraphQL federation, URL versioning, and generated
+  client SDKs.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://swagger.io/specification/"
+sourceUrls:
+  - "https://spec.openapis.org/oas/latest.html"
+  - "https://trpc.io/docs"
+  - "https://graphql.org/learn/"
+  - "https://www.apollographql.com/docs/federation/"
 installable: false
 usageSnippet: >-
   You are an API-first development architect specializing in OpenAPI/Swagger


### PR DESCRIPTION
## What

Clears the registry uniqueness floor for the `api-first-development-architect` rules entry (flagged by `report:thin-content` at **0.36**, threshold 0.42) and strengthens its source grounding.

## Changes

One file. Frontmatter only:

- **`description` / `cardDescription` / `seoDescription`** — rewritten so each field carries a distinct angle (purpose → review behavior → keyword-rich summary) instead of repeating the same "API-first development expert with OpenAPI/Swagger…" sentence. Removes the truncated `…` artifacts the auto-generated copy left in `cardDescription` and `seoDescription`.
- **`seoTitle`** — now distinct from `title` ("Contract-First API Design Rules for Claude Code").
- **`sourceUrls`** — added official specs/docs for every technology the rule covers, so claims about tRPC, GraphQL federation, and OpenAPI are grounded (previously only `documentationUrl` → swagger.io covered OpenAPI).

`copySnippet` body, `documentationUrl`, author, and dates are unchanged. Every claim in the new copy maps to a line in the existing `copySnippet`.

## Grounding (all 200)

- `documentationUrl`: https://swagger.io/specification/
- https://spec.openapis.org/oas/latest.html
- https://trpc.io/docs
- https://graphql.org/learn/
- https://www.apollographql.com/docs/federation/

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.36 → 0.63**
- `seoDescription` is 155 chars (inside the 120–160 window → renders clean, no boilerplate suffix or truncation)
- `git diff --check` → clean
