### PR TITLE
fix(newsletter): schedule weekly brief send slot

### DIFF
--- a/apps/web/plugins/newsletter-digest-scheduled.ts
+++ b/apps/web/plugins/newsletter-digest-scheduled.ts
@@ -22,9 +22,10 @@ import { siteConfig } from "@/lib/site";
 // maintainer a preview with an approve link.
 const GENERATE_CRON = "0 14 * * FRI";
 
-// 6-hourly (the existing source-signals trigger). We piggyback to send any
-// approved brief whose scheduled send time has arrived — no new cron needed.
-const SEND_CRON = "17 */6 * * *";
+// 6-hourly (the existing source-signals trigger) plus the exact Sunday
+// 16:00 UTC Weekly Brief slot. Both paths send approved briefs whose scheduled
+// send time has arrived.
+const SEND_CRONS = new Set(["17 */6 * * *", "0 16 * * SUN"]);
 
 const APPROVE_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
@@ -36,10 +37,10 @@ type CloudflareScheduledPayload = {
 
 /**
  * The Weekly Brief pipeline — the single weekly newsletter send. Friday:
- * generate a draft + email the maintainer an approve link. 6-hourly: send any
- * approved-and-due brief to the Resend audience (scheduled for Sunday 16:00 UTC
- * on approval). The cron hook fires for every trigger, so each branch gates on
- * its cron string. Inert until configured + a brief is approved — nothing
+ * generate a draft + email the maintainer an approve link. 6-hourly and Sunday
+ * 16:00 UTC: send any approved-and-due brief to the Resend audience
+ * (scheduled for Sunday 16:00 UTC on approval). The cron hook fires for every
+ * trigger, so each branch gates on its cron string. Inert until configured + a brief is approved — nothing
  * reaches the audience automatically. (Replaced the old auto-send Sunday digest.)
  */
 export default definePlugin((nitroApp) => {
@@ -102,8 +103,9 @@ export default definePlugin((nitroApp) => {
         return;
       }
 
-      // 6-hourly: send any approved brief whose scheduled time has arrived.
-      if (controller?.cron === SEND_CRON) {
+      // 6-hourly and Sunday 16:00 UTC: send approved briefs whose scheduled
+      // time has arrived.
+      if (controller?.cron && SEND_CRONS.has(controller.cron)) {
         const sendRequest = new Request("https://heyclau.de/__scheduled/brief-send");
         await runWithCloudflareRuntime(sendRequest, env, context, async () => {
           try {

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -21,12 +21,11 @@
     "mode": "smart",
   },
   "triggers": {
-    // 6-hourly: source-repo signals + send any approved Weekly Brief that is due.
+    // 6-hourly: source-repo signals + catch up on approved Weekly Brief sends.
     // Daily 05:00 UTC: IndexNow changed-URL push.
     // Fridays 14:00 UTC: generate the next Weekly Brief draft for review.
-    // (The Weekly Brief is the single weekly send — approved issues go out
-    //  Sunday 16:00 UTC via the 6-hourly check; no separate Sunday cron.)
-    "crons": ["17 */6 * * *", "0 5 * * *", "0 14 * * FRI"],
+    // Sundays 16:00 UTC: send the approved Weekly Brief at its scheduled slot.
+    "crons": ["17 */6 * * *", "0 5 * * *", "0 14 * * FRI", "0 16 * * SUN"],
   },
   "assets": {
     "directory": "dist/client",

--- a/tests/weekly-brief-schedule.test.ts
+++ b/tests/weekly-brief-schedule.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = join(__dirname, "..");
+const sundaySendCron = "0 16 * * SUN";
+
+describe("weekly brief schedule", () => {
+  it("runs the send branch at the configured Sunday 16:00 UTC send slot", () => {
+    const plugin = readFileSync(
+      join(repoRoot, "apps/web/plugins/newsletter-digest-scheduled.ts"),
+      "utf8",
+    );
+    const wranglerConfig = readFileSync(
+      join(repoRoot, "apps/web/wrangler.jsonc"),
+      "utf8",
+    );
+
+    expect(plugin).toContain(sundaySendCron);
+    expect(wranglerConfig).toContain(sundaySendCron);
+  });
+});


### PR DESCRIPTION
### Motivation
- Approved Weekly Briefs were scheduled for Sunday 16:00 UTC but the Cloudflare triggers no longer included that exact cron, causing approved briefs to be sent only at the next 6-hourly run instead of at the stored send slot.

### Description
- Allow the scheduled send branch to run on both the existing 6-hourly cron and the exact Sunday 16:00 UTC cron by introducing `SEND_CRONS` in `apps/web/plugins/newsletter-digest-scheduled.ts` and gating the send branch on that set.
- Restore the Sunday 16:00 UTC cron trigger in `apps/web/wrangler.jsonc` so the worker is invoked at the stored send slot.
- Add a regression test `tests/weekly-brief-schedule.test.ts` that asserts the Sunday 16:00 cron appears in both the scheduled plugin and Wrangler config.

### Testing
- Ran `pnpm exec vitest run tests/weekly-brief-schedule.test.ts` and the new test passed.
- Ran `git diff --check` to validate no whitespace diffs and it succeeded.
- Attempted a full web type-check (`pnpm --filter web type-check` / `pnpm --dir apps/web exec tsc --noEmit`) but these could not complete in this environment because generated web artifacts (e.g., `src/generated/atlas-registry.json`, `routeTree.gen`) are missing when skipping the project's pretype generation step; this is unrelated to the scheduling change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303ba107d4832ab0f57902d77df920)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Newsletter digest scheduling has been expanded to include an additional weekly send slot on Sundays at 16:00 UTC, complementing the existing delivery schedule for improved newsletter frequency.

* **Tests**
  * Added test coverage to verify that the newsletter scheduled send configuration correctly includes and references the new Sunday 16:00 UTC delivery schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->