### PR TITLE
fix(content): remove unsafe agent teams cost control

### DIFF
--- a/content/guides/team-cost-governance-for-claude-code-usage.mdx
+++ b/content/guides/team-cost-governance-for-claude-code-usage.mdx
@@ -136,7 +136,6 @@ Claude Code's official costs documentation lists these commands and settings for
 /model              # Switch model mid-session (Sonnet costs less than Opus)
 /clear              # Start fresh between unrelated tasks to drop stale context
 MAX_THINKING_TOKENS=8000                 # Lower extended-thinking budget on fixed-budget models
-CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1   # Agent teams are disabled by default
 ```
 
 The costs documentation also recommends per-user Token Per Minute (TPM) and Request Per Minute (RPM) rate limits scaled to organization size:


### PR DESCRIPTION
### Motivation
- The guide listed `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` under “Built-in Cost Controls”, which is an enablement flag (not a spend cap) and could encourage users to enable an experimental feature that increases request volume and risk runaway subagent fan-out.

### Description
- Removed the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` line from `content/guides/team-cost-governance-for-claude-code-usage.mdx` while preserving the other documented cost-control references.

### Testing
- Ran `pnpm validate:content:strict` (passed) and `git diff --check` (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311e013840832a9210ad186d6a6352)