### PR TITLE
fix(ui): keep ancestor breadcrumbs clickable

### DIFF
--- a/apps/web/src/components/breadcrumbs.tsx
+++ b/apps/web/src/components/breadcrumbs.tsx
@@ -15,10 +15,13 @@ export interface Crumb {
 export function Breadcrumbs({
   items,
   home = false,
+  markLastAsCurrent = true,
   className,
 }: {
   items: Crumb[];
   home?: boolean;
+  /** Treat the final crumb as the current page. Disable for ancestor-only trails. */
+  markLastAsCurrent?: boolean;
   className?: string;
 }) {
   return (
@@ -38,10 +41,11 @@ export function Breadcrumbs({
         )}
         {items.map((c, i) => {
           const isLast = i === items.length - 1;
+          const isCurrent = markLastAsCurrent && isLast;
           return (
             <Fragment key={`${c.label}-${i}`}>
               <li className="min-w-0">
-                {c.to && !isLast ? (
+                {c.to && !isCurrent ? (
                   <Link
                     to={c.to}
                     params={c.params}
@@ -52,10 +56,10 @@ export function Breadcrumbs({
                   </Link>
                 ) : (
                   <span
-                    aria-current={isLast ? "page" : undefined}
+                    aria-current={isCurrent ? "page" : undefined}
                     className={cn(
                       "block truncate px-1.5 py-0.5 font-medium",
-                      isLast ? "text-ink" : "text-ink-muted",
+                      isCurrent ? "text-ink" : "text-ink-muted",
                     )}
                   >
                     {c.label}

--- a/apps/web/src/components/page-header.tsx
+++ b/apps/web/src/components/page-header.tsx
@@ -32,7 +32,7 @@ export function PageHeader({
   return (
     <div className={cn(className)}>
       {breadcrumbs && breadcrumbs.length > 0 && (
-        <Breadcrumbs home items={breadcrumbs} className="mb-6" />
+        <Breadcrumbs home items={breadcrumbs} markLastAsCurrent={false} className="mb-6" />
       )}
       <SectionHeader
         as="h1"

--- a/tests/breadcrumbs.test.ts
+++ b/tests/breadcrumbs.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("PageHeader ancestor breadcrumbs", () => {
+  it("opts out of marking the last crumb current for ancestor-only trails", () => {
+    const pageHeaderSource = readFileSync(
+      "apps/web/src/components/page-header.tsx",
+      "utf8",
+    );
+    const breadcrumbsSource = readFileSync(
+      "apps/web/src/components/breadcrumbs.tsx",
+      "utf8",
+    );
+
+    expect(pageHeaderSource).toContain("markLastAsCurrent={false}");
+    expect(breadcrumbsSource).toContain("markLastAsCurrent = true");
+    expect(breadcrumbsSource).toContain(
+      "const isCurrent = markLastAsCurrent && isLast",
+    );
+    expect(breadcrumbsSource).toContain("c.to && !isCurrent");
+    expect(breadcrumbsSource).toContain(
+      'aria-current={isCurrent ? "page" : undefined}',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation

- PageHeader’s contract documents that callers pass ancestor-only crumbs, but Breadcrumbs previously treated the final item as the current page and suppressed its link, causing ancestor links like `/browse` or `/tags` to become non-clickable.

### Description

- Add an optional `markLastAsCurrent` prop to `Breadcrumbs` (defaults to `true`) so existing full breadcrumb trails preserve the current-page semantics. 
- Compute `isCurrent` from `markLastAsCurrent && isLast` and use it to decide link rendering and `aria-current="page"` instead of deriving this solely from the final item index. 
- Have `PageHeader` opt out of marking the final breadcrumb as current by forwarding `markLastAsCurrent={false}` when it passes ancestor-only crumbs. 
- Add a small regression test `tests/breadcrumbs.test.ts` that verifies the `PageHeader` -> `Breadcrumbs` wiring and the new `isCurrent` behavior.

### Testing

- Ran `pnpm exec vitest run tests/breadcrumbs.test.ts --reporter=verbose` and the new test passed. 
- Ran targeted type-check `pnpm --filter web type-check` which passed for the web package. 
- Ran `git diff --check` which reported no whitespace or lint diffs for the touched files. 
- A repository-wide `pnpm exec tsc --noEmit` was attempted and failed due to unrelated pre-existing generated-route and Cloudflare worker type issues, but these failures are outside the scope of the UI fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1a510832caa890195f2b0bcb6)