### PR TITLE
docs(content): improve playwright-test-runner hook keywords

### DIFF
--- a/content/hooks/playwright-test-runner.mdx
+++ b/content/hooks/playwright-test-runner.mdx
@@ -57,18 +57,15 @@ tags:
   - testing
   - automation
   - browser-testing
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - browser-testing
-  - claude
-  - development
-  - e2e
-  - hooks
-  - playwright
-  - runner
-  - test
-  - testing
-  - tools
+  - playwright test runner hook
+  - claude code playwright test runner hook
+  - playwright test runner claude hook
+  - claude playwright test runner automation
 readingTime: 3
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `playwright-test-runner` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.