### PR TITLE
fix(content): reground auto-save-backup keywords + sources

### DIFF
--- a/content/hooks/auto-save-backup.mdx
+++ b/content/hooks/auto-save-backup.mdx
@@ -18,6 +18,9 @@ seoDescription: >-
   Mult...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/hooks"
+retrievalSources:
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -60,17 +63,15 @@ tags:
   - safety
   - file-management
   - data-protection
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - auto
-  - backup
-  - claude
-  - data-protection
-  - development
-  - file-management
-  - hooks
-  - safety
-  - save
-  - tools
+  - auto save backup hook
+  - claude code auto save backup hook
+  - auto save backup claude hook
+  - claude auto save backup automation
 readingTime: 1
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.