### PR TITLE
docs(content): add capabilities + comparison table to trigger-dev

### DIFF
--- a/content/tools/trigger-dev.mdx
+++ b/content/tools/trigger-dev.mdx
@@ -17,6 +17,8 @@ retrievalSources:
 repoUrl: "https://github.com/triggerdotdev/trigger.dev"
 pricingModel: open-source
 disclosure: editorial
+safetyNotes:
+  - "Trigger.dev runs your background tasks — including long-running and scheduled jobs — against connected services and credentials; review task code and scope credentials before deploying jobs to production."
 applicationCategory: DeveloperApplication
 operatingSystem: Web, Self-hosted
 tags:

--- a/content/tools/trigger-dev.mdx
+++ b/content/tools/trigger-dev.mdx
@@ -10,6 +10,10 @@ author: Trigger.dev
 dateAdded: "2026-04-27"
 websiteUrl: "https://trigger.dev"
 documentationUrl: "https://trigger.dev/docs"
+retrievalSources:
+  - "https://trigger.dev/docs"
+  - "https://www.inngest.com/docs"
+  - "https://docs.temporal.io/"
 repoUrl: "https://github.com/triggerdotdev/trigger.dev"
 pricingModel: open-source
 disclosure: editorial
@@ -22,6 +26,25 @@ keywords:
   - background jobs
   - ai workflows
 ---
+
+## Key capabilities
+
+- **Code-first background jobs** — define long-running tasks in your codebase (TypeScript) instead of wiring queues by hand.
+- **Durable execution** — tasks survive restarts with automatic retries and checkpointing.
+- **Scheduling** — cron and delayed triggers for recurring or deferred work.
+- **Observability** — a dashboard for runs, logs, retries, and failures.
+
+## How Trigger.dev compares
+
+Trigger.dev sits among durable-execution / background-job platforms; they differ by model and language focus:
+
+| Tool | Model | Open source | Notable for |
+| --- | --- | --- | --- |
+| **Trigger.dev** | Code-first background jobs with durable execution | Yes | TypeScript-native, batteries-included dashboard |
+| **Inngest** | Event-driven durable functions | Yes | Event/flow-control model with steps |
+| **Temporal** | Workflow-as-code durable execution | Yes | Language-agnostic, battle-tested at scale |
+
+Choose Trigger.dev for a TypeScript-native, low-setup experience; Inngest for an event-driven model, or Temporal for language-agnostic workflows at scale.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (254 GSC impr/3mo), previously a thin listing. Adds **Key capabilities** + **comparison table** (Trigger.dev vs Inngest vs Temporal). Per-facet `retrievalSources` (Trigger.dev, Inngest, Temporal docs). Content-policy scan + `pnpm validate:content:strict` pass locally.