### PR TITLE
docs(content): improve plaid-mcp-server keywords

### DIFF
--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -72,17 +72,10 @@ tags:
   - financial-data
   - account-linking
 keywords:
-  - account-linking
-  - banking
-  - claude
-  - development
-  - financial-data
-  - fintech
-  - mcp
-  - mcp servers
-  - plaid
-  - server
-  - tools
+  - plaid mcp server
+  - claude plaid integration
+  - banking data mcp server
+  - plaid fintech mcp
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the plaid-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.