### PR TITLE
docs(content): improve agent-skills-framework-engineer keywords

### DIFF
--- a/content/agents/agent-skills-framework-engineer.mdx
+++ b/content/agents/agent-skills-framework-engineer.mdx
@@ -842,19 +842,10 @@ tags:
   - skills-framework
   - agent-sdk
 keywords:
-  - agent
-  - agent-sdk
-  - agent-skills
-  - agents
-  - claude
-  - development
-  - domain-expertise
-  - engineer
-  - framework
-  - procedural-knowledge
-  - skills
-  - skills-framework
-  - tools
+  - agent skills framework engineer agent
+  - claude agent skills framework engineer agent
+  - agent skills framework engineer ai agent
+  - claude code agent skills framework engineer
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `agent-skills-framework-engineer` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.