### PR TITLE
fix(content): diversify SEO copy for communications-kit launch guide

### DIFF
--- a/content/guides/communications-kit-for-claude-code-launch-campaigns.mdx
+++ b/content/guides/communications-kit-for-claude-code-launch-campaigns.mdx
@@ -3,13 +3,15 @@ title: Communications Kit for Claude Code Launch Campaigns
 slug: communications-kit-for-claude-code-launch-campaigns
 category: guides
 description: >-
-  Use the Claude Code communications kit for launch campaigns: message calendar,
-  stakeholder templates, FAQ handling, and aligning announcements with champion rollout.
-cardDescription: Plan internal launch communications for Claude Code using the communications kit.
-seoTitle: Communications Kit for Claude Code Launch Campaigns
+  How to run an internal Claude Code launch with the communications kit:
+  stakeholder message templates, an announcement timeline, FAQ ownership, and
+  aligning the rollout with your champion pilot.
+cardDescription: Coordinate internal messaging for a Claude Code rollout — who to brief, in what order, and how to answer objections.
+seoTitle: Claude Code Launch Communications Kit Guide
 seoDescription: >-
-  Use the Claude Code communications kit for launch campaigns: message calendar,
-  stakeholder templates, FAQ handling, and aligning announcements with champion rollout.
+  Plan a Claude Code rollout: sequence messaging to execs, managers, and
+  engineers, assign FAQ owners for cost and security, and time it to pilot
+  readiness.
 author: kiannidev
 authorProfileUrl: "https://github.com/kiannidev"
 submittedBy: kiannidev
@@ -20,8 +22,8 @@ sourceSubmissionNumber: 1447
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1447"
 documentationUrl: "https://code.claude.com/docs/en/communications-kit"
 usageSnippet: >-
-  Use this guide to plan internal Claude Code launch announcements with the official
-  communications kit templates and timeline.
+  Follow this guide to sequence audiences, schedule each message, and prepare
+  answers for cost, data-retention, and support questions before you announce.
 prerequisites:
   - Access to communications kit templates and approved brand/voice guidelines.
   - Launch date aligned with champion pilot readiness—not before permissions work.
@@ -37,8 +39,6 @@ privacyNotes:
   - Collect FAQ questions internally without forwarding customer-identifiable Slack threads to public lists.
 sourceUrls:
   - "https://code.claude.com/docs/en/communications-kit"
-  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
-  - "https://github.com/anthropics/claude-code"
 tags:
   - claude-code
   - communications


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `communications-kit-for-claude-code-launch-campaigns` guide (`report:thin-content` 0.41 → cleared; description and seoDescription were identical).

## Changes (one file, frontmatter only)
- **`description` / `cardDescription` / `seoDescription` / `usageSnippet`** — rewritten as four distinct angles (overview, coordination, phased sequencing, pre-announce prep) instead of one repeated sentence.
- **`seoTitle`** — now distinct from `title`.
- **`sourceUrls`** — reduced to the on-subject communications-kit doc (removed an off-topic Google SEO URL and the generic repo).

`documentationUrl`, body, author, dates, submission refs unchanged.

## Grounding
`documentationUrl` https://code.claude.com/docs/en/communications-kit documents the kit's announcements, champion rollout, FAQ, and stakeholder templates the guide walks through.

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `git diff --check` clean
