### PR TITLE
docs(content): improve session-metrics-collector hook keywords

### DIFF
--- a/content/hooks/session-metrics-collector.mdx
+++ b/content/hooks/session-metrics-collector.mdx
@@ -54,18 +54,15 @@ tags:
   - stop-hook
   - performance
   - statistics
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - analytics
-  - claude
-  - collector
-  - development
-  - hooks
-  - metrics
-  - performance
-  - session
-  - statistics
-  - stop-hook
-  - tools
+  - session metrics collector hook
+  - claude code session metrics collector hook
+  - session metrics collector claude hook
+  - claude session metrics collector automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `session-metrics-collector` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.