### PR TITLE
fix(api): avoid hiding backdated registry diff entries

### DIFF
--- a/apps/web/src/routes/api/registry/diff.ts
+++ b/apps/web/src/routes/api/registry/diff.ts
@@ -17,40 +17,6 @@ function looksLikeHash(value: string | null) {
   return Boolean(value && /^[a-f0-9]{32,128}$/i.test(value));
 }
 
-// Filter `added` entries to those at or after the cursor. `dateAdded` is the
-// only per-entry timestamp recorded in `registry-changelog.json`, and it only
-// has meaning for entries whose `type === "added"`.
-function entriesAddedSince(entries: ChangelogEntry[], sinceDate: number) {
-  return entries.filter((entry) => {
-    if (entry.type !== "added") return false;
-    const added = Date.parse(entry.dateAdded);
-    return Number.isFinite(added) && added >= sinceDate;
-  });
-}
-
-// `updated` and `removed` entries carry no per-entry `updatedAt` / `removedAt`,
-// so a date cursor cannot honor them. Surface every such entry on a date-cursor
-// fetch, preserving the "edited entries are not missed" guarantee.
-function entriesUpdatedOrRemoved(entries: ChangelogEntry[]) {
-  return entries.filter((entry) => entry.type !== "added");
-}
-
-// Merge two slices of the same changelog in original-order, deduping by `key`
-// (the changelog generator already enforces one row per key; the dedupe is a
-// defensive belt-and-suspenders in case overlap is ever introduced).
-function mergeChangelogEntries(all: ChangelogEntry[], selected: ChangelogEntry[]) {
-  const keepKeys = new Set(selected.map((entry) => entry.key));
-  const seen = new Set<string>();
-  const merged: ChangelogEntry[] = [];
-  for (const entry of all) {
-    if (!keepKeys.has(entry.key)) continue;
-    if (seen.has(entry.key)) continue;
-    seen.add(entry.key);
-    merged.push(entry);
-  }
-  return merged;
-}
-
 export const GET = createApiHandler("registry.diff", async ({ request, query: parsedQuery }) => {
   const { since, limit } = parsedQuery as InferApiQuery<typeof registryDiffQuerySchema>;
   const sinceDate = parseSinceDate(since);
@@ -61,12 +27,11 @@ export const GET = createApiHandler("registry.diff", async ({ request, query: pa
   if (since && since === currentSignature) {
     entries = [];
   } else if (sinceDate) {
-    // Date-cursor fetch: include `added` entries at or after the cursor plus
-    // every `updated`/`removed` row (un-date-filterable). Merge in changelog
-    // order, deduped by key.
-    const addedSince = entriesAddedSince(changelog.entries, sinceDate);
-    const editsAndRemovals = entriesUpdatedOrRemoved(changelog.entries);
-    entries = mergeChangelogEntries(changelog.entries, [...addedSince, ...editsAndRemovals]);
+    // Date cursors are advisory only: changelog rows currently do not carry an
+    // append-only publication timestamp, and `dateAdded` comes from content
+    // metadata. Return the full static snapshot so newly merged backdated or
+    // invalid-date additions cannot be hidden from incremental consumers.
+    entries = changelog.entries;
   } else {
     entries = changelog.entries;
   }
@@ -86,7 +51,7 @@ export const GET = createApiHandler("registry.diff", async ({ request, query: pa
         since && looksLikeHash(since) && since !== currentSignature
           ? "Unknown hash for this static registry snapshot; returning latest available changes."
           : sinceDate
-            ? "Date cursors filter `added` entries by the cursor and include every `updated`/`removed` entry so edited entries are not missed; use currentSignature for precise polling."
+            ? "Date cursors are advisory for this static snapshot and return all available changes so backdated additions and edited entries are not missed; use currentSignature for precise polling."
             : undefined,
       entries: entries.slice(0, limit),
     },

--- a/tests/registry-diff-api.test.ts
+++ b/tests/registry-diff-api.test.ts
@@ -125,67 +125,58 @@ describe("/api/registry/diff", () => {
     });
   });
 
-  it("filters added entries by sinceDate and always surfaces updated/removed entries", async () => {
+  it("returns the full changelog for date cursors so backdated additions are not hidden", async () => {
     const { GET } = await import("../apps/web/src/routes/api/registry/diff");
     const response = await GET(request("?since=2026-01-01&limit=10"));
 
     expect(response.status).toBe(200);
     const body = await response.json();
     const keys = body.entries.map((entry: { key: string }) => entry.key);
-    // `added` entries on or after 2026-01-01 (drops the 2025-10-10 row).
-    expect(keys).toContain("skills:new-may");
-    expect(keys).toContain("mcp:new-apr");
-    expect(keys).not.toContain("hooks:old-2025");
-    // Every updated/removed entry passes through regardless of dateAdded.
-    expect(keys).toContain("skills:edit-recent");
-    expect(keys).toContain("mcp:removed-thing");
-    expect(body.totalAvailable).toBe(4);
+    expect(keys).toEqual([
+      "skills:new-may",
+      "mcp:new-apr",
+      "hooks:old-2025",
+      "skills:edit-recent",
+      "mcp:removed-thing",
+    ]);
+    expect(body.totalAvailable).toBe(5);
   });
 
-  it("returns only updated/removed entries when sinceDate is newer than every added entry", async () => {
+  it("returns the full changelog even when sinceDate is newer than every added entry", async () => {
     const { GET } = await import("../apps/web/src/routes/api/registry/diff");
     const response = await GET(request("?since=2030-01-01&limit=10"));
 
     expect(response.status).toBe(200);
     const body = await response.json();
-    const keys = body.entries.map((entry: { key: string }) => entry.key);
-    expect(keys).toEqual(
-      expect.arrayContaining(["skills:edit-recent", "mcp:removed-thing"]),
-    );
-    expect(keys).not.toContain("skills:new-may");
-    expect(keys).not.toContain("mcp:new-apr");
-    expect(keys).not.toContain("hooks:old-2025");
-  });
-
-  it("returns every entry when sinceDate is older than every added entry", async () => {
-    const { GET } = await import("../apps/web/src/routes/api/registry/diff");
-    const response = await GET(request("?since=2024-01-01&limit=10"));
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
+    expect(body.entries.map((entry: { key: string }) => entry.key)).toEqual([
+      "skills:new-may",
+      "mcp:new-apr",
+      "hooks:old-2025",
+      "skills:edit-recent",
+      "mcp:removed-thing",
+    ]);
     expect(body.totalAvailable).toBe(5);
   });
 
-  it("preserves entries order (changelog order, not filter-class order)", async () => {
+  it("preserves changelog order for date cursor responses", async () => {
     const { GET } = await import("../apps/web/src/routes/api/registry/diff");
     const response = await GET(request("?since=2026-01-01&limit=10"));
     const body = await response.json();
     const keys = body.entries.map((entry: { key: string }) => entry.key);
-    // Original changelog order: new-may, new-apr, old-2025, edit-recent, removed-thing
-    // With old-2025 filtered out, we expect: new-may, new-apr, edit-recent, removed-thing
     expect(keys).toEqual([
       "skills:new-may",
       "mcp:new-apr",
+      "hooks:old-2025",
       "skills:edit-recent",
       "mcp:removed-thing",
     ]);
   });
 
-  it("applies limit AFTER filtering", async () => {
+  it("applies limit after selecting the date-cursor changelog", async () => {
     const { GET } = await import("../apps/web/src/routes/api/registry/diff");
     const response = await GET(request("?since=2026-01-01&limit=2"));
     const body = await response.json();
-    expect(body.totalAvailable).toBe(4);
+    expect(body.totalAvailable).toBe(5);
     expect(body.count).toBe(2);
     expect(body.entries).toHaveLength(2);
   });
@@ -210,12 +201,12 @@ describe("/api/registry/diff", () => {
     expect(body.totalAvailable).toBe(5);
   });
 
-  it("emits the date-cursor note explaining filtered semantics", async () => {
+  it("emits the date-cursor note explaining advisory semantics", async () => {
     const { GET } = await import("../apps/web/src/routes/api/registry/diff");
     const response = await GET(request("?since=2026-01-01"));
     const body = await response.json();
-    expect(body.note).toMatch(/Date cursors filter/);
-    expect(body.note).toMatch(/updated.*removed/);
+    expect(body.note).toMatch(/Date cursors are advisory/);
+    expect(body.note).toMatch(/backdated additions/);
   });
 
   it("still returns response.ok for the e2e smoke shape", async () => {


### PR DESCRIPTION
### Motivation
- The registry diff endpoint previously filtered `added` changelog rows by each entry's `dateAdded`, which is copied from content frontmatter and can be backdated or invalid, allowing newly merged additions to be omitted from date-cursor incremental polling. 
- The change makes date cursors advisory for the static changelog so incremental consumers cannot be blind-sided by content-controlled `dateAdded` values.

### Description
- Date-based filtering for `added` rows was removed from `/api/registry/diff` so date-cursor requests now return the full static changelog (except when `since` matches `currentSignature`, which still returns an empty set). 
- The endpoint `note` text was updated to explain that date cursors are advisory for the static snapshot and that consumers should use `currentSignature` for precise polling. 
- Test expectations in `tests/registry-diff-api.test.ts` were updated to assert that date-cursor requests do not hide backdated or invalid-date additions and that ordering and limit semantics remain correct.

### Testing
- Ran `pnpm exec vitest run tests/registry-diff-api.test.ts`, which executed the file-level suite and reported: 1 test file, 10 tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347fa9b17c832c8272d54ef85618b3)