### PR TITLE
docs(content): add code and comparison table to usage-analytics guide

### DIFF
--- a/content/guides/usage-analytics-for-claude-code-team-rollout.mdx
+++ b/content/guides/usage-analytics-for-claude-code-team-rollout.mdx
@@ -127,6 +127,21 @@ coaching with consent and policy cover.
 | Plugin install rate | Measure standard bundle success |
 | Support tickets tagged claude-code | Correlate friction with metrics |
 
+## Analytics Dashboards by Plan
+
+| Plan | Dashboard URL | Includes |
+| --- | --- | --- |
+| Claude for Teams / Enterprise | claude.ai/analytics/claude-code | Usage metrics, contribution metrics with GitHub integration, leaderboard, data export |
+| API (Claude Console) | platform.claude.com/claude-code | Usage metrics, spend tracking, team insights |
+
+## Query Claude Code-Assisted PRs
+
+Merged pull requests containing Claude Code-assisted lines are labeled `claude-code-assisted` in GitHub. To query this data through GitHub, search for PRs with that label:
+
+```text
+label:claude-code-assisted
+```
+
 ## Troubleshooting
 
 ### Dashboard shows zero activity despite known users


### PR DESCRIPTION
Tier 4 AI-SEO content-depth (batch 3): adds a grounded code example and comparison table to a guide that had neither; every addition traces to the entry's documentationUrl (re-anchored to the specific feature doc where applicable). Single file.