### PR TITLE
docs(content): improve Bun runtime skill keywords

### DIFF
--- a/content/skills/bun-runtime-modern-javascript.mdx
+++ b/content/skills/bun-runtime-modern-javascript.mdx
@@ -71,16 +71,11 @@ tags:
   - typescript
   - performance
 keywords:
-  - bun
-  - claude
-  - development
-  - javascript
-  - modern
-  - performance
-  - runtime
-  - skills
-  - tools
-  - typescript
+  - bun runtime
+  - bun javascript
+  - bun typescript
+  - bun vs node
+  - bun claude code
 readingTime: 4
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the Bun runtime skill (already grounded on bun.sh/docs + retrievalSources; notes present).

- `keywords`: replaced single-token auto-extractions (`claude`, `development`, `modern`, `skills`, `tools`) with real query phrases (`bun runtime`, `bun typescript`, `bun vs node`).

`pnpm validate:content:strict` and the content-policy scan pass locally.