### PR TITLE
docs(content): fix truncated seoDescription for log-parsing-incident-timeline

### DIFF
--- a/content/skills/log-parsing-incident-timeline.mdx
+++ b/content/skills/log-parsing-incident-timeline.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Parse web, application, and system logs into structured incidents and timelines with anomaly detection."
 cardDescription: "Parse web, application, and system logs into structured incidents and timelines with anomaly detection."
 seoTitle: Log Parsing + Incident Timeline Skill
-seoDescription: "Parse web, application, and system logs into structured incidents and timelines with anomaly detection. Supports multiple log formats (Apache/Nginx access lo..."
+seoDescription: "Parse Apache, Nginx, and application logs into structured incidents and timelines with anomaly detection across multiple log formats."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.