### PR TITLE
docs(content): improve plugin-ecosystem-architect keywords

### DIFF
--- a/content/agents/plugin-ecosystem-architect.mdx
+++ b/content/agents/plugin-ecosystem-architect.mdx
@@ -608,18 +608,10 @@ tags:
   - customization
   - bundles
 keywords:
-  - agents
-  - architect
-  - bundles
-  - claude
-  - customization
-  - development
-  - ecosystem
-  - extensibility
-  - marketplace
-  - plugin
-  - plugins
-  - tools
+  - plugin ecosystem architect agent
+  - claude plugin ecosystem architect agent
+  - plugin ecosystem architect ai agent
+  - claude code plugin ecosystem architect
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `plugin-ecosystem-architect` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.