### PR TITLE
docs(content): improve developer-productivity-booster collection keywords

### DIFF
--- a/content/collections/developer-productivity-booster.mdx
+++ b/content/collections/developer-productivity-booster.mdx
@@ -18,6 +18,12 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-02"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
+retrievalSources:
+  - "https://code.claude.com/docs/en/hooks"
+  - "https://code.claude.com/docs/en/statusline"
+safetyNotes:
+  - "Bundles hooks that run automatically on Claude Code events and write to your working tree (auto-formatting files and creating backups), plus statuslines that execute a command on every refresh; review each bundled hook/statusline script before enabling so it only touches paths you expect."
 installable: false
 usageSnippet: >-
   Start with `auto-code-formatter-hook` → `auto-save-backup` →
@@ -55,17 +61,10 @@ tags:
   - efficiency
   - developer-tools
 keywords:
-  - automation
-  - booster
-  - claude
-  - collections
-  - developer
-  - developer-tools
-  - development
-  - efficiency
-  - productivity
-  - tools
-  - workflow
+  - developer productivity collection claude
+  - productivity hooks and statuslines
+  - workflow automation tools claude
+  - developer efficiency toolkit
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the developer-productivity-booster collection: junk single-token `keywords` → real search phrases; grounded `documentationUrl`/`retrievalSources` on Claude Code hooks + statusline docs; added `safetyNotes` (bundled hooks auto-run and write to the working tree; statuslines run a command each refresh) required by the content-policy scan. Local scan + `pnpm validate:content:strict` pass.