### PR TITLE
fix(content): diversify SEO copy and add sources for website-crawler-summarizer skill

### DIFF
--- a/content/skills/website-crawler-summarizer.mdx
+++ b/content/skills/website-crawler-summarizer.mdx
@@ -2,10 +2,10 @@
 title: Website Crawler + Summarizer Skill
 slug: website-crawler-summarizer
 category: skills
-description: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries. Perfect for research, competitive analysis, and content aggregation."
-cardDescription: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries."
-seoTitle: Website Crawler + Summarizer Skill
-seoDescription: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries. Perfect for research, competitive analysis, and content aggr..."
+description: "A Claude skill that fetches web pages, strips boilerplate with Mozilla Readability, respects robots.txt, removes duplicate content, and turns the result into structured summaries."
+cardDescription: "Fetches and renders pages, extracts main article text with Readability, honors robots.txt, dedupes, and outputs structured summaries."
+seoTitle: Web Crawler & Content Summarizer Skill for Claude
+seoDescription: "Claude skill that crawls websites, extracts readable article text with Mozilla Readability, respects robots.txt, and generates structured page summaries."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"
@@ -31,6 +31,8 @@ verificationStatus: draft
 verifiedAt: "2025-10-15"
 retrievalSources:
   - "https://github.com/mozilla/readability"
+  - "https://playwright.dev/docs/intro"
+  - "https://www.robotstxt.org/robotstxt.html"
 testedPlatforms:
   - Claude
   - Codex


### PR DESCRIPTION
## What

Clears the registry uniqueness floor for the `website-crawler-summarizer` skill (flagged by `report:thin-content` at **0.40**, threshold 0.42) and broadens source grounding to match what the skill claims.

## Changes

One file. Frontmatter only:

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle instead of repeating "Crawl domains respectfully, extract readable content, dedupe…". Removes the truncated `…` artifact in `seoDescription`.
- **`seoTitle`** — now distinct from `title` ("Web Crawler & Content Summarizer Skill for Claude").
- **`retrievalSources`** — added Playwright (page rendering) and the robots.txt spec so the skill's crawling and robots.txt claims are grounded, not just the Mozilla Readability extraction shown in `copySnippet`.

`copySnippet`, `installCommand`/`downloadUrl`, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

- `documentationUrl` / `repoUrl`: https://github.com/mozilla/readability
- https://playwright.dev/docs/intro
- https://www.robotstxt.org/robotstxt.html

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.40 → 0.57**
- `seoDescription` 153 chars (inside the 120–160 window → renders clean)
- `git diff --check` → clean
