### PR TITLE
docs(content): improve mcp-server-status-monitor statusline keywords

### DIFF
--- a/content/statuslines/mcp-server-status-monitor.mdx
+++ b/content/statuslines/mcp-server-status-monitor.mdx
@@ -59,18 +59,18 @@ tags:
   - servers
   - tools
   - performance
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - development
-  - mcp
-  - monitor
-  - monitoring
-  - performance
-  - server
-  - servers
-  - status
-  - statuslines
-  - tools
+  - mcp server status statusline
+  - claude mcp monitor
+  - mcp connection statusline
+  - claude code statusline
 readingTime: 1
 difficultyScore: 3
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the mcp-server-status-monitor statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.