### PR TITLE
docs(content): improve asana-mcp-server keywords

### DIFF
--- a/content/mcp/asana-mcp-server.mdx
+++ b/content/mcp/asana-mcp-server.mdx
@@ -67,17 +67,10 @@ tags:
   - team-collaboration
   - workflow
 keywords:
-  - asana
-  - claude
-  - development
-  - mcp
-  - mcp servers
-  - project-management
-  - server
-  - tasks
-  - team-collaboration
-  - tools
-  - workflow
+  - asana mcp server
+  - claude asana integration
+  - asana task management mcp
+  - connect claude to asana
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the asana-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.