### PR TITLE
docs(content): add Liveblocks MCP server

### DIFF
--- a/content/mcp/liveblocks-mcp-server.mdx
+++ b/content/mcp/liveblocks-mcp-server.mdx
@@ -1,0 +1,182 @@
+---
+title: Liveblocks MCP Server for Claude
+slug: liveblocks-mcp-server
+category: mcp
+description: >-
+  Manage Liveblocks real-time collaboration infrastructure from Claude — create and manage
+  rooms, broadcast events, retrieve collaborative storage and Yjs documents, manage threads
+  and comments, handle inbox notifications, and configure notification settings — with the
+  official Liveblocks MCP server.
+cardDescription: "Official Liveblocks MCP: rooms, real-time events, threads, comments & inbox notifications from Claude."
+seoTitle: "Liveblocks MCP Server for Claude — Rooms, Real-Time Events, Threads & Collaborative Storage"
+seoDescription: "Connect Claude to Liveblocks with the official MCP server: create and manage collaboration rooms, broadcast events, retrieve Yjs documents, manage threads and comments, handle inbox notifications, and configure notification settings — Apache-2.0 licensed."
+author: Liveblocks
+authorProfileUrl: "https://github.com/liveblocks"
+dateAdded: "2026-06-18"
+documentationUrl: "https://raw.githubusercontent.com/liveblocks/liveblocks-mcp-server/main/README.md"
+websiteUrl: "https://liveblocks.io"
+repoUrl: "https://github.com/liveblocks/liveblocks-mcp-server"
+retrievalSources:
+  - "https://raw.githubusercontent.com/liveblocks/liveblocks-mcp-server/main/README.md"
+  - "https://code.claude.com/docs/en/mcp"
+installable: true
+installCommand: "claude mcp add liveblocks -e LIVEBLOCKS_SECRET_KEY=sk_<your-key> -- npx -y github:liveblocks/liveblocks-mcp-server"
+usageSnippet: >-
+  Ask Claude to list all active Liveblocks rooms, retrieve the collaborative storage state
+  from a room, broadcast an event to all connected users, manage comment threads, or check
+  inbox notifications for a specific user — using natural language against the Liveblocks API.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "liveblocks": {
+        "command": "npx",
+        "args": ["-y", "github:liveblocks/liveblocks-mcp-server"],
+        "env": {
+          "LIVEBLOCKS_SECRET_KEY": "sk_<your-key>"
+        }
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "liveblocks": {
+        "command": "npx",
+        "args": ["-y", "github:liveblocks/liveblocks-mcp-server"],
+        "env": {
+          "LIVEBLOCKS_SECRET_KEY": "sk_<your-key>"
+        }
+      }
+    }
+  }
+estimatedSetupTime: 5 minutes
+difficulty: beginner
+prerequisites:
+  - "A Liveblocks account — sign up at liveblocks.io."
+  - "A Liveblocks secret key from the Dashboard: Project Settings → API Keys → Secret key."
+  - "Node.js with `npx` available."
+  - "An MCP client such as Claude Code or Claude Desktop."
+safetyNotes:
+  - "Tools can create, update, and delete rooms, threads, and comments — changes affect your live Liveblocks collaboration infrastructure."
+  - "Broadcasting events via `broadcast-event` sends real-time messages to all connected users in a room immediately."
+privacyNotes:
+  - "Room metadata, collaborative storage content, Yjs document state, thread and comment content, and user notification settings from your Liveblocks project are surfaced in Claude's context."
+  - "Your `LIVEBLOCKS_SECRET_KEY` grants full project API access — keep it in the MCP config env and never commit it."
+tags:
+  - liveblocks
+  - real-time
+  - collaboration
+  - comments
+  - notifications
+  - yjs
+keywords:
+  - liveblocks mcp server
+  - liveblocks mcp claude
+  - real-time collaboration mcp claude code
+  - liveblocks rooms mcp
+  - collaborative editing ai claude
+  - liveblocks threads mcp claude
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+The **Liveblocks MCP Server** is the official Model Context Protocol server from Liveblocks,
+the platform for building real-time collaborative features. It provides 39 tools covering rooms,
+collaborative storage, Yjs documents, threads, comments, inbox notifications, and notification
+settings — giving Claude direct management access to your Liveblocks collaboration
+infrastructure. Apache-2.0 licensed.
+
+Note: The package is installed directly from GitHub (not yet published to npm registry) using
+the `github:` specifier.
+
+## Key capabilities
+
+- **Rooms** — create, get, update, and delete collaboration rooms; get active users.
+- **Events** — broadcast real-time events to all users in a room.
+- **Storage** — retrieve collaborative storage documents.
+- **Yjs documents** — get Yjs document state from rooms.
+- **Threads** — create, manage, and resolve comment threads.
+- **Comments** — create, edit, and react to comments within threads.
+- **Inbox notifications** — get, trigger, and mark notifications.
+- **Notification settings** — update and retrieve notification preferences.
+
+## Tools (39 total, key selection)
+
+| Tool | Category | Purpose |
+|---|---|---|
+| `get-rooms` / `create-room` / `update-room` / `delete-room` | Rooms | Room lifecycle |
+| `get-active-users` | Rooms | List active users in a room |
+| `broadcast-event` | Events | Send real-time event to room users |
+| `get-storage-document` | Storage | Retrieve collaborative storage state |
+| `get-yjs-document` | Storage | Get Yjs document from a room |
+| `get-threads` / `create-thread` / `edit-thread-metadata` / `mark-thread-as-resolved` | Threads | Thread management |
+| `create-comment` / `edit-comment` / `add-comment-reaction` | Comments | Comment management |
+| `get-inbox-notifications` / `trigger-inbox-notification` | Notifications | Inbox management |
+| `subscribe-to-thread` / `unsubscribe-from-thread` | Notifications | Thread subscriptions |
+| `get-notification-settings` / `update-notification-settings` | Settings | Notification prefs |
+
+## How it compares
+
+| Server | Real-time rooms | Collaborative storage | Thread/comments | Inbox | Notes |
+|---|---|---|---|---|---|
+| **Liveblocks MCP** | Yes | Yes | Yes | Yes | Official, 39 tools |
+| Pusher MCP | Yes (channels) | No | No | No | Event broadcasting |
+| Socket.io MCP | Limited | No | No | No | Community |
+
+Liveblocks MCP is the only real-time collaboration infrastructure MCP with integrated
+comment threads, Yjs document access, and inbox notification management.
+
+## Installation
+
+### Claude Code
+
+```bash
+claude mcp add liveblocks \
+  -e LIVEBLOCKS_SECRET_KEY=sk_<your-key> \
+  -- npx -y github:liveblocks/liveblocks-mcp-server
+```
+
+### Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "liveblocks": {
+      "command": "npx",
+      "args": ["-y", "github:liveblocks/liveblocks-mcp-server"],
+      "env": {
+        "LIVEBLOCKS_SECRET_KEY": "sk_<your-key>"
+      }
+    }
+  }
+}
+```
+
+Get your secret key from **Dashboard → Project Settings → API Keys → Secret key** (format:
+`sk_prod_...` or `sk_dev_...`).
+
+## Requirements
+
+- A Liveblocks account with at least one project.
+- Secret key (`sk_...`) from the Liveblocks Dashboard.
+- Node.js (for `npx`).
+- An MCP client (Claude Code or Claude Desktop).
+
+## Security
+
+- `LIVEBLOCKS_SECRET_KEY` grants full project API access — never commit it or share it.
+- Broadcasting events is instant — confirm the target room before triggering.
+- Use separate `sk_dev_...` keys for development to avoid affecting production rooms.
+
+## Source Verification Notes
+
+Verified on **2026-06-18**:
+
+- Official repository `liveblocks/liveblocks-mcp-server` (Apache-2.0) documents the GitHub
+  specifier install, `LIVEBLOCKS_SECRET_KEY` configuration (format `sk_...`), all 39 tools
+  across rooms, events, storage, Yjs, threads, comments, inbox notifications, and notification
+  settings.
+- Claude Code MCP documentation at `code.claude.com/docs/en/mcp` describes the stdio connector
+  pattern used above.


### PR DESCRIPTION
Adds the official Liveblocks MCP server entry.

- **Repo**: liveblocks/liveblocks-mcp-server (Apache-2.0, 16 stars)
- **Install**: `npx -y github:liveblocks/liveblocks-mcp-server` with `LIVEBLOCKS_SECRET_KEY`
- **Capabilities**: 39 tools — rooms, real-time events, collaborative storage, Yjs docs, threads, comments, inbox notifications
- **documentationUrl**: raw README (SSR, 200)