### PR TITLE
docs(content): optimize seoTitle/seoDescription for security-first-react-components

### DIFF
--- a/content/rules/security-first-react-components.mdx
+++ b/content/rules/security-first-react-components.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Security-first React component architect with XSS prevention, CSP integration,
   input sanitization, and OWASP Top 10 mitigation patterns
-seoTitle: Security-First React Components for Claude
-seoDescription: >-
-  Security-first React component architect with XSS prevention, CSP integration,
-  input sanitization, and OWASP Top 10 mitigation patterns Discover tools for
-  AI...
+seoTitle: "Security-First React Component Rules for Claude"
+seoDescription: "Turn Claude into a security-first React architect — XSS prevention, CSP integration, input sanitization, and OWASP Top 10 mitigation patterns."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.