### PR TITLE
feat(ci): integrate Codecov coverage and scope Superagent to code PRs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,74 @@
+name: coverage
+
+# Non-required coverage signal for Codecov. Runs only when CODE changes (never
+# on content-only PRs/pushes — content does not affect the node-suite coverage),
+# so the heavy v8-instrumented run stays off the content-submission hot path and
+# off the required `validate-web` gate. Uploads lcov to Codecov, which posts the
+# project/patch statuses (informational; see codecov.yml).
+on:
+  pull_request:
+    paths-ignore:
+      - "content/**"
+      - "README.md"
+      - "docs/**"
+      - "**/*.md"
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "content/**"
+      - "README.md"
+      - "docs/**"
+      - "**/*.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@4f4305e1fe60ad818b8ae6fc4a697cc47eab0b2d
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version: 24.16.0
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Prepare test reports dir
+        run: rm -rf reports/junit && mkdir -p reports/junit
+
+      - name: Build registry artifacts
+        run: pnpm --filter web run prebuild
+
+      - name: Apply local D1 migrations
+        run: pnpm --filter web db:migrate:local
+
+      - name: Run Vitest suite with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/superagent-security.yml
+++ b/.github/workflows/superagent-security.yml
@@ -2,6 +2,14 @@ name: Superagent Repo Scan
 
 on:
   pull_request:
+    # Content-only PRs add curated .mdx/markdown text, not executable code, so a
+    # full-repo Superagent scan adds no signal. Skip them (mirrors
+    # pipelock-security.yml); code/config PRs are still scanned.
+    paths-ignore:
+      - "content/**"
+      - "README.md"
+      - "docs/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,23 +97,23 @@ git diff --check
 
 ### Test coverage gate
 
-`pnpm test:coverage` runs the full Vitest suite with v8 coverage and enforces
-global thresholds defined in `vitest.config.ts`. Coverage is scoped to the
-source the node suite actually exercises (the `registry`/`mcp` packages, web
-`lib`/`data`/`types`, the submission gate, and build scripts); React components
-and routes are out of scope because they are not run under the node environment.
+`pnpm test:coverage` runs the full Vitest suite with v8 coverage and writes an
+lcov report to `coverage/lcov.info`. Coverage is scoped to the source the node
+suite actually exercises (the `registry`/`mcp` packages, web `lib`/`data`/`types`,
+the submission gate, and build scripts); React components and routes are out of
+scope because they are not run under the node environment.
 
-The thresholds are a **ratchet**: they are pinned just below current coverage so
-`pnpm test:coverage` locks in today's level and fails on regressions. When you add
-tests that raise coverage, raise the matching thresholds in `vitest.config.ts` to
-the new floor. Never lower them to make a change pass — add the missing tests
-instead.
-
-Run `pnpm test:coverage` locally before pushing. It is a **local / pre-merge**
-gate, not part of the required CI lane: the required `validate-web` job runs the
-plain `pnpm test` suite, because v8 coverage instrumentation slows the suite
-enough to risk hitting Vitest's per-test timeout on CI hardware. Promoting it to
-a non-required CI job is a follow-up once that timeout is tuned.
+**Coverage gating is owned by Codecov, not a vitest threshold.** The `coverage`
+workflow (`.github/workflows/coverage.yml`) runs on code changes only (never
+content-only PRs/pushes) and uploads the lcov report. Codecov posts two statuses
+per `codecov.yml`: `codecov/patch` (coverage of the PR diff) and `codecov/project`
+(`target: auto`, base-relative). Both are **informational** (report-only) for
+now — flip `patch.informational` to `false` in `codecov.yml` when you want new
+code enforceable. `target: auto` compares each PR against its own base commit, so
+merging one PR never moves the bar under other open PRs — the cross-PR churn we
+had with the old global vitest threshold ratchet (now removed). The coverage run
+is kept off the required `validate-web` lane because v8 instrumentation is slow;
+`validate-web` still runs the plain `pnpm test`.
 
 ## PR Hygiene
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,44 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecovyml-reference
+#
+# Coverage is uploaded by .github/workflows/coverage.yml (lcov from Vitest v8,
+# scoped in vitest.config.ts to registry/mcp packages, web lib/data/types, the
+# submission gate, and build scripts).
+#
+# Rollout posture: both statuses are INFORMATIONAL (report-only, never block a
+# merge) so we can watch the signal first. To make new code enforceable later,
+# set `informational: false` on `patch` (and add it to branch protection). We
+# deliberately avoid a fixed global target — `target: auto` compares each PR
+# against its own base commit, so merging one PR never moves the bar under other
+# open PRs (the churn we hit with vitest's global threshold ratchet).
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+        if_ci_failed: ignore
+        only_pulls: false
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+        if_ci_failed: ignore
+        only_pulls: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: true
+
+# vitest.config.ts already scopes instrumentation via coverage.include/exclude;
+# these are belt-and-suspenders so non-source files never enter the math.
+ignore:
+  - "tests"
+  - "**/*.test.ts"
+  - "**/*.config.ts"
+  - "apps/web/src/generated"
+  - "apps/web/public/data"
+  - "integrations"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,9 @@ export default defineConfig({
     testTimeout: 30_000,
     coverage: {
       provider: "v8",
-      reporter: ["text", "text-summary", "json-summary"],
+      // `lcov` feeds Codecov (coverage/lcov.info); the text/json reporters are
+      // for local inspection.
+      reporter: ["text", "text-summary", "json-summary", "lcov"],
       reportsDirectory: "coverage",
       // Scope coverage to the source the node test suite actually exercises
       // (registry + mcp packages, web server/lib/data logic, the submission
@@ -43,15 +45,11 @@ export default defineConfig({
         "**/*.json",
         "tests/**",
       ],
-      // Thresholds lock in current coverage and ratchet upward over time.
-      // When coverage rises, bump these to match — never lower them.
-      // See AGENTS.md "Validation" for the ratcheting policy.
-      thresholds: {
-        statements: 47,
-        branches: 44,
-        functions: 56,
-        lines: 48,
-      },
+      // Coverage gating is owned by Codecov (codecov.yml: patch + project,
+      // base-relative via `target: auto`) instead of a global vitest threshold
+      // ratchet, which caused cross-PR churn (a merge moved the bar under other
+      // open PRs). `pnpm test:coverage` here is for local inspection + producing
+      // the lcov report uploaded by the `coverage` workflow.
     },
   },
 });


### PR DESCRIPTION
Single PR for the two CI items from the pipeline analysis.

## 1. Codecov (replaces the churny global threshold)

**Problem:** `vitest.config.ts` enforced fixed global coverage thresholds (a manual ratchet). That's the cross-PR churn source — one merge effectively moves the bar, so other open PRs that barely met it start failing.

**Fix — Codecov owns coverage, base-relative:**
- `vitest.config.ts`: add an `lcov` reporter; **remove the global `thresholds` block** (no test pins it).
- `codecov.yml`: `codecov/patch` (diff-only) + `codecov/project` (`target: auto` → compared to each PR's **own base commit**, never a moving global number) with `threshold`. **Both `informational: true`** so nothing blocks during rollout; flip `patch.informational` to `false` later to enforce new-code coverage.
- `.github/workflows/coverage.yml` (new): runs the v8-instrumented suite **on code changes only** (`paths-ignore: content/**, *.md, docs/**` for both PR and push-to-main), **off** the required `validate-web` lane (v8 is slow), uploads lcov via `codecov/codecov-action@fb8b358…` (**v7.0.0**, SHA-pinned per repo convention). Non-required.

Verified locally: full `pnpm test:coverage` passes (exit 0) and writes `coverage/lcov.info` (541 KB). Current coverage ~49/46/57/51%.

## 2. Superagent scoped to code PRs

`superagent-security.yml` ran a **full-repo scan on every content PR** (clone + install + scan, up to 10 min) — no signal for curated `.mdx` text. Added `paths-ignore: content/**, README.md, docs/**, **/*.md`, mirroring `pipelock-security.yml`. Code/config PRs are still scanned. (The "Superagent Security Scan" Marketplace app is separate/dashboard-configured.)

## Rollout / safety
- Codecov token: installed by maintainer (repo secret `CODECOV_TOKEN`).
- Both Codecov statuses are **informational** and **not** in `required-pr-gate`/branch protection — they can't block merges. First upload happens on this PR.
- Content-submission PRs are unaffected (coverage + superagent both skip them).

## Validation
`pnpm test:coverage` ✓ (lcov produced) · prettier (pinned 3.8.3) ✓ · YAML parse ✓ · `tests/submission-workflows.test.ts` Superagent assertions ✓ · Trunk ✓ · AGENTS.md coverage section updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Integrated Codecov for automated code coverage tracking and reporting
  * Added GitHub Actions workflow for continuous coverage analysis
  * Configured coverage gates as informational status checks on pull requests
  * Optimized CI workflows to skip unnecessary runs on documentation-only changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->