### PR TITLE
fix(content): update MCP spec link and add safety notes in codex-plugin-creator

### DIFF
--- a/content/skills/codex-plugin-creator-capability-pack.mdx
+++ b/content/skills/codex-plugin-creator-capability-pack.mdx
@@ -30,7 +30,7 @@ verifiedAt: "2026-04-11"
 retrievalSources:
   - "https://github.com/openai/codex"
   - "https://github.com/modelcontextprotocol"
-  - "https://spec.modelcontextprotocol.io/specification/"
+  - "https://modelcontextprotocol.io/specification/"
 testedPlatforms:
   - Claude
   - Codex
@@ -42,6 +42,8 @@ prerequisites:
   - Plugin use case and scope
   - Manifest and MCP requirements
   - Deployment target constraints
+safetyNotes:
+  - "Scaffolds and validates plugin manifests and may run plugin or build commands; review generated manifests and scripts before installing or executing them."
 tags:
   - codex
   - plugins
@@ -71,7 +73,7 @@ This capability pack is pinned to documentation verified on **2026-04-11**.
 
 - https://github.com/openai/codex
 - https://github.com/modelcontextprotocol
-- https://spec.modelcontextprotocol.io/specification/
+- https://modelcontextprotocol.io/specification/
 
 ## Core Workflow
 


### PR DESCRIPTION
Audit fix: repairs a dead/fabricated/stale source reference and adds the safety/privacy notes the full-body policy scan requires (entry predated that requirement). Single file.