### PR TITLE
docs(content): improve terraform-plan-executor hook keywords

### DIFF
--- a/content/hooks/terraform-plan-executor.mdx
+++ b/content/hooks/terraform-plan-executor.mdx
@@ -65,17 +65,10 @@ tags:
   - devops
   - cloud
 keywords:
-  - claude
-  - cloud
-  - development
-  - devops
-  - executor
-  - hooks
-  - iac
-  - infrastructure
-  - plan
-  - terraform
-  - tools
+  - terraform plan executor hook
+  - claude code terraform plan executor hook
+  - terraform plan executor claude hook
+  - claude terraform plan executor automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `terraform-plan-executor` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.