### PR TITLE
docs(content): add keywords for mcp-oauth-server-hardening-capability-pack

### DIFF
--- a/content/skills/mcp-oauth-server-hardening-capability-pack.mdx
+++ b/content/skills/mcp-oauth-server-hardening-capability-pack.mdx
@@ -67,6 +67,11 @@ tags:
   - oauth
   - security
   - claude-code
+keywords:
+  - mcp oauth server hardening
+  - mcp oauth security
+  - secure mcp server oauth
+  - mcp authentication hardening
 readingTime: 9
 difficultyScore: 74
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.