### PR TITLE
fix(submissions): keep canonical source retries blocking

### DIFF
--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -399,10 +399,7 @@ function hasVerifiableCanonicalSource(urls: SourceEvidenceItem[]) {
 }
 
 function isDowngradableInconclusiveSource(item: SourceEvidenceItem) {
-  return (
-    item.status === "retryable" &&
-    !PRIMARY_CANONICAL_SOURCE_FIELDS.has(item.field)
-  );
+  return item.role === "distribution" && item.status === "retryable";
 }
 
 function downgradeInconclusiveSourceWarnings(urls: SourceEvidenceItem[]) {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -963,7 +963,7 @@ downloadUrl: "https://github.com/example/project/archive/refs/heads/main.zip"
     });
   });
 
-  it("treats isolated auxiliary source fetch errors as warnings when canonical evidence passes", async () => {
+  it("keeps retryable auxiliary canonical source fields blocking when canonical evidence passes", async () => {
     const report = await checkSubmittedSourceEvidence(
       `---
 title: GitHub Blob Warning Fixture
@@ -982,15 +982,17 @@ sourceUrls:
       }),
     );
 
-    expect(report.status).toBe("passed");
-    expect(report.warnings).toHaveLength(1);
-    expect(report.warnings[0]).toMatchObject({
-      field: "sourceUrls",
-      status: "retryable",
-      outcome: "fetch_error",
-      role: "canonical",
-      blocking: false,
-    });
+    expect(report.status).toBe("retryable");
+    expect(report.warnings).toHaveLength(0);
+    expect(report.urls).toContainEqual(
+      expect.objectContaining({
+        field: "sourceUrls",
+        status: "retryable",
+        outcome: "fetch_error",
+        role: "canonical",
+        blocking: true,
+      }),
+    );
     expect(sourceEvidenceCloseDecision(report)).toBeNull();
   });
 


### PR DESCRIPTION
### Motivation
- A recent change widened the inconclusive-source downgrade to affect all retryable source evidence, which allowed retryable canonical URLs (401/403/429/5xx/fetch errors) to become non-blocking when another canonical source passed, weakening deterministic verification.
- The intent is to restore the prior stricter behavior so canonical source retryable failures remain blocking and halt deterministic automation until retried or handled manually.

### Description
- Restrict downgrades so only items with `role === "distribution"` and `status === "retryable"` are marked non-blocking by `isDowngradableInconclusiveSource` in `apps/submission-gate/src/source-evidence.ts`.
- Update the regression test in `tests/submission-gate-worker.test.ts` to assert that retryable canonical `sourceUrls` remain blocking and keep the overall report `retryable` when other canonical evidence passes.

### Testing
- Ran `pnpm exec vitest run tests/source-evidence.test.ts tests/submission-gate-worker.test.ts` and all tests passed (`Test Files 2 passed`, `Tests 99 passed`).
- Ran repository hygiene checks including `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1986c832c926907edf2adb941)