### PR TITLE
docs(content): add Microsoft AI Agents for Beginners

### DIFF
--- a/content/guides/microsoft-ai-agents-for-beginners.mdx
+++ b/content/guides/microsoft-ai-agents-for-beginners.mdx
@@ -1,0 +1,206 @@
+---
+title: Microsoft AI Agents for Beginners
+slug: microsoft-ai-agents-for-beginners
+category: guides
+description: >-
+  Microsoft open-source course for learning AI agents with lessons on agentic
+  frameworks, design patterns, tool use, agentic RAG, trustworthy agents,
+  planning, multi-agent systems, MCP/A2A/NLWeb, memory, browser use, and
+  Microsoft Agent Framework.
+cardDescription: >-
+  Learn AI agents through Microsoft's course covering frameworks, design
+  patterns, tool use, agentic RAG, production, protocols, memory, and security.
+seoTitle: Microsoft AI Agents for Beginners Course for Agentic AI, MCP, RAG, and Multi-Agent Systems
+seoDescription: >-
+  Use Microsoft's AI Agents for Beginners course to learn agentic AI,
+  Microsoft Agent Framework, Azure AI Foundry, tool use, agentic RAG,
+  multi-agent design, MCP, A2A, NLWeb, memory, browser use, and security.
+author: Microsoft
+authorProfileUrl: "https://github.com/microsoft"
+dateAdded: "2026-06-18"
+websiteUrl: "https://aka.ms/ai-agents-beginners"
+documentationUrl: "https://github.com/microsoft/ai-agents-for-beginners"
+repoUrl: "https://github.com/microsoft/ai-agents-for-beginners"
+pricingModel: free
+disclosure: editorial
+installable: false
+usageSnippet: >-
+  Use the Microsoft AI Agents for Beginners course to teach or learn AI agent
+  fundamentals, agentic frameworks, design patterns, tool use, agentic RAG,
+  production concerns, MCP/A2A/NLWeb protocols, memory, browser use, and
+  Microsoft Agent Framework samples.
+prerequisites:
+  - "Basic Python and command-line comfort for running the course code samples."
+  - "A fork or local clone of the course repository if you want to run examples instead of only reading lessons."
+  - "Microsoft Foundry access and an Azure account for examples that use Microsoft Agent Framework with Azure AI Foundry Agent Service V2."
+  - "Non-production model provider keys for optional samples that use Microsoft Foundry, Azure AI Foundry, OpenAI-compatible providers, or MiniMax."
+  - "Sparse checkout or enough disk space if cloning the repository with its 50+ translated language directories and translated images."
+safetyNotes:
+  - "Course samples can create agent workflows that call tools, use model providers, read files, connect to Azure services, use browser automation, and run code; keep examples in sandbox projects."
+  - "Lessons involving Azure AI Foundry, Microsoft Agent Framework, production agents, browser-use, MCP, A2A, NLWeb, and security may create real cloud resources, tokens, endpoints, logs, or automated actions if run against live accounts."
+  - "Do not run sample agents against production tickets, repositories, customer data, browsers with logged-in sessions, or cloud subscriptions until tool scope and cost controls are reviewed."
+  - "Treat course code as learning material. Pin dependency versions, inspect sample notebooks or scripts, and isolate credentials before adapting examples to internal agent workflows."
+privacyNotes:
+  - "Prompts, model responses, code samples, agent traces, browser interactions, Azure diagnostics, Foundry resources, model-provider logs, and generated outputs may contain sensitive data."
+  - "Running examples can send prompts, tool arguments, files, browser state, resource names, or dataset snippets to Microsoft services, model providers, browser automation services, or external APIs depending on configuration."
+  - "Keep API keys, Azure subscription IDs, deployment names, generated config files, course lab outputs, and copied sample data out of public commits, screenshots, prompts, and issue comments."
+  - "For team onboarding, define allowed providers, allowed datasets, cloud teardown steps, retention rules, and who can approve moving a sample into production."
+sourceUrls:
+  - "https://github.com/microsoft/ai-agents-for-beginners"
+  - "https://raw.githubusercontent.com/microsoft/ai-agents-for-beginners/main/README.md"
+  - "https://raw.githubusercontent.com/microsoft/ai-agents-for-beginners/main/STUDY_GUIDE.md"
+  - "https://github.com/microsoft/ai-agents-for-beginners/tree/main/00-course-setup"
+  - "https://github.com/microsoft/ai-agents-for-beginners/tree/main/11-agentic-protocols"
+  - "https://github.com/microsoft/ai-agents-for-beginners/tree/main/14-microsoft-agent-framework"
+  - "https://github.com/microsoft/ai-agents-for-beginners/tree/main/18-securing-ai-agents"
+  - "https://github.com/microsoft/ai-agents-for-beginners/blob/main/LICENSE"
+tags:
+  - ai-agents
+  - microsoft
+  - agentic-ai
+  - agentic-rag
+  - multi-agent
+  - mcp
+  - a2a
+  - nlweb
+  - semantic-kernel
+  - azure-ai-foundry
+keywords:
+  - Microsoft AI Agents for Beginners
+  - AI Agents for Beginners
+  - agentic AI course
+  - Microsoft Agent Framework tutorial
+  - Azure AI Foundry agents
+  - agentic RAG tutorial
+  - multi-agent design pattern
+  - MCP A2A NLWeb protocols
+  - AI agent memory course
+  - browser-use AI agents
+readingTime: 9
+difficultyScore: 50
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Microsoft AI Agents for Beginners is an open-source course for learning how AI
+agents work and how to start building them. The course covers agentic
+frameworks, design patterns, tool use, agentic RAG, trustworthy agents,
+planning, multi-agent systems, metacognition, production, agentic protocols,
+context engineering, memory, browser-use, Microsoft Agent Framework, and agent
+security.
+
+It is a high-value long-tail entry for Microsoft AI Agents for Beginners, AI
+Agents for Beginners, agentic AI course, Microsoft Agent Framework tutorial,
+Azure AI Foundry agents, agentic RAG tutorial, multi-agent design pattern, MCP
+A2A NLWeb protocols, AI agent memory, and browser-use AI agents.
+
+## Course Structure
+
+| Lesson Area | Coverage |
+| --- | --- |
+| Foundations | Intro to AI agents, agent use cases, and agentic frameworks |
+| Design Patterns | Agentic design patterns, tool use, planning, metacognition, and multi-agent coordination |
+| Retrieval | Agentic RAG and how agents combine retrieval with tool-using workflows |
+| Trust and Production | Trustworthy agents, production agent concerns, and securing AI agents |
+| Protocols | Agentic protocols including MCP, A2A, and NLWeb |
+| Context and Memory | Context engineering and managing agentic memory |
+| Microsoft Stack | Microsoft Agent Framework and Azure AI Foundry Agent Service V2 samples |
+| Browser Workflows | Building computer-use agents and browser-use examples |
+
+## How to Use It
+
+Use the course as a structured onboarding path:
+
+1. Start with the introductory and framework lessons to align on agent terms.
+2. Move into design patterns, tool use, planning, and multi-agent lessons before
+   trying to build larger agent systems.
+3. Use the agentic RAG, memory, context engineering, and protocol lessons to
+   connect the course to real MCP and retrieval workflows.
+4. Run samples only with sandbox credentials and disposable cloud resources.
+5. Use the production and security lessons as a checklist before adapting course
+   examples to internal workflows.
+
+## Agent, MCP, and Skills Fit
+
+This guide belongs in the agent ecosystem because it teaches the conceptual
+layer behind many tools already in the directory: CrewAI, LangGraph, OpenAI
+Agents SDK, Microsoft AutoGen, Semantic Kernel, Browser Use, agentic RAG
+systems, and MCP-connected workflows. It also gives MCP learners a broader
+agent context by covering MCP alongside A2A and NLWeb in the protocol lesson.
+
+For teams adopting Claude Code, Codex, Gemini CLI, OpenClaw, or other agent
+workflows, the course can serve as a shared vocabulary before engineers build
+or review production agent systems.
+
+## Source Review
+
+Verified on **2026-06-18**:
+
+- GitHub reports `microsoft/ai-agents-for-beginners` as an MIT-licensed
+  Microsoft repository with active development, 67,000+ stars, and 22,000+
+  forks.
+- The repository description says it provides 12 lessons to get started
+  building AI agents.
+- The README describes a course covering AI agent fundamentals, with written
+  lessons, short videos, Python code samples, and extra learning resources.
+- The README says the exercises use Microsoft Agent Framework with Azure AI
+  Foundry Agent Service V2, with some samples supporting OpenAI-compatible
+  providers such as MiniMax.
+- The lesson table includes agent use cases, agentic frameworks, design
+  patterns, tool use, agentic RAG, trustworthy agents, planning, multi-agent
+  design, metacognition, production, MCP/A2A/NLWeb protocols, context
+  engineering, agent memory, Microsoft Agent Framework, browser-use, and
+  securing AI agents.
+- The README documents 50+ automated translations and sparse checkout commands
+  for cloning without translation directories.
+
+## Safety and Privacy
+
+Treat the repository as runnable course material. Some lessons are safe to read
+only, but examples can involve cloud accounts, model providers, browser
+automation, agent tools, resource creation, and logs. Use test data and sandbox
+credentials until the behavior, cost, and data flow are understood.
+
+For team training, provide a starter environment with approved providers,
+sample datasets, spend limits, teardown instructions, and guidance for when a
+learning example is allowed to become production code.
+
+## Troubleshooting
+
+### The repository clone is large
+
+Use the sparse checkout commands from the README to skip translations and
+translated images if you only need the main course and code samples.
+
+### Azure or Foundry examples fail
+
+Check account access, region availability, resource names, model deployments,
+environment variables, and whether the sample expects Azure AI Foundry Agent
+Service V2.
+
+### Browser-use examples behave unpredictably
+
+Run them in a disposable browser profile without personal logins. Review what
+the agent can click, type, read, download, or submit before using real sites.
+
+### Agent protocol lessons feel disconnected from a local tool
+
+Pair the MCP/A2A/NLWeb lesson with a small MCP server or client example from
+the Microsoft MCP for Beginners curriculum, then compare the protocol concepts
+side by side.
+
+## Duplicate Check
+
+Checked current `content/guides/`, `content/tools/`, `content/mcp/`,
+`content/agents/`, `content/skills/`, collections, README output, open pull
+requests, and repository-wide content for `microsoft/ai-agents-for-beginners`,
+Microsoft AI Agents for Beginners, AI Agents for Beginners, agentic AI course,
+Microsoft Agent Framework tutorial, Azure AI Foundry agents, agentic RAG
+tutorial, multi-agent design pattern, MCP A2A NLWeb protocols, AI agent memory,
+and browser-use AI agents. No dedicated Microsoft AI Agents for Beginners guide,
+exact source URL duplicate, target file, or open duplicate PR was found.


### PR DESCRIPTION
## Summary
- add a source-backed guide entry for Microsoft AI Agents for Beginners

## What changed
- adds `content/guides/microsoft-ai-agents-for-beginners.mdx`
- covers course lessons for agentic frameworks, design patterns, tool use, agentic RAG, trustworthy agents, planning, multi-agent workflows, production, MCP/A2A/NLWeb, context engineering, memory, browser-use, Microsoft Agent Framework, and security
- includes safety/privacy notes for Azure AI Foundry, Microsoft Agent Framework samples, model provider keys, browser automation, and course code execution

## Why
- Microsoft AI Agents for Beginners is a high-demand agent curriculum that should rank for AI Agents for Beginners, Microsoft Agent Framework tutorial, Azure AI Foundry agents, agentic RAG tutorial, multi-agent design pattern, MCP A2A NLWeb protocols, and AI agent memory searches

## Validation
- `pnpm validate:content:strict -- --category guides`
- `node scripts/ci/validate-content-policy.mjs --repo-root . --files-json <new content file>`
- `pnpm validate:content:strict`
- `pnpm validate:packages`
- `pnpm scan:packages`
- `pnpm validate:clean`
- `pnpm audit:content`
- `git diff --check`
- `git diff --cached --check`

## Notes
- `pnpm audit:content` stayed at the existing baseline of 3 semantic issues; generated audit output was not included in this PR.