### PR TITLE
docs(content): optimize Square MCP server entry for search intent

### DIFF
--- a/content/mcp/square-mcp-server.mdx
+++ b/content/mcp/square-mcp-server.mdx
@@ -8,10 +8,8 @@ privacyNotes:
 category: mcp
 description: "Build on Square APIs for payments, inventory, and order management"
 cardDescription: "Build on Square APIs for payments, inventory, and order management"
-seoTitle: Square MCP Server for Claude
-seoDescription: >-
-  Build on Square APIs for payments, inventory, and order management Discover
-  tools for AI development.
+seoTitle: "Square MCP Server for Claude — Payments, Orders & Inventory"
+seoDescription: "Connect Claude to Square with the Square MCP server: build on Square APIs for payments, orders, inventory, and customer management from your AI agent."
 author: Square
 authorProfileUrl: "https://squareup.com/"
 dateAdded: "2025-09-18"
@@ -67,17 +65,11 @@ tags:
   - inventory
   - commerce
 keywords:
-  - claude
-  - commerce
-  - development
-  - inventory
-  - mcp
-  - mcp servers
-  - payments
-  - pos
-  - server
-  - square
-  - tools
+  - square mcp server
+  - square mcp claude
+  - claude square integration
+  - square payments api
+  - mcp server
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Optimizes the Square MCP server entry for the queries it ranks for.

**Why:** GSC (last 3 months): **~108 impressions, position ~7.3, 0% CTR** for "square mcp".

**Changes (metadata only):**
- `seoTitle`: → "Square MCP Server for Claude — Payments, Orders & Inventory".
- `seoDescription`: fixed the run-on boilerplate ("…order management Discover tools for AI development.").
- `keywords`: replaced single-token auto-extractions with real query phrases.

Existing `safetyNotes`/`privacyNotes` retained; grounded on developer.squareup.com/docs/mcp. `pnpm validate:content:strict` and the content-policy scan pass locally.