### PR TITLE
docs(content): improve git-auto-commit-on-stop hook keywords

### DIFF
--- a/content/hooks/git-auto-commit-on-stop.mdx
+++ b/content/hooks/git-auto-commit-on-stop.mdx
@@ -57,17 +57,10 @@ tags:
   - automation
   - commit
 keywords:
-  - auto
-  - automation
-  - claude
-  - commit
-  - development
-  - git
-  - hooks
-  - stop
-  - stop-hook
-  - tools
-  - version-control
+  - git auto commit on stop hook
+  - claude code git auto commit on stop hook
+  - git auto commit on stop claude hook
+  - claude git auto commit on stop automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `git-auto-commit-on-stop` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.