### PR TITLE
content(skills): add Subagent Transcript Cleanup Capability Pack

### DIFF
--- a/content/skills/subagent-transcript-cleanup-capability-pack.mdx
+++ b/content/skills/subagent-transcript-cleanup-capability-pack.mdx
@@ -1,0 +1,164 @@
+---
+title: Subagent Transcript Cleanup Capability Pack Skill
+slug: subagent-transcript-cleanup-capability-pack
+category: skills
+description: >-
+  Community capability pack for cleaning subagent transcripts before parent-session handoff
+  using official Claude Code sub-agents documentation: redaction patterns, summary contracts,
+  retention limits, and privacy-safe delegation closeout checklists.
+cardDescription: Clean subagent transcripts for parent handoff using official sub-agents documentation.
+seoTitle: Subagent Transcript Cleanup Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack for subagent transcript cleanup grounded in Claude Code
+  sub-agents documentation: redaction, summaries, retention, privacy-safe handoff.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+sourceSubmissionNumber: 1539
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1539"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill after subagent work completes to redact sensitive transcript content, produce
+  parent-session summaries, and verify handoff contracts per sub-agents documentation.
+copySnippet: |-
+  # Trigger
+  "Apply the subagent transcript cleanup capability pack."
+
+  # Required output
+  1) Transcript redaction and retention checklist
+  2) Parent-session summary contract
+  3) Sensitive data findings from subagent output
+  4) Handoff approval gate before merging results upstream
+  5) Privacy-safe closeout note
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-16"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://github.com/anthropics/claude-code"
+testedPlatforms:
+  - Claude Code
+  - Cursor
+  - Generic AGENTS
+prerequisites:
+  - Completed or paused subagent session with transcript or tool output to review.
+  - Parent-session handoff requirements including required fields and approval owners.
+  - Policy on whether raw subagent logs may be stored or must be summarized only.
+  - List of sensitive patterns to redact such as tokens, customer data, and internal URLs.
+safetyNotes:
+  - Do not merge unreviewed subagent output into parent sessions when destructive actions were attempted.
+  - Redaction is not encryption—assume summarized content may still leak context if poorly written.
+  - Background subagents may produce long transcripts—apply retention limits before archiving.
+  - This skill guides cleanup; it does not replace human review for regulated data handling.
+privacyNotes:
+  - Subagent transcripts may contain secrets from tool output, file reads, and MCP responses.
+  - Parent summaries should use findings and citations, not paste full tool logs.
+  - Shared tickets must not attach raw subagent transcripts with proprietary code or credentials.
+tags:
+  - subagent
+  - transcript
+  - cleanup
+  - capability-pack
+  - privacy
+  - handoff
+keywords:
+  - subagent transcript cleanup
+  - claude code subagent handoff
+  - subagent redaction capability pack
+  - parent session summary contract
+robotsIndex: true
+robotsFollow: true
+---
+
+## Content
+
+Subagent Transcript Cleanup Capability Pack is a community-authored skill checklist for
+closing subagent sessions safely. It applies official Claude Code sub-agents documentation—not
+an official Anthropic transcript management product.
+
+## Scope Note
+
+This capability pack operationalizes documented subagent isolation and handoff concepts from
+code.claude.com. Foreground versus background delegation mode selection is covered by
+subagent-foreground-background-delegation-capability-pack.
+
+## Capability Pack
+
+Apply this pack when a subagent finishes work and results must return to the parent session.
+
+### Phase 1 — Transcript inventory
+
+1. Collect subagent tool calls, file reads, MCP responses, and draft edits produced.
+2. Identify sections that must never leave the subagent context verbatim.
+3. Note destructive or production-touching actions attempted during the subagent run.
+
+### Phase 2 — Redaction
+
+1. Remove API keys, JWTs, cookies, and connection strings from handoff text.
+2. Replace customer identifiers with stable internal aliases when summaries require references.
+3. Strip large file dumps—retain paths and line ranges instead of full content.
+4. Flag unresolved secrets discovered during cleanup for credential rotation owners.
+
+### Phase 3 — Summary contract
+
+1. Produce a parent-session summary with: goal, outcome, blockers, and next steps.
+2. Attach evidence as citations (paths, command names, doc links)—not raw tool JSON.
+3. Separate confirmed facts from subagent hypotheses labeled as needs verification.
+4. Include explicit approval gate if parent must accept destructive follow-ups.
+
+### Phase 4 — Retention and closeout
+
+1. Apply team retention policy to subagent logs—delete or archive per policy.
+2. Record which MCP servers and files were touched for audit trails.
+3. Emit a privacy-safe closeout note suitable for shared project trackers.
+
+## Features
+
+- Maps sub-agents documentation to transcript cleanup workflows.
+- Separates redaction from summarization with explicit handoff contracts.
+- Complements foreground/background delegation skill without duplicating mode selection.
+- Produces audit-friendly closeout notes without raw transcript attachments.
+
+## Use Cases
+
+- Close background research subagents before merging findings into a parent coding session.
+- Sanitize MCP-heavy subagent runs before posting summaries to Slack or Linear.
+- Enterprise workflows requiring redaction before subagent output enters shared tickets.
+- Post-incident cleanup when subagents read sensitive configuration files.
+
+## Source Notes
+
+Verified against Claude Code sub-agents documentation on **2026-06-16**:
+
+- Official sub-agents documentation describes how Claude Code delegates work to isolated
+  subagent contexts with separate conversation history from the parent session.
+- Documentation explains subagent specialization and coordination patterns that imply distinct
+  transcript boundaries requiring deliberate handoff back to the parent session.
+- Sub-agents guidance complements skills documentation for packaging reusable workflow checklists.
+
+## Duplicate Check
+
+Checked content/skills for transcript cleanup coverage.
+subagent-foreground-background-delegation-capability-pack covers delegation mode selection.
+No skills entry applies sub-agents documentation to transcript redaction and parent handoff
+summary contracts after subagent completion.
+
+## Editorial Disclosure
+
+Submitted as an independent community skills entry by kiannidev, based on public Claude Code
+sub-agents documentation and the public anthropics/claude-code repository.
+No paid placement, referral, or affiliate relationship.
+
+## Sources
+
+- Claude Code sub-agents - https://code.claude.com/docs/en/sub-agents
+- Claude Code skills - https://code.claude.com/docs/en/skills
+- Claude Code repository - https://github.com/anthropics/claude-code


### PR DESCRIPTION
## Summary
- Adds `content/skills/subagent-transcript-cleanup-capability-pack.mdx` for issue #1539.
- Closes #1539.

## Grounding note
- Community capability pack applying documented Claude Code sub-agents workflow steps—not an official Anthropic skill product.

## Duplicate check
- Searched `content/skills/`, generated catalog text, and open PRs for overlapping titles, slugs, repo URLs, and docs domains.
- This entry targets a distinct workflow not covered by existing skills entries.

## Test plan
- [x] Verified source URLs are reachable.
- [x] Ran whitespace cleanup on the submission file.
- [ ] All validation checks pass.