### PR TITLE
chore(links): canonicalize 1 moved source URL

### DIFF
--- a/content/tools/lakera-guard.mdx
+++ b/content/tools/lakera-guard.mdx
@@ -8,7 +8,7 @@ seoTitle: Lakera Guard AI security for LLM apps
 seoDescription: Lakera Guard helps detect prompt injection, unsafe content, data leakage, and abuse in LLM applications.
 author: Lakera
 dateAdded: "2026-04-27"
-websiteUrl: "https://www.lakera.ai/lakera-guard"
+websiteUrl: "https://www.lakera.ai/ai-agent-security"
 documentationUrl: "https://docs.lakera.ai"
 pricingModel: paid
 disclosure: editorial


### PR DESCRIPTION
Automated link-health canonicalization. One source URL gives a permanent (301) redirect to a real same-domain content page; rewritten to the canonical target.

| file | field | old → new |
| --- | --- | --- |
| content/tools/lakera-guard.mdx | websiteUrl | https://www.lakera.ai/lakera-guard → https://www.lakera.ai/ai-agent-security |

**Why:** Lakera renamed the "Lakera Guard" product page to "AI Agent Security" (same `www.lakera.ai` registrable domain, permanent 301 → 200). Verified the new page still documents Lakera Guard (body references "Lakera Guard"), and the entry's sibling `documentationUrl` (docs.lakera.ai) returns 200, so the content-gate re-verification should pass.

Auto-merge intentionally OFF — merge after the green link-check + a glance at the table above.

_Dead links from the same sweep are tracked in #2879._