### PR TITLE
docs(content): optimize Python Rich statusline for search intent

### DIFF
--- a/content/statuslines/python-rich-statusline.mdx
+++ b/content/statuslines/python-rich-statusline.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Feature-rich statusline using Python's Rich library for beautiful formatting,
   progress bars, and real-time token cost tracking
-seoTitle: Python Rich Statusline - Statuslines
-seoDescription: >-
-  Feature-rich statusline using Python's Rich library for beautiful formatting,
-  progress bars, and real-time token cost tracking Discover tools for AI
-  developm...
+seoTitle: "Python Rich Statusline for Claude Code"
+seoDescription: "A colorful Claude Code statusline built with Python's Rich library — shows the model, workspace, Git branch, token usage, and real-time cost in your terminal."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-01"
@@ -62,15 +59,11 @@ tags:
   - progress
   - colorful
 keywords:
-  - advanced
-  - claude
-  - colorful
-  - cost-tracking
-  - development
-  - progress
-  - python
-  - rich
-  - statusline
+  - claude statusline
+  - claude code statusline
+  - python rich statusline
+  - statusline cost tracking
+  - rich terminal statusline
   - statuslines
   - tools
 readingTime: 1


### PR DESCRIPTION
Optimizes the Python Rich statusline entry for the queries it ranks for.

**Why:** GSC (last 3 months): **460 impressions, ~0.9% CTR**, ranking **pos ~5** for "claude statusline"/"claude statuslines" and pos ~6.6 for "python rich status" — but the `seoTitle` didn't contain "Claude" and the `seoDescription` was truncated/garbled.

**Changes (metadata only):**
- `seoTitle`: "Python Rich Statusline - Statuslines" → "Python Rich Statusline for Claude Code".
- `seoDescription`: fixed the truncated "…Discover tools for AI developm…" boilerplate → a complete, intent-matching snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases (`claude statusline`, `claude code statusline`).

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.