### PR TITLE
chore(links): canonicalize 17 moved source URLs

### DIFF
--- a/content/mcp/archestra-mcp-platform.mdx
+++ b/content/mcp/archestra-mcp-platform.mdx
@@ -23,7 +23,7 @@ dateAdded: "2026-06-06"
 brandName: Archestra
 brandDomain: archestra.ai
 repoUrl: "https://github.com/archestra-ai/archestra"
-documentationUrl: "https://www.archestra.ai/docs/platform-quickstart"
+documentationUrl: "https://archestra.ai/docs/platform-quickstart"
 packageUrl: "https://hub.docker.com/r/archestra/platform"
 installable: true
 installCommand: "docker pull archestra/platform:latest"

--- a/content/mcp/archestra-mcp-platform.mdx
+++ b/content/mcp/archestra-mcp-platform.mdx
@@ -65,13 +65,13 @@ sourceUrls:
   - "https://github.com/archestra-ai/archestra/blob/main/README.md"
   - "https://github.com/archestra-ai/archestra/blob/main/platform/package.json"
   - "https://github.com/archestra-ai/archestra/blob/main/platform/.env.example"
-  - "https://www.archestra.ai/docs/platform-quickstart"
-  - "https://www.archestra.ai/docs/platform-mcp-gateway"
-  - "https://www.archestra.ai/docs/platform-private-registry"
-  - "https://www.archestra.ai/docs/platform-orchestrator"
-  - "https://www.archestra.ai/docs/platform-ai-tool-guardrails"
-  - "https://www.archestra.ai/docs/platform-observability"
-  - "https://www.archestra.ai/docs/platform-deployment"
+  - "https://archestra.ai/docs/platform-quickstart"
+  - "https://archestra.ai/docs/platform-mcp-gateway"
+  - "https://archestra.ai/docs/platform-private-registry"
+  - "https://archestra.ai/docs/platform-orchestrator"
+  - "https://archestra.ai/docs/platform-ai-tool-guardrails"
+  - "https://archestra.ai/docs/platform-observability"
+  - "https://archestra.ai/docs/platform-deployment"
   - "https://hub.docker.com/r/archestra/platform"
 tags:
   - gateway
@@ -109,13 +109,13 @@ Archestra owning their runtime.
 - https://github.com/archestra-ai/archestra/blob/main/README.md
 - https://github.com/archestra-ai/archestra/blob/main/platform/package.json
 - https://github.com/archestra-ai/archestra/blob/main/platform/.env.example
-- https://www.archestra.ai/docs/platform-quickstart
-- https://www.archestra.ai/docs/platform-mcp-gateway
-- https://www.archestra.ai/docs/platform-private-registry
-- https://www.archestra.ai/docs/platform-orchestrator
-- https://www.archestra.ai/docs/platform-ai-tool-guardrails
-- https://www.archestra.ai/docs/platform-observability
-- https://www.archestra.ai/docs/platform-deployment
+- https://archestra.ai/docs/platform-quickstart
+- https://archestra.ai/docs/platform-mcp-gateway
+- https://archestra.ai/docs/platform-private-registry
+- https://archestra.ai/docs/platform-orchestrator
+- https://archestra.ai/docs/platform-ai-tool-guardrails
+- https://archestra.ai/docs/platform-observability
+- https://archestra.ai/docs/platform-deployment
 - https://hub.docker.com/r/archestra/platform
 
 These sources were reviewed on **2026-06-06**. Prefer the live repository,

--- a/content/mcp/knock-mcp-server.mdx
+++ b/content/mcp/knock-mcp-server.mdx
@@ -17,7 +17,7 @@ websiteUrl: "https://knock.app"
 repoUrl: "https://github.com/knocklabs/knock-mcp"
 retrievalSources:
   - "https://github.com/knocklabs/knock-mcp"
-  - "https://docs.knock.app/developer-tools/mcp-server"
+  - "https://docs.knock.app/ai/mcp-server"
   - "https://knock.app"
   - "https://code.claude.com/docs/en/mcp"
 installable: true
@@ -153,7 +153,7 @@ Verified on **2026-06-18**:
 - The official repository `github.com/knocklabs/knock-mcp` (MIT) confirms the remote endpoint
   `https://mcp.knock.app/mcp`, OAuth 2.1 + PKCE auth, Cloudflare Workers deployment, and the
   no-deletion-by-design policy.
-- Knock's developer documentation at `docs.knock.app/developer-tools/mcp-server` documents the
+- Knock's developer documentation at `docs.knock.app/ai/mcp-server` documents the
   Claude Code and Claude Desktop installation commands, OAuth authentication flow, and the full
   capability set.
 - Claude Code's MCP documentation describes the `--transport http` flag used in the installation

--- a/content/mcp/knock-mcp-server.mdx
+++ b/content/mcp/knock-mcp-server.mdx
@@ -12,7 +12,7 @@ seoDescription: "Connect Claude to Knock with the official remote MCP server: cr
 author: Knock
 authorProfileUrl: "https://github.com/knocklabs"
 dateAdded: "2026-06-18"
-documentationUrl: "https://docs.knock.app/developer-tools/mcp-server"
+documentationUrl: "https://docs.knock.app/ai/mcp-server"
 websiteUrl: "https://knock.app"
 repoUrl: "https://github.com/knocklabs/knock-mcp"
 retrievalSources:

--- a/content/mcp/logfire-mcp-server.mdx
+++ b/content/mcp/logfire-mcp-server.mdx
@@ -15,7 +15,7 @@ dateAdded: "2026-06-18"
 documentationUrl: "https://pydantic.dev/docs/logfire/guides/mcp-server/"
 websiteUrl: "https://pydantic.dev/logfire"
 retrievalSources:
-  - "https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/"
+  - "https://pydantic.dev/docs/logfire/guides/mcp-server/"
   - "https://code.claude.com/docs/en/mcp"
 installable: true
 installCommand: "claude mcp add logfire --transport http https://logfire-us.pydantic.dev/mcp"
@@ -178,7 +178,7 @@ Generate an API key with `project:read` scope from **Organization Settings → A
 
 Verified on **2026-06-18**:
 
-- Official Pydantic Logfire documentation at `logfire.pydantic.dev/docs/how-to-guides/mcp-server/`
+- Official Pydantic Logfire documentation at `pydantic.dev/docs/logfire/guides/mcp-server/`
   (Astro SSG page) documents the hosted endpoints (`logfire-us.pydantic.dev/mcp` and
   `logfire-eu.pydantic.dev/mcp`), OAuth and API key auth methods, Claude Code install command,
   and the full tool families: query execution, exception search, project discovery, and

--- a/content/mcp/logfire-mcp-server.mdx
+++ b/content/mcp/logfire-mcp-server.mdx
@@ -12,7 +12,7 @@ seoDescription: "Connect Claude to Pydantic Logfire with the official remote MCP
 author: Pydantic
 authorProfileUrl: "https://github.com/pydantic"
 dateAdded: "2026-06-18"
-documentationUrl: "https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/"
+documentationUrl: "https://pydantic.dev/docs/logfire/guides/mcp-server/"
 websiteUrl: "https://pydantic.dev/logfire"
 retrievalSources:
   - "https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/"

--- a/content/mcp/rootly-mcp-server.mdx
+++ b/content/mcp/rootly-mcp-server.mdx
@@ -14,7 +14,7 @@ authorProfileUrl: "https://github.com/Rootly-AI-Labs"
 dateAdded: "2026-06-18"
 documentationUrl: "https://docs.rootly.com/integrations/mcp-server"
 websiteUrl: "https://rootly.com"
-repoUrl: "https://github.com/Rootly-AI-Labs/Rootly-MCP-server"
+repoUrl: "https://github.com/rootlyhq/rootly-mcp-server"
 retrievalSources:
   - "https://docs.rootly.com/integrations/mcp-server"
   - "https://rootly.com/blog/introducing-the-rootly-mcp-server"

--- a/content/mcp/tinybird-mcp-server.mdx
+++ b/content/mcp/tinybird-mcp-server.mdx
@@ -12,7 +12,7 @@ seoDescription: "Connect Claude to Tinybird with the official hosted MCP server:
 author: Tinybird
 authorProfileUrl: "https://github.com/tinybirdco"
 dateAdded: "2026-06-18"
-documentationUrl: "https://www.tinybird.co/docs/forward/work-with-data/mcp"
+documentationUrl: "https://www.tinybird.co/docs/forward/query-data/mcp"
 websiteUrl: "https://tinybird.co"
 retrievalSources:
   - "https://www.tinybird.co/docs/forward/work-with-data/mcp"

--- a/content/mcp/tinybird-mcp-server.mdx
+++ b/content/mcp/tinybird-mcp-server.mdx
@@ -15,7 +15,7 @@ dateAdded: "2026-06-18"
 documentationUrl: "https://www.tinybird.co/docs/forward/query-data/mcp"
 websiteUrl: "https://tinybird.co"
 retrievalSources:
-  - "https://www.tinybird.co/docs/forward/work-with-data/mcp"
+  - "https://www.tinybird.co/docs/forward/query-data/mcp"
   - "https://www.tinybird.co/blog/introducing-the-tinybird-mcp-server-your-real-time-data-llm-ready"
   - "https://www.tinybird.co/docs/forward/analytics-agents/mcp"
   - "https://code.claude.com/docs/en/mcp"
@@ -150,7 +150,7 @@ parameter is always required.
 
 Verified on **2026-06-18**:
 
-- Tinybird's MCP documentation at `tinybird.co/docs/forward/work-with-data/mcp` confirms the
+- Tinybird's MCP documentation at `tinybird.co/docs/forward/query-data/mcp` confirms the
   hosted endpoint `https://mcp.tinybird.co`, Streamable HTTP transport, token authentication,
   the endpoint-as-tools model, and the core tools (`text_to_sql`, `execute_query`, `explore_data`,
   `list_datasources`, `list_endpoints`).

--- a/content/mcp/unleash-mcp-server.mdx
+++ b/content/mcp/unleash-mcp-server.mdx
@@ -17,7 +17,7 @@ websiteUrl: "https://getunleash.io"
 repoUrl: "https://github.com/Unleash/unleash-mcp"
 retrievalSources:
   - "https://raw.githubusercontent.com/Unleash/unleash-mcp/main/README.md"
-  - "https://docs.getunleash.io/integrations/mcp"
+  - "https://docs.getunleash.io/integrate/mcp"
   - "https://code.claude.com/docs/en/mcp"
 installable: true
 installCommand: "claude mcp add unleash -e UNLEASH_BASE_URL=https://your-instance.unleash.cloud -e UNLEASH_PAT=your-pat -- npx -y @unleash/mcp@latest --log-level error"
@@ -189,7 +189,7 @@ Verified on **2026-06-18**:
   package, `UNLEASH_BASE_URL`/`UNLEASH_PAT` configuration, Node.js 22+ requirement, all 11
   tools, the Claude Code install command, the four-step core workflow (evaluate → detect →
   create → wrap), and the experimental remote HTTP mode.
-- Unleash documentation at `docs.getunleash.io/integrations/mcp` (HTTP 200) covers setup and
+- Unleash documentation at `docs.getunleash.io/integrate/mcp` (HTTP 200) covers setup and
   tool reference.
 - Claude Code MCP documentation at `code.claude.com/docs/en/mcp` describes the connector
   pattern used above.

--- a/content/mcp/unleash-mcp-server.mdx
+++ b/content/mcp/unleash-mcp-server.mdx
@@ -12,7 +12,7 @@ seoDescription: "Connect Claude to Unleash with the official MCP server: evaluat
 author: Unleash
 authorProfileUrl: "https://github.com/Unleash"
 dateAdded: "2026-06-18"
-documentationUrl: "https://docs.getunleash.io/integrations/mcp"
+documentationUrl: "https://docs.getunleash.io/integrate/mcp"
 websiteUrl: "https://getunleash.io"
 repoUrl: "https://github.com/Unleash/unleash-mcp"
 retrievalSources:

--- a/content/rules/trpc-expert.mdx
+++ b/content/rules/trpc-expert.mdx
@@ -27,7 +27,7 @@ dateAdded: "2026-06-19"
 submittedAt: "2026-06-19"
 documentationUrl: "https://trpc.io/docs/server/overview"
 sourceUrls:
-  - "https://trpc.io/docs/server/introduction"
+  - "https://trpc.io/docs/server/overview"
   - "https://trpc.io/docs/server/procedures"
   - "https://trpc.io/docs/server/middlewares"
   - "https://trpc.io/docs/client/react"

--- a/content/rules/trpc-expert.mdx
+++ b/content/rules/trpc-expert.mdx
@@ -25,7 +25,7 @@ submittedBy: jaso0n0818
 submittedByUrl: "https://github.com/jaso0n0818"
 dateAdded: "2026-06-19"
 submittedAt: "2026-06-19"
-documentationUrl: "https://trpc.io/docs/server/introduction"
+documentationUrl: "https://trpc.io/docs/server/overview"
 sourceUrls:
   - "https://trpc.io/docs/server/introduction"
   - "https://trpc.io/docs/server/procedures"

--- a/content/skills/anthropic-agent-skills.mdx
+++ b/content/skills/anthropic-agent-skills.mdx
@@ -20,7 +20,7 @@ authorProfileUrl: "https://github.com/anthropics"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/anthropics/skills"
 documentationUrl: "https://github.com/anthropics/skills#readme"
-websiteUrl: "https://skills.sh/anthropics/skills"
+websiteUrl: "https://www.skills.sh/anthropics/skills"
 downloadUrl: "https://github.com/anthropics/skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "/plugin marketplace add anthropics/skills"

--- a/content/skills/dart-agent-skills.mdx
+++ b/content/skills/dart-agent-skills.mdx
@@ -21,7 +21,7 @@ authorProfileUrl: "https://github.com/dart-lang"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/dart-lang/skills"
 documentationUrl: "https://github.com/dart-lang/skills#readme"
-websiteUrl: "https://skills.sh/dart-lang/skills"
+websiteUrl: "https://www.skills.sh/dart-lang/skills"
 downloadUrl: "https://github.com/dart-lang/skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "npx skills add dart-lang/skills --skill '*' --agent universal --yes"

--- a/content/skills/dart-agent-skills.mdx
+++ b/content/skills/dart-agent-skills.mdx
@@ -41,7 +41,7 @@ verifiedAt: "2026-06-18"
 retrievalSources:
   - "https://github.com/dart-lang/skills"
   - "https://raw.githubusercontent.com/dart-lang/skills/main/README.md"
-  - "https://skills.sh/dart-lang/skills"
+  - "https://www.skills.sh/dart-lang/skills"
   - "https://raw.githubusercontent.com/dart-lang/skills/main/skills/dart-run-static-analysis/SKILL.md"
   - "https://raw.githubusercontent.com/dart-lang/skills/main/skills/dart-setup-ffi-assets/SKILL.md"
   - "https://raw.githubusercontent.com/dart-lang/skills/main/skills/dart-fix-runtime-errors/SKILL.md"

--- a/content/skills/flutter-agent-skills.mdx
+++ b/content/skills/flutter-agent-skills.mdx
@@ -22,7 +22,7 @@ authorProfileUrl: "https://github.com/flutter"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/flutter/skills"
 documentationUrl: "https://github.com/flutter/skills#readme"
-websiteUrl: "https://skills.sh/flutter/skills"
+websiteUrl: "https://www.skills.sh/flutter/skills"
 downloadUrl: "https://github.com/flutter/skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "npx skills add flutter/skills --skill '*' --agent universal --yes"

--- a/content/skills/flutter-agent-skills.mdx
+++ b/content/skills/flutter-agent-skills.mdx
@@ -42,7 +42,7 @@ verifiedAt: "2026-06-18"
 retrievalSources:
   - "https://github.com/flutter/skills"
   - "https://raw.githubusercontent.com/flutter/skills/main/README.md"
-  - "https://skills.sh/flutter/skills"
+  - "https://www.skills.sh/flutter/skills"
   - "https://raw.githubusercontent.com/flutter/skills/main/skills/flutter-fix-layout-issues/SKILL.md"
   - "https://raw.githubusercontent.com/flutter/skills/main/skills/flutter-add-integration-test/SKILL.md"
   - "https://raw.githubusercontent.com/flutter/skills/main/skills/flutter-apply-architecture-best-practices/SKILL.md"

--- a/content/skills/google-cloud-agent-skills.mdx
+++ b/content/skills/google-cloud-agent-skills.mdx
@@ -22,7 +22,7 @@ authorProfileUrl: "https://github.com/google"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/google/skills"
 documentationUrl: "https://github.com/google/skills#readme"
-websiteUrl: "https://skills.sh/google/skills"
+websiteUrl: "https://www.skills.sh/google/skills"
 downloadUrl: "https://github.com/google/skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "npx skills add google/skills"

--- a/content/skills/google-cloud-agent-skills.mdx
+++ b/content/skills/google-cloud-agent-skills.mdx
@@ -43,7 +43,7 @@ verifiedAt: "2026-06-18"
 retrievalSources:
   - "https://github.com/google/skills"
   - "https://raw.githubusercontent.com/google/skills/main/README.md"
-  - "https://skills.sh/google/skills"
+  - "https://www.skills.sh/google/skills"
   - "https://raw.githubusercontent.com/google/skills/main/skills/cloud/agent-platform-skill-registry/SKILL.md"
   - "https://raw.githubusercontent.com/google/skills/main/skills/cloud/gemini-api/SKILL.md"
   - "https://raw.githubusercontent.com/google/skills/main/skills/cloud/gcloud/SKILL.md"

--- a/content/skills/microsoft-agent-skills.mdx
+++ b/content/skills/microsoft-agent-skills.mdx
@@ -19,7 +19,7 @@ authorProfileUrl: "https://github.com/microsoft"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/microsoft/skills"
 documentationUrl: "https://microsoft.github.io/skills/"
-websiteUrl: "https://skills.sh/microsoft/skills"
+websiteUrl: "https://www.skills.sh/microsoft/skills"
 downloadUrl: "https://github.com/microsoft/skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "npx skills add microsoft/skills"

--- a/content/skills/microsoft-agent-skills.mdx
+++ b/content/skills/microsoft-agent-skills.mdx
@@ -43,7 +43,7 @@ retrievalSources:
   - "https://raw.githubusercontent.com/microsoft/skills/main/README.md"
   - "https://raw.githubusercontent.com/microsoft/skills/main/Agents.md"
   - "https://microsoft.github.io/skills/"
-  - "https://skills.sh/microsoft/skills"
+  - "https://www.skills.sh/microsoft/skills"
 testedPlatforms:
   - Claude
   - Codex

--- a/content/skills/vercel-agent-skills.mdx
+++ b/content/skills/vercel-agent-skills.mdx
@@ -20,7 +20,7 @@ authorProfileUrl: "https://github.com/vercel-labs"
 dateAdded: "2026-06-18"
 repoUrl: "https://github.com/vercel-labs/agent-skills"
 documentationUrl: "https://github.com/vercel-labs/agent-skills#readme"
-websiteUrl: "https://skills.sh/vercel-labs/agent-skills"
+websiteUrl: "https://www.skills.sh/vercel-labs/agent-skills"
 downloadUrl: "https://github.com/vercel-labs/agent-skills/archive/refs/heads/main.zip"
 installable: true
 installCommand: "npx skills add vercel-labs/agent-skills"

--- a/content/skills/vercel-agent-skills.mdx
+++ b/content/skills/vercel-agent-skills.mdx
@@ -50,7 +50,7 @@ retrievalSources:
   - "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/vercel-cli-with-tokens/SKILL.md"
   - "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/web-design-guidelines/SKILL.md"
   - "https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/writing-guidelines/SKILL.md"
-  - "https://skills.sh/vercel-labs/agent-skills"
+  - "https://www.skills.sh/vercel-labs/agent-skills"
 testedPlatforms:
   - Agent Skills compatible hosts
   - Claude Code compatible skill installers

--- a/content/tools/great-expectations.mdx
+++ b/content/tools/great-expectations.mdx
@@ -12,7 +12,7 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-04"
 websiteUrl: "https://greatexpectations.io/"
 documentationUrl: "https://docs.greatexpectations.io/docs/core/introduction/"
-repoUrl: "https://github.com/great-expectations/great_expectations"
+repoUrl: "https://github.com/fivetran/great_expectations"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication

--- a/content/tools/langchain.mdx
+++ b/content/tools/langchain.mdx
@@ -18,7 +18,7 @@ seoDescription: >-
 author: LangChain
 authorProfileUrl: "https://github.com/langchain-ai"
 dateAdded: "2026-06-18"
-websiteUrl: "https://docs.langchain.com/langchain/"
+websiteUrl: "https://docs.langchain.com/oss/python/langchain/overview"
 documentationUrl: "https://docs.langchain.com/oss/python/langchain/overview"
 repoUrl: "https://github.com/langchain-ai/langchain"
 packageUrl: "https://pypi.org/project/langchain/"

--- a/content/tools/langsmith.mdx
+++ b/content/tools/langsmith.mdx
@@ -9,7 +9,7 @@ seoDescription: "LangSmith is a platform for tracing, observability, evaluation,
 author: LangChain
 dateAdded: "2026-04-27"
 websiteUrl: "https://www.langchain.com/langsmith/observability"
-documentationUrl: "https://docs.langchain.com/langsmith/home"
+documentationUrl: "https://docs.langchain.com/langsmith/observability"
 retrievalSources:
   - "https://docs.langchain.com/langsmith/home"
   - "https://arize.com/docs/phoenix"

--- a/content/tools/langsmith.mdx
+++ b/content/tools/langsmith.mdx
@@ -11,7 +11,7 @@ dateAdded: "2026-04-27"
 websiteUrl: "https://www.langchain.com/langsmith/observability"
 documentationUrl: "https://docs.langchain.com/langsmith/observability"
 retrievalSources:
-  - "https://docs.langchain.com/langsmith/home"
+  - "https://docs.langchain.com/langsmith/observability"
   - "https://arize.com/docs/phoenix"
   - "https://docs.helicone.ai/"
   - "https://www.braintrust.dev/docs"

--- a/content/tools/skills-cli.mdx
+++ b/content/tools/skills-cli.mdx
@@ -20,7 +20,7 @@ seoDescription: >-
 author: Vercel Labs
 authorProfileUrl: "https://github.com/vercel-labs"
 dateAdded: "2026-06-18"
-websiteUrl: "https://skills.sh/vercel-labs/skills"
+websiteUrl: "https://www.skills.sh/vercel-labs/skills"
 documentationUrl: "https://github.com/vercel-labs/skills#readme"
 repoUrl: "https://github.com/vercel-labs/skills"
 packageUrl: "https://registry.npmjs.org/skills/latest"


### PR DESCRIPTION
Canonicalize source URLs that now serve a **permanent (301/308) redirect** to a different canonical URL for the **same resource**. Each was verified: permanent first-hop redirect, final 200, same registrable domain (or subdomain/host consolidation), non-trivial final path, and a semantic title/H1 check confirming the destination documents the same tool/resource.

Eyeball the old → new table below (one row per change); merge after the green link-check.

| file | field | old → new |
| --- | --- | --- |
| `content/mcp/rootly-mcp-server.mdx` | repoUrl | https://github.com/Rootly-AI-Labs/Rootly-MCP-server → https://github.com/rootlyhq/rootly-mcp-server |
| `content/tools/great-expectations.mdx` | repoUrl | https://github.com/great-expectations/great_expectations → https://github.com/fivetran/great_expectations |
| `content/mcp/logfire-mcp-server.mdx` | documentationUrl | https://logfire.pydantic.dev/docs/how-to-guides/mcp-server/ → https://pydantic.dev/docs/logfire/guides/mcp-server/ |
| `content/mcp/unleash-mcp-server.mdx` | documentationUrl | https://docs.getunleash.io/integrations/mcp → https://docs.getunleash.io/integrate/mcp |
| `content/mcp/knock-mcp-server.mdx` | documentationUrl | https://docs.knock.app/developer-tools/mcp-server → https://docs.knock.app/ai/mcp-server |
| `content/tools/langchain.mdx` | websiteUrl | https://docs.langchain.com/langchain/ → https://docs.langchain.com/oss/python/langchain/overview |
| `content/tools/langsmith.mdx` | documentationUrl | https://docs.langchain.com/langsmith/home → https://docs.langchain.com/langsmith/observability |
| `content/rules/trpc-expert.mdx` | documentationUrl | https://trpc.io/docs/server/introduction → https://trpc.io/docs/server/overview |
| `content/mcp/tinybird-mcp-server.mdx` | documentationUrl | https://www.tinybird.co/docs/forward/work-with-data/mcp → https://www.tinybird.co/docs/forward/query-data/mcp |
| `content/mcp/archestra-mcp-platform.mdx` | documentationUrl | https://www.archestra.ai/docs/platform-quickstart → https://archestra.ai/docs/platform-quickstart |
| `content/skills/anthropic-agent-skills.mdx` | websiteUrl | https://skills.sh/anthropics/skills → https://www.skills.sh/anthropics/skills |
| `content/skills/dart-agent-skills.mdx` | websiteUrl | https://skills.sh/dart-lang/skills → https://www.skills.sh/dart-lang/skills |
| `content/skills/flutter-agent-skills.mdx` | websiteUrl | https://skills.sh/flutter/skills → https://www.skills.sh/flutter/skills |
| `content/skills/google-cloud-agent-skills.mdx` | websiteUrl | https://skills.sh/google/skills → https://www.skills.sh/google/skills |
| `content/skills/microsoft-agent-skills.mdx` | websiteUrl | https://skills.sh/microsoft/skills → https://www.skills.sh/microsoft/skills |
| `content/skills/vercel-agent-skills.mdx` | websiteUrl | https://skills.sh/vercel-labs/agent-skills → https://www.skills.sh/vercel-labs/agent-skills |
| `content/tools/skills-cli.mdx` | websiteUrl | https://skills.sh/vercel-labs/skills → https://www.skills.sh/vercel-labs/skills |

**Categories:** GitHub repo transfers (rootlyhq, fivetran), docs subdomain/domain consolidation (logfire→pydantic.dev), real path-segment restructures (knock, getunleash, tinybird, trpc, langchain, langsmith), and www-host canonicalization (skills.sh, archestra).

**Intentionally skipped** (not genuine relocations): ~21 docs-framework root→first-page redirects (bare docs root still works and is the more durable URL), cosmetic help-center slug / query-param additions, www/trailing-slash homepage normalizations, and any cross-domain migration not on the allowlist (left for human review).
