### PR TITLE
fix(ci): accept content deletions — thread per-file status, exempt removed entries

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -77,24 +77,44 @@ function pullRequestDiffRange() {
   throw new Error("BASE_SHA must be a full Git commit SHA for PR validation");
 }
 
+// Map git's `--name-status` codes to the status vocabulary the content-policy
+// scanner consumes (added / modified / removed). Deletions (D) MUST surface as
+// `removed` so delete-only PRs are exempted from content scanning downstream
+// instead of tripping missing_pr_file_content. (#content-deletion)
+const STATUS_BY_CODE = { A: "added", C: "added", D: "removed" };
+
 function changedFiles() {
   if (forceFullFromEvent) return [];
   if (eventName !== "pull_request" && !workflowDispatchDiff) return [];
   const output = execFileSync(
     "git",
-    ["diff", "--name-only", ...pullRequestDiffRange()],
+    ["diff", "--name-status", ...pullRequestDiffRange()],
     {
       encoding: "utf8",
     },
   );
   return output
     .split(/\r?\n/)
-    .map((line) => line.trim())
+    .map((line) => {
+      const parts = line.split("\t").map((part) => part.trim());
+      // Rename/copy lines are `R100\told\tnew` — take the destination path, as
+      // `--name-only` did; a normal line is `CODE\tpath`.
+      const code = parts[0] || "";
+      const filename = parts[parts.length - 1] || "";
+      if (parts.length < 2 || !code || !filename) return null;
+      return {
+        filename,
+        status: STATUS_BY_CODE[code[0].toUpperCase()] || "modified",
+      };
+    })
     .filter(Boolean)
-    .sort();
+    .sort((a, b) => a.filename.localeCompare(b.filename));
 }
 
-const files = changedFiles();
+const fileEntries = changedFiles();
+// Bare filename list — every lane flag below classifies on path only; status
+// rides along solely in the emitted `changed_files_json` for the policy scanner.
+const files = fileEntries.map((entry) => entry.filename);
 const workflowDispatchReadmeOnly =
   workflowDispatchDiff && files.length === 1 && files[0] === "README.md";
 const all =
@@ -253,7 +273,7 @@ const lines = [
   `content_categories=${contentCategories.join(",")}`,
   `content_categories_json=${JSON.stringify(contentCategories)}`,
   `changed_count=${files.length}`,
-  `changed_files_json=${JSON.stringify(files)}`,
+  `changed_files_json=${JSON.stringify(fileEntries)}`,
 ];
 
 if (outputPath) {

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -235,7 +235,21 @@ function resolveFiles({ repoRoot, args }) {
   return source
     .map((file) => {
       const filename = normalizeText(file.filename);
-      const status = normalizeText(file.status) || "modified";
+      let status = normalizeText(file.status) || "modified";
+      // Defense-in-depth for delete-only PRs: a file reported as added/modified
+      // that is absent from the working tree (and carries no inline content) is
+      // effectively a deletion — e.g. its status was lost upstream (a bare-string
+      // --files-json defaults to "modified"). Reclassify as `removed` so it is
+      // exempted from content scanning instead of tripping missing_pr_file_content.
+      // Real PR CI checks the file out, so genuine adds/edits are unaffected. (#content-deletion)
+      if (
+        status !== "removed" &&
+        typeof file.content !== "string" &&
+        filename &&
+        !fs.existsSync(path.join(repoRoot, filename))
+      ) {
+        status = "removed";
+      }
       return {
         filename,
         status,

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -225,7 +225,29 @@ describe("PR change classifier", () => {
       raycast: "false",
     });
     expect(JSON.parse(outputs.changed_files_json)).toEqual([
-      "packages/registry/src/package-spec.js",
+      { filename: "packages/registry/src/package-spec.js", status: "added" },
+    ]);
+  });
+
+  it("threads a delete-only content PR as a removed entry (#content-deletion)", () => {
+    const { cwd } = createFixtureRepo();
+
+    const contentDir = path.join(cwd, "content", "agents");
+    fs.mkdirSync(contentDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(contentDir, "example.mdx"),
+      "---\ntitle: Example\n---\n",
+    );
+    git(cwd, ["add", "content/agents/example.mdx"]);
+    git(cwd, ["commit", "-m", "add content entry"]);
+    const baseSha = git(cwd, ["rev-parse", "HEAD"]);
+
+    git(cwd, ["rm", "content/agents/example.mdx"]);
+    git(cwd, ["commit", "-m", "remove content entry"]);
+
+    const outputs = runClassifier(cwd, baseSha);
+    expect(JSON.parse(outputs.changed_files_json)).toEqual([
+      { filename: "content/agents/example.mdx", status: "removed" },
     ]);
   });
 

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -10,7 +10,9 @@ function runContentPolicy(
   tmpDir: string,
   content: string,
   sourceType = "same_repo_direct",
-  files = [
+  files: Array<
+    string | { filename: string; status?: string; content?: string }
+  > = [
     {
       filename: "content/tools/example-tool.mdx",
       status: "added",
@@ -800,5 +802,43 @@ LLM providers through a proxy gateway.
         expect.stringContaining("commercial_listing_route"),
       ]),
     );
+  });
+
+  it("exempts a delete-only content PR (removed status, no missing content flag) (#content-deletion)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const result = runContentPolicy(tmpDir, "", "same_repo_direct", [
+      { filename: "content/tools/removed-tool.mdx", status: "removed" },
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(true);
+    expect(
+      output.reviewFlags.map((flag: { id: string }) => flag.id),
+    ).not.toContain("missing_pr_file_content");
+  });
+
+  it("infers removal for an entry whose file is absent from the tree (lost-status defense) (#content-deletion)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    // status reported as "modified" (the bare-string --files-json default) but the
+    // file does not exist on disk — i.e. a deletion whose status was lost upstream.
+    // The defense-in-depth reclassifies it as removed instead of flagging it.
+    const result = runContentPolicy(tmpDir, "", "same_repo_direct", [
+      {
+        filename: "content/tools/__absent-deleted-entry__.mdx",
+        status: "modified",
+      },
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.ok).toBe(true);
+    expect(
+      output.reviewFlags.map((flag: { id: string }) => flag.id),
+    ).not.toContain("missing_pr_file_content");
   });
 });


### PR DESCRIPTION
## Problem

Content PRs that only **remove** a file are auto-failed at the required `validate-content-policy` check with `missing_pr_file_content`, so legitimate maintainer cleanups (e.g. dedupes) can't merge.

Root cause: `classify-pr-changes.mjs` emitted bare filenames (`git diff --name-only`), and `validate-content-policy.mjs` defaults every bare entry to status `"modified"` — so a **deleted** file was scanned as if it must still exist on disk, then flagged as missing.

## Fix

- **`classify-pr-changes.mjs`** — diff with `--name-status` and emit `changed_files_json` as `[{filename, status}]` (`D`→`removed`, `A`→`added`, `M`→`modified`; rename takes the destination path, as `--name-only` did). The internal lane flags still classify on path only; status rides along solely in the emitted JSON.
- **`validate-content-policy.mjs`** — defense-in-depth in `resolveFiles`: an entry reported `added`/`modified` that is **absent from the working tree** (and carries no inline content) is reclassified `removed`, so a deletion whose status was lost upstream is exempted instead of tripping `missing_pr_file_content`. Real PR CI checks files out, so genuine adds/edits are unaffected.

The policy scanner already dropped `removed` entries from `contentFiles` and exempted them in `readFileContent`; the bug was purely that status never reached it.

## Tests

- Classifier threads `D`→`removed` end-to-end (real git fixture).
- Policy exempts a `removed` entry and infers removal for an absent file — neither flags `missing_pr_file_content`.
- Existing `changed_files_json` assertion updated to the `{filename, status}` object shape.

## Acceptance

- [x] Delete-only content PRs pass `validate-content-policy` (no `missing_pr_file_content`).
- [x] Mixed PRs still scan added/modified and ignore removed entries.
- [x] Existing classification behavior unchanged (lane flags classify on path).
- [x] New regression tests; full `classify-pr-changes` + `content-policy-validation` suites green (30 tests).

Unblocks the delete-only dedupe in #2961.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of delete-only pull requests in content policy validation to properly identify removed files and exempt them from content scanning requirements.

* **Tests**
  * Updated tests to verify correct handling of file deletion scenarios and content exemption for delete-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->