### PR TITLE
docs(content): improve cloud-infrastructure-architect-agent keywords

### DIFF
--- a/content/agents/cloud-infrastructure-architect-agent.mdx
+++ b/content/agents/cloud-infrastructure-architect-agent.mdx
@@ -1573,18 +1573,10 @@ tags:
   - infrastructure
   - architecture
 keywords:
-  - agent
-  - agents
-  - architect
-  - architecture
-  - aws
-  - azure
-  - claude
-  - cloud
-  - development
-  - gcp
-  - infrastructure
-  - tools
+  - cloud infrastructure architect agent
+  - claude cloud infrastructure architect agent
+  - cloud infrastructure architect ai agent
+  - claude code cloud infrastructure architect
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `cloud-infrastructure-architect-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.