### PR TITLE
docs(content): improve life-sciences-research-specialist keywords

### DIFF
--- a/content/agents/life-sciences-research-specialist.mdx
+++ b/content/agents/life-sciences-research-specialist.mdx
@@ -328,19 +328,10 @@ tags:
   - scientific-analysis
   - literature-review
 keywords:
-  - agents
-  - biomedical
-  - claude
-  - development
-  - life
-  - life-sciences
-  - literature-review
-  - research
-  - research-automation
-  - sciences
-  - scientific-analysis
-  - specialist
-  - tools
+  - life sciences research specialist agent
+  - claude life sciences research specialist agent
+  - life sciences research specialist ai agent
+  - claude code life sciences research specialist
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `life-sciences-research-specialist` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.