### PR TITLE
fix(content): reground cursor-windsurf-ai-ide-setup keywords + sources

### DIFF
--- a/content/skills/cursor-windsurf-ai-ide-setup.mdx
+++ b/content/skills/cursor-windsurf-ai-ide-setup.mdx
@@ -5,11 +5,11 @@ category: skills
 description: "Configure and optimize Cursor and Windsurf AI code editors for maximum productivity. Set up agent mode, composer features, keybindings, and AI-powered refactoring workflows. Customize with .cursorrules and .windsurfrules for project-specific guidance."
 cardDescription: Configure and optimize Cursor and Windsurf AI code editors for maximum productivity.
 seoTitle: Cursor Windsurf AI Code Editor Skill - Claude Code Skills
-seoDescription: "Configure and optimize Cursor and Windsurf AI code editors for maximum productivity. Set up agent mode, composer features, keybindings, and AI-powered refact..."
+seoDescription: "Configure and optimize Cursor and Windsurf AI editors: agent mode, composer, keybindings, and .cursorrules/.windsurfrules for project-specific AI workflows."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"
-documentationUrl: "https://cursor.com/docs"
+documentationUrl: "https://docs.cursor.com/welcome"
 downloadUrl: /downloads/skills/cursor-windsurf-ai-ide-setup.zip
 installable: true
 safetyNotes:
@@ -71,7 +71,9 @@ skillLevel: advanced
 verificationStatus: draft
 verifiedAt: "2025-10-23"
 retrievalSources:
-  - "https://cursor.sh/docs"
+  - "https://docs.cursor.com/welcome"
+  - "https://docs.cursor.com/context/rules-for-ai"
+  - "https://docs.windsurf.com/windsurf/cascade"
 testedPlatforms:
   - Claude
   - Codex
@@ -93,11 +95,10 @@ tags:
   - ai-coding
   - editor
 keywords:
-  - cursor ide setup
-  - windsurf setup
-  - cursor vs windsurf
-  - ai code editor setup
-  - cursor windsurf config
+  - cursor windsurf setup
+  - cursor ai editor configuration
+  - windsurf ide setup
+  - cursorrules windsurfrules
 readingTime: 6
 packageVerified: true
 difficultyScore: 100


### PR DESCRIPTION
Resubmit. The skill covers both Cursor and Windsurf, but was grounded only on Cursor docs. Adds per-facet `retrievalSources` (Cursor welcome + rules-for-AI, Windsurf Cascade) and fixes the truncated seoDescription. Local scan + `pnpm validate:content:strict` pass.