### PR TITLE
chore(seo): remove deprecated FAQPage + HowTo JSON-LD

### DIFF
--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -93,15 +93,6 @@ export const Route = createFileRoute("/$category")({
         { "@type": "ListItem", position: 2, name: label, item: url },
       ],
     };
-    const faq = {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      mainEntity: faqFor(id, label).map((item) => ({
-        "@type": "Question",
-        name: item.q,
-        acceptedAnswer: { "@type": "Answer", text: item.a },
-      })),
-    };
 
     return {
       meta: [
@@ -130,7 +121,6 @@ export const Route = createFileRoute("/$category")({
       scripts: [
         { type: "application/ld+json", children: stringifyJsonLd(itemList) },
         { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
-        { type: "application/ld+json", children: stringifyJsonLd(faq) },
       ],
     };
   },

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -116,26 +116,6 @@ function entrySchema(e: Entry, url: string): Record<string, unknown> {
   return { ...base, "@type": "CreativeWork" };
 }
 
-// Guides are how-to content: emit a HowTo whose steps come from the guide's H2/H3 headings,
-// so step-by-step guides become eligible for HowTo rich results.
-function guideHeadingSteps(e: Entry) {
-  return (e.headings ?? []).filter((heading) => heading.depth === 2 || heading.depth === 3);
-}
-function guideHowTo(e: Entry, url: string) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "HowTo",
-    name: e.title,
-    description: e.description,
-    step: guideHeadingSteps(e).map((heading, index) => ({
-      "@type": "HowToStep",
-      position: index + 1,
-      name: heading.text,
-      url: `${url}#${heading.id}`,
-    })),
-  };
-}
-
 export const Route = createFileRoute("/entry/$category/$slug")({
   loader: async ({ params }): Promise<{ entry: import("@/types/registry").Entry }> => {
     // Consolidated/removed entries 301 to their surviving canonical page so the
@@ -217,9 +197,6 @@ export const Route = createFileRoute("/entry/$category/$slug")({
         { type: "application/ld+json", children: stringifyJsonLd(ld) },
         { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
         { type: "application/ld+json", children: stringifyJsonLd(entrySchema(e, url)) },
-        ...(e.category === "guides" && guideHeadingSteps(e).length >= 2
-          ? [{ type: "application/ld+json", children: stringifyJsonLd(guideHowTo(e, url)) }]
-          : []),
       ],
     };
   },

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -54,20 +54,6 @@ export const Route = createFileRoute("/for/$platform")({
         { "@type": "ListItem", position: 3, name: label, item: url },
       ],
     };
-    const faq = {
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      mainEntity: [
-        {
-          "@type": "Question",
-          name: `What Claude resources work with ${label}?`,
-          acceptedAnswer: {
-            "@type": "Answer",
-            text: `HeyClaude lists ${entries.length} ${label}-compatible resources across MCP servers, agents, skills, hooks, commands, rules, and more — each metadata-reviewed for source and safety signals.`,
-          },
-        },
-      ],
-    };
     return {
       meta: [
         { title },
@@ -86,7 +72,6 @@ export const Route = createFileRoute("/for/$platform")({
       scripts: [
         { type: "application/ld+json", children: stringifyJsonLd(itemList) },
         { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
-        { type: "application/ld+json", children: stringifyJsonLd(faq) },
       ],
     };
   },

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2055,6 +2055,27 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   describe("trust-review helper edge cases", () => {
+    // Find an entry that GENUINELY has no safety/privacy notes by reading entry
+    // detail files (directory-index strips notes). Assuming a specific entry is
+    // note-less is brittle — content enrichment adds notes over time.
+    function findEntryWithoutNotes(category: string) {
+      const dir = path.join(dataDir, "entries", category);
+      for (const file of fs.readdirSync(dir).sort()) {
+        const detail = JSON.parse(
+          fs.readFileSync(path.join(dir, file), "utf8"),
+        ) as {
+          entry?: { slug: string; safetyNotes?: string; privacyNotes?: string };
+        };
+        const entry = detail.entry;
+        if (entry && !entry.safetyNotes && !entry.privacyNotes) {
+          return { category, slug: entry.slug };
+        }
+      }
+      throw new Error(
+        `No ${category} entry without safety/privacy notes found`,
+      );
+    }
+
     it("explains trust for entry with safety and privacy notes", async () => {
       const trust = await callRegistryTool(
         "explain_entry_trust",
@@ -2079,14 +2100,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     it("explains trust for entry without safety or privacy notes", async () => {
-      const directory = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
-      ) as {
-        entries: Array<{ category: string; slug: string }>;
-      };
-      const entryWithoutNotes = directory.entries.find(
-        (e) => e.category === "hooks" && e.slug !== "documentation-generator",
-      );
+      const entryWithoutNotes = findEntryWithoutNotes("hooks");
       expect(entryWithoutNotes).toBeTruthy();
 
       const trust = await callRegistryTool(
@@ -2229,17 +2243,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     it("reviews safety for entry without safety notes highlights manual inspection", async () => {
-      const directory = JSON.parse(
-        fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
-      ) as {
-        entries: Array<{ category: string; slug: string }>;
-      };
-      const entryWithoutNotes = directory.entries.find(
-        (e) =>
-          e.category === "hooks" &&
-          e.slug !== "documentation-generator" &&
-          e.slug !== "retro-daily",
-      );
+      const entryWithoutNotes = findEntryWithoutNotes("hooks");
       expect(entryWithoutNotes).toBeTruthy();
 
       const review = await callRegistryTool(


### PR DESCRIPTION
Implements #3303 (roadmap epic #3302).

## What
- Remove `FAQPage` JSON-LD from category hubs (`$category.tsx`) and platform pages (`for.$platform.tsx`)
- Remove `HowTo` JSON-LD (`guideHowTo`/`guideHeadingSteps`) from guide entry pages (`entry.$category.$slug.tsx`)

## Why
Google **deprecated** FAQPage (Aug 2023) and HowTo (Sep 2023) rich results — they no longer render, and the GEO research flags them as noise that can slightly hurt. Removing them simplifies the JSON-LD and drops a counterproductive signal.

## Kept intact
- The **visible** category FAQ section (the `faqFor`/`faqs` UI stands on its own as user content — only the schema was removed)
- All endorsed schema: `SoftwareApplication`, `CreativeWork`, `TechArticle`, `BreadcrumbList`, `ItemList`

## Validation
`git grep` shows zero `FAQPage`/`HowTo`/`HowToStep`/`Question`/`Answer` schema in `apps/web/src` · `type-check` clean · `seo-jsonld` + `seo-metadata` + `json-ld-script-safety` tests (16) pass · prettier 3.8.3 + Trunk clean.

Closes #3303.