### PR TITLE
docs(content): improve dead-code-eliminator hook keywords

### DIFF
--- a/content/hooks/dead-code-eliminator.mdx
+++ b/content/hooks/dead-code-eliminator.mdx
@@ -56,18 +56,10 @@ tags:
   - refactoring
   - automation
 keywords:
-  - automation
-  - claude
-  - cleanup
-  - code
-  - code-quality
-  - dead
-  - development
-  - eliminator
-  - hooks
-  - optimization
-  - refactoring
-  - tools
+  - dead code eliminator hook
+  - claude code dead code eliminator hook
+  - dead code eliminator claude hook
+  - claude dead code eliminator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `dead-code-eliminator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.