### PR TITLE
docs(content): improve production readiness toolkit collection keywords

### DIFF
--- a/content/collections/production-readiness-toolkit.mdx
+++ b/content/collections/production-readiness-toolkit.mdx
@@ -57,18 +57,10 @@ tags:
   - deployment
   - best-practices
 keywords:
-  - best-practices
-  - claude
-  - code-quality
-  - collections
-  - compliance
-  - deployment
-  - development
-  - production
-  - readiness
-  - security
-  - toolkit
-  - tools
+  - production readiness toolkit
+  - deployment checklist tools claude
+  - production security tools collection
+  - release readiness automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the production readiness toolkit collection: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.