### PR TITLE
docs(content): improve github-mcp-server keywords

### DIFF
--- a/content/mcp/github-mcp-server.mdx
+++ b/content/mcp/github-mcp-server.mdx
@@ -91,17 +91,10 @@ tags:
   - api
   - official
 keywords:
-  - api
-  - claude
-  - development
-  - git
-  - github
-  - mcp
-  - mcp servers
-  - official
-  - repositories
-  - server
-  - tools
+  - github mcp server
+  - claude github integration
+  - github api mcp server
+  - connect claude to github
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the github-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.