### PR TITLE
fix(links): repair 20 dead source URLs tracked in #2524

### DIFF
--- a/content/agents/claude-md-knowledge-manager-agent.mdx
+++ b/content/agents/claude-md-knowledge-manager-agent.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://docs.claude.com/en/docs/claude-code/custom-instructions"
+documentationUrl: "https://code.claude.com/docs/en/claude-md"
 installable: false
 usageSnippet: >-
   You are a CLAUDE.md knowledge management specialist, designed to help users

--- a/content/agents/web-async-agent-coordinator.mdx
+++ b/content/agents/web-async-agent-coordinator.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
-documentationUrl: "https://docs.claude.com/en/docs/claude-code/web-interface"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
 installable: false
 usageSnippet: >-
   You are a web-based asynchronous agent coordinator, designed to orchestrate

--- a/content/commands/context-analyzer.mdx
+++ b/content/commands/context-analyzer.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
-documentationUrl: "https://docs.claude.com/en/docs/claude-code/analysis"
+documentationUrl: "https://code.claude.com/docs/en/common-workflows"
 installable: true
 installCommand: "/context-analyzer [scope] [options]"
 usageSnippet: "/context-analyzer [scope] [options]"

--- a/content/commands/debug.mdx
+++ b/content/commands/debug.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/debug"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: /debug
 usageSnippet: /debug

--- a/content/commands/docs.mdx
+++ b/content/commands/docs.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/docs"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/docs [options] <file_or_project>"
 usageSnippet: "/docs [options] <file_or_project>"

--- a/content/commands/explain.mdx
+++ b/content/commands/explain.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/explain"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/explain [options] <code_or_file>"
 usageSnippet: "/explain [options] <code_or_file>"

--- a/content/commands/generate-tests.mdx
+++ b/content/commands/generate-tests.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/test-gen"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/test-gen [options] <file_or_function>"
 usageSnippet: "/test-gen [options] <file_or_function>"

--- a/content/commands/optimize.mdx
+++ b/content/commands/optimize.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/optimize"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/optimize [options] <file_or_function>"
 usageSnippet: "/optimize [options] <file_or_function>"

--- a/content/commands/plan-mode.mdx
+++ b/content/commands/plan-mode.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
-documentationUrl: "https://docs.claude.com/en/docs/claude-code/extended-thinking"
+documentationUrl: "https://code.claude.com/docs/en/common-workflows"
 installable: true
 installCommand: "/plan-mode [task] [depth]"
 usageSnippet: "/plan-mode [task] [depth]"

--- a/content/commands/refactor.mdx
+++ b/content/commands/refactor.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/refactor"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/refactor [options] <file_or_selection>"
 usageSnippet: "/refactor [options] <file_or_selection>"

--- a/content/commands/review.mdx
+++ b/content/commands/review.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/review"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/review [options] <file_or_directory>"
 usageSnippet: "/review [options] <file_or_directory>"

--- a/content/commands/security-audit.mdx
+++ b/content/commands/security-audit.mdx
@@ -16,7 +16,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
-documentationUrl: "https://docs.claude.ai/commands/security-audit"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/security-audit [scope]"
 usageSnippet: "/security-audit [scope]"

--- a/content/commands/security.mdx
+++ b/content/commands/security.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/security"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/security [options] <file_or_project>"
 usageSnippet: "/security [options] <file_or_project>"

--- a/content/commands/tdd-workflow.mdx
+++ b/content/commands/tdd-workflow.mdx
@@ -17,7 +17,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
-documentationUrl: "https://docs.claude.com/en/docs/claude-code/testing"
+documentationUrl: "https://code.claude.com/docs/en/common-workflows"
 installable: true
 installCommand: "/tdd-workflow [feature] [options]"
 usageSnippet: "/tdd-workflow [feature] [options]"

--- a/content/commands/test-advanced.mdx
+++ b/content/commands/test-advanced.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/commands/test"
+documentationUrl: "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/test [options] <file_or_function>"
 usageSnippet: "/test [options] <file_or_function>"

--- a/content/mcp/expo-mcp-server.mdx
+++ b/content/mcp/expo-mcp-server.mdx
@@ -22,7 +22,6 @@ submittedBy: oktofeesh1
 submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-04"
 websiteUrl: "https://expo.dev"
-documentationUrl: "https://docs.expo.dev/eas/ai/mcp/"
 repoUrl: "https://github.com/expo/expo"
 installable: true
 installCommand: "claude mcp add --transport http expo https://mcp.expo.dev/mcp"

--- a/content/rules/code-review-expert.mdx
+++ b/content/rules/code-review-expert.mdx
@@ -15,7 +15,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://docs.claude.ai/rules/code-review"
+documentationUrl: "https://code.claude.com/docs/en/overview"
 installable: false
 usageSnippet: >-
   You are a code review expert focused on providing comprehensive, constructive

--- a/content/skills/coderabbit-lite-pr-review-capability-pack.mdx
+++ b/content/skills/coderabbit-lite-pr-review-capability-pack.mdx
@@ -9,7 +9,7 @@ seoDescription: "Advanced AI skill for local PR review automation with risk scor
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2026-04-11"
-documentationUrl: "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/code-review/about-pull-request-reviews"
+documentationUrl: "https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews"
 downloadUrl: /downloads/skills/coderabbit-lite-pr-review-capability-pack.zip
 installable: true
 installCommand: "curl -L https://heyclau.de/downloads/skills/coderabbit-lite-pr-review-capability-pack.zip -o coderabbit-lite-pr-review-capability-pack.zip && unzip -o coderabbit-lite-pr-review-capability-pack.zip -d ./coderabbit-lite-pr-review-capability-pack"

--- a/content/skills/n8n-production-security-capability-pack.mdx
+++ b/content/skills/n8n-production-security-capability-pack.mdx
@@ -9,7 +9,7 @@ seoDescription: "Advanced AI skill for securing n8n in production with workflow 
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2026-04-10"
-documentationUrl: "https://docs.n8n.io/hosting/securing/"
+documentationUrl: "https://docs.n8n.io/hosting/securing/overview/"
 downloadUrl: /downloads/skills/n8n-production-security-capability-pack.zip
 installable: true
 installCommand: "curl -L https://heyclau.de/downloads/skills/n8n-production-security-capability-pack.zip -o n8n-production-security-capability-pack.zip && unzip -o n8n-production-security-capability-pack.zip -d ./n8n-production-security-capability-pack"

--- a/content/tools/lakera-guard.mdx
+++ b/content/tools/lakera-guard.mdx
@@ -8,7 +8,7 @@ seoTitle: Lakera Guard AI security for LLM apps
 seoDescription: Lakera Guard helps detect prompt injection, unsafe content, data leakage, and abuse in LLM applications.
 author: Lakera
 dateAdded: "2026-04-27"
-websiteUrl: "https://www.lakera.ai/guard"
+websiteUrl: "https://www.lakera.ai/lakera-guard"
 documentationUrl: "https://docs.lakera.ai"
 pricingModel: paid
 disclosure: editorial


### PR DESCRIPTION
Repairs the dead source-URL frontmatter fields flagged by the link-health sweep in #2524. Every replacement was verified to return **HTTP 200** with a plain default-UA fetch (the gate's fetch style), so this should verify cleanly — unlike a redirect-canonicalization, here we're replacing *unreachable* URLs with *reachable* ones.

### Replacements (verified 200)
| entries | field | → |
|---|---|---|
| 10× `commands/*` (debug, docs, explain, optimize, refactor, review, security, security-audit, test-advanced, generate-tests) | `documentationUrl` | `docs.claude.ai/commands/*` (NXDOMAIN) → `code.claude.com/docs/en/slash-commands` |
| `rules/code-review-expert` | `documentationUrl` | `docs.claude.ai/rules/code-review` (NXDOMAIN) → `code.claude.com/docs/en/overview` |
| `commands/context-analyzer`, `commands/plan-mode`, `commands/tdd-workflow` | `documentationUrl` | `docs.claude.com/.../{analysis,extended-thinking,testing}` (301→404) → `code.claude.com/docs/en/common-workflows` |
| `agents/claude-md-knowledge-manager-agent` | `documentationUrl` | `.../custom-instructions` (301→404) → `code.claude.com/docs/en/claude-md` |
| `agents/web-async-agent-coordinator` | `documentationUrl` | `.../web-interface` (301→404) → `code.claude.com/docs/en/sub-agents` |
| `skills/coderabbit-lite-pr-review-capability-pack` | `documentationUrl` | GitHub moved the `code-review` segment → `.../reviewing-changes-in-pull-requests/about-pull-request-reviews` |
| `skills/n8n-production-security-capability-pack` | `documentationUrl` | `docs.n8n.io/hosting/securing/` (404) → `.../securing/overview/` |
| `tools/lakera-guard` | `websiteUrl` | `www.lakera.ai/guard` (404) → `www.lakera.ai/lakera-guard` |

### Field removal
- `mcp/expo-mcp-server` — removed `documentationUrl: https://docs.expo.dev/eas/ai/mcp/` (genuinely 404, not bot-blocked). The entry retains `websiteUrl` (`expo.dev`) and `repoUrl` (`github.com/expo/expo`), so it stays verifiable.

### Not included (false positives)
The two `example.com` entries in #2524 are **placeholder examples inside a skill body** (`heyclaude-content-submission-factory`), not real frontmatter — the skill's actual `documentationUrl` is `heyclau.de/submit` (live). I'll prune those lines from the tracking issue rather than edit content.

Frontmatter-only; no body text changed. Resolves the actionable items in #2524.