### PR TITLE
docs(content): improve API development starter kit collection keywords

### DIFF
--- a/content/collections/api-development-starter-kit.mdx
+++ b/content/collections/api-development-starter-kit.mdx
@@ -44,17 +44,10 @@ tags:
   - documentation
   - testing
 keywords:
-  - api
-  - backend
-  - claude
-  - collections
-  - development
-  - documentation
-  - kit
-  - rest
-  - starter
-  - testing
-  - tools
+  - api development starter kit
+  - rest api claude collection
+  - openapi tooling collection
+  - api testing tools claude
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the API development starter kit collection: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.