### PR TITLE
fix(content): reground go-module-tidy keywords + sources

### DIFF
--- a/content/hooks/go-module-tidy.mdx
+++ b/content/hooks/go-module-tidy.mdx
@@ -15,6 +15,10 @@ seoDescription: >-
   manage...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://go.dev/doc/modules/managing-dependencies"
+retrievalSources:
+  - "https://go.dev/doc/modules/managing-dependencies"
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -56,17 +60,15 @@ tags:
   - modules
   - dependencies
   - cleanup
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - claude
-  - cleanup
-  - dependencies
-  - development
-  - golang
-  - hooks
-  - module
-  - modules
-  - tidy
-  - tools
+  - go module tidy hook
+  - claude code go module tidy hook
+  - go module tidy claude hook
+  - claude go module tidy automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.