### PR TITLE
docs(content): improve frontend-specialist-agent keywords

### DIFF
--- a/content/agents/frontend-specialist-agent.mdx
+++ b/content/agents/frontend-specialist-agent.mdx
@@ -2084,18 +2084,15 @@ tags:
   - typescript
   - ui-ux
   - performance
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - claude
-  - development
-  - frontend
-  - performance
-  - react
-  - specialist
-  - tools
-  - typescript
-  - ui-ux
+  - frontend specialist agent
+  - claude frontend specialist agent
+  - frontend specialist ai agent
+  - claude code frontend specialist
 readingTime: 12
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `frontend-specialist-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.