### PR TITLE
fix(content): shorten database-migration-safety-gate description under 320 chars

### DIFF
--- a/content/hooks/database-migration-safety-gate.mdx
+++ b/content/hooks/database-migration-safety-gate.mdx
@@ -2,13 +2,7 @@
 title: Database Migration Safety Gate - Claude Code Hook
 slug: database-migration-safety-gate
 category: hooks
-description: >-
-  PreToolUse hook that inspects a database migration before it is written and
-  blocks irreversible or lock-heavy operations — DROP TABLE/COLUMN, TRUNCATE,
-  table/column RENAME, and CREATE INDEX without CONCURRENTLY — following the
-  strong_migrations safe-migration checks. An explicit acknowledgement comment
-  lets an intentional change through, so risky schema edits are a deliberate
-  choice rather than an accident.
+description: "PreToolUse hook that inspects a database migration before it is written and blocks irreversible or lock-heavy operations — DROP TABLE/COLUMN, TRUNCATE, table/column RENAME, and CREATE INDEX without CONCURRENTLY — following the strong_migrations safe-migration checks."
 cardDescription: >-
   Block DROP, TRUNCATE, RENAME, and non-concurrent index migrations unless
   explicitly acknowledged.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.