### PR TITLE
docs(content): improve real-time-activity-tracker hook keywords

### DIFF
--- a/content/hooks/real-time-activity-tracker.mdx
+++ b/content/hooks/real-time-activity-tracker.mdx
@@ -63,19 +63,10 @@ tags:
   - real-time
   - debugging
 keywords:
-  - activity
-  - claude
-  - debugging
-  - development
-  - hooks
-  - logging
-  - monitoring
-  - notification
-  - real
-  - real-time
-  - time
-  - tools
-  - tracker
+  - real time activity tracker hook
+  - claude code real time activity tracker hook
+  - real time activity tracker claude hook
+  - claude real time activity tracker automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `real-time-activity-tracker` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.