### PR TITLE
docs(content): ground /review command + search metadata

### DIFF
--- a/content/commands/review.mdx
+++ b/content/commands/review.mdx
@@ -8,18 +8,22 @@ description: >-
 cardDescription: >-
   Comprehensive code review with security analysis, performance optimization,
   and best practices validation
-seoTitle: /review - Code Review Command for Claude Code
-seoDescription: >-
-  Comprehensive code review with security analysis, performance optimization,
-  and best practices validation Discover tools for AI development.
+seoTitle: "/review — Code Review Command for Claude Code"
+seoDescription: "The /review slash command runs a comprehensive Claude Code review of a file or directory — security analysis, performance checks, and best-practice validation."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
 documentationUrl: "https://code.claude.com/docs/en/slash-commands"
+retrievalSources:
+  - "https://code.claude.com/docs/en/slash-commands"
 installable: true
 installCommand: "/review [options] <file_or_directory>"
 usageSnippet: "/review [options] <file_or_directory>"
 copySnippet: "/review [options] <file_or_directory>"
+safetyNotes:
+  - "The /review command reads and analyzes the targeted files and runs review tooling within Claude Code; review its scope before running it on large or untrusted directories."
+privacyNotes:
+  - "Running /review sends the targeted source files and diffs to Claude as review context; avoid pointing it at secrets or restricted code you don't want transmitted to the model provider."
 tags:
   - code-review
   - security
@@ -27,16 +31,11 @@ tags:
   - quality
   - analysis
 keywords:
-  - analysis
-  - claude
-  - code-review
-  - commands
-  - development
-  - performance
-  - quality
-  - review
-  - security
-  - tools
+  - claude code review
+  - /review command
+  - code review command
+  - security code review
+  - claude code slash command
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Re-submits the /review command SEO improvement (previously declined #2979).

**Why #2979 was declined:** `dual_review_declined` — the slash-commands docs don't describe a `/review` command with these specific options.

**Note on grounding:** `/review` is a **custom/community slash command**, so by design no first-party doc lists this exact command — its options are the author's. This re-submission grounds it against the Claude Code slash-command *mechanism* docs (which substantiate that custom commands with arguments are a supported feature) via `documentationUrl` + `retrievalSources`. If the gate requires `/review`-specific documentation, this is a genuine structural limit for original commands rather than a fixable gap.

**Metadata wins (regardless of grounding outcome):**
- `seoTitle` cleanup; `seoDescription` fixed the run-on boilerplate.
- `keywords` → real query phrases (`claude code review`, `/review command`).
- Added `safetyNotes`/`privacyNotes`.

GSC: ~286 impressions, pos ~11. `pnpm validate:content:strict` and the content-policy scan pass locally.