### PR TITLE
fix(content): rewrite context-analyzer to document the real /context command

### DIFF
--- a/content/commands/context-analyzer.mdx
+++ b/content/commands/context-analyzer.mdx
@@ -2,45 +2,37 @@
 title: Context Analyzer for Claude Code
 slug: context-analyzer
 category: commands
-description: >-
-  Analyze codebase context with agentic search to understand architecture,
-  patterns, and dependencies before major refactors or feature implementations
-cardDescription: >-
-  Analyze codebase context with agentic search to understand architecture,
-  patterns, and dependencies before major refactors or feature imp...
-seoTitle: Context Analyzer for Claude Code
-seoDescription: >-
-  Analyze codebase context with agentic search to understand architecture,
-  patterns, and dependencies before major refactors or feature implementations
-  Discove...
+description: Use the built-in /context command to inspect Claude Code's context-window usage, plus a custom .claude/commands recipe for repeatable codebase-context analysis before refactors.
+cardDescription: Inspect what fills Claude Code's context window with the built-in /context command, and build a custom /analyze-context recipe to gather codebase context before big changes.
+seoTitle: Claude Code /context Command and Custom Analysis Recipe
+seoDescription: Run /context in Claude Code for a live context-window breakdown with optimization tips, and create a custom .claude/commands recipe to analyze codebase context.
 author: JSONbored
-authorProfileUrl: "https://github.com/JSONbored"
-dateAdded: "2025-10-25"
-documentationUrl: "https://code.claude.com/docs/en/common-workflows"
-installable: true
-installCommand: "/context-analyzer [scope] [options]"
-usageSnippet: "/context-analyzer [scope] [options]"
-copySnippet: "/context-analyzer [scope] [options]"
+authorProfileUrl: https://github.com/JSONbored
+dateAdded: '2025-10-25'
+documentationUrl: https://code.claude.com/docs/en/context-window
+installable: false
+usageSnippet: /context
+copySnippet: /context
 tags:
-  - context-analysis
-  - codebase-understanding
-  - architecture
-  - agentic-search
-  - refactoring
-  - planning
+- context-analysis
+- codebase-understanding
+- architecture
+- agentic-search
+- refactoring
+- planning
 keywords:
-  - agentic-search
-  - analyzer
-  - architecture
-  - claude
-  - codebase-understanding
-  - commands
-  - context
-  - context-analysis
-  - development
-  - planning
-  - refactoring
-  - tools
+- agentic-search
+- analyzer
+- architecture
+- claude
+- codebase-understanding
+- commands
+- context
+- context-analysis
+- development
+- planning
+- refactoring
+- tools
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true
@@ -48,580 +40,83 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
-commandSyntax: "/context-analyzer [scope] [options]"
+commandSyntax: /context
+retrievalSources:
+- https://code.claude.com/docs/en/context-window
+- https://code.claude.com/docs/en/slash-commands
+- https://code.claude.com/docs/en/common-workflows
+safetyNotes:
+- The custom /analyze-context command makes Claude read files across your repository; scope it with a path argument to limit how much is pulled into context.
+- Analysis output reflects Claude's reading of the code in that session, not a deterministic static-analysis tool — verify any load-bearing metrics or recommendations against the actual source.
+privacyNotes:
+- Both /context and a custom analysis command operate on whatever files and project memory are loaded in the session; no data leaves your machine beyond the normal Claude Code model request, but file contents you ask Claude to read become part of the conversation context sent to the model.
 ---
 
-The `/context-analyzer` command performs deep codebase analysis using Claude's agentic search to understand architecture, patterns, and dependencies for informed decision-making.
+There is no built-in `/context-analyzer` command in Claude Code, and the `[scope]`/`[options]` flags shown in older versions of this page (`--full`, `--architecture`, `--module=`, `--quality`, `--save-to=`, and so on) do not exist. This page documents two real things instead:
 
-## Features
+1. The built-in `/context` command, for inspecting Claude Code's context window.
+2. How to build your own `/analyze-context` custom command for repeatable codebase analysis before a refactor or feature.
 
-- **Agentic Search**: Scan and interpret entire project automatically
-- **Architecture Mapping**: Visualize system structure and relationships
-- **Pattern Detection**: Identify common patterns and conventions
-- **Dependency Analysis**: Understand module dependencies and coupling
-- **Tech Stack Discovery**: Auto-detect frameworks, libraries, versions
-- **Code Quality Metrics**: Assess maintainability and technical debt
-- **Refactoring Prerequisites**: Gather context before major changes
-- **Onboarding Tool**: Help new developers understand codebase
+## The built-in `/context` command
 
-## Usage
+`/context` shows a live breakdown of what is currently filling your context window, grouped by category, along with optimization suggestions. It takes no arguments or flags.
 
 ```bash
-/context-analyzer [scope] [options]
+/context
 ```
 
-### Scope
+It accounts for the things that consume the window, including:
 
-- `--full` - Analyze entire codebase (default)
-- `--directory=<path>` - Analyze specific directory
-- `--module=<name>` - Analyze specific module/feature
-- `--file=<path>` - Deep analysis of single file
+- **System prompt** — the always-loaded core instructions (you never see these directly).
+- **CLAUDE.md / memory** — project and user memory files loaded at startup. Use `/memory` to see exactly which files loaded.
+- **MCP tools** — tool names (and, depending on `ENABLE_TOOL_SEARCH`, schemas) from connected MCP servers.
+- **Skill / command listings** — one-line descriptions of skills Claude can invoke.
+- **Conversation messages and file reads** — your prompts, Claude's responses, and the contents of files Claude has read (file reads typically dominate usage).
 
-### Analysis Types
+Use it when responses start to feel sluggish, when you are deciding whether to run `/compact` or `/clear`, or when you want to understand why a session is approaching its limit. For the underlying model of how the window fills and compacts, see the [context window documentation](https://code.claude.com/docs/en/context-window).
 
-- `--architecture` - System architecture and structure
-- `--patterns` - Code patterns and conventions
-- `--dependencies` - Dependency graph and coupling
-- `--tech-stack` - Technology stack inventory
-- `--quality` - Code quality and technical debt
-- `--all` - Comprehensive analysis (all types)
+### Related built-ins
 
-### Output
+- `/compact` — summarizes the conversation to free space while preserving startup content (CLAUDE.md, memory, MCP tools reload automatically; the skill listing is the one exception). Claude Code also compacts automatically as you approach the limit.
+- `/clear` — resets the conversation.
+- `/memory` — shows which CLAUDE.md and auto-memory files loaded at startup.
 
-- `--summary` - Executive summary only
-- `--detailed` - Full analysis report
-- `--save-to=<file>` - Save report to file
+## Building a custom codebase-analysis command
 
-## Examples
+Claude Code does not ship a command that auto-generates architecture reports, dependency graphs, or quality metrics. You can, however, create your own custom slash command that asks Claude to analyze a codebase the same way every time. Custom commands are user-created Markdown files — they are not built-in, and the quality of the output depends entirely on the prompt you write and what Claude can read in your repo.
 
-### Full Codebase Analysis
+Create a file at `.claude/commands/analyze-context.md` (project-scoped) or `~/.claude/commands/analyze-context.md` (personal). The file name becomes the command name, so this file creates `/analyze-context`. Custom commands have merged into [skills](https://code.claude.com/docs/en/slash-commands); a file under `.claude/commands/` still works and supports the same frontmatter, while skills add optional features like supporting files and automatic invocation.
 
-**Command:**
+```markdown
+---
+description: Analyze the architecture, patterns, and dependencies of a codebase area
+argument-hint: [path]
+---
+
+Analyze the code under `$ARGUMENTS` (default to the repo root if empty).
+
+Read the relevant files and report:
+1. Tech stack and frameworks actually present (cite package manifests).
+2. The architecture / layering you observe, with key directories.
+3. Recurring patterns and conventions, with file references.
+4. Internal coupling and any obvious refactor risks.
+5. Where tests exist and where coverage looks thin.
+
+Cite real files and line ranges. Do not invent metrics or numbers
+you cannot derive from the code you actually read.
+```
+
+Invoke it with an optional path:
 
 ```bash
-/context-analyzer --full --all
+/analyze-context src/auth
 ```
 
-**Analysis Report:**
+The `$ARGUMENTS` placeholder is replaced with everything you type after the command name. You can also target a single argument with `$0`/`$ARGUMENTS[0]`, or declare named arguments in frontmatter. See the [arguments reference](https://code.claude.com/docs/en/slash-commands) for the full substitution rules.
 
-````
-[Context Analysis: Full Codebase]
-[Using Agentic Search to scan project...]
+## When to use which
 
-====================
-PROJECT OVERVIEW
-====================
+- Reach for **`/context`** to understand and manage token usage in the current session.
+- Reach for a **custom `/analyze-context` command** when you want a consistent, repeatable codebase walk-through before a refactor, when onboarding to an unfamiliar area, or before scoping a large change.
 
-Name: E-Commerce SaaS Platform
-Size: 450 files, 85K LOC
-Languages: TypeScript (95%), CSS (3%), JSON (2%)
-Last Modified: 2 hours ago
-
-====================
-TECH STACK
-====================
-
-Frontend:
-  - React 19.1.1 (Server Components)
-  - Next.js 15.5.2 (App Router)
-  - TailwindCSS v4.1.13
-  - shadcn/ui components
-  - Framer Motion 11.x
-
-Backend:
-  - Next.js API Routes
-  - tRPC 11.x (type-safe APIs)
-  - Prisma 5.x (ORM)
-  - PostgreSQL 16
-
-Authentication:
-  - better-auth v1.3.9
-  - JWT + Refresh tokens
-  - OAuth2 (Google, GitHub)
-
-Testing:
-  - Vitest (unit/integration)
-  - Playwright (E2E)
-  - React Testing Library
-
-Tooling:
-  - TypeScript 5.3 (strict mode)
-  - Biome (linting/formatting)
-  - pnpm (package manager)
-
-====================
-ARCHITECTURE
-====================
-
-Pattern: Layered Architecture
-
-1. Presentation Layer (app/)
-   - Route groups: (auth), (dashboard), (marketing)
-   - Server Components for data fetching
-   - Client Components for interactivity
-   - Layouts with nested routing
-
-2. API Layer (app/api/)
-   - tRPC routers (type-safe)
-   - REST endpoints (webhooks, public API)
-   - Middleware (auth, rate limiting)
-
-3. Business Logic (lib/)
-   - Services: auth, payments, notifications
-   - Utilities: validation, formatting
-   - Types: shared interfaces
-
-4. Data Layer (prisma/)
-   - Schema: 15 models
-   - Migrations: 23 migrations
-   - Seeders: test data
-
-Key Directories:
-  app/           - Next.js routes (78 files)
-  components/    - React components (125 files)
-  lib/          - Business logic (45 files)
-  hooks/        - Custom React hooks (18 files)
-  prisma/       - Database schema (3 files)
-  tests/        - Test files (89 files)
-
-====================
-CODE PATTERNS
-====================
-
-Detected Patterns:
-
-1. Server Component Data Fetching:
-   ```typescript
-   // Pattern found in 42 files
-   export async function Component() {
-     const data = await db.query();
-     return <div>{data}</div>;
-   }
-````
-
-2. Form Handling (react-hook-form + Zod):
-
-   ```typescript
-   // Pattern found in 15 files
-   const form = useForm({
-     resolver: zodResolver(schema),
-   });
-   ```
-
-3. tRPC API Calls:
-
-   ```typescript
-   // Pattern found in 38 files
-   const { data, isLoading } = trpc.users.list.useQuery();
-   ```
-
-4. Error Boundaries:
-
-   ```typescript
-   // Pattern found in 8 layouts
-   <ErrorBoundary fallback={<ErrorPage />}>
-     {children}
-   </ErrorBoundary>
-   ```
-
-5. Authentication Guards:
-   ```typescript
-   // Pattern found in 12 routes
-   const session = await auth();
-   if (!session) redirect("/login");
-   ```
-
-====================
-DEPENDENCY ANALYSIS
-====================
-
-High Coupling (Needs Refactoring):
-
-- auth.service.ts → 23 files depend on it
-- db/client.ts → 45 files import directly
-- utils/validation.ts → 18 files
-
-Low Coupling (Good):
-
-- components/ui/\* → Self-contained
-- hooks/\* → Independent
-
-Circular Dependencies: None detected ✓
-
-External Dependencies:
-
-- Production: 45 packages
-- Development: 28 packages
-- Total bundle size: 287 KB (gzipped)
-
-Heaviest Dependencies:
-
-1. next: 105 KB
-2. react-dom: 42 KB
-3. framer-motion: 38 KB
-4. @trpc/client: 28 KB
-
-====================
-CODE QUALITY
-====================
-
-Metrics:
-
-- Test Coverage: 78% (target: 80%)
-- TypeScript Errors: 0
-- Linting Warnings: 3
-- Duplicate Code: 2.1%
-- Complexity (avg): 4.2 (good)
-
-Technical Debt:
-🟡 Medium Debt (Manageable)
-
-Priority Issues:
-
-1. auth.service.ts high coupling (23 dependencies)
-2. 3 components exceed 250 lines
-3. 5 files missing JSDoc comments
-4. 2% test coverage gap
-
-Strengths:
-✓ Consistent naming conventions
-✓ Strong TypeScript usage (strict mode)
-✓ Good file organization
-✓ Modern React patterns
-✓ Proper error handling
-
-====================
-RECOMMENDATIONS
-====================
-
-1. Refactor auth.service.ts
-   - Extract to smaller services
-   - Reduce coupling (23 → <10 dependencies)
-
-2. Increase test coverage
-   - Add tests for: payments/, notifications/
-   - Target: 78% → 80%
-
-3. Component splitting
-   - Break down large components (>250 lines)
-   - Extract reusable logic to hooks
-
-4. Documentation
-   - Add JSDoc to public APIs
-   - Update architecture diagrams
-
-5. Performance
-   - Consider code splitting for framer-motion
-   - Lazy load heavy components
-
-====================
-SUMMARY
-====================
-
-Codebase Health: 🟢 Healthy
-
-The codebase is well-structured with modern patterns.
-Minor technical debt is manageable. Ready for feature
-development with recommended refactorings noted above.
-
-Key Findings:
-
-- Strong TypeScript foundation
-- Consistent React 19 patterns
-- Good test coverage (close to target)
-- Manageable technical debt
-- Clear architecture
-
-Recommended Next Steps:
-
-1. Address auth.service.ts coupling
-2. Reach 80% test coverage
-3. Proceed with feature development
-
-````
-
-### Module-Specific Analysis
-
-**Command:**
-```bash
-/context-analyzer --module=authentication --detailed
-````
-
-**Report:**
-
-```
-[Authentication Module Analysis]
-
-====================
-MODULE OVERVIEW
-====================
-
-Location: lib/auth/
-Files: 8 files
-Lines: 1,250 LOC
-Tests: 12 test files (85% coverage)
-
-====================
-FILE STRUCTURE
-====================
-
-lib/auth/
-  ├── index.ts              (Exports)
-  ├── auth.service.ts       (Core logic)
-  ├── jwt.util.ts          (Token handling)
-  ├── password.util.ts     (Hashing)
-  ├── session.manager.ts   (Session mgmt)
-  ├── oauth.provider.ts    (OAuth flow)
-  ├── middleware.ts        (Auth middleware)
-  └── types.ts            (TypeScript types)
-
-====================
-DEPENDENCIES
-====================
-
-External:
-  - bcrypt: Password hashing
-  - jsonwebtoken: JWT creation/verification
-  - better-auth: Core auth library
-
-Internal:
-  → db/client.ts (Database access)
-  → lib/email/service.ts (Verification emails)
-  → lib/config/env.ts (Environment vars)
-
-Dependent Modules:
-  ← app/api/auth/* (23 files)
-  ← middleware.ts (Route protection)
-  ← app/(dashboard)/* (18 files)
-
-====================
-KEY PATTERNS
-====================
-
-1. JWT Strategy:
-   - Access token: 15 min expiry
-   - Refresh token: 7 days expiry
-   - Stored in HTTP-only cookies
-
-2. Password Security:
-   - bcrypt with cost factor 12
-   - Password validation: min 8 chars, complexity rules
-
-3. OAuth Flow:
-   - Supported: Google, GitHub
-   - PKCE flow for security
-   - State parameter for CSRF protection
-
-4. Session Management:
-   - Server-side session validation
-   - Automatic refresh on activity
-   - Logout clears all tokens
-
-====================
-SECURITY ANALYSIS
-====================
-
-✓ Strengths:
-  - HTTP-only secure cookies
-  - CSRF protection
-  - Rate limiting on auth endpoints
-  - Password complexity requirements
-  - JWT expiration enforced
-
-⚠️  Recommendations:
-  - Add 2FA support
-  - Implement session device tracking
-  - Add anomaly detection
-
-====================
-TESTING
-====================
-
-Coverage: 85%
-
-Test Types:
-  - Unit: auth.service.test.ts (42 tests)
-  - Integration: api/auth.test.ts (18 tests)
-  - E2E: auth-flow.spec.ts (8 tests)
-
-Gaps:
-  - OAuth error handling (not tested)
-  - Token refresh edge cases (partial)
-
-====================
-REFACTORING NEEDS
-====================
-
-Priority: Medium
-
-Recommendations:
-1. Split auth.service.ts (currently 350 lines)
-   - Extract JWT logic → jwt.service.ts
-   - Extract OAuth → oauth.service.ts
-
-2. Reduce coupling (23 dependencies)
-   - Use dependency injection
-   - Create interfaces for external services
-
-3. Add JSDoc documentation
-   - Document public API methods
-   - Add usage examples
-
-Estimated Effort: 2-3 days
-```
-
-### Before Refactoring Analysis
-
-**Command:**
-
-```bash
-/context-analyzer --directory=src/components/dashboard --architecture
-```
-
-**Use Case: Planning Refactor**
-
-```
-[Pre-Refactoring Analysis]
-
-Goal: Refactor dashboard components
-
-Current State:
-  Files: 25 components
-  LOC: 3,450 lines
-  Complexity: High (avg 6.8)
-  Dependencies: 45 internal imports
-
-Architecture Issues:
-  1. Prop drilling (5 levels deep)
-  2. State duplication (3 components)
-  3. Large components (4 files >200 lines)
-  4. Tight coupling (shared state)
-
-Recommended Approach:
-  1. Extract state to Zustand store
-  2. Split large components:
-     - DashboardOverview (280 lines) → 3 components
-     - UserTable (320 lines) → 4 components
-  3. Create composable sub-components
-  4. Use context for shared data
-
-Impact Analysis:
-  - Affected files: 25
-  - Dependent modules: 8
-  - Test files to update: 18
-  - Estimated time: 1 week
-
-Ready to proceed? (y/n)
-```
-
-## Use Cases
-
-### 1. Onboarding New Developers
-
-```bash
-/context-analyzer --full --summary
-
-# New developer gets:
-- Tech stack overview
-- Architecture understanding
-- Code patterns
-- Key files to know
-
-Result: Productive in hours, not days
-```
-
-### 2. Pre-Refactoring Planning
-
-```bash
-/context-analyzer --module=payments --dependencies
-
-# Before refactoring, understand:
-- What depends on this module
-- Internal coupling
-- Impact of changes
-- Test coverage
-
-Result: Informed refactoring decisions
-```
-
-### 3. Technical Debt Assessment
-
-```bash
-/context-analyzer --full --quality
-
-# Management gets:
-- Code quality metrics
-- Technical debt level
-- Refactoring priorities
-- Estimated effort
-
-Result: Data-driven planning
-```
-
-### 4. Architecture Documentation
-
-```bash
-/context-analyzer --architecture --save-to=ARCHITECTURE.md
-
-# Auto-generate:
-- Architecture diagrams
-- Module relationships
-- Data flow
-- Deployment structure
-
-Result: Up-to-date documentation
-```
-
-## Best Practices
-
-1. **Run Before Major Changes**
-   - Understand current state
-   - Identify affected areas
-   - Plan migration path
-
-2. **Regular Health Checks**
-   - Monthly quality analysis
-   - Track metrics over time
-   - Identify degradation early
-
-3. **Onboarding Tool**
-   - Run for new team members
-   - Generate onboarding docs
-   - Update as project evolves
-
-4. **Save Reports**
-   - Version control analysis
-   - Track improvements
-   - Share with team
-
-## Integration with Other Commands
-
-### Context Analysis → Plan Mode
-
-```bash
-/context-analyzer --module=authentication --dependencies
-# Understand current architecture
-
-/plan-mode "Refactor authentication module" --think-harder
-# Create detailed refactoring plan
-```
-
-### Context Analysis → TDD
-
-```bash
-/context-analyzer --file=payment.service.ts --quality
-# Identify untested code paths
-
-/tdd-workflow "Add tests for payment edge cases" --unit
-# Implement missing tests
-```
-
-### Context Analysis → Subagents
-
-```bash
-/context-analyzer --full --quality
-# Identify refactoring needs
-
-/subagent-create --refactoring-specialist --code-reviewer
-# Deploy specialists for refactoring
-```
+Because the custom command is just a prompt, its findings are Claude's reading of your code in that session — not a deterministic static-analysis tool. Treat metrics and recommendations it produces as Claude's assessment, and verify anything load-bearing against the actual source.


### PR DESCRIPTION
Rewrites a fabricated entry into an accurate one documenting the REAL Claude Code command/capability, grounded in official docs. No invented commands/flags. validate:content:strict + policy pass; thin-content cleared; seoDescription within 120-160; single file.