### PR TITLE
fix(content): remove unsafe PAL MCP install path

### DIFF
--- a/content/mcp/pal-mcp-server.mdx
+++ b/content/mcp/pal-mcp-server.mdx
@@ -22,35 +22,13 @@ dateAdded: "2026-06-05"
 brandName: PAL MCP
 repoUrl: "https://github.com/BeehiveInnovations/pal-mcp-server"
 documentationUrl: "https://github.com/BeehiveInnovations/pal-mcp-server"
-installable: true
-installCommand: "git clone https://github.com/BeehiveInnovations/pal-mcp-server.git && cd pal-mcp-server && ./run-server.sh"
+installable: false
 usageSnippet: "Use PAL MCP when an MCP client should ask other model providers or CLI subagents for reviews, plans, debugging, consensus, or handoff work."
-copySnippet: |-
-  {
-    "mcpServers": {
-      "pal": {
-        "command": "bash",
-        "args": [
-          "-c",
-          "uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git pal-mcp-server"
-        ],
-        "env": {
-          "DEFAULT_MODEL": "auto",
-          "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY",
-          "OPENAI_API_KEY": "YOUR_OPENAI_API_KEY"
-        }
-      }
-    }
-  }
 configSnippet: |-
   {
     "mcpServers": {
       "pal": {
-        "command": "bash",
-        "args": [
-          "-c",
-          "uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git pal-mcp-server"
-        ],
+        "command": "<reviewed-local-pal-mcp-server-command>",
         "env": {
           "DEFAULT_MODEL": "auto",
           "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY",
@@ -70,6 +48,7 @@ safetyNotes:
   - PAL can send code, prompts, files, findings, and conversation context to multiple external model providers.
   - CLI subagents may inspect the workspace, run tools, and return results from separate contexts; restrict roles and provider access.
   - Keep disabled tools disabled unless the workflow needs them, and review tool configuration before broad code analysis or security review.
+  - Review and pin a trusted upstream release, tag, or commit before running any source-based PAL setup command.
   - Multi-model consensus can still be wrong; use it as review input, not automatic approval.
 privacyNotes:
   - Provider API keys, OpenRouter keys, Azure credentials, local model endpoints, and CLI auth tokens are sensitive secrets.
@@ -130,25 +109,17 @@ configuration flags.
 
 ## Installation
 
-Clone and run the automatic setup:
+PAL MCP's upstream repository documents source-based setup paths. Before adding
+it to an MCP client, choose and review a trusted release, tag, or commit from the
+upstream project instead of running code from the mutable default branch.
 
-```sh
-git clone https://github.com/BeehiveInnovations/pal-mcp-server.git
-cd pal-mcp-server
-./run-server.sh
-```
-
-The repository also documents an `uvx` setup shape for MCP clients:
+Use a reviewed local command in your MCP client configuration:
 
 ```json
 {
   "mcpServers": {
     "pal": {
-      "command": "bash",
-      "args": [
-        "-c",
-        "uvx --from git+https://github.com/BeehiveInnovations/pal-mcp-server.git pal-mcp-server"
-      ],
+      "command": "<reviewed-local-pal-mcp-server-command>",
       "env": {
         "DEFAULT_MODEL": "auto",
         "GEMINI_API_KEY": "YOUR_GEMINI_API_KEY",


### PR DESCRIPTION
### Motivation
- The PAL MCP entry recommended cloning a mutable GitHub default branch and immediately executing `./run-server.sh`, creating a supply-chain remote-code-execution risk for users who copy the install instructions. 
- The repository's existing unsafe-install detection did not flag this `git clone && cd && ./run-server.sh` pattern, so the registrable content needed to be hardened to avoid encouraging execution of unpinned upstream code.

### Description
- Marked the PAL MCP entry as not directly installable by setting `installable: false` and removed the unpinned `installCommand` and copyable `uvx git+https://...` command. 
- Replaced the copyable MCP client command with a reviewed-local placeholder by updating `configSnippet` to use `"command": "<reviewed-local-pal-mcp-server-command>"`. 
- Removed the clone-and-run example from the `Installation` section and replaced it with guidance to review and pin a trusted upstream release, tag, or commit before running any source-based setup. 
- Added a safety note recommending that users review and pin a trusted upstream release or commit before running source-based PAL setup commands.

### Testing
- Ran `pnpm validate:content:strict` and observed it completed successfully. 
- Ran `pnpm validate:packages` and `node scripts/validate-content.mjs --strict-recommended`, both of which passed without errors. 
- Verified `git diff --check` returned no whitespace or formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343ff3b58c832caa7c4860ff3b190a)