### PR TITLE
docs(content): improve golang-expert keywords

### DIFF
--- a/content/rules/golang-expert.mdx
+++ b/content/rules/golang-expert.mdx
@@ -362,18 +362,15 @@ tags:
   - libraries
   - modules
   - build-tools
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - build-tools
-  - claude
-  - cli
-  - development
-  - expert
-  - golang
-  - libraries
-  - modules
-  - rules
-  - tooling
-  - tools
+  - golang expert
+  - claude golang rules
+  - golang best practices
+  - golang coding rules
 readingTime: 4
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `golang-expert` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.