### PR TITLE
fix(content): remove Bash from Agent SDK quickstart

### DIFF
--- a/content/guides/claude-agent-sdk-quickstart-for-production-agents.mdx
+++ b/content/guides/claude-agent-sdk-quickstart-for-production-agents.mdx
@@ -93,7 +93,7 @@ Recent fixes address streaming mode notification delivery and end-of-stream exce
 
 ## Minimal Query Loop (Python)
 
-The Agent SDK runs the same agent loop and built-in tools as Claude Code, programmable from a `query` call. This minimal example lists files in the working directory using an explicit, narrow tool allowlist:
+The Agent SDK runs the same agent loop and built-in tools as Claude Code, programmable from a `query` call. This minimal example lists files in the working directory using an explicit read-only tool allowlist. Avoid allowing `Bash` for directory-listing tasks because it grants broad shell execution rather than read-only discovery; run production agents from an isolated working directory and add command-scoped or sandboxed shell permissions only when a workflow truly requires them:
 
 ```python
 import asyncio
@@ -102,8 +102,8 @@ from claude_agent_sdk import query, ClaudeAgentOptions
 
 async def main():
     async for message in query(
-        prompt="What files are in this directory?",
-        options=ClaudeAgentOptions(allowed_tools=["Bash", "Glob"]),
+        prompt="Use Glob to list the files in this directory.",
+        options=ClaudeAgentOptions(allowed_tools=["Glob"]),
     ):
         if hasattr(message, "result"):
             print(message.result)


### PR DESCRIPTION
### Motivation
- The quickstart example previously allowed `Bash` alongside `Glob` for a simple directory-listing task which grants broad shell execution and could encourage unsafe production configurations.

### Description
- Update `content/guides/claude-agent-sdk-quickstart-for-production-agents.mdx` to replace the example `allowed_tools=["Bash", "Glob"]` with a `Glob`-only allowlist, change the prompt to instruct using `Glob`, and add a short warning to avoid `Bash` for read-only directory discovery.

### Testing
- Ran `pnpm validate:content:strict` which passed, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1c260832c8cb4cca8a3a0e5b3)