### PR TITLE
docs(content): improve hugging-face-mcp-server keywords

### DIFF
--- a/content/mcp/hugging-face-mcp-server.mdx
+++ b/content/mcp/hugging-face-mcp-server.mdx
@@ -69,18 +69,10 @@ tags:
   - models
   - datasets
 keywords:
-  - claude
-  - datasets
-  - development
-  - face
-  - hugging
-  - hugging-face
-  - machine-learning
-  - mcp
-  - mcp servers
-  - models
-  - server
-  - tools
+  - hugging face mcp server
+  - claude hugging face integration
+  - huggingface models mcp
+  - hf datasets mcp server
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the hugging-face-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.