### PR TITLE
docs(content): improve kubernetes-devsecops-engineer keywords

### DIFF
--- a/content/rules/kubernetes-devsecops-engineer.mdx
+++ b/content/rules/kubernetes-devsecops-engineer.mdx
@@ -744,17 +744,15 @@ tags:
   - security
   - gitops
   - rbac
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - claude
-  - development
-  - devsecops
-  - engineer
-  - gitops
-  - kubernetes
-  - rbac
-  - rules
-  - security
-  - tools
+  - kubernetes devsecops engineer rules
+  - claude kubernetes devsecops engineer rules
+  - kubernetes devsecops engineer best practices
+  - claude code kubernetes devsecops engineer
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `kubernetes-devsecops-engineer` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.