### PR TITLE
fix(seo): guard audit import entrypoint

### DIFF
--- a/scripts/audit-seo-snippets.mjs
+++ b/scripts/audit-seo-snippets.mjs
@@ -245,7 +245,10 @@ export async function main(argv = process.argv.slice(2)) {
   return all;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
   main().catch((error) => {
     console.error(error instanceof Error ? error.message : error);
     process.exit(1);

--- a/tests/audit-seo-snippets.test.ts
+++ b/tests/audit-seo-snippets.test.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from "node:child_process";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -134,5 +136,20 @@ describe("auditEntries", () => {
 describe("normalizeSnippet", () => {
   it("collapses whitespace and lowercases", () => {
     expect(normalizeSnippet("  Foo   Bar\n")).toBe("foo bar");
+  });
+});
+
+describe("module import", () => {
+  it("does not run the CLI guard when process.argv[1] is absent", () => {
+    const output = execFileSync(
+      process.execPath,
+      [
+        "-e",
+        "import('./scripts/audit-seo-snippets.mjs').then(({ auditEntries }) => console.log(typeof auditEntries))",
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    expect(output.trim()).toBe("function");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the ESM module from throwing a TypeError during import in Node execution modes that don't set `process.argv[1]`, so exported helpers can be imported safely (e.g., `node -e "import('./scripts/audit-seo-snippets.mjs')"`).

### Description
- Add a presence check for `process.argv[1]` before passing it to `pathToFileURL` in `scripts/audit-seo-snippets.mjs` so the direct-execution guard no longer crashes during import. 
- Add a regression test in `tests/audit-seo-snippets.test.ts` that uses `node -e` to import the module and verifies the exported `auditEntries` helper remains accessible. 
- Run `prettier --write` formatting on the touched files to keep style consistent.

### Testing
- Ran the unit tests with `pnpm exec vitest run tests/audit-seo-snippets.test.ts` and all tests passed. 
- Verified the module can be imported via `node -e "import('./scripts/audit-seo-snippets.mjs').then(({ auditEntries }) => console.log(typeof auditEntries))"` and it prints `function`. 
- Ran `pnpm exec prettier --check scripts/audit-seo-snippets.mjs tests/audit-seo-snippets.test.ts` and `git diff --check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33b784dd68832cb045c9d2a33a0498)