### PR TITLE
docs(content): improve test-runner-hook hook keywords

### DIFF
--- a/content/hooks/test-runner-hook.mdx
+++ b/content/hooks/test-runner-hook.mdx
@@ -59,19 +59,15 @@ tags:
   - ci-cd
   - watch
   - parallel
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - ci-cd
-  - claude
-  - development
-  - hook
-  - hooks
-  - parallel
-  - runner
-  - test
-  - testing
-  - tools
-  - watch
+  - test runner hook
+  - claude code test runner hook
+  - test runner claude hook
+  - claude test runner automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `test-runner-hook` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.