### PR TITLE
docs(content): improve monday-mcp-server keywords

### DIFF
--- a/content/mcp/monday-mcp-server.mdx
+++ b/content/mcp/monday-mcp-server.mdx
@@ -70,17 +70,10 @@ tags:
   - workflow
   - team-management
 keywords:
-  - claude
-  - crm
-  - development
-  - mcp
-  - mcp servers
-  - monday
-  - project-management
-  - server
-  - team-management
-  - tools
-  - workflow
+  - monday.com mcp server
+  - claude monday integration
+  - monday project management mcp
+  - connect claude to monday
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the monday-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.