### PR TITLE
docs(content): improve docker-image-security-scanner hook keywords

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -60,18 +60,15 @@ tags:
   - containers
   - vulnerability
   - devops
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - containers
-  - development
-  - devops
-  - docker
-  - hooks
-  - image
-  - scanner
-  - security
-  - tools
-  - vulnerability
+  - docker image security scanner hook
+  - claude code docker image security scanner hook
+  - docker image security scanner claude hook
+  - claude docker image security scanner automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `docker-image-security-scanner` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.