### PR TITLE
fix(content): shorten building-a-claude-code-plugin-marketplace description under 320 chars

### DIFF
--- a/content/guides/building-a-claude-code-plugin-marketplace.mdx
+++ b/content/guides/building-a-claude-code-plugin-marketplace.mdx
@@ -2,12 +2,7 @@
 title: Building a Claude Code Plugin Marketplace
 slug: building-a-claude-code-plugin-marketplace
 category: guides
-description: >-
-  A practical walkthrough of building and distributing a Claude Code plugin
-  marketplace. Define a marketplace.json catalog, host it on a git repository,
-  and let users add it with /plugin marketplace add, install with /plugin
-  install, and refresh with /plugin marketplace update — plus private-repo
-  hosting and a version-vs-commit-SHA update strategy.
+description: "A practical walkthrough of building and distributing a Claude Code plugin marketplace."
 cardDescription: >-
   Publish a marketplace.json catalog on a git repo so users can /plugin
   marketplace add and /plugin install — including private-repo hosting.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.