### PR TITLE
content(skills): add Claude Code Computer Use GUI QA Capability Pack

### DIFF
--- a/content/skills/claude-code-computer-use-gui-qa-capability-pack.mdx
+++ b/content/skills/claude-code-computer-use-gui-qa-capability-pack.mdx
@@ -1,0 +1,227 @@
+---
+title: Claude Code Computer Use GUI QA Capability Pack Skill
+slug: claude-code-computer-use-gui-qa-capability-pack
+category: skills
+description: >-
+  Expert Claude Code computer use GUI QA capability pack that applies documented
+  computer-use MCP enablement, per-app session approval, screenshot checkpoints,
+  and macOS permission workflows for native app validation—not an official Anthropic QA product.
+cardDescription: >-
+  Run GUI QA with Claude Code computer use using source-backed enablement,
+  approval, and screenshot checkpoint checklists.
+seoTitle: Claude Code Computer Use GUI QA Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack for Claude Code computer use GUI QA: enable
+  computer-use MCP, grant macOS permissions, per-app approval, screenshot
+  loops, and safety stop steps from official computer-use documentation.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+sourceSubmissionNumber: 1523
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1523"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://code.claude.com/docs/en/computer-use"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when planning Claude Code computer use GUI validation after
+  enabling the computer-use MCP server and before approving per-app session control.
+copySnippet: |-
+  # Trigger
+  "Apply the Claude Code computer use GUI QA capability pack for this flow."
+
+  # Required output
+  1) Enablement and macOS permission checklist
+  2) Per-app approval and sentinel review notes
+  3) Screenshot-indexed test steps and observations
+  4) Stop/rollback actions taken
+  5) Privacy-safe QA summary
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-16"
+retrievalSources:
+  - "https://code.claude.com/docs/en/computer-use"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://code.claude.com/docs/en/features-overview"
+  - "https://code.claude.com/docs/en/security"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude
+  - Claude Code
+  - Codex
+  - Cursor
+  - Generic AGENTS
+prerequisites:
+  - "Interactive Claude Code session on macOS v2.1.85+ with Pro or Max plan per computer-use docs."
+  - "computer-use MCP server enabled through /mcp for the project."
+  - "macOS Accessibility and Screen Recording permissions granted when prompted."
+  - "Disposable QA target app or simulator without live customer data on screen."
+safetyNotes:
+  - "Computer use controls real desktop apps with per-app session approval—not sandboxed Bash."
+  - "Review sentinel warnings before approving Terminal, Finder, or System Settings access."
+  - "Press Esc or Ctrl+C to stop computer use and release the machine-wide lock immediately."
+  - "Only one Claude Code session can hold the computer-use lock at a time."
+privacyNotes:
+  - "Screenshots are downscaled before model upload but may still capture sensitive UI content."
+  - "Your terminal window is excluded from screenshots per official documentation."
+  - "Redact customer or proprietary UI details before sharing screenshot evidence externally."
+  - "Other visible apps are hidden while Claude works; still minimize sensitive windows before starting."
+tags:
+  - claude-code
+  - computer-use
+  - gui-qa
+  - desktop-testing
+  - capability-pack
+keywords:
+  - Claude Code computer use GUI QA capability pack
+  - computer use MCP enablement checklist
+  - Claude Code screenshot GUI validation
+  - macOS computer use per-app approval
+  - native app GUI QA Claude Code
+readingTime: 9
+difficultyScore: 78
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+This capability pack is grounded in Claude Code computer-use, skills, features
+overview, and security documentation verified on **2026-06-16**. Computer use is
+a research preview on macOS with plan and version requirements that can change;
+prefer live official docs over cached workflow assumptions.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/computer-use
+- https://code.claude.com/docs/en/skills
+- https://code.claude.com/docs/en/features-overview
+- https://code.claude.com/docs/en/security
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified against official Claude Code computer-use documentation on **2026-06-16**:
+
+- Computer use runs through the built-in `computer-use` MCP server, disabled until
+  enabled in `/mcp`, and requires interactive macOS sessions on Pro or Max plans.
+- macOS Accessibility and Screen Recording permissions are required before control begins.
+- Per-app session approval gates which applications Claude may control; sentinel
+  warnings flag Terminal, Finder, and System Settings as high-reach approvals.
+- A machine-wide lock allows only one computer-use session at a time; Esc or
+  Ctrl+C stops control and releases the lock.
+- Screenshots are downscaled automatically; the terminal window is excluded from captures.
+- Official examples cover native build validation, layout bug reproduction, and
+  iOS Simulator tap-through flows.
+
+## Scope Note
+
+This is a community reusable QA workflow skill—not an official Anthropic test
+product. It applies documented computer use enablement, approval, screenshot,
+and stop steps from code.claude.com. Browser-only automation is covered by
+Claude in Chrome documentation instead.
+
+## Core Workflow
+
+1. Confirm eligibility: macOS, Claude Code v2.1.85+, Pro/Max plan, interactive session.
+2. Enable `computer-use` in `/mcp` if not already enabled for the project.
+3. Grant Accessibility and Screen Recording when macOS prompts; restart if needed.
+4. Define the GUI flow under test with explicit pass/fail criteria and screenshot checkpoints.
+5. Start the task; approve only the target apps when session prompts appear.
+6. Review sentinel warnings before approving high-reach apps such as Terminal.
+7. Capture screenshot-indexed observations at each documented checkpoint.
+8. Stop with Esc or Ctrl+C if UI content looks suspicious or the flow completes.
+9. Produce a privacy-safe QA summary with findings—not a formal CI test harness.
+
+## Capability Scope
+
+- computer-use MCP enablement checklist.
+- macOS permission and plan eligibility verification.
+- Per-app approval and sentinel review notes.
+- Screenshot-indexed GUI validation steps.
+- Lock, stop, and rollback guidance.
+- Privacy-safe QA reporting.
+
+## Compatibility
+
+### Native
+
+- **Claude Code / Claude**: use as an Agent Skill when running documented computer
+  use GUI validation on macOS interactive sessions.
+
+### Manual Adaptation
+
+- **Codex, Cursor, Generic AGENTS**: apply the checklist when reviewing computer
+  use QA plans against public Claude Code documentation.
+
+## Required Inputs
+
+- Target application, simulator, or native build to validate.
+- Expected user flow steps and acceptance criteria.
+- QA environment free of unrelated sensitive windows.
+- Owner for final merge or release sign-off.
+
+## Production Rules
+
+- Never run computer use on production admin desktops with live customer data.
+- Approve only apps required for the scoped flow; deny broad Terminal access unless needed.
+- Stop immediately if on-screen content suggests prompt injection or unexpected dialogs.
+- Do not share raw screenshots externally without redaction.
+- Verify another session is not holding the computer-use lock before starting.
+- Treat findings as draft until a human validates screenshots and repro steps.
+
+## Review Matrix
+
+| Flow type | Approval focus | Screenshot checkpoint |
+| --- | --- | --- |
+| Native build launch | Target app only | Post-launch main window |
+| Layout bug repro | Target app + resize | Clipped state capture |
+| Simulator onboarding | Simulator app | Each onboarding screen |
+| IDE/build tools | Sentinel on Terminal | Build success/failure UI |
+| Unexpected system dialog | Stop and escalate | Dialog before any click |
+
+## Output Contract
+
+1. Enablement and permission checklist results.
+2. Apps approved and sentinel warnings reviewed.
+3. Screenshot-indexed step observations.
+4. Stop/rollback actions taken.
+5. Privacy-safe QA summary for human sign-off.
+
+## Troubleshooting
+
+**Issue:** computer-use missing from /mcp
+**Fix:** Confirm macOS, v2.1.85+, Pro/Max plan, claude.ai auth, interactive session.
+
+**Issue:** Permission prompt repeats
+**Fix:** Quit Claude Code fully after granting Screen Recording; retry Try again.
+
+**Issue:** Another session holds the lock
+**Fix:** Finish or exit the other session; lock releases when the process ends.
+
+**Issue:** Text too small after downscaling
+**Fix:** Increase in-app font or control size per docs—not display resolution alone.
+
+## Duplicate Check
+
+Checked `content/skills/`, `content/guides/`, `content/agents/`, and open PRs.
+`computer-use-from-the-claude-code-cli-for-gui-qa` is a step-by-step guide.
+`computer-use-gui-test-agent` is a reusable agent prompt. No `skills` entry
+provides this computer use GUI QA capability pack with review matrix and output
+contract grounded in official computer-use documentation.
+
+## Editorial Disclosure
+
+Submitted as an independent source-backed HeyClaude content entry by `kiannidev`.
+It is based on public Claude Code computer-use documentation and the public
+Anthropic `claude-code` repository. No paid placement, referral link, affiliate
+link, or vendor sponsorship is used.


### PR DESCRIPTION
## Summary
- Adds `content/skills/claude-code-computer-use-gui-qa-capability-pack.mdx` for issue #1523.
- Closes #1523.

## Grounding note
- Community capability pack applying documented computer-use MCP enablement, macOS permissions, per-app approval, screenshot checkpoints, and Esc/Ctrl+C stop steps from code.claude.com/docs/en/computer-use—not an official Anthropic QA product.

## Duplicate check
- Distinct from `computer-use-from-the-claude-code-cli-for-gui-qa` (guide) and `computer-use-gui-test-agent` (agent prompt); this skill adds review matrix and output contract.

## Test plan
- [x] Fixed prior submission: `documentationUrl` now points to live computer-use doc (not repo-only).
- [x] Verified all source URLs are reachable.
- [x] Ran whitespace cleanup on the submission file.
- [ ] All validation checks pass.

Made with [Cursor](https://cursor.com)