### PR TITLE
docs(content): improve vercel-mcp-server keywords

### DIFF
--- a/content/mcp/vercel-mcp-server.mdx
+++ b/content/mcp/vercel-mcp-server.mdx
@@ -65,17 +65,10 @@ tags:
   - devops
   - infrastructure
 keywords:
-  - claude
-  - deployment
-  - development
-  - devops
-  - hosting
-  - infrastructure
-  - mcp
-  - mcp servers
-  - server
-  - tools
-  - vercel
+  - vercel mcp server
+  - claude vercel integration
+  - vercel deployment mcp
+  - connect claude to vercel
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the vercel-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.