### PR TITLE
docs(content): add community cybersecurity agent skills

### DIFF
--- a/content/skills/community-cybersecurity-agent-skills.mdx
+++ b/content/skills/community-cybersecurity-agent-skills.mdx
@@ -1,0 +1,238 @@
+---
+title: Community Cybersecurity Agent Skills
+slug: community-cybersecurity-agent-skills
+category: skills
+description: >-
+  Independent community library of 754 cybersecurity Agent Skills mapped to
+  MITRE ATT&CK, NIST CSF 2.0, MITRE ATLAS, D3FEND, and NIST AI RMF for
+  defensive security analysis, incident response, forensics, cloud security,
+  SOC operations, and governed red-team workflows.
+cardDescription: >-
+  Community cybersecurity skills library for AI agents, with 754 Agent Skills
+  across 26 domains and five security framework mappings.
+seoTitle: Community Cybersecurity Agent Skills for Claude Code, Codex, and SOC Teams
+seoDescription: >-
+  Install a community cybersecurity Agent Skills library for Claude Code, Codex,
+  Cursor, Copilot, Gemini, and compatible agents, with 754 security skills for
+  DFIR, threat hunting, SOC, cloud, API security, malware analysis, and MITRE
+  framework mapped workflows.
+author: Mahipal Nehra
+authorProfileUrl: "https://github.com/mukul975"
+dateAdded: "2026-06-18"
+repoUrl: "https://github.com/mukul975/Anthropic-Cybersecurity-Skills"
+documentationUrl: "https://github.com/mukul975/Anthropic-Cybersecurity-Skills#readme"
+websiteUrl: "https://www.mahipal.engineer/Anthropic-Cybersecurity-Skills/"
+downloadUrl: "https://github.com/mukul975/Anthropic-Cybersecurity-Skills/archive/refs/heads/main.zip"
+installable: true
+installCommand: "npx skills add mukul975/Anthropic-Cybersecurity-Skills"
+usageSnippet: >-
+  Install the community cybersecurity skills library, then use scoped,
+  authorized, defensive workflows for incident response, forensics, threat
+  hunting, cloud security, SOC analysis, and compliance mapping.
+copySnippet: |-
+  npx skills add mukul975/Anthropic-Cybersecurity-Skills
+
+  # Update installed skills
+  npx skills update
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-18"
+retrievalSources:
+  - "https://github.com/mukul975/Anthropic-Cybersecurity-Skills"
+  - "https://raw.githubusercontent.com/mukul975/Anthropic-Cybersecurity-Skills/main/README.md"
+  - "https://raw.githubusercontent.com/mukul975/Anthropic-Cybersecurity-Skills/main/skills/performing-memory-forensics-with-volatility3/SKILL.md"
+  - "https://raw.githubusercontent.com/mukul975/Anthropic-Cybersecurity-Skills/main/skills/analyzing-azure-activity-logs-for-threats/SKILL.md"
+  - "https://raw.githubusercontent.com/mukul975/Anthropic-Cybersecurity-Skills/main/skills/analyzing-email-headers-for-phishing-investigation/SKILL.md"
+  - "https://raw.githubusercontent.com/mukul975/Anthropic-Cybersecurity-Skills/main/LICENSE"
+  - "https://www.mahipal.engineer/Anthropic-Cybersecurity-Skills/"
+testedPlatforms:
+  - Claude Code
+  - Codex
+  - GitHub Copilot
+  - Cursor
+  - Gemini CLI
+  - Agent Skills compatible hosts
+prerequisites:
+  - "An Agent Skills compatible host or local skill installer."
+  - "Explicit authorization for the systems, logs, samples, accounts, networks, cloud resources, or artifacts being analyzed."
+  - "A defined defensive, incident-response, forensics, audit, training, or approved red-team objective before loading sensitive skills."
+  - "Relevant security tools installed only when a specific skill requires them, such as Volatility 3, SIEM access, cloud CLIs, malware-analysis sandboxes, or forensic utilities."
+  - "Data-handling rules for evidence, customer data, malware samples, credentials, logs, and generated reports."
+safetyNotes:
+  - "This is an independent community project, not an official Anthropic project, even though the upstream repository name contains `Anthropic`."
+  - "Cybersecurity skills can include dual-use topics such as penetration testing, red teaming, malware analysis, credential-theft detection, cloud breach investigation, and vulnerability management."
+  - "Use these skills only for authorized defensive work, sanctioned assessments, training labs, or internal security operations."
+  - "Do not use the skills to attack third-party systems, evade detection, steal credentials, deploy malware, persist in environments, or bypass access controls."
+  - "Keep potentially destructive actions, exploit validation, live cloud changes, quarantine operations, and report publication behind human review."
+privacyNotes:
+  - "Security workflows can expose memory dumps, disk images, network captures, logs, SIEM queries, credentials in evidence, malware samples, customer records, internal hostnames, IP addresses, cloud subscription IDs, and incident timelines."
+  - "Agent prompts and tool calls may reveal sensitive indicators, detections, internal controls, incident scope, and defensive gaps to the model provider or connected tooling."
+  - "Redact secrets, customer data, private infrastructure details, and regulated evidence before sharing prompts, examples, issues, PRs, screenshots, or generated reports."
+  - "Follow evidence handling, chain-of-custody, malware containment, legal, and disclosure requirements for the environment being investigated."
+tags:
+  - cybersecurity
+  - skills
+  - dfir
+  - incident-response
+  - threat-hunting
+  - soc
+  - mitre-attack
+  - cloud-security
+keywords:
+  - cybersecurity agent skills
+  - Claude Code cybersecurity skills
+  - Codex cybersecurity skills
+  - MITRE ATT&CK agent skills
+  - DFIR AI skills
+  - SOC agent skills
+  - incident response skills
+  - Anthropic Cybersecurity Skills community
+  - agentskills cybersecurity
+readingTime: 8
+difficultyScore: 88
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+# Community Cybersecurity Agent Skills
+
+`mukul975/Anthropic-Cybersecurity-Skills` is an independent community library of
+cybersecurity Agent Skills. The README states that it contains 754 structured
+skills across 26 security domains, mapped to MITRE ATT&CK, NIST CSF 2.0, MITRE
+ATLAS, MITRE D3FEND, and NIST AI RMF.
+
+Use this listing for the community skills library itself. It is not affiliated
+with Anthropic PBC; the upstream README explicitly labels it as an independent
+community project.
+
+## Knowledge Freshness
+
+Security frameworks, tools, cloud audit APIs, detection logic, malware-analysis
+methods, and attack techniques change frequently. The README references current
+framework coverage, but users should verify framework versions, tool commands,
+cloud APIs, detections, and legal constraints before applying a workflow to real
+evidence or live systems.
+
+Use these skills as structured workflow guidance for authorized security work,
+then check current vendor docs, security-tool manuals, organizational policy,
+and local evidence-handling requirements.
+
+## Retrieval Sources
+
+This listing is grounded in:
+
+- The upstream repository README.
+- The upstream license file.
+- Representative skill files for memory forensics, Azure activity-log analysis,
+  and phishing email-header investigation.
+- The public project website.
+- Current GitHub repository metadata.
+
+## Core Workflow
+
+Install the skills library:
+
+```bash
+npx skills add mukul975/Anthropic-Cybersecurity-Skills
+```
+
+Update installed skills:
+
+```bash
+npx skills update
+```
+
+Then invoke it with an authorized, scoped security task:
+
+```text
+Use the community cybersecurity Agent Skills for this authorized incident-response investigation.
+```
+
+Before executing any workflow, confirm the target scope, authorization, allowed
+tools, evidence-handling rules, and whether the work is defensive analysis,
+training, audit, or a sanctioned assessment.
+
+## Capability Scope
+
+The README describes 26 security domains:
+
+| Domain | Example scope |
+| --- | --- |
+| Digital forensics | Memory, disk, browser, timeline, and artifact analysis |
+| Incident response | Containment, ransomware response, breach analysis, and recovery |
+| Threat hunting | Hypothesis-driven hunts, log analysis, and behavioral analytics |
+| SOC operations | Alert triage, SIEM correlation, escalation, and metrics |
+| Malware analysis | Static and dynamic analysis, sandboxing, and reverse engineering |
+| Cloud security | AWS, Azure, GCP hardening, CSPM, and cloud forensics |
+| Container security | Kubernetes, image scanning, runtime detection, and container forensics |
+| API and web security | OWASP API and web application security workflows |
+| Identity and access | IAM, PAM, zero trust, Okta, and SailPoint workflows |
+| DevSecOps | CI/CD security, Terraform auditing, and code-signing checks |
+| Compliance | CIS, SOC 2, regulatory, and governance workflows |
+
+The repository structure described by the README uses per-skill folders with
+`SKILL.md`, optional `references/`, optional `scripts/`, and optional `assets/`
+for report templates or checklists.
+
+## Production Rules
+
+Use these skills with security-operations discipline:
+
+- Confirm authorization before loading or executing a skill against any system,
+  sample, account, network, log source, cloud resource, or customer artifact.
+- Prefer defensive and investigative workflows over exploit execution.
+- Keep malware samples, memory dumps, disk images, pcap files, and credentials
+  in controlled environments.
+- Treat scripts and commands from community skills as untrusted until reviewed.
+- Record evidence provenance and preserve chain-of-custody where required.
+- Redact sensitive data before sharing summaries or generated reports.
+- Separate training-lab use from production incident response.
+- Do not publish exploit steps, live credentials, customer indicators, or
+  internal defensive gaps in public artifacts.
+
+## Use Cases
+
+- Use a DFIR skill to guide memory forensics with Volatility 3 in an authorized
+  incident investigation.
+- Ask an agent to map a finding to MITRE ATT&CK, NIST CSF, ATLAS, D3FEND, or
+  AI RMF categories for reporting.
+- Guide SOC triage workflows for phishing, suspicious authentication, cloud log
+  analysis, or endpoint alerts.
+- Use cloud security skills to inspect Azure, AWS, or GCP evidence inside an
+  approved tenant or lab.
+- Use training-lab scenarios to teach analysts how to structure investigation
+  steps without exposing production data.
+
+## Source Review
+
+- The README states the project is an independent community project and not
+  affiliated with Anthropic PBC.
+- The README describes 754 structured cybersecurity skills across 26 domains.
+- The README says skills follow the agentskills.io open standard and map to
+  MITRE ATT&CK, NIST CSF 2.0, MITRE ATLAS, MITRE D3FEND, and NIST AI RMF.
+- Representative `SKILL.md` files include YAML frontmatter with domain,
+  subdomain, tags, version, author, license, and framework mappings.
+- The memory-forensics skill includes prerequisites and a stepwise workflow
+  around Volatility 3.
+- The repository reports Apache-2.0 license terms.
+
+## Duplicate Review
+
+Checked current `content/skills/`, `content/mcp/`, `content/agents/`,
+`content/tools/`, open pull requests, and repository-wide content for
+`mukul975/Anthropic-Cybersecurity-Skills`, Community Cybersecurity Agent Skills,
+Anthropic Cybersecurity Skills, cybersecurity Agent Skills, MITRE ATT&CK skills,
+DFIR AI skills, SOC agent skills, and agentskills cybersecurity. Existing
+security content covers narrower MCP servers, scanners, and review agents, but
+no dedicated community cybersecurity Agent Skills library entry, exact source
+URL duplicate, target file, or open duplicate PR was found.
+
+## Disclosure
+
+Editorial listing. No paid placement or affiliate link is used. This is an
+independent community project by Mahipal Nehra and is not affiliated with
+Anthropic PBC.


### PR DESCRIPTION
## Summary
- Add a source-backed community cybersecurity Agent Skills listing for a large independent skills library mapped to MITRE ATT&CK, NIST CSF, ATLAS, D3FEND, and AI RMF.

## What changed
- Added `content/skills/community-cybersecurity-agent-skills.mdx` with install instructions, capability scope, production rules, safety/privacy notes, source review, duplicate review, and explicit non-affiliation disclosure.

## Why
- This is high-demand skills content for AI-assisted DFIR, SOC, threat hunting, cloud security, and incident response workflows, while needing clear boundaries around independent community provenance and authorized defensive use.

## Validation
- `pnpm validate:content:strict`
- `pnpm validate:packages`
- `pnpm scan:packages`
- `pnpm validate:clean`
- `pnpm audit:content`
- `git diff --check`
- Checked source URLs for README, representative skill files, license, and project website.

## Notes
- `pnpm audit:content` rewrote `content/data/content-audit.json`; it was restored so this PR remains a one-file content submission.
- The upstream README states this is an independent community project and not affiliated with Anthropic PBC.