### PR TITLE
content(mcp): add Railway MCP Server

### DIFF
--- a/content/mcp/railway-mcp-server.mdx
+++ b/content/mcp/railway-mcp-server.mdx
@@ -1,0 +1,171 @@
+---
+title: Railway MCP Server for Claude
+slug: railway-mcp-server
+category: mcp
+description: >-
+  Manage Railway projects, services, deployments, and environments from Claude — create projects,
+  deploy templates, pull variables, trigger redeployments, and more — with the official Railway MCP
+  server built into the Railway CLI.
+cardDescription: "Official Railway MCP: manage projects, deployments & environments from Claude Code."
+seoTitle: "Railway MCP Server for Claude — Deploy & Manage Railway Projects"
+seoDescription: "Connect Claude to Railway with the official MCP server (built into the Railway CLI): create projects, deploy templates, manage services, pull environment variables, and trigger redeployments from Claude Code or Desktop."
+author: Railway
+authorProfileUrl: "https://github.com/railwayapp"
+dateAdded: "2026-06-18"
+documentationUrl: "https://docs.railway.com/cli/mcp"
+websiteUrl: "https://railway.com"
+repoUrl: "https://github.com/railwayapp/cli"
+retrievalSources:
+  - "https://github.com/railwayapp/cli"
+  - "https://docs.railway.com/cli/mcp"
+  - "https://docs.railway.com/ai/mcp-server"
+  - "https://code.claude.com/docs/en/mcp"
+installable: true
+installCommand: "railway mcp install --agent claude-code"
+usageSnippet: >-
+  Ask Claude to list your Railway projects, deploy a template, check service logs, or pull environment variables from a project.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "railway": {
+        "command": "railway",
+        "args": ["mcp"]
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "railway": {
+        "command": "railway",
+        "args": ["mcp"]
+      }
+    }
+  }
+estimatedSetupTime: 10 minutes
+difficulty: beginner
+prerequisites:
+  - "Railway CLI installed: `bash <(curl -fsSL https://railway.com/install.sh)`"
+  - "Logged in to Railway: `railway login`"
+  - "An MCP client such as Claude Code or Claude Desktop."
+safetyNotes:
+  - "The Railway CLI MCP server runs as a local stdio process with full access to your authenticated Railway account — it can create, delete, and modify projects and services."
+  - "Use Railway's environment scoping and project permissions to limit blast radius; avoid running the MCP server under an account with access to production environments unless intentional."
+  - "The remote option (`--remote`) routes requests through `mcp.railway.com`; prefer local stdio if you prefer to keep credentials on-device."
+privacyNotes:
+  - "Railway commands may expose environment variable names and values from your projects into the Claude context; treat these as secrets."
+  - "The Railway CLI authenticates via stored tokens — keep your Railway account credentials secure."
+tags:
+  - railway
+  - deployment
+  - cloud
+  - infrastructure
+  - paas
+  - devops
+keywords:
+  - railway mcp server
+  - deploy railway from claude
+  - railway cli mcp
+  - manage railway projects with ai
+  - railway deployment mcp
+  - paas mcp server claude
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+The **Railway MCP Server** is the official Model Context Protocol integration built directly into
+the Railway CLI. It lets Claude manage your Railway infrastructure — creating projects, deploying
+templates, inspecting services, pulling environment variables, and triggering redeployments —
+through natural language. It runs as a local stdio process using your existing `railway login`
+session and is licensed under MIT.
+
+A remote option is also available (`railway mcp install --remote`) which routes requests through
+`https://mcp.railway.com` instead of your local CLI.
+
+## Key capabilities
+
+- **Project management** — list, create, and inspect Railway projects.
+- **Service operations** — view services, check deployment status, trigger redeployments.
+- **Environment variables** — pull and inspect variables from any project environment.
+- **Template deployment** — deploy Railway templates from natural language.
+- **Log inspection** — retrieve recent service logs for debugging.
+- **Environment management** — list and switch between Railway environments.
+
+## How it compares
+
+| Server | Cloud deployments | Env var access | Log retrieval | Transport |
+|---|---|---|---|---|
+| **Railway MCP** | Yes (Railway PaaS) | Yes | Yes | stdio (local) or Remote |
+| Fly.io MCP | Yes (Fly.io) | Yes | Yes | stdio |
+| DigitalOcean MCP | Yes (DO cloud) | Limited | Limited | Remote |
+| Vercel MCP | Yes (Vercel) | Yes | Yes | Remote |
+| Render MCP | Yes (Render) | Limited | Yes | Remote |
+
+Railway's MCP is unique in bundling the integration into the CLI binary rather than shipping a
+separate npm package, meaning it always stays in sync with the Railway API.
+
+## Installation
+
+### Automatic (recommended)
+
+```bash
+# Install or upgrade the Railway CLI
+bash <(curl -fsSL https://railway.com/install.sh)
+
+# Log in
+railway login
+
+# Auto-configure Claude Code
+railway mcp install --agent claude-code
+
+# Or configure Claude Desktop and other tools
+railway mcp install
+```
+
+### Manual Claude Desktop config
+
+```json
+{
+  "mcpServers": {
+    "railway": {
+      "command": "railway",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+### Remote (no local CLI required)
+
+```bash
+railway mcp install --remote
+```
+
+This configures your MCP client to use `https://mcp.railway.com` instead of the local CLI.
+
+## Requirements
+
+- Railway CLI (install via `bash <(curl -fsSL https://railway.com/install.sh)`)
+- A Railway account logged in (`railway login`)
+- An MCP client (Claude Code or Claude Desktop)
+
+## Security
+
+- The MCP server inherits your full Railway account permissions — scope your Railway user/token
+  to only the projects you need.
+- For production environments, consider creating a dedicated Railway account with limited scope.
+- Treat all environment variables Railway surfaces in Claude's context as secrets.
+
+## Source Verification Notes
+
+Verified on **2026-06-18**:
+
+- The official Railway CLI repository `github.com/railwayapp/cli` (MIT) is the authoritative
+  source for the `railway mcp` command and confirms the local stdio transport.
+- Railway's MCP documentation at `docs.railway.com/cli/mcp` documents the `railway mcp install`
+  command, agent-specific flags, and the remote option.
+- Railway's AI/MCP guide at `docs.railway.com/ai/mcp-server` confirms project, service,
+  environment variable, and deployment management as the primary capabilities.
+- Claude Code's MCP documentation describes the connector setup pattern used here.


### PR DESCRIPTION
Adds the official Railway MCP server to the catalog.

**What it does:** Lets Claude manage Railway infrastructure — projects, services, deployments, environment variables, logs — via the MCP server built into the Railway CLI (`railway mcp`). Also supports a remote option at mcp.railway.com.

**Why it belongs:** Official from Railway (MIT), actively maintained CLI, CLI-integrated (always in sync with Railway API). Fills a PaaS/deployment gap in the MCP catalog.

- documentationUrl: https://docs.railway.com/cli/mcp ✓
- repoUrl: https://github.com/railwayapp/cli (active, MIT) ✓
- Comparison table vs Fly.io/DigitalOcean/Vercel/Render ✓
- safetyNotes: full account access, env var exposure ✓
- privacyNotes: credential handling ✓