### PR TITLE
content(mcp): add Agent Skills Search Server MCP Server

### DIFF
--- a/content/mcp/agent-skills-search-server-mcp-server.mdx
+++ b/content/mcp/agent-skills-search-server-mcp-server.mdx
@@ -1,0 +1,99 @@
+        ---
+        title: Agent Skills Search Server MCP Server
+        slug: agent-skills-search-server-mcp-server
+        category: mcp
+        description: >-
+          Agent Skills Search MCP discovers skills from the skills.sh ecosystem using the Agent Skills open format.
+        cardDescription: >-
+          Agent Skills Search MCP discovers skills from the skills.sh ecosystem using the Agent Skills open format.
+        seoTitle: Agent Skills Search Server MCP Server for Claude
+        seoDescription: >-
+          Configure Agent Skills Search Server MCP Server (ai.com.mcp/skills-search) with streamable HTTP transport and documented auth boundaries.
+        author: Agent Skills
+        authorProfileUrl: "https://github.com/agentskills"
+        submittedBy: kiannidev
+        submittedByUrl: "https://github.com/kiannidev"
+        dateAdded: "2026-06-17"
+        submittedAt: "2026-06-17"
+        sourceSubmissionNumber: 1494
+        sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1494"
+        repoUrl: "https://github.com/agentskills/agentskills"
+documentationUrl: "https://raw.githubusercontent.com/agentskills/agentskills/main/README.md"
+        websiteUrl: "https://agentskills.io"
+        retrievalSources:
+          - "https://raw.githubusercontent.com/agentskills/agentskills/main/README.md"
+  - "https://agentskills.io"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+        installable: true
+        installCommand: "Connect your MCP client to the registry-listed skills-search remote after verifying the current endpoint in MCP Registry search results."
+        usageSnippet: >-
+          Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+        copySnippet: |-
+          {
+  "mcpServers": {
+    "agent": {
+      "url": "https://agentskills.io",
+      "type": "http"
+
+    }
+  }
+}
+        configSnippet: |-
+          {
+  "mcpServers": {
+    "agent": {
+      "url": "https://agentskills.io",
+      "type": "http"
+
+    }
+  }
+}
+        estimatedSetupTime: 15 minutes
+        difficulty: intermediate
+        prerequisites:
+          - "MCP client with streamable HTTP transport support."
+          - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+          - "Security review of tool write scope before production use."
+        safetyNotes:
+          - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+          - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+        privacyNotes:
+          - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+          - "Review data residency and retention policies before connecting production accounts."
+        tags:
+          - mcp
+          - registry
+        keywords:
+          - Agent Skills Search Server MCP Server
+          - ai.com.mcp/skills-search MCP server
+        robotsIndex: true
+        robotsFollow: true
+        ---
+
+        ## Overview
+
+        **Agent Skills Search Server MCP Server** is listed in the MCP Registry as **`ai.com.mcp/skills-search`**.
+        Agent Skills Search MCP discovers skills from the skills.sh ecosystem using the Agent Skills open format.
+
+        ## Installation
+
+        ```bash
+        Connect your MCP client to the registry-listed skills-search remote after verifying the current endpoint in MCP Registry search results.
+        ```
+
+        ## Source Verification Notes
+
+        Verified on **2026-06-17**:
+
+        - MCP Registry search returns **`ai.com.mcp/skills-search`** with documented remote transport metadata.
+        - Primary documentation URL **https://raw.githubusercontent.com/agentskills/agentskills/main/README.md** is publicly reachable.
+        - Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+        ## Duplicate Check
+
+        Distinct from Agent Skills authoring/review capability packs; this entry covers the registry search server only.
+
+        ## Editorial Disclosure
+
+        Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1494

## Summary
- Adds `content/mcp/agent-skills-search-server-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`