### PR TITLE
docs(content): improve react-19-concurrent-features-specialist keywords

### DIFF
--- a/content/rules/react-19-concurrent-features-specialist.mdx
+++ b/content/rules/react-19-concurrent-features-specialist.mdx
@@ -908,18 +908,10 @@ tags:
   - streaming-ssr
   - performance
 keywords:
-  - claude
-  - concurrent
-  - development
-  - features
-  - performance
-  - react
-  - react-19
-  - rules
-  - specialist
-  - streaming-ssr
-  - suspense
-  - tools
+  - react 19 concurrent features specialist rules
+  - claude react 19 concurrent features specialist rules
+  - react 19 concurrent features specialist best practices
+  - claude code react 19 concurrent features specialist
 readingTime: 5
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `react-19-concurrent-features-specialist` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.