### PR TITLE
fix(registry): avoid tokenized source repo lookups

### DIFF
--- a/apps/web/src/lib/source-repo-signals.server.ts
+++ b/apps/web/src/lib/source-repo-signals.server.ts
@@ -221,9 +221,9 @@ export async function fetchGitHubSourceSignal(repoKey: string, fetcher: Fetcher 
     "user-agent": "heyclau.de-source-signals",
     "x-github-api-version": GITHUB_API_VERSION,
   };
-  const token = getEnvString("GITHUB_TOKEN");
-  if (token) headers.authorization = `Bearer ${token}`;
-
+  // Registry entries control repo URLs, so do not attach the Worker GitHub
+  // token here. A broadly scoped token could otherwise turn this public signal
+  // refresh into an oracle for private repositories the token can access.
   const response = await fetcher(`https://api.github.com/repos/${owner}/${repo}`, {
     headers,
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
@@ -236,6 +236,8 @@ export async function fetchGitHubSourceSignal(repoKey: string, fetcher: Fetcher 
   }
 
   const data = (await response.json()) as Record<string, unknown>;
+  if (data.private === true) throw new Error("github_api_private_repo");
+
   return {
     stars: typeof data.stargazers_count === "number" ? data.stargazers_count : null,
     forks: typeof data.forks_count === "number" ? data.forks_count : null,

--- a/tests/source-repo-signals.test.ts
+++ b/tests/source-repo-signals.test.ts
@@ -250,6 +250,68 @@ describe("source repo signals", () => {
     });
   });
 
+  it("does not send configured GitHub tokens for content-controlled repo lookups", async () => {
+    const previousToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = "secret-token";
+    const seenHeaders: HeadersInit[] = [];
+
+    try {
+      await fetchGitHubSourceSignal("example/tool", async (_url, init) => {
+        seenHeaders.push(init?.headers ?? {});
+        return new Response(
+          JSON.stringify({
+            private: false,
+            stargazers_count: 10,
+            forks_count: 2,
+            updated_at: "2026-06-02T11:00:00Z",
+          }),
+          { status: 200 },
+        );
+      });
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.GITHUB_TOKEN;
+      } else {
+        process.env.GITHUB_TOKEN = previousToken;
+      }
+    }
+
+    expect(seenHeaders).toHaveLength(1);
+    expect(JSON.stringify(seenHeaders[0]).toLowerCase()).not.toContain(
+      "authorization",
+    );
+  });
+
+  it("rejects private GitHub repository payloads before caching", async () => {
+    const db = new FakeD1();
+    const result = await refreshSourceRepoSignalsForEntries(
+      [{ repoUrl: "https://github.com/example/private-tool" }],
+      {
+        db,
+        now: new Date("2026-06-02T12:00:00Z"),
+        fetcher: async () =>
+          new Response(
+            JSON.stringify({
+              private: true,
+              stargazers_count: 123,
+              forks_count: 9,
+              updated_at: "2026-06-02T11:00:00Z",
+            }),
+            { status: 200 },
+          ),
+      },
+    );
+
+    expect(result).toMatchObject({ refreshed: 0, failed: 1 });
+    expect(db.rows.get("example/private-tool")).toMatchObject({
+      stars: null,
+      forks: null,
+      repo_updated_at: null,
+      status: "error",
+      last_error: "github_api_private_repo",
+    });
+  });
+
   it("falls back to Shields stars when GitHub is unavailable", async () => {
     let call = 0;
     const signal = await fetchGitHubSourceSignal("example/tool", async () => {


### PR DESCRIPTION
### Motivation
- Prevent a Worker `GITHUB_TOKEN` from being used as an oracle for private GitHub repositories when refreshing source-repo signals derived from content-controlled `repoUrl` fields.

### Description
- Stop attaching the Worker `GITHUB_TOKEN` to GitHub API requests in `fetchGitHubSourceSignal` so content-controlled lookups are performed unauthenticated.
- Reject GitHub API payloads with `private: true` by throwing an error before any data is cached or returned from `fetchGitHubSourceSignal`.
- Add regression tests in `tests/source-repo-signals.test.ts` that assert (1) no `Authorization` header is sent for content-controlled lookups and (2) private-repo payloads are treated as refresh failures and not cached.
- Modified files: `apps/web/src/lib/source-repo-signals.server.ts` and `tests/source-repo-signals.test.ts`.

### Testing
- Ran `pnpm exec vitest run tests/source-repo-signals.test.ts`, which passed all tests.
- Ran `git diff --check` to ensure no whitespace/format issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347a97072c832ca44e8ccf9cd552fe)