### PR TITLE
fix(content): harden GitLab Claude CI guide

### DIFF
--- a/content/guides/claude-code-gitlab-ci-cd-workflow.mdx
+++ b/content/guides/claude-code-gitlab-ci-cd-workflow.mdx
@@ -3,15 +3,16 @@ title: Claude Code GitLab CI/CD Workflow
 slug: claude-code-gitlab-ci-cd-workflow
 category: guides
 description: >-
-  Set up Claude Code in GitLab CI/CD with masked ANTHROPIC_API_KEY variables,
-  npm-based CLI install, claude -p jobs, and Bedrock or Vertex OIDC alternatives
-  from official GitLab integration docs.
+  Set up Claude Code in GitLab CI/CD with maintainer-approved prompts,
+  least-privilege tool access, and Bedrock or Vertex OIDC alternatives from
+  official GitLab integration docs.
 cardDescription: >-
-  Run Claude Code in GitLab CI with masked secrets, scoped jobs, and provider options.
+  Run Claude Code in GitLab CI with least-privilege tools, review gates, and provider options.
 seoTitle: Claude Code GitLab CI/CD Workflow
 seoDescription: >-
-  Guide to Claude Code GitLab CI/CD: masked variables, npm CLI install, claude -p
-  automation, GitLab MCP tools, and Bedrock or Vertex authentication from official docs.
+  Guide to Claude Code GitLab CI/CD: maintainer-approved prompts, npm CLI
+  install, claude -p automation, GitLab MCP tools, and Bedrock or Vertex
+  authentication from official docs.
 author: kiannidev
 authorProfileUrl: "https://github.com/kiannidev"
 submittedBy: kiannidev
@@ -22,18 +23,19 @@ sourceSubmissionNumber: 1390
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1390"
 documentationUrl: "https://code.claude.com/docs/en/gitlab-ci-cd"
 usageSnippet: >-
-  Add masked ANTHROPIC_API_KEY, install Claude Code with npm in a CI job, run
-  claude -p with scoped --allowedTools, and review MR output before merge.
+  Install Claude Code with npm in a manually triggered CI job, run claude -p
+  with least-privilege --allowedTools, and review MR output before merge.
 prerequisites:
   - "GitLab project with CI/CD variables permission and a protected default branch policy."
-  - "Anthropic API key or approved Bedrock or Vertex provider configuration."
+  - "Anthropic API key or approved Bedrock or Vertex provider configuration restricted to protected, maintainer-approved pipelines."
   - "Human review before merging Claude-opened merge requests."
 safetyNotes:
-  - "CI jobs run claude with --permission-mode acceptEdits in official examples—scope repositories and tools narrowly."
-  - "Never commit API keys; store ANTHROPIC_API_KEY as a masked CI/CD variable."
+  - "Do not run write-capable Claude jobs from untrusted MR, mention, or user-supplied prompt text without maintainer approval."
+  - "Avoid Bash by default; grant exact tools only for the task, and keep --permission-mode acceptEdits out of attacker-influenced flows."
+  - "Never commit API keys; store ANTHROPIC_API_KEY only in protected CI/CD variables or use cloud OIDC/WIF for protected pipelines."
   - "GitLab MCP write tools can open MRs and post comments as the job identity."
 privacyNotes:
-  - "Issue titles, MR diffs, and AI_FLOW variables enter model context during jobs."
+  - "Issue titles, MR diffs, and AI_FLOW variables can enter model context during jobs; treat them as untrusted input unless a maintainer curated them."
   - "CI logs may retain prompts—align retention with corporate policy."
 sourceUrls:
   - "https://code.claude.com/docs/en/gitlab-ci-cd"
@@ -59,25 +61,27 @@ robotsFollow: true
 ## TL;DR
 
 Official GitLab CI/CD documentation describes running Claude Code in isolated
-GitLab jobs with masked **`ANTHROPIC_API_KEY`**, repository cloning, and
-**`claude -p`** automation. This guide follows those steps using an
-**npm-based CLI install** instead of remote install scripts.
+GitLab jobs with repository cloning and **`claude -p`** automation. This guide
+uses an **npm-based CLI install** and adds safer defaults: maintainer-triggered
+jobs, protected credentials, no default Bash access, and human review before
+any generated changes are merged.
 
 ## Prerequisites & Requirements
 
-- [ ] {"task": "Masked secret", "description": "ANTHROPIC_API_KEY stored under Settings → CI/CD → Variables"}
-- [ ] {"task": "Job scope", "description": "rules limit when the Claude job runs (web, merge_request_event, or mention triggers)"}
+- [ ] {"task": "Protected secret", "description": "ANTHROPIC_API_KEY stored as a protected CI/CD variable, or replaced with Bedrock/Vertex OIDC for protected pipelines"}
+- [ ] {"task": "Job scope", "description": "rules limit write-capable Claude jobs to maintainer-triggered protected pipelines"}
 - [ ] {"task": "Review gate", "description": "Maintainers review Claude MRs like any contributor"}
 - [ ] {"task": "CLAUDE.md", "description": "Repository standards file guides automated changes"}
 
 ## Step-by-Step Setup
 
-1. Add **`ANTHROPIC_API_KEY`** as a masked (and protected if needed) CI/CD variable.
+1. Add **`ANTHROPIC_API_KEY`** only as a protected, masked CI/CD variable available to protected maintainer-triggered pipelines, or use Bedrock/Vertex OIDC for protected pipelines.
 2. Add a **`claude`** stage job using a Node image; install Git and the CLI with **`npm install -g @anthropic-ai/claude-code`**.
 3. Set **`GIT_STRATEGY: fetch`** so the job clones the target repository.
-4. Run **`claude -p`** with an explicit prompt and **`--allowedTools`** scoped to read and write needs (official examples include **`mcp__gitlab`** when GitLab MCP is enabled).
-5. Optionally enable **`/bin/gitlab-mcp-server`** when your runner image provides it.
-6. For **Amazon Bedrock** or **Google Vertex AI**, follow the OIDC or Workload Identity Federation sections in the official doc instead of **`ANTHROPIC_API_KEY`**.
+4. Run **`claude -p`** with a maintainer-controlled prompt and an exact **`--allowedTools`** list. Start read-only; add write or GitLab MCP tools only for trusted, reviewed flows.
+5. Do not grant **`Bash`** or use **`--permission-mode acceptEdits`** when prompts can be influenced by MRs, mentions, issues, or other untrusted users.
+6. Optionally enable **`/bin/gitlab-mcp-server`** when your runner image provides it and restrict GitLab MCP tools to the specific read/write actions required.
+7. For **Amazon Bedrock** or **Google Vertex AI**, follow the OIDC or Workload Identity Federation sections in the official doc instead of **`ANTHROPIC_API_KEY`**.
 
 ## Example job shape (npm install)
 
@@ -97,21 +101,24 @@ claude:
     - npm install -g @anthropic-ai/claude-code
   script:
     - >
-      claude -p "${AI_FLOW_INPUT:-'Review this MR and implement requested changes'}"
-      --permission-mode acceptEdits
-      --allowedTools "Bash Read Edit Write"
+      claude -p "${MAINTAINER_APPROVED_PROMPT:-'Summarize the repository and suggest a reviewed change plan'}"
+      --allowedTools "Read"
 ```
 
-Adjust **`--allowedTools`** to least privilege. Official docs also document Bedrock and Vertex job templates with cloud OIDC.
+Start with read-only tools. For trusted maintainer-triggered jobs that should
+prepare changes, add only the exact non-shell tools required, keep generated
+changes behind merge-request review, and avoid exposing protected credentials to
+untrusted MR, mention, or variable-driven prompts. Official docs also document
+Bedrock and Vertex job templates with cloud OIDC.
 
 ## Source Verification Notes
 
 Verified against **Claude Code GitLab CI/CD** documentation on **2026-06-16**:
 
 - Integration is maintained by GitLab and runs Claude Code in isolated CI jobs.
-- Quick setup requires **`ANTHROPIC_API_KEY`** as a masked CI/CD variable.
-- Jobs can react to web triggers, merge request events, or mention-driven flows with **`AI_FLOW_*`** variables.
-- Official examples use **`claude -p`**, **`--permission-mode acceptEdits`**, and scoped **`--allowedTools`**.
+- Quick setup can use **`ANTHROPIC_API_KEY`** as a masked CI/CD variable, but production jobs should restrict secrets to protected maintainer-approved pipelines or use cloud OIDC/WIF.
+- Jobs can react to web triggers, merge request events, or mention-driven flows with **`AI_FLOW_*`** variables; treat those values as untrusted unless a maintainer curated them.
+- Official examples use **`claude -p`** and scoped **`--allowedTools`**; keep risky tools such as **`Bash`** out of default copy-paste workflows.
 - Enterprise setups document **Bedrock OIDC** and **Vertex Workload Identity Federation** alternatives.
 
 ## Duplicate Check


### PR DESCRIPTION
### Motivation
- Remove a dangerous copy-paste CI example that exposed `ANTHROPIC_API_KEY` to a prompt-driven job and granted `Bash` + write-capable tools with `--permission-mode acceptEdits`, which could allow attacker-influenced prompts to read secrets and modify repo contents.
- Encourage safe, production-ready defaults (protected credentials, maintainer approval, least-privilege tools) so downstream projects do not accidentally create privileged, prompt-driven CI workflows.

### Description
- Updated `content/guides/claude-code-gitlab-ci-cd-workflow.mdx` to require protected, maintainer-triggered pipelines or cloud OIDC/WIF for secrets and to treat `AI_FLOW_*`/MR/mention inputs as untrusted unless curated by a maintainer. 
- Replaced the unsafe example that used `AI_FLOW_INPUT`, `--permission-mode acceptEdits`, and `--allowedTools "Bash Read Edit Write"` with a safer default using a maintainer-approved prompt variable and `--allowedTools "Read"` only. 
- Added safetyNotes and prerequisites clarifying to avoid Bash by default, not to run write-capable jobs from untrusted prompts, and to restrict granting write/GitLab MCP tools to trusted, reviewed flows. 
- Adjusted TL;DR and usageSnippet to emphasize maintainer approval, least-privilege tooling, and review gates; file modified: `content/guides/claude-code-gitlab-ci-cd-workflow.mdx`.

### Testing
- Ran `pnpm validate:content:strict`, which completed successfully. 
- Ran `git diff --check` (no issues found) and committed the change; automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d3ed75bc832c96d59fa66a881aea)