### PR TITLE
fix(content): add keywords to express-expert rule

### DIFF
--- a/content/rules/express-expert.mdx
+++ b/content/rules/express-expert.mdx
@@ -14,6 +14,17 @@ seoDescription: >-
   Rules to transform Claude into an Express.js expert covering routers,
   middleware chains, request validation, centralized error handling, and
   production security settings.
+keywords:
+  - claude
+  - express
+  - expressjs
+  - middleware
+  - routing
+  - error-handling
+  - security
+  - nodejs
+  - validation
+  - rules
 author: jaso0n0818
 authorProfileUrl: "https://github.com/jaso0n0818"
 submittedBy: jaso0n0818


### PR DESCRIPTION
Audit fix: `scripts/audit-content.mjs` flags this entry (missing_keywords). Adds a keywords array. Content otherwise unchanged.