### PR TITLE
feat(web): measure AI citations via Analytics Engine tap + umami referral event

### DIFF
--- a/apps/web/src/components/ai-referral.tsx
+++ b/apps/web/src/components/ai-referral.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+import { trackEvent } from "@/lib/analytics";
+import { matchAiReferrer } from "@/lib/ai-sources";
+
+const SESSION_FLAG = "ai-referral-tracked";
+
+/**
+ * Fire a one-per-session umami `ai-referral` event when the visitor arrived from an AI
+ * assistant (ChatGPT, Claude, Perplexity, Gemini, Copilot, …). This is the human-facing
+ * counterpart to the server-side Analytics Engine tap: umami gives a clean, shareable
+ * dashboard of real (JS-running) sessions, grouped by the `source` property.
+ *
+ * `document.referrer` persists across SPA navigations within a session, so we guard with
+ * a sessionStorage flag to avoid re-emitting on every route change. Renders nothing.
+ */
+export function AiReferral() {
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    let alreadyTracked = false;
+    try {
+      alreadyTracked = window.sessionStorage.getItem(SESSION_FLAG) === "1";
+    } catch {
+      // sessionStorage can throw in private modes; fall through and just track once.
+    }
+    if (alreadyTracked) return;
+
+    const source = matchAiReferrer(document.referrer);
+    if (!source) return;
+
+    try {
+      window.sessionStorage.setItem(SESSION_FLAG, "1");
+    } catch {
+      // ignore — worst case we emit again next mount, which umami dedupes poorly but
+      // is rare and harmless.
+    }
+    trackEvent("ai-referral", { source, landing: window.location.pathname });
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/ai-referral.tsx
+++ b/apps/web/src/components/ai-referral.tsx
@@ -24,6 +24,10 @@ export function emitAiReferralEvent(source: string, landing: string): boolean {
   return true;
 }
 
+export function shouldWaitForAiReferralLoad(): boolean {
+  return typeof document !== "undefined" && document.readyState !== "complete";
+}
+
 /**
  * Fire a one-per-session umami `ai-referral` event when the visitor arrived from an AI
  * assistant (ChatGPT, Claude, Perplexity, Gemini, Copilot, …). This is the human-facing
@@ -49,6 +53,10 @@ export function AiReferral() {
 
     const emit = () => emitAiReferralEvent(source, window.location.pathname);
     if (emit()) return;
+    if (!shouldWaitForAiReferralLoad()) {
+      emit();
+      return;
+    }
 
     const onLoad = () => {
       emit();

--- a/apps/web/src/components/ai-referral.tsx
+++ b/apps/web/src/components/ai-referral.tsx
@@ -5,6 +5,25 @@ import { matchAiReferrer } from "@/lib/ai-sources";
 
 const SESSION_FLAG = "ai-referral-tracked";
 
+export function emitAiReferralEvent(source: string, landing: string): boolean {
+  if (typeof window === "undefined") return false;
+  const umami = (window as Window & { umami?: { track?: (...args: unknown[]) => void } }).umami;
+  if (typeof umami?.track !== "function") return false;
+
+  try {
+    trackEvent("ai-referral", { source, landing });
+  } catch {
+    return false;
+  }
+
+  try {
+    window.sessionStorage.setItem(SESSION_FLAG, "1");
+  } catch {
+    // ignore -- worst case we emit again next mount.
+  }
+  return true;
+}
+
 /**
  * Fire a one-per-session umami `ai-referral` event when the visitor arrived from an AI
  * assistant (ChatGPT, Claude, Perplexity, Gemini, Copilot, …). This is the human-facing
@@ -28,13 +47,14 @@ export function AiReferral() {
     const source = matchAiReferrer(document.referrer);
     if (!source) return;
 
-    try {
-      window.sessionStorage.setItem(SESSION_FLAG, "1");
-    } catch {
-      // ignore — worst case we emit again next mount, which umami dedupes poorly but
-      // is rare and harmless.
-    }
-    trackEvent("ai-referral", { source, landing: window.location.pathname });
+    const emit = () => emitAiReferralEvent(source, window.location.pathname);
+    if (emit()) return;
+
+    const onLoad = () => {
+      emit();
+    };
+    window.addEventListener("load", onLoad, { once: true });
+    return () => window.removeEventListener("load", onLoad);
   }, []);
 
   return null;

--- a/apps/web/src/lib/ai-signals.server.ts
+++ b/apps/web/src/lib/ai-signals.server.ts
@@ -1,0 +1,80 @@
+// Server-side AI-citation signal tap. Runs in the Worker `fetch` handler and writes
+// two kinds of data points to a Cloudflare Workers Analytics Engine dataset:
+//
+//   • crawler — an AI bot fetched a page (leading indicator of being citable). The
+//     `search`/`user` purposes are the high-signal "answering a live query" hits;
+//     `train` is the slower, weaker signal.
+//   • referral — a human landed from an AI assistant (server-side backstop for the
+//     client-side umami event, so we still capture hits when JS is blocked).
+//
+// This is best-effort and fire-and-forget: writeDataPoint is synchronous and must
+// never throw into the request path, so the whole thing is wrapped in try/catch and
+// silently no-ops when the binding is absent (e.g. local dev without the dataset).
+//
+// Query the dataset via the Analytics Engine SQL API, e.g. crawler activity this week:
+//   SELECT blob2 AS operator, blob3 AS bot, blob4 AS purpose,
+//          SUM(_sample_interval * double1) AS hits
+//   FROM ai_signals
+//   WHERE blob1 = 'crawler' AND timestamp > NOW() - INTERVAL '7' DAY
+//   GROUP BY operator, bot, purpose ORDER BY hits DESC
+
+import { matchAiBot, matchAiReferrer } from "@/lib/ai-sources";
+
+/** Minimal shape of the Analytics Engine binding (avoids a hard dep on the CF types). */
+interface AnalyticsEngineDataset {
+  writeDataPoint(event: {
+    blobs?: (string | null)[];
+    doubles?: number[];
+    indexes?: string[];
+  }): void;
+}
+
+function getDataset(env: unknown): AnalyticsEngineDataset | null {
+  const dataset = (env as Record<string, unknown> | null | undefined)?.AI_SIGNALS;
+  return dataset && typeof (dataset as AnalyticsEngineDataset).writeDataPoint === "function"
+    ? (dataset as AnalyticsEngineDataset)
+    : null;
+}
+
+// AE blobs cap at 5120 bytes each; bound the path so a pathological URL can't bloat a
+// data point (and trim the query string, which adds cardinality without value here).
+function normalizePath(url: string): string {
+  try {
+    return new URL(url).pathname.slice(0, 256);
+  } catch {
+    return "/";
+  }
+}
+
+/**
+ * Record AI crawler + AI-referral signals for a request. Safe to call on every request;
+ * only matched requests write a data point. Never throws.
+ */
+export function logAiSignals(request: Request, env: unknown): void {
+  try {
+    const dataset = getDataset(env);
+    if (!dataset) return;
+
+    const ua = request.headers.get("user-agent");
+    const bot = matchAiBot(ua);
+    if (bot) {
+      dataset.writeDataPoint({
+        blobs: ["crawler", bot.operator, bot.token, bot.purpose, normalizePath(request.url)],
+        doubles: [1],
+        indexes: [bot.operator],
+      });
+      return; // a crawler is never also a human referral
+    }
+
+    const source = matchAiReferrer(request.headers.get("referer"));
+    if (source) {
+      dataset.writeDataPoint({
+        blobs: ["referral", source, normalizePath(request.url)],
+        doubles: [1],
+        indexes: ["referral"],
+      });
+    }
+  } catch {
+    // Measurement must never break a response.
+  }
+}

--- a/apps/web/src/lib/ai-sources.ts
+++ b/apps/web/src/lib/ai-sources.ts
@@ -1,0 +1,106 @@
+// Isomorphic AI-source detection (no server or DOM deps) shared by the server-side
+// Analytics Engine tap (ai-signals.server.ts) and the client-side umami event
+// (components/ai-referral.tsx). Two concerns live here:
+//
+//   1. AI *referrers* — humans arriving from an AI assistant/answer engine. Detected
+//      by the referring hostname.
+//   2. AI *crawlers* — bots fetching our pages. Detected by a user-agent token.
+//
+// Both lists churn as vendors ship/rename bots; re-audit quarterly against the vendor
+// docs (OpenAI/Anthropic/Perplexity/Google crawler pages + Cloudflare's AI Crawl
+// Control bot reference).
+
+/**
+ * Map of AI-assistant referrer hostnames → a short, stable source key for grouping.
+ * Matching is suffix-based (`host === key || host.endsWith("." + key)`) so subdomains
+ * like `www.perplexity.ai` resolve to the same source.
+ *
+ * Note: Google AI Overviews are intentionally absent — those clicks carry a plain
+ * `google.com` referrer indistinguishable from normal organic, so they can't be
+ * attributed here. Only the standalone `gemini.google.com` assistant is detectable.
+ */
+const REFERRER_SOURCES: Record<string, string> = {
+  "chatgpt.com": "chatgpt",
+  "chat.openai.com": "chatgpt",
+  "openai.com": "chatgpt",
+  "claude.ai": "claude",
+  "anthropic.com": "claude",
+  "perplexity.ai": "perplexity",
+  "gemini.google.com": "gemini",
+  "copilot.microsoft.com": "copilot",
+  "mistral.ai": "mistral",
+  "deepseek.com": "deepseek",
+  "poe.com": "poe",
+  "you.com": "you",
+  "phind.com": "phind",
+  "meta.ai": "meta",
+  "grok.com": "grok",
+  "x.ai": "grok",
+};
+
+/**
+ * Resolve a referrer URL (or bare hostname) to its AI source key, or null if it is not
+ * a known AI assistant. Accepts a full URL string, a hostname, or "" — never throws.
+ */
+export function matchAiReferrer(referrer: string | null | undefined): string | null {
+  if (!referrer) return null;
+  let host = referrer.trim().toLowerCase();
+  if (!host) return null;
+  // Accept full URLs as well as bare hostnames.
+  if (host.includes("/") || host.includes(":")) {
+    try {
+      host = new URL(host.includes("://") ? host : `https://${host}`).hostname;
+    } catch {
+      return null;
+    }
+  }
+  host = host.replace(/^www\./, "");
+  for (const [domain, source] of Object.entries(REFERRER_SOURCES)) {
+    if (host === domain || host.endsWith(`.${domain}`)) return source;
+  }
+  return null;
+}
+
+/** Purpose of an AI crawler hit — the signal strength for "are we being cited". */
+export type AiBotPurpose = "search" | "user" | "train" | "other";
+
+export type AiBot = {
+  /** Stable user-agent token to substring-match (e.g. "OAI-SearchBot"). */
+  token: string;
+  /** Short operator key for grouping (e.g. "openai"). */
+  operator: string;
+  /** What the fetch is for. `search`/`user` are the high-signal citation proxies. */
+  purpose: AiBotPurpose;
+};
+
+/**
+ * AI crawler user-agent tokens, most-specific first so substring matching never
+ * misclassifies (e.g. "ChatGPT-User" is checked before the generic training bots).
+ * `search` and `user` bots fetch pages to answer a live query — the closest proxy we
+ * have to "we got cited" — and should be read separately from the `train` bots.
+ */
+export const AI_BOTS: readonly AiBot[] = [
+  { token: "OAI-SearchBot", operator: "openai", purpose: "search" },
+  { token: "ChatGPT-User", operator: "openai", purpose: "user" },
+  { token: "GPTBot", operator: "openai", purpose: "train" },
+  { token: "Claude-SearchBot", operator: "anthropic", purpose: "search" },
+  { token: "Claude-User", operator: "anthropic", purpose: "user" },
+  { token: "ClaudeBot", operator: "anthropic", purpose: "train" },
+  { token: "PerplexityBot", operator: "perplexity", purpose: "search" },
+  { token: "Perplexity-User", operator: "perplexity", purpose: "user" },
+  { token: "Google-CloudVertexBot", operator: "google", purpose: "train" },
+  { token: "GoogleOther", operator: "google", purpose: "other" },
+  { token: "DuckAssistBot", operator: "duckduckgo", purpose: "search" },
+  { token: "MistralAI-User", operator: "mistral", purpose: "user" },
+  { token: "Bytespider", operator: "bytedance", purpose: "train" },
+  { token: "meta-externalagent", operator: "meta", purpose: "train" },
+  { token: "Amazonbot", operator: "amazon", purpose: "other" },
+  { token: "Applebot-Extended", operator: "apple", purpose: "train" },
+  { token: "CCBot", operator: "commoncrawl", purpose: "train" },
+] as const;
+
+/** Match a user-agent string to a known AI crawler, or null. Case-sensitive (tokens are). */
+export function matchAiBot(userAgent: string | null | undefined): AiBot | null {
+  if (!userAgent) return null;
+  return AI_BOTS.find((bot) => userAgent.includes(bot.token)) ?? null;
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -23,6 +23,7 @@ import { ShortcutsProvider } from "@/components/shortcuts-dialog";
 import { SkipLink } from "@/components/skip-link";
 import { RouteProgress } from "@/components/route-progress";
 import { WebMcpProvider } from "@/components/webmcp-provider";
+import { AiReferral } from "@/components/ai-referral";
 import { WebVitals } from "@/components/web-vitals";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
@@ -244,6 +245,7 @@ function RootComponent() {
                 <BackToTop />
                 <WebMcpProvider />
                 <WebVitals />
+                <AiReferral />
                 <Toaster
                   position="bottom-right"
                   mobileOffset={{ bottom: "16px" }}

--- a/apps/web/src/server.ts
+++ b/apps/web/src/server.ts
@@ -1,5 +1,6 @@
 import "./lib/error-capture";
 
+import { logAiSignals } from "./lib/ai-signals.server";
 import { runWithCloudflareRuntime } from "./lib/cloudflare-env.server";
 import { consumeLastCapturedError } from "./lib/error-capture";
 import { renderErrorPage } from "./lib/error-page";
@@ -51,6 +52,9 @@ async function normalizeCatastrophicSsrResponse(response: Response): Promise<Res
 
 export default {
   async fetch(request: Request, env: unknown, ctx: unknown) {
+    // Best-effort AI-citation signal tap (crawler hits + AI-referral landings). Synchronous,
+    // never throws, no-ops without the AI_SIGNALS Analytics Engine binding.
+    logAiSignals(request, env);
     return runWithCloudflareRuntime(request, env, ctx, async () => {
       try {
         const handler = await getServerEntry();

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -84,4 +84,12 @@
       "migrations_dir": "migrations",
     },
   ],
+  // AI-citation signal tap: crawler hits + AI-referral landings (see lib/ai-signals.server.ts).
+  // Query via the Analytics Engine SQL API; free tier covers our volume (3-month retention).
+  "analytics_engine_datasets": [
+    {
+      "binding": "AI_SIGNALS",
+      "dataset": "ai_signals",
+    },
+  ],
 }

--- a/tests/ai-referral.test.ts
+++ b/tests/ai-referral.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { emitAiReferralEvent } from "@/components/ai-referral";
+
+function sessionStorageStub() {
+  return {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+  };
+}
+
+describe("emitAiReferralEvent", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not mark the session when the tracker is unavailable", () => {
+    const sessionStorage = sessionStorageStub();
+    vi.stubGlobal("window", {
+      umami: {},
+      sessionStorage,
+    });
+
+    expect(emitAiReferralEvent("chatgpt", "/")).toBe(false);
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("marks the session after the referral event is dispatched", () => {
+    const track = vi.fn();
+    const sessionStorage = sessionStorageStub();
+    vi.stubGlobal("window", {
+      umami: { track },
+      sessionStorage,
+    });
+
+    expect(emitAiReferralEvent("claude", "/agents")).toBe(true);
+    expect(track).toHaveBeenCalledWith("ai-referral", {
+      source: "claude",
+      landing: "/agents",
+    });
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      "ai-referral-tracked",
+      "1",
+    );
+  });
+
+  it("does not mark the session when dispatch throws", () => {
+    const sessionStorage = sessionStorageStub();
+    vi.stubGlobal("window", {
+      umami: {
+        track: vi.fn(() => {
+          throw new Error("tracker failed");
+        }),
+      },
+      sessionStorage,
+    });
+
+    expect(emitAiReferralEvent("perplexity", "/mcp")).toBe(false);
+    expect(sessionStorage.setItem).not.toHaveBeenCalled();
+  });
+});

--- a/tests/ai-referral.test.ts
+++ b/tests/ai-referral.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { emitAiReferralEvent } from "@/components/ai-referral";
+import {
+  emitAiReferralEvent,
+  shouldWaitForAiReferralLoad,
+} from "@/components/ai-referral";
 
 function sessionStorageStub() {
   return {
@@ -57,5 +60,16 @@ describe("emitAiReferralEvent", () => {
 
     expect(emitAiReferralEvent("perplexity", "/mcp")).toBe(false);
     expect(sessionStorage.setItem).not.toHaveBeenCalled();
+  });
+
+  it("only waits for load while the document is still loading", () => {
+    vi.stubGlobal("document", { readyState: "loading" });
+    expect(shouldWaitForAiReferralLoad()).toBe(true);
+
+    vi.stubGlobal("document", { readyState: "interactive" });
+    expect(shouldWaitForAiReferralLoad()).toBe(true);
+
+    vi.stubGlobal("document", { readyState: "complete" });
+    expect(shouldWaitForAiReferralLoad()).toBe(false);
   });
 });

--- a/tests/ai-sources.test.ts
+++ b/tests/ai-sources.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { AI_BOTS, matchAiBot, matchAiReferrer } from "@/lib/ai-sources";
+
+describe("matchAiReferrer", () => {
+  it("maps assistant hostnames (incl. subdomains) to a stable source key", () => {
+    expect(matchAiReferrer("https://chatgpt.com/")).toBe("chatgpt");
+    expect(matchAiReferrer("https://chat.openai.com/c/abc")).toBe("chatgpt");
+    expect(matchAiReferrer("https://www.perplexity.ai/search")).toBe(
+      "perplexity",
+    );
+    expect(matchAiReferrer("https://gemini.google.com/app")).toBe("gemini");
+    expect(matchAiReferrer("claude.ai")).toBe("claude");
+  });
+
+  it("returns null for non-AI / organic / empty referrers", () => {
+    expect(matchAiReferrer("https://www.google.com/search?q=x")).toBeNull();
+    expect(matchAiReferrer("https://news.ycombinator.com/")).toBeNull();
+    expect(matchAiReferrer("")).toBeNull();
+    expect(matchAiReferrer(null)).toBeNull();
+    expect(matchAiReferrer("not a url")).toBeNull();
+  });
+
+  it("does not match look-alike hostnames", () => {
+    // a phishing-style host that merely contains the brand must not match.
+    expect(matchAiReferrer("https://chatgpt.com.evil.example/")).toBeNull();
+    expect(matchAiReferrer("https://notperplexity.ai/")).toBeNull();
+  });
+});
+
+describe("matchAiBot", () => {
+  it("classifies search/user/training bots by their UA token", () => {
+    expect(
+      matchAiBot(
+        "Mozilla/5.0 ... OAI-SearchBot/1.3; +https://openai.com/searchbot",
+      ),
+    ).toMatchObject({ operator: "openai", purpose: "search" });
+    expect(
+      matchAiBot(
+        "Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+      ),
+    ).toMatchObject({ operator: "anthropic", purpose: "train" });
+    expect(
+      matchAiBot(
+        "Mozilla/5.0 ... PerplexityBot/1.0; +https://perplexity.ai/perplexitybot",
+      ),
+    ).toMatchObject({ operator: "perplexity", purpose: "search" });
+  });
+
+  it("prefers the most specific token (ChatGPT-User over the generic GPTBot)", () => {
+    expect(
+      matchAiBot("Mozilla/5.0 ... ChatGPT-User/1.0; +https://openai.com/bot"),
+    ).toMatchObject({
+      operator: "openai",
+      purpose: "user",
+    });
+  });
+
+  it("returns null for a normal browser UA", () => {
+    expect(
+      matchAiBot(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124 Safari/537.36",
+      ),
+    ).toBeNull();
+    expect(matchAiBot(null)).toBeNull();
+  });
+
+  it("keeps bot tokens unique so substring matching can't misclassify", () => {
+    const tokens = AI_BOTS.map((b) => b.token);
+    expect(new Set(tokens).size).toBe(tokens.length);
+  });
+});


### PR DESCRIPTION
## What

Adds native **AI-citation measurement** using only infrastructure we already run (Cloudflare Workers + Analytics Engine, self-hosted umami). Two complementary layers:

### 1. Server-side Worker tap → Workers Analytics Engine *(primary)*
`apps/web/src/lib/ai-signals.server.ts`, called from the Worker `fetch` handler in `server.ts`. On every request it best-effort writes to a new `AI_SIGNALS` Analytics Engine dataset:
- **crawler** hits — an AI bot fetched a page (leading indicator of being citable), keyed by `operator / bot / purpose / path`.
- **referral** landings — a human arrived from an AI assistant, keyed by `source / path` (server-side backstop for the umami event; catches JS-blocked sessions).

Fire-and-forget (`writeDataPoint` is synchronous), wrapped in try/catch, and **no-ops without the binding** so local dev and unconfigured envs are unaffected. Adds the `analytics_engine_datasets` binding to `wrangler.jsonc` (free tier covers our volume; 3-month retention).

### 2. Client-side umami event *(human dashboard)*
`apps/web/src/components/ai-referral.tsx`, mounted in `__root.tsx` beside `<WebVitals/>`. Fires a once-per-session `ai-referral` umami event (grouped by `source`) when `document.referrer` matches an AI assistant.

### Shared detection
`apps/web/src/lib/ai-sources.ts` (isomorphic, no server/DOM deps): AI-assistant referrer hostnames and crawler UA tokens. **Segments `search`/`user` bots (the live-query citation proxy) from `train` bots.** Suffix-matched so look-alike hosts (`chatgpt.com.evil.example`) don't match.

## Why this design
- Crawler signal needs no JS → catches bots *and* ad-blocked sessions; the umami event covers real human sessions with a shareable dashboard.
- Google AI Overviews are intentionally **not** attributable (they carry a plain `google.com` referrer) — only standalone `gemini.google.com` is detected. Noted in code.

## Querying
Crawler activity this week via the Analytics Engine SQL API:
```sql
SELECT blob2 AS operator, blob3 AS bot, blob4 AS purpose,
       SUM(_sample_interval * double1) AS hits
FROM ai_signals
WHERE blob1 = 'crawler' AND timestamp > NOW() - INTERVAL '7' DAY
GROUP BY operator, bot, purpose ORDER BY hits DESC
```
This can later feed the Weekly Brief ("AI crawler activity this week / top entries fetched by OAI-SearchBot").

## Test / validation
- `tests/ai-sources.test.ts` — referrer mapping, look-alike rejection, bot classification, token uniqueness (7 tests).
- `tsc --noEmit` clean; `pnpm build` clean (client bundle does not pull the server-only tap).
- Runtime smoke test: GPTBot / OAI-SearchBot / chatgpt.com-referrer / normal-browser requests all return 200 with no exceptions.

## Follow-ups (not in this PR)
- Enable Cloudflare **AI Crawl Control** (free, zero-config dashboard) as a baseline.
- Re-audit the referrer-host / bot-UA lists quarterly.

> Note: CI build currently fails on `main` due to a pre-existing duplicate-YAML-key in `content/collections/backend-development-suite.mdx` (fixed in a separate content PR). This branch will build green once that lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-load AI referral tracker that emits a one-time `ai-referral` event and persists a per-session “tracked” flag.
  * Introduced server-side AI signal logging for crawler and referral traffic via an Analytics Engine dataset.
  * Added traffic classification utilities to detect AI assistant referrers and AI crawler user agents.
* **Tests**
  * Added Vitest coverage for AI referrer/bot matching utilities and `ai-referral` emission/session behavior, including load-state handling.
  * Added tests for the document loading wait logic used by the referral tracker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->