### PR TITLE
docs(content): improve database-migration-runner hook keywords

### DIFF
--- a/content/hooks/database-migration-runner.mdx
+++ b/content/hooks/database-migration-runner.mdx
@@ -71,16 +71,10 @@ tags:
   - deployment
   - sql
 keywords:
-  - automation
-  - claude
-  - database
-  - deployment
-  - development
-  - hooks
-  - migration
-  - runner
-  - sql
-  - tools
+  - database migration runner hook
+  - claude code database migration runner hook
+  - database migration runner claude hook
+  - claude database migration runner automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `database-migration-runner` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.