### PR TITLE
docs(content): improve python-import-optimizer hook keywords

### DIFF
--- a/content/hooks/python-import-optimizer.mdx
+++ b/content/hooks/python-import-optimizer.mdx
@@ -56,18 +56,15 @@ tags:
   - formatting
   - optimization
   - isort
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - formatting
-  - hooks
-  - import
-  - imports
-  - isort
-  - optimization
-  - optimizer
-  - python
-  - tools
+  - python import optimizer hook
+  - claude code python import optimizer hook
+  - python import optimizer claude hook
+  - claude python import optimizer automation
 readingTime: 3
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `python-import-optimizer` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.