### PR TITLE
docs(content): improve svelte-component-compiler hook keywords

### DIFF
--- a/content/hooks/svelte-component-compiler.mdx
+++ b/content/hooks/svelte-component-compiler.mdx
@@ -216,17 +216,10 @@ tags:
   - validation
   - frontend
 keywords:
-  - claude
-  - compilation
-  - compiler
-  - component
-  - components
-  - development
-  - frontend
-  - hooks
-  - svelte
-  - tools
-  - validation
+  - svelte component compiler hook
+  - claude code svelte component compiler hook
+  - svelte component compiler claude hook
+  - claude svelte component compiler automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `svelte-component-compiler` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.