### PR TITLE
docs(content): fix garbled HubSpot MCP description + keywords

### DIFF
--- a/content/mcp/hubspot-mcp-server.mdx
+++ b/content/mcp/hubspot-mcp-server.mdx
@@ -8,14 +8,14 @@ privacyNotes:
 category: mcp
 description: "Access and manage HubSpot CRM data including contacts, companies, and deals"
 cardDescription: "Access and manage HubSpot CRM data including contacts, companies, and deals"
-seoTitle: Hubspot MCP Server for Claude
-seoDescription: >-
-  Access and manage HubSpot CRM data including contacts, companies, and deals
-  Discover tools for AI development.
+seoTitle: "HubSpot MCP Server for Claude — CRM Contacts & Deals"
+seoDescription: "Connect Claude to HubSpot with the HubSpot MCP server: access and manage CRM data including contacts, companies, and deals from your AI agent."
 author: HubSpot
 authorProfileUrl: "https://www.hubspot.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://developers.hubspot.com/ai-tools/mcp"
+retrievalSources:
+  - "https://developers.hubspot.com/ai-tools/mcp"
 downloadUrl: /downloads/mcp/hubspot-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -69,17 +69,11 @@ tags:
   - marketing
   - customer-data
 keywords:
-  - claude
-  - crm
-  - customer-data
-  - development
-  - hubspot
-  - marketing
-  - mcp
-  - mcp servers
-  - sales
-  - server
-  - tools
+  - hubspot mcp server
+  - hubspot mcp claude
+  - claude hubspot integration
+  - hubspot crm mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the HubSpot MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Hubspot…" → "HubSpot MCP Server for Claude — CRM Contacts & Deals" (brand casing + intent).
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (developers.hubspot.com MCP docs).

`pnpm validate:content:strict` and content-policy scan pass locally.