### PR TITLE
fix(content): repair home assistant agent fences

### DIFF
--- a/content/agents/home-assistant-core-repository-contributor-agent.mdx
+++ b/content/agents/home-assistant-core-repository-contributor-agent.mdx
@@ -91,7 +91,7 @@ robotsFollow: true
 Create this file as
 `.claude/agents/home-assistant-core-repository-contributor.md`:
 
-```markdown
+````markdown
 ---
 name: home-assistant-core-repository-contributor
 description: Use when the user asks Claude to investigate, patch, test, or review work in the official home-assistant/core repository from source-backed repository instructions.
@@ -246,7 +246,7 @@ Safety/privacy notes:
 Remaining risk:
 - ...
 ```
-```
+````
 
 ## Source Review
 


### PR DESCRIPTION
### Motivation
- Fix a rendering/navigation bug in the Home Assistant agent MDX where nested triple-backtick fences caused the outer code block to be unterminated and produced malformed outline extraction.

### Description
- Replace the outer triple-backtick fence with a four-backtick fence in `content/agents/home-assistant-core-repository-contributor-agent.mdx` so the nested ```markdown``` block is preserved and Markdown parsers and the repository outline extractor behave correctly.

### Testing
- Ran `pnpm validate:content:strict` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34515b3464832cb604e30bd724bda0)