### PR TITLE
docs(content): improve angular-expert keywords

### DIFF
--- a/content/rules/angular-expert.mdx
+++ b/content/rules/angular-expert.mdx
@@ -41,16 +41,10 @@ tags:
   - typescript
   - frontend
 keywords:
-  - angular
-  - claude
-  - rules
-  - signals
-  - dependency-injection
-  - rxjs
-  - standalone
-  - components
-  - expert
-  - frontend
+  - angular expert
+  - claude angular rules
+  - angular best practices
+  - angular coding rules
 ---
 
 You are an expert Angular developer with deep knowledge of Angular's


### PR DESCRIPTION
Catalog keyword hygiene for the `angular-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.