### PR TITLE
fix(content): clarify csv wrangler privacy note

### DIFF
--- a/content/skills/csv-excel-data-wrangler.mdx
+++ b/content/skills/csv-excel-data-wrangler.mdx
@@ -13,7 +13,7 @@ documentationUrl: "https://pandas.pydata.org/"
 downloadUrl: /downloads/skills/csv-excel-data-wrangler.zip
 installable: true
 privacyNotes:
-  - "The skill reads your CSV/Excel/JSON files locally with pandas; processing stays on-machine, but generated outputs and logs can contain values from your source data — review before sharing."
+  - "Claude Pro / Code Interpreter workflows require uploading CSV or Excel files to the Claude conversation for remote processing; local pandas runs read files on your machine. Generated outputs, logs, and conversation history can contain values from your source data — review before sharing."
 safetyNotes:
   - "Installs Python packages (pip install pandas openpyxl) and runs scripts that read and write data files, overwriting outputs at the target path; review transformations before running on important data."
 installCommand: pip install pandas openpyxl


### PR DESCRIPTION
### Motivation
- Correct a misleading privacy note that claimed all processing "stays on-machine" while the skill documents `Claude Pro` / `Code Interpreter` usage that requires uploading CSV/XLSX files to the conversation for remote processing.

### Description
- Update `privacyNotes` in `content/skills/csv-excel-data-wrangler.mdx` to explicitly state that `Claude Pro` / `Code Interpreter` workflows require uploading files for remote processing while preserving the disclosure for local `pandas` runs and leaving `safetyNotes` unchanged.

### Testing
- Ran `pnpm validate:content:strict` which passed, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d174f4832c850b20f202ca551d)