### PR TITLE
content(mcp): add BlueNexus Universal MCP MCP Server

### DIFF
--- a/content/mcp/bluenexus-universal-mcp-mcp-server.mdx
+++ b/content/mcp/bluenexus-universal-mcp-mcp-server.mdx
@@ -1,0 +1,101 @@
+        ---
+        title: BlueNexus Universal MCP MCP Server
+        slug: bluenexus-universal-mcp-mcp-server
+        category: mcp
+        description: >-
+          BlueNexus Universal MCP connects assistants to 200+ data sources with compliance-oriented filtering.
+        cardDescription: >-
+          BlueNexus Universal MCP connects assistants to 200+ data sources with compliance-oriented filtering.
+        seoTitle: BlueNexus Universal MCP MCP Server for Claude
+        seoDescription: >-
+          Configure BlueNexus Universal MCP MCP Server (ai.bluenexus/universal-mcp) with streamable HTTP transport and documented auth boundaries.
+        author: BlueNexus
+        authorProfileUrl: "https://bluenexus.ai"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1479
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1479"
+        documentationUrl: "https://bluenexus.ai"
+        websiteUrl: "https://bluenexus.ai"
+        retrievalSources:
+          - "https://bluenexus.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http bluenexus YOUR_BLUENEXUS_MCP_REMOTE --header "Authorization: Bearer YOUR_TOKEN""
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+          "mcpServers": {
+            "bluenexus": {
+              "url": "https://YOUR_BLUENEXUS_MCP_REMOTE",
+              "type": "http",
+              "headers": {
+  "Authorization": "Bearer YOUR_TOKEN"
+},
+            }
+          }
+        }
+        configSnippet: |-
+          {
+          "mcpServers": {
+            "bluenexus": {
+              "url": "https://YOUR_BLUENEXUS_MCP_REMOTE",
+              "type": "http",
+              "headers": {
+  "Authorization": "Bearer YOUR_TOKEN"
+},
+            }
+          }
+        }
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - BlueNexus Universal MCP MCP Server
+          - ai.bluenexus/universal-mcp MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **BlueNexus Universal MCP MCP Server** is listed in the MCP Registry as **`ai.bluenexus/universal-mcp`**.
+        BlueNexus Universal MCP connects assistants to 200+ data sources with compliance-oriented filtering.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http bluenexus YOUR_BLUENEXUS_MCP_REMOTE --header "Authorization: Bearer YOUR_TOKEN"
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.bluenexus/universal-mcp`** with documented remote transport metadata.
+        - Primary documentation URL **https://bluenexus.ai** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ai.bluenexus/universal-mcp`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1479

## Summary
- Adds `content/mcp/bluenexus-universal-mcp-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`