### PR TITLE
fix(content): reground file-size-warning-monitor keywords + sources

### DIFF
--- a/content/hooks/file-size-warning-monitor.mdx
+++ b/content/hooks/file-size-warning-monitor.mdx
@@ -16,6 +16,9 @@ seoDescription: >-
   crea...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
+retrievalSources:
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -57,20 +60,15 @@ tags:
   - notification
   - monitoring
   - optimization
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - development
-  - file
-  - file-size
-  - hooks
-  - monitor
-  - monitoring
-  - notification
-  - optimization
-  - performance
-  - size
-  - tools
-  - warning
+  - file size warning monitor hook
+  - claude code file size warning monitor hook
+  - file size warning monitor claude hook
+  - claude file size warning monitor automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.