### PR TITLE
docs(content): optimize seoTitle/seoDescription for catppuccin-mocha-theme

### DIFF
--- a/content/statuslines/catppuccin-mocha-theme.mdx
+++ b/content/statuslines/catppuccin-mocha-theme.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Soothing Catppuccin Mocha theme statusline with 26 pastel colors, Powerline
   separators, and modular segments for Git, model info, and tok...
-seoTitle: Catppuccin Mocha Theme - Statuslines
-seoDescription: >-
-  Soothing Catppuccin Mocha theme statusline with 26 pastel colors, Powerline
-  separators, and modular segments for Git, model info, and token tracking.
-  Discove...
+seoTitle: "Catppuccin Mocha Statusline for Claude Code"
+seoDescription: "Soothing Catppuccin Mocha statusline for Claude Code — 26 pastel colors, Powerline separators, and Git, model, and token segments."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-23"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.