### PR TITLE
docs(content): improve multi-provider-token-counter statusline keywords

### DIFF
--- a/content/statuslines/multi-provider-token-counter.mdx
+++ b/content/statuslines/multi-provider-token-counter.mdx
@@ -67,19 +67,10 @@ tags:
   - ai-models
   - monitoring
 keywords:
-  - ai-models
-  - claude
-  - context-limits
-  - counter
-  - development
-  - monitoring
-  - multi
-  - multi-provider
-  - provider
-  - statuslines
-  - token
-  - tokens
-  - tools
+  - multi provider token counter
+  - ai model token statusline
+  - context limit statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the multi-provider-token-counter statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.