### PR TITLE
docs(content): optimize Browser Use entry for search intent

### DIFF
--- a/content/tools/browser-use.mdx
+++ b/content/tools/browser-use.mdx
@@ -4,8 +4,8 @@ slug: browser-use
 category: tools
 description: Open-source browser automation library for building AI agents that can navigate, click, type, and inspect websites.
 cardDescription: Open-source browser automation for AI agents.
-seoTitle: Browser Use automation library for AI agents
-seoDescription: Browser Use is an open-source library for building AI agents that navigate, click, type, and inspect websites.
+seoTitle: "Browser Use: AI Browser Automation Library — Overview & Docs"
+seoDescription: "Browser Use is an open-source library for building AI agents that navigate, click, type, and inspect websites — overview, official docs, and setup for browser automation."
 author: Browser Use
 dateAdded: "2026-04-27"
 websiteUrl: "https://browser-use.com"
@@ -15,12 +15,18 @@ pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Windows, Linux
+safetyNotes:
+  - "Browser Use drives a real browser and can navigate, click, type, and submit forms autonomously; run it against trusted sites and review actions before granting access to logged-in sessions or sensitive accounts."
+privacyNotes:
+  - "Page content, screenshots, and DOM data are sent to the configured LLM provider to plan actions, and agents can read and submit data on authenticated sites; control credentials and which pages agents can access."
 tags:
   - browser-automation
   - open-source
 keywords:
-  - browser agents
-  - ai web automation
+  - browser use
+  - browser-use documentation
+  - ai browser automation
+  - web automation agents
 ---
 
 ## Editorial notes


### PR DESCRIPTION
Optimizes the Browser Use tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~774 impressions, position ~8.7, 0% CTR** (e.g. "browser-use official documentation ai browser automation").

**Changes:**
- `seoTitle`: "Browser Use automation library for AI agents" → "Browser Use: AI Browser Automation Library — Overview & Docs".
- `seoDescription`: rewritten to promise overview + official docs + setup.
- `keywords`: expanded with real query phrases (`ai browser automation`, `browser-use documentation`).
- Added `safetyNotes`/`privacyNotes` (autonomous browser control + page data sent to LLM provider) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.