### PR TITLE
docs(content): optimize LangGraph entry for search intent

### DIFF
--- a/content/tools/langgraph.mdx
+++ b/content/tools/langgraph.mdx
@@ -4,8 +4,8 @@ slug: langgraph
 category: tools
 description: Agent orchestration framework for building stateful, controllable, multi-step LLM and agent workflows.
 cardDescription: Stateful orchestration framework for LLM agents.
-seoTitle: LangGraph agent orchestration framework
-seoDescription: LangGraph helps build stateful, controllable, multi-step LLM and agent workflows with graph-based orchestration.
+seoTitle: "LangGraph: Stateful Agent Orchestration Framework & Docs"
+seoDescription: "LangGraph is an open-source framework for building stateful, controllable, multi-step LLM and agent workflows with graph-based orchestration — overview, official docs, and setup."
 author: LangChain
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.langchain.com/langgraph"
@@ -21,8 +21,11 @@ tags:
   - agent-framework
   - orchestration
 keywords:
-  - agent orchestration
+  - langgraph
+  - langgraph documentation
+  - agent orchestration framework
   - stateful llm workflows
+  - multi-agent workflows
 ---
 
 ## Editorial notes


### PR DESCRIPTION
Optimizes the LangGraph tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~1,031 impressions, position ~8.7, 0% CTR** (e.g. "langgraph official documentation agents workflows state").

**Changes:**
- `seoTitle`: "LangGraph agent orchestration framework" → "LangGraph: Stateful Agent Orchestration Framework & Docs".
- `seoDescription`: rewritten to promise overview + official docs + setup.
- `keywords`: expanded with real query phrases (`langgraph documentation`, `agent orchestration framework`, `multi-agent workflows`).

Existing `privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.