### PR TITLE
fix(content): reground golang-expert keywords + sources

### DIFF
--- a/content/rules/golang-expert.mdx
+++ b/content/rules/golang-expert.mdx
@@ -16,7 +16,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://go.dev/doc/"
+documentationUrl: "https://go.dev/doc/effective_go"
+retrievalSources:
+  - "https://go.dev/doc/effective_go"
+  - "https://go.dev/ref/mod"
+  - "https://go.dev/doc/"
 installable: false
 usageSnippet: >-
   You are a Go ecosystem expert specializing in tooling, library development,
@@ -362,18 +366,15 @@ tags:
   - libraries
   - modules
   - build-tools
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - build-tools
-  - claude
-  - cli
-  - development
-  - expert
-  - golang
-  - libraries
-  - modules
-  - rules
-  - tooling
-  - tools
+  - golang expert
+  - claude go rules
+  - go best practices
+  - go coding rules
 readingTime: 4
 difficultyScore: 100
 hasTroubleshooting: true

--- a/content/statuslines/multi-provider-token-counter.mdx
+++ b/content/statuslines/multi-provider-token-counter.mdx
@@ -21,6 +21,7 @@ dateAdded: "2025-10-16"
 documentationUrl: "https://code.claude.com/docs/en/statusline"
 retrievalSources:
   - "https://code.claude.com/docs/en/statusline"
+  - "https://code.claude.com/docs/en/costs"
 safetyNotes:
   - Reads session JSON from stdin and writes formatted text to stdout only; does not modify files or make network calls.
 privacyNotes:
@@ -67,19 +68,10 @@ tags:
   - ai-models
   - monitoring
 keywords:
-  - ai-models
-  - claude
-  - context-limits
-  - counter
-  - development
-  - monitoring
-  - multi
-  - multi-provider
-  - provider
-  - statuslines
-  - token
-  - tokens
-  - tools
+  - multi provider token counter
+  - ai model token statusline
+  - context limit statusline
+  - claude code statusline
 readingTime: 2
 difficultyScore: 4
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.