### PR TITLE
docs(content): improve code-complexity-alert-monitor hook keywords

### DIFF
--- a/content/hooks/code-complexity-alert-monitor.mdx
+++ b/content/hooks/code-complexity-alert-monitor.mdx
@@ -58,18 +58,10 @@ tags:
   - monitoring
   - maintainability
 keywords:
-  - alert
-  - claude
-  - code
-  - code-quality
-  - complexity
-  - development
-  - hooks
-  - maintainability
-  - monitor
-  - monitoring
-  - notification
-  - tools
+  - code complexity alert monitor hook
+  - claude code code complexity alert monitor hook
+  - code complexity alert monitor claude hook
+  - claude code complexity alert monitor automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `code-complexity-alert-monitor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.