### PR TITLE
docs(content): improve nextjs-route-analyzer hook keywords

### DIFF
--- a/content/hooks/nextjs-route-analyzer.mdx
+++ b/content/hooks/nextjs-route-analyzer.mdx
@@ -56,18 +56,15 @@ tags:
   - pages
   - analysis
   - documentation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - analysis
-  - analyzer
-  - claude
-  - development
-  - documentation
-  - hooks
-  - nextjs
-  - pages
-  - route
-  - routing
-  - tools
+  - nextjs route analyzer hook
+  - claude code nextjs route analyzer hook
+  - nextjs route analyzer claude hook
+  - claude nextjs route analyzer automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `nextjs-route-analyzer` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.