### PR TITLE
fix(content): remove duplicate YAML keys in backend-development-suite

### DIFF
--- a/content/collections/backend-development-suite.mdx
+++ b/content/collections/backend-development-suite.mdx
@@ -23,12 +23,6 @@ retrievalSources:
 privacyNotes:
   - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 dateAdded: "2025-10-02"
-documentationUrl: "https://code.claude.com/docs/en/sub-agents"
-retrievalSources:
-  - "https://code.claude.com/docs/en/sub-agents"
-  - "https://code.claude.com/docs/en/mcp"
-privacyNotes:
-  - "Bundles a cloud-services MCP server and backend agents that connect to databases and cloud accounts; configure them with your own credentials and review what connection strings, secrets, and infrastructure data each bundled tool reads before use."
 installable: false
 usageSnippet: >-
   Start with `backend-architect-agent` → `database-specialist-agent` →


### PR DESCRIPTION
## Problem

`content/collections/backend-development-suite.mdx` has duplicate frontmatter keys — `documentationUrl`, `retrievalSources`, and `privacyNotes` each appear twice (with identical values), interleaved around `dateAdded`.

`js-yaml` (used by gray-matter in the content-index generator) rejects this as a **`duplicated mapping key`**, which breaks `scripts/build-content-index.mjs` and therefore `pnpm build` on `main`.

## Fix

Remove the duplicate block; the original `documentationUrl` / `retrievalSources` / `privacyNotes` above `dateAdded` are kept unchanged. One file, no value changes.

## Validation

- `node scripts/build-content-index.mjs` parses clean (was throwing `YAMLException: duplicated mapping key`).
- No duplicate top-level frontmatter keys remain.
- No generated-artifact churn included.