### PR TITLE
docs(content): improve lines-per-minute-tracker statusline keywords

### DIFF
--- a/content/statuslines/lines-per-minute-tracker.mdx
+++ b/content/statuslines/lines-per-minute-tracker.mdx
@@ -55,20 +55,17 @@ tags:
   - coding-speed
   - lines-per-minute
   - output-tracking
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - coding-speed
-  - development
-  - lines
-  - lines-per-minute
-  - minute
-  - output-tracking
-  - per
-  - productivity
-  - statuslines
-  - tools
-  - tracker
-  - velocity
+  - coding speed statusline
+  - lines per minute tracker
+  - claude output velocity statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 5
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the lines-per-minute-tracker statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.