### PR TITLE
docs(content): improve content-creation-workflow collection keywords

### DIFF
--- a/content/collections/content-creation-workflow.mdx
+++ b/content/collections/content-creation-workflow.mdx
@@ -15,6 +15,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-02"
+documentationUrl: "https://code.claude.com/docs/en/mcp"
+retrievalSources:
+  - "https://code.claude.com/docs/en/mcp"
+privacyNotes:
+  - "Bundles MCP servers that connect to third-party SaaS accounts (project management, design, and asset hosting); each uses your own API tokens and sends project and content data to those services, so review their terms and scope tokens to least privilege."
 installable: false
 usageSnippet: Start with `asana-mcp-server` → `clickup-mcp-server` → `canva-mcp-server`
 items:
@@ -48,17 +53,10 @@ tags:
   - automation
   - social-media
 keywords:
-  - automation
-  - claude
-  - collections
-  - content
-  - creation
-  - design
-  - development
-  - marketing
-  - social-media
-  - tools
-  - workflow
+  - content creation workflow claude
+  - marketing automation tools collection
+  - content tools for claude
+  - social media content workflow
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true

--- a/content/collections/content-creation-workflow.mdx
+++ b/content/collections/content-creation-workflow.mdx
@@ -18,6 +18,8 @@ dateAdded: "2025-10-02"
 documentationUrl: "https://code.claude.com/docs/en/mcp"
 retrievalSources:
   - "https://code.claude.com/docs/en/mcp"
+safetyNotes:
+  - "Bundles MCP servers that install via npm and make authenticated network calls to external SaaS APIs (and can create/modify projects, designs, and uploaded assets in those accounts); review each server and its configured scopes before enabling."
 privacyNotes:
   - "Bundles MCP servers that connect to third-party SaaS accounts (project management, design, and asset hosting); each uses your own API tokens and sends project and content data to those services, so review their terms and scope tokens to least privilege."
 installable: false


### PR DESCRIPTION
Catalog hygiene for the content-creation-workflow collection: junk single-token `keywords` → real search phrases; grounded `documentationUrl`/`retrievalSources` on Claude Code MCP docs; added `privacyNotes` (bundled SaaS MCP servers send project/content data to third parties) required by the content-policy scan. Local scan + `pnpm validate:content:strict` pass.