### PR TITLE
docs(content): improve backend-development-suite collection keywords

### DIFF
--- a/content/collections/backend-development-suite.mdx
+++ b/content/collections/backend-development-suite.mdx
@@ -17,6 +17,12 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-02"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/mcp"
+privacyNotes:
+  - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 installable: false
 usageSnippet: >-
   Start with `backend-architect-agent` → `database-specialist-agent` →
@@ -50,17 +56,10 @@ tags:
   - aws
   - infrastructure
 keywords:
-  - architecture
-  - aws
-  - backend
-  - claude
-  - cloud
-  - collections
-  - database
-  - development
-  - infrastructure
-  - suite
-  - tools
+  - backend development collection
+  - backend agents claude
+  - database and cloud backend tools
+  - scalable backend suite claude
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the backend-development-suite collection: junk single-token `keywords` → real search phrases; grounded `documentationUrl`/`retrievalSources` on Claude Code sub-agents + MCP docs; added `privacyNotes` (bundled cloud/DB tools use your credentials) required by the content-policy scan. Local scan + `pnpm validate:content:strict` pass.