### PR TITLE
docs(content): improve prisma-schema-sync hook keywords

### DIFF
--- a/content/hooks/prisma-schema-sync.mdx
+++ b/content/hooks/prisma-schema-sync.mdx
@@ -57,17 +57,15 @@ tags:
   - orm
   - schema
   - migrations
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - database
-  - development
-  - hooks
-  - migrations
-  - orm
-  - prisma
-  - schema
-  - sync
-  - tools
+  - prisma schema sync hook
+  - claude code prisma schema sync hook
+  - prisma schema sync claude hook
+  - claude prisma schema sync automation
 readingTime: 3
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `prisma-schema-sync` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.