### PR TITLE
docs(content): improve jest-snapshot-auto-updater hook keywords

### DIFF
--- a/content/hooks/jest-snapshot-auto-updater.mdx
+++ b/content/hooks/jest-snapshot-auto-updater.mdx
@@ -56,19 +56,15 @@ tags:
   - snapshots
   - react
   - automation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - automation
-  - claude
-  - development
-  - hooks
-  - jest
-  - react
-  - snapshot
-  - snapshots
-  - testing
-  - tools
-  - updater
+  - jest snapshot auto updater hook
+  - claude code jest snapshot auto updater hook
+  - jest snapshot auto updater claude hook
+  - claude jest snapshot auto updater automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `jest-snapshot-auto-updater` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.