### PR TITLE
docs(content): improve biome-strict-linting-rules keywords

### DIFF
--- a/content/rules/biome-strict-linting-rules.mdx
+++ b/content/rules/biome-strict-linting-rules.mdx
@@ -547,17 +547,10 @@ tags:
   - configuration
   - typescript
 keywords:
-  - biome
-  - claude
-  - code-quality
-  - configuration
-  - development
-  - linting
-  - rules
-  - strict
-  - tools
-  - typescript
-  - validation
+  - biome strict linting rules
+  - claude biome strict linting rules
+  - biome strict linting best practices
+  - claude code biome strict linting
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `biome-strict-linting-rules` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.