### PR TITLE
docs(content): target HIPAA search intent in healthcare guide

### DIFF
--- a/content/guides/healthcare-hipaa-guide.mdx
+++ b/content/guides/healthcare-hipaa-guide.mdx
@@ -7,11 +7,8 @@ description: >-
   no-training commercial policy, retention windows, Zero Data Retention,
   encryption, local transcript handling, telemetry opt-outs, and security model.
 cardDescription: The documented Claude Code data-handling controls that matter for PHI-sensitive teams.
-seoTitle: "Claude Code in Healthcare and PHI-Sensitive Environments"
-seoDescription: >-
-  How Claude Code handles data: commercial no-training policy, retention windows,
-  Zero Data Retention, encryption, local transcripts, telemetry opt-outs, and
-  the security model—mapped to what Anthropic actually documents.
+seoTitle: "Claude Code for HIPAA & PHI-Sensitive Healthcare Teams"
+seoDescription: "Using Claude Code in HIPAA and PHI-sensitive healthcare settings: no-training policy, retention windows, Zero Data Retention, encryption, and telemetry opt-outs, mapped to Anthropic's docs."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"
@@ -51,10 +48,10 @@ tags:
   - privacy
 keywords:
   - claude code healthcare
-  - claude code data retention
+  - claude code hipaa
+  - is claude code hipaa compliant
   - zero data retention claude code
   - claude code phi
-  - claude code security controls
 readingTime: 6
 difficultyScore: 60
 hasTroubleshooting: false


### PR DESCRIPTION
Optimizes the healthcare/PHI guide for the queries it already ranks for.

**Why:** GSC (last 3 months) shows this page at **676 impressions, position 14.7, 0% CTR**, and the query "hipaa compliant claude" surfaces it at position ~44. The page is *about* HIPAA/PHI data controls but the `seoTitle` never contained the word "HIPAA".

**Changes (metadata only):**
- `seoTitle`: "…Healthcare and PHI-Sensitive Environments" → "Claude Code for HIPAA & PHI-Sensitive Healthcare Teams" — adds the HIPAA term without claiming compliance (the guide explicitly states it does not establish HIPAA compliance).
- `seoDescription`: front-loads "HIPAA and PHI-sensitive healthcare" while keeping the documented controls.
- `keywords`: added `claude code hipaa` and `is claude code hipaa compliant`.

All claims remain grounded in documentationUrl + retrievalSources. `pnpm validate:content:strict` and the content-policy scan pass locally.