### PR TITLE
docs(content): improve git-pre-commit-validator hook keywords

### DIFF
--- a/content/hooks/git-pre-commit-validator.mdx
+++ b/content/hooks/git-pre-commit-validator.mdx
@@ -55,19 +55,15 @@ tags:
   - code-quality
   - testing
   - automation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - claude
-  - code-quality
-  - commit
-  - development
-  - git
-  - hooks
-  - pre
-  - testing
-  - tools
-  - validation
-  - validator
+  - git pre commit validator hook
+  - claude code git pre commit validator hook
+  - git pre commit validator claude hook
+  - claude git pre commit validator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `git-pre-commit-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.