### PR TITLE
docs(content): improve auto-code-formatter-hook hook keywords

### DIFF
--- a/content/hooks/auto-code-formatter-hook.mdx
+++ b/content/hooks/auto-code-formatter-hook.mdx
@@ -125,20 +125,15 @@ tags:
   - black
   - code-quality
   - automation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - automation
-  - black
-  - claude
-  - code
-  - code-quality
-  - development
-  - formatter
-  - formatting
-  - hook
-  - hooks
-  - prettier
-  - tools
+  - auto code formatter hook
+  - claude code auto code formatter hook
+  - auto code formatter claude hook
+  - claude auto code formatter automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `auto-code-formatter-hook` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.