### PR TITLE
fix(docs): validate cloud session branch names

### DIFF
--- a/content/guides/claude-code-desktop-parallel-sessions-workflow.mdx
+++ b/content/guides/claude-code-desktop-parallel-sessions-workflow.mdx
@@ -126,11 +126,14 @@ side by side.
 
 When you hand a session off to the cloud (or resume a Dispatch session), the
 branch it created may not exist on your machine yet. Copy the branch name from
-the session toolbar, then fetch and check it out:
+the session toolbar, validate it as a branch name, then use quoted arguments
+when you fetch and check it out:
 
 ```bash
-git fetch origin <branch-name>
-git checkout <branch-name>
+branch='<branch-name>'
+git check-ref-format --branch "$branch"
+git fetch origin "$branch"
+git checkout "$branch"
 ```
 
 ## Step-by-Step Implementation Guide


### PR DESCRIPTION
### Motivation
- Close a documentation security issue where unquoted branch-name examples could allow shell metacharacter injection when users paste branch names into shell commands.
- Encourage a safe, copy-paste-friendly workflow that validates and quotes branch names before using them in `git` commands.

### Description
- Updated `content/guides/claude-code-desktop-parallel-sessions-workflow.mdx` to replace unquoted placeholder commands with a variable-based workflow that validates the branch with `git check-ref-format --branch "$branch"` and uses quoted arguments for `git fetch` and `git checkout`.
- The example now assigns the copied branch to `branch='<branch-name>'` and uses `"$branch"` in subsequent commands to prevent shell interpretation of metacharacters.

### Testing
- Ran `pnpm validate:content:strict`, which passed for the modified content file.
- Ran `git diff --check`, which reported no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1832c832cbea363f5f13c514f)