### PR TITLE
fix(content): reground docker-image-security-scanner keywords + sources

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -19,7 +19,10 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
-documentationUrl: "https://aquasecurity.github.io/trivy/"
+documentationUrl: "https://github.com/aquasecurity/trivy"
+retrievalSources:
+  - "https://github.com/aquasecurity/trivy"
+  - "https://code.claude.com/docs/en/hooks"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch .claude/hooks/docker-image-security-scanner.sh
@@ -60,18 +63,15 @@ tags:
   - containers
   - vulnerability
   - devops
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - containers
-  - development
-  - devops
-  - docker
-  - hooks
-  - image
-  - scanner
-  - security
-  - tools
-  - vulnerability
+  - docker image security scanner hook
+  - claude code docker image security scanner hook
+  - docker image security scanner claude hook
+  - claude docker image security scanner automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.