### PR TITLE
fix(content): reground team-summary-email-generator keywords + sources

### DIFF
--- a/content/hooks/team-summary-email-generator.mdx
+++ b/content/hooks/team-summary-email-generator.mdx
@@ -15,6 +15,9 @@ seoDescription: >-
   com...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
+retrievalSources:
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -63,16 +66,10 @@ tags:
   - summary
   - communication
 keywords:
-  - claude
-  - communication
-  - development
-  - email
-  - generator
-  - hooks
-  - stop-hook
-  - summary
-  - team
-  - tools
+  - team summary email generator hook
+  - claude code team summary email generator hook
+  - team summary email generator claude hook
+  - claude team summary email generator automation
 readingTime: 4
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.