### PR TITLE
docs(content): optimize seoTitle/seoDescription for json-schema-validator

### DIFF
--- a/content/hooks/json-schema-validator.mdx
+++ b/content/hooks/json-schema-validator.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Validates JSON files against their schemas when modified to ensure data
   integrity.
-seoTitle: JSON Schema Validator - Hooks
-seoDescription: >-
-  Validates JSON files against their schemas when modified to ensure data
-  integrity. This PostToolUse hook provides comprehensive JSON schema validation
-  with c...
+seoTitle: "JSON Schema Validator Hook for Claude Code"
+seoDescription: "Claude Code hook that validates JSON files against their schemas on save, catching data-integrity errors before they reach production."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 documentationUrl: "https://json-schema.org/"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.