### PR TITLE
docs(content): improve kotlin-expert keywords

### DIFF
--- a/content/rules/kotlin-expert.mdx
+++ b/content/rules/kotlin-expert.mdx
@@ -92,13 +92,10 @@ tags:
   - android
   - backend
 keywords:
-  - kotlin
-  - coroutines
-  - jvm
-  - android
-  - backend
-  - claude
-  - expert
+  - kotlin expert
+  - claude kotlin rules
+  - kotlin best practices
+  - kotlin coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `kotlin-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.