### PR TITLE
fix(content): reground rust-cargo-check keywords + sources

### DIFF
--- a/content/hooks/rust-cargo-check.mdx
+++ b/content/hooks/rust-cargo-check.mdx
@@ -11,6 +11,10 @@ seoDescription: >-
   compilati...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://doc.rust-lang.org/cargo/commands/cargo-check.html"
+retrievalSources:
+  - "https://doc.rust-lang.org/cargo/commands/cargo-check.html"
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -52,17 +56,15 @@ tags:
   - clippy
   - linting
   - compilation
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - cargo
-  - check
-  - claude
-  - clippy
-  - compilation
-  - development
-  - hooks
-  - linting
-  - rust
-  - tools
+  - rust cargo check hook
+  - claude code rust cargo check hook
+  - rust cargo check claude hook
+  - claude rust cargo check automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.