### PR TITLE
docs(content): improve claude-mcp-skills-integration-agent keywords

### DIFF
--- a/content/agents/claude-mcp-skills-integration-agent.mdx
+++ b/content/agents/claude-mcp-skills-integration-agent.mdx
@@ -649,17 +649,10 @@ tags:
   - tool-permissions
   - orchestration
 keywords:
-  - agent
-  - agents
-  - claude
-  - development
-  - integration
-  - mcp
-  - orchestration
-  - remote-servers
-  - skills
-  - tool-permissions
-  - tools
+  - claude mcp skills integration agent
+  - claude claude mcp skills integration agent
+  - claude mcp skills integration ai agent
+  - claude code claude mcp skills integration
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `claude-mcp-skills-integration-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.