### PR TITLE
docs(content): improve pagespeed-insights-optimizer keywords

### DIFF
--- a/content/skills/pagespeed-insights-optimizer.mdx
+++ b/content/skills/pagespeed-insights-optimizer.mdx
@@ -35,6 +35,8 @@ verificationStatus: draft
 verifiedAt: "2026-04-10"
 retrievalSources:
   - "https://web.dev/articles/vitals"
+safetyNotes:
+  - "The install command downloads a zip from heyclau.de and unzips it into the working directory, and the skill runs local build/type-check commands and can patch frontend code for verification; review the package and any proposed code changes before applying."
 privacyNotes:
   - "Running PageSpeed Insights / Lighthouse submits the target URL to Google's PSI service (and field data may be drawn from the public CrUX dataset); only test URLs you are authorized to assess and avoid authenticated or preview URLs that would expose private content."
 testedPlatforms:

--- a/content/skills/pagespeed-insights-optimizer.mdx
+++ b/content/skills/pagespeed-insights-optimizer.mdx
@@ -35,6 +35,8 @@ verificationStatus: draft
 verifiedAt: "2026-04-10"
 retrievalSources:
   - "https://web.dev/articles/vitals"
+privacyNotes:
+  - "Running PageSpeed Insights / Lighthouse submits the target URL to Google's PSI service (and field data may be drawn from the public CrUX dataset); only test URLs you are authorized to assess and avoid authenticated or preview URLs that would expose private content."
 testedPlatforms:
   - Claude
   - Codex
@@ -54,16 +56,10 @@ tags:
   - web-performance
   - optimization
 keywords:
-  - ai-skill
-  - pagespeed
-  - lighthouse
-  - lcp
-  - cls
-  - tbt
-  - performance
-  - optimization
-  - core-web-vitals
-  - skills
+  - pagespeed insights optimizer skill
+  - lighthouse optimization claude
+  - core web vitals skill
+  - improve pagespeed score claude
 readingTime: 7
 packageVerified: true
 difficultyScore: 78


### PR DESCRIPTION
Catalog hygiene for the `pagespeed-insights-optimizer` skill: junk single-token `keywords` → real search phrases, plus `privacyNotes` (PSI/Lighthouse submits the target URL to Google) required by the content-policy scan. Local scan + `pnpm validate:content:strict` pass.