### PR TITLE
docs(content): improve filesystem-mcp-server keywords

### DIFF
--- a/content/mcp/filesystem-mcp-server.mdx
+++ b/content/mcp/filesystem-mcp-server.mdx
@@ -78,17 +78,10 @@ tags:
   - official
   - anthropic
 keywords:
-  - anthropic
-  - claude
-  - development
-  - directories
-  - files
-  - filesystem
-  - mcp
-  - mcp servers
-  - official
-  - server
-  - tools
+  - filesystem mcp server
+  - claude filesystem access mcp
+  - local file mcp server
+  - official filesystem mcp
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the filesystem-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.