### PR TITLE
content(skills): add Claude Code Desktop Scheduled Maintenance Capability Pack

### DIFF
--- a/content/skills/claude-code-desktop-scheduled-maintenance-capability-pack.mdx
+++ b/content/skills/claude-code-desktop-scheduled-maintenance-capability-pack.mdx
@@ -1,0 +1,169 @@
+---
+title: Claude Code Desktop Scheduled Maintenance Capability Pack Skill
+slug: claude-code-desktop-scheduled-maintenance-capability-pack
+category: skills
+description: >-
+  Expert desktop scheduled maintenance capability pack applying documented Desktop scheduled task setup, triggers, environment scoping, and safety review from official desktop scheduled tasks documentation.
+cardDescription: >-
+  Plan Claude Code Desktop scheduled maintenance with trigger and environment checklists.
+seoTitle: Claude Code Desktop Scheduled Maintenance Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack applying documented Claude Code steps from official documentation—not an official Anthropic product.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+sourceSubmissionNumber: 1519
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1519"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://code.claude.com/docs/en/desktop-scheduled-tasks"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when planning or reviewing claude code desktop scheduled maintenance capability pack workflows using official Claude Code documentation.
+copySnippet: |-
+  # Trigger
+  "Apply the claude code desktop scheduled maintenance capability pack capability pack."
+
+  # Required output
+  1) Scope and configuration checklist
+  2) Risk and policy findings
+  3) Review matrix actions
+  4) Verification and rollback plan
+  5) Privacy-safe summary
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-16"
+retrievalSources:
+  - "https://code.claude.com/docs/en/desktop-scheduled-tasks"
+  - "https://code.claude.com/docs/en/desktop"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude Code
+  - Claude
+  - Cursor
+  - Generic AGENTS
+prerequisites:
+  - "Claude Code version and plan eligibility per official documentation."
+  - "Team policy for autonomous or scheduled workflows."
+  - "Staging environment for safe validation."
+  - "Human owner for production rollout approval."
+safetyNotes:
+  - "Autonomous workflows can run shell commands without mid-run user input—scope paths and tools first."
+  - "Do not enable destructive automation without explicit approval gates."
+  - "Review outputs as draft until a human validates evidence."
+privacyNotes:
+  - "Workflow and session output may contain proprietary code and credentials."
+  - "Summaries for external channels require redaction."
+tags:
+  - claude-code
+  - capability-pack
+readingTime: 9
+difficultyScore: 76
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+Grounded in official Claude Code documentation verified on **2026-06-16**. Behavior can change with releases; prefer live docs.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/desktop-scheduled-tasks
+- https://code.claude.com/docs/en/skills
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified on **2026-06-16**:
+
+- Desktop scheduled tasks documentation covers creating recurring Claude Code maintenance runs from Desktop.
+- Tasks run as autonomous cloud or desktop sessions depending on configuration documented on code.claude.com.
+- Environments control network access and variables available to scheduled runs.
+- Teams should scope repositories, connectors, and triggers to minimum necessary blast radius.
+
+## Scope Note
+
+Community reusable workflow skill applying documented steps—not an official Anthropic product. Applies Desktop scheduled task docs—not a separate Anthropic maintenance product.
+
+## Core Workflow
+
+1. Define maintenance goal (deps audit, doc sync, test sweep).
+2. Configure schedule, repository scope, and environment per docs.
+3. Review connectors and network allowlists before enabling.
+4. Pilot on staging repo; inspect first run output manually.
+5. Document rollback to disable task if behavior drifts.
+
+## Capability Scope
+
+- Configuration and eligibility checklist.
+- Risk and policy review.
+- Staging verification steps.
+- Rollback planning.
+- Privacy-safe stakeholder summary.
+
+## Compatibility
+
+### Native
+
+- **Claude Code**: use as an Agent Skill during rollout planning.
+
+### Manual Adaptation
+
+- **Generic AGENTS**: apply checklist against public documentation.
+
+## Required Inputs
+
+- Target repository or organization context.
+- Current settings and policy constraints.
+- Stakeholders for security review when applicable.
+
+## Production Rules
+
+- Require human approval before production-impacting automation.
+- Redact secrets from skill outputs and public tickets.
+- Prefer official documentation over forum assumptions.
+- Document rollback before enabling scheduled or autonomous runs.
+
+## Review Matrix
+
+| Signal | Action |
+| --- | --- |
+| Missing repro | Block autonomous run |
+| Broad tool scope | Narrow allowlists |
+| Draft findings | Label unverified until human review |
+| Policy drift | Align to managed settings |
+
+## Output Contract
+
+1. Scope and configuration summary.
+2. Findings with severity.
+3. Review matrix actions.
+4. Verification and rollback plan.
+5. Privacy-safe summary.
+
+## Troubleshooting
+
+**Issue:** Feature unavailable on your plan
+**Fix:** Confirm `/status` and official doc eligibility requirements.
+
+**Issue:** Run stalls on permissions
+**Fix:** Pre-approve read tools in staging; narrow path scope.
+
+## Duplicate Check
+
+Complements `routines-for-recurring-claude-code-maintenance` guide; no skills pack with review matrix yet.
+
+## Editorial Disclosure
+
+Independent entry by `kiannidev` from public Claude Code documentation. No paid placement or affiliate links.


### PR DESCRIPTION
## Summary
- Adds `content/skills/claude-code-desktop-scheduled-maintenance-capability-pack.mdx` for issue #1519.
- Closes #1519.
## Grounding note
- Community capability pack applying documented steps from primary documentationUrl—not an official Anthropic product.

Made with [Cursor](https://cursor.com)