### PR TITLE
docs(content): improve debugging troubleshooting system collection keywords

### DIFF
--- a/content/collections/debugging-troubleshooting-system.mdx
+++ b/content/collections/debugging-troubleshooting-system.mdx
@@ -43,16 +43,10 @@ tags:
   - diagnostics
   - problem-solving
 keywords:
-  - claude
-  - collections
-  - debugging
-  - development
-  - diagnostics
-  - error-handling
-  - problem-solving
-  - system
-  - tools
-  - troubleshooting
+  - debugging troubleshooting collection claude
+  - debugging tools for claude
+  - error diagnosis tools collection
+  - claude debugging workflow
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Catalog keyword hygiene for the debugging troubleshooting system collection: junk single-token `keywords` replaced with real search phrases users would type. No other fields changed; content-policy scan and `pnpm validate:content:strict` pass locally.