### PR TITLE
fix(brand-assets): require exact icon domain matches

### DIFF
--- a/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
+++ b/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
@@ -43,8 +43,7 @@ async function resolveBrandIconUrl(domain: string, clientId: string) {
   const results = (await searchResponse.json()) as BrandSearchResult[];
   if (!Array.isArray(results)) return "";
 
-  const exact =
-    results.find((result) => normalizeBrandDomain(result.domain) === domain) || results[0];
+  const exact = results.find((result) => normalizeBrandDomain(result.domain) === domain);
   return typeof exact?.icon === "string" ? exact.icon : "";
 }
 

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -377,6 +377,66 @@ describe("central API router security", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("serves Brandfetch icons only for exact normalized domain matches", async () => {
+    process.env.BRANDFETCH_CLIENT_ID = "test-client";
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json([
+          {
+            domain: "www.example.com",
+            icon: "https://cdn.brandfetch.io/example/icon.png",
+          },
+        ]),
+      )
+      .mockResolvedValueOnce(
+        new Response("png", {
+          headers: {
+            "content-length": "3",
+            "content-type": "image/png; charset=utf-8",
+          },
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/routes/api/brand-assets/$kind/$domain");
+    const response = await GET(
+      new Request("https://heyclau.de/api/brand-assets/icon/example.com"),
+      { params: { kind: "icon", domain: "example.com" } },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    await expect(response.text()).resolves.toBe("png");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not serve the first Brandfetch icon when the result domain differs", async () => {
+    process.env.BRANDFETCH_CLIENT_ID = "test-client";
+    const fetchMock = vi.fn(async () =>
+      Response.json([
+        {
+          domain: "other.example",
+          icon: "https://cdn.brandfetch.io/other/icon.png",
+        },
+      ]),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/routes/api/brand-assets/$kind/$domain");
+    const response = await GET(
+      new Request("https://heyclau.de/api/brand-assets/icon/example.com"),
+      { params: { kind: "icon", domain: "example.com" } },
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "brand_asset_not_found" },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects Brandfetch icons outside the trusted asset CDN", async () => {
     process.env.BRANDFETCH_CLIENT_ID = "test-client";
     const fetchMock = vi.fn(async () =>


### PR DESCRIPTION
## Summary
- Prevent the brand icon proxy from serving a Brandfetch search result for a different domain.

## What changed
- Require normalized Brandfetch search result domains to match the requested brand domain before using an icon URL.
- Added exact-match and mismatch regression tests for the icon proxy path.

## Why
- Brand search results can be fuzzy, and falling back to the first result can cache or display the wrong brand icon for an entry.

## Validation
- `pnpm exec vitest run tests/api-router-security.test.ts --pool forks --maxWorkers 1 --reporter verbose`
- `pnpm type-check`
- `git diff --check`
