### PR TITLE
fix(content): reground golang-expert keywords + sources

### DIFF
--- a/content/rules/golang-expert.mdx
+++ b/content/rules/golang-expert.mdx
@@ -16,7 +16,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://go.dev/doc/"
+documentationUrl: "https://go.dev/doc/effective_go"
+retrievalSources:
+  - "https://go.dev/doc/effective_go"
+  - "https://go.dev/ref/mod"
+  - "https://go.dev/doc/"
 installable: false
 usageSnippet: >-
   You are a Go ecosystem expert specializing in tooling, library development,
@@ -362,18 +366,15 @@ tags:
   - libraries
   - modules
   - build-tools
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - build-tools
-  - claude
-  - cli
-  - development
-  - expert
-  - golang
-  - libraries
-  - modules
-  - rules
-  - tooling
-  - tools
+  - golang expert
+  - claude go rules
+  - go best practices
+  - go coding rules
 readingTime: 4
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.