### PR TITLE
docs(content): improve oh-my-zsh robbyrussell statusline keywords

### DIFF
--- a/content/statuslines/oh-my-zsh-robbyrussell.mdx
+++ b/content/statuslines/oh-my-zsh-robbyrussell.mdx
@@ -19,6 +19,7 @@ authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
 documentationUrl: "https://github.com/ohmyzsh/ohmyzsh/wiki/Themes#robbyrussell"
 retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
   - "https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme"
   - "https://docs.claude.com/en/docs/claude-code/statusline"
 installable: true
@@ -138,17 +139,13 @@ tags:
   - shell-replica
   - git-integration
   - classic
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
 keywords:
-  - classic
-  - claude
-  - development
-  - git-integration
-  - oh-my-zsh
-  - robbyrussell
-  - shell-replica
-  - statuslines
-  - tools
-  - zsh
+  - oh my zsh robbyrussell statusline
+  - zsh theme statusline
+  - robbyrussell claude statusline
+  - claude code statusline
 readingTime: 1
 difficultyScore: 3
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the oh-my-zsh robbyrussell statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.