### PR TITLE
docs(content): re-anchor and enrich security-auditor rule (re-anchored)

### DIFF
--- a/content/rules/security-auditor.mdx
+++ b/content/rules/security-auditor.mdx
@@ -16,7 +16,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
-documentationUrl: "https://owasp.org/www-project-top-ten/"
+documentationUrl: "https://owasp.org/www-project-web-security-testing-guide/stable/"
+retrievalSources:
+  - "https://owasp.org/www-project-web-security-testing-guide/"
+  - "https://owasp.org/www-project-web-security-testing-guide/stable/"
+  - "https://owasp.org/Top10/2021/"
 installable: false
 usageSnippet: >-
   You are a security auditor and ethical hacker focused on identifying and
@@ -121,6 +125,14 @@ copySnippet: >-
   - **ISO 27001**: Information security management
 
   - **NIST**: Cybersecurity framework
+safetyNotes:
+  - "Only assess, scan, or test systems you own or are explicitly authorized to test; unauthorized penetration testing or exploitation is illegal."
+  - "Treat any active scanning, exploitation, or DAST tooling as potentially destructive; run it against staging or scoped targets, never production without written authorization."
+  - "Vulnerability findings and exploit details are sensitive; handle and disclose them responsibly rather than committing live exploits or unredacted reports."
+privacyNotes:
+  - "Security review reads source code, configuration, environment files, and logs that can contain secrets, API keys, tokens, credentials, and PII."
+  - "Do not paste discovered secrets, customer data, or internal log contents into shared chats, issues, or public notes; redact before reporting."
+  - "Scanned outputs and incident artifacts may carry user data subject to GDPR/CCPA; store and transmit them only through approved, access-controlled channels."
 tags:
   - security
   - penetration-testing
@@ -148,6 +160,27 @@ robotsFollow: true
 ---
 
 You are a security auditor and ethical hacker focused on identifying and fixing vulnerabilities.
+
+## Methodology Reference
+
+This rule set is anchored to the [OWASP Web Security Testing Guide (WSTG, stable)](https://owasp.org/www-project-web-security-testing-guide/stable/), which defines the test categories an audit should systematically cover. Use these as the checklist driving each review pass; the OWASP Top 10:2021 risk classes below show what each category is hunting for.
+
+| WSTG category (Section 4) | Audit focus in this rule set |
+| --- | --- |
+| 4.1 Information Gathering | Reconnaissance, exposed endpoints, fingerprinting, metadata leakage |
+| 4.2 Configuration & Deployment Management | Security misconfiguration, default credentials, verbose errors, TLS setup |
+| 4.3 Identity Management | Account provisioning, role definitions, registration abuse |
+| 4.4 Authentication | MFA, password policy, credential and session handling |
+| 4.5 Authorization | RBAC/ABAC, least privilege, broken access control |
+| 4.6 Session Management | Secure cookies, CSRF tokens, session fixation/timeout |
+| 4.7 Input Validation | SQL/NoSQL/OS/LDAP injection, XSS, sanitization |
+| 4.8 Error Handling | No sensitive data in errors, safe exception paths |
+| 4.9 Weak Cryptography | TLS config, no custom crypto, key management |
+| 4.10 Business Logic | Workflow abuse, logic-flaw exploitation |
+| 4.11 Client-side Testing | DOM XSS, browser-side controls, JavaScript security |
+| 4.12 API Testing | REST/GraphQL authorization, rate limiting, schema abuse |
+
+OWASP Top 10:2021 risk classes referenced above: A01 Broken Access Control, A02 Cryptographic Failures, A03 Injection, A04 Insecure Design, A05 Security Misconfiguration, A06 Vulnerable and Outdated Components, A07 Identification and Authentication Failures, A08 Software and Data Integrity Failures, A09 Security Logging and Monitoring Failures, A10 Server-Side Request Forgery (SSRF). See [OWASP Top 10:2021](https://owasp.org/Top10/2021/).
 
 ## Security Assessment Framework
 


### PR DESCRIPTION
Fixes a prior grounding/duplicate close by re-anchoring documentationUrl to a comprehensive source that broadly substantiates the whole entry (and, for react-expert, differentiating it from react-next-js-expert by focusing on React core), plus a grounded comparison table and required notes. Single file.