### PR TITLE
docs(content): improve code-test-runner-hook hook keywords

### DIFF
--- a/content/hooks/code-test-runner-hook.mdx
+++ b/content/hooks/code-test-runner-hook.mdx
@@ -71,19 +71,10 @@ tags:
   - watch
   - parallel
 keywords:
-  - automation
-  - ci-cd
-  - claude
-  - code
-  - development
-  - hook
-  - hooks
-  - parallel
-  - runner
-  - test
-  - testing
-  - tools
-  - watch
+  - code test runner hook
+  - claude code code test runner hook
+  - code test runner claude hook
+  - claude code test runner automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `code-test-runner-hook` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.