### PR TITLE
docs(content): improve json-schema-validator hook keywords

### DIFF
--- a/content/hooks/json-schema-validator.mdx
+++ b/content/hooks/json-schema-validator.mdx
@@ -56,17 +56,15 @@ tags:
   - validation
   - data-integrity
   - api
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - api
-  - claude
-  - data-integrity
-  - development
-  - hooks
-  - json
-  - schema
-  - tools
-  - validation
-  - validator
+  - json schema validator hook
+  - claude code json schema validator hook
+  - json schema validator claude hook
+  - claude json schema validator automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `json-schema-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.