### PR TITLE
docs(content): improve intercom-mcp-server keywords

### DIFF
--- a/content/mcp/intercom-mcp-server.mdx
+++ b/content/mcp/intercom-mcp-server.mdx
@@ -72,17 +72,10 @@ tags:
   - helpdesk
   - crm
 keywords:
-  - chat
-  - claude
-  - crm
-  - customer-support
-  - development
-  - helpdesk
-  - intercom
-  - mcp
-  - mcp servers
-  - server
-  - tools
+  - intercom mcp server
+  - claude intercom integration
+  - customer support mcp server
+  - connect claude to intercom
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the intercom-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.