### PR TITLE
fix(mcp): expose duplicate URL inputs

### DIFF
--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -274,6 +274,11 @@ export const SearchDuplicateEntriesInputSchema = z
     name: z.string().trim().min(1).max(240).optional(),
     title: z.string().trim().min(1).max(240).optional(),
     sourceUrl: z.string().trim().min(1).max(500).optional(),
+    sourceUrls: z.array(z.string().trim().min(1).max(500)).max(10).optional(),
+    githubUrl: z.string().trim().min(1).max(500).optional(),
+    docsUrl: z.string().trim().min(1).max(500).optional(),
+    downloadUrl: z.string().trim().min(1).max(500).optional(),
+    websiteUrl: z.string().trim().min(1).max(500).optional(),
     brandDomain: z.string().trim().min(1).max(255).optional(),
     limit: z.number().int().min(1).max(10).optional(),
   })

--- a/tests/mcp-submission-duplicate-urls.test.ts
+++ b/tests/mcp-submission-duplicate-urls.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import { callRegistryTool } from "../packages/mcp/src/registry.js";
+import {
+  jsonSchemaForTool,
+  parseToolArguments,
+} from "../packages/mcp/src/schemas.js";
 import { searchDuplicateEntries } from "../packages/mcp/src/submissions.js";
 
 type RegistryEntry = Record<string, unknown>;
@@ -219,6 +224,88 @@ describe("searchDuplicateEntries source-URL matching", () => {
     expect(
       (websiteResult.matches as Array<{ reasons: string[] }>)[0].reasons,
     ).toContain("source_url");
+  });
+
+  it("exposes sourceUrls and fielded URL args through the public MCP schema", () => {
+    expect(() =>
+      parseToolArguments("search_duplicate_entries", {
+        sourceUrls: ["https://github.com/domdomegg/airtable-mcp-server"],
+        githubUrl: "https://github.com/domdomegg/airtable-mcp-server",
+        docsUrl: "https://docs.example.com/airtable",
+        downloadUrl: "https://example.com/downloads/airtable.zip",
+        websiteUrl: "https://airtable-mcp.example",
+      }),
+    ).not.toThrow();
+
+    const inputSchema = jsonSchemaForTool("search_duplicate_entries") as {
+      properties?: Record<string, unknown>;
+    };
+    expect(inputSchema.properties).toMatchObject({
+      sourceUrls: expect.any(Object),
+      githubUrl: expect.any(Object),
+      docsUrl: expect.any(Object),
+      downloadUrl: expect.any(Object),
+      websiteUrl: expect.any(Object),
+    });
+  });
+
+  it("accepts fielded URL args through the public MCP tool path", async () => {
+    const result = await callRegistryTool(
+      "search_duplicate_entries",
+      {
+        githubUrl: "https://github.com/domdomegg/airtable-mcp-server/",
+        limit: 3,
+      },
+      {
+        readJsonArtifact: async (relativePath: string) => {
+          if (relativePath === "search-index.json") {
+            return { entries: [entry()] };
+          }
+          throw new Error(`Unexpected artifact read: ${relativePath}`);
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      count: 1,
+      matches: [
+        expect.objectContaining({
+          reasons: expect.arrayContaining(["source_url"]),
+        }),
+      ],
+    });
+  });
+
+  it("accepts sourceUrls through the public MCP tool path", async () => {
+    const result = await callRegistryTool(
+      "search_duplicate_entries",
+      {
+        sourceUrls: [
+          "https://github.com/unrelated/repo",
+          "https://github.com/domdomegg/airtable-mcp-server/",
+        ],
+        limit: 3,
+      },
+      {
+        readJsonArtifact: async (relativePath: string) => {
+          if (relativePath === "search-index.json") {
+            return { entries: [entry()] };
+          }
+          throw new Error(`Unexpected artifact read: ${relativePath}`);
+        },
+      },
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      count: 1,
+      matches: [
+        expect.objectContaining({
+          reasons: expect.arrayContaining(["source_url"]),
+        }),
+      ],
+    });
   });
 
   it("returns count: 0 when no URL candidates are supplied", () => {


### PR DESCRIPTION
### Motivation
- The duplicate-detection helpers already accept `sourceUrls` plus fielded URL args (`githubUrl`, `docsUrl`, `downloadUrl`, `websiteUrl`) but the public MCP `search_duplicate_entries` input schema remained strict and only exposed the legacy `sourceUrl`, causing public MCP calls with the new fields to be rejected.

### Description
- Add `sourceUrls`, `githubUrl`, `docsUrl`, `downloadUrl`, and `websiteUrl` to the `SearchDuplicateEntriesInputSchema` so the public MCP tool accepts the same URL inputs the duplicate-matching code already supports (`packages/mcp/src/schemas.js`).
- Add tests that assert the public schema advertises these properties and that public MCP dispatch (`callRegistryTool("search_duplicate_entries", ...)`) accepts and exercises both fielded URL args and the `sourceUrls` array (`tests/mcp-submission-duplicate-urls.test.ts`).
- Wire test stubs for artifact reads so the public tool path can be exercised without relying on external generated artifacts, and run prettier on touched files for consistent formatting.

### Testing
- Ran the focused unit file with `pnpm exec vitest run tests/mcp-submission-duplicate-urls.test.ts`, which passed (17 tests passed).
- Generated web artifacts and ran the package-level MCP test suite with `pnpm --filter web run prebuild && pnpm test:mcp`, which passed (mcp/package tests passed; overall MCP tests passed).
- Verified `git diff --check` and `pnpm exec prettier --check packages/mcp/src/schemas.js tests/mcp-submission-duplicate-urls.test.ts` succeeded with no formatting or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347d79000c832c82f2fe6249d189b0)