### PR TITLE
content(mcp): add AutEng MCP Markdown Publishing MCP Server

### DIFF
--- a/content/mcp/auteng-mcp-markdown-publishing-and-document-share-links-mcp-server.mdx
+++ b/content/mcp/auteng-mcp-markdown-publishing-and-document-share-links-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: AutEng MCP Markdown Publishing MCP Server
+slug: auteng-mcp-markdown-publishing-and-document-share-links-mcp-server
+category: mcp
+description: >-
+  AutEng MCP publishes markdown documents as public share links with mermaid diagram support.
+cardDescription: >-
+  AutEng MCP publishes markdown documents as public share links with mermaid diagram support.
+seoTitle: AutEng MCP Markdown Publishing MCP Server for Claude
+seoDescription: >-
+  Configure AutEng MCP Markdown Publishing MCP Server (ai.auteng/docs) with streamable HTTP transport and documented auth boundaries.
+author: AutEng
+authorProfileUrl: "https://auteng.ai"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1472
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1472"
+documentationUrl: "https://auteng.ai"
+websiteUrl: "https://auteng.ai"
+retrievalSources:
+  - "https://auteng.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "claude mcp add --transport http auteng YOUR_AUTENG_MCP_REMOTE"
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "auteng": {
+        "url": "https://YOUR_AUTENG_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "auteng": {
+        "url": "https://YOUR_AUTENG_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - AutEng MCP Markdown Publishing MCP Server
+  - ai.auteng/docs MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**AutEng MCP Markdown Publishing MCP Server** is listed in the MCP Registry as **`ai.auteng/docs`**.
+AutEng MCP publishes markdown documents as public share links with mermaid diagram support.
+
+## Installation
+
+```bash
+claude mcp add --transport http auteng YOUR_AUTENG_MCP_REMOTE
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`ai.auteng/docs`** with documented remote transport metadata.
+- Primary documentation URL **https://auteng.ai** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+No existing `content/mcp/` entry documents registry package `ai.auteng/docs`.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1472

## Summary
- Adds `content/mcp/auteng-mcp-markdown-publishing-and-document-share-links-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`