### PR TITLE
docs(content): improve mobile-app-development-expert keywords

### DIFF
--- a/content/rules/mobile-app-development-expert.mdx
+++ b/content/rules/mobile-app-development-expert.mdx
@@ -110,16 +110,10 @@ tags:
   - apple
   - architecture-review
 keywords:
-  - apple
-  - architecture
-  - claude
-  - code-review
-  - concurrency
-  - ios
-  - rules
-  - swift
-  - swiftui
-  - tools
+  - mobile app development expert
+  - claude mobile app development rules
+  - mobile app development best practices
+  - mobile app development coding rules
 readingTime: 3
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `mobile-app-development-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.