### PR TITLE
docs(content): improve test-driven-development-enforcer keywords

### DIFF
--- a/content/rules/test-driven-development-enforcer.mdx
+++ b/content/rules/test-driven-development-enforcer.mdx
@@ -1555,19 +1555,10 @@ tags:
   - test-coverage
   - red-green-refactor
 keywords:
-  - claude
-  - development
-  - driven
-  - enforcer
-  - jest
-  - red-green-refactor
-  - rules
-  - tdd
-  - test
-  - test-coverage
-  - testing
-  - tools
-  - vitest
+  - test driven development enforcer rules
+  - claude test driven development enforcer rules
+  - test driven development enforcer best practices
+  - claude code test driven development enforcer
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the `test-driven-development-enforcer` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.