### PR TITLE
docs(content): improve performance-impact-monitor hook keywords

### DIFF
--- a/content/hooks/performance-impact-monitor.mdx
+++ b/content/hooks/performance-impact-monitor.mdx
@@ -44,18 +44,15 @@ tags:
   - notification
   - profiling
   - alerts
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - alerts
-  - claude
-  - development
-  - hooks
-  - impact
-  - monitor
-  - monitoring
-  - notification
-  - performance
-  - profiling
-  - tools
+  - performance impact monitor hook
+  - claude code performance impact monitor hook
+  - performance impact monitor claude hook
+  - claude performance impact monitor automation
 readingTime: 3
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `performance-impact-monitor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.