### PR TITLE
fix(hooks): sanitize package lock risk output

### DIFF
--- a/content/hooks/package-lock-risk-detector-hook.mdx
+++ b/content/hooks/package-lock-risk-detector-hook.mdx
@@ -71,9 +71,16 @@ scriptBody: |-
     *package-lock.json|*yarn.lock|*pnpm-lock.yaml) ;;
     *) exit 0 ;;
   esac
-  echo "package-lock-risk: reviewing $(basename "$FILE")" >&2
+  SAFE_FILE=$(basename "$FILE" | LC_ALL=C tr -d '\000-\037\177')
+  echo "package-lock-risk: reviewing $SAFE_FILE" >&2
   if [[ "$FILE" == *package-lock.json ]] && command -v jq >/dev/null 2>&1; then
-    HOSTS=$(jq -r '..|.resolved? // empty' "$FILE" 2>/dev/null | sed -n 's#.*//\([^/]*\)/.*#\1#p' | sort -u | head -n 20)
+    HOSTS=$(jq -r '..|.resolved? // empty' "$FILE" 2>/dev/null \
+      | LC_ALL=C tr -d '\000-\037\177' \
+      | sed -n 's#^[A-Za-z][A-Za-z0-9+.-]*://##p' \
+      | sed 's#/.*##; s#.*@##; s#^\[\([^]]*\)\].*#\1#; s#:[0-9][0-9]*$##' \
+      | awk 'NF' \
+      | sort -u \
+      | head -n 20)
     if [ -n "$HOSTS" ]; then
       echo "Resolved registry hosts:" >&2
       printf '%s\n' "$HOSTS" >&2


### PR DESCRIPTION
### Motivation
- The hook printed attacker-controlled lockfile basenames and URL authority strings to stderr unsanitized, which could allow terminal control sequences or disclosure of URL userinfo to be emitted during review.

### Description
- Sanitize the printed lockfile basename in `content/hooks/package-lock-risk-detector-hook.mdx` by stripping ASCII control characters with `tr -d '\000-\037\177'` before writing to stderr.
- Sanitize `package-lock.json` `resolved` URL output by removing control characters, stripping URL scheme and path, dropping userinfo and port components, normalizing IPv6 bracketed hosts, filtering empty lines, deduplicating, and limiting output to 20 hosts.
- Keep the hook read-only and preserve behavior of only reporting candidate registry hostnames for `package-lock.json` files.

### Testing
- Ran the extracted hook against a crafted `package-lock.json` containing JSON-escaped OSC/BEL sequences and URL userinfo and verified with `cat -v` and `od` that stderr contained only the sanitized hostname (`registry.npmjs.org`) and no raw control bytes.
- Ran `pnpm validate:content:strict` which passed.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d0d5ddac832cac9b11e4f05e161e)