### PR TITLE
fix(content): ground plugin-ecosystem-architect in Claude Code plugins docs, diversify SEO

### DIFF
--- a/content/agents/plugin-ecosystem-architect.mdx
+++ b/content/agents/plugin-ecosystem-architect.mdx
@@ -3,21 +3,30 @@ title: Plugin Ecosystem Architect - Agents
 slug: plugin-ecosystem-architect
 category: agents
 description: >-
-  Design and publish Claude Code plugins for the October 2025 marketplace
-  launch. Handles plugin bundling, custom tool integration, and marketplace
-  distribution workflows.
+  A Claude agent persona for building and publishing Claude Code plugins:
+  bundling commands, agents, hooks, and MCP servers into a plugin and
+  distributing it through a plugin marketplace.
 cardDescription: >-
-  Design and publish Claude Code plugins for the October 2025 marketplace
-  launch.
-seoTitle: Plugin Ecosystem Architect - Agents
+  Design Claude Code plugins — bundle commands, agents, hooks, and MCP servers —
+  and publish them to a plugin marketplace.
+seoTitle: Claude Code Plugin & Marketplace Architect Agent
 seoDescription: >-
-  Design and publish Claude Code plugins for the October 2025 marketplace
-  launch. Handles plugin bundling, custom tool integration, and marketplace
-  distributio...
+  Claude agent persona for Claude Code plugins: bundle commands, agents, hooks,
+  and MCP servers into a plugin and publish it to a marketplace others install
+  from.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
+documentationUrl: "https://code.claude.com/docs/en/plugins"
+retrievalSources:
+  - "https://code.claude.com/docs/en/plugins"
+  - "https://code.claude.com/docs/en/plugin-marketplaces"
+  - "https://code.claude.com/docs/en/discover-plugins"
 installable: false
+safetyNotes:
+  - "This is an agent persona (prompt guidance), not executable code, but the plugins it designs bundle hooks and MCP servers that run commands with your permissions; review bundled hooks and tools before installing a plugin from any marketplace."
+privacyNotes:
+  - "Plugins installed from third-party marketplaces run in your environment and can read local files or call external services; vet the marketplace source and a plugin's MCP servers before adding it."
 usageSnippet: >-
   You are a Plugin Ecosystem Architect specializing in Claude Code plugin
   development, bundling, and marketplace distribution for the October 2025


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `plugin-ecosystem-architect` agent (`report:thin-content` 0.372 → cleared) and adds source grounding (it had no `documentationUrl`).

## Changes (one file, frontmatter only)
- **`documentationUrl`** → Claude Code plugins docs. Added.
- **`description` / `cardDescription` / `seoDescription`** — were near-identical; rewritten as distinct angles grounded in the plugins docs (a plugin bundles commands, agents, hooks, and MCP servers; published via a marketplace). Dropped the dated "October 2025 marketplace launch" framing for the timeless capability.
- **`seoTitle`** — now distinct from `title`.
- **`retrievalSources`** — plugins, plugin-marketplaces, discover-plugins.
- **`safetyNotes` / `privacyNotes`** — added (bundled hooks/MCP execute; third-party marketplace install), required by the policy scanner.

Body unchanged.

## Grounding (all 200)
code.claude.com/docs/en/plugins · plugin-marketplaces · discover-plugins

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 160 chars; `git diff --check` clean
