### PR TITLE
fix(brand-assets): serve logo proxy route

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -2984,7 +2984,7 @@
         "description": "Returns a cacheable HeyClaude-hosted brand asset backed by Brandfetch when a registry entry has a validated brand domain.",
         "parameters": [
           {
-            "schema": { "type": "string", "enum": ["icon"] },
+            "schema": { "type": "string", "enum": ["icon", "logo"] },
             "required": true,
             "name": "kind",
             "in": "path"

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -3517,6 +3517,7 @@ paths:
             type: string
             enum:
               - icon
+              - logo
           required: true
           name: kind
           in: path

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -775,7 +775,7 @@ export const ogQuerySchema = z.object({
 });
 
 export const brandAssetParamsSchema = z.object({
-  kind: z.literal("icon"),
+  kind: z.enum(["icon", "logo"]),
   domain: z
     .string()
     .trim()

--- a/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
+++ b/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
@@ -1,6 +1,9 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
-import { normalizeBrandDomain } from "@heyclaude/registry/brand-assets";
+import {
+  brandfetchLogoUrl,
+  normalizeBrandDomain,
+} from "@heyclaude/registry/brand-assets";
 
 import { brandAssetParamsSchema } from "@/lib/api/contracts";
 import { apiError, createApiHandler, type InferApiParams } from "@/lib/api/router";
@@ -43,6 +46,15 @@ async function resolveBrandIconUrl(domain: string, clientId: string) {
   const exact =
     results.find((result) => normalizeBrandDomain(result.domain) === domain) || results[0];
   return typeof exact?.icon === "string" ? exact.icon : "";
+}
+
+function resolveBrandLogoUrl(domain: string, clientId: string) {
+  return brandfetchLogoUrl(domain, {
+    clientId,
+    height: 256,
+    type: "logo",
+    width: 512,
+  });
 }
 
 function normalizeTrustedBrandAssetUrl(value: string) {
@@ -120,7 +132,7 @@ async function readArrayBufferWithinLimit(response: Response, maxBytes: number) 
 }
 
 export const GET = createApiHandler("brandAsset.read", async ({ params, requestId }) => {
-  const { domain } = params as InferApiParams<typeof brandAssetParamsSchema>;
+  const { domain, kind } = params as InferApiParams<typeof brandAssetParamsSchema>;
   const normalizedDomain = normalizeBrandDomain(domain);
   const clientId = brandfetchClientId();
 
@@ -131,7 +143,10 @@ export const GET = createApiHandler("brandAsset.read", async ({ params, requestI
     return apiError("brand_asset_not_configured", 503, { requestId });
   }
 
-  const upstreamCandidate = await resolveBrandIconUrl(normalizedDomain, clientId);
+  const upstreamCandidate =
+    kind === "logo"
+      ? resolveBrandLogoUrl(normalizedDomain, clientId)
+      : await resolveBrandIconUrl(normalizedDomain, clientId);
   if (!upstreamCandidate) {
     return apiError("brand_asset_not_found", 404, { requestId });
   }

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -3520,6 +3520,7 @@ paths:
             type: string
             enum:
               - icon
+              - logo
           required: true
           name: kind
           in: path

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -343,6 +343,40 @@ describe("central API router security", () => {
     expect(routerSource).toContain("binding.limit({ key })");
   });
 
+  it("serves Brandfetch logo proxy URLs through the trusted asset CDN", async () => {
+    process.env.BRANDFETCH_CLIENT_ID = "test-client";
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        input instanceof Request
+          ? input.url
+          : input instanceof URL
+            ? input.toString()
+            : String(input);
+      expect(url).toContain("https://cdn.brandfetch.io/domain/example.com/");
+      expect(url).toContain("/logo.png");
+      expect(url).toContain("c=test-client");
+      return new Response("png", {
+        headers: {
+          "content-length": "3",
+          "content-type": "image/png",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/routes/api/brand-assets/$kind/$domain");
+    const response = await GET(
+      new Request("https://heyclau.de/api/brand-assets/logo/example.com"),
+      { params: { kind: "logo", domain: "example.com" } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("x-brand-asset-source")).toBe("brandfetch");
+    await expect(response.text()).resolves.toBe("png");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects Brandfetch icons outside the trusted asset CDN", async () => {
     process.env.BRANDFETCH_CLIENT_ID = "test-client";
     const fetchMock = vi.fn(async () =>


### PR DESCRIPTION
## Summary
- Fix the brand asset proxy route so generated logo URLs work.

## What changed
- Allow `/api/brand-assets/logo/{domain}` in the API route contract.
- Resolve logo requests through the trusted Brandfetch CDN URL builder.
- Keep trusted-host, response content-type, redirect, and byte-limit checks on proxied logo assets.
- Regenerate OpenAPI artifacts for the expanded `kind` enum.

## Why
The brand asset helper can generate logo proxy URLs and the API docs describe icons or logos, but the route schema only accepted `icon`. Logo proxy requests were rejected before the handler could fetch the trusted asset.

## Validation
- `pnpm type-check`
- `pnpm validate:openapi`
- `pnpm exec vitest run tests/api-router-security.test.ts tests/api-contracts.test.ts tests/brand-assets.test.ts --pool forks --maxWorkers 1`
- `pnpm exec vitest run tests/api-router-security.test.ts tests/api-contracts.test.ts tests/brand-assets.test.ts --coverage --pool forks --maxWorkers 1`
- `pnpm exec vitest run tests/api-router-security.test.ts -t "Brandfetch logo" --pool forks --maxWorkers 1`
- `git diff --check`
