### PR TITLE
docs(content): improve parallel-subagent-distributor keywords

### DIFF
--- a/content/agents/parallel-subagent-distributor.mdx
+++ b/content/agents/parallel-subagent-distributor.mdx
@@ -218,18 +218,10 @@ tags:
   - performance
   - git-worktrees
 keywords:
-  - agents
-  - claude
-  - concurrent-subagents
-  - development
-  - distributor
-  - git-worktrees
-  - parallel
-  - parallel-processing
-  - performance
-  - subagent
-  - tools
-  - workload-distribution
+  - parallel subagent distributor agent
+  - claude parallel subagent distributor agent
+  - parallel subagent distributor ai agent
+  - claude code parallel subagent distributor
 readingTime: 3
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `parallel-subagent-distributor` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.