### PR TITLE
docs(content): improve api-first-development-architect keywords

### DIFF
--- a/content/rules/api-first-development-architect.mdx
+++ b/content/rules/api-first-development-architect.mdx
@@ -2029,20 +2029,10 @@ tags:
   - schema-first
   - contract-driven
 keywords:
-  - api
-  - api-design
-  - architect
-  - claude
-  - contract-driven
-  - development
-  - first
-  - graphql
-  - openapi
-  - rest
-  - rules
-  - schema-first
-  - tools
-  - trpc
+  - api first development architect rules
+  - claude api first development architect rules
+  - api first development architect best practices
+  - claude code api first development architect
 readingTime: 11
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `api-first-development-architect` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.