### PR TITLE
content(mcp): add ai.buyersense/buyersense MCP Server

### DIFF
--- a/content/mcp/ai-buyersense-buyersense-mcp-server.mdx
+++ b/content/mcp/ai-buyersense-buyersense-mcp-server.mdx
@@ -1,0 +1,97 @@
+        ---
+        title: ai.buyersense/buyersense MCP Server
+        slug: ai-buyersense-buyersense-mcp-server
+        category: mcp
+        description: >-
+          BuyerSense MCP exposes buyer-intent signals for GTM workflows through a streamable HTTP endpoint.
+        cardDescription: >-
+          BuyerSense MCP exposes buyer-intent signals for GTM workflows through a streamable HTTP endpoint.
+        seoTitle: ai.buyersense/buyersense MCP Server for Claude
+        seoDescription: >-
+          Configure ai.buyersense/buyersense MCP Server (ai.buyersense/buyersense) with streamable HTTP transport and documented auth boundaries.
+        author: BuyerSense
+        authorProfileUrl: "https://www.buyersense.ai"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1485
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1485"
+        documentationUrl: "https://www.buyersense.ai"
+        websiteUrl: "https://www.buyersense.ai"
+        retrievalSources:
+          - "https://www.buyersense.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "claude mcp add --transport http buyersense YOUR_BUYERSENSE_MCP_REMOTE"
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "ai": {
+      "url": "https://YOUR_BUYERSENSE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "ai": {
+      "url": "https://YOUR_BUYERSENSE_MCP_REMOTE",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - ai.buyersense/buyersense MCP Server
+          - ai.buyersense/buyersense MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **ai.buyersense/buyersense MCP Server** is listed in the MCP Registry as **`ai.buyersense/buyersense`**.
+        BuyerSense MCP exposes buyer-intent signals for GTM workflows through a streamable HTTP endpoint.
+
+        ## Installation
+
+        ```bash
+        claude mcp add --transport http buyersense YOUR_BUYERSENSE_MCP_REMOTE
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.buyersense/buyersense`** with documented remote transport metadata.
+        - Primary documentation URL **https://www.buyersense.ai** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        No existing `content/mcp/` entry documents registry package `ai.buyersense/buyersense`.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1485

## Summary
- Adds `content/mcp/ai-buyersense-buyersense-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`