### PR TITLE
docs(content): improve ruby-on-rails-expert keywords

### DIFF
--- a/content/rules/ruby-on-rails-expert.mdx
+++ b/content/rules/ruby-on-rails-expert.mdx
@@ -119,13 +119,10 @@ tags:
   - api
   - backend
 keywords:
-  - rails
-  - ruby
-  - active-record
-  - api
-  - backend
-  - claude
-  - expert
+  - ruby on rails expert
+  - claude ruby on rails rules
+  - ruby on rails best practices
+  - ruby on rails coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `ruby-on-rails-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.