### PR TITLE
docs(content): improve memory-usage-monitor hook keywords

### DIFF
--- a/content/hooks/memory-usage-monitor.mdx
+++ b/content/hooks/memory-usage-monitor.mdx
@@ -46,18 +46,15 @@ tags:
   - monitoring
   - notification
   - resources
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - hooks
-  - memory
-  - monitor
-  - monitoring
-  - notification
-  - performance
-  - resources
-  - tools
-  - usage
+  - memory usage monitor hook
+  - claude code memory usage monitor hook
+  - memory usage monitor claude hook
+  - claude memory usage monitor automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `memory-usage-monitor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.