### PR TITLE
docs(content): optimize Mintlify documentation skill for search intent

### DIFF
--- a/content/skills/mintlify-documentation-automation.mdx
+++ b/content/skills/mintlify-documentation-automation.mdx
@@ -4,8 +4,8 @@ slug: mintlify-documentation-automation
 category: skills
 description: "Automate beautiful, searchable documentation creation with Mintlify - the modern AI-native documentation platform."
 cardDescription: "Automate beautiful, searchable documentation creation with Mintlify - the modern AI-native documentation platform."
-seoTitle: Mintlify AI Documentation Automation Skill
-seoDescription: "Automate beautiful, searchable documentation creation with Mintlify - the modern AI-native documentation platform. Generate comprehensive API reference docum..."
+seoTitle: "Mintlify Documentation Automation — Generate API Docs with Claude"
+seoDescription: "Automate searchable documentation with Mintlify, the AI-native docs platform: generate API reference, MDX guides, and OpenAPI docs from your codebase using Claude."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -76,6 +76,10 @@ prerequisites:
   - "OpenAPI specification (optional, for API reference)"
   - Mintlify account and API access (free tier available) for documentation site hosting and deployment
   - "File system read/write access for Mintlify configuration files (mint.json), documentation source files, and generated documentation outputs"
+safetyNotes:
+  - "Installs the Mintlify CLI globally (npm install -g mintlify) and can write and deploy documentation files and configuration (mint.json); review generated output and deployment targets before publishing."
+privacyNotes:
+  - "Generating and hosting docs can read your source code, API specs, and JSDoc/TypeScript types and send content to Mintlify's platform and account; review what is uploaded and the platform's data-handling terms."
 tags:
   - mintlify
   - documentation
@@ -83,15 +87,11 @@ tags:
   - api-docs
   - automation
 keywords:
-  - api-docs
-  - automation
-  - claude
-  - development
-  - documentation
-  - mdx
   - mintlify
-  - skills
-  - tools
+  - mintlify documentation
+  - api documentation generator
+  - mdx documentation
+  - docs automation
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Optimizes the Mintlify documentation-automation skill for search.

**Why:** GSC (last 3 months): **~470 impressions, position ~8.8, 0% CTR**.

**Changes:**
- `seoTitle`: was identical to the display title → "Mintlify Documentation Automation — Generate API Docs with Claude".
- `seoDescription`: was truncated mid-word with a literal "…" → complete, keyword-rich snippet.
- `keywords`: replaced auto-extracted junk tokens (`claude`, `development`, `skills`, `tools`) with real search phrases.
- Added `safetyNotes`/`privacyNotes` (installs the CLI globally, deploys docs, reads source/specs) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.