### PR TITLE
content(mcp): add inference.sh MCP Server

### DIFF
--- a/content/mcp/inference-sh-mcp-server.mdx
+++ b/content/mcp/inference-sh-mcp-server.mdx
@@ -1,0 +1,98 @@
+        ---
+        title: inference.sh MCP Server
+        slug: inference-sh-mcp-server
+        category: mcp
+        description: >-
+          inference.sh MCP runs 150+ AI apps for image, video, audio, LLM, and 3D workflows over streamable HTTP.
+        cardDescription: >-
+          inference.sh MCP runs 150+ AI apps for image, video, audio, LLM, and 3D workflows over streamable HTTP.
+        seoTitle: inference.sh MCP Server for Claude
+        seoDescription: >-
+          Configure inference.sh MCP Server (ac.inference.sh/mcp) with streamable HTTP transport and documented auth boundaries.
+        author: inference.sh
+        authorProfileUrl: "https://inference.sh"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1452
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1452"
+        documentationUrl: "https://docs.inference.sh"
+        websiteUrl: "https://inference.sh"
+        retrievalSources:
+          - "https://docs.inference.sh"
+  - "https://inference.sh"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http inference-sh YOUR_INFERENCE_MCP_REMOTE"
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "inference": {
+      "url": "https://YOUR_INFERENCE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "inference": {
+      "url": "https://YOUR_INFERENCE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - inference.sh MCP Server
+          - ac.inference.sh/mcp MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **inference.sh MCP Server** is listed in the MCP Registry as **`ac.inference.sh/mcp`**.
+        inference.sh MCP runs 150+ AI apps for image, video, audio, LLM, and 3D workflows over streamable HTTP.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http inference-sh YOUR_INFERENCE_MCP_REMOTE
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ac.inference.sh/mcp`** with documented remote transport metadata.
+        - Primary documentation URL **https://docs.inference.sh** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ac.inference.sh/mcp`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1452

## Summary
- Adds `content/mcp/inference-sh-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`