### PR TITLE
docs(content): fix truncated seoDescription for postgresql-query-optimization

### DIFF
--- a/content/skills/postgresql-query-optimization.mdx
+++ b/content/skills/postgresql-query-optimization.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Analyze and optimize PostgreSQL queries for OLTP and OLAP workloads with AI-assisted performance tuning, indexing strategies, and execution plan analysis."
 cardDescription: "Analyze and optimize PostgreSQL queries for OLTP and OLAP workloads with AI-assisted performance tuning, indexing strategies, and executi..."
 seoTitle: PostgreSQL Query Optimization Skill
-seoDescription: "Analyze and optimize PostgreSQL queries for OLTP and OLAP workloads with AI-assisted performance tuning, indexing strategies, and execution plan analysis. In..."
+seoDescription: "Analyze and optimize PostgreSQL queries for OLTP and OLAP workloads with AI-assisted tuning, indexing strategies, and EXPLAIN execution-plan analysis."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.