### PR TITLE
docs(content): broaden Zod skill grounding + search keywords

### DIFF
--- a/content/skills/zod-schema-validator.mdx
+++ b/content/skills/zod-schema-validator.mdx
@@ -59,6 +59,9 @@ verificationStatus: draft
 verifiedAt: "2025-10-16"
 retrievalSources:
   - "https://zod.dev/"
+  - "https://github.com/colinhacks/zod"
+  - "https://trpc.io/docs"
+  - "https://react-hook-form.com/get-started"
 testedPlatforms:
   - Claude
   - Cursor
@@ -76,16 +79,11 @@ tags:
   - type-safety
   - schema
 keywords:
-  - claude
-  - development
-  - schema
-  - skills
-  - tools
-  - type-safety
-  - typescript
-  - validation
-  - validator
-  - zod
+  - zod claude code
+  - zod schema validation
+  - typescript runtime validation
+  - zod typescript inference
+  - api payload validation
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Re-submits the Zod skill SEO improvement (previously declined #2974) with broader grounding.

**Why #2974 was declined:** `dual_review_declined` — a single `zod.dev` source didn't substantiate the body's specific feature and integration claims.

**Fix:** expanded `retrievalSources` to cover the body's claim clusters (verified reachable + on-topic):
- zod.dev (core API)
- github.com/colinhacks/zod (parse/safeParse, refine, discriminatedUnion, infer)
- trpc.io/docs (tRPC input-validator integration)
- react-hook-form.com/get-started (zodResolver integration)

Plus the original metadata win: `keywords` replaced single-token auto-extractions with real query phrases.

GSC: ~194 impressions, pos ~8 for "zod claude code". `pnpm validate:content:strict` and the content-policy scan pass locally.