### PR TITLE
fix(content): shorten lockfile-provenance-checker description under 320 chars

### DIFF
--- a/content/hooks/lockfile-provenance-checker.mdx
+++ b/content/hooks/lockfile-provenance-checker.mdx
@@ -2,13 +2,7 @@
 title: Lockfile Provenance Checker - Claude Code Hook
 slug: lockfile-provenance-checker
 category: hooks
-description: >-
-  PostToolUse hook that inspects an edited npm package-lock.json for
-  supply-chain provenance risk rather than known CVEs — dependencies resolved
-  from outside the public npm registry (git, alternate-registry, or insecure
-  transports) and registry tarballs missing an integrity hash. It mirrors the
-  lockfile-lint provenance checks so a tampered or unexpected dependency source
-  is caught at edit time. Advisory only; it never installs or runs anything.
+description: "PostToolUse hook that inspects an edited npm package-lock.json for supply-chain provenance risk rather than known CVEs — dependencies resolved from outside the public npm registry (git, alternate-registry, or insecure transports) and registry tarballs missing an integrity hash."
 cardDescription: >-
   Flag npm lockfile entries resolved outside the public registry or missing an
   integrity hash.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.