### PR TITLE
fix(infra): clarify retired dev deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev": "pnpm --filter web dev",
     "build": "pnpm --filter web build",
     "preview": "pnpm --filter web preview",
-    "deploy:dev": "pnpm --filter web run deploy:dev",
+    "deploy:dev": "node -e \"console.error('Dev deployments were retired; use pnpm deploy:prod for production deployments.'); process.exit(1)\"",
     "deploy:prod": "pnpm --filter web run deploy:prod",
     "type-check": "pnpm --filter web type-check",
     "validate:content": "node scripts/validate-content.mjs",


### PR DESCRIPTION
### Motivation
- The root `deploy:dev` script still delegated to a now-removed `apps/web` `deploy:dev` target, causing `pnpm --filter web run deploy:dev` to fail unexpectedly for operators and automation.

### Description
- Update the root `scripts.deploy:dev` in `package.json` to a short failing `node -e` one-liner that prints an explicit retirement message and exits, directing users to `pnpm deploy:prod`.

### Testing
- Ran `pnpm deploy:dev` which exited with code 1 and printed the retirement guidance, and ran `git diff --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1c530832c94a10b8cf4450573)