### PR TITLE
fix(content): SEO, sources, and safety/privacy notes for api-first-development-architect rule

### DIFF
--- a/content/rules/api-first-development-architect.mdx
+++ b/content/rules/api-first-development-architect.mdx
@@ -3,22 +3,33 @@ title: API First Dev Expert - CLAUDE.md Rules for Claude Code
 slug: api-first-development-architect
 category: rules
 description: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and
-  contract-driven development for scalable backend architectures.
+  A CLAUDE.md rule set for contract-first backend work: define OpenAPI, tRPC,
+  and GraphQL schemas before code, generate typed clients, and enforce request
+  and response validation.
 cardDescription: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and...
-seoTitle: API First Dev Expert - CLAUDE.md Rules for Claude Code
+  Guides schema-first API design, URL-based versioning, generated SDK clients,
+  and Swagger UI documentation across REST, tRPC, and GraphQL services.
+seoTitle: Contract-First API Design Rules for Claude Code
 seoDescription: >-
-  API-first development expert with OpenAPI/Swagger schema design, tRPC
-  type-safe procedures, REST best practices, GraphQL federation, and
-  contract-driven deve...
+  CLAUDE.md rules for API-first development: OpenAPI 3.1 contracts, tRPC
+  type-safe procedures, GraphQL federation, URL versioning, and generated
+  client SDKs.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://swagger.io/specification/"
+sourceUrls:
+  - "https://spec.openapis.org/oas/latest.html"
+  - "https://trpc.io/docs"
+  - "https://graphql.org/learn/"
+  - "https://www.apollographql.com/docs/federation/"
 installable: false
+safetyNotes:
+  - "This rule is prompt guidance, not executable code, but it directs Claude to design REST, tRPC, and GraphQL endpoints that create and modify records (for example POST and PATCH handlers); review and authorize generated write operations before deploying them."
+  - "The guidance exposes public, versioned API surfaces and recommends SDK/client generation; enforce request validation and the documented middleware order so authentication runs before authorization on every generated endpoint."
+privacyNotes:
+  - "The recommended patterns authenticate with JWT, OAuth 2.0/OIDC, and bearer tokens; keep API keys, client secrets, and tokens in environment variables or a secrets manager and never commit them or paste them into OpenAPI examples."
+  - "Generated contracts can return user records such as email, role, and identifiers; apply authorization and field-level filtering so responses do not over-expose personal data."
 usageSnippet: >-
   You are an API-first development architect specializing in OpenAPI/Swagger
   schema design, tRPC type-safe procedures, REST best practices, and GraphQL


### PR DESCRIPTION
## What

Improves the `api-first-development-architect` rules entry: clears the registry uniqueness floor (`report:thin-content` **0.36 → 0.63**) **and** brings it into current policy compliance by adding the `safetyNotes` / `privacyNotes` disclosures the gate now requires for entries that describe authenticated, write-capable API surfaces.

(Supersedes #2595, which was closed for `missing_safety_notes` / `missing_privacy_notes` — editing the entry re-subjects it to the current disclosure policy.)

## Changes (one file, frontmatter only)

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle; removes the truncated `…` artifacts.
- **`seoTitle`** — now distinct from `title`.
- **`sourceUrls`** — added official specs/docs for tRPC, GraphQL, OpenAPI, and Apollo Federation (previously only swagger.io grounded OpenAPI).
- **`safetyNotes` / `privacyNotes`** — added honest disclosures grounded in the rule's own content (write/destructive endpoint generation, middleware ordering; JWT/OAuth/bearer credentials and user-record exposure).

`copySnippet` body, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

swagger.io/specification · spec.openapis.org/oas/latest.html · trpc.io/docs · graphql.org/learn · apollographql.com/docs/federation

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.36 → 0.63**
- `seoDescription` 155 chars (120–160 window)
- `git diff --check` → clean
