### PR TITLE
content(mcp): add Bunzee MCP Server

### DIFF
--- a/content/mcp/bunzee-mcp-server.mdx
+++ b/content/mcp/bunzee-mcp-server.mdx
@@ -1,0 +1,97 @@
+        ---
+        title: Bunzee MCP Server
+        slug: bunzee-mcp-server
+        category: mcp
+        description: >-
+          Bunzee MCP turns app ideas into IA, wireframes, PRDs, style guides, and dev specs for coding agents.
+        cardDescription: >-
+          Bunzee MCP turns app ideas into IA, wireframes, PRDs, style guides, and dev specs for coding agents.
+        seoTitle: Bunzee MCP Server for Claude
+        seoDescription: >-
+          Configure Bunzee MCP Server (ai.bunzee/bunzee) with streamable HTTP transport and documented auth boundaries.
+        author: Bunzee
+        authorProfileUrl: "https://bunzee.ai"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1483
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1483"
+        documentationUrl: "https://bunzee.ai"
+        websiteUrl: "https://bunzee.ai"
+        retrievalSources:
+          - "https://bunzee.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http bunzee YOUR_BUNZEE_MCP_REMOTE"
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "bunzee": {
+      "url": "https://YOUR_BUNZEE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "bunzee": {
+      "url": "https://YOUR_BUNZEE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - Bunzee MCP Server
+          - ai.bunzee/bunzee MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **Bunzee MCP Server** is listed in the MCP Registry as **`ai.bunzee/bunzee`**.
+        Bunzee MCP turns app ideas into IA, wireframes, PRDs, style guides, and dev specs for coding agents.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http bunzee YOUR_BUNZEE_MCP_REMOTE
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.bunzee/bunzee`** with documented remote transport metadata.
+        - Primary documentation URL **https://bunzee.ai** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ai.bunzee/bunzee`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1483

## Summary
- Adds `content/mcp/bunzee-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`