### PR TITLE
docs(content): improve daily-usage-percentage-tracker statusline keywords

### DIFF
--- a/content/statuslines/daily-usage-percentage-tracker.mdx
+++ b/content/statuslines/daily-usage-percentage-tracker.mdx
@@ -59,20 +59,17 @@ tags:
   - usage-percentage
   - budget-pacing
   - limit-monitoring
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - budget-pacing
-  - claude
-  - daily
-  - daily-limit
-  - development
-  - limit-monitoring
-  - percentage
-  - quota-tracking
-  - statuslines
-  - tools
-  - tracker
-  - usage
-  - usage-percentage
+  - claude daily usage percentage
+  - daily limit tracker statusline
+  - quota pacing statusline
+  - claude code statusline
 readingTime: 3
 difficultyScore: 8
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the daily-usage-percentage-tracker statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.