### PR TITLE
docs(content): ground Technical Documentation Writer agent + fix metadata

### DIFF
--- a/content/agents/technical-documentation-writer-agent.mdx
+++ b/content/agents/technical-documentation-writer-agent.mdx
@@ -8,13 +8,16 @@ description: >-
 cardDescription: >-
   Specialized in creating clear, comprehensive technical documentation for APIs,
   software, and complex systems
-seoTitle: Technical Doc Writer
-seoDescription: >-
-  Specialized in creating clear, comprehensive technical documentation for APIs,
-  software, and complex systems Discover tools for AI development.
+seoTitle: "Technical Documentation Writer Agent for Claude"
+seoDescription: "A Claude agent for clear, comprehensive technical documentation — API references, software docs, developer guides, and process docs following established docs style frameworks."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
+documentationUrl: "https://developers.google.com/style"
+retrievalSources:
+  - "https://developers.google.com/style"
+  - "https://diataxis.fr/"
+  - "https://www.writethedocs.org/guide/"
 installable: false
 usageSnippet: >-
   You are a technical documentation specialist focused on creating clear,
@@ -100,17 +103,11 @@ tags:
   - technical-writing
   - developer-resources
 keywords:
-  - agent
-  - agents
-  - api
-  - claude
-  - developer-resources
-  - development
-  - documentation
-  - technical
-  - technical-writing
-  - tools
-  - writer
+  - technical writer agent
+  - documentation agent claude
+  - api documentation writer
+  - technical writing claude
+  - developer docs agent
 readingTime: 1
 difficultyScore: 23
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the Technical Documentation Writer agent.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "Technical Doc Writer" → "Technical Documentation Writer Agent for Claude".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `documentationUrl` (Google dev docs style guide, it had none) + `retrievalSources` (Google style, Diátaxis, Write the Docs).

`pnpm validate:content:strict` and the content-policy scan pass locally.