### PR TITLE
fix(content): correct docker scanner provenance

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -19,7 +19,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
-documentationUrl: "https://github.com/aquasecurity/trivy"
+documentationUrl: "https://aquasecurity.github.io/trivy/latest/"
 retrievalSources:
   - "https://github.com/aquasecurity/trivy"
   - "https://code.claude.com/docs/en/hooks"


### PR DESCRIPTION
### Motivation
- Prevent the registry/web pipeline from misattributing this in-repo hook to `aquasecurity/trivy` by removing a top-level GitHub `documentationUrl` that was being promoted to `repoUrl` during inference.

### Description
- Change `content/hooks/docker-image-security-scanner.mdx` to set `documentationUrl` to `https://aquasecurity.github.io/trivy/latest/` instead of `https://github.com/aquasecurity/trivy`, while preserving the `retrievalSources` entries; this prevents `inferRepoUrl` from producing an external `repoUrl` for the hook.

### Testing
- Ran a focused Node check using `inferStructuredFields` which confirmed no `repoUrl` is inferred for the updated file (passes).
- Ran `pnpm validate:content:strict` which completed successfully.
- Ran `git diff --check` to ensure no whitespace or formatting issues (no problems).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33c18c25cc832c9acfe19339562abd)