### PR TITLE
feat(seo): add CTR-snippet audit tool (audit:seo-snippets)

### DIFF
--- a/docs/seo/gsc-feedback-loop.md
+++ b/docs/seo/gsc-feedback-loop.md
@@ -75,6 +75,15 @@ Look for:
   cause.
 - Pages with rising impressions but flat clicks — snippet ceiling; tune copy.
 
+**Tooling:** before (or alongside) the manual pass, run `pnpm audit:seo-snippets`
+to get a ranked list of entries with weak `seoTitle`/`seoDescription` (missing,
+out-of-length, duplicate across entries, or just echoing the on-page title). Pass
+a GSC Pages CSV export to prioritize by impressions:
+`pnpm audit:seo-snippets -- --gsc gsc-pages.csv`. The tool only **detects and
+ranks** — write the improved snippets by hand (auto-generated snippets read as
+duplicate/templated and Google discounts them). Route confirmed thin/duplicate
+pages to #2260 / #2261.
+
 Compare CTR **within a page type** (entry vs. compare vs. category), not across
 types. A 2% CTR on a broad category page and a 2% CTR on a long-tail compare
 page mean different things.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "generate:readme": "node scripts/generate-readme.mjs",
     "validate:readme": "node scripts/generate-readme.mjs --check",
     "audit:content": "node scripts/audit-content.mjs",
+    "audit:seo-snippets": "node scripts/audit-seo-snippets.mjs",
     "report:thin-content": "node scripts/report-thin-content.mjs",
     "report:trust-coverage": "node scripts/report-trust-coverage.mjs",
     "validate:mcp-trust": "node scripts/report-trust-coverage.mjs --category mcp --check --min-risk-coverage 100 --min-attribution-coverage 100",

--- a/scripts/audit-seo-snippets.mjs
+++ b/scripts/audit-seo-snippets.mjs
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+/**
+ * SEO snippet audit — flags weak `seoTitle` / `seoDescription` on entry pages so
+ * they can be improved by hand. GSC shows our bottleneck is CTR (not ranking),
+ * and fully auto-writing snippets reads as duplicate/spammy, so this tool only
+ * DETECTS and PRIORITIZES — it never writes content.
+ *
+ * Source: the generated registry (`apps/web/src/generated/atlas-registry.json`).
+ * Run `pnpm --filter web run prebuild` first if the artifact is missing.
+ *
+ * Usage:
+ *   pnpm audit:seo-snippets               # ranked markdown report
+ *   pnpm audit:seo-snippets -- --json     # machine-readable JSON
+ *   pnpm audit:seo-snippets -- --gsc gsc-pages.csv   # weight by GSC impressions
+ *   pnpm audit:seo-snippets -- --limit 50
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..");
+
+export const TITLE_MIN = 25;
+export const TITLE_MAX = 60;
+export const DESC_MIN = 70;
+export const DESC_MAX = 160;
+
+export function normalizeSnippet(value) {
+  return String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function entryPath(entry) {
+  return `/entry/${entry.category}/${entry.slug}`;
+}
+
+/** Structural issues for a single entry's seoTitle/seoDescription. */
+export function snippetIssues(entry) {
+  const issues = [];
+  const checkText = (field, value, sibling, min, max) => {
+    const text = String(value ?? "").trim();
+    if (!text) {
+      issues.push({
+        field,
+        code: "missing",
+        detail: `no ${field} (falls back to a generic snippet)`,
+      });
+      return;
+    }
+    if (text.length > max) {
+      issues.push({
+        field,
+        code: "too-long",
+        detail: `${text.length} chars (>${max}, truncated in SERP)`,
+      });
+    } else if (text.length < min) {
+      issues.push({
+        field,
+        code: "too-short",
+        detail: `${text.length} chars (<${min}, under-uses the snippet)`,
+      });
+    }
+    if (normalizeSnippet(text) === normalizeSnippet(sibling)) {
+      issues.push({
+        field,
+        code: "echoes-base",
+        detail: `${field} just repeats the on-page ${field === "seoTitle" ? "title" : "description"}`,
+      });
+    }
+  };
+  checkText("seoTitle", entry.seoTitle, entry.title, TITLE_MIN, TITLE_MAX);
+  checkText(
+    "seoDescription",
+    entry.seoDescription,
+    entry.description,
+    DESC_MIN,
+    DESC_MAX,
+  );
+  return issues;
+}
+
+/**
+ * Keys (`category/slug`) whose seoTitle or seoDescription is shared, verbatim,
+ * by at least one other entry — i.e. templated/duplicate snippets.
+ */
+export function findDuplicateSnippets(entries) {
+  const byTitle = new Map();
+  const byDesc = new Map();
+  for (const entry of entries) {
+    const key = `${entry.category}/${entry.slug}`;
+    const t = normalizeSnippet(entry.seoTitle);
+    const d = normalizeSnippet(entry.seoDescription);
+    if (t) byTitle.set(t, [...(byTitle.get(t) ?? []), key]);
+    if (d) byDesc.set(d, [...(byDesc.get(d) ?? []), key]);
+  }
+  const dupTitleKeys = new Set();
+  const dupDescKeys = new Set();
+  for (const keys of byTitle.values())
+    if (keys.length > 1) keys.forEach((k) => dupTitleKeys.add(k));
+  for (const keys of byDesc.values())
+    if (keys.length > 1) keys.forEach((k) => dupDescKeys.add(k));
+  return { dupTitleKeys, dupDescKeys };
+}
+
+/** Parse a GSC "Pages" CSV export → Map<pathname, impressions>. Best-effort. */
+export function parseGscImpressions(csv) {
+  const lines = String(csv ?? "")
+    .split(/\r?\n/)
+    .filter(Boolean);
+  if (lines.length < 2) return new Map();
+  const splitRow = (line) =>
+    line.split(",").map((c) => c.replace(/^"|"$/g, "").trim());
+  const header = splitRow(lines[0]).map((h) => h.toLowerCase());
+  const pageIdx = header.findIndex((h) => /page|url|landing/.test(h));
+  const imprIdx = header.findIndex((h) => /impression/.test(h));
+  if (pageIdx === -1 || imprIdx === -1) return new Map();
+  const map = new Map();
+  for (const line of lines.slice(1)) {
+    const cols = splitRow(line);
+    const raw = cols[pageIdx];
+    const impressions =
+      Number(String(cols[imprIdx] ?? "").replace(/[^0-9.]/g, "")) || 0;
+    if (!raw) continue;
+    let pathname = raw;
+    try {
+      pathname = new URL(raw).pathname;
+    } catch {
+      /* already a path */
+    }
+    pathname = pathname.replace(/\/+$/, "") || "/";
+    map.set(pathname, (map.get(pathname) ?? 0) + impressions);
+  }
+  return map;
+}
+
+/** Audit all entries → findings sorted worst-first (by issue count, then impressions). */
+export function auditEntries(entries, { gscImpressions = new Map() } = {}) {
+  const { dupTitleKeys, dupDescKeys } = findDuplicateSnippets(entries);
+  const findings = [];
+  for (const entry of entries) {
+    const key = `${entry.category}/${entry.slug}`;
+    const issues = snippetIssues(entry);
+    if (dupTitleKeys.has(key))
+      issues.push({
+        field: "seoTitle",
+        code: "duplicate",
+        detail: "seoTitle is shared verbatim with other entries",
+      });
+    if (dupDescKeys.has(key))
+      issues.push({
+        field: "seoDescription",
+        code: "duplicate",
+        detail: "seoDescription is shared verbatim with other entries",
+      });
+    if (issues.length === 0) continue;
+    const pathname = entryPath(entry);
+    findings.push({
+      key,
+      category: entry.category,
+      slug: entry.slug,
+      path: pathname,
+      impressions: gscImpressions.get(pathname) ?? 0,
+      issues,
+    });
+  }
+  findings.sort(
+    (a, b) =>
+      b.issues.length - a.issues.length ||
+      b.impressions - a.impressions ||
+      a.key.localeCompare(b.key),
+  );
+  return findings;
+}
+
+function loadEntries() {
+  const atlasPath = path.join(
+    REPO_ROOT,
+    "apps/web/src/generated/atlas-registry.json",
+  );
+  if (!fs.existsSync(atlasPath)) {
+    throw new Error(
+      "Missing apps/web/src/generated/atlas-registry.json — run `pnpm --filter web run prebuild` first.",
+    );
+  }
+  return JSON.parse(fs.readFileSync(atlasPath, "utf8")).entries ?? [];
+}
+
+function parseArgs(argv) {
+  const args = { json: false, limit: 50, gsc: "" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--json") args.json = true;
+    else if (a === "--limit") args.limit = Number(argv[++i]) || args.limit;
+    else if (a === "--gsc") args.gsc = argv[++i] ?? "";
+  }
+  return args;
+}
+
+function renderMarkdown(findings, total) {
+  const weighted = findings.some((f) => f.impressions > 0);
+  const lines = [
+    "# SEO snippet audit",
+    "",
+    `${findings.length} of ${total} entries have weak seoTitle/seoDescription${weighted ? " (ranked by GSC impressions)" : ""}.`,
+    "Detection only — improve these by hand; do not auto-generate snippets.",
+    "",
+  ];
+  for (const f of findings) {
+    const impr = f.impressions ? ` · ${f.impressions} impressions` : "";
+    lines.push(`## ${f.path}${impr}`);
+    for (const issue of f.issues)
+      lines.push(`- **${issue.field} / ${issue.code}** — ${issue.detail}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const entries = loadEntries();
+  const gscImpressions = args.gsc
+    ? parseGscImpressions(fs.readFileSync(args.gsc, "utf8"))
+    : new Map();
+  const all = auditEntries(entries, { gscImpressions });
+  const findings = all.slice(0, args.limit);
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        { total: entries.length, flagged: all.length, findings },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(renderMarkdown(findings, entries.length));
+    if (all.length > findings.length) {
+      console.log(
+        `… and ${all.length - findings.length} more (raise --limit to see them).`,
+      );
+    }
+  }
+  return all;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  });
+}

--- a/tests/audit-seo-snippets.test.ts
+++ b/tests/audit-seo-snippets.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  auditEntries,
+  findDuplicateSnippets,
+  normalizeSnippet,
+  parseGscImpressions,
+  snippetIssues,
+} from "../scripts/audit-seo-snippets.mjs";
+
+const goodTitle = "Postgres MCP Server for Claude Code — schema-aware queries";
+const goodDesc =
+  "A Model Context Protocol server that gives Claude read-only Postgres access with schema introspection, parameterized queries, and per-connection scoping.";
+
+function entry(over: Record<string, unknown> = {}) {
+  return {
+    category: "mcp",
+    slug: "postgres",
+    title: "Postgres MCP Server",
+    description: "Query Postgres from Claude.",
+    seoTitle: goodTitle,
+    seoDescription: goodDesc,
+    ...over,
+  };
+}
+
+describe("snippetIssues", () => {
+  it("passes a well-formed entry", () => {
+    expect(snippetIssues(entry())).toEqual([]);
+  });
+
+  it("flags missing snippets", () => {
+    const issues = snippetIssues(
+      entry({ seoTitle: "", seoDescription: undefined }),
+    );
+    expect(issues.map((i) => i.code)).toContain("missing");
+    expect(issues.filter((i) => i.code === "missing")).toHaveLength(2);
+  });
+
+  it("flags length out of bounds", () => {
+    const issues = snippetIssues(
+      entry({ seoTitle: "Too short", seoDescription: "x".repeat(200) }),
+    );
+    expect(issues.find((i) => i.field === "seoTitle")?.code).toBe("too-short");
+    expect(issues.find((i) => i.field === "seoDescription")?.code).toBe(
+      "too-long",
+    );
+  });
+
+  it("flags snippets that just echo the base title/description", () => {
+    const issues = snippetIssues(
+      entry({
+        seoTitle: "Postgres MCP Server",
+        seoDescription: "Query Postgres from Claude.",
+      }),
+    );
+    expect(
+      issues.some((i) => i.field === "seoTitle" && i.code === "echoes-base"),
+    ).toBe(true);
+    expect(
+      issues.some(
+        (i) => i.field === "seoDescription" && i.code === "echoes-base",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("findDuplicateSnippets", () => {
+  it("detects verbatim shared snippets across entries", () => {
+    const entries = [
+      entry({
+        slug: "a",
+        seoTitle: "Same Title Used Across Many Entries Here",
+      }),
+      entry({
+        slug: "b",
+        seoTitle: "Same Title Used Across Many Entries Here",
+      }),
+      entry({ slug: "c", seoTitle: "A Genuinely Unique Title For This Entry" }),
+    ];
+    const { dupTitleKeys } = findDuplicateSnippets(entries);
+    expect(dupTitleKeys.has("mcp/a")).toBe(true);
+    expect(dupTitleKeys.has("mcp/b")).toBe(true);
+    expect(dupTitleKeys.has("mcp/c")).toBe(false);
+  });
+});
+
+describe("parseGscImpressions", () => {
+  it("maps page pathnames to impressions from a GSC CSV", () => {
+    const csv = [
+      "Page,Clicks,Impressions,CTR,Position",
+      "https://heyclau.de/entry/mcp/postgres,12,3400,0.35%,4.2",
+      '"https://heyclau.de/entry/mcp/redis/",3,900,0.33%,7.1',
+    ].join("\n");
+    const map = parseGscImpressions(csv);
+    expect(map.get("/entry/mcp/postgres")).toBe(3400);
+    expect(map.get("/entry/mcp/redis")).toBe(900);
+  });
+
+  it("returns an empty map for unrecognized CSVs", () => {
+    expect(parseGscImpressions("foo,bar\n1,2").size).toBe(0);
+  });
+});
+
+describe("auditEntries", () => {
+  it("excludes clean entries, includes duplicates, and ranks worst-first", () => {
+    const entries = [
+      entry({ slug: "clean" }),
+      entry({
+        slug: "dupe-a",
+        seoTitle: "Shared Templated Title Across Two Listings",
+        seoDescription:
+          "A distinct, valid description for the first listing that comfortably clears the minimum length bound here.",
+      }),
+      entry({
+        slug: "dupe-b",
+        seoTitle: "Shared Templated Title Across Two Listings",
+        seoDescription:
+          "A different, valid description for the second listing that also clears the minimum length bound comfortably.",
+      }),
+      entry({ slug: "broken", seoTitle: "", seoDescription: "short" }),
+    ];
+    const findings = auditEntries(entries, {
+      gscImpressions: new Map([["/entry/mcp/dupe-a", 5000]]),
+    });
+    const keys = findings.map((f) => f.key);
+    expect(keys).not.toContain("mcp/clean");
+    expect(keys).toContain("mcp/dupe-a");
+    // "broken" has the most issues → ranked first
+    expect(findings[0].key).toBe("mcp/broken");
+  });
+});
+
+describe("normalizeSnippet", () => {
+  it("collapses whitespace and lowercases", () => {
+    expect(normalizeSnippet("  Foo   Bar\n")).toBe("foo bar");
+  });
+});


### PR DESCRIPTION
Implements #3305 (roadmap epic #3302).

## What
`pnpm audit:seo-snippets` — a **detection-only** tool that flags entry pages with weak `seoTitle`/`seoDescription`, ranked worst-first, so they can be improved by hand.

Flags: **missing**, **out-of-length** (title 25–60, desc 70–160), **echoes-base** (snippet just repeats the on-page title/description), and **duplicate** (same snippet verbatim across entries). Optional GSC weighting: `pnpm audit:seo-snippets -- --gsc gsc-pages.csv` prioritizes by impressions. `--json` for machine output.

## Why detection-only
GSC shows our bottleneck is **CTR, not ranking**. But fully auto-writing snippets reads as templated/duplicate and Google discounts them — so this tool **never writes content**; it produces the prioritized worklist for a human pass. Wired into `docs/seo/gsc-feedback-loop.md`; findings route to #2260/#2261 where they overlap.

## Accuracy / testing
Reads the generated registry (`atlas-registry.json`). Pure functions (`snippetIssues`, `findDuplicateSnippets`, `parseGscImpressions`, `auditEntries`) are unit-tested (9 tests: length/echo/missing/duplicate detection, GSC CSV parsing, ranking). On the live registry it surfaces **~595 entries** with actionable snippet issues.

## Note
This PR (and #3461) will fail `validate-web` until #3458 lands — that PR fixes a **pre-existing main breakage** (brittle `mcp-server` trust-review tests) blocking all web PRs. I’ll rebase this onto main once #3458 merges.

Closes #3305.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `audit:seo-snippets` tool to identify pages with weak or duplicate SEO titles and descriptions. Supports Google Search Console data integration for impression-based ranking.

* **Documentation**
  * Updated GSC feedback-loop runbook with instructions for reviewing and improving SEO snippets using the new auditing tool.

* **Tests**
  * Added test suite for SEO snippet auditing utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->