### PR TITLE
fix(guides): correct MCP rollback config filename

### DIFF
--- a/content/guides/package-provenance-checks-before-installing-mcp-servers.mdx
+++ b/content/guides/package-provenance-checks-before-installing-mcp-servers.mdx
@@ -131,7 +131,7 @@ Verified against official documentation on **2026-06-16**:
 - MCP registry catalogs servers with publisher metadata for discovery.
 - Claude Code security docs state Anthropic does not security-audit third-party MCP servers.
 - Teams should verify publisher, repository, and release artifact before install.
-- Rollback removes .mmp.json entries and revokes OAuth via /mcp when applicable.
+- Rollback removes .mcp.json entries and revokes OAuth via /mcp when applicable.
 
 ## Duplicate Check
 


### PR DESCRIPTION
### Motivation
- Correct a documentation typo in the MCP package provenance guide where the rollback note erroneously referenced `.mmp.json`, which could mislead users and leave an unwanted MCP server configuration in place instead of removing the real `.mcp.json` project config.

### Description
- Update `content/guides/package-provenance-checks-before-installing-mcp-servers.mdx` to replace the incorrect `.mmp.json` reference with the correct `.mcp.json` in the Source Verification Notes.

### Testing
- Ran `pnpm validate:content:strict`, which completed successfully, and ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d25350832cb7642e0ef1c5dd1a)