### PR TITLE
docs(content): improve multi-agent-orchestration-specialist keywords

### DIFF
--- a/content/agents/multi-agent-orchestration-specialist.mdx
+++ b/content/agents/multi-agent-orchestration-specialist.mdx
@@ -648,19 +648,15 @@ tags:
   - multi-agent
   - orchestration
   - workflow-automation
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - claude
-  - crewai
-  - development
-  - langgraph
-  - multi
-  - multi-agent
-  - orchestration
-  - specialist
-  - tools
-  - workflow-automation
+  - multi agent orchestration specialist agent
+  - claude multi agent orchestration specialist agent
+  - multi agent orchestration specialist ai agent
+  - claude code multi agent orchestration specialist
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `multi-agent-orchestration-specialist` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.