### PR TITLE
perf(ci): test prebuild artifact cache on the coverage lane

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -57,7 +57,29 @@ jobs:
       - name: Prepare test reports dir
         run: rm -rf reports/junit && mkdir -p reports/junit
 
+      # EXPERIMENT: cache the generated prebuild artifacts. Key hashes every
+      # input to `prebuild` (content, the build script, registry builder source,
+      # routes, prettier via the lockfile). A hit restores the artifacts and the
+      # build step below is skipped. Because content/** changes on nearly every
+      # merge, this only hits across runs that share an identical content
+      # snapshot — in practice, re-pushes of the same code PR (the iterate loop).
+      # Note: prebuild also derives entry `updatedAt` from `git log -- content`;
+      # a hit requires byte-identical content, so within a non-rebased PR the git
+      # history (and thus updatedAt) is identical too. The display timestamp can
+      # only go stale in the rare case of byte-identical content with a different
+      # commit touch-history, which is acceptable for a non-required lane.
+      - name: Restore prebuild artifacts
+        id: prebuild-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            apps/web/public/data
+            apps/web/src/generated
+            apps/web/src/routeTree.gen.ts
+          key: prebuild-v1-${{ runner.os }}-${{ hashFiles('content/**', 'scripts/build-content-index.mjs', 'packages/registry/src/**', 'packages/registry/package.json', 'apps/web/src/routes/**', 'pnpm-lock.yaml') }}
+
       - name: Build registry artifacts
+        if: steps.prebuild-cache.outputs.cache-hit != 'true'
         run: pnpm --filter web run prebuild
 
       - name: Apply local D1 migrations


### PR DESCRIPTION
**Experiment** (prebuild-caching item #4 from the audit) — scoped to the **non-required `coverage` lane only** so it can't affect the merge gate while we validate it.

## What it does
Caches the generated prebuild outputs (`apps/web/public/data`, `src/generated`, `routeTree.gen.ts` — all gitignored) keyed on `hashFiles` of **every prebuild input**: `content/**`, `scripts/build-content-index.mjs`, `packages/registry/src/**`, `packages/registry/package.json`, `apps/web/src/routes/**`, `pnpm-lock.yaml`. On a cache hit the `pnpm --filter web run prebuild` step is **skipped**.

## What the investigation found (why scoped + careful)
- prebuild is **~40s local / ~60–90s CI**.
- The output also depends on **git history** (`updatedAt` comes from `git log -- content`). A hit requires byte-identical `content/**`, so within a non-rebased PR the git history (and `updatedAt`) is identical too → correct. The only staleness case is byte-identical content with a *different* commit touch-history — rare, display-only, acceptable on a non-required lane.
- **Cross-run cache rarely hits across time** because `content/**` changes on nearly every merge → the key changes constantly. It also can't help the 4 parallel prebuild lanes share within one run (cache saves at job end).
- **Where it pays off: re-pushes of the same code PR** (stable content snapshot) — exactly the iterate-on-a-PR loop. That's the win we're testing.

## Test plan
1. First coverage run on this PR = **cache miss** → builds + saves.
2. I'll re-run the `coverage` workflow (content unchanged) = **cache hit** → prebuild skipped; compare timings.
3. If it behaves correctly, follow-up PR extends the same cache to `validate-web` / `validate-registry` / `validate-raycast`.

Non-required lane; SHA-pinned `actions/cache@v5.0.5`; prettier + actionlint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline efficiency through intelligent artifact caching. Prebuild artifacts are now automatically restored from cache during workflow execution, and subsequent build steps execute only when necessary based on cache validation status. This optimization significantly reduces redundant processing, decreases overall pipeline execution time, and improves the development experience when code dependencies remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->