### PR TITLE
docs(content): improve invideo-mcp-server keywords

### DIFF
--- a/content/mcp/invideo-mcp-server.mdx
+++ b/content/mcp/invideo-mcp-server.mdx
@@ -69,17 +69,10 @@ tags:
   - content-creation
   - ai-video
 keywords:
-  - ai-video
-  - claude
-  - content-creation
-  - development
-  - invideo
-  - mcp
-  - mcp servers
-  - media
-  - server
-  - tools
-  - video
+  - invideo mcp server
+  - claude invideo integration
+  - ai video generation mcp
+  - invideo mcp for claude
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the invideo-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.