### PR TITLE
docs(content): optimize seoTitle/seoDescription for golang-expert

### DIFF
--- a/content/rules/golang-expert.mdx
+++ b/content/rules/golang-expert.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Transform Claude into a Go ecosystem expert specializing in tooling, library
   development, CLI applications, and Go build system mastery
-seoTitle: Go Golang Language Expert - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  Transform Claude into a Go ecosystem expert specializing in tooling, library
-  development, CLI applications, and Go build system mastery Discover tools for
-  AI...
+seoTitle: "Go Expert Rules for Claude Code (CLAUDE.md)"
+seoDescription: "Turn Claude into a Go ecosystem expert — tooling, modules, CLI apps, concurrency, and build-system mastery — via CLAUDE.md project rules."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.