### PR TITLE
fix(content): reground ai-code-review-security-agent keywords + sources

### DIFF
--- a/content/agents/ai-code-review-security-agent.mdx
+++ b/content/agents/ai-code-review-security-agent.mdx
@@ -16,6 +16,10 @@ seoDescription: >-
   practic...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://owasp.org/www-project-top-ten/"
 dateAdded: "2025-10-16"
 installable: false
 usageSnippet: >-
@@ -1529,18 +1533,15 @@ tags:
   - ai
   - vulnerability-detection
   - static-analysis
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
+privacyNotes:
+  - "Guides Claude to read your repository files plus any code, logs, configuration, or credentials you share in the session; nothing is transmitted beyond the model, but review what you expose before sharing."
 keywords:
-  - agent
-  - agents
-  - claude
-  - code
-  - code-review
-  - development
-  - review
-  - security
-  - static-analysis
-  - tools
-  - vulnerability-detection
+  - ai code review security agent
+  - claude ai code review security agent
+  - ai code review security ai agent
+  - claude code ai code review security
 readingTime: 10
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.