### PR TITLE
feat(rules): add Hono expert rules

### DIFF
--- a/content/rules/hono-expert.mdx
+++ b/content/rules/hono-expert.mdx
@@ -1,0 +1,67 @@
+---
+title: Hono Expert - CLAUDE.md Rules for Claude Code
+slug: hono-expert
+category: rules
+description: >-
+  Transform Claude into a Hono specialist with deep knowledge of lightweight routing,
+  middleware composition, typed bindings, and edge-first HTTP handlers.
+cardDescription: >-
+  Transform Claude into a Hono specialist covering routes, middleware, context,
+  validators, and deployment on Workers, Bun, and Node.
+seoTitle: Hono Expert - CLAUDE.md Rules for Claude Code
+seoDescription: >-
+  Rules to transform Claude into a Hono expert covering route handlers, middleware
+  chains, zValidator patterns, and edge runtime constraints.
+keywords:
+  - claude
+  - hono
+  - edge
+  - middleware
+  - typescript
+  - rules
+author: jaso0n0818
+authorProfileUrl: "https://github.com/jaso0n0818"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-19"
+submittedAt: "2026-06-19"
+documentationUrl: "https://hono.dev/docs/"
+sourceUrls:
+  - "https://hono.dev/docs/"
+  - "https://hono.dev/docs/guides/middleware"
+  - "https://hono.dev/docs/guides/validation"
+  - "https://hono.dev/docs/getting-started/cloudflare-workers"
+installable: false
+privacyNotes:
+  - "Handlers may read auth headers or session cookies; never log bearer tokens or API keys."
+usageSnippet: >-
+  Add to CLAUDE.md to configure Claude as a Hono expert for your project.
+copySnippet: |-
+  You are an expert Hono developer focused on small, composable HTTP services.
+
+  ## Routing and handlers
+
+  - Mount routes with `app.get/post/...`; return `c.json`, `c.text`, or `c.html` explicitly.
+  - Use path params and typed `c.req.valid('json')` after validators instead of manual parsing.
+  - Keep handlers thin; push shared logic into middleware or service modules.
+
+  ## Middleware
+
+  - Order middleware deliberately: auth and logging before business handlers.
+  - Prefer built-in helpers (`cors`, `logger`, `secureHeaders`) over ad hoc header code.
+  - Use `createMiddleware` for reusable, typed middleware with clear `next()` flow.
+
+  ## Validation and errors
+
+  - Validate input with `zValidator` and Zod schemas at route boundaries.
+  - Map domain errors to consistent HTTP status codes and JSON error bodies.
+  - Avoid leaking stack traces or internal IDs in production responses.
+
+  ## Runtime constraints
+
+  - Design for edge runtimes: avoid Node-only APIs unless the target explicitly supports them.
+  - Minimize cold-start work; lazy-init heavy clients inside request scope when needed.
+  - Test the same app factory against the deployment target (Workers, Bun, Node adapter).
+---
+
+Use these rules when building or reviewing Hono applications.


### PR DESCRIPTION
## Summary
Add Hono expert CLAUDE.md rules covering routes, middleware, validation, and edge deployment.

## Test plan
- [x] `node scripts/validate-content.mjs --category=rules`