### PR TITLE
docs(content): improve production-codebase-auditor keywords

### DIFF
--- a/content/rules/production-codebase-auditor.mdx
+++ b/content/rules/production-codebase-auditor.mdx
@@ -183,21 +183,10 @@ tags:
   - open-source
   - production
 keywords:
-  - auditor
-  - claude
-  - code-quality
-  - codebase
-  - dead-code
-  - development
-  - duplication
-  - open-source
-  - production
-  - rules
-  - security-audit
-  - tools
-  - typescript
-  - validation
-  - zod
+  - production codebase auditor rules
+  - claude production codebase auditor rules
+  - production codebase auditor best practices
+  - claude code production codebase auditor
 readingTime: 2
 difficultyScore: 32
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `production-codebase-auditor` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.