### PR TITLE
docs(content): add capabilities + comparison table to browserbase

### DIFF
--- a/content/tools/browserbase.mdx
+++ b/content/tools/browserbase.mdx
@@ -10,8 +10,15 @@ author: Browserbase
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.browserbase.com"
 documentationUrl: "https://docs.browserbase.com"
+retrievalSources:
+  - "https://docs.browserbase.com/"
+  - "https://playwright.dev/docs/intro"
+  - "https://docs.browser-use.com"
+  - "https://docs.stagehand.dev/"
 pricingModel: paid
 disclosure: editorial
+privacyNotes:
+  - "Browserbase runs browsers in its cloud, so the pages you visit, screenshots, and session data are processed on Browserbase infrastructure; avoid driving authenticated or sensitive sessions without reviewing data handling and retention."
 applicationCategory: DeveloperApplication
 operatingSystem: Web
 tags:
@@ -21,6 +28,26 @@ keywords:
   - cloud browser
   - browser agents
 ---
+
+## Key capabilities
+
+- **Hosted headless browsers** — spin up and drive cloud browsers via API/SDK without managing infrastructure.
+- **Session management** — create, observe, and replay browser sessions, with live view and recordings.
+- **Stealth and proxies** — built-in options to reduce bot detection for legitimate automation.
+- **Framework integration** — works with Playwright, Puppeteer, and Stagehand (its AI automation layer).
+
+## How Browserbase compares
+
+Browserbase provides the *infrastructure*, where other directory entries provide the *automation logic*:
+
+| Tool | Role | Open source | Notable for |
+| --- | --- | --- | --- |
+| **Browserbase** | Hosted headless-browser infrastructure | No | Managed cloud browsers you drive via SDK/API |
+| **Playwright** | Browser automation framework | Yes | Deterministic scripted control |
+| **Browser Use** | AI agent browser automation | Yes | LLM plans actions from a natural-language task |
+| **Stagehand** | AI browser automation framework | Yes | Natural-language actions on Playwright |
+
+Use Browserbase when you need managed cloud browsers at scale; pair it with Playwright for scripted flows or Browser Use / Stagehand for AI-driven automation.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (158 GSC impr/3mo), previously a thin listing. Adds **Key capabilities** + **comparison table** (Browserbase vs Playwright vs Browser Use vs Stagehand) + `privacyNotes` (cloud browsers process visited pages). Per-facet `retrievalSources`. Content-policy scan + `pnpm validate:content:strict` pass locally.