### PR TITLE
docs(content): add theme-format code and field table to custom-color-themes guide

### DIFF
--- a/content/guides/custom-color-themes-for-claude-code-plugins.mdx
+++ b/content/guides/custom-color-themes-for-claude-code-plugins.mdx
@@ -18,7 +18,7 @@ dateAdded: "2026-06-14"
 submittedAt: "2026-06-14"
 sourceSubmissionNumber: 1429
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1429"
-documentationUrl: "https://code.claude.com/docs/en/whats-new/2026-w17"
+documentationUrl: "https://code.claude.com/docs/en/terminal-config"
 usageSnippet: >-
   Use this guide to bundle custom Claude Code color themes in a plugin for
   consistent branded terminal experiences across a team.
@@ -123,6 +123,39 @@ a user runs.
    settings or plugin defaults.
 
 8. **Iterate on feedback.** Adjust contrast before wide rollout; keep a changelog
+
+## Theme File Format
+
+A custom theme is a JSON file in `~/.claude/themes/`. The filename (without
+`.json`) is the theme's slug, and selecting it stores `custom:<slug>` as your
+theme preference. The file has three optional fields:
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | string | Display label shown in `/theme`. Defaults to the filename slug. |
+| `base` | string | Built-in preset to start from: `dark`, `light`, `dark-daltonized`, `light-daltonized`, `dark-ansi`, or `light-ansi`. Defaults to `dark`. |
+| `overrides` | object | Map of color token names to values. Tokens not listed fall through to the base preset. |
+
+Color values accept `#rrggbb`, `#rgb`, `rgb(r,g,b)`, `ansi256(n)`, or
+`ansi:<name>` (one of the 16 standard ANSI names). Unknown tokens and invalid
+values are ignored, so a typo cannot break rendering. The example below keeps the
+dark preset and recolors the brand accent, error text, and success text:
+
+```json
+{
+  "name": "Dracula",
+  "base": "dark",
+  "overrides": {
+    "claude": "#bd93f9",
+    "error": "#ff5555",
+    "success": "#50fa7b"
+  }
+}
+```
+
+Claude Code watches `~/.claude/themes/` and reloads on file change, so edits
+apply to a running session without a restart. Plugins can ship themes too, which
+then appear in the `/theme` picker alongside your own.
    entry per palette revision.
 
 ## Accessibility Checklist


### PR DESCRIPTION
Resubmission of #2774 (closed: documentationUrl pointed at release notes that don't describe the theme format). Re-anchors documentationUrl to the terminal-config doc that actually documents the theme JSON (name/base/overrides), where the added code block and field table are grounded. Single file.