### PR TITLE
docs(content): optimize seoTitle/seoDescription for ai-code-review-security-agent

### DIFF
--- a/content/agents/ai-code-review-security-agent.mdx
+++ b/content/agents/ai-code-review-security-agent.mdx
@@ -9,11 +9,8 @@ description: >-
 cardDescription: >-
   AI-powered code review specialist focusing on security vulnerabilities, OWASP
   Top 10, static analysis, secrets detection, and automated s...
-seoTitle: AI Code Review Security Agent - Agents
-seoDescription: >-
-  AI-powered code review specialist focusing on security vulnerabilities, OWASP
-  Top 10, static analysis, secrets detection, and automated security best
-  practic...
+seoTitle: "AI Code Review Security Agent for Claude Code"
+seoDescription: "AI code-review agent for Claude that flags security vulnerabilities, OWASP Top 10 issues, exposed secrets, and risky dependencies via static analysis."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.