### PR TITLE
fix(content): use YAML list form for safetyNotes/privacyNotes in chatgpt-migration-guide

### DIFF
--- a/content/guides/chatgpt-migration-guide.mdx
+++ b/content/guides/chatgpt-migration-guide.mdx
@@ -25,17 +25,10 @@ usageSnippet: >-
   coding tool. Covers installation, your first session, and a reference table
   mapping common coding tasks to Claude Code commands and prompt recipes.
 safetyNotes:
-  - >-
-    Claude Code edits files and runs commands in your project. It asks for
-    permission before modifying files, but review proposed changes before
-    approving.
-  - >-
-    Be cautious with "Accept all" mode and non-interactive (`-p`) runs in
-    scripts or CI, which skip the per-change approval prompt.
+  - "Claude Code edits files and runs commands in your project. It asks for permission before modifying files, but review proposed changes before approving."
+  - "Be cautious with \"Accept all\" mode and non-interactive (`-p`) runs in scripts or CI, which skip the per-change approval prompt."
 privacyNotes:
-  - >-
-    Claude Code reads your project files to build context and stores
-    conversation history locally so sessions can be resumed.
+  - "Claude Code reads your project files to build context and stores conversation history locally so sessions can be resumed."
   - "Authentication credentials are stored on your system after login."
 tags:
   - tutorial


### PR DESCRIPTION
Converts the `safetyNotes:` and `privacyNotes:` frontmatter from folded `>-` block-scalar list items to plain quoted-string list items (the required list-of-strings shape); inner quotes are escaped. Wording is unchanged. `pnpm validate:content:strict` passes. Single file.