### PR TITLE
docs(content): improve docker-container-auto-rebuild hook keywords

### DIFF
--- a/content/hooks/docker-container-auto-rebuild.mdx
+++ b/content/hooks/docker-container-auto-rebuild.mdx
@@ -65,17 +65,10 @@ tags:
   - devops
   - automation
 keywords:
-  - auto
-  - automation
-  - claude
-  - container
-  - containers
-  - development
-  - devops
-  - docker
-  - hooks
-  - rebuild
-  - tools
+  - docker container auto rebuild hook
+  - claude code docker container auto rebuild hook
+  - docker container auto rebuild claude hook
+  - claude docker container auto rebuild automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `docker-container-auto-rebuild` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.