### PR TITLE
docs(content): improve wcag-accessibility-auditor keywords

### DIFF
--- a/content/rules/wcag-accessibility-auditor.mdx
+++ b/content/rules/wcag-accessibility-auditor.mdx
@@ -708,17 +708,15 @@ tags:
   - a11y
   - aria
   - inclusive-design
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - a11y
-  - accessibility
-  - aria
-  - auditor
-  - claude
-  - development
-  - inclusive-design
-  - rules
-  - tools
-  - wcag
+  - wcag accessibility auditor rules
+  - claude wcag accessibility auditor rules
+  - wcag accessibility auditor best practices
+  - claude code wcag accessibility auditor
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `wcag-accessibility-auditor` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.