### PR TITLE
docs(content): improve token-cost-budget-optimizer keywords

### DIFF
--- a/content/agents/token-cost-budget-optimizer.mdx
+++ b/content/agents/token-cost-budget-optimizer.mdx
@@ -1285,20 +1285,15 @@ tags:
   - usage-tracking
   - cost-analysis
   - roi
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - agents
-  - budget
-  - budget-optimization
-  - claude
-  - cost
-  - cost-analysis
-  - development
-  - optimizer
-  - roi
-  - token
-  - token-cost
-  - tools
-  - usage-tracking
+  - token cost budget optimizer agent
+  - claude token cost budget optimizer agent
+  - token cost budget optimizer ai agent
+  - claude code token cost budget optimizer
 readingTime: 11
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `token-cost-budget-optimizer` agents entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (AI agent reads your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.