### PR TITLE
fix(registry): preserve source URL path casing

### DIFF
--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -112,6 +112,7 @@ export function canonicalizeSourceUrl(value) {
   try {
     const url = new URL(stripped);
     url.hash = "";
+    url.protocol = url.protocol.toLowerCase();
     url.hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
     while (url.pathname !== "/" && url.pathname.endsWith("/")) {
       url.pathname = url.pathname.slice(0, -1);
@@ -123,7 +124,7 @@ export function canonicalizeSourceUrl(value) {
     for (const [key, paramValue] of sortedParams) {
       url.searchParams.append(key, paramValue);
     }
-    return url.toString().toLowerCase();
+    return url.toString();
   } catch {
     return stripped.toLowerCase();
   }

--- a/tests/source-url.test.ts
+++ b/tests/source-url.test.ts
@@ -42,6 +42,14 @@ describe("source URL canonicalization", () => {
         "https://www.Example.com/docs/?utm_source=newsletter&b=2&a=1#install",
       ),
     ).toBe("https://example.com/docs?a=1&b=2");
+    expect(
+      canonicalizeSourceUrl(
+        "https://www.Example.com/Docs/Install?Version=Beta#intro",
+      ),
+    ).toBe("https://example.com/Docs/Install?Version=Beta");
+    expect(canonicalizeSourceUrl("https://example.com/Docs")).not.toBe(
+      canonicalizeSourceUrl("https://example.com/docs"),
+    );
     expect(canonicalizeSourceUrl("not a url")).toBe("not a url");
   });
 });

--- a/tests/submission-api.test.ts
+++ b/tests/submission-api.test.ts
@@ -328,6 +328,51 @@ describe("website submission preflight API", () => {
     });
   });
 
+  it("preserves source URL path casing when deciding duplicate blockers", async () => {
+    directoryEntriesMock.mockResolvedValue([
+      {
+        category: "mcp",
+        slug: "case-sensitive-docs",
+        title: "Path Case Reference",
+        documentationUrl: "https://docs.example.org/Docs/Install",
+        canonicalUrl: "https://heyclau.de/entry/mcp/case-sensitive-docs",
+        trustSignals: { sourceUrls: [] },
+      },
+    ]);
+
+    const { POST } = await import("@/routes/api/submissions/preflight");
+    const response = await POST(
+      preflightRequest(
+        {
+          fields: validFields({
+            name: "Independent Mixed Path",
+            slug: "independent-mixed-path",
+            docs_url: "https://docs.example.org/docs/install",
+          }),
+        },
+        "203.0.113.20",
+      ),
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.routeSuggestion).toBe("submit_pr");
+    expect(body.blockers).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "duplicate_existing" }),
+      ]),
+    );
+    expect(body.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "possible_duplicate_existing",
+          message:
+            "Possible related existing entry mcp:case-sensitive-docs: same source host.",
+        }),
+      ]),
+    );
+  });
+
   it("warns on similar titles and shared source hosts without blocking submission", async () => {
     directoryEntriesMock.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
- Preserve case-sensitive source URL path and query components during canonical duplicate comparison.

## What changed
- Lowercase only the URL protocol and hostname while still stripping `www`, hashes, tracking params, and trailing path slashes.
- Added regression coverage to keep `/Docs` and `/docs` as distinct canonical source URLs.

## Why
- The previous canonicalizer lowercased the full serialized URL, which could collapse distinct case-sensitive paths or query values and produce false duplicate blockers during submission preflight.

## Validation
- `pnpm exec vitest run tests/source-url.test.ts tests/submission-api.test.ts tests/submission-pr-first.test.ts --pool forks --maxWorkers 1 --reporter verbose`
- `pnpm type-check`
- `git diff --check`
