### PR TITLE
docs(content): fix truncated seoDescription for trpc-type-safe-api

### DIFF
--- a/content/skills/trpc-type-safe-api.mdx
+++ b/content/skills/trpc-type-safe-api.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Build end-to-end type-safe APIs with tRPC and TypeScript, eliminating code generation and runtime bloat for full-stack applications. tRPC provides end-to-end type safety without code generation, schema stitching, or serialization layers - delivering a lighter, more intuitive developer experience than REST or GraphQL."
 cardDescription: "Build end-to-end type-safe APIs with tRPC and TypeScript, eliminating code generation and runtime bloat for full-stack applications."
 seoTitle: tRPC Type-Safe API Builder Skill
-seoDescription: "Build end-to-end type-safe APIs with tRPC and TypeScript, eliminating code generation and runtime bloat for full-stack applications. tRPC provides end-to-end..."
+seoDescription: "Build end-to-end type-safe APIs with tRPC and TypeScript — no code generation, schema stitching, or serialization; lighter than REST or GraphQL."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.