### PR TITLE
fix(content): shorten packrift-mcp-server description under 320 chars

### DIFF
--- a/content/mcp/packrift-mcp-server.mdx
+++ b/content/mcp/packrift-mcp-server.mdx
@@ -6,7 +6,7 @@ safetyNotes:
 privacyNotes:
   - Product searches, pricing context, cart URLs, packaging requirements, and merchant interaction details may be sent through tool calls.
 category: mcp
-description: Packrift MCP Server exposes Packrift's packaging-supplies catalog through a remote MCP endpoint. It lets AI agents search packaging products, retrieve pricing and inventory context, and create cart URLs for ecommerce packaging workflows. Use it when an agent needs packaging-supply discovery, carton or mailer selection, or cart-building support.
+description: "Packrift MCP Server exposes Packrift's packaging-supplies catalog through a remote MCP endpoint. It lets AI agents search packaging products, retrieve pricing and inventory context, and create cart URLs for ecommerce packaging workflows."
 cardDescription: Remote MCP server for Packrift packaging catalog search, pricing and inventory context, and ecommerce cart URL creation.
 seoTitle: Packrift MCP Server - MCP Servers for Claude
 seoDescription: Remote MCP server for Packrift packaging catalog search, pricing and inventory context, and ecommerce cart URL creation.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.