### PR TITLE
fix(seo): verify contributor author links

### DIFF
--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -56,3 +56,13 @@ export const CONTRIBUTORS: Contributor[] = (() => {
 export function getContributor(slug: string) {
   return CONTRIBUTORS.find((c) => c.slug === slug);
 }
+
+export function contributorForVerifiedAuthor(author?: string, submittedBy?: string) {
+  if (!author || !submittedBy) return undefined;
+
+  const authorSlug = contributorSlug(author);
+  const submittedBySlug = contributorSlug(submittedBy);
+  if (!authorSlug || authorSlug !== submittedBySlug) return undefined;
+
+  return getContributor(submittedBySlug);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -24,7 +24,7 @@ import { getEntry, related, relatedGroups } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
 import { BEST_LISTS } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
-import { CONTRIBUTORS } from "@/data/contributors";
+import { contributorForVerifiedAuthor } from "@/data/contributors";
 import {
   CategoryPill,
   PlatformChip,
@@ -232,9 +232,7 @@ function Dossier() {
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
-  const authorContributor = CONTRIBUTORS.find(
-    (c) => c.handle === entry.author || c.handle === entry.submittedBy || c.name === entry.author,
-  );
+  const authorContributor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
   const recents = useRecents();
   useEffect(() => {
     recents.pushEntry({ category: entry.category, slug: entry.slug, title: entry.title });

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -22,6 +22,7 @@ import { ENTRIES } from "../apps/web/src/data/entries";
 import { COMPARISONS } from "../apps/web/src/data/comparisons";
 import {
   CONTRIBUTORS,
+  contributorForVerifiedAuthor,
   contributorSlug,
   getContributor,
   githubHandle,
@@ -550,6 +551,12 @@ describe("web non-UI utility coverage", () => {
     const topContributor = CONTRIBUTORS[0];
     expect(getContributor(topContributor.slug)).toBe(topContributor);
     expect(topContributor.acceptedCount).toBeGreaterThan(0);
+    expect(
+      contributorForVerifiedAuthor(topContributor.name, topContributor.name),
+    ).toBe(topContributor);
+    expect(
+      contributorForVerifiedAuthor(topContributor.name, "spoofing-submitter"),
+    ).toBeUndefined();
 
     expect(SPONSORS.map((sponsor) => sponsor.slug)).toEqual([
       "cloudflare",


### PR DESCRIPTION
### Motivation
- Prevent unverified `entry.author` values from resolving to unrelated high-count contributor profiles and thus avoid misleading attribution links on entry pages.
- Keep contributor-profile linking strictly tied to verified submission provenance (`submittedBy`) rather than permissive string matches.

### Description
- Add `contributorForVerifiedAuthor(author?, submittedBy?)` in `apps/web/src/data/contributors.ts` to return a contributor only when the normalized `author` and `submittedBy` map to the same contributor slug.
- Replace the permissive lookup on `CONTRIBUTORS.find(...)` with `contributorForVerifiedAuthor(entry.author, entry.submittedBy)` in `apps/web/src/routes/entry.$category.$slug.tsx` so entry pages only link when `author` normalizes to the verified submitter.
- Add regression assertions to `tests/web-non-ui-utilities.test.ts` to cover a valid verified-author link and a spoofed author/submittedBy mismatch.

### Testing
- Ran `pnpm validate:content:strict`, which passed for the content set.
- Ran `pnpm validate:packages`, which completed successfully.
- Ran `git diff --check`, which showed no whitespace or diff issues.
- Attempted `pnpm exec vitest run tests/web-non-ui-utilities.test.ts`, but the suite was blocked in this checkout because `apps/web/src/generated/atlas-registry.json` is not present; `pnpm --filter web run prebuild` was attempted to generate artifacts but did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1939c832c9efc978e78b4bb94)