### PR TITLE
docs(content): improve security-first-react-components keywords

### DIFF
--- a/content/rules/security-first-react-components.mdx
+++ b/content/rules/security-first-react-components.mdx
@@ -1365,18 +1365,15 @@ tags:
   - xss
   - csp
   - owasp
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - claude
-  - components
-  - csp
-  - development
-  - first
-  - owasp
-  - react
-  - rules
-  - security
-  - tools
-  - xss
+  - security first react components rules
+  - claude security first react components rules
+  - security first react components best practices
+  - claude code security first react components
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `security-first-react-components` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.