### PR TITLE
fix(content): reground backend-development-suite keywords + sources

### DIFF
--- a/content/collections/backend-development-suite.mdx
+++ b/content/collections/backend-development-suite.mdx
@@ -16,6 +16,12 @@ seoDescription: >-
   scalable...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/mcp"
+privacyNotes:
+  - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 dateAdded: "2025-10-02"
 installable: false
 usageSnippet: >-
@@ -50,17 +56,10 @@ tags:
   - aws
   - infrastructure
 keywords:
-  - architecture
-  - aws
-  - backend
-  - claude
-  - cloud
-  - collections
-  - database
-  - development
-  - infrastructure
-  - suite
-  - tools
+  - backend development collection
+  - backend agents claude
+  - database and cloud backend tools
+  - scalable backend suite claude
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds `documentationUrl`/`retrievalSources` (Claude Code sub-agents + MCP docs), `privacyNotes` (bundled cloud/DB tools use your credentials), and the keyword cleanup. Content-policy scan + `pnpm validate:content:strict` pass locally.