### PR TITLE
fix(content): preserve statusline stdin at EOF

### DIFF
--- a/content/statuslines/context-pressure-statusline.mdx
+++ b/content/statuslines/context-pressure-statusline.mdx
@@ -43,7 +43,7 @@ scriptBody: |-
   set -u
 
   main() {
-  read -r input || input=""
+  read -r input || input="${input:-}"
   limit="${CLAUDE_CONTEXT_LIMIT:-200000}"
   used=$(printf '%s' "$input" | jq -r '.session.totalTokens // .usage.input_tokens // .cost.total_tokens // 0')
 


### PR DESCRIPTION
### Motivation
- The embedded Bash statusline reset `input` to an empty string on `read` failure at EOF (`read -r input || input=""`), which discarded valid JSON sent without a trailing newline and caused incorrect token reporting.

### Description
- Replace `read -r input || input=""` with `read -r input || input="${input:-}"` so a partial assignment performed by `read` at EOF is preserved and `jq` can parse valid JSON while retaining the empty-stdin fallback.

### Testing
- Verified behavior with `printf '{"session":{"totalTokens":118432}}\n' | /tmp/context-pressure-statusline.sh` and `printf '{"session":{"totalTokens":118432}}' | /tmp/context-pressure-statusline.sh`, and ran `pnpm validate:content:strict` and `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346eeb4f24832ca030fc96ecb05e74)