### PR TITLE
docs(content): fix truncated seoDescription for windsurf-collaborative-development

### DIFF
--- a/content/skills/windsurf-collaborative-development.mdx
+++ b/content/skills/windsurf-collaborative-development.mdx
@@ -5,7 +5,7 @@ category: skills
 description: "Master collaborative AI-assisted development with Windsurf IDE's Cascade AI, multi-file context awareness, and Flow patterns for team workflows."
 cardDescription: "Master collaborative AI-assisted development with Windsurf IDE's Cascade AI, multi-file context awareness, and Flow patterns for team wor..."
 seoTitle: Windsurf AI-Native Collaborative Development Skill
-seoDescription: "Master collaborative AI-assisted development with Windsurf IDE's Cascade AI, multi-file context awareness, and Flow patterns for team workflows. Windsurf is ..."
+seoDescription: "Master AI-assisted development with Windsurf IDE's Cascade AI, multi-file context awareness, and Flow patterns for collaborative team workflows."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
The `seoDescription` was a truncated copy of `description` ending in `...`, which renders a cut-off snippet in search results. Replaced it with a complete, self-contained sentence (≤160 chars) covering the same substance — no claims changed, so grounding is unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.