### PR TITLE
docs(content): improve Cursor/Windsurf IDE setup skill keywords

### DIFF
--- a/content/skills/cursor-windsurf-ai-ide-setup.mdx
+++ b/content/skills/cursor-windsurf-ai-ide-setup.mdx
@@ -12,6 +12,10 @@ dateAdded: "2025-10-23"
 documentationUrl: "https://cursor.com/docs"
 downloadUrl: /downloads/skills/cursor-windsurf-ai-ide-setup.zip
 installable: true
+safetyNotes:
+  - "Setup downloads and unzips a package and changes IDE configuration files; review what it writes and run it in a trusted workspace."
+privacyNotes:
+  - "Cursor and Windsurf send your code and prompts to their AI backends to power completion and chat; review each editor's data-handling settings and keep API keys out of committed config."
 installCommand: "curl -L https://heyclau.de/downloads/skills/cursor-windsurf-ai-ide-setup.zip -o cursor-windsurf-ai-ide-setup.zip && unzip -o cursor-windsurf-ai-ide-setup.zip -d ./cursor-windsurf-ai-ide-setup"
 usageSnippet: "Claude can help you configure and optimize Cursor or Windsurf AI code editors for maximum productivity. Both editors provide AI-powered code completion, multi-file editing, and intelligent refactoring. Cursor excels with its Agent mode and Composer features, while Windsurf emphasizes collaborative flows and Cascade AI. From initial setup to advanced workflows, Claude handles IDE configuration and optimization."
 copySnippet: |-
@@ -89,18 +93,11 @@ tags:
   - ai-coding
   - editor
 keywords:
-  - ai-coding
-  - claude
-  - cursor
-  - cursor/windsurf
-  - development
-  - editor
-  - ide
-  - optimization
-  - setup
-  - skills
-  - tools
-  - windsurf
+  - cursor ide setup
+  - windsurf setup
+  - cursor vs windsurf
+  - ai code editor setup
+  - cursor windsurf config
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene + required notes for the Cursor/Windsurf IDE setup skill (grounded on cursor.com/docs + retrievalSources).

- `keywords`: single-token auto-extractions → real query phrases (`cursor ide setup`, `cursor vs windsurf`).
- Added `safetyNotes`/`privacyNotes` (downloads/unzips a package + edits IDE config; editors send code to AI backends) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.