### PR TITLE
docs(content): fix truncated seoDescription for markdown-knowledge-base-composer

### DIFF
--- a/content/skills/markdown-knowledge-base-composer.mdx
+++ b/content/skills/markdown-knowledge-base-composer.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Aggregate Markdown folders into cohesive knowledge bases with automated table of contents generation, cross-link validation and rewriting, heading normalization, and multi-format export (HTML, PDF, DOCX, EPUB)."
 cardDescription: "Aggregate Markdown folders into cohesive knowledge bases with automated table of contents generation, cross-link validation and rewriting..."
 seoTitle: Markdown Knowledge Base Composer Skill
-seoDescription: "Aggregate Markdown folders into cohesive knowledge bases with automated table of contents generation, cross-link validation and rewriting, heading normalizat..."
+seoDescription: "Aggregate Markdown folders into knowledge bases with auto table-of-contents, cross-link validation, heading normalization, and HTML/PDF/DOCX/EPUB export."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.