### PR TITLE
fix(content): reground css-unused-selector-detector keywords + sources

### DIFF
--- a/content/hooks/css-unused-selector-detector.mdx
+++ b/content/hooks/css-unused-selector-detector.mdx
@@ -17,6 +17,10 @@ seoDescription: >-
   wr...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://purgecss.com/"
+retrievalSources:
+  - "https://purgecss.com/"
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -58,19 +62,15 @@ tags:
   - cleanup
   - performance
   - purge
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - cleanup
-  - css
-  - detector
-  - development
-  - hooks
-  - optimization
-  - performance
-  - purge
-  - selector
-  - tools
-  - unused
+  - css unused selector detector hook
+  - claude code css unused selector detector hook
+  - css unused selector detector claude hook
+  - claude css unused selector detector automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.