### PR TITLE
docs(content): improve session-timer statusline keywords

### DIFF
--- a/content/statuslines/session-timer-statusline.mdx
+++ b/content/statuslines/session-timer-statusline.mdx
@@ -60,19 +60,18 @@ tags:
   - bash
   - time-tracking
   - analytics
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - analytics
-  - bash
-  - claude
-  - development
-  - metrics
-  - productivity
-  - session
-  - statusline
-  - statuslines
-  - time-tracking
-  - timer
-  - tools
+  - claude session timer statusline
+  - session time tracking statusline
+  - productivity timer statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the session-timer statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.