### PR TITLE
docs(content): improve laravel-expert keywords

### DIFF
--- a/content/rules/laravel-expert.mdx
+++ b/content/rules/laravel-expert.mdx
@@ -100,13 +100,10 @@ tags:
   - api
   - backend
 keywords:
-  - laravel
-  - php
-  - eloquent
-  - api
-  - backend
-  - claude
-  - expert
+  - laravel expert
+  - claude laravel rules
+  - laravel best practices
+  - laravel coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `laravel-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.