### PR TITLE
docs(content): improve discord-activity-notifier hook keywords

### DIFF
--- a/content/hooks/discord-activity-notifier.mdx
+++ b/content/hooks/discord-activity-notifier.mdx
@@ -49,18 +49,15 @@ tags:
   - collaboration
   - webhooks
   - team
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - activity
-  - claude
-  - collaboration
-  - development
-  - discord
-  - hooks
-  - notification
-  - notifier
-  - team
-  - tools
-  - webhooks
+  - discord activity notifier hook
+  - claude code discord activity notifier hook
+  - discord activity notifier claude hook
+  - claude discord activity notifier automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `discord-activity-notifier` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.