### PR TITLE
fix(collections): remove duplicate frontmatter keys in backend-development-suite

### DIFF
--- a/content/collections/backend-development-suite.mdx
+++ b/content/collections/backend-development-suite.mdx
@@ -23,12 +23,6 @@ retrievalSources:
 privacyNotes:
   - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 dateAdded: "2025-10-02"
-documentationUrl: "https://code.claude.com/docs/en/sub-agents"
-retrievalSources:
-  - "https://code.claude.com/docs/en/sub-agents"
-  - "https://code.claude.com/docs/en/mcp"
-privacyNotes:
-  - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 installable: false
 usageSnippet: >-
   Start with `backend-architect-agent` → `database-specialist-agent` →


### PR DESCRIPTION
Removes duplicated frontmatter keys and null byte that break `validate-content.mjs` full-repo scans.