### PR TITLE
docs(content): improve Image OCR table extraction skill keywords

### DIFF
--- a/content/skills/image-ocr-table-extraction.mdx
+++ b/content/skills/image-ocr-table-extraction.mdx
@@ -59,18 +59,11 @@ tags:
   - opencv
   - tables
 keywords:
-  - and
-  - claude
-  - development
-  - extraction
-  - image
-  - ocr
-  - opencv
-  - pytesseract
-  - skills
-  - table
-  - tables
-  - tools
+  - image ocr extraction
+  - table extraction ocr
+  - tesseract ocr python
+  - extract tables from images
+  - pytesseract opencv
 readingTime: 5
 packageVerified: true
 difficultyScore: 96


### PR DESCRIPTION
Catalog keyword hygiene for the Image OCR/table extraction skill (grounded on tesseract-ocr docs + retrievalSources; notes present).

- `keywords`: replaced junk single tokens (including the literal `and`) with real query phrases (`image ocr extraction`, `extract tables from images`, `tesseract ocr python`).

`pnpm validate:content:strict` and the content-policy scan pass locally.