### PR TITLE
docs(content): improve website crawler summarizer skill keywords

### DIFF
--- a/content/skills/website-crawler-summarizer.mdx
+++ b/content/skills/website-crawler-summarizer.mdx
@@ -58,18 +58,11 @@ tags:
   - summarization
   - readability
 keywords:
-  - and
-  - claude
-  - content
-  - crawler
-  - development
-  - readability
-  - scraping
-  - skills
-  - summarization
-  - summarizer
-  - tools
-  - website
+  - website crawler
+  - web scraping claude code
+  - content summarizer
+  - extract article text
+  - mozilla readability
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene for the website crawler/summarizer skill (grounded on mozilla/readability + retrievalSources).

- `keywords`: junk single tokens (incl. `and`) → real query phrases (`website crawler`, `web scraping claude code`, `extract article text`).

`pnpm validate:content:strict` and the content-policy scan pass locally.