### PR TITLE
fix(submissions): fail neutral Superagent checks

### DIFF
--- a/apps/submission-gate/src/github.ts
+++ b/apps/submission-gate/src/github.ts
@@ -582,14 +582,6 @@ export async function getCommitValidationState(params: {
       });
       continue;
     }
-    if (/superagent/i.test(name) && run.conclusion === "neutral") {
-      checkResults.push({
-        name,
-        status: "passed",
-        details: "concluded neutral",
-      });
-      continue;
-    }
     if (run.conclusion !== "success") {
       checkResults.push({
         name,

--- a/apps/submission-gate/src/notifications.ts
+++ b/apps/submission-gate/src/notifications.ts
@@ -153,7 +153,7 @@ function compactCiSummary(value: unknown) {
         : lower.includes("failed") || lower.includes("failure")
           ? "failed"
           : lower.includes("neutral")
-            ? "neutral, non-blocking"
+            ? "neutral/inconclusive"
             : lower.includes("passed") || lower.includes("success")
               ? "passed"
               : "reported";

--- a/tests/submission-gate-github-client.test.ts
+++ b/tests/submission-gate-github-client.test.ts
@@ -261,7 +261,7 @@ describe("submission gate GitHub client", () => {
         expect.objectContaining({ name: "validate-web", status: "passed" }),
         expect.objectContaining({
           name: "Superagent Security Scan",
-          status: "passed",
+          status: "failed",
           details: "concluded neutral",
         }),
         expect.objectContaining({

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -353,7 +353,7 @@ describe("Cloudflare submission gate helpers", () => {
     });
   });
 
-  it("treats neutral Superagent scans as a non-blocking validation pass", async () => {
+  it("requires manual review for neutral Superagent scans", async () => {
     const fetchMock = vi.fn(async () =>
       Response.json({
         check_runs: [
@@ -382,12 +382,14 @@ describe("Cloudflare submission gate helpers", () => {
         requiredChecks: ["validate-content", "Superagent Security Scan"],
       }),
     ).resolves.toMatchObject({
-      state: "passed",
+      state: "failed",
+      summary:
+        "Required validation failed: Superagent Security Scan concluded neutral.",
       checks: [
         { name: "validate-content", status: "passed" },
         {
           name: "Superagent Security Scan",
-          status: "passed",
+          status: "failed",
           details: "concluded neutral",
         },
       ],
@@ -1793,7 +1795,7 @@ ${urls}
     );
   });
 
-  it("formats neutral Superagent Discord status as non-blocking", () => {
+  it("formats neutral Superagent Discord status as inconclusive", () => {
     const payload = buildDiscordDecisionPayload({
       repoFullName: "JSONbored/awesome-claude",
       prNumber: 826,
@@ -1812,7 +1814,7 @@ ${urls}
       "#826 merged · Chrome DevTools MCP server",
     );
     expect(JSON.stringify(payload)).toContain(
-      "Superagent neutral, non-blocking",
+      "Superagent neutral/inconclusive",
     );
   });
 


### PR DESCRIPTION
### Motivation
- Prevent a security validation bypass where a neutral Superagent check-run was treated as passing and allowed PRs to proceed to automated private review and merge.

### Description
- Remove the special-case that mapped Superagent `conclusion: "neutral"` to a passing required check in `getCommitValidationState` so only `conclusion: "success"` yields a passed required check (`apps/submission-gate/src/github.ts`).
- Change CI/Discord summary rendering to label neutral results as `neutral/inconclusive` instead of presenting them as non-blocking (`apps/submission-gate/src/notifications.ts`).
- Update tests to assert neutral Superagent scans fail required validation and are reported as inconclusive (`tests/submission-gate-worker.test.ts`).

### Testing
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "neutral Superagent|classifies required" --reporter=verbose --pool=threads` and the targeted tests passed.
- Ran the full worker test file with `pnpm exec vitest run tests/submission-gate-worker.test.ts --reporter=verbose --pool=threads` and all worker tests passed (96 passed, 0 failed).
- Ran `git diff --check` with no issues reported.
- Attempted `pnpm type-check`, but pre-type-check artifact generation (`node ../../scripts/build-content-index.mjs`) was long-running and was terminated, so a full type-check was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a341846eda8832ca755b4835b97dd60)