### PR TITLE
docs(content): fix truncated seoDescription for csv-excel-data-wrangler

### DIFF
--- a/content/skills/csv-excel-data-wrangler.mdx
+++ b/content/skills/csv-excel-data-wrangler.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Clean, filter, join, pivot, and export CSV/XLSX data reliably with reproducible steps. Transform messy spreadsheets into production-ready datasets with pandas. Handle encoding issues, data type conversion, missing values, duplicates, and complex merges."
 cardDescription: "Clean, filter, join, pivot, and export CSV/XLSX data reliably with reproducible steps."
 seoTitle: CSV/Excel Data Wrangler Skill
-seoDescription: "Clean, filter, join, pivot, and export CSV/XLSX data reliably with reproducible steps. Transform messy spreadsheets into production-ready datasets with panda..."
+seoDescription: "Clean, filter, join, pivot, and export CSV/XLSX data with reproducible pandas steps — handling encoding, type conversion, missing values, and complex merges."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.