### PR TITLE
docs(content): improve react-server-components-expert keywords

### DIFF
--- a/content/rules/react-server-components-expert.mdx
+++ b/content/rules/react-server-components-expert.mdx
@@ -919,18 +919,10 @@ tags:
   - next-js
   - react-19
 keywords:
-  - claude
-  - components
-  - development
-  - expert
-  - next-js
-  - react
-  - react-19
-  - rsc
-  - rules
-  - server
-  - server-components
-  - tools
+  - react server components expert
+  - claude react server components rules
+  - react server components best practices
+  - react server components coding rules
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `react-server-components-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.