### PR TITLE
fix(content): diversify SEO copy for context-window-simulator guide

### DIFF
--- a/content/guides/using-the-context-window-simulator-for-prompt-design.mdx
+++ b/content/guides/using-the-context-window-simulator-for-prompt-design.mdx
@@ -3,18 +3,18 @@ title: Using the Context Window Simulator for Prompt Design
 slug: using-the-context-window-simulator-for-prompt-design
 category: guides
 description: >-
-  A practical walkthrough of the Claude Code context window explorer: what
-  consumes context (system prompt, memory, CLAUDE.md, MCP tools, skills, file
-  reads, history), how each loads, and how to use it plus /context to design
-  leaner prompts and setups.
+  A practical walkthrough of the Claude Code context window: what consumes it
+  (system prompt, memory, CLAUDE.md, MCP tools, skills, file reads, history),
+  how each piece loads, and how the /context view helps you design leaner
+  prompts and setups.
 cardDescription: >-
-  Use the Claude Code context window explorer and /context to see what consumes
-  context and design leaner prompts and setups.
-seoTitle: Using the Context Window Simulator for Prompt Design
+  Read the /context breakdown to see what fills the window, then trim CLAUDE.md,
+  skills, and MCP tools to reclaim tokens.
+seoTitle: Claude Code /context & Context Window Guide
 seoDescription: >-
-  How to use Claude Code's interactive context window explorer and the /context
-  command to see what fills context (CLAUDE.md, MCP tools, skills, file reads,
-  history) and design leaner prompts and project setups.
+  Use Claude Code's /context view to see what fills the context window —
+  CLAUDE.md, MCP tools, skills, file reads, history — and design leaner prompts
+  and setups.
 author: JPette1783
 authorProfileUrl: "https://github.com/JPette1783"
 submittedBy: JPette1783
@@ -22,7 +22,7 @@ submittedByUrl: "https://github.com/JPette1783"
 dateAdded: "2026-06-05"
 submittedAt: "2026-06-05"
 documentationUrl: "https://code.claude.com/docs/en/context-window"
-usageSnippet: "Use this guide to understand what fills the Claude Code context window and to design leaner CLAUDE.md, skills, and MCP setups using the context explorer and /context."
+usageSnippet: "Follow this guide to read the /context breakdown, attribute token cost to system prompt, CLAUDE.md, MCP tools, skills, and history, and trim each to design leaner setups."
 prerequisites:
   - "Access to the Claude Code context window documentation and its interactive explorer."
   - "A project with CLAUDE.md, skills, or MCP servers whose context cost you want to understand."


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `using-the-context-window-simulator-for-prompt-design` guide (`report:thin-content` 0.383 → cleared). SEO diversification; grounding already on-subject.

## Changes (one file, frontmatter only)
- **`description` / `cardDescription` / `seoDescription` / `usageSnippet`** — rewritten with distinct angles using the doc's own terms (`/context` view, the context-window consumers: system prompt, CLAUDE.md, MCP tools, skills, file reads, history).
- **`seoTitle`** — now distinct from `title`.

`documentationUrl`, body, author, dates unchanged.

## Grounding
`documentationUrl` https://code.claude.com/docs/en/context-window documents `/context` and the context-window breakdown (CLAUDE.md, MCP tools, system prompt, history) the guide walks through.

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `git diff --check` clean
