### PR TITLE
docs(content): improve documentation-coverage-checker hook keywords

### DIFF
--- a/content/hooks/documentation-coverage-checker.mdx
+++ b/content/hooks/documentation-coverage-checker.mdx
@@ -61,18 +61,15 @@ tags:
   - analysis
   - automation
   - best-practices
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - analysis
-  - automation
-  - best-practices
-  - checker
-  - claude
-  - code-quality
-  - coverage
-  - development
-  - documentation
-  - hooks
-  - tools
+  - documentation coverage checker hook
+  - claude code documentation coverage checker hook
+  - documentation coverage checker claude hook
+  - claude documentation coverage checker automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `documentation-coverage-checker` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.