### PR TITLE
fix(content): reground package-vulnerability-scanner keywords + sources

### DIFF
--- a/content/hooks/package-vulnerability-scanner.mdx
+++ b/content/hooks/package-vulnerability-scanner.mdx
@@ -15,6 +15,10 @@ seoDescription: >-
   vuln...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://docs.npmjs.com/cli/v10/commands/npm-audit"
+retrievalSources:
+  - "https://docs.npmjs.com/cli/v10/commands/npm-audit"
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -56,19 +60,15 @@ tags:
   - dependencies
   - npm
   - pip
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - dependencies
-  - development
-  - hooks
-  - npm
-  - package
-  - pip
-  - scanner
-  - security
-  - tools
-  - vulnerabilities
-  - vulnerability
+  - package vulnerability scanner hook
+  - claude code package vulnerability scanner hook
+  - package vulnerability scanner claude hook
+  - claude package vulnerability scanner automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.