### PR TITLE
docs(content): add capabilities + comparison table to cursor

### DIFF
--- a/content/tools/cursor.mdx
+++ b/content/tools/cursor.mdx
@@ -10,6 +10,11 @@ author: Cursor
 dateAdded: "2026-04-27"
 websiteUrl: "https://cursor.com"
 documentationUrl: "https://cursor.com/docs"
+retrievalSources:
+  - "https://cursor.com/docs"
+  - "https://zed.dev/docs/"
+  - "https://docs.github.com/en/copilot"
+  - "https://code.claude.com/docs/en/overview"
 pricingModel: freemium
 disclosure: heyclaude_pick
 applicationCategory: DeveloperApplication
@@ -23,6 +28,26 @@ keywords:
   - claude tools
   - ai code editor
 ---
+
+## Key capabilities
+
+- **Agent mode** — describe a change and Cursor plans and applies edits across multiple files.
+- **Tab completion** — multi-line, context-aware autocomplete tuned for editing flow.
+- **Codebase context** — index and query your repository so prompts reference the right files.
+- **VS Code compatibility** — built as a VS Code fork, so most extensions, themes, and keybindings carry over.
+
+## How Cursor compares
+
+Cursor is one of several AI coding tools in this directory; they differ by form factor:
+
+| Tool | Form factor | Open source | Notable for |
+| --- | --- | --- | --- |
+| **Cursor** | AI-native editor (VS Code fork) | No | Agent mode, multi-file edits, tab completion |
+| **Zed** | High-performance native editor with AI | Yes | Native speed and real-time collaboration |
+| **GitHub Copilot** | Assistant that runs inside existing editors | No | Drops into VS Code, JetBrains, and others |
+| **Claude Code** | Terminal-based agentic coding tool | No | CLI/agent workflow with MCP, hooks, and subagents |
+
+Choose Cursor for a full AI-native editor experience; Zed for raw editor performance, Copilot to stay in your current editor, or Claude Code for a terminal/agent workflow.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (522 GSC impr/3mo), previously a thin listing. Adds a **Key capabilities** section + **comparison table** (Cursor vs Zed vs GitHub Copilot vs Claude Code). Per-facet `retrievalSources` (Cursor, Zed, Copilot, Claude Code docs). Content-policy scan + `pnpm validate:content:strict` pass locally.