### PR TITLE
fix(content): shorten cloudflare-deploy-readiness description under 320 chars

### DIFF
--- a/content/commands/cloudflare-deploy-readiness.mdx
+++ b/content/commands/cloudflare-deploy-readiness.mdx
@@ -2,12 +2,7 @@
 title: /deploy-readiness - Cloudflare Deploy Readiness Command for Claude Code
 slug: cloudflare-deploy-readiness
 category: commands
-description: >-
-  Slash command that runs a pre-deploy readiness check for a Cloudflare Workers
-  project before you ship. It confirms Wrangler auth, validates the worker
-  config, dry-runs the build to catch bundling errors without deploying,
-  cross-checks that secrets and bindings referenced in code actually exist, and
-  returns a clear go or no-go summary.
+description: "Slash command that runs a pre-deploy readiness check for a Cloudflare Workers project before you ship."
 cardDescription: >-
   Pre-deploy readiness check for Cloudflare Workers - auth, config, dry-run
   build, and secret/binding coverage.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.