### PR TITLE
docs(content): optimize seoTitle for husky-commit-governance-capability-pack

### DIFF
--- a/content/skills/husky-commit-governance-capability-pack.mdx
+++ b/content/skills/husky-commit-governance-capability-pack.mdx
@@ -4,7 +4,7 @@ slug: husky-commit-governance-capability-pack
 category: skills
 description: "Expert husky capability pack for lightweight local quality gates, commit message enforcement, and low-friction contributor workflows."
 cardDescription: "Set up practical pre-commit and commit-msg hooks that improve quality without bloating CI costs."
-seoTitle: Husky Commit Governance Capability Pack Skill
+seoTitle: "Husky Commit Governance Skill for Claude"
 seoDescription: "Advanced AI skill for Husky hook design, commit quality enforcement, and maintainable local developer guardrails."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
@@ -48,6 +48,10 @@ tags:
   - commitlint
   - developer-experience
   - capability-pack
+safetyNotes:
+  - "Installs from a downloaded package and may run local commands or scaffold files as part of the workflow; review the package and any generated changes before applying."
+privacyNotes:
+  - "Operates on your local project files and any context you share in the session; review what you expose before sharing — nothing is sent beyond the model unless a step calls an external service."
 keywords:
   - husky hooks setup
   - commit governance


### PR DESCRIPTION
CTR optimization for a trafficked skill whose `seoTitle` was the raw title. Sets a keyword-rich `seoTitle` and adds the `safetyNotes`/`privacyNotes` the content-policy scan requires for installable skills. Scan + `pnpm validate:content:strict` pass locally.