### PR TITLE
docs(content): fix truncated seoDescription for rest-api-client-harness

### DIFF
--- a/content/skills/rest-api-client-harness.mdx
+++ b/content/skills/rest-api-client-harness.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Explore and script against REST APIs with comprehensive authentication support (API keys, OAuth 2.0, JWT Bearer tokens, Basic Auth), pagination utilities (cursor-based, offset-based, page-based), retry logic with exponential backoff and jitter, error handling for HTTP status codes, rate limiting with Retry-After hea..."
 cardDescription: "Explore and script against REST APIs with comprehensive authentication support (API keys, OAuth 2.0, JWT Bearer tokens, Basic Auth), pagi..."
 seoTitle: REST API Client Harness Skill
-seoDescription: "Explore and script against REST APIs with comprehensive authentication support (API keys, OAuth 2.0, JWT Bearer tokens, Basic Auth), pagination utilities (cu..."
+seoDescription: "Explore and script REST APIs with auth (API keys, OAuth 2.0, JWT, Basic), pagination, retry with exponential backoff, and rate-limit handling."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-15"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.