### PR TITLE
docs(content): improve slack-progress-notifier hook keywords

### DIFF
--- a/content/hooks/slack-progress-notifier.mdx
+++ b/content/hooks/slack-progress-notifier.mdx
@@ -63,17 +63,10 @@ tags:
   - collaboration
   - monitoring
 keywords:
-  - claude
-  - collaboration
-  - development
-  - hooks
-  - monitoring
-  - notifications
-  - notifier
-  - progress
-  - slack
-  - team
-  - tools
+  - slack progress notifier hook
+  - claude code slack progress notifier hook
+  - slack progress notifier claude hook
+  - claude slack progress notifier automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `slack-progress-notifier` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.