### PR TITLE
docs(content): improve memesio-mcp-server keywords

### DIFF
--- a/content/mcp/memesio-mcp-server.mdx
+++ b/content/mcp/memesio-mcp-server.mdx
@@ -49,17 +49,10 @@ tags:
   - api
   - content
 keywords:
-  - mcp
-  - memes
-  - image-generation
-  - templates
-  - social-media
-  - api
-  - content
-  - mcp servers
-  - claude
-  - heyclaude
   - memesio mcp server
+  - meme generation mcp
+  - claude meme image mcp
+  - social media meme mcp
 robotsIndex: true
 robotsFollow: true
 ---


### PR DESCRIPTION
Catalog keyword hygiene for the memesio-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.