### PR TITLE
docs(content): sharpen MCP error -32000 guide for search intent

### DIFF
--- a/content/guides/fix-mcp-connection-errors.mdx
+++ b/content/guides/fix-mcp-connection-errors.mdx
@@ -7,11 +7,8 @@ description: >-
   for error -32000, disconnections, and configuration issues with proven
   solutions.
 cardDescription: Resolve Claude Desktop MCP server connection errors fast.
-seoTitle: Fix Claude MCP Error -32000
-seoDescription: >-
-  Resolve Claude Desktop MCP server connection errors fast. Step-by-step fixes
-  for error -32000, disconnections, and configuration issues with proven
-  solutions.
+seoTitle: "Fix Claude MCP Error -32000 — Connection Troubleshooting"
+seoDescription: "Fix the Claude MCP \"error -32000\" / connection-closed failures fast: step-by-step fixes for disconnections, transport, and configuration issues with proven solutions."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-27"
@@ -34,10 +31,11 @@ tags:
   - connection-errors
   - solutions
 keywords:
+  - mcp error -32000
+  - mcp error 32000
   - mcp connection errors
-  - fix mcp server
   - claude mcp troubleshooting
-  - model context protocol errors
+  - fix mcp server
 readingTime: 2
 difficultyScore: 12
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the MCP connection-errors guide for the exact error-code queries it ranks for.

**Why:** GSC (last 3 months): this guide ranks **position ~7** for "mcp error 32000" / "mcp error -32000" (~38 impressions on those alone, ~460 total across the page) at **0% CTR**. The literal error code wasn't in `keywords`.

**Changes (metadata only):**
- `seoTitle`: added a connection-troubleshooting hook.
- `seoDescription`: leads with the literal "error -32000" / connection-closed phrasing.
- `keywords`: added `mcp error -32000` and `mcp error 32000`.

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.