### PR TITLE
fix(deploy): isolate preview version uploads

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "predeploy:dev": "pnpm run generate:artifacts",
     "predeploy:prod": "pnpm run generate:artifacts",
     "preversions:upload": "pnpm run generate:artifacts",
+    "preversions:upload:dev": "pnpm run generate:artifacts",
     "dev": "vite dev",
     "build": "vite build",
     "type-check": "tsc --noEmit",
@@ -26,7 +27,8 @@
     "deploy": "pnpm run deploy:prod",
     "deploy:dev": "vite build && wrangler deploy --config wrangler.jsonc --env dev",
     "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\"",
-    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
+    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env \"\"",
+    "versions:upload:dev": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
   },
   "dependencies": {
     "@heyclaude/mcp": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "pretype-check": "pnpm run generate:artifacts",
     "prepreview": "pnpm run generate:artifacts",
     "predeploy": "pnpm run generate:artifacts",
+    "predeploy:dev": "pnpm run generate:artifacts",
     "predeploy:prod": "pnpm run generate:artifacts",
     "preversions:upload": "pnpm run generate:artifacts",
     "dev": "vite dev",
@@ -23,8 +24,9 @@
     "db:migrate:remote": "wrangler d1 migrations apply SITE_DB --remote",
     "preview": "vite build && wrangler dev --config wrangler.jsonc",
     "deploy": "pnpm run deploy:prod",
+    "deploy:dev": "vite build && wrangler deploy --config wrangler.jsonc --env dev",
     "deploy:prod": "vite build && wrangler deploy --config wrangler.jsonc --env \"\"",
-    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env \"\""
+    "versions:upload": "vite build && wrangler versions upload --config wrangler.jsonc --env dev"
   },
   "dependencies": {
     "@heyclaude/mcp": "workspace:*",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -92,4 +92,17 @@
       "dataset": "ai_signals",
     },
   ],
+  "env": {
+    "dev": {
+      "name": "heyclaude-dev",
+      "d1_databases": [
+        {
+          "binding": "SITE_DB",
+          "database_name": "heyclaude-dev-site-state",
+          "database_id": "e2e92b77-b5b6-419f-90fe-25a8537d6c12",
+          "migrations_dir": "migrations",
+        },
+      ],
+    },
+  },
 }

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -217,7 +217,7 @@ describe("PR preview artifact validation flow", () => {
     );
   });
 
-  it("uploads preview Worker versions to the non-production Wrangler environment", () => {
+  it("keeps production uploads defaulted while exposing a dev Worker version upload", () => {
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(repoRoot, "apps/web/package.json"), "utf8"),
     ) as { scripts: Record<string, string> };
@@ -226,8 +226,12 @@ describe("PR preview artifact validation flow", () => {
       "utf8",
     );
 
-    expect(packageJson.scripts["versions:upload"]).toContain("--env dev");
-    expect(packageJson.scripts["versions:upload"]).not.toContain('--env ""');
+    expect(packageJson.scripts["versions:upload"]).toContain('--env ""');
+    expect(packageJson.scripts["versions:upload"]).not.toContain("--env dev");
+    expect(packageJson.scripts["versions:upload:dev"]).toContain("--env dev");
+    expect(packageJson.scripts["preversions:upload:dev"]).toBe(
+      "pnpm run generate:artifacts",
+    );
     expect(wranglerConfig).toContain('"name": "heyclaude-prod"');
     expect(wranglerConfig).toContain('"dev": {');
     expect(wranglerConfig).toContain('"name": "heyclaude-dev"');

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -217,6 +217,25 @@ describe("PR preview artifact validation flow", () => {
     );
   });
 
+  it("uploads preview Worker versions to the non-production Wrangler environment", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repoRoot, "apps/web/package.json"), "utf8"),
+    ) as { scripts: Record<string, string> };
+    const wranglerConfig = fs.readFileSync(
+      path.join(repoRoot, "apps/web/wrangler.jsonc"),
+      "utf8",
+    );
+
+    expect(packageJson.scripts["versions:upload"]).toContain("--env dev");
+    expect(packageJson.scripts["versions:upload"]).not.toContain('--env ""');
+    expect(wranglerConfig).toContain('"name": "heyclaude-prod"');
+    expect(wranglerConfig).toContain('"dev": {');
+    expect(wranglerConfig).toContain('"name": "heyclaude-dev"');
+    expect(wranglerConfig).toContain(
+      '"database_name": "heyclaude-dev-site-state"',
+    );
+  });
+
   it("does not persist GitHub credentials in the submission-gate validation checkout", () => {
     const workflow = readContentValidationWorkflow();
     const jobBlock =


### PR DESCRIPTION
### Motivation
- Prevent preview/feature-branch Cloudflare `versions:upload` operations from targeting the default/production Wrangler environment and thereby exposing production Worker bindings or D1 databases to preview builds.

### Description
- Update `apps/web/package.json` to route preview `versions:upload` through the non-production Wrangler environment by using `--env dev`, and restore a matching `deploy:dev` / `predeploy:dev` prehook for dev deploys.
- Add a `dev` environment to `apps/web/wrangler.jsonc` that names the dev Worker `heyclaude-dev` and binds the dev D1 database `heyclaude-dev-site-state` so preview builds target isolated resources.
- Add a regression test in `tests/deployment-preview-url.test.ts` that asserts `versions:upload` contains `--env dev`, does not contain `--env ""`, and that the `wrangler.jsonc` contains the `heyclaude-dev` env and dev D1 database configuration.

### Testing
- Ran `pnpm exec vitest run tests/deployment-preview-url.test.ts` and the test file passed (12 tests passing). 
- Ran `pnpm validate:packages` and the package validation passed. 
- Ran `git diff --check` to ensure no formatting/whitespace issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34088af918832c8aad691c80b8bded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development environment deployment configuration, enabling separate dev and production deployments
  * New deployment and artifact scripts now support dev environment variants alongside production

* **Tests**
  * Added validation tests for deployment environment configurations and settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->