### PR TITLE
fix(content): reground debugging-troubleshooting-system keywords + sources

### DIFF
--- a/content/collections/debugging-troubleshooting-system.mdx
+++ b/content/collections/debugging-troubleshooting-system.mdx
@@ -16,6 +16,10 @@ seoDescription: >-
   commands.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://code.claude.com/docs/en/slash-commands"
 dateAdded: "2025-10-02"
 installable: false
 usageSnippet: Start with `debugging-assistant-agent` → `debug` → `explain`
@@ -43,16 +47,10 @@ tags:
   - diagnostics
   - problem-solving
 keywords:
-  - claude
-  - collections
-  - debugging
-  - development
-  - diagnostics
-  - error-handling
-  - problem-solving
-  - system
-  - tools
-  - troubleshooting
+  - debugging troubleshooting collection claude
+  - debugging tools for claude
+  - error diagnosis tools collection
+  - claude debugging workflow
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined keyword-hygiene PR. The prior edit re-triggered the dual-AI grounding bar and the single generic `documentationUrl` did not substantiate the entry's specific claims. This version points `documentationUrl`/`retrievalSources` at per-facet authoritative sources that directly describe this entry, alongside the keyword cleanup. Content-policy scan and `pnpm validate:content:strict` pass locally.