### PR TITLE
fix(content): SEO, sources, and safety/privacy notes for ai-prompt-engineering-expert rule

### DIFF
--- a/content/rules/ai-prompt-engineering-expert.mdx
+++ b/content/rules/ai-prompt-engineering-expert.mdx
@@ -3,22 +3,31 @@ title: AI Prompt Engineering Expert for Claude
 slug: ai-prompt-engineering-expert
 category: rules
 description: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative refinement, and
-  context management for optimal AI assistance
+  A CLAUDE.md rule set that turns Claude into a prompt-engineering reviewer for
+  coding work — enforcing explicit requirements, task decomposition,
+  example-driven prompts, and context management.
 cardDescription: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative...
-seoTitle: AI Prompt Engineering Expert for Claude
+  Coaches clear, specific coding prompts: name languages and versions,
+  decompose large tasks, supply input/output examples, and define success
+  criteria upfront.
+seoTitle: Prompt Engineering Rules for Claude Code Coding Tasks
 seoDescription: >-
-  Expert in AI prompt engineering for Claude Code and Claude Desktop, focusing
-  on coding tasks, test-driven development patterns, iterative refinement, and
-  con...
+  CLAUDE.md rules for prompt engineering in Claude Code: write explicit coding
+  prompts, break complex tasks into steps, and manage context for reliable
+  results.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
 documentationUrl: "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/overview"
+sourceUrls:
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/be-clear-and-direct"
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/multishot-prompting"
+  - "https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/chain-prompts"
 installable: false
+safetyNotes:
+  - "This rule is prompt guidance, not executable code, but its example prompts direct Claude to generate authentication and payment logic (bcrypt password hashing, JWT issuance, Stripe payments); review and test generated security- and money-handling code before using it in production."
+privacyNotes:
+  - "Example prompts reference credentials and third-party providers (JWT, Supabase auth, Stripe); keep API keys, tokens, and secrets in environment variables or a secrets manager and never paste them into prompts or commit them."
 usageSnippet: >-
   You are an AI prompt engineering expert specializing in crafting effective
   prompts for Claude Code and Claude Desktop coding assistants. Focus on


### PR DESCRIPTION
## What

Improves the `ai-prompt-engineering-expert` rules entry: clears the registry uniqueness floor (`report:thin-content` **0.39 → 0.71**) and adds the `safetyNotes` / `privacyNotes` disclosures the gate now requires (the entry's example prompts touch auth and payment flows).

(Supersedes #2596, closed for `missing_safety_notes` / `missing_privacy_notes` — editing the entry re-subjects it to the current disclosure policy.)

## Changes (one file, frontmatter only)

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle; removes the truncated `…` artifacts.
- **`seoTitle`** — now distinct from `title`.
- **`sourceUrls`** — added the official Anthropic prompt-engineering pages (be clear and direct, multishot prompting, prompt chaining) that ground the rule.
- **`safetyNotes` / `privacyNotes`** — added honest disclosures grounded in the rule's own example prompts (bcrypt/JWT/Stripe code generation; credentials and third-party providers).

`copySnippet` body, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

platform.claude.com/docs/en/build-with-claude/prompt-engineering/{overview, be-clear-and-direct, multishot-prompting, chain-prompts}

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.39 → 0.71**
- `seoDescription` 158 chars (120–160 window)
- `git diff --check` → clean
