### PR TITLE
docs(content): fix garbled Kubernetes MCP description + keywords

### DIFF
--- a/content/mcp/kubernetes-mcp-server.mdx
+++ b/content/mcp/kubernetes-mcp-server.mdx
@@ -12,15 +12,15 @@ description: >-
 cardDescription: >-
   Kubernetes cluster management and container orchestration through MCP
   integration
-seoTitle: Kubernetes MCP Server - MCP Servers
-seoDescription: >-
-  Kubernetes cluster management and container orchestration through MCP
-  integration Discover tools for AI development.
+seoTitle: "Kubernetes MCP Server for Claude — Cluster Management"
+seoDescription: "Connect Claude to Kubernetes with the Kubernetes MCP server: manage clusters, inspect workloads, and run container-orchestration operations from your AI agent."
 author: feiskyer
 authorProfileUrl: "https://github.com/feiskyer"
 dateAdded: "2025-09-20"
 repoUrl: "https://github.com/feiskyer/mcp-kubernetes-server"
 documentationUrl: "https://github.com/feiskyer/mcp-kubernetes-server"
+retrievalSources:
+  - "https://github.com/feiskyer/mcp-kubernetes-server"
 downloadUrl: /downloads/mcp/kubernetes-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -89,17 +89,11 @@ tags:
   - orchestration
   - devops
 keywords:
-  - claude
-  - container
-  - development
-  - devops
-  - k8s
-  - kubernetes
-  - mcp
-  - mcp servers
-  - orchestration
-  - server
-  - tools
+  - kubernetes mcp server
+  - kubernetes mcp claude
+  - claude kubernetes integration
+  - k8s mcp server
+  - mcp server
 readingTime: 1
 difficultyScore: 10
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Kubernetes MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Kubernetes MCP Server - MCP Servers" → "Kubernetes MCP Server for Claude — Cluster Management".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (feiskyer/mcp-kubernetes-server repo).

`pnpm validate:content:strict` and content-policy scan pass locally.