### PR TITLE
docs(content): improve block-timer-tracker statusline keywords

### DIFF
--- a/content/statuslines/block-timer-tracker.mdx
+++ b/content/statuslines/block-timer-tracker.mdx
@@ -172,19 +172,17 @@ tags:
   - 5-hour-limit
   - warnings
   - productivity
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - 5-hour-limit
-  - block
-  - claude
-  - countdown
-  - development
-  - productivity
-  - session-block
-  - statuslines
-  - timer
-  - tools
-  - tracker
-  - warnings
+  - claude 5 hour block timer
+  - session block countdown statusline
+  - claude usage block tracker
+  - claude code statusline
 readingTime: 2
 difficultyScore: 5
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the block-timer-tracker statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.