### PR TITLE
docs(content): add keywords for claude-code-plugin-marketplace-authoring-capability-pack

### DIFF
--- a/content/skills/claude-code-plugin-marketplace-authoring-capability-pack.mdx
+++ b/content/skills/claude-code-plugin-marketplace-authoring-capability-pack.mdx
@@ -66,6 +66,11 @@ tags:
   - claude-code
   - plugins
   - marketplace
+keywords:
+  - claude code plugin marketplace
+  - claude plugin authoring
+  - plugin marketplace publishing
+  - claude code plugin development
 readingTime: 9
 difficultyScore: 74
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.