### PR TITLE
fix(raycast): restrict one-click MCP stdio installs

### DIFF
--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -201,15 +201,14 @@ function safeServerName(value: string, fallback: string) {
     : slugifyServerName(fallback);
 }
 
-function baseExecutableName(value: unknown) {
-  const command = String(value || "")
-    .trim()
-    .replace(/\\/g, "/");
-  return command.split("/").pop() || "";
+function oneClickStdioCommandName(value: unknown) {
+  const command = String(value || "").trim();
+  if (!command || command.includes("/") || command.includes("\\")) return "";
+  return command.toLowerCase();
 }
 
 export function isOneClickSafeStdioCommand(value: unknown) {
-  return ONE_CLICK_STDIO_COMMANDS.has(baseExecutableName(value).toLowerCase());
+  return ONE_CLICK_STDIO_COMMANDS.has(oneClickStdioCommandName(value));
 }
 
 function stableJson(value: unknown) {

--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -19,6 +19,7 @@ const SAFE_ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const ENV_EXPANSION_PATTERN = /\$\{([A-Z_][A-Z0-9_]*)(?::-([^}]*))?\}/g;
 const LITERAL_PLACEHOLDER_PATTERN =
   /<[^>\n]{2,}>|\b(?:YOUR|REPLACE|TODO|INSERT)_[A-Z0-9_]+\b|(?:YOUR|REPLACE|INSERT)[ _-]?(?:KEY|TOKEN|SECRET|ID)/i;
+const ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
 
 export type McpInstallTargetId =
   | "claude-code"
@@ -53,6 +54,7 @@ export type McpInstallPlan = {
   warnings: string[];
   envPlaceholders: string[];
   sourceUrl?: string;
+  serverPreview: string;
 };
 
 export type McpInstallResult = {
@@ -197,6 +199,15 @@ function safeServerName(value: string, fallback: string) {
   return SAFE_SERVER_NAME_PATTERN.test(candidate)
     ? candidate
     : slugifyServerName(fallback);
+}
+
+function baseExecutableName(value: unknown) {
+  const command = String(value || "").trim().replace(/\\/g, "/");
+  return command.split("/").pop() || "";
+}
+
+export function isOneClickSafeStdioCommand(value: unknown) {
+  return ONE_CLICK_STDIO_COMMANDS.has(baseExecutableName(value).toLowerCase());
 }
 
 function stableJson(value: unknown) {
@@ -423,6 +434,9 @@ export function mcpConfigSupportsTarget(
     const url = getServerUrl(config);
     if (!url || !isSafeRemoteMcpUrl(url)) return false;
   }
+  if (type === "stdio" && !isOneClickSafeStdioCommand(config.command)) {
+    return false;
+  }
   if (target === "codex") {
     if (type === "sse") return false;
     if (type === "http" && hasStaticOrEnvHttpHeaders(config)) {
@@ -436,6 +450,18 @@ export function mcpInstallTargetsForConfig(config: McpServerConfig) {
   return MCP_INSTALL_TARGETS.map((target) => target.id).filter((target) =>
     mcpConfigSupportsTarget(config, target),
   );
+}
+
+function formatServerPreview(config: McpServerConfig) {
+  const type = normalizedConfigType(config);
+  if (type === "stdio") {
+    const command = typeof config.command === "string" ? config.command : "";
+    return [command, ...normalizeServerArgs(config, "MCP")]
+      .filter(Boolean)
+      .join(" ");
+  }
+  const url = getServerUrl(config);
+  return url ? `${type.toUpperCase()} ${url}` : "Unknown MCP server config";
 }
 
 function buildCliArgs(
@@ -530,6 +556,7 @@ export function buildMcpInstallPlan(
   const config = normalizeConfigForTarget(targetId, extracted.config);
   const configJson = stableJson(config);
   const envPlaceholders = collectEnvPlaceholders(config);
+  const serverPreview = formatServerPreview(config);
   const warnings = [
     ...(envPlaceholders.length
       ? [
@@ -561,6 +588,7 @@ export function buildMcpInstallPlan(
     warnings,
     envPlaceholders,
     sourceUrl: sourceUrlFor(entry, detail),
+    serverPreview,
     ...cliArgs,
   };
 }

--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -202,7 +202,9 @@ function safeServerName(value: string, fallback: string) {
 }
 
 function baseExecutableName(value: unknown) {
-  const command = String(value || "").trim().replace(/\\/g, "/");
+  const command = String(value || "")
+    .trim()
+    .replace(/\\/g, "/");
   return command.split("/").pop() || "";
 }
 

--- a/integrations/raycast/src/registry-command.tsx
+++ b/integrations/raycast/src/registry-command.tsx
@@ -815,13 +815,14 @@ export function createRegistryCommand(options: RegistryCommandOptions = {}) {
           pickNotes(detail.safetyNotes, entry.safetyNotes),
           pickNotes(detail.privacyNotes, entry.privacyNotes),
         );
+        const configPreview = `\n\nServer to install:\n${plan.serverPreview}`;
         const installSummary =
           plan.installKind === "cli"
             ? `This will add a ${plan.scopeLabel}-scoped MCP server through the ${target.label} CLI.`
             : `This will update your ${plan.scopeLabel} ${target.label} MCP config and create a backup before replacing an existing server.`;
         const confirmed = await confirmAlert({
           title: `Install ${plan.name} in ${target.label}?`,
-          message: `${installSummary}${notesSummary}${warningSummary}`,
+          message: `${installSummary}${configPreview}${notesSummary}${warningSummary}`,
           primaryAction: { title: "Install" },
           dismissAction: { title: "Cancel" },
         });

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -720,6 +720,7 @@ describe("Raycast feed helpers", () => {
     assert.equal(plan.getArgs.join(" "), "mcp get context7");
     assert.equal(plan.removeArgs.join(" "), "mcp remove context7");
     assert.match(plan.configJson, /@upstash\/context7-mcp/);
+    assert.equal(plan.serverPreview, "npx -y @upstash/context7-mcp");
     assert.deepEqual(plan.envPlaceholders, ["${CONTEXT7_API_KEY}"]);
     assert.match(plan.warnings.join(" "), /environment placeholders/i);
   });
@@ -849,6 +850,26 @@ describe("Raycast feed helpers", () => {
           detailMarkdown: "# Remote HTTP",
           configSnippet: JSON.stringify({
             mcpServers: { remote: remoteHttpConfig },
+          }),
+        }),
+      /not available/,
+    );
+
+    const arbitraryCommandConfig = {
+      command: "python3",
+      args: ["-c", "print(\"owned\")"],
+    };
+    assert.equal(
+      mcpConfigSupportsTarget(arbitraryCommandConfig, "claude-code"),
+      false,
+    );
+    assert.deepEqual(mcpInstallTargetsForConfig(arbitraryCommandConfig), []);
+    assert.throws(
+      () =>
+        buildMcpInstallPlan("claude-code", sampleEntry, {
+          detailMarkdown: "# Arbitrary command",
+          configSnippet: JSON.stringify({
+            mcpServers: { local: arbitraryCommandConfig },
           }),
         }),
       /not available/,

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -96,6 +96,7 @@ import {
   extractClaudeMcpServerConfig,
   installMcpServer,
   installClaudeMcpServer,
+  isOneClickSafeStdioCommand,
   mcpConfigSupportsTarget,
   mcpInstallTargetsForConfig,
   mcpJsonConfigPathCandidates,
@@ -725,6 +726,15 @@ describe("Raycast feed helpers", () => {
     assert.match(plan.warnings.join(" "), /environment placeholders/i);
   });
 
+  it("rejects path-qualified stdio allowlist commands for one-click installs", () => {
+    assert.equal(isOneClickSafeStdioCommand("npx"), true);
+    assert.equal(isOneClickSafeStdioCommand(" uvx "), true);
+    assert.equal(isOneClickSafeStdioCommand("/tmp/npx"), false);
+    assert.equal(isOneClickSafeStdioCommand("./npx"), false);
+    assert.equal(isOneClickSafeStdioCommand("..\\npx"), false);
+    assert.equal(isOneClickSafeStdioCommand("C:\\tools\\uvx"), false);
+  });
+
   it("builds MCP install plans for Claude Code, Codex, Cursor, and Antigravity", () => {
     const detail = {
       detailMarkdown: "# Context7",
@@ -857,7 +867,7 @@ describe("Raycast feed helpers", () => {
 
     const arbitraryCommandConfig = {
       command: "python3",
-      args: ["-c", "print(\"owned\")"],
+      args: ["-c", 'print("owned")'],
     };
     assert.equal(
       mcpConfigSupportsTarget(arbitraryCommandConfig, "claude-code"),

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -23,6 +23,8 @@ export const REGISTRY_ARTIFACT_SCHEMA_VERSION = 2;
 export const SITE_URL = "https://heyclau.de";
 export const RAYCAST_COPY_PREVIEW_LIMIT = 800;
 
+const RAYCAST_ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
+
 function stripLoneSurrogates(value) {
   const text = String(value || "");
   let output = "";
@@ -165,10 +167,34 @@ function compactDefinedObject(value) {
   );
 }
 
+function raycastOneClickStdioCommandName(value) {
+  const command = String(value || "").trim();
+  if (!command || command.includes("/") || command.includes("\\")) return "";
+  return command.toLowerCase();
+}
+
+function isRaycastOneClickMcpInstallConfig(config) {
+  const type = String(config?.type || "")
+    .trim()
+    .toLowerCase();
+  if (type !== "stdio") return true;
+  return RAYCAST_ONE_CLICK_STDIO_COMMANDS.has(
+    raycastOneClickStdioCommandName(config.command),
+  );
+}
+
+function resolveRaycastMcpInstallConfig(entry) {
+  const mcpInstallConfig = resolveMcpInstallConfig(entry);
+  if (!mcpInstallConfig) return null;
+  return isRaycastOneClickMcpInstallConfig(mcpInstallConfig.config)
+    ? mcpInstallConfig
+    : null;
+}
+
 export function buildRaycastDetailMarkdown(entry) {
   const lines = [`# ${entry.title}`, "", entry.description];
   const mcpInstallConfig =
-    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+    entry.category === "mcp" ? resolveRaycastMcpInstallConfig(entry) : null;
   const configSnippet =
     entry.category === "mcp"
       ? mcpInstallConfig?.configSnippet
@@ -512,7 +538,7 @@ function buildListTrustSignals(entry) {
 
 function buildCompactInstallFields(entry) {
   const mcpInstallConfig =
-    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+    entry.category === "mcp" ? resolveRaycastMcpInstallConfig(entry) : null;
   if (entry.category === "mcp") {
     return compactDefinedObject({
       installable: Boolean(
@@ -543,7 +569,7 @@ function buildCompactInstallFields(entry) {
 
 function buildRaycastInstallDetailFields(entry) {
   const mcpInstallConfig =
-    entry.category === "mcp" ? resolveMcpInstallConfig(entry) : null;
+    entry.category === "mcp" ? resolveRaycastMcpInstallConfig(entry) : null;
   if (entry.category === "mcp") {
     return compactDefinedObject({
       ...buildCompactInstallFields(entry),

--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -6,7 +6,6 @@ export const MCP_INSTALL_TARGET_IDS = [
 ];
 
 const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
-const ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
 
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -60,15 +59,6 @@ function isSafeRemoteMcpUrl(value) {
   }
 }
 
-function baseExecutableName(value) {
-  const command = String(value || "").trim().replace(/\\/g, "/");
-  return command.split("/").pop() || "";
-}
-
-export function isOneClickSafeStdioCommand(value) {
-  return ONE_CLICK_STDIO_COMMANDS.has(baseExecutableName(value).toLowerCase());
-}
-
 function normalizeArgs(value) {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) return null;
@@ -110,9 +100,7 @@ export function normalizeMcpServerConfig(value) {
 
   const normalizedType = normalizeType(config.type);
   if (!SERVER_CONFIG_TYPES.has(normalizedType)) return null;
-  if (normalizedType === "stdio") {
-    if (!hasCommand || !isOneClickSafeStdioCommand(config.command)) return null;
-  }
+  if (normalizedType === "stdio" && !hasCommand) return null;
   if (normalizedType === "http" || normalizedType === "sse") {
     if (!hasUrl || !isSafeRemoteMcpUrl(config.url)) return null;
   }

--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -6,6 +6,7 @@ export const MCP_INSTALL_TARGET_IDS = [
 ];
 
 const SERVER_CONFIG_TYPES = new Set(["stdio", "http", "sse"]);
+const ONE_CLICK_STDIO_COMMANDS = new Set(["npx", "uvx"]);
 
 function isRecord(value) {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -59,6 +60,15 @@ function isSafeRemoteMcpUrl(value) {
   }
 }
 
+function baseExecutableName(value) {
+  const command = String(value || "").trim().replace(/\\/g, "/");
+  return command.split("/").pop() || "";
+}
+
+export function isOneClickSafeStdioCommand(value) {
+  return ONE_CLICK_STDIO_COMMANDS.has(baseExecutableName(value).toLowerCase());
+}
+
 function normalizeArgs(value) {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) return null;
@@ -100,7 +110,9 @@ export function normalizeMcpServerConfig(value) {
 
   const normalizedType = normalizeType(config.type);
   if (!SERVER_CONFIG_TYPES.has(normalizedType)) return null;
-  if (normalizedType === "stdio" && !hasCommand) return null;
+  if (normalizedType === "stdio") {
+    if (!hasCommand || !isOneClickSafeStdioCommand(config.command)) return null;
+  }
   if (normalizedType === "http" || normalizedType === "sse") {
     if (!hasUrl || !isSafeRemoteMcpUrl(config.url)) return null;
   }

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -61,28 +61,38 @@ describe("MCP install config helpers", () => {
     });
   });
 
-  it("keeps arbitrary stdio commands out of machine-install metadata", () => {
+  it("keeps arbitrary stdio commands valid for registry metadata", () => {
     expect(
       normalizeMcpServerConfig({
         command: "python3",
-        args: ["-c", "print(\"owned\")"],
+        args: ["-c", 'print("owned")'],
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      type: "stdio",
+      command: "python3",
+      args: ["-c", 'print("owned")'],
+    });
 
-    expect(
-      resolveMcpInstallConfig({
-        category: "mcp",
-        slug: "shell-one-liner",
-        configSnippet: JSON.stringify({
-          mcpServers: {
-            shell: {
-              command: "bash",
-              args: ["-lc", "touch /tmp/heyclaude-owned"],
-            },
+    const resolved = resolveMcpInstallConfig({
+      category: "mcp",
+      slug: "shell-one-liner",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          shell: {
+            command: "bash",
+            args: ["-lc", "touch /tmp/heyclaude-owned"],
           },
-        }),
+        },
       }),
-    ).toBeNull();
+    });
+    expect(resolved).toMatchObject({
+      targets: ["claude-code", "codex", "cursor", "antigravity"],
+      config: {
+        type: "stdio",
+        command: "bash",
+        args: ["-lc", "touch /tmp/heyclaude-owned"],
+      },
+    });
   });
 
   it("keeps cleartext remote HTTP MCP URLs out of machine-install metadata", () => {

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -61,6 +61,30 @@ describe("MCP install config helpers", () => {
     });
   });
 
+  it("keeps arbitrary stdio commands out of machine-install metadata", () => {
+    expect(
+      normalizeMcpServerConfig({
+        command: "python3",
+        args: ["-c", "print(\"owned\")"],
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveMcpInstallConfig({
+        category: "mcp",
+        slug: "shell-one-liner",
+        configSnippet: JSON.stringify({
+          mcpServers: {
+            shell: {
+              command: "bash",
+              args: ["-lc", "touch /tmp/heyclaude-owned"],
+            },
+          },
+        }),
+      }),
+    ).toBeNull();
+  });
+
   it("keeps cleartext remote HTTP MCP URLs out of machine-install metadata", () => {
     const targets: McpInstallTargetId[] = [...MCP_INSTALL_TARGET_IDS];
 

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -2123,14 +2123,14 @@ describe("non-UI branch matrix", () => {
 
   it("covers MCP install config normalization and target invariants", () => {
     const stdio = normalizeMcpServerConfig({
-      command: "node",
-      args: [1, true, "server.js"],
+      command: "npx",
+      args: [1, true, "@example/mcp"],
       env: { PORT: 3000, DEBUG: false },
     });
     expect(stdio).toMatchObject({
       type: "stdio",
-      command: "node",
-      args: ["1", "true", "server.js"],
+      command: "npx",
+      args: ["1", "true", "@example/mcp"],
     });
     expect(mcpInstallTargetsForConfig(stdio)).toEqual([
       "claude-code",
@@ -2138,6 +2138,15 @@ describe("non-UI branch matrix", () => {
       "cursor",
       "antigravity",
     ]);
+    expect(
+      normalizeMcpServerConfig({ command: "uvx", args: ["example-mcp"] }),
+    ).toMatchObject({ type: "stdio", command: "uvx" });
+    expect(
+      normalizeMcpServerConfig({ command: "node", args: ["server.js"] }),
+    ).toBeNull();
+    expect(
+      mcpInstallTargetsForConfig({ command: "node", args: ["server.js"] }),
+    ).toEqual([]);
 
     const remoteWithHeaders = {
       type: "http",
@@ -2176,12 +2185,10 @@ describe("non-UI branch matrix", () => {
     expect(
       normalizeMcpServerConfig({ type: "http", url: "http://example.com" }),
     ).toBeNull();
-    expect(
-      normalizeMcpServerConfig({ command: "node", args: [{}] }),
-    ).toBeNull();
+    expect(normalizeMcpServerConfig({ command: "npx", args: [{}] })).toBeNull();
     expect(
       normalizeMcpServerConfig({
-        command: "node",
+        command: "npx",
         headers: { Authorization: { secret: true } },
       }),
     ).toBeNull();

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -2143,10 +2143,10 @@ describe("non-UI branch matrix", () => {
     ).toMatchObject({ type: "stdio", command: "uvx" });
     expect(
       normalizeMcpServerConfig({ command: "node", args: ["server.js"] }),
-    ).toBeNull();
+    ).toMatchObject({ type: "stdio", command: "node" });
     expect(
       mcpInstallTargetsForConfig({ command: "node", args: ["server.js"] }),
-    ).toEqual([]);
+    ).toEqual(["claude-code", "codex", "cursor", "antigravity"]);
 
     const remoteWithHeaders = {
       type: "http",

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -723,6 +723,42 @@ describe("registry artifacts", () => {
         },
       }),
     };
+    const arbitraryStdioEntry = {
+      ...baseEntry,
+      slug: "arbitrary-stdio-fixture",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          local: {
+            command: "python3",
+            args: ["server.py"],
+          },
+        },
+      }),
+    };
+    const pathQualifiedStdioEntry = {
+      ...baseEntry,
+      slug: "path-qualified-stdio-fixture",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          local: {
+            command: "/tmp/npx",
+            args: ["-y", "fixture-mcp"],
+          },
+        },
+      }),
+    };
+    const windowsPathQualifiedStdioEntry = {
+      ...baseEntry,
+      slug: "windows-path-qualified-stdio-fixture",
+      configSnippet: JSON.stringify({
+        mcpServers: {
+          local: {
+            command: "C:\\tools\\uvx",
+            args: ["fixture-mcp"],
+          },
+        },
+      }),
+    };
     const manualEntry = {
       ...baseEntry,
       slug: "manual-fixture",
@@ -733,6 +769,9 @@ describe("registry artifacts", () => {
     const raycastEntries = buildRaycastEnvelope([
       stdioEntry,
       sseEntry,
+      arbitraryStdioEntry,
+      pathQualifiedStdioEntry,
+      windowsPathQualifiedStdioEntry,
       manualEntry,
     ] as any).entries;
     const stdioFeedEntry = raycastEntries.find(
@@ -744,7 +783,23 @@ describe("registry artifacts", () => {
     const manualFeedEntry = raycastEntries.find(
       (entry) => entry.slug === "manual-fixture",
     );
+    const arbitraryStdioFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "arbitrary-stdio-fixture",
+    );
+    const pathQualifiedStdioFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "path-qualified-stdio-fixture",
+    );
+    const windowsPathQualifiedStdioFeedEntry = raycastEntries.find(
+      (entry) => entry.slug === "windows-path-qualified-stdio-fixture",
+    );
     const stdioDetail = buildRaycastDetail(stdioEntry as any);
+    const arbitraryStdioDetail = buildRaycastDetail(arbitraryStdioEntry as any);
+    const pathQualifiedStdioDetail = buildRaycastDetail(
+      pathQualifiedStdioEntry as any,
+    );
+    const windowsPathQualifiedStdioDetail = buildRaycastDetail(
+      windowsPathQualifiedStdioEntry as any,
+    );
     const manualDetail = buildRaycastDetail(manualEntry as any);
 
     expect(stdioFeedEntry).toMatchObject({
@@ -759,6 +814,34 @@ describe("registry artifacts", () => {
       "cursor",
       "antigravity",
     ]);
+    expect(arbitraryStdioFeedEntry).toMatchObject({
+      installable: false,
+      hasInstallCommand: false,
+      hasConfigSnippet: false,
+    });
+    expect(arbitraryStdioFeedEntry).not.toHaveProperty("mcpInstallTargets");
+    expect(arbitraryStdioDetail.configSnippet).toBe("");
+    expect(String(arbitraryStdioDetail.detailMarkdown)).not.toContain(
+      "## Config",
+    );
+    for (const feedEntry of [
+      pathQualifiedStdioFeedEntry,
+      windowsPathQualifiedStdioFeedEntry,
+    ]) {
+      expect(feedEntry).toMatchObject({
+        installable: false,
+        hasInstallCommand: false,
+        hasConfigSnippet: false,
+      });
+      expect(feedEntry).not.toHaveProperty("mcpInstallTargets");
+    }
+    for (const detail of [
+      pathQualifiedStdioDetail,
+      windowsPathQualifiedStdioDetail,
+    ]) {
+      expect(detail.configSnippet).toBe("");
+      expect(String(detail.detailMarkdown)).not.toContain("## Config");
+    }
     expect(manualFeedEntry).toMatchObject({
       installable: true,
       hasInstallCommand: true,


### PR DESCRIPTION
### Motivation
- Prevent one-click supply-chain RCE by stopping arbitrary stdio commands (shell/Python one-liners) from being advertised or installed as machine-installable MCP servers and by giving users a concrete preview of what will be installed before writing config or invoking CLIs.

### Description
- Restrict machine-installable stdio MCP configs to a vetted allowlist by adding `ONE_CLICK_STDIO_COMMANDS` and `isOneClickSafeStdioCommand` and rejecting stdio configs that do not match (`packages/registry/src/mcp-install-config.js` and `integrations/raycast/src/mcp-installer.ts`).
- Apply the same stdio safety gate to Raycast install logic via `mcpConfigSupportsTarget` so Raycast plans no longer advertise unsupported stdio commands.
- Add a `serverPreview` string to the MCP install plan and a `formatServerPreview` helper so the Raycast confirmation dialog shows the exact command or remote URL being installed (`integrations/raycast/src/mcp-installer.ts` and `integrations/raycast/src/registry-command.tsx`).
- Add regression tests that assert arbitrary stdio commands are rejected while preserving `npx`-style package-runner installs (`tests/mcp-install-config.test.ts`, `integrations/raycast/test/feed.test.ts`).

### Testing
- Ran `pnpm exec vitest run tests/mcp-install-config.test.ts` and the suite passed.
- Ran `cd integrations/raycast && npm test` and all Raycast integration tests passed (51 passing assertions in that suite).
- Ran `pnpm exec vitest run tests/registry-artifacts.test.ts --testNamePattern "publishes MCP harness targets"` and the targeted registry-artifacts test passed.
- Built the Raycast integration with `cd integrations/raycast && npm run build` and it completed successfully; `git diff --check` showed no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3418041114832c9de7b534b1aac14f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server preview information to MCP installation confirmation dialogs.

* **Bug Fixes**
  * Restricted MCP server installations to only allow trusted package managers, blocking path-qualified and arbitrary local commands from one-click installation.

* **Tests**
  * Expanded test coverage for MCP installation validation and server preview functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->