### PR TITLE
docs(content): fix garbled Playwright E2E skill description + keywords

### DIFF
--- a/content/skills/playwright-e2e-testing.mdx
+++ b/content/skills/playwright-e2e-testing.mdx
@@ -4,8 +4,8 @@ slug: playwright-e2e-testing
 category: skills
 description: "Write and maintain reliable end-to-end tests with Playwright — Microsoft's browser automation library that auto-waits for actionable elements and runs the same suite against Chromium, Firefox, and WebKit."
 cardDescription: "Playwright auto-waits for elements before acting, isolates every test context, and targets Chromium, Firefox, and WebKit from a single cross-platform API..."
-seoTitle: Playwright E2E Testing Automation Skill
-seoDescription: "Playwright enables TypeScript-first E2E browser automation with getByRole and getByLabel selectors that survive DOM refactors, network interception for mocking slow APIs, parallel execution with CI sharding, and a built-in trace viewer that captures screenshots and DOM snapshots for diagnosing flaky failures. Discover tools for AI development."
+seoTitle: "Playwright E2E Testing Skill for Claude Code"
+seoDescription: "Playwright E2E skill for Claude: TypeScript browser tests with role/label selectors that survive DOM refactors, network mocking, parallel CI sharding, and trace-viewer debugging."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
@@ -67,14 +67,11 @@ tags:
   - automation
   - ai
 keywords:
-  - automation
-  - claude
-  - development
-  - e2e
-  - playwright
-  - skills
-  - testing
-  - tools
+  - playwright e2e testing
+  - playwright claude code
+  - browser test automation
+  - playwright typescript
+  - end to end testing
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog SEO hygiene for the Playwright E2E testing skill (grounded on playwright.dev, existing retrievalSources retained).

- `seoDescription`: stripped the "… Discover tools for AI development." boilerplate from an otherwise strong description.
- `seoTitle`: → "Playwright E2E Testing Skill for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.

`pnpm validate:content:strict` and content-policy scan pass locally.