### PR TITLE
docs(content): improve file-size-warning-monitor hook keywords

### DIFF
--- a/content/hooks/file-size-warning-monitor.mdx
+++ b/content/hooks/file-size-warning-monitor.mdx
@@ -57,20 +57,15 @@ tags:
   - notification
   - monitoring
   - optimization
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - file
-  - file-size
-  - hooks
-  - monitor
-  - monitoring
-  - notification
-  - optimization
-  - performance
-  - size
-  - tools
-  - warning
+  - file size warning monitor hook
+  - claude code file size warning monitor hook
+  - file size warning monitor claude hook
+  - claude file size warning monitor automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `file-size-warning-monitor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.