### PR TITLE
fix(content): SEO and sources for database-query-performance-logger hook

### DIFF
--- a/content/hooks/database-query-performance-logger.mdx
+++ b/content/hooks/database-query-performance-logger.mdx
@@ -3,22 +3,27 @@ title: Database Query Performance Logger - Hooks
 slug: database-query-performance-logger
 category: hooks
 description: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreSQL
-  pg_stat_statements, Prisma query logging, Sequelize query logging, TypeORM
-  query logging, and Bullet N+1 detection patterns.
+  A PostToolUse hook that logs database query timings after Claude runs code,
+  flagging slow statements and N+1 access patterns from PostgreSQL, Prisma,
+  Sequelize, and TypeORM query logs.
 cardDescription: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreS...
-seoTitle: Database Query Performance Logger - Hooks
+  Captures query latency after each tool run, surfaces slow statements via
+  pg_stat_statements, and spots N+1 patterns in Prisma, Sequelize, and TypeORM
+  output.
+seoTitle: Database Query Performance Logger Hook for Claude Code
 seoDescription: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreSQL
-  pg_stat_statement...
+  PostToolUse hook that logs database query performance for Claude Code,
+  detects slow queries with pg_stat_statements, and flags N+1 patterns in ORM
+  query logs.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
 documentationUrl: "https://www.postgresql.org/docs/current/runtime-config-logging.html"
+retrievalSources:
+  - "https://www.postgresql.org/docs/current/runtime-config-logging.html"
+  - "https://www.postgresql.org/docs/current/pgstatstatements.html"
+  - "https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/logging"
+  - "https://github.com/flyerhzm/bullet"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `database-query-performance-logger` hook (`report:thin-content` **0.38 → cleared**) and strengthens grounding.

## Changes (one file, frontmatter only)
- **`description` / `cardDescription` / `seoDescription`** — rewritten with distinct angles (were near-identical copies with `…` truncation artifacts).
- **`seoTitle`** — now distinct from `title`.
- **`retrievalSources`** — added Postgres `pg_stat_statements`, Prisma logging, and Bullet (N+1) docs so the ORM/slow-query claims are grounded beyond the Postgres logging-config `documentationUrl`.

`copySnippet`/`scriptBody` body, existing `safetyNotes`/`privacyNotes`, `documentationUrl`, author, and dates unchanged.

## Grounding (all 200)
postgresql.org runtime-config-logging · postgresql.org pgstatstatements · prisma.io logging · github.com/flyerhzm/bullet

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- `seoDescription` 158 chars; `git diff --check` clean
