### PR TITLE
docs(content): improve vue3-composition-api-expert keywords

### DIFF
--- a/content/rules/vue3-composition-api-expert.mdx
+++ b/content/rules/vue3-composition-api-expert.mdx
@@ -110,16 +110,10 @@ tags:
   - typescript
   - frontend
 keywords:
-  - claude
-  - rules
-  - vue3
-  - composition-api
-  - pinia
-  - vue-router
-  - frontend
-  - expert
-  - script-setup
-  - composables
+  - vue3 composition api expert
+  - claude vue3 composition api rules
+  - vue3 composition api best practices
+  - vue3 composition api coding rules
 ---
 
 ## Usage


### PR DESCRIPTION
Catalog keyword hygiene for the `vue3-composition-api-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.