### PR TITLE
docs(content): improve express-expert keywords

### DIFF
--- a/content/rules/express-expert.mdx
+++ b/content/rules/express-expert.mdx
@@ -15,16 +15,10 @@ seoDescription: >-
   middleware chains, request validation, centralized error handling, and
   production security settings.
 keywords:
-  - claude
-  - express
-  - expressjs
-  - middleware
-  - routing
-  - error-handling
-  - security
-  - nodejs
-  - validation
-  - rules
+  - express expert
+  - claude express rules
+  - express best practices
+  - express coding rules
 author: jaso0n0818
 authorProfileUrl: "https://github.com/jaso0n0818"
 submittedBy: jaso0n0818


### PR DESCRIPTION
Catalog keyword hygiene for the `express-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.