### PR TITLE
docs(content): repoint secure-claude-code-workstation off deduplicated entries

### DIFF
--- a/content/collections/secure-claude-code-workstation.mdx
+++ b/content/collections/secure-claude-code-workstation.mdx
@@ -31,15 +31,13 @@ items:
     category: hooks
   - slug: lockfile-provenance-checker
     category: hooks
-  - slug: dependency-security-scanner
-    category: hooks
   - slug: package-vulnerability-scanner
     category: hooks
   - slug: dependency-risk-review
     category: commands
   - slug: security-audit
     category: commands
-  - slug: security-auditor-penetration-tester
+  - slug: security-auditor
     category: rules
   - slug: mcp-server-security-hardening
     category: skills
@@ -49,11 +47,10 @@ installationOrder:
   - pre-write-secret-scanner
   - sensitive-data-alert-scanner
   - lockfile-provenance-checker
-  - dependency-security-scanner
   - package-vulnerability-scanner
   - dependency-risk-review
   - security-audit
-  - security-auditor-penetration-tester
+  - security-auditor
   - mcp-server-security-hardening
   - prompt-injection-defense-guardrails
 estimatedSetupTime: 40 minutes
@@ -92,13 +89,13 @@ A layered, defense-in-depth setup for an agentic Claude Code workstation, organi
 ### 2. Dependency and supply-chain (SSDF PS — protect the software)
 
 - **lockfile-provenance-checker** (hook) — flags npm lockfile entries resolved from outside the public registry or missing an integrity hash.
-- **dependency-security-scanner** (hook) and **package-vulnerability-scanner** (hook) — scan dependency changes for known vulnerabilities.
+- **package-vulnerability-scanner** (hook) — scans dependency changes for known vulnerabilities.
 - **dependency-risk-review** (command) — reviews supply-chain posture with OpenSSF Scorecard health signals.
 
 ### 3. Audit and policy (SSDF RV — respond to vulnerabilities)
 
 - **security-audit** (command) — runs an on-demand code security audit.
-- **security-auditor-penetration-tester** (rules) — keeps the assistant in a security-first, adversarial mindset.
+- **security-auditor** (rules) — keeps the assistant in a security-first, adversarial mindset.
 
 ### 4. MCP and prompt-injection hardening
 


### PR DESCRIPTION
Single-file content edit. Removes the two near-duplicate entries from this collection ahead of their deletion:
- drops `dependency-security-scanner` (kept `package-vulnerability-scanner`, already in the bundle)
- repoints `security-auditor-penetration-tester` → `security-auditor`

Updates items, installationOrder, and the prose to match. Must merge before the two deletion PRs so the collection never references a removed entry. Content-policy scan + `pnpm validate:content:strict` pass locally.