### PR TITLE
docs(content): improve socket-mcp-server keywords

### DIFF
--- a/content/mcp/socket-mcp-server.mdx
+++ b/content/mcp/socket-mcp-server.mdx
@@ -68,18 +68,10 @@ tags:
   - npm
   - supply-chain
 keywords:
-  - claude
-  - dependencies
-  - development
-  - mcp
-  - mcp servers
-  - npm
-  - security
-  - server
-  - socket
-  - supply-chain
-  - tools
-  - vulnerability-scanning
+  - socket mcp server
+  - claude dependency security mcp
+  - npm vulnerability scanning mcp
+  - socket.dev mcp for claude
 readingTime: 1
 difficultyScore: 11
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the socket-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.