### PR TITLE
docs(content): improve rust-cargo-check hook keywords

### DIFF
--- a/content/hooks/rust-cargo-check.mdx
+++ b/content/hooks/rust-cargo-check.mdx
@@ -52,17 +52,15 @@ tags:
   - clippy
   - linting
   - compilation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - cargo
-  - check
-  - claude
-  - clippy
-  - compilation
-  - development
-  - hooks
-  - linting
-  - rust
-  - tools
+  - rust cargo check hook
+  - claude code rust cargo check hook
+  - rust cargo check claude hook
+  - claude rust cargo check automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `rust-cargo-check` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.