### PR TITLE
fix(content): multi-agent-orchestration-specialist sources + seoTitle

### DIFF
--- a/content/agents/multi-agent-orchestration-specialist.mdx
+++ b/content/agents/multi-agent-orchestration-specialist.mdx
@@ -9,13 +9,15 @@ description: >-
 cardDescription: >-
   Multi-agent orchestration specialist using LangGraph and CrewAI for complex,
   stateful workflows with graph-driven reasoning and role-base...
-seoTitle: Multi Agent Orchestration Specialist - Agents
-seoDescription: >-
-  Multi-agent orchestration specialist using LangGraph and CrewAI for complex,
-  stateful workflows with graph-driven reasoning and role-based agent
-  coordination
+seoTitle: "Multi-Agent Orchestration Agent (LangGraph, CrewAI)"
+seoDescription: "Claude agent for orchestrating complex, stateful multi-agent workflows with LangGraph and CrewAI — graph-driven reasoning and role-based coordination."
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
+documentationUrl: "https://code.claude.com/docs/en/sub-agents"
+retrievalSources:
+  - "https://code.claude.com/docs/en/sub-agents"
+  - "https://langchain-ai.github.io/langgraph/"
+  - "https://docs.crewai.com/"
 dateAdded: "2025-10-16"
 installable: false
 usageSnippet: >-
@@ -653,10 +655,10 @@ privacyNotes:
 safetyNotes:
   - "Recommendations may include shell commands, package installs, or file edits; review and run any suggested changes yourself instead of applying them unverified."
 keywords:
-  - multi agent orchestration specialist agent
-  - claude multi agent orchestration specialist agent
-  - multi agent orchestration specialist ai agent
-  - claude code multi agent orchestration specialist
+  - multi-agent orchestration agent
+  - langgraph crewai agent
+  - claude multi-agent workflows
+  - agent orchestration claude
 readingTime: 8
 difficultyScore: 100
 hasTroubleshooting: true


### PR DESCRIPTION
Resubmit. Adds per-facet `retrievalSources` (Claude sub-agents, LangGraph, CrewAI docs) for the orchestration claims + notes, with the optimized seoTitle/seoDescription. Local scan + `pnpm validate:content:strict` pass.