### PR TITLE
fix(ci): avoid Codecov token on PR coverage uploads

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,7 +88,15 @@ jobs:
       - name: Run Vitest suite with coverage
         run: pnpm test:coverage
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov (pull request)
+        if: github.event_name == 'pull_request'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
+      - name: Upload coverage to Codecov (trusted)
+        if: github.event_name != 'pull_request'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent exposing `secrets.CODECOV_TOKEN` to untrusted pull request code by avoiding a secret-consuming action after repository-controlled install/build/test steps in the same job.

### Description
- Split the coverage upload into two conditional steps in `.github/workflows/coverage.yml`: a tokenless Codecov upload gated with `if: github.event_name == 'pull_request'` and a tokened upload gated with `if: github.event_name != 'pull_request'` that uses `secrets.CODECOV_TOKEN` for trusted contexts.

### Testing
- Ran `git diff --check` which succeeded. 
- Ran a targeted Python assertion verifying the pull request Codecov step does not reference `secrets.CODECOV_TOKEN`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d2a7a4832c844c9f8927fc0ab6)