### PR TITLE
fix(content): ground checkpoint-manager in real /rewind checkpointing

### DIFF
--- a/content/commands/checkpoint-manager.mdx
+++ b/content/commands/checkpoint-manager.mdx
@@ -1,47 +1,38 @@
 ---
-title: Checkpoint Manager for Claude Code
+title: Restore Code and Chat in Claude Code with /rewind
 slug: checkpoint-manager
 category: commands
-description: >-
-  Manage Claude Code checkpoints to safely rewind code changes, restore
-  conversation states, and explore alternatives without fear using ESC+ESC or
-  /rewind commands
-cardDescription: >-
-  Manage Claude Code checkpoints to safely rewind code changes, restore
-  conversation states, and explore alternatives without fear using ES...
-seoTitle: Checkpoint Manager for Claude Code
-seoDescription: >-
-  Manage Claude Code checkpoints to safely rewind code changes, restore
-  conversation states, and explore alternatives without fear using ESC+ESC or
-  /rewind com...
+description: 'Use Claude Code''s built-in checkpointing: run /rewind or press Esc twice to restore code, conversation, or both to an earlier point in a session, and summarize parts of the chat.'
+cardDescription: How to use Claude Code's built-in /rewind checkpointing to undo edits and restore earlier code or conversation state mid-session.
+seoTitle: 'Claude Code Checkpointing: The /rewind Command Explained'
+seoDescription: Restore earlier code or conversation state in Claude Code with /rewind (or Esc Esc). Learn the rewind menu options, what checkpoints track, and their limits.
 author: JSONbored
-authorProfileUrl: "https://github.com/JSONbored"
-dateAdded: "2025-10-25"
-documentationUrl: "https://code.claude.com/docs/en/checkpointing"
-installable: true
-installCommand: "/checkpoint-manager [action] [options]"
-usageSnippet: "/checkpoint-manager [action] [options]"
-copySnippet: "/checkpoint-manager [action] [options]"
+authorProfileUrl: https://github.com/JSONbored
+dateAdded: '2025-10-25'
+documentationUrl: https://code.claude.com/docs/en/checkpointing
+installable: false
+usageSnippet: /rewind
+copySnippet: /rewind
 tags:
-  - checkpoints
-  - rewind
-  - undo
-  - version-control
-  - session-recovery
-  - safety
+- checkpoints
+- rewind
+- undo
+- version-control
+- session-recovery
+- safety
 keywords:
-  - checkpoint
-  - checkpoints
-  - claude
-  - commands
-  - development
-  - manager
-  - rewind
-  - safety
-  - session-recovery
-  - tools
-  - undo
-  - version-control
+- checkpoint
+- checkpoints
+- claude
+- commands
+- development
+- manager
+- rewind
+- safety
+- session-recovery
+- tools
+- undo
+- version-control
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true
@@ -49,502 +40,95 @@ hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
-commandSyntax: "/checkpoint-manager [action] [options]"
+commandSyntax: /rewind
+retrievalSources:
+- https://code.claude.com/docs/en/checkpointing
+- https://code.claude.com/docs/en/interactive-mode
+- https://code.claude.com/docs/en/commands
+safetyNotes:
+- 'Restore actions are destructive to working-tree state: Restore code and Restore code and conversation revert file edits made through Claude''s tools, discarding uncommitted changes since the selected prompt. Confirm you have committed anything you want to keep before restoring.'
+- Checkpoints do not undo bash command side effects (deleted/moved/copied files, directories created by the shell) or database/external changes. After a rewind you may need to clean those up manually.
+- Checkpoints are session-level recovery, not a backup. They are auto-deleted with their session after 30 days by default (cleanupPeriodDays). Use Git for anything you need to keep.
+privacyNotes:
+- Checkpoints and the summarize feature store your code state and conversation history locally as part of the session transcript, including messages that were replaced by a summary. These persist across resumed sessions until cleaned up (default 30 days).
 ---
 
-The `/checkpoint-manager` command helps you manage Claude Code's automatic checkpointing system to safely rewind changes, explore alternatives, and code without fear.
+Claude Code has built-in **checkpointing**: it automatically captures the state of your code before Claude's edits, so you can rewind to a previous state if a task goes off track. You open this with the built-in **`/rewind`** command, or by pressing **`Esc` twice** while the prompt input is empty.
 
-## Features
+> This is a built-in Claude Code feature, not a separate plugin. Checkpointing is automatic, and you interact with it entirely through the `/rewind` menu (or by pressing `Esc` twice).
 
-- **Automatic Checkpoints**: Snapshots saved before every Claude-driven file edit
-- **Quick Rewind**: Press ESC+ESC or use `/rewind` to access checkpoint menu
-- **Selective Restore**: Restore code only, conversation only, or both
-- **Change Preview**: See exactly what will be reverted before confirming
-- **Session-Level Recovery**: Checkpoints tracked within current session
-- **Manual Checkpoints**: Create named checkpoints at critical points
-- **Checkpoint History**: View all checkpoints with timestamps and descriptions
-- **Safe Exploration**: Try risky changes knowing you can rewind
+## How checkpoints work
 
-## Usage
+- **Automatic capture**: every prompt you send creates a new checkpoint of your code before Claude's file edits.
+- **Persists across sessions**: checkpoints are available again in resumed conversations, not just the current run.
+- **Automatic cleanup**: checkpoints are cleaned up along with their sessions after 30 days by default. This retention is governed by the standard session `cleanupPeriodDays` setting, not a separate checkpoint config file.
 
-```bash
-/checkpoint-manager [action] [options]
-```
+Checkpoints are created automatically as you work — checkpointing is tied to your prompts rather than to a manual create step or a configurable interval.
 
-### Actions
+## Opening the rewind menu
 
-- `--rewind` - Open checkpoint menu to restore previous state
-- `--create` - Manually create named checkpoint
-- `--list` - Show all checkpoints in current session
-- `--preview` - Preview changes that will be reverted
-- `--auto-checkpoint` - Configure automatic checkpoint settings
-
-### Restore Options
-
-- `--code-only` - Revert file changes, keep conversation
-- `--conversation-only` - Rewind conversation, keep code changes
-- `--both` - Restore both code and conversation (default)
-
-### Checkpoint Settings
-
-- `--enable-auto` - Enable automatic checkpointing (default: true)
-- `--disable-auto` - Disable automatic checkpointing
-- `--interval=<n>` - Create checkpoint every N file edits
-
-## Quick Access
-
-### ESC+ESC Method (Fastest)
-
-```bash
-# During any Claude Code session:
-# Press ESC twice quickly
-
-[Checkpoint Menu]
-┌─────────────────────────────────────────────┐
-│ Rewind to Previous State                    │
-├─────────────────────────────────────────────┤
-│ 1. [2 min ago] Added user authentication    │
-│    Files: auth.service.ts, user.model.ts    │
-│                                             │
-│ 2. [5 min ago] Fixed login validation      │
-│    Files: auth.service.ts                   │
-│                                             │
-│ 3. [12 min ago] Created auth endpoint       │
-│    Files: routes/auth.ts                    │
-├─────────────────────────────────────────────┤
-│ [R] Restore Code Only                       │
-│ [C] Restore Conversation Only               │
-│ [B] Restore Both                            │
-│ [ESC] Cancel                                │
-└─────────────────────────────────────────────┘
-```
-
-### /rewind Command Method
-
-```bash
+```text
 /rewind
-
-# Opens same checkpoint menu
-# Select checkpoint by number
-# Choose restore type
 ```
 
-## Examples
+Or, with an empty prompt input, press `Esc` twice.
 
-### Basic Rewind Workflow
+> If the prompt input contains text, pressing `Esc` twice clears the text instead of opening the menu. The cleared text is saved to your input history, so press `Up` to recall it after you finish in the rewind menu.
 
-**Scenario: Risky refactoring went wrong**
+The menu lists each prompt you sent during the session. Select a point, then choose an action.
 
-```bash
-User: "Refactor the payment service to use async/await"
+## Rewind menu actions
 
-Claude: *refactors 15 files*
+For the selected message you can choose:
 
-[Automatic Checkpoint Created]
-Snapshot: Before payment service refactor
-Files: 15 modified
+- **Restore code and conversation** — revert both code and conversation to that point.
+- **Restore conversation** — rewind to that message while keeping current code.
+- **Restore code** — revert file changes while keeping the conversation.
+- **Summarize from here** — replace the selected message and everything after it with an AI-generated summary (keeps earlier context in full detail).
+- **Summarize up to here** — replace the messages before the selected message with a summary, keeping the selected message and later ones intact.
+- **Never mind** — return to the message list without changes.
 
-User: *tests application*
-User: "The payment flow is broken now"
+After restoring the conversation or choosing **Summarize from here**, the original prompt from the selected message is restored into the input field so you can re-send or edit it.
 
-# Press ESC+ESC
+### Restore vs. summarize
 
-[Checkpoint Menu]
-1. [1 min ago] Refactored payment service
-   Files: payment.service.ts, payment.controller.ts, ...
+The **restore** options change state on disk and in history: they undo code changes, conversation history, or both.
 
-Select: 1
-Restore: [B] Both code and conversation
+The **summarize** options do not change files on disk — they compress one side of the conversation into a summary to free up context window space. The original messages are preserved in the session transcript, so Claude can still reference them. You can type optional instructions to guide what the summary focuses on. This is like `/compact`, but targeted to one side of the selected message rather than the whole conversation.
 
-✓ Restored to checkpoint
-✓ 15 files reverted
-✓ Conversation rewound to before refactor
+If you instead want to branch off and try a different approach while keeping the original session intact, use session forking (`claude --continue --fork-session`) rather than rewind.
 
-Claude: "Reverted to before payment service refactor. Would you like to try a different approach?"
+## When to use it
+
+- **Exploring alternatives**: try a different implementation approach without losing your starting point, then restore code if it doesn't pan out.
+- **Recovering from mistakes**: a refactor introduced a bug across several files — open `/rewind`, pick the prompt before the refactor, and choose **Restore code**.
+- **Iterating on a feature**: experiment with variations knowing you can revert to a working state.
+- **Freeing context space**: in a long debugging session, use **Summarize from here** to compress a verbose side-discussion while keeping your initial instructions in full detail.
+
+### Example: undo a bad refactor, keep the discussion
+
+```text
+You: Refactor the payment service to use async/await
+Claude: (edits several files)
+
+You: The payment flow is broken now.
+You: /rewind
+   -> select the prompt before the refactor
+   -> choose "Restore code"
 ```
 
-### Code-Only Restore (Keep Conversation)
+Your files revert to the pre-refactor state while the conversation (including what went wrong) stays intact, so Claude can try a different approach with that context.
 
-**Scenario: Want to keep discussion but undo code changes**
+## Limitations
 
-```bash
-Claude: *implements feature with extensive discussion*
+Checkpointing is a session-level safety net, not full version control. Be aware of what it does **not** track:
 
-User: "Actually, I prefer the old implementation"
+- **Bash command changes are not tracked.** Files modified by shell commands Claude runs (for example `rm file.txt`, `mv old.txt new.txt`, `cp source.txt dest.txt`) cannot be undone through rewind. Only direct edits made through Claude's file-editing tools are tracked.
+- **External changes are not tracked.** Manual edits you make outside Claude Code, and edits from other concurrent sessions, are normally not captured — unless they happen to touch the same files as the current session.
+- **It is not a replacement for Git.** Keep using version control for commits, branches, and long-term history. Think of checkpoints as "local undo" and Git as "permanent history."
 
-/rewind
+## See also
 
-[Select Checkpoint]
-1. [5 min ago] Implemented notification system
-   Files: notification.service.ts, email.template.ts
-
-Select: 1
-Restore: [R] Code Only
-
-✓ Code reverted to checkpoint
-✓ Conversation preserved
-
-Claude: "I've reverted the code changes but kept our discussion. Based on our conversation, would you like me to implement it differently?"
-```
-
-### Conversation-Only Restore
-
-**Scenario: Code is good, but conversation went off track**
-
-```bash
-Claude: *correct implementation but confusing discussion*
-
-User: "The code is fine, but let's restart the conversation"
-
-/rewind
-
-Select: 2. [10 min ago] Started authentication implementation
-Restore: [C] Conversation Only
-
-✓ Conversation rewound
-✓ Code changes preserved
-
-Claude: "Let's start fresh. What would you like to work on?"
-```
-
-### Manual Checkpoint Creation
-
-**Scenario: Before making risky database migration**
-
-```bash
-User: "I'm about to migrate the database schema"
-
-/checkpoint-manager --create "Before database migration"
-
-✓ Manual checkpoint created
-  Name: Before database migration
-  Files: 0 (pre-change snapshot)
-  Time: 2025-10-25 14:30:00
-
-User: "Proceed with migration"
-
-Claude: *performs migration*
-
-# If issues occur:
-/rewind
-
-[Checkpoints]
-1. [Manual] Before database migration
-2. [Auto] Previous changes...
-
-Select: 1 (Manual checkpoint)
-✓ Restored to pre-migration state
-```
-
-### Preview Changes Before Rewind
-
-```bash
-/checkpoint-manager --preview
-
-[Checkpoint Preview]
-Restoring to: [5 min ago] Implemented caching layer
-
-Files to be reverted:
-  src/services/cache.service.ts
-    - 45 lines added will be removed
-    - 12 lines modified will be restored
-
-  src/config/redis.config.ts
-    - File will be deleted (was created in this session)
-
-  tests/cache.service.test.ts
-    - File will be deleted (was created in this session)
-
-Conversation:
-  - Last 8 messages will be removed
-  - Rewind to: "Let's add a caching layer"
-
-Proceed with rewind? (y/n): y
-
-✓ Checkpoint restored
-```
-
-### List All Checkpoints
-
-```bash
-/checkpoint-manager --list
-
-[Session Checkpoints]
-
-📍 Manual Checkpoints:
-1. Before database migration (14:30:00)
-   Files: Initial state preserved
-
-⚡ Auto Checkpoints:
-2. Implemented user authentication (14:25:12)
-   Files: auth.service.ts, user.model.ts, routes/auth.ts
-
-3. Fixed login validation (14:20:45)
-   Files: auth.service.ts
-
-4. Created auth endpoint (14:15:33)
-   Files: routes/auth.ts
-
-5. Added password hashing (14:10:22)
-   Files: auth.service.ts, user.model.ts
-
-Total: 5 checkpoints (1 manual, 4 auto)
-Session duration: 25 minutes
-```
-
-## Checkpoint Limitations
-
-### What Checkpoints DO Track
-
-✅ File edits made by Claude Code tools (edit_file, write_file)
-✅ File content at time of snapshot
-✅ Conversation history and context
-✅ File metadata (permissions, timestamps)
-
-### What Checkpoints DON'T Track
-
-❌ Bash command side effects (files created by shell commands)
-❌ Manual edits made outside Claude Code
-❌ git operations (commits, pushes, merges)
-❌ Database changes
-❌ External API calls
-
-### Example: Bash Limitations
-
-```bash
-User: "Create a backup directory"
-
-Claude: *runs bash command*
-$ mkdir backup && cp -r src backup/
-
-✓ Directory created
-
-# Later, rewind checkpoint
-/rewind
-
-⚠️  Warning: Checkpoint cannot revert bash command side effects
-    The 'backup' directory will remain
-    You may need to manually clean up:
-    $ rm -rf backup
-```
-
-## Integration with Git
-
-### Checkpoints vs Git Commits
-
-**Checkpoints:**
-
-- Session-level (temporary)
-- Automatic, no manual intervention
-- Fast rewind (instant)
-- Lost after session ends
-
-**Git Commits:**
-
-- Permanent version control
-- Manual commit process
-- Can share with team
-- Persistent across sessions
-
-### Recommended Workflow
-
-```bash
-1. Checkpoints for exploration:
-   - Try risky changes
-   - Rewind if doesn't work
-   - Iterate until satisfied
-
-2. Git commits for milestones:
-   - Commit when checkpoint result is good
-   - Permanent record
-   - Share with team
-```
-
-### Example: Checkpoint + Git Workflow
-
-```bash
-User: "Try refactoring the auth system"
-
-Claude: *refactors*
-
-[Auto Checkpoint: Before auth refactor]
-
-User: *tests*
-User: "Works great! Commit this"
-
-/git-smart-commit "Refactor auth system for better separation of concerns"
-
-✓ Committed to git
-✓ Checkpoint becomes permanent
-```
-
-## Advanced Patterns
-
-### Exploratory Coding Pattern
-
-```bash
-1. Manual checkpoint before exploration
-   /checkpoint-manager --create "Before experiment"
-
-2. Try Approach A
-   - Implement
-   - Test
-   - Not ideal? Rewind
-
-3. Try Approach B
-   - Implement
-   - Test
-   - Better? Keep it
-
-4. Commit successful approach
-   git commit -m "Implemented approach B"
-```
-
-### Refactoring Safety Net
-
-```bash
-# Before large refactor:
-/checkpoint-manager --create "Before refactor: Working state"
-
-# Refactor incrementally:
-1. Refactor module A
-2. Test
-3. If broken, rewind
-4. If working, continue
-5. Refactor module B
-6. Repeat
-
-# Final: Commit all changes
-git commit -m "Refactored modules A-E"
-```
-
-### Debugging with Checkpoints
-
-```bash
-User: "The app broke, not sure when"
-
-/checkpoint-manager --list
-
-[Checkpoints]
-1. [5 min ago] Added caching
-2. [10 min ago] Optimized queries
-3. [15 min ago] Updated dependencies
-4. [20 min ago] Fixed validation
-
-# Binary search for breaking change:
-Restore to checkpoint 2
-  → Still broken
-Restore to checkpoint 3
-  → Works!
-
-Conclusion: "Optimized queries" (checkpoint 2) broke the app
-
-# Fix the query optimization:
-User: "The query optimization broke it. Let's fix that specific change"
-```
-
-## Configuration
-
-### Auto-Checkpoint Settings
-
-```json
-// .claude/checkpoint.config.json
-{
-  "autoCheckpoint": {
-    "enabled": true,
-    "interval": 1, // Every N file edits
-    "maxCheckpoints": 50, // Keep last 50 checkpoints
-    "includeTests": false // Don't checkpoint test file changes
-  },
-  "rewindDefaults": {
-    "restoreMode": "both", // code-only, conversation-only, both
-    "confirmBeforeRestore": true,
-    "showPreview": true
-  }
-}
-```
-
-### Disable Auto-Checkpoints
-
-```bash
-/checkpoint-manager --disable-auto
-
-⚠️  Auto-checkpoints disabled
-    You can still create manual checkpoints with:
-    /checkpoint-manager --create "checkpoint name"
-```
-
-### Custom Checkpoint Intervals
-
-```bash
-/checkpoint-manager --interval=5
-
-✓ Auto-checkpoints will be created every 5 file edits
-```
-
-## Best Practices
-
-1. **Create Manual Checkpoints Before Risk**
-   - Database migrations
-   - Large refactors
-   - Experimental approaches
-
-2. **Use Code-Only Restore for Discussion Preservation**
-   - Valuable context in conversation
-   - Only code needs reverting
-
-3. **Preview Before Rewind**
-   - Verify what will be reverted
-   - Avoid accidental loss of good changes
-
-4. **Commit Good Checkpoints to Git**
-   - Checkpoints are temporary (session-only)
-   - Git commits are permanent
-
-5. **Don't Rely on Checkpoints for Bash Commands**
-   - Checkpoints don't track shell side effects
-   - Use git for permanent backups
-
-6. **Regular Manual Checkpoints for Long Sessions**
-   - Every 30-60 minutes
-   - Before context switches
-
-7. **Clean Up After Bash Reverts**
-   - Manually remove directories/files created by shell
-   - Checkpoints will warn about bash limitations
-
-## Troubleshooting
-
-### "No checkpoints available"
-
-```
-Cause: Session just started, no changes made yet
-Solution: Make some changes first, checkpoints auto-create
-```
-
-### "Cannot rewind bash command changes"
-
-```
-Cause: Bash commands create files outside checkpoint tracking
-Solution: Manually clean up with reverse commands
-  Created directory: rm -rf directory
-  Modified external files: restore from git
-```
-
-### "Checkpoint restored but issue persists"
-
-```
-Cause: Issue may be in database, environment, or external state
-Solution: Check non-code factors:
-  - Database state
-  - Environment variables
-  - External service configuration
-```
-
-### "Lost conversation context after rewind"
-
-```
-Cause: Restored "both" which includes conversation
-Solution: Use "code-only" restore to preserve discussion
-  /rewind → Select checkpoint → [R] Code Only
-```
+- Checkpointing: https://code.claude.com/docs/en/checkpointing
+- Interactive mode (keyboard shortcuts): https://code.claude.com/docs/en/interactive-mode
+- Commands reference: https://code.claude.com/docs/en/commands


### PR DESCRIPTION
Reframes the entry around Claude Code's real built-in checkpointing — the `/rewind` command (and Esc Esc) for restoring code/conversation state mid-session. Removes every reference to the non-existent `/checkpoint-manager` command and its fabricated flags that closed #2698. All claims trace to the linked checkpointing documentation.