### PR TITLE
docs(content): improve accessibility-first statusline keywords

### DIFF
--- a/content/statuslines/accessibility-first-statusline.mdx
+++ b/content/statuslines/accessibility-first-statusline.mdx
@@ -17,7 +17,14 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://www.w3.org/WAI/WCAG22/quickref/?versions=2.1"
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+  - "https://www.w3.org/WAI/WCAG22/quickref/?versions=2.1"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 installable: true
 usageSnippet: "▪ Model: claude-sonnet-4.5 | Directory: ~/projects/my-app | Tokens: 12450"
 copySnippet: |-
@@ -158,18 +165,11 @@ tags:
   - inclusive
   - a11y
 keywords:
-  - a11y
-  - accessibility
-  - claude
-  - development
-  - first
-  - high-contrast
-  - inclusive
-  - screen-reader
-  - statusline
-  - statuslines
-  - tools
-  - wcag
+  - accessible claude statusline
+  - screen reader statusline
+  - high contrast statusline
+  - wcag statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 10
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the accessibility-first statusline.

- `keywords`: junk single tokens → real query phrases (`accessible claude statusline`, `screen reader statusline`).
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (mechanism) + WCAG quickref (accessibility claims).
- Added `safetyNotes`/`privacyNotes` (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.