### PR TITLE
chore(deps): update workflow node runtime to 24.17.0

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -120,7 +120,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.ci == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -244,7 +244,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
 
       - name: Validate direct content policy
         env:
@@ -313,7 +313,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -399,7 +399,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -486,7 +486,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.registry == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -637,7 +637,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.web == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -720,7 +720,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.mcp == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -781,7 +781,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.raycast == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -862,7 +862,7 @@ jobs:
         if: ${{ needs.classify-pr.outputs.packages == 'true' }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -902,7 +902,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies
@@ -940,7 +940,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/jobs-source-revalidation.yml
+++ b/.github/workflows/jobs-source-revalidation.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/mcp-package.yml
+++ b/.github/workflows/mcp-package.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/mcp-release-watch.yml
+++ b/.github/workflows/mcp-release-watch.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
 
       - name: Check MCP release status
         env:

--- a/.github/workflows/package-artifact-scan.yml
+++ b/.github/workflows/package-artifact-scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/publish-mcp-npm.yml
+++ b/.github/workflows/publish-mcp-npm.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           registry-url: https://registry.npmjs.org
 
       - name: Validate release version

--- a/.github/workflows/raycast-extension.yml
+++ b/.github/workflows/raycast-extension.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install workspace dependencies

--- a/.github/workflows/raycast-release-watch.yml
+++ b/.github/workflows/raycast-release-watch.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
 
       - name: Check Raycast upstream update status
         env:

--- a/.github/workflows/readme-refresh-pr.yml
+++ b/.github/workflows/readme-refresh-pr.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/superagent-security.yml
+++ b/.github/workflows/superagent-security.yml
@@ -57,7 +57,7 @@ jobs:
         if: ${{ steps.scanner-secrets.outputs.available == 'true' }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.16.0
+          node-version: 24.17.0
           cache: pnpm
           # Scanner deps install from the trusted base checkout in
           # scanner-tools/, so the cache key hashes that lockfile.


### PR DESCRIPTION
## Summary
- Update GitHub Actions Node runtime pins from `24.16.0` to `24.17.0`.

## What changed
- Updated workflow `node-version` values across content validation, coverage, MCP, Raycast, package scan, publishing, README refresh, and Superagent security jobs.
- Left action SHAs, Node 22 usage, and package dependency updates untouched for separate review.

## Why
The dependency dashboard reports Node `24.17.0` as the current patch update for these workflow runtime pins.

## Validation
- Parsed all workflow YAML files with the repo `yaml` dependency.
- `git diff --check`

## Notes
Refs #300