### PR TITLE
fix(submissions): detect website duplicate sources

### DIFF
--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -118,10 +118,18 @@ function normalizeError(error: unknown) {
   return { message: String(error) };
 }
 
+function submittedSourceValues(fields: Record<string, unknown>) {
+  return [
+    fields.github_url,
+    fields.docs_url,
+    fields.source_url,
+    fields.download_url,
+    fields.website_url,
+  ];
+}
+
 function submittedSourceUrls(fields: Record<string, unknown>) {
-  return [fields.github_url, fields.docs_url, fields.source_url, fields.download_url]
-    .map(canonicalizeSourceUrl)
-    .filter(Boolean);
+  return submittedSourceValues(fields).map(canonicalizeSourceUrl).filter(Boolean);
 }
 
 function entrySourceValues(entry: DirectoryEntry) {
@@ -129,7 +137,14 @@ function entrySourceValues(entry: DirectoryEntry) {
     entry.repoUrl,
     entry.githubUrl,
     entry.documentationUrl,
+    entry.docsUrl,
+    entry.sourceUrl,
+    entry.packageUrl,
+    entry.repositoryUrl,
+    entry.websiteUrl,
     entry.downloadUrl,
+    ...(entry.sourceUrls ?? []),
+    ...(entry.retrievalSources ?? []),
     ...(entry.trustSignals?.sourceUrls ?? []),
   ];
 }
@@ -141,12 +156,7 @@ function duplicateCandidates(params: {
   slug: string;
 }) {
   const title = normalizeComparable(params.fields.name || params.fields.title || "");
-  const submittedValues = [
-    params.fields.github_url,
-    params.fields.docs_url,
-    params.fields.source_url,
-    params.fields.download_url,
-  ];
+  const submittedValues = submittedSourceValues(params.fields);
   const submittedProfile = sourceProfile(submittedValues);
   const sourceUrlSet = new Set(submittedSourceUrls(params.fields));
   const candidates: DuplicateCandidate[] = [];

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -242,6 +242,92 @@ describe("website submission preflight API", () => {
     });
   });
 
+  it("blocks website URL duplicates before PR submission", async () => {
+    directoryEntriesMock.mockResolvedValue([
+      {
+        category: "mcp",
+        slug: "website-backed-source",
+        title: "Website Backed Source",
+        websiteUrl: "https://product.example.com/claude-mcp",
+        canonicalUrl: "https://heyclau.de/entry/mcp/website-backed-source",
+        trustSignals: { sourceUrls: [] },
+      },
+    ]);
+
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest(
+        {
+          fields: validFields({
+            name: "New Website Backed Source",
+            slug: "new-website-backed-source",
+            docs_url: "https://docs.example.com/new-website-backed-source",
+            website_url:
+              "https://www.product.example.com/claude-mcp/?utm_source=newsletter#overview",
+          }),
+        },
+        "203.0.113.18",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      routeSuggestion: "fix_required",
+      blockers: expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_existing",
+          message:
+            "Likely duplicate of mcp:website-backed-source: same source.",
+        }),
+      ]),
+      duplicates: expect.arrayContaining([
+        expect.objectContaining({
+          key: "mcp:website-backed-source",
+          reasonLabels: expect.arrayContaining(["same source"]),
+        }),
+      ]),
+    });
+  });
+
+  it("matches top-level directory sourceUrls during duplicate preflight", async () => {
+    directoryEntriesMock.mockResolvedValue([
+      {
+        category: "mcp",
+        slug: "source-list-backed",
+        title: "Source List Backed",
+        sourceUrls: ["https://docs.example.net/source-list-backed"],
+        canonicalUrl: "https://heyclau.de/entry/mcp/source-list-backed",
+        trustSignals: { sourceUrls: [] },
+      },
+    ]);
+
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest(
+        {
+          fields: validFields({
+            name: "New Source List Backed",
+            slug: "new-source-list-backed",
+            docs_url:
+              "https://docs.example.net/source-list-backed/?utm_campaign=launch",
+          }),
+        },
+        "203.0.113.19",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      routeSuggestion: "fix_required",
+      blockers: expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_existing",
+          message: "Likely duplicate of mcp:source-list-backed: same source.",
+        }),
+      ]),
+    });
+  });
+
   it("warns on similar titles and shared source hosts without blocking submission", async () => {
     directoryEntriesMock.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
- Expand website submission preflight duplicate detection to cover website and directory source URL fields that were previously skipped.

## What changed
- Include submitted `website_url` in the canonical source URL comparison set.
- Compare against directory `docsUrl`, `sourceUrl`, `packageUrl`, `repositoryUrl`, `websiteUrl`, top-level `sourceUrls`, and retrieval sources.
- Added regressions for website URL duplicates and top-level directory `sourceUrls` matches.

## Why
- Existing entries can be source-backed through website/source URL fields that were present in the registry artifact but invisible to the preflight duplicate check, letting duplicate submissions reach the PR path.

## Validation
- `pnpm exec vitest run tests/submission-api.test.ts --pool forks --maxWorkers 1 --reporter verbose`
- `pnpm exec vitest run tests/submission-api.test.ts tests/submission-pr-first.test.ts tests/source-url.test.ts --pool forks --maxWorkers 1 --reporter verbose`
- `pnpm type-check`
- `git diff --check`
