### PR TITLE
docs(content): improve environment-cleanup-handler hook keywords

### DIFF
--- a/content/hooks/environment-cleanup-handler.mdx
+++ b/content/hooks/environment-cleanup-handler.mdx
@@ -48,18 +48,15 @@ tags:
   - maintenance
   - resources
   - optimization
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - cleanup
-  - development
-  - environment
-  - handler
-  - hooks
-  - maintenance
-  - optimization
-  - resources
-  - stop-hook
-  - tools
+  - environment cleanup handler hook
+  - claude code environment cleanup handler hook
+  - environment cleanup handler claude hook
+  - claude environment cleanup handler automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `environment-cleanup-handler` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.