### PR TITLE
fix(rules): clarify Vite sourcemap guidance

### DIFF
--- a/content/rules/vite-expert.mdx
+++ b/content/rules/vite-expert.mdx
@@ -55,7 +55,7 @@ copySnippet: |-
 
   - Prefer official or well-maintained plugins; pin versions alongside Vite major releases
   - Use `build.rollupOptions.output.manualChunks` for route-level or vendor splits
-  - Enable `build.sourcemap` in staging; disable or use hidden maps in public production when size matters
+  - Enable `build.sourcemap` in staging only; disable production source maps unless they are uploaded to a private error-reporting service and excluded from public deploys
 
   ## Performance checks
 


### PR DESCRIPTION
### Motivation
- The Vite CLAUDE.md rule recommended using hidden source maps in public production, which still emits `.map` files that can expose original source if deployed publicly, so the guidance must explicitly discourage public production sourcemaps.

### Description
- Update `content/rules/vite-expert.mdx` to replace the line recommending hidden sourcemaps with guidance that enables `build.sourcemap` in staging only and advises disabling production source maps unless they are uploaded to a private error-reporting service and excluded from public deploys.

### Testing
- Ran `pnpm validate:content:strict` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345f17081c832ca6e132d39e89d381)