### PR TITLE
docs(content): improve code-reviewer-agent keywords

### DIFF
--- a/content/agents/code-reviewer-agent.mdx
+++ b/content/agents/code-reviewer-agent.mdx
@@ -28,19 +28,15 @@ tags:
   - best-practices
   - security
   - performance
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - best-practices
-  - claude
-  - code
-  - code-review
-  - development
-  - performance
-  - quality
-  - reviewer
-  - security
-  - tools
+  - code reviewer agent
+  - claude code reviewer agent
+  - code reviewer ai agent
+  - claude code code reviewer
 readingTime: 3
 difficultyScore: 28
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `code-reviewer-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.