### PR TITLE
fix(content): debugging-assistant-agent sources + seoTitle

### DIFF
--- a/content/agents/debugging-assistant-agent.mdx
+++ b/content/agents/debugging-assistant-agent.mdx
@@ -8,13 +8,13 @@ description: >-
 cardDescription: >-
   Advanced debugging agent that helps identify, analyze, and resolve software
   bugs with systematic troubleshooting methodologies
-seoTitle: Debugging Assistant Agent - Agents
-seoDescription: >-
-  Advanced debugging agent that helps identify, analyze, and resolve software
-  bugs with systematic troubleshooting methodologies Discover tools for AI
-  developm...
+seoTitle: "Debugging Assistant Agent for Claude Code"
+seoDescription: "Claude agent that systematically identifies, analyzes, and resolves software bugs with structured troubleshooting and root-cause methodologies."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
 dateAdded: "2025-09-16"
 installable: false
 usageSnippet: >-
@@ -553,9 +553,9 @@ safetyNotes:
   - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
   - debugging assistant agent
-  - claude debugging assistant agent
-  - debugging assistant ai agent
-  - claude code debugging assistant
+  - claude debugging agent
+  - bug troubleshooting agent
+  - claude code debugging agent
 readingTime: 7
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit. The seoTitle/description edit re-triggered grounding and the agent had no `retrievalSources`; adds `documentationUrl`/`retrievalSources` (Claude Code sub-agents docs) + notes, alongside the optimized seoTitle/seoDescription. Local scan + `pnpm validate:content:strict` pass.