### PR TITLE
fix(content): keep Aiven MCP config read-only

### DIFF
--- a/content/mcp/aiven-mcp-server.mdx
+++ b/content/mcp/aiven-mcp-server.mdx
@@ -45,7 +45,7 @@ configSnippet: |-
         "args": ["-y", "mcp-aiven"],
         "env": {
           "AIVEN_TOKEN": "<your-token>",
-          "AIVEN_READ_ONLY": "false",
+          "AIVEN_READ_ONLY": "true",
           "AIVEN_SERVICES_SCOPE": "kafka,pg"
         }
       }


### PR DESCRIPTION
### Motivation
- The published MCP `configSnippet` exposed a copyable payload that set `AIVEN_READ_ONLY` to `"false"`, which could accidentally enable account-level write operations; the default should be read-only to match the documented security guidance.

### Description
- Updated `content/mcp/aiven-mcp-server.mdx` to set `AIVEN_READ_ONLY` to `"true"` in the copyable `configSnippet`, preserving `AIVEN_SERVICES_SCOPE` and the existing safety/privacy notes.

### Testing
- Ran `pnpm validate:content:strict` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33af20b588832caa8fd3a1a5cadfa9)