### PR TITLE
fix(content): SEO, sources, and safety/privacy notes for website-crawler-summarizer skill

### DIFF
--- a/content/skills/website-crawler-summarizer.mdx
+++ b/content/skills/website-crawler-summarizer.mdx
@@ -2,10 +2,10 @@
 title: Website Crawler + Summarizer Skill
 slug: website-crawler-summarizer
 category: skills
-description: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries. Perfect for research, competitive analysis, and content aggregation."
-cardDescription: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries."
-seoTitle: Website Crawler + Summarizer Skill
-seoDescription: "Crawl domains respectfully, extract readable content, dedupe, and generate structured summaries. Perfect for research, competitive analysis, and content aggr..."
+description: "A Claude skill that fetches web pages, strips boilerplate with Mozilla Readability, respects robots.txt, removes duplicate content, and turns the result into structured summaries."
+cardDescription: "Fetches and renders pages, extracts main article text with Readability, honors robots.txt, dedupes, and outputs structured summaries."
+seoTitle: Web Crawler & Content Summarizer Skill for Claude
+seoDescription: "Claude skill that crawls websites, extracts readable article text with Mozilla Readability, respects robots.txt, and generates structured page summaries."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"
@@ -31,6 +31,13 @@ verificationStatus: draft
 verifiedAt: "2025-10-15"
 retrievalSources:
   - "https://github.com/mozilla/readability"
+  - "https://playwright.dev/docs/intro"
+  - "https://www.robotstxt.org/robotstxt.html"
+safetyNotes:
+  - "Executes network requests to crawl third-party websites and installs scraping libraries (Playwright, BeautifulSoup) on first use; respect robots.txt, rate limits, and each site's terms of service, and review target URLs before running."
+  - "Crawled pages are written to local files (Markdown, JSON, CSV); review output paths so the skill does not overwrite existing files."
+privacyNotes:
+  - "Fetches and stores content from external websites locally and may use site cookies or auth tokens to reach gated pages; do not crawl private or authenticated data without authorization, and keep any credentials out of saved output."
 testedPlatforms:
   - Claude
   - Codex


### PR DESCRIPTION
## What

Improves the `website-crawler-summarizer` skill: clears the registry uniqueness floor (`report:thin-content` **0.40 → 0.57**), broadens source grounding, and adds the `safetyNotes` / `privacyNotes` disclosures the gate now requires for a skill that executes network crawling, installs packages, writes local files, and may use site credentials.

(Supersedes #2597, closed for `missing_safety_notes` / `missing_privacy_notes`.)

## Changes (one file, frontmatter only)

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle; removes the truncated `…` artifact.
- **`seoTitle`** — now distinct from `title`.
- **`retrievalSources`** — added Playwright (rendering) and the robots.txt spec so the crawling and robots.txt claims are grounded, not just the Mozilla Readability extraction in `copySnippet`.
- **`safetyNotes` / `privacyNotes`** — added honest disclosures (third-party crawling, library install, local file writes; external content storage and possible cookie/token use), grounded in the skill body's own best-practices section.

`copySnippet`, `installCommand`/`downloadUrl`, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

github.com/mozilla/readability · playwright.dev/docs/intro · robotstxt.org/robotstxt.html

## Validation

- `pnpm validate:content:strict` → passed
- `report:thin-content` unique-word ratio **0.40 → 0.57**
- `seoDescription` 153 chars (120–160 window)
- `git diff --check` → clean
