### PR TITLE
fix(content): replace dead source URLs flagged in link health sweep

### DIFF
--- a/content/mcp/hexstrike-ai-mcp-server.mdx
+++ b/content/mcp/hexstrike-ai-mcp-server.mdx
@@ -23,7 +23,6 @@ brandName: HexStrike AI
 brandDomain: hexstrike.com
 repoUrl: "https://github.com/0x4m4/hexstrike-ai"
 documentationUrl: "https://github.com/0x4m4/hexstrike-ai"
-websiteUrl: "https://www.hexstrike.com/"
 installable: true
 installCommand: "git clone https://github.com/0x4m4/hexstrike-ai.git && cd hexstrike-ai && python3 -m venv hexstrike-env && hexstrike-env/bin/pip install -r requirements.txt"
 usageSnippet: "Start `hexstrike-env/bin/python hexstrike_server.py`, then configure your MCP client to run `hexstrike_mcp.py` with the server argument documented in the repository."

--- a/content/tools/humanlayer.mdx
+++ b/content/tools/humanlayer.mdx
@@ -23,7 +23,7 @@ submittedByUrl: "https://github.com/JPette1783"
 submittedAt: "2026-06-05"
 websiteUrl: "https://www.humanlayer.dev"
 repoUrl: "https://github.com/humanlayer/humanlayer"
-documentationUrl: "https://www.humanlayer.dev/code"
+documentationUrl: "https://raw.githubusercontent.com/humanlayer/humanlayer/main/README.md"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication


### PR DESCRIPTION
Fixes #2879

## Summary
- **humanlayer**: point `documentationUrl` at the live GitHub README (`/code` redirects to homepage).
- **hexstrike-ai-mcp-server**: drop dead `websiteUrl` (`hexstrike.com` redirects to unrelated brand); repo/docs URLs remain.

## Validation
- `node scripts/validate-content.mjs --category tools,mcp`

Made with [Cursor](https://cursor.com)