### PR TITLE
docs(content): fix garbled seoDescription for filesystem-mcp-server

### DIFF
--- a/content/mcp/filesystem-mcp-server.mdx
+++ b/content/mcp/filesystem-mcp-server.mdx
@@ -13,9 +13,7 @@ cardDescription: >-
   Official MCP server providing secure file system operations for Claude Desktop
   and Claude Code
 seoTitle: Filesystem MCP Server - MCP Servers
-seoDescription: >-
-  Official MCP server providing secure file system operations for Claude Desktop
-  and Claude Code Discover tools for AI development.
+seoDescription: "Official MCP server giving Claude Desktop and Claude Code secure file system operations — read, write, and manage local files within allowed directories."
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-15"


### PR DESCRIPTION
The `seoDescription` had the garbled boilerplate suffix `Discover tools for AI development.` appended to it, which reads as broken filler in search results. Replaced with a clean, complete sentence covering the entry's actual purpose — substance unchanged, grounding unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.