### PR TITLE
feat(rules): add Astro expert CLAUDE.md rules

### DIFF
--- a/content/rules/astro-expert.mdx
+++ b/content/rules/astro-expert.mdx
@@ -1,0 +1,61 @@
+---
+title: Astro Expert - CLAUDE.md Rules for Claude Code
+slug: astro-expert
+category: rules
+description: >-
+  Transform Claude into an Astro specialist with deep knowledge of islands architecture,
+  content collections, view transitions, and hybrid static/server rendering.
+cardDescription: >-
+  Transform Claude into an Astro specialist covering islands, content collections,
+  view transitions, and hybrid rendering strategies.
+seoTitle: Astro Expert - CLAUDE.md Rules for Claude Code
+seoDescription: >-
+  Rules to transform Claude into an Astro expert covering .astro components, islands,
+  content collections, SSR adapters, and performance-minded partial hydration.
+keywords:
+  - claude
+  - astro
+  - islands
+  - content collections
+  - static site
+  - rules
+author: jaso0n0818
+authorProfileUrl: "https://github.com/jaso0n0818"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-19"
+submittedAt: "2026-06-19"
+documentationUrl: "https://docs.astro.build/en/getting-started/"
+sourceUrls:
+  - "https://docs.astro.build/en/concepts/islands/"
+  - "https://docs.astro.build/en/guides/content-collections/"
+  - "https://docs.astro.build/en/guides/view-transitions/"
+  - "https://docs.astro.build/en/guides/server-side-rendering/"
+installable: false
+privacyNotes:
+  - "Server endpoints may access environment secrets; keep keys in server-only modules."
+usageSnippet: >-
+  Add to CLAUDE.md to configure Claude as an Astro expert for your project.
+copySnippet: |-
+  You are an expert Astro developer focused on content sites and partial hydration.
+
+  ## Islands and components
+
+  - Default to static `.astro` components; add `client:*` directives only where interactivity is required.
+  - Keep framework islands small; pass serializable props across the server/client boundary.
+  - Prefer slot-based composition in layouts over prop-drilling large trees.
+
+  ## Content and data
+
+  - Define content collections with Zod schemas; validate frontmatter at build time.
+  - Use `getCollection`/`getEntry` in pages; avoid duplicating slug logic across routes.
+  - Generate RSS, sitemaps, and search indexes from the same canonical content source.
+
+  ## Performance and rendering
+
+  - Choose static output unless SSR or on-demand rendering is truly needed.
+  - Lazy-load heavy client islands; audit bundle size for each `client:load` island.
+  - Use view transitions for in-site navigation without shipping a full SPA router.
+---
+
+Use these rules when building or reviewing Astro sites and hybrid applications.


### PR DESCRIPTION
Adds a single `content/rules/astro-expert.mdx` entry backed by official Astro documentation.

- Category: rules
- Source URLs verified reachable
- Local `pnpm validate:content:strict` passed