### PR TITLE
fix(content): reground github-mcp-server keywords + sources

### DIFF
--- a/content/mcp/github-mcp-server.mdx
+++ b/content/mcp/github-mcp-server.mdx
@@ -20,7 +20,9 @@ seoDescription: >-
 author: GitHub
 authorProfileUrl: "https://github.com/github"
 dateAdded: "2025-09-18"
-documentationUrl: "https://www.npmjs.com/package/@modelcontextprotocol/server-github"
+documentationUrl: "https://github.com/github/github-mcp-server"
+retrievalSources:
+  - "https://github.com/github/github-mcp-server"
 downloadUrl: /downloads/mcp/github-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -91,17 +93,10 @@ tags:
   - api
   - official
 keywords:
-  - api
-  - claude
-  - development
-  - git
-  - github
-  - mcp
-  - mcp servers
-  - official
-  - repositories
-  - server
-  - tools
+  - github mcp server
+  - claude github integration
+  - github api mcp server
+  - connect claude to github
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.