### PR TITLE
docs(content): improve workspace-project-depth-indicator statusline keywords

### DIFF
--- a/content/statuslines/workspace-project-depth-indicator.mdx
+++ b/content/statuslines/workspace-project-depth-indicator.mdx
@@ -55,20 +55,17 @@ tags:
   - directory-depth
   - project-context
   - workspace-tracking
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - depth
-  - development
-  - directory-depth
-  - indicator
-  - monorepo-navigation
-  - project
-  - project-context
-  - statuslines
-  - tools
-  - workspace
-  - workspace-depth
-  - workspace-tracking
+  - workspace depth statusline
+  - monorepo path statusline
+  - project directory depth statusline
+  - claude code statusline
 readingTime: 3
 difficultyScore: 8
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the workspace-project-depth-indicator statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.