### PR TITLE
docs(content): clean Python data-science expert rule metadata

### DIFF
--- a/content/rules/python-data-science-expert.mdx
+++ b/content/rules/python-data-science-expert.mdx
@@ -11,12 +11,7 @@ cardDescription: >-
   and fitting on test data
   for defensible model evaluation
 seoTitle: Python scikit-learn Expert - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  A scikit-learn rule that flags data leakage, requires Pipelines so
-  preprocessing fits per fold, and checks split choices like StratifiedKFold and
-  GroupKFold
-  (StratifiedKFold, GroupKFold, TimeSeriesSplit) for defensible model
-  evaluation. Discover tools for AI development.
+seoDescription: "A scikit-learn rule that flags data leakage, requires Pipelines so preprocessing fits per fold, and checks split choices (StratifiedKFold, GroupKFold, TimeSeriesSplit) for defensible model evaluation."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
@@ -91,17 +86,11 @@ tags:
   - data-leakage
   - model-evaluation
 keywords:
-  - claude
-  - scikit-learn
-  - sklearn
-  - machine-learning
-  - cross-validation
-  - data-leakage
-  - pipeline
-  - model-evaluation
-  - python
-  - rules
-  - tools
+  - scikit-learn claude code
+  - data leakage detection
+  - sklearn pipeline
+  - cross-validation strategy
+  - machine learning code review
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene for the Python data-science (scikit-learn) expert rule (already well-grounded — 3 scikit-learn retrievalSources + distinct seoTitle).

- `seoDescription`: removed the "…Discover tools for AI development." boilerplate and a duplicated split-strategy phrase → one clean sentence.
- `keywords`: tightened to real query phrases.

`pnpm validate:content:strict` and the content-policy scan pass locally.