### PR TITLE
docs(content): improve domain-specialist-ai-agents keywords

### DIFF
--- a/content/agents/domain-specialist-ai-agents.mdx
+++ b/content/agents/domain-specialist-ai-agents.mdx
@@ -183,18 +183,15 @@ tags:
   - finance
   - compliance
   - domain-specific
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agents
-  - claude
-  - compliance
-  - development
-  - domain
-  - domain-specific
-  - finance
-  - healthcare
-  - legal
-  - specialist
-  - tools
+  - domain specialist ai agents agent
+  - claude domain specialist ai agents agent
+  - domain specialist ai agents ai agent
+  - claude code domain specialist ai agents
 readingTime: 2
 difficultyScore: 67
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `domain-specialist-ai-agents` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.