### PR TITLE
docs(content): improve slash-command-orchestrator-agent keywords

### DIFF
--- a/content/agents/slash-command-orchestrator-agent.mdx
+++ b/content/agents/slash-command-orchestrator-agent.mdx
@@ -31,21 +31,15 @@ tags:
   - orchestration
   - productivity
   - custom-commands
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - automation
-  - claude
-  - command
-  - custom-commands
-  - development
-  - orchestration
-  - orchestrator
-  - productivity
-  - slash
-  - slash-commands
-  - tools
-  - workflows
+  - slash command orchestrator agent
+  - claude slash command orchestrator agent
+  - slash command orchestrator ai agent
+  - claude code slash command orchestrator
 readingTime: 10
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `slash-command-orchestrator-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.