### PR TITLE
docs(content): optimize Data Pipeline Engineering agent for search intent

### DIFF
--- a/content/agents/data-pipeline-engineering-agent.mdx
+++ b/content/agents/data-pipeline-engineering-agent.mdx
@@ -9,11 +9,12 @@ description: >-
 cardDescription: >-
   Modern data pipeline specialist focused on real-time streaming, ETL/ELT
   orchestration, data quality validation, and scalable data infrast...
-seoTitle: Data Pipeline Engineering Agent - Agents
-seoDescription: >-
-  Modern data pipeline specialist focused on real-time streaming, ETL/ELT
-  orchestration, data quality validation, and scalable data infrastructure with
-  Apache ...
+seoTitle: "Data Pipeline Engineering Agent for Claude"
+seoDescription: "A Claude agent for data pipeline engineering: real-time streaming, ETL/ELT orchestration with Airflow and dbt, data-quality validation, and scalable infrastructure."
+safetyNotes:
+  - "Generated pipelines run ETL/streaming jobs and connect to external data systems and brokers; review and test generated code in a non-production environment before scheduling it."
+privacyNotes:
+  - "Pipeline code this agent generates can connect to data sources, warehouses, and message brokers; review connection strings and credentials and keep them out of committed code."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -483,7 +484,7 @@ copySnippet: >-
   class SalesEventProcessor:
       def __init__(self):
           self.schema_registry = SchemaRegistryClient({
-              'url': 'http://schema-registry:8081'
+              'url': 'https://schema-registry:8081'
           })
           
           self.consumer = KafkaConsumer(
@@ -1322,7 +1323,7 @@ scriptBody: >-
   class SalesEventProcessor:
       def __init__(self):
           self.schema_registry = SchemaRegistryClient({
-              'url': 'http://schema-registry:8081'
+              'url': 'https://schema-registry:8081'
           })
           
           self.consumer = KafkaConsumer(
@@ -1709,20 +1710,11 @@ tags:
   - streaming
   - data-quality
 keywords:
-  - agent
-  - agents
-  - airflow
-  - claude
-  - data
-  - data-engineering
-  - data-quality
-  - dbt
-  - development
-  - engineering
-  - etl
-  - pipeline
-  - streaming
-  - tools
+  - data pipeline agent
+  - data engineering agent
+  - etl pipeline claude
+  - airflow dbt pipeline
+  - streaming data pipeline
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true
@@ -2125,7 +2117,7 @@ from psycopg2.extras import execute_batch
 class SalesEventProcessor:
     def __init__(self):
         self.schema_registry = SchemaRegistryClient({
-            'url': 'http://schema-registry:8081'
+            'url': 'https://schema-registry:8081'
         })
 
         self.consumer = KafkaConsumer(


### PR DESCRIPTION
Optimizes the Data Pipeline Engineering agent entry for search.

**Why:** GSC (last 3 months): **~166 impressions, position ~8.4, 0% CTR**.

**Changes:**
- `seoTitle`: "Data Pipeline Engineering Agent - Agents" → "Data Pipeline Engineering Agent for Claude".
- `seoDescription`: fixed the truncated "…with Apache …" → a complete snippet.
- `keywords`: replaced single-token auto-extractions with real query phrases.
- Added `safetyNotes`/`privacyNotes` (generated pipelines run jobs + connect to data systems) and switched three illustrative internal `http://schema-registry:8081` example URLs to `https://` — both required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.