### PR TITLE
feat(web): match OG cards to light-mode palette, add trust pill + GitHub footer

### DIFF
--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -101,15 +101,16 @@ export function renderOgSvg(opts: {
     ? wrap(clampOgText(opts.description, OG_TEXT_LIMITS.description), 60, 2)
     : [];
 
+  // 32px graph-paper grid matching the site's `.grid-bg` utility (1px lines in
+  // `--border` over warm-paper `--background`). Kept in sync with renderOgPng.
+  const gridSegments: string[] = [];
+  for (let x = 32; x < OG_WIDTH; x += 32) gridSegments.push(`M${x} 0V${OG_HEIGHT}`);
+  for (let y = 32; y < OG_HEIGHT; y += 32) gridSegments.push(`M0 ${y}H${OG_WIDTH}`);
+
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#f7f5ef"/>
-      <stop offset="1" stop-color="#ece8df"/>
-    </linearGradient>
-  </defs>
-  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect width="1200" height="630" fill="#f7f5ef"/>
+  <path d="${gridSegments.join("")}" stroke="#d8d3c7" stroke-width="1" stroke-opacity="0.55" fill="none"/>
   <rect x="0" y="0" width="14" height="630" fill="${accent}"/>
   <g transform="translate(80,90)">
     <text x="0" y="0" font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64" letter-spacing="2">

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -99,6 +99,26 @@ export function wrap(value: string, perLine: number, maxLines: number) {
   return lines;
 }
 
+/**
+ * Wrap a description into at most `maxLines`. If the text doesn't fully fit, end the
+ * last line with an ellipsis at a WORD boundary — trimming a dangling trailing comma
+ * or connector ("and", "or", "for", …) — so the card never cuts off mid-phrase like
+ * "…, file operations, and". Returns the full text unmodified when it fits.
+ */
+export function descriptionLines(value: string, perLine: number, maxLines: number) {
+  const clamped = clampOgText(value, OG_TEXT_LIMITS.description);
+  const lines = wrap(clamped, perLine, maxLines);
+  const shown = lines.join(" ");
+  if (shown.length < clamped.length && lines.length) {
+    const last = lines[lines.length - 1];
+    const trimmed = last
+      .replace(/[\s,;:]+(?:and|or|the|a|an|of|for|to|with|in|on|&)?$/i, "")
+      .trimEnd();
+    lines[lines.length - 1] = `${trimmed || last.trimEnd()}…`;
+  }
+  return lines;
+}
+
 /** Deterministic 1200×630 OG card SVG. Shared by /og/$category/$slug and the generic /og route. */
 export function renderOgSvg(opts: {
   eyebrow?: string;
@@ -112,9 +132,7 @@ export function renderOgSvg(opts: {
     clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),
   );
   const titleLines = wrap(clampOgText(opts.title, OG_TEXT_LIMITS.title), 22, 2);
-  const descLines = opts.description
-    ? wrap(clampOgText(opts.description, OG_TEXT_LIMITS.description), 60, 2)
-    : [];
+  const descLines = opts.description ? descriptionLines(opts.description, 58, 3) : [];
 
   // 32px graph-paper grid matching the site's `.grid-bg` utility (1px lines in
   // `--border` over warm-paper `--background`). Kept in sync with renderOgPng.

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -1,5 +1,19 @@
 import { absoluteUrl } from "@/lib/seo";
 
+/**
+ * OG card palette — the exact light-mode design tokens from styles.css, converted
+ * from their OKLCH source values to hex so the cards match the live site:
+ *   --background #f8f6ed · --ink #13110d · --ink-muted #58554e · --ink-subtle #6d6a63
+ *   --border #dad7cf · --accent #e1f32a (citron) · --accent-soft #effaac
+ */
+export const OG_BG = "#f8f6ed";
+export const OG_INK = "#13110d";
+export const OG_INK_MUTED = "#58554e";
+export const OG_INK_SUBTLE = "#6d6a63";
+export const OG_BORDER = "#dad7cf";
+export const OG_ACCENT_SOFT = "#effaac";
+export const OG_ACCENT_INK = "#13110d";
+
 // Per-category accent colors (shared by the entry OG route and generic OG route).
 const PALETTE: Record<string, string> = {
   mcp: "#7cd17c",
@@ -13,7 +27,8 @@ const PALETTE: Record<string, string> = {
   statuslines: "#9bd6f0",
 };
 
-const DEFAULT_ACCENT = "#c5e84e";
+// Brand citron (`--accent`) used when no per-category accent applies.
+const DEFAULT_ACCENT = "#e1f32a";
 
 export const OG_TEXT_LIMITS = {
   eyebrow: 40,
@@ -109,33 +124,33 @@ export function renderOgSvg(opts: {
 
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
-  <rect width="1200" height="630" fill="#f7f5ef"/>
-  <path d="${gridSegments.join("")}" stroke="#d8d3c7" stroke-width="1" stroke-opacity="0.55" fill="none"/>
+  <rect width="1200" height="630" fill="${OG_BG}"/>
+  <path d="${gridSegments.join("")}" stroke="${OG_BORDER}" stroke-width="1" stroke-opacity="0.6" fill="none"/>
   <rect x="0" y="0" width="14" height="630" fill="${accent}"/>
   <g transform="translate(80,90)">
-    <text x="0" y="0" font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64" letter-spacing="2">
+    <text x="0" y="0" font-family="ui-monospace, Menlo, monospace" font-size="20" fill="${OG_INK_SUBTLE}" letter-spacing="2">
       ${eyebrow}
     </text>
     ${titleLines
       .map(
         (l, i) =>
-          `<text x="0" y="${110 + i * 88}" font-family="Space Grotesk, system-ui, sans-serif" font-weight="700" font-size="78" fill="#171614">${esc(l)}</text>`,
+          `<text x="0" y="${110 + i * 88}" font-family="Space Grotesk, system-ui, sans-serif" font-weight="700" font-size="78" fill="${OG_INK}">${esc(l)}</text>`,
       )
       .join("")}
     ${descLines
       .map(
         (l, i) =>
-          `<text x="0" y="${340 + i * 38}" font-family="DM Sans, system-ui, sans-serif" font-size="28" fill="#4d4c47">${esc(l)}</text>`,
+          `<text x="0" y="${340 + i * 38}" font-family="DM Sans, system-ui, sans-serif" font-size="28" fill="${OG_INK_MUTED}">${esc(l)}</text>`,
       )
       .join("")}
     ${
       opts.author
-        ? `<text x="0" y="460" font-family="DM Sans, system-ui, sans-serif" font-size="22" fill="#6b6a64">by <tspan font-weight="600" fill="#171614">${esc(opts.author)}</tspan></text>`
+        ? `<text x="0" y="460" font-family="DM Sans, system-ui, sans-serif" font-size="22" fill="${OG_INK_SUBTLE}">by <tspan font-weight="600" fill="${OG_INK}">${esc(opts.author)}</tspan></text>`
         : ""
     }
   </g>
   <g transform="translate(80,540)">
-    <text font-family="ui-monospace, Menlo, monospace" font-size="20" fill="#6b6a64">heyclau.de</text>
+    <text font-family="ui-monospace, Menlo, monospace" font-size="20" fill="${OG_INK_SUBTLE}">heyclau.de</text>
   </g>
 </svg>`;
 }

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -2,8 +2,6 @@ import type { ImageResponse } from "workers-og";
 
 import { getOgFonts } from "@/lib/og-fonts";
 import {
-  OG_ACCENT_INK,
-  OG_ACCENT_SOFT,
   OG_BG,
   OG_BORDER,
   OG_HEIGHT,
@@ -13,6 +11,7 @@ import {
   OG_TEXT_LIMITS,
   OG_WIDTH,
   clampOgText,
+  descriptionLines,
   safeAccent,
   wrap,
 } from "@/lib/og-image";
@@ -59,6 +58,18 @@ function escForSatori(value: string) {
 }
 
 /**
+ * Convert a #rgb / #rrggbb / #rrggbbaa hex (already validated by safeAccent) to an
+ * `rgba()` string so the category swash can be drawn semi-transparent — matching the
+ * homepage hero's `bg-accent/70` marker highlight.
+ */
+function withAlpha(hex: string, alpha: number) {
+  const h = hex.replace("#", "");
+  const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h.slice(0, 6);
+  const n = Number.parseInt(full, 16);
+  return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
+}
+
+/**
  * Render the OG card as a PNG. Same 1200×630 design as renderOgSvg, but built as an
  * HTML string for Satori (via workers-og's ImageResponse) so social scrapers that do
  * NOT rasterize SVG og:images (Twitter/X, Facebook, LinkedIn, Slack, Discord) get a
@@ -80,23 +91,20 @@ function escForSatori(value: string) {
  * which getOgFonts() supplies from a bundled, base64-embedded Space Grotesk subset.
  */
 export async function renderOgPng(opts: {
+  /** Category/section label shown as the highlighted eyebrow (e.g. "MCP", "Agents"). */
   eyebrow?: string;
   title: string;
   description?: string;
   author?: string;
   accent?: string;
-  /** Positive trust signal shown as a pill (e.g. "First-party", "Source-backed"). */
-  badge?: string;
 }): Promise<ImageResponse> {
   const { ImageResponse } = await import("workers-og");
   const accent = safeAccent(opts.accent);
-  const eyebrow = escForSatori(
+  const label = escForSatori(
     clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),
   );
   const titleLines = wrap(clampOgText(opts.title, OG_TEXT_LIMITS.title), 22, 2);
-  const descLines = opts.description
-    ? wrap(clampOgText(opts.description, OG_TEXT_LIMITS.description), 60, 2)
-    : [];
+  const descLines = opts.description ? descriptionLines(opts.description, 58, 3) : [];
 
   const titleHtml = titleLines
     .map(
@@ -118,28 +126,24 @@ export async function renderOgPng(opts: {
         .join("")}</div>`
     : "";
 
-  // Use a plain space, not the "&nbsp;" HTML entity: workers-og parses the markup with
-  // HTMLRewriter, which does not decode entities, so "&nbsp;" would render verbatim.
   const authorHtml = opts.author
-    ? `<div style="display:flex;margin-top:32px;font-family:'Space Grotesk';font-weight:500;font-size:22px;color:${OG_INK_SUBTLE};">by <span style="font-weight:700;color:${OG_INK};">${escForSatori(
+    ? `<div style="display:flex;margin-top:28px;font-family:'Space Grotesk';font-weight:500;font-size:22px;color:${OG_INK_SUBTLE};">by<span style="margin-left:8px;font-weight:700;color:${OG_INK};">${escForSatori(
         clampOgText(opts.author, OG_TEXT_LIMITS.author),
       )}</span></div>`
     : "";
 
-  // Trust pill (positive signals only) — citron-soft chip aligned with the eyebrow.
-  const badge = opts.badge ? escForSatori(clampOgText(opts.badge, 24)) : "";
-  const badgeHtml = badge
-    ? `<div style="display:flex;align-items:center;height:40px;padding:0 18px;border-radius:999px;background:${OG_ACCENT_SOFT};font-family:'Space Grotesk';font-weight:700;font-size:18px;letter-spacing:1px;color:${OG_ACCENT_INK};">${badge}</div>`
-    : "";
+  // Category eyebrow with the homepage hero's marker-swash highlight, color-coded by the
+  // category accent. The swash is a hard-stop linear-gradient background filling the lower
+  // 14px behind the text — a single flex node (Satori requires display:flex on any div
+  // with >1 child, so the highlight is drawn as a background rather than a nested element).
+  const swash = withAlpha(accent, 0.85);
+  const labelHtml = `<div style="display:flex;align-self:flex-start;padding:0 6px 3px 6px;font-family:'Space Grotesk';font-weight:700;font-size:26px;letter-spacing:3px;color:${OG_INK};background:linear-gradient(to top, ${swash} 0px, ${swash} 14px, transparent 14px, transparent 100%);">${label}</div>`;
 
   const html = `<div style="display:flex;width:1200px;height:630px;background-color:${OG_BG};background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
   <div style="display:flex;width:14px;height:630px;background:${accent};"></div>
   <div style="display:flex;flex-direction:column;flex:1;padding:80px 80px;">
-    <div style="display:flex;align-items:center;justify-content:${badge ? "space-between" : "flex-start"};">
-      <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;letter-spacing:2px;color:${OG_INK_SUBTLE};">${eyebrow}</div>
-      ${badgeHtml}
-    </div>
-    <div style="display:flex;flex-direction:column;margin-top:44px;">${titleHtml}</div>
+    ${labelHtml}
+    <div style="display:flex;flex-direction:column;margin-top:40px;">${titleHtml}</div>
     ${descHtml}
     ${authorHtml}
     <div style="display:flex;flex:1;"></div>

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -4,6 +4,23 @@ import { getOgFonts } from "@/lib/og-fonts";
 import { OG_HEIGHT, OG_TEXT_LIMITS, OG_WIDTH, clampOgText, safeAccent, wrap } from "@/lib/og-image";
 
 /**
+ * Warm-paper + 32px graph-paper grid that matches the site's `.grid-bg` utility
+ * (1px lines in `--border` at ~60% over the warm-paper `--background`). Baked as a
+ * full-bleed SVG data URI because Satori draws a background image but can't tile via
+ * `background-size`, so the whole grid is drawn once at 1200×630. URL-encoded (not
+ * base64) to avoid a Buffer/btoa dependency in the Workers runtime.
+ */
+const GRID_BG_DATA_URI = (() => {
+  const segments: string[] = [];
+  for (let x = 32; x < OG_WIDTH; x += 32) segments.push(`M${x} 0V${OG_HEIGHT}`);
+  for (let y = 32; y < OG_HEIGHT; y += 32) segments.push(`M0 ${y}H${OG_WIDTH}`);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${OG_WIDTH}" height="${OG_HEIGHT}"><path d="${segments.join(
+    "",
+  )}" stroke="#d8d3c7" stroke-width="1" stroke-opacity="0.55" fill="none"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+})();
+
+/**
  * Sanitize a text value for the Satori HTML template.
  *
  * workers-og parses markup with Cloudflare's HTMLRewriter, which treats `<…>` as tags
@@ -83,7 +100,7 @@ export async function renderOgPng(opts: {
       )}</span></div>`
     : "";
 
-  const html = `<div style="display:flex;width:1200px;height:630px;background:linear-gradient(135deg,#f7f5ef,#ece8df);">
+  const html = `<div style="display:flex;width:1200px;height:630px;background-color:#f7f5ef;background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
   <div style="display:flex;width:14px;height:630px;background:${accent};"></div>
   <div style="display:flex;flex-direction:column;flex:1;padding:90px 80px;">
     <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;letter-spacing:2px;color:#6b6a64;">${eyebrow}</div>

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -60,45 +60,34 @@ function escForSatori(value: string) {
 /**
  * Convert a #rgb / #rrggbb / #rrggbbaa hex (already validated by safeAccent) to an
  * `rgba()` string so the category swash can be drawn semi-transparent — matching the
- * homepage hero's `bg-accent/70` marker highlight.
+ * homepage hero's `bg-accent/70` marker highlight. Exported for unit testing.
  */
-function withAlpha(hex: string, alpha: number) {
+export function withAlpha(hex: string, alpha: number) {
   const h = hex.replace("#", "");
   const full = h.length === 3 ? [...h].map((c) => c + c).join("") : h.slice(0, 6);
   const n = Number.parseInt(full, 16);
   return `rgba(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255}, ${alpha})`;
 }
 
-/**
- * Render the OG card as a PNG. Same 1200×630 design as renderOgSvg, but built as an
- * HTML string for Satori (via workers-og's ImageResponse) so social scrapers that do
- * NOT rasterize SVG og:images (Twitter/X, Facebook, LinkedIn, Slack, Discord) get a
- * real raster image.
- *
- * This module is server-only on purpose: workers-og statically imports its own resvg +
- * yoga `.wasm` modules, which must not be pulled into the browser bundle. The Vite
- * `serverOnlyClientStubs` plugin stubs `*.server` imports for the client build.
- *
- * workers-og is imported lazily (dynamic `import()` below) rather than at module top
- * level: TanStack's dev SSR eagerly evaluates the whole route tree, so a static import
- * here would pull workers-og's `.wasm` into Node's ESM loader for EVERY page and 500 the
- * entire site under `vite dev` (Node can't resolve the bundled `.wasm`). Deferring it
- * keeps `pnpm dev` working for all routes; only an actual request to `/og*` loads it
- * (still server-only — the Cloudflare/Workers runtime resolves the WASM in prod).
- *
- * workers-og initializes the WASM lazily on first render, so no manual WASM handling is
- * required here. Satori needs real font bytes (it cannot resolve CSS font-family names),
- * which getOgFonts() supplies from a bundled, base64-embedded Space Grotesk subset.
- */
-export async function renderOgPng(opts: {
+export type OgCardOptions = {
   /** Category/section label shown as the highlighted eyebrow (e.g. "MCP", "Agents"). */
   eyebrow?: string;
   title: string;
   description?: string;
   author?: string;
   accent?: string;
-}): Promise<ImageResponse> {
-  const { ImageResponse } = await import("workers-og");
+};
+
+/**
+ * Build the Satori HTML string for the 1200×630 OG card. Pure (no WASM / font / async
+ * deps) so it can be unit-tested directly; renderOgPng wraps it in an ImageResponse.
+ *
+ * Layout: category eyebrow with a color-coded marker-swash highlight, a 2-line title, a
+ * 3-line clean-truncated description, an optional author, and a GitHub footer. All
+ * caller text is run through escForSatori; the accent is run through safeAccent — so an
+ * entry- or query-derived value can never inject markup or break a style attribute.
+ */
+export function buildOgCardHtml(opts: OgCardOptions): string {
   const accent = safeAccent(opts.accent);
   const label = escForSatori(
     clampOgText(opts.eyebrow || "HeyClaude", OG_TEXT_LIMITS.eyebrow).toUpperCase(),
@@ -139,7 +128,7 @@ export async function renderOgPng(opts: {
   const swash = withAlpha(accent, 0.85);
   const labelHtml = `<div style="display:flex;align-self:flex-start;padding:0 6px 3px 6px;font-family:'Space Grotesk';font-weight:700;font-size:26px;letter-spacing:3px;color:${OG_INK};background:linear-gradient(to top, ${swash} 0px, ${swash} 14px, transparent 14px, transparent 100%);">${label}</div>`;
 
-  const html = `<div style="display:flex;width:1200px;height:630px;background-color:${OG_BG};background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
+  return `<div style="display:flex;width:1200px;height:630px;background-color:${OG_BG};background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
   <div style="display:flex;width:14px;height:630px;background:${accent};"></div>
   <div style="display:flex;flex-direction:column;flex:1;padding:80px 80px;">
     ${labelHtml}
@@ -155,8 +144,32 @@ export async function renderOgPng(opts: {
     </div>
   </div>
 </div>`;
+}
 
-  return new ImageResponse(html, {
+/**
+ * Render the OG card as a PNG. Same 1200×630 design as renderOgSvg, but built as an
+ * HTML string for Satori (via workers-og's ImageResponse) so social scrapers that do
+ * NOT rasterize SVG og:images (Twitter/X, Facebook, LinkedIn, Slack, Discord) get a
+ * real raster image.
+ *
+ * This module is server-only on purpose: workers-og statically imports its own resvg +
+ * yoga `.wasm` modules, which must not be pulled into the browser bundle. The Vite
+ * `serverOnlyClientStubs` plugin stubs `*.server` imports for the client build.
+ *
+ * workers-og is imported lazily (dynamic `import()` below) rather than at module top
+ * level: TanStack's dev SSR eagerly evaluates the whole route tree, so a static import
+ * here would pull workers-og's `.wasm` into Node's ESM loader for EVERY page and 500 the
+ * entire site under `vite dev` (Node can't resolve the bundled `.wasm`). Deferring it
+ * keeps `pnpm dev` working for all routes; only an actual request to `/og*` loads it
+ * (still server-only — the Cloudflare/Workers runtime resolves the WASM in prod).
+ *
+ * workers-og initializes the WASM lazily on first render, so no manual WASM handling is
+ * required here. Satori needs real font bytes (it cannot resolve CSS font-family names),
+ * which getOgFonts() supplies from a bundled, base64-embedded Space Grotesk subset.
+ */
+export async function renderOgPng(opts: OgCardOptions): Promise<ImageResponse> {
+  const { ImageResponse } = await import("workers-og");
+  return new ImageResponse(buildOgCardHtml(opts), {
     width: OG_WIDTH,
     height: OG_HEIGHT,
     format: "png",

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -135,7 +135,7 @@ export async function renderOgPng(opts: {
   const html = `<div style="display:flex;width:1200px;height:630px;background-color:${OG_BG};background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
   <div style="display:flex;width:14px;height:630px;background:${accent};"></div>
   <div style="display:flex;flex-direction:column;flex:1;padding:80px 80px;">
-    <div style="display:flex;align-items:center;justify-content:space-between;">
+    <div style="display:flex;align-items:center;justify-content:${badge ? "space-between" : "flex-start"};">
       <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;letter-spacing:2px;color:${OG_INK_SUBTLE};">${eyebrow}</div>
       ${badgeHtml}
     </div>

--- a/apps/web/src/lib/og-render.server.ts
+++ b/apps/web/src/lib/og-render.server.ts
@@ -1,7 +1,21 @@
 import type { ImageResponse } from "workers-og";
 
 import { getOgFonts } from "@/lib/og-fonts";
-import { OG_HEIGHT, OG_TEXT_LIMITS, OG_WIDTH, clampOgText, safeAccent, wrap } from "@/lib/og-image";
+import {
+  OG_ACCENT_INK,
+  OG_ACCENT_SOFT,
+  OG_BG,
+  OG_BORDER,
+  OG_HEIGHT,
+  OG_INK,
+  OG_INK_MUTED,
+  OG_INK_SUBTLE,
+  OG_TEXT_LIMITS,
+  OG_WIDTH,
+  clampOgText,
+  safeAccent,
+  wrap,
+} from "@/lib/og-image";
 
 /**
  * Warm-paper + 32px graph-paper grid that matches the site's `.grid-bg` utility
@@ -16,7 +30,17 @@ const GRID_BG_DATA_URI = (() => {
   for (let y = 32; y < OG_HEIGHT; y += 32) segments.push(`M0 ${y}H${OG_WIDTH}`);
   const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${OG_WIDTH}" height="${OG_HEIGHT}"><path d="${segments.join(
     "",
-  )}" stroke="#d8d3c7" stroke-width="1" stroke-opacity="0.55" fill="none"/></svg>`;
+  )}" stroke="${OG_BORDER}" stroke-width="1" stroke-opacity="0.6" fill="none"/></svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+})();
+
+/**
+ * GitHub mark (lucide `github` icon) for the card footer, embedded as an SVG data URI
+ * `<img>` because the bundled Space Grotesk font subset has no icon glyphs. Stroked in
+ * the muted ink so it sits quietly next to the footer text.
+ */
+const GITHUB_ICON_DATA_URI = (() => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="${OG_INK_SUBTLE}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>`;
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 })();
 
@@ -61,6 +85,8 @@ export async function renderOgPng(opts: {
   description?: string;
   author?: string;
   accent?: string;
+  /** Positive trust signal shown as a pill (e.g. "First-party", "Source-backed"). */
+  badge?: string;
 }): Promise<ImageResponse> {
   const { ImageResponse } = await import("workers-og");
   const accent = safeAccent(opts.accent);
@@ -75,7 +101,7 @@ export async function renderOgPng(opts: {
   const titleHtml = titleLines
     .map(
       (l) =>
-        `<div style="display:flex;font-family:'Space Grotesk';font-weight:700;font-size:78px;line-height:88px;color:#171614;">${escForSatori(
+        `<div style="display:flex;font-family:'Space Grotesk';font-weight:700;font-size:78px;line-height:88px;color:${OG_INK};">${escForSatori(
           l,
         )}</div>`,
     )
@@ -85,7 +111,7 @@ export async function renderOgPng(opts: {
     ? `<div style="display:flex;flex-direction:column;margin-top:28px;">${descLines
         .map(
           (l) =>
-            `<div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:28px;line-height:38px;color:#4d4c47;">${escForSatori(
+            `<div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:28px;line-height:38px;color:${OG_INK_MUTED};">${escForSatori(
               l,
             )}</div>`,
         )
@@ -95,20 +121,34 @@ export async function renderOgPng(opts: {
   // Use a plain space, not the "&nbsp;" HTML entity: workers-og parses the markup with
   // HTMLRewriter, which does not decode entities, so "&nbsp;" would render verbatim.
   const authorHtml = opts.author
-    ? `<div style="display:flex;margin-top:32px;font-family:'Space Grotesk';font-weight:500;font-size:22px;color:#6b6a64;">by <span style="font-weight:700;color:#171614;">${escForSatori(
+    ? `<div style="display:flex;margin-top:32px;font-family:'Space Grotesk';font-weight:500;font-size:22px;color:${OG_INK_SUBTLE};">by <span style="font-weight:700;color:${OG_INK};">${escForSatori(
         clampOgText(opts.author, OG_TEXT_LIMITS.author),
       )}</span></div>`
     : "";
 
-  const html = `<div style="display:flex;width:1200px;height:630px;background-color:#f7f5ef;background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
+  // Trust pill (positive signals only) — citron-soft chip aligned with the eyebrow.
+  const badge = opts.badge ? escForSatori(clampOgText(opts.badge, 24)) : "";
+  const badgeHtml = badge
+    ? `<div style="display:flex;align-items:center;height:40px;padding:0 18px;border-radius:999px;background:${OG_ACCENT_SOFT};font-family:'Space Grotesk';font-weight:700;font-size:18px;letter-spacing:1px;color:${OG_ACCENT_INK};">${badge}</div>`
+    : "";
+
+  const html = `<div style="display:flex;width:1200px;height:630px;background-color:${OG_BG};background-image:url('${GRID_BG_DATA_URI}');background-size:1200px 630px;background-repeat:no-repeat;">
   <div style="display:flex;width:14px;height:630px;background:${accent};"></div>
-  <div style="display:flex;flex-direction:column;flex:1;padding:90px 80px;">
-    <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;letter-spacing:2px;color:#6b6a64;">${eyebrow}</div>
-    <div style="display:flex;flex-direction:column;margin-top:48px;">${titleHtml}</div>
+  <div style="display:flex;flex-direction:column;flex:1;padding:80px 80px;">
+    <div style="display:flex;align-items:center;justify-content:space-between;">
+      <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;letter-spacing:2px;color:${OG_INK_SUBTLE};">${eyebrow}</div>
+      ${badgeHtml}
+    </div>
+    <div style="display:flex;flex-direction:column;margin-top:44px;">${titleHtml}</div>
     ${descHtml}
     ${authorHtml}
     <div style="display:flex;flex:1;"></div>
-    <div style="display:flex;font-family:'Space Grotesk';font-weight:500;font-size:20px;color:#6b6a64;">heyclau.de</div>
+    <div style="display:flex;align-items:center;font-family:'Space Grotesk';font-weight:500;font-size:20px;color:${OG_INK_SUBTLE};">
+      <span style="display:flex;">heyclau.de</span>
+      <span style="display:flex;margin:0 14px;color:${OG_BORDER};">|</span>
+      <img src="${GITHUB_ICON_DATA_URI}" width="22" height="22" style="margin-right:8px;" />
+      <span style="display:flex;">github.com/JSONbored/awesome-claude</span>
+    </div>
   </div>
 </div>`;
 

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -19,23 +19,13 @@ export const Route = createFileRoute("/og/$category/$slug")({
         const author = entry?.author ?? "HeyClaude";
         const category = entry?.category ?? params.category;
 
-        // Surface only positive trust signals as a pill; everything else stays unbadged.
-        const badge =
-          entry?.source === "first-party"
-            ? "First-party"
-            : entry?.source === "source-backed"
-              ? "Source-backed"
-              : entry?.trust === "trusted"
-                ? "Trusted"
-                : undefined;
-
         const image = await renderOgPng({
-          eyebrow: `${category} · HeyClaude`,
+          // The category is the highlighted eyebrow; its accent color-codes the swash + rail.
+          eyebrow: category,
           title,
           description,
           author,
           accent: categoryAccent(category),
-          badge,
         });
 
         // ImageResponse already sets Content-Type: image/png; add our cache policy.

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -19,12 +19,23 @@ export const Route = createFileRoute("/og/$category/$slug")({
         const author = entry?.author ?? "HeyClaude";
         const category = entry?.category ?? params.category;
 
+        // Surface only positive trust signals as a pill; everything else stays unbadged.
+        const badge =
+          entry?.source === "first-party"
+            ? "First-party"
+            : entry?.source === "source-backed"
+              ? "Source-backed"
+              : entry?.trust === "trusted"
+                ? "Trusted"
+                : undefined;
+
         const image = await renderOgPng({
           eyebrow: `${category} · HeyClaude`,
           title,
           description,
           author,
           accent: categoryAccent(category),
+          badge,
         });
 
         // ImageResponse already sets Content-Type: image/png; add our cache policy.

--- a/tests/og-image.test.ts
+++ b/tests/og-image.test.ts
@@ -4,6 +4,7 @@ import {
   OG_TEXT_LIMITS,
   categoryAccent,
   clampOgText,
+  descriptionLines,
   renderOgSvg,
   safeAccent,
   wrap,
@@ -49,5 +50,38 @@ describe("og image text bounds", () => {
 
     expect(lines).toHaveLength(2);
     expect(lines.every((line) => line.length <= 22)).toBe(true);
+  });
+});
+
+describe("og description truncation", () => {
+  it("returns short descriptions unchanged with no ellipsis", () => {
+    const lines = descriptionLines("A short description.", 58, 3);
+    expect(lines.join(" ")).toBe("A short description.");
+    expect(lines.join("")).not.toContain("…");
+  });
+
+  it("ellipsizes overflow at a word boundary, trimming a dangling comma + connector", () => {
+    // perLine 17 / maxLines 1 forces the visible line to end at "alpha beta gamma,"
+    // right before "and …" — exactly the mid-phrase cut we want to clean up.
+    const lines = descriptionLines(
+      "alpha beta gamma, and delta epsilon zeta",
+      17,
+      1,
+    );
+
+    expect(lines).toEqual(["alpha beta gamma…"]);
+  });
+
+  it("ellipsizes long descriptions and never ends on a dangling connector", () => {
+    const text =
+      "Official GitHub MCP server providing comprehensive GitHub API access for " +
+      "repository management, file operations, and search functionality, plus issues, " +
+      "pull requests, branches, releases, and webhooks across all of your repositories";
+    const lines = descriptionLines(text, 58, 3);
+
+    expect(lines.length).toBeLessThanOrEqual(3);
+    const last = lines[lines.length - 1];
+    expect(last.endsWith("…")).toBe(true);
+    expect(last).not.toMatch(/(?:,|\band)\s*…$/i);
   });
 });

--- a/tests/og-image.test.ts
+++ b/tests/og-image.test.ts
@@ -18,19 +18,19 @@ describe("og image accent sanitization", () => {
   });
 
   it("falls back to the default accent for missing or non-hex values", () => {
-    expect(safeAccent(undefined)).toBe("#c5e84e");
-    expect(safeAccent(null)).toBe("#c5e84e");
-    expect(safeAccent("red")).toBe("#c5e84e");
-    expect(safeAccent("#ggg")).toBe("#c5e84e");
+    expect(safeAccent(undefined)).toBe("#e1f32a");
+    expect(safeAccent(null)).toBe("#e1f32a");
+    expect(safeAccent("red")).toBe("#e1f32a");
+    expect(safeAccent("#ggg")).toBe("#e1f32a");
   });
 
   it("rejects attribute-breakout payloads so the SVG cannot be injected", () => {
     const payload = '"><script>alert(1)</script>';
-    expect(safeAccent(payload)).toBe("#c5e84e");
+    expect(safeAccent(payload)).toBe("#e1f32a");
 
     const svg = renderOgSvg({ title: "Hello", accent: payload });
     expect(svg).not.toContain("<script>");
-    expect(svg).toContain('fill="#c5e84e"');
+    expect(svg).toContain('fill="#e1f32a"');
   });
 });
 

--- a/tests/og-render.test.ts
+++ b/tests/og-render.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOgCardHtml, withAlpha } from "@/lib/og-render.server";
+import { categoryAccent } from "@/lib/og-image";
+
+// Note: renderOgPng is a thin wrapper that constructs a workers-og ImageResponse, whose
+// resvg/yoga WASM cannot load under the node test runtime. All of its logic lives in the
+// pure buildOgCardHtml below, which is exercised directly here.
+
+describe("withAlpha", () => {
+  it("expands 3-digit, 6-digit, and 8-digit hex to rgba()", () => {
+    expect(withAlpha("#fff", 1)).toBe("rgba(255, 255, 255, 1)");
+    expect(withAlpha("#7cd17c", 0.85)).toBe("rgba(124, 209, 124, 0.85)");
+    // 8-digit: the source hex alpha is ignored; the explicit alpha arg wins.
+    expect(withAlpha("#e1f32aff", 0.5)).toBe("rgba(225, 243, 42, 0.5)");
+  });
+});
+
+describe("buildOgCardHtml", () => {
+  it("uses the light-mode warm-paper background and the graph-paper grid", () => {
+    const html = buildOgCardHtml({ title: "Hello" });
+    expect(html).toContain("background-color:#f8f6ed");
+    expect(html).toContain("background-image:url('data:image/svg+xml,");
+  });
+
+  it("color-codes the accent rail + swash by category (MCP = green)", () => {
+    const html = buildOgCardHtml({
+      title: "X",
+      eyebrow: "mcp",
+      accent: categoryAccent("mcp"),
+    });
+    expect(categoryAccent("mcp")).toBe("#7cd17c");
+    expect(html).toContain("background:#7cd17c"); // left rail
+    expect(html).toContain("rgba(124, 209, 124, 0.85)"); // hero-style swash
+    expect(html).toContain("linear-gradient(to top,");
+  });
+
+  it("falls back to the citron brand accent for an unknown/missing category", () => {
+    const html = buildOgCardHtml({ title: "X" });
+    expect(html).toContain("background:#e1f32a");
+    expect(html).toContain("rgba(225, 243, 42, 0.85)");
+  });
+
+  it("uppercases the category eyebrow and defaults it to HEYCLAUDE", () => {
+    expect(buildOgCardHtml({ title: "X", eyebrow: "skills" })).toContain(
+      ">SKILLS<",
+    );
+    expect(buildOgCardHtml({ title: "X" })).toContain(">HEYCLAUDE<");
+  });
+
+  it("renders the GitHub footer with the icon data-URI and repo URL", () => {
+    const html = buildOgCardHtml({ title: "X" });
+    expect(html).toContain("heyclau.de");
+    expect(html).toContain("github.com/JSONbored/awesome-claude");
+    expect(html).toContain('<img src="data:image/svg+xml,');
+  });
+
+  it("includes the author with explicit spacing, and omits it when absent", () => {
+    const withAuthor = buildOgCardHtml({ title: "X", author: "GitHub" });
+    expect(withAuthor).toContain('by<span style="margin-left:8px;');
+    expect(withAuthor).toContain("GitHub");
+    expect(buildOgCardHtml({ title: "X" })).not.toContain("by<span");
+  });
+
+  it("omits the description block entirely when no description is given", () => {
+    const html = buildOgCardHtml({ title: "X" });
+    expect(html).not.toContain("font-size:28px;line-height:38px");
+  });
+
+  it("ellipsizes a long description and shows a short one in full", () => {
+    const long = buildOgCardHtml({
+      title: "X",
+      description:
+        "Official GitHub MCP server providing comprehensive GitHub API access for " +
+        "repository management, file operations, search, issues, pull requests, branches, " +
+        "releases, webhooks, and a great many other capabilities across all repositories",
+    });
+    expect(long).toContain("…");
+
+    const short = buildOgCardHtml({
+      title: "X",
+      description: "A short blurb.",
+    });
+    expect(short).toContain("A short blurb.");
+    expect(short).not.toContain("…");
+  });
+
+  it("strips angle brackets so caller text can't inject markup", () => {
+    const html = buildOgCardHtml({
+      title: '"><script>alert(1)</script>',
+      author: "<b>evil</b>",
+      description: "<img src=x onerror=1>",
+    });
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("</script>");
+    expect(html).not.toContain("<b>");
+    expect(html).not.toContain("onerror=1>");
+  });
+
+  it("sanitizes a malicious accent via safeAccent (no attribute breakout)", () => {
+    const html = buildOgCardHtml({
+      title: "X",
+      accent: '"><script>alert(1)</script>',
+    });
+    expect(html).not.toContain("<script>");
+    // Falls back to the citron default rather than echoing the payload.
+    expect(html).toContain("background:#e1f32a");
+  });
+});


### PR DESCRIPTION
## What

Redesigns the per-entry and generic OG cards so they match the live site's light mode, and adds two requested elements.

- **Exact light-mode palette.** Both renderers (`renderOgPng` / `renderOgSvg`) now use the site's design tokens converted to hex: `--background` `#f8f6ed` paper, `--ink` `#13110d`, `--ink-muted` `#58554e`, `--ink-subtle` `#6d6a63`, `--border` `#dad7cf`, and `--accent` citron `#e1f32a`. This replaces the previous off-palette flat `#f7f5ef` + `#171614` text + `#c5e84e` accent.
- **Graph-paper grid** matching the site's `.grid-bg` utility (32px, 1px lines in `--border` at 60%), baked as a full-bleed SVG data URI (Satori can't tile via `background-size`).
- **Trust pill** — positive signals only: `First-party` → `Source-backed` → `Trusted`, otherwise unbadged. Rendered as a citron-soft chip in the top row, aligned with the eyebrow.
- **GitHub footer** — `heyclau.de | [GitHub mark] github.com/JSONbored/awesome-claude`. The mark is a lucide `github` SVG `<img>` data URI because the bundled Space Grotesk subset has no icon glyphs.

**Font is unchanged** — served cards still use the bundled Space Grotesk subset.

## Preview

Mockup of the per-entry card (production renders in Space Grotesk; mockup uses Helvetica because the local rasterizer lacks the bundled font):

`MCP · HEYCLAUDE` eyebrow + `First-party` pill · large title · muted description · `by GitHub` · footer with GitHub mark.

## Test

- `pnpm exec vitest run tests/og-image.test.ts` — updated default-accent assertions to citron `#e1f32a`.
- `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements (Visual)**
  * Updated OG card background to a warm-paper design with a graph-paper grid.
  * Refreshed typography and unified ink/border/accent colors across OG cards.
  * Expanded the footer to include richer GitHub branding and updated layout.
  * Improved eyebrow/label presentation and more accurate description wrapping.

* **Bug Fixes**
  * Ensured accent color always falls back to a safe default when input is missing or invalid.
  * Fixed description truncation to ellipsize cleanly at word boundaries without awkward trailing punctuation.

* **Tests**
  * Expanded OG rendering tests for accent fallback, truncation, and injection safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->