### PR TITLE
docs(content): improve java-spring-boot-expert keywords

### DIFF
--- a/content/rules/java-spring-boot-expert.mdx
+++ b/content/rules/java-spring-boot-expert.mdx
@@ -107,17 +107,10 @@ tags:
   - testcontainers
   - backend
 keywords:
-  - java
-  - spring-boot
-  - claude
-  - rules
-  - spring-data
-  - spring-security
-  - rest
-  - jpa
-  - expert
-  - backend
-  - testcontainers
+  - java spring boot expert
+  - claude java spring boot rules
+  - java spring boot best practices
+  - java spring boot coding rules
 ---
 
 ## Usage


### PR DESCRIPTION
Catalog keyword hygiene for the `java-spring-boot-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.