### PR TITLE
docs(content): optimize seoTitle/seoDescription for aws-cloudformation-validator

### DIFF
--- a/content/hooks/aws-cloudformation-validator.mdx
+++ b/content/hooks/aws-cloudformation-validator.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Validates AWS CloudFormation templates for syntax errors and best practices
   using cfn-lint v1.40.4+ and AWS CLI v2.27.54+.
-seoTitle: AWS CloudFormation Validator - Hooks
-seoDescription: >-
-  Validates AWS CloudFormation templates for syntax errors and best practices
-  using cfn-lint v1.40.4+ and AWS CLI v2.27.54+. This hook automatically detects
-  Cl...
+seoTitle: "AWS CloudFormation Validator Hook for Claude Code"
+seoDescription: "Claude Code hook that validates AWS CloudFormation templates for syntax errors and best practices on save, using cfn-lint and AWS CLI v2."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.