### PR TITLE
docs(content): improve postgresql-expert keywords

### DIFF
--- a/content/rules/postgresql-expert.mdx
+++ b/content/rules/postgresql-expert.mdx
@@ -83,14 +83,10 @@ tags:
   - sql
   - backend
 keywords:
-  - postgresql
-  - postgres
-  - sql
-  - database
-  - indexing
-  - explain
-  - claude
-  - expert
+  - postgresql expert
+  - claude postgresql rules
+  - postgresql best practices
+  - postgresql coding rules
 readingTime: 4
 difficultyScore: 82
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `postgresql-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.