### PR TITLE
fix(content): diversify SEO copy and add sources for cache-efficiency-monitor statusline

### DIFF
--- a/content/statuslines/cache-efficiency-monitor.mdx
+++ b/content/statuslines/cache-efficiency-monitor.mdx
@@ -3,21 +3,24 @@ title: Cache Efficiency Monitor - Statuslines
 slug: cache-efficiency-monitor
 category: statuslines
 description: >-
-  Claude Code prompt caching efficiency monitor tracking cache hits, write
-  efficiency, and cost savings with visual hit rate indicators and optimization
-  recommendations.
+  A Claude Code statusline that reads prompt-cache token metrics from session
+  JSON and renders a color-coded hit-rate bar with an estimated token-savings
+  readout.
 cardDescription: >-
-  Claude Code prompt caching efficiency monitor tracking cache hits, write
-  efficiency, and cost savings with visual hit rate indicators and...
-seoTitle: Cache Efficiency Monitor - Statuslines
+  Shows cache hit rate as a 20-char bar, flags low-reuse sessions, and
+  estimates tokens saved from cache reads — refreshed every two seconds.
+seoTitle: Prompt Cache Hit-Rate Statusline for Claude Code
 seoDescription: >-
-  Claude Code prompt caching efficiency monitor tracking cache hits, write
-  efficiency, and cost savings with visual hit rate indicators and optimization
-  recomm...
+  Claude Code statusline that tracks prompt-cache hit rate, write efficiency,
+  and estimated token savings from session cost metrics, with color-coded
+  status.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-caching"
 installable: true
 usageSnippet: "✓ Cache: ████████████░░░░░░░░ 60% | \U0001F4B0 ~4,500 tok saved"
 copySnippet: |-


### PR DESCRIPTION
## What

Clears the registry uniqueness floor for the `cache-efficiency-monitor` statusline (flagged by `report:thin-content` at **0.37**, threshold 0.42) and adds source grounding.

## Changes

One file. Frontmatter only:

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle instead of repeating "Claude Code prompt caching efficiency monitor tracking cache hits, write efficiency, and cost savings…". Removes the truncated `…` artifacts in `cardDescription` and `seoDescription`.
- **`seoTitle`** — now distinct from `title` ("Prompt Cache Hit-Rate Statusline for Claude Code").
- **`retrievalSources`** — added the Claude Code statusline docs (the JSON stdin / `cost.*` fields the script reads) and the prompt-caching docs (the cache-read cost model the savings estimate is based on).

Every claim maps to the existing `scriptBody`: it reads `cost.cache_read_input_tokens` / `cost.cache_creation_input_tokens` from session JSON, renders a 20-char hit-rate bar, color-codes by hit rate, estimates tokens saved, and refreshes every 2000 ms. `scriptBody`, `copySnippet`, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

- `documentationUrl`: https://code.claude.com/docs/en/statusline
- https://platform.claude.com/docs/en/build-with-claude/prompt-caching

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.37 → 0.60**
- `seoDescription` 154 chars (inside the 120–160 window → renders clean)
- `git diff --check` → clean
