### PR TITLE
docs(content): improve devops-sre-expert keywords

### DIFF
--- a/content/agents/devops-sre-expert.mdx
+++ b/content/agents/devops-sre-expert.mdx
@@ -165,17 +165,10 @@ tags:
   - ci-cd
   - monitoring
 keywords:
-  - agents
-  - ci-cd
-  - claude
-  - development
-  - devops
-  - expert
-  - kubernetes
-  - monitoring
-  - sre
-  - terraform
-  - tools
+  - devops sre expert agent
+  - claude devops sre expert agent
+  - devops sre expert ai agent
+  - claude code devops sre expert
 readingTime: 2
 difficultyScore: 21
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `devops-sre-expert` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.