### PR TITLE
docs(content): ground React/Next.js expert rule + fix metadata

### DIFF
--- a/content/rules/react-next-js-expert.mdx
+++ b/content/rules/react-next-js-expert.mdx
@@ -10,15 +10,16 @@ cardDescription: >-
   Next.js App Router production-architecture specialist focused on the
   server/client boundary, the explicit caching model, route handlers, and
   Node-vs-Edge runtime tradeoffs — decisions, not component tips
-seoTitle: React Next.js Expert - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  Next.js App Router production-architecture specialist focused on the
-  server/client boundary, caching model, route handlers, and runtime tradeoffs.
-  Discover tools for AI development.
+seoTitle: "React & Next.js App Router Expert — CLAUDE.md Rule for Claude Code"
+seoDescription: "A CLAUDE.md rule for Next.js App Router architecture: the server/client component boundary, the caching model, route handlers, streaming, and runtime tradeoffs."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
 documentationUrl: "https://nextjs.org/docs"
+retrievalSources:
+  - "https://nextjs.org/docs/app/building-your-application/rendering/server-components"
+  - "https://nextjs.org/docs/app/building-your-application/caching"
+  - "https://nextjs.org/docs/app/building-your-application/routing/route-handlers"
 installable: false
 usageSnippet: >-
   You are a Next.js App Router architecture specialist. Drive every decision
@@ -108,16 +109,11 @@ tags:
   - architecture
   - performance
 keywords:
-  - app-router
-  - caching
-  - claude
-  - edge-runtime
-  - nextjs
-  - performance
-  - react
-  - rules
-  - server-components
-  - tools
+  - nextjs app router claude
+  - react server components
+  - nextjs caching
+  - next.js claude.md rule
+  - server client boundary
 readingTime: 3
 difficultyScore: 25
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the React/Next.js App Router expert rule.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "React & Next.js App Router Expert — CLAUDE.md Rule for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.
- Added per-facet `retrievalSources` (Next.js server components, caching, route handlers) so the body's claims are grounded.

`pnpm validate:content:strict` and the content-policy scan pass locally.