### PR TITLE
fix(registry): preserve explicit retrievalSources for non-skill entries

### DIFF
--- a/packages/registry/src/content-schema.js
+++ b/packages/registry/src/content-schema.js
@@ -600,16 +600,13 @@ export function inferStructuredFields(data, body, category) {
           ? String(data.dateAdded).trim()
           : ""
       : "";
-  const retrievalSources =
-    category === "skills"
-      ? Array.isArray(data.retrievalSources)
-        ? data.retrievalSources
-            .map(String)
-            .map((value) => value.trim())
-            .filter(Boolean)
-        : data.documentationUrl
-          ? [String(data.documentationUrl).trim()]
-          : []
+  const retrievalSources = Array.isArray(data.retrievalSources)
+    ? data.retrievalSources
+        .map(String)
+        .map((value) => value.trim())
+        .filter(Boolean)
+    : category === "skills" && data.documentationUrl
+      ? [String(data.documentationUrl).trim()]
       : [];
   const testedPlatforms =
     category === "skills"

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -28,6 +28,26 @@ describe("inferStructuredFields", () => {
     expect(inferred.copySnippet).toBe("## Rule Body\n\nUse these rules.");
   });
 
+  it("preserves explicit retrieval sources for rules entries", () => {
+    const inferred = inferStructuredFields(
+      {
+        documentationUrl: "https://aws.amazon.com/architecture/well-architected/",
+        retrievalSources: [
+          "https://aws.amazon.com/architecture/well-architected/",
+          " https://docs.aws.amazon.com/ ",
+          "",
+        ],
+      },
+      "## Usage\n\nUse AWS rules.",
+      "rules",
+    );
+
+    expect(inferred.retrievalSources).toEqual([
+      "https://aws.amazon.com/architecture/well-architected/",
+      "https://docs.aws.amazon.com/",
+    ]);
+  });
+
   it("does not infer guide code examples as install commands", () => {
     const inferred = inferStructuredFields(
       {},


### PR DESCRIPTION
### Motivation
- A rules entry added `retrievalSources` frontmatter but the registry inference only preserved retrievalSources for `skills`, causing explicit source metadata for other categories to be dropped.
- The intent is to preserve explicit source grounding metadata supplied by authors while retaining the existing `documentationUrl` fallback for skills when explicit `retrievalSources` is not provided.

### Description
- Update `packages/registry/src/content-schema.js` to accept and normalize an explicit `retrievalSources` array for all categories and to keep the `documentationUrl` fallback only for `skills` when `retrievalSources` is absent.
- Add a regression test in `tests/content-schema.test.ts` that asserts rules entries with explicit `retrievalSources` are trimmed, filtered, and preserved as inferred fields.
- The change preserves prior behavior for `skills` (still falls back to `documentationUrl` when `retrievalSources` is omitted) and only surfaces explicit frontmatter that was previously discarded.

### Testing
- Ran `pnpm exec vitest run tests/content-schema.test.ts` and the test suite passed (all tests in the file succeeded).
- Ran `pnpm validate:packages` which completed without errors.
- Ran `git diff --check` which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33bfe2b200832caac6118405a4bf01)