### PR TITLE
docs(content): improve linear-mcp-server keywords

### DIFF
--- a/content/mcp/linear-mcp-server.mdx
+++ b/content/mcp/linear-mcp-server.mdx
@@ -65,17 +65,10 @@ tags:
   - tasks
   - agile
 keywords:
-  - agile
-  - claude
-  - development
-  - issues
-  - linear
-  - mcp
-  - mcp servers
-  - project-management
-  - server
-  - tasks
-  - tools
+  - linear mcp server
+  - claude linear integration
+  - linear issue tracking mcp
+  - connect claude to linear
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the linear-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.