### PR TITLE
fix(content): SEO, sources, and safety note for agent-skills-framework-engineer agent

### DIFF
--- a/content/agents/agent-skills-framework-engineer.mdx
+++ b/content/agents/agent-skills-framework-engineer.mdx
@@ -3,27 +3,34 @@ title: Agent Skills Framework Engineer - Claude Code Agents
 slug: agent-skills-framework-engineer
 category: agents
 description: >-
-  Agent Skills framework specialist for creating procedural knowledge files,
-  domain-specific expertise, and skill-based agent capabilities using
-  Anthropic's new Skills system.
+  An agent persona for authoring Claude Agent Skills: structured SKILL.md files
+  with name and description frontmatter, progressively disclosed instructions,
+  and bundled scripts the model loads on demand.
 cardDescription: >-
-  Agent Skills framework specialist for creating procedural knowledge files,
-  domain-specific expertise, and skill-based agent capabilities...
-seoTitle: Agent Skills Framework Engineer - Claude Code Agents
+  Designs SKILL.md files — sharp trigger descriptions, progressive disclosure,
+  and bundled resources — so Claude loads procedural knowledge only when a task
+  needs it.
+seoTitle: Claude Agent Skills (SKILL.md) Authoring Agent
 seoDescription: >-
-  Agent Skills framework specialist for creating procedural knowledge files,
-  domain-specific expertise, and skill-based agent capabilities using
-  Anthropic's ne...
+  Claude Code agent for authoring Agent Skills: write SKILL.md frontmatter,
+  apply progressive disclosure, bundle scripts, and tune triggers that load
+  on demand.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: >-
   https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk
+retrievalSources:
+  - "https://code.claude.com/docs/en/skills"
+  - "https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk"
 installable: false
+safetyNotes:
+  - "This is an agent persona (prompt guidance), not executable code, but the Agent Skills it designs can bundle helper scripts that Claude runs with its available tools; review bundled scripts and scope each skill's trigger before installing a generated skill into a project."
 usageSnippet: >-
-  You are an Agent Skills framework engineer, specialized in creating procedural
-  knowledge files and domain-specific expertise using Anthropic's Agent Skills
-  system announced in October 2025.
+  You are an Agent Skills engineer. Author SKILL.md files with precise name and
+  description frontmatter, apply progressive disclosure, bundle helper scripts
+  and reference files, and write triggers so Claude invokes each skill only when
+  relevant.
 copySnippet: >-
   You are an Agent Skills framework engineer, specialized in creating procedural
   knowledge files and domain-specific expertise using Anthropic's Agent Skills


### PR DESCRIPTION
## What

Clears the registry uniqueness floor for the `agent-skills-framework-engineer` agent (the lowest-uniqueness entry in the backlog: `report:thin-content` **0.35 → 0.54**) and tightens its source grounding.

## Changes (one file, frontmatter only)

- **`description` / `cardDescription` / `seoDescription`** — each rewritten with a distinct angle (the three were near-identical copies, two still carrying literal `…` truncation artifacts).
- **`seoTitle`** — now distinct from `title` ("Claude Agent Skills (SKILL.md) Authoring Agent").
- **`usageSnippet`** — diversified (it duplicated the description verbatim, which also dragged the uniqueness ratio down).
- **`retrievalSources`** — added the canonical Claude **Agent Skills** docs (`code.claude.com/docs/en/skills`) so the dual-AI reviewer sees the exact subject (SKILL.md authoring) documented, alongside the existing Agent SDK engineering post in `documentationUrl`.
- **`safetyNotes`** — added one honest disclosure: the Skills this agent designs can bundle helper scripts Claude runs with its tools, so review/scope them before installing. (The policy scanner flags the body's execute/install language; verified the warning clears with the note via a local `validate-content-policy.mjs --files-json` run.)

`copySnippet` body, `documentationUrl`, author, and dates are unchanged.

## Grounding (all 200)

- `documentationUrl`: https://www.anthropic.com/engineering/building-agents-with-the-claude-agent-sdk
- https://code.claude.com/docs/en/skills

## Validation

- `pnpm validate:content:strict` → passed
- `scripts/ci/validate-content-policy.mjs --files-json` → "HeyClaude content policy passed"
- `report:thin-content` unique-word ratio **0.35 → 0.54** (entry removed from the flagged list)
- `seoDescription` 158 chars (120–160 window)
- `git diff --check` → clean
