### PR TITLE
docs(content): ground Mobile App Developer rule + fix metadata

### DIFF
--- a/content/rules/mobile-app-developer.mdx
+++ b/content/rules/mobile-app-developer.mdx
@@ -8,14 +8,21 @@ description: >-
 cardDescription: >-
   Expert in iOS, Android, and cross-platform mobile development with React
   Native, Flutter, and native frameworks
-seoTitle: Mobile App Dev - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  Expert in iOS, Android, and cross-platform mobile development with React
-  Native, Flutter, and native frameworks Discover tools for AI development.
+seoTitle: "Mobile App Developer — CLAUDE.md Rule for Claude Code"
+seoDescription: "A CLAUDE.md rule for mobile development: iOS (Swift/SwiftUI), Android (Kotlin/Jetpack Compose), and cross-platform with React Native and Flutter."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
 documentationUrl: "https://developer.apple.com/documentation/"
+retrievalSources:
+  - "https://developer.apple.com/documentation/"
+  - "https://developer.android.com/develop"
+  - "https://reactnative.dev/docs/getting-started"
+  - "https://docs.flutter.dev/"
+safetyNotes:
+  - "Guidance-only CLAUDE.md text. Following it leads Claude to run mobile toolchains (Xcode/xcodebuild, Gradle, CocoaPods, npm/yarn, flutter) and install dependencies; review generated build and dependency commands before running them."
+privacyNotes:
+  - "Guidance-only CLAUDE.md text; its examples touch device permissions, push tokens, and user data — review what a generated app collects, stores, or transmits and follow platform privacy rules."
 installable: false
 usageSnippet: >-
   You are a mobile development expert with comprehensive knowledge of native and
@@ -437,19 +444,11 @@ tags:
   - swift
   - kotlin
 keywords:
-  - android
-  - app
-  - claude
-  - developer
-  - development
-  - flutter
-  - ios
-  - kotlin
-  - mobile
-  - react-native
-  - rules
-  - swift
-  - tools
+  - mobile app developer claude
+  - ios android claude code
+  - react native flutter rule
+  - swiftui jetpack compose
+  - cross-platform mobile
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Mobile App Developer rule.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Mobile App Dev - CLAUDE.md Rules…" → "Mobile App Developer — CLAUDE.md Rule for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.
- Added per-facet `retrievalSources` (Apple, Android, React Native, Flutter docs) so iOS/Android/RN/Flutter claims are grounded.
- Added `safetyNotes`/`privacyNotes` (mobile toolchains; device permissions/user data) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.