### PR TITLE
docs(content): optimize seoTitle/seoDescription for aws-cloud-architect

### DIFF
--- a/content/rules/aws-cloud-architect.mdx
+++ b/content/rules/aws-cloud-architect.mdx
@@ -8,10 +8,8 @@ description: >-
 cardDescription: >-
   Expert AWS architect with deep knowledge of cloud services, best practices,
   and Well-Architected Framework
-seoTitle: AWS Cloud Architect - CLAUDE.md Rules for Claude Code
-seoDescription: >-
-  Expert AWS architect with deep knowledge of cloud services, best practices,
-  and Well-Architected Framework Discover tools for AI development.
+seoTitle: "AWS Cloud Architect Rules for Claude Code (CLAUDE.md)"
+seoDescription: "Turn Claude into an expert AWS architect — cloud services, Well-Architected Framework, cost optimization, and infrastructure best practices."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"


### PR DESCRIPTION
CTR optimization for a page with real GSC search demand whose `seoTitle` was just the raw title and `seoDescription` was empty/generic. Sets a keyword-rich, query-aligned `seoTitle` and a complete `seoDescription` (no claims changed → grounding holds). Content-policy scan + `pnpm validate:content:strict` pass locally.