### PR TITLE
docs(content): improve Supabase realtime database skill keywords

### DIFF
--- a/content/skills/supabase-realtime-database.mdx
+++ b/content/skills/supabase-realtime-database.mdx
@@ -65,16 +65,11 @@ tags:
   - backend
   - database
 keywords:
-  - backend
-  - builder
-  - claude
-  - database
-  - development
-  - postgres
-  - realtime
-  - skills
-  - supabase
-  - tools
+  - supabase realtime
+  - supabase claude code
+  - supabase postgres database
+  - realtime subscriptions
+  - supabase backend
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the Supabase realtime database skill (grounded on supabase.com/docs + retrievalSources).

- `keywords`: junk single tokens → real query phrases (`supabase realtime`, `supabase claude code`, `realtime subscriptions`).

`pnpm validate:content:strict` and the content-policy scan pass locally.