### PR TITLE
chore(links): canonicalize 1 moved source URL

### DIFF
--- a/content/hooks/package-download-checksum-guard-hook.mdx
+++ b/content/hooks/package-download-checksum-guard-hook.mdx
@@ -20,7 +20,7 @@ submittedByUrl: "https://github.com/MkDev11"
 dateAdded: "2026-06-05"
 submittedAt: "2026-06-05"
 documentationUrl: "https://www.gnu.org/software/coreutils/manual/html_node/sha2-utilities.html"
-repoUrl: "https://git.savannah.gnu.org/cgit/coreutils.git"
+repoUrl: "https://cgit.git.savannah.gnu.org/cgit/coreutils.git"
 installable: true
 installCommand: |-
   mkdir -p .claude/hooks


### PR DESCRIPTION
Automated link-health sweep found one stored source URL that issues a **permanent (301)** redirect to a canonical host. Rewriting it to the final URL so the link resolves without a redirect hop.

Only the frontmatter `repoUrl` field was changed — body text and the `sourceUrls` list were left untouched.

| file | field | old → new |
|------|-------|-----------|
| `content/hooks/package-download-checksum-guard-hook.mdx` | `repoUrl` | `https://git.savannah.gnu.org/cgit/coreutils.git` → `https://cgit.git.savannah.gnu.org/cgit/coreutils.git` |

**Safety checks (all pass):** permanent 301 → 200, same registrable domain (`gnu.org`), non-trivial path (`/cgit/coreutils.git`), identical resource (the GNU Coreutils git repo on the canonical cgit subdomain).

Auto-merge intentionally left off — merge after the 10-second eyeball + green link check.