### PR TITLE
docs(content): fix garbled AWS MCP description + keywords

### DIFF
--- a/content/mcp/aws-services-mcp-server.mdx
+++ b/content/mcp/aws-services-mcp-server.mdx
@@ -12,15 +12,15 @@ description: >-
 cardDescription: >-
   Comprehensive AWS cloud services integration for infrastructure management,
   deployment, and monitoring
-seoTitle: AWS Services MCP Server - MCP Servers
-seoDescription: >-
-  Comprehensive AWS cloud services integration for infrastructure management,
-  deployment, and monitoring Discover tools for AI development.
+seoTitle: "AWS MCP Server for Claude — Cloud Infrastructure & Ops"
+seoDescription: "Connect Claude to AWS with the AWS Labs MCP servers: manage cloud infrastructure, deployments, and monitoring across AWS services from your AI agent."
 author: AWS Labs
 authorProfileUrl: "https://github.com/awslabs"
 dateAdded: "2025-09-16"
 repoUrl: "https://github.com/awslabs/mcp"
 documentationUrl: "https://github.com/awslabs/mcp"
+retrievalSources:
+  - "https://github.com/awslabs/mcp"
 downloadUrl: /downloads/mcp/aws-services-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -94,17 +94,11 @@ tags:
   - monitoring
 keywords:
   - aws
-  - claude
-  - cloud
-  - deployment
-  - development
-  - infrastructure
-  - mcp
-  - mcp servers
-  - monitoring
-  - server
-  - services
-  - tools
+  - aws mcp server
+  - aws mcp claude
+  - claude aws integration
+  - aws labs mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the AWS Services MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "AWS Services MCP Server - MCP Servers" → "AWS MCP Server for Claude — Cloud Infrastructure & Ops".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (awslabs/mcp repo).

`pnpm validate:content:strict` and content-policy scan pass locally.