### PR TITLE
fix(content): clarify Grounded Docs MCP privacy exposure

### DIFF
--- a/content/mcp/arabold-docs-mcp-server.mdx
+++ b/content/mcp/arabold-docs-mcp-server.mdx
@@ -49,11 +49,11 @@ prerequisites:
   - "Start the server with `npx @arabold/docs-mcp-server@latest` before connecting — it listens at http://localhost:6280."
   - "An MCP client such as Claude Code or Claude Desktop."
 safetyNotes:
-  - "The server runs entirely on your machine — no data is sent to external services; all indexed content and queries stay local."
-  - "The `scrape` tool fetches URLs and GitHub repos from the internet to build the index — only scrape documentation you are authorized to access."
+  - "The server stores its index locally, but MCP tool arguments and returned search/fetch results can be visible to your MCP client and model provider transcript."
+  - "The `scrape_documentation` and `fetch_url` tools can fetch URLs, GitHub repos, packages, or local paths — only index sources you are authorized to access and constrain local paths and network targets."
 privacyNotes:
-  - "All indexed documentation and search queries stay within your local environment — nothing is sent to external APIs."
-  - "Scraped content (HTML, Markdown, PDF, Office documents, source code) is stored in a local SQLite database on your machine."
+  - "Indexed documentation, local file contents, URLs, search queries, extracted text, and search results may be exposed to Claude or another MCP client when tools are invoked."
+  - "Scraped content (HTML, Markdown, PDF, Office documents, source code) is stored in a local SQLite database on your machine; avoid indexing secrets, private repositories, internal URLs, or sensitive folders unless you intend them to be available through MCP results."
 tags:
   - documentation
   - semantic-search
@@ -173,9 +173,11 @@ npx @arabold/docs-mcp-server@latest search react "useEffect cleanup" --output ya
 
 ## Security
 
-- Fully local — no network traffic to external APIs.
-- All data stored in a local SQLite database; only `scrape_documentation` makes outbound requests
-  to fetch the source URLs you specify.
+- The index is stored in a local SQLite database, but MCP tool arguments, fetched URLs, extracted
+  text, search queries, and search results can be sent to the connected MCP client and may appear
+  in the model-provider transcript.
+- `scrape_documentation` and `fetch_url` make outbound requests for the sources you specify; limit
+  them to trusted, authorized network targets and local paths.
 
 ## Source Verification Notes
 


### PR DESCRIPTION
### Motivation
- The original MCP listing made broad claims that "nothing is sent to external APIs" while advertising indexing of local files and fetched URLs, which can mislead users about potential disclosure of indexed content through MCP tool outputs and the model-provider transcript. 
- The listing needs explicit, accurate privacy/safety guidance so users know to avoid indexing secrets, internal URLs, or sensitive local folders without intent to expose them via MCP results.

### Description
- Update `content/mcp/arabold-docs-mcp-server.mdx` to replace overbroad locality claims with a clear disclosure that MCP tool arguments and returned search/fetch results can be visible to the connected MCP client and may appear in the model-provider transcript.  
- Replace the blanket "no data is sent to external services" and "nothing is sent to external APIs" language with scoped guidance that `scrape_documentation` and `fetch_url` make outbound requests and that local paths and network targets should be constrained.  
- Add explicit privacy guidance advising maintainers to avoid indexing secrets, private repositories, internal URLs, or sensitive folders unless those contents are intended to be available through MCP results.  
- Update the Security section to disclose that fetched URLs, extracted text, search queries, and search results can be sent to the connected MCP client and may appear in the transcript, and to recommend limiting outbound fetch targets.

### Testing
- Ran `pnpm validate:content:strict` and validation passed.  
- Ran `git diff --check` to ensure no repository formatting issues were introduced and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33af24748c832cbdd6990f6d5e4292)