### PR TITLE
docs(content): improve database-connection-cleanup hook keywords

### DIFF
--- a/content/hooks/database-connection-cleanup.mdx
+++ b/content/hooks/database-connection-cleanup.mdx
@@ -60,16 +60,10 @@ tags:
   - connections
   - resources
 keywords:
-  - claude
-  - cleanup
-  - connection
-  - connections
-  - database
-  - development
-  - hooks
-  - resources
-  - stop-hook
-  - tools
+  - database connection cleanup hook
+  - claude code database connection cleanup hook
+  - database connection cleanup claude hook
+  - claude database connection cleanup automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `database-connection-cleanup` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.