### PR TITLE
fix(content): reground windsurf-ai-native-ide-patterns keywords + sources

### DIFF
--- a/content/rules/windsurf-ai-native-ide-patterns.mdx
+++ b/content/rules/windsurf-ai-native-ide-patterns.mdx
@@ -16,7 +16,10 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"
-documentationUrl: "https://docs.codeium.com/windsurf"
+documentationUrl: "https://docs.windsurf.com/windsurf/getting-started"
+retrievalSources:
+  - "https://docs.windsurf.com/windsurf/getting-started"
+  - "https://docs.windsurf.com/windsurf/cascade"
 installable: false
 usageSnippet: >-
   You are a Windsurf AI-native IDE specialist focusing on Cascade AI flows,
@@ -1357,19 +1360,15 @@ tags:
   - cascade
   - flow
   - collaboration
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - ai-ide
-  - cascade
-  - claude
-  - collaboration
-  - development
-  - flow
-  - ide
-  - native
-  - patterns
-  - rules
-  - tools
-  - windsurf
+  - windsurf ai native ide patterns rules
+  - claude windsurf ai native ide patterns rules
+  - windsurf ai native ide patterns best practices
+  - claude code windsurf ai native ide patterns
 readingTime: 9
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.