### PR TITLE
fix(content): shorten secure-claude-code-workstation description under 320 chars

### DIFF
--- a/content/collections/secure-claude-code-workstation.mdx
+++ b/content/collections/secure-claude-code-workstation.mdx
@@ -2,13 +2,7 @@
 title: Secure Claude Code Workstation
 slug: secure-claude-code-workstation
 category: collections
-description: >-
-  A defense-in-depth bundle for hardening an agentic Claude Code workstation:
-  block secrets and sensitive data before they are written, verify dependency
-  provenance and known vulnerabilities, review supply-chain risk and run code
-  security audits, and harden MCP tool access against prompt injection. It pulls
-  together existing hooks, commands, rules, and skills into one secure setup,
-  organized around the NIST Secure Software Development Framework.
+description: "A defense-in-depth bundle for hardening an agentic Claude Code workstation: block secrets and sensitive data before they are written, verify dependency provenance and known vulnerabilities, review supply-chain risk and run code security audits, and harden MCP tool access against prompt injection."
 cardDescription: >-
   Defense-in-depth bundle of secret, dependency, audit, and MCP hardening
   entries for an agentic Claude Code setup.


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (description_too_long). Trims the description to a complete sentence under the 320-char limit; no other fields changed. Content otherwise unchanged.