### PR TITLE
fix(submissions): replace pre-merge accepted comment with merge-pending report on retryable merge failures

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -3760,6 +3760,22 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               }`,
               "- The gate will retry after transient GitHub merge state settles.",
             ].join("\n");
+            const pendingDecision = defaultManualDecision(pendingSummary, {
+              code: "merge_retry_pending",
+              retryable: true,
+              message: error instanceof Error ? error.message : "unknown",
+            });
+            const pendingReport = await upsertMarkerComment({
+              token,
+              repo,
+              issueNumber: target.number,
+              marker: env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+              body: markerComment(
+                pendingDecision,
+                env.REVIEW_MARKER || DEFAULT_REVIEW_MARKER,
+              ),
+              apiVersion: env.GITHUB_API_VERSION,
+            });
             await upsertPrState(env.SUBMISSION_GATE_DB, {
               repo: target.repoFullName,
               number: target.number,
@@ -3773,7 +3789,7 @@ async function handleReviewMessage(env: Env, message: QueueMessage) {
               verdictSummary: pendingSummary,
               nextReviewAt: isoAfter(retryDelaySeconds),
               lastError: error instanceof Error ? error.message : "unknown",
-              ...decisionMetadata(acceptedDecision, acceptedReport),
+              ...decisionMetadata(pendingDecision, pendingReport),
             });
             await insertAudit(env.SUBMISSION_GATE_DB, {
               id: crypto.randomUUID(),

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2060,6 +2060,14 @@ ${urls}
     expect(retryBranch).toContain('status: "merge_pending"');
     expect(retryBranch).toContain('decision: "merge_pending"');
     expect(retryBranch).toContain("merge retry pending");
+    expect(retryBranch).toContain(
+      "const pendingDecision = defaultManualDecision",
+    );
+    expect(retryBranch).toContain(
+      "const pendingReport = await upsertMarkerComment",
+    );
+    expect(retryBranch).toContain("markerComment(");
+    expect(retryBranch).toContain("pendingDecision");
     expect(retryBranch).toContain("nextReviewAt: isoAfter(retryDelaySeconds)");
     expect(retryBranch).toContain("retryDelaySeconds");
     expect(retryBranch).toContain(


### PR DESCRIPTION
### Motivation
- The worker posted the canonical `Accepted and merged` marker comment before attempting the final GitHub merge, leaving a misleading public report when the merge later failed transiently. 
- This weakens the integrity of the gate's public decision record and can mislead maintainers into trusting an unmerged or unreviewed head SHA.

### Description
- On retryable merge failures, create a `pendingDecision` via `defaultManualDecision(...)` and publish a `pendingReport` with `upsertMarkerComment(...)` using `markerComment(pendingDecision)` to replace the prior pre-merge comment.
- Persist the `merge_pending` PR state using `decisionMetadata(pendingDecision, pendingReport)` so stored comment/review metadata references the pending report instead of the earlier accepted report.
- Update `tests/submission-gate-worker.test.ts` to assert the retryable merge branch builds a pending decision, upserts the marker comment, and renders the pending decision before requeueing.

### Testing
- Ran the targeted test: `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "keeps transient accepted-merge failures pending for retry" --reporter=dot`, which passed.
- Ran the submission-gate worker test suite: `pnpm exec vitest run tests/submission-gate-worker.test.ts --reporter=dot`, which passed (all tests in the file passed).
- Ran `git diff --check` to verify no whitespace/check errors, which reported clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344de6f7b4832c84ce0b3b233db2c0)