### PR TITLE
docs(content): add keywords for claude-code-dynamic-workflows-capability-pack

### DIFF
--- a/content/skills/claude-code-dynamic-workflows-capability-pack.mdx
+++ b/content/skills/claude-code-dynamic-workflows-capability-pack.mdx
@@ -63,6 +63,11 @@ privacyNotes:
 tags:
   - claude-code
   - capability-pack
+keywords:
+  - claude code dynamic workflows
+  - dynamic workflow automation claude
+  - claude workflow orchestration
+  - adaptive claude workflows
 readingTime: 9
 difficultyScore: 76
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.