### PR TITLE
docs(content): improve docker-health statusline keywords

### DIFF
--- a/content/statuslines/docker-health-statusline.mdx
+++ b/content/statuslines/docker-health-statusline.mdx
@@ -62,20 +62,17 @@ tags:
   - CLI
   - claude-code
   - devops
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - claude-code
-  - CLI
-  - containers
-  - development
-  - devops
-  - docker
-  - health
-  - health-check
-  - monitoring
-  - statusline
-  - statuslines
-  - tools
+  - docker container health statusline
+  - docker stats statusline
+  - container monitoring statusline
+  - claude code statusline
 readingTime: 1
 difficultyScore: 2
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the docker-health statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.