### PR TITLE
docs(content): improve Semantic Kernel agent keywords for search

### DIFF
--- a/content/agents/semantic-kernel-enterprise-agent.mdx
+++ b/content/agents/semantic-kernel-enterprise-agent.mdx
@@ -619,19 +619,11 @@ tags:
   - dotnet
   - python
 keywords:
-  - agent
-  - agents
-  - azure
-  - claude
-  - development
-  - dotnet
-  - enterprise
-  - kernel
-  - microsoft
-  - python
-  - semantic
-  - semantic-kernel
-  - tools
+  - microsoft semantic kernel
+  - semantic kernel agent
+  - semantic kernel sdk
+  - azure openai integration
+  - semantic kernel plugins
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Improves search targeting for the Semantic Kernel enterprise agent entry.

**Why:** GSC (last 3 months): **~421 impressions, position ~11.6, 0% CTR**. The `keywords` were single-token auto-extractions (`agent`, `azure`, `claude`, `development`, `kernel`, `tools`) that match nothing useful.

**Changes (metadata only):**
- `keywords`: replaced with real search phrases (`microsoft semantic kernel`, `semantic kernel sdk`, `semantic kernel plugins`, `azure openai integration`).

The existing distinct `seoTitle`/`seoDescription` and `privacyNotes` are retained. `pnpm validate:content:strict` and the content-policy scan pass locally.