### PR TITLE
docs(content): improve sentry-mcp-server keywords

### DIFF
--- a/content/mcp/sentry-mcp-server.mdx
+++ b/content/mcp/sentry-mcp-server.mdx
@@ -61,17 +61,10 @@ tags:
   - errors
   - devops
 keywords:
-  - claude
-  - debugging
-  - development
-  - devops
-  - errors
-  - mcp
-  - mcp servers
-  - monitoring
-  - sentry
-  - server
-  - tools
+  - sentry mcp server
+  - claude sentry integration
+  - error monitoring mcp server
+  - connect claude to sentry
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the sentry-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.