### PR TITLE
docs(content): optimize Discord MCP server entry for search intent

### DIFF
--- a/content/mcp/discord-mcp-server.mdx
+++ b/content/mcp/discord-mcp-server.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Discord bot integration for community management, moderation, and server
   automation
-seoTitle: Discord MCP Server for Claude
-seoDescription: >-
-  Discord bot integration for community management, moderation, and server
-  automation Discover tools for AI development.
+seoTitle: "Discord MCP Server for Claude — Bot, Moderation & Automation"
+seoDescription: "Connect Claude to Discord with an MCP server: manage communities, moderate channels, send messages, and automate your server through natural language."
 author: saseq
 authorProfileUrl: "https://github.com/saseq"
 dateAdded: "2025-09-20"
@@ -89,17 +87,11 @@ tags:
   - moderation
   - social
 keywords:
-  - bot
-  - claude
-  - community
-  - development
-  - discord
-  - mcp
-  - mcp servers
-  - moderation
-  - server
-  - social
-  - tools
+  - discord mcp server
+  - discord mcp claude
+  - claude discord bot
+  - discord moderation mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the Discord MCP server entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~210 impressions, 0% CTR**, ranking pos ~9 for "discord mcp claude"/"claude discord mcp" (and far back for the broad "discord mcp").

**Changes (metadata only):**
- `seoTitle`: → "Discord MCP Server for Claude — Bot, Moderation & Automation".
- `seoDescription`: fixed the run-on boilerplate → a clean, intent-matching snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases.

Existing `safetyNotes`/`privacyNotes` retained. `pnpm validate:content:strict` and the content-policy scan pass locally.