### PR TITLE
fix(content): reground git-mcp-server keywords + sources

### DIFF
--- a/content/mcp/git-mcp-server.mdx
+++ b/content/mcp/git-mcp-server.mdx
@@ -19,7 +19,10 @@ seoDescription: >-
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"
-documentationUrl: "https://modelcontextprotocol.io/examples"
+documentationUrl: "https://github.com/modelcontextprotocol/servers/blob/main/src/git/README.md"
+retrievalSources:
+  - "https://github.com/modelcontextprotocol/servers/blob/main/src/git/README.md"
+  - "https://modelcontextprotocol.io/introduction"
 downloadUrl: /downloads/mcp/git-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -82,17 +85,10 @@ tags:
   - official
   - anthropic
 keywords:
-  - anthropic
-  - claude
-  - development
-  - git
-  - mcp
-  - mcp servers
-  - official
-  - repositories
-  - server
-  - tools
-  - version-control
+  - git mcp server
+  - claude git integration mcp
+  - local git repository mcp
+  - official git mcp server
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.