### PR TITLE
docs(content): improve data engineering suite collection keywords

### DIFF
--- a/content/collections/data-engineering-suite.mdx
+++ b/content/collections/data-engineering-suite.mdx
@@ -56,17 +56,10 @@ tags:
   - cloud
   - engineering
 keywords:
-  - claude
-  - cloud
-  - collections
-  - data
-  - database
-  - development
-  - engineering
-  - etl
-  - sql
-  - suite
-  - tools
+  - data engineering suite claude
+  - etl pipeline tools collection
+  - sql data tools claude
+  - data engineering automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the data engineering suite collection: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.