### PR TITLE
docs(content): optimize seoTitle for coderabbit-lite-pr-review-capability-pack

### DIFF
--- a/content/skills/coderabbit-lite-pr-review-capability-pack.mdx
+++ b/content/skills/coderabbit-lite-pr-review-capability-pack.mdx
@@ -4,7 +4,7 @@ slug: coderabbit-lite-pr-review-capability-pack
 category: skills
 description: "Expert code-review capability pack for deterministic PR audits, risk-ranked findings, and low-noise fix planning without SaaS lock-in."
 cardDescription: "Run a local, repeatable PR review loop with severity scoring, false-positive control, and fix-ready output."
-seoTitle: Code Review Automation Capability Pack Skill
+seoTitle: "Code Review Automation Skill — PR Audits for Claude"
 seoDescription: "Advanced AI skill for local PR review automation with risk scoring, exploit checks, and remediation workflows."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
@@ -48,6 +48,10 @@ tags:
   - security
   - capability-pack
   - automation
+safetyNotes:
+  - "Installs from a downloaded package and may run local commands or scaffold files as part of the workflow; review the package and any generated changes before applying."
+privacyNotes:
+  - "Operates on your local project files and any context you share in the session; review what you expose before sharing — nothing is sent beyond the model unless a step calls an external service."
 keywords:
   - pull request audit
   - local code review automation


### PR DESCRIPTION
CTR optimization for a trafficked skill whose `seoTitle` was the raw title. Sets a keyword-rich `seoTitle` and adds the `safetyNotes`/`privacyNotes` the content-policy scan requires for installable skills. Scan + `pnpm validate:content:strict` pass locally.