### PR TITLE
content(mcp): add agency.lona/trading MCP Server

### DIFF
--- a/content/mcp/agency-lona-trading-mcp-server.mdx
+++ b/content/mcp/agency-lona-trading-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: agency.lona/trading MCP Server
+slug: agency-lona-trading-mcp-server
+category: mcp
+description: >-
+  Lona trading MCP provides AI-assisted strategy development, backtesting, market data, and portfolio analysis.
+cardDescription: >-
+  Lona trading MCP provides AI-assisted strategy development, backtesting, market data, and portfolio analysis.
+seoTitle: agency.lona/trading MCP Server for Claude
+seoDescription: >-
+  Configure agency.lona/trading MCP Server (agency.lona/trading) with streamable HTTP transport and documented auth boundaries.
+author: Lona
+authorProfileUrl: "https://github.com/mindsightventures"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1454
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1454"
+documentationUrl: "https://lona.agency"
+websiteUrl: "https://lona.agency"
+retrievalSources:
+  - "https://lona.agency"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "claude mcp add --transport http lona-trading YOUR_LONA_MCP_REMOTE"
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "agency": {
+        "url": "https://YOUR_LONA_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "agency": {
+        "url": "https://YOUR_LONA_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - agency.lona/trading MCP Server
+  - agency.lona/trading MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**agency.lona/trading MCP Server** is listed in the MCP Registry as **`agency.lona/trading`**.
+Lona trading MCP provides AI-assisted strategy development, backtesting, market data, and portfolio analysis.
+
+## Installation
+
+```bash
+claude mcp add --transport http lona-trading YOUR_LONA_MCP_REMOTE
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`agency.lona/trading`** with documented remote transport metadata.
+- Primary documentation URL **https://lona.agency** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+Distinct from generic TradingView charting MCP entries; this registry package targets Lona strategy/backtesting tooling.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1454

## Summary
- Adds `content/mcp/agency-lona-trading-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`