### PR TITLE
docs(content): add code and comparison table to typescript-api-client rule

### DIFF
--- a/content/rules/typescript-api-client-compatibility-review-rules.mdx
+++ b/content/rules/typescript-api-client-compatibility-review-rules.mdx
@@ -270,6 +270,27 @@ surfaces, API Extractor reports, inferred router inputs and outputs, runtime
 validator alignment, downstream compilation, and privacy-safe review evidence
 for typed web app consumers.
 
+## Declaration Publishing Reference
+
+| Field / construct | Handbook guidance |
+| --- | --- |
+| `types` | Points to your bundled declaration file (for example `"types": "./lib/main.d.ts"`). |
+| `typings` | Synonymous with `types` and can be used alternatively. |
+| Declaration dependencies | Must be marked in the `"dependencies"` section, not `"devDependencies"`, so consumers have access to required type declarations. |
+| `/// <reference types="..." />` | Use this form to depend on a declaration package. |
+| `/// <reference path="..." />` | Red flag — do not use this to reference another package's types. |
+
+```json
+{
+  "name": "package-name",
+  "version": "1.0.0",
+  "types": "./index.d.ts",
+  "typesVersions": {
+    ">=3.1": { "*": ["ts3.1/*"] }
+  }
+}
+```
+
 ## Sources
 
 - TypeScript declaration publishing: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html


### PR DESCRIPTION
Tier 4 AI-SEO content-depth (rules batch 1): adds a grounded code example and comparison table to a rule whose body had neither; every addition traces to the entry's documentationUrl. The rule text (copySnippet) is unchanged. Single file.