### PR TITLE
fix(content): shorten documentation-automation description under 320 chars

### DIFF
--- a/content/collections/documentation-automation.mdx
+++ b/content/collections/documentation-automation.mdx
@@ -2,12 +2,7 @@
 title: Documentation Automation
 slug: documentation-automation
 category: collections
-description: >-
-  An automation bundle for keeping project documentation accurate and current:
-  generate docs from code, measure documentation coverage, validate README
-  structure and links, document API endpoints, and publish to a docs site. It
-  pulls together existing hooks and commands into one documentation workflow
-  organized around the Diataxis framework.
+description: "An automation bundle for keeping project documentation accurate and current: generate docs from code, measure documentation coverage, validate README structure and links, document API endpoints, and publish to a docs site."
 cardDescription: >-
   Automation bundle to generate, measure, validate, and publish project
   documentation that stays current.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.