### PR TITLE
docs(content): improve clickup-mcp-server keywords

### DIFF
--- a/content/mcp/clickup-mcp-server.mdx
+++ b/content/mcp/clickup-mcp-server.mdx
@@ -87,17 +87,10 @@ tags:
   - productivity
   - team-collaboration
 keywords:
-  - claude
-  - clickup
-  - development
-  - mcp
-  - mcp servers
-  - productivity
-  - project-management
-  - server
-  - tasks
-  - team-collaboration
-  - tools
+  - clickup mcp server
+  - claude clickup integration
+  - clickup task management mcp
+  - connect claude to clickup
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the clickup-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.