### PR TITLE
fix(content): pin TweetClaw install sources

### DIFF
--- a/content/skills/tweetclaw-openclaw-x-automation.mdx
+++ b/content/skills/tweetclaw-openclaw-x-automation.mdx
@@ -13,28 +13,29 @@ submittedByUrl: "https://github.com/kriptoburak"
 dateAdded: "2026-06-09"
 repoUrl: "https://github.com/Xquik-dev/tweetclaw"
 documentationUrl: "https://github.com/Xquik-dev/tweetclaw#readme"
-packageUrl: "https://registry.npmjs.org/%40xquik%2Ftweetclaw/latest"
-downloadUrl: "https://github.com/Xquik-dev/tweetclaw/archive/refs/heads/master.zip"
+packageUrl: "https://registry.npmjs.org/%40xquik%2Ftweetclaw/1.6.31"
+downloadUrl: "https://github.com/Xquik-dev/tweetclaw/archive/refs/tags/v1.6.31.zip"
 installable: true
-installCommand: "npx skills add xquik-dev/tweetclaw"
+installCommand: "npx skills add xquik-dev/tweetclaw@v1.6.31"
 usageSnippet: "Use the TweetClaw skill before installing or operating the @xquik/tweetclaw OpenClaw plugin."
 copySnippet: |-
   # Trigger
   "Use the TweetClaw skill to set up a safe X/Twitter automation workflow."
 
   # Skill install
-  npx skills add xquik-dev/tweetclaw
+  npx skills add xquik-dev/tweetclaw@v1.6.31
 
   # OpenClaw plugin install
-  openclaw plugins install npm:@xquik/tweetclaw
+  openclaw plugins install npm:@xquik/tweetclaw@1.6.31
 skillType: general
 skillLevel: advanced
 verificationStatus: validated
 verifiedAt: "2026-06-09"
 retrievalSources:
   - "https://github.com/Xquik-dev/tweetclaw"
-  - "https://raw.githubusercontent.com/Xquik-dev/tweetclaw/master/skills/tweetclaw/SKILL.md"
-  - "https://registry.npmjs.org/%40xquik%2Ftweetclaw/latest"
+  - "https://raw.githubusercontent.com/Xquik-dev/tweetclaw/v1.6.31/skills/tweetclaw/SKILL.md"
+  - "https://registry.npmjs.org/%40xquik%2Ftweetclaw/1.6.31"
+  - "https://github.com/Xquik-dev/tweetclaw/archive/refs/tags/v1.6.31.zip"
 testedPlatforms:
   - OpenClaw
   - Claude
@@ -92,13 +93,13 @@ Use the skill when an agent needs to install TweetClaw, decide which credential 
 Install the reusable Agent Skill:
 
 ```bash
-npx skills add xquik-dev/tweetclaw
+npx skills add xquik-dev/tweetclaw@v1.6.31
 ```
 
 Install the OpenClaw plugin runtime from npm:
 
 ```bash
-openclaw plugins install npm:@xquik/tweetclaw
+openclaw plugins install npm:@xquik/tweetclaw@1.6.31
 ```
 
 Verify the runtime before live work:
@@ -129,5 +130,6 @@ The runtime should show the read-only `explore` catalog tool, optional `tweetcla
 ## Retrieval Sources
 
 - https://github.com/Xquik-dev/tweetclaw
-- https://raw.githubusercontent.com/Xquik-dev/tweetclaw/master/skills/tweetclaw/SKILL.md
-- https://registry.npmjs.org/%40xquik%2Ftweetclaw/latest
+- https://raw.githubusercontent.com/Xquik-dev/tweetclaw/v1.6.31/skills/tweetclaw/SKILL.md
+- https://registry.npmjs.org/%40xquik%2Ftweetclaw/1.6.31
+- https://github.com/Xquik-dev/tweetclaw/archive/refs/tags/v1.6.31.zip


### PR DESCRIPTION
### Motivation
- Close a supply-chain/content-integrity gap where a validated skill listing referenced mutable `latest`/`master` resources and unpinned install commands that could be swapped after review.
- Ensure the registry entry for a write-capable X/Twitter automation plugin references reviewed, immutable artifacts to reduce risk of credential theft or unauthorized actions.

### Description
- Pin `packageUrl` to `https://registry.npmjs.org/%40xquik%2Ftweetclaw/1.6.31` and replace the moving npm `/latest` reference with the specific version `1.6.31` in `content/skills/tweetclaw-openclaw-x-automation.mdx`.
- Replace the mutable GitHub `master.zip` archive with the versioned tag archive `https://github.com/Xquik-dev/tweetclaw/archive/refs/tags/v1.6.31.zip` in the same file.
- Update the user-facing `installCommand` and copy/installation snippets to pin the skill and OpenClaw plugin installs to `v1.6.31` / `1.6.31` respectively.
- Update `retrievalSources` to use versioned evidence URLs (tagged raw SKILL.md and the versioned npm endpoint).

### Testing
- Ran `pnpm validate:content:strict` and it passed after the changes.
- Ran `git diff --check` and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3416b5290c832c9ba89cc104f36f5e)