### PR TITLE
docs(content): improve aws-cloudformation-validator hook keywords

### DIFF
--- a/content/hooks/aws-cloudformation-validator.mdx
+++ b/content/hooks/aws-cloudformation-validator.mdx
@@ -106,17 +106,15 @@ tags:
   - infrastructure
   - validation
   - cloud
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - aws
-  - claude
-  - cloud
-  - cloudformation
-  - development
-  - hooks
-  - infrastructure
-  - tools
-  - validation
-  - validator
+  - aws cloudformation validator hook
+  - claude code aws cloudformation validator hook
+  - aws cloudformation validator claude hook
+  - claude aws cloudformation validator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `aws-cloudformation-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.