### PR TITLE
fix(commands): validate MCP smoke-test server names

### DIFF
--- a/content/commands/mcp-smoke-test.mdx
+++ b/content/commands/mcp-smoke-test.mdx
@@ -35,6 +35,7 @@ prerequisites:
 safetyNotes:
   - "Prefer read-only tools during verification; avoid destructive MCP tools on production data."
   - "Remove failing servers from MCP config before sharing logs externally."
+  - "Before using the server-name argument in terminal commands, select an exact name from claude mcp list and reject names that do not match ^[A-Za-z0-9_.-]{1,64}$."
 privacyNotes:
   - "MCP tool outputs may include repository paths; redact before posting publicly."
 tags:
@@ -69,11 +70,12 @@ code.claude.com.
 When you invoke this command, follow these steps:
 
 1. **List configured servers.** Run `claude mcp list` and confirm the target server appears with the expected scope (project, user, or local).
-2. **Inspect one server.** Run `claude mcp get <server-name>` to review transport, command or URL, and pending approval status documented in the MCP guide.
-3. **Check live status in Claude Code.** Ask the operator to open `/mcp` and confirm authentication status, tool count, and any servers flagged as needing auth.
-4. **Handle pending approval.** If the guide shows `Pending approval` for a project `.mcp.json` server, complete the interactive approval flow before testing tools.
-5. **Exercise one read-only tool.** With explicit user approval, invoke a documented read-only MCP tool with minimal arguments and record errors or OAuth prompts.
-6. **Summarize rollback.** If verification fails, document removal steps using `claude mcp remove <server-name>` and reverting `.mcp.json` edits.
+2. **Validate the target name.** Select the exact server name from the `claude mcp list` output. Reject the input and stop if it contains whitespace, shell metacharacters, or does not match `^[A-Za-z0-9_.-]{1,64}$`.
+3. **Inspect one server safely.** Run `claude mcp get -- "<validated-server-name>"` to review transport, command or URL, and pending approval status documented in the MCP guide. Treat the validated name as a separate quoted argument; do not paste or interpolate unvalidated text into a shell command.
+4. **Check live status in Claude Code.** Ask the operator to open `/mcp` and confirm authentication status, tool count, and any servers flagged as needing auth.
+5. **Handle pending approval.** If the guide shows `Pending approval` for a project `.mcp.json` server, complete the interactive approval flow before testing tools.
+6. **Exercise one read-only tool.** With explicit user approval, invoke a documented read-only MCP tool with minimal arguments and record errors or OAuth prompts.
+7. **Summarize rollback.** If verification fails, document removal steps using `claude mcp remove -- "<validated-server-name>"` and reverting `.mcp.json` edits.
 
 ## Output format
 
@@ -89,11 +91,11 @@ Verified against Claude Code MCP documentation on **2026-06-16**:
 
 - **`claude mcp list`** lists configured MCP servers and shows pending approval
   states for project-scoped `.mcp.json` entries.
-- **`claude mcp get <name>`** prints configuration details for a single server.
+- **`claude mcp get <name>`** prints configuration details for a single server; this runbook requires validating the name first and passing it as a separate quoted argument.
 - The **`/mcp` panel** shows authentication status, tool counts, and servers
   that advertise tools but expose none.
 - Remote servers may require **OAuth** completed through the `/mcp` menu.
-- **`claude mcp remove <name>`** removes a configured server when rollback is needed.
+- **`claude mcp remove <name>`** removes a configured server when rollback is needed; use only the same validated name selected from `claude mcp list`.
 
 ## Duplicate Check
 


### PR DESCRIPTION
### Motivation
- The runbook previously allowed a user-controlled `server-name` to be interpolated into shell command examples, creating a command-injection risk if names contained whitespace or shell metacharacters.
- Make the verification workflow safe while preserving the original MCP verification steps and usability.

### Description
- Add a `safetyNotes` entry requiring the operator to pick an exact server name from `claude mcp list` and to reject names that do not match the conservative pattern `^[A-Za-z0-9_.-]{1,64}$` in `content/commands/mcp-smoke-test.mdx`.
- Replace the unvalidated `claude mcp get <server-name>` and `claude mcp remove <server-name>` instructions with steps that validate the name first and pass it as a separate quoted argument (for example `claude mcp get -- "<validated-server-name>"`).
- Update the source verification notes to document the new requirement to validate and quote the MCP server name before invoking CLI operations.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully and reported content validation passed.
- Ran `git diff --check` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d773147c832c8c04e52f899a99c6)