### PR TITLE
docs(content): add code and comparison table to documentation-freshness rule

### DIFF
--- a/content/rules/documentation-freshness-rules.mdx
+++ b/content/rules/documentation-freshness-rules.mdx
@@ -203,6 +203,19 @@ portable do/don't behavior for contributors and reviewers deciding whether a
 public registry entry's documentation and source claims are fresh enough to
 merge.
 
+## DWBP Best Practices for Freshness Metadata
+
+The W3C *Data on the Web Best Practices* recommendation defines reusable best practices that map directly to freshness-metadata and stable-source review. Use them as a standards-backed checklist for what a public registry entry must record.
+
+| Best Practice | W3C statement |
+| --- | --- |
+| BP 1: Provide metadata | "Provide metadata for both human users and computer applications." |
+| BP 5: Provide data provenance information | "Provide complete information about the origins of the data and any changes you have made." |
+| BP 6: Provide data quality information | "Provide information about data quality and fitness for particular purposes." |
+| BP 7: Provide a version indicator | "Assign and indicate a version number or date for each dataset." |
+| BP 8: Provide version history | "Provide a complete version history that explains the changes made in each version." |
+| BP 9: Use persistent URIs as identifiers | "Use persistent URIs as identifiers of datasets." |
+
 ## References
 
 - W3C Data on the Web Best Practices: https://www.w3.org/TR/dwbp/


### PR DESCRIPTION
Tier 4 AI-SEO content-depth (rules batch 2): adds a grounded comparison table (and code where applicable) to a rule whose body had neither; every cell traces to the entry's documentationUrl. Rule text (copySnippet) unchanged. Single file.