### PR TITLE
fix(cache): share ETag revalidation matching

### DIFF
--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -10,6 +10,7 @@
 import { ENTRIES } from "@/data/entries";
 import { CHANGELOG, RELEASE_NOTES } from "@/data/changelog";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
+import { ifNoneMatchMatches } from "@/lib/http-cache";
 import { CATEGORIES, type Category } from "@/types/registry";
 
 export const SITE_NAME = "HeyClaude";
@@ -143,14 +144,13 @@ export async function respondFeed(
   contentType = "application/rss+xml; charset=utf-8",
 ): Promise<Response> {
   const etag = await etagFor(body);
-  const ifNoneMatch = request.headers.get("if-none-match");
   const headers: Record<string, string> = {
     "Content-Type": contentType,
     "Cache-Control": XML_CACHE,
     ETag: etag,
     "Last-Modified": new Date(lastBuilt).toUTCString(),
   };
-  if (ifNoneMatch && ifNoneMatch === etag) {
+  if (ifNoneMatchMatches(request.headers.get("if-none-match"), etag)) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(body, { headers });

--- a/apps/web/src/lib/http-cache.ts
+++ b/apps/web/src/lib/http-cache.ts
@@ -18,15 +18,18 @@ export async function buildEtag(body: string) {
   return `"sha256-${toHex(digest).slice(0, 32)}"`;
 }
 
-function hasMatchingEtag(request: Request, etag: string) {
-  const normalize = (value: string) => value.replace(/^W\//, "");
+export function ifNoneMatchMatches(header: string | null, etag: string) {
+  if (!header) return false;
+  const normalize = (value: string) => value.trim().replace(/^W\//i, "");
   const normalizedEtag = normalize(etag);
-  return request.headers
-    .get("if-none-match")
-    ?.split(",")
-    .map((value) => value.trim())
+  return header
+    .split(",")
     .map(normalize)
-    .includes(normalizedEtag);
+    .some((candidate) => candidate === "*" || candidate === normalizedEtag);
+}
+
+function hasMatchingEtag(request: Request, etag: string) {
+  return ifNoneMatchMatches(request.headers.get("if-none-match"), etag);
 }
 
 export async function cachedJsonResponse(

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -10,6 +10,7 @@
 import { ENTRIES, REGISTRY_ENTRIES } from "@/data/entries";
 import { CATEGORIES } from "@/types/registry";
 import { etagFor } from "@/lib/feeds";
+import { ifNoneMatchMatches } from "@/lib/http-cache";
 import { applySecurityHeaders } from "@/lib/security-headers";
 import { buildEntryCitationFacts } from "@heyclaude/registry";
 
@@ -134,7 +135,6 @@ const TEXT_CACHE = "public, max-age=300, stale-while-revalidate=3600";
 
 export async function respondText(request: Request, body: string): Promise<Response> {
   const etag = await etagFor(body);
-  const ifNoneMatch = request.headers.get("if-none-match");
   const headers = applySecurityHeaders(
     new Headers({
       "Content-Type": "text/plain; charset=utf-8",
@@ -142,7 +142,7 @@ export async function respondText(request: Request, body: string): Promise<Respo
       ETag: etag,
     }),
   );
-  if (ifNoneMatch && ifNoneMatch === etag) {
+  if (ifNoneMatchMatches(request.headers.get("if-none-match"), etag)) {
     return new Response(null, { status: 304, headers });
   }
   return new Response(body, { headers });

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -127,6 +127,21 @@ describe("respondFeed conditional GET", () => {
     expect(await res.text()).toBe("");
   });
 
+  it("returns 304 for weak, wildcard, and list If-None-Match validators", async () => {
+    const etag = await etagFor(body);
+    for (const header of [`W/${etag}`, `"deadbeef", ${etag}`, "*"]) {
+      const res = await respondFeed(
+        new Request("https://heyclau.de/feed.xml", {
+          headers: { "if-none-match": header },
+        }),
+        body,
+        lastBuilt,
+      );
+      expect(res.status).toBe(304);
+      expect(await res.text()).toBe("");
+    }
+  });
+
   it("returns 200 when If-None-Match does not match", async () => {
     const res = await respondFeed(
       new Request("https://heyclau.de/feed.xml", { headers: { "if-none-match": '"deadbeef"' } }),

--- a/tests/http-cache.test.ts
+++ b/tests/http-cache.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from "vitest";
 
 import { respondFeed } from "@/lib/feeds";
-import { cachedJsonResponse, cachedTextResponse } from "@/lib/http-cache";
+import {
+  cachedJsonResponse,
+  cachedTextResponse,
+  ifNoneMatchMatches,
+} from "@/lib/http-cache";
+import { respondText } from "@/lib/llms";
 
 describe("HTTP cache helpers", () => {
+  it("matches strong, weak, list, and wildcard ETag validators", () => {
+    const etag = '"sha256-abcdef"';
+    expect(ifNoneMatchMatches(null, etag)).toBe(false);
+    expect(ifNoneMatchMatches('"sha256-deadbeef"', etag)).toBe(false);
+    expect(ifNoneMatchMatches(etag, etag)).toBe(true);
+    expect(ifNoneMatchMatches(`W/${etag}`, etag)).toBe(true);
+    expect(ifNoneMatchMatches(`"sha256-deadbeef", W/${etag}`, etag)).toBe(true);
+    expect(ifNoneMatchMatches("*", etag)).toBe(true);
+  });
+
   it("accepts Cloudflare weak ETag revalidation headers", async () => {
     const first = await cachedJsonResponse(
       new Request("https://heyclau.de/api/registry/feed"),
@@ -22,6 +37,26 @@ describe("HTTP cache helpers", () => {
     );
 
     expect(second.status).toBe(304);
+
+    const multi = await cachedJsonResponse(
+      new Request("https://heyclau.de/api/registry/feed", {
+        headers: {
+          "if-none-match": `"deadbeef", W/${etag}`,
+        },
+      }),
+      { ok: true },
+    );
+    expect(multi.status).toBe(304);
+
+    const wildcard = await cachedJsonResponse(
+      new Request("https://heyclau.de/api/registry/feed", {
+        headers: {
+          "if-none-match": "*",
+        },
+      }),
+      { ok: true },
+    );
+    expect(wildcard.status).toBe(304);
   });
 
   it("attaches security headers to cacheable registry responses", async () => {
@@ -64,6 +99,31 @@ describe("HTTP cache helpers", () => {
     );
     expect(second.status).toBe(304);
     expect(await second.text()).toBe("");
+  });
+
+  it("revalidates LLM text responses with weak and wildcard ETags", async () => {
+    const first = await respondText(
+      new Request("https://heyclau.de/llms.txt"),
+      "# HeyClaude\n",
+    );
+    const etag = first.headers.get("etag");
+    expect(etag).toBeTruthy();
+
+    const weak = await respondText(
+      new Request("https://heyclau.de/llms.txt", {
+        headers: { "if-none-match": `W/${etag}` },
+      }),
+      "# HeyClaude\n",
+    );
+    expect(weak.status).toBe(304);
+
+    const wildcard = await respondText(
+      new Request("https://heyclau.de/llms.txt", {
+        headers: { "if-none-match": "*" },
+      }),
+      "# HeyClaude\n",
+    );
+    expect(wildcard.status).toBe(304);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fix conditional GET handling so cacheable endpoints share the same `If-None-Match` matching behavior.

## What changed
- Added a shared matcher for strong, weak, comma-separated, and wildcard ETag validators.
- Reused the matcher for JSON/text cache helpers, feed responses, and `llms.txt` responses.
- Added regression coverage for weak validators, validator lists, and wildcard revalidation paths.

## Why
- Some endpoints only compared ETags exactly, so valid revalidation headers could miss `304 Not Modified` and redownload unchanged content.

## Validation
- `pnpm exec vitest run tests/http-cache.test.ts tests/feeds.test.ts --pool forks --maxWorkers 1 --reporter verbose`
- `pnpm type-check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP caching revalidation to properly handle weak ETags, multiple validators, and wildcard matching across feed and text response endpoints.

* **Tests**
  * Added comprehensive test coverage for ETag matching behavior including weak validators, list formats, and wildcard scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->