### PR TITLE
docs(content): improve python-data-science keywords

### DIFF
--- a/content/rules/python-data-science.mdx
+++ b/content/rules/python-data-science.mdx
@@ -98,16 +98,10 @@ tags:
   - dataframe
   - data-wrangling
 keywords:
-  - claude
-  - data
-  - dataframe
-  - data-wrangling
-  - pandas
-  - groupby
-  - merge
-  - python
-  - rules
-  - tools
+  - python data science rules
+  - claude python data science rules
+  - python data science best practices
+  - claude code python data science
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `python-data-science` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.