### PR TITLE
docs(content): improve graphql-schema-validator hook keywords

### DIFF
--- a/content/hooks/graphql-schema-validator.mdx
+++ b/content/hooks/graphql-schema-validator.mdx
@@ -52,17 +52,15 @@ tags:
   - schema
   - validation
   - breaking-changes
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - api
-  - breaking-changes
-  - claude
-  - development
-  - graphql
-  - hooks
-  - schema
-  - tools
-  - validation
-  - validator
+  - graphql schema validator hook
+  - claude code graphql schema validator hook
+  - graphql schema validator claude hook
+  - claude graphql schema validator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `graphql-schema-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.