### PR TITLE
docs(content): improve starship-powerline statusline keywords

### DIFF
--- a/content/statuslines/starship-powerline-theme.mdx
+++ b/content/statuslines/starship-powerline-theme.mdx
@@ -112,16 +112,18 @@ tags:
   - nerd-fonts
   - git
   - theme
+documentationUrl: "https://code.claude.com/docs/en/statusline"
+retrievalSources:
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Runs as a Claude Code statusline command on every refresh and depends on the local shell environment; a failure only affects status rendering, not your session."
+privacyNotes:
+  - "Reads the Claude Code statusline JSON from stdin (model, workspace path, token usage) and renders it in the local terminal; it does not send data off-machine."
 keywords:
-  - claude
-  - development
-  - git
-  - nerd-fonts
-  - powerline
-  - starship
-  - statuslines
-  - theme
-  - tools
+  - starship statusline claude
+  - powerline nerd font statusline
+  - starship theme statusline
+  - claude code statusline
 readingTime: 1
 difficultyScore: 2
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene + grounding for the starship-powerline statusline.

- `keywords`: junk single tokens → real query phrases.
- `documentationUrl`/`retrievalSources`: grounded on Claude Code statusline docs (plus the relevant upstream where applicable).
- Added `safetyNotes`/`privacyNotes` where missing (runs as statusline command; reads session JSON) — required by the content-policy scan.

`pnpm validate:content:strict` and the content-policy scan pass locally.