### PR TITLE
docs(content): improve prompt-optimization-specialist keywords

### DIFF
--- a/content/agents/prompt-optimization-specialist.mdx
+++ b/content/agents/prompt-optimization-specialist.mdx
@@ -540,18 +540,15 @@ tags:
   - optimization
   - meta-prompting
   - performance
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agents
-  - claude
-  - development
-  - meta-prompting
-  - optimization
-  - performance
-  - prompt
-  - prompt-engineering
-  - specialist
-  - system-prompts
-  - tools
+  - prompt optimization specialist agent
+  - claude prompt optimization specialist agent
+  - prompt optimization specialist ai agent
+  - claude code prompt optimization specialist
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `prompt-optimization-specialist` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.