### PR TITLE
fix(registry): ignore public engagement in trending rank

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -1495,7 +1495,7 @@
       "get": {
         "tags": ["Registry"],
         "summary": "Public registry trending entries",
-        "description": "Returns bounded privacy-safe trending registry entries from aggregate votes, community signals, intent events, and static trust metadata.",
+        "description": "Returns bounded privacy-safe trending registry entries ranked from maintainer-controlled static trust metadata; public engagement aggregates are reported only as availability metadata.",
         "parameters": [
           {
             "schema": {

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -1867,9 +1867,9 @@ paths:
       tags:
         - Registry
       summary: Public registry trending entries
-      description:
-        Returns bounded privacy-safe trending registry entries from aggregate votes, community
-        signals, intent events, and static trust metadata.
+      description: Returns bounded privacy-safe trending registry entries ranked from
+        maintainer-controlled static trust metadata; public engagement aggregates are reported only
+        as availability metadata.
       parameters:
         - schema:
             anyOf:

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -889,7 +889,7 @@ export const apiRouteDefinitions = {
     path: "/api/registry/trending",
     summary: "Public registry trending entries",
     description:
-      "Returns bounded privacy-safe trending registry entries from aggregate votes, community signals, intent events, and static trust metadata.",
+      "Returns bounded privacy-safe trending registry entries ranked from maintainer-controlled static trust metadata; public engagement aggregates are reported only as availability metadata.",
     tags: ["Registry"],
     originCheck: true,
     querySchema: registryTrendingQuerySchema,

--- a/apps/web/src/lib/growth-ranking.ts
+++ b/apps/web/src/lib/growth-ranking.ts
@@ -3,13 +3,7 @@ import type { IntentEventCounts } from "@/lib/intent-events";
 
 export function totalIntentCount(counts: IntentEventCounts | undefined) {
   if (!counts) return 0;
-  return (
-    counts.copy +
-    counts.open +
-    counts.install * 3 +
-    counts.download * 2 +
-    counts.vote
-  );
+  return counts.copy + counts.open + counts.install * 3 + counts.download * 2 + counts.vote;
 }
 
 export function communityDiscoveryScore(params: {
@@ -19,14 +13,8 @@ export function communityDiscoveryScore(params: {
   firstPartyPackage?: boolean;
   productionVerified?: boolean;
 }) {
-  const signals = params.communitySignals;
-  return (
-    (params.votes ?? 0) * 4 +
-    (signals?.used ?? 0) * 3 +
-    (signals?.works ?? 0) * 5 -
-    (signals?.broken ?? 0) * 5 +
-    totalIntentCount(params.intentCounts) +
-    (params.firstPartyPackage ? 2 : 0) +
-    (params.productionVerified ? 2 : 0)
-  );
+  // Public engagement counters are unauthenticated and caller-controlled. Keep
+  // them available for non-ranking display/telemetry, but do not let them
+  // promote or suppress entries in machine-readable discovery surfaces.
+  return (params.firstPartyPackage ? 2 : 0) + (params.productionVerified ? 2 : 0);
 }

--- a/apps/web/src/routes/api/registry/trending.ts
+++ b/apps/web/src/routes/api/registry/trending.ts
@@ -4,7 +4,7 @@ import { ENTRIES } from "@/data/entries";
 import { registryTrendingQuerySchema } from "@/lib/api/contracts";
 import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { entryCommunityTarget, safeCommunitySignalCounts } from "@/lib/community-signals";
-import { communityDiscoveryScore, totalIntentCount } from "@/lib/growth-ranking";
+import { communityDiscoveryScore } from "@/lib/growth-ranking";
 import { cachedJsonResponse } from "@/lib/http-cache";
 import { safeIntentEventCounts } from "@/lib/intent-events";
 import { safeVoteCounts } from "@/lib/votes";
@@ -42,10 +42,6 @@ const matchesPlatform = (entry: Entry, value: string) => {
 
 const reasonCodes = (input: ReturnType<typeof trendInput>) =>
   [
-    input.votes ? "upvotes" : "",
-    input.communitySignals?.used ? "community_used" : "",
-    input.communitySignals?.works ? "community_works" : "",
-    totalIntentCount(input.intentCounts) ? "recent_intent" : "",
     input.firstPartyPackage ? "first_party_package" : "",
     input.productionVerified ? "production_verified" : "",
   ].filter(Boolean);

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -1869,8 +1869,9 @@ paths:
         - Registry
       summary: Public registry trending entries
       description:
-        Returns bounded privacy-safe trending registry entries from aggregate votes, community
-        signals, intent events, and static trust metadata.
+        Returns bounded privacy-safe trending registry entries ranked from
+        maintainer-controlled static trust metadata; public engagement aggregates are reported only
+        as availability metadata.
       parameters:
         - schema:
             anyOf:

--- a/tests/growth-ranking.test.ts
+++ b/tests/growth-ranking.test.ts
@@ -6,25 +6,31 @@ import {
 } from "../apps/web/src/lib/growth-ranking";
 
 describe("growth ranking", () => {
-  it("weights aggregate community and intent signals without requiring GitHub stats", () => {
-    const activeEntryScore = communityDiscoveryScore({
-      communitySignals: { used: 2, works: 2, broken: 0 },
-      intentCounts: { copy: 3, open: 5, install: 2, download: 1, vote: 0 },
-      votes: 4,
+  it("only uses maintainer-controlled trust metadata for discovery ranking", () => {
+    const trustedEntryScore = communityDiscoveryScore({
+      communitySignals: { used: 0, works: 0, broken: 99 },
+      intentCounts: { copy: 0, open: 0, install: 0, download: 0, vote: 0 },
+      votes: 0,
       firstPartyPackage: true,
       productionVerified: true,
     });
-    const staleEntryScore = communityDiscoveryScore({
-      communitySignals: { used: 1, works: 0, broken: 2 },
-      intentCounts: { copy: 1, open: 1, install: 0, download: 0, vote: 0 },
-      votes: 0,
+    const forgedEngagementScore = communityDiscoveryScore({
+      communitySignals: { used: 200, works: 200, broken: 0 },
+      intentCounts: {
+        copy: 200,
+        open: 200,
+        install: 200,
+        download: 200,
+        vote: 200,
+      },
+      votes: 200,
     });
 
-    expect(activeEntryScore).toBeGreaterThan(staleEntryScore);
-    expect(staleEntryScore).toBeLessThan(0);
+    expect(trustedEntryScore).toBe(4);
+    expect(forgedEngagementScore).toBe(0);
   });
 
-  it("counts install and download actions more heavily than passive opens", () => {
+  it("still summarizes intent actions for non-ranking analytics", () => {
     expect(
       totalIntentCount({
         copy: 1,

--- a/tests/registry-trending-api.test.ts
+++ b/tests/registry-trending-api.test.ts
@@ -65,7 +65,10 @@ describe("/api/registry/trending", () => {
     state.entries.length = 0;
     state.entries.push(
       entry("alpha"),
-      entry("beta"),
+      entry("beta", {
+        downloadTrust: "first-party",
+        verificationStatus: "production",
+      }),
       entry("skill", { category: "skills" }),
     );
     state.votes = {
@@ -101,16 +104,13 @@ describe("/api/registry/trending", () => {
       kind: "registry-trending",
       category: "mcp",
       platform: "claude",
-      count: 2,
+      count: 1,
       signalsAvailable: { votes: true, community: true, intent: true },
     });
     expect(body.entries[0]).toMatchObject({
       slug: "beta",
-      reasons: expect.arrayContaining([
-        "upvotes",
-        "community_works",
-        "recent_intent",
-      ]),
+      score: 4,
+      reasons: ["first_party_package", "production_verified"],
       trustSignals: { sourceStatus: "available" },
     });
     for (const entry of body.entries) {


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated, caller-controlled signals (votes, community signals, intent events) from manipulating the registry "trending" recommendation surface and causing supply-chain / recommendation-integrity issues.

### Description
- Hardened ranking by changing `communityDiscoveryScore` in `apps/web/src/lib/growth-ranking.ts` to only use maintainer-controlled static trust metadata (`firstPartyPackage` and `productionVerified`) for machine-readable discovery scores and to ignore public engagement aggregates.
- Removed public engagement reason codes from the `/api/registry/trending` response in `apps/web/src/routes/api/registry/trending.ts` so only static trust reasons (`first_party_package`, `production_verified`) are exposed as ranking reasons.
- Updated API route documentation text in `apps/web/src/lib/api/contracts.ts` and regenerated OpenAPI artifacts to state that trending is ranked from maintainer-controlled static trust metadata and that dynamic public engagement aggregates are reported only as availability metadata.
- Added/adjusted tests in `tests/growth-ranking.test.ts` and `tests/registry-trending-api.test.ts` to assert that forged engagement no longer increases discovery score while trusted static metadata still ranks.

### Testing
- Ran `pnpm exec vitest run tests/growth-ranking.test.ts tests/registry-trending-api.test.ts tests/api-contracts.test.ts` and all tests passed (3 files, 19 tests total).
- Ran `pnpm generate:openapi` and `pnpm validate:openapi` to regenerate and verify OpenAPI artifacts and both completed successfully.
- Ran repository checks (`git diff --check`) and no formatting/diff issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347faa2544832c9b68bf4de4c1d46d)