### PR TITLE
content(mcp): add ABMeter MCP Server

### DIFF
--- a/content/mcp/abmeter-mcp-server.mdx
+++ b/content/mcp/abmeter-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: ABMeter MCP Server
+slug: abmeter-mcp-server
+category: mcp
+description: >-
+  ABMeter MCP exposes experimentation and analytics tooling over streamable HTTP for MCP clients.
+cardDescription: >-
+  ABMeter MCP exposes experimentation and analytics tooling over streamable HTTP for MCP clients.
+seoTitle: ABMeter MCP Server for Claude
+seoDescription: >-
+  Configure ABMeter MCP Server (ai.abmeter/abmeter) with streamable HTTP transport and documented auth boundaries.
+author: ABMeter
+authorProfileUrl: "https://abmeter.ai"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1455
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1455"
+documentationUrl: "https://abmeter.ai"
+websiteUrl: "https://abmeter.ai"
+retrievalSources:
+  - "https://abmeter.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "claude mcp add --transport http abmeter YOUR_ABMETER_MCP_REMOTE"
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "abmeter": {
+        "url": "https://YOUR_ABMETER_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "abmeter": {
+        "url": "https://YOUR_ABMETER_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - ABMeter MCP Server
+  - ai.abmeter/abmeter MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**ABMeter MCP Server** is listed in the MCP Registry as **`ai.abmeter/abmeter`**.
+ABMeter MCP exposes experimentation and analytics tooling over streamable HTTP for MCP clients.
+
+## Installation
+
+```bash
+claude mcp add --transport http abmeter YOUR_ABMETER_MCP_REMOTE
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`ai.abmeter/abmeter`** with documented remote transport metadata.
+- Primary documentation URL **https://abmeter.ai** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+No existing `content/mcp/` entry documents registry package `ai.abmeter/abmeter`.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1455

## Summary
- Adds `content/mcp/abmeter-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`