### PR TITLE
fix(content): shorten render-mcp-server description under 320 chars

### DIFF
--- a/content/mcp/render-mcp-server.mdx
+++ b/content/mcp/render-mcp-server.mdx
@@ -2,12 +2,7 @@
 title: "Render MCP Server"
 slug: render-mcp-server
 category: mcp
-description: >-
-  The official Render MCP server lets LLMs manage Render resources: create and
-  manage web services, static sites, cron jobs, Postgres and Key-Value
-  instances, monitor deploys, query logs and metrics, and run read-only SQL
-  against Render Postgres. Connect via Render's hosted server or a local Go
-  binary using a RENDER_API_KEY.
+description: "The official Render MCP server lets LLMs manage Render resources: create and manage web services, static sites, cron jobs, Postgres and Key-Value instances, monitor deploys, query logs and metrics, and run read-only SQL against Render Postgres."
 cardDescription: >-
   Official Render MCP server (render-oss) for managing Render web services,
   static sites, cron jobs, Postgres, and Key-Value stores, plus deploys, logs,


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.