### PR TITLE
docs(content): improve packrift-mcp-server keywords

### DIFF
--- a/content/mcp/packrift-mcp-server.mdx
+++ b/content/mcp/packrift-mcp-server.mdx
@@ -54,16 +54,10 @@ tags:
   - inventory
   - ai-agents
 keywords:
-  - mcp
-  - ecommerce
-  - packaging
-  - catalog
-  - inventory
-  - ai-agents
-  - mcp servers
-  - claude
-  - heyclaude
   - packrift mcp server
+  - ecommerce catalog mcp
+  - inventory packaging mcp
+  - claude ecommerce mcp
 robotsIndex: true
 robotsFollow: true
 ---


### PR DESCRIPTION
Catalog keyword hygiene for the packrift-mcp-server entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.