### PR TITLE
docs(content): optimize seoTitle/seoDescription for paypal-mcp-server

### DIFF
--- a/content/mcp/paypal-mcp-server.mdx
+++ b/content/mcp/paypal-mcp-server.mdx
@@ -12,10 +12,8 @@ description: >-
 cardDescription: >-
   Integrate PayPal commerce capabilities, payment processing, and transaction
   management
-seoTitle: Paypal MCP Server for Claude
-seoDescription: >-
-  Integrate PayPal commerce capabilities, payment processing, and transaction
-  management Discover tools for AI development.
+seoTitle: "PayPal MCP Server for Claude — Payments & Commerce"
+seoDescription: "Connect Claude to PayPal for payment processing, transaction management, and commerce automation through the PayPal MCP server."
 author: PayPal
 authorProfileUrl: "https://www.paypal.com/"
 dateAdded: "2025-09-18"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.