### PR TITLE
docs(content): improve rust-expert keywords

### DIFF
--- a/content/rules/rust-expert.mdx
+++ b/content/rules/rust-expert.mdx
@@ -84,14 +84,10 @@ tags:
   - backend
   - async
 keywords:
-  - rust
-  - ownership
-  - borrow-checker
-  - traits
-  - tokio
-  - backend
-  - claude
-  - expert
+  - rust expert
+  - claude rust rules
+  - rust best practices
+  - rust coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `rust-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.