### PR TITLE
docs(content): improve scss-auto-compiler hook keywords

### DIFF
--- a/content/hooks/scss-auto-compiler.mdx
+++ b/content/hooks/scss-auto-compiler.mdx
@@ -52,18 +52,15 @@ tags:
   - css
   - styling
   - compilation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - claude
-  - compilation
-  - compiler
-  - css
-  - development
-  - hooks
-  - sass
-  - scss
-  - styling
-  - tools
+  - scss auto compiler hook
+  - claude code scss auto compiler hook
+  - scss auto compiler claude hook
+  - claude scss auto compiler automation
 readingTime: 5
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `scss-auto-compiler` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.