### PR TITLE
docs(content): improve jira-mcp-server keywords

### DIFF
--- a/content/mcp/jira-mcp-server.mdx
+++ b/content/mcp/jira-mcp-server.mdx
@@ -70,17 +70,10 @@ tags:
   - project-management
   - documentation
 keywords:
-  - atlassian
-  - claude
-  - confluence
-  - development
-  - documentation
-  - jira
-  - mcp
-  - mcp servers
-  - project-management
-  - server
-  - tools
+  - jira mcp server
+  - claude jira integration
+  - jira issue tracking mcp
+  - connect claude to jira
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the jira-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.