### PR TITLE
docs(content): fix garbled Box MCP description + keywords

### DIFF
--- a/content/mcp/box-mcp-server.mdx
+++ b/content/mcp/box-mcp-server.mdx
@@ -8,14 +8,14 @@ privacyNotes:
 category: mcp
 description: "Access enterprise content, analyze unstructured data, and automate workflows"
 cardDescription: "Access enterprise content, analyze unstructured data, and automate workflows"
-seoTitle: Box MCP Server for Claude
-seoDescription: >-
-  Access enterprise content, analyze unstructured data, and automate workflows
-  Discover tools for AI development.
+seoTitle: "Box MCP Server for Claude — Enterprise Content"
+seoDescription: "Connect Claude to Box with the Box MCP server: access enterprise content, analyze unstructured documents, and automate content workflows from your AI agent."
 author: Box
 authorProfileUrl: "https://www.box.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developer.box.com/guides/box-mcp/setup"
+retrievalSources:
+  - "https://developer.box.com/guides/box-mcp/setup"
 downloadUrl: /downloads/mcp/box-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -67,16 +67,11 @@ tags:
   - collaboration
 keywords:
   - box
-  - claude
-  - collaboration
-  - development
-  - document-management
-  - enterprise
-  - mcp
-  - mcp servers
-  - server
-  - storage
-  - tools
+  - box mcp server
+  - box mcp claude
+  - claude box integration
+  - box content management mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Box MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Box MCP Server for Claude — Enterprise Content".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (developer.box.com Box MCP setup guide).

`pnpm validate:content:strict` and content-policy scan pass locally.