### PR TITLE
docs(content): improve canva-mcp-server keywords

### DIFF
--- a/content/mcp/canva-mcp-server.mdx
+++ b/content/mcp/canva-mcp-server.mdx
@@ -69,17 +69,10 @@ tags:
   - templates
   - creative
 keywords:
-  - canva
-  - claude
-  - creative
-  - design
-  - development
-  - graphics
-  - mcp
-  - mcp servers
-  - server
-  - templates
-  - tools
+  - canva mcp server
+  - claude canva integration
+  - canva design automation mcp
+  - connect claude to canva
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the canva-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.