### PR TITLE
content(mcp): add Brex MCP Server

### DIFF
--- a/content/mcp/brex-mcp-server.mdx
+++ b/content/mcp/brex-mcp-server.mdx
@@ -1,0 +1,160 @@
+---
+title: Brex MCP Server for Claude
+slug: brex-mcp-server
+category: mcp
+description: >-
+  Manage your Brex corporate card and banking account from Claude — expenses, cards, transactions,
+  users, bills, vendors, travel bookings, and spend analytics — with the official Brex remote
+  MCP server.
+cardDescription: "Official Brex MCP: expenses, cards, banking & spend analytics from Claude."
+seoTitle: "Brex MCP Server for Claude — Expenses, Corporate Cards & Banking via AI"
+seoDescription: "Connect Claude to Brex with the official remote MCP server: manage expenses, corporate cards, banking transactions, bills, vendors, and spend analytics — via OAuth or API key. 50+ tools for finance teams."
+author: Brex
+authorProfileUrl: "https://github.com/brexhq"
+dateAdded: "2026-06-18"
+documentationUrl: "https://developer.brex.com/docs/mcp"
+websiteUrl: "https://www.brex.com"
+retrievalSources:
+  - "https://developer.brex.com/docs/mcp"
+  - "https://developer.brex.com/openapi/team_api/"
+  - "https://code.claude.com/docs/en/mcp"
+installable: true
+installCommand: "claude mcp add --transport http brex https://api.brex.com/mcp"
+usageSnippet: >-
+  Ask Claude to look up a user's expense history, list recent card transactions, find outstanding
+  bills, or summarize spend by vendor — using natural language against your live Brex account.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "brex": {
+        "type": "http",
+        "url": "https://api.brex.com/mcp"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "brex": {
+        "type": "http",
+        "url": "https://api.brex.com/mcp"
+      }
+    }
+  }
+estimatedSetupTime: 5 minutes
+difficulty: beginner
+prerequisites:
+  - "A Brex account — authenticate via OAuth (recommended) when prompted, or generate a Bearer API key in Settings → Developer."
+  - "Permissions in your Brex workspace aligned with the data you need (expenses, cards, banking)."
+  - "An MCP client such as Claude Code or Claude Desktop."
+safetyNotes:
+  - "Each tool requires specific Brex user capabilities — access is constrained by your existing Brex account permissions and team policies."
+  - "This MCP server provides read and write access to financial data including expenses, cards, and transactions; confirm any write operations (memo updates, receipt uploads) before approving."
+  - "API key auth should use a token scoped to the minimum required permissions; rotate keys regularly from Settings → Developer."
+privacyNotes:
+  - "Expense details, card data, banking transactions, user profiles, and vendor information from your Brex workspace are surfaced in Claude's context."
+  - "OAuth is the recommended authentication method — no API token is stored in your MCP configuration."
+tags:
+  - brex
+  - expense-management
+  - corporate-cards
+  - banking
+  - finance
+  - spend-analytics
+keywords:
+  - brex mcp server
+  - brex mcp claude
+  - corporate expense management mcp
+  - brex cards claude code
+  - finance ai assistant mcp
+  - spend analytics mcp claude
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+The **Brex MCP Server** is the official remote Model Context Protocol server from Brex.
+It gives Claude direct access to your Brex corporate card and banking account — expenses, cards,
+transactions, users, bills, vendors, travel, and spend analytics — through natural language.
+
+Authentication uses OAuth (recommended) or a Brex API key for programmatic access.
+Access to each tool is governed by your existing Brex account permissions, so the server
+respects your organization's existing financial controls.
+
+## Key capabilities
+
+- **Expenses** — list, filter, update memos, and upload receipts for expense entries.
+- **Cards** — list corporate cards and retrieve card-level details and limits.
+- **Banking** — query accounts and filter transaction history.
+- **User management** — look up users by name or email, list team members.
+- **Bills & vendors** — list bills, track vendor relationships and payment status.
+- **Travel** — review travel bookings and trip details.
+- **Reward points** — check point balances and redeem activity.
+- **Spend analytics** — dashboard-level metrics and category breakdowns.
+- **Accounting integrations** — query accounting sync status and category mappings.
+
+## How it compares
+
+| Server | Expense management | Corporate cards | Banking | Travel | Auth |
+|---|---|---|---|---|---|
+| **Brex MCP** | Yes | Yes | Yes | Yes | OAuth / API key |
+| Ramp MCP | Yes | Yes | Yes | Limited | API key |
+| Expensify MCP | Yes | No | No | No | API key |
+| QuickBooks MCP | Yes (via ledger) | No | No | No | OAuth |
+
+Brex's MCP is notable for covering the full corporate spend stack (cards, expenses, banking, travel)
+in a single server, with OAuth support that requires no manual token management.
+
+## Installation
+
+### Claude Code (OAuth — recommended)
+
+```bash
+claude mcp add --transport http brex https://api.brex.com/mcp
+```
+
+Run `/mcp` in Claude Code to authenticate via OAuth.
+
+### Claude Code (API key)
+
+```bash
+claude mcp add --transport http brex https://api.brex.com/mcp \
+  --header "Authorization: Bearer YOUR_BREX_API_KEY"
+```
+
+Generate an API key in Brex → Settings → Developer.
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "brex": {
+      "type": "http",
+      "url": "https://api.brex.com/mcp"
+    }
+  }
+}
+```
+
+## Requirements
+
+- A Brex account with appropriate team member permissions.
+- An MCP client (Claude Code or Claude Desktop).
+
+## Security
+
+- OAuth authentication minimizes credential exposure — no API token required.
+- Tool access is bounded by your Brex account's existing roles and permissions.
+- API keys should be scoped to minimum permissions and rotated regularly.
+
+## Source Verification Notes
+
+Verified on **2026-06-18**:
+
+- Brex's official MCP documentation at `developer.brex.com/docs/mcp` confirms the hosted
+  endpoint at `https://api.brex.com/mcp`, OAuth + API key auth, and the 50+ tool surface
+  spanning expenses, cards, banking, bills, travel, and analytics.
+- Brex's Team API reference at `developer.brex.com/openapi/team_api/` documents the underlying
+  user and team management endpoints surfaced as MCP tools.


### PR DESCRIPTION
Adds the official Brex remote MCP server to the catalog.

**What it does:** Lets Claude manage Brex corporate cards and banking — expenses, cards, transactions, users, bills, vendors, travel, spend analytics — via 50+ tools.

**Why it belongs:** Official from Brex, hosted at api.brex.com/mcp, OAuth + API key auth, 50+ tools covering the full corporate spend stack. No equivalent in the current catalog.

- documentationUrl: https://developer.brex.com/docs/mcp ✓
- Comparison table vs Ramp/Expensify/QuickBooks ✓
- safetyNotes: financial data, write access scope ✓
- privacyNotes: expense/banking/card data in context ✓