### PR TITLE
fix(content): remove generic hook docs provenance

### DIFF
--- a/content/hooks/team-summary-email-generator.mdx
+++ b/content/hooks/team-summary-email-generator.mdx
@@ -15,9 +15,6 @@ seoDescription: >-
   com...
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
-documentationUrl: "https://code.claude.com/docs/en/hooks"
-retrievalSources:
-  - "https://code.claude.com/docs/en/hooks"
 dateAdded: "2025-09-19"
 installable: true
 installCommand: >-


### PR DESCRIPTION
### Motivation
- Remove a generic `documentationUrl` and `retrievalSources` from the Team Summary Email Generator entry because the registry treated any documentation URL as source evidence and this generic docs link incorrectly elevated the hook to `source-backed` provenance.

### Description
- Deleted the `documentationUrl` and `retrievalSources` fields from `content/hooks/team-summary-email-generator.mdx` so the entry no longer cites the generic Claude hooks docs as source provenance.

### Testing
- Ran `pnpm validate:content:strict` which passed, and `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33bfe32980832cb66ae640e9cc54d4)