### PR TITLE
docs(content): improve redis-cache-invalidator hook keywords

### DIFF
--- a/content/hooks/redis-cache-invalidator.mdx
+++ b/content/hooks/redis-cache-invalidator.mdx
@@ -56,17 +56,15 @@ tags:
   - performance
   - data-models
   - invalidation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - cache
-  - claude
-  - data-models
-  - development
-  - hooks
-  - invalidation
-  - invalidator
-  - performance
-  - redis
-  - tools
+  - redis cache invalidator hook
+  - claude code redis cache invalidator hook
+  - redis cache invalidator claude hook
+  - claude redis cache invalidator automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `redis-cache-invalidator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.