### PR TITLE
docs(content): improve legal-fournier-spain-legal-mcp keywords

### DIFF
--- a/content/mcp/legal-fournier-spain-legal-mcp.mdx
+++ b/content/mcp/legal-fournier-spain-legal-mcp.mdx
@@ -49,18 +49,10 @@ tags:
   - nie
   - beckham-law
 keywords:
-  - mcp
-  - legal
-  - immigration
-  - spain
-  - visa
-  - residency
-  - nie
-  - beckham-law
-  - mcp servers
-  - claude
-  - heyclaude
-  - spain legal by legal fournier
+  - spain legal mcp server
+  - spain visa residency mcp
+  - beckham law nie mcp
+  - spain immigration mcp for claude
 robotsIndex: true
 robotsFollow: true
 ---


### PR DESCRIPTION
Catalog keyword hygiene for the legal-fournier-spain-legal-mcp entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.