### PR TITLE
docs(content): optimize Microsoft AutoGen entry + fix docs URL

### DIFF
--- a/content/tools/microsoft-autogen.mdx
+++ b/content/tools/microsoft-autogen.mdx
@@ -4,8 +4,8 @@ slug: microsoft-autogen
 category: tools
 description: Open-source framework for building multi-agent AI applications, conversations, workflows, and autonomous systems.
 cardDescription: Open-source framework for multi-agent AI applications.
-seoTitle: Microsoft AutoGen multi-agent AI framework
-seoDescription: Microsoft AutoGen is an open-source framework for multi-agent AI applications, workflows, and autonomous systems.
+seoTitle: "Microsoft AutoGen: Multi-Agent AI Framework Overview & Docs"
+seoDescription: "Microsoft AutoGen is an open-source multi-agent framework for building conversational AI agents, workflows, and autonomous systems — overview, official docs, and repo links."
 author: Microsoft
 dateAdded: "2026-04-27"
 websiteUrl: "https://microsoft.github.io/autogen/"
@@ -15,12 +15,18 @@ pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Windows, Linux
+safetyNotes:
+  - "AutoGen runs multi-agent workflows that can execute code and call external tools autonomously; sandbox execution and review agent actions before granting tool or system access."
+privacyNotes:
+  - "AutoGen agents send prompts, code, and tool outputs to the configured LLM provider(s); review what data your agents transmit and each provider's data-handling and retention terms."
 tags:
   - agent-framework
   - multi-agent
 keywords:
-  - autogen
-  - multi-agent ai
+  - microsoft autogen
+  - autogen multi-agent framework
+  - autogen documentation
+  - multi-agent ai framework
 ---
 
 ## Editorial notes

--- a/content/tools/microsoft-autogen.mdx
+++ b/content/tools/microsoft-autogen.mdx
@@ -9,7 +9,7 @@ seoDescription: "Microsoft AutoGen is an open-source multi-agent framework for b
 author: Microsoft
 dateAdded: "2026-04-27"
 websiteUrl: "https://microsoft.github.io/autogen/"
-documentationUrl: "https://microsoft.github.io/autogen/"
+documentationUrl: "https://microsoft.github.io/autogen/stable/"
 repoUrl: "https://github.com/microsoft/autogen"
 pricingModel: open-source
 disclosure: editorial


### PR DESCRIPTION
Optimizes the Microsoft AutoGen tool entry and fixes its source URL.

**Why:** GSC (last 3 months): **~3,800 impressions across ~12 query variants** at **position ~9 but 0% CTR** — the catalog's largest block of un-clicked impressions. A first attempt (#2948) was gate-declined for grounding because the old `documentationUrl` (`microsoft.github.io/autogen/`) is a meta-refresh redirect stub whose link text reads "example.com", so the reviewer couldn't verify claims.

**Changes:**
- `documentationUrl`: → `https://microsoft.github.io/autogen/stable/`, which serves the actual AutoGen docs (verified reachable, on-topic).
- `seoTitle`: "Microsoft AutoGen multi-agent AI framework" → "Microsoft AutoGen: Multi-Agent AI Framework Overview & Docs".
- `seoDescription`: rewritten to promise overview + official docs + repo links.
- `keywords`: expanded with real query phrases.
- Added `safetyNotes`/`privacyNotes` (autonomous code execution + prompts sent to LLM providers).

`pnpm validate:content:strict` and the content-policy scan pass locally.