### PR TITLE
fix(submissions): avoid strict cross-category URL duplicates

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -6,7 +6,6 @@ export type ContentDuplicateSignals = {
   normalizedTitle: string;
   normalizedDescription: string;
   urls: string[];
-  strictDuplicateUrls: string[];
   domains: string[];
   label?: string;
   url?: string;
@@ -78,24 +77,6 @@ const URL_FIELDS = new Set([
   "website_url",
 ]);
 
-const CROSS_CATEGORY_STRICT_URL_FIELDS = new Set([
-  "downloadUrl",
-  "githubUrl",
-  "packageUrl",
-  "repoUrl",
-  "repositoryUrl",
-  "sourceUrl",
-  "sourceUrls",
-  "websiteUrl",
-  "download_url",
-  "github_url",
-  "package_url",
-  "repo_url",
-  "repository_url",
-  "source_url",
-  "source_urls",
-  "website_url",
-]);
 const DOMAIN_ONLY_EXCLUSIONS = new Set([
   "github.com",
   "npmjs.com",
@@ -291,14 +272,6 @@ export function extractContentDuplicateSignals(params: {
     (entry) => entry.url,
   );
   const urls = [...new Set(urlEntries.map((entry) => entry.url))];
-  const strictDuplicateUrls = [
-    ...new Set(
-      urlEntries
-        .filter((entry) => CROSS_CATEGORY_STRICT_URL_FIELDS.has(entry.key))
-        .map((entry) => entry.url),
-    ),
-  ];
-
   return {
     filePath: params.filePath,
     category: normalizeText(fields.category) || parts.category,
@@ -307,7 +280,6 @@ export function extractContentDuplicateSignals(params: {
     normalizedTitle: normalizeText(fields.title),
     normalizedDescription: normalizeText(fields.description),
     urls,
-    strictDuplicateUrls,
     domains: [...new Set(urls.map(domainFromUrl).filter(Boolean))],
     label: params.label,
     url: params.url,
@@ -449,9 +421,6 @@ export function findStrictContentDuplicateMatch(
 
     const sharedUrls = intersection(candidate.urls, existing.urls);
     const blockingSharedUrls = strictDuplicateUrls(sharedUrls);
-    const crossCategoryBlockingSharedUrls = strictDuplicateUrls(
-      intersection(candidate.strictDuplicateUrls, existing.strictDuplicateUrls),
-    );
     const catalogSubpathUrls = multiEntryCatalogSubpathUrls(blockingSharedUrls);
     if (
       catalogSubpathUrls.length &&
@@ -460,17 +429,6 @@ export function findStrictContentDuplicateMatch(
     ) {
       reasons.push(
         `same multi-entry catalog subpath URL ${catalogSubpathUrls[0]}`,
-      );
-    }
-    if (
-      crossCategoryBlockingSharedUrls.length &&
-      candidate.category &&
-      existing.category &&
-      candidate.category !== existing.category &&
-      !isCollectionBridge(candidate, existing)
-    ) {
-      reasons.push(
-        `same canonical source URL ${crossCategoryBlockingSharedUrls[0]} across ${candidate.category}/${existing.category}`,
       );
     }
     if (

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2768,7 +2768,7 @@ docsUrl: "https://docs.anthropic.com/en/docs/claude-code/security#events"
     );
   });
 
-  it("treats same canonical project across different categories as a strict duplicate", () => {
+  it("treats same canonical project across different categories as related, not strict duplicate", () => {
     const existingMcp = extractContentDuplicateSignals({
       filePath: "content/mcp/langchain-mcp-server.mdx",
       content: `---
@@ -2794,13 +2794,7 @@ repoUrl: "https://github.com/langchain-ai/langchain.git"
 
     expect(
       findStrictContentDuplicateMatch(candidateSkill, [existingMcp]),
-    ).toMatchObject({
-      reasons: expect.arrayContaining([
-        expect.stringContaining(
-          "same canonical source URL https://github.com/langchain-ai/langchain across skills/mcp",
-        ),
-      ]),
-    });
+    ).toBeNull();
     expect(findRelatedContentMatches(candidateSkill, [existingMcp])).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -2814,7 +2808,7 @@ repoUrl: "https://github.com/langchain-ai/langchain.git"
     );
   });
 
-  it("treats same canonical website across different categories as a strict duplicate", () => {
+  it("treats same canonical website across different categories as related, not strict duplicate", () => {
     const existingTool = extractContentDuplicateSignals({
       filePath: "content/tools/acme-claude.mdx",
       content: `---
@@ -2840,13 +2834,7 @@ websiteUrl: "https://acme-claude.example/product?utm_source=submission"
 
     expect(
       findStrictContentDuplicateMatch(candidateMcp, [existingTool]),
-    ).toMatchObject({
-      reasons: expect.arrayContaining([
-        expect.stringContaining(
-          "same canonical source URL https://acme-claude.example/product across mcp/tools",
-        ),
-      ]),
-    });
+    ).toBeNull();
     expect(findRelatedContentMatches(candidateMcp, [existingTool])).toEqual(
       expect.arrayContaining([
         expect.objectContaining({


### PR DESCRIPTION
### Motivation
- Prevent deterministic auto-closure of legitimate submissions caused by treating any shared canonical URL across different non-collection categories as a strict duplicate. 
- Close an availability/integrity gap where earlier open PRs could be used to squat a popular source URL and block later legitimate submissions.

### Description
- Remove the separate `strictDuplicateUrls` extraction and the `CROSS_CATEGORY_STRICT_URL_FIELDS` set from `apps/submission-gate/src/duplicates.ts` so cross-category URL fields are no longer elevated to strict duplicate signals. 
- Remove the cross-category blocking branch from `findStrictContentDuplicateMatch` that pushed a `same canonical source URL ... across X/Y` reason for different categories. 
- Preserve cross-category shared URLs in the related-match code path so reviewers still see shared canonical URLs as context. 
- Update `tests/submission-gate-worker.test.ts` to assert that shared GitHub project and website URLs across different categories are treated as related (and not strict duplicates) and adjust test names/assertions accordingly.

### Testing
- Ran the targeted Vitest selectors with `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "canonical project across different categories|canonical website across different categories|shared official docs across categories"` and the targeted checks passed. 
- Ran the full submission-gate worker test file with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and all tests in that file passed. 
- Ran `pnpm exec tsc --noEmit --pretty false --project apps/submission-gate/tsconfig.json` which could not complete because `apps/submission-gate/tsconfig.json` is not present in this repository (noted as an environmental mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d29a90832cb11bc42b277fc0fa)