### PR TITLE
docs(content): improve environment-variable-validator hook keywords

### DIFF
--- a/content/hooks/environment-variable-validator.mdx
+++ b/content/hooks/environment-variable-validator.mdx
@@ -59,18 +59,15 @@ tags:
   - validation
   - deployment
   - security
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - configuration
-  - deployment
-  - development
-  - environment
-  - hooks
-  - security
-  - tools
-  - validation
-  - validator
-  - variable
+  - environment variable validator hook
+  - claude code environment variable validator hook
+  - environment variable validator claude hook
+  - claude environment variable validator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `environment-variable-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.