### PR TITLE
fix(content): remove undisclosed migration hook commands

### DIFF
--- a/content/hooks/database-migration-runner.mdx
+++ b/content/hooks/database-migration-runner.mdx
@@ -55,7 +55,7 @@ configSnippet: |-
     }
   }
 scriptLanguage: bash
-scriptBody: "#!/usr/bin/env bash\n\n# Read the tool input from stdin\nINPUT=$(cat)\nTOOL_NAME=$(echo \"$INPUT\" | jq -r '.tool_name')\nFILE_PATH=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // .tool_input.path // \"\"')\n\nif [ -z \"$FILE_PATH\" ]; then\n  exit 0\nfi\n\n# Check if it's a migration-related file\nif [[ \"$FILE_PATH\" == *migration* ]] || [[ \"$FILE_PATH\" == *schema* ]] || [[ \"$FILE_PATH\" == *.sql ]]; then\n  echo \"\U0001F5C3️ Database migration file detected: $FILE_PATH\" >&2\n  \n  # Check for common migration frameworks\n  if [ -f \"package.json\" ] && (grep -q \"knex\" package.json || grep -q \"sequelize\" package.json || grep -q \"typeorm\" package.json); then\n    echo \"\U0001F4E6 Node.js migration framework detected\" >&2\n    \n    # Knex migrations\n    if command -v npx &> /dev/null && npx knex --version &> /dev/null 2>&1; then\n      echo \"\U0001F527 Running Knex migration status check...\" >&2\n      MIGRATION_STATUS=$(npx knex migrate:status 2>/dev/null || echo \"No pending migrations\")\n      echo \"\U0001F4CA Migration Status: $MIGRATION_STATUS\" >&2\n      \n      # Check for pending migrations\n      if echo \"$MIGRATION_STATUS\" | grep -q \"pending\"; then\n        echo \"⚠️ Pending migrations detected. Run 'npx knex migrate:latest' to apply them\" >&2\n      else\n        echo \"✅ All migrations are up to date\" >&2\n      fi\n      \n    # Sequelize migrations\n    elif command -v npx &> /dev/null && npx sequelize-cli --version &> /dev/null 2>&1; then\n      echo \"\U0001F527 Sequelize CLI detected\" >&2\n      echo \"\U0001F4A1 Run 'npx sequelize-cli db:migrate:status' to check migration status\" >&2\n      \n    # TypeORM migrations\n    elif command -v npx &> /dev/null && npx typeorm --version &> /dev/null 2>&1; then\n      echo \"\U0001F527 TypeORM detected\" >&2\n      echo \"\U0001F4A1 Run 'npx typeorm migration:show' to check migration status\" >&2\n    fi\n    \n  # Django migrations\n  elif [ -f \"manage.py\" ]; then\n    echo \"\U0001F40D Django project detected\" >&2\n    if command -v python &> /dev/null; then\n      echo \"\U0001F527 Checking Django migration status...\" >&2\n      python manage.py showmigrations --plan 2>/dev/null | tail -5 | head -3 || echo \"\U0001F4A1 Run 'python manage.py showmigrations' to check status\" >&2\n    fi\n    \n  # Rails migrations\n  elif [ -f \"Gemfile\" ] && grep -q \"rails\" Gemfile; then\n    echo \"\U0001F48E Rails project detected\" >&2\n    if command -v bundle &> /dev/null; then\n      echo \"\U0001F527 Checking Rails migration status...\" >&2\n      bundle exec rails db:migrate:status 2>/dev/null | tail -5 || echo \"\U0001F4A1 Run 'rails db:migrate:status' to check status\" >&2\n    fi\n    \n  # Raw SQL files\n  elif [[ \"$FILE_PATH\" == *.sql ]]; then\n    echo \"\U0001F4DC Raw SQL migration file detected\" >&2\n    \n    # Check file size and complexity\n    if [ -f \"$FILE_PATH\" ]; then\n      LINE_COUNT=$(wc -l < \"$FILE_PATH\" 2>/dev/null || echo \"0\")\n      echo \"\U0001F4CA SQL file contains $LINE_COUNT lines\" >&2\n      \n      # Check for potentially destructive operations\n      if grep -i \"DROP\\|DELETE\\|TRUNCATE\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"⚠️ WARNING: Potentially destructive SQL operations detected (DROP/DELETE/TRUNCATE)\" >&2\n        echo \"\U0001F4A1 Consider creating a backup before executing this migration\" >&2\n      fi\n      \n      # Check for common patterns\n      if grep -i \"CREATE TABLE\\|ALTER TABLE\\|CREATE INDEX\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"\U0001F3D7️ Schema modification statements detected\" >&2\n      fi\n      \n      if grep -i \"INSERT\\|UPDATE\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"\U0001F4DD Data modification statements detected\" >&2\n      fi\n    fi\n  fi\n  \n  # General migration best practices reminder\n  echo \"\U0001F4CB Migration Best Practices:\" >&2\n  echo \"   • Always backup database before running migrations\" >&2\n  echo \"   • Test migrations on development/staging first\" >&2\n  echo \"   • Ensure migrations are reversible when possible\" >&2\n  echo \"   • Use transactions for atomic operations\" >&2\n  \nelse\n  echo \"File $FILE_PATH is not a migration file, skipping analysis\" >&2\nfi\n\nexit 0"
+scriptBody: "#!/usr/bin/env bash\n\n# Read the tool input from stdin\nINPUT=$(cat)\nTOOL_NAME=$(echo \"$INPUT\" | jq -r '.tool_name')\nFILE_PATH=$(echo \"$INPUT\" | jq -r '.tool_input.file_path // .tool_input.path // \"\"')\n\nif [ -z \"$FILE_PATH\" ]; then\n  exit 0\nfi\n\n# Check if it's a migration-related file\nif [[ \"$FILE_PATH\" == *migration* ]] || [[ \"$FILE_PATH\" == *schema* ]] || [[ \"$FILE_PATH\" == *.sql ]]; then\n  echo \"\U0001F5C3️ Database migration file detected: $FILE_PATH\" >&2\n  \n  # Check for Knex migrations\n  if [ -f \"package.json\" ] && grep -q \"knex\" package.json; then\n    echo \"\U0001F4E6 Knex migration framework detected\" >&2\n    \n    # Knex migrations\n    if command -v npx &> /dev/null && npx knex --version &> /dev/null 2>&1; then\n      echo \"\U0001F527 Running Knex migration status check...\" >&2\n      MIGRATION_STATUS=$(npx knex migrate:status 2>/dev/null || echo \"No pending migrations\")\n      echo \"\U0001F4CA Migration Status: $MIGRATION_STATUS\" >&2\n      \n      # Check for pending migrations\n      if echo \"$MIGRATION_STATUS\" | grep -q \"pending\"; then\n        echo \"⚠️ Pending migrations detected. Run 'npx knex migrate:latest' to apply them\" >&2\n      else\n        echo \"✅ All migrations are up to date\" >&2\n      fi\n      \n    fi\n    \n  # Django migrations\n  elif [ -f \"manage.py\" ]; then\n    echo \"\U0001F40D Django project detected\" >&2\n    if command -v python &> /dev/null; then\n      echo \"\U0001F527 Checking Django migration status...\" >&2\n      python manage.py showmigrations --plan 2>/dev/null | tail -5 | head -3 || echo \"\U0001F4A1 Run 'python manage.py showmigrations' to check status\" >&2\n    fi\n    \n  # Raw SQL files\n  elif [[ \"$FILE_PATH\" == *.sql ]]; then\n    echo \"\U0001F4DC Raw SQL migration file detected\" >&2\n    \n    # Check file size and complexity\n    if [ -f \"$FILE_PATH\" ]; then\n      LINE_COUNT=$(wc -l < \"$FILE_PATH\" 2>/dev/null || echo \"0\")\n      echo \"\U0001F4CA SQL file contains $LINE_COUNT lines\" >&2\n      \n      # Check for potentially destructive operations\n      if grep -i \"DROP\\|DELETE\\|TRUNCATE\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"⚠️ WARNING: Potentially destructive SQL operations detected (DROP/DELETE/TRUNCATE)\" >&2\n        echo \"\U0001F4A1 Consider creating a backup before executing this migration\" >&2\n      fi\n      \n      # Check for common patterns\n      if grep -i \"CREATE TABLE\\|ALTER TABLE\\|CREATE INDEX\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"\U0001F3D7️ Schema modification statements detected\" >&2\n      fi\n      \n      if grep -i \"INSERT\\|UPDATE\" \"$FILE_PATH\" >/dev/null 2>&1; then\n        echo \"\U0001F4DD Data modification statements detected\" >&2\n      fi\n    fi\n  fi\n  \n  # General migration best practices reminder\n  echo \"\U0001F4CB Migration Best Practices:\" >&2\n  echo \"   • Always backup database before running migrations\" >&2\n  echo \"   • Test migrations on development/staging first\" >&2\n  echo \"   • Ensure migrations are reversible when possible\" >&2\n  echo \"   • Use transactions for atomic operations\" >&2\n  \nelse\n  echo \"File $FILE_PATH is not a migration file, skipping analysis\" >&2\nfi\n\nexit 0"
 trigger: PostToolUse
 safetyNotes:
   - Runs automatically after write or edit activity on migration, schema, and SQL files.
@@ -160,9 +160,9 @@ fi
 if [[ "$FILE_PATH" == *migration* ]] || [[ "$FILE_PATH" == *schema* ]] || [[ "$FILE_PATH" == *.sql ]]; then
   echo "🗃️ Database migration file detected: $FILE_PATH" >&2
 
-  # Check for common migration frameworks
-  if [ -f "package.json" ] && (grep -q "knex" package.json || grep -q "sequelize" package.json || grep -q "typeorm" package.json); then
-    echo "📦 Node.js migration framework detected" >&2
+  # Check for Knex migrations
+  if [ -f "package.json" ] && grep -q "knex" package.json; then
+    echo "📦 Knex migration framework detected" >&2
 
     # Knex migrations
     if command -v npx &> /dev/null && npx knex --version &> /dev/null 2>&1; then
@@ -177,15 +177,6 @@ if [[ "$FILE_PATH" == *migration* ]] || [[ "$FILE_PATH" == *schema* ]] || [[ "$F
         echo "✅ All migrations are up to date" >&2
       fi
 
-    # Sequelize migrations
-    elif command -v npx &> /dev/null && npx sequelize-cli --version &> /dev/null 2>&1; then
-      echo "🔧 Sequelize CLI detected" >&2
-      echo "💡 Run 'npx sequelize-cli db:migrate:status' to check migration status" >&2
-
-    # TypeORM migrations
-    elif command -v npx &> /dev/null && npx typeorm --version &> /dev/null 2>&1; then
-      echo "🔧 TypeORM detected" >&2
-      echo "💡 Run 'npx typeorm migration:show' to check migration status" >&2
     fi
 
   # Django migrations
@@ -194,14 +185,6 @@ if [[ "$FILE_PATH" == *migration* ]] || [[ "$FILE_PATH" == *schema* ]] || [[ "$F
     if command -v python &> /dev/null; then
       echo "🔧 Checking Django migration status..." >&2
       python manage.py showmigrations --plan 2>/dev/null | tail -5 | head -3 || echo "💡 Run 'python manage.py showmigrations' to check status" >&2
-    fi
-
-  # Rails migrations
-  elif [ -f "Gemfile" ] && grep -q "rails" Gemfile; then
-    echo "💎 Rails project detected" >&2
-    if command -v bundle &> /dev/null; then
-      echo "🔧 Checking Rails migration status..." >&2
-      bundle exec rails db:migrate:status 2>/dev/null | tail -5 || echo "💡 Run 'rails db:migrate:status' to check status" >&2
     fi
 
   # Raw SQL files
@@ -260,7 +243,7 @@ if [ -z "$FILE_PATH" ]; then
 fi
 if [[ "$FILE_PATH" == *migration* ]] || [[ "$FILE_PATH" == *schema* ]] || [[ "$FILE_PATH" == *.sql ]]; then
   echo "Database migration file detected: $FILE_PATH" >&2
-  if [ -f "package.json" ] && (grep -q "knex" package.json || grep -q "sequelize" package.json || grep -q "typeorm" package.json); then
+  if [ -f "package.json" ] && grep -q "knex" package.json; then
     if command -v npx &> /dev/null && npx knex --version &> /dev/null 2>&1; then
       echo "Running Knex migration status check..." >&2
       MIGRATION_STATUS=$(npx knex migrate:status 2>/dev/null || echo "No pending migrations")


### PR DESCRIPTION
### Motivation
- Fix a security-relevant metadata/script mismatch where the entry frontmatter and safety notes were narrowed to Knex/Django but the shipped `scriptBody` and displayed hook still auto-detected and could run Sequelize, TypeORM, and Rails project CLIs.
- Ensure the hook implementation matches the documented behavior to avoid surprising users with undisclosed project-local command execution.

### Description
- Removed the Sequelize, TypeORM, and Rails detection/command branches from the installable `scriptBody` so the script only checks Knex (via `package.json`), Django (via `manage.py`), and raw SQL handling. 
- Updated the displayed hook script and example snippets to match the narrowed Knex/Django-only behavior and to remove references to the removed frameworks. 
- Kept the entry metadata and safety notes aligned with the implementation so the documentation accurately discloses what the hook may execute. 
- Changes committed on the current branch with commit `52ad6ea` and packaged as the PR titled `fix(content): remove undisclosed migration hook commands`.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully. 
- Ran `git diff --check` and static checks with no issues reported. 
- Verified absence of undisclosed strings using `rg -n "sequelize|typeorm|bundle exec rails|Gemfile|rails db:migrate" content/hooks/database-migration-runner.mdx`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303ab196b8832a86a2cacbd8a32296)