### PR TITLE
docs(content): fix truncated seoDescription for vite-build-optimization

### DIFF
--- a/content/skills/vite-build-optimization.mdx
+++ b/content/skills/vite-build-optimization.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Optimize frontend build performance with Vite's lightning-fast HMR, code splitting, and tree-shaking. Modern build tooling that has replaced Webpack as the developer favorite."
 cardDescription: "Optimize frontend build performance with Vite's lightning-fast HMR, code splitting, and tree-shaking."
 seoTitle: Vite Frontend Build Performance Optimization Skill
-seoDescription: "Optimize frontend build performance with Vite's lightning-fast HMR, code splitting, and tree-shaking. Modern build tooling that has replaced Webpack as the d..."
+seoDescription: "Optimize frontend builds with Vite — lightning-fast HMR, code splitting, and tree-shaking. Modern tooling that replaced Webpack as the developer favorite."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.