### PR TITLE
docs(content): improve cloudinary-mcp-server keywords

### DIFF
--- a/content/mcp/cloudinary-mcp-server.mdx
+++ b/content/mcp/cloudinary-mcp-server.mdx
@@ -79,17 +79,10 @@ tags:
   - video
   - asset-management
 keywords:
-  - asset-management
-  - claude
-  - cloudinary
-  - development
-  - images
-  - mcp
-  - mcp servers
-  - media
-  - server
-  - tools
-  - video
+  - cloudinary mcp server
+  - claude cloudinary integration
+  - cloudinary media management mcp
+  - image asset mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the cloudinary-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.