### PR TITLE
fix(content): diversify and ground hyperbrowser tool listing

### DIFF
--- a/content/tools/hyperbrowser.mdx
+++ b/content/tools/hyperbrowser.mdx
@@ -2,18 +2,30 @@
 title: Hyperbrowser
 slug: hyperbrowser
 category: tools
-description: Browser automation infrastructure for AI agents, web scraping, browser sessions, and large-scale web workflows.
-cardDescription: Browser automation infrastructure for AI workflows.
-seoTitle: Hyperbrowser browser automation infrastructure
-seoDescription: Hyperbrowser provides browser automation infrastructure for AI agents, web scraping, browser sessions, and web workflows.
+description: "Hyperbrowser is a cloud platform for running headless Chrome browser sessions that AI agents and developers control remotely. It supports Puppeteer/Playwright and native Python and Node SDKs, structured data scraping and crawling APIs, session recording, stealth and bot-detection evasion, and built-in integrations for Claude, OpenAI, Gemini, and BrowserUse agents plus an MCP server."
+cardDescription: "Cloud-hosted Chrome sessions with scraping APIs and agent integrations for Claude, OpenAI, and BrowserUse."
+seoTitle: "Hyperbrowser: Cloud Chrome Sessions and Scraping for AI Agents"
+seoDescription: "Hyperbrowser runs remote Chrome sessions for AI agents with Puppeteer, Playwright, Python and Node SDKs, scraping and crawling APIs, stealth, and an MCP server."
 author: Hyperbrowser
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.hyperbrowser.ai"
 documentationUrl: "https://docs.hyperbrowser.ai"
+retrievalSources:
+  - "https://docs.hyperbrowser.ai"
+  - "https://hyperbrowser.ai/docs/introduction"
+  - "https://www.hyperbrowser.ai"
 pricingModel: paid
 disclosure: editorial
 applicationCategory: DeveloperApplication
 operatingSystem: Web
+safetyNotes:
+  - "Drives real remote Chrome browsers that load and interact with live websites and execute arbitrary navigation and form actions on the user's behalf."
+  - "Offers stealth and bot-detection evasion features; using them against sites that prohibit automated access may violate target sites' terms of service."
+  - "Paid hosted service: usage consumes account credits and requires an API key with network access to the Hyperbrowser cloud."
+privacyNotes:
+  - "Browsing, scraping, and agent sessions run on Hyperbrowser's cloud infrastructure, so page content, scraped data, and any credentials entered during automated sessions are transmitted to and processed by a third party."
+  - "Session video recording can capture on-screen data from automated browsing sessions."
+  - "Requires a Hyperbrowser API key; review the vendor's data retention and handling policies before sending sensitive or authenticated content."
 tags:
   - browser-automation
   - agent-infrastructure


### PR DESCRIPTION
Backlog SEO/grounding fix (one file). Diversified description/cardDescription/seoDescription, seoTitle distinct from title, grounded documentationUrl + retrievalSources (all live), body claims corrected to match the actual script/source, safety/privacy notes where applicable. validate:content:strict + policy pass; thin-content cleared; seoDescription within 120-160.