### PR TITLE
fix(content): reground filesystem-mcp-server keywords + sources

### DIFF
--- a/content/mcp/filesystem-mcp-server.mdx
+++ b/content/mcp/filesystem-mcp-server.mdx
@@ -19,7 +19,10 @@ seoDescription: >-
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-15"
-documentationUrl: "https://modelcontextprotocol.io/examples"
+documentationUrl: "https://github.com/modelcontextprotocol/servers/blob/main/src/filesystem/README.md"
+retrievalSources:
+  - "https://github.com/modelcontextprotocol/servers/blob/main/src/filesystem/README.md"
+  - "https://modelcontextprotocol.io/introduction"
 downloadUrl: /downloads/mcp/filesystem-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -78,17 +81,10 @@ tags:
   - official
   - anthropic
 keywords:
-  - anthropic
-  - claude
-  - development
-  - directories
-  - files
-  - filesystem
-  - mcp
-  - mcp servers
-  - official
-  - server
-  - tools
+  - filesystem mcp server
+  - claude filesystem access mcp
+  - local file mcp server
+  - official filesystem mcp
 readingTime: 1
 difficultyScore: 1
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.