### PR TITLE
content(commands): add OpenAPI Diff Review Runbook

### DIFF
--- a/content/commands/openapi-diff-review-runbook.mdx
+++ b/content/commands/openapi-diff-review-runbook.mdx
@@ -1,0 +1,59 @@
+---
+title: /openapi-diff-review-runbook - OpenAPI Diff Review Runbook Slash Command
+slug: openapi-diff-review-runbook
+category: commands
+description: >-
+  Slash command checklist for openapi diff review runbook slash command grounded in public documentation.
+cardDescription: >-
+  Checklist-oriented slash command runbook for openapi diff review runbook.
+seoTitle: /openapi-diff-review-runbook - OpenAPI Diff Review Runbook Slash Command
+seoDescription: >-
+  Source-backed command runbook for openapi diff review runbook with duplicate-safe checklist framing.
+author: kiannidev
+authorProfileUrl: "https://github.com/kiannidev"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 754
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/754"
+documentationUrl: "https://github.com/stoplightio/spectral/blob/develop/README.md"
+repoUrl: "https://github.com/JSONbored/awesome-claude"
+sourceUrls:
+  - "https://github.com/stoplightio/spectral/blob/develop/README.md"
+  - "https://github.com/JSONbored/awesome-claude/blob/main/scripts/validate-content.mjs"
+installable: true
+installCommand: "/openapi-diff-review-runbook"
+commandSyntax: "/openapi-diff-review-runbook"
+usageSnippet: "/openapi-diff-review-runbook"
+copySnippet: "/openapi-diff-review-runbook"
+prerequisites:
+  - "Understand this is a checklist runbook command, not a built-in Claude Code slash alias."
+safetyNotes:
+  - "Checklist only—does not execute CI, browser, or eval jobs automatically."
+privacyNotes:
+  - "Session context may include repository paths referenced by the checklist."
+tags:
+  - commands
+  - runbook
+keywords:
+  - openapi-diff-review-runbook
+robotsIndex: true
+robotsFollow: true
+---
+
+## Purpose
+
+Checklist runbook command for contributors. Distinct from `/openapi-diff-review`—documents pre-merge OpenAPI diff checklist with Spectral docs.
+
+## Source Verification Notes
+
+Verified on **2026-06-17** against `https://github.com/stoplightio/spectral/blob/develop/README.md`.
+
+## Duplicate Check
+
+Distinct from `/openapi-diff-review`—documents pre-merge OpenAPI diff checklist with Spectral docs.
+
+## Editorial Disclosure
+
+Community runbook by **kiannidev**.


### PR DESCRIPTION
Closes #754

## Summary
- Adds `content/commands/openapi-diff-review-runbook.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- All frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/commands/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category commands`