### PR TITLE
docs(security): avoid writable credential dirs in sandbox guide

### DIFF
--- a/content/guides/sandboxed-bash-setup-for-autonomous-coding-agents.mdx
+++ b/content/guides/sandboxed-bash-setup-for-autonomous-coding-agents.mdx
@@ -111,14 +111,14 @@ Even with `autoAllowBashIfSandboxed` (auto-allow mode), the sandbox does not bla
 | Content-scoped ask rules like `Bash(git push *)` | Still force a prompt even for sandboxed commands |
 | A bare `Bash` ask rule, or the equivalent `Bash(*)` form | Skipped for sandboxed commands; still applies to commands that fall back to the regular permission flow |
 
-When a subprocess tool an agent runs (`kubectl`, `terraform`, or `npm`) needs to write outside the working directory, grant the specific path with `sandbox.filesystem.allowWrite` rather than excluding the tool from the sandbox entirely:
+When a subprocess tool an agent runs (`kubectl`, `terraform`, or `npm`) needs to write outside the working directory, grant only disposable project-local or temporary paths with `sandbox.filesystem.allowWrite` rather than excluding the tool from the sandbox entirely. Do not make home credential directories such as `~/.kube`, `~/.aws`, or `~/.ssh` writable for autonomous sandboxed commands.
 
 ```json
 {
   "sandbox": {
     "enabled": true,
     "filesystem": {
-      "allowWrite": ["~/.kube", "/tmp/build"]
+      "allowWrite": ["./.agent-tmp", "/tmp/build"]
     }
   }
 }


### PR DESCRIPTION
### Motivation

- The guide previously recommended adding `~/.kube` to `sandbox.filesystem.allowWrite`, which can allow sandboxed autonomous commands to modify Kubernetes credential/config files and thus weaken the intended sandbox protections, so the example and wording need to be safer.

### Description

- Update `content/guides/sandboxed-bash-setup-for-autonomous-coding-agents.mdx` to replace the unsafe `"allowWrite": ["~/.kube", "/tmp/build"]` example with a disposable project-local path (`"allowWrite": ["./.agent-tmp", "/tmp/build"]`) and add an explicit warning not to grant write access to home credential directories such as `~/.kube`, `~/.aws`, or `~/.ssh` for autonomous sandboxed commands.

### Testing

- Ran `pnpm validate:content:strict`, which passed, and `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a311ca6bfd8832abcfae5317c12abbc)