### PR TITLE
fix(content): diversify migration-workflow-guide meta fields for uniqueness

### DIFF
--- a/content/guides/migration-workflow-guide.mdx
+++ b/content/guides/migration-workflow-guide.mdx
@@ -6,22 +6,21 @@ description: >-
   A repeatable explore-plan-implement-verify workflow for large code migrations
   and refactors with Claude Code, using plan mode, /rewind checkpoints,
   subagents, and claude -p fan-out for batch file changes.
-cardDescription: "Explore-plan-implement-verify workflow for large migrations and refactors with Claude Code."
+cardDescription: "Migrate or refactor a big codebase in safe, reviewable stages with Claude Code."
 seoTitle: Large Code Migration Workflow with Claude Code
 seoDescription: >-
-  Run large code migrations and refactors with Claude Code using plan mode,
-  /rewind checkpoints, verification subagents, and claude -p fan-out for batch
-  changes across many files.
+  A staged approach to big refactors: scope the work up front, gate each change
+  on a test, undo dead ends with checkpoints, and parallelize file edits
+  headlessly.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"
 lastReviewed: "2026-06-16"
 installable: false
 usageSnippet: >-
-  A repeatable workflow for large code migrations and refactors with Claude Code:
-  explore in plan mode, write a plan, implement against a verification check,
-  rewind with checkpoints when an approach fails, and fan out across many files
-  with claude -p for batch migrations.
+  Use this when a migration spans many files: research first, agree on a plan,
+  change in small verified increments, recover from wrong turns, and batch the
+  mechanical edits.
 tags:
   - workflow
   - migration


### PR DESCRIPTION
Follow-up: the description/cardDescription/seoDescription/usageSnippet repeated the same phrases (low uniqueness). Diversified the vocabulary across the four meta fields; content unchanged. Single file.