### PR TITLE
fix(content): drop fabricated MCP Hub ref, add notes in claude-mcp-skills-integration-agent

### DIFF
--- a/content/agents/claude-mcp-skills-integration-agent.mdx
+++ b/content/agents/claude-mcp-skills-integration-agent.mdx
@@ -336,7 +336,6 @@ copySnippet: >-
 
   **Sources:**
 
-  - MCP Hub: https://mcp-hub.anthropic.com (October 2025 launch)
 
   - GitHub: Search "mcp-server" topic
 
@@ -638,6 +637,10 @@ copySnippet: >-
   }
 
   ```
+safetyNotes:
+  - "This agent advises connecting and using MCP servers and skills, which can run tools and commands and reach the external systems each server integrates with; review what every MCP server and skill is permitted to do before enabling it."
+privacyNotes:
+  - "Connected MCP servers can read the project data you share with them and send it to the external systems they integrate with (issue trackers, databases, monitoring); review each server's data access before enabling it."
 tags:
   - mcp
   - skills
@@ -888,7 +891,6 @@ npm search @modelcontextprotocol/server-
 
 **Sources:**
 
-- MCP Hub: https://mcp-hub.anthropic.com (October 2025 launch)
 - GitHub: Search "mcp-server" topic
 - NPM: Search "mcp" keyword
 


### PR DESCRIPTION
Audit fix: repairs a dead/fabricated/stale source reference and adds the safety/privacy notes the full-body policy scan requires (entry predated that requirement). Single file.