### PR TITLE
fix(content): shorten hyperbrowser description under 320 chars

### DIFF
--- a/content/tools/hyperbrowser.mdx
+++ b/content/tools/hyperbrowser.mdx
@@ -2,7 +2,7 @@
 title: Hyperbrowser
 slug: hyperbrowser
 category: tools
-description: "Hyperbrowser is a cloud platform for running headless Chrome browser sessions that AI agents and developers control remotely. It supports Puppeteer/Playwright and native Python and Node SDKs, structured data scraping and crawling APIs, session recording, stealth and bot-detection evasion, and built-in integrations for Claude, OpenAI, Gemini, and BrowserUse agents plus an MCP server."
+description: "Hyperbrowser is a cloud platform for running headless Chrome browser sessions that AI agents and developers control remotely."
 cardDescription: "Cloud-hosted Chrome sessions with scraping APIs and agent integrations for Claude, OpenAI, and BrowserUse."
 seoTitle: "Hyperbrowser: Cloud Chrome Sessions and Scraping for AI Agents"
 seoDescription: "Hyperbrowser runs remote Chrome sessions for AI agents with Puppeteer, Playwright, Python and Node SDKs, scraping and crawling APIs, stealth, and an MCP server."


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.