### PR TITLE
content(tools): add Archon

### DIFF
--- a/content/tools/archon.mdx
+++ b/content/tools/archon.mdx
@@ -1,0 +1,105 @@
+---
+title: Archon
+slug: archon
+category: tools
+description: >-
+  Open-source harness builder for AI coding that runs YAML-defined development workflows
+  to make agent-assisted coding more deterministic and repeatable across Claude Code and
+  other AI coding clients.
+cardDescription: Open-source harness builder for deterministic, repeatable AI coding workflows.
+seoTitle: Archon — Open-Source Harness Builder for AI Coding
+seoDescription: >-
+  Archon is an open-source harness builder for AI coding that runs YAML-defined workflows
+  to make agent-assisted development deterministic and repeatable.
+author: coleam00
+dateAdded: "2026-06-16"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+submittedAt: "2026-06-16"
+sourceSubmissionNumber: 1593
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1593"
+websiteUrl: "https://archon.diy"
+repoUrl: "https://github.com/coleam00/Archon"
+documentationUrl: "https://github.com/coleam00/Archon"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: macOS, Windows, Linux
+prerequisites:
+  - Local environment capable of running Archon per repository setup instructions.
+  - YAML workflow definitions describing the development process you want agents to follow.
+  - AI coding client or agent runtime compatible with Archon harness integration.
+  - Version control for workflow files you expect agents to execute repeatedly.
+safetyNotes:
+  - "Workflow harnesses can execute shell, file, and tool steps; review YAML before running in production repos."
+  - "Treat Archon like any agent orchestration layer and scope credentials and repository access narrowly."
+  - "Self-hosted deployments require patching and backup like other internal developer platforms."
+  - "Deterministic workflows reduce variance but do not replace human review of generated changes."
+privacyNotes:
+  - "Workflow execution data stays in your Archon deployment and connected repositories."
+  - "Agent clients may send prompts and tool output to model providers per client privacy settings."
+  - "Shared workflow repos may expose internal process details; restrict access accordingly."
+  - "Review Archon repository security guidance before exposing harness endpoints publicly."
+tags:
+  - workflow-engine
+  - harness
+  - open-source
+  - ai-coding
+  - automation
+keywords:
+  - archon ai coding harness
+  - yaml workflow engine agents
+  - deterministic ai coding workflows
+  - archon coleam00
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Archon is an open-source harness builder for AI coding. The project describes itself as
+making AI-assisted development deterministic and repeatable by running YAML-defined
+development workflows rather than ad hoc chat sessions alone.
+
+Teams use Archon to encode repeatable agent processes—build, test, review, and handoff
+steps—so coding agents follow the same harness across sessions.
+
+## Features
+
+- YAML-defined development workflows for AI coding agents.
+- Harness builder focused on repeatable agent-assisted development.
+- Open-source project with repository documentation and community adoption.
+- Website at archon.diy with project overview and links to repository resources.
+
+## Use Cases
+
+- Standardize how coding agents run build-and-verify loops across a team.
+- Encode repeatable review or release checklists as workflow harnesses.
+- Prototype deterministic agent processes before building custom orchestration.
+- Compare harness-driven agent runs against one-off Claude Code sessions.
+
+## Source Notes
+
+Verified against the public Archon repository and website on **2026-06-16**:
+
+- The coleam00/Archon repository describes Archon as the first open-source harness builder
+  for AI coding, focused on making AI coding deterministic and repeatable.
+- Project README and repository documentation emphasize YAML workflow execution rather than
+  ad hoc prompt-only sessions.
+- The archon.diy website provides project overview aligned with the harness-builder positioning.
+
+## Duplicate Check
+
+Checked content/tools for Archon or duplicate AI coding harness platforms.
+No existing tools entry covers coleam00/Archon as an open-source harness builder for AI coding.
+
+## Editorial Disclosure
+
+Submitted as an independent community tools entry by kiannidev, based on the public
+coleam00/Archon repository and archon.diy website. No paid placement, referral, or
+affiliate relationship.
+
+## Sources
+
+- Archon repository - https://github.com/coleam00/Archon
+- Archon website - https://archon.diy


### PR DESCRIPTION
## Summary
- Adds `content/tools/archon.mdx` for issue #1593.
- Closes #1593.

## Duplicate check
- Searched `content/tools/`, generated catalog text, and open PRs for overlapping titles, slugs, repo URLs, and docs domains.
- This entry targets a distinct workflow not covered by existing tools entries.

## Test plan
- [x] Verified source URLs are reachable.
- [x] Ran whitespace cleanup on the submission file.
- [ ] All validation checks pass.