### PR TITLE
docs(content): improve documentation-generator hook keywords

### DIFF
--- a/content/hooks/documentation-generator.mdx
+++ b/content/hooks/documentation-generator.mdx
@@ -239,16 +239,10 @@ tags:
   - markdown
   - jsdoc
 keywords:
-  - api
-  - automation
-  - claude
-  - development
-  - documentation
-  - generator
-  - hooks
-  - jsdoc
-  - markdown
-  - tools
+  - documentation generator hook
+  - claude code documentation generator hook
+  - documentation generator claude hook
+  - claude documentation generator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `documentation-generator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.