### PR TITLE
docs(content): optimize seoTitle/seoDescription for multi-agent-orchestration-specialist

### DIFF
--- a/content/agents/multi-agent-orchestration-specialist.mdx
+++ b/content/agents/multi-agent-orchestration-specialist.mdx
@@ -9,11 +9,8 @@ description: >-
 cardDescription: >-
   Multi-agent orchestration specialist using LangGraph and CrewAI for complex,
   stateful workflows with graph-driven reasoning and role-base...
-seoTitle: Multi Agent Orchestration Specialist - Agents
-seoDescription: >-
-  Multi-agent orchestration specialist using LangGraph and CrewAI for complex,
-  stateful workflows with graph-driven reasoning and role-based agent
-  coordination
+seoTitle: "Multi-Agent Orchestration Agent (LangGraph, CrewAI)"
+seoDescription: "Claude agent for orchestrating complex, stateful multi-agent workflows with LangGraph and CrewAI — graph-driven reasoning and role-based coordination."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.