### PR TITLE
docs(content): improve context-window-optimizer-agent keywords

### DIFF
--- a/content/agents/context-window-optimizer-agent.mdx
+++ b/content/agents/context-window-optimizer-agent.mdx
@@ -31,21 +31,15 @@ tags:
   - truncation-prevention
   - memory
   - long-conversations
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - claude
-  - context
-  - context-management
-  - development
-  - long-conversations
-  - memory
-  - optimization
-  - optimizer
-  - summarization
-  - tools
-  - truncation-prevention
-  - window
+  - context window optimizer agent
+  - claude context window optimizer agent
+  - context window optimizer ai agent
+  - claude code context window optimizer
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `context-window-optimizer-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.