### PR TITLE
fix(content): shorten docker-container-auto-rebuild description under 320 chars

### DIFF
--- a/content/hooks/docker-container-auto-rebuild.mdx
+++ b/content/hooks/docker-container-auto-rebuild.mdx
@@ -2,7 +2,7 @@
 title: Docker Container Auto Rebuild - Hooks
 slug: docker-container-auto-rebuild
 category: hooks
-description: "A PostToolUse hook that watches for edits to Docker-related files (Dockerfile, docker-compose, .dockerfile, .dockerignore). When one changes it checks that the Docker CLI and daemon are available, then runs docker build for a Dockerfile or docker compose build for a compose file, reporting image ID/size or service status."
+description: "A PostToolUse hook that watches for edits to Docker-related files (Dockerfile, docker-compose, .dockerfile, .dockerignore)."
 cardDescription: "PostToolUse hook that runs docker build or docker compose build whenever a Dockerfile, compose file, or .dockerignore is edited."
 seoTitle: "Auto-Rebuild Docker Images on File Edits with a Claude Hook"
 seoDescription: "Claude Code PostToolUse hook that detects Dockerfile, compose, and .dockerignore edits, verifies the Docker daemon, then triggers docker build or compose build."


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.