### PR TITLE
docs(content): improve swift-expert keywords

### DIFF
--- a/content/rules/swift-expert.mdx
+++ b/content/rules/swift-expert.mdx
@@ -99,13 +99,10 @@ tags:
   - concurrency
   - apple
 keywords:
-  - swift
-  - swiftui
-  - ios
-  - concurrency
-  - apple
-  - claude
-  - expert
+  - swift expert
+  - claude swift rules
+  - swift best practices
+  - swift coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `swift-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.