### PR TITLE
docs(content): fix garbled Cloudflare MCP description + keywords

### DIFF
--- a/content/mcp/cloudflare-mcp-server.mdx
+++ b/content/mcp/cloudflare-mcp-server.mdx
@@ -12,15 +12,15 @@ description: >-
 cardDescription: >-
   Build applications, analyze traffic, and manage security settings through
   Cloudflare
-seoTitle: Cloudflare MCP Server - MCP Servers
-seoDescription: >-
-  Build applications, analyze traffic, and manage security settings through
-  Cloudflare Discover tools for AI development.
+seoTitle: "Cloudflare MCP Server for Claude — Workers, DNS & Security"
+seoDescription: "Connect Claude to Cloudflare with the Cloudflare MCP servers: build applications, analyze traffic, and manage DNS and security settings from your AI agent."
 author: Cloudflare
 authorProfileUrl: "https://www.cloudflare.com/"
 dateAdded: "2025-09-18"
 documentationUrl: >-
   https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/
+retrievalSources:
+  - "https://developers.cloudflare.com/agents/model-context-protocol/mcp-servers-for-cloudflare/"
 downloadUrl: /downloads/mcp/cloudflare-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -93,17 +93,11 @@ tags:
   - dns
   - infrastructure
 keywords:
-  - cdn
-  - claude
-  - cloudflare
-  - development
-  - dns
-  - infrastructure
-  - mcp
-  - mcp servers
-  - security
-  - server
-  - tools
+  - cloudflare mcp server
+  - cloudflare mcp claude
+  - claude cloudflare integration
+  - cloudflare workers mcp
+  - mcp server
 readingTime: 1
 difficultyScore: 5
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Cloudflare MCP server entry.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Cloudflare MCP Server - MCP Servers" → "Cloudflare MCP Server for Claude — Workers, DNS & Security".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `retrievalSources` (Cloudflare MCP servers docs).

`pnpm validate:content:strict` and content-policy scan pass locally.