### PR TITLE
fix(content): rewrite tdd-workflow as a custom TDD command recipe

### DIFF
--- a/content/commands/tdd-workflow.mdx
+++ b/content/commands/tdd-workflow.mdx
@@ -1,46 +1,37 @@
 ---
-title: TDD Workflow for Claude Code
+title: TDD Workflow Custom Command for Claude Code
 slug: tdd-workflow
 category: commands
-description: >-
-  Implement test-driven development workflows with Claude Code using
-  red-green-refactor cycles, automatic test generation, and AI-guided iteration
-  until all tests pass
-cardDescription: >-
-  Implement test-driven development workflows with Claude Code using
-  red-green-refactor cycles, automatic test generation, and AI-guided it...
-seoTitle: TDD Workflow for Claude Code
-seoDescription: >-
-  Implement test-driven development workflows with Claude Code using
-  red-green-refactor cycles, automatic test generation, and AI-guided iteration
-  until all te...
+description: 'A user-created custom slash command that runs a red-green-refactor TDD loop in Claude Code: write failing tests first, implement until they pass, then refactor. Built with the documented custom-command frontmatter and $ARGUMENTS substitution, not a built-in feature.'
+cardDescription: A custom .claude/commands/tdd-workflow.md recipe that drives a red-green-refactor loop in Claude Code. Not a built-in command.
+seoTitle: TDD Workflow Custom Slash Command for Claude Code
+seoDescription: 'Build a custom /tdd-workflow slash command for Claude Code that runs a red-green-refactor loop: write failing tests first, implement to green, then refactor.'
 author: JSONbored
-authorProfileUrl: "https://github.com/JSONbored"
-dateAdded: "2025-10-25"
-documentationUrl: "https://code.claude.com/docs/en/common-workflows"
-installable: true
-installCommand: "/tdd-workflow [feature] [options]"
-usageSnippet: "/tdd-workflow [feature] [options]"
-copySnippet: "/tdd-workflow [feature] [options]"
+authorProfileUrl: https://github.com/JSONbored
+dateAdded: '2025-10-25'
+documentationUrl: https://code.claude.com/docs/en/slash-commands
+installable: false
+usageSnippet: 'Create .claude/commands/tdd-workflow.md, then run: /tdd-workflow add a slugify() helper'
+copySnippet: /tdd-workflow add a slugify() helper that strips punctuation
 tags:
-  - tdd
-  - testing
-  - red-green-refactor
-  - test-automation
-  - quality
-  - ai-testing
+- tdd
+- testing
+- red-green-refactor
+- test-automation
+- quality
+- ai-testing
 keywords:
-  - ai-testing
-  - claude
-  - commands
-  - development
-  - quality
-  - red-green-refactor
-  - tdd
-  - test-automation
-  - testing
-  - tools
-  - workflow
+- ai-testing
+- claude
+- commands
+- development
+- quality
+- red-green-refactor
+- tdd
+- test-automation
+- testing
+- tools
+- workflow
 readingTime: 11
 difficultyScore: 100
 hasTroubleshooting: true
@@ -48,709 +39,98 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
-commandSyntax: "/tdd-workflow [feature] [options]"
+commandSyntax: 'Create .claude/commands/tdd-workflow.md, then run: /tdd-workflow add a slugify() helper'
+retrievalSources:
+- https://code.claude.com/docs/en/slash-commands
+- https://code.claude.com/docs/en/common-workflows
+safetyNotes:
+- The recipe's allowed-tools pre-approves Bash test commands (e.g. npm/pnpm/npx test), letting Claude run them without per-call confirmation. Scope these to your real runner and review project-scope .claude/commands files before trusting a repository, since a checked-in command can grant broad tool access.
+- Claude may create and edit test and source files as part of the loop (Read/Edit/Write). Run it in version control so changes are reviewable and reversible.
+- If you extend the prompt with auto-commit or deploy steps, add explicit safety review; the base recipe does not commit or push.
+privacyNotes:
+- The command body can read project files via @ references and !`command` injection; only reference files you are comfortable sending to the model as prompt context. The base recipe reads package.json to detect the test framework.
 ---
 
-The `/tdd-workflow` command implements test-driven development (TDD) in Claude Code with AI-assisted red-green-refactor cycles, preventing hallucination through test-anchored iteration.
+`/tdd-workflow` is **not a built-in Claude Code command**. There is no shipped TDD command and no built-in TDD flags. This entry is a **custom slash command recipe**: you save a Markdown prompt file in your repo and Claude Code exposes it as `/tdd-workflow`. It works by injecting a fixed red-green-refactor prompt into the session, then letting Claude drive your existing test runner.
 
-## Features
+Custom commands are documented here: https://code.claude.com/docs/en/slash-commands
 
-- **Red-Green-Refactor Automation**: Full TDD cycle with failing tests → passing code → optimization
-- **Test-First Enforcement**: Claude writes tests BEFORE implementing features
-- **Iteration Until Pass**: AI refines code until all tests pass (no manual fixes)
-- **Anti-Hallucination**: Tests serve as ground truth preventing scope drift
-- **Coverage Tracking**: Automatic code coverage measurement (80%+ target)
-- **Test Templates**: Pre-built patterns for unit, integration, and E2E tests
-- **Framework Support**: Vitest, Jest, Playwright, Cypress
-- **Continuous Verification**: Run tests after each code change
+## How custom commands work
 
-## Usage
+- A file at `.claude/commands/<name>.md` (project scope, checked into the repo) or `~/.claude/commands/<name>.md` (personal scope) becomes the slash command `/<name>`. The command name is the file name without the `.md` extension.
+- The Markdown body is the prompt that gets sent to Claude when you invoke the command.
+- Optional YAML frontmatter controls behavior. Documented fields include `description`, `argument-hint`, `arguments`, `allowed-tools`, `disallowed-tools`, `disable-model-invocation`, `model`, and `shell`.
+- Arguments are substituted into the body: `$ARGUMENTS` expands to everything you typed after the command; `$1`/`$2` (shorthand for `$ARGUMENTS[1]`/`$ARGUMENTS[2]`, 0-based) access positional arguments; named placeholders like `$feature` work when you declare them in the `arguments` frontmatter.
+- The body can run shell commands at expansion time with `` !`command` `` and reference files with `@path/to/file`.
+
+> Note: As of the current docs, custom commands have been merged into skills. A file at `.claude/commands/tdd-workflow.md` and a skill at `.claude/skills/tdd-workflow/SKILL.md` both create `/tdd-workflow` and behave the same way; existing `.claude/commands/` files keep working. Use the skill form if you want supporting files or automatic invocation.
+
+## Create the command
+
+Save this as `.claude/commands/tdd-workflow.md`:
+
+```markdown
+---
+description: Drive a red-green-refactor TDD loop for the requested change
+argument-hint: [feature description]
+allowed-tools: Read, Edit, Write, Bash(npm test*), Bash(pnpm test*), Bash(npx vitest*)
+disable-model-invocation: true
+---
+
+Follow strict test-driven development for: $ARGUMENTS
+
+1. RED — Before writing any implementation, add focused failing tests that
+   describe only the requested behavior. Run the project's test command and
+   show me the failing output. Do not implement yet.
+2. GREEN — Write the minimum implementation needed to make those tests pass.
+   Re-run the tests and show that they pass. Do not add behavior the tests
+   do not require.
+3. REFACTOR — Clean up names and structure while keeping the tests green.
+   Re-run the tests after refactoring.
+
+Use the test framework already configured in this project. Detect it from
+@package.json rather than assuming one. Stop and ask me before changing test
+configuration or adding new dependencies.
+```
+
+`disable-model-invocation: true` keeps Claude from triggering the loop on its own; you invoke it deliberately. The `allowed-tools` entries pre-approve the test commands so Claude does not prompt for each run — adjust them to match your actual runner (Jest, Vitest, pytest, go test, etc.).
+
+## Invoke it
 
 ```bash
-/tdd-workflow [feature] [options]
+/tdd-workflow add a slugify() helper that strips punctuation and lowercases
 ```
 
-### Workflow Modes
+Everything after the command name becomes `$ARGUMENTS`. Claude then walks the red-green-refactor steps from the prompt, using whatever test framework your project already has.
 
-- `--unit` - Unit test TDD workflow (default)
-- `--integration` - Integration test workflow
-- `--e2e` - End-to-end test workflow
-- `--full` - Complete test pyramid (unit + integration + e2e)
+If you want positional arguments instead, declare them in frontmatter:
 
-### Test Frameworks
+```markdown
+---
+description: TDD a change in a specific module
+argument-hint: [module] [behavior]
+arguments: [module, behavior]
+---
 
-- `--vitest` - Vitest (default for unit/integration)
-- `--jest` - Jest testing framework
-- `--playwright` - Playwright for E2E
-- `--cypress` - Cypress for E2E
-
-### Coverage Options
-
-- `--coverage` - Generate coverage report (default: true)
-- `--min-coverage=<percent>` - Minimum coverage threshold (default: 80)
-- `--strict` - Fail if coverage below threshold
-
-### Behavior Modifiers
-
-- `--watch` - Watch mode, re-run tests on file changes
-- `--debug` - Show detailed test execution logs
-- `--commit-on-green` - Auto-commit when all tests pass
-
-## Examples
-
-### Basic TDD Workflow - User Authentication
-
-**Command:**
-
-```bash
-/tdd-workflow "user authentication service with email/password" --unit
+TDD the behavior "$behavior" in the module `$module`, red-green-refactor.
 ```
 
-**TDD Cycle:**
+Then `/tdd-workflow auth "rejects expired tokens"` maps `$module` to `auth` and `$behavior` to `rejects expired tokens` (quote multi-word values).
 
-**Phase 1: RED (Write Failing Tests)**
+## When to use it
 
-```typescript
-// Claude generates: tests/unit/auth.service.test.ts
-import { describe, it, expect, beforeEach } from "vitest";
-import { AuthService } from "@/services/auth.service";
+- You want to enforce test-first discipline in agent-assisted work, so the tests pin down scope before implementation.
+- You repeatedly paste the same "write failing tests, then implement, then refactor" instructions and want a one-keystroke entry point.
+- You want the loop checked into the repo so the whole team shares the same TDD prompt (project-scope `.claude/commands/`).
 
-describe("AuthService", () => {
-  let authService: AuthService;
+## Honest limitations
 
-  beforeEach(() => {
-    authService = new AuthService();
-  });
+- This is just a saved prompt. It does not add new flags to Claude Code, does not enforce coverage thresholds, and cannot guarantee Claude writes tests first — it strongly steers the model, but the model still drives.
+- Coverage numbers, watch mode, and auto-commit are features of your test runner and git, not of this command. Wire them in by adding the relevant commands to the prompt body or `allowed-tools` (for example a `--coverage` flag your runner supports).
+- Behavior depends on your installed test framework and scripts; the command does not install or configure tooling.
 
-  describe("login", () => {
-    it("should return user token for valid credentials", async () => {
-      const result = await authService.login({
-        email: "user@example.com",
-        password: "ValidPass123",
-      });
+## Customizing the loop
 
-      expect(result).toHaveProperty("token");
-      expect(result).toHaveProperty("user");
-      expect(result.user.email).toBe("user@example.com");
-    });
-
-    it("should throw error for invalid email", async () => {
-      await expect(
-        authService.login({ email: "invalid", password: "pass" }),
-      ).rejects.toThrow("Invalid email format");
-    });
-
-    it("should throw error for incorrect password", async () => {
-      await expect(
-        authService.login({ email: "user@example.com", password: "wrong" }),
-      ).rejects.toThrow("Invalid credentials");
-    });
-
-    it("should hash password before comparison", async () => {
-      const loginSpy = vi.spyOn(authService, "comparePassword");
-      await authService.login({ email: "user@example.com", password: "pass" });
-
-      expect(loginSpy).toHaveBeenCalledWith("pass", expect.any(String));
-    });
-  });
-
-  describe("register", () => {
-    it("should create new user and return token", async () => {
-      const result = await authService.register({
-        email: "new@example.com",
-        password: "ValidPass123",
-        name: "New User",
-      });
-
-      expect(result).toHaveProperty("token");
-      expect(result.user.email).toBe("new@example.com");
-    });
-
-    it("should reject weak passwords", async () => {
-      await expect(
-        authService.register({ email: "user@example.com", password: "123" }),
-      ).rejects.toThrow("Password must be at least 8 characters");
-    });
-
-    it("should reject duplicate emails", async () => {
-      await authService.register({
-        email: "dup@example.com",
-        password: "ValidPass123",
-      });
-
-      await expect(
-        authService.register({
-          email: "dup@example.com",
-          password: "ValidPass123",
-        }),
-      ).rejects.toThrow("Email already exists");
-    });
-  });
-});
-```
-
-**Run Tests (Expect Failures):**
-
-```bash
-pnpm test auth.service.test.ts
-
-❌ FAIL  tests/unit/auth.service.test.ts
-  AuthService
-    login
-      ✗ should return user token for valid credentials
-        → Cannot find module '@/services/auth.service'
-      ✗ should throw error for invalid email
-      ✗ should throw error for incorrect password
-      ✗ should hash password before comparison
-```
-
-Claude: "Tests written and failing as expected. Proceeding to GREEN phase."
-
-**Phase 2: GREEN (Implement Minimum Code to Pass)**
-
-```typescript
-// Claude generates: src/services/auth.service.ts
-import { hash, compare } from "bcrypt";
-import { sign } from "jsonwebtoken";
-import { z } from "zod";
-
-const loginSchema = z.object({
-  email: z.string().email("Invalid email format"),
-  password: z.string().min(1),
-});
-
-const registerSchema = z.object({
-  email: z.string().email("Invalid email format"),
-  password: z.string().min(8, "Password must be at least 8 characters"),
-  name: z.string().min(1),
-});
-
-interface User {
-  id: string;
-  email: string;
-  name: string;
-  passwordHash: string;
-}
-
-export class AuthService {
-  private users: Map<string, User> = new Map();
-
-  async login(credentials: { email: string; password: string }) {
-    const validated = loginSchema.parse(credentials);
-
-    const user = Array.from(this.users.values()).find(
-      (u) => u.email === validated.email,
-    );
-
-    if (!user) {
-      throw new Error("Invalid credentials");
-    }
-
-    const passwordMatch = await this.comparePassword(
-      validated.password,
-      user.passwordHash,
-    );
-
-    if (!passwordMatch) {
-      throw new Error("Invalid credentials");
-    }
-
-    const token = this.generateToken(user);
-
-    return {
-      token,
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-      },
-    };
-  }
-
-  async register(data: { email: string; password: string; name: string }) {
-    const validated = registerSchema.parse(data);
-
-    if (
-      Array.from(this.users.values()).some((u) => u.email === validated.email)
-    ) {
-      throw new Error("Email already exists");
-    }
-
-    const passwordHash = await hash(validated.password, 10);
-    const user: User = {
-      id: crypto.randomUUID(),
-      email: validated.email,
-      name: validated.name,
-      passwordHash,
-    };
-
-    this.users.set(user.id, user);
-
-    const token = this.generateToken(user);
-
-    return {
-      token,
-      user: {
-        id: user.id,
-        email: user.email,
-        name: user.name,
-      },
-    };
-  }
-
-  async comparePassword(password: string, hash: string): Promise<boolean> {
-    return compare(password, hash);
-  }
-
-  private generateToken(user: User): string {
-    return sign({ userId: user.id }, process.env.JWT_SECRET || "dev-secret", {
-      expiresIn: "7d",
-    });
-  }
-}
-```
-
-**Run Tests Again:**
-
-```bash
-pnpm test auth.service.test.ts
-
-✓ PASS  tests/unit/auth.service.test.ts
-  AuthService
-    login
-      ✓ should return user token for valid credentials (45ms)
-      ✓ should throw error for invalid email (12ms)
-      ✓ should throw error for incorrect password (38ms)
-      ✓ should hash password before comparison (42ms)
-    register
-      ✓ should create new user and return token (48ms)
-      ✓ should reject weak passwords (8ms)
-      ✓ should reject duplicate emails (52ms)
-
-Test Coverage:
-  File: auth.service.ts
-  Statements: 95.2%
-  Branches: 100%
-  Functions: 100%
-  Lines: 94.7%
-```
-
-Claude: "All tests passing! Coverage: 95.2%. Proceeding to REFACTOR phase."
-
-**Phase 3: REFACTOR (Optimize While Keeping Tests Green)**
-
-```typescript
-// Claude refactors for better organization
-export class AuthService {
-  private users: Map<string, User> = new Map();
-  private readonly saltRounds = 10;
-  private readonly tokenExpiry = "7d";
-
-  async login(credentials: LoginCredentials): Promise<AuthResult> {
-    const validated = this.validateLoginCredentials(credentials);
-    const user = await this.findUserByEmail(validated.email);
-    await this.verifyPassword(validated.password, user.passwordHash);
-
-    return this.createAuthResult(user);
-  }
-
-  async register(data: RegisterData): Promise<AuthResult> {
-    const validated = this.validateRegisterData(data);
-    await this.ensureEmailNotExists(validated.email);
-
-    const user = await this.createUser(validated);
-    return this.createAuthResult(user);
-  }
-
-  private validateLoginCredentials(credentials: unknown): LoginCredentials {
-    return loginSchema.parse(credentials);
-  }
-
-  private async findUserByEmail(email: string): Promise<User> {
-    const user = Array.from(this.users.values()).find((u) => u.email === email);
-    if (!user) {
-      throw new Error("Invalid credentials");
-    }
-    return user;
-  }
-
-  private async verifyPassword(password: string, hash: string): Promise<void> {
-    const match = await compare(password, hash);
-    if (!match) {
-      throw new Error("Invalid credentials");
-    }
-  }
-
-  private createAuthResult(user: User): AuthResult {
-    return {
-      token: this.generateToken(user),
-      user: this.sanitizeUser(user),
-    };
-  }
-
-  // ... more refactored methods
-}
-```
-
-**Run Tests After Refactor:**
-
-```bash
-pnpm test auth.service.test.ts
-
-✓ All tests still passing
-✓ Coverage maintained: 95.2%
-```
-
-Claude: "Refactoring complete. All tests green. Ready for commit."
-
-### Integration Testing Workflow
-
-**Command:**
-
-```bash
-/tdd-workflow "user registration API endpoint" --integration
-```
-
-**Generated Integration Tests:**
-
-```typescript
-// tests/integration/auth.api.test.ts
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import request from "supertest";
-import { app } from "@/app";
-import { db } from "@/lib/db";
-
-describe("POST /api/auth/register", () => {
-  beforeAll(async () => {
-    await db.migrate.latest();
-  });
-
-  afterAll(async () => {
-    await db.migrate.rollback();
-    await db.destroy();
-  });
-
-  it("should register new user and return 201", async () => {
-    const response = await request(app).post("/api/auth/register").send({
-      email: "newuser@example.com",
-      password: "ValidPass123",
-      name: "New User",
-    });
-
-    expect(response.status).toBe(201);
-    expect(response.body).toHaveProperty("token");
-    expect(response.body.user.email).toBe("newuser@example.com");
-  });
-
-  it("should return 400 for invalid email format", async () => {
-    const response = await request(app)
-      .post("/api/auth/register")
-      .send({ email: "invalid", password: "pass", name: "User" });
-
-    expect(response.status).toBe(400);
-    expect(response.body.error).toContain("Invalid email");
-  });
-
-  it("should return 409 for duplicate email", async () => {
-    await request(app).post("/api/auth/register").send({
-      email: "dup@example.com",
-      password: "ValidPass123",
-      name: "User",
-    });
-
-    const response = await request(app).post("/api/auth/register").send({
-      email: "dup@example.com",
-      password: "ValidPass123",
-      name: "User2",
-    });
-
-    expect(response.status).toBe(409);
-    expect(response.body.error).toContain("already exists");
-  });
-
-  it("should store hashed password in database", async () => {
-    const password = "PlainPassword123";
-
-    await request(app)
-      .post("/api/auth/register")
-      .send({ email: "hash@example.com", password, name: "User" });
-
-    const user = await db("users").where({ email: "hash@example.com" }).first();
-
-    expect(user.password).not.toBe(password);
-    expect(user.password).toMatch(/^\$2[aby]\$/);
-  });
-});
-```
-
-### E2E Testing Workflow with Playwright
-
-**Command:**
-
-```bash
-/tdd-workflow "complete user registration flow" --e2e --playwright
-```
-
-**Generated E2E Tests:**
-
-```typescript
-// tests/e2e/auth.spec.ts
-import { test, expect } from "@playwright/test";
-
-test.describe("User Registration Flow", () => {
-  test("should complete full registration process", async ({ page }) => {
-    // Navigate to registration page
-    await page.goto("/register");
-
-    // Fill registration form
-    await page.fill('[name="email"]', "e2e@example.com");
-    await page.fill('[name="password"]', "ValidPass123");
-    await page.fill('[name="confirmPassword"]', "ValidPass123");
-    await page.fill('[name="name"]', "E2E User");
-
-    // Submit form
-    await page.click('[type="submit"]');
-
-    // Verify redirect to dashboard
-    await expect(page).toHaveURL("/dashboard");
-
-    // Verify user name displayed
-    await expect(page.locator('[data-testid="user-name"]')).toHaveText(
-      "E2E User",
-    );
-  });
-
-  test("should show validation errors for invalid inputs", async ({ page }) => {
-    await page.goto("/register");
-
-    // Submit empty form
-    await page.click('[type="submit"]');
-
-    // Verify error messages
-    await expect(page.locator('[data-testid="email-error"]')).toBeVisible();
-    await expect(page.locator('[data-testid="password-error"]')).toBeVisible();
-  });
-
-  test("should persist session after registration", async ({
-    page,
-    context,
-  }) => {
-    await page.goto("/register");
-
-    // Register user
-    await page.fill('[name="email"]', "session@example.com");
-    await page.fill('[name="password"]', "ValidPass123");
-    await page.fill('[name="confirmPassword"]', "ValidPass123");
-    await page.fill('[name="name"]', "Session User");
-    await page.click('[type="submit"]');
-
-    // Verify cookies set
-    const cookies = await context.cookies();
-    expect(cookies.find((c) => c.name === "auth_token")).toBeDefined();
-
-    // Reload page - should stay authenticated
-    await page.reload();
-    await expect(page).toHaveURL("/dashboard");
-  });
-});
-```
-
-### Full Test Pyramid Workflow
-
-**Command:**
-
-```bash
-/tdd-workflow "payment processing feature" --full --min-coverage=90
-```
-
-**Claude Executes:**
-
-1. **Unit Tests** (70% of test suite)
-   - Service layer logic
-   - Utility functions
-   - Data validation
-   - Business rules
-
-2. **Integration Tests** (20% of test suite)
-   - API endpoints
-   - Database operations
-   - External service mocks
-
-3. **E2E Tests** (10% of test suite)
-   - Critical user flows
-   - Payment completion
-   - Error handling UX
-
-**Coverage Report:**
-
-```
-Test Results:
-  Unit: 45 tests passing
-  Integration: 12 tests passing
-  E2E: 3 tests passing
-
-Coverage:
-  Overall: 92.3% ✓
-  Statements: 93.1%
-  Branches: 89.7%
-  Functions: 95.2%
-  Lines: 92.8%
-
-Target: 90% - PASSED ✓
-```
-
-## TDD Best Practices
-
-### 1. Write Tests First (Always)
-
-```bash
-# Claude will REFUSE to implement before tests exist
-User: "Implement user authentication"
-
-Claude: "I'll follow TDD workflow:
-1. First, I'll write comprehensive tests
-2. Run tests (expect failures)
-3. Implement minimal code to pass
-4. Refactor while keeping tests green
-
-Starting with test creation..."
-```
-
-### 2. Test Behavior, Not Implementation
-
-```typescript
-// ❌ Bad: Testing implementation details
-it("should call bcrypt.hash with saltRounds=10", () => {
-  expect(bcrypt.hash).toHaveBeenCalledWith(password, 10);
-});
-
-// ✅ Good: Testing behavior
-it("should store hashed password", async () => {
-  await authService.register({ email, password });
-  const user = await db.users.findOne({ email });
-
-  expect(user.password).not.toBe(password);
-  expect(await bcrypt.compare(password, user.password)).toBe(true);
-});
-```
-
-### 3. Descriptive Test Names
-
-```typescript
-// ✅ Clear test names following Given-When-Then
-describe("AuthService", () => {
-  describe("when user provides valid credentials", () => {
-    it("should return auth token and user data", async () => {
-      // test
-    });
-  });
-
-  describe("when password is incorrect", () => {
-    it("should throw InvalidCredentialsError", async () => {
-      // test
-    });
-  });
-});
-```
-
-### 4. Arrange-Act-Assert Pattern
-
-```typescript
-it("should update user email", async () => {
-  // Arrange: Set up test data
-  const user = await createTestUser({ email: "old@example.com" });
-
-  // Act: Perform action
-  await userService.updateEmail(user.id, "new@example.com");
-
-  // Assert: Verify outcome
-  const updated = await userService.findById(user.id);
-  expect(updated.email).toBe("new@example.com");
-});
-```
-
-## Anti-Hallucination Benefits
-
-### Problem: LLM Scope Drift
-
-```bash
-User: "Add user authentication"
-
-Claude (without TDD):
-*Implements auth + session management + password reset + 2FA + OAuth*
-# Hallucinated features not requested
-```
-
-### Solution: Test-Anchored Iteration
-
-```bash
-Claude (with TDD):
-1. Writes tests ONLY for requested features
-2. Tests define exact scope and behavior
-3. Implementation guided by test requirements
-4. Iteration stops when tests pass
-5. No feature creep - tests are ground truth
-```
-
-## Watch Mode & Continuous Testing
-
-```bash
-/tdd-workflow "shopping cart service" --watch
-```
-
-**Behavior:**
-
-- Monitors file changes
-- Re-runs affected tests automatically
-- Shows real-time coverage updates
-- Alerts when tests fail
-
-**Terminal Output:**
-
-```
-Watching: src/**/*.ts, tests/**/*.test.ts
-
-✓ 24 tests passing
-✓ Coverage: 87.3%
-
-Waiting for changes... (press 'q' to quit)
-
-[File changed: src/services/cart.service.ts]
-Re-running tests...
-
-✗ 1 test failing
-  CartService > should remove item from cart
-    Expected: 1 item, Received: 2 items
-
-Coverage: 85.1% (↓ 2.2%)
-```
-
-## Configuration
-
-### Custom Test Runner
-
-```json
-// .claude/tdd.config.json
-{
-  "framework": "vitest",
-  "coverage": {
-    "enabled": true,
-    "threshold": 80,
-    "reportDir": "coverage"
-  },
-  "testMatch": ["**/*.test.ts", "**/*.spec.ts"],
-  "autoCommit": true,
-  "commitMessage": "test: {{feature}} - all tests passing ✓"
-}
-```
-
-## Best Practices Summary
-
-1. **Always Write Tests First**: No implementation before failing tests
-2. **Iterate Until Green**: Let AI refine until all tests pass
-3. **Minimum Code**: Implement only what's needed to pass tests
-4. **Refactor Fearlessly**: Tests protect against regressions
-5. **Descriptive Names**: Test names document expected behavior
-6. **High Coverage**: Target 80%+ for production code
-7. **Fast Feedback**: Use watch mode for continuous verification
-8. **Commit on Green**: Auto-commit when test suite passes
+- Swap the test command in `allowed-tools` and in the prompt to match your stack.
+- Add a final step that runs your linter/formatter if you want those gated too.
+- For E2E or integration variants, create sibling files like `.claude/commands/tdd-e2e.md` with a prompt tailored to that layer, rather than relying on flags.


### PR DESCRIPTION
Rewrites a fabricated entry into an accurate one documenting the REAL Claude Code command/capability, grounded in official docs. No invented commands/flags. validate:content:strict + policy pass; thin-content cleared; seoDescription within 120-160; single file.