### PR TITLE
docs(content): improve Zod skill keywords for search

### DIFF
--- a/content/skills/zod-schema-validator.mdx
+++ b/content/skills/zod-schema-validator.mdx
@@ -76,16 +76,11 @@ tags:
   - type-safety
   - schema
 keywords:
-  - claude
-  - development
-  - schema
-  - skills
-  - tools
-  - type-safety
-  - typescript
-  - validation
-  - validator
-  - zod
+  - zod claude code
+  - zod schema validation
+  - typescript runtime validation
+  - zod typescript inference
+  - api payload validation
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Improves search targeting for the Zod schema-validation skill.

**Why:** GSC (last 3 months): **~194 impressions, 0% CTR**, ranking pos ~8 for "zod claude code". The `seoTitle`/`seoDescription` are already strong; the `keywords` were single-token auto-extractions.

**Changes (metadata only):**
- `keywords`: replaced with real query phrases (`zod claude code`, `zod schema validation`, `typescript runtime validation`).

`pnpm validate:content:strict` and the content-policy scan pass locally.