### PR TITLE
docs(content): add plotting-libraries comparison to cli-data-viz-quickstart

### DIFF
--- a/content/skills/cli-data-viz-quickstart.mdx
+++ b/content/skills/cli-data-viz-quickstart.mdx
@@ -29,6 +29,7 @@ retrievalSources:
   - "https://matplotlib.org/"
   - "https://pandas.pydata.org/docs/"
   - "https://seaborn.pydata.org/"
+  - "https://plotly.com/python/"
 testedPlatforms:
   - Claude
   - Codex
@@ -229,6 +230,18 @@ Show monthly data as area chart"
 - 3D visualizations
 - Animated charts
 - Interactive dashboards
+
+## Plotting libraries compared
+
+This skill leans on the Python plotting stack; pick the library by output type:
+
+| Library | Type | Notable for |
+| --- | --- | --- |
+| **Matplotlib** | Foundational plotting | Maximum control and publication-quality static charts |
+| **Seaborn** | Statistical viz on top of Matplotlib | Concise statistical plots with good defaults |
+| **Plotly** | Interactive visualization | Interactive HTML charts and dashboards |
+
+Use Matplotlib for precise static figures, Seaborn for quick statistical charts, or Plotly when you need interactivity in a browser.
 
 ## Tips for Best Results
 


### PR DESCRIPTION
Content-depth enrichment (102 GSC impr/3mo). Adds a grounded **comparison table** (Matplotlib vs Seaborn vs Plotly). Per-facet `retrievalSources`. Content-policy scan + `pnpm validate:content:strict` pass locally.