### PR TITLE
docs(content): refresh WSL setup guide search metadata

### DIFF
--- a/content/guides/wsl-setup-guide.mdx
+++ b/content/guides/wsl-setup-guide.mdx
@@ -1,15 +1,13 @@
 ---
-title: Claude Code WSL Setup 2025
+title: Claude Code WSL Setup 2026
 slug: wsl-setup-guide
 category: guides
 description: >-
   Complete Claude Code WSL2 installation tutorial in 30 minutes. Configure
   Node.js, resolve PATH conflicts, and optimize Windows development performance.
 cardDescription: Complete Claude Code WSL2 installation tutorial in 30 minutes.
-seoTitle: Claude Code WSL Setup 2025
-seoDescription: >-
-  Complete Claude Code WSL2 installation tutorial in 30 minutes. Configure
-  Node.js, resolve PATH conflicts, and optimize Windows development performance.
+seoTitle: "Install Claude Code on WSL2 (Windows) — 2026 Setup Guide"
+seoDescription: "Install Claude Code on Windows via WSL2 in about 30 minutes: set up Node.js, resolve PATH conflicts, and tune development performance. Step-by-step for Windows devs."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"


### PR DESCRIPTION
Optimizes the Claude Code WSL setup guide for search.

**Why:** GSC (last 3 months) shows this page at **1,291 impressions, position 11.4, 0.15% CTR** — and the title still said "2025", a stale-freshness signal heading into a fresh-sensitive query (Windows/WSL setup).

**Changes (no protected fields; `dateAdded` unchanged):**
- `title`: "2025" → "2026".
- `seoTitle`: was identical to the display title → "Install Claude Code on WSL2 (Windows) — 2026 Setup Guide" (front-loads the action + platform).
- `seoDescription`: rewritten as a complete, intent-matching SERP snippet.

`pnpm validate:content:strict` and the content-policy scan pass locally.