### PR TITLE
docs(content): fix garbled Stripe MCP description + keywords

### DIFF
--- a/content/mcp/stripe-mcp-server.mdx
+++ b/content/mcp/stripe-mcp-server.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Payment processing, subscription management, and financial transaction
   handling
-seoTitle: Stripe MCP Server for Claude
-seoDescription: >-
-  Payment processing, subscription management, and financial transaction
-  handling Discover tools for AI development.
+seoTitle: "Stripe MCP Server for Claude — Payments & Subscriptions"
+seoDescription: "Connect Claude to Stripe with the Stripe MCP server: manage payments, subscriptions, invoices, and financial transactions from your AI agent."
 author: Stripe
 authorProfileUrl: "https://stripe.com/"
 dateAdded: "2025-09-18"
@@ -67,17 +65,11 @@ tags:
   - subscriptions
   - commerce
 keywords:
-  - billing
-  - claude
-  - commerce
-  - development
-  - mcp
-  - mcp servers
-  - payments
-  - server
-  - stripe
-  - subscriptions
-  - tools
+  - stripe mcp server
+  - stripe mcp claude
+  - claude stripe integration
+  - stripe payments api
+  - stripe subscriptions
 readingTime: 1
 difficultyScore: 11
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene: fixes the garbled `seoDescription` boilerplate and junk keywords on the Stripe MCP server entry.

**Changes (metadata only):**
- `seoDescription`: "…transaction handling Discover tools for AI development." → a clean, intent-matching snippet.
- `seoTitle`: → "Stripe MCP Server for Claude — Payments & Subscriptions".
- `keywords`: single-token auto-extractions → real query phrases.

Part of the catalog-wide cleanup of ~40 garbled descriptions. `pnpm validate:content:strict` and the content-policy scan pass locally.