### PR TITLE
fix(content): shorten dead-code-eliminator description under 320 chars

### DIFF
--- a/content/hooks/dead-code-eliminator.mdx
+++ b/content/hooks/dead-code-eliminator.mdx
@@ -2,7 +2,7 @@
 title: Dead Code Eliminator - Hooks
 slug: dead-code-eliminator
 category: hooks
-description: "A Claude Code SessionEnd hook that scans a project for dead code and writes a report to .claude/reports. It runs available tools per language: ESLint and Knip for JS/TS, autoflake or pylint for Python, Knip for unused npm dependencies, ripgrep for unreferenced src files, and jq to flag zero-coverage files. Defaults to DRY_RUN=true so nothing is deleted; it only analyzes and reports."
+description: "A Claude Code SessionEnd hook that scans a project for dead code and writes a report to .claude/reports. It runs available tools per language: ESLint and Knip for JS/TS, autoflake or pylint for Python, Knip for unused npm dependencies, ripgrep for unreferenced src files, and jq to flag zero-coverage files."
 cardDescription: "SessionEnd Bash hook that reports dead code via ESLint, Knip, autoflake, and Knip. Dry-run by default; writes findings to .claude/reports."
 seoTitle: "SessionEnd Dead Code Report Hook for Claude Code"
 seoDescription: "Claude Code hook that runs ESLint, Knip, autoflake, and Knip at session end, reporting unused code and dependencies to a file. Dry-run by default."


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.