### PR TITLE
docs(content): fix garbled Plaid MCP description + keywords

### DIFF
--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -12,14 +12,14 @@ description: >-
 cardDescription: >-
   Analyze, troubleshoot, and optimize Plaid integrations for banking data and
   financial account linking
-seoTitle: Plaid MCP Server for Claude
-seoDescription: >-
-  Analyze, troubleshoot, and optimize Plaid integrations for banking data and
-  financial account linking Discover tools for AI development.
+seoTitle: "Plaid MCP Server for Claude — Banking & Account Linking"
+seoDescription: "Connect Claude to Plaid with the Plaid MCP server: analyze, troubleshoot, and optimize Plaid integrations for banking data and financial account linking."
 author: Plaid
 authorProfileUrl: "https://plaid.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://plaid.com/blog/plaid-mcp-ai-assistant-claude/"
+retrievalSources:
+  - "https://plaid.com/blog/plaid-mcp-ai-assistant-claude/"
 downloadUrl: /downloads/mcp/plaid-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -72,17 +72,11 @@ tags:
   - financial-data
   - account-linking
 keywords:
-  - account-linking
-  - banking
-  - claude
-  - development
-  - financial-data
-  - fintech
-  - mcp
-  - mcp servers
-  - plaid
-  - server
-  - tools
+  - plaid mcp server
+  - plaid mcp claude
+  - claude plaid integration
+  - plaid banking api
+  - mcp server
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Plaid MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Plaid MCP Server for Claude — Banking & Account Linking".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (Plaid MCP announcement docs).

`pnpm validate:content:strict` and content-policy scan pass locally.