### PR TITLE
docs(content): fix truncated seoDescription for docx-report-generator

### DIFF
--- a/content/skills/docx-report-generator.mdx
+++ b/content/skills/docx-report-generator.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Fill templated DOCX with data to produce reports, invoices, and formatted documents. Generate professional Word documents programmatically with python-docx or use Jinja2 templates with docxtpl for dynamic content insertion. Support tables, images, headers, footers, and custom styling."
 cardDescription: "Fill templated DOCX with data to produce reports, invoices, and formatted documents."
 seoTitle: DOCX Report Generator Skill
-seoDescription: "Fill templated DOCX with data to produce reports, invoices, and formatted documents. Generate professional Word documents programmatically with python-docx o..."
+seoDescription: "Generate Word reports, invoices, and formatted documents from DOCX templates using python-docx and docxtpl — tables, images, headers, footers, and styling."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.