### PR TITLE
docs(content): improve WebAssembly skill keywords for search

### DIFF
--- a/content/skills/webassembly-module-development.mdx
+++ b/content/skills/webassembly-module-development.mdx
@@ -90,16 +90,11 @@ tags:
   - performance
   - wasi
 keywords:
-  - claude
-  - development
-  - module
-  - performance
-  - rust
-  - skills
-  - tools
-  - wasi
-  - wasm
-  - webassembly
+  - webassembly module
+  - wasm module
+  - claude code wasm
+  - compile rust to wasm
+  - wasm-bindgen
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Improves search targeting for the WebAssembly module-development skill.

**Why:** GSC (last 3 months): **~338 impressions, 0% CTR** for "wasm module", "webassembly module", "claude code wasm". The `seoTitle`/`seoDescription` already match; `keywords` were single-token auto-extractions.

**Changes (metadata only):**
- `keywords`: replaced with real query phrases (`webassembly module`, `wasm module`, `claude code wasm`, `compile rust to wasm`).

`pnpm validate:content:strict` and the content-policy scan pass locally.