### PR TITLE
fix(submissions): include sourceUrls in duplicate scans

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -65,6 +65,7 @@ const URL_FIELDS = new Set([
   "repoUrl",
   "repositoryUrl",
   "sourceUrl",
+  "sourceUrls",
   "websiteUrl",
   "docs_url",
   "download_url",
@@ -73,6 +74,7 @@ const URL_FIELDS = new Set([
   "repo_url",
   "repository_url",
   "source_url",
+  "source_urls",
   "website_url",
 ]);
 
@@ -83,6 +85,7 @@ const CROSS_CATEGORY_STRICT_URL_FIELDS = new Set([
   "repoUrl",
   "repositoryUrl",
   "sourceUrl",
+  "sourceUrls",
   "websiteUrl",
   "download_url",
   "github_url",
@@ -90,6 +93,7 @@ const CROSS_CATEGORY_STRICT_URL_FIELDS = new Set([
   "repo_url",
   "repository_url",
   "source_url",
+  "source_urls",
   "website_url",
 ]);
 const DOMAIN_ONLY_EXCLUSIONS = new Set([
@@ -135,6 +139,37 @@ export function parseSimpleFrontmatter(source: string) {
     if (!value || value === "|" || value === ">") continue;
     fields[key] = unquoteYamlScalar(value);
   }
+  return fields;
+}
+
+function parseSimpleFrontmatterListFields(
+  source: string,
+  listFields: Set<string>,
+) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(
+    String(source || ""),
+  );
+  const fields: Record<string, string[]> = {};
+  if (!match) return fields;
+
+  let currentKey = "";
+  for (const line of match[1].split(/\r?\n/)) {
+    const listStart = /^([A-Za-z][A-Za-z0-9_]*):\s*$/.exec(line);
+    if (listStart) {
+      currentKey = listFields.has(listStart[1]) ? listStart[1] : "";
+      if (currentKey) fields[currentKey] = fields[currentKey] || [];
+      continue;
+    }
+    if (!currentKey) continue;
+    const item = /^\s+-\s*(.*?)\s*$/.exec(line);
+    if (item) {
+      const value = unquoteYamlScalar(item[1]);
+      if (value) fields[currentKey].push(value);
+      continue;
+    }
+    if (!/^\s/.test(line)) currentKey = "";
+  }
+
   return fields;
 }
 
@@ -236,13 +271,25 @@ export function extractContentDuplicateSignals(params: {
 }): ContentDuplicateSignals {
   const fields = parseSimpleFrontmatter(params.content);
   const parts = pathParts(params.filePath);
-  const urlEntries = Object.entries(fields)
+  const listFields = parseSimpleFrontmatterListFields(
+    params.content,
+    URL_FIELDS,
+  );
+  const scalarUrlEntries = Object.entries(fields)
     .filter(([key]) => URL_FIELDS.has(key))
     .map(([key, value]) => ({
       key,
       url: normalizeUrl(value),
-    }))
-    .filter((entry) => entry.url);
+    }));
+  const listUrlEntries = Object.entries(listFields).flatMap(([key, values]) =>
+    values.map((value) => ({
+      key,
+      url: normalizeUrl(value),
+    })),
+  );
+  const urlEntries = [...scalarUrlEntries, ...listUrlEntries].filter(
+    (entry) => entry.url,
+  );
   const urls = [...new Set(urlEntries.map((entry) => entry.url))];
   const strictDuplicateUrls = [
     ...new Set(

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2163,6 +2163,12 @@ function contentSignalSourceFromDirectoryEntry(entry: Record<string, unknown>) {
     const value = entry[field];
     if (value) lines.push(`${field}: ${yamlScalar(value)}`);
   }
+  if (Array.isArray(entry.sourceUrls) && entry.sourceUrls.length) {
+    lines.push("sourceUrls:");
+    for (const value of entry.sourceUrls) {
+      lines.push(`  - ${yamlScalar(value)}`);
+    }
+  }
   lines.push("---", "");
   return lines.join("\n");
 }

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2518,6 +2518,44 @@ ${urls}
     }
     expect(helperSource).toContain("DIRECTORY_ENTRY_URL_SIGNAL_FIELDS");
     expect(helperSource).toContain("entry[field]");
+    expect(helperSource).toContain("Array.isArray(entry.sourceUrls)");
+  });
+
+  it("detects duplicate submissions from list-form source URLs", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/tools/source-list.mdx",
+      content: `---
+title: Shared Source Tool
+slug: source-list
+category: tools
+description: Local CLI for analyzing Claude Code usage.
+sourceUrls:
+  - "https://github.com/acme/shared-project"
+---
+`,
+      label: "accepted entry content/tools/source-list.mdx",
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/tools/source-list-copy.mdx",
+      content: `---
+title: Shared Source Tool Copy
+slug: source-list-copy
+category: tools
+description: Local CLI for analyzing Claude Code usage.
+sourceUrls:
+  - "https://github.com/acme/shared-project?utm_source=form"
+---
+`,
+    });
+
+    expect(candidate.urls).toContain("https://github.com/acme/shared-project");
+    expect(
+      findStrictContentDuplicateMatch(candidate, [existing]),
+    ).toMatchObject({
+      reasons: expect.arrayContaining([
+        expect.stringContaining("same canonical source URL"),
+      ]),
+    });
   });
 
   it("detects neutral duplicate submissions from canonical source URLs", () => {


### PR DESCRIPTION
### Motivation
- The registry started preserving `sourceUrls` arrays in public artifacts and trust signals, but duplicate-detection code only consumed scalar URL fields, letting same-source submissions bypass deterministic duplicate checks.  
- This weakened the submission gate's integrity by allowing accepted entries whose canonical evidence lived only in `sourceUrls` to be ignored during accepted-entry reconstruction.  
- The change aims to ensure list-form source evidence is treated equivalently to scalar URL fields for strict duplicate matching.

### Description
- Include `sourceUrls` and `source_urls` in the URL allowlists by adding them to `URL_FIELDS` and `CROSS_CATEGORY_STRICT_URL_FIELDS` in `apps/submission-gate/src/duplicates.ts`.  
- Add `parseSimpleFrontmatterListFields` to parse list-form YAML frontmatter and merge list-form URL entries with scalar URL fields when extracting duplicate signals in `apps/submission-gate/src/duplicates.ts`.  
- Reconstruct accepted directory entries to emit `sourceUrls` arrays into the synthetic frontmatter used for deterministic duplicate scans in `apps/submission-gate/src/index.ts`.  
- Add a regression test in `tests/submission-gate-worker.test.ts` that verifies duplicate detection works when both accepted and candidate entries only provide list-form `sourceUrls` evidence.

### Testing
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts`, which exercised the new parsing and reconstruction logic and completed with all tests passing (`97 passed`).  
- Verified the worker-source reconstruction helper now emits `sourceUrls` and that list-form `sourceUrls` produce normalized URLs consumed by duplicate checks via the new regression test.  
- Ran `git diff --check` to ensure no trailing whitespace or diff issues were introduced and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d18c94832cb26494e8831492c1)