### PR TITLE
docs(content): improve documentation-auto-generator-on-stop hook keywords

### DIFF
--- a/content/hooks/documentation-auto-generator-on-stop.mdx
+++ b/content/hooks/documentation-auto-generator-on-stop.mdx
@@ -46,19 +46,15 @@ tags:
   - automation
   - markdown
   - jsdoc
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - automation
-  - claude
-  - development
-  - documentation
-  - generator
-  - hooks
-  - jsdoc
-  - markdown
-  - stop
-  - stop-hook
-  - tools
+  - documentation auto generator on stop hook
+  - claude code documentation auto generator on stop hook
+  - documentation auto generator on stop claude hook
+  - claude documentation auto generator on stop automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `documentation-auto-generator-on-stop` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.