### PR TITLE
fix(content): shorten pentest-ai-mcp-server description under 320 chars

### DIFF
--- a/content/mcp/pentest-ai-mcp-server.mdx
+++ b/content/mcp/pentest-ai-mcp-server.mdx
@@ -2,12 +2,7 @@
 title: Pentest AI MCP Server
 slug: pentest-ai-mcp-server
 category: mcp
-description: >-
-  Offensive-security MCP server from pentest-ai that lets Claude list and run
-  wrapped security tools, plan and install missing tools, launch authorized
-  engagements, run web, recon, API, cloud, AD, credential, vulnerability,
-  mobile, wireless, and LLM-red-team assessments, and retrieve findings,
-  attack chains, reports, and process status.
+description: "Offensive-security MCP server from pentest-ai that lets Claude list and run wrapped security tools, plan and install missing tools, launch authorized engagements, run web, recon, API, cloud, AD, credential, vulnerability, mobile, wireless, and LLM-red-team assessments, and retrieve findings, attack chains, reports."
 cardDescription: Connect Claude to authorized pentest-ai engagements, tools, probes, and findings.
 seoTitle: Pentest AI MCP Server for Claude
 seoDescription: >-


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.