### PR TITLE
fix(content): fail validation on duplicate frontmatter keys (build-breaker)

### DIFF
--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -107,27 +107,34 @@ function findPredictableSharedTmpDebugPaths(scriptBody) {
 // a repeated indent-0 key is unambiguously a dupe (no false positives). The block-scalar / sequence skipping
 // keeps indented nested/list lines from being mistaken for a top-level key. (#frontmatter-dupe-key)
 function duplicateTopLevelFrontmatterKeys(source) {
-  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(String(source || ""));
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(
+    String(source || ""),
+  );
   if (!match) return [];
   const lines = match[1].split(/\r?\n/);
   const seen = new Set();
   const dupes = new Set();
   let i = 0;
   while (i < lines.length) {
-    const head = /^([A-Za-z][A-Za-z0-9_]*):(.*)$/.exec(lines[i]);
+    const head = /^([^#\s][^:]*?)\s*:(.*)$/.exec(lines[i]);
     if (!head) {
       i += 1;
       continue;
     }
-    const key = head[1];
+    const key = head[1].trim().replace(/^['"]|['"]$/g, "");
     if (seen.has(key)) dupes.add(key);
     else seen.add(key);
     const inline = head[2].trim();
     i += 1;
     if (/^[|>][+-]?\d*$/.test(inline)) {
-      while (i < lines.length && (lines[i].trim() === "" || /^\s/.test(lines[i]))) i += 1;
+      while (
+        i < lines.length &&
+        (lines[i].trim() === "" || /^\s/.test(lines[i]))
+      )
+        i += 1;
     } else if (inline === "") {
-      while (i < lines.length && /^\s/.test(lines[i]) && lines[i].trim() !== "") i += 1;
+      while (i < lines.length && /^\s/.test(lines[i]) && lines[i].trim() !== "")
+        i += 1;
     }
   }
   return [...dupes];
@@ -148,6 +155,16 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
 
     const filePath = path.join(categoryDir, fileName);
     const source = fs.readFileSync(filePath, "utf8");
+    const entry = `${category}/${fileName}`;
+
+    const dupeFrontmatterKeys = duplicateTopLevelFrontmatterKeys(source);
+    if (dupeFrontmatterKeys.length > 0) {
+      failures.push(
+        `${entry}: duplicate frontmatter keys -> ${dupeFrontmatterKeys.join(", ")} (the site build's YAML parser rejects duplicate mapping keys and the deploy fails)`,
+      );
+      continue;
+    }
+
     const parsed = parseSafeFrontmatter(source);
     const normalizedBody = normalizeBody(parsed.content, category);
     const inferred = inferStructuredFields(
@@ -165,15 +182,6 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
     )
       .trim()
       .toLowerCase();
-
-    const entry = `${category}/${fileName}`;
-
-    const dupeFrontmatterKeys = duplicateTopLevelFrontmatterKeys(source);
-    if (dupeFrontmatterKeys.length > 0) {
-      failures.push(
-        `${entry}: duplicate frontmatter keys -> ${dupeFrontmatterKeys.join(", ")} (the site build's YAML parser rejects duplicate mapping keys and the deploy fails)`,
-      );
-    }
 
     if (!normalizedBody.trim()) {
       failures.push(`${entry}: metadata-only content is not allowed`);

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -99,6 +99,40 @@ function findPredictableSharedTmpDebugPaths(scriptBody) {
   return [...paths];
 }
 
+// Duplicate top-level frontmatter keys crash the site build: gray-matter / js-yaml (build-content-index.mjs)
+// throws "duplicated mapping key" and the whole content-index build — and every deploy — fails. The lenient
+// parseSafeFrontmatter keeps the last value, so a duplicate-key file otherwise passes review AND this
+// validator, then breaks production (the backend-development-suite incident, via a templated enrichment edit).
+// Catch it here so the PR fails before merge. Scoped to top-level keys (indent 0) — the build-breaking case;
+// a repeated indent-0 key is unambiguously a dupe (no false positives). The block-scalar / sequence skipping
+// keeps indented nested/list lines from being mistaken for a top-level key. (#frontmatter-dupe-key)
+function duplicateTopLevelFrontmatterKeys(source) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(String(source || ""));
+  if (!match) return [];
+  const lines = match[1].split(/\r?\n/);
+  const seen = new Set();
+  const dupes = new Set();
+  let i = 0;
+  while (i < lines.length) {
+    const head = /^([A-Za-z][A-Za-z0-9_]*):(.*)$/.exec(lines[i]);
+    if (!head) {
+      i += 1;
+      continue;
+    }
+    const key = head[1];
+    if (seen.has(key)) dupes.add(key);
+    else seen.add(key);
+    const inline = head[2].trim();
+    i += 1;
+    if (/^[|>][+-]?\d*$/.test(inline)) {
+      while (i < lines.length && (lines[i].trim() === "" || /^\s/.test(lines[i]))) i += 1;
+    } else if (inline === "") {
+      while (i < lines.length && /^\s/.test(lines[i]) && lines[i].trim() !== "") i += 1;
+    }
+  }
+  return [...dupes];
+}
+
 for (const category of Object.keys(CATEGORY_SCHEMAS)) {
   if (selectedCategories.size > 0 && !selectedCategories.has(category)) {
     continue;
@@ -133,6 +167,13 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
       .toLowerCase();
 
     const entry = `${category}/${fileName}`;
+
+    const dupeFrontmatterKeys = duplicateTopLevelFrontmatterKeys(source);
+    if (dupeFrontmatterKeys.length > 0) {
+      failures.push(
+        `${entry}: duplicate frontmatter keys -> ${dupeFrontmatterKeys.join(", ")} (the site build's YAML parser rejects duplicate mapping keys and the deploy fails)`,
+      );
+    }
 
     if (!normalizedBody.trim()) {
       failures.push(`${entry}: metadata-only content is not allowed`);

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -116,7 +116,7 @@ function duplicateTopLevelFrontmatterKeys(source) {
   const dupes = new Set();
   let i = 0;
   while (i < lines.length) {
-    const head = /^([^#\s][^:]*?)\s*:(.*)$/.exec(lines[i]);
+    const head = /^(?!-\s)([^#\s][^:]*?)\s*:(.*)$/.exec(lines[i]);
     if (!head) {
       i += 1;
       continue;

--- a/tests/content-validation.test.ts
+++ b/tests/content-validation.test.ts
@@ -152,11 +152,12 @@ describe("content validation", () => {
 
   it("rejects duplicate top-level frontmatter keys with YAML-safe key syntax", () => {
     const tmpDir = makeTempContentRoot();
-    const hookDir = path.join(tmpDir, "content", "hooks");
-    fs.mkdirSync(hookDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(hookDir, "duplicate-keys.mdx"),
-      `---
+    try {
+      const hookDir = path.join(tmpDir, "content", "hooks");
+      fs.mkdirSync(hookDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(hookDir, "duplicate-keys.mdx"),
+        `---
 title: Duplicate Keys
 slug: duplicate-keys
 category: hooks
@@ -172,12 +173,50 @@ scriptBody: |-
 
 Example hook body.
 `,
-      "utf8",
-    );
+        "utf8",
+      );
 
-    expect(() => runContentValidation(tmpDir)).toThrow(
-      /duplicate frontmatter keys -> build-status/,
-    );
+      expect(() => runContentValidation(tmpDir)).toThrow(
+        /duplicate frontmatter keys -> build-status/,
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not treat top-level YAML sequence URLs as duplicate keys", () => {
+    const tmpDir = makeTempContentRoot();
+    try {
+      const hookDir = path.join(tmpDir, "content", "hooks");
+      fs.mkdirSync(hookDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(hookDir, "url-list.mdx"),
+        `---
+title: URL List
+slug: url-list
+category: hooks
+description: Example hook used by validation tests.
+cardDescription: Example hook used by validation tests.
+scriptLanguage: bash
+sourceUrls:
+- https://example.com/docs
+- https://example.com/source
+scriptBody: |-
+  #!/bin/bash
+  printf "%s\\n" "safe hook"
+---
+
+Example hook body.
+`,
+        "utf8",
+      );
+
+      expect(runContentValidation(tmpDir)).toContain(
+        "Content validation passed.",
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("rejects predictable shared /tmp debug logs in hook script bodies", () => {

--- a/tests/content-validation.test.ts
+++ b/tests/content-validation.test.ts
@@ -150,6 +150,36 @@ describe("content validation", () => {
     );
   });
 
+  it("rejects duplicate top-level frontmatter keys with YAML-safe key syntax", () => {
+    const tmpDir = makeTempContentRoot();
+    const hookDir = path.join(tmpDir, "content", "hooks");
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, "duplicate-keys.mdx"),
+      `---
+title: Duplicate Keys
+slug: duplicate-keys
+category: hooks
+description: Example hook used by validation tests.
+cardDescription: Example hook used by validation tests.
+scriptLanguage: bash
+build-status: stable
+"build-status": broken
+scriptBody: |-
+  #!/bin/bash
+  printf "%s\\n" "safe hook"
+---
+
+Example hook body.
+`,
+      "utf8",
+    );
+
+    expect(() => runContentValidation(tmpDir)).toThrow(
+      /duplicate frontmatter keys -> build-status/,
+    );
+  });
+
   it("rejects predictable shared /tmp debug logs in hook script bodies", () => {
     const tmpDir = makeTempContentRoot();
     writeHookFixture(


### PR DESCRIPTION
Adds a deterministic duplicate-top-level-frontmatter-key check to `scripts/validate-content.mjs` so a PR fails before merge.

**Why:** the site build parses frontmatter with gray-matter (js-yaml), which throws `duplicated mapping key` and crashes `build-content-index.mjs` -> every deploy fails. The lenient `parseSafeFrontmatter` keeps the last value, so a duplicate-key file passed this validator and broke production (the `backend-development-suite` incident via enrichment edits #3142/#3317; hand-fixed in #3571). reviewbot's gate got the matching check in JSONbored/reviewbot#224 — this is the deterministic CI backstop that catches it on every PR regardless of path.

Scoped to top-level keys (indent 0) — the build-breaking case; a repeated indent-0 key is unambiguously a dupe (no false positives). Block-scalar/sequence skipping keeps nested/list lines from being mistaken for a top-level key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect duplicate top-level keys in content file frontmatter, preventing build-time YAML parsing failures.
  * When duplicates are found, validation now stops processing that file and reports the specific duplicate key.
* **Tests**
  * Added a test case covering duplicate frontmatter keys to ensure the validation error is surfaced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->