### PR TITLE
fix(content): reground kubernetes-devsecops-engineer keywords + sources

### DIFF
--- a/content/rules/kubernetes-devsecops-engineer.mdx
+++ b/content/rules/kubernetes-devsecops-engineer.mdx
@@ -18,6 +18,9 @@ author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
 documentationUrl: "https://kubernetes.io/docs/concepts/security/"
+retrievalSources:
+  - "https://kubernetes.io/docs/concepts/security/"
+  - "https://kubernetes.io/docs/concepts/overview/working-with-objects/"
 installable: false
 usageSnippet: >-
   You are a Kubernetes DevSecOps engineer specializing in secure, automated
@@ -744,17 +747,15 @@ tags:
   - security
   - gitops
   - rbac
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - claude
-  - development
-  - devsecops
-  - engineer
-  - gitops
-  - kubernetes
-  - rbac
-  - rules
-  - security
-  - tools
+  - kubernetes devsecops engineer rules
+  - claude kubernetes devsecops engineer rules
+  - kubernetes devsecops engineer best practices
+  - claude code kubernetes devsecops engineer
 readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.