### PR TITLE
docs(content): improve notion-mcp-server keywords

### DIFF
--- a/content/mcp/notion-mcp-server.mdx
+++ b/content/mcp/notion-mcp-server.mdx
@@ -71,17 +71,10 @@ tags:
   - notes
   - knowledge-base
 keywords:
-  - claude
-  - development
-  - documentation
-  - knowledge-base
-  - mcp
-  - mcp servers
-  - notes
-  - notion
-  - server
-  - tools
-  - wiki
+  - notion mcp server
+  - claude notion integration
+  - notion knowledge base mcp
+  - connect claude to notion
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the notion-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.