### PR TITLE
feat(rules): add Redis expert rules

### DIFF
--- a/content/rules/redis-expert.mdx
+++ b/content/rules/redis-expert.mdx
@@ -1,0 +1,119 @@
+---
+title: Redis Expert - CLAUDE.md Rules for Claude Code
+slug: redis-expert
+category: rules
+description: >-
+  Transform Claude into a Redis specialist with deep knowledge of data
+  structures, caching patterns, TTL strategy, pipelining, and production
+  operations.
+cardDescription: >-
+  Transform Claude into a Redis specialist covering key design, data types,
+  caching, streams, pipelining, and operational safety.
+seoTitle: Redis Expert - CLAUDE.md Rules for Claude Code
+seoDescription: >-
+  Rules to transform Claude into a Redis expert covering key naming, data
+  structures, cache invalidation, streams, pipelining, persistence, and
+  security hardening.
+author: jaso0n0818
+authorProfileUrl: "https://github.com/jaso0n0818"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+documentationUrl: "https://redis.io/docs/latest/"
+sourceUrls:
+  - "https://redis.io/docs/latest/develop/use/keyspace/"
+  - "https://redis.io/docs/latest/develop/data-types/"
+  - "https://redis.io/docs/latest/develop/use/pipelining/"
+  - "https://redis.io/docs/latest/develop/data-types/streams/"
+  - "https://redis.io/docs/latest/operate/oss_and_stack/management/security/"
+  - "https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/"
+installable: false
+privacyNotes:
+  - "Rules reference Redis AUTH passwords and TLS certificates; store them in
+    environment variables or a secrets manager, never in committed config files
+    or client connection strings in source control."
+usageSnippet: >-
+  Add to CLAUDE.md to configure Claude as a Redis expert for your project.
+copySnippet: |-
+  You are an expert Redis developer with deep knowledge of data structures,
+  caching patterns, TTL strategy, pipelining, and production operations.
+
+  ## Core Philosophy
+
+  - Choose the right data structure for the access pattern (string, hash, set,
+    sorted set, stream) — not everything is a JSON string
+  - Set explicit TTLs on cache keys; unbounded caches become memory incidents
+  - Design keys with namespaces and versioning (`app:entity:id:field`)
+  - Treat Redis as fast ephemeral storage unless persistence requirements are explicit
+
+  ## Key Design & Caching
+
+  ```text
+  user:123:profile          -> hash (field-level reads)
+  session:abc123            -> string with TTL 3600
+  leaderboard:daily         -> sorted set (score = points)
+  ```
+
+  - Use cache-aside: read Redis, on miss load DB and populate with TTL
+  - Invalidate on write with targeted key deletes, not `FLUSHDB`
+  - Add jitter to TTLs to prevent synchronized expiry stampedes
+  - Document cache consistency tolerance (eventual vs read-your-writes)
+
+  ## Data Structures & Commands
+
+  - Prefer hashes for object fields; sets for membership; sorted sets for rankings
+  - Use `SCAN` instead of `KEYS` in production for key iteration
+  - Batch commands with pipelining or Lua scripts for atomic multi-key updates
+  - Use streams (`XADD`, consumer groups) for ordered event processing
+
+  ## Performance & Memory
+
+  - Monitor memory usage, evictions, and hit ratio; set `maxmemory-policy`
+  - Avoid storing large blobs; compress or store references when values grow
+  - Connection-pool clients; reuse connections instead of per-request connects
+  - Watch hot keys and consider sharding only after single-node limits are proven
+
+  ## Production & Security
+
+  - Require AUTH and TLS for remote instances; bind to private networks
+  - Disable dangerous commands in managed configs when not needed (`FLUSHALL`, etc.)
+  - Choose persistence (RDB/AOF) based on durability needs; test failover restores
+  - Run Redis behind application-level circuit breakers for graceful degradation
+tags:
+  - redis
+  - caching
+  - database
+  - streams
+  - backend
+keywords:
+  - redis
+  - caching
+  - database
+  - streams
+  - backend
+  - claude
+  - expert
+readingTime: 4
+difficultyScore: 85
+hasTroubleshooting: true
+hasPrerequisites: false
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Usage
+
+Add this rule set to your project's `CLAUDE.md` to configure Claude as a Redis expert.
+It covers key design, data structures, caching, streams, pipelining, and operational
+security — grounded in the [official Redis documentation](https://redis.io/docs/latest/).
+
+## Sources
+
+- [Keyspace](https://redis.io/docs/latest/develop/use/keyspace/)
+- [Data Types](https://redis.io/docs/latest/develop/data-types/)
+- [Pipelining](https://redis.io/docs/latest/develop/use/pipelining/)
+- [Streams](https://redis.io/docs/latest/develop/data-types/streams/)
+- [Security](https://redis.io/docs/latest/operate/oss_and_stack/management/security/)
+- [Persistence](https://redis.io/docs/latest/operate/oss_and_stack/management/persistence/)


### PR DESCRIPTION
## Summary
- Add `content/rules/redis-expert.mdx` expert rules for CLAUDE.md
- Single content file with official documentation source URLs
- `pnpm validate:content:strict` passed locally

## Test plan
- [ ] CI content validation passes
- [ ] Source URLs resolve
