### PR TITLE
docs(content): improve package-vulnerability-scanner hook keywords

### DIFF
--- a/content/hooks/package-vulnerability-scanner.mdx
+++ b/content/hooks/package-vulnerability-scanner.mdx
@@ -56,19 +56,15 @@ tags:
   - dependencies
   - npm
   - pip
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - dependencies
-  - development
-  - hooks
-  - npm
-  - package
-  - pip
-  - scanner
-  - security
-  - tools
-  - vulnerabilities
-  - vulnerability
+  - package vulnerability scanner hook
+  - claude code package vulnerability scanner hook
+  - package vulnerability scanner claude hook
+  - claude package vulnerability scanner automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `package-vulnerability-scanner` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.