### PR TITLE
docs(content): improve model-switch-history-tracker statusline keywords

### DIFF
--- a/content/statuslines/model-switch-history-tracker.mdx
+++ b/content/statuslines/model-switch-history-tracker.mdx
@@ -64,20 +64,13 @@ tags:
   - cost-optimization
   - model-tracking
   - switch-history
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - cost-optimization
-  - development
-  - history
-  - model
-  - model-switching
-  - model-tracking
-  - opus-sonnet-haiku
-  - statuslines
-  - switch
-  - switch-history
-  - tools
-  - tracker
+  - claude model switch history
+  - opus sonnet haiku tracker
+  - model switching statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the model-switch-history-tracker statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.