### PR TITLE
docs(content): optimize seoTitle for ai-business-idea-validation-capability-pack

### DIFF
--- a/content/skills/ai-business-idea-validation-capability-pack.mdx
+++ b/content/skills/ai-business-idea-validation-capability-pack.mdx
@@ -4,7 +4,7 @@ slug: ai-business-idea-validation-capability-pack
 category: skills
 description: "Expert business-validation capability pack for testing AI product ideas, market demand, pricing readiness, and launch feasibility."
 cardDescription: "Validate AI business ideas with evidence-driven demand checks, positioning tests, and practical go/no-go decisions."
-seoTitle: AI Business Idea Validation Capability Pack Skill
+seoTitle: "AI Business Idea Validation Skill for Claude"
 seoDescription: "Advanced AI skill for market validation, pricing experiments, and zero-to-one launch decision frameworks for AI products."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
@@ -48,6 +48,10 @@ tags:
   - product-strategy
   - growth
   - capability-pack
+safetyNotes:
+  - "Installs from a downloaded package and may run local commands or scaffold files as part of the workflow; review the package and any generated changes before applying."
+privacyNotes:
+  - "Operates on your local project files and any context you share in the session; review what you expose before sharing — nothing is sent beyond the model unless a step calls an external service."
 keywords:
   - ai startup validation
   - product market demand


### PR DESCRIPTION
CTR optimization for a trafficked skill whose `seoTitle` was the raw title. Sets a keyword-rich `seoTitle` and adds the `safetyNotes`/`privacyNotes` the content-policy scan requires for installable skills. Scan + `pnpm validate:content:strict` pass locally.