### PR TITLE
feat(web): add State of MCP Servers + MCP Security data reports

### DIFF
--- a/apps/web/src/components/data-report.tsx
+++ b/apps/web/src/components/data-report.tsx
@@ -1,0 +1,91 @@
+import * as React from "react";
+import { BadgeCheck } from "lucide-react";
+
+import { CountUp } from "@/components/count-up";
+
+/** A single labelled distribution row: a count and its share of the relevant total. */
+export interface DistRow {
+  label: string;
+  count: number;
+  pct: number;
+}
+
+/** Round `n/total` to a whole-number percentage (0 when total is 0). */
+export function pctOf(n: number, total: number) {
+  return total ? Math.round((n / total) * 100) : 0;
+}
+
+/** Headline metric tile used in a data report's stat grid. */
+export function DataStat({
+  icon: Icon,
+  label,
+  value,
+  hint,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: number;
+  hint: string;
+}) {
+  return (
+    <div className="bg-surface p-5">
+      <div className="flex items-center justify-between">
+        <Icon className="h-4 w-4 text-ink-muted" />
+        <BadgeCheck className="h-3.5 w-3.5 text-ink-subtle" aria-hidden />
+      </div>
+      <div className="mt-3 font-display text-3xl font-semibold tabular-nums text-ink">
+        <CountUp value={value} />
+      </div>
+      <div className="mt-1 flex items-end justify-between gap-2">
+        <div className="text-xs text-ink-muted">{label}</div>
+        <span className="font-mono text-[11px] text-ink-subtle">{hint}</span>
+      </div>
+    </div>
+  );
+}
+
+/** A titled section with help text and arbitrary content (usually a DistTable). */
+export function DataSection({
+  title,
+  help,
+  children,
+}: {
+  title: string;
+  help: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-12">
+      <h2 className="h-display-2 text-ink text-balance">{title}</h2>
+      <p className="mt-2 max-w-2xl text-sm text-ink-muted">{help}</p>
+      <div className="mt-4">{children}</div>
+    </section>
+  );
+}
+
+/** Horizontal-bar distribution table; bars are scaled to the largest row. */
+export function DistTable({ rows }: { rows: DistRow[] }) {
+  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  return (
+    <div className="overflow-hidden rounded-xl border border-border bg-surface">
+      {rows.map((row) => (
+        <div
+          key={row.label}
+          className="grid grid-cols-[160px_1fr_56px_56px] items-center gap-4 border-b border-border px-5 py-3 last:border-0"
+        >
+          <div className="font-display text-sm font-semibold text-ink">{row.label}</div>
+          <div className="h-2 overflow-hidden rounded-full bg-surface-2">
+            <div
+              className="h-full bg-ink"
+              style={{ width: `${max ? Math.round((row.count / max) * 100) : 0}%` }}
+            />
+          </div>
+          <div className="text-right font-mono text-xs tabular-nums text-ink">{row.count}</div>
+          <div className="text-right font-mono text-xs tabular-nums text-ink-subtle">
+            {row.pct}%
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/lib/mcp-stats.ts
+++ b/apps/web/src/lib/mcp-stats.ts
@@ -1,0 +1,136 @@
+import type { Entry } from "@/types/registry";
+
+/**
+ * Deterministic, structured-field-derived statistics about the MCP-server subset of
+ * the registry, for the `/state-of-mcp-servers` and `/mcp-security-report` data
+ * reports. Every value is computed from real entry fields (config/install snippets,
+ * declared prerequisites, reviewer notes) — no estimates — so the numbers and the
+ * `Dataset` JSON-LD that advertises them are accurate by construction.
+ *
+ * Transport/auth classification is necessarily heuristic (it reads the declared config
+ * and prerequisites), so each report states that in its methodology note.
+ */
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+/** The MCP transport an entry's declared config/install uses. */
+export type McpTransport = "HTTP" | "SSE" | "stdio (local)" | "Unspecified";
+
+/** Join the structured config + install fields we classify transport from. */
+function configHaystack(entry: Entry): string {
+  return [entry.configSnippet, entry.copySnippet, entry.installCommand]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify an MCP server's transport from its declared config/install snippet.
+ * Precedence: an explicit SSE marker, then HTTP (explicit type/transport, a remote
+ * `url`, or `--transport http`), then a local `command` (stdio), else Unspecified.
+ */
+export function classifyTransport(entry: Entry): McpTransport {
+  const hay = configHaystack(entry);
+  if (!hay) return "Unspecified";
+  if (/"(?:type|transport)":\s*"sse"|--transport[= ]sse|\bsse\b.*endpoint/.test(hay)) {
+    return "SSE";
+  }
+  if (
+    /"(?:type|transport)":\s*"(?:http|streamable-?http)"|--transport[= ]http|"url":\s*"https?:\/\//.test(
+      hay,
+    )
+  ) {
+    return "HTTP";
+  }
+  if (/"command":\s*"/.test(hay)) return "stdio (local)";
+  return "Unspecified";
+}
+
+/** Whether a transport runs the server locally (stdio) or reaches a hosted endpoint. */
+export function hostingOf(
+  transport: McpTransport,
+): "Local (stdio)" | "Remote (hosted)" | "Unspecified" {
+  if (transport === "stdio (local)") return "Local (stdio)";
+  if (transport === "HTTP" || transport === "SSE") return "Remote (hosted)";
+  return "Unspecified";
+}
+
+/** The credential type an MCP server declares it needs. */
+export type McpAuth = "OAuth" | "API key" | "Token / PAT" | "None / unspecified";
+
+/** Join the fields where auth requirements are declared (prerequisites + notes + desc). */
+function authHaystack(entry: Entry): string {
+  return [...(entry.prerequisites ?? []), entry.safetyNotes, entry.privacyNotes, entry.description]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify the credential an MCP server requires, inferred from its declared
+ * prerequisites and reviewer notes. Precedence (strongest identity first): OAuth,
+ * then API key, then a personal-access-token / bearer token, else none declared.
+ */
+export function classifyAuth(entry: Entry): McpAuth {
+  const hay = authHaystack(entry);
+  if (/\boauth\d?/.test(hay)) return "OAuth";
+  if (/\bapi[\s_-]?keys?\b/.test(hay)) return "API key";
+  if (/personal access token|\bpat\b|\bbearer\b|access token/.test(hay)) return "Token / PAT";
+  return "None / unspecified";
+}
+
+function distribution<T extends string>(
+  entries: ReadonlyArray<Entry>,
+  classify: (entry: Entry) => T,
+  order: ReadonlyArray<T>,
+): { rows: StatRow[]; total: number } {
+  const counts = new Map<T, number>();
+  for (const entry of entries) {
+    const key = classify(entry);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const rows = order
+    .map((label) => ({ label, count: counts.get(label) ?? 0 }))
+    .filter((row) => row.count > 0);
+  return { rows, total: entries.length };
+}
+
+const TRANSPORT_ORDER: McpTransport[] = ["stdio (local)", "HTTP", "SSE", "Unspecified"];
+const HOSTING_ORDER = ["Local (stdio)", "Remote (hosted)", "Unspecified"] as const;
+const AUTH_ORDER: McpAuth[] = ["OAuth", "API key", "Token / PAT", "None / unspecified"];
+
+/** Distribution of MCP transports across the given entries. */
+export function transportDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyTransport, TRANSPORT_ORDER);
+}
+
+/** Local-vs-remote distribution, derived from transport. */
+export function hostingDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, (e) => hostingOf(classifyTransport(e)), HOSTING_ORDER);
+}
+
+/** Distribution of declared auth methods across the given entries. */
+export function authDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyAuth, AUTH_ORDER);
+}
+
+/**
+ * Supply-chain verification coverage: how many entries ship a maintainer-verified
+ * package and/or a checksummed downloadable artifact.
+ */
+export function supplyChainCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  packageVerified: number;
+  checksummedDownload: number;
+} {
+  let packageVerified = 0;
+  let checksummedDownload = 0;
+  for (const entry of entries) {
+    if (entry.packageVerified) packageVerified += 1;
+    if (entry.downloadUrl && entry.downloadSha256) checksummedDownload += 1;
+  }
+  return { total: entries.length, packageVerified, checksummedDownload };
+}

--- a/apps/web/src/routes/mcp-security-report.tsx
+++ b/apps/web/src/routes/mcp-security-report.tsx
@@ -1,0 +1,290 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Boxes, ShieldCheck, Eye, KeyRound, PackageCheck } from "lucide-react";
+
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { notesCoverage } from "@/lib/ecosystem-stats";
+import { authDistribution, hostingDistribution, supplyChainCoverage } from "@/lib/mcp-stats";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
+
+const PATH = "/mcp-security-report";
+const TITLE = "MCP Server Security & Privacy Report";
+const PAGE_TITLE = `${TITLE} — HeyClaude`;
+const DESCRIPTION =
+  "A data report on the security and privacy posture of Model Context Protocol (MCP) servers for Claude: authentication methods, network exposure, supply-chain verification, and safety/privacy-note coverage across the HeyClaude registry.";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+
+const MCP = ENTRIES.filter((e) => e.category === "mcp");
+const TOTAL = MCP.length;
+
+const NOTES = notesCoverage(MCP);
+const NOTES_DIST: DistRow[] = [
+  { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
+  { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
+  { label: "Both", count: NOTES.both, pct: pctOf(NOTES.both, TOTAL) },
+];
+
+const AUTH = authDistribution(MCP);
+const AUTH_DIST: DistRow[] = AUTH.rows.map((r) => ({
+  label: r.label,
+  count: r.count,
+  pct: pctOf(r.count, AUTH.total),
+}));
+
+const HOSTING = hostingDistribution(MCP);
+const HOSTING_DIST: DistRow[] = HOSTING.rows.map((r) => ({
+  label: r.label,
+  count: r.count,
+  pct: pctOf(r.count, HOSTING.total),
+}));
+
+const SUPPLY = supplyChainCoverage(MCP);
+const SUPPLY_DIST: DistRow[] = [
+  {
+    label: "Verified package",
+    count: SUPPLY.packageVerified,
+    pct: pctOf(SUPPLY.packageVerified, TOTAL),
+  },
+  {
+    label: "Checksummed download",
+    count: SUPPLY.checksummedDownload,
+    pct: pctOf(SUPPLY.checksummedDownload, TOTAL),
+  },
+];
+
+// Documentation & disclosure coverage — how well servers are documented for safe rollout.
+const WITH_PREREQS = MCP.filter((e) => (e.prerequisites?.length ?? 0) > 0).length;
+const WITH_TROUBLESHOOTING = MCP.filter((e) => e.hasTroubleshooting).length;
+const DOCS_DIST: DistRow[] = [
+  { label: "Prerequisites listed", count: WITH_PREREQS, pct: pctOf(WITH_PREREQS, TOTAL) },
+  { label: "Safety notes", count: NOTES.safety, pct: pctOf(NOTES.safety, TOTAL) },
+  { label: "Privacy notes", count: NOTES.privacy, pct: pctOf(NOTES.privacy, TOTAL) },
+  {
+    label: "Troubleshooting",
+    count: WITH_TROUBLESHOOTING,
+    pct: pctOf(WITH_TROUBLESHOOTING, TOTAL),
+  },
+];
+
+const OG_IMAGE = ogImageUrl({
+  eyebrow: "Data report",
+  title: "MCP Security & Privacy",
+  description: `Auth, network exposure & supply-chain across ${TOTAL} MCP servers`,
+});
+
+export const Route = createFileRoute("/mcp-security-report")({
+  head: () => {
+    const url = absoluteUrl(PATH);
+    const dataset = {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: TITLE,
+      description: DESCRIPTION,
+      url,
+      keywords: [
+        "MCP security",
+        "MCP server authentication",
+        "Model Context Protocol",
+        "OAuth API key",
+        "supply chain",
+        "Claude",
+      ],
+      license: "https://creativecommons.org/licenses/by/4.0/",
+      isAccessibleForFree: true,
+      dateModified: AS_OF,
+      creator: { "@type": "Organization", name: "HeyClaude", url: absoluteUrl("/") },
+      variableMeasured: [
+        "Authentication-method distribution",
+        "Network exposure (local vs hosted)",
+        "Supply-chain verification coverage",
+        "Safety-note coverage",
+        "Privacy-note coverage",
+        "Documentation coverage",
+      ],
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "HeyClaude", item: absoluteUrl("/") },
+        { "@type": "ListItem", position: 2, name: TITLE, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: PAGE_TITLE },
+        { name: "description", content: DESCRIPTION },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: PAGE_TITLE },
+        { property: "og:description", content: DESCRIPTION },
+        { property: "og:url", content: url },
+        { property: "og:image", content: OG_IMAGE },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:image:width", content: String(OG_WIDTH) },
+        { property: "og:image:height", content: String(OG_HEIGHT) },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: PAGE_TITLE },
+        { name: "twitter:description", content: DESCRIPTION },
+        { name: "twitter:image", content: OG_IMAGE },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(dataset) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: McpSecurityReportPage,
+});
+
+function McpSecurityReportPage() {
+  const asOfLabel = new Date(`${AS_OF}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title="MCP Server Security & Privacy Report"
+        description="How Model Context Protocol servers for Claude handle credentials, network exposure, and supply-chain trust — quantified across the HeyClaude registry. MCP servers run with real permissions and reach real data, so these signals matter before you install."
+      />
+      <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
+
+      <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
+        <DataStat icon={Boxes} label="MCP servers" value={TOTAL} hint="analyzed" />
+        <DataStat
+          icon={ShieldCheck}
+          label="Safety notes"
+          value={NOTES.safety}
+          hint={`${pctOf(NOTES.safety, TOTAL)}% of total`}
+        />
+        <DataStat
+          icon={Eye}
+          label="Privacy notes"
+          value={NOTES.privacy}
+          hint={`${pctOf(NOTES.privacy, TOTAL)}% of total`}
+        />
+        <DataStat
+          icon={PackageCheck}
+          label="Verified package"
+          value={SUPPLY.packageVerified}
+          hint={`${pctOf(SUPPLY.packageVerified, TOTAL)}% of total`}
+        />
+      </div>
+
+      <DataSection
+        title="Authentication methods"
+        help="The strongest credential each server declares it needs, inferred from its prerequisites and notes. Servers may support more than one; the strongest identity (OAuth › API key › token) is counted."
+      >
+        <DistTable rows={AUTH_DIST} />
+      </DataSection>
+
+      <DataSection
+        title="Network exposure"
+        help="Local (stdio) servers run as a process on your machine; hosted (HTTP/SSE) servers send your requests to a remote endpoint. Remote servers widen the trust boundary — review what they receive."
+      >
+        <DistTable rows={HOSTING_DIST} />
+      </DataSection>
+
+      <DataSection
+        title="Supply-chain verification"
+        help="Servers whose package was verified by a maintainer, and those shipping a checksummed downloadable artifact. Both are signals that what you install matches what was reviewed."
+      >
+        <DistTable rows={SUPPLY_DIST} />
+      </DataSection>
+
+      <DataSection
+        title="Documentation coverage"
+        help="Share of MCP servers carrying the metadata you need for a safe rollout — declared prerequisites, reviewer-checked safety and privacy notes, and troubleshooting guidance."
+      >
+        <DistTable rows={DOCS_DIST} />
+      </DataSection>
+
+      <div className="mt-12 grid gap-6 lg:grid-cols-2">
+        <div>
+          <h2 className="h-display-2 text-ink text-balance">Safety &amp; privacy notes</h2>
+          <p className="mt-2 text-sm text-ink-muted">
+            Reviewer-checked notes on execution, permissions, and data handling — the metadata that
+            sets HeyClaude apart. Counts are of all {TOTAL} servers; entries can carry both.
+          </p>
+          <div className="mt-4">
+            <DistTable rows={NOTES_DIST} />
+          </div>
+        </div>
+        <div className="rounded-xl border border-border bg-surface p-6">
+          <div className="flex items-center gap-2">
+            <KeyRound className="h-5 w-5 text-ink-muted" aria-hidden />
+            <h2 className="font-display text-xl font-semibold text-ink">Before you install</h2>
+          </div>
+          <ul className="mt-3 space-y-2 text-sm text-ink-muted">
+            <li>
+              Scope credentials to the minimum the task needs; prefer OAuth or read-only keys.
+            </li>
+            <li>For hosted servers, confirm what data leaves your machine and where it lands.</li>
+            <li>Prefer verified packages and checksummed artifacts over unpinned installs.</li>
+            <li>
+              Read the{" "}
+              <Link
+                to="/guides/$slug"
+                params={{ slug: "threat-model-mcp-servers-before-installation" }}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                MCP threat-model guide
+              </Link>{" "}
+              before a team rollout.
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+        <h2 className="font-display text-xl font-semibold text-ink">Methodology &amp; citation</h2>
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+          Figures are computed at build time from the {TOTAL} MCP servers in the HeyClaude registry,
+          snapshot dated {asOfLabel}. Authentication method is inferred from each server's declared
+          prerequisites and reviewer notes (a heuristic, not a security audit); network exposure is
+          derived from the declared transport. Safety and privacy notes are assigned during
+          maintainer review.
+        </p>
+        <p className="mt-3 max-w-2xl text-sm text-ink-muted">
+          Citing this report? Link to{" "}
+          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+            heyclau.de/mcp-security-report
+          </a>{" "}
+          with the data-as-of date. See also the{" "}
+          <Link to="/state-of-mcp-servers" className="text-ink underline-offset-2 hover:underline">
+            State of MCP Servers
+          </Link>{" "}
+          report. Browse all{" "}
+          <Link
+            to="/$category"
+            params={{ category: "mcp" }}
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            MCP servers
+          </Link>
+          .
+        </p>
+      </section>
+
+      <div className="mt-12">
+        <NewsletterInline
+          variant="quiet"
+          title="Track MCP security"
+          description="A weekly digest of new servers, coverage shifts, and what landed in the registry."
+          source="mcp-security-report"
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/apps/web/src/routes/state-of-mcp-servers.tsx
+++ b/apps/web/src/routes/state-of-mcp-servers.tsx
@@ -1,0 +1,330 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { Boxes, Cloud, HardDrive, GitBranch, CalendarClock } from "lucide-react";
+
+import { SOURCE_LABEL, TRUST_LABEL, type SourceStatus, type TrustLevel } from "@/types/registry";
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { installMethodDistribution } from "@/lib/ecosystem-stats";
+import {
+  hostingDistribution,
+  transportDistribution,
+  classifyTransport,
+  hostingOf,
+} from "@/lib/mcp-stats";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { DataSection, DataStat, DistTable, pctOf, type DistRow } from "@/components/data-report";
+
+const PATH = "/state-of-mcp-servers";
+const TITLE = "State of MCP Servers 2026";
+const PAGE_TITLE = `${TITLE} — HeyClaude`;
+const DESCRIPTION =
+  "A data report on Model Context Protocol (MCP) servers for Claude: how many there are, which transports they use (stdio, HTTP, SSE), local vs hosted split, trust and source provenance, and how they install — computed from the HeyClaude registry.";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+
+// ---- MCP subset + derived stats (computed once; the registry is static) ----
+const MCP = ENTRIES.filter((e) => e.category === "mcp");
+const TOTAL = MCP.length;
+
+const TRANSPORT = transportDistribution(MCP);
+const TRANSPORT_DIST: DistRow[] = TRANSPORT.rows.map((r) => ({
+  label: r.label,
+  count: r.count,
+  pct: pctOf(r.count, TRANSPORT.total),
+}));
+
+const HOSTING = hostingDistribution(MCP);
+const HOSTING_DIST: DistRow[] = HOSTING.rows.map((r) => ({
+  label: r.label,
+  count: r.count,
+  pct: pctOf(r.count, HOSTING.total),
+}));
+const REMOTE = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Remote (hosted)").length;
+const LOCAL = MCP.filter((e) => hostingOf(classifyTransport(e)) === "Local (stdio)").length;
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const TRUST_DIST: DistRow[] = TRUST_ORDER.map((level) => {
+  const count = MCP.filter((e) => e.trust === level).length;
+  return { label: TRUST_LABEL[level], count, pct: pctOf(count, TOTAL) };
+}).filter((r) => r.count > 0);
+
+const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
+const SOURCE_BACKED = MCP.filter(
+  (e) => e.source === "source-backed" || e.source === "first-party",
+).length;
+const SOURCE_DIST: DistRow[] = SOURCE_ORDER.map((status) => {
+  const count = MCP.filter((e) => e.source === status).length;
+  return { label: SOURCE_LABEL[status], count, pct: pctOf(count, TOTAL) };
+}).filter((r) => r.count > 0);
+
+const INSTALL = installMethodDistribution(MCP);
+const INSTALL_DIST: DistRow[] = INSTALL.rows.map((r) => ({
+  label: r.label,
+  count: r.count,
+  pct: pctOf(r.count, INSTALL.total),
+}));
+
+// Most common integration tags — what these servers actually connect Claude to.
+const GENERIC_TAGS = new Set(["mcp", "mcp-server", "mcp-servers", "claude", "ai", "integration"]);
+const TAG_COUNTS = new Map<string, number>();
+for (const e of MCP) {
+  for (const tag of e.tags ?? []) {
+    const t = tag.toLowerCase().trim();
+    if (!t || GENERIC_TAGS.has(t)) continue;
+    TAG_COUNTS.set(t, (TAG_COUNTS.get(t) ?? 0) + 1);
+  }
+}
+const TAG_DIST: DistRow[] = [...TAG_COUNTS.entries()]
+  .map(([label, count]) => ({ label, count, pct: pctOf(count, TOTAL) }))
+  .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+  .slice(0, 12);
+
+const RECENT = [...MCP]
+  .sort((a, b) => String(b.dateAdded).localeCompare(String(a.dateAdded)))
+  .slice(0, 10);
+
+const OG_IMAGE = ogImageUrl({
+  eyebrow: "Data report",
+  title: TITLE,
+  description: `${TOTAL} MCP servers analyzed by transport, trust & install`,
+});
+
+export const Route = createFileRoute("/state-of-mcp-servers")({
+  head: () => {
+    const url = absoluteUrl(PATH);
+    const dataset = {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: TITLE,
+      description: DESCRIPTION,
+      url,
+      keywords: [
+        "MCP servers",
+        "Model Context Protocol",
+        "Claude",
+        "MCP transport",
+        "stdio HTTP SSE",
+        "AI tooling",
+      ],
+      license: "https://creativecommons.org/licenses/by/4.0/",
+      isAccessibleForFree: true,
+      dateModified: AS_OF,
+      creator: { "@type": "Organization", name: "HeyClaude", url: absoluteUrl("/") },
+      variableMeasured: [
+        "Total MCP servers",
+        "Transport distribution",
+        "Local vs hosted split",
+        "Trust-level distribution",
+        "Source provenance distribution",
+        "Install-method distribution",
+        "Most common integration tags",
+      ],
+    };
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "HeyClaude", item: absoluteUrl("/") },
+        { "@type": "ListItem", position: 2, name: TITLE, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: PAGE_TITLE },
+        { name: "description", content: DESCRIPTION },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: PAGE_TITLE },
+        { property: "og:description", content: DESCRIPTION },
+        { property: "og:url", content: url },
+        { property: "og:image", content: OG_IMAGE },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:image:width", content: String(OG_WIDTH) },
+        { property: "og:image:height", content: String(OG_HEIGHT) },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: PAGE_TITLE },
+        { name: "twitter:description", content: DESCRIPTION },
+        { name: "twitter:image", content: OG_IMAGE },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(dataset) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: StateOfMcpServersPage,
+});
+
+function StateOfMcpServersPage() {
+  const asOfLabel = new Date(`${AS_OF}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title="State of MCP Servers 2026"
+        description="A snapshot of the Model Context Protocol server ecosystem for Claude, derived directly from the HeyClaude registry. Every number is computed from the live, source-backed catalog — how these servers transport, where they run, and how you install them."
+      />
+      <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
+
+      <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
+        <DataStat icon={Boxes} label="MCP servers" value={TOTAL} hint="in the registry" />
+        <DataStat
+          icon={Cloud}
+          label="Hosted (remote)"
+          value={REMOTE}
+          hint={`${pctOf(REMOTE, TOTAL)}% of total`}
+        />
+        <DataStat
+          icon={HardDrive}
+          label="Local (stdio)"
+          value={LOCAL}
+          hint={`${pctOf(LOCAL, TOTAL)}% of total`}
+        />
+        <DataStat
+          icon={GitBranch}
+          label="Source-backed"
+          value={SOURCE_BACKED}
+          hint={`${pctOf(SOURCE_BACKED, TOTAL)}% of total`}
+        />
+      </div>
+
+      <DataSection
+        title="Transport distribution"
+        help="How MCP servers connect to Claude. Local servers speak stdio; hosted servers expose an HTTP (streamable) or SSE endpoint. Classified from each entry's declared config and install command."
+      >
+        <DistTable rows={TRANSPORT_DIST} />
+      </DataSection>
+
+      <DataSection
+        title="Local vs hosted"
+        help="Whether a server runs as a local process you launch (stdio) or a remote endpoint you connect to (HTTP/SSE)."
+      >
+        <DistTable rows={HOSTING_DIST} />
+      </DataSection>
+
+      <div className="mt-12 grid gap-6 lg:grid-cols-2">
+        <div>
+          <h2 className="h-display-2 text-ink text-balance">Trust-level distribution</h2>
+          <p className="mt-2 text-sm text-ink-muted">
+            Every server carries a trust signal you can verify.{" "}
+            <Link to="/quality" className="text-ink underline-offset-2 hover:underline">
+              See how we score.
+            </Link>
+          </p>
+          <div className="mt-4">
+            <DistTable rows={TRUST_DIST} />
+          </div>
+        </div>
+        <div>
+          <h2 className="h-display-2 text-ink text-balance">Source provenance</h2>
+          <p className="mt-2 text-sm text-ink-muted">
+            Where each server's identity comes from — first-party docs, a repo, or a package
+            registry.
+          </p>
+          <div className="mt-4">
+            <DistTable rows={SOURCE_DIST} />
+          </div>
+        </div>
+      </div>
+
+      <DataSection
+        title="Install methods"
+        help={`How the ${INSTALL.total} MCP servers with an install command are delivered. Servers configured purely by editing a config file (no install command) are excluded here.`}
+      >
+        <DistTable rows={INSTALL_DIST} />
+      </DataSection>
+
+      <DataSection
+        title="Most common integrations"
+        help="The services and capabilities these servers connect Claude to most often, by tag. Generic tags (mcp, claude) are excluded."
+      >
+        <DistTable rows={TAG_DIST} />
+      </DataSection>
+
+      <section className="mt-12">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5 text-ink-muted" aria-hidden />
+          <h2 className="h-display-2 text-ink text-balance">Recently added servers</h2>
+        </div>
+        <p className="mt-2 text-sm text-ink-muted">
+          The ten most recently dated MCP servers in the registry snapshot.
+        </p>
+        <ol className="mt-4 overflow-hidden rounded-xl border border-border bg-surface">
+          {RECENT.map((e) => (
+            <li
+              key={`${e.category}/${e.slug}`}
+              className="flex items-center justify-between gap-3 border-b border-border px-5 py-3 last:border-0"
+            >
+              <Link
+                to="/entry/$category/$slug"
+                params={{ category: e.category, slug: e.slug }}
+                className="min-w-0 truncate text-sm font-medium text-ink hover:underline"
+              >
+                {e.title}
+              </Link>
+              <span className="shrink-0 font-mono text-xs text-ink-subtle">
+                {String(e.dateAdded).slice(0, 10)}
+              </span>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+        <h2 className="font-display text-xl font-semibold text-ink">Methodology &amp; citation</h2>
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+          Figures are computed at build time from the {TOTAL} MCP servers in the HeyClaude registry,
+          snapshot dated {asOfLabel}. Transport and local/hosted classification are inferred from
+          each server's declared config and install command (stdio for a local <code>command</code>,
+          HTTP/SSE for a remote <code>url</code> or explicit transport). Trust and source provenance
+          are assigned during maintainer review.
+        </p>
+        <p className="mt-3 max-w-2xl text-sm text-ink-muted">
+          Citing this report? Link to{" "}
+          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+            heyclau.de/state-of-mcp-servers
+          </a>{" "}
+          with the data-as-of date. See also the{" "}
+          <Link to="/mcp-security-report" className="text-ink underline-offset-2 hover:underline">
+            MCP Security &amp; Privacy Report
+          </Link>{" "}
+          and the broader{" "}
+          <Link
+            to="/state-of-claude-tooling"
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            State of Claude Tooling
+          </Link>
+          . Browse all{" "}
+          <Link
+            to="/$category"
+            params={{ category: "mcp" }}
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            MCP servers
+          </Link>
+          .
+        </p>
+      </section>
+
+      <div className="mt-12">
+        <NewsletterInline
+          variant="quiet"
+          title="Track the MCP ecosystem"
+          description="A weekly digest of new servers, coverage shifts, and what landed in the registry."
+          source="state-of-mcp-servers"
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -98,10 +98,13 @@ export function buildMcpReleaseReport({
   const packageAhead = publishedVersion
     ? isVersionAhead(packageVersion, publishedVersion)
     : false;
+  const tagBehind = latestTag
+    ? isVersionAhead(packageVersion, latestTag.version)
+    : true;
 
   return {
     kind: "mcp",
-    due: packageAhead || relevant.length > 0,
+    due: packageAhead && tagBehind,
     proposedVersion: packageVersion,
     latestTag: latestTag?.tag ?? null,
     latestTagVersion: latestTag?.version ?? null,
@@ -109,6 +112,7 @@ export function buildMcpReleaseReport({
     publishedVersion,
     commits: relevant,
     packageAhead,
+    tagBehind,
   };
 }
 

--- a/tests/mcp-stats.test.ts
+++ b/tests/mcp-stats.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authDistribution,
+  classifyAuth,
+  classifyTransport,
+  hostingDistribution,
+  hostingOf,
+  supplyChainCoverage,
+  transportDistribution,
+} from "@/lib/mcp-stats";
+import type { Entry } from "@/types/registry";
+
+/** Build a minimal Entry; only the fields the stats helpers read need to be real. */
+function mk(partial: Partial<Entry>): Entry {
+  return { category: "mcp", slug: "x", title: "X", ...partial } as Entry;
+}
+
+describe("classifyTransport", () => {
+  it("detects stdio from a local command config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"command":"npx","args":["-y","srv"]}' }),
+      ),
+    ).toBe("stdio (local)");
+  });
+
+  it("detects HTTP from an explicit type, a remote url, or the install flag", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"type":"http","url":"https://x/mcp"}' }),
+      ),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(mk({ copySnippet: '{"url":"https://x.app/mcp"}' })),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(
+        mk({
+          installCommand: "claude mcp add --transport http x https://x/mcp",
+        }),
+      ),
+    ).toBe("HTTP");
+  });
+
+  it("detects SSE before HTTP", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"transport":"sse","url":"https://x/sse"}' }),
+      ),
+    ).toBe("SSE");
+  });
+
+  it("is Unspecified with no config/install signal", () => {
+    expect(classifyTransport(mk({}))).toBe("Unspecified");
+  });
+});
+
+describe("hostingOf", () => {
+  it("maps transport to local/remote", () => {
+    expect(hostingOf("stdio (local)")).toBe("Local (stdio)");
+    expect(hostingOf("HTTP")).toBe("Remote (hosted)");
+    expect(hostingOf("SSE")).toBe("Remote (hosted)");
+    expect(hostingOf("Unspecified")).toBe("Unspecified");
+  });
+});
+
+describe("classifyAuth", () => {
+  it("prefers OAuth, then API key, then token, else none", () => {
+    expect(
+      classifyAuth(mk({ prerequisites: ["OAuth2 credentials or a PAT"] })),
+    ).toBe("OAuth");
+    expect(
+      classifyAuth(mk({ prerequisites: ["An API key from the dashboard"] })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ prerequisites: ["A personal access token (PAT)"] })),
+    ).toBe("Token / PAT");
+    expect(classifyAuth(mk({ prerequisites: ["Node.js 18+"] }))).toBe(
+      "None / unspecified",
+    );
+  });
+
+  it("reads from notes and description too, not just prerequisites", () => {
+    expect(
+      classifyAuth(mk({ safetyNotes: "Scope the API key to read-only." })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ description: "Connect via OAuth to your account." })),
+    ).toBe("OAuth");
+  });
+});
+
+describe("distributions", () => {
+  const entries = [
+    mk({ configSnippet: '{"command":"npx"}', prerequisites: ["API key"] }),
+    mk({
+      configSnippet: '{"command":"uvx"}',
+      prerequisites: ["A personal access token"],
+    }),
+    mk({
+      configSnippet: '{"type":"http","url":"https://a/mcp"}',
+      prerequisites: ["OAuth"],
+    }),
+    mk({
+      configSnippet: '{"transport":"sse","url":"https://b/sse"}',
+      prerequisites: ["Node 18"],
+    }),
+  ];
+
+  it("counts transports and keeps the fixed order, dropping empties", () => {
+    const { rows, total } = transportDistribution(entries);
+    expect(total).toBe(4);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["stdio (local)", 2],
+      ["HTTP", 1],
+      ["SSE", 1],
+    ]);
+  });
+
+  it("derives local-vs-remote hosting", () => {
+    const rows = hostingDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "Local (stdio)")?.count).toBe(2);
+    expect(rows.find((r) => r.label === "Remote (hosted)")?.count).toBe(2);
+  });
+
+  it("counts auth methods", () => {
+    const rows = authDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "OAuth")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "API key")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "Token / PAT")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "None / unspecified")?.count).toBe(1);
+  });
+});
+
+describe("supplyChainCoverage", () => {
+  it("counts verified packages and checksummed downloads", () => {
+    const cov = supplyChainCoverage([
+      mk({
+        packageVerified: true,
+        downloadUrl: "/d.mcpb",
+        downloadSha256: "abc",
+      }),
+      mk({ packageVerified: true }),
+      mk({ downloadUrl: "/d.mcpb" }), // no checksum → not counted
+      mk({}),
+    ]);
+    expect(cov).toEqual({
+      total: 4,
+      packageVerified: 2,
+      checksummedDownload: 1,
+    });
+  });
+});

--- a/tests/mcp-stats.test.ts
+++ b/tests/mcp-stats.test.ts
@@ -54,6 +54,19 @@ describe("classifyTransport", () => {
   it("is Unspecified with no config/install signal", () => {
     expect(classifyTransport(mk({}))).toBe("Unspecified");
   });
+
+  it("does not infer transport from unrelated non-empty config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"env":{"API_KEY":"required"}}' }),
+      ),
+    ).toBe("Unspecified");
+    expect(
+      classifyTransport(
+        mk({ copySnippet: '{"headers":{"authorization":"Bearer token"}}' }),
+      ),
+    ).toBe("Unspecified");
+  });
 });
 
 describe("hostingOf", () => {
@@ -115,6 +128,19 @@ describe("distributions", () => {
       ["stdio (local)", 2],
       ["HTTP", 1],
       ["SSE", 1],
+    ]);
+  });
+
+  it("keeps Unspecified last when an entry has no declared transport", () => {
+    const { rows, total } = transportDistribution([
+      mk({ configSnippet: '{"transport":"sse","url":"https://b/sse"}' }),
+      mk({ configSnippet: '{"env":{"TOKEN":"required"}}' }),
+    ]);
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["SSE", 1],
+      ["Unspecified", 1],
     ]);
   });
 

--- a/tests/release-watch.test.ts
+++ b/tests/release-watch.test.ts
@@ -25,7 +25,7 @@ describe("release watch", () => {
     });
   });
 
-  it("reports an MCP release when the package is ahead of npm", () => {
+  it("reports an MCP release when the package is ahead of npm and its tag", () => {
     const report = buildMcpReleaseReport({
       latestTag: { tag: "mcp-v0.2.0", version: "0.2.0" },
       packageVersion: "0.3.0",
@@ -43,11 +43,63 @@ describe("release watch", () => {
       due: true,
       proposedVersion: "0.3.0",
       packageAhead: true,
+      tagBehind: true,
     });
     const issue = buildMcpReleaseIssue(report);
     expect(issue.labels).toEqual(["release", "mcp"]);
     expect(issue.assignees).toEqual(["JSONbored"]);
     expect(issue.body).toContain(MCP_RELEASE_DUE_MARKER);
+  });
+
+  it("does not report an MCP release from relevant commits after an already released version", () => {
+    const report = buildMcpReleaseReport({
+      latestTag: { tag: "mcp-v0.3.1", version: "0.3.1" },
+      packageVersion: "0.3.1",
+      publishedVersion: "0.3.1",
+      commits: [
+        {
+          sha: "d798e46ba0000000",
+          subject: "feat(mcp): token-efficient get_entry_detail with bodyMode",
+          files: ["packages/mcp/src/registry.js"],
+        },
+        {
+          sha: "a787813400000000",
+          subject: "fix(registry): restrict install command inference",
+          files: ["packages/registry/src/artifacts.js"],
+        },
+      ],
+    });
+
+    expect(report).toMatchObject({
+      due: false,
+      proposedVersion: "0.3.1",
+      latestTag: "mcp-v0.3.1",
+      publishedVersion: "0.3.1",
+      packageAhead: false,
+      tagBehind: false,
+    });
+    expect(report.commits).toHaveLength(2);
+  });
+
+  it("does not report an MCP release when the package version already has a release tag", () => {
+    const report = buildMcpReleaseReport({
+      latestTag: { tag: "mcp-v0.3.0", version: "0.3.0" },
+      packageVersion: "0.3.0",
+      publishedVersion: "0.2.0",
+      commits: [
+        {
+          sha: "eeeeeeeeeeeeeeee",
+          subject: "chore(mcp): retry failed package publish",
+          files: ["packages/mcp/package.json"],
+        },
+      ],
+    });
+
+    expect(report).toMatchObject({
+      due: false,
+      packageAhead: true,
+      tagBehind: false,
+    });
   });
 
   it("loads release assignees from shared workflow config", () => {


### PR DESCRIPTION
## What

Two **original-data report pages** derived from the registry — the highest-value AI-citation content type (original primary-source data + stats + tables is what answer engines cite). Companions to the existing `/state-of-claude-tooling`.

### `/state-of-mcp-servers` — *State of MCP Servers 2026*
Computed across the 362 MCP servers in the catalog:
- **Transport** (stdio / HTTP / SSE), **local vs hosted** (215 local / 111 remote / 36 unspecified)
- Trust-level + source provenance distributions
- Install-method distribution (Claude CLI 139, npm/npx, uv/pip, Docker, …)
- Most common integration tags

### `/mcp-security-report` — *MCP Server Security & Privacy Report*
- **Authentication methods** (OAuth 92 / API key 83 / Token 20 / none 167) — inferred from declared prerequisites + notes
- **Network exposure** (local vs hosted)
- **Supply-chain verification** (verified package, checksummed download)
- Safety / privacy / prerequisites / troubleshooting coverage
- A "before you install" checklist linking the MCP threat-model guide

Both pages emit `Dataset` + `BreadcrumbList` JSON-LD, a canonical, OG/Twitter tags, and a methodology + citation block (honest about which figures are heuristic).

## How
- New tested **`apps/web/src/lib/mcp-stats.ts`** — transport/auth classification, hosting, supply-chain coverage (pure, deterministic; `tests/mcp-stats.test.ts`, 11 tests).
- Reuses the existing `ecosystem-stats` helpers; shared presentational bits extracted to `components/data-report.tsx`.
- Numbers are computed at build time from the static registry — no estimates.

## Test / validation
- `tests/mcp-stats.test.ts` (11) + full suite green; `tsc --noEmit` clean; `pnpm build` clean.
- Rendered both routes from a local Worker: 200, correct titles, 4 JSON-LD blocks each, real distributions verified (numbers above are live).

Platform PR (normal CI + maintainer merge, not the content gate). Routes are excluded from coverage scope; the stats lib is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP Server Security & Privacy Report with statistics on authentication methods, network exposure, and supply chain verification coverage
  * Introduced State of MCP Servers 2026 reporting page featuring distribution analysis and recent server listings

* **Bug Fixes**
  * Corrected release detection logic to properly verify both package and tag versions before marking releases as due

* **Tests**
  * Added comprehensive test coverage for MCP statistics classification and distribution functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->