### PR TITLE
docs(content): improve code quality toolkit collection keywords

### DIFF
--- a/content/collections/code-quality-toolkit.mdx
+++ b/content/collections/code-quality-toolkit.mdx
@@ -40,18 +40,10 @@ tags:
   - best-practices
   - refactoring
 keywords:
-  - best-practices
-  - claude
-  - code
-  - code-quality
-  - collections
-  - development
-  - quality
-  - refactoring
-  - review
-  - testing
-  - toolkit
-  - tools
+  - code quality toolkit claude
+  - code review tools collection
+  - refactoring tools claude
+  - code quality automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the code quality toolkit collection: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.