### PR TITLE
docs(content): improve workflow-completion-report hook keywords

### DIFF
--- a/content/hooks/workflow-completion-report.mdx
+++ b/content/hooks/workflow-completion-report.mdx
@@ -54,18 +54,15 @@ tags:
   - analytics
   - summary
   - stop-hook
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - analytics
-  - claude
-  - completion
-  - development
-  - hooks
-  - report
-  - reporting
-  - stop-hook
-  - summary
-  - tools
-  - workflow
+  - workflow completion report hook
+  - claude code workflow completion report hook
+  - workflow completion report claude hook
+  - claude workflow completion report automation
 readingTime: 5
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog hygiene for the `workflow-completion-report` hook: junk single-token `keywords` replaced with real multi-word search phrases, plus `safetyNotes`/`privacyNotes` where missing (hooks run automatically on events and execute shell logic against your project/session) — required by the content-policy scan. Scan and `pnpm validate:content:strict` pass locally.