### PR TITLE
docs(content): optimize Graphite Diamond entry for search intent

### DIFF
--- a/content/tools/graphite-diamond.mdx
+++ b/content/tools/graphite-diamond.mdx
@@ -4,8 +4,8 @@ slug: graphite-diamond
 category: tools
 description: AI code review assistant for pull requests, engineering feedback, and review workflow acceleration inside Graphite.
 cardDescription: AI code review assistant inside Graphite workflows.
-seoTitle: Graphite Diamond AI code review
-seoDescription: Graphite Diamond supports AI-assisted pull request review, engineering feedback, and faster code review workflows.
+seoTitle: "Graphite Diamond: AI Code Review for Pull Requests"
+seoDescription: "Graphite Diamond is an AI code-review assistant for pull requests — automated review feedback and faster review workflows inside Graphite. Overview, docs, and setup."
 author: Graphite
 dateAdded: "2026-04-27"
 websiteUrl: "https://graphite.com/features/ai-reviews"
@@ -18,8 +18,11 @@ tags:
   - code-review
   - pull-requests
 keywords:
-  - ai code review
   - graphite diamond
+  - graphite diamond ai code review
+  - ai code review
+  - pull request review
+  - automated code review
 ---
 
 ## Editorial notes


### PR DESCRIPTION
Optimizes the Graphite Diamond tool entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~330 impressions, position ~6.4, 0% CTR** for "graphite diamond ai code review official" (+ "…official docs", "…documentation"). Navigational-to-official intent; the snippet didn't promise overview/docs value.

**Changes (metadata only):**
- `seoTitle`: "Graphite Diamond AI code review" → "Graphite Diamond: AI Code Review for Pull Requests".
- `seoDescription`: rewritten to promise overview + docs + setup.
- `keywords`: added the real query phrases (`graphite diamond ai code review`, `pull request review`, `automated code review`).

`pnpm validate:content:strict` and the content-policy scan pass locally.