### PR TITLE
content(commands): add CI Failure Triage Runbook

### DIFF
--- a/content/commands/ci-failure-triage-runbook.mdx
+++ b/content/commands/ci-failure-triage-runbook.mdx
@@ -1,0 +1,59 @@
+---
+title: /ci-failure-triage-runbook - CI Failure Triage Runbook Slash Command
+slug: ci-failure-triage-runbook
+category: commands
+description: >-
+  Slash command checklist for ci failure triage runbook slash command grounded in public documentation.
+cardDescription: >-
+  Checklist-oriented slash command runbook for ci failure triage runbook.
+seoTitle: /ci-failure-triage-runbook - CI Failure Triage Runbook Slash Command
+seoDescription: >-
+  Source-backed command runbook for ci failure triage runbook with duplicate-safe checklist framing.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 746
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/746"
+documentationUrl: "https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging"
+repoUrl: "https://github.com/JSONbored/awesome-claude"
+sourceUrls:
+  - "https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging"
+  - "https://github.com/JSONbored/awesome-claude/blob/main/scripts/validate-content.mjs"
+installable: true
+installCommand: "/ci-failure-triage-runbook"
+commandSyntax: "/ci-failure-triage-runbook"
+usageSnippet: "/ci-failure-triage-runbook"
+copySnippet: "/ci-failure-triage-runbook"
+prerequisites:
+  - "Understand this is a checklist runbook command, not a built-in Claude Code slash alias."
+safetyNotes:
+  - "Checklist only—does not execute CI, browser, or eval jobs automatically."
+privacyNotes:
+  - "Session context may include repository paths referenced by the checklist."
+tags:
+  - commands
+  - runbook
+keywords:
+  - ci-failure-triage-runbook
+robotsIndex: true
+robotsFollow: true
+---
+
+## Purpose
+
+Checklist runbook command for contributors. Runbook wrapper distinct from `/ci-failure-triage` command—focuses on GitHub Actions log slicing checklist.
+
+## Source Verification Notes
+
+Verified on **2026-06-17** against `https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging`.
+
+## Duplicate Check
+
+Runbook wrapper distinct from `/ci-failure-triage` command—focuses on GitHub Actions log slicing checklist.
+
+## Editorial Disclosure
+
+Community runbook by **kiannidev**.


### PR DESCRIPTION
Closes #746

## Summary
- Adds `content/commands/ci-failure-triage-runbook.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/commands/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category commands`