### PR TITLE
fix(deploy): point versions:upload at heyclaude-prod

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "predeploy:dev": "pnpm run generate:artifacts",
     "predeploy:prod": "pnpm run generate:artifacts",
     "preversions:upload": "pnpm run generate:artifacts",
+    "preversions:upload:dev": "pnpm run generate:artifacts",
     "dev": "vite dev",
     "build": "vite build",
     "type-check": "tsc --noEmit",
@@ -26,7 +27,8 @@
     "deploy": "pnpm run deploy:prod",
     "deploy:dev": "vite build && wrangler deploy --config wrangler.jsonc --env dev",
     "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\"",
-    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
+    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env \"\"",
+    "versions:upload:dev": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
   },
   "dependencies": {
     "@heyclaude/mcp": "workspace:*",


### PR DESCRIPTION
## Problem

Cloudflare Workers Builds (connected to `main` → **heyclaude-prod**) has been failing at the deploy step with:

```
▲ Failed to match Worker name. Your config file is using the Worker name "heyclaude-dev",
   but the CI system expected "heyclaude-prod". Overriding using the CI provided Worker name.
✘ A request to the Cloudflare API (/accounts/…/workers/services/heyclaude-prod) failed.
   Unable to authenticate request [code: 10001]
web@0.1.0 versions:upload: `… wrangler versions upload --config wrangler.jsonc --env dev`
```

The build itself (clone → install → vite/nitro build) succeeds; only the final deploy fails.

## Root cause

#2320 ("isolate preview version uploads") changed the **shared** `versions:upload` script from `--env ""` (prod) to `--env dev`. That repurposed the production build's deploy command to target the **heyclaude-dev** worker. The main-branch Workers Build is wired to **heyclaude-prod**, so wrangler hits a name mismatch, CF overrides the name back to `heyclaude-prod`, and the follow-up API request fails auth (`10001`). Older wrangler tolerated this; wrangler `4.95.0` makes it a hard failure.

## Fix

- `versions:upload` → `--env ""` (heyclaude-prod), matching the existing `deploy:prod` convention and the connected worker. No name override → the build-scoped token authenticates.
- New `versions:upload:dev` (+ `preversions:upload:dev`) keeps the `--env dev` preview path that #2320 wanted, on its own script so it no longer clobbers prod.

## Follow-up (dashboard, not code)

If a separate Workers Build project builds previews against **heyclaude-dev**, set its deploy command to `pnpm --filter web run versions:upload:dev`. The production build keeps using `versions:upload` unchanged.