### PR TITLE
docs(content): improve css-unused-selector-detector hook keywords

### DIFF
--- a/content/hooks/css-unused-selector-detector.mdx
+++ b/content/hooks/css-unused-selector-detector.mdx
@@ -58,19 +58,15 @@ tags:
   - cleanup
   - performance
   - purge
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - cleanup
-  - css
-  - detector
-  - development
-  - hooks
-  - optimization
-  - performance
-  - purge
-  - selector
-  - tools
-  - unused
+  - css unused selector detector hook
+  - claude code css unused selector detector hook
+  - css unused selector detector claude hook
+  - claude css unused selector detector automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `css-unused-selector-detector` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.