### PR TITLE
fix(content): reground wcag-accessibility-auditor keywords + sources

### DIFF
--- a/content/rules/wcag-accessibility-auditor.mdx
+++ b/content/rules/wcag-accessibility-auditor.mdx
@@ -16,7 +16,10 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
-documentationUrl: "https://www.w3.org/WAI/WCAG22/quickref/"
+documentationUrl: "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA"
+retrievalSources:
+  - "https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA"
+  - "https://www.w3.org/WAI/standards-guidelines/wcag/"
 installable: false
 usageSnippet: >-
   You are a WCAG 2.2 accessibility expert specializing in creating inclusive web
@@ -708,17 +711,15 @@ tags:
   - a11y
   - aria
   - inclusive-design
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - a11y
-  - accessibility
-  - aria
-  - auditor
-  - claude
-  - development
-  - inclusive-design
-  - rules
-  - tools
-  - wcag
+  - wcag accessibility auditor rules
+  - claude wcag accessibility auditor rules
+  - wcag accessibility auditor best practices
+  - claude code wcag accessibility auditor
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.