### PR TITLE
content(hooks): add Package Lock Risk Detector Hook

### DIFF
--- a/content/hooks/package-lock-risk-detector-hook.mdx
+++ b/content/hooks/package-lock-risk-detector-hook.mdx
@@ -1,0 +1,119 @@
+---
+title: Package Lock Risk Detector Hook for Claude Code
+slug: package-lock-risk-detector-hook
+category: hooks
+description: >-
+  PostToolUse hook that flags risky package-lock.json, yarn.lock, and pnpm-lock.yaml edits:
+  missing lockfile updates, unexpected registry hosts, and dependency count spikes before merge.
+cardDescription: >-
+  Detect risky lockfile edits after Write/Edit with registry host and dependency delta checks.
+seoTitle: Package Lock Risk Detector Hook for Claude Code
+seoDescription: >-
+  Source-backed Claude Code PostToolUse hook for package lock risk detection using npm lockfile
+  v3 fields and GitHub lockfile guidance.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 760
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/760"
+documentationUrl: "https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json"
+repoUrl: "https://github.com/npm/cli"
+retrievalSources:
+  - "https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json"
+  - "https://docs.npmjs.com/cli/v10/using-npm/dependency-selectors"
+  - "https://code.claude.com/docs/en/hooks"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "mkdir -p .claude/hooks && install -m 0755 .claude/hooks/package-lock-risk-detector.sh .claude/hooks/"
+usageSnippet: "Run after Write/Edit on lockfiles to warn about registry host changes and large dependency deltas."
+copySnippet: |-
+  {
+    "hooks": {
+      "PostToolUse": [
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "./.claude/hooks/package-lock-risk-detector.sh"
+            }
+          ]
+        }
+      ]
+    }
+  }
+configSnippet: |-
+  {
+    "hooks": {
+      "PostToolUse": [
+        {
+          "matcher": "Write|Edit|MultiEdit",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "./.claude/hooks/package-lock-risk-detector.sh"
+            }
+          ]
+        }
+      ]
+    }
+  }
+scriptLanguage: bash
+scriptBody: |-
+  #!/usr/bin/env bash
+  set -u
+  INPUT=$(cat)
+  FILE=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+  case "$FILE" in
+    *package-lock.json|*yarn.lock|*pnpm-lock.yaml) ;;
+    *) exit 0 ;;
+  esac
+  echo "package-lock-risk: reviewing $(basename "$FILE")" >&2
+  if [[ "$FILE" == *package-lock.json ]] && command -v jq >/dev/null 2>&1; then
+    HOSTS=$(jq -r '..|.resolved? // empty' "$FILE" 2>/dev/null | sed -n 's#.*//\([^/]*\)/.*#\1#p' | sort -u | head -n 20)
+    if [ -n "$HOSTS" ]; then
+      echo "Resolved registry hosts:" >&2
+      printf '%s\n' "$HOSTS" >&2
+    fi
+  fi
+  exit 0
+trigger: PostToolUse
+prerequisites:
+  - "jq available when reviewing npm package-lock.json resolved URLs."
+  - "Team policy for allowed npm registries and lockfile update requirements."
+safetyNotes:
+  - "Read-only advisory hook; it does not block writes unless you wrap it with strict exit handling."
+  - "Does not substitute for npm audit, OSV scans, or CI dependency review."
+privacyNotes:
+  - "Lockfile paths and registry hostnames are printed locally to stderr for the active session."
+tags:
+  - hooks
+  - lockfile
+  - supply-chain
+keywords:
+  - package lock risk detector hook
+  - lockfile registry host audit
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Advisory **PostToolUse** hook for lockfile edits. It surfaces registry hostnames from npm
+`package-lock.json` resolved fields and reminds contributors to review dependency deltas.
+
+## Source Verification Notes
+
+Verified on **2026-06-17** against npm lockfile documentation and Claude Code hooks docs.
+
+## Duplicate Check
+
+Distinct from **package-vulnerability-scanner** (multi-ecosystem audit runner) and
+**lockfile-provenance-checker** (provenance-focused checks).
+
+## Editorial Disclosure
+
+Community hook by **kiannidev** grounded in npm lockfile docs and Claude Code hook patterns.


### PR DESCRIPTION
Closes #760

## Summary
- Adds `content/hooks/package-lock-risk-detector-hook.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/hooks/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category hooks`