### PR TITLE
fix(web): make umami analytics opt-in

### DIFF
--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -47,11 +47,10 @@ export const siteConfig = {
   jobsEmail: "jobs@heyclau.de",
   twitterUrl: publicEnv("NEXT_PUBLIC_TWITTER_URL") || "https://x.com/jsonbored",
   discordUrl: publicEnv("NEXT_PUBLIC_DISCORD_URL") || "https://discord.com/invite/Ax3Py4YDrq",
-  // Served same-origin via the /u/script.js proxy (see routes/u.script[.]js.ts)
-  // so the CSP needs no third-party script-src. umami auto-derives its collector
-  // from the script directory (/u/api/send). The instance origin is configured
-  // server-side as UMAMI_UPSTREAM_URL on the proxy routes.
-  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL") || "/u/script.js",
+  // Analytics is opt-in: set VITE_UMAMI_SCRIPT_URL (for example /u/script.js)
+  // after configuring and reviewing the corresponding script source. Keeping the
+  // default empty avoids sitewide execution of JavaScript from an external origin.
+  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL"),
   umamiWebsiteId: publicEnv("VITE_UMAMI_WEBSITE_ID") || "b734c138-2949-4527-9160-7fe5d0e81121",
   // Empty string intentionally disables the private gate and shows manual PR instructions.
   submissionGateUrl: publicHttpUrl(

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -198,7 +198,9 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 
 function RootShell({ children }: { children: React.ReactNode }) {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const shouldLoadAnalytics = pathname !== "/brief/approve";
+  const shouldLoadAnalytics =
+    pathname !== "/brief/approve" &&
+    Boolean(siteConfig.umamiScriptUrl && siteConfig.umamiWebsiteId);
 
   return (
     <html lang="en">

--- a/apps/web/src/routes/u.api.send.ts
+++ b/apps/web/src/routes/u.api.send.ts
@@ -11,7 +11,6 @@ import {
 import { logApiWarn } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
-const DEFAULT_UPSTREAM = "https://tasty.aethereal.dev";
 const BODY_LIMIT_BYTES = 16 * 1024;
 const RATE_LIMIT = {
   scope: "umami-collector",
@@ -114,7 +113,9 @@ export async function POST(request: Request): Promise<Response> {
     throw error;
   }
 
-  const upstream = getEnvString("UMAMI_UPSTREAM_URL") || DEFAULT_UPSTREAM;
+  const upstream = getEnvString("UMAMI_UPSTREAM_URL");
+  if (!upstream) return apiError("analytics_not_configured", 404, { requestId });
+
   const headers = new Headers({
     "content-type": "application/json",
     // umami drops requests without a User-Agent.

--- a/apps/web/src/routes/u.script[.]js.ts
+++ b/apps/web/src/routes/u.script[.]js.ts
@@ -2,8 +2,6 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
-const DEFAULT_UPSTREAM = "https://tasty.aethereal.dev";
-
 /**
  * First-party umami tracker proxy.
  *
@@ -19,7 +17,8 @@ export const Route = createFileRoute("/u/script.js")({
   server: {
     handlers: {
       GET: async () => {
-        const upstream = getEnvString("UMAMI_UPSTREAM_URL") || DEFAULT_UPSTREAM;
+        const upstream = getEnvString("UMAMI_UPSTREAM_URL");
+        if (!upstream) return new Response("", { status: 404 });
         try {
           const response = await fetch(`${upstream}/script.js`, {
             signal: AbortSignal.timeout(8000),


### PR DESCRIPTION
### Motivation
- A recent change allowed the site to load the Umami analytics script from an external origin (`tasty.aethereal.dev`) sitewide, which grants that origin first-party JS execution privileges and is a high-security risk. 
- The intent is to avoid implicitly trusting an external analytics origin by default and require explicit configuration before any analytics script is injected or proxied.

### Description
- Stop providing a default script URL so `siteConfig.umamiScriptUrl` is empty by default and analytics are opt-in (`apps/web/src/lib/site.ts`).
- Only render the Umami `<script>` in the root HTML when both `umamiScriptUrl` and `umamiWebsiteId` are configured (`apps/web/src/routes/__root.tsx`).
- Remove the fallback to `https://tasty.aethereal.dev` in the first-party script proxy so `/u/script.js` returns `404` unless `UMAMI_UPSTREAM_URL` is set (`apps/web/src/routes/u.script[.]js.ts`).
- Require `UMAMI_UPSTREAM_URL` for the collector proxy and return an API error when unset so `/u/api/send` no longer forwards to the external default origin (`apps/web/src/routes/u.api.send.ts`).

### Testing
- Ran formatting checks with `pnpm exec prettier --check ...` and fixed style issues; check passed for modified files.
- Ran the project type-check with `pnpm type-check` which completed successfully after generation steps.
- Built the web app with `pnpm build` and the build completed successfully.
- Ran `git diff --check` to validate no whitespace/formatting errors and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3449d28b60832c9bcec32d9fed9454)