### PR TITLE
docs(content): fix garbled Redis MCP description + keywords

### DIFF
--- a/content/mcp/redis-mcp-server.mdx
+++ b/content/mcp/redis-mcp-server.mdx
@@ -12,15 +12,15 @@ description: >-
 cardDescription: >-
   Official Redis MCP server providing natural language interface for Redis data
   management and operations
-seoTitle: Redis MCP Server for Claude
-seoDescription: >-
-  Official Redis MCP server providing natural language interface for Redis data
-  management and operations Discover tools for AI development.
+seoTitle: "Redis MCP Server for Claude — Cache & Data Operations"
+seoDescription: "Connect Claude to Redis with the official Redis MCP server: query, cache, and manage Redis data and key operations through a natural-language interface."
 author: Redis
 authorProfileUrl: "https://redis.io/"
 dateAdded: "2025-09-20"
 repoUrl: "https://github.com/redis/mcp-redis"
 documentationUrl: "https://github.com/redis/mcp-redis"
+retrievalSources:
+  - "https://github.com/redis/mcp-redis"
 downloadUrl: /downloads/mcp/redis-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -81,17 +81,11 @@ tags:
   - nosql
   - official
 keywords:
-  - cache
-  - claude
-  - database
-  - development
-  - mcp
-  - mcp servers
-  - nosql
-  - official
-  - redis
-  - server
-  - tools
+  - redis mcp server
+  - redis mcp claude
+  - claude redis integration
+  - redis cache mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Redis MCP server entry.

**Changes (metadata only):**
- `seoDescription`: "…operations Discover tools for AI development." → a clean snippet.
- `seoTitle`: → "Redis MCP Server for Claude — Cache & Data Operations".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (official redis/mcp-redis repo) to reinforce grounding.

`pnpm validate:content:strict` and the content-policy scan pass locally.