### PR TITLE
docs(content): improve auto-save-backup hook keywords

### DIFF
--- a/content/hooks/auto-save-backup.mdx
+++ b/content/hooks/auto-save-backup.mdx
@@ -60,17 +60,15 @@ tags:
   - safety
   - file-management
   - data-protection
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - backup
-  - claude
-  - data-protection
-  - development
-  - file-management
-  - hooks
-  - safety
-  - save
-  - tools
+  - auto save backup hook
+  - claude code auto save backup hook
+  - auto save backup claude hook
+  - claude auto save backup automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `auto-save-backup` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.