### PR TITLE
fix(registry): key entry identity by category and slug

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -25,6 +25,7 @@ import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { HarnessVariantPicker } from "./harness-variant-picker";
 import { useHarnessPref, useCopyPref, type CopyVariant } from "@/lib/dossier-prefs";
+import { entryDomId } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 import { setHotPeek, clearHotPeek, installPeekShortcut } from "@/lib/peek-hotkey";
 
@@ -46,6 +47,7 @@ export const PeekButton = React.forwardRef<PeekHandle, Props>(function PeekButto
   { entry, className },
   ref,
 ) {
+  const peekId = entryDomId(entry);
   const [open, setOpen] = React.useState(false);
   React.useImperativeHandle(ref, () => ({ open: () => setOpen(true) }), []);
   React.useEffect(() => {
@@ -81,15 +83,15 @@ export const PeekButton = React.forwardRef<PeekHandle, Props>(function PeekButto
       <SheetContent
         side="right"
         className="w-full overflow-y-auto sm:max-w-md"
-        aria-labelledby={`peek-title-${entry.slug}`}
+        aria-labelledby={`peek-title-${peekId}`}
       >
-        <PeekBody entry={entry} titleId={`peek-title-${entry.slug}`} />
+        <PeekBody entry={entry} peekId={peekId} />
       </SheetContent>
     </Sheet>
   );
 });
 
-function PeekBody({ entry, titleId }: { entry: Entry; titleId: string }) {
+function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
   const harnessAvailable = React.useMemo<Harness[]>(
     () => (entry.harnessVariants ? (Object.keys(entry.harnessVariants) as Harness[]) : []),
     [entry.harnessVariants],
@@ -109,7 +111,10 @@ function PeekBody({ entry, titleId }: { entry: Entry; titleId: string }) {
         <div className="flex min-w-0 items-start gap-3">
           <EntryBrandMark entry={entry} size="md" priority className="mt-0.5" />
           <div className="min-w-0 flex-1">
-            <SheetTitle id={titleId} className="font-display text-lg leading-tight text-ink">
+            <SheetTitle
+              id={`peek-title-${peekId}`}
+              className="font-display text-lg leading-tight text-ink"
+            >
               {entry.title}
             </SheetTitle>
             <SheetDescription className="mt-1.5 text-sm text-ink-muted">
@@ -142,27 +147,27 @@ function PeekBody({ entry, titleId }: { entry: Entry; titleId: string }) {
 
       {harnessAvailable.length >= 2 && (
         <div className="mt-4">
-          <div id={`peek-harness-${entry.slug}`} className="eyebrow mb-2">
+          <div id={`peek-harness-${peekId}`} className="eyebrow mb-2">
             Harness variant
           </div>
           <HarnessVariantPicker
             available={harnessAvailable}
             value={harness as Harness | null}
             onChange={setHarness}
-            labelId={`peek-harness-${entry.slug}`}
+            labelId={`peek-harness-${peekId}`}
           />
         </div>
       )}
 
       <div className="mt-4">
         <div className="mb-2 flex flex-wrap items-center gap-2">
-          <span id={`peek-snippet-${entry.slug}`} className="eyebrow mr-1">
+          <span id={`peek-snippet-${peekId}`} className="eyebrow mr-1">
             Snippet
           </span>
           <CopySegmented
             variants={variants}
             entryTitle={entry.title}
-            labelId={`peek-snippet-${entry.slug}`}
+            labelId={`peek-snippet-${peekId}`}
           />
         </div>
         {variants.find((v) => v.id === variants.find((x) => x.value)?.id)?.value && (

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -46,7 +46,7 @@ function ResourceCardInner({
   rank?: number;
 }) {
   const { toggle, setOpen } = useCompareActions();
-  const inCompare = useIsCompared(entry.slug);
+  const inCompare = useIsCompared(entry);
   const peekRef = React.useRef<PeekHandle>(null);
   const handle = React.useMemo(() => ({ open: () => peekRef.current?.open() }), []);
   const [hovered, setHovered] = React.useState(false);

--- a/apps/web/src/data/entries.ts
+++ b/apps/web/src/data/entries.ts
@@ -1,5 +1,6 @@
 import atlasRegistry from "@/generated/atlas-registry.json";
 import { seoClusterDefinitions } from "@/data/seo-cluster-definitions";
+import { entryRef } from "@/lib/entry-identity";
 import type { Category, Entry } from "@/types/registry";
 import { buildEntry, type RegistryEntry } from "@/data/entry-normalize";
 
@@ -21,9 +22,7 @@ export const ENTRIES: Entry[] = REGISTRY_ENTRIES.map(buildEntry);
 // O(1) lookup by `category/slug`. Hot SSR paths (entry loader, /og route, the
 // /$category/$slug redirect, related()/relatedGroups(), trending) previously did
 // O(n) ENTRIES.find per lookup — and trending does ~50 lookups per request.
-const ENTRY_BY_REF: Map<string, Entry> = new Map(
-  ENTRIES.map((entry) => [`${entry.category}/${entry.slug}`, entry]),
-);
+const ENTRY_BY_REF: Map<string, Entry> = new Map(ENTRIES.map((entry) => [entryRef(entry), entry]));
 
 export function entryByRef(category: string, slug: string): Entry | undefined {
   return ENTRY_BY_REF.get(`${category}/${slug}`);

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -1,4 +1,5 @@
 import { ENTRIES, entryByRef } from "./entries";
+import { sameEntry } from "@/lib/entry-identity";
 import type {
   Category,
   Entry,
@@ -81,7 +82,12 @@ export function related(entry: Entry, limit = 4): Entry[] {
 
   if (graphEntries.length > 0) return graphEntries;
 
-  return ENTRIES.filter((e) => e.slug !== entry.slug)
+  return relatedBySimilarity(entry, ENTRIES, limit);
+}
+
+export function relatedBySimilarity(entry: Entry, entries: Entry[], limit = 4): Entry[] {
+  return entries
+    .filter((candidate) => !sameEntry(candidate, entry))
     .map((e) => {
       let score = 0;
       if (e.category === entry.category) score += 3;
@@ -119,13 +125,10 @@ export function relatedGroups(
     if (rel.relation === "duplicate") continue;
     const candidate = entryByRef(rel.category, rel.slug);
     if (!candidate) continue;
-    if (candidate.category === entry.category && candidate.slug === entry.slug) continue;
+    if (sameEntry(candidate, entry)) continue;
     const list = byRelation.get(rel.relation) ?? [];
     if (!byRelation.has(rel.relation)) byRelation.set(rel.relation, list);
-    if (
-      list.length < perGroup &&
-      !list.some((e) => e.category === candidate.category && e.slug === candidate.slug)
-    ) {
+    if (list.length < perGroup && !list.some((e) => sameEntry(e, candidate))) {
       list.push(candidate);
     }
   }

--- a/apps/web/src/lib/compare-selection.ts
+++ b/apps/web/src/lib/compare-selection.ts
@@ -1,0 +1,50 @@
+import { entryRef, parseEntryRef, sameEntry, type EntryIdentity } from "@/lib/entry-identity";
+
+const DEFAULT_COMPARE_LIMIT = 4;
+
+export function hasCompareItem(items: EntryIdentity[], entry: EntryIdentity) {
+  return items.some((item) => sameEntry(item, entry));
+}
+
+export function toggleCompareItem<T extends EntryIdentity>(
+  items: T[],
+  entry: T,
+  limit = DEFAULT_COMPARE_LIMIT,
+): T[] {
+  if (hasCompareItem(items, entry)) {
+    return items.filter((item) => !sameEntry(item, entry));
+  }
+  if (items.length >= limit) return items;
+  return [...items, entry];
+}
+
+export function serializeCompareItems(items: EntryIdentity[]) {
+  return items.map(entryRef).join(",");
+}
+
+export function resolveCompareParam<T extends EntryIdentity>(
+  entries: T[],
+  param: string,
+  limit = DEFAULT_COMPARE_LIMIT,
+): T[] {
+  if (!param) return [];
+
+  const refs = param
+    .split(",")
+    .map((value) => parseEntryRef(value.trim()))
+    .filter((ref): ref is EntryIdentity => Boolean(ref));
+
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const ref of refs) {
+    if (out.length >= limit) break;
+    const key = entryRef(ref);
+    if (seen.has(key)) continue;
+    const entry = entries.find((candidate) => sameEntry(candidate, ref));
+    if (entry) {
+      out.push(entry);
+      seen.add(key);
+    }
+  }
+  return out;
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,11 +1,18 @@
 import * as React from "react";
+import {
+  hasCompareItem,
+  resolveCompareParam,
+  serializeCompareItems,
+  toggleCompareItem,
+} from "@/lib/compare-selection";
+import type { EntryIdentity } from "@/lib/entry-identity";
 import type { Entry } from "@/types/registry";
 
 interface CompareActions {
   setOpen: (open: boolean) => void;
   toggle: (e: Entry) => void;
   clear: () => void;
-  has: (slug: string) => boolean;
+  has: (entry: EntryIdentity) => boolean;
   /** Hydrate selection from a `cat/slug,cat/slug` URL param string. */
   hydrate: (param: string) => void;
   /** Serialize current selection back to URL param shape. */
@@ -30,27 +37,6 @@ export interface CompareCtx extends CompareState, CompareActions {}
 
 const StoreCtx = React.createContext<CompareStore | null>(null);
 
-function resolve(entries: Entry[], param: string): Entry[] {
-  if (!param) return [];
-  const refs = param
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .slice(0, 4);
-  const seen = new Set<string>();
-  const out: Entry[] = [];
-  for (const ref of refs) {
-    const [cat, slug] = ref.split("/");
-    if (!cat || !slug || seen.has(ref)) continue;
-    const e = entries.find((x) => x.category === cat && x.slug === slug);
-    if (e) {
-      out.push(e);
-      seen.add(ref);
-    }
-  }
-  return out;
-}
-
 /**
  * A tiny external store backs the compare selection. Splitting state from the
  * stable `actions` object lets cards subscribe narrowly (see `useIsCompared`):
@@ -73,11 +59,7 @@ function createCompareStore(): CompareStore {
     },
     toggle: (e) => {
       const cur = state.items;
-      const next = cur.find((x) => x.slug === e.slug)
-        ? cur.filter((x) => x.slug !== e.slug)
-        : cur.length >= 4
-          ? cur
-          : [...cur, e];
+      const next = toggleCompareItem(cur, e);
       if (next === cur) return; // at the 4-item cap — no change
       setState({ ...state, items: next });
     },
@@ -85,7 +67,7 @@ function createCompareStore(): CompareStore {
       if (state.items.length === 0 && !state.open) return;
       setState({ items: [], open: false });
     },
-    has: (slug) => state.items.some((x) => x.slug === slug),
+    has: (entry) => hasCompareItem(state.items, entry),
     hydrate: (param) => {
       if (!param) {
         if (state.items.length) setState({ ...state, items: [] });
@@ -94,15 +76,15 @@ function createCompareStore(): CompareStore {
       // Lazy-load the dataset only when a compare selection is hydrated from the
       // URL, keeping the registry dataset out of the universal client bundle.
       void import("@/data/entries").then(({ ENTRIES }) => {
-        const next = resolve(ENTRIES, param);
-        const sig = next.map((e) => `${e.category}/${e.slug}`).join(",");
-        const curSig = state.items.map((e) => `${e.category}/${e.slug}`).join(",");
+        const next = resolveCompareParam(ENTRIES, param);
+        const sig = serializeCompareItems(next);
+        const curSig = serializeCompareItems(state.items);
         if (sig !== curSig) setState({ ...state, items: next });
       });
     },
-    serialize: () => state.items.map((e) => `${e.category}/${e.slug}`).join(","),
+    serialize: () => serializeCompareItems(state.items),
     getShareUrl: () => {
-      const sig = state.items.map((e) => `${e.category}/${e.slug}`).join(",");
+      const sig = serializeCompareItems(state.items);
       const origin = typeof window !== "undefined" ? window.location.origin : "";
       return sig ? `${origin}/browse?compare=${encodeURIComponent(sig)}` : `${origin}/browse`;
     },
@@ -137,11 +119,11 @@ export function useCompareActions(): CompareActions {
 
 /** Narrow per-card subscription: a card re-renders only when its own
  * membership in the compare set flips, not on every selection change. */
-export function useIsCompared(slug: string): boolean {
+export function useIsCompared(entry: EntryIdentity): boolean {
   const store = useStore();
   return React.useSyncExternalStore(
     store.subscribe,
-    () => store.getState().items.some((x) => x.slug === slug),
+    () => hasCompareItem(store.getState().items, entry),
     () => false,
   );
 }

--- a/apps/web/src/lib/detail-assembly.ts
+++ b/apps/web/src/lib/detail-assembly.ts
@@ -1,6 +1,7 @@
 import { marked } from "marked";
 import sanitizeHtml from "sanitize-html";
 
+import { sameEntry } from "@/lib/entry-identity";
 import type { ContentEntry, DirectoryEntry } from "@/lib/content.server";
 
 export function stripCodeBlocks(markdown: string) {
@@ -257,7 +258,7 @@ function hashString(value: string) {
 }
 
 export function getRelatedEntries(entry: ContentEntry, allEntries: DirectoryEntry[]) {
-  const relatedPool = allEntries.filter((item) => item.slug !== entry.slug);
+  const relatedPool = allEntries.filter((item) => !sameEntry(item, entry));
   const entryTagSet = new Set((entry.tags ?? []).map((tag) => tag.toLowerCase()));
   const anchorHash = hashString(`${entry.category}:${entry.slug}`);
 

--- a/apps/web/src/lib/entry-identity.ts
+++ b/apps/web/src/lib/entry-identity.ts
@@ -1,0 +1,24 @@
+export interface EntryIdentity {
+  category: string;
+  slug: string;
+}
+
+export function entryRef(entry: EntryIdentity) {
+  return `${entry.category}/${entry.slug}`;
+}
+
+export function entryDomId(entry: EntryIdentity) {
+  return `${entry.category}-${entry.slug}`;
+}
+
+export function sameEntry(left: EntryIdentity, right: EntryIdentity) {
+  return left.category === right.category && left.slug === right.slug;
+}
+
+export function parseEntryRef(ref: string): EntryIdentity | null {
+  const parts = ref.split("/");
+  if (parts.length !== 2) return null;
+  const [category, slug] = parts.map((part) => part.trim());
+  if (!category || !slug) return null;
+  return { category, slug };
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -10,6 +10,8 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { CopyButton } from "@/components/copy-button";
 import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
+import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
+import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -41,23 +43,7 @@ export const Route = createFileRoute("/compare/")({
 });
 
 function resolveIds(ids: string): Entry[] {
-  if (!ids) return [];
-  const seen = new Set<string>();
-  const out: Entry[] = [];
-  for (const ref of ids
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .slice(0, 4)) {
-    if (seen.has(ref)) continue;
-    const [cat, slug] = ref.split("/");
-    const e = ENTRIES.find((x) => x.category === cat && x.slug === slug);
-    if (e) {
-      out.push(e);
-      seen.add(ref);
-    }
-  }
-  return out;
+  return resolveCompareParam(ENTRIES, ids);
 }
 
 function ComparePage() {
@@ -76,26 +62,26 @@ function ComparePage() {
   const [pickerOpen, setPickerOpen] = React.useState(false);
 
   const pushIds = (next: Entry[]) => {
-    const ids = next.map((e) => `${e.category}/${e.slug}`).join(",");
+    const ids = serializeCompareItems(next);
     navigate({ search: { ids } });
   };
 
   const removeItem = (e: Entry) => {
-    const next = items.filter((x) => !(x.category === e.category && x.slug === e.slug));
+    const next = items.filter((x) => !sameEntry(x, e));
     compare.toggle(e);
     pushIds(next);
   };
 
   const addItem = (e: Entry) => {
     if (items.length >= 4) return;
-    if (items.some((x) => x.category === e.category && x.slug === e.slug)) return;
+    if (items.some((x) => sameEntry(x, e))) return;
     compare.toggle(e);
     pushIds([...items, e]);
     setPickerOpen(false);
   };
 
   const copyShare = () => {
-    const sig = items.map((e) => `${e.category}/${e.slug}`).join(",");
+    const sig = serializeCompareItems(items);
     const origin = typeof window !== "undefined" ? window.location.origin : "";
     return sig ? `${origin}/compare?ids=${encodeURIComponent(sig)}` : `${origin}/compare`;
   };
@@ -292,7 +278,7 @@ function AddColumn({
   const [q, setQ] = React.useState("");
   const results = React.useMemo(() => {
     const list = search({ q, sort: "popular" }).slice(0, 8);
-    return list.filter((e) => !exclude.some((x) => x.category === e.category && x.slug === e.slug));
+    return list.filter((e) => !exclude.some((x) => sameEntry(x, e)));
   }, [q, exclude]);
 
   if (!open) {

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -19,6 +19,7 @@ import { CountUp } from "@/components/count-up";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { entryRef } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/quality")({
@@ -422,7 +423,7 @@ function Queue({ title, help, rows }: { title: string; help: string; rows: Quali
       </div>
       <ul>
         {rows.map((r) => (
-          <li key={r.entry.slug} className="border-b border-border px-5 py-3 last:border-0">
+          <li key={entryRef(r.entry)} className="border-b border-border px-5 py-3 last:border-0">
             <div className="flex items-center justify-between gap-3">
               <Link
                 to="/entry/$category/$slug"

--- a/tests/entry-identity.test.ts
+++ b/tests/entry-identity.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasCompareItem,
+  resolveCompareParam,
+  serializeCompareItems,
+  toggleCompareItem,
+} from "../apps/web/src/lib/compare-selection";
+import {
+  entryDomId,
+  entryRef,
+  parseEntryRef,
+  sameEntry,
+  type EntryIdentity,
+} from "../apps/web/src/lib/entry-identity";
+import { relatedBySimilarity } from "../apps/web/src/data/search";
+import { getRelatedEntries } from "../apps/web/src/lib/detail-assembly";
+import type { Entry } from "../apps/web/src/types/registry";
+import type { ContentEntry, DirectoryEntry } from "@heyclaude/registry";
+
+function identity(category: Entry["category"], slug: string): EntryIdentity {
+  return { category, slug };
+}
+
+function registryEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): Entry {
+  return {
+    category,
+    slug,
+    title: `${category} ${slug}`,
+    description: `${category} ${slug} description`,
+    author: "Example",
+    tags,
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "unverified",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+  };
+}
+
+function directoryEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): DirectoryEntry {
+  return {
+    category,
+    slug,
+    title: `${category} ${slug}`,
+    description: `${category} ${slug} description`,
+    tags,
+    dateAdded: "2026-01-01",
+  } as DirectoryEntry;
+}
+
+function contentEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): ContentEntry {
+  return {
+    ...directoryEntry(category, slug, tags),
+    body: "Example body",
+  } as ContentEntry;
+}
+
+describe("entry identity", () => {
+  it("uses category and slug as the stable registry identity", () => {
+    const mcpEntry = identity("mcp", "shared-slug");
+    const skillEntry = identity("skills", "shared-slug");
+
+    expect(entryRef(mcpEntry)).toBe("mcp/shared-slug");
+    expect(entryDomId(mcpEntry)).toBe("mcp-shared-slug");
+    expect(sameEntry(mcpEntry, identity("mcp", "shared-slug"))).toBe(true);
+    expect(sameEntry(mcpEntry, skillEntry)).toBe(false);
+  });
+
+  it("parses only exact category/slug references", () => {
+    expect(parseEntryRef(" mcp/shared-slug ")).toEqual({
+      category: "mcp",
+      slug: "shared-slug",
+    });
+    expect(parseEntryRef("mcp")).toBeNull();
+    expect(parseEntryRef("mcp/shared/extra")).toBeNull();
+    expect(parseEntryRef("/shared-slug")).toBeNull();
+    expect(parseEntryRef("mcp/")).toBeNull();
+  });
+});
+
+describe("compare selection identity", () => {
+  it("allows entries with the same slug from different categories", () => {
+    const mcpEntry = identity("mcp", "shared-slug");
+    const skillEntry = identity("skills", "shared-slug");
+
+    const selected = toggleCompareItem([mcpEntry], skillEntry);
+
+    expect(selected).toEqual([mcpEntry, skillEntry]);
+    expect(hasCompareItem(selected, mcpEntry)).toBe(true);
+    expect(hasCompareItem(selected, skillEntry)).toBe(true);
+    expect(toggleCompareItem(selected, mcpEntry)).toEqual([skillEntry]);
+  });
+
+  it("serializes and hydrates category-qualified compare refs", () => {
+    const entries = [
+      identity("mcp", "shared-slug"),
+      identity("skills", "shared-slug"),
+      identity("hooks", "runner"),
+      identity("commands", "deploy"),
+    ];
+
+    const resolved = resolveCompareParam(
+      entries,
+      "bad-ref,mcp/shared-slug,skills/shared-slug,mcp/shared-slug,missing/nope,hooks/runner,commands/deploy",
+      3,
+    );
+
+    expect(resolved).toEqual([entries[0], entries[1], entries[2]]);
+    expect(serializeCompareItems(resolved)).toBe(
+      "mcp/shared-slug,skills/shared-slug,hooks/runner",
+    );
+  });
+});
+
+describe("related entry identity", () => {
+  it("excludes only the exact entry in client related fallback results", () => {
+    const anchor = registryEntry("mcp", "shared-slug", ["alpha"]);
+    const exactSameEntry = registryEntry("mcp", "shared-slug", ["alpha"]);
+    const sameSlugDifferentCategory = registryEntry("skills", "shared-slug", [
+      "alpha",
+    ]);
+    const sameCategoryDifferentSlug = registryEntry("mcp", "runner", ["alpha"]);
+
+    const related = relatedBySimilarity(
+      anchor,
+      [exactSameEntry, sameSlugDifferentCategory, sameCategoryDifferentSlug],
+      3,
+    );
+
+    expect(related).not.toContain(exactSameEntry);
+    expect(related).toEqual(
+      expect.arrayContaining([
+        sameSlugDifferentCategory,
+        sameCategoryDifferentSlug,
+      ]),
+    );
+  });
+
+  it("excludes only the exact entry in detail related results", () => {
+    const anchor = contentEntry("mcp", "shared-slug", ["alpha"]);
+    const exactSameEntry = directoryEntry("mcp", "shared-slug", ["alpha"]);
+    const sameSlugDifferentCategory = directoryEntry("skills", "shared-slug", [
+      "alpha",
+    ]);
+    const sameCategoryDifferentSlug = directoryEntry("mcp", "runner", [
+      "alpha",
+    ]);
+
+    const related = getRelatedEntries(anchor, [
+      exactSameEntry,
+      sameSlugDifferentCategory,
+      sameCategoryDifferentSlug,
+    ]);
+
+    expect(related).not.toContain(exactSameEntry);
+    expect(related).toEqual(
+      expect.arrayContaining([
+        sameSlugDifferentCategory,
+        sameCategoryDifferentSlug,
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fix entry identity checks that treated `slug` as globally unique.
- Preserve same-slug entries from different categories in compare state and related-entry surfaces.

## What changed
- Added shared entry identity helpers for `category/slug` refs, DOM ids, and equality checks.
- Reworked compare selection hydration, toggling, serialization, and picker exclusion to use category-qualified identity.
- Updated related-entry fallback logic, detail related entries, quality queue keys, and peek drawer ids to avoid slug-only collisions.
- Added regression coverage for duplicate slugs across categories.

## Why
Entries are addressed throughout the registry by category plus slug. Slug-only checks could remove or hide the wrong entry when two categories contain the same slug, and slug-only DOM ids could duplicate on pages rendering both entries.

## Validation
- `pnpm exec vitest run tests/entry-identity.test.ts`
- `pnpm exec vitest run tests/entry-identity.test.ts tests/web-non-ui-utilities.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm build` still reports the existing large client chunk warning; this PR does not change that bundle-loading behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of entry deduplication in search results and related entry suggestions
  * Enhanced stability of compare feature with more reliable entry identification

* **Refactor**
  * Standardized internal entry identification system for consistent comparison and filtering across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->