### PR TITLE
docs(content): add ARIS Auto-Research-In-Sleep

### DIFF
--- a/content/skills/aris-auto-research-in-sleep.mdx
+++ b/content/skills/aris-auto-research-in-sleep.mdx
@@ -1,0 +1,263 @@
+---
+title: ARIS Auto-Research-In-Sleep
+slug: aris-auto-research-in-sleep
+category: skills
+description: >-
+  ARIS is a Markdown-only skill workflow pack for autonomous ML research
+  agents, with idea discovery, experiment planning, auto-review loops, paper
+  writing, rebuttal, resubmission, slides, posters, Research Wiki, and
+  cross-model reviewer workflows for Claude Code, Codex, OpenClaw, Cursor, and
+  other agent hosts.
+cardDescription: >-
+  Markdown research-agent skills for idea discovery, experiment automation,
+  paper writing, rebuttal, and cross-model review loops.
+seoTitle: ARIS Auto-Research-In-Sleep Skills for Claude Code, Codex, OpenClaw, and ML Research Agents
+seoDescription: >-
+  Use ARIS Auto-Research-In-Sleep as a source-backed skill workflow pack for
+  autonomous ML research agents, including Claude Code research pipelines,
+  Codex research skills, OpenClaw adaptation, experiment review loops, paper
+  writing, rebuttal, slides, posters, and cross-model MCP reviewers.
+author: wanshuiyin
+authorProfileUrl: "https://github.com/wanshuiyin"
+dateAdded: "2026-06-18"
+repoUrl: "https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep"
+documentationUrl: "https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep#readme"
+websiteUrl: "https://wanshuiyin.github.io/Auto-claude-code-research-in-sleep/ARIS_INTRO.html"
+downloadUrl: "https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep/archive/refs/heads/main.zip"
+installable: true
+installCommand: "git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git"
+usageSnippet: >-
+  Copy the relevant ARIS `skills/<name>/SKILL.md` workflows, or the
+  `skills/skills-codex/` mirror for Codex, into your agent skill path, then
+  invoke research workflows such as `/research-pipeline`, `/idea-discovery`,
+  `/experiment-bridge`, `/auto-review-loop`, `/paper-writing`, or `/rebuttal`.
+copySnippet: |-
+  git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
+
+  # Copy selected skills into your agent skill directory.
+  # Codex users can review the skills/skills-codex mirror first.
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-18"
+retrievalSources:
+  - "https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/README.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/AGENT_GUIDE.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/research-pipeline/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/idea-discovery/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/experiment-bridge/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/auto-review-loop/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/paper-writing/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/rebuttal/SKILL.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/skills/shared-references/assurance-contract.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/docs/OPENCLAW_ADAPTATION.md"
+  - "https://raw.githubusercontent.com/wanshuiyin/Auto-claude-code-research-in-sleep/main/LICENSE"
+testedPlatforms:
+  - Claude Code
+  - Codex
+  - Cursor
+  - OpenClaw
+  - Antigravity
+  - GitHub Copilot CLI
+  - Trae
+  - Generic Markdown skill hosts
+prerequisites:
+  - "A research project, ML paper idea, baseline repository, dataset, review packet, or experiment plan that is appropriate for agent-assisted research automation."
+  - "A compatible agent host that can consume Markdown skills, such as Claude Code, Codex, Cursor, OpenClaw, Antigravity, Trae, GitHub Copilot CLI, or a manual prompt workflow."
+  - "Model-provider credentials, MCP reviewer configuration, or local model routing only when using cross-model review or external reviewer loops."
+  - "Compute budget, GPU quota, experiment sandboxing, version control, and artifact directories before allowing autonomous experiment execution."
+  - "Human review checkpoints for expensive runs, paper claims, rebuttal text, submission decisions, and any use of unpublished or confidential research material."
+safetyNotes:
+  - "ARIS skills can guide agents through code changes, experiment planning, experiment execution, paper drafting, rebuttal drafting, and cross-model review loops; treat those workflows as high-impact research automation rather than passive documentation."
+  - "The `research-pipeline` skill supports auto-proceed modes and reviewer loops. Keep expensive runs, repository mutations, cloud/GPU jobs, and paper-submission decisions behind explicit human approval."
+  - "Cross-model review through Codex MCP, Claude-review, Gemini-review, or similar reviewer adapters is a quality-control signal, not scientific proof or peer review."
+  - "Generated claims, citations, tables, plots, ablations, rebuttals, and paper text need source checks, experiment audits, citation audits, and human scientific review before being relied on or submitted."
+  - "Review all copied skills, scripts, MCP server configuration, and reviewer routing before installing them into a sensitive repository or giving them shell, file, web, cloud, or GPU access."
+privacyNotes:
+  - "Research automation can expose unpublished hypotheses, paper drafts, peer-review text, datasets, logs, source code, experiment traces, model outputs, reviewer comments, account names, and GPU or cloud configuration to the selected model providers and MCP tools."
+  - "Cross-model review loops may send the same research artifact to multiple providers or local/remote reviewer services depending on configuration."
+  - "Research Wiki, traces, generated reports, paper artifacts, and run logs can persist confidential results or private review material on disk."
+  - "Do not share confidential reviews, unreleased findings, private datasets, credentials, proprietary code, or submission-sensitive artifacts with external services unless the research and account policies allow it."
+tags:
+  - aris
+  - skills
+  - research-agents
+  - ml-research
+  - claude-code
+  - codex
+  - openclaw
+  - mcp
+keywords:
+  - ARIS Auto-Research-In-Sleep
+  - Auto-Research-In-Sleep skills
+  - Claude Code research pipeline
+  - Codex research skills
+  - OpenClaw research workflow
+  - autonomous ML research agent
+  - cross-model review loop
+  - paper writing agent skills
+  - experiment automation skills
+  - research-pipeline skill
+readingTime: 9
+difficultyScore: 90
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+# ARIS Auto-Research-In-Sleep
+
+`wanshuiyin/Auto-claude-code-research-in-sleep` publishes ARIS, a
+Markdown-first research-agent workflow system. The repository describes ARIS as
+a methodology rather than a platform: its core behavior is stored in
+`SKILL.md` files that can be copied into Claude Code, Codex, Cursor, OpenClaw,
+Antigravity, GitHub Copilot CLI, Trae, or other Markdown-compatible agent
+workflows.
+
+Use this listing for the ARIS skill workflow pack itself. Use narrower entries
+when reviewing a single ARIS skill, a separate MCP reviewer server, or a
+platform-specific adaptation.
+
+## Knowledge Freshness
+
+The repository is active, with current release and GitHub metadata verified on
+2026-06-18. The README and `AGENT_GUIDE.md` document Claude Code usage, Codex
+skill mirrors, cross-model reviewer routes, OpenClaw adaptation notes, and a
+large catalog of research skills.
+
+Research tooling, model behavior, MCP reviewer setup, OpenClaw support, GPU
+environments, paper venues, citation sources, and ML baselines can change
+quickly. Treat ARIS as a structured research automation harness, then verify
+commands, dependencies, venue rules, citations, datasets, reviewer
+configuration, and experiment evidence in the target project before relying on
+generated results.
+
+## Retrieval Sources
+
+This listing is grounded in:
+
+- The upstream repository README.
+- The upstream `AGENT_GUIDE.md`.
+- Representative ARIS `SKILL.md` files for research pipeline, idea discovery,
+  experiment bridge, auto-review loop, paper writing, and rebuttal workflows.
+- The shared assurance contract reference.
+- The OpenClaw adaptation guide.
+- The MIT license file.
+- Current GitHub repository metadata.
+
+## Core Workflow
+
+Clone the repository:
+
+```bash
+git clone https://github.com/wanshuiyin/Auto-claude-code-research-in-sleep.git
+```
+
+Review the relevant skill files, then copy only the skills you want into your
+agent host. Codex users should review the `skills/skills-codex/` mirror before
+copying, while OpenClaw users should read the OpenClaw adaptation guide and map
+skills to file-first task phases.
+
+Common ARIS entry points include:
+
+```text
+/research-pipeline "factorized gap in discrete diffusion LMs"
+/idea-discovery "improve method X"
+/experiment-bridge "turn this idea into an experiment plan"
+/auto-review-loop "review paper/ and experiments/"
+/paper-writing "results/ + notes/"
+/rebuttal "paper/ + reviews" -- venue: ICML
+```
+
+## Capability Scope
+
+The upstream `AGENT_GUIDE.md` organizes ARIS around research lifecycle
+workflows:
+
+| Workflow | Scope |
+| --- | --- |
+| `/idea-discovery` | Survey a research direction, find gaps, and propose candidate ideas |
+| `/experiment-bridge` | Turn a selected idea into experiment plans, runbooks, and implementation steps |
+| `/auto-review-loop` | Run adversarial or cross-model reviews against code, experiments, and papers |
+| `/paper-writing` | Convert evidence, results, and claims into paper drafts |
+| `/rebuttal` | Draft response material from paper files and reviewer comments |
+| `/resubmit-pipeline` | Prepare revision and resubmission workflows |
+| `/paper-talk` | Produce talk-oriented paper presentation material |
+| `/paper-slides` | Generate slide artifacts from a paper |
+| `/paper-poster-html` | Generate poster-oriented HTML artifacts |
+| `/research-wiki` | Maintain a persistent research knowledge record |
+
+The guide also documents assurance and audit skills such as
+`/experiment-audit`, `/result-to-claim`, `/paper-claim-audit`,
+`/citation-audit`, and `/kill-argument`. Those checks are important because
+research-agent output can look polished while still being weak, stale, or
+unsupported.
+
+## Platform Fit
+
+ARIS is built around portable Markdown skills rather than a single hosted
+runtime. The repository documents several usage patterns:
+
+- Claude Code skills under `skills/<name>/SKILL.md`.
+- Codex-specific mirrors under `skills/skills-codex/`.
+- Codex plus Claude-review or Gemini-review overlays under the corresponding
+  reviewer skill folders.
+- Cursor, Trae, Antigravity, GitHub Copilot CLI, and manual Markdown skill
+  usage.
+- OpenClaw adaptation through a file-first phase map that writes outputs such
+  as `lit_scan.md`, `idea_report.md`, `experiment_plan.md`, `runbook.md`, and
+  `review_loop.md`.
+
+This makes ARIS useful for teams comparing "Claude Code research pipeline",
+"Codex research skills", "OpenClaw research workflow", and "cross-model review
+loop" approaches without committing to one agent runtime immediately.
+
+## Production Rules
+
+- Start with a narrow research objective and define success criteria before
+  invoking an autonomous pipeline.
+- Keep repository changes, shell execution, GPU/cloud jobs, and long-running
+  loops behind checkpoints until the workflow is trusted.
+- Use the assurance and audit skills before turning results into paper claims.
+- Verify citations, datasets, baselines, venue rules, and license constraints
+  against primary sources.
+- Keep unpublished reviews, internal results, private datasets, and proprietary
+  code out of prompts sent to providers that are not approved for that data.
+- Treat cross-model reviewer output as adversarial feedback, not a replacement
+  for human ML review.
+
+## Source Review
+
+- The repository README describes ARIS as "lightweight Markdown-only skills"
+  for autonomous ML research, cross-model review loops, idea discovery, and
+  experiment automation.
+- The README states that ARIS works with Claude Code, Codex, Cursor, Trae,
+  Antigravity, GitHub Copilot CLI, OpenClaw, and standalone/manual workflows.
+- `AGENT_GUIDE.md` describes ARIS as a research harness whose source of truth
+  is `skills/<name>/SKILL.md` plus shared reference contracts.
+- The guide documents 79 skills and maps common workflows across idea
+  discovery, experiment bridging, review loops, paper writing, rebuttal,
+  resubmission, talks, slides, posters, audits, and Research Wiki usage.
+- `skills/research-pipeline/SKILL.md` chains idea discovery, experiment bridge,
+  auto-review loop, and paper writing, with parameters for auto-proceed,
+  human checkpoints, code review, base repositories, venues, HTML rendering,
+  and resumable execution.
+- `docs/OPENCLAW_ADAPTATION.md` maps ARIS workflows into OpenClaw-friendly,
+  file-first phases with explicit output artifacts.
+- The repository license is MIT.
+
+## Duplicate Check
+
+No existing HeyClaude content entry or open PR was found for ARIS,
+Auto-Research-In-Sleep, or `wanshuiyin/Auto-claude-code-research-in-sleep` at
+the time this listing was created.
+
+## Disclosure
+
+This is a community project listing based on public source material. It is not
+an endorsement that autonomous research results, generated experiments, paper
+claims, or rebuttal drafts are correct, novel, reproducible, or venue-ready
+without independent review.


### PR DESCRIPTION
## Summary
- Add a source-backed skills entry for ARIS Auto-Research-In-Sleep.
- Covers the Markdown research-agent workflow pack for Claude Code, Codex, OpenClaw, Cursor, Antigravity, Copilot CLI, Trae, and compatible agent hosts.

## What changed
- Added `content/skills/aris-auto-research-in-sleep.mdx`.
- Included verified source URLs for the upstream README, AGENT_GUIDE, representative skill files, assurance contract, OpenClaw adaptation guide, and MIT license.
- Added safety and privacy notes for autonomous experiment execution, cross-model reviewer loops, paper/rebuttal generation, GPU/cloud cost, confidential research artifacts, and citation/claim verification.

## Why
- No tracking issue; this is a focused content submission for a high-demand research-agent and skill-workflow project.
- ARIS is a currently active Markdown skill system with strong demand signals around autonomous ML research, Claude Code research pipelines, Codex skills, OpenClaw adaptation, MCP reviewer workflows, paper writing, rebuttals, and experiment automation.

## Validation
- `pnpm validate:content:strict -- --category skills`
- `node scripts/ci/validate-content-policy.mjs --repo-root . --files-json <changed-files-json>`
- `pnpm validate:content:strict`
- `pnpm validate:packages`
- `pnpm scan:packages`
- `pnpm validate:clean`
- `pnpm audit:content` reported the expected baseline: 0 missing required fields, 0 missing recommended fields, 0 metadata-only entries, 3 semantic issues.
- `git diff --check`
- `git diff --cached --check`

## Notes
- The audit script rewrote `content/data/content-audit.json`; that generated artifact was restored and is not part of this PR.
