### PR TITLE
docs(content): improve fastapi-expert keywords

### DIFF
--- a/content/rules/fastapi-expert.mdx
+++ b/content/rules/fastapi-expert.mdx
@@ -89,14 +89,10 @@ tags:
   - async
   - backend
 keywords:
-  - fastapi
-  - pydantic
-  - openapi
-  - async
-  - python
-  - api
-  - claude
-  - expert
+  - fastapi expert
+  - claude fastapi rules
+  - fastapi best practices
+  - fastapi coding rules
 readingTime: 4
 difficultyScore: 80
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `fastapi-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.