### PR TITLE
fix(content): harden metamcp install steps

### DIFF
--- a/content/mcp/metamcp-gateway.mdx
+++ b/content/mcp/metamcp-gateway.mdx
@@ -24,7 +24,7 @@ repoUrl: "https://github.com/metatool-ai/metamcp"
 documentationUrl: "https://docs.metamcp.com"
 packageUrl: "https://github.com/metatool-ai/metamcp/pkgs/container/metamcp"
 installable: true
-installCommand: "git clone https://github.com/metatool-ai/metamcp.git && cd metamcp && cp example.env .env && docker compose up -d"
+installCommand: "git clone https://github.com/metatool-ai/metamcp.git && cd metamcp && cp example.env .env && ${EDITOR:-vi} .env"
 usageSnippet: "Deploy MetaMCP with Docker Compose, create namespaces and endpoints, then connect MCP clients to the generated SSE or Streamable HTTP endpoint with the approved auth mode."
 copySnippet: |-
   {
@@ -148,12 +148,17 @@ The repository documents Docker Compose as the recommended quick start:
 git clone https://github.com/metatool-ai/metamcp.git
 cd metamcp
 cp example.env .env
-docker compose up -d
+${EDITOR:-vi} .env
 ```
 
-Review `.env` before starting the service. Replace default secrets, bootstrap
-users, bootstrap passwords, API key settings, app URL, registration settings,
-Postgres credentials, and OIDC settings before exposing the service.
+Review and save `.env` before starting the service. Replace default secrets,
+bootstrap users, bootstrap passwords, API key settings, app URL, registration
+settings, Postgres credentials, and OIDC settings before exposing the service.
+After hardening the environment and network settings, start MetaMCP:
+
+```bash
+docker compose up -d
+```
 
 For MCP clients that support remote servers, connect to the MetaMCP endpoint URL
 with the approved auth header. For stdio-only clients, the README recommends


### PR DESCRIPTION
### Motivation
- Prevent users from launching MetaMCP with the example `.env` (which contains bootstrap credentials and permissive defaults) before they have a chance to review and replace secrets.

### Description
- Update `content/mcp/metamcp-gateway.mdx` so `installCommand` stops after copying `example.env` and opens `.env` for editing (`${EDITOR:-vi} .env`) instead of immediately running `docker compose up -d`.
- Split the installation instructions to require users to review and save `.env` first, then run `docker compose up -d` as a separate, explicit step.
- Preserve existing safety and privacy notes while aligning the quick-start commands with those notes.

### Testing
- Ran `pnpm validate:content:strict` which completed successfully.
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1dc84832c9a35bb0b3dd349a4)