### PR TITLE
fix(content): reground plaid-mcp-server keywords + sources

### DIFF
--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -20,6 +20,9 @@ author: Plaid
 authorProfileUrl: "https://plaid.com/"
 dateAdded: "2025-09-18"
 documentationUrl: "https://plaid.com/blog/plaid-mcp-ai-assistant-claude/"
+retrievalSources:
+  - "https://plaid.com/blog/plaid-mcp-ai-assistant-claude/"
+  - "https://modelcontextprotocol.io/introduction"
 downloadUrl: /downloads/mcp/plaid-mcp-server.mcpb
 packageVerified: true
 installable: true
@@ -72,17 +75,10 @@ tags:
   - financial-data
   - account-linking
 keywords:
-  - account-linking
-  - banking
-  - claude
-  - development
-  - financial-data
-  - fintech
-  - mcp
-  - mcp servers
-  - plaid
-  - server
-  - tools
+  - plaid mcp server
+  - claude plaid integration
+  - banking data mcp server
+  - plaid fintech mcp
 readingTime: 1
 difficultyScore: 6
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. `documentationUrl`/`retrievalSources` now point at Plaid's official MCP-for-Claude blog post (which describes the `api.dashboard.plaid.com/mcp` server) plus the MCP introduction, alongside the keyword cleanup. Content-policy scan + `pnpm validate:content:strict` pass locally.