### PR TITLE
docs(content): improve v0 rapid prototyping skill keywords

### DIFF
--- a/content/skills/v0-rapid-prototyping.mdx
+++ b/content/skills/v0-rapid-prototyping.mdx
@@ -112,15 +112,11 @@ tags:
   - shadcn
   - react
 keywords:
-  - claude
-  - development
-  - prototyping
-  - rapid
-  - react
-  - shadcn
-  - skills
-  - tools
-  - workflow
+  - v0 rapid prototyping
+  - v0 vercel ui
+  - shadcn ui generation
+  - react prototyping claude
+  - v0 to production
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the v0 rapid-prototyping skill (grounded on v0.app/docs + retrievalSources).

- `keywords`: junk single tokens → real query phrases (`v0 rapid prototyping`, `v0 vercel ui`, `shadcn ui generation`).

`pnpm validate:content:strict` and the content-policy scan pass locally.