### PR TITLE
docs(content): improve monorepo rule keywords for search

### DIFF
--- a/content/rules/monorepo-workspace-manager.mdx
+++ b/content/rules/monorepo-workspace-manager.mdx
@@ -548,17 +548,11 @@ tags:
   - multi-package
   - workspace-management
 keywords:
-  - claude
-  - development
-  - manager
-  - monorepo
-  - multi-package
-  - pnpm-workspaces
-  - rules
-  - tools
-  - turborepo
-  - workspace
-  - workspace-management
+  - monorepo claude code
+  - turborepo pipeline
+  - pnpm workspaces
+  - nx monorepo
+  - monorepo dependency management
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Improves search targeting for the monorepo workspace-manager rule.

**Why:** GSC (last 3 months): **~301 impressions, position ~9.2, 0.33% CTR**. The `seoTitle`/`seoDescription` are already strong; the `keywords` were single-token auto-extractions (`claude`, `development`, `manager`, `rules`, `tools`).

**Changes (metadata only):**
- `keywords`: replaced with real search phrases (`monorepo claude code`, `turborepo pipeline`, `pnpm workspaces`, `nx monorepo`).

`pnpm validate:content:strict` and the content-policy scan pass locally.