### PR TITLE
docs(content): improve dependency-update-checker hook keywords

### DIFF
--- a/content/hooks/dependency-update-checker.mdx
+++ b/content/hooks/dependency-update-checker.mdx
@@ -60,19 +60,15 @@ tags:
   - automation
   - npm
   - package-management
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - checker
-  - claude
-  - dependencies
-  - dependency
-  - development
-  - hooks
-  - npm
-  - package-management
-  - security
-  - tools
-  - update
+  - dependency update checker hook
+  - claude code dependency update checker hook
+  - dependency update checker claude hook
+  - claude dependency update checker automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `dependency-update-checker` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.