### PR TITLE
fix(content): ground cloud-infrastructure-architect-agent in Well-Architected frameworks

### DIFF
--- a/content/agents/cloud-infrastructure-architect-agent.mdx
+++ b/content/agents/cloud-infrastructure-architect-agent.mdx
@@ -3,21 +3,31 @@ title: Cloud Infrastructure Architect Agent - Agents
 slug: cloud-infrastructure-architect-agent
 category: agents
 description: >-
-  Multi-cloud infrastructure specialist focused on AWS, GCP, and Azure
-  architecture, cost optimization, disaster recovery, high availability, and
-  cloud-native design patterns
+  An agent persona for designing multi-cloud infrastructure across AWS, GCP,
+  and Azure using their Well-Architected frameworks: cost optimization,
+  reliability (high availability and disaster recovery), security, and
+  operational excellence.
 cardDescription: >-
-  Multi-cloud infrastructure specialist focused on AWS, GCP, and Azure
-  architecture, cost optimization, disaster recovery, high availabilit...
-seoTitle: Cloud Infrastructure Architect Agent - Agents
+  Design AWS/GCP/Azure architectures against the Well-Architected pillars —
+  cost, reliability, security, and operations — with HA and DR patterns.
+seoTitle: Multi-Cloud Architecture Agent (AWS/GCP/Azure)
 seoDescription: >-
-  Multi-cloud infrastructure specialist focused on AWS, GCP, and Azure
-  architecture, cost optimization, disaster recovery, high availability, and
-  cloud-native ...
+  Agent for multi-cloud architecture on AWS, GCP, and Azure: apply the
+  Well-Architected pillars — cost, reliability, HA/DR, security, and
+  operations.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
+documentationUrl: "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html"
+retrievalSources:
+  - "https://docs.aws.amazon.com/wellarchitected/latest/framework/welcome.html"
+  - "https://learn.microsoft.com/en-us/azure/well-architected/"
+  - "https://cloud.google.com/architecture/framework"
 installable: false
+safetyNotes:
+  - "This is an agent persona (prompt guidance); the infrastructure-as-code and CLI commands it produces provision and modify real cloud resources that incur cost — review plans (e.g. terraform plan) and apply them through your change process."
+privacyNotes:
+  - "Cloud architecture work involves account credentials and configuration; keep provider keys in a secrets manager or your cloud's IAM/role mechanism, never hard-coded in IaC or committed."
 usageSnippet: >-
   You are a cloud infrastructure architect agent specializing in designing
   scalable, secure, cost-optimized multi-cloud architectures. You combine deep


### PR DESCRIPTION
## What
Clears the registry uniqueness floor for the `cloud-infrastructure-architect-agent` (`report:thin-content` 0.417 → cleared) and adds source grounding (no `documentationUrl` before).

## Changes (one file, frontmatter only)
- **`documentationUrl`** → AWS Well-Architected Framework. Added.
- **`description` / `cardDescription` / `seoDescription`** — were identical; rewritten as distinct angles grounded in the cloud providers' Well-Architected frameworks (cost optimization, reliability/HA/DR, security, operational excellence).
- **`seoTitle`** distinct from `title`.
- **`retrievalSources`** — AWS, Azure, and GCP Well-Architected/architecture frameworks.
- **`safetyNotes` / `privacyNotes`** — added (generated IaC provisions real, billable resources; credential handling).

Body (example IaC patterns) unchanged.

## Grounding (all 200)
docs.aws.amazon.com/wellarchitected · learn.microsoft.com/azure/well-architected · cloud.google.com/architecture/framework — these define the cost/reliability/security/operations pillars the agent applies.

## Validation
- `pnpm validate:content:strict` → passed · policy → "passed"
- `report:thin-content` → entry removed from flagged list
- single file; `seoDescription` 146 chars; `git diff --check` clean
