### PR TITLE
docs(content): optimize Microsoft AutoGen entry for search intent

### DIFF
--- a/content/tools/microsoft-autogen.mdx
+++ b/content/tools/microsoft-autogen.mdx
@@ -4,8 +4,8 @@ slug: microsoft-autogen
 category: tools
 description: Open-source framework for building multi-agent AI applications, conversations, workflows, and autonomous systems.
 cardDescription: Open-source framework for multi-agent AI applications.
-seoTitle: Microsoft AutoGen multi-agent AI framework
-seoDescription: Microsoft AutoGen is an open-source framework for multi-agent AI applications, workflows, and autonomous systems.
+seoTitle: "Microsoft AutoGen: Multi-Agent AI Framework Overview & Docs"
+seoDescription: "Microsoft AutoGen is an open-source multi-agent framework for building conversational AI agents, workflows, and autonomous systems — overview, official docs, and repo links."
 author: Microsoft
 dateAdded: "2026-04-27"
 websiteUrl: "https://microsoft.github.io/autogen/"
@@ -15,12 +15,18 @@ pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Windows, Linux
+safetyNotes:
+  - "AutoGen runs multi-agent workflows that can execute code and call external tools autonomously; sandbox execution and review agent actions before granting tool or system access."
+privacyNotes:
+  - "AutoGen agents send prompts, code, and tool outputs to the configured LLM provider(s); review what data your agents transmit and each provider's data-handling and retention terms."
 tags:
   - agent-framework
   - multi-agent
 keywords:
-  - autogen
-  - multi-agent ai
+  - microsoft autogen
+  - autogen multi-agent framework
+  - autogen documentation
+  - multi-agent ai framework
 ---
 
 ## Editorial notes


### PR DESCRIPTION
Optimizes the Microsoft AutoGen tool entry for the queries it ranks for.

**Why:** GSC (last 3 months) shows this page drawing **~3,800 impressions across ~12 query variants** (e.g. "microsoft autogen multi-agent framework official documentation") at **position ~9 but 0% CTR** — the largest single block of un-clicked impressions in the catalog. Searchers want the framework's docs/overview; our snippet didn't signal that.

**Changes:**
- `seoTitle`: "Microsoft AutoGen multi-agent AI framework" → "Microsoft AutoGen: Multi-Agent AI Framework Overview & Docs".
- `seoDescription`: rewritten to promise overview + official docs + repo links.
- `keywords`: expanded to the real query phrases (`autogen documentation`, `autogen multi-agent framework`).
- Added `safetyNotes`/`privacyNotes` (autonomous code execution + prompts sent to LLM providers) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.