### PR TITLE
fix(content): shorten readme-refresh-validator description under 320 chars

### DIFF
--- a/content/hooks/readme-refresh-validator.mdx
+++ b/content/hooks/readme-refresh-validator.mdx
@@ -2,13 +2,7 @@
 title: README Refresh Validator - Claude Code Hook
 slug: readme-refresh-validator
 category: hooks
-description: >-
-  PostToolUse hook that keeps a project's README in sync with the code. When the
-  README or package.json is edited it checks for the standard-readme core
-  sections (Install and Usage) and verifies that every CLI command the package
-  exposes through its package.json bin field is actually documented, so the
-  README does not drift out of date as the project changes. Advisory only; it
-  never edits files.
+description: "PostToolUse hook that keeps a project's README in sync with the code. When the README or package.json is edited it checks for the standard-readme core sections (Install and Usage) and verifies that the CLI commands exposed via package.json bin are documented. Advisory only; it never edits files."
 cardDescription: >-
   Check that a README has Install and Usage sections and documents every
   package.json bin command.


### PR DESCRIPTION
Trims the readme-refresh-validator hook description to a complete sentence under the 320-char audit limit (`scripts/audit-content.mjs` description_too_long). Single file; no other fields changed. (Clean resubmission — prior attempts #2731/#2741 failed on a transient merge race and a stale multi-file diff.)