### PR TITLE
docs(content): add capabilities + comparison table to raycast

### DIFF
--- a/content/tools/raycast.mdx
+++ b/content/tools/raycast.mdx
@@ -10,8 +10,13 @@ author: Raycast
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.raycast.com"
 documentationUrl: "https://developers.raycast.com"
+retrievalSources:
+  - "https://developers.raycast.com"
+  - "https://www.alfredapp.com/help/"
 pricingModel: freemium
 disclosure: editorial
+privacyNotes:
+  - "Raycast AI features send your prompts (and selected context) to AI model providers; review which commands invoke AI and what data they include before using them on sensitive content."
 applicationCategory: ProductivityApplication
 operatingSystem: macOS
 tags:
@@ -21,6 +26,25 @@ keywords:
   - raycast ai
   - macos productivity
 ---
+
+## Key capabilities
+
+- **Launcher** — fast keyboard-driven access to apps, files, and actions.
+- **Extension store** — a large library of community and official extensions for developer and team workflows.
+- **AI commands** — built-in AI for quick actions, drafting, and Q&A from the launcher.
+- **Productivity built-ins** — clipboard history, snippets, window management, and quicklinks.
+
+## How Raycast compares
+
+Raycast is a macOS launcher/productivity platform; the main alternatives differ in extensibility and AI:
+
+| Tool | Platform | Extensible | Notable for |
+| --- | --- | --- | --- |
+| **Raycast** | macOS | Yes (extension store) | Developer-focused extensions + built-in AI |
+| **Alfred** | macOS | Yes (workflows) | Mature workflow/automation ecosystem |
+| **Spotlight** | macOS (built-in) | No | Default, zero-setup search |
+
+Choose Raycast for a modern, extensible launcher with AI; Alfred for deep custom workflows, or Spotlight when you want the built-in, no-install option.
 
 ## Editorial notes
 


### PR DESCRIPTION
Content-depth enrichment (190 GSC impr/3mo), previously a thin listing. Adds **Key capabilities** + **comparison table** (Raycast vs Alfred vs Spotlight) + `privacyNotes` (AI commands send prompts to providers). Per-facet `retrievalSources`. Content-policy scan + `pnpm validate:content:strict` pass locally.