### PR TITLE
docs(content): add Context Engineering Agent Skills

### DIFF
--- a/content/skills/context-engineering-agent-skills.mdx
+++ b/content/skills/context-engineering-agent-skills.mdx
@@ -1,0 +1,228 @@
+---
+title: Context Engineering Agent Skills
+slug: context-engineering-agent-skills
+category: skills
+description: >-
+  MIT-licensed Agent Skills collection for context engineering, harness
+  engineering, multi-agent architectures, filesystem context, memory systems,
+  tool design, evaluation, hosted agents, and production agent operating loops
+  for Claude Code, Cursor, Codex, and Open Plugins-compatible agent tools.
+cardDescription: >-
+  Agent Skills pack for context windows, multi-agent systems, filesystem
+  memory, tool design, evaluation, harness engineering, and production agents.
+seoTitle: Context Engineering Agent Skills for Claude Code, Cursor, Codex, and Production AI Agents
+seoDescription: >-
+  Install Context Engineering Agent Skills for Claude Code, Cursor, Codex, and
+  compatible agent tools to guide context-window design, context compression,
+  filesystem context, memory systems, multi-agent patterns, MCP tool design,
+  hosted agents, LLM evaluation, harness engineering, and production AI agent
+  systems.
+author: Muratcan Koylan
+authorProfileUrl: "https://github.com/muratcankoylan"
+dateAdded: "2026-06-18"
+documentationUrl: "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering#readme"
+repoUrl: "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering"
+downloadUrl: "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/archive/refs/heads/main.zip"
+installable: true
+installCommand: "/plugin marketplace add muratcankoylan/Agent-Skills-for-Context-Engineering"
+usageSnippet: >-
+  Register the repository as a Claude Code plugin marketplace, install the
+  `context-engineering` plugin, or copy individual `SKILL.md` files into an
+  agent host that supports Agent Skills or custom instruction packs.
+copySnippet: |-
+  /plugin marketplace add muratcankoylan/Agent-Skills-for-Context-Engineering
+  /plugin install context-engineering@context-engineering-marketplace
+skillType: capability-pack
+skillLevel: expert
+verificationStatus: validated
+verifiedAt: "2026-06-18"
+retrievalSources:
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/README.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/.plugin/plugin.json"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/context-fundamentals/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/filesystem-context/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/tool-design/SKILL.md"
+  - "https://raw.githubusercontent.com/muratcankoylan/Agent-Skills-for-Context-Engineering/main/researcher/benchmarks/router/results-published/2026-05-19.md"
+sourceUrls:
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/README.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/.plugin/plugin.json"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/context-fundamentals/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/filesystem-context/SKILL.md"
+  - "https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/tool-design/SKILL.md"
+  - "https://raw.githubusercontent.com/muratcankoylan/Agent-Skills-for-Context-Engineering/main/researcher/benchmarks/router/results-published/2026-05-19.md"
+testedPlatforms:
+  - Claude Code
+  - Cursor
+  - Codex
+  - GitHub Copilot
+  - Open Plugins-compatible agent tools
+  - Agent Skills-compatible hosts
+prerequisites:
+  - "Claude Code plugin support, Cursor Open Plugins support, or an agent host that can load Agent Skills or custom instruction files."
+  - "A project where context-window behavior, multi-agent structure, tool design, memory, evaluation, or harness reliability is a real design concern."
+  - "A version-controlled workspace for any scripts, examples, benchmark artifacts, or generated skill changes."
+  - "Human review before applying benchmark-derived skill changes, modifying persistent agent memory, changing tool schemas, or deploying autonomous harness loops."
+safetyNotes:
+  - "These skills alter how agents select context, delegate work, persist state, design tools, evaluate outputs, and operate autonomous loops; use them as engineering guidance, not as automatic authority to change a production agent system."
+  - "Filesystem-context and memory-system patterns can cause agents to write durable plans, scratchpads, logs, summaries, preferences, or shared handoff files. Keep cleanup, ownership, and review rules explicit."
+  - "Harness-engineering, hosted-agent, and evaluation workflows can launch long-running loops, background agents, benchmark suites, paid model calls, or remote sandbox work. Require budgets, kill switches, rollback rules, and approval gates."
+  - "Tool-design guidance can change MCP schemas, tool descriptions, return formats, and error contracts. Test routing and compatibility before deploying changes to users."
+  - "Benchmark results are source evidence for this repository's claims, but they are workload-specific. Re-run or adapt benchmarks before relying on the reported routing numbers in a different agent stack."
+privacyNotes:
+  - "Context-engineering work often touches prompts, system instructions, tool definitions, retrieved documents, message history, tool outputs, logs, scratch files, memory stores, benchmark prompts, and model responses."
+  - "Do not persist secrets, customer data, private source code, incident data, unpublished strategy, or regulated records into scratchpads, skill examples, benchmark fixtures, or shared agent workspaces."
+  - "If benchmark runners or hosted-agent examples call external models or remote sandboxes, review what prompts, traces, files, and logs are sent outside the local workspace."
+  - "Agent memory and filesystem-context patterns should include deletion, redaction, retention, and access-control rules before being used with private projects."
+tags:
+  - context-engineering
+  - agent-skills
+  - claude-code
+  - cursor
+  - codex
+  - multi-agent
+  - tool-design
+  - mcp
+  - evaluation
+  - agent-harness
+keywords:
+  - Context Engineering Agent Skills
+  - Agent Skills for Context Engineering
+  - Claude Code context engineering skills
+  - Cursor context engineering plugin
+  - Codex context engineering skills
+  - AI agent context engineering
+  - filesystem context agent skill
+  - multi-agent architecture skills
+  - MCP tool design skill
+  - agent harness engineering skill
+  - context compression agent skill
+readingTime: 7
+difficultyScore: 84
+hasTroubleshooting: true
+hasPrerequisites: true
+hasBreakingChanges: false
+robotsIndex: true
+robotsFollow: true
+---
+
+# Context Engineering Agent Skills
+
+Context Engineering Agent Skills is a 15-skill collection for designing,
+debugging, and operating production-grade AI agent systems. It focuses on
+what enters the model context, how agents route work to skills and tools, how
+multi-agent systems isolate state, and how durable files, memory, evaluation,
+and harnesses keep long-running agent work coherent.
+
+Use this listing for the skills collection itself. Use separate entries when
+reviewing a specific MCP server, hosted-agent runtime, evaluation framework,
+or agent platform.
+
+## Knowledge Freshness
+
+Verified on **2026-06-18**, the repository reported plugin version `2.3.0`,
+latest GitHub release `v2.3.0` published on 2026-05-22, MIT licensing, and
+recent GitHub activity in late May 2026 with live repository updates visible
+on 2026-06-18.
+
+The pack includes benchmark artifacts and measured routing results, but those
+numbers are tied to the repository's fixtures, models, prompts, and runner.
+Treat them as useful source evidence, not universal performance guarantees.
+
+## Retrieval Sources
+
+This listing is grounded in:
+
+- The upstream README and root collection `SKILL.md`.
+- The Open Plugins manifest for the `context-engineering` plugin.
+- Representative `context-fundamentals`, `filesystem-context`, and
+  `tool-design` skill files.
+- The published 2026-05-19 router benchmark report.
+- Current GitHub repository metadata for license, stars, release, and activity.
+
+## Core Workflow
+
+Claude Code users can install the collection as a plugin:
+
+```text
+/plugin marketplace add muratcankoylan/Agent-Skills-for-Context-Engineering
+/plugin install context-engineering@context-engineering-marketplace
+```
+
+For a smaller install, copy only the individual skill folder needed for the
+current task into the target agent host's skills or custom-instructions
+directory. The README lists skills such as `context-fundamentals`,
+`context-degradation`, `context-compression`, `filesystem-context`,
+`multi-agent-patterns`, `memory-systems`, `tool-design`, `evaluation`,
+`advanced-evaluation`, `harness-engineering`, `hosted-agents`,
+`project-development`, and `bdi-mental-states`.
+
+## Capability Scope
+
+| Area | Coverage |
+| --- | --- |
+| Context fundamentals | Context-window anatomy, attention budgets, U-shaped attention, progressive disclosure, and signal-density reasoning |
+| Context failure and compression | Lost-in-middle behavior, context poisoning, distraction, compaction, summarization, masking, and context optimization |
+| Filesystem context | Scratchpads, tool-output offloading, plan persistence, sub-agent handoff files, terminal logs, and dynamic skill loading |
+| Multi-agent systems | Orchestrator, peer-to-peer, hierarchical, hosted-agent, and sandboxed background-agent patterns |
+| Memory systems | Short-term memory, long-term memory, knowledge graphs, retrieval semantics, and persistent workspace state |
+| Tool and MCP design | Tool descriptions, schemas, return formats, error recovery, namespacing, consolidation, and MCP tool naming |
+| Evaluation and harnesses | Deterministic checks, LLM-as-judge design, rubrics, novelty gates, durable logs, rollback rules, and human approval boundaries |
+
+## Use Cases
+
+- Diagnose context-window failures in a long-running coding or research agent.
+- Design a filesystem-backed scratchpad, handoff, or memory layer for agent
+  workflows.
+- Reduce an agent tool catalog to clearer MCP or native tool contracts.
+- Decide when sub-agents are useful for context isolation instead of only role
+  simulation.
+- Build deterministic evaluation and regression gates for an agent system.
+- Design autonomous harnesses with locked metrics, budgets, logs, rollback
+  rules, and approval checkpoints.
+
+## Production Rules
+
+- Load the full skill only when the task directly matches its trigger; broad
+  context stuffing defeats the purpose of a context-engineering pack.
+- Keep context, memory, and filesystem artifacts scoped to the task and
+  readable by humans.
+- Review and test tool-schema or MCP changes before deploying them to agent
+  users.
+- Add budgets and hard stops before benchmark runners, hosted-agent loops,
+  model calls, or autonomous research loops.
+- Treat benchmark results as repo-specific evidence and revalidate on your own
+  model, prompt set, tool catalog, and agent runtime before making product
+  claims.
+
+## Source Review
+
+Verified on **2026-06-18**:
+
+- GitHub metadata reported
+  `muratcankoylan/Agent-Skills-for-Context-Engineering` as an MIT-licensed
+  repository with more than 16,000 stars, default branch `main`, latest
+  release `v2.3.0`, and recent repository activity.
+- The README described a 15-skill collection across context fundamentals,
+  context degradation, compression, optimization, latent briefing,
+  multi-agent patterns, memory systems, tool design, filesystem context,
+  hosted agents, evaluation, advanced evaluation, harness engineering,
+  project development, and BDI mental states.
+- `.plugin/plugin.json` declared plugin name `context-engineering`, version
+  `2.3.0`, author `Muratcan Koylan`, and a description covering context
+  engineering, harness engineering, multi-agent coordination, memory systems,
+  tool design, evaluation, autonomous harnesses, and measured router
+  benchmark results.
+- The root `SKILL.md` described the collection as platform-agnostic and
+  oriented around building, optimizing, evaluating, and debugging agent
+  systems with effective context management.
+- `skills/filesystem-context/SKILL.md` documented scratchpads, tool-output
+  offloading, plan persistence, sub-agent communication through files,
+  dynamic skill loading, and terminal/log persistence.
+- `skills/tool-design/SKILL.md` documented tool descriptions, schema design,
+  response formats, actionable errors, MCP tool namespacing, and tool catalog
+  consolidation.
+- The 2026-05-19 router benchmark report documented 600 runs across four
+  models with 600/600 usable records, 0 format failures, and reported
+  per-model top-1 and top-3 routing accuracy for the repository's fixture.


### PR DESCRIPTION
## Summary
- add a one-file skills entry for Agent Skills for Context Engineering

## What changed
- documents the context-engineering plugin install path for Claude Code and compatible agent hosts
- captures the 15-skill coverage across context fundamentals, compression, filesystem context, multi-agent patterns, memory, tool design, evaluation, hosted agents, harness engineering, and BDI mental states
- includes safety and privacy notes for persistent context, tool schema changes, benchmark runners, hosted agents, and autonomous harness loops

## Why
- fills a high-demand context engineering / production agent systems gap with strong GitHub demand signals and direct `SKILL.md` plus benchmark-source evidence

## Validation
- `pnpm validate:content:strict -- --category skills`
- `node scripts/ci/validate-content-policy.mjs --repo-root . --files-json <one-file-list.json>`
- source evidence probe for `content/skills/context-engineering-agent-skills.mdx` passed with 10 submitted URLs
- ASCII scan for `content/skills/context-engineering-agent-skills.mdx`
- `git diff --check`

## Notes
- The listing treats upstream benchmark numbers as repo-specific evidence, not universal performance claims.