### PR TITLE
docs(content): add code and comparison table to privacy-metadata rule

### DIFF
--- a/content/rules/privacy-metadata-rules.mdx
+++ b/content/rules/privacy-metadata-rules.mdx
@@ -194,6 +194,23 @@ because it gives portable do/don't behavior for contributors and reviewers who
 must decide whether any AI workflow directory entry has enough privacy metadata
 to merge.
 
+## DPV Concept Mapping
+
+The W3C Data Privacy Vocabulary (`dpv`, namespace `https://w3id.org/dpv#`) provides standardized top-level concepts that map onto the privacy facts these rules ask reviewers to capture. Use the DPV term as a shared vocabulary when a submitter's privacy notes need a precise label.
+
+| DPV concept | DPV definition (verbatim) |
+| --- | --- |
+| `PersonalData` | Data and Personal Data categories |
+| `Processing` | operations over data |
+| `Purpose` | that justify the (end) goal for which data is processed or technologies are used |
+| `Entity` | for actors and the roles they can take |
+| `DataSubject` | The individual (or category of individuals) whose personal data is being processed. |
+| `DataController` | The individual or organisation that decides (or controls) the purpose(s) of processing personal data. |
+| `LegalBasis` | such as consent or contract that justify the process |
+| `Risk` | for assessment and management of risks and impacts |
+| `Right` | rights applicable or provided to a Data Subject |
+| `Rule` | such as permissions and prohibitions |
+
 ## References
 
 - W3C Data Privacy Vocabulary: https://w3c.github.io/dpv/2.3/dpv/


### PR DESCRIPTION
Tier 4 AI-SEO content-depth (rules batch 2): adds a grounded comparison table (and code where applicable) to a rule whose body had neither; every cell traces to the entry's documentationUrl. Rule text (copySnippet) unchanged. Single file.