### PR TITLE
docs(content): improve ai-code-review-security-agent keywords

### DIFF
--- a/content/agents/ai-code-review-security-agent.mdx
+++ b/content/agents/ai-code-review-security-agent.mdx
@@ -1529,18 +1529,15 @@ tags:
   - ai
   - vulnerability-detection
   - static-analysis
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - claude
-  - code
-  - code-review
-  - development
-  - review
-  - security
-  - static-analysis
-  - tools
-  - vulnerability-detection
+  - ai code review security agent
+  - claude ai code review security agent
+  - ai code review security ai agent
+  - claude code ai code review security
 readingTime: 10
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `ai-code-review-security-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.