### PR TITLE
feat(web): advertise tools entries in the sitemap

### DIFF
--- a/apps/web/src/lib/sitemap-policy.ts
+++ b/apps/web/src/lib/sitemap-policy.ts
@@ -9,17 +9,19 @@ export function safeSitemapDate(value?: string | null) {
 /**
  * Whether an entry's detail page should be advertised in the sitemap.
  *
- * `tools` entries are commercial listings (routed to the website lead flows per
- * AGENTS.md) and are thin-by-design, so we keep them crawlable via internal links
- * but do not advertise them in the sitemap. Anything explicitly `robotsIndex:false`
- * is excluded too. Accepts any entry-shaped object so both the server
- * `DirectoryEntry` and the client registry `Entry` satisfy it.
+ * Every category — including `tools` — is advertised unless the entry explicitly
+ * opts out with `robotsIndex:false`. `tools` were previously excluded as
+ * thin-by-design commercial listings, but they draw substantial organic search
+ * demand, so we now advertise their canonical `/entry/tools/<slug>` pages and
+ * gate quality per-entry via `robotsIndex` instead. Accepts any entry-shaped
+ * object so both the server `DirectoryEntry` and the client registry `Entry`
+ * satisfy it.
  */
 export function isSitemapIndexableEntry(entry: {
   category: string;
   robotsIndex?: boolean;
 }) {
-  return entry.category !== "tools" && entry.robotsIndex !== false;
+  return entry.robotsIndex !== false;
 }
 
 export function sitemapEntryLastModified(entry: DirectoryEntry) {

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -129,9 +129,8 @@ async function renderSitemap() {
     ...intersectionPaths.map((pathname) => urlItem(pathname, "0.55")),
     ...COMPARISONS.map((comparison) => urlItem(`/compare/${comparison.slug}`, "0.6")),
     ...bestPaths.map((pathname) => urlItem(pathname, "0.75")),
-    // Advertise only indexable entry pages. `tools` entries are commercial,
-    // thin-by-design listings (see isSitemapIndexableEntry / AGENTS.md): still
-    // crawlable via internal links, just not advertised in the sitemap.
+    // Advertise every indexable entry page (all categories, including `tools`).
+    // Entries opt out per-entry with `robotsIndex:false` (see isSitemapIndexableEntry).
     ...ENTRIES.filter(isSitemapIndexableEntry).map((entry) =>
       urlItem(
         `/entry/${entry.category}/${entry.slug}`,

--- a/tests/sitemap-policy.test.ts
+++ b/tests/sitemap-policy.test.ts
@@ -23,6 +23,31 @@ describe("sitemap policy", () => {
     ).toBe(false);
   });
 
+  it("advertises tools entries unless they opt out via robotsIndex:false", () => {
+    expect(
+      isSitemapIndexableEntry({
+        category: "tools",
+        slug: "indexable-tool",
+        title: "Indexable Tool",
+        description: "A tool listing.",
+        tags: [],
+        keywords: [],
+      } as any),
+    ).toBe(true);
+
+    expect(
+      isSitemapIndexableEntry({
+        category: "tools",
+        slug: "hidden-tool",
+        title: "Hidden Tool",
+        description: "A hidden tool listing.",
+        robotsIndex: false,
+        tags: [],
+        keywords: [],
+      } as any),
+    ).toBe(false);
+  });
+
   it("prefers content modified metadata for sitemap lastmod", () => {
     const lastModified = sitemapEntryLastModified({
       category: "skills",
@@ -55,8 +80,8 @@ describe("sitemap policy", () => {
     expect(source).not.toContain('"/validators/mcp-config"');
     expect(source).not.toContain('"/validators/skill-package"');
     expect(source).not.toContain("lastModified: new Date()");
-    // Entry pages are filtered through the sitemap-indexable policy (drops
-    // commercial `tools` listings + any robotsIndex:false entries).
+    // Entry pages are filtered through the sitemap-indexable policy (advertises
+    // every category, including `tools`, except robotsIndex:false entries).
     expect(source).toContain("ENTRIES.filter(isSitemapIndexableEntry)");
     // Category hub landing pages with per-category + per-entry lastmod.
     expect(source).toContain("categoryLastmod");


### PR DESCRIPTION
## What
Removes the blanket `tools` exclusion from `isSitemapIndexableEntry`, so tool detail pages (`/entry/tools/<slug>`) are advertised in `sitemap.xml` like every other category. Per-entry opt-out via `robotsIndex:false` is preserved.

## Why
Tools were excluded as "thin-by-design commercial listings", but Google Search Console (last 3 months) shows tool detail pages draw the **most** organic search demand in the catalog — e.g. `/entry/tools/microsoft-autogen` pulls ~3,800 impressions across its query cluster, plus LangGraph, Browser Use, Arize Phoenix, LangSmith, LlamaIndex each in the hundreds–thousands. They were indexed only via legacy/internal-link discovery and never advertised. This lets the high-demand pages get crawled and surfaced properly.

## Changes
- `apps/web/src/lib/sitemap-policy.ts` — `isSitemapIndexableEntry` now returns `robotsIndex !== false` for all categories (was additionally excluding `tools`); doc comment updated.
- `apps/web/src/routes/sitemap[.]xml.ts` — updated the explanatory comment.
- `tests/sitemap-policy.test.ts` — added coverage: tools entries are advertised unless `robotsIndex:false`; fixed the stale source-assertion comment.

## Validation
- `pnpm --filter web run type-check` passes.
- `tests/sitemap-policy.test.ts` + adjacent suites (indexnow, crawler-policy, atlas-production-data) pass (19 tests).

## Note
All 129 current tool entries set `robotsIndex` (default) so all become advertised. If any specific tool listing should stay out, set `robotsIndex: false` on that entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded sitemap generation to advertise all content categories, including tools, for improved search engine visibility. Entries are now indexed by default and can be individually opted out through per-entry settings instead of category-wide exclusion.

* **Tests**
  * Added test coverage for updated sitemap indexability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->