### PR TITLE
docs(content): optimize seoTitle/seoDescription for multi-line-statusline

### DIFF
--- a/content/statuslines/multi-line-statusline.mdx
+++ b/content/statuslines/multi-line-statusline.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Comprehensive multi-line statusline displaying detailed session information
   across two lines with organized sections and visual separators
-seoTitle: Multi Line Statusline - Statuslines
-seoDescription: >-
-  Comprehensive multi-line statusline displaying detailed session information
-  across two lines with organized sections and visual separators Discover tools
-  for...
+seoTitle: "Multi-Line Statusline for Claude Code"
+seoDescription: "Comprehensive two-line Claude Code statusline with organized sections and visual separators for detailed session info at a glance."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-01"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.