### PR TITLE
docs(content): clean Code Review Expert rule metadata

### DIFF
--- a/content/rules/code-review-expert.mdx
+++ b/content/rules/code-review-expert.mdx
@@ -8,10 +8,8 @@ description: >-
 cardDescription: >-
   Comprehensive code review rules for thorough analysis and constructive
   feedback
-seoTitle: Code Review Expert for Claude
-seoDescription: >-
-  Comprehensive code review rules for thorough analysis and constructive
-  feedback Discover tools for AI development.
+seoTitle: "Code Review Expert — CLAUDE.md Rule for Claude Code"
+seoDescription: "A CLAUDE.md rule that makes Claude a thorough code reviewer — review priorities, a structured review process, and what a reviewer checks, modeled on Google's engineering code-review practices."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
@@ -94,16 +92,11 @@ tags:
   - quality
   - development
 keywords:
-  - best-practices
-  - claude
-  - code
-  - code-review
-  - development
-  - expert
-  - quality
-  - review
-  - rules
-  - tools
+  - code review claude code
+  - code review rule
+  - claude.md code review
+  - code review checklist
+  - pull request review
 readingTime: 1
 difficultyScore: 3
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene for the Code Review Expert rule (already grounded on Google eng-practices + existing retrievalSources).

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: → "Code Review Expert — CLAUDE.md Rule for Claude Code".
- `keywords`: single-token auto-extractions → real query phrases.

`pnpm validate:content:strict` and the content-policy scan pass locally.