### PR TITLE
docs(content): fix garbled Airtable MCP description + keywords

### DIFF
--- a/content/mcp/airtable-mcp-server.mdx
+++ b/content/mcp/airtable-mcp-server.mdx
@@ -12,15 +12,15 @@ description: >-
 cardDescription: >-
   Read and write records, manage bases and tables in Airtable directly from
   Claude
-seoTitle: Airtable MCP Server for Claude
-seoDescription: >-
-  Read and write records, manage bases and tables in Airtable directly from
-  Claude. Discover tools for AI development.
+seoTitle: "Airtable MCP Server for Claude — Bases & Records"
+seoDescription: "Connect Claude to Airtable with the Airtable MCP server: read and write records and manage bases and tables directly from your AI agent."
 author: domdomegg
 authorProfileUrl: "https://github.com/domdomegg"
 dateAdded: "2025-09-18"
 repoUrl: "https://github.com/domdomegg/airtable-mcp-server"
 documentationUrl: "https://github.com/domdomegg/airtable-mcp-server"
+retrievalSources:
+  - "https://github.com/domdomegg/airtable-mcp-server"
 downloadUrl: /downloads/mcp/airtable-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -86,16 +86,11 @@ tags:
   - tables
 keywords:
   - airtable
-  - claude
-  - crud
-  - data-management
-  - database
-  - development
-  - mcp
-  - mcp servers
-  - server
-  - tables
-  - tools
+  - airtable mcp server
+  - airtable mcp claude
+  - claude airtable integration
+  - airtable api mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Airtable MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Airtable MCP Server for Claude — Bases & Records".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (official airtable-mcp-server repo).

`pnpm validate:content:strict` and content-policy scan pass locally.