### PR TITLE
docs(content): improve go-module-tidy hook keywords

### DIFF
--- a/content/hooks/go-module-tidy.mdx
+++ b/content/hooks/go-module-tidy.mdx
@@ -56,17 +56,15 @@ tags:
   - modules
   - dependencies
   - cleanup
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - cleanup
-  - dependencies
-  - development
-  - golang
-  - hooks
-  - module
-  - modules
-  - tidy
-  - tools
+  - go module tidy hook
+  - claude code go module tidy hook
+  - go module tidy claude hook
+  - claude go module tidy automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `go-module-tidy` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.