### PR TITLE
docs(content): improve webpack-bundle-analyzer hook keywords

### DIFF
--- a/content/hooks/webpack-bundle-analyzer.mdx
+++ b/content/hooks/webpack-bundle-analyzer.mdx
@@ -52,17 +52,15 @@ tags:
   - performance
   - optimization
   - analysis
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - analysis
-  - analyzer
-  - bundle
-  - claude
-  - development
-  - hooks
-  - optimization
-  - performance
-  - tools
-  - webpack
+  - webpack bundle analyzer hook
+  - claude code webpack bundle analyzer hook
+  - webpack bundle analyzer claude hook
+  - claude webpack bundle analyzer automation
 readingTime: 5
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `webpack-bundle-analyzer` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.