### PR TITLE
docs(content): improve Markdown KB composer skill keywords

### DIFF
--- a/content/skills/markdown-knowledge-base-composer.mdx
+++ b/content/skills/markdown-knowledge-base-composer.mdx
@@ -13,6 +13,8 @@ repoUrl: "https://github.com/remarkjs/remark"
 documentationUrl: "https://github.com/remarkjs/remark"
 downloadUrl: /downloads/skills/markdown-knowledge-base-composer.zip
 installable: true
+safetyNotes:
+  - "Installs npm packages (remark, unified) and runs scripts that read your Markdown files and write composed/transformed output to disk, overwriting files at the target path; review before running on an existing knowledge base."
 installCommand: npm i remark unified
 usageSnippet: npm i remark unified
 copySnippet: |-
@@ -63,17 +65,11 @@ tags:
   - remark
   - node
 keywords:
-  - base
-  - claude
-  - composer
-  - development
-  - docs
-  - knowledge
-  - markdown
-  - node
-  - remark
-  - skills
-  - tools
+  - markdown knowledge base
+  - markdown docs generator
+  - remark markdown processing
+  - knowledge base claude code
+  - markdown automation
 readingTime: 5
 packageVerified: true
 difficultyScore: 96


### PR DESCRIPTION
Catalog keyword hygiene + required notes for the Markdown knowledge-base composer skill (grounded on remark + retrievalSources).

- `keywords`: junk single tokens (`base`, `claude`, `docs`, `node`, `skills`, `tools`) → real query phrases (`markdown knowledge base`, `remark markdown processing`).
- Added `safetyNotes` (installs remark/unified; reads/writes Markdown files) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.