### PR TITLE
docs(content): align audio-transcription skill with search intent

### DIFF
--- a/content/skills/audio-transcription-summarization.mdx
+++ b/content/skills/audio-transcription-summarization.mdx
@@ -4,8 +4,8 @@ slug: audio-transcription-summarization
 category: skills
 description: "Transcribe audio files (MP3, WAV, M4A, etc.) using OpenAI Whisper AI and ffmpeg to produce structured, timestamped transcripts with automatic summarization and action item extraction. Supports multilingual transcription, speaker diarization, and meeting minutes generation."
 cardDescription: "Transcribe audio files (MP3, WAV, M4A, etc.) using OpenAI Whisper AI and ffmpeg to produce structured, timestamped transcripts with autom..."
-seoTitle: Audio Transcription + Summarization Skill
-seoDescription: "Transcribe audio files (MP3, WAV, M4A, etc.) using OpenAI Whisper AI and ffmpeg to produce structured, timestamped transcripts with automatic summarization a..."
+seoTitle: "Transcribe Audio with Claude — Whisper Transcription Skill"
+seoDescription: "Yes, Claude can transcribe audio — pair it with OpenAI Whisper and ffmpeg to turn MP3/WAV/M4A files into timestamped transcripts, summaries, and action items."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"
@@ -47,16 +47,12 @@ tags:
   - whisper
   - ffmpeg
 keywords:
-  - and
-  - audio
-  - claude
-  - development
-  - ffmpeg
-  - skills
-  - summarization
-  - tools
-  - transcription
-  - whisper
+  - claude audio transcription
+  - transcribe audio with claude
+  - whisper transcription skill
+  - audio to text
+  - meeting transcription
+  - speaker diarization
 readingTime: 3
 packageVerified: true
 difficultyScore: 71


### PR DESCRIPTION
Optimizes the audio-transcription-summarization skill for the queries it already ranks for.

**Why:** Google Search Console (last 3 months) shows this page at **4,371 impressions, position 8.7, but 0.62% CTR** — it ranks on page 1 yet barely gets clicked. Top queries are question-intent: "can claude transcribe audio", "is claude good at transcribing audio files", "claude audio transcription".

**Changes (frontmatter only, no protected fields):**
- `seoTitle`: was identical to the display title with no "Claude"/"transcribe" — now "Transcribe Audio with Claude — Whisper Transcription Skill".
- `seoDescription`: was truncated mid-word with a literal "…" — now a complete, intent-matching snippet that leads with the answer to the top query. Claims (Whisper, ffmpeg, MP3/WAV/M4A, summaries, action items) are grounded in the existing description and documentationUrl.
- `keywords`: replaced auto-extracted junk tokens with the real search phrases.

`pnpm validate:content:strict` passes.