### PR TITLE
docs(content): improve multi-line statusline keywords

### DIFF
--- a/content/statuslines/multi-line-statusline.mdx
+++ b/content/statuslines/multi-line-statusline.mdx
@@ -156,20 +156,18 @@ tags:
   - bash
   - powerline
   - dashboard
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - bash
-  - claude
-  - comprehensive
-  - dashboard
-  - detailed
-  - development
-  - line
-  - multi
-  - multi-line
-  - powerline
-  - statusline
-  - statuslines
-  - tools
+  - multi-line claude statusline
+  - detailed dashboard statusline
+  - comprehensive claude statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the multi-line statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.