### PR TITLE
docs(content): improve JSON schema validation skill keywords

### DIFF
--- a/content/skills/json-schema-validation-transformation.mdx
+++ b/content/skills/json-schema-validation-transformation.mdx
@@ -59,17 +59,11 @@ tags:
   - ajv
   - zod
 keywords:
-  - ajv
-  - and
-  - claude
-  - development
-  - json
-  - schema
-  - skills
-  - tools
-  - transformation
-  - validation
-  - zod
+  - json schema validation
+  - ajv json schema
+  - json data transformation
+  - json schema claude code
+  - validate json payloads
 readingTime: 5
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the JSON schema validation/transformation skill (grounded on ajv.js.org + retrievalSources).

- `keywords`: replaced junk single tokens (including `and`) with real query phrases (`json schema validation`, `ajv json schema`, `json data transformation`).

`pnpm validate:content:strict` and the content-policy scan pass locally.