### PR TITLE
docs(content): improve kubernetes-manifest-validator hook keywords

### DIFF
--- a/content/hooks/kubernetes-manifest-validator.mdx
+++ b/content/hooks/kubernetes-manifest-validator.mdx
@@ -56,18 +56,15 @@ tags:
   - yaml
   - validation
   - devops
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - devops
-  - hooks
-  - k8s
-  - kubernetes
-  - manifest
-  - tools
-  - validation
-  - validator
-  - yaml
+  - kubernetes manifest validator hook
+  - claude code kubernetes manifest validator hook
+  - kubernetes manifest validator claude hook
+  - claude kubernetes manifest validator automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `kubernetes-manifest-validator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.