### PR TITLE
docs(content): fix garbled Docker MCP description + keywords

### DIFF
--- a/content/mcp/docker-mcp-server.mdx
+++ b/content/mcp/docker-mcp-server.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Manage Docker containers, images, and services directly through Claude with
   comprehensive Docker API integration
-seoTitle: Docker MCP Server for Claude
-seoDescription: >-
-  Manage Docker containers, images, and services directly through Claude with
-  comprehensive Docker API integration Discover tools for AI development.
+seoTitle: "Docker MCP Server for Claude — Containers & Images"
+seoDescription: "Manage Docker containers, images, and services directly through Claude with the Docker MCP server — build, run, inspect, and orchestrate from your AI agent."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
@@ -92,17 +90,11 @@ tags:
   - orchestration
   - deployment
 keywords:
-  - claude
-  - containers
-  - deployment
-  - development
-  - devops
-  - docker
-  - mcp
-  - mcp servers
-  - orchestration
-  - server
-  - tools
+  - docker mcp server
+  - docker mcp claude
+  - claude docker integration
+  - manage docker containers
+  - mcp server
 readingTime: 1
 difficultyScore: 5
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene: fixes the garbled `seoDescription` boilerplate and junk keywords on the Docker MCP server entry.

**Changes (metadata only):**
- `seoDescription`: "…Docker API integration Discover tools for AI development." → a clean snippet.
- `seoTitle`: → "Docker MCP Server for Claude — Containers & Images".
- `keywords`: single-token auto-extractions → real query phrases.

Part of the catalog-wide cleanup of ~40 garbled descriptions. `pnpm validate:content:strict` and the content-policy scan pass locally.