### PR TITLE
docs(content): improve jam-mcp-server keywords

### DIFF
--- a/content/mcp/jam-mcp-server.mdx
+++ b/content/mcp/jam-mcp-server.mdx
@@ -73,17 +73,10 @@ tags:
   - bug-tracking
   - developer-tools
 keywords:
-  - bug-tracking
-  - claude
-  - debugging
-  - developer-tools
-  - development
-  - jam
-  - mcp
-  - mcp servers
-  - server
-  - testing
-  - tools
+  - jam mcp server
+  - claude jam debugging integration
+  - bug report mcp server
+  - jam.dev mcp for claude
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the jam-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.