### PR TITLE
docs(content): improve extended-thinking-orchestrator keywords

### DIFF
--- a/content/agents/extended-thinking-orchestrator.mdx
+++ b/content/agents/extended-thinking-orchestrator.mdx
@@ -51,18 +51,10 @@ tags:
   - ultrathink
   - complexity
 keywords:
-  - agents
-  - claude
-  - complexity
-  - deep-reasoning
-  - development
-  - extended
-  - extended-thinking
-  - orchestrator
-  - thinking
-  - thinking-budget
-  - tools
-  - ultrathink
+  - extended thinking orchestrator agent
+  - claude extended thinking orchestrator agent
+  - extended thinking orchestrator ai agent
+  - claude code extended thinking orchestrator
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `extended-thinking-orchestrator` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.