### PR TITLE
docs(content): improve ai-prompt-engineering-expert keywords

### DIFF
--- a/content/rules/ai-prompt-engineering-expert.mdx
+++ b/content/rules/ai-prompt-engineering-expert.mdx
@@ -564,16 +564,10 @@ tags:
   - copilot
   - llm
 keywords:
-  - claude
-  - copilot
-  - development
-  - engineering
-  - expert
-  - llm
-  - prompt
-  - prompt-engineering
-  - rules
-  - tools
+  - ai prompt engineering expert
+  - claude ai prompt engineering rules
+  - ai prompt engineering best practices
+  - ai prompt engineering coding rules
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `ai-prompt-engineering-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.