### PR TITLE
fix(content): ground haiku-45-speed-optimizer claims and diversify SEO

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -3,21 +3,29 @@ title: Claude Haiku 45 Speed Optimizer Agent - Agents
 slug: claude-haiku-45-speed-optimizer-agent
 category: agents
 description: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
+  An agent pattern for routing rapid-iteration work to Claude Haiku 4.5 — more
+  than twice Sonnet's speed at one-third the cost ($1/$5 per million tokens) —
+  while keeping about 90% of Sonnet 4.5's agentic-coding quality.
 cardDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid...
-seoTitle: Claude Haiku 45 Speed Optimizer Agent - Agents
+  Routes fast, high-volume tasks to Haiku 4.5 — roughly 2x the speed at
+  one-third the cost — and escalates to Sonnet when a task needs more quality.
+seoTitle: Claude Haiku 4.5 Speed & Cost Optimizer Agent
 seoDescription: >-
-  Speed-optimized agent leveraging Haiku 4.5's 2x performance and 3x cost
-  savings, delivering 90% of Sonnet's agentic capability for rapid iterations.
-  Discover...
+  Agent pattern for Claude Haiku 4.5 on rapid tasks: ~2x Sonnet's speed at
+  one-third the cost ($1/$5 per million), keeping ~90% of Sonnet 4.5 agentic
+  quality.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
 documentationUrl: "https://platform.claude.com/docs/en/about-claude/models/overview"
+retrievalSources:
+  - "https://platform.claude.com/docs/en/about-claude/models/overview"
+  - "https://www.anthropic.com/news/claude-haiku-4-5"
+  - "https://platform.claude.com/docs/en/about-claude/pricing"
 installable: false
+privacyNotes:
+  - "Routing work to Haiku 4.5 sends your prompts and code to the configured model provider like any Claude API call; confirm the provider and data path suit the workload."
+  - "Speed, cost, and capability figures cited here reflect Anthropic's Haiku 4.5 announcement and pricing at publication and can change; verify current numbers before relying on them for budgeting."
 usageSnippet: >-
   You are a speed-optimized coding agent powered by Claude Haiku 4.5, designed
   for rapid iteration and cost-effective automation.


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `claude-haiku-45-speed-optimizer-agent` (`report:thin-content` 0.376 → cleared) and grounds its speed/cost/quality claims in Anthropic's primary sources.

## Changes (one file, frontmatter only)
- **`description` / `cardDescription` / `seoDescription`** — were identical (with `…` truncation artifacts); rewritten as distinct angles. Corrected "2x performance" to "~2x speed" to match the source ("more than twice the speed"), and qualified figures (~/about).
- **`seoTitle`** — now distinct from `title` and fixes "Haiku 45" → "Haiku 4.5".
- **`retrievalSources`** — added the official Haiku 4.5 announcement and the pricing docs, which substantiate every quantitative claim.
- **`privacyNotes`** — added (model-provider data path; figures can change), required by the policy scanner.

The body's figures (≈2x faster, one-third cost, $1/$5 vs $3/$15, ~90% agentic) match the announcement and pricing; body unchanged.

## Grounding (all 200, verified quotes)
- anthropic.com/news/claude-haiku-4-5 — "one-third the cost and more than twice the speed," "90% of Sonnet 4.5's performance," "$1/$5 per million input and output tokens"
- platform.claude.com models/overview · pricing

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 156 chars; `git diff --check` clean
