### PR TITLE
docs(content): fix garbled Jam MCP description + keywords

### DIFF
--- a/content/mcp/jam-mcp-server.mdx
+++ b/content/mcp/jam-mcp-server.mdx
@@ -12,14 +12,14 @@ description: >-
 cardDescription: >-
   Debug faster with AI agents that access video recordings, console logs, and
   network requests
-seoTitle: Jam MCP Server for Claude
-seoDescription: >-
-  Debug faster with AI agents that access video recordings, console logs, and
-  network requests Discover tools for AI development.
+seoTitle: "Jam MCP Server for Claude — Debug with Recordings & Logs"
+seoDescription: "Connect Claude to Jam with the Jam MCP server: debug faster using bug reports with video recordings, console logs, and network requests from your AI agent."
 author: Jam
 authorProfileUrl: "https://jam.dev/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://jam.dev/docs/jam-mcp"
+retrievalSources:
+  - "https://jam.dev/docs/jam-mcp"
 downloadUrl: /downloads/mcp/jam-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -73,17 +73,11 @@ tags:
   - bug-tracking
   - developer-tools
 keywords:
-  - bug-tracking
-  - claude
-  - debugging
-  - developer-tools
-  - development
-  - jam
-  - mcp
-  - mcp servers
-  - server
-  - testing
-  - tools
+  - jam mcp server
+  - jam mcp claude
+  - claude jam integration
+  - jam debugging mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Jam MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Jam MCP Server for Claude — Debug with Recordings & Logs".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (jam.dev/docs/jam-mcp).

`pnpm validate:content:strict` and content-policy scan pass locally.