### PR TITLE
content(mcp): add ai.adramp/google-ads MCP Server

### DIFF
--- a/content/mcp/ai-adramp-google-ads-mcp-server.mdx
+++ b/content/mcp/ai-adramp-google-ads-mcp-server.mdx
@@ -1,0 +1,97 @@
+        ---
+        title: ai.adramp/google-ads MCP Server
+        slug: ai-adramp-google-ads-mcp-server
+        category: mcp
+        description: >-
+          AdRamp Google Ads MCP connects MCP clients to Google Ads campaign tooling over SSE transport.
+        cardDescription: >-
+          AdRamp Google Ads MCP connects MCP clients to Google Ads campaign tooling over SSE transport.
+        seoTitle: ai.adramp/google-ads MCP Server for Claude
+        seoDescription: >-
+          Configure ai.adramp/google-ads MCP Server (ai.adramp/google-ads) with streamable HTTP transport and documented auth boundaries.
+        author: AdRamp
+        authorProfileUrl: "https://adramp.ai"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1458
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1458"
+        documentationUrl: "https://adramp.ai"
+        websiteUrl: "https://adramp.ai"
+        retrievalSources:
+          - "https://adramp.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http adramps YOUR_ADRAMP_MCP_REMOTE"
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "ai": {
+      "url": "https://YOUR_ADRAMP_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "ai": {
+      "url": "https://YOUR_ADRAMP_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - ai.adramp/google-ads MCP Server
+          - ai.adramp/google-ads MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **ai.adramp/google-ads MCP Server** is listed in the MCP Registry as **`ai.adramp/google-ads`**.
+        AdRamp Google Ads MCP connects MCP clients to Google Ads campaign tooling over SSE transport.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http adramps YOUR_ADRAMP_MCP_REMOTE
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.adramp/google-ads`** with documented remote transport metadata.
+        - Primary documentation URL **https://adramp.ai** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ai.adramp/google-ads`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1458

## Summary
- Adds `content/mcp/ai-adramp-google-ads-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`