### PR TITLE
fix(registry): validate retrievalSources are HTTPS across categories

### DIFF
--- a/packages/registry/src/content-schema.js
+++ b/packages/registry/src/content-schema.js
@@ -829,6 +829,15 @@ export function validateEntry(category, data, inferred = {}) {
     }
   }
 
+  if (Array.isArray(merged.retrievalSources)) {
+    for (const retrievalSource of merged.retrievalSources) {
+      if (!isHttpsUrl(retrievalSource)) {
+        semanticErrors.push("retrievalSources must use https URLs");
+        break;
+      }
+    }
+  }
+
   for (const field of [
     "submittedByUrl",
     "sourceSubmissionUrl",

--- a/scripts/validate-content.mjs
+++ b/scripts/validate-content.mjs
@@ -250,25 +250,26 @@ for (const category of Object.keys(CATEGORY_SCHEMAS)) {
       }
     }
 
+    const retrievalSources = Array.isArray(parsed.data.retrievalSources)
+      ? parsed.data.retrievalSources
+          .map((value) => String(value).trim())
+          .filter(Boolean)
+      : [];
+
+    for (const url of retrievalSources) {
+      if (!/^https:\/\//i.test(url)) {
+        failures.push(
+          `${entry}: retrievalSources must use https URLs -> ${url}`,
+        );
+      }
+    }
+
     if (category === "skills") {
       const skillType = String(
         parsed.data.skillType ?? inferred.skillType ?? "",
       )
         .trim()
         .toLowerCase();
-      const retrievalSources = Array.isArray(parsed.data.retrievalSources)
-        ? parsed.data.retrievalSources
-            .map((value) => String(value).trim())
-            .filter(Boolean)
-        : [];
-
-      for (const url of retrievalSources) {
-        if (!/^https:\/\//i.test(url)) {
-          failures.push(
-            `${entry}: retrievalSources must use https URLs -> ${url}`,
-          );
-        }
-      }
 
       if (skillType === "capability-pack") {
         const requiredSections = [

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -64,6 +64,21 @@ describe("inferStructuredFields", () => {
     ]);
   });
 
+  it("rejects non-HTTPS retrieval sources for non-skill entries", () => {
+    const result = validateEntry("rules", {
+      slug: "demo-rule",
+      title: "Demo Rule",
+      description: "Test rule",
+      author: "JSONbored",
+      dateAdded: "2026-01-01",
+      retrievalSources: ["not-a-url", "ftp://attacker.invalid/source"],
+    });
+
+    expect(result.semanticErrors).toContain(
+      "retrievalSources must use https URLs",
+    );
+  });
+
   it("does not infer guide code examples as install commands", () => {
     const inferred = inferStructuredFields(
       {},


### PR DESCRIPTION
### Motivation
- Recent inference changes preserved explicit `retrievalSources` for every category but validation only enforced them for `skills`, allowing non-skill entries to publish unvalidated retrieval sources that could be treated as source-backed evidence.

### Description
- Enforce HTTPS-only validation for `retrievalSources` in `validateEntry` (`packages/registry/src/content-schema.js`) so any explicit array must contain only HTTPS URLs.
- Apply the same `retrievalSources` HTTPS check in the content validator (`scripts/validate-content.mjs`) before category-specific skill checks run.
- Add a regression unit test in `tests/content-schema.test.ts` that asserts non-skill entries with non-HTTPS `retrievalSources` produce a semantic error.
- Preserve the existing inference behavior that keeps explicit `retrievalSources` while preventing invalid values from passing validation.

### Testing
- Ran unit tests with `pnpm exec vitest run tests/content-schema.test.ts` and they passed (`10 tests`).
- Ran the content validation script with `node scripts/validate-content.mjs --category rules` and it reported `Content validation passed.` while rejecting invalid retrieval sources during testing.
- Verified the validator run output showing validated content files and that the added test triggers the expected semantic error when supplied invalid `retrievalSources`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d2e310832ca432fc6ae72a13ad)