### PR TITLE
fix(content): reground v0-rapid-prototyping keywords + sources

### DIFF
--- a/content/skills/v0-rapid-prototyping.mdx
+++ b/content/skills/v0-rapid-prototyping.mdx
@@ -90,7 +90,9 @@ skillLevel: advanced
 verificationStatus: draft
 verifiedAt: "2025-10-16"
 retrievalSources:
-  - "https://v0.dev/docs"
+  - "https://v0.app/docs"
+  - "https://ui.shadcn.com/docs"
+  - "https://nextjs.org/docs/app"
 testedPlatforms:
   - Claude
   - Codex
@@ -112,15 +114,10 @@ tags:
   - shadcn
   - react
 keywords:
-  - claude
-  - development
-  - prototyping
-  - rapid
-  - react
-  - shadcn
-  - skills
-  - tools
-  - workflow
+  - v0 rapid prototyping skill
+  - v0 vercel ui generation
+  - shadcn ui generator claude
+  - v0 react prototyping
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.