### PR TITLE
docs(content): improve windsurf-ai-native-ide-patterns keywords

### DIFF
--- a/content/rules/windsurf-ai-native-ide-patterns.mdx
+++ b/content/rules/windsurf-ai-native-ide-patterns.mdx
@@ -1357,19 +1357,15 @@ tags:
   - cascade
   - flow
   - collaboration
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - ai-ide
-  - cascade
-  - claude
-  - collaboration
-  - development
-  - flow
-  - ide
-  - native
-  - patterns
-  - rules
-  - tools
-  - windsurf
+  - windsurf ai native ide patterns rules
+  - claude windsurf ai native ide patterns rules
+  - windsurf ai native ide patterns best practices
+  - claude code windsurf ai native ide patterns
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `windsurf-ai-native-ide-patterns` rules entry: junk single-token `keywords` replaced with real multi-word search phrases, and added `safetyNotes`/`privacyNotes` required by the content-policy scan (guides Claude to read your code/data and may suggest commands). Content-policy scan and `pnpm validate:content:strict` pass locally.