### PR TITLE
feat(web): expand comparison pages (4 new + Phoenix in observability)

### DIFF
--- a/apps/web/src/data/comparisons.ts
+++ b/apps/web/src/data/comparisons.ts
@@ -27,7 +27,8 @@ export const COMPARISONS: Comparison[] = [
     heading: "Database MCP servers compared",
     seoDescription:
       "Compare PostgreSQL, Redis, MongoDB, and Supabase MCP servers for Claude Code — trust, install, safety, and config side by side.",
-    intro: "The most-used database MCP servers for Claude Code, compared on trust, install, and safety signals.",
+    intro:
+      "The most-used database MCP servers for Claude Code, compared on trust, install, and safety signals.",
     refs: [
       "mcp/postgresql-mcp-server",
       "mcp/redis-mcp-server",
@@ -55,17 +56,24 @@ export const COMPARISONS: Comparison[] = [
     heading: "AI coding agents compared",
     seoDescription:
       "Compare Cursor, Aider, Cline, and Continue — AI coding tools that work with Claude — side by side.",
-    intro: "The leading AI coding tools that pair with Claude, compared on platforms, source, and setup.",
+    intro:
+      "The leading AI coding tools that pair with Claude, compared on platforms, source, and setup.",
     refs: ["tools/cursor", "tools/aider", "tools/cline", "tools/continue"],
   },
   {
     slug: "llm-observability-tools",
-    title: "Langfuse vs LangSmith vs Helicone vs Braintrust",
+    title: "Phoenix vs Langfuse vs LangSmith vs Helicone vs Braintrust",
     heading: "LLM observability tools compared",
     seoDescription:
-      "Compare Langfuse, LangSmith, Helicone, and Braintrust — LLM observability and eval tools — side by side.",
+      "Compare Arize Phoenix, Langfuse, LangSmith, Helicone, and Braintrust — LLM observability and eval tools — side by side.",
     intro: "Observability and eval platforms for LLM apps, compared on trust, source, and setup.",
-    refs: ["tools/langfuse", "tools/langsmith", "tools/helicone", "tools/braintrust"],
+    refs: [
+      "tools/arize-phoenix",
+      "tools/langfuse",
+      "tools/langsmith",
+      "tools/helicone",
+      "tools/braintrust",
+    ],
   },
   {
     slug: "search-mcp-servers",
@@ -135,6 +143,46 @@ export const COMPARISONS: Comparison[] = [
       "mcp/basic-memory-mcp-server",
       "mcp/codebase-memory-mcp-server",
     ],
+  },
+  {
+    slug: "rag-agent-frameworks",
+    title: "LlamaIndex vs LangGraph vs CrewAI vs AutoGen",
+    heading: "RAG & agent frameworks compared",
+    seoDescription:
+      "Compare LlamaIndex, LangGraph, CrewAI, and AutoGen — RAG and multi-agent orchestration frameworks for LLM apps — side by side.",
+    intro:
+      "The leading open-source frameworks for building RAG pipelines and multi-agent systems, compared on focus, source, and setup.",
+    refs: ["tools/llamaindex", "tools/langgraph", "tools/crewai", "tools/microsoft-autogen"],
+  },
+  {
+    slug: "llm-security-redteaming-tools",
+    title: "Garak vs Lakera Guard vs PyRIT vs Promptfoo",
+    heading: "LLM security & red-teaming tools compared",
+    seoDescription:
+      "Compare Garak, Lakera Guard, PyRIT, and Promptfoo — LLM security scanning, runtime guardrails, and red-teaming — side by side.",
+    intro:
+      "Tools for probing and protecting LLM applications — vulnerability scanning, runtime guardrails, and adversarial red-teaming — compared.",
+    refs: ["tools/garak", "tools/lakera-guard", "tools/pyrit", "tools/promptfoo"],
+  },
+  {
+    slug: "llm-eval-tools",
+    title: "Braintrust vs Promptfoo vs DeepEval vs Phoenix",
+    heading: "LLM evaluation tools compared",
+    seoDescription:
+      "Compare Braintrust, Promptfoo, DeepEval, and Arize Phoenix — LLM evaluation and experimentation tools — side by side.",
+    intro:
+      "Evaluation and experimentation platforms for LLM apps, compared on approach, source, and setup.",
+    refs: ["tools/braintrust", "tools/promptfoo", "tools/deepeval", "tools/arize-phoenix"],
+  },
+  {
+    slug: "ai-code-editors",
+    title: "Cursor vs Zed vs Windsurf vs Continue",
+    heading: "AI code editors compared",
+    seoDescription:
+      "Compare Cursor, Zed, Windsurf, and Continue — AI-powered code editors and assistants — side by side on trust, install, and platform support.",
+    intro:
+      "AI-native editors and assistants for day-to-day coding, compared on form factor, source, and setup.",
+    refs: ["tools/cursor", "tools/zed", "tools/windsurf", "tools/continue"],
   },
 ];
 


### PR DESCRIPTION
Programmatic SEO/AI-citation win — scales without touching content files. The `/compare/$slug` route already renders full SSR'd, sitemap'd comparison pages from `COMPARISONS` data, but the list was only ~12 curated pairs. This adds **4 high-intent comparison landing pages** (and adds Arize Phoenix — the site's #1 page — to the existing observability comparison), each targeting real 'X vs Y' search intent and rendering the existing rich `<ComparisonTable>`:

- **rag-agent-frameworks** — LlamaIndex vs LangGraph vs CrewAI vs AutoGen
- **llm-security-redteaming-tools** — Garak vs Lakera Guard vs PyRIT vs Promptfoo
- **llm-eval-tools** — Braintrust vs Promptfoo vs DeepEval vs Phoenix
- **ai-code-editors** — Cursor vs Zed vs Windsurf vs Continue
- **llm-observability-tools** — now includes Arize Phoenix

All refs verified to resolve to existing catalog entries (the route 404s if <2 resolve, so no thin pages). New pages auto-flow into `sitemap.xml`. Platform change (apps/web data only) — normal CI, not the content gate. Prettier + ref-resolution checks pass locally.