### PR TITLE
content(mcp): add Arclan MCP Registry MCP Server

### DIFF
--- a/content/mcp/arclan-mcp-registry-mcp-server.mdx
+++ b/content/mcp/arclan-mcp-registry-mcp-server.mdx
@@ -1,0 +1,97 @@
+        ---
+        title: Arclan MCP Registry MCP Server
+        slug: arclan-mcp-registry-mcp-server
+        category: mcp
+        description: >-
+          Arclan MCP Registry scores and monitors MCP servers with live handshake validation.
+        cardDescription: >-
+          Arclan MCP Registry scores and monitors MCP servers with live handshake validation.
+        seoTitle: Arclan MCP Registry MCP Server for Claude
+        seoDescription: >-
+          Configure Arclan MCP Registry MCP Server (ai.arclan/registry) with streamable HTTP transport and documented auth boundaries.
+        author: Arclan
+        authorProfileUrl: "https://arclan.ai"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1470
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1470"
+        documentationUrl: "https://arclan.ai"
+        websiteUrl: "https://arclan.ai"
+        retrievalSources:
+          - "https://arclan.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http arclan YOUR_ARCLAN_MCP_REMOTE"
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "arclan": {
+      "url": "https://YOUR_ARCLAN_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "arclan": {
+      "url": "https://YOUR_ARCLAN_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - Arclan MCP Registry MCP Server
+          - ai.arclan/registry MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **Arclan MCP Registry MCP Server** is listed in the MCP Registry as **`ai.arclan/registry`**.
+        Arclan MCP Registry scores and monitors MCP servers with live handshake validation.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http arclan YOUR_ARCLAN_MCP_REMOTE
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.arclan/registry`** with documented remote transport metadata.
+        - Primary documentation URL **https://arclan.ai** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ai.arclan/registry`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1470

## Summary
- Adds `content/mcp/arclan-mcp-registry-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`