### PR TITLE
docs(content): improve zapier-mcp-server keywords

### DIFF
--- a/content/mcp/zapier-mcp-server.mdx
+++ b/content/mcp/zapier-mcp-server.mdx
@@ -58,17 +58,10 @@ tags:
   - workflow
   - no-code
 keywords:
-  - automation
-  - claude
-  - development
-  - integration
-  - mcp
-  - mcp servers
-  - no-code
-  - server
-  - tools
-  - workflow
-  - zapier
+  - zapier mcp server
+  - claude zapier integration
+  - zapier automation mcp
+  - connect claude to zapier
 readingTime: 1
 difficultyScore: 11
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the zapier-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.