### PR TITLE
fix(guides): avoid inheriting host env in tenant SDK example

### DIFF
--- a/content/guides/hosting-the-claude-agent-sdk-with-multi-tenant-isolation.mdx
+++ b/content/guides/hosting-the-claude-agent-sdk-with-multi-tenant-isolation.mdx
@@ -102,19 +102,24 @@ are applied at your proxy, not inside the SDK call alone.
 1. **Provision per-tenant directories.** Create `tenantDir` and `configDir` paths
    with permissions so tenants cannot read each other's files.
 
-2. **Apply SDK options on every query.** TypeScript example from official docs:
+2. **Apply SDK options on every query.** Build a minimal allowlisted
+   environment for the tenant subprocess instead of inheriting all host
+   variables, which may include deployment-wide secrets:
 
 ```typescript
+const tenantEnv = {
+  PATH: process.env.PATH ?? "",
+  HOME: tenantDir,
+  CLAUDE_CONFIG_DIR: configDir,
+  CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
+};
+
 for await (const message of query({
   prompt,
   options: {
     cwd: tenantDir,
     settingSources: [],
-    env: {
-      ...process.env,
-      CLAUDE_CONFIG_DIR: configDir,
-      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
-    },
+    env: tenantEnv,
   },
 })) {
   // handle messages


### PR DESCRIPTION
### Motivation

- The original guide example spread the entire host `process.env` into each tenant SDK subprocess, which can expose deployment-wide secrets to tenant-controlled sessions. 
- The change aims to reduce information exposure by recommending a minimal, allowlisted environment for tenant subprocesses. 

### Description

- Updated `content/guides/hosting-the-claude-agent-sdk-with-multi-tenant-isolation.mdx` to replace the unsafe `...process.env` usage in the TypeScript example with a minimal `tenantEnv` object. 
- The `tenantEnv` preserves necessary runtime values (`PATH`, per-tenant `HOME`/`tenantDir`) and CLAUDE-specific settings (`CLAUDE_CONFIG_DIR`, `CLAUDE_CODE_DISABLE_AUTO_MEMORY`) while avoiding copying host secrets. 
- The example now passes `env: tenantEnv` into the `query()` `options` while keeping `cwd` and `settingSources: []` unchanged to preserve the intended isolation behavior. 

### Testing

- Ran `pnpm validate:content:strict`, and content validation passed. 
- Ran `git diff --check` and there were no check failures. 
- The updated guide example is textual/documentation-only and no unit tests were required or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1c234832c8ce897dd8109fe96)