### PR TITLE
docs(content): fix truncated seoDescription for github-actions-ai-cicd

### DIFF
--- a/content/skills/github-actions-ai-cicd.mdx
+++ b/content/skills/github-actions-ai-cicd.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Build intelligent CI/CD pipelines with GitHub Actions, AI-assisted workflow generation, automated testing, and deployment orchestration."
 cardDescription: "Build intelligent CI/CD pipelines with GitHub Actions, AI-assisted workflow generation, automated testing, and deployment orchestration."
 seoTitle: GitHub Actions AI-Powered CI/CD Automation Skill
-seoDescription: "Build intelligent CI/CD pipelines with GitHub Actions, AI-assisted workflow generation, automated testing, and deployment orchestration. Includes OIDC authen..."
+seoDescription: "Build intelligent GitHub Actions CI/CD pipelines with AI-assisted workflow generation, automated testing, OIDC auth, and deployment orchestration."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.