### PR TITLE
docs(content): improve codebase-migration-refactoring-agent keywords

### DIFF
--- a/content/agents/codebase-migration-refactoring-agent.mdx
+++ b/content/agents/codebase-migration-refactoring-agent.mdx
@@ -1259,18 +1259,10 @@ tags:
   - legacy-code
   - framework-upgrade
 keywords:
-  - agent
-  - agents
-  - automation
-  - claude
-  - codebase
-  - development
-  - framework-upgrade
-  - legacy-code
-  - migration
-  - modernization
-  - refactoring
-  - tools
+  - codebase migration refactoring agent
+  - claude codebase migration refactoring agent
+  - codebase migration refactoring ai agent
+  - claude code codebase migration refactoring
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `codebase-migration-refactoring-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.