### PR TITLE
fix(seo): exclude external entries from source-backed stats

### DIFF
--- a/apps/web/src/lib/hub-highlights.ts
+++ b/apps/web/src/lib/hub-highlights.ts
@@ -184,7 +184,9 @@ export function hubStats(entries: Entry[]): HubStat[] {
   const pct = (n: number) => Math.round((n / total) * 100);
 
   const trusted = entries.filter((e) => e.trust === "trusted").length;
-  const sourced = entries.filter((e) => e.source !== "unverified").length;
+  const sourced = entries.filter(
+    (e) => e.source === "source-backed" || e.source === "first-party",
+  ).length;
   const safety = entries.filter((e) => Boolean(e.safetyNotes)).length;
   const privacy = entries.filter((e) => Boolean(e.privacyNotes)).length;
   const reviewed = entries.filter((e) => Boolean(e.reviewed)).length;

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -599,6 +599,12 @@ describe("web non-UI utility coverage", () => {
         repoStats: { stars: 42 },
         dateAdded: "2026-01-04",
       }),
+      entry({
+        slug: "external",
+        title: "External",
+        source: "external",
+        dateAdded: "2026-01-03",
+      }),
       entry({ slug: "newest", title: "Newest", dateAdded: "2026-01-07" }),
     ];
 
@@ -618,7 +624,14 @@ describe("web non-UI utility coverage", () => {
         "reviewed",
       ]),
     );
-    expect(trustPosture(entries)).toEqual({ trusted: 1, pct: 25 });
+    expect(
+      hubStats(entries).find((stat) => stat.key === "sourced"),
+    ).toMatchObject({
+      label: "Source-backed",
+      count: 3,
+      pct: 60,
+    });
+    expect(trustPosture(entries)).toEqual({ trusted: 1, pct: 20 });
     expect(trustPosture([])).toEqual({ trusted: 0, pct: 0 });
   });
 


### PR DESCRIPTION
### Motivation
- The hub-level "Source-backed" stat counted any entry whose `source` was not `unverified`, which incorrectly included `external` listings and overstated provenance on hub/tag pages.

### Description
- Update `apps/web/src/lib/hub-highlights.ts` to compute `sourced` as entries where `e.source === "source-backed" || e.source === "first-party"` instead of `e.source !== "unverified"` so `external` entries are excluded from the "Source-backed" stat.
- Add a regression in `tests/web-non-ui-utilities.test.ts` that includes an `external` fixture and asserts the `sourced` stat only counts `source-backed`/`first-party` entries and that `trustPosture` is updated accordingly.
- This is a minimal behavioral fix that preserves existing labels and UI rendering while aligning the aggregate stat with the `SourceStatus` taxonomy.

### Testing
- Ran `pnpm --filter web run prebuild && pnpm exec vitest run tests/web-non-ui-utilities.test.ts` and the test suite passed.
- Ran `pnpm type-check` and TypeScript checks passed.
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1bbd0832c80650902a222e965)