### PR TITLE
fix(content): update MCP spec link and add safety notes in codex-automations-orchestrator

### DIFF
--- a/content/skills/codex-automations-orchestrator-capability-pack.mdx
+++ b/content/skills/codex-automations-orchestrator-capability-pack.mdx
@@ -29,7 +29,7 @@ verificationStatus: validated
 verifiedAt: "2026-04-11"
 retrievalSources:
   - "https://github.com/openai/codex"
-  - "https://spec.modelcontextprotocol.io/specification/"
+  - "https://modelcontextprotocol.io/specification/"
   - "https://www.rfc-editor.org/rfc/rfc5545"
 testedPlatforms:
   - Claude
@@ -42,6 +42,8 @@ prerequisites:
   - Automation goals and success metrics
   - Notification channel
   - Operational owner
+safetyNotes:
+  - "Designs and runs automation workflows that can execute commands and trigger external actions; review each automation's permissions and triggers before enabling it."
 tags:
   - codex
   - automation
@@ -70,7 +72,7 @@ This capability pack is pinned to documentation verified on **2026-04-11**.
 ## Retrieval Sources
 
 - https://github.com/openai/codex
-- https://spec.modelcontextprotocol.io/specification/
+- https://modelcontextprotocol.io/specification/
 - https://www.rfc-editor.org/rfc/rfc5545
 
 ## Core Workflow


### PR DESCRIPTION
Audit fix: repairs a dead/fabricated/stale source reference and adds the safety/privacy notes the full-body policy scan requires (entry predated that requirement). Single file.