### PR TITLE
fix(registry): preserve inline content provenance

### DIFF
--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -1060,7 +1060,7 @@ export function buildPluginExportFeed(entries) {
     category: entry.category,
     ...buildEntryProvenanceFields(entry),
     ...buildEntryBrandFields(entry),
-    sourceUrl: entry.repoUrl || entry.documentationUrl || entry.githubUrl,
+    sourceUrl: entry.repoUrl || entry.githubUrl || entry.documentationUrl,
     installCommand: entry.installCommand || entry.commandSyntax || "",
     platformCompatibility:
       entry.category === "skills" ? buildSkillPlatformCompatibility(entry) : [],

--- a/packages/registry/src/content-schema.js
+++ b/packages/registry/src/content-schema.js
@@ -434,15 +434,6 @@ export function inferRepoUrl(data = {}) {
     return String(data.repoUrl);
   }
 
-  if (
-    data.documentationUrl &&
-    /^https:\/\/github\.com\/[^/]+\/[^/]+\/?$/i.test(
-      String(data.documentationUrl).trim(),
-    )
-  ) {
-    return String(data.documentationUrl).trim();
-  }
-
   return "";
 }
 

--- a/tests/provenance.test.ts
+++ b/tests/provenance.test.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { buildPluginExportFeed } from "@heyclaude/registry";
+import { buildContentEntryFromMdx } from "@heyclaude/registry/content-builder";
+
+const repoRoot = process.cwd();
+
+describe("registry provenance", () => {
+  it("does not promote documentation-only GitHub URLs to source repositories", () => {
+    const entry = buildContentEntryFromMdx({
+      category: "hooks",
+      fileName: "documentation-only-hook.mdx",
+      filePath: path.join(repoRoot, "content/hooks/documentation-only-hook.mdx"),
+      repoRoot,
+      contentRoot: path.join(repoRoot, "content"),
+      source: `---
+title: Documentation Only Hook
+slug: documentation-only-hook
+category: hooks
+description: Demonstrates that documentation links do not become provenance.
+cardDescription: Documentation-only source provenance fixture.
+dateAdded: 2026-06-18
+documentationUrl: https://github.com/example/documentation-project
+---
+Use this hook after reviewing the documentation.`,
+    });
+
+    expect(entry.repoUrl).toBeNull();
+    expect(entry.githubUrl).toBe(
+      "https://github.com/JSONbored/awesome-claude/blob/main/content/hooks/documentation-only-hook.mdx",
+    );
+
+    const [plugin] = buildPluginExportFeed([entry]).plugins;
+    expect(plugin.sourceUrl).toBe(entry.githubUrl);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent documentation-only GitHub URLs from being treated as the implementation repository and thus spoofing provenance for inline registry content.
- Ensure public feeds and UI show the actual registry `githubUrl` for inline content when no explicit `repoUrl` is provided.

### Description
- Stop inferring `repoUrl` from a bare `documentationUrl` by removing the GitHub-URL fallback in `inferRepoUrl` in `packages/registry/src/content-schema.js`.
- Prefer the registry `githubUrl` over `documentationUrl` when building plugin feed entries by changing the `sourceUrl` order in `packages/registry/src/artifacts.js` to `entry.repoUrl || entry.githubUrl || entry.documentationUrl`.
- Add a regression test `tests/provenance.test.ts` that verifies documentation-only GitHub links do not become `repoUrl` and that plugin feed `sourceUrl` uses the inline `githubUrl`.

### Testing
- Ran `pnpm exec vitest run tests/provenance.test.ts` and the new test passed.
- Ran `pnpm validate:content:strict` and `pnpm validate:packages` and both validations passed.
- Ran `git diff --check` and no whitespace or diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33bdde7208832cb5c3f8116f89275e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL resolution precedence to prioritize explicit repository URLs over documentation URLs, preventing documentation-only URLs from being incorrectly treated as source repositories.

* **Tests**
  * Added test coverage to verify proper handling of documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->