### PR TITLE
docs(content): fix garbled Minimal Powerline statusline + keywords

### DIFF
--- a/content/statuslines/minimal-powerline.mdx
+++ b/content/statuslines/minimal-powerline.mdx
@@ -8,15 +8,20 @@ description: >-
 cardDescription: >-
   Clean, performance-optimized statusline with Powerline glyphs showing model,
   directory, and token count
-seoTitle: Minimal Powerline - Statuslines
-seoDescription: >-
-  Clean, performance-optimized statusline with Powerline glyphs showing model,
-  directory, and token count Discover tools for AI development.
+seoTitle: "Minimal Powerline Statusline for Claude Code"
+seoDescription: "A clean, performance-optimized Claude Code statusline with Powerline glyphs showing the model, current directory, and token count."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-01"
 repoUrl: "https://github.com/powerline/powerline"
-documentationUrl: "https://github.com/powerline/powerline"
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+  - "https://github.com/powerline/powerline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local bash environment and a Powerline-patched font; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token count) and renders it in the local terminal; it does not send data off-machine."
 installable: true
 usageSnippet: " claude-sonnet-4.5  ~/projects/my-app   1,234 "
 copySnippet: |-
@@ -110,15 +115,11 @@ tags:
   - bash
   - lightweight
 keywords:
-  - bash
-  - claude
-  - development
-  - lightweight
-  - minimal
-  - performance
-  - powerline
-  - statuslines
-  - tools
+  - powerline statusline
+  - claude code statusline
+  - minimal statusline
+  - claude statusline bash
+  - powerline glyphs
 readingTime: 1
 difficultyScore: 2
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Minimal Powerline statusline.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Minimal Powerline - Statuslines" → "Minimal Powerline Statusline for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.
- `documentationUrl` → Claude Code statusline docs; added `retrievalSources` (statusline docs + Powerline repo for the glyphs).
- Added `safetyNotes`/`privacyNotes` (runs as a statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and content-policy scan pass locally.