### PR TITLE
docs(content): optimize seoTitle/seoDescription for debugging-assistant-agent

### DIFF
--- a/content/agents/debugging-assistant-agent.mdx
+++ b/content/agents/debugging-assistant-agent.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Advanced debugging agent that helps identify, analyze, and resolve software
   bugs with systematic troubleshooting methodologies
-seoTitle: Debugging Assistant Agent - Agents
-seoDescription: >-
-  Advanced debugging agent that helps identify, analyze, and resolve software
-  bugs with systematic troubleshooting methodologies Discover tools for AI
-  developm...
+seoTitle: "Debugging Assistant Agent for Claude Code"
+seoDescription: "Claude agent that systematically identifies, analyzes, and resolves software bugs with structured troubleshooting and root-cause methodologies."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.