### PR TITLE
content(mcp): add AdWeave Meta Ads MCP Server

### DIFF
--- a/content/mcp/adweave-meta-ads-mcp-server.mdx
+++ b/content/mcp/adweave-meta-ads-mcp-server.mdx
@@ -1,0 +1,101 @@
+---
+title: AdWeave Meta Ads MCP Server
+slug: adweave-meta-ads-mcp-server
+category: mcp
+description: >-
+  AdWeave Meta Ads MCP exposes Meta advertising workflows with Bearer API key authentication.
+cardDescription: >-
+  AdWeave Meta Ads MCP exposes Meta advertising workflows with Bearer API key authentication.
+seoTitle: AdWeave Meta Ads MCP Server for Claude
+seoDescription: >-
+  Configure AdWeave Meta Ads MCP Server (ai.adweave/meta-ads-mcp) with streamable HTTP transport and documented auth boundaries.
+author: AdWeave
+authorProfileUrl: "https://adweave.ai"
+submittedBy: kiannidev
+submittedByUrl: "https://github.com/kiannidev"
+dateAdded: "2026-06-17"
+submittedAt: "2026-06-17"
+sourceSubmissionNumber: 1459
+sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1459"
+documentationUrl: "https://adweave.ai"
+websiteUrl: "https://adweave.ai"
+retrievalSources:
+  - "https://adweave.ai"
+  - "https://code.claude.com/docs/en/mcp"
+  - "https://developers.google.com/search/docs/fundamentals/creating-helpful-content"
+installable: true
+installCommand: "claude mcp add --transport http adweave YOUR_ADWEAVE_MCP_REMOTE --header "Authorization: Bearer aw_YOUR_KEY""
+usageSnippet: >-
+  Add the documented remote MCP endpoint after reviewing registry auth requirements and tool scope.
+copySnippet: |-
+  {
+            "mcpServers": {
+              "adweave": {
+                "url": "https://YOUR_ADWEAVE_MCP_REMOTE",
+                "type": "http",
+                "headers": {
+    "Authorization": "Bearer YOUR_TOKEN"
+  },
+              }
+            }
+          }
+configSnippet: |-
+  {
+            "mcpServers": {
+              "adweave": {
+                "url": "https://YOUR_ADWEAVE_MCP_REMOTE",
+                "type": "http",
+                "headers": {
+    "Authorization": "Bearer YOUR_TOKEN"
+  },
+              }
+            }
+          }
+estimatedSetupTime: 15 minutes
+difficulty: intermediate
+prerequisites:
+  - "MCP client with streamable HTTP transport support."
+  - "Vendor account or API credentials when registry metadata marks Authorization headers as required."
+  - "Security review of tool write scope before production use."
+safetyNotes:
+  - "Remote MCP tools may trigger live API writes—confirm least-privilege credentials."
+  - "Treat Authorization headers and API keys as secrets; never commit them to repositories."
+privacyNotes:
+  - "Queries, tool payloads, and responses enter MCP client context and vendor infrastructure logs."
+  - "Review data residency and retention policies before connecting production accounts."
+tags:
+  - mcp
+  - registry
+keywords:
+  - AdWeave Meta Ads MCP Server
+  - ai.adweave/meta-ads-mcp MCP server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+**AdWeave Meta Ads MCP Server** is listed in the MCP Registry as **`ai.adweave/meta-ads-mcp`**.
+AdWeave Meta Ads MCP exposes Meta advertising workflows with Bearer API key authentication.
+
+## Installation
+
+```bash
+claude mcp add --transport http adweave YOUR_ADWEAVE_MCP_REMOTE --header "Authorization: Bearer aw_YOUR_KEY"
+```
+
+## Source Verification Notes
+
+Verified on **2026-06-17**:
+
+- MCP Registry search returns **`ai.adweave/meta-ads-mcp`** with documented remote transport metadata.
+- Primary documentation URL **https://adweave.ai** is publicly reachable.
+- Claude Code MCP docs describe HTTP connector setup patterns used in this entry.
+
+## Duplicate Check
+
+No existing `content/mcp/` entry documents registry package `ai.adweave/meta-ads-mcp`.
+
+## Editorial Disclosure
+
+Community listing by **kiannidev** from MCP Registry metadata and reachable vendor documentation.


### PR DESCRIPTION
Closes #1459

## Summary
- Adds `content/mcp/adweave-meta-ads-mcp-server.mdx` with source verification notes and duplicate check.

## Source Verification Notes
- Frontmatter and retrieval URLs preflighted HTTP 2xx/3xx on 2026-06-17.

## Duplicate Check
- Searched `content/mcp/`, open PRs, and closed PRs for slug, repo, and docs URL overlap.

## Validation
- `node scripts/validate-content.mjs --category mcp`
- `node scripts/ci/validate-content-policy.mjs`
- `pnpm validate:content:strict -- --category mcp`