### PR TITLE
docs(content): fix garbled seoDescription for plaid-mcp-server

### DIFF
--- a/content/mcp/plaid-mcp-server.mdx
+++ b/content/mcp/plaid-mcp-server.mdx
@@ -13,9 +13,7 @@ cardDescription: >-
   Analyze, troubleshoot, and optimize Plaid integrations for banking data and
   financial account linking
 seoTitle: Plaid MCP Server for Claude
-seoDescription: >-
-  Analyze, troubleshoot, and optimize Plaid integrations for banking data and
-  financial account linking Discover tools for AI development.
+seoDescription: "Connect Claude to Plaid to analyze, troubleshoot, and optimize integrations for banking data and financial account linking."
 author: Plaid
 authorProfileUrl: "https://plaid.com/"
 dateAdded: "2025-09-18"


### PR DESCRIPTION
The `seoDescription` had the garbled boilerplate suffix `Discover tools for AI development.` appended to it, which reads as broken filler in search results. Replaced with a clean, complete sentence covering the entry's actual purpose — substance unchanged, grounding unaffected. Content-policy scan + `pnpm validate:content:strict` pass locally.