### PR TITLE
docs(content): fix postgresql-mcp-server seoDescription + grounding

### DIFF
--- a/content/mcp/postgresql-mcp-server.mdx
+++ b/content/mcp/postgresql-mcp-server.mdx
@@ -13,13 +13,14 @@ cardDescription: >-
   Official MCP server providing read-only access to PostgreSQL databases with
   schema inspection and query capabilities
 seoTitle: Postgresql MCP Server - MCP Servers
-seoDescription: >-
-  Official MCP server providing read-only access to PostgreSQL databases with
-  schema inspection and query capabilities Discover tools for AI development.
+seoDescription: "Official (archived) MCP server giving Claude read-only access to PostgreSQL databases with schema inspection and SQL query execution."
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"
-documentationUrl: "https://modelcontextprotocol.io/examples"
+documentationUrl: "https://github.com/modelcontextprotocol/servers-archived/blob/main/src/postgres/README.md"
+retrievalSources:
+  - "https://github.com/modelcontextprotocol/servers-archived/blob/main/src/postgres/README.md"
+  - "https://modelcontextprotocol.io/introduction"
 downloadUrl: /downloads/mcp/postgresql-mcp-server.mcpb
 packageVerified: true
 installable: true


### PR DESCRIPTION
Fixes the garbled `seoDescription` (had the `Discover tools for AI development.` filler suffix) and upgrades the generic `documentationUrl` (modelcontextprotocol.io/examples) to the authoritative server README in `modelcontextprotocol/servers-archived` (the Postgres reference server is archived) plus the MCP intro as `retrievalSources`. Keywords unchanged. Content-policy scan + `pnpm validate:content:strict` pass locally.