### PR TITLE
fix(submissions): validate public contact aliases

### DIFF
--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -64,7 +64,11 @@ export const HEADING_KEY_MAP = {
   "author-profile-url": "author_profile_url",
   "submitted-via": "submitted_via",
   "contact-email": "contact_email",
+  contact: "contact_email",
+  contactemail: "contact_email",
   email: "contact_email",
+  "public-contact": "contact_email",
+  "public-email": "contact_email",
   tags: "tags",
   description: "description",
   "what-it-does": "description",
@@ -296,6 +300,9 @@ function mapJsonData(data) {
     category: "category",
     description: "description",
     author: "author",
+    contact: "contact_email",
+    contactEmail: "contact_email",
+    publicContact: "contact_email",
     github: "github_url",
     githubUrl: "github_url",
     repoUrl: "github_url",
@@ -717,8 +724,17 @@ function isValidPublicContact(value) {
   const normalized = normalizeValue(value);
   if (!normalized) return true;
   if (normalized.includes("@")) {
-    const [local, domain] = normalized.split("@");
-    if (local && domain && domain.includes(".") && !normalized.includes(" ")) {
+    const parts = normalized.split("@");
+    const [local, domain] = parts;
+    if (
+      parts.length === 2 &&
+      local &&
+      domain &&
+      domain.includes(".") &&
+      !domain.startsWith(".") &&
+      !domain.endsWith(".") &&
+      !normalized.includes(" ")
+    ) {
       return true;
     }
   }

--- a/tests/submission-builders.test.ts
+++ b/tests/submission-builders.test.ts
@@ -162,6 +162,9 @@ describe("registry submission parsing and validation", () => {
       "Add MCP Server: Demo MCP Server",
     );
     expect(buildSubmissionPrBody(validMcpFields)).toContain("### Safety notes");
+    expect(parseSubmissionPrBody(draft.body)).toMatchObject({
+      contact_email: "@example",
+    });
     expect(looksLikeSubmissionPrDraft(draft)).toBe(true);
     expect(
       validateSubmission({ title: "Add MCP server: Demo", body: draft.body }),
@@ -233,6 +236,20 @@ describe("registry submission parsing and validation", () => {
     ).toEqual(
       expect.arrayContaining([
         "Skills install_command references a local installer script; include the exact installer source URL in retrieval_sources or provide full_copyable_content",
+      ]),
+    );
+
+    expect(
+      validateSubmission({
+        title: "Add MCP server: Bad contact",
+        body: buildSubmissionPrBody({
+          ...validMcpFields,
+          contact_email: "user@example.com@attacker.com",
+        }),
+      }).errors,
+    ).toEqual(
+      expect.arrayContaining([
+        "Invalid public contact: use a GitHub handle, GitHub profile URL, or email",
       ]),
     );
   });

--- a/tests/submission-builders.test.ts
+++ b/tests/submission-builders.test.ts
@@ -239,19 +239,25 @@ describe("registry submission parsing and validation", () => {
       ]),
     );
 
-    expect(
-      validateSubmission({
-        title: "Add MCP server: Bad contact",
-        body: buildSubmissionPrBody({
-          ...validMcpFields,
-          contact_email: "user@example.com@attacker.com",
-        }),
-      }).errors,
-    ).toEqual(
-      expect.arrayContaining([
-        "Invalid public contact: use a GitHub handle, GitHub profile URL, or email",
-      ]),
-    );
+    for (const contact_email of [
+      "user@example.com@attacker.com",
+      "user@.example.com",
+      "user@example.com.",
+    ]) {
+      expect(
+        validateSubmission({
+          title: "Add MCP server: Bad contact",
+          body: buildSubmissionPrBody({
+            ...validMcpFields,
+            contact_email,
+          }),
+        }).errors,
+      ).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("Invalid public contact"),
+        ]),
+      );
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix submission public contact parsing and validation.

## What changed
- Normalize generated `Public contact` headings and common contact aliases to `contact_email`.
- Reject email-like public contacts that contain multiple `@` separators.
- Add regression coverage for generated draft round-tripping and malformed contacts.

## Why
Generated submission drafts used the `Public contact` label, but the parser did not map that heading back to `contact_email`. That allowed malformed public contacts to skip validation.

## Validation
- `pnpm exec vitest run tests/submission-builders.test.ts --pool forks --maxWorkers 1`
- `pnpm exec vitest run tests/submission-builders.test.ts tests/submission-api.test.ts tests/submission-pr-first.test.ts --pool forks --maxWorkers 1`
- `pnpm exec vitest run tests/registry-artifacts.test.ts --pool forks --maxWorkers 1`
- `git diff --check`
