### PR TITLE
fix(submissions): restrict manual recheck resets

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2348,6 +2348,7 @@ async function enqueueReviewTarget(
   eventName: string,
   webhook?: Record<string, unknown>,
   forceRecheck = false,
+  trustedManualRecheck = false,
 ) {
   if (target.baseRef !== contentGateBaseRef(env)) return false;
   const targetKey = targetKeyForReview(target);
@@ -2367,7 +2368,8 @@ async function enqueueReviewTarget(
       isReopenedPullRequestEvent(eventName, webhook) ||
       eventName === "scheduled");
   const shouldResetManualTerminal =
-    forceRecheck === true && String(existing?.status || "") === "manual";
+    trustedManualRecheck === true &&
+    String(existing?.status || "") === "manual";
   const shouldQueueReview =
     !hasTerminalGateDecision(existing) ||
     shouldResetIgnoredScan ||
@@ -2408,7 +2410,14 @@ async function enqueueReviewTarget(
   await env.SUBMISSION_REVIEW_QUEUE.send({
     kind: "review_pr",
     targetKey,
-    payload: { eventName, deliveryId, target, webhook, forceRecheck },
+    payload: {
+      eventName,
+      deliveryId,
+      target,
+      webhook,
+      forceRecheck,
+      trustedManualRecheck,
+    },
   });
   return true;
 }
@@ -2721,6 +2730,7 @@ async function githubWebhookRoute(
       eventName,
       payload,
       true,
+      true,
     );
     const targetKey = targetKeyForReview(target);
     return json({ ok: true, queued: true, targetKey });
@@ -3027,6 +3037,9 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
       const forceRecheck =
         message.payload.forceRecheck === true ||
         String(message.payload.eventName || "") === "issue_comment";
+      const trustedManualRecheck =
+        message.payload.trustedManualRecheck === true ||
+        String(message.payload.eventName || "") === "issue_comment";
       const existing = await getPrState(env.SUBMISSION_GATE_DB, {
         repo: target.repoFullName,
         number: target.number,
@@ -3072,7 +3085,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
             return;
           }
           const existingStatus = String(existing?.status || "");
-          if (existingStatus === "manual" && !forceRecheck) {
+          if (existingStatus === "manual" && !trustedManualRecheck) {
             await insertAudit(env.SUBMISSION_GATE_DB, {
               id: crypto.randomUUID(),
               targetKey: message.targetKey,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -579,12 +579,16 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain('"MEMBER"');
     expect(source).toContain('"COLLABORATOR"');
     expect(source).toContain("targetFromIssueCommentRecheck");
+    expect(source).toContain("trustedManualRecheck = false");
     expect(source).toContain("shouldResetManualTerminal");
     expect(source).toContain("shouldResetTerminalState");
     expect(source).toContain(
       "resetAttemptCount: shouldResetManualTerminal || shouldResetTerminalState",
     );
     expect(source).toContain(
+      'trustedManualRecheck === true &&\n    String(existing?.status || "") === "manual"',
+    );
+    expect(source).not.toContain(
       'forceRecheck === true && String(existing?.status || "") === "manual"',
     );
     expect(source).toContain(
@@ -593,7 +597,7 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain(
       "forceRecheck === true ||\n      isReopenedPullRequestEvent",
     );
-    expect(issueCommentBlock).toContain("payload,\n      true,");
+    expect(issueCommentBlock).toContain("payload,\n      true,\n      true,");
   });
 
   it("renders Taopedia-style verdict comments with stable sections", () => {
@@ -2142,9 +2146,13 @@ ${urls}
     expect(terminalSetBlock).not.toContain('"merge"');
     expect(terminalSetBlock).not.toContain('"import"');
     expect(source).toContain("forceRecheck = false");
+    expect(source).toContain("trustedManualRecheck = false");
+    expect(source).toContain("trustedManualRecheck === true");
+    expect(source).toContain("message.payload.trustedManualRecheck === true");
     expect(source).toContain(
-      "payload: { eventName, deliveryId, target, webhook, forceRecheck }",
+      'if (existingStatus === "manual" && !trustedManualRecheck)',
     );
+    expect(source).toContain("trustedManualRecheck,");
     expect(source).toContain(
       'String(message.payload.eventName || "") === "issue_comment"',
     );


### PR DESCRIPTION
### Motivation

- A timing/authorization bug allowed any path that passed the generic `forceRecheck` boolean (including contributor-triggered `pull_request` webhooks) to clear a `manual` terminal gate state, enabling a TOCTOU reset of manual hold decisions.
- The intent is to require a trusted maintainer `/recheck` (issue comment) to clear `manual` terminal state, so the fix restricts manual resets to an explicit trusted signal.

### Description

- Added a distinct `trustedManualRecheck` flag to `enqueueReviewTarget` and to queued review payloads so manual-terminal resets require an explicit trusted marker instead of the generic `forceRecheck` boolean.
- Updated `githubWebhookRoute`/`issue_comment` enqueue call to pass the trusted flag only for the maintainer `/recheck` path and preserved existing `pull_request`/validation requeue behavior without granting manual-reset authority.
- Modified the review worker (`handleReviewMessage`) to consult `trustedManualRecheck` when deciding whether to override a stored `manual` terminal state.
- Adjusted `tests/submission-gate-worker.test.ts` assertions to reflect the new `trustedManualRecheck` behavior and updated source-string checks accordingly.

### Testing

- Ran formatting: `pnpm exec prettier --write apps/submission-gate/src/index.ts tests/submission-gate-worker.test.ts` (succeeded).
- Ran unit tests: `pnpm exec vitest run tests/submission-gate-worker.test.ts` and all tests passed (`96 passed`).
- Ran `git diff --check` to ensure no whitespace/format issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d26144832ca65c19acc1a8d4e7)