### PR TITLE
docs(content): add keywords for mcp-streamable-http-migration-capability-pack

### DIFF
--- a/content/skills/mcp-streamable-http-migration-capability-pack.mdx
+++ b/content/skills/mcp-streamable-http-migration-capability-pack.mdx
@@ -67,6 +67,11 @@ tags:
   - transport
   - streamable-http
   - claude-code
+keywords:
+  - mcp streamable http migration
+  - mcp http transport
+  - migrate mcp to streamable http
+  - mcp transport upgrade
 readingTime: 9
 difficultyScore: 74
 hasTroubleshooting: true


### PR DESCRIPTION
This skill had no `keywords` (flagged by content audit), so it was missing discoverability signal. Adds real multi-word search phrases. No other fields changed; content-policy scan + `pnpm validate:content:strict` pass locally.