### PR TITLE
docs(content): improve subagent-factory-agent keywords

### DIFF
--- a/content/agents/subagent-factory-agent.mdx
+++ b/content/agents/subagent-factory-agent.mdx
@@ -936,20 +936,15 @@ tags:
   - task-decomposition
   - architecture
   - specialized-agents
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agent
-  - agents
-  - architecture
-  - claude
-  - delegation
-  - development
-  - factory
-  - parallel-execution
-  - specialized-agents
-  - subagent
-  - subagents
-  - task-decomposition
-  - tools
+  - subagent factory agent
+  - claude subagent factory agent
+  - subagent factory ai agent
+  - claude code subagent factory
 readingTime: 10
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `subagent-factory-agent` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.