### PR TITLE
docs(content): improve accessibility-checker hook keywords

### DIFF
--- a/content/hooks/accessibility-checker.mdx
+++ b/content/hooks/accessibility-checker.mdx
@@ -59,17 +59,15 @@ tags:
   - wcag
   - testing
   - compliance
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - a11y
-  - accessibility
-  - checker
-  - claude
-  - compliance
-  - development
-  - hooks
-  - testing
-  - tools
-  - wcag
+  - accessibility checker hook
+  - claude code accessibility checker hook
+  - accessibility checker claude hook
+  - claude accessibility checker automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `accessibility-checker` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.