### PR TITLE
chore(links): canonicalize 4 moved source URLs

### DIFF
--- a/content/collections/accessibility-qa-for-ai-built-interfaces.mdx
+++ b/content/collections/accessibility-qa-for-ai-built-interfaces.mdx
@@ -19,7 +19,7 @@ dateAdded: "2026-06-17"
 submittedAt: "2026-06-17"
 sourceSubmissionNumber: 803
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/803"
-documentationUrl: "https://www.w3.org/WAI/WCAG21/quickref/"
+documentationUrl: "https://www.w3.org/WAI/WCAG22/quickref/?versions=2.1"
 sourceUrls:
   - "https://www.w3.org/WAI/WCAG21/quickref/"
   - "https://playwright.dev/docs/accessibility-testing"

--- a/content/mcp/desktop-mcp-setup.mdx
+++ b/content/mcp/desktop-mcp-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: Claude Desktop MCP Setup
 slug: desktop-mcp-setup
-documentationUrl: "https://modelcontextprotocol.io/quickstart/user"
+documentationUrl: "https://modelcontextprotocol.io/docs/develop/connect-local-servers"
 retrievalSources:
   - "https://modelcontextprotocol.io/quickstart/user"
   - "https://code.claude.com/docs/en/mcp"

--- a/content/mcp/postgresql-mcp-server.mdx
+++ b/content/mcp/postgresql-mcp-server.mdx
@@ -17,7 +17,7 @@ seoDescription: "Reference MCP server giving Claude read-only access to PostgreS
 author: Anthropic
 authorProfileUrl: "https://github.com/modelcontextprotocol"
 dateAdded: "2025-09-16"
-documentationUrl: "https://modelcontextprotocol.io/introduction"
+documentationUrl: "https://modelcontextprotocol.io/docs/getting-started/intro"
 retrievalSources:
   - "https://modelcontextprotocol.io/introduction"
 downloadUrl: /downloads/mcp/postgresql-mcp-server.mcpb

--- a/content/skills/github-actions-security-review-capability-pack.mdx
+++ b/content/skills/github-actions-security-review-capability-pack.mdx
@@ -21,7 +21,7 @@ submittedAt: "2026-06-16"
 sourceSubmissionNumber: 715
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/715"
 repoUrl: "https://github.com/github/docs"
-documentationUrl: "https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions"
+documentationUrl: "https://docs.github.com/en/actions/reference/security/secure-use"
 downloadUrl: "https://github.com/github/docs/archive/refs/heads/main.zip"
 installable: false
 usageSnippet: >-


### PR DESCRIPTION
Automated link-health sweep. Each stored URL below returns a **permanent (301/308)** redirect to a real, same-resource content page on the same registrable domain. Final pages were fetched and semantically verified (title/H1 matches the entry). Old → new for a 10-second eyeball:

| file | field | old | new | redirect | new-page title |
|------|-------|-----|-----|----------|----------------|
| `content/skills/github-actions-security-review-capability-pack.mdx` | documentationUrl | `docs.github.com/en/actions/security-guides/security-hardening-for-github-actions` | `docs.github.com/en/actions/reference/security/secure-use` | 301 | "Secure use reference" |
| `content/mcp/postgresql-mcp-server.mdx` | documentationUrl | `modelcontextprotocol.io/introduction` | `modelcontextprotocol.io/docs/getting-started/intro` | 308 | "What is the Model Context Protocol (MCP)?" |
| `content/mcp/desktop-mcp-setup.mdx` | documentationUrl | `modelcontextprotocol.io/quickstart/user` | `modelcontextprotocol.io/docs/develop/connect-local-servers` | 308 | "Connect to local MCP servers" |
| `content/collections/accessibility-qa-for-ai-built-interfaces.mdx` | documentationUrl | `www.w3.org/WAI/WCAG21/quickref/` | `www.w3.org/WAI/WCAG22/quickref/?versions=2.1` | 301 | "How to Meet WCAG (Quickref Reference)" (2.1 view preserved) |

Only the `documentationUrl` frontmatter field was changed in each file — no body, no other fields. Cosmetic redirects (root→intro, www-only, query-param-only, slug-append, locale) were intentionally skipped. Auto-merge is off on this repo; merge after the green link-check + glance.