### PR TITLE
docs(content): optimize seoTitle/seoDescription for python-import-optimizer

### DIFF
--- a/content/hooks/python-import-optimizer.mdx
+++ b/content/hooks/python-import-optimizer.mdx
@@ -8,11 +8,8 @@ description: >-
 cardDescription: >-
   Automatically sorts and optimizes Python imports using isort when Python files
   are modified.
-seoTitle: Python Import Optimizer - Hooks
-seoDescription: >-
-  Automatically sorts and optimizes Python imports using isort when Python files
-  are modified. This PostToolUse hook provides comprehensive Python import
-  optim...
+seoTitle: "Python Import Optimizer Hook for Claude Code"
+seoDescription: "Claude Code hook that automatically sorts and optimizes Python imports with isort whenever you modify a .py file."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-19"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.