### PR TITLE
fix(content): preserve osv vulnerability reports

### DIFF
--- a/content/statuslines/osv-dependency-risk-statusline.mdx
+++ b/content/statuslines/osv-dependency-risk-statusline.mdx
@@ -56,7 +56,8 @@ scriptBody: |-
     tmp_report=$(mktemp "$report_dir/.osv-report.XXXXXX") || exit 0
     trap 'rm -f "$tmp_report"' EXIT
 
-    if osv-scanner --format json . > "$tmp_report" 2>/dev/null; then
+    osv-scanner --format json . > "$tmp_report" 2>/dev/null || true
+    if [ -s "$tmp_report" ] && { ! command -v jq >/dev/null 2>&1 || jq -e . "$tmp_report" >/dev/null 2>&1; }; then
       mv -f "$tmp_report" "$report"
       trap - EXIT
     fi


### PR DESCRIPTION
### Motivation
- Restore correct behavior for the OSV dependency-risk statusline by preserving valid JSON output from `osv-scanner` even when the scanner exits non-zero due to found vulnerabilities, because the prior change discarded those reports and produced stale/missing signals.

### Description
- Change the auto-scan flow to always write scanner output to a temporary file (`osv-scanner --format json . > "$tmp_report" || true`) and replace the final report only when the temp file is non-empty and contains valid JSON (validated with `jq` when available), while keeping the symlink safety and temporary-file replacement behavior.

### Testing
- Reproduced the issue and verified the fix using a targeted extracted statusline run with a fake `osv-scanner` that emits valid JSON and exits `1`, which now produces `deps: vulns 1 | review` as expected. 
- Ran `pnpm validate:content:strict` which passed. 
- Ran `git diff --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1bb14832c8f81972623313e55)