### PR TITLE
fix(content): reground playwright-test-runner keywords + sources

### DIFF
--- a/content/hooks/playwright-test-runner.mdx
+++ b/content/hooks/playwright-test-runner.mdx
@@ -16,7 +16,10 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"
-documentationUrl: "https://playwright.dev"
+documentationUrl: "https://playwright.dev/docs/intro"
+retrievalSources:
+  - "https://playwright.dev/docs/intro"
+  - "https://code.claude.com/docs/en/hooks"
 installable: true
 installCommand: >-
   mkdir -p .claude/hooks && touch .claude/hooks/playwright-test-runner.sh &&
@@ -57,18 +60,15 @@ tags:
   - testing
   - automation
   - browser-testing
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - automation
-  - browser-testing
-  - claude
-  - development
-  - e2e
-  - hooks
-  - playwright
-  - runner
-  - test
-  - testing
-  - tools
+  - playwright test runner hook
+  - claude code playwright test runner hook
+  - playwright test runner claude hook
+  - claude playwright test runner automation
 readingTime: 3
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.