### PR TITLE
docs(content): improve team-summary-email-generator hook keywords

### DIFF
--- a/content/hooks/team-summary-email-generator.mdx
+++ b/content/hooks/team-summary-email-generator.mdx
@@ -63,16 +63,10 @@ tags:
   - summary
   - communication
 keywords:
-  - claude
-  - communication
-  - development
-  - email
-  - generator
-  - hooks
-  - stop-hook
-  - summary
-  - team
-  - tools
+  - team summary email generator hook
+  - claude code team summary email generator hook
+  - team summary email generator claude hook
+  - claude team summary email generator automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `team-summary-email-generator` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.