### PR TITLE
docs(content): improve postgresql-mcp-server keywords

### DIFF
--- a/content/mcp/postgresql-mcp-server.mdx
+++ b/content/mcp/postgresql-mcp-server.mdx
@@ -78,17 +78,10 @@ tags:
   - official
   - anthropic
 keywords:
-  - anthropic
-  - claude
-  - database
-  - development
-  - mcp
-  - mcp servers
-  - official
-  - postgresql
-  - server
-  - sql
-  - tools
+  - postgresql mcp server
+  - claude postgres integration
+  - postgresql database mcp
+  - official postgres mcp server
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the postgresql-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.