### PR TITLE
fix(content): reground json-schema-validator keywords + sources

### DIFF
--- a/content/hooks/json-schema-validator.mdx
+++ b/content/hooks/json-schema-validator.mdx
@@ -15,6 +15,11 @@ seoDescription: >-
   with c...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://json-schema.org/"
+retrievalSources:
+  - "https://json-schema.org/"
+  - "https://ajv.js.org/"
+  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-
@@ -56,17 +61,15 @@ tags:
   - validation
   - data-integrity
   - api
+safetyNotes:
+  - "Runs automatically on its configured Claude Code hook event and executes shell logic that can read, modify, or delete files in your project (and may run builds, installs, or network calls); review the script and scope it to expected paths before enabling."
+privacyNotes:
+  - "Receives Claude Code hook input (session metadata, file paths, and tool output) and reads local project files; review what the script logs or forwards to external services and keep credentials out of its output."
 keywords:
-  - api
-  - claude
-  - data-integrity
-  - development
-  - hooks
-  - json
-  - schema
-  - tools
-  - validation
-  - validator
+  - json schema validator hook
+  - claude code json schema validator hook
+  - json schema validator claude hook
+  - claude json schema validator automation
 readingTime: 2
 difficultyScore: 0
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit of a gate-declined PR. Adds per-facet `retrievalSources` (the specific tool/docs the entry relies on) so the dual-AI can verify the claims, plus safety/privacy notes and keyword hygiene. Content-policy scan + `pnpm validate:content:strict` pass locally.