### PR TITLE
docs(content): improve test-coverage-final-report hook keywords

### DIFF
--- a/content/hooks/test-coverage-final-report.mdx
+++ b/content/hooks/test-coverage-final-report.mdx
@@ -50,19 +50,15 @@ tags:
   - stop-hook
   - reporting
   - quality
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - coverage
-  - development
-  - final
-  - hooks
-  - quality
-  - report
-  - reporting
-  - stop-hook
-  - test
-  - testing
-  - tools
+  - test coverage final report hook
+  - claude code test coverage final report hook
+  - test coverage final report claude hook
+  - claude test coverage final report automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `test-coverage-final-report` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.