### PR TITLE
docs(content): improve simple-text statusline keywords

### DIFF
--- a/content/statuslines/simple-text-statusline.mdx
+++ b/content/statuslines/simple-text-statusline.mdx
@@ -89,19 +89,18 @@ tags:
   - bash
   - lightweight
   - no-dependencies
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - bash
-  - claude
-  - development
-  - lightweight
-  - minimal
-  - no-dependencies
-  - plain-text
-  - simple
-  - statusline
-  - statuslines
-  - text
-  - tools
+  - minimal claude statusline
+  - plain text statusline
+  - lightweight statusline
+  - claude code statusline
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the simple-text statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.