### PR TITLE
docs(content): improve full-stack-ai-development-agent keywords

### DIFF
--- a/content/agents/full-stack-ai-development-agent.mdx
+++ b/content/agents/full-stack-ai-development-agent.mdx
@@ -1802,19 +1802,15 @@ tags:
   - react
   - nextjs
   - machine-learning
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - claude
-  - development
-  - full
-  - full-stack
-  - machine-learning
-  - nextjs
-  - react
-  - stack
-  - tools
-  - typescript
+  - full stack ai development agent
+  - claude full stack ai development agent
+  - full stack ai development ai agent
+  - claude code full stack ai development
 readingTime: 11
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `full-stack-ai-development-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.