### PR TITLE
fix(content): shorten large-generated-diff-detector description under 320 chars

### DIFF
--- a/content/hooks/large-generated-diff-detector.mdx
+++ b/content/hooks/large-generated-diff-detector.mdx
@@ -2,12 +2,7 @@
 title: Large Generated Diff Detector - Claude Code Hook
 slug: large-generated-diff-detector
 category: hooks
-description: >-
-  PostToolUse hook that flags two review hazards as Claude writes files: edits
-  to generated or vendored artifacts (lockfiles, minified bundles, source maps,
-  dist/build output, snapshots, protobuf output) and oversized diffs that change
-  more lines than a configurable threshold versus the committed version. It
-  keeps machine-generated churn and unreviewably large changes out of commits.
+description: "PostToolUse hook that flags two review hazards as Claude writes files: edits to generated or vendored artifacts (lockfiles, minified bundles, source maps, dist/build output, snapshots, protobuf output) and oversized diffs that change more lines than a configurable threshold versus the committed version."
 cardDescription: >-
   Flag edits to generated/vendored files and oversized diffs so machine churn
   stays out of reviewable commits.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.