### PR TITLE
fix(content): ground parallel-subagent-distributor, cut fabricated speedups

### DIFF
--- a/content/agents/parallel-subagent-distributor.mdx
+++ b/content/agents/parallel-subagent-distributor.mdx
@@ -3,36 +3,36 @@ title: Parallel Subagent Distributor - Agents
 slug: parallel-subagent-distributor
 category: agents
 description: >-
-  Parallel subagent workload distribution specialist coordinating concurrent
-  Claude Code subagents for massive speedups using native parallel execution
-  capabilities.
+  An agent that splits independent work across concurrent Claude Code subagents
+  via the Task tool — each in an isolated context window with scoped tools — and
+  reconciles their results.
 cardDescription: >-
-  Parallel subagent workload distribution specialist coordinating concurrent
-  Claude Code subagents for massive speedups using native parall...
-seoTitle: Parallel Subagent Distributor - Agents
+  Coordinates concurrent Claude Code subagents on independent subtasks, each
+  with isolated context and scoped tools, then merges their output.
+seoTitle: Parallel Claude Code Subagent Coordinator Agent
 seoDescription: >-
-  Parallel subagent workload distribution specialist coordinating concurrent
-  Claude Code subagents for massive speedups using native parallel execution
-  capabil...
+  Agent that distributes independent work across parallel Claude Code subagents
+  — isolated context, scoped tools, partition by file path — then merges
+  results.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
 installable: false
+privacyNotes:
+  - "Subagents read repository files in their own context to do their share of the work; partition by path and scope each subagent's tools so they only access what they need."
 usageSnippet: >-
-  You are a parallel subagent workload distributor, coordinating multiple Claude
-  Code subagents executing concurrently for massive performance gains.
+  You are a subagent workload distributor: partition independent work, launch
+  Claude Code subagents in parallel via the Task tool with scoped tools and
+  isolated context, then reconcile their results.
 copySnippet: >-
   You are a parallel subagent workload distributor, coordinating multiple Claude
-  Code subagents executing concurrently for massive performance gains.
+  Code subagents executing concurrently in isolated context windows.
 
 
   ## Parallel Subagents Overview
-
-
-  **Hacker News (October 2025):**
-
-  > "How to use Claude Code subagents to parallelize development - 10x speedup"
 
 
   **Key Capability:** Claude Code's Task tool runs subagents in separate threads
@@ -189,18 +189,10 @@ copySnippet: >-
   ## Performance Benchmarks
 
 
-  **Test Case:** Refactor 50-file codebase
-
-
-  | Approach | Duration | Speedup |
-
-  |----------|----------|--------|
-
-  | Single agent | 10 hours | 1x |
-
-  | 5 parallel subagents | 2.5 hours | 4x |
-
-  | 10 parallel subagents | 1.5 hours | 6.7x |
+  **Rule of thumb:** splitting genuinely independent work across N subagents
+  moves wall-clock time toward 1/N of serial execution, minus coordination and
+  merge overhead. Actual gains depend on how independent the subtasks are and
+  how much output has to be reconciled afterward.
 
 
   ## Best Practices
@@ -217,8 +209,8 @@ copySnippet: >-
   5. **Aggregate results** - Collect outputs before merging
 
 
-  I coordinate parallel Claude Code subagent workloads for 3-10x performance
-  improvements on parallelizable development tasks.
+  I coordinate parallel Claude Code subagent workloads to shorten wall-clock
+  time on parallelizable development tasks.
 tags:
   - parallel-processing
   - concurrent-subagents
@@ -247,13 +239,9 @@ robotsIndex: true
 robotsFollow: true
 ---
 
-You are a parallel subagent workload distributor, coordinating multiple Claude Code subagents executing concurrently for massive performance gains.
+You are a parallel subagent workload distributor, coordinating multiple Claude Code subagents executing concurrently in isolated context windows.
 
 ## Parallel Subagents Overview
-
-**Hacker News (October 2025):**
-
-> "How to use Claude Code subagents to parallelize development - 10x speedup"
 
 **Key Capability:** Claude Code's Task tool runs subagents in separate threads with isolated context windows.
 
@@ -355,13 +343,7 @@ git merge feature/migrations # No conflicts (independent)
 
 ## Performance Benchmarks
 
-**Test Case:** Refactor 50-file codebase
-
-| Approach              | Duration  | Speedup |
-| --------------------- | --------- | ------- |
-| Single agent          | 10 hours  | 1x      |
-| 5 parallel subagents  | 2.5 hours | 4x      |
-| 10 parallel subagents | 1.5 hours | 6.7x    |
+**Rule of thumb:** splitting genuinely independent work across N subagents moves wall-clock time toward 1/N of serial execution, minus coordination and merge overhead. Actual gains depend on how independent the subtasks are and how much output has to be reconciled afterward.
 
 ## Best Practices
 
@@ -371,4 +353,4 @@ git merge feature/migrations # No conflicts (independent)
 4. **Define dependencies** - Sequential when needed
 5. **Aggregate results** - Collect outputs before merging
 
-I coordinate parallel Claude Code subagent workloads for 3-10x performance improvements on parallelizable development tasks.
+I coordinate parallel Claude Code subagent workloads to shorten wall-clock time on parallelizable development tasks.


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `parallel-subagent-distributor` (`report:thin-content` 0.40 → cleared) and removes unsupported performance claims.

## Changes (one file)
- **`description` / `cardDescription` / `seoDescription` / `usageSnippet`** — were identical with vague "massive speedups"; rewritten as distinct angles grounded in the subagents docs (Task tool, isolated context windows, scoped tools, partition by file path).
- **`seoTitle`** — distinct from `title`.
- **Body** — removed an unverifiable "Hacker News … 10x speedup" quote, a fabricated benchmark table ("Refactor 50-file codebase: 10h→1.5h, 6.7x"), and "3-10x performance" / "massive performance gains" claims; replaced with a grounded rule-of-thumb (toward 1/N of serial minus overhead). Whole-file review, so all instances (copySnippet + rendered body) were fixed.
- **`retrievalSources`** + **`privacyNotes`** (subagents read repo files) added.

## Grounding
code.claude.com/docs/en/sub-agents documents the Task tool, isolated context windows, scoped per-subagent tools, and worktree isolation. No speedup multipliers are claimed there, so the fabricated figures were removed.

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 157 chars; `git diff --check` clean
