### PR TITLE
docs(content): improve redis-expert keywords

### DIFF
--- a/content/rules/redis-expert.mdx
+++ b/content/rules/redis-expert.mdx
@@ -87,13 +87,10 @@ tags:
   - streams
   - backend
 keywords:
-  - redis
-  - caching
-  - database
-  - streams
-  - backend
-  - claude
-  - expert
+  - redis expert
+  - claude redis rules
+  - redis best practices
+  - redis coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `redis-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.