### PR TITLE
docs(content): add keywords for github-actions-security-review-capability-pack

### DIFF
--- a/content/skills/github-actions-security-review-capability-pack.mdx
+++ b/content/skills/github-actions-security-review-capability-pack.mdx
@@ -67,6 +67,11 @@ tags:
   - security
   - ci-cd
   - capability-pack
+keywords:
+  - github actions security review
+  - ci cd security audit
+  - github workflow security
+  - github actions security hardening
 readingTime: 9
 difficultyScore: 72
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.