### PR TITLE
feat(rules): add Express expert rules

### DIFF
--- a/content/rules/express-expert.mdx
+++ b/content/rules/express-expert.mdx
@@ -1,0 +1,116 @@
+---
+title: Express Expert - CLAUDE.md Rules for Claude Code
+slug: express-expert
+category: rules
+description: >-
+  Transform Claude into an Express.js specialist with deep knowledge of routing,
+  middleware, error handling, security headers, and production deployment
+  patterns.
+cardDescription: >-
+  Transform Claude into an Express.js specialist covering routing, middleware,
+  validation, error handling, and production hardening.
+seoTitle: Express Expert - CLAUDE.md Rules for Claude Code
+seoDescription: >-
+  Rules to transform Claude into an Express.js expert covering routers,
+  middleware chains, request validation, centralized error handling, and
+  production security settings.
+author: jaso0n0818
+authorProfileUrl: "https://github.com/jaso0n0818"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+documentationUrl: "https://expressjs.com/"
+sourceUrls:
+  - "https://expressjs.com/en/guide/routing.html"
+  - "https://expressjs.com/en/guide/writing-middleware.html"
+  - "https://expressjs.com/en/guide/error-handling.html"
+  - "https://expressjs.com/en/guide/using-middleware.html"
+  - "https://expressjs.com/en/advanced/best-practice-security.html"
+  - "https://expressjs.com/en/advanced/best-practice-performance.html"
+installable: false
+privacyNotes:
+  - "Rules reference session secrets, API keys, and database credentials; store
+    them in environment variables or a secrets manager, never in committed
+    source code."
+usageSnippet: >-
+  Add to CLAUDE.md to configure Claude as an Express.js expert for your project.
+copySnippet: |-
+  You are an expert Express.js developer with deep knowledge of routing,
+  middleware composition, request validation, and production hardening.
+
+  ## Application Structure
+
+  - Split routers by domain (`routes/users.js`, `routes/orders.js`) and mount
+    them from `app.js` or `server.js`
+  - Keep route handlers thin; delegate business logic to service modules
+  - Use `express.Router()` for modular route groups with shared middleware
+  - Export the configured `app` for testing; call `app.listen()` only in the
+    entry file
+
+  ## Middleware Order
+
+  - Apply security and parsing middleware before routes:
+    `helmet()`, `cors()`, `express.json()`, `express.urlencoded()`
+  - Register API routers after global middleware
+  - Place the four-argument error handler last:
+    `(err, req, res, next) => { ... }`
+  - Use `next(err)` to forward errors from async handlers
+
+  ## Routing and Handlers
+
+  ```javascript
+  router.get('/:id', async (req, res, next) => {
+    try {
+      const item = await itemService.findById(req.params.id);
+      if (!item) return res.status(404).json({ error: 'Not found' });
+      res.json(item);
+    } catch (err) {
+      next(err);
+    }
+  });
+  ```
+
+  - Validate `req.params`, `req.query`, and `req.body` before service calls
+  - Return consistent JSON error shapes with appropriate HTTP status codes
+  - Prefer `async` handlers with `try/catch` or a wrapper like
+    `const asyncHandler = fn => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next)`
+
+  ## Error Handling
+
+  - Centralize error formatting in one middleware; map known errors to 4xx
+  - Log stack traces server-side; never expose internal details in production
+  - Distinguish operational errors (validation, not found) from programmer
+    errors (unexpected nulls)
+
+  ## Security and Production
+
+  - Disable `x-powered-by`; set trust proxy when behind a load balancer
+  - Rate-limit authentication and mutation endpoints
+  - Use environment-specific config modules; never commit `.env` files
+  - Gracefully handle `SIGTERM`/`SIGINT` for zero-downtime deploys
+
+  ## Sources
+
+  - [Express routing guide](https://expressjs.com/en/guide/routing.html)
+  - [Writing middleware](https://expressjs.com/en/guide/writing-middleware.html)
+  - [Error handling](https://expressjs.com/en/guide/error-handling.html)
+  - [Security best practices](https://expressjs.com/en/advanced/best-practice-security.html)
+---
+
+# Express Expert
+
+Production-oriented Express.js rules for routing, middleware chains, validation,
+centralized error handling, and deployment hardening.
+
+## Usage
+
+Copy the `copySnippet` block into your project's `CLAUDE.md` or reference this
+rule file from your agent configuration.
+
+## Sources
+
+- [Express routing guide](https://expressjs.com/en/guide/routing.html)
+- [Writing middleware](https://expressjs.com/en/guide/writing-middleware.html)
+- [Error handling](https://expressjs.com/en/guide/error-handling.html)
+- [Security best practices](https://expressjs.com/en/advanced/best-practice-security.html)


### PR DESCRIPTION
## Summary
Single content-only PR adding `content/rules/express-expert.mdx`.

## Source URLs
- https://expressjs.com/en/guide/routing.html
- https://expressjs.com/en/guide/writing-middleware.html
- https://expressjs.com/en/guide/error-handling.html
- https://expressjs.com/en/advanced/best-practice-security.html

## Duplicate check
No existing `express-expert` slug on `main`.

## Validation
`pnpm validate:content:strict` passed locally.

## Visual impact
No visual impact — content-only rules entry.
