### PR TITLE
fix(content): harden mcp auth statusline install

### DIFF
--- a/content/statuslines/mcp-auth-surface-statusline.mdx
+++ b/content/statuslines/mcp-auth-surface-statusline.mdx
@@ -20,8 +20,34 @@ sourceUrls:
   - "https://code.claude.com/docs/en/statusline"
   - "https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization"
 installable: true
-installCommand: >-
-  mkdir -p .claude/statuslines && touch .claude/statuslines/mcp-auth-surface.sh && chmod +x .claude/statuslines/mcp-auth-surface.sh
+installCommand: |-
+  mkdir -p .claude/statuslines
+  tmp="$(mktemp .claude/statuslines/mcp-auth-surface.sh.XXXXXX)"
+  cat > "$tmp" <<'EOF'
+  #!/usr/bin/env bash
+  set -u
+
+  input=$(cat)
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'MCP auth: jq unavailable\n'
+    exit 0
+  fi
+
+  servers=$(printf '%s' "$input" | jq -c '.mcp.servers // []' 2>/dev/null || printf '[]')
+  server_count=$(printf '%s' "$servers" | jq 'length' 2>/dev/null || printf '0')
+  remote_count=$(printf '%s' "$servers" | jq '[.[] | select((.url // .endpoint // "") | test("^https?://"))] | length' 2>/dev/null || printf '0')
+  credential_hint=$(printf '%s' "$servers" | jq '[.[] | select((.auth // .authorization // .headers // .env // null) != null)] | length' 2>/dev/null || printf '0')
+
+  if [ "$credential_hint" -gt 0 ]; then
+    state="credentials: review"
+  else
+    state="credentials: none shown"
+  fi
+
+  printf 'MCP auth: %s servers | %s remote | %s\n' "$server_count" "$remote_count" "$state"
+  EOF
+  chmod 700 "$tmp"
+  mv -f "$tmp" .claude/statuslines/mcp-auth-surface.sh
 usageSnippet: "MCP auth: 3 servers | 1 remote | credentials: review"
 copySnippet: |-
   {


### PR DESCRIPTION
### Motivation
- The entry's `installCommand` previously only `touch`ed and `chmod`ed `.claude/statuslines/mcp-auth-surface.sh` without writing the reviewed `scriptBody`, allowing a preexisting project-local script to be preserved and executed.
- That behavior enables a local-repo hijack where an attacker-supplied script is made executable and then invoked by the documented Claude Code config.
- The intent of the change is to ensure the reviewed script is the one installed and executed, preventing activation of attacker-controlled files.

### Description
- Replace the one-liner `mkdir && touch && chmod` with an installer that writes the reviewed script into a `mktemp`-created temporary file and atomically moves it into `.claude/statuslines/mcp-auth-surface.sh`.
- The installer sets restrictive permissions via `chmod 700` and uses `mv -f` to ensure the documented path cannot be left pointing at preexisting or symlinked content.
- Preserve the existing `configSnippet` and `scriptBody` frontmatter while changing only the `installCommand` so installation produces the reviewed, audited script.

### Testing
- Ran `pnpm validate:content:strict` and it passed.
- Ran package artifact checks with `pnpm scan:packages` and they passed.
- Ran the unit test file via `pnpm exec vitest run tests/statusline-scripts.test.ts` and the tests passed.
- Ran repository checks including `git diff --check` and content linting/format checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449b33584832c903a1e4ffad63302)