### PR TITLE
fix(submissions): align attestation policy checks

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -56,6 +56,23 @@ const PRIVACY_NOTE_REQUIRED_FLAGS = new Set([
 
 const UNSAFE_FRONTMATTER_LANGUAGE_ERROR =
   "Executable JavaScript frontmatter is not allowed in content policy validation";
+const FINANCIAL_OR_IDENTITY_PATTERN =
+  /\b(private key|wallet|kyc|usdc|x402|payment|crypto|on-chain)\b/i;
+// Keep generic artifact attestations out of the financial/identity bucket while
+// still catching nearby wallet, KYC, identity-proof, passport, or biometric use.
+const SENSITIVE_ATTESTATION_WINDOW = 120;
+const SENSITIVE_ATTESTATION_FORWARD_TERMS =
+  "wallet|kyc|payment|crypto|on-chain identity|personal identity|identity proof|identity verification|proof of personhood|verifiable credential|passport|government id|government-issued id|govt id|biometric";
+const SENSITIVE_ATTESTATION_REVERSE_TERMS =
+  "wallet|kyc|payment|crypto|on-chain identity|identity|personal identity|identity proof|identity verification|proof of personhood|verifiable credential|passport|government id|government-issued id|govt id|biometric";
+const IDENTITY_ATTESTATION_PATTERN = new RegExp(
+  `\\battestations?\\b[\\s\\S]{0,${SENSITIVE_ATTESTATION_WINDOW}}\\b(?:${SENSITIVE_ATTESTATION_FORWARD_TERMS})s?\\b`,
+  "i",
+);
+const IDENTITY_ATTESTATION_REVERSE_PATTERN = new RegExp(
+  `\\b(?:${SENSITIVE_ATTESTATION_REVERSE_TERMS})s?\\b[\\s\\S]{0,${SENSITIVE_ATTESTATION_WINDOW}}\\battestations?\\b`,
+  "i",
+);
 const DEFENSIVE_SECURITY_MITIGATION_PATTERN =
   /\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b[\s\S]{0,160}\b(?:(?:credential|password|cookie|session|token|wallet|secret|leak)s?|expos(?:e|ing|ure))\b|\b(?:credential|password|cookie|session|token|wallet|secret)s?\b[\s\S]{0,160}\b(prevent|protect|warn(?:s|ing)? before|block|detect|detection|redact|sanitize|audit|review|remediate|remediation|hardening|least privilege|safe configuration|avoid (?:pasting|exposing|leaking)|leak warning)\b/i;
 const RESOURCE_THEFT_CAPABILITY_PATTERN =
@@ -152,6 +169,14 @@ function hasDefensiveSecuritySafeHarbor(text) {
     !CREDENTIAL_THEFT_DESTINATION_PATTERN.test(text) &&
     !EXPLICIT_CREDENTIAL_STEALING_PATTERN.test(text) &&
     !ABUSE_ENABLEMENT_PATTERN.test(text)
+  );
+}
+
+function hasFinancialOrIdentitySensitiveSignal(text) {
+  return (
+    FINANCIAL_OR_IDENTITY_PATTERN.test(text) ||
+    IDENTITY_ATTESTATION_PATTERN.test(text) ||
+    IDENTITY_ATTESTATION_REVERSE_PATTERN.test(text)
   );
 }
 
@@ -955,11 +980,7 @@ function addContentRiskSignals(report, fields, content) {
     );
   }
 
-  if (
-    /\b(private key|wallet|kyc|usdc|x402|payment|crypto|on-chain|attestation)\b/i.test(
-      text,
-    )
-  ) {
+  if (hasFinancialOrIdentitySensitiveSignal(text)) {
     addFlag(
       report,
       "high",

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -842,6 +842,133 @@ LLM providers through a proxy gateway.
     ).not.toContain("missing_pr_file_content");
   });
 
+  it("does not classify GitHub artifact attestations as identity-sensitive", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: GitHub Artifact Attestation Checklist
+category: guides
+description: Source-backed guide for verifying GitHub Artifact Attestations, release artifact provenance, build workflow metadata, and digest evidence.
+documentationUrl: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Attestations prove artifact provenance, not malware safety or runtime behavior.
+---
+
+Use this checklist to verify GitHub artifact attestation provenance before
+trusting release artifacts.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/guides/github-artifact-attestation-checklist.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(
+      output.reviewFlags.map((flag: { id: string }) => flag.id),
+    ).not.toContain("financial_or_identity_sensitive");
+  });
+
+  it("still classifies wallet attestations as identity-sensitive", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Wallet Attestation MCP
+category: mcp
+description: MCP server for wallet attestations, KYC review, and on-chain identity workflows.
+documentationUrl: https://example.com/wallet-attestation-mcp
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Requires explicit user approval before reading wallet or identity data.
+privacyNotes:
+  - Can process wallet, KYC, and on-chain identity records.
+---
+
+Use wallet attestations only after reviewing account permissions.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/mcp/wallet-attestation-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags.map((flag: { id: string }) => flag.id)).toContain(
+      "financial_or_identity_sensitive",
+    );
+  });
+
+  it("classifies reverse-order identity proof attestations as identity-sensitive", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Passport Proof Attestation Review
+category: guides
+description: Guide for passport identity proof review before issuing user attestations.
+documentationUrl: https://example.com/passport-proof-attestations
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Requires explicit user approval before reviewing identity documents.
+privacyNotes:
+  - Can process passport and identity proof evidence.
+---
+
+Use passport identity proof data only with consent before producing an attestation.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/guides/passport-proof-attestation-review.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.reviewFlags.map((flag: { id: string }) => flag.id)).toContain(
+      "financial_or_identity_sensitive",
+    );
+  });
+
+  it("does not classify distant generic attestation references as identity-sensitive", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const filler = "release provenance metadata ".repeat(10);
+    const content = `---
+title: Artifact Attestation Release Notes
+category: guides
+description: Guide for GitHub artifact attestation review using release provenance metadata.
+documentationUrl: https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+safetyNotes:
+  - Attestations prove build provenance only.
+---
+
+Artifact attestation checks verify build provenance and digest evidence. ${filler}
+Passport checks belong to a separate identity review and are not part of this artifact workflow.
+`;
+    const result = runContentPolicy(tmpDir, content, "same_repo_direct", [
+      {
+        filename: "content/guides/artifact-attestation-release-notes.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(
+      output.reviewFlags.map((flag: { id: string }) => flag.id),
+    ).not.toContain("financial_or_identity_sensitive");
+  });
+
   it("allows the TODO|FIXME|XXX code-comment marker (prohibited_content false positive)", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
### Motivation
- The registry submission-risk heuristic was narrowed to only treat attestations as identity-sensitive in explicit financial or identity-proof contexts, but the CI content-policy script still used a broad `attestation` match, causing inconsistent review flags.

### Description
- Updated `scripts/ci/validate-content-policy.mjs` to introduce the same attestation-sensitive regexes and the helper `hasFinancialOrIdentitySensitiveSignal(text)` and to use it when setting the `financial_or_identity_sensitive` flag.
- Added `IDENTITY_ATTESTATION_*` and `FINANCIAL_OR_IDENTITY_PATTERN` constants to mirror the registry-side logic so CI and the package analyzer agree.
- Added two regression tests in `tests/content-policy-validation.test.ts` to ensure ordinary GitHub artifact attestations are not flagged and that wallet/on-chain attestations remain flagged.
- Kept behavior unchanged for other risk checks and preserved existing test coverage.

### Testing
- Ran `pnpm exec vitest run tests/content-policy-validation.test.ts tests/submission-pr-first.test.ts` and all tests passed (58 tests; 0 failures). 
- Ran `git diff --check` to ensure no formatting or diff errors (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d24ee4832cbfa28ff8112d1f44)