### PR TITLE
docs(content): improve git-mcp-server keywords

### DIFF
--- a/content/mcp/git-mcp-server.mdx
+++ b/content/mcp/git-mcp-server.mdx
@@ -82,17 +82,10 @@ tags:
   - official
   - anthropic
 keywords:
-  - anthropic
-  - claude
-  - development
-  - git
-  - mcp
-  - mcp servers
-  - official
-  - repositories
-  - server
-  - tools
-  - version-control
+  - git mcp server
+  - claude git integration mcp
+  - local git repository mcp
+  - official git mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the git-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.