### PR TITLE
fix(content): shorten api-contract-check description under 320 chars

### DIFF
--- a/content/commands/api-contract-check.mdx
+++ b/content/commands/api-contract-check.mdx
@@ -2,13 +2,7 @@
 title: /api-contract-check - API Contract Check Command for Claude Code
 slug: api-contract-check
 category: commands
-description: >-
-  Slash command that runs consumer-driven contract verification for an HTTP API
-  using Pact. It locates the consumer contracts (local pact files or a Pact
-  Broker), verifies the provider against every recorded interaction, reports
-  which consumer expectations the provider breaks, and, when no contracts exist
-  yet, lays out how to record and publish them. It checks real interaction
-  contracts, not just schema shape.
+description: "Slash command that runs consumer-driven contract verification for an HTTP API using Pact."
 cardDescription: >-
   Verify an HTTP provider against its Pact consumer contracts and report which
   expectations it breaks.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.