### PR TITLE
fix(content): repair dead/stale link in chrome-mcp-server

### DIFF
--- a/content/mcp/chrome-mcp-server.mdx
+++ b/content/mcp/chrome-mcp-server.mdx
@@ -64,7 +64,7 @@ privacyNotes:
   - Browser automation prompts may reveal personal browsing habits, internal applications, and authenticated service access.
 sourceUrls:
   - "https://github.com/hangwin/mcp-chrome"
-  - "https://github.com/hangwin/mcp-chrome/blob/main/docs/TOOLS.md"
+  - "https://github.com/hangwin/mcp-chrome/blob/master/README.md"
   - "https://www.npmjs.com/package/mcp-chrome-bridge"
 tags:
   - chrome
@@ -96,7 +96,7 @@ stdio bridge path for clients that do not support streamable HTTP.
 ## Source Review
 
 - https://github.com/hangwin/mcp-chrome
-- https://github.com/hangwin/mcp-chrome/blob/main/docs/TOOLS.md
+- https://github.com/hangwin/mcp-chrome/blob/master/README.md
 - https://www.npmjs.com/package/mcp-chrome-bridge
 
 These sources were reviewed on **2026-06-05**. Prefer the live repository for


### PR DESCRIPTION
Dead/stale-link audit fix. Single file; only the outdated/dead URL is updated to its live, current location. No other content changed.