### PR TITLE
fix(web): gate source repo scheduled refresh

### DIFF
--- a/apps/web/plugins/source-repo-signals-scheduled.ts
+++ b/apps/web/plugins/source-repo-signals-scheduled.ts
@@ -4,7 +4,11 @@ import { runWithCloudflareRuntime } from "@/lib/cloudflare-env.server";
 import { getDirectoryEntries } from "@/lib/content.server";
 import { refreshSourceRepoSignalsForEntries } from "@/lib/source-repo-signals.server";
 
+// 6-hourly source-repo signal refresh. Must match wrangler.jsonc exactly.
+const SOURCE_REPO_SIGNALS_CRON = "17 */6 * * *";
+
 type CloudflareScheduledPayload = {
+  controller?: { cron?: string };
   env: unknown;
   context: unknown;
 };
@@ -12,7 +16,9 @@ type CloudflareScheduledPayload = {
 export default definePlugin((nitroApp) => {
   nitroApp.hooks?.hook(
     "cloudflare:scheduled",
-    async ({ env, context }: CloudflareScheduledPayload) => {
+    async ({ controller, env, context }: CloudflareScheduledPayload) => {
+      if (controller?.cron !== SOURCE_REPO_SIGNALS_CRON) return;
+
       const request = new Request("https://heyclau.de/__scheduled/source-repo-signals");
       await runWithCloudflareRuntime(request, env, context, async () => {
         try {

--- a/tests/source-repo-signals-scheduled.test.ts
+++ b/tests/source-repo-signals-scheduled.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getDirectoryEntries: vi.fn(),
+  refreshSourceRepoSignalsForEntries: vi.fn(),
+  runWithCloudflareRuntime: vi.fn(async (_request, _env, _context, callback) =>
+    callback(),
+  ),
+}));
+
+vi.mock("nitro", () => ({
+  definePlugin: (setup: unknown) => setup,
+}));
+
+vi.mock("@/lib/cloudflare-env.server", () => ({
+  runWithCloudflareRuntime: mocks.runWithCloudflareRuntime,
+}));
+
+vi.mock("@/lib/content.server", () => ({
+  getDirectoryEntries: mocks.getDirectoryEntries,
+}));
+
+vi.mock("@/lib/source-repo-signals.server", () => ({
+  refreshSourceRepoSignalsForEntries: mocks.refreshSourceRepoSignalsForEntries,
+}));
+
+import setupSourceRepoSignalsScheduled from "../apps/web/plugins/source-repo-signals-scheduled";
+
+type ScheduledHandler = (payload: {
+  controller?: { cron?: string };
+  env: unknown;
+  context: unknown;
+}) => Promise<void>;
+
+function getScheduledHandler() {
+  let handler: ScheduledHandler | undefined;
+  setupSourceRepoSignalsScheduled({
+    hooks: {
+      hook(name: string, callback: ScheduledHandler) {
+        if (name === "cloudflare:scheduled") handler = callback;
+      },
+    },
+  });
+  expect(handler).toBeDefined();
+  return handler as ScheduledHandler;
+}
+
+describe("source repo signals scheduled plugin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDirectoryEntries.mockResolvedValue([
+      { repoUrl: "https://github.com/example/tool" },
+    ]);
+    mocks.refreshSourceRepoSignalsForEntries.mockResolvedValue({
+      available: true,
+      totalRepos: 1,
+      refreshed: 1,
+      failed: 0,
+    });
+  });
+
+  it("ignores scheduled events for other cron triggers", async () => {
+    const handler = getScheduledHandler();
+
+    await handler({
+      controller: { cron: "0 14 * * FRI" },
+      env: {},
+      context: {},
+    });
+
+    expect(mocks.runWithCloudflareRuntime).not.toHaveBeenCalled();
+    expect(mocks.getDirectoryEntries).not.toHaveBeenCalled();
+    expect(mocks.refreshSourceRepoSignalsForEntries).not.toHaveBeenCalled();
+  });
+
+  it("refreshes source repo signals on the configured source cron", async () => {
+    const handler = getScheduledHandler();
+
+    await handler({
+      controller: { cron: "17 */6 * * *" },
+      env: {},
+      context: {},
+    });
+
+    expect(mocks.runWithCloudflareRuntime).toHaveBeenCalledOnce();
+    expect(mocks.getDirectoryEntries).toHaveBeenCalledOnce();
+    expect(mocks.refreshSourceRepoSignalsForEntries).toHaveBeenCalledWith([
+      { repoUrl: "https://github.com/example/tool" },
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation
- The source-repo scheduled plugin ran its refresh on every Cloudflare scheduled dispatch because it did not inspect `controller.cron`, causing unintended D1 reads and external GitHub/Shields fetches when the new Friday brief cron fired.

### Description
- Add an explicit `SOURCE_REPO_SIGNALS_CRON = "17 */6 * * *"` and return early unless `controller?.cron` matches that string in `apps/web/plugins/source-repo-signals-scheduled.ts`.
- Extend the scheduled payload type to include `controller?: { cron?: string }` and gate the handler on the configured cron only. 
- Preserve the existing `runWithCloudflareRuntime`, directory loading, and `refreshSourceRepoSignalsForEntries` call so runtime behavior for the intended cron is unchanged. 
- Add a targeted Vitest file `tests/source-repo-signals-scheduled.test.ts` that verifies the plugin ignores the Friday brief cron and runs only on the source-repo cron.

### Testing
- Ran `pnpm exec vitest run tests/source-repo-signals-scheduled.test.ts` and the new test suite passed (2 tests).
- Ran `git diff --check` which produced no issues and ran the repository type-check/build steps via the project `type-check` flow which completed successfully.
- These are focused automated checks only; the change is a small behavioral gate with targeted unit coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fc6ab89e4832a8b4518a489c81194)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed source repository signal refresh from executing on incorrect scheduled intervals.

* **Tests**
  * Added test coverage for scheduled signal refresh filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->