### PR TITLE
fix(submissions): tighten defensive theft safe harbor

### DIFF
--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -103,6 +103,14 @@ function isLoopbackHttpUrl(value) {
 }
 const CREDENTIAL_THEFT_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
+const THEFT_INTERDICTION_ACTION_PATTERN =
+  /\b(?:detects?|blocks?|prevents?|warns? before)\b/i;
+const THEFT_INTERDICTION_TARGET_PATTERN =
+  /\b(?:commands?|patterns?|attempts?|requests?|prompts?|output)\b/i;
+const THEFT_INTERDICTION_RESULT_PATTERN =
+  /\b(?:blocks?|prevents?|before they run)\b/i;
+const THEFT_INTERDICTION_WINDOW = 120;
+const THEFT_CONTEXT_TO_CLAIM_WINDOW = 220;
 const CREDENTIAL_THEFT_DESTINATION_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,120}\b(?:to|into|via|through|over|using|at)\b[\s\S]{0,40}\b(webhooks?|remote servers?|external endpoints?|third[- ]part(?:y|ies)|apis?|https?:\/\/)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,120}\b(?:to|into|via|through|over|using|at)\b[\s\S]{0,40}\b(webhooks?|remote servers?|external endpoints?|third[- ]part(?:y|ies)|apis?|https?:\/\/)\b/i;
 const EXPLICIT_CREDENTIAL_STEALING_PATTERN =
@@ -161,9 +169,51 @@ function hasFinancialOrIdentitySensitiveSignal(text) {
   );
 }
 
+function globalPattern(pattern) {
+  const flags = pattern.flags.includes("g")
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+}
+
+function hasOrderedPatternWindow(text, firstPattern, secondPattern, maxChars) {
+  for (const match of text.matchAll(globalPattern(firstPattern))) {
+    const start = (match.index ?? 0) + match[0].length;
+    if (secondPattern.test(text.slice(start, start + maxChars))) return true;
+  }
+  return false;
+}
+
+function hasDefensiveTheftInterdiction(text) {
+  // Only safe-harbor theft wording when it describes blocking/detecting risky
+  // command, prompt, request, or output patterns, not the tool's own capability.
+  const actionBeforeTarget = hasOrderedPatternWindow(
+    text,
+    THEFT_INTERDICTION_ACTION_PATTERN,
+    THEFT_INTERDICTION_TARGET_PATTERN,
+    THEFT_INTERDICTION_WINDOW,
+  );
+  const targetBeforeTheft = hasOrderedPatternWindow(
+    text,
+    THEFT_INTERDICTION_TARGET_PATTERN,
+    CREDENTIAL_THEFT_PATTERN,
+    THEFT_CONTEXT_TO_CLAIM_WINDOW,
+  );
+  const theftBeforeResult = hasOrderedPatternWindow(
+    text,
+    CREDENTIAL_THEFT_PATTERN,
+    THEFT_INTERDICTION_RESULT_PATTERN,
+    THEFT_INTERDICTION_WINDOW,
+  );
+
+  return (actionBeforeTarget && targetBeforeTheft) || theftBeforeResult;
+}
+
 function hasDefensiveSecuritySafeHarbor(text) {
+  const hasCredentialTheftWording = CREDENTIAL_THEFT_PATTERN.test(text);
   return (
     DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
+    (!hasCredentialTheftWording || hasDefensiveTheftInterdiction(text)) &&
     !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
     !CREDENTIAL_THEFT_DESTINATION_PATTERN.test(text) &&
     !EXPLICIT_CREDENTIAL_STEALING_PATTERN.test(text) &&

--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -62,6 +62,14 @@ const RESOURCE_THEFT_CAPABILITY_PATTERN =
   /\b(?:this|the|our)?\s*(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b[\s\S]{0,40}\b(?:can|will|does|advertises?|offers?|enables?|designed to|built to)\b[\s\S]{0,80}\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b|\b(steals?|exfiltrates?|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(?:with|using|through|by)\b[\s\S]{0,40}\b(?:agent|command|hook|mcp|server|skill|statusline|tool|workflow)\b/i;
 const CREDENTIAL_THEFT_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b/i;
+const THEFT_INTERDICTION_ACTION_PATTERN =
+  /\b(?:detects?|blocks?|prevents?|warns? before)\b/i;
+const THEFT_INTERDICTION_TARGET_PATTERN =
+  /\b(?:commands?|patterns?|attempts?|requests?|prompts?|output)\b/i;
+const THEFT_INTERDICTION_RESULT_PATTERN =
+  /\b(?:blocks?|prevents?|before they run)\b/i;
+const THEFT_INTERDICTION_WINDOW = 120;
+const THEFT_CONTEXT_TO_CLAIM_WINDOW = 220;
 const CREDENTIAL_THEFT_DESTINATION_PATTERN =
   /\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,80}\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,120}\b(?:to|into|via|through|over|using|at)\b[\s\S]{0,40}\b(webhooks?|remote servers?|external endpoints?|third[- ]part(?:y|ies)|apis?|https?:\/\/)\b|\b(steals?|exfiltrat(?:e|es|ing|ion)|harvests?|dumps?)\b[\s\S]{0,80}\b(credential|password|cookie|session|token|wallet)s?\b[\s\S]{0,120}\b(?:to|into|via|through|over|using|at)\b[\s\S]{0,40}\b(webhooks?|remote servers?|external endpoints?|third[- ]part(?:y|ies)|apis?|https?:\/\/)\b/i;
 const EXPLICIT_CREDENTIAL_STEALING_PATTERN =
@@ -145,9 +153,51 @@ function normalizeRepo(value) {
   return normalizeText(value).toLowerCase();
 }
 
+function globalPattern(pattern) {
+  const flags = pattern.flags.includes("g")
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+}
+
+function hasOrderedPatternWindow(text, firstPattern, secondPattern, maxChars) {
+  for (const match of text.matchAll(globalPattern(firstPattern))) {
+    const start = (match.index ?? 0) + match[0].length;
+    if (secondPattern.test(text.slice(start, start + maxChars))) return true;
+  }
+  return false;
+}
+
+function hasDefensiveTheftInterdiction(text) {
+  // Only safe-harbor theft wording when it describes blocking/detecting risky
+  // command, prompt, request, or output patterns, not the tool's own capability.
+  const actionBeforeTarget = hasOrderedPatternWindow(
+    text,
+    THEFT_INTERDICTION_ACTION_PATTERN,
+    THEFT_INTERDICTION_TARGET_PATTERN,
+    THEFT_INTERDICTION_WINDOW,
+  );
+  const targetBeforeTheft = hasOrderedPatternWindow(
+    text,
+    THEFT_INTERDICTION_TARGET_PATTERN,
+    CREDENTIAL_THEFT_PATTERN,
+    THEFT_CONTEXT_TO_CLAIM_WINDOW,
+  );
+  const theftBeforeResult = hasOrderedPatternWindow(
+    text,
+    CREDENTIAL_THEFT_PATTERN,
+    THEFT_INTERDICTION_RESULT_PATTERN,
+    THEFT_INTERDICTION_WINDOW,
+  );
+
+  return (actionBeforeTarget && targetBeforeTheft) || theftBeforeResult;
+}
+
 function hasDefensiveSecuritySafeHarbor(text) {
+  const hasCredentialTheftWording = CREDENTIAL_THEFT_PATTERN.test(text);
   return (
     DEFENSIVE_SECURITY_MITIGATION_PATTERN.test(text) &&
+    (!hasCredentialTheftWording || hasDefensiveTheftInterdiction(text)) &&
     !RESOURCE_THEFT_CAPABILITY_PATTERN.test(text) &&
     !CREDENTIAL_THEFT_DESTINATION_PATTERN.test(text) &&
     !EXPLICIT_CREDENTIAL_STEALING_PATTERN.test(text) &&

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -732,6 +732,43 @@ Detect token usage and dump token values to a webhook for review.
     );
   });
 
+  it("does not let broad review words bypass cookie dumping claims", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Session Review Hook
+category: hooks
+description: Audit review hook that can dump session cookies from browser profiles.
+sourceUrl: https://github.com/example/session-review-hook
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Runs before commands and inspects browser profile state.
+privacyNotes:
+  - Reads session cookie material from user browser profiles.
+---
+
+Warning reviewers that this hook can dump session cookies from browser profiles.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/hooks/session-review-hook.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "malicious_data_theft_capability" }),
+      ]),
+    );
+  });
+
   it("does not let defensive words bypass explicit token stealing claims", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),

--- a/tests/submission-pr-first.test.ts
+++ b/tests/submission-pr-first.test.ts
@@ -470,6 +470,45 @@ Native macOS MCP server.`);
     );
   });
 
+  it("keeps credential-theft request changes for cookie dumping with review wording", () => {
+    const report = analyzeDirectContentRisk({
+      pullRequest: {
+        number: 132,
+        title: "content(hooks): add session review hook",
+        user: { login: "contributor" },
+        head: { repo: { full_name: "contributor/awesome-claude" } },
+        base: { repo: { full_name: "JSONbored/awesome-claude" } },
+      },
+      files: [
+        sourceFile(
+          validMcpMdx({
+            title: "Session Review Hook",
+            slug: "session-review-hook",
+            category: "hooks",
+            description:
+              "Audit review hook that can dump session cookies from browser profiles.",
+            repoUrl: "https://github.com/example/session-review-hook",
+            docsUrl: "https://example.com/session-review-hook",
+            safetyNotes: [
+              "Runs before commands and inspects browser profile state.",
+            ],
+            privacyNotes: [
+              "Reads session cookie material from user browser profiles.",
+            ],
+          }),
+          "content/hooks/session-review-hook.mdx",
+        ),
+      ],
+    });
+
+    expect(report.reviewFlags.map((flag) => flag.id)).toContain(
+      "malicious_data_theft_capability",
+    );
+    expect(directContentRequestChangesReasons(report).join("\n")).toContain(
+      "credential, token, session, or wallet theft",
+    );
+  });
+
   it("keeps credential-theft request changes for explicit stealing claims with defensive wording", () => {
     const report = analyzeDirectContentRisk({
       pullRequest: {


### PR DESCRIPTION
### Motivation
- A broad defensive-keyword safe harbor could suppress the `malicious_data_theft_capability` flag when a submission included generic words like "warn" or "review", enabling a bypass for credential/token theft wording.
- The change narrows the safe harbor so only genuinely defensive interdiction phrasing around explicit theft wording will suppress the critical theft blocker.

### Description
- Added a new `DEFENSIVE_THEFT_INTERDICTION_PATTERN` and mirrored it into both the CI validator and registry risk analyzer (`scripts/ci/validate-content-policy.mjs` and `packages/registry/src/submission-risk.js`).
- Tightened `hasDefensiveSecuritySafeHarbor` so it requires either no credential-theft wording or a match of the new interdiction pattern when credential-theft wording is present.
- Added regression tests asserting that broad "review"/"warning" wording does not bypass cookie/session dumping or token-dumping theft checks by updating `tests/content-policy-validation.test.ts` and `tests/submission-pr-first.test.ts`.
- Changes are limited to detection/logic and test files to preserve existing functionality while closing the bypass.

### Testing
- Ran `pnpm exec vitest run tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts` and all tests passed.
- Ran `git diff --check` to ensure no whitespace or diff issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3447a36c80832c8a0498a58e6c7dbf)