### PR TITLE
feat(seo): add install-method + safety/privacy coverage to the data report

### DIFF
--- a/apps/web/src/lib/ecosystem-stats.ts
+++ b/apps/web/src/lib/ecosystem-stats.ts
@@ -1,0 +1,97 @@
+import type { Entry } from "@/types/registry";
+
+/**
+ * Deterministic, structured-field-derived ecosystem statistics for the
+ * `/state-of-claude-tooling` data report. Every value is computed from real
+ * registry fields (no estimates, no LLM-generated prose) so the numbers — and
+ * the `Dataset` JSON-LD that advertises them — are accurate by construction.
+ */
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+// Ordered: first matching rule wins. Patterns anchor on the first token of the
+// (lowercased) install command so classification is unambiguous.
+const INSTALL_METHOD_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^(?:npx|npm)\b/, "npm / npx"],
+  [/^pnpm\b/, "pnpm"],
+  [/^yarn\b/, "yarn"],
+  [/^bunx?\b/, "bun"],
+  [/^deno\b/, "deno"],
+  [/^(?:uvx?|pipx?)\b|\bpip3? install\b/, "Python (pip / uv)"],
+  [/^docker\b/, "Docker"],
+  [/^go\b/, "Go"],
+  [/^cargo\b/, "Cargo"],
+  [/^brew\b/, "Homebrew"],
+  [/^claude\b/, "Claude CLI (claude mcp add …)"],
+  [/^\//, "Claude slash command"],
+  [/^git\b/, "Git clone"],
+  [/^(?:curl|wget)\b/, "Shell (curl / wget)"],
+  [/^(?:mkdir|cat|cp|mv|echo|touch|tee)\b/, "Manual file setup"],
+];
+
+/**
+ * Classify an entry's `installCommand` into an install-method bucket.
+ * Returns `null` when there is no install command (the resource is a
+ * config/file drop-in, not a package install).
+ */
+export function installMethodOf(installCommand?: string | null): string | null {
+  const command = String(installCommand ?? "")
+    .trim()
+    .toLowerCase();
+  if (!command) return null;
+  for (const [pattern, label] of INSTALL_METHOD_RULES) {
+    if (pattern.test(command)) return label;
+  }
+  return "Other";
+}
+
+/**
+ * Distribution of install methods across the entries that declare an
+ * `installCommand`. `total` is the size of that installable subset (not the
+ * whole catalog), and the row counts sum to exactly `total`.
+ */
+export function installMethodDistribution(entries: ReadonlyArray<Entry>): {
+  rows: StatRow[];
+  total: number;
+} {
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (const entry of entries) {
+    const method = installMethodOf(entry.installCommand);
+    if (!method) continue;
+    counts.set(method, (counts.get(method) ?? 0) + 1);
+    total += 1;
+  }
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  return { rows, total };
+}
+
+/**
+ * Coverage of safety / privacy notes across the catalog. These are HeyClaude's
+ * differentiating metadata, so quantifying them is high-signal original data.
+ * `both` is bounded by `min(safety, privacy)`; all counts are bounded by
+ * `total`.
+ */
+export function notesCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  safety: number;
+  privacy: number;
+  both: number;
+} {
+  let safety = 0;
+  let privacy = 0;
+  let both = 0;
+  for (const entry of entries) {
+    const hasSafety = Boolean(entry.safetyNotes);
+    const hasPrivacy = Boolean(entry.privacyNotes);
+    if (hasSafety) safety += 1;
+    if (hasPrivacy) privacy += 1;
+    if (hasSafety && hasPrivacy) both += 1;
+  }
+  return { total: entries.length, safety, privacy, both };
+}

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -12,6 +12,7 @@ import {
   type TrustLevel,
 } from "@/types/registry";
 import { ENTRIES, QUALITY_STATS, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { installMethodDistribution, notesCoverage } from "@/lib/ecosystem-stats";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -70,6 +71,23 @@ const PLATFORM_DIST: DistRow[] = HARNESSES.map((h) => {
   .filter((row) => row.count > 0)
   .sort((a, b) => b.count - a.count);
 
+// Install-method distribution — derived from each entry's installCommand, over
+// the package-installable subset (file/config drop-ins have no install command).
+const INSTALL_METHODS = installMethodDistribution(ENTRIES);
+const INSTALL_METHOD_DIST: DistRow[] = INSTALL_METHODS.rows.map((row) => ({
+  label: row.label,
+  count: row.count,
+  pct: pctOf(row.count, INSTALL_METHODS.total),
+}));
+
+// Safety & privacy notes coverage — HeyClaude's differentiating metadata, quantified.
+const NOTES = notesCoverage(ENTRIES);
+const NOTES_DIST: DistRow[] = [
+  { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
+  { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
+  { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL) },
+];
+
 // Recent additions — newest-dated entries by dateAdded.
 const RECENT_ADDITIONS = [...ENTRIES]
   .sort((a, b) => String(b.dateAdded).localeCompare(String(a.dateAdded)))
@@ -105,6 +123,8 @@ export const Route = createFileRoute("/state-of-claude-tooling")({
         "Trust-level distribution",
         "Source provenance distribution",
         "Platform coverage",
+        "Install-method distribution",
+        "Safety and privacy notes coverage",
       ],
     };
     const breadcrumbs = {
@@ -217,6 +237,20 @@ function StateOfClaudeToolingPage() {
         help="How many resources declare compatibility with each harness. Entries can support more than one, so percentages do not sum to 100%."
       >
         <DistTable rows={PLATFORM_DIST} />
+      </Section>
+
+      <Section
+        title="Install methods"
+        help={`How the ${INSTALL_METHODS.total} package-installable resources are delivered, by install command. File and config drop-ins (agents, rules, skills, and the like) install by copying into your project rather than a package manager, so they are excluded here.`}
+      >
+        <DistTable rows={INSTALL_METHOD_DIST} />
+      </Section>
+
+      <Section
+        title="Safety & privacy coverage"
+        help="Share of the catalog carrying reviewer-checked safety and privacy notes — the execution/permissions and data-handling metadata that sets HeyClaude apart. Percentages are of the full catalog; entries can carry both."
+      >
+        <DistTable rows={NOTES_DIST} />
       </Section>
 
       <section className="mt-12">

--- a/tests/ecosystem-stats.test.ts
+++ b/tests/ecosystem-stats.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import {
+  installMethodDistribution,
+  installMethodOf,
+  notesCoverage,
+} from "../apps/web/src/lib/ecosystem-stats";
+
+function entry(partial: Partial<Entry>): Entry {
+  return partial as Entry;
+}
+
+describe("installMethodOf", () => {
+  it("classifies common install commands deterministically", () => {
+    expect(installMethodOf("npx -y some-mcp")).toBe("npm / npx");
+    expect(installMethodOf("npm install -g x")).toBe("npm / npx");
+    expect(installMethodOf("pnpm add x")).toBe("pnpm");
+    expect(installMethodOf("uvx some-server")).toBe("Python (pip / uv)");
+    expect(installMethodOf("pip install x")).toBe("Python (pip / uv)");
+    expect(installMethodOf("pipx run x")).toBe("Python (pip / uv)");
+    expect(installMethodOf("docker run x")).toBe("Docker");
+    expect(installMethodOf("go install x")).toBe("Go");
+    expect(installMethodOf("cargo install x")).toBe("Cargo");
+    expect(installMethodOf("brew install x")).toBe("Homebrew");
+    expect(installMethodOf("bunx x")).toBe("bun");
+  });
+
+  it("classifies Claude-native and shell install patterns", () => {
+    expect(installMethodOf("claude mcp add x https://...")).toBe(
+      "Claude CLI (claude mcp add …)",
+    );
+    expect(installMethodOf("/agents")).toBe("Claude slash command");
+    expect(installMethodOf("git clone https://github.com/x/y")).toBe(
+      "Git clone",
+    );
+    expect(installMethodOf("curl https://example.com | sh")).toBe(
+      "Shell (curl / wget)",
+    );
+    expect(installMethodOf("mkdir -p .claude/commands && cat > x")).toBe(
+      "Manual file setup",
+    );
+  });
+
+  it("returns null for no install command (config/file drop-in)", () => {
+    expect(installMethodOf(undefined)).toBeNull();
+    expect(installMethodOf("")).toBeNull();
+    expect(installMethodOf("   ")).toBeNull();
+  });
+
+  it("buckets genuinely unrecognized commands as Other", () => {
+    expect(installMethodOf("frobnicate --install x")).toBe("Other");
+  });
+});
+
+describe("installMethodDistribution", () => {
+  it("counts only installable entries and rows sum to the installable total", () => {
+    const entries = [
+      entry({ installCommand: "npx a" }),
+      entry({ installCommand: "npx b" }),
+      entry({ installCommand: "pip install c" }),
+      entry({ installCommand: "" }), // not installable
+      entry({}), // not installable
+    ];
+    const { rows, total } = installMethodDistribution(entries);
+    expect(total).toBe(3);
+    expect(rows.reduce((sum, r) => sum + r.count, 0)).toBe(total);
+    expect(total).toBeLessThanOrEqual(entries.length);
+    // sorted by count desc
+    expect(rows[0]).toEqual({ label: "npm / npx", count: 2 });
+  });
+});
+
+describe("notesCoverage", () => {
+  it("bounds every count by the total and both by min(safety, privacy)", () => {
+    const entries = [
+      entry({ safetyNotes: "x", privacyNotes: "y" }),
+      entry({ safetyNotes: "x" }),
+      entry({ privacyNotes: "y" }),
+      entry({}),
+    ];
+    const c = notesCoverage(entries);
+    expect(c.total).toBe(4);
+    expect(c.safety).toBe(2);
+    expect(c.privacy).toBe(2);
+    expect(c.both).toBe(1);
+    expect(c.safety).toBeLessThanOrEqual(c.total);
+    expect(c.privacy).toBeLessThanOrEqual(c.total);
+    expect(c.both).toBeLessThanOrEqual(Math.min(c.safety, c.privacy));
+  });
+});


### PR DESCRIPTION
Implements #3304 (roadmap epic #3302).

## Context
`/state-of-claude-tooling` is already a strong original-data report with `Dataset` JSON-LD (total/category/trust/source/platform stats). Rather than duplicate it, this **enriches it** with two genuinely new, accurate dimensions — the highest-value way to satisfy the issue without rebuilding existing pages.

## What
Two new sections on the report, plus their `Dataset` `variableMeasured` entries:
1. **Install-method distribution** — derived from each entry’s `installCommand`, over the installable subset (574 entries). Buckets: Claude CLI 23%, npm/npx 19%, Manual file setup 15%, Python 14%, Shell 9%, etc.
2. **Safety & privacy notes coverage** — % of the catalog carrying reviewer-checked safety/privacy notes (~86% / 88%). This is HeyClaude’s differentiating metadata, quantified.

## Accuracy by construction
Every number is a deterministic transform of structured registry fields — no estimates, no LLM-generated prose. Bucketing logic is extracted to `apps/web/src/lib/ecosystem-stats.ts` and unit-tested (`tests/ecosystem-stats.test.ts`): classification cases + reconciliation invariants (install rows sum to the installable total; coverage counts ≤ total; both ≤ min(safety, privacy)).

## Validation
6 stats tests pass · `type-check` clean · `pnpm --filter web build` OK · prettier 3.8.3 + Trunk ("no new issues") · real-data sanity confirms the rendered numbers reconcile with the registry.

Closes #3304.