### PR TITLE
docs(content): improve five-hour-window-tracker statusline keywords

### DIFF
--- a/content/statuslines/five-hour-window-tracker.mdx
+++ b/content/statuslines/five-hour-window-tracker.mdx
@@ -156,19 +156,10 @@ tags:
   - countdown
   - rolling-window
 keywords:
-  - 5-hour-window
-  - claude
-  - countdown
-  - development
-  - five
-  - hour
-  - rolling-window
-  - session-tracking
-  - statuslines
-  - tools
-  - tracker
-  - usage-limits
-  - window
+  - claude 5 hour window tracker
+  - rolling usage window statusline
+  - claude session limit countdown
+  - claude code statusline
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the five-hour-window-tracker statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.