### PR TITLE
docs(content): improve api-design-expert keywords

### DIFF
--- a/content/rules/api-design-expert.mdx
+++ b/content/rules/api-design-expert.mdx
@@ -190,17 +190,10 @@ tags:
   - design
   - architecture
 keywords:
-  - api
-  - architecture
-  - claude
-  - design
-  - development
-  - expert
-  - graphql
-  - openapi
-  - rest
-  - rules
-  - tools
+  - api design expert
+  - claude api design rules
+  - api design best practices
+  - api design coding rules
 readingTime: 3
 difficultyScore: 94
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `api-design-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.