### PR TITLE
docs(content): improve production-reliability-engineer keywords

### DIFF
--- a/content/agents/production-reliability-engineer.mdx
+++ b/content/agents/production-reliability-engineer.mdx
@@ -643,18 +643,15 @@ tags:
   - observability
   - sre
   - self-healing
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agents
-  - claude
-  - development
-  - engineer
-  - monitoring
-  - observability
-  - production
-  - reliability
-  - self-healing
-  - sre
-  - tools
+  - production reliability engineer agent
+  - claude production reliability engineer agent
+  - production reliability engineer ai agent
+  - claude code production reliability engineer
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `production-reliability-engineer` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.