### PR TITLE
docs(content): rewrite skeleton claude-vs-cursor-codeium comparison with grounded content

### DIFF
--- a/content/guides/claude-vs-cursor-codeium.mdx
+++ b/content/guides/claude-vs-cursor-codeium.mdx
@@ -1,26 +1,34 @@
 ---
-title: Claude Code vs Cursor vs Codeium Complete Comparison 2025
+title: Claude Code vs Cursor vs Windsurf (Codeium)
 slug: claude-vs-cursor-codeium
 category: guides
 description: >-
-  Compare Claude Code vs Cursor vs Codeium AI coding assistants. Complete
-  feature analysis, performance benchmarks, pricing, and recommendations for
-  developers.
-cardDescription: Compare Claude Code vs Cursor vs Codeium AI coding assistants.
-seoTitle: Claude Code vs Cursor vs Codeium Complete Comparison 2025
+  Capability comparison of Claude Code, Cursor, and Windsurf (formerly Codeium):
+  form factor, where each runs, agentic vs autocomplete, MCP extensibility, and
+  free tiers, grounded in each tool's official docs.
+cardDescription: >-
+  Compare Claude Code, Cursor, and Windsurf (formerly Codeium) on form factor,
+  agentic features, MCP support, and free tiers.
+seoTitle: Claude Code vs Cursor vs Windsurf (Codeium) Comparison
 seoDescription: >-
-  Compare Claude Code vs Cursor vs Codeium AI coding assistants. Complete
-  feature analysis, performance benchmarks, pricing, and recommendations for
-  developers.
+  Capability comparison of Claude Code, Cursor, and Windsurf (formerly Codeium):
+  form factor, agentic vs autocomplete, MCP extensibility, IDE support, and free
+  tiers, grounded in each vendor's official documentation.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"
+documentationUrl: "https://code.claude.com/docs/en/overview"
+retrievalSources:
+  - "https://code.claude.com/docs/en/overview"
+  - "https://cursor.com/docs"
+  - "https://docs.windsurf.com"
 installable: false
 usageSnippet: >-
-  Comprehensive comparison of Claude Code, Cursor, and Codeium for AI-powered
-  development in 2025. We analyzed SWE-bench scores, pricing models, IDE
-  integration approaches, and enterprise deployments to help you choose the best
-  solution for your coding workflow.
+  Capability comparison of Claude Code, Cursor, and Windsurf (formerly Codeium).
+  Grounded in each tool's official docs to help you pick the right AI coding
+  assistant for your workflow.
+privacyNotes:
+  - "This guide compares third-party AI coding tools; each tool sends your code and prompts to its own provider under that vendor's terms, so review each tool's data-handling and retention policy before using it on sensitive code."
 tags:
   - comparison
   - AI coding assistants
@@ -28,11 +36,12 @@ tags:
   - evaluation
 keywords:
   - claude vs cursor
+  - claude vs windsurf
   - claude vs codeium
   - ai ide comparison
   - coding assistant tools
-readingTime: 3
-difficultyScore: 18
+readingTime: 4
+difficultyScore: 16
 hasTroubleshooting: false
 hasPrerequisites: false
 hasBreakingChanges: false
@@ -42,83 +51,64 @@ robotsFollow: true
 
 ## TL;DR
 
-Comprehensive comparison of Claude Code, Cursor, and Codeium for AI-powered development in 2025. We analyzed SWE-bench scores, pricing models, IDE integration approaches, and enterprise deployments to help you choose the best solution for your coding workflow.
-
-**Key Points:**
-
-- Claude Code - Terminal-native with 200K context - $20/month
-- Cursor - Complete IDE replacement with multi-file editing - $20/month
-- Codeium - Universal IDE support with free tier - $0-30/month
-- Claude achieves 72.7-74.5% on SWE-bench vs Copilot's 33.2%
-
-Choosing the right AI coding assistant impacts development velocity significantly. This comprehensive comparison examines Claude Code, Cursor, and Codeium based on benchmark data, real deployments, and pricing analysis.
+Claude Code, Cursor, and Windsurf (formerly Codeium) all bring AI to coding, but they pick different form factors. Claude Code is an agentic tool that lives in your terminal, IDE, desktop app, and browser. Cursor is a standalone editor (a VS Code fork) built around its Tab autocomplete and Agent. Windsurf is a standalone editor built around its Cascade agent, with plugins for other IDEs. This guide compares them on the dimensions that actually change your workflow, grounded in each tool's official documentation.
 
 > **Comparison Overview**
 >
-> **Tools Compared:** Claude Code, Cursor, Codeium, GitHub Copilot  
-> **Use Case Focus:** Professional software development and team collaboration  
-> **Comparison Date:** September 2025  
-> **Data Sources:** SWE-bench, Aider Leaderboards, GitClear analysis, vendor documentation  
-> **Testing Methodology:** Real-world benchmarks and production deployment metrics
+> **Tools Compared:** Claude Code, Cursor, Windsurf (formerly Codeium)
+> **Use Case Focus:** Professional software development
+> **Sources:** Each tool's own official documentation (see Additional Resources)
 
-## Quick Comparison Table
+## Capability Comparison
 
-<!-- Section type: comparison_table -->
+Each cell below is grounded in the respective tool's official docs.
 
-## Detailed Platform Analysis
+| Capability | Claude Code | Cursor | Windsurf (Codeium) |
+| --- | --- | --- | --- |
+| Form factor / IDE model | Agentic coding tool, not an editor; layers onto your existing setup | Standalone editor, a fork of the VS Code codebase | Standalone editor (Windsurf Editor) plus plugins for other IDEs |
+| Where it runs | Terminal CLI, VS Code/JetBrains extensions, desktop app, and browser, all on one engine | Downloadable app for macOS, Windows, and Linux | Downloadable Windsurf Editor; plugins for VS Code, JetBrains, Visual Studio, Vim/Neovim, and more (most non-JetBrains plugins are in maintenance mode) |
+| Primary interaction | Agentic: reads the codebase, edits files, runs commands, works across multiple files and tools | Agent (Cmd+I) for autonomous multi-file work, plus Tab inline autocomplete | Cascade agent (Code/Chat modes) plus inline autocomplete |
+| Agentic vs autocomplete | Agent-first; designed to plan and complete tasks across files | Both: Agent for tasks, Tab for predictive inline completions and cross-file edits | Both: Cascade agent for tasks, autocomplete for inline suggestions |
+| Extensibility / MCP | Supports MCP to connect external data sources and tools; plus CLAUDE.md memory, skills, hooks, and subagents | Supports MCP (stdio, SSE, streamable HTTP), marketplace one-click install, and `mcp.json` config | Cascade supports MCP servers to extend the agent's capabilities |
+| Git / CI integration | Works directly with git (commits, branches, PRs); GitHub Actions and GitLab CI/CD | Editor-based git workflows; agent can run terminal commands | Editor-based workflows; agent can run code and use tools |
+| Free tier | Most surfaces require a paid Claude subscription or Anthropic Console account; Terminal CLI and VS Code also support third-party providers | Hobby plan available; paid tiers add capacity | Sign-up is free with a credits/usage model; paid tiers unlock more |
 
-<!-- Section type: tabs -->
+## How each one is positioned
 
-## Performance Benchmarks
+**Claude Code** is described in its docs as "an agentic coding tool that reads your codebase, edits files, runs commands, and integrates with your development tools," available in the terminal, IDE, desktop app, and browser. The key idea is one engine across many surfaces: your CLAUDE.md files, settings, and MCP servers carry across the CLI, VS Code, JetBrains, desktop, and web. It is not an editor you switch to; it works alongside whatever editor you already use, and it leans agent-first (planning and completing multi-file tasks, creating commits and PRs).
 
-> **Benchmark Results**
->
-> Latest SWE-bench and Aider Leaderboard scores reveal significant performance gaps. Claude-based systems achieve 72.7-74.5% success rates on real-world tasks. GitHub Copilot scores 33.2% using GPT-4 models. Language matters significantly - Python shows 60-85% completion rates while Rust and C++ achieve only 40-55% success.
+**Cursor** is a standalone editor built on the VS Code codebase, so the editing surface is familiar while the AI is first-class. Its docs describe two pillars: **Tab**, "Cursor's AI-powered autocomplete" that suggests inline code and predicts your next edit location, and **Agent** (Cmd+I), which can edit files, run terminal commands, and complete complex tasks across the codebase with automatic checkpoints for rollback. Cursor supports MCP across stdio, SSE, and streamable HTTP transports, with marketplace and `mcp.json` configuration.
 
-## Use Case Recommendations
+**Windsurf** (formerly Codeium) centers on **Cascade**, its agentic assistant with Code and Chat modes, tool calling, checkpoints, and real-time awareness of your actions. It ships as a standalone Windsurf Editor and also as plugins for a wide range of IDEs (JetBrains, VS Code, Visual Studio, Vim/Neovim, and others), though its docs note most non-JetBrains plugins are in maintenance mode and recommend the native editor or JetBrains plugin for the newest agentic features. Cascade supports MCP servers to extend its capabilities.
 
-<!-- Section type: accordion -->
+## A Claude Code quickstart
 
-## Security Considerations
+Claude Code installs and runs from the terminal:
 
-> **Security and Compliance Features**
->
-> Studies reveal AI-assisted developers can generate more security vulnerabilities while producing more code. Claude Code's Compliance API, Cursor's privacy mode, and Codeium's FedRAMP certification address these concerns differently. Teams must balance productivity gains against security risks through proper tooling configuration and review processes.
+```bash
+brew install --cask claude-code
+cd your-project
+claude
+```
 
-## Cost-Benefit Analysis
+You are prompted to log in on first use. Other surfaces (VS Code, JetBrains, desktop, web) connect to the same engine.
 
-<!-- Section type: feature_grid -->
+## Which to Choose
 
-## Migration Strategies
+- **Choose Claude Code** if you want an agent that works across your terminal, editor, desktop, and browser without committing to a specific editor, with strong git/CI automation and portable configuration via CLAUDE.md, skills, and MCP.
+- **Choose Cursor** if you want a polished standalone editor with best-in-class inline autocomplete (Tab) plus an in-editor agent, and you are comfortable adopting a VS Code fork as your primary IDE.
+- **Choose Windsurf** if you prefer an agent-centric editor (Cascade) or need to add agentic AI to an IDE you already use through its plugins, especially JetBrains.
 
-1. **Evaluate Current Workflow**
-
-2. **Run Pilot Program**
-
-3. **Configure Security Policies**
-
-4. **Team Training**
-
-5. **Gradual Rollout**
-
-6. **Optimization Phase**
-
-## Decision Matrix
-
-<!-- Section type: accordion -->
-
-## Frequently Asked Questions
+The categories overlap: Claude Code's VS Code and JetBrains extensions let you keep Cursor or another editor while adding Claude's agent, so these are not strictly mutually exclusive. The cleanest decision is whether you want the AI to be the editor (Cursor, Windsurf) or to ride alongside whatever editor and surfaces you already use (Claude Code).
 
 ## Additional Resources
 
-<!-- Section type: related_content -->
+- Claude Code overview: https://code.claude.com/docs/en/overview
+- Cursor documentation: https://cursor.com/docs
+- Windsurf documentation: https://docs.windsurf.com
 
 > **Make Your Decision**
 >
-> **Ready to choose?** Use this comparison data to evaluate which tool best fits your development workflow and budget constraints.
->
-> **Need more specific guidance?** Join our [community](/community) to discuss your requirements with users of all platforms.
->
-> **Want hands-on experience?** Codeium offers a free tier, while Cursor and Claude Code provide trials. Test with your actual codebase before committing.
+> Test each tool with your actual codebase before committing. Form factor, not benchmark headlines, is usually what determines whether a tool fits your workflow.
 
-_Last updated: September 2025 | Comparison based on SWE-bench scores and production deployments | Found this helpful? Share with your team and explore more [AI tool comparisons](/guides/comparisons)._
+_Comparison grounded in each tool's official documentation. Found this helpful? Explore more [AI tool comparisons](/guides/comparisons)._


### PR DESCRIPTION
Tier 4 skeleton rewrite: replaces empty placeholder sections + stale/unsourced benchmarks with grounded content — capability tables where each tool's facts trace to that tool's official docs (comparison pages), or Claude Code security/data + HHS sources (domain pages); documentationUrl + retrievalSources + required notes added. Single file.