### PR TITLE
docs(content): optimize PayPal MCP server entry for search intent

### DIFF
--- a/content/mcp/paypal-mcp-server.mdx
+++ b/content/mcp/paypal-mcp-server.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Integrate PayPal commerce capabilities, payment processing, and transaction
   management
-seoTitle: Paypal MCP Server for Claude
-seoDescription: >-
-  Integrate PayPal commerce capabilities, payment processing, and transaction
-  management Discover tools for AI development.
+seoTitle: "PayPal MCP Server for Claude — Payments & Commerce Tools"
+seoDescription: "Connect Claude to PayPal with the PayPal MCP server: process payments, manage orders and transactions, and automate commerce workflows from your AI agent."
 author: PayPal
 authorProfileUrl: "https://www.paypal.com/"
 dateAdded: "2025-09-18"
@@ -75,17 +73,11 @@ tags:
   - transactions
   - financial
 keywords:
-  - claude
-  - commerce
-  - development
-  - financial
-  - mcp
-  - mcp servers
-  - payments
-  - paypal
-  - server
-  - tools
-  - transactions
+  - paypal mcp server
+  - paypal mcp
+  - claude paypal integration
+  - payment processing mcp
+  - commerce automation
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the PayPal MCP server entry for search.

**Why:** GSC (last 3 months): **~404 impressions, position ~7.9, 0.25% CTR**.

**Changes (metadata only; protected fields untouched):**
- `seoTitle`: "Paypal MCP Server for Claude" → "PayPal MCP Server for Claude — Payments & Commerce Tools" (correct brand casing + intent).
- `seoDescription`: fixed the run-on boilerplate ("…transaction management Discover tools for AI development.") → a clean, intent-matching snippet.
- `keywords`: replaced single-token auto-extractions with real search phrases (`paypal mcp server`, `claude paypal integration`).

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.