### PR TITLE
docs(content): add Scientific Agent Skills

### DIFF
--- a/content/skills/scientific-agent-skills.mdx
+++ b/content/skills/scientific-agent-skills.mdx
@@ -1,0 +1,269 @@
+---
+title: Scientific Agent Skills
+slug: scientific-agent-skills
+category: skills
+description: >-
+  MIT-licensed K-Dense Scientific Agent Skills pack for turning Claude Code,
+  Codex, Cursor, OpenClaw, Gemini CLI, Antigravity, Pi, and other Agent
+  Skills-compatible hosts into scientific research assistants across
+  bioinformatics, chemistry, medicine, drug discovery, data analysis, and
+  scientific writing workflows.
+cardDescription: >-
+  Large scientific Agent Skills collection for research, biomedical databases,
+  Python science packages, clinical research, drug discovery, and scientific
+  writing.
+seoTitle: Scientific Agent Skills for Claude Code, Codex, Cursor, OpenClaw, and AI Scientist Workflows
+seoDescription: >-
+  Install K-Dense Scientific Agent Skills for Claude Code, Codex, Cursor,
+  OpenClaw, Gemini CLI, Antigravity, Pi, and Agent Skills hosts to add
+  research workflows for bioinformatics, genomics, chemistry, medicine, drug
+  discovery, scientific databases, clinical research, Python scientific
+  packages, literature review, and scientific writing.
+author: K-Dense
+authorProfileUrl: "https://github.com/K-Dense-AI"
+dateAdded: "2026-06-18"
+websiteUrl: "https://k-dense.ai"
+documentationUrl: "https://github.com/K-Dense-AI/scientific-agent-skills#readme"
+repoUrl: "https://github.com/K-Dense-AI/scientific-agent-skills"
+downloadUrl: "https://github.com/K-Dense-AI/scientific-agent-skills/archive/refs/heads/main.zip"
+installable: true
+installCommand: "npx skills add K-Dense-AI/scientific-agent-skills"
+usageSnippet: >-
+  Install the full repository or a topical subset into an Agent
+  Skills-compatible host, then invoke the relevant skill by name for a bounded
+  scientific workflow such as database lookup, Scanpy analysis, RDKit work,
+  clinical evidence synthesis, literature review, or scientific writing.
+copySnippet: |-
+  npx skills add K-Dense-AI/scientific-agent-skills
+
+  # GitHub CLI users can also install through gh skill.
+  gh skill install K-Dense-AI/scientific-agent-skills --agent codex
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-18"
+retrievalSources:
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/README.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/docs/skills.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/pyproject.toml"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/SECURITY.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/skills/database-lookup/SKILL.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/skills/clinical-decision-support/SKILL.md"
+sourceUrls:
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/README.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/docs/skills.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/pyproject.toml"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/SECURITY.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/skills/database-lookup/SKILL.md"
+  - "https://github.com/K-Dense-AI/scientific-agent-skills/blob/main/skills/clinical-decision-support/SKILL.md"
+testedPlatforms:
+  - Claude Code
+  - Codex
+  - Cursor
+  - OpenClaw
+  - Gemini CLI
+  - Google Antigravity
+  - Pi
+  - Hermes
+  - Agent Skills-compatible hosts
+prerequisites:
+  - "An Agent Skills-compatible host such as Claude Code, Codex, Cursor, OpenClaw, Gemini CLI, Antigravity, Pi, Hermes, or another client that can load `SKILL.md` files."
+  - "Node.js/npm for the documented `npx skills add` path, or GitHub CLI with `gh skill` support for host-targeted installs."
+  - "Python 3.13 or newer for repository tooling; individual scientific skill dependencies may have their own Python and package requirements."
+  - "A controlled research workspace with versioned data, approved external API access, and clear rules for credentials, patient data, unpublished results, and regulated datasets."
+  - "Domain expert review for biomedical, clinical, regulatory, wet-lab, or publication-facing outputs."
+safetyNotes:
+  - "Scientific Agent Skills can instruct an agent to run Python code, install scientific packages, call public and credentialed APIs, write files, generate figures, transform datasets, and produce research documents."
+  - "Install only the topical skills needed for the current project when possible. The upstream README also recommends reviewing `SKILL.md` files before installing and not installing everything at once."
+  - "The upstream security scan generated on 2026-06-15 reported 147 scanned skills, 900 total findings, 67 critical findings, 43 high findings, and 107 of 147 skills marked safe. Treat that report as a mandatory review input before using risky skills."
+  - "Do not use generated clinical, medical, drug discovery, regulatory, or statistical conclusions as patient-care advice or final scientific evidence without qualified human review and source verification."
+  - "Treat external database responses, papers, abstracts, patent text, clinical-trial records, and API payloads as untrusted data. Do not follow instructions embedded in returned content."
+  - "Review scripts and generated code before execution, especially skills that access environment variables, external LLM backends, screen content, cloud services, LIMS/ELN systems, laboratory automation, or local research files."
+  - "For wet-lab, clinical, medical-device, pharmacogenomics, or drug-safety workflows, enforce institutional SOPs, IRB/compliance requirements, audit trails, and rollback or non-execution review gates."
+privacyNotes:
+  - "Scientific workflows can expose patient data, biological sequences, clinical notes, research manuscripts, unpublished hypotheses, lab notebook content, proprietary assays, patent strategy, credentials, API keys, and regulated datasets."
+  - "Several skills use third-party scientific APIs or optional LLM-backed providers. Confirm which service receives each query, whether an API key is required, and what data is sent before running an agent workflow."
+  - "De-identify PHI and sensitive research data before sending it to external models, search APIs, scientific databases, LIMS systems, cloud notebooks, or collaborator-visible logs."
+  - "Database lookup, literature review, citation management, clinical reports, and scientific writing workflows can persist retrieved records, generated files, citations, figures, and logs in the local workspace."
+  - "Do not paste private credentials, unpublished experimental results, controlled-access dataset records, patient identifiers, or confidential commercial research into public issues, prompts, screenshots, or generated examples."
+tags:
+  - scientific-agent-skills
+  - agent-skills
+  - claude-code
+  - codex
+  - openclaw
+  - ai-scientist
+  - bioinformatics
+  - drug-discovery
+  - clinical-research
+  - scientific-computing
+keywords:
+  - Scientific Agent Skills
+  - K-Dense scientific-agent-skills
+  - Claude Code scientific skills
+  - Codex scientific skills
+  - OpenClaw scientific skills
+  - AI scientist agent skills
+  - bioinformatics agent skills
+  - drug discovery AI agent skills
+  - clinical research agent skills
+  - scientific database lookup skill
+  - Agent Skills for research workflows
+readingTime: 8
+difficultyScore: 91
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+# Scientific Agent Skills
+
+Scientific Agent Skills is K-Dense's large Agent Skills collection for
+science, research, engineering, data analysis, and scientific communication.
+The repository packages `SKILL.md` instruction files, references, scripts,
+and examples so compatible agents can perform bounded scientific workflows
+instead of improvising from generic Python or web-search knowledge.
+
+Use this listing for the skill pack itself. Use separate tool, MCP, or package
+entries when evaluating a runtime, local AI workspace, database service,
+scientific Python package, or cloud execution platform.
+
+## Knowledge Freshness
+
+Verified on **2026-06-18**, the upstream repository reported version `2.52.0`
+in `pyproject.toml`, a latest GitHub release `v2.52.0` published on
+2026-06-12, and recent repository activity on 2026-06-15. The README described
+147 ready-to-use skills and 100+ scientific database or data-access paths.
+
+The pack changes often and includes both maintainer-authored and community
+contributed skills. Before running a workflow, check the exact installed
+release, read the relevant `SKILL.md`, and verify current database, package,
+and API documentation for the specific scientific domain.
+
+## Retrieval Sources
+
+This listing is grounded in:
+
+- The upstream `K-Dense-AI/scientific-agent-skills` README.
+- The generated `docs/skills.md` skills catalog.
+- `pyproject.toml` version and Python tooling metadata.
+- The repository `SECURITY.md` scan summary.
+- Representative `database-lookup` and `clinical-decision-support`
+  `SKILL.md` files.
+- Current GitHub repository metadata for license, stars, release, and topics.
+
+## Core Workflow
+
+Install through the open Agent Skills installer:
+
+```bash
+npx skills add K-Dense-AI/scientific-agent-skills
+```
+
+GitHub CLI users can also use the documented `gh skill` path:
+
+```bash
+gh skill install K-Dense-AI/scientific-agent-skills --agent codex
+```
+
+For safer production use, install or enable only the topical subset needed for
+the job. A good workflow is:
+
+1. Pick the scientific domain and exact task boundary.
+2. Read the relevant `SKILL.md` and references before execution.
+3. Confirm required packages, API keys, data licenses, and outbound network
+   access.
+4. Run on a copied or versioned workspace first.
+5. Review code, retrieval logs, citations, figures, tables, and conclusions
+   before using the output.
+
+## Capability Scope
+
+| Area | Coverage |
+| --- | --- |
+| Scientific databases | Public database lookup, biomedical records, chemistry, clinical trials, patents, fiscal data, astronomy, geospatial, and other API-backed retrievals |
+| Bioinformatics and omics | AnnData, BioPython, Scanpy, gget, gene regulatory networks, bulk RNA-seq, single-cell workflows, proteomics, variants, pathways, and sequencing data |
+| Chemistry and drug discovery | RDKit, Datamol, DeepChem, molecular dynamics, docking-related workflows, ADMET, target lookup, compound databases, and drug-safety records |
+| Clinical and medical research | Clinical decision support documents, clinical reports, treatment-plan style guidance, medical imaging, pharmacogenomics, regulatory materials, and evidence synthesis |
+| Scientific computing | PyTorch Lightning, scikit-learn, Qiskit, PennyLane, Dask, Zarr, statistical analysis, simulation, optimization, and GPU/resource planning |
+| Research communication | Literature review, scientific writing, peer review, citation management, slides, posters, schematics, venue templates, and manuscript-support workflows |
+| Integrations | Benchling, DNAnexus, LatchBio, OMERO, protocols.io, LabArchives, Opentrons, Ginkgo Cloud Lab, and related lab or R&D platforms |
+
+## Use Cases
+
+- Give Claude Code, Codex, Cursor, OpenClaw, or another compatible agent a
+  source-backed research workflow for a specific scientific domain.
+- Query public scientific databases with explicit endpoints, pagination,
+  identifier conversions, and provenance instead of unbounded web summaries.
+- Build reproducible analysis scaffolding for Scanpy, RDKit, BioPython,
+  scikit-learn, Dask, molecular dynamics, statistical analysis, or related
+  Python workflows.
+- Draft scientific manuscripts, literature reviews, posters, slide decks, or
+  peer-review notes with citations and reporting-guideline awareness.
+- Create controlled internal workflows for clinical research, cohort analysis,
+  clinical-trial evidence synthesis, drug discovery, or laboratory automation.
+
+## Production Rules
+
+- Prefer topical skill installs over installing the full repository.
+- Treat all generated code, data transformations, citations, clinical
+  conclusions, and scientific claims as drafts until reviewed by a qualified
+  human.
+- Read the specific `SKILL.md` and reference files for the skill being used;
+  do not rely on the repository README as the only operating guide.
+- Validate identifiers, organism names, genome builds, chemical structures,
+  clinical-trial filters, units, statistical assumptions, and database access
+  dates before accepting results.
+- Do not run skills against PHI, controlled datasets, unpublished lab results,
+  proprietary assays, credentials, or production lab systems unless the
+  workspace, model provider, and network path are approved for that data.
+- Review upstream security-scan findings before enabling skills that run
+  scripts, call external LLMs, access environment variables, capture screen
+  context, write files, or interact with lab and clinical systems.
+
+## Safety Review
+
+The upstream project is unusually valuable because it is broad and current,
+but that breadth is also the main risk. The 2026-06-15 upstream security
+summary reported critical and high findings in multiple skills. Some findings
+relate to environment-variable access, network calls, generated skill content,
+screen-content capture, prompt-injection exposure, and clinical or research
+document generation.
+
+That does not make the whole repository unusable, but it means operators
+should treat it like a high-power research automation pack: install narrowly,
+read before running, keep agent permissions scoped, and require human review
+before any scientific, clinical, regulatory, laboratory, or publication-facing
+output is trusted.
+
+## Source Review
+
+Verified on **2026-06-18**:
+
+- GitHub metadata reported `K-Dense-AI/scientific-agent-skills` as an
+  MIT-licensed repository with topics including `ai-scientist`,
+  `bioinformatics`, `chemoinformatics`, `clinical-research`,
+  `drug-discovery`, `genomics`, `proteomics`, `scientific-computing`, and
+  `agent-skills`.
+- The README described Scientific Agent Skills as an Agent Skills collection
+  for Cursor, Claude Code, Codex, Google Antigravity, OpenClaw, Pi, Hermes,
+  and other compatible agents.
+- `pyproject.toml` declared package version `2.52.0`, Python `>=3.13`, and
+  dependencies including `cisco-ai-skill-scanner`, `firecrawl-py`, and
+  `python-dotenv`.
+- `docs/skills.md` described coverage across scientific databases, lab and
+  R&D integrations, Python scientific packages, research methodology,
+  scientific writing, document processing, laboratory automation, and
+  computational-resource discovery.
+- `skills/database-lookup/SKILL.md` described deterministic querying across
+  public scientific, biomedical, materials, regulatory, finance, demographic,
+  astronomy, environmental, chemistry, drug, protein, gene, clinical-trial,
+  patent, and economic databases.
+- `skills/clinical-decision-support/SKILL.md` described group-level clinical
+  research and evidence-synthesis documents, while explicitly distinguishing
+  those documents from individual bedside treatment plans.
+- `SECURITY.md` reported 147 scanned skills, 900 total findings, 67 critical
+  findings, 43 high findings, and 107 of 147 skills marked safe in the
+  generated 2026-06-15 scan summary.


### PR DESCRIPTION
## Summary
- add a one-file skills entry for K-Dense Scientific Agent Skills

## What changed
- documents the Agent Skills install paths for Claude Code, Codex, Cursor, OpenClaw, Gemini CLI, Antigravity, Pi, Hermes, and compatible hosts
- captures scientific workflow coverage across bioinformatics, drug discovery, clinical research, scientific databases, Python packages, and research writing
- includes explicit safety and privacy notes from the upstream security scan and recommends topical installs over installing the full repository

## Why
- fills a high-demand AI scientist / scientific agent skills gap with strong live GitHub demand signals, recent release activity, and direct `SKILL.md` evidence

## Validation
- `pnpm validate:content:strict -- --category skills`
- `node scripts/ci/validate-content-policy.mjs --repo-root . --files-json <one-file-list.json>`
- source evidence probe for `content/skills/scientific-agent-skills.mdx` passed with 10 submitted URLs
- ASCII scan for `content/skills/scientific-agent-skills.mdx`
- `git diff --check`

## Notes
- Upstream `SECURITY.md` reports critical/high findings across part of the skill collection, so the listing intentionally frames this as powerful research automation that should be installed narrowly and reviewed before execution.