### PR TITLE
fix(hooks): repair hardcoded secret guard matching

### DIFF
--- a/content/hooks/environment-variable-leak-warning-hook.mdx
+++ b/content/hooks/environment-variable-leak-warning-hook.mdx
@@ -74,7 +74,7 @@ scriptBody: |-
     *) exit 0 ;;
   esac
   file_path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // .toolInput.file_path // .tool_input.path // .toolInput.path // empty')
-  content=$(printf '%s' "$input" | jq -r '[.tool_input.content,.toolInput.content,.tool_input.new_string,.toolInput.new_string] | map(select(. != null and . != "")) | .[0] // empty')
+  content=$(printf '%s' "$input" | jq -r '[.tool_input.content,.toolInput.content,.tool_input.new_string,.toolInput.new_string,.tool_input.edits[]?.new_string,.toolInput.edits[]?.new_string] | map(select(type == "string" and . != "")) | join("\n")')
   case "$file_path" in
     *.md|*.mdx|*.ts|*.tsx|*.js|*.jsx|*.py|*.go|*.yaml|*.yml|*.json|*.env*) ;;
     *) exit 0 ;;
@@ -82,7 +82,7 @@ scriptBody: |-
   case "$file_path" in
     *.env|*.env.*|*/.env|*/.env/*) exit 0 ;;
   esac
-  if printf '%s' "$content" | grep -Eiq 'AKIA[0-9A-Z]{{16}}|ghp_[A-Za-z0-9]{{20,}}|github_pat_[A-Za-z0-9_]{{40,}}'; then
+  if printf '%s' "$content" | grep -Eiq 'AKIA[0-9A-Z]{16}|ghp_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{40,}'; then
     echo "Blocked: proposed edit matches common hardcoded credential shapes." >&2
     exit 2
   fi


### PR DESCRIPTION
### Motivation
- The published PreToolUse hook intended to block hardcoded AWS/GitHub tokens used doubled ERE braces like `{{16}}` which do not act as repetition quantifiers in `grep -E`, causing the guard to fail open. 
- The hook also advertised MultiEdit protection but only inspected top-level `content`/`new_string` fields and missed `edits[].new_string` arrays, so many MultiEdit payloads went unscanned.

### Description
- Replace the faulty doubled quantifiers with valid ERE quantifiers (`{16}`, `{20,}`, `{40,}`) in the hook `grep -Eiq` pattern to match AWS and GitHub token shapes. 
- Extend the `jq` extraction to include `.tool_input.edits[]?.new_string` and `.toolInput.edits[]?.new_string`, coerce to strings, and `join("\n")` so MultiEdit edit arrays are scanned. 
- Change is limited to `content/hooks/environment-variable-leak-warning-hook.mdx` in the `scriptBody` only and preserves original behavior for non-matching/ignored file paths.

### Testing
- Verified the hook script extracted from `scriptBody` blocks a Write payload with an AWS-like token with exit code `2`, blocks a MultiEdit payload with a GitHub-like token with exit code `2`, and allows safe content with exit code `0` using a local shell simulation. 
- Ran `pnpm validate:content:strict` which completed successfully. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3448950f24832cb18c669be49ff9c3)