### PR TITLE
docs(content): fix garbled Daloopa MCP description + keywords

### DIFF
--- a/content/mcp/daloopa-mcp-server.mdx
+++ b/content/mcp/daloopa-mcp-server.mdx
@@ -12,14 +12,14 @@ description: >-
 cardDescription: >-
   Access high-quality fundamental financial data from SEC filings and investor
   presentations
-seoTitle: Daloopa MCP Server for Claude
-seoDescription: >-
-  Access high-quality fundamental financial data from SEC filings and investor
-  presentations Discover tools for AI development.
+seoTitle: "Daloopa MCP Server for Claude — Financial Data"
+seoDescription: "Connect Claude to Daloopa with the Daloopa MCP server: pull high-quality fundamental financial data from SEC filings and investor presentations into your AI agent."
 author: Daloopa
 authorProfileUrl: "https://www.daloopa.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.daloopa.com/docs/daloopa-mcp"
+retrievalSources:
+  - "https://docs.daloopa.com/docs/daloopa-mcp"
 downloadUrl: /downloads/mcp/daloopa-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -69,17 +69,11 @@ tags:
   - financial-data
   - investor-relations
 keywords:
-  - claude
-  - daloopa
-  - development
-  - finance
-  - financial-data
-  - investor-relations
-  - mcp
-  - mcp servers
-  - sec-filings
-  - server
-  - tools
+  - daloopa mcp server
+  - daloopa mcp claude
+  - financial data mcp
+  - sec filings data
+  - claude financial data
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Daloopa MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Daloopa MCP Server for Claude — Financial Data".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (docs.daloopa.com Daloopa MCP).

`pnpm validate:content:strict` and content-policy scan pass locally.