### PR TITLE
fix(content): diversify bun-runtime-modern-javascript SEO copy

### DIFF
--- a/content/skills/bun-runtime-modern-javascript.mdx
+++ b/content/skills/bun-runtime-modern-javascript.mdx
@@ -2,10 +2,10 @@
 title: Bun JavaScript Runtime Development Skill
 slug: bun-runtime-modern-javascript
 category: skills
-description: "Build JavaScript and TypeScript apps with Bun, the all-in-one runtime: run TypeScript directly, and use the built-in bundler, test runner, and package manager from a single binary with Node.js compatibility."
-cardDescription: "Use Bun as runtime, bundler, test runner, and package manager in one binary — run TypeScript directly with Node.js compatibility."
+description: "Build JavaScript and TypeScript apps with Bun, an all-in-one toolchain that replaces Node.js, npm, a bundler, and a test runner with one fast binary that executes TypeScript directly."
+cardDescription: "One binary in place of Node.js, npm, a bundler, and a test runner — plus built-in SQLite and an HTTP server API."
 seoTitle: Bun All-in-One JavaScript Runtime Skill
-seoDescription: "Build with Bun: a single binary that runs TypeScript directly and bundles, tests, and installs packages, with drop-in Node.js compatibility."
+seoDescription: "Bun skill: write HTTP servers, CLIs, and SQLite-backed apps; bundle and test with one toolchain; reuse npm packages via Node compatibility."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
@@ -13,7 +13,7 @@ documentationUrl: "https://bun.sh/docs"
 downloadUrl: /downloads/skills/bun-runtime-modern-javascript.zip
 installable: true
 installCommand: npm install -g bun
-usageSnippet: "Claude can build and run JavaScript/TypeScript apps with Bun: run .ts files directly, bundle with `bun build`, test with `bun test`, install with `bun install`, and serve HTTP with `Bun.serve` — using Bun's Node.js compatibility for existing packages."
+usageSnippet: "Claude can scaffold Bun projects: serve HTTP with `Bun.serve`, query SQLite via `bun:sqlite`, bundle with `bun build`, and run the test runner — executing `.ts` files with no build step."
 copySnippet: |-
   const server = Bun.serve({
     port: 3000,


### PR DESCRIPTION
The prior merge landed an intermediate revision; the entry is still at unique-word ratio 0.41. This diversifies description/cardDescription/seoDescription/usageSnippet into distinct angles (toolchain replacement, SQLite/HTTP, use cases, workflow) → ratio clears 0.42. Grounded in bun.sh/docs; single file; policy passes.