### PR TITLE
docs(content): rewrite skeleton claude-vs-copilot-python comparison with grounded content

### DIFF
--- a/content/guides/claude-vs-copilot-python.mdx
+++ b/content/guides/claude-vs-copilot-python.mdx
@@ -1,25 +1,36 @@
 ---
-title: Claude vs GitHub Copilot vs ChatGPT for Python Dev 2025
+title: Claude Code vs GitHub Copilot vs ChatGPT for Python Dev
 slug: claude-vs-copilot-python
 category: guides
 description: >-
-  Claude vs GitHub Copilot vs ChatGPT for Python development. Features, pricing,
-  benchmarks, and real results for choosing the best AI coding assistant.
-cardDescription: Claude vs GitHub Copilot vs ChatGPT for Python development.
-seoTitle: Claude vs GitHub Copilot vs ChatGPT for Python Dev 2025
+  Capability comparison of Claude Code, GitHub Copilot, and ChatGPT (Codex) for
+  Python development. Form factor, where each runs, agentic vs inline, IDE
+  integration, MCP, and free tiers, grounded in each tool's official docs.
+cardDescription: >-
+  How Claude Code, GitHub Copilot, and ChatGPT (Codex) compare for Python work.
+seoTitle: Claude Code vs GitHub Copilot vs ChatGPT for Python
 seoDescription: >-
-  Claude vs GitHub Copilot vs ChatGPT for Python development. Features, pricing,
-  benchmarks, and real results for choosing the best AI coding assistant.
+  Capability comparison of Claude Code, GitHub Copilot, and ChatGPT (Codex) for
+  Python development: form factor, agentic vs inline completion, IDE support,
+  MCP extensibility, and free tiers, grounded in official documentation.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"
+documentationUrl: "https://code.claude.com/docs/en/overview"
+retrievalSources:
+  - "https://code.claude.com/docs/en/overview"
+  - "https://docs.github.com/en/copilot"
+  - "https://developers.openai.com/codex/"
 installable: false
 usageSnippet: >-
-  Comprehensive comparison of Claude, GitHub Copilot, and ChatGPT for Python
-  development. Claude achieves 93.7% on HumanEval benchmarks with 200K token
-  context. Copilot offers superior IDE integration at $10/month. ChatGPT
-  provides versatility with web browsing. Optimal strategy combines tools based
-  on task complexity.
+  A capability comparison of three AI coding tools for Python: Claude Code (an
+  agentic CLI/IDE/desktop/web tool), GitHub Copilot (inline completion plus chat
+  and a coding agent inside the GitHub ecosystem), and ChatGPT with Codex
+  (OpenAI's coding agent included in paid ChatGPT plans). Choose based on whether
+  you want agentic multi-file work, inline editor completion, or a chat-first
+  assistant.
+privacyNotes:
+  - "This guide compares third-party AI coding tools; each tool sends your code and prompts to its own provider under that vendor's terms, so review each tool's data-handling and retention policy before using it on sensitive code."
 tags:
   - comparison
   - python-development
@@ -28,9 +39,9 @@ tags:
 keywords:
   - claude vs copilot
   - python coding assistant
-  - claude python development
+  - claude code python development
   - github copilot alternative
-readingTime: 3
+readingTime: 4
 difficultyScore: 16
 hasTroubleshooting: false
 hasPrerequisites: false
@@ -41,101 +52,101 @@ robotsFollow: true
 
 ## TL;DR
 
-Comprehensive comparison of Claude, GitHub Copilot, and ChatGPT for Python development. Claude achieves 93.7% on HumanEval benchmarks with 200K token context. Copilot offers superior IDE integration at $10/month. ChatGPT provides versatility with web browsing. Optimal strategy combines tools based on task complexity.
+This guide compares three AI coding tools for Python work: **Claude Code**,
+**GitHub Copilot**, and **ChatGPT** (with OpenAI's **Codex** coding agent). They
+solve overlapping problems with different shapes, so the right pick depends on
+how you want to work rather than on any single headline number.
 
-**Key Points:**
+- **Claude Code** is an agentic coding tool that reads your codebase, edits
+  files, runs commands, and works across the terminal, IDEs, a desktop app, and
+  the browser.
+- **GitHub Copilot** is strongest as inline completion inside your editor, with
+  a chat surface and an agentic coding agent across the GitHub ecosystem.
+- **ChatGPT** is a chat-first assistant; for hands-on coding, OpenAI ships
+  **Codex**, an agentic coding tool included with paid ChatGPT plans.
 
-- Claude - Superior reasoning and context (200K tokens) - $20/month
-- GitHub Copilot - Best IDE integration and speed - $10/month
-- ChatGPT - Versatile with web browsing capability - $20/month
-- Hybrid approach delivers 25-35% higher productivity
+The descriptions below are grounded in each tool's official documentation. No
+benchmark scores are quoted, because vendor docs do not present comparable,
+verifiable per-tool Python benchmark numbers.
 
-Choosing the right AI assistant for Python development requires understanding each platform's strengths. This comprehensive comparison examines Claude, GitHub Copilot, and ChatGPT based on benchmarks, real testing, and developer feedback across data science, web development, and machine learning applications.
+## Capability comparison
 
-> **Comparison Overview**
->
-> **Tools Compared:** Claude 3.5 Sonnet, GitHub Copilot, ChatGPT Plus  
-> **Use Case Focus:** Python development and data science  
-> **Comparison Date:** September 2025  
-> **Data Sources:** HumanEval, SWE-bench, METR studies, developer surveys  
-> **Testing Methodology:** Five coding challenges, real project implementation
+| Capability | Claude Code | GitHub Copilot | ChatGPT (with Codex) |
+| --- | --- | --- | --- |
+| **Primary form factor** | Agentic coding tool that reads the codebase, edits files, and runs commands | Inline code completion in the editor, plus chat and an agentic agent | Chat assistant; Codex adds an agentic coding tool |
+| **Where it runs** | Terminal CLI, VS Code, JetBrains, desktop app, and the browser | VS Code, Visual Studio, JetBrains, Eclipse, a CLI, GitHub.com, and GitHub Mobile | ChatGPT (web/desktop/mobile); Codex via CLI, IDE extension, and `chatgpt.com/codex` on the web |
+| **Agentic vs inline** | Agentic by design: plans, edits across multiple files, runs commands, and verifies | Both: inline completion as you type, plus a coding agent that plans changes and opens PRs | Codex is agentic (refactors, tests, migrations); ChatGPT chat is conversational |
+| **IDE integration** | VS Code and JetBrains extensions with inline diffs, @-mentions, and plan review | Deep editor integration across VS Code, Visual Studio, JetBrains, and Eclipse | Codex ships an IDE extension; ChatGPT itself is not an in-editor completion tool |
+| **Extensibility / MCP** | Supports MCP, plus `CLAUDE.md` instructions, skills, hooks, and subagents | Supports MCP, custom instructions, custom agents, and CLI plugins/hooks | Custom GPTs and connectors in ChatGPT; Codex is configurable per repo |
+| **Git / PR workflow** | Stages changes, writes commits, opens PRs; CI via GitHub Actions / GitLab | Coding agent creates branches and opens pull requests; native to GitHub | Codex connects to GitHub repos and opens pull requests from completed work |
+| **Free tier** | Most surfaces require a paid Claude subscription or Anthropic Console account | Offers a free Copilot tier with usage limits, plus Pro/Business/Enterprise | Codex is included with paid ChatGPT plans (Plus, Pro, Business, Edu, Enterprise) |
 
-## Quick Comparison Table
+## Per-tool summary
 
-<!-- Section type: comparison_table -->
+### Claude Code
 
-## Detailed Platform Analysis
+Claude Code is an agentic coding tool: it reads your codebase, edits files
+across multiple locations, runs commands, and integrates with your development
+tools. It runs in the terminal, in VS Code and JetBrains via extensions, in a
+standalone desktop app, and in the browser, with the same engine and settings
+across surfaces. For Python projects this means it can plan a change, write code
+across modules, run your test suite, and fix failures in one workflow rather than
+returning isolated snippets. It connects to external systems through the Model
+Context Protocol (MCP), and you can shape its behavior with a `CLAUDE.md` file,
+shareable skills, hooks, and subagents. It works directly with git to stage
+changes, write commit messages, and open pull requests, and it can run in CI via
+GitHub Actions or GitLab CI/CD. Most surfaces require a paid Claude subscription
+or an Anthropic Console account.
 
-<!-- Section type: tabs -->
+### GitHub Copilot
 
-## Performance Benchmarks
+GitHub Copilot is an AI coding assistant whose core strength is real-time inline
+suggestions as you type, available across VS Code, Visual Studio, JetBrains
+IDEs, and Eclipse. Beyond completion it offers Copilot Chat for asking questions
+about code, a command-line agent, and an agentic coding agent that can research
+a repository, plan an implementation, make changes on a branch, and open a pull
+request. It is tightly integrated with the GitHub ecosystem, including GitHub.com
+and GitHub Mobile. Copilot supports the Model Context Protocol, custom
+instructions at repository/organization/personal levels, custom agents, and CLI
+plugins and hooks. It can also select among multiple underlying models. There is
+a free Copilot tier with usage limits, alongside Pro, Business, and Enterprise
+plans. For Python developers who live in their editor and want low-friction
+autocomplete plus an agent close to their repositories, Copilot fits naturally.
 
-> **Benchmark Methodology**
->
-> **Testing Period:** January-September 2025  
-> **Test Environment:** Python 3.12, VS Code, standard library plus numpy/pandas  
-> **Evaluation Criteria:** Accuracy, speed, error handling, documentation quality  
-> **Data Source:** HumanEval, SWE-bench, LeetCode challenges, METR productivity study
+### ChatGPT (with Codex)
 
-<!-- Section type: comparison_table -->
+ChatGPT is a general-purpose chat assistant available on the web, desktop, and
+mobile, useful for explaining Python concepts, drafting functions, and reviewing
+pasted code conversationally. For hands-on, repository-level coding, OpenAI
+provides **Codex**, described as its coding agent that can read, edit, and run
+code. Codex runs via a CLI, an IDE extension, and a cloud/web interface at
+`chatgpt.com/codex`, and it can execute tasks in the background, connect to
+GitHub repositories, and open pull requests from completed work. It is built for
+agentic workflows such as refactoring, testing, and migrations. Codex is included
+with paid ChatGPT plans (Plus, Pro, Business, Edu, and Enterprise). If your team
+already standardizes on ChatGPT, Codex extends that into agentic coding without a
+separate subscription.
 
-## Use Case Analysis
+## Which to choose for Python
 
-<!-- Section type: accordion -->
+- **Choose Claude Code** if you want an agentic tool that owns multi-file
+  changes end to end, runs your tests and commands, and meets you in the
+  terminal, your IDE, a desktop app, or the browser, with MCP, skills, and hooks
+  for customizing how it works on your Python projects.
+- **Choose GitHub Copilot** if you primarily want fast inline completion inside
+  your editor and tight GitHub integration, with the option of a coding agent and
+  chat. The free tier makes it a low-cost starting point.
+- **Choose ChatGPT (with Codex)** if your team already relies on ChatGPT for
+  explanations and exploration, and you want an agentic coding tool bundled into
+  paid ChatGPT plans for refactors, tests, and migrations connected to GitHub.
 
-## Real User Experiences
+These tools are not mutually exclusive: many Python developers use an inline
+completer in the editor and reach for an agentic tool for larger, multi-file
+tasks. Evaluate each against your own repositories and workflow before
+committing.
 
-<!-- Section type: expert_quote -->
+## Sources
 
-> **User Feedback Summary**
->
-> **Survey Source:** Developer community feedback
-> **Sample Size:** Large scale developer survey
-> **Top Satisfaction Factors:** Claude's explanations, Copilot's speed, ChatGPT's versatility  
-> **Common Concerns:** IDE integration gaps, accuracy issues, context limitations
-
-## Decision Framework
-
-<!-- Section type: feature_grid -->
-
-## Cost Analysis
-
-<!-- Section type: comparison_table -->
-
-## Migration Considerations
-
-> **Switching Costs and Considerations**
->
-> **Data Export:** All platforms support code export without vendor lock-in  
-> **Training Impact:** 1-2 weeks adaptation period for new tool workflows  
-> **Integration Changes:** Copilot requires least change, Claude needs workflow adjustment  
-> **Downtime Estimate:** Zero for adding tools, 2-3 days for complete switches
-
-## Final Recommendation
-
-## TL;DR
-
-Based on comprehensive testing comparing Claude, GitHub Copilot, and ChatGPT, our recommendation for Python development is a hybrid approach. This choice provides superior reasoning from Claude while maintaining Copilot's speed. Teams report productivity gains using multiple tools strategically.
-
-**Key Points:**
-
-- Primary tool selection depends on project complexity - Claude excels at architecture
-- Budget-conscious teams should start with Copilot at $10/month - lowest entry cost
-- Add Claude for complex debugging and learning - worth the $20 premium
-- Reserve ChatGPT for research tasks - unique web browsing capability
-
-## Frequently Asked Questions
-
-## Additional Resources
-
-<!-- Section type: related_content -->
-
-> **Make Your Decision**
->
-> **Ready to choose?** Start with free trials to test each tool with your actual Python projects.
->
-> **Need more specific guidance?** Join our [community](/community) to discuss your requirements with developers using all three platforms.
->
-> **Want hands-on experience?** Most tools offer free tiers - test them with your specific use case before committing.
-
-_Last updated: September 2025 | Comparison based on Q3 2025 benchmarks and testing | Found this helpful? Share with your team and explore more [AI tool comparisons](/guides/comparisons)._
+- [Claude Code overview](https://code.claude.com/docs/en/overview)
+- [GitHub Copilot documentation](https://docs.github.com/en/copilot)
+- [OpenAI Codex documentation](https://developers.openai.com/codex/)


### PR DESCRIPTION
Tier 4 skeleton rewrite: replaces empty placeholder sections + stale/unsourced benchmarks with grounded content — capability tables where each tool's facts trace to that tool's official docs (comparison pages), or Claude Code security/data + HHS sources (domain pages); documentationUrl + retrievalSources + required notes added. Single file.