### PR TITLE
docs(content): improve terraform-infrastructure-architect keywords

### DIFF
--- a/content/rules/terraform-infrastructure-architect.mdx
+++ b/content/rules/terraform-infrastructure-architect.mdx
@@ -680,16 +680,10 @@ tags:
   - cloud
   - devops
 keywords:
-  - architect
-  - claude
-  - cloud
-  - development
-  - devops
-  - iac
-  - infrastructure
-  - rules
-  - terraform
-  - tools
+  - terraform infrastructure architect rules
+  - claude terraform infrastructure architect rules
+  - terraform infrastructure architect best practices
+  - claude code terraform infrastructure architect
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `terraform-infrastructure-architect` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.