### PR TITLE
fix(skills): remove mutable NanoClaw package URL

### DIFF
--- a/content/skills/nanoclaw-container-isolation-review-capability-pack.mdx
+++ b/content/skills/nanoclaw-container-isolation-review-capability-pack.mdx
@@ -24,7 +24,6 @@ sourceSubmissionNumber: 1551
 sourceSubmissionUrl: "https://github.com/JSONbored/awesome-claude/issues/1551"
 repoUrl: "https://github.com/nanocoai/nanoclaw"
 documentationUrl: "https://github.com/nanocoai/nanoclaw"
-downloadUrl: "https://github.com/nanocoai/nanoclaw/archive/refs/heads/main.zip"
 installable: false
 usageSnippet: >-
   Use this skill when reviewing a NanoClaw deployment's container isolation before

--- a/packages/registry/src/content-schema.js
+++ b/packages/registry/src/content-schema.js
@@ -664,8 +664,10 @@ export function validateEntry(category, data, inferred = {}) {
   }
 
   if ((category === "mcp" || category === "skills") && !merged.installable) {
-    const installIndex = recommendedFields.indexOf("installCommand");
-    if (installIndex >= 0) recommendedFields.splice(installIndex, 1);
+    for (const field of ["installCommand", "downloadUrl"]) {
+      const installIndex = recommendedFields.indexOf(field);
+      if (installIndex >= 0) recommendedFields.splice(installIndex, 1);
+    }
   }
 
   if (category === "skills" && merged.downloadUrl && !merged.installCommand) {

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -279,6 +279,27 @@ describe("inferStructuredFields", () => {
     );
   });
 
+  it("does not recommend package fields for non-installable skills", () => {
+    const result = validateEntry("skills", {
+      slug: "copy-only-capability-pack",
+      title: "Copy-only Capability Pack",
+      description: "Review capability pack with copyable instructions.",
+      cardDescription: "Copyable review instructions.",
+      installable: false,
+      usageSnippet: "Use this pack during a review.",
+      copySnippet: "Review checklist.",
+      skillType: "capability-pack",
+      skillLevel: "expert",
+      verificationStatus: "validated",
+      verifiedAt: "2026-01-01",
+      retrievalSources: ["https://docs.example.com"],
+      testedPlatforms: ["Claude"],
+    });
+
+    expect(result.missingRecommended).not.toContain("installCommand");
+    expect(result.missingRecommended).not.toContain("downloadUrl");
+  });
+
   it("orders frontmatter while dropping empty values and appending unknown keys", () => {
     expect(
       orderFrontmatter({

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -1322,10 +1322,23 @@ Use this hook after reviewing the notes.`,
       (entry) => entry.category === "skills",
     );
     expect(skills.length).toBeGreaterThan(0);
+    const packageBackedSkills = skills.filter((entry) => entry.downloadUrl);
+    const copyOnlySkill = skills.find(
+      (entry) =>
+        entry.slug === "nanoclaw-container-isolation-review-capability-pack",
+    );
+    expect(packageBackedSkills.length).toBeGreaterThan(0);
+    expect(copyOnlySkill?.installable).toBe(false);
+    expect(copyOnlySkill?.downloadUrl).toBe("");
+    expect(copyOnlySkill?.skillPackage).toBeUndefined();
 
     for (const entry of skills) {
-      expect(entry.skillPackage?.format).toBe("agent-skill");
-      expect(entry.skillPackage?.entrypoint).toBe("SKILL.md");
+      if (entry.downloadUrl) {
+        expect(entry.skillPackage?.format).toBe("agent-skill");
+        expect(entry.skillPackage?.entrypoint).toBe("SKILL.md");
+      } else {
+        expect(entry.skillPackage).toBeUndefined();
+      }
       expect(entry.platformCompatibility?.map((item) => item.platform)).toEqual(
         expect.arrayContaining([
           "Claude",


### PR DESCRIPTION
### Motivation
- A newly added skill entry advertised a mutable GitHub branch ZIP (`refs/heads/main.zip`) as `downloadUrl`, which the registry pipeline treated as a package and emitted as installable metadata despite the entry being marked non-installable, creating a supply-chain integrity risk. 
- The change ensures copy-only capability packs do not surface unpinned external archives as package/installable artifacts.

### Description
- Removed the `downloadUrl` field from `content/skills/nanoclaw-container-isolation-review-capability-pack.mdx` so the entry is not treated as a package. 
- Updated `packages/registry/src/content-schema.js` to stop recommending package fields for non-installable MCP/skill entries by excluding both `installCommand` and `downloadUrl` from recommended checks when `installable` is `false`. 
- Added regression coverage in `tests/content-schema.test.ts` with a new test ensuring non-installable skills are not required to provide package metadata.

### Testing
- Ran the targeted unit tests with `pnpm exec vitest run tests/content-schema.test.ts` and the suite passed (`10 tests` passed). 
- Ran content validation with `pnpm validate:content:strict` and it passed (`Content validation passed`). 
- Ran package/download validation with `pnpm validate:packages` / `node scripts/validate-download-packages.mjs` and it passed (`Package download validation passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d280f8832ca759aa5b2a5d4149)