### PR TITLE
docs(content): improve api-endpoint-documentation-generator hook keywords

### DIFF
--- a/content/hooks/api-endpoint-documentation-generator.mdx
+++ b/content/hooks/api-endpoint-documentation-generator.mdx
@@ -68,18 +68,13 @@ tags:
   - openapi
   - swagger
   - automation
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - api
-  - automation
-  - claude
-  - development
-  - documentation
-  - endpoint
-  - generator
-  - hooks
-  - openapi
-  - swagger
-  - tools
+  - api endpoint documentation generator hook
+  - claude code api endpoint documentation generator hook
+  - api endpoint documentation generator claude hook
+  - claude api endpoint documentation generator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `api-endpoint-documentation-generator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.