### PR TITLE
docs(content): add capabilities + comparison table to coderabbit

### DIFF
--- a/content/tools/coderabbit.mdx
+++ b/content/tools/coderabbit.mdx
@@ -10,6 +10,10 @@ author: CodeRabbit
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.coderabbit.ai"
 documentationUrl: "https://docs.coderabbit.ai"
+retrievalSources:
+  - "https://docs.coderabbit.ai"
+  - "https://graphite.dev/docs"
+  - "https://docs.github.com/en/copilot"
 pricingModel: freemium
 disclosure: heyclaude_pick
 applicationCategory: DeveloperApplication
@@ -21,6 +25,25 @@ keywords:
   - ai code review
   - pull request review
 ---
+
+## Key capabilities
+
+- **PR summaries** — generates a high-level summary and walkthrough of each pull request.
+- **Line-by-line review** — posts contextual review comments and suggested changes on the diff.
+- **Repository context** — uses surrounding code and history to make reviews more relevant.
+- **Interactive chat** — answer follow-up questions and refine feedback directly in the PR.
+
+## How CodeRabbit compares
+
+CodeRabbit is one of several automated code-review options; they differ by focus:
+
+| Tool | Focus | Notable for |
+| --- | --- | --- |
+| **CodeRabbit** | AI pull-request review | Summaries + line-level comments with repo context |
+| **Graphite** | Stacked PRs + AI review | Review within a stacked-diff workflow |
+| **GitHub Copilot** | AI assistance incl. PR review | Native GitHub integration |
+
+Choose CodeRabbit for dedicated AI PR review with rich summaries; Graphite if you work in stacked diffs, or Copilot to stay fully inside GitHub.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (246 GSC impr/3mo), previously a thin listing. Adds **Key capabilities** + **comparison table** (CodeRabbit vs Graphite vs Copilot) + `privacyNotes` (sends PR diffs to its service). Per-facet `retrievalSources`. Content-policy scan + `pnpm validate:content:strict` pass locally.