### PR TITLE
docs(content): ground image-OCR table extraction + keywords

### DIFF
--- a/content/skills/image-ocr-table-extraction.mdx
+++ b/content/skills/image-ocr-table-extraction.mdx
@@ -34,6 +34,7 @@ retrievalSources:
   - "https://tesseract-ocr.github.io/"
   - "https://docs.opencv.org/"
   - "https://pypi.org/project/pytesseract/"
+  - "https://github.com/xavctn/img2table"
 testedPlatforms:
   - Claude
   - Codex
@@ -59,18 +60,11 @@ tags:
   - opencv
   - tables
 keywords:
-  - and
-  - claude
-  - development
-  - extraction
-  - image
-  - ocr
-  - opencv
-  - pytesseract
-  - skills
-  - table
-  - tables
-  - tools
+  - image ocr extraction
+  - table extraction ocr
+  - tesseract ocr python
+  - extract tables from images
+  - pytesseract opencv
 readingTime: 5
 packageVerified: true
 difficultyScore: 96


### PR DESCRIPTION
Resubmit of #3101 (declined: grounding — sources verified OCR/OpenCV but not the table-to-CSV/JSON reconstruction claim).

**Fix:** added `https://github.com/xavctn/img2table` to `retrievalSources` — a real OSS library for extracting tables from images to DataFrame/CSV — so the table-reconstruction claim is grounded alongside Tesseract/OpenCV/pytesseract. Plus the original keyword fix.

`pnpm validate:content:strict` and the content-policy scan pass locally.