### PR TITLE
docs(content): improve git-branch-protection hook keywords

### DIFF
--- a/content/hooks/git-branch-protection.mdx
+++ b/content/hooks/git-branch-protection.mdx
@@ -57,17 +57,15 @@ tags:
   - branch-protection
   - workflow
   - safety
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - branch
-  - branch-protection
-  - claude
-  - development
-  - git
-  - hooks
-  - protection
-  - safety
-  - tools
-  - workflow
+  - git branch protection hook
+  - claude code git branch protection hook
+  - git branch protection claude hook
+  - claude git branch protection automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `git-branch-protection` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.