### PR TITLE
fix(content): shorten curio-mcp-server description under 320 chars

### DIFF
--- a/content/mcp/curio-mcp-server.mdx
+++ b/content/mcp/curio-mcp-server.mdx
@@ -2,12 +2,7 @@
 title: Curio MCP Server for Claude
 slug: curio-mcp-server
 category: mcp
-description: >-
-  Curio is a design-style library for AI: hundreds of real design styles —
-  movements, brands, and cultural traditions — packaged as token-complete,
-  machine-readable specs. The remote MCP server lets Claude search the
-  library, preview styles, and fetch full design specs (colors, typography,
-  spacing, components) to apply to slides, websites, and products.
+description: "Curio is a design-style library for AI: hundreds of real design styles — movements, brands, and cultural traditions — packaged as token-complete, machine-readable specs."
 cardDescription: >-
   Design-style library for AI — search hundreds of real styles and fetch
   machine-readable design specs Claude applies to sites, decks, and products.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.