### PR TITLE
docs(content): optimize Arize Phoenix entry for search intent

### DIFF
--- a/content/tools/arize-phoenix.mdx
+++ b/content/tools/arize-phoenix.mdx
@@ -4,8 +4,8 @@ slug: arize-phoenix
 category: tools
 description: Open-source observability and evaluation tooling for LLM applications, traces, datasets, and experiments.
 cardDescription: Open-source LLM observability and evaluation tooling.
-seoTitle: Arize Phoenix LLM observability
-seoDescription: Arize Phoenix provides open-source observability and evaluation for LLM applications, traces, datasets, and experiments.
+seoTitle: "Arize Phoenix: Open-Source LLM Observability & Evaluation"
+seoDescription: "Arize Phoenix is open-source LLM observability and evaluation tooling for traces, datasets, experiments, and prompt analysis — overview, official docs, and setup."
 author: Arize AI
 dateAdded: "2026-04-27"
 websiteUrl: "https://arize.com/phoenix/"
@@ -19,8 +19,11 @@ tags:
   - observability
   - evaluation
 keywords:
-  - llm tracing
-  - ai evaluation
+  - arize phoenix
+  - llm observability
+  - phoenix tracing
+  - llm evaluation
+  - phoenix documentation
 ---
 
 ## Editorial notes


### PR DESCRIPTION
Optimizes the Arize Phoenix tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~841 impressions, position ~9.4, 0% CTR** (e.g. "arize phoenix").

**Changes:**
- `seoTitle`: "Arize Phoenix LLM observability" → "Arize Phoenix: Open-Source LLM Observability & Evaluation".
- `seoDescription`: rewritten to promise overview + official docs + setup.
- `keywords`: expanded with real query phrases (`arize phoenix`, `llm observability`, `phoenix tracing`).

`pnpm validate:content:strict` and the content-policy scan pass locally.