### PR TITLE
docs(content): optimize Netlify MCP server entry for search intent

### DIFF
--- a/content/mcp/netlify-mcp-server.mdx
+++ b/content/mcp/netlify-mcp-server.mdx
@@ -8,10 +8,8 @@ privacyNotes:
 category: mcp
 description: "Create, deploy, and manage websites on Netlify platform"
 cardDescription: "Create, deploy, and manage websites on Netlify platform"
-seoTitle: Netlify MCP Server for Claude
-seoDescription: >-
-  Create, deploy, and manage websites on Netlify platform Discover tools for AI
-  development.
+seoTitle: "Netlify MCP Server for Claude — Deploy & Manage Sites"
+seoDescription: "Connect Claude to Netlify with the Netlify MCP server: create, deploy, and manage sites, environment variables, and domains from Claude Code or Claude Desktop."
 author: Netlify
 authorProfileUrl: "https://www.netlify.com/"
 dateAdded: "2025-09-18"
@@ -69,17 +67,11 @@ tags:
   - static-sites
   - serverless
 keywords:
-  - claude
-  - deployment
-  - development
-  - hosting
-  - mcp
-  - mcp servers
-  - netlify
-  - server
-  - serverless
-  - static-sites
-  - tools
+  - netlify mcp server
+  - netlify mcp claude code
+  - connect claude to netlify
+  - netlify deployment
+  - mcp server
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the Netlify MCP server entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~600 impressions across two URL shapes, position ~7, 0% CTR** for queries like "netlify mcp claude code", "netlify mcp claude", "connect claude to netlify".

**Changes (metadata only; protected fields untouched):**
- `seoTitle`: → "Netlify MCP Server for Claude — Deploy & Manage Sites".
- `seoDescription`: fixed the run-on boilerplate ("…Netlify platform Discover tools for AI development.") → a clean, intent-matching snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases.

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.