### PR TITLE
docs(content): improve react-component-test-generator hook keywords

### DIFF
--- a/content/hooks/react-component-test-generator.mdx
+++ b/content/hooks/react-component-test-generator.mdx
@@ -58,19 +58,15 @@ tags:
   - jest
   - components
   - automation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - claude
-  - component
-  - components
-  - development
-  - generator
-  - hooks
-  - jest
-  - react
-  - test
-  - testing
-  - tools
+  - react component test generator hook
+  - claude code react component test generator hook
+  - react component test generator claude hook
+  - claude react component test generator automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `react-component-test-generator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.