### PR TITLE
docs(content): improve final-bundle-size-reporter hook keywords

### DIFF
--- a/content/hooks/final-bundle-size-reporter.mdx
+++ b/content/hooks/final-bundle-size-reporter.mdx
@@ -44,20 +44,15 @@ tags:
   - stop-hook
   - optimization
   - reporting
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - bundle
-  - bundle-size
-  - claude
-  - development
-  - final
-  - hooks
-  - optimization
-  - performance
-  - reporter
-  - reporting
-  - size
-  - stop-hook
-  - tools
+  - final bundle size reporter hook
+  - claude code final bundle size reporter hook
+  - final bundle size reporter claude hook
+  - claude final bundle size reporter automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `final-bundle-size-reporter` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.