### PR TITLE
content(mcp):

### DIFF
--- a/content/mcp/agentic-shelf-mcp-server.mdx
+++ b/content/mcp/agentic-shelf-mcp-server.mdx
@@ -1,0 +1,97 @@
+---
+title: Agentic Shelf MCP Server
+slug: agentic-shelf-mcp-server
+category: mcp
+description: >-
+  Agentic Shelf MCP provides a live MCP catalog surface for hosted agent tools and integrations.
+cardDescription: >-
+  Agentic Shelf MCP provides a live MCP catalog surface for hosted agent tools and integrations.
+seoTitle: Agentic Shelf MCP Server for Claude
+seoDescription: >-
+  Configure Agentic Shelf MCP Server (ai.agenticshelf/mcp) with streamable HTTP transport and documented auth boundaries.
+author: Agentic Shelf
+authorProfileUrl: "https://www.graffeo.com"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1462
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1462"
+documentationUrl: "https://www.graffeo.com"
+websiteUrl: "https://www.graffeo.com"
+retrievalSources:
+  - "https://www.graffeo.com"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "claude mcp add --transport http agentic-shelf YOUR_AGENTIC_SHELF_MCP_REMOTE"
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "agentic": {
+        "url": "https://YOUR_AGENTIC_SHELF_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "agentic": {
+        "url": "https://YOUR_AGENTIC_SHELF_MCP_REMOTE",
+        "type": "http"
+
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - Agentic Shelf MCP Server
+  - ai.agenticshelf/mcp MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**Agentic Shelf MCP Server** is listed in the MCP Registry as **`ai.agenticshelf/mcp`**.
+Agentic Shelf MCP provides a live MCP catalog surface for hosted agent tools and integrations.
+
+## Installation
+
+```bash
+claude mcp add --transport http agentic-shelf YOUR_AGENTIC_SHELF_MCP_REMOTE
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`ai.agenticshelf/mcp`** with documented remote transport metadata.
+- Primary documentation URL **https://www.graffeo.com** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+No existing `content/mcp/` entry documents registry package `ai.agenticshelf/mcp`.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1462

## Summary
- Adds `content/mcp/agentic-shelf-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`