### PR TITLE
fix(content): reground claude-mcp-skills-integration-agent keywords + sources

### DIFF
--- a/content/agents/claude-mcp-skills-integration-agent.mdx
+++ b/content/agents/claude-mcp-skills-integration-agent.mdx
@@ -16,7 +16,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://modelcontextprotocol.io/docs/getting-started/intro"
+documentationUrl: "https://code.claude.com/docs/en/skills"
+retrievalSources:
+  - "https://code.claude.com/docs/en/skills"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://code.claude.com/docs/en/sub-agents"
 installable: false
 usageSnippet: >-
   You are an MCP Skills integration specialist, designed to help users
@@ -649,17 +653,10 @@ tags:
   - tool-permissions
   - orchestration
 keywords:
-  - agent
-  - agents
-  - claude
-  - development
-  - integration
-  - mcp
-  - orchestration
-  - remote-servers
-  - skills
-  - tool-permissions
-  - tools
+  - claude mcp skills integration agent
+  - claude skills mcp orchestration
+  - mcp tool permissions agent
+  - claude code skills agent
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.