### PR TITLE
docs(content): improve web-async-agent-coordinator keywords

### DIFF
--- a/content/agents/web-async-agent-coordinator.mdx
+++ b/content/agents/web-async-agent-coordinator.mdx
@@ -35,19 +35,10 @@ tags:
   - autonomous
   - long-running-tasks
 keywords:
-  - agent
-  - agents
-  - async
-  - asynchronous
-  - autonomous
-  - browser-based
-  - claude
-  - coordinator
-  - development
-  - long-running-tasks
-  - tools
-  - web
-  - web-interface
+  - web async agent coordinator agent
+  - claude web async agent coordinator agent
+  - web async agent coordinator ai agent
+  - claude code web async agent coordinator
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `web-async-agent-coordinator` agents entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.