### PR TITLE
fix(content): shorten pre-write-secret-scanner description under 320 chars

### DIFF
--- a/content/hooks/pre-write-secret-scanner.mdx
+++ b/content/hooks/pre-write-secret-scanner.mdx
@@ -2,12 +2,7 @@
 title: Pre-Write Secret Scanner - Claude Code Hook
 slug: pre-write-secret-scanner
 category: hooks
-description: >-
-  PreToolUse hook that scans the exact text Claude Code is about to write or
-  edit for high-confidence secret formats (AWS access keys, GitHub tokens,
-  OpenAI keys, Slack tokens, Google API keys, Stripe keys, and private key
-  blocks) and blocks the write with a non-zero exit before the secret ever
-  reaches disk. Pattern set mirrors the canonical gitleaks rules.
+description: "PreToolUse hook that scans the exact text Claude Code is about to write or edit for high-confidence secret formats (AWS access keys, GitHub tokens, OpenAI keys, Slack tokens, Google API keys, Stripe keys, and private key blocks) and blocks the write with a non-zero exit before the secret ever reaches disk."
 cardDescription: >-
   Block writes that would commit AWS, GitHub, OpenAI, Slack, Google, or Stripe
   secrets before they reach disk.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.