### PR TITLE
docs(content): improve sensitive-data-alert-scanner hook keywords

### DIFF
--- a/content/hooks/sensitive-data-alert-scanner.mdx
+++ b/content/hooks/sensitive-data-alert-scanner.mdx
@@ -59,19 +59,10 @@ tags:
   - scanning
   - privacy
 keywords:
-  - alert
-  - claude
-  - data
-  - development
-  - hooks
-  - notification
-  - privacy
-  - scanner
-  - scanning
-  - security
-  - sensitive
-  - sensitive-data
-  - tools
+  - sensitive data alert scanner hook
+  - claude code sensitive data alert scanner hook
+  - sensitive data alert scanner claude hook
+  - claude sensitive data alert scanner automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `sensitive-data-alert-scanner` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.