### PR TITLE
fix(content): reground laravel-expert keywords + sources

### DIFF
--- a/content/rules/laravel-expert.mdx
+++ b/content/rules/laravel-expert.mdx
@@ -20,6 +20,8 @@ submittedByUrl: "https://github.com/jaso0n0818"
 dateAdded: "2026-06-16"
 submittedAt: "2026-06-16"
 documentationUrl: "https://laravel.com/docs"
+retrievalSources:
+  - "https://laravel.com/docs"
 sourceUrls:
   - "https://laravel.com/docs/routing"
   - "https://laravel.com/docs/eloquent"
@@ -99,14 +101,13 @@ tags:
   - eloquent
   - api
   - backend
+safetyNotes:
+  - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - laravel
-  - php
-  - eloquent
-  - api
-  - backend
-  - claude
-  - expert
+  - laravel expert
+  - claude laravel rules
+  - laravel best practices
+  - laravel coding rules
 readingTime: 4
 difficultyScore: 85
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.