### PR TITLE
fix(readme): use exact refresh branch lookup

### DIFF
--- a/.github/workflows/readme-refresh-pr.yml
+++ b/.github/workflows/readme-refresh-pr.yml
@@ -86,7 +86,7 @@ jobs:
           git add README.md
           git commit -m "docs(readme): refresh generated catalog index"
 
-          remote_branch_sha="$(git ls-remote --heads origin "$BRANCH_NAME" | awk '{print $1}')"
+          remote_branch_sha="$(git ls-remote --heads origin "refs/heads/$BRANCH_NAME" | awk '{print $1}')"
           if [[ -n "$remote_branch_sha" ]]; then
             git push --force-with-lease="refs/heads/$BRANCH_NAME:$remote_branch_sha" origin "$BRANCH_NAME:$BRANCH_NAME"
           else

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -924,7 +924,10 @@ scriptBody: |-
       "git restore --worktree --staged -- . ':!README.md'",
     );
     expect(source).toContain("unexpected_files");
-    expect(source).toContain('git ls-remote --heads origin "$BRANCH_NAME"');
+    expect(source).toContain(
+      'git ls-remote --heads origin "refs/heads/$BRANCH_NAME"',
+    );
+    expect(source).not.toContain('git ls-remote --heads origin "$BRANCH_NAME"');
     expect(source).toContain(
       '--force-with-lease="refs/heads/$BRANCH_NAME:$remote_branch_sha"',
     );


### PR DESCRIPTION
### Motivation
- The README refresh workflow used `git ls-remote --heads origin "$BRANCH_NAME"`, which performs tail-matching and can return unrelated branch refs that end with the same suffix, breaking `--force-with-lease` expectations and blocking branch recreation.

### Description
- Use the full ref when checking for the automation branch by querying `git ls-remote --heads origin "refs/heads/$BRANCH_NAME"` in `.github/workflows/readme-refresh-pr.yml` to ensure exact-match behavior.
- Update `tests/submission-workflows.test.ts` to assert the new exact-ref lookup and to assert the old tail-matching pattern is not present.

### Testing
- Ran the targeted Vitest file with `pnpm exec vitest run tests/submission-workflows.test.ts` and all tests passed (68 tests).
- Ran repository checks (`git diff --check`) after formatting and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d1bdd0832c916bb80f6af14714)