### PR TITLE
docs(content): improve security-scanner-hook hook keywords

### DIFF
--- a/content/hooks/security-scanner-hook.mdx
+++ b/content/hooks/security-scanner-hook.mdx
@@ -68,17 +68,10 @@ tags:
   - automation
   - compliance
 keywords:
-  - automation
-  - claude
-  - compliance
-  - development
-  - hook
-  - hooks
-  - scanner
-  - scanning
-  - security
-  - tools
-  - vulnerability
+  - security scanner hook
+  - claude code security scanner hook
+  - security scanner claude hook
+  - claude security scanner automation
 readingTime: 5
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `security-scanner-hook` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.