### PR TITLE
docs(content): improve i18n-translation-validator hook keywords

### DIFF
--- a/content/hooks/i18n-translation-validator.mdx
+++ b/content/hooks/i18n-translation-validator.mdx
@@ -56,17 +56,15 @@ tags:
   - translation
   - localization
   - validation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - hooks
-  - i18n
-  - internationalization
-  - localization
-  - tools
-  - translation
-  - validation
-  - validator
+  - i18n translation validator hook
+  - claude code i18n translation validator hook
+  - i18n translation validator claude hook
+  - claude i18n translation validator automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `i18n-translation-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.