### PR TITLE
docs(content): improve database-expert keywords

### DIFF
--- a/content/agents/database-expert.mdx
+++ b/content/agents/database-expert.mdx
@@ -220,18 +220,10 @@ tags:
   - optimization
   - design
 keywords:
-  - agents
-  - claude
-  - database
-  - design
-  - development
-  - expert
-  - mongodb
-  - nosql
-  - optimization
-  - postgresql
-  - sql
-  - tools
+  - database expert agent
+  - claude database expert agent
+  - database expert ai agent
+  - claude code database expert
 readingTime: 3
 difficultyScore: 10
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `database-expert` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.