### PR TITLE
docs(content): improve api-latency-breakdown statusline keywords

### DIFF
--- a/content/statuslines/api-latency-breakdown.mdx
+++ b/content/statuslines/api-latency-breakdown.mdx
@@ -161,18 +161,10 @@ tags:
   - bottleneck
   - network
 keywords:
-  - api
-  - api-latency
-  - bottleneck
-  - breakdown
-  - claude
-  - development
-  - latency
-  - monitoring
-  - network
-  - performance
-  - statuslines
-  - tools
+  - claude api latency statusline
+  - ttft statusline
+  - network latency breakdown statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the api-latency-breakdown statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.