### PR TITLE
docs(content): improve database-query-performance-logger hook keywords

### DIFF
--- a/content/hooks/database-query-performance-logger.mdx
+++ b/content/hooks/database-query-performance-logger.mdx
@@ -76,17 +76,10 @@ tags:
   - optimization
   - logging
 keywords:
-  - claude
-  - database
-  - development
-  - hooks
-  - logger
-  - logging
-  - monitoring
-  - optimization
-  - performance
-  - query
-  - tools
+  - database query performance logger hook
+  - claude code database query performance logger hook
+  - database query performance logger claude hook
+  - claude database query performance logger automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `database-query-performance-logger` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.