### PR TITLE
docs(content): optimize Helicone entry for search intent

### DIFF
--- a/content/tools/helicone.mdx
+++ b/content/tools/helicone.mdx
@@ -4,8 +4,8 @@ slug: helicone
 category: tools
 description: Open-source LLM observability platform for logging, metrics, cost tracking, feedback, and gateway workflows.
 cardDescription: LLM observability and cost tracking platform.
-seoTitle: Helicone LLM observability and cost tracking
-seoDescription: Helicone provides LLM logging, metrics, cost tracking, feedback, and gateway workflows for AI applications.
+seoTitle: "Helicone: Open-Source LLM Observability & Cost Tracking"
+seoDescription: "Helicone is an open-source LLM observability platform for logging, metrics, cost tracking, feedback, and gateway routing — overview, official docs, and setup."
 author: Helicone
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.helicone.ai"
@@ -19,7 +19,10 @@ tags:
   - observability
   - cost-tracking
 keywords:
+  - helicone
+  - llm observability
   - llm cost tracking
+  - helicone documentation
   - llm logs
 ---
 


### PR DESCRIPTION
Optimizes the Helicone tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): the query "helicone llm observability cost tracking official docs" surfaces this page at **position ~6.3 but 0% CTR**.

**Changes:**
- `seoTitle`: "Helicone LLM observability and cost tracking" → "Helicone: Open-Source LLM Observability & Cost Tracking".
- `seoDescription`: rewritten to promise overview + official docs + setup.
- `keywords`: expanded with real query phrases (`helicone`, `llm observability`, `helicone documentation`).

`pnpm validate:content:strict` and the content-policy scan pass locally.