### PR TITLE
docs(content): add code and comparison table to commercial-content-routing rule

### DIFF
--- a/content/rules/commercial-content-routing-rules.mdx
+++ b/content/rules/commercial-content-routing-rules.mdx
@@ -222,6 +222,20 @@ affiliate/referral URLs. This rules entry is distinct because it gives portable
 do/don't behavior for deciding whether a directory submission belongs in
 ordinary editorial review, maintainer-owned commercial review, or rejection.
 
+## Spam-Policy Mapping
+
+Google Search Central documents the spam policies below. Each names a pattern that commercial and promotional directory submissions commonly trigger, which is why routing happens before quality review. Definitions are quoted from Google's spam policies page.
+
+| Google spam policy | What Google says it covers (verbatim) |
+| --- | --- |
+| Thin affiliation | "the practice of publishing content with product affiliate links where the product descriptions and reviews are copied directly from the original merchant without any original content or added value." |
+| Link spam | "the practice of creating links to or from a site primarily for the purpose of manipulating search rankings." |
+| Scaled content abuse | "when many pages are generated for the primary purpose of manipulating search rankings and not helping users." |
+| Scraping | "the practice of taking content from other sites, often through automated means, and hosting it with the purpose of manipulating search rankings." |
+| Site reputation abuse | "a tactic where third-party content is published on a host site mainly because of that host's already-established ranking signals." |
+| User-generated spam | "spammy content added to a site by users through a channel intended for user content." |
+| Misleading functionality | "intentionally creating sites that trick users into thinking they would be able to access some content or services but in reality can't." |
+
 ## References
 
 - Google Search Central spam policies: https://developers.google.com/search/docs/essentials/spam-policies


### PR DESCRIPTION
Tier 4 AI-SEO content-depth (rules batch 2): adds a grounded comparison table (and code where applicable) to a rule whose body had neither; every cell traces to the entry's documentationUrl. Rule text (copySnippet) unchanged. Single file.