### PR TITLE
fix(submissions): parse protected metadata with safe frontmatter

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -1,3 +1,5 @@
+import { parseSafeFrontmatter } from "../../../packages/registry/src/frontmatter.js";
+
 export type ContentDuplicateSignals = {
   filePath: string;
   category: string;
@@ -107,19 +109,18 @@ function unquoteYamlScalar(value: string) {
 }
 
 export function parseSimpleFrontmatter(source: string) {
-  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(
-    String(source || ""),
-  );
+  const { data } = parseSafeFrontmatter(source, { fallbackOnError: true });
   const fields: Record<string, string> = {};
-  if (!match) return fields;
 
-  for (const line of match[1].split(/\r?\n/)) {
-    const scalar = /^([A-Za-z][A-Za-z0-9_]*):\s*(.*?)\s*$/.exec(line);
-    if (!scalar) continue;
-    const [, key, value] = scalar;
-    if (!value || value === "|" || value === ">") continue;
-    fields[key] = unquoteYamlScalar(value);
+  for (const [key, value] of Object.entries(data || {})) {
+    if (value === null || typeof value === "undefined") continue;
+    if (typeof value === "string") {
+      fields[key] = value.trim();
+      continue;
+    }
+    fields[key] = String(value).trim();
   }
+
   return fields;
 }
 

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -3245,6 +3245,31 @@ websiteUrl: "https://www.w3.org/WAI/test-evaluate/"
     });
   });
 
+  it("blocks protected metadata edits written with valid YAML forms", () => {
+    const before = `---
+title: Existing Tool
+slug: existing-tool
+category: tools
+---
+`;
+    const after = `---
+title: Existing Tool
+slug: existing-tool
+category: tools
+"repoUrl": https://github.com/example/evil
+downloadUrl: >
+  https://example.com/evil-package.zip
+packageVerified: true
+---
+`;
+
+    expect(protectedFrontmatterChanges(before, after)).toEqual([
+      "downloadUrl",
+      "packageVerified",
+      "repoUrl",
+    ]);
+  });
+
   it("blocks content edits that change protected provenance fields", () => {
     const before = `---
 title: Existing Tool


### PR DESCRIPTION
### Motivation
- Close a bypass where the submission gate used a hand-rolled scalar-only frontmatter parser that missed valid YAML forms (quoted keys, folded block scalars, booleans) and thus failed to detect additions of protected metadata such as `repoUrl` and `downloadUrl`.
- Harden direct content prechecks so protected provenance/source/package metadata is compared using the same safe parser used by registry build tools.

### Description
- Replace the scalar-only parsing in `parseSimpleFrontmatter` with the registry-safe parser by calling `parseSafeFrontmatter(source, { fallbackOnError: true })` and normalizing entries into trimmed strings so quoted keys and folded scalars are recognized.
- Keep the change narrowly scoped to protected-field detection so existing list parsing and other duplicate-detection logic are preserved.
- Add a regression test in `tests/submission-gate-worker.test.ts` that asserts `protectedFrontmatterChanges` catches a quoted `repoUrl`, a folded `downloadUrl`, and a boolean `packageVerified` addition.

### Testing
- Ran `PNPM_CONFIG_OFFLINE=true pnpm exec vitest run tests/submission-gate-worker.test.ts` and the test file passed (`1 file`, `98 tests` passed). 
- An initial run attempt with `--runInBand` failed due to Vitest not supporting that flag, and was subsequently rerun without the flag which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347a9753d4832c8ddf6953668aabb0)