### PR TITLE
fix(submissions): requeue reopened closed PRs

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -873,6 +873,8 @@ async function recordReviewedScanKey(params: {
 async function shouldInspectPullRequestFilesForWebhook(
   env: Env,
   target: ReviewTarget,
+  eventName?: string,
+  webhook?: Record<string, unknown>,
 ) {
   const existing = await getPrState(env.SUBMISSION_GATE_DB, {
     repo: target.repoFullName,
@@ -880,11 +882,19 @@ async function shouldInspectPullRequestFilesForWebhook(
   });
   const reviewScanKey = reviewScanKeyForTarget(target);
   const existingReviewKey = String(existing?.lastReviewKey || "");
+  const existingStatus = String(existing?.status || "");
   if (
     hasTerminalGateDecision(existing) &&
-    String(existing?.status || "") !== "closed" &&
+    existingStatus === "closed" &&
+    isReopenedPullRequestEvent(String(eventName || ""), webhook)
+  ) {
+    return true;
+  }
+  if (
+    hasTerminalGateDecision(existing) &&
+    existingStatus !== "closed" &&
     !(
-      String(existing?.status || "") === "ignored" &&
+      existingStatus === "ignored" &&
       reviewScanKey &&
       existingReviewKey !== reviewScanKey
     )
@@ -2660,6 +2670,8 @@ async function githubWebhookRoute(
     const shouldInspect = await shouldInspectPullRequestFilesForWebhook(
       env,
       target,
+      eventName,
+      payload,
     );
     if (!shouldInspect) {
       return json({ ok: true, ignored: true, reason: "already_reviewed" });

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1940,6 +1940,16 @@ ${urls}
       "directContentReviewabilityForTarget(",
     );
     const applyIndex = pullRequestBlock.indexOf("applyUnderReviewToTarget");
+    const shouldInspectBlock = source.slice(
+      source.indexOf("async function shouldInspectPullRequestFilesForWebhook"),
+      source.indexOf("function reviewTargetFromPullPayload"),
+    );
+    const reopenedClosedIndex = shouldInspectBlock.indexOf(
+      'existingStatus === "closed"',
+    );
+    const reviewKeySkipIndex = shouldInspectBlock.indexOf(
+      "return !reviewScanKey || existingReviewKey !== reviewScanKey",
+    );
 
     expect(source).toContain('reason: "No source content entry file changed."');
     expect(source).toContain("function recordReviewedScanKey");
@@ -1964,6 +1974,8 @@ ${urls}
     expect(inspectIndex).toBeGreaterThan(0);
     expect(classifyIndex).toBeGreaterThan(inspectIndex);
     expect(applyIndex).toBeGreaterThan(classifyIndex);
+    expect(reopenedClosedIndex).toBeGreaterThan(0);
+    expect(reviewKeySkipIndex).toBeGreaterThan(reopenedClosedIndex);
   });
 
   it("distinguishes generated-artifact tampering from ordinary non-content PRs", () => {

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1952,6 +1952,11 @@ ${urls}
     expect(source).toContain(
       "resetAttemptCount: shouldResetManualTerminal || shouldResetTerminalState",
     );
+    expect(source).toContain('existingStatus === "closed"');
+    expect(source).toContain(
+      'isReopenedPullRequestEvent(String(eventName || ""), webhook)',
+    );
+    expect(source).toContain("eventName,");
     expect(source).toContain("clearTerminal:");
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
     expect(source).toContain('reason: "already_reviewed"');


### PR DESCRIPTION
### Motivation
- A reopened pull request that had previously been closed by the content gate could be suppressed by the new last-review-key dedupe when its head SHA and base ref did not change, preventing the existing closed-state reconciliation from requeuing the PR. 
- The intent is to ensure reopened PR events reach the queue reconciliation logic so the gate can clear/requeue terminal decisions when the GitHub PR is actually open again. 

### Description
- Change `shouldInspectPullRequestFilesForWebhook` to accept `eventName` and `webhook` context and short-circuit to `true` for reopened events when an existing row has a terminal `closed` decision so that reopened closed PRs bypass last-review-key dedupe (`apps/submission-gate/src/index.ts`).
- Pass `eventName` and `payload` into the dedupe helper from the `pull_request` webhook route so reopened events are visible to the helper (`apps/submission-gate/src/index.ts`).
- Update the worker source assertions to include the reopened-closed behavior so the test source-pinning checks reflect the new logic (`tests/submission-gate-worker.test.ts`).

### Testing
- Ran unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and the test file passed (97 tests passed). 
- Ran OpenAPI generation check with `pnpm validate:openapi` which completed successfully. 
- Ran `git diff --check` to ensure no whitespace/patch issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347a97f70c832c81bedf62d0fc4fd3)