### PR TITLE
fix(content): shorten release-notes-drafting description under 320 chars

### DIFF
--- a/content/commands/release-notes-drafting.mdx
+++ b/content/commands/release-notes-drafting.mdx
@@ -2,12 +2,7 @@
 title: /draft-release-notes - Release Notes Drafting Command for Claude Code
 slug: release-notes-drafting
 category: commands
-description: >-
-  Slash command that drafts release notes from the Conventional Commits made
-  since the last release tag. It reads the git log, groups changes into Keep a
-  Changelog sections (Added, Changed, Fixed, and more), recommends the
-  Semantic Versioning bump, and produces human-readable notes ready to paste
-  into a CHANGELOG or GitHub release.
+description: "Slash command that drafts release notes from the Conventional Commits made since the last release tag."
 cardDescription: >-
   Draft Keep a Changelog release notes from Conventional Commits since the last
   tag and recommend the SemVer bump.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.