### PR TITLE
docs(content): improve nextjs-15-performance-architect keywords

### DIFF
--- a/content/rules/nextjs-15-performance-architect.mdx
+++ b/content/rules/nextjs-15-performance-architect.mdx
@@ -1299,18 +1299,15 @@ tags:
   - optimization
   - turbopack
   - web-vitals
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - architect
-  - claude
-  - development
-  - next-js
-  - nextjs
-  - optimization
-  - performance
-  - rules
-  - tools
-  - turbopack
-  - web-vitals
+  - nextjs 15 performance architect rules
+  - claude nextjs 15 performance architect rules
+  - nextjs 15 performance architect best practices
+  - claude code nextjs 15 performance architect
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `nextjs-15-performance-architect` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.