### PR TITLE
docs(content): optimize LangSmith entry for search intent

### DIFF
--- a/content/tools/langsmith.mdx
+++ b/content/tools/langsmith.mdx
@@ -4,8 +4,8 @@ slug: langsmith
 category: tools
 description: Observability, evaluation, tracing, and testing platform for LLM applications and agent workflows.
 cardDescription: Observability and evaluation platform for LLM apps.
-seoTitle: LangSmith LLM observability and evaluation
-seoDescription: LangSmith provides tracing, observability, evaluation, and testing workflows for LLM applications and agents.
+seoTitle: "LangSmith: LLM Observability, Tracing & Evaluation Platform"
+seoDescription: "LangSmith is a platform for tracing, observability, evaluation, and testing of LLM applications and agent workflows — overview, official docs, and setup."
 author: LangChain
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.langchain.com/langsmith/observability"
@@ -18,7 +18,10 @@ tags:
   - observability
   - evaluation
 keywords:
+  - langsmith
   - llm observability
+  - langsmith documentation
+  - llm tracing
   - agent evaluation
 ---
 


### PR DESCRIPTION
Optimizes the LangSmith tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~349 impressions, position ~9, 0% CTR**.

**Changes:**
- `seoTitle`: "LangSmith LLM observability and evaluation" → "LangSmith: LLM Observability, Tracing & Evaluation Platform".
- `seoDescription`: rewritten to promise overview + official docs + setup.
- `keywords`: expanded with real query phrases (`langsmith`, `langsmith documentation`, `llm tracing`).

`pnpm validate:content:strict` and the content-policy scan pass locally.