### PR TITLE
docs(content): improve git-status statusline keywords

### DIFF
--- a/content/statuslines/git-status-statusline.mdx
+++ b/content/statuslines/git-status-statusline.mdx
@@ -116,19 +116,17 @@ tags:
   - bash
   - powerline
   - status-indicators
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - bash
-  - claude
-  - developer
-  - development
-  - git
-  - powerline
-  - status
-  - status-indicators
-  - statusline
-  - statuslines
-  - tools
-  - version-control
+  - git status statusline
+  - git branch statusline
+  - version control statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 3
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the git-status statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.