### PR TITLE
docs(content): improve claude-md-knowledge-manager-agent keywords

### DIFF
--- a/content/agents/claude-md-knowledge-manager-agent.mdx
+++ b/content/agents/claude-md-knowledge-manager-agent.mdx
@@ -33,21 +33,15 @@ tags:
   - ai-guidance
   - documentation
   - context-preservation
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - ai-guidance
-  - claude
-  - claude-md
-  - claude.md
-  - context-preservation
-  - development
-  - documentation
-  - knowledge
-  - knowledge-management
-  - manager
-  - project-instructions
-  - tools
+  - claude md knowledge manager agent
+  - claude claude md knowledge manager agent
+  - claude md knowledge manager ai agent
+  - claude code claude md knowledge manager
 readingTime: 10
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `claude-md-knowledge-manager-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.