### PR TITLE
docs(content): improve catppuccin-mocha-theme statusline keywords

### DIFF
--- a/content/statuslines/catppuccin-mocha-theme.mdx
+++ b/content/statuslines/catppuccin-mocha-theme.mdx
@@ -132,17 +132,17 @@ tags:
   - theme
   - powerline
   - aesthetics
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - aesthetics
-  - catppuccin
-  - claude
-  - development
-  - mocha
-  - pastel
-  - powerline
-  - statuslines
-  - theme
-  - tools
+  - catppuccin mocha statusline
+  - catppuccin claude theme
+  - pastel powerline statusline
+  - claude code statusline theme
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the catppuccin-mocha-theme statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.