### PR TITLE
docs(content): optimize Reddit MCP Buddy entry for search intent

### DIFF
--- a/content/mcp/reddit-mcp-buddy.mdx
+++ b/content/mcp/reddit-mcp-buddy.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Browse Reddit, search posts, and analyze user activity directly from Claude -
   no API keys required
-seoTitle: Reddit MCP Buddy for Claude
-seoDescription: >-
-  Browse Reddit, search posts, and analyze user activity directly from Claude -
-  no API keys required Discover tools for AI development.
+seoTitle: "Reddit MCP Buddy for Claude — Browse & Search Reddit"
+seoDescription: "Browse Reddit, search posts, and analyze user activity directly from Claude with the Reddit MCP Buddy server — no Reddit API keys required."
 author: karanb192
 authorProfileUrl: "https://github.com/karanb192"
 dateAdded: "2025-09-27"
@@ -71,17 +69,11 @@ tags:
   - analytics
   - community
 keywords:
-  - analytics
-  - buddy
-  - claude
-  - community
-  - development
-  - mcp
-  - mcp servers
-  - reddit
-  - search
-  - social-media
-  - tools
+  - reddit mcp buddy
+  - reddit mcp server
+  - claude reddit mcp
+  - reddit mcp claude
+  - browse reddit with claude
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the Reddit MCP Buddy entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~173 impressions, position ~8, 0% CTR** for "reddit mcp buddy", "reddit-mcp-buddy", "reddit buddy mcp".

**Changes (metadata only; submitter attribution preserved):**
- `seoTitle`: → "Reddit MCP Buddy for Claude — Browse & Search Reddit".
- `seoDescription`: fixed the run-on boilerplate ("…no API keys required Discover tools for AI development.") → a clean snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases.

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.