### PR TITLE
docs(content): improve zyntra-mail keywords

### DIFF
--- a/content/mcp/zyntra-mail.mdx
+++ b/content/mcp/zyntra-mail.mdx
@@ -55,16 +55,10 @@ tags:
   - temp-mail
   - automation
 keywords:
-  - email
-  - testing
-  - disposable
-  - temp-mail
-  - automation
-  - mcp servers
-  - mcp
-  - claude
-  - heyclaude
-  - zyntra - temp e-mails mcp
+  - zyntra temp email mcp
+  - disposable email mcp server
+  - temp mail mcp for claude
+  - email testing mcp
 robotsIndex: true
 robotsFollow: true
 ---


### PR DESCRIPTION
Catalog keyword hygiene for the zyntra-mail entry: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.