### PR TITLE
docs(content): fix truncated seoDescription for svelte-sveltekit-fullstack

### DIFF
--- a/content/skills/svelte-sveltekit-fullstack.mdx
+++ b/content/skills/svelte-sveltekit-fullstack.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Build full-stack web apps with Svelte and SvelteKit. Minimal runtime overhead, reactive components, and server-side rendering. The most admired frontend framework of 2025. Svelte compiles components to vanilla JavaScript at build time, resulting in zero runtime overhead and exceptional performance."
 cardDescription: "Build full-stack web apps with Svelte and SvelteKit. Minimal runtime overhead, reactive components, and server-side rendering."
 seoTitle: Svelte SvelteKit Full-Stack Development Skill
-seoDescription: "Build full-stack web apps with Svelte and SvelteKit. Minimal runtime overhead, reactive components, and server-side rendering. The most admired frontend fram..."
+seoDescription: "Build full-stack web apps with Svelte and SvelteKit — reactive components, server-side rendering, and zero runtime overhead via compile-time output."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.