### PR TITLE
fix(content): ground cloud-backup-on-session-stop in hooks + backup-tool docs

### DIFF
--- a/content/hooks/cloud-backup-on-session-stop.mdx
+++ b/content/hooks/cloud-backup-on-session-stop.mdx
@@ -3,20 +3,25 @@ title: Cloud Backup On Session Stop - Hooks
 slug: cloud-backup-on-session-stop
 category: hooks
 description: >-
-  Automatically backs up changed files to cloud storage when Claude Code session
-  ends using AWS S3, Google Cloud Storage, or rclone for universal cloud
-  provider support.
+  A Stop hook that syncs your changed files to cloud storage when a Claude Code
+  session ends — using `aws s3 sync`, `gsutil rsync`, or `rclone` so you can
+  back up to any provider.
 cardDescription: >-
-  Automatically backs up changed files to cloud storage when Claude Code session
-  ends using AWS S3, Google Cloud Storage, or rclone for uni...
-seoTitle: Cloud Backup On Session Stop - Hooks
+  On session end, syncs modified files to S3, Google Cloud Storage, or any
+  rclone remote so a session's work is never lost.
+seoTitle: Cloud Backup Stop Hook for Claude Code
 seoDescription: >-
-  Automatically backs up changed files to cloud storage when Claude Code session
-  ends using AWS S3, Google Cloud Storage, or rclone for universal cloud
-  provide...
+  Stop hook for Claude Code that backs up changed files when a session ends via
+  `aws s3 sync`, `gsutil rsync`, or `rclone` — to S3, GCS, or any provider.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
+retrievalSources:
+  - "https://code.claude.com/docs/en/hooks"
+  - "https://docs.aws.amazon.com/cli/latest/reference/s3/sync.html"
+  - "https://docs.cloud.google.com/storage/docs/gsutil/commands/rsync"
+  - "https://rclone.org/docs/"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch .claude/hooks/cloud-backup-on-session-stop.sh


### PR DESCRIPTION
Clears uniqueness floor (0.357 → cleared) and adds grounding (no documentationUrl before). documentationUrl = Claude Code hooks (Stop mechanism); retrievalSources add the backup tools the hook uses (aws s3 sync, gsutil rsync, rclone). Diversified description/cardDescription/seoDescription; seoTitle distinct from title; existing safety/privacy notes retained. Single file; validate + policy pass; thin-content cleared.