### PR TITLE
fix(content): shorten github-maintainer-operations description under 320 chars

### DIFF
--- a/content/collections/github-maintainer-operations.mdx
+++ b/content/collections/github-maintainer-operations.mdx
@@ -2,12 +2,7 @@
 title: GitHub Maintainer Operations
 slug: github-maintainer-operations
 category: collections
-description: >-
-  An operations bundle for maintainers running a busy GitHub repository: triage
-  failing CI, review pull requests, keep commits and changelogs disciplined,
-  validate workflows and links, and draft release notes. It pulls together
-  existing commands, hooks, and skills into one maintainer workflow grounded in
-  the GitHub Open Source Guides.
+description: "An operations bundle for maintainers running a busy GitHub repository: triage failing CI, review pull requests, keep commits and changelogs disciplined, validate workflows and links, and draft release notes."
 cardDescription: >-
   Maintainer workflow bundle for CI triage, PR review, commit governance,
   releases, and workflow validation.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.