### PR TITLE
docs(content): optimize seoTitle for raycast-extension-dev-publish-capability-pack

### DIFF
--- a/content/skills/raycast-extension-dev-publish-capability-pack.mdx
+++ b/content/skills/raycast-extension-dev-publish-capability-pack.mdx
@@ -4,7 +4,7 @@ slug: raycast-extension-dev-publish-capability-pack
 category: skills
 description: "Expert Raycast extension capability skill for command design, extension architecture, testing, and store-ready publication workflows."
 cardDescription: "Deep Raycast builder skill for creating, validating, and shipping high-quality extensions to the Raycast ecosystem."
-seoTitle: Raycast Extension Dev Publish Capability Pack Skill
+seoTitle: "Raycast Extension Dev & Publish Skill for Claude"
 seoDescription: "Advanced AI skill for Raycast extension development and publishing, including architecture, quality checks, and store submission readiness."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
@@ -48,6 +48,10 @@ tags:
   - developer-tools
   - publishing
   - capability-pack
+safetyNotes:
+  - "Installs from a downloaded package and may run local commands or scaffold files as part of the workflow; review the package and any generated changes before applying."
+privacyNotes:
+  - "Operates on your local project files and any context you share in the session; review what you expose before sharing — nothing is sent beyond the model unless a step calls an external service."
 keywords:
   - raycast extension development
   - raycast store publishing


### PR DESCRIPTION
CTR optimization for a trafficked skill whose `seoTitle` was the raw title. Sets a keyword-rich `seoTitle` and adds the `safetyNotes`/`privacyNotes` the content-policy scan requires for installable skills. Scan + `pnpm validate:content:strict` pass locally.