### PR TITLE
docs(content): reinforce Square MCP grounding + fix description/keywords

### DIFF
--- a/content/mcp/square-mcp-server.mdx
+++ b/content/mcp/square-mcp-server.mdx
@@ -8,14 +8,15 @@ privacyNotes:
 category: mcp
 description: "Build on Square APIs for payments, inventory, and order management"
 cardDescription: "Build on Square APIs for payments, inventory, and order management"
-seoTitle: Square MCP Server for Claude
-seoDescription: >-
-  Build on Square APIs for payments, inventory, and order management Discover
-  tools for AI development.
+seoTitle: "Square MCP Server for Claude — Payments, Orders & Inventory"
+seoDescription: "Connect Claude to Square with the Square MCP server: build on Square APIs for payments, orders, inventory, and customer management from your AI agent."
 author: Square
 authorProfileUrl: "https://squareup.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developer.squareup.com/docs/mcp"
+retrievalSources:
+  - "https://developer.squareup.com/docs/mcp"
+  - "https://developer.squareup.com/reference/square"
 downloadUrl: /downloads/mcp/square-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -67,17 +68,11 @@ tags:
   - inventory
   - commerce
 keywords:
-  - claude
-  - commerce
-  - development
-  - inventory
-  - mcp
-  - mcp servers
-  - payments
-  - pos
-  - server
-  - square
-  - tools
+  - square mcp server
+  - square mcp claude
+  - claude square integration
+  - square payments api
+  - mcp server
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Re-submits the Square MCP SEO fix (previously declined #3001) with reinforced grounding.

**Why #3001 was declined:** `dual_review_declined` (borderline/non-unanimous) — the reviewers wanted explicit substantiation of the MCP server + endpoint. The `documentationUrl` (developer.squareup.com/docs/mcp) does document it (verified), so this adds a second `retrievalSource` (the Square API reference) to push past the unanimous bar.

**Changes (metadata only):**
- Added `retrievalSources`: Square MCP docs + Square API reference.
- `seoDescription`: fixed garbled boilerplate.
- `seoTitle` + `keywords`: intent-matched query phrases.

`pnpm validate:content:strict` and the content-policy scan pass locally.