### PR TITLE
docs(content): optimize /review command entry for search intent

### DIFF
--- a/content/commands/review.mdx
+++ b/content/commands/review.mdx
@@ -18,6 +18,8 @@ installable: true
 installCommand: "/review [options] <file_or_directory>"
 usageSnippet: "/review [options] <file_or_directory>"
 copySnippet: "/review [options] <file_or_directory>"
+safetyNotes:
+  - "The /review command reads and analyzes the targeted files and runs review tooling within Claude Code; review its scope before running it on large or untrusted directories."
 privacyNotes:
   - "Running /review sends the targeted source files and diffs to Claude as review context; avoid pointing it at secrets or restricted code you don't want transmitted to the model provider."
 tags:

--- a/content/commands/review.mdx
+++ b/content/commands/review.mdx
@@ -8,10 +8,8 @@ description: >-
 cardDescription: >-
   Comprehensive code review with security analysis, performance optimization,
   and best practices validation
-seoTitle: /review - Code Review Command for Claude Code
-seoDescription: >-
-  Comprehensive code review with security analysis, performance optimization,
-  and best practices validation Discover tools for AI development.
+seoTitle: "/review — Code Review Command for Claude Code"
+seoDescription: "The /review slash command runs a comprehensive Claude Code review of a file or directory — security analysis, performance checks, and best-practice validation."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
@@ -20,6 +18,8 @@ installable: true
 installCommand: "/review [options] <file_or_directory>"
 usageSnippet: "/review [options] <file_or_directory>"
 copySnippet: "/review [options] <file_or_directory>"
+privacyNotes:
+  - "Running /review sends the targeted source files and diffs to Claude as review context; avoid pointing it at secrets or restricted code you don't want transmitted to the model provider."
 tags:
   - code-review
   - security
@@ -27,16 +27,11 @@ tags:
   - quality
   - analysis
 keywords:
-  - analysis
-  - claude
-  - code-review
-  - commands
-  - development
-  - performance
-  - quality
-  - review
-  - security
-  - tools
+  - claude code review
+  - /review command
+  - code review command
+  - security code review
+  - claude code slash command
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the /review code-review command entry for search.

**Why:** GSC (last 3 months): **~286 impressions, position ~11, 1.75% CTR**.

**Changes:**
- `seoTitle`: minor cleanup.
- `seoDescription`: fixed the run-on boilerplate ("…validation Discover tools for AI development.") → a clean snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases (`claude code review`, `/review command`).
- Added `privacyNotes` (the command sends reviewed source/diffs to the model) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.