### PR TITLE
docs(content): improve debugging-assistant-agent keywords

### DIFF
--- a/content/agents/debugging-assistant-agent.mdx
+++ b/content/agents/debugging-assistant-agent.mdx
@@ -547,18 +547,15 @@ tags:
   - error-analysis
   - diagnostics
   - problem-solving
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - assistant
-  - claude
-  - debugging
-  - development
-  - diagnostics
-  - error-analysis
-  - problem-solving
-  - tools
-  - troubleshooting
+  - debugging assistant agent
+  - claude debugging assistant agent
+  - debugging assistant ai agent
+  - claude code debugging assistant
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `debugging-assistant-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.