### PR TITLE
docs(content): optimize LlamaIndex entry for search intent

### DIFF
--- a/content/tools/llamaindex.mdx
+++ b/content/tools/llamaindex.mdx
@@ -4,8 +4,8 @@ slug: llamaindex
 category: tools
 description: Open-source framework for building agentic LLM applications over private data with ingestion, indexes, retrieval, RAG, tools, workflows, and evaluation.
 cardDescription: Build agents, RAG pipelines, retrieval, indexing, and data-aware LLM apps.
-seoTitle: LlamaIndex framework for agents and RAG applications
-seoDescription: LlamaIndex helps teams build agentic LLM applications over private data with ingestion, indexes, retrieval, RAG pipelines, tools, workflows, MCP, observability, and evaluation.
+seoTitle: "LlamaIndex: RAG & Agent Framework for LLM Apps — Docs"
+seoDescription: "LlamaIndex is an open-source framework for building agentic LLM apps over private data — ingestion, indexing, retrieval, RAG, tools, and workflows. Overview, docs, and setup."
 author: LlamaIndex
 submittedBy: oktofeesh1
 submittedByUrl: "https://github.com/oktofeesh1"
@@ -25,6 +25,7 @@ keywords:
   - llamaindex
   - llama index
   - rag framework
+  - llamaindex documentation
   - data agents
   - retrieval augmented generation
 prerequisites:


### PR DESCRIPTION
Optimizes the LlamaIndex tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~461 impressions, position ~9.8, 0% CTR**.

**Changes (submitter attribution preserved):**
- `seoTitle`: "LlamaIndex framework for agents and RAG applications" → "LlamaIndex: RAG & Agent Framework for LLM Apps — Docs".
- `seoDescription`: tightened to a complete SERP snippet promising overview + docs + setup.
- `keywords`: added `llamaindex documentation`.

`pnpm validate:content:strict` and the content-policy scan pass locally.