### PR TITLE
docs(content): improve claude-haiku-45-speed-optimizer-agent keywords

### DIFF
--- a/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
+++ b/content/agents/claude-haiku-45-speed-optimizer-agent.mdx
@@ -335,19 +335,10 @@ tags:
   - rapid-iteration
   - ci-cd
 keywords:
-  - agent
-  - agents
-  - ci-cd
-  - claude
-  - cost-optimization
-  - development
-  - haiku
-  - haiku-4.5
-  - optimizer
-  - performance
-  - rapid-iteration
-  - speed
-  - tools
+  - claude haiku 45 speed optimizer agent
+  - claude claude haiku 45 speed optimizer agent
+  - claude haiku 45 speed optimizer ai agent
+  - claude code claude haiku 45 speed optimizer
 readingTime: 4
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `claude-haiku-45-speed-optimizer-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.