### PR TITLE
docs(content): improve error-rate-monitor hook keywords

### DIFF
--- a/content/hooks/error-rate-monitor.mdx
+++ b/content/hooks/error-rate-monitor.mdx
@@ -48,19 +48,15 @@ tags:
   - notification
   - debugging
   - alerts
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - alerts
-  - claude
-  - debugging
-  - development
-  - error
-  - errors
-  - hooks
-  - monitor
-  - monitoring
-  - notification
-  - rate
-  - tools
+  - error rate monitor hook
+  - claude code error rate monitor hook
+  - error rate monitor claude hook
+  - claude error rate monitor automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `error-rate-monitor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.