### PR TITLE
docs(content): improve product-management-ai-agent keywords

### DIFF
--- a/content/agents/product-management-ai-agent.mdx
+++ b/content/agents/product-management-ai-agent.mdx
@@ -760,19 +760,15 @@ tags:
   - user-stories
   - ab-testing
   - roadmap
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - ab-testing
-  - agent
-  - agents
-  - analytics
-  - claude
-  - development
-  - management
-  - product
-  - product-management
-  - roadmap
-  - tools
-  - user-stories
+  - product management ai agent
+  - claude product management ai agent
+  - product management ai ai agent
+  - claude code product management ai
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `product-management-ai-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.