### PR TITLE
fix(content): ground semantic-kernel-enterprise-agent in Microsoft SK docs, diversify SEO

### DIFF
--- a/content/agents/semantic-kernel-enterprise-agent.mdx
+++ b/content/agents/semantic-kernel-enterprise-agent.mdx
@@ -3,21 +3,29 @@ title: Semantic Kernel Enterprise Agent - Agents
 slug: semantic-kernel-enterprise-agent
 category: agents
 description: >-
-  Microsoft Semantic Kernel enterprise agent specialist for building
-  Azure-native AI applications with multi-language SDK support, plugin
-  governance, and enterprise-grade deployment
+  A Claude agent persona for building with Microsoft Semantic Kernel: composing
+  plugins and functions, using the C#, Python, and Java SDKs, and wiring Azure
+  OpenAI into production AI applications.
 cardDescription: >-
-  Microsoft Semantic Kernel enterprise agent specialist for building
-  Azure-native AI applications with multi-language SDK support, plugin g...
-seoTitle: Semantic Kernel Enterprise Agent - Agents
+  Guides Semantic Kernel app design — plugin and function composition, the
+  C#/Python/Java SDKs, the agent framework, and Azure OpenAI integration.
+seoTitle: Microsoft Semantic Kernel Builder — Claude Agent
 seoDescription: >-
-  Microsoft Semantic Kernel enterprise agent specialist for building
-  Azure-native AI applications with multi-language SDK support, plugin
-  governance, and enter...
+  Claude agent persona for Microsoft Semantic Kernel: compose plugins and
+  functions, use the C#/Python/Java SDKs and agent framework, and integrate
+  Azure OpenAI.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
+documentationUrl: "https://learn.microsoft.com/en-us/semantic-kernel/overview/"
+retrievalSources:
+  - "https://learn.microsoft.com/en-us/semantic-kernel/overview/"
+  - "https://learn.microsoft.com/en-us/semantic-kernel/concepts/plugins/"
+  - "https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/"
 installable: false
+privacyNotes:
+  - "Semantic Kernel apps send prompts and context to Azure OpenAI or another configured model provider; confirm the provider and data path suit the workload."
+  - "Keep Azure OpenAI keys and endpoints in a secrets store (Azure Key Vault or dotnet user-secrets), never hard-coded in source or committed configuration."
 usageSnippet: >-
   You are a Microsoft Semantic Kernel enterprise agent specialist focused on
   building production-ready AI applications with Azure integration,


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `semantic-kernel-enterprise-agent` (`report:thin-content` 0.368 → cleared) and adds source grounding (it had no `documentationUrl`).

## Changes (one file, frontmatter only)
- **`documentationUrl`** → Microsoft Semantic Kernel overview (the framework the persona is built on). Added.
- **`description` / `cardDescription` / `seoDescription`** — were identical (with `…` truncation); rewritten as distinct angles scoped to what the SK docs document (plugin/function composition, the C#/Python/Java SDKs, the agent framework, Azure OpenAI integration). Dropped vague "plugin governance / enterprise-grade deployment" in favor of documented concepts.
- **`seoTitle`** — now distinct from `title`.
- **`retrievalSources`** — SK overview, plugins, and agent framework docs.
- **`privacyNotes`** — added (Azure OpenAI data path; keep keys in a secrets store), required by the policy scanner.

Body unchanged.

## Grounding (all 200)
learn.microsoft.com/en-us/semantic-kernel/overview · concepts/plugins · frameworks/agent

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 159 chars; `git diff --check` clean
