### PR TITLE
docs(content): fix truncated seoDescription for cursor-windsurf-ai-ide-setup

### DIFF
--- a/content/skills/cursor-windsurf-ai-ide-setup.mdx
+++ b/content/skills/cursor-windsurf-ai-ide-setup.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Configure and optimize Cursor and Windsurf AI code editors for maximum productivity. Set up agent mode, composer features, keybindings, and AI-powered refactoring workflows. Customize with .cursorrules and .windsurfrules for project-specific guidance."
 cardDescription: Configure and optimize Cursor and Windsurf AI code editors for maximum productivity.
 seoTitle: Cursor Windsurf AI Code Editor Skill - Claude Code Skills
-seoDescription: "Configure and optimize Cursor and Windsurf AI code editors for maximum productivity. Set up agent mode, composer features, keybindings, and AI-powered refact..."
+seoDescription: "Configure and optimize Cursor and Windsurf AI editors: agent mode, composer, keybindings, and .cursorrules/.windsurfrules for project-specific AI workflows."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.