### PR TITLE
docs(content): improve dotnet-csharp-expert keywords

### DIFF
--- a/content/rules/dotnet-csharp-expert.mdx
+++ b/content/rules/dotnet-csharp-expert.mdx
@@ -118,17 +118,10 @@ tags:
   - xunit
   - backend
 keywords:
-  - dotnet
-  - csharp
-  - claude
-  - rules
-  - aspnet-core
-  - entity-framework-core
-  - minimal-api
-  - async
-  - expert
-  - backend
-  - xunit
+  - dotnet csharp expert
+  - claude dotnet csharp rules
+  - dotnet csharp best practices
+  - dotnet csharp coding rules
 ---
 
 ## Usage


### PR DESCRIPTION
Catalog keyword hygiene for the `dotnet-csharp-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.