### PR TITLE
docs(content): ground UI/UX Design Expert agent + fix metadata

### DIFF
--- a/content/agents/ui-ux-design-expert-agent.mdx
+++ b/content/agents/ui-ux-design-expert-agent.mdx
@@ -8,13 +8,18 @@ description: >-
 cardDescription: >-
   Specialized in creating beautiful, intuitive user interfaces and exceptional
   user experiences
-seoTitle: UI UX Design Expert Agent - Agents
-seoDescription: >-
-  Specialized in creating beautiful, intuitive user interfaces and exceptional
-  user experiences Discover tools for AI development.
+seoTitle: "UI/UX Design Expert Agent for Claude"
+seoDescription: "A Claude agent for UI/UX design: intuitive interfaces, usability and accessibility (WCAG), and design-system patterns grounded in Material Design and Apple's Human Interface Guidelines."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-15"
+documentationUrl: "https://m3.material.io/foundations"
+retrievalSources:
+  - "https://m3.material.io/foundations"
+  - "https://developer.apple.com/design/human-interface-guidelines"
+  - "https://www.w3.org/WAI/WCAG21/quickref/"
+privacyNotes:
+  - "UX work may involve user-research data, analytics, and session recordings that can contain personal information; anonymize and obtain consent, and avoid pasting real user PII into prompts."
 installable: false
 usageSnippet: >-
   You are a UI/UX design expert focused on creating intuitive, accessible, and
@@ -51,15 +56,11 @@ tags:
   - user-experience
   - interface
 keywords:
-  - agent
-  - agents
-  - claude
-  - design
-  - development
-  - expert
-  - interface
-  - tools
-  - user-experience
+  - ui ux design agent
+  - ux design claude
+  - design system agent
+  - accessibility design claude
+  - interface design agent
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog SEO hygiene + grounding for the UI/UX Design Expert agent.

- `seoDescription`: removed "…Discover tools for AI development." boilerplate → clean snippet.
- `seoTitle`: "UI UX Design Expert Agent - Agents" → "UI/UX Design Expert Agent for Claude".
- `keywords`: single-token auto-extractions → real query phrases.
- Added `documentationUrl` (Material Design, it had none) + `retrievalSources` (Material Design, Apple HIG, WCAG).
- Added `privacyNotes` (user-research data/analytics may contain PII) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.