### PR TITLE
docs(content): improve autogen-conversation-agent-builder keywords

### DIFF
--- a/content/agents/autogen-conversation-agent-builder.mdx
+++ b/content/agents/autogen-conversation-agent-builder.mdx
@@ -565,18 +565,10 @@ tags:
   - agent-runtime
   - multi-agent
 keywords:
-  - agent-runtime
-  - agent
-  - agents
-  - autogen
-  - builder
-  - claude
-  - conversation
-  - conversation-ai
-  - development
-  - microsoft
-  - multi-agent
-  - tools
+  - autogen conversation agent builder agent
+  - claude autogen conversation agent builder agent
+  - autogen conversation agent builder ai agent
+  - claude code autogen conversation agent builder
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `autogen-conversation-agent-builder` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.