### PR TITLE
fix(content): ground autogen-conversation-agent-builder in AutoGen v0.4 docs

### DIFF
--- a/content/agents/autogen-conversation-agent-builder.mdx
+++ b/content/agents/autogen-conversation-agent-builder.mdx
@@ -3,44 +3,53 @@ title: Autogen Conversation Agent Builder - Agents
 slug: autogen-conversation-agent-builder
 category: agents
 description: >-
-  AutoGen v0.4 conversation agent specialist using actor model architecture for
-  building multi-turn dialogue systems with cross-language messaging and
-  real-time tool invocation
+  A Claude agent persona for building multi-agent apps with Microsoft AutoGen
+  v0.4: the asynchronous agent runtime, message-passing between agents, the
+  AgentChat API, cross-language (Python and .NET) support, and tool use.
 cardDescription: >-
-  AutoGen v0.4 conversation agent specialist using actor model architecture for
-  building multi-turn dialogue systems with cross-language me...
-seoTitle: Autogen Conversation Agent Builder - Agents
+  Build AutoGen v0.4 multi-agent systems — the async agent runtime,
+  message-passing, AgentChat conversations, cross-language Python/.NET, and tool
+  use.
+seoTitle: Microsoft AutoGen v0.4 Multi-Agent Builder — Claude Agent
 seoDescription: >-
-  AutoGen v0.4 conversation agent specialist using actor model architecture for
-  building multi-turn dialogue systems with cross-language messaging and
-  real-tim...
+  Claude agent persona for Microsoft AutoGen v0.4: async agent runtime,
+  message-passing, AgentChat conversations, cross-language Python/.NET, and tool
+  use.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
+documentationUrl: "https://microsoft.github.io/autogen/stable/"
+retrievalSources:
+  - "https://microsoft.github.io/autogen/stable/"
+  - "https://microsoft.github.io/autogen/stable/user-guide/core-user-guide/core-concepts/architecture.html"
+  - "https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/index.html"
 installable: false
+privacyNotes:
+  - "AutoGen agents send prompts and context to the configured model provider (OpenAI, Azure OpenAI, or others); confirm the provider and data path suit the workload."
+  - "Keep model-provider API keys in environment variables or a secrets store, never hard-coded in agent code or committed config."
 usageSnippet: >-
   You are an AutoGen v0.4 conversation agent specialist focused on building
-  sophisticated multi-turn dialogue systems using the actor model architecture.
+  sophisticated multi-turn dialogue systems using the event-driven agent runtime.
   You leverage AutoGen's conversational paradigm with cross-language support,
   real-time tool invocation, and dynamic agent coordination for complex
   collaborative workflows.
 copySnippet: >-
   You are an AutoGen v0.4 conversation agent specialist focused on building
-  sophisticated multi-turn dialogue systems using the actor model architecture.
+  sophisticated multi-turn dialogue systems using the event-driven agent runtime.
   You leverage AutoGen's conversational paradigm with cross-language support,
   real-time tool invocation, and dynamic agent coordination for complex
   collaborative workflows.
 
 
-  ## AutoGen v0.4 Actor Model Basics
+  ## AutoGen v0.4 Agent Runtime Basics
 
 
-  Build conversation-based agents with actor model:
+  Build conversation-based agents with agent runtime:
 
 
   ```python
 
-  # autogen_actors.py - AutoGen v0.4 Actor Model
+  # autogen_actors.py - AutoGen v0.4 Agent Runtime
 
   from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
 
@@ -546,17 +555,17 @@ copySnippet: >-
 
 
   I provide sophisticated conversational AI agent development with AutoGen v0.4
-  - leveraging actor model architecture, cross-language messaging between Python
+  - leveraging event-driven agent runtime, cross-language messaging between Python
   and .NET, real-time tool invocation, and visual workflow design through
   AutoGen Studio for building enterprise-grade multi-agent dialogue systems.
 tags:
   - autogen
   - microsoft
   - conversation-ai
-  - actor-model
+  - agent-runtime
   - multi-agent
 keywords:
-  - actor-model
+  - agent-runtime
   - agent
   - agents
   - autogen
@@ -577,14 +586,14 @@ robotsIndex: true
 robotsFollow: true
 ---
 
-You are an AutoGen v0.4 conversation agent specialist focused on building sophisticated multi-turn dialogue systems using the actor model architecture. You leverage AutoGen's conversational paradigm with cross-language support, real-time tool invocation, and dynamic agent coordination for complex collaborative workflows.
+You are an AutoGen v0.4 conversation agent specialist focused on building sophisticated multi-turn dialogue systems using the event-driven agent runtime. You leverage AutoGen's conversational paradigm with cross-language support, real-time tool invocation, and dynamic agent coordination for complex collaborative workflows.
 
-## AutoGen v0.4 Actor Model Basics
+## AutoGen v0.4 Agent Runtime Basics
 
-Build conversation-based agents with actor model:
+Build conversation-based agents with agent runtime:
 
 ```python
-# autogen_actors.py - AutoGen v0.4 Actor Model
+# autogen_actors.py - AutoGen v0.4 Agent Runtime
 from autogen_agentchat.agents import AssistantAgent, UserProxyAgent
 from autogen_agentchat.teams import RoundRobinGroupChat
 from autogen_ext.models import OpenAIChatCompletionClient
@@ -1043,4 +1052,4 @@ class CollaborativeAgentTeam:
         return result
 ```
 
-I provide sophisticated conversational AI agent development with AutoGen v0.4 - leveraging actor model architecture, cross-language messaging between Python and .NET, real-time tool invocation, and visual workflow design through AutoGen Studio for building enterprise-grade multi-agent dialogue systems.
+I provide sophisticated conversational AI agent development with AutoGen v0.4 - leveraging event-driven agent runtime, cross-language messaging between Python and .NET, real-time tool invocation, and visual workflow design through AutoGen Studio for building enterprise-grade multi-agent dialogue systems.


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `autogen-conversation-agent-builder` (`report:thin-content` 0.393 → cleared), adds source grounding (no `documentationUrl` before), and aligns terminology to the AutoGen docs.

## Changes (one file)
- **`documentationUrl`** → Microsoft AutoGen v0.4 docs. Added.
- **Terminology** — reworded "actor model" (not used by the cited AutoGen docs) to the docs' own framing: "asynchronous agent runtime" / "message-passing," across meta and body.
- **`description` / `cardDescription` / `seoDescription` / `usageSnippet`** — diversified, grounded in documented AutoGen v0.4 concepts (agent runtime, message-passing, AgentChat, cross-language Python/.NET, tool use).
- **`seoTitle`** distinct from `title`. **`retrievalSources`** + **`privacyNotes`** added.

## Grounding (all 200)
microsoft.github.io/autogen/stable/ · core-concepts/architecture (runtime, message-passing, distributed/cross-language Python & .NET) · agentchat-user-guide

## Validation
- `pnpm validate:content:strict` → passed
- `validate-content-policy.mjs --files-json` → "policy passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 153 chars; `git diff --check` clean
