### PR TITLE
fix(rules): prevent client-controlled Rails order status

### DIFF
--- a/content/rules/ruby-on-rails-expert.mdx
+++ b/content/rules/ruby-on-rails-expert.mdx
@@ -69,6 +69,7 @@ copySnippet: |-
 
     def create
       order = current_user.orders.build(order_params)
+      order.status = "pending"
       authorize order
       order.save!
       render json: order, status: :created
@@ -77,13 +78,14 @@ copySnippet: |-
     private
 
     def order_params
-      params.require(:order).permit(:status, line_items_attributes: [:product_id, :quantity])
+      params.require(:order).permit(line_items_attributes: [:product_id, :quantity])
     end
   end
   ```
 
   - Use `resources` and namespaces for predictable REST endpoints
   - Permit attributes only through strong parameters; never mass-assign blindly
+  - Keep workflow state fields like order status server-controlled; use policy-checked transitions instead of accepting them from request params
   - Return appropriate HTTP status codes and consistent JSON error payloads
 
   ## Active Record


### PR DESCRIPTION
### Motivation
- Prevent a downstream security issue where the public copyable Rails example permitted clients to mass-assign `order.status` via strong parameters, which could allow unauthorized workflow/state transitions.

### Description
- Updated `content/rules/ruby-on-rails-expert.mdx` to set `order.status = "pending"` server-side in the sample `create` action and removed `:status` from the `order_params` strong-parameters list so clients can no longer mass-assign workflow state.
- Added explicit guidance in the rule reminding readers to keep workflow state fields server-controlled and to use policy-checked transitions rather than accepting them from request params.

### Testing
- Ran `pnpm validate:content:strict` which passed successfully, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ea23b81c832a88f021463083ccce)