### PR TITLE
docs(content): fix garbled Figma MCP description + keywords

### DIFF
--- a/content/mcp/figma-mcp-server.mdx
+++ b/content/mcp/figma-mcp-server.mdx
@@ -8,14 +8,14 @@ privacyNotes:
 category: mcp
 description: "Access designs, export assets, and interact with Figma files through Claude"
 cardDescription: "Access designs, export assets, and interact with Figma files through Claude"
-seoTitle: Figma MCP Server for Claude
-seoDescription: >-
-  Access designs, export assets, and interact with Figma files through Claude
-  Discover tools for AI development.
+seoTitle: "Figma MCP Server for Claude — Designs & Dev Mode"
+seoDescription: "Connect Claude to Figma with the Figma MCP server: access designs, inspect Dev Mode specs, and export assets from your Figma files through your AI agent."
 author: Figma
 authorProfileUrl: "https://www.figma.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://help.figma.com/hc/en-us/articles/32132100833559"
+retrievalSources:
+  - "https://help.figma.com/hc/en-us/articles/32132100833559"
 downloadUrl: /downloads/mcp/figma-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -76,16 +76,11 @@ tags:
   - graphics
 keywords:
   - assets
-  - claude
-  - design
-  - development
-  - figma
-  - graphics
-  - mcp
-  - mcp servers
-  - server
-  - tools
-  - ui-ux
+  - figma mcp server
+  - figma mcp claude
+  - claude figma integration
+  - figma dev mode mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Figma MCP server entry.

**Changes (metadata only):**
- `seoDescription`: "…through Claude Discover tools for AI development." → a clean, intent-matching snippet (designs, Dev Mode, asset export).
- `seoTitle`: → "Figma MCP Server for Claude — Designs & Dev Mode".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (the Figma MCP help doc) to reinforce grounding.

`pnpm validate:content:strict` and the content-policy scan pass locally.