### PR TITLE
fix(content): diversify SEO copy and add sources for ai-prompt-engineering-expert rule

### DIFF
--- a/content/rules/ai-prompt-engineering-expert.mdx
+++ b/content/rules/ai-prompt-engineering-expert.mdx
@@ -3,21 +3,26 @@ title: AI Prompt Engineering Expert for Claude
 slug: ai-prompt-engineering-expert
 category: rules
 description: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative refinement, and
-  context management for optimal AI assistance
+  A CLAUDE.md rule set that turns Claude into a prompt-engineering reviewer for
+  coding work — enforcing explicit requirements, task decomposition,
+  example-driven prompts, and context management.
 cardDescription: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative...
-seoTitle: AI Prompt Engineering Expert for Claude
+  Coaches clear, specific coding prompts: name languages and versions,
+  decompose large tasks, supply input/output examples, and define success
+  criteria upfront.
+seoTitle: Prompt Engineering Rules for Claude Code Coding Tasks
 seoDescription: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative refinement, and
-  con...
+  CLAUDE.md rules for prompt engineering in Claude Code: write explicit coding
+  prompts, break complex tasks into steps, and manage context for reliable
+  results.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
 documentationUrl: "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview"
+sourceUrls:
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/be-clear-and-direct"
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/multishot-prompting"
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/chain-prompts"
 installable: false
 usageSnippet: >-
   You are an AI prompt engineering expert specializing in crafting effective


### PR DESCRIPTION
## What

Clears the registry uniqueness floor for the `ai-prompt-engineering-expert` rules entry (flagged by `report:thin-content` at **0.39**, threshold 0.42) and adds source grounding.

## Changes

One file. Frontmatter only:

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle instead of repeating "Expert in AI prompt engineering for Claude Code and Claude Desktop…". Removes the truncated `…` artifacts in `cardDescription` and `seoDescription`.
- **`seoTitle`** — now distinct from `title` ("Prompt Engineering Rules for Claude Code Coding Tasks").
- **`sourceUrls`** — added official Anthropic prompt-engineering docs pages that ground the rule's guidance (be clear and direct, multishot/example prompting, prompt chaining).

`copySnippet` body, `documentationUrl`, author, and dates are unchanged. Every claim maps to the existing `copySnippet`.

## Grounding (all 200)

- `documentationUrl`: https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/be-clear-and-direct
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/multishot-prompting
- https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/chain-prompts

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.39 → 0.71**
- `seoDescription` 158 chars (inside the 120–160 window → renders clean)
- `git diff --check` → clean
