### PR TITLE
docs(content): fix garbled Workato MCP description + keywords

### DIFF
--- a/content/mcp/workato-mcp-server.mdx
+++ b/content/mcp/workato-mcp-server.mdx
@@ -8,14 +8,14 @@ privacyNotes:
 category: mcp
 description: "Access any application, workflows, or data via Workato's integration platform"
 cardDescription: "Access any application, workflows, or data via Workato's integration platform"
-seoTitle: Workato MCP Server for Claude
-seoDescription: >-
-  Access any application, workflows, or data via Workato's integration platform
-  Discover tools for AI development.
+seoTitle: "Workato MCP Server for Claude — iPaaS Integrations"
+seoDescription: "Connect Claude to Workato with the Workato MCP server: access any application, workflow, or data through Workato's integration (iPaaS) platform from your AI agent."
 author: Workato
 authorProfileUrl: "https://www.workato.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://docs.workato.com/mcp.html"
+retrievalSources:
+  - "https://docs.workato.com/mcp.html"
 downloadUrl: /downloads/mcp/workato-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -66,17 +66,11 @@ tags:
   - workflow
   - iPaaS
 keywords:
-  - automation
-  - claude
-  - development
-  - integration
-  - iPaaS
-  - mcp
-  - mcp servers
-  - server
-  - tools
-  - workato
-  - workflow
+  - workato mcp server
+  - workato mcp claude
+  - claude workato integration
+  - workato ipaas mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Workato MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Workato MCP Server for Claude — iPaaS Integrations".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (docs.workato.com/mcp.html).

`pnpm validate:content:strict` and content-policy scan pass locally.