### PR TITLE
fix(content): shorten dependency-risk-review description under 320 chars

### DIFF
--- a/content/commands/dependency-risk-review.mdx
+++ b/content/commands/dependency-risk-review.mdx
@@ -2,13 +2,7 @@
 title: /dependency-risk-review - Dependency Risk Review Command for Claude Code
 slug: dependency-risk-review
 category: commands
-description: >-
-  Slash command that reviews the supply-chain risk of a project's dependencies
-  using OpenSSF Scorecard health signals rather than CVE counts. It identifies
-  high-impact dependencies, looks up each one's Scorecard checks (Maintained,
-  Dangerous-Workflow, Pinned-Dependencies, Signed-Releases, Code-Review, and
-  more) through the public API, cross-references OSV for known advisories, ranks
-  the riskiest dependencies, and recommends concrete actions.
+description: "Slash command that reviews the supply-chain risk of a project's dependencies using OpenSSF Scorecard health signals rather than CVE counts."
 cardDescription: >-
   Rank dependency supply-chain risk from OpenSSF Scorecard health signals and
   OSV advisories, with actions.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.