### PR TITLE
content(mcp): add ai.autoblocks/ctxl MCP Server

### DIFF
--- a/content/mcp/ai-autoblocks-ctxl-mcp-server.mdx
+++ b/content/mcp/ai-autoblocks-ctxl-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: ai.autoblocks/ctxl MCP Server
+slug: ai-autoblocks-ctxl-mcp-server
+category: mcp
+description: >-
+  Autoblocks ContextLayer MCP manages personal context for AI assistants through documented Autoblocks tooling.
+cardDescription: >-
+  Autoblocks ContextLayer MCP manages personal context for AI assistants through documented Autoblocks tooling.
+seoTitle: ai.autoblocks/ctxl MCP Server for Claude
+seoDescription: >-
+  Configure ai.autoblocks/ctxl MCP Server (ai.autoblocks/contextlayer-mcp) with streamable HTTP transport and documented auth boundaries.
+author: Autoblocks
+authorProfileUrl: "https://www.autoblocks.ai"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1473
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1473"
+documentationUrl: "https://www.autoblocks.ai"
+websiteUrl: "https://www.autoblocks.ai"
+retrievalSources:
+  - "https://www.autoblocks.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "Follow Autoblocks ContextLayer MCP setup from product documentation for your workspace."
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "ai": {
+        "url": "https://www.autoblocks.ai",
+        "type": "http"
+
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "ai": {
+        "url": "https://www.autoblocks.ai",
+        "type": "http"
+
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - ai.autoblocks/ctxl MCP Server
+  - ai.autoblocks/contextlayer-mcp MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**ai.autoblocks/ctxl MCP Server** is listed in the MCP Registry as **`ai.autoblocks/contextlayer-mcp`**.
+Autoblocks ContextLayer MCP manages personal context for AI assistants through documented Autoblocks tooling.
+
+## Installation
+
+```bash
+Follow Autoblocks ContextLayer MCP setup from product documentation for your workspace.
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`ai.autoblocks/contextlayer-mcp`** with documented remote transport metadata.
+- Primary documentation URL **https://www.autoblocks.ai** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+No existing `content/mcp/` entry documents registry package `ai.autoblocks/contextlayer-mcp`.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1473

## Summary
- Adds `content/mcp/ai-autoblocks-ctxl-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`