### PR TITLE
docs(content): optimize seoTitle/seoDescription for prisma-schema-sync

### DIFF
--- a/content/hooks/prisma-schema-sync.mdx
+++ b/content/hooks/prisma-schema-sync.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Automatically generates Prisma client and creates migrations when
   schema.prisma is modified.
-seoTitle: Prisma Schema Sync - Hooks
-seoDescription: >-
-  Automatically generates Prisma client and creates migrations when
-  schema.prisma is modified. This PostToolUse hook provides comprehensive Prisma
-  schema synch...
+seoTitle: "Prisma Schema Sync Hook for Claude Code"
+seoDescription: "Claude Code hook that auto-generates the Prisma client and creates migrations whenever schema.prisma changes — keeping your database layer in sync."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.