### PR TITLE
docs(content): improve Windsurf collaborative dev skill keywords

### DIFF
--- a/content/skills/windsurf-collaborative-development.mdx
+++ b/content/skills/windsurf-collaborative-development.mdx
@@ -9,9 +9,13 @@ seoDescription: "Master collaborative AI-assisted development with Windsurf IDE'
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
-documentationUrl: "https://docs.codeium.com/windsurf"
+documentationUrl: "https://docs.windsurf.com/"
 downloadUrl: /downloads/skills/windsurf-collaborative-development.zip
 installable: true
+safetyNotes:
+  - "Setup downloads and unzips a package and changes Windsurf IDE configuration; review what it writes and run it in a trusted workspace."
+privacyNotes:
+  - "Windsurf (Cascade) sends your code and prompts to its AI backend to power multi-file operations; review Windsurf's data-handling settings and keep API keys and secrets out of committed config."
 installCommand: "curl -L https://heyclau.de/downloads/skills/windsurf-collaborative-development.zip -o windsurf-collaborative-development.zip && unzip -o windsurf-collaborative-development.zip -d ./windsurf-collaborative-development"
 usageSnippet: "Claude can guide you through Windsurf's AI-native development environment, featuring Cascade AI for context-aware multi-file operations, Flow collaboration patterns for team coordination, and intelligent code navigation. Windsurf is emerging as a powerful alternative to GitHub Copilot in 2025, with superior multi-file refactoring and real-time collaboration features."
 copySnippet: |-
@@ -50,7 +54,8 @@ skillLevel: advanced
 verificationStatus: draft
 verifiedAt: "2025-10-16"
 retrievalSources:
-  - "https://docs.codeium.com/windsurf"
+  - "https://docs.windsurf.com/"
+  - "https://docs.windsurf.com/windsurf/cascade/cascade"
 testedPlatforms:
   - Claude
   - Codex
@@ -72,17 +77,11 @@ tags:
   - ai-ide
   - workflow
 keywords:
-  - ai-ide
-  - cascade
-  - claude
-  - collaboration
-  - collaborative
-  - development
-  - native
-  - skills
-  - tools
-  - windsurf
-  - workflow
+  - windsurf cascade
+  - windsurf ai ide
+  - windsurf claude
+  - cascade multi-file editing
+  - windsurf collaboration
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Catalog keyword hygiene + required notes for the Windsurf collaborative-development skill.

- `keywords`: junk single tokens → real query phrases (`windsurf cascade`, `windsurf ai ide`, `cascade multi-file editing`).
- `documentationUrl`/`retrievalSources`: moved legacy `docs.codeium.com/windsurf` → current `docs.windsurf.com` (+ Cascade docs).
- Added `safetyNotes`/`privacyNotes` (downloads/unzips + IDE config; Cascade sends code to AI backend) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.