### PR TITLE
docs(content): add keywords for agent-skills-zip-packaging-qa-capability-pack

### DIFF
--- a/content/skills/agent-skills-zip-packaging-qa-capability-pack.mdx
+++ b/content/skills/agent-skills-zip-packaging-qa-capability-pack.mdx
@@ -64,6 +64,11 @@ tags:
   - zip
   - qa
   - capability-pack
+keywords:
+  - agent skills zip packaging
+  - claude skill package qa
+  - agent skills distribution
+  - claude skill packaging validation
 readingTime: 8
 difficultyScore: 68
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.