### PR TITLE
fix(submissions): clean stale gate labels on ignored PRs

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -1022,6 +1022,30 @@ async function applyUnderReviewToTarget(
   });
 }
 
+async function cleanupIgnoredReviewTarget(
+  env: Env,
+  target: ReviewTarget,
+  deliveryId: string,
+) {
+  const token = await installationTokenForTarget(env, target);
+  if (token) {
+    const repo = parseRepo(target.repoFullName);
+    await removeLabels({
+      token,
+      repo,
+      issueNumber: target.number,
+      labels: RECONCILED_GATE_LABELS,
+      apiVersion: env.GITHUB_API_VERSION,
+    });
+  }
+  await recordReviewedScanKey({
+    env,
+    target,
+    deliveryId,
+    status: "ignored",
+  });
+}
+
 async function directContentReviewabilityForTarget(
   env: Env,
   target: ReviewTarget,
@@ -2681,12 +2705,7 @@ async function githubWebhookRoute(
       });
     }
     if (reviewability.kind === "ignore") {
-      await recordReviewedScanKey({
-        env,
-        target,
-        deliveryId,
-        status: "ignored",
-      });
+      await cleanupIgnoredReviewTarget(env, target, deliveryId);
       return json({ ok: true, ignored: true, reason: reviewability.reason });
     }
     const reviewScope =
@@ -2724,6 +2743,7 @@ async function githubWebhookRoute(
       });
     }
     if (reviewability.kind === "ignore") {
+      await cleanupIgnoredReviewTarget(env, target, deliveryId);
       return json({ ok: true, ignored: true, reason: reviewability.reason });
     }
     const reviewScope =
@@ -2755,7 +2775,10 @@ async function githubWebhookRoute(
         await recordRetryableTargetError(env, target, deliveryId, error);
         continue;
       }
-      if (reviewability.kind === "ignore") continue;
+      if (reviewability.kind === "ignore") {
+        await cleanupIgnoredReviewTarget(env, target, deliveryId);
+        continue;
+      }
       if (
         await enqueueReviewTarget(env, target, deliveryId, eventName, payload)
       ) {
@@ -4067,12 +4090,11 @@ async function discoverOpenContentPullRequests(
       continue;
     }
     if (reviewability.kind === "ignore") {
-      await recordReviewedScanKey({
+      await cleanupIgnoredReviewTarget(
         env,
         target,
-        deliveryId: `scheduled-discovery-${Date.now()}-${target.number}`,
-        status: "ignored",
-      });
+        `scheduled-discovery-${Date.now()}-${target.number}`,
+      );
       continue;
     }
     const reviewScope =

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1943,6 +1943,8 @@ ${urls}
 
     expect(source).toContain('reason: "No source content entry file changed."');
     expect(source).toContain("function recordReviewedScanKey");
+    expect(source).toContain("async function cleanupIgnoredReviewTarget");
+    expect(source).toContain("labels: RECONCILED_GATE_LABELS");
     expect(source).toContain(
       "function shouldInspectPullRequestFilesForWebhook",
     );
@@ -1956,9 +1958,48 @@ ${urls}
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
     expect(source).toContain('reason: "already_reviewed"');
     expect(pullRequestBlock).toContain('reviewability.kind === "ignore"');
+    expect(pullRequestBlock).toContain(
+      "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
+    );
     expect(inspectIndex).toBeGreaterThan(0);
     expect(classifyIndex).toBeGreaterThan(inspectIndex);
     expect(applyIndex).toBeGreaterThan(classifyIndex);
+  });
+
+  it("cleans stale gate metadata when webhook paths ignore former content PRs", () => {
+    const source = readWorkerSource();
+    const pullRequestIndex = source.indexOf(
+      'if (eventName === "pull_request")',
+    );
+    const issueCommentIndex = source.indexOf(
+      'if (eventName === "issue_comment")',
+      pullRequestIndex,
+    );
+    const validationIndex = source.indexOf(
+      "if (VALIDATION_WEBHOOK_EVENTS.has(eventName))",
+      issueCommentIndex,
+    );
+    const pullRequestBlock = source.slice(pullRequestIndex, issueCommentIndex);
+    const issueCommentBlock = source.slice(issueCommentIndex, validationIndex);
+    const validationBlock = source.slice(
+      validationIndex,
+      source.indexOf(
+        "return json({ ok: true, ignored: true });",
+        validationIndex,
+      ),
+    );
+
+    expect(source).toContain("async function cleanupIgnoredReviewTarget");
+    expect(source).toContain("labels: RECONCILED_GATE_LABELS");
+    expect(pullRequestBlock).toContain(
+      "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
+    );
+    expect(issueCommentBlock).toContain(
+      "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
+    );
+    expect(validationBlock).toContain(
+      "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
+    );
   });
 
   it("distinguishes generated-artifact tampering from ordinary non-content PRs", () => {


### PR DESCRIPTION
### Motivation
- The webhook paths for `pull_request`, `issue_comment`, validation, and scheduled discovery early-return when a PR is classified as non-content, which skipped the queued worker cleanup and left stale submission-gate/category labels and marker comments on PRs.

### Description
- Add a shared helper `cleanupIgnoredReviewTarget(env, target, deliveryId)` that removes `RECONCILED_GATE_LABELS` and records the reviewed scan key for ignored targets.
- Invoke `cleanupIgnoredReviewTarget` from the `pull_request`, `issue_comment`, validation webhook, and scheduled discovery ignore branches so cleanup runs immediately before returning/continuing.
- Add regression coverage in `tests/submission-gate-worker.test.ts` asserting the new helper exists and that ignored webhook paths call it and reference `RECONCILED_GATE_LABELS`.
- Run and apply Prettier formatting fixes for the modified files.

### Testing
- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts` and the test file passed (98 tests passed).
- Ran `pnpm exec vitest run tests/classify-pr-changes.test.ts tests/deployment-preview-url.test.ts tests/submission-gate-worker.test.ts` and all test suites passed (118 tests passed across 3 files).
- Ran `pnpm exec prettier --check` on the changed files and fixed formatting with `prettier --write`, then re-checked; formatting now passes.
- Verified `git diff --check` returned no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347996cf74832ca1301394dc1512d8)