### PR TITLE
docs(content): improve CLI data-viz skill keywords

### DIFF
--- a/content/skills/cli-data-viz-quickstart.mdx
+++ b/content/skills/cli-data-viz-quickstart.mdx
@@ -53,18 +53,11 @@ tags:
   - python
   - vega
 keywords:
-  - charts
-  - claude
-  - cli
-  - data
-  - development
-  - python
-  - quickstart
-  - skills
-  - tools
-  - vega
-  - visualization
-  - viz
+  - cli data visualization
+  - terminal charts
+  - matplotlib cli
+  - data viz claude code
+  - vega-lite charts
 readingTime: 5
 packageVerified: true
 difficultyScore: 96


### PR DESCRIPTION
Catalog keyword hygiene for the CLI data-viz quickstart skill (grounded on matplotlib.org + retrievalSources).

- `keywords`: single-token auto-extractions (`charts`, `claude`, `data`, `viz`, `skills`, `tools`) → real query phrases (`cli data visualization`, `terminal charts`, `matplotlib cli`).

`pnpm validate:content:strict` and the content-policy scan pass locally.