### PR TITLE
docs(content): improve react-expert keywords

### DIFF
--- a/content/rules/react-expert.mdx
+++ b/content/rules/react-expert.mdx
@@ -116,16 +116,10 @@ tags:
   - state
   - components
 keywords:
-  - claude
-  - components
-  - effects
-  - hooks
-  - react
-  - rules
-  - rules-of-hooks
-  - state
-  - tools
-  - usestate
+  - react expert
+  - claude react rules
+  - react best practices
+  - react coding rules
 readingTime: 2
 difficultyScore: 20
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `react-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.