### PR TITLE
content(skills): add MCP Streamable HTTP Migration Capability Pack

### DIFF
--- a/content/skills/mcp-streamable-http-migration-capability-pack.mdx
+++ b/content/skills/mcp-streamable-http-migration-capability-pack.mdx
@@ -1,0 +1,176 @@
+---
+title: MCP Streamable HTTP Migration Capability Pack Skill
+slug: mcp-streamable-http-migration-capability-pack
+category: skills
+description: >-
+  Expert MCP Streamable HTTP migration capability pack applying documented transport selection, SSE-to-HTTP migration checkpoints, timeout policies, and enterprise network review from official MCP and transport specification documentation.
+cardDescription: >-
+  Migrate MCP servers to Streamable HTTP with transport and network checklists.
+seoTitle: MCP Streamable HTTP Migration Capability Pack Skill
+seoDescription: >-
+  Source-backed capability pack applying documented steps from official documentation—not an official Anthropic product.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-16"
+submittedAt: "2026-06-16"
+sourceSubmissionNumber: 1529
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1529"
+repoUrl: "https://github.com/anthropics/claude-code"
+documentationUrl: "https://code.claude.com/docs/en/mcp"
+downloadUrl: "https://github.com/anthropics/claude-code/archive/refs/heads/main.zip"
+installable: false
+usageSnippet: >-
+  Use this skill when planning or reviewing workflows using official documentation steps.
+copySnippet: |-
+  # Trigger
+  "Apply the mcp streamable http migration capability pack capability pack."
+
+  # Required output
+  1) Scope and configuration checklist
+  2) Risk and policy findings
+  3) Review matrix actions
+  4) Verification and rollback plan
+  5) Privacy-safe summary
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-16"
+retrievalSources:
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://modelcontextprotocol.io/specification/2025-03-26/basic/transports"
+  - "https://code.claude.com/docs/en/security"
+  - "https://code.claude.com/docs/en/skills"
+  - "https://github.com/anthropics/claude-code"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+testedPlatforms:
+  - Claude Code
+  - Claude
+  - Cursor
+  - Generic AGENTS
+prerequisites:
+  - "Claude Code version and plan eligibility per official documentation."
+  - "Team policy for autonomous or shared automation workflows."
+  - "Staging environment for safe validation."
+  - "Human owner for production rollout approval."
+safetyNotes:
+  - "Autonomous runs can execute tools without mid-run user input—scope paths and connectors first."
+  - "Do not enable destructive automation without explicit approval gates."
+  - "Review outputs as draft until a human validates evidence."
+privacyNotes:
+  - "Run output may contain proprietary code and credentials."
+  - "Summaries for external channels require redaction."
+tags:
+  - capability-pack
+  - mcp
+  - transport
+  - streamable-http
+  - claude-code
+readingTime: 9
+difficultyScore: 74
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Knowledge Freshness
+
+Grounded in official documentation verified on **2026-06-16**. Behavior can change with releases; prefer live docs.
+
+## Retrieval Sources
+
+- https://code.claude.com/docs/en/mcp
+- https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
+- https://code.claude.com/docs/en/security
+- https://code.claude.com/docs/en/skills
+- https://github.com/anthropics/claude-code
+- https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+
+## Source Verification Notes
+
+Verified on **2026-06-16**:
+
+- MCP transport specification documents Streamable HTTP as an HTTP-based transport.
+- Claude Code MCP docs cover remote HTTP server configuration and authentication.
+- Long-running SSE streams need idle timeout and reconnect policies.
+- Remote transports cross network boundaries and require TLS review.
+- Stdio remains preferred for local-only tools with minimal network exposure.
+
+## Scope Note
+
+Community reusable workflow skill applying documented steps—not an official Anthropic product. Applies documented MCP transport migration steps—not a separate Anthropic migration service.
+
+## Core Workflow
+
+1. Inventory current MCP transport (stdio, SSE, HTTP) per integration.
+2. Map migration targets to Streamable HTTP per MCP spec.
+3. Update server endpoints, auth, and client .mcp.json entries.
+4. Test reconnect, timeout, and proxy compatibility in staging.
+5. Roll back to prior transport if enterprise firewall blocks new paths.
+
+## Capability Scope
+
+- Configuration and eligibility checklist.
+- Risk and policy review.
+- Staging verification steps.
+- Rollback planning.
+- Privacy-safe stakeholder summary.
+
+## Compatibility
+
+### Native
+
+- **Claude Code**: use as an Agent Skill during rollout planning.
+
+### Manual Adaptation
+
+- **Generic AGENTS**: apply checklist against public documentation.
+
+## Required Inputs
+
+- Target repository or organization context.
+- Current settings and policy constraints.
+- Stakeholders for security review when applicable.
+
+## Production Rules
+
+- Require human approval before production-impacting automation.
+- Redact secrets from skill outputs and public tickets.
+- Prefer official documentation over forum assumptions.
+- Document rollback before enabling scheduled or autonomous runs.
+
+## Review Matrix
+
+| Signal | Action |
+| --- | --- |
+| Missing repro | Block autonomous run |
+| Broad tool scope | Narrow allowlists |
+| Draft findings | Label unverified until human review |
+| Policy drift | Align to managed settings |
+
+## Output Contract
+
+1. Scope and configuration summary.
+2. Findings with severity.
+3. Review matrix actions.
+4. Verification and rollback plan.
+5. Privacy-safe summary.
+
+## Troubleshooting
+
+**Issue:** Feature unavailable on your plan
+**Fix:** Confirm `/status` and official doc eligibility requirements.
+
+**Issue:** Run stalls on permissions
+**Fix:** Pre-approve read tools in staging; narrow path scope.
+
+## Duplicate Check
+
+Complements `choosing-mcp-transport-stdio-http-sse-and-websocket` guide; distinct skills review matrix for migration rollout.
+
+## Editorial Disclosure
+
+Independent entry by `kiannidev` from public documentation. No paid placement or affiliate links.


### PR DESCRIPTION
## Summary
- Adds `content/skills/mcp-streamable-http-migration-capability-pack.mdx` for issue #1529.
- Closes #1529.
## Grounding note
- Community capability pack applying documented steps from primary documentationUrl—not an official Anthropic product.

Made with [Cursor](https://cursor.com)