### PR TITLE
docs(content): improve fireflies-mcp-server keywords

### DIFF
--- a/content/mcp/fireflies-mcp-server.mdx
+++ b/content/mcp/fireflies-mcp-server.mdx
@@ -62,17 +62,10 @@ tags:
   - notes
   - ai-assistant
 keywords:
-  - ai-assistant
-  - claude
-  - development
-  - fireflies
-  - mcp
-  - mcp servers
-  - meetings
-  - notes
-  - server
-  - tools
-  - transcription
+  - fireflies mcp server
+  - claude fireflies integration
+  - meeting transcription mcp
+  - fireflies ai notes mcp
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the fireflies-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.