### PR TITLE
docs(content): improve vue-composition-api-linter hook keywords

### DIFF
--- a/content/hooks/vue-composition-api-linter.mdx
+++ b/content/hooks/vue-composition-api-linter.mdx
@@ -52,19 +52,15 @@ tags:
   - composition-api
   - linting
   - best-practices
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - api
-  - best-practices
-  - claude
-  - composition
-  - composition-api
-  - development
-  - hooks
-  - linter
-  - linting
-  - tools
-  - vue
-  - vue3
+  - vue composition api linter hook
+  - claude code vue composition api linter hook
+  - vue composition api linter claude hook
+  - claude vue composition api linter automation
 readingTime: 5
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `vue-composition-api-linter` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.