### PR TITLE
docs(content): improve security-auditor keywords

### DIFF
--- a/content/rules/security-auditor.mdx
+++ b/content/rules/security-auditor.mdx
@@ -140,16 +140,10 @@ tags:
   - owasp
   - audit
 keywords:
-  - audit
-  - auditor
-  - claude
-  - development
-  - owasp
-  - penetration-testing
-  - rules
-  - security
-  - tools
-  - vulnerability
+  - security auditor rules
+  - claude security auditor rules
+  - security auditor best practices
+  - claude code security auditor
 readingTime: 2
 difficultyScore: 25
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `security-auditor` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.