### PR TITLE
docs(content): improve django-expert keywords

### DIFF
--- a/content/rules/django-expert.mdx
+++ b/content/rules/django-expert.mdx
@@ -100,13 +100,10 @@ tags:
   - orm
   - backend
 keywords:
-  - django
-  - python
-  - drf
-  - orm
-  - backend
-  - claude
-  - expert
+  - django expert
+  - claude django rules
+  - django best practices
+  - django coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `django-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.