### PR TITLE
docs(content): improve aws-cloud-infrastructure-bundle collection keywords

### DIFF
--- a/content/collections/aws-cloud-infrastructure-bundle.mdx
+++ b/content/collections/aws-cloud-infrastructure-bundle.mdx
@@ -17,6 +17,12 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-02"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/hooks"
+safetyNotes:
+  - "Bundles an AWS MCP server, a CloudFormation-validation hook, and infra agents that act against your AWS account using your own credentials and can run a hook automatically on events; review each bundled tool's permissions and IAM scope, and validate generated infrastructure changes before applying."
 installable: false
 usageSnippet: >-
   Start with `aws-cloud-architect` → `devops-sre-expert` →
@@ -53,17 +59,10 @@ tags:
   - cloudformation
   - serverless
 keywords:
-  - aws
-  - bundle
-  - claude
-  - cloud
-  - cloudformation
-  - collections
-  - development
-  - devops
-  - infrastructure
-  - serverless
-  - tools
+  - aws cloud infrastructure collection
+  - aws devops tools for claude
+  - aws infrastructure bundle claude
+  - cloudformation and aws agents collection
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true

--- a/content/collections/aws-cloud-infrastructure-bundle.mdx
+++ b/content/collections/aws-cloud-infrastructure-bundle.mdx
@@ -152,7 +152,7 @@ Prioritize AWS cloud architect rule for AWS-specific patterns. Use backend archi
 
 ### AWS CLI version 1.x incompatible with MCP server features
 
-Upgrade to AWS CLI v2: curl https://awscli.amazonaws.com/install | bash. Verify with aws --version. MCP server requires CLI v2.0+ for SSO support.
+Upgrade to AWS CLI v2 using the official installer: download `https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip`, unzip it, and run `sudo ./aws/install`. Verify with `aws --version`. MCP server requires CLI v2.0+ for SSO support.
 
 ### Permission errors when validator checks CloudFormation templates
 


### PR DESCRIPTION
Catalog hygiene for the aws-cloud-infrastructure-bundle collection: junk single-token `keywords` → real search phrases; grounded `documentationUrl`/`retrievalSources` on Claude Code sub-agents + hooks docs; added `safetyNotes` (bundled AWS MCP/hook/agents act on your AWS account with your credentials and a hook runs automatically) required by the content-policy scan. Local scan + `pnpm validate:content:strict` pass.