### PR TITLE
docs(content): add capabilities + comparison table to zed

### DIFF
--- a/content/tools/zed.mdx
+++ b/content/tools/zed.mdx
@@ -10,9 +10,16 @@ author: Zed Industries
 dateAdded: "2026-04-27"
 websiteUrl: "https://zed.dev"
 documentationUrl: "https://zed.dev/docs"
+retrievalSources:
+  - "https://zed.dev/docs/"
+  - "https://cursor.com/docs"
+  - "https://docs.github.com/en/copilot"
+  - "https://code.claude.com/docs/en/overview"
 repoUrl: "https://github.com/zed-industries/zed"
 pricingModel: freemium
 disclosure: editorial
+privacyNotes:
+  - "Zed's AI features send code and prompts to the configured model provider, and the editor collects configurable usage telemetry; review provider and telemetry settings and keep secrets out of shared collaborative buffers."
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Linux
 tags:
@@ -22,6 +29,26 @@ keywords:
   - ai code editor
   - collaborative editor
 ---
+
+## Key capabilities
+
+- **Native performance** — a GPU-accelerated editor written in Rust for low-latency editing on large files and projects.
+- **AI assistant** — inline assist and an agent panel for AI-driven edits and questions about your code.
+- **Real-time collaboration** — multiplayer editing, shared projects, and channels built in.
+- **Multibuffer editing** — edit matches from many files in a single buffer.
+
+## How Zed compares
+
+Zed is one of several AI-enabled coding tools in this directory; they differ by form factor:
+
+| Tool | Form factor | Open source | Notable for |
+| --- | --- | --- | --- |
+| **Zed** | High-performance native editor with AI | Yes | Native speed and real-time collaboration |
+| **Cursor** | AI-native editor (VS Code fork) | No | Agent mode and deep VS Code compatibility |
+| **GitHub Copilot** | Assistant inside existing editors | No | Works in VS Code, JetBrains, and others |
+| **Claude Code** | Terminal-based agentic coding tool | No | CLI/agent workflow with MCP, hooks, subagents |
+
+Choose Zed for raw editor performance and collaboration; Cursor for a full AI-native editor, Copilot to stay in your current editor, or Claude Code for a terminal/agent workflow.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (168 GSC impr/3mo), previously a thin listing. Adds **Key capabilities** + **comparison table** (Zed vs Cursor vs Copilot vs Claude Code) + `privacyNotes` (AI features send code to a provider; telemetry). Per-facet `retrievalSources`. Content-policy scan + `pnpm validate:content:strict` pass locally.