### PR TITLE
docs(content): improve dependency-security-audit-on-stop hook keywords

### DIFF
--- a/content/hooks/dependency-security-audit-on-stop.mdx
+++ b/content/hooks/dependency-security-audit-on-stop.mdx
@@ -67,17 +67,10 @@ tags:
   - stop-hook
   - vulnerabilities
 keywords:
-  - audit
-  - claude
-  - dependencies
-  - dependency
-  - development
-  - hooks
-  - security
-  - stop
-  - stop-hook
-  - tools
-  - vulnerabilities
+  - dependency security audit on stop hook
+  - claude code dependency security audit on stop hook
+  - dependency security audit on stop claude hook
+  - claude dependency security audit on stop automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `dependency-security-audit-on-stop` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.