### PR TITLE
docs(content): improve paypal-mcp-server keywords

### DIFF
--- a/content/mcp/paypal-mcp-server.mdx
+++ b/content/mcp/paypal-mcp-server.mdx
@@ -75,17 +75,10 @@ tags:
   - transactions
   - financial
 keywords:
-  - claude
-  - commerce
-  - development
-  - financial
-  - mcp
-  - mcp servers
-  - payments
-  - paypal
-  - server
-  - tools
-  - transactions
+  - paypal mcp server
+  - claude paypal integration
+  - paypal payments mcp
+  - connect claude to paypal
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the paypal-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.