### PR TITLE
fix(content): ground cloudflare-workers-ai-edge and cut fabricated stats

### DIFF
--- a/content/skills/cloudflare-workers-ai-edge.mdx
+++ b/content/skills/cloudflare-workers-ai-edge.mdx
@@ -2,10 +2,10 @@
 title: Cloudflare Workers AI Edge Functions Skill
 slug: cloudflare-workers-ai-edge
 category: skills
-description: "Deploy AI models and serverless functions to Cloudflare's global edge network with sub-5ms cold starts and 40% edge computing market share. Access 50+ open-source AI models (Llama-2, Whisper, Stable Diffusion) with pay-per-use pricing."
-cardDescription: Deploy AI models and serverless functions to Cloudflare's global edge network with sub-5ms cold starts and 40% edge computing market share.
-seoTitle: Cloudflare Workers AI Edge Functions Skill
-seoDescription: Deploy AI models and serverless functions to Cloudflare's global edge network with sub-5ms cold starts and 40% edge computing market share. Access 50+ open-s...
+description: "Run AI inference and serverless functions on Cloudflare Workers AI: call hosted models like Llama, Whisper, and Stable Diffusion through the Workers AI binding, deploy with wrangler, and use D1/R2/KV storage plus the free daily Neuron allocation."
+cardDescription: Run hosted AI models (Llama, Whisper, Stable Diffusion) on Cloudflare Workers AI via the AI binding, deployed with wrangler and backed by D1/R2/KV.
+seoTitle: Cloudflare Workers AI Inference Skill for Claude
+seoDescription: "Cloudflare Workers AI skill: call hosted models (Llama, Whisper, Stable Diffusion) via env.AI.run, deploy with wrangler, and use D1/R2/KV storage."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -14,6 +14,12 @@ downloadUrl: /downloads/skills/cloudflare-workers-ai-edge.zip
 installable: true
 installCommand: npm install -g wrangler
 usageSnippet: npm install -g wrangler
+safetyNotes:
+  - "Deploying with wrangler writes Workers and bindings to your Cloudflare account; review what you deploy, since it serves live traffic."
+  - "Running Workers AI models consumes paid Neurons beyond the free daily allocation; set usage expectations before deploying inference at scale."
+privacyNotes:
+  - "Requests sent to Workers AI models are processed on Cloudflare's network; review what data your function forwards to the model."
+  - "Keep Cloudflare API tokens in wrangler's secret store or environment variables, never hard-coded or committed."
 copySnippet: |-
   export interface Env {
     AI: any;
@@ -90,7 +96,7 @@ robotsIndex: true
 robotsFollow: true
 ---
 
-Deploy AI models and serverless functions to Cloudflare's global edge network with sub-5ms cold starts and 40% edge computing market share. Access 50+ open-source AI models (Llama-2, Whisper, Stable Diffusion) with pay-per-use pricing. Includes 10,000 free Neurons per day, integrated D1/R2/KV storage, and deployment to 275+ cities worldwide.
+Run AI inference and serverless functions on Cloudflare Workers AI. Call hosted open-source models such as Llama, Whisper, and Stable Diffusion through the Workers AI binding, with pay-per-use Neuron pricing (including a free daily allocation), integrated D1/R2/KV storage, and deployment to Cloudflare's global edge network.
 
 ## Content
 
@@ -98,7 +104,7 @@ Deploy AI models and serverless functions to Cloudflare's global edge network wi
 
 ## What This Skill Enables
 
-Claude can build and deploy AI-powered serverless functions on Cloudflare's global edge network, spanning 275+ cities with sub-5ms cold start times (10-80x faster than AWS Lambda@Edge). With 40% edge computing market share and 4,000% year-over-year growth in AI inference requests, Cloudflare Workers AI brings machine learning models directly to users worldwide with minimal latency.
+Claude can build and deploy AI-powered serverless functions on Cloudflare's global edge network. Workers run on V8 isolates (no per-request cold start), and the Workers AI binding (`env.AI.run`) gives functions direct access to Cloudflare's catalog of hosted models, bringing inference close to users worldwide.
 
 ## Compatibility
 
@@ -282,9 +288,9 @@ Include TypeScript types and deployment scripts."
 
 ## Features
 
-- Sub-5ms cold starts with V8 isolates
-- 20+ AI models: Llama-2, Whisper, Stable Diffusion
-- Deploy to 275+ cities globally
+- Runs on V8 isolates (no per-request cold start)
+- Hosted models via the Workers AI catalog: Llama, Whisper, Stable Diffusion
+- Deploys to Cloudflare's global edge network
 - Integrated with D1, R2, KV, Queues
 - 50+ open-source AI models in catalog
 - Pay-per-use pricing with 10,000 free Neurons/day


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `cloudflare-workers-ai-edge` skill (`report:thin-content` 0.409 → cleared) and removes unverifiable marketing claims.

## Changes (one file)
- **`description` / `cardDescription` / `seoDescription`** — were identical; rewritten as distinct angles grounded in the Workers AI docs (hosted models via the AI binding `env.AI.run`, wrangler deploy, D1/R2/KV, Neuron pricing).
- **`seoTitle`** — distinct from `title`.
- **Body** — removed unverifiable stats: "40% edge computing market share", "4,000% year-over-year growth", "10-80x faster than AWS Lambda@Edge", and "sub-5ms cold starts" (reframed to the documented "V8 isolates, no per-request cold start"). Kept grounded facts (Llama/Whisper/Stable Diffusion, free Neuron allocation, D1/R2/KV).
- **`safetyNotes` / `privacyNotes`** — added (wrangler account-write deploy; paid Neurons; data sent to Workers AI; API token handling), required by the policy scanner.

## Grounding
developers.cloudflare.com/workers-ai documents the AI binding, the hosted model catalog (Llama, Whisper, Stable Diffusion), Neuron pricing/free allocation, and wrangler deployment. The removed market-share/growth/Lambda-comparison figures are not from Cloudflare's docs.

## Validation
- `pnpm validate:content:strict` → passed · policy → "passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 153 chars; `git diff --check` clean
