### PR TITLE
docs(content): improve retro-daily hook keywords

### DIFF
--- a/content/hooks/retro-daily.mdx
+++ b/content/hooks/retro-daily.mdx
@@ -172,16 +172,10 @@ tags:
   - retro
   - analytics
 keywords:
-  - sessionstart
-  - hook
-  - dashboard
-  - metrics
-  - retro
-  - sparkline
-  - heatmap
-  - competency
-  - claude-code
-  - analytics
+  - retro daily hook
+  - claude code retro daily hook
+  - retro daily claude hook
+  - claude retro daily automation
 readingTime: 2
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `retro-daily` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.