### PR TITLE
docs(content): improve Cloudflare Workers AI skill keywords

### DIFF
--- a/content/skills/cloudflare-workers-ai-edge.mdx
+++ b/content/skills/cloudflare-workers-ai-edge.mdx
@@ -76,16 +76,11 @@ tags:
   - serverless
   - workers
 keywords:
-  - claude
-  - cloudflare
-  - development
-  - edge
-  - edge-computing
-  - functions
-  - serverless
-  - skills
-  - tools
-  - workers
+  - cloudflare workers ai
+  - edge ai inference
+  - cloudflare workers claude
+  - serverless ai edge
+  - workers ai models
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the Cloudflare Workers AI edge skill (grounded on developers.cloudflare.com/workers-ai + retrievalSources).

- `keywords`: single-token auto-extractions → real query phrases (`cloudflare workers ai`, `edge ai inference`, `workers ai models`).

`pnpm validate:content:strict` and the content-policy scan pass locally.