### PR TITLE
fix(content): repair dead/stale link in five-hour-window-tracker

### DIFF
--- a/content/statuslines/five-hour-window-tracker.mdx
+++ b/content/statuslines/five-hour-window-tracker.mdx
@@ -390,7 +390,7 @@ if ! command -v jq &> /dev/null; then
     elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
         sudo apt-get install -y jq || sudo yum install -y jq
     else
-        echo "Please install jq manually: https://stedolan.github.io/jq/"
+        echo "Please install jq manually: https://jqlang.github.io/jq/"
     fi
 fi
 


### PR DESCRIPTION
Dead/stale-link audit fix. Single file; only the outdated/dead URL is updated to its live, current location. No other content changed.