### PR TITLE
docs(content): clean Security Auditor/Pentester rule metadata

### DIFF
--- a/content/rules/security-auditor-penetration-tester.mdx
+++ b/content/rules/security-auditor-penetration-tester.mdx
@@ -10,11 +10,8 @@ cardDescription: >-
   Active penetration-testing rule organized by the OWASP WSTG — drive each test
   category (info gathering, authn, authz, session, input validation) through the
   WSTG five-phase model, against authorized scope only
-seoTitle: Security Auditor Pentester - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  Active penetration-testing rule organized by the OWASP Web Security Testing
-  Guide (WSTG) — test categories, identifiers, and the five-phase model.
-  Discover tools for AI development.
+seoTitle: "Security Auditor & Pentester — CLAUDE.md Rule for Claude Code"
+seoDescription: "A CLAUDE.md rule for security auditing and penetration testing organized by the OWASP Web Security Testing Guide (WSTG): test categories, identifiers, and the five-phase model."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
@@ -41,16 +38,11 @@ tags:
   - wstg
   - vulnerability
 keywords:
-  - penetration-testing
-  - pentest
-  - claude
-  - wstg
-  - owasp
-  - remediation
-  - rules
-  - security
-  - tools
-  - vulnerability
+  - penetration testing claude
+  - owasp wstg
+  - security audit rule
+  - claude pentest
+  - vulnerability assessment
 retrievalSources:
   - "https://owasp.org/www-project-web-security-testing-guide/stable/"
   - "https://owasp.org/www-project-web-security-testing-guide/"


### PR DESCRIPTION
Catalog SEO hygiene for the Security Auditor & Pentester rule (already grounded on the OWASP WSTG + existing retrievalSources).

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Security Auditor & Pentester — CLAUDE.md Rule for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.

`pnpm validate:content:strict` and the content-policy scan pass locally.