### PR TITLE
fix(content): reground security-first-react-components keywords + sources

### DIFF
--- a/content/rules/security-first-react-components.mdx
+++ b/content/rules/security-first-react-components.mdx
@@ -16,7 +16,11 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
-documentationUrl: "https://owasp.org/www-project-top-ten/"
+documentationUrl: "https://react.dev/learn"
+retrievalSources:
+  - "https://react.dev/learn"
+  - "https://owasp.org/www-community/attacks/xss/"
+  - "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP"
 installable: false
 usageSnippet: >-
   You are a security-first React component architect specializing in XSS
@@ -1365,18 +1369,15 @@ tags:
   - xss
   - csp
   - owasp
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - claude
-  - components
-  - csp
-  - development
-  - first
-  - owasp
-  - react
-  - rules
-  - security
-  - tools
-  - xss
+  - security first react components rules
+  - claude security first react components rules
+  - security first react components best practices
+  - claude code security first react components
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.