### PR TITLE
docs(content): optimize seoTitle for openclaw-skill-authoring-factory-capability-pack

### DIFF
--- a/content/skills/openclaw-skill-authoring-factory-capability-pack.mdx
+++ b/content/skills/openclaw-skill-authoring-factory-capability-pack.mdx
@@ -4,7 +4,7 @@ slug: openclaw-skill-authoring-factory-capability-pack
 category: skills
 description: "Expert OpenClaw skill-authoring capability pack for repeatable research, validation, packaging, and distribution workflows."
 cardDescription: "Build high-quality OpenClaw-compatible skills with deterministic structure, freshness controls, and packaging standards."
-seoTitle: OpenClaw Skill Authoring Factory Capability Pack Skill
+seoTitle: "OpenClaw Skill Authoring Factory for Claude"
 seoDescription: "Advanced AI skill for creating and maintaining production-grade OpenClaw skills with reliable packaging and validation."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
@@ -48,6 +48,10 @@ tags:
   - packaging
   - ai-agents
   - capability-pack
+safetyNotes:
+  - "Installs from a downloaded package and may run local commands or scaffold files as part of the workflow; review the package and any generated changes before applying."
+privacyNotes:
+  - "Operates on your local project files and any context you share in the session; review what you expose before sharing — nothing is sent beyond the model unless a step calls an external service."
 keywords:
   - openclaw skills
   - skill packaging workflow


### PR DESCRIPTION
CTR optimization for a trafficked skill whose `seoTitle` was the raw title. Sets a keyword-rich `seoTitle` and adds the `safetyNotes`/`privacyNotes` the content-policy scan requires for installable skills. Scan + `pnpm validate:content:strict` pass locally.