### PR TITLE
docs(content): improve hubspot-mcp-server keywords

### DIFF
--- a/content/mcp/hubspot-mcp-server.mdx
+++ b/content/mcp/hubspot-mcp-server.mdx
@@ -69,17 +69,10 @@ tags:
   - marketing
   - customer-data
 keywords:
-  - claude
-  - crm
-  - customer-data
-  - development
-  - hubspot
-  - marketing
-  - mcp
-  - mcp servers
-  - sales
-  - server
-  - tools
+  - hubspot mcp server
+  - claude hubspot crm integration
+  - hubspot mcp for claude
+  - connect claude to hubspot
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the hubspot-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.