### PR TITLE
fix(content): repair dead/stale link in webiny-mcp-server

### DIFF
--- a/content/mcp/webiny-mcp-server.mdx
+++ b/content/mcp/webiny-mcp-server.mdx
@@ -73,7 +73,7 @@ sourceUrls:
   - "https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/cli/ConfigureMcp.ts"
   - "https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/agents/discover.ts"
   - "https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/agents/instructions.ts"
-  - "https://raw.githubusercontent.com/webiny/webiny-js/next/.mcp.json"
+  - "https://github.com/webiny/webiny-js/tree/next/packages/mcp"
 tags:
   - webiny
   - skills
@@ -112,7 +112,7 @@ extensions, packages, configuration, or Webiny framework code.
 - https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/cli/ConfigureMcp.ts
 - https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/agents/discover.ts
 - https://raw.githubusercontent.com/webiny/webiny-js/next/packages/mcp/src/agents/instructions.ts
-- https://raw.githubusercontent.com/webiny/webiny-js/next/.mcp.json
+- https://github.com/webiny/webiny-js/tree/next/packages/mcp
 
 These sources were reviewed on **2026-06-06**. Prefer the live repository, MCP
 package metadata, npm registry metadata, root license, CLI implementation, MCP


### PR DESCRIPTION
Dead/stale-link audit fix. Single file; only the outdated/dead URL is updated to its live, current location. No other content changed.