### PR TITLE
docs(content): add capabilities + comparison table to continue

### DIFF
--- a/content/tools/continue.mdx
+++ b/content/tools/continue.mdx
@@ -10,6 +10,11 @@ author: Continue
 dateAdded: "2026-04-27"
 websiteUrl: "https://continue.dev"
 documentationUrl: "https://docs.continue.dev"
+retrievalSources:
+  - "https://docs.continue.dev"
+  - "https://docs.github.com/en/copilot"
+  - "https://cursor.com/docs"
+  - "https://code.claude.com/docs/en/overview"
 repoUrl: "https://github.com/continuedev/continue"
 pricingModel: open-source
 disclosure: heyclaude_pick
@@ -22,6 +27,26 @@ keywords:
   - open-source ai coding
   - custom model routing
 ---
+
+## Key capabilities
+
+- **Editor chat and edits** — chat about code and apply AI edits inside VS Code and JetBrains.
+- **Autocomplete** — inline multi-line completions from your chosen model.
+- **Custom model routing** — bring your own models (hosted or local) and configure per-task routing.
+- **Open source** — fully open-source and self-configurable.
+
+## How Continue compares
+
+Continue is an open-source AI coding assistant; alternatives differ in openness and form factor:
+
+| Tool | Form factor | Open source | Notable for |
+| --- | --- | --- | --- |
+| **Continue** | Assistant inside existing editors | Yes | Bring-your-own-model routing (hosted or local) |
+| **GitHub Copilot** | Assistant inside existing editors | No | Broad ecosystem and native GitHub integration |
+| **Cursor** | AI-native editor (VS Code fork) | No | Agent mode and multi-file edits |
+| **Claude Code** | Terminal-based agentic coding tool | No | CLI/agent workflow with MCP, hooks, subagents |
+
+Choose Continue when you want an open-source assistant with full model control; Copilot for the broad ecosystem, Cursor for a full AI-native editor, or Claude Code for a terminal/agent workflow.
 
 ## Editorial notes
 

--- a/content/tools/continue.mdx
+++ b/content/tools/continue.mdx
@@ -18,6 +18,8 @@ retrievalSources:
 repoUrl: "https://github.com/continuedev/continue"
 pricingModel: open-source
 disclosure: heyclaude_pick
+privacyNotes:
+  - "Continue sends code, file context, and prompts to whichever model provider you configure (including local models); choose providers deliberately and keep secrets out of shared context."
 applicationCategory: DeveloperApplication
 operatingSystem: macOS, Windows, Linux
 tags:


### PR DESCRIPTION
Content-depth enrichment (114 GSC impr/3mo). Adds **Key capabilities** + **comparison table** (Continue vs Copilot vs Cursor vs Claude Code) + `privacyNotes`. Per-facet `retrievalSources`. Scan + strict pass locally.