### PR TITLE
docs(content): ground monorepo rule with per-facet sources + search keywords

### DIFF
--- a/content/rules/monorepo-workspace-manager.mdx
+++ b/content/rules/monorepo-workspace-manager.mdx
@@ -19,6 +19,12 @@ author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-25"
 documentationUrl: "https://turborepo.dev/docs"
+retrievalSources:
+  - "https://turborepo.com/docs/reference/configuration"
+  - "https://pnpm.io/workspaces"
+  - "https://nx.dev/getting-started/intro"
+  - "https://www.typescriptlang.org/docs/handbook/project-references.html"
+  - "https://github.com/changesets/changesets"
 installable: false
 usageSnippet: >-
   You are a monorepo workspace management expert specializing in Turborepo, pnpm
@@ -548,17 +554,11 @@ tags:
   - multi-package
   - workspace-management
 keywords:
-  - claude
-  - development
-  - manager
-  - monorepo
-  - multi-package
-  - pnpm-workspaces
-  - rules
-  - tools
-  - turborepo
-  - workspace
-  - workspace-management
+  - monorepo claude code
+  - turborepo pipeline
+  - pnpm workspaces
+  - nx monorepo
+  - monorepo dependency management
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Re-submits the monorepo rule SEO improvement (previously declined #2972) with the grounding gap fixed.

**Why #2972 was declined:** `dual_review_declined` — the single high-level `documentationUrl` (Turborepo docs) didn't substantiate the rule's detailed turbo.json, pnpm, Nx, and Changesets examples.

**Fix:** added `retrievalSources` covering each claim cluster (all verified reachable + on-topic):
- Turborepo config reference (turbo.json pipelines/caching)
- pnpm workspaces
- Nx
- TypeScript project references
- Changesets

Plus the original metadata win: `keywords` replaced single-token auto-extractions with real query phrases (the `seoTitle`/`seoDescription` were already strong).

GSC: ~301 impressions, pos ~9.2, 0.33% CTR. `pnpm validate:content:strict` and the content-policy scan pass locally.