### PR TITLE
docs(content): improve nestjs-expert keywords

### DIFF
--- a/content/rules/nestjs-expert.mdx
+++ b/content/rules/nestjs-expert.mdx
@@ -125,16 +125,10 @@ tags:
   - interceptors
   - backend
 keywords:
-  - nestjs
-  - claude
-  - rules
-  - nodejs
-  - typescript
-  - dependency-injection
-  - microservices
-  - decorators
-  - expert
-  - backend
+  - nestjs expert
+  - claude nestjs rules
+  - nestjs best practices
+  - nestjs coding rules
 ---
 
 ## Usage


### PR DESCRIPTION
Catalog keyword hygiene for the `nestjs-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.