### PR TITLE
fix(content): align database-query-performance-logger claims to sources

### DIFF
--- a/content/hooks/database-query-performance-logger.mdx
+++ b/content/hooks/database-query-performance-logger.mdx
@@ -3,31 +3,33 @@ title: Database Query Performance Logger - Hooks
 slug: database-query-performance-logger
 category: hooks
 description: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreSQL
-  pg_stat_statements, Prisma query logging, Sequelize query logging, TypeORM
-  query logging, and Bullet N+1 detection patterns.
+  A PostToolUse hook that reminds you to enable native query logging for
+  PostgreSQL, Prisma, Sequelize, and TypeORM, and flags possible N+1 patterns
+  when you edit SQL or data-access files.
 cardDescription: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreS...
-seoTitle: Database Query Performance Logger - Hooks
+  On each edit to SQL or ORM files, points to PostgreSQL, Prisma, Sequelize,
+  and TypeORM query-logging settings and flags queries inside loops as possible
+  N+1.
+seoTitle: Database Query Logging & N+1 Reminder Hook for Claude
 seoDescription: >-
-  Monitors and logs database query performance metrics with slow query
-  detection, N+1 analysis, and optimization suggestions using PostgreSQL
-  pg_stat_statement...
+  PostToolUse hook for Claude Code that surfaces PostgreSQL, Prisma, Sequelize,
+  and TypeORM query-logging options and flags possible N+1 patterns on edit.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
 documentationUrl: "https://www.postgresql.org/docs/current/runtime-config-logging.html"
-installable: true
-installCommand: >-
-  mkdir -p .claude/hooks && touch
-  .claude/hooks/database-query-performance-logger.sh && chmod +x
-  .claude/hooks/database-query-performance-logger.sh
+retrievalSources:
+  - "https://www.postgresql.org/docs/current/runtime-config-logging.html"
+  - "https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/logging"
+  - "https://sequelize.org/docs/v6/getting-started/"
+  - "https://github.com/typeorm/typeorm/blob/master/docs/docs/logging.md"
+  - "https://github.com/flyerhzm/bullet"
+installable: false
 usageSnippet: >-
-  mkdir -p .claude/hooks && touch
-  .claude/hooks/database-query-performance-logger.sh && chmod +x
-  .claude/hooks/database-query-performance-logger.sh
+  Save the provided script as
+  .claude/hooks/database-query-performance-logger.sh, then register it in
+  .claude/settings.json as a PostToolUse command so it surfaces query-logging
+  settings and N+1 warnings after each bash, write, or edit.
 copySnippet: |-
   {
     "hooks": {


### PR DESCRIPTION
## What
Resubmission of the `database-query-performance-logger` hook SEO/grounding fix. Supersedes #2613, which was closed by one reviewer: the meta over-claimed ("logs query timings / slow-query detection") relative to what the script does and what the sources verify.

This revision tightens every claim to exactly what the script does and what the linked docs support: the hook **reminds you to enable native query logging** for PostgreSQL/Prisma/Sequelize/TypeORM and **flags queries inside loops as possible N+1** — nothing more.

## Changes (one file, frontmatter only)
- **`description` / `cardDescription` / `seoDescription`** — rewritten and de-scoped to the grounded behavior (enable-logging reminders + N+1 heuristic); removes `…` truncation artifacts.
- **`seoTitle`** — distinct from `title`.
- **`retrievalSources`** — PostgreSQL, Prisma, Sequelize, TypeORM logging docs (ground the enable-logging guidance) + Bullet (grounds the N+1 flag).
- **`installable: false`** + real usage line — the prior `installCommand` (`touch` an empty file) didn't install a working hook; this hook is a settings.json config + script you place.

`scriptBody`/`copySnippet` body, existing `safetyNotes`/`privacyNotes`, `documentationUrl`, author, dates unchanged.

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `git diff --check` clean
