### PR TITLE
fix(content): disable Godot MCP debug default

### DIFF
--- a/content/mcp/godot-mcp-server.mdx
+++ b/content/mcp/godot-mcp-server.mdx
@@ -33,8 +33,7 @@ copySnippet: |-
         "command": "npx",
         "args": ["@coding-solo/godot-mcp"],
         "env": {
-          "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE",
-          "DEBUG": "true"
+          "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE"
         }
       }
     }
@@ -46,8 +45,7 @@ configSnippet: |-
         "command": "npx",
         "args": ["@coding-solo/godot-mcp"],
         "env": {
-          "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE",
-          "DEBUG": "true"
+          "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE"
         }
       }
     }
@@ -121,7 +119,7 @@ environment variables, and setup details.
 - Create scenes, add nodes, load sprites and textures, export MeshLibrary
   resources, and save scenes.
 - Get and update UID references for Godot 4.4 and newer projects.
-- Optional debug logging through the `DEBUG` environment variable.
+- Optional debug logging through the `DEBUG` environment variable when troubleshooting.
 
 ## Installation
 
@@ -134,8 +132,7 @@ For MCP clients that launch stdio servers:
       "command": "npx",
       "args": ["@coding-solo/godot-mcp"],
       "env": {
-        "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE",
-        "DEBUG": "true"
+        "GODOT_PATH": "PATH_TO_GODOT_EXECUTABLE"
       }
     }
   }
@@ -143,7 +140,9 @@ For MCP clients that launch stdio servers:
 ```
 
 Omit `GODOT_PATH` when automatic Godot detection works for your environment.
-Restart the MCP client after adding the server.
+Leave debug logging disabled for normal use; set `DEBUG` to `true` only while
+troubleshooting and review logs before sharing them. Restart the MCP client after
+adding the server.
 
 ## Use Cases
 


### PR DESCRIPTION
### Motivation

- The new Godot MCP entry shipped a copyable configuration that set `DEBUG: "true"` by default, which can leak project paths, assets, errors, and other sensitive runtime details.
- The entry's own safety/privacy notes warn that debug output may expose sensitive project internals, so the safe default should disable debug logging and make it an opt-in troubleshooting option.

### Description

- Removed the `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d29070832cb666d3c0544d4456)