### PR TITLE
content(collections): add Accessibility QA For AI-Built Interfaces

### DIFF
--- a/content/collections/accessibility-qa-for-ai-built-interfaces.mdx
+++ b/content/collections/accessibility-qa-for-ai-built-interfaces.mdx
@@ -1,0 +1,92 @@
+---
+title: Accessibility QA For AI-Built Interfaces
+slug: accessibility-qa-for-ai-built-interfaces
+category: collections
+description: >-
+  Collection for validating AI-generated UI: computer-use GUI QA skill, DevTools and Playwright
+  MCP servers, accessibility hook, and frontend visual QA command for AI-built interfaces.
+cardDescription: >-
+  QA bundle for AI-built UIs with computer use, DevTools, Playwright, and a11y hooks.
+seoTitle: Accessibility QA For AI-Built Interfaces
+seoDescription: >-
+  HeyClaude collection for AI-built interface QA: computer-use GUI skill, Chrome DevTools MCP,
+  Playwright MCP, accessibility checker hook, and frontend visual QA command.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 803
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/803"
+documentationUrl: "https://www.w3.org/WAI/WCAG21/quickref/"
+sourceUrls:
+  - "https://www.w3.org/WAI/WCAG21/quickref/"
+  - "https://playwright.dev/docs/accessibility-testing"
+  - "https://code.claude.com/docs/en/computer-use"
+installable: false
+usageSnippet: >-
+  Run accessibility-checker on AI-generated markup, validate with frontend-visual-qa, then
+  add DevTools and Playwright MCP plus computer-use GUI QA for interactive checks.
+items:
+  - slug: accessibility-checker
+    category: hooks
+  - slug: frontend-visual-qa
+    category: commands
+  - slug: claude-code-computer-use-gui-qa-capability-pack
+    category: skills
+  - slug: chrome-devtools-mcp-server
+    category: mcp
+  - slug: playwright-mcp-server
+    category: mcp
+installationOrder:
+  - accessibility-checker
+  - frontend-visual-qa
+  - claude-code-computer-use-gui-qa-capability-pack
+  - chrome-devtools-mcp-server
+  - playwright-mcp-server
+estimatedSetupTime: 70 minutes
+difficulty: intermediate
+prerequisites:
+  - "Local or preview environment for AI-generated UI—not production first."
+  - "WCAG target agreed with design stakeholders."
+safetyNotes:
+  - "Browser automation can submit forms or trigger side effects—use staging URLs."
+  - "Computer-use flows may interact with real desktop applications—scope carefully."
+privacyNotes:
+  - "Screenshots and DOM snapshots may capture user data—scrub before sharing."
+tags:
+  - accessibility
+  - ai-built-ui
+  - qa
+  - playwright
+keywords:
+  - accessibility QA AI-built interfaces collection
+robotsIndex: true
+robotsFollow: true
+---
+
+## What this collection sets up
+
+Focuses on **AI-generated interface QA** (computer-use and visual validation) rather than
+general frontend test harness setup alone.
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+| Layer | Source |
+| --- | --- |
+| WCAG checks | W3C WCAG 2.1 quick reference |
+| Visual QA command | Claude Code frontend visual QA workflow |
+| Computer-use GUI QA | code.claude.com computer-use documentation |
+| Browser MCP servers | Playwright and Chrome DevTools MCP entry docs |
+
+## Duplicate Check
+
+Distinct from **`frontend-qa-accessibility-workflow`** (broader Storybook/BrowserStack bundle).
+This collection emphasizes **AI-built UI validation** with computer-use and visual QA command steps.
+
+## Editorial Disclosure
+
+Curated bundle by **kiannidev** linking existing source-backed HeyClaude entries.


### PR DESCRIPTION
Closes #803

## Summary
- Adds `content/collections/accessibility-qa-for-ai-built-interfaces.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/collections/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category collections`