### PR TITLE
docs(content): fix garbled seoDescription for git-mcp-server

### DIFF
--- a/content/mcp/git-mcp-server.mdx
+++ b/content/mcp/git-mcp-server.mdx
@@ -13,9 +13,7 @@ cardDescription: >-
   Official MCP server providing Git repository tools for reading, searching, and
   manipulating Git repositories
 seoTitle: Git MCP Server for Claude
-seoDescription: >-
-  Official MCP server providing Git repository tools for reading, searching, and
-  manipulating Git repositories Discover tools for AI development.
+seoDescription: "Official MCP server providing Git tools for Claude to read, search, and manipulate Git repositories — branches, commits, diffs, and history."
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"


### PR DESCRIPTION
The `seoDescription` had the garbled boilerplate suffix `Discover tools for AI development.` appended to it, which reads as broken filler in search results. Replaced with a clean, complete sentence covering the entry's actual purpose — substance unchanged, grounding unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.