### PR TITLE
fix(security): cap public github webhook bodies

### DIFF
--- a/apps/web/src/routes/api/public/github/webhook.ts
+++ b/apps/web/src/routes/api/public/github/webhook.ts
@@ -12,11 +12,13 @@
  */
 import { createApiFileRoute } from "@/lib/api/file-route";
 
+import { BodyTooLargeError, readRequestTextWithinLimit } from "@/lib/api-security";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
 const ALLOWED_REPO = "jsonbored/awesome-claude";
 const ALLOWED_BRANCH = "main";
 const CACHE_KEY = "https://heyclau.de/internal/alerts-cache";
+export const GITHUB_WEBHOOK_BODY_LIMIT_BYTES = 1024 * 1024;
 
 export interface RegistryEvent {
   id: string;
@@ -119,76 +121,87 @@ async function appendEvents(events: RegistryEvent[]): Promise<void> {
 export const Route = createApiFileRoute("/api/public/github/webhook")({
   server: {
     handlers: {
-      POST: async ({ request }) => {
-        const secret = getEnvString("GITHUB_WEBHOOK_SECRET");
-        if (!secret) return new Response("Webhook not configured", { status: 503 });
-
-        const body = await request.text();
-        const sig = request.headers.get("x-hub-signature-256");
-        if (!(await verify(secret, sig, body))) {
-          return new Response("Invalid signature", { status: 401 });
-        }
-
-        const event = request.headers.get("x-github-event") ?? "";
-        if (event === "ping") return new Response("pong");
-
-        let payload: Record<string, unknown>;
-        try {
-          payload = JSON.parse(body);
-        } catch {
-          return new Response("Invalid JSON", { status: 400 });
-        }
-
-        const repo = (payload.repository as { full_name?: string } | undefined)?.full_name;
-        if (repo && repo !== ALLOWED_REPO) {
-          return new Response("Unknown repo", { status: 403 });
-        }
-
-        const events: RegistryEvent[] = [];
-
-        if (event === "push") {
-          const ref = String(payload.ref ?? "");
-          if (ref !== `refs/heads/${ALLOWED_BRANCH}`) {
-            return new Response("Ignored branch", { status: 200 });
-          }
-          const commits = (payload.commits ?? []) as PushFile[];
-          for (const c of commits) {
-            const commit = c.id ?? "unknown";
-            const date = c.timestamp ?? new Date().toISOString();
-            for (const p of c.added ?? []) {
-              const ev = classify(p, "added", commit, date);
-              if (ev) events.push(ev);
-            }
-            for (const p of c.modified ?? []) {
-              const ev = classify(p, "updated", commit, date);
-              if (ev) events.push(ev);
-            }
-            for (const p of c.removed ?? []) {
-              const ev = classify(p, "removed", commit, date);
-              if (ev) events.push(ev);
-            }
-          }
-        } else if (event === "release") {
-          const rel = payload.release as
-            | { tag_name?: string; published_at?: string; html_url?: string }
-            | undefined;
-          events.push({
-            id: `release:${rel?.tag_name ?? Date.now()}`,
-            kind: "changelog",
-            action: "added",
-            commit: rel?.tag_name ?? "release",
-            date: rel?.published_at ?? new Date().toISOString(),
-            title: rel?.tag_name,
-          });
-        } else {
-          return new Response("Ignored event", { status: 200 });
-        }
-
-        if (events.length) await appendEvents(events);
-        return new Response(JSON.stringify({ ok: true, count: events.length }), {
-          headers: { "Content-Type": "application/json" },
-        });
-      },
+      POST: async ({ request }) => handleGithubWebhookPost(request),
     },
   },
 });
+
+export async function handleGithubWebhookPost(request: Request) {
+  const secret = getEnvString("GITHUB_WEBHOOK_SECRET");
+  if (!secret) return new Response("Webhook not configured", { status: 503 });
+
+  let body: string;
+  try {
+    body = await readRequestTextWithinLimit(request, GITHUB_WEBHOOK_BODY_LIMIT_BYTES);
+  } catch (error) {
+    if (error instanceof BodyTooLargeError) {
+      return new Response("Payload too large", { status: 413 });
+    }
+    throw error;
+  }
+
+  const sig = request.headers.get("x-hub-signature-256");
+  if (!(await verify(secret, sig, body))) {
+    return new Response("Invalid signature", { status: 401 });
+  }
+
+  const event = request.headers.get("x-github-event") ?? "";
+  if (event === "ping") return new Response("pong");
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return new Response("Invalid JSON", { status: 400 });
+  }
+
+  const repo = (payload.repository as { full_name?: string } | undefined)?.full_name;
+  if (repo && repo !== ALLOWED_REPO) {
+    return new Response("Unknown repo", { status: 403 });
+  }
+
+  const events: RegistryEvent[] = [];
+
+  if (event === "push") {
+    const ref = String(payload.ref ?? "");
+    if (ref !== `refs/heads/${ALLOWED_BRANCH}`) {
+      return new Response("Ignored branch", { status: 200 });
+    }
+    const commits = (payload.commits ?? []) as PushFile[];
+    for (const c of commits) {
+      const commit = c.id ?? "unknown";
+      const date = c.timestamp ?? new Date().toISOString();
+      for (const p of c.added ?? []) {
+        const ev = classify(p, "added", commit, date);
+        if (ev) events.push(ev);
+      }
+      for (const p of c.modified ?? []) {
+        const ev = classify(p, "updated", commit, date);
+        if (ev) events.push(ev);
+      }
+      for (const p of c.removed ?? []) {
+        const ev = classify(p, "removed", commit, date);
+        if (ev) events.push(ev);
+      }
+    }
+  } else if (event === "release") {
+    const rel = payload.release as
+      | { tag_name?: string; published_at?: string; html_url?: string }
+      | undefined;
+    events.push({
+      id: `release:${rel?.tag_name ?? Date.now()}`,
+      kind: "changelog",
+      action: "added",
+      commit: rel?.tag_name ?? "release",
+      date: rel?.published_at ?? new Date().toISOString(),
+      title: rel?.tag_name,
+    });
+  } else {
+    return new Response("Ignored event", { status: 200 });
+  }
+
+  if (events.length) await appendEvents(events);
+  return new Response(JSON.stringify({ ok: true, count: events.length }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/tests/github-webhook-route.test.ts
+++ b/tests/github-webhook-route.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  GITHUB_WEBHOOK_BODY_LIMIT_BYTES,
+  handleGithubWebhookPost,
+} from "../apps/web/src/routes/api/public/github/webhook";
+
+const SECRET = "test-webhook-secret";
+const WEBHOOK_URL = "https://heyclau.de/api/public/github/webhook";
+
+const globalWithEnv = globalThis as typeof globalThis & { __env__?: unknown };
+
+function toHex(buffer: ArrayBuffer) {
+  return [...new Uint8Array(buffer)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function signatureFor(body: string) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body),
+  );
+  return `sha256=${toHex(digest)}`;
+}
+
+async function signedWebhookRequest(
+  event: string,
+  body: string,
+  headers: HeadersInit = {},
+) {
+  return new Request(WEBHOOK_URL, {
+    method: "POST",
+    headers: {
+      "x-github-event": event,
+      "x-hub-signature-256": await signatureFor(body),
+      ...headers,
+    },
+    body,
+  });
+}
+
+describe("public GitHub webhook route", () => {
+  beforeEach(() => {
+    globalWithEnv.__env__ = { GITHUB_WEBHOOK_SECRET: SECRET };
+  });
+
+  afterEach(() => {
+    delete globalWithEnv.__env__;
+  });
+
+  it("handles signed ping events", async () => {
+    const body = JSON.stringify({ zen: "keep payloads bounded" });
+
+    const response = await handleGithubWebhookPost(
+      await signedWebhookRequest("ping", body),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("pong");
+  });
+
+  it("rejects invalid signatures for bounded payloads", async () => {
+    const response = await handleGithubWebhookPost(
+      new Request(WEBHOOK_URL, {
+        method: "POST",
+        headers: {
+          "x-github-event": "ping",
+          "x-hub-signature-256": "sha256=not-the-signature",
+        },
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe("Invalid signature");
+  });
+
+  it("rejects oversized declared bodies before signature verification", async () => {
+    const response = await handleGithubWebhookPost(
+      new Request(WEBHOOK_URL, {
+        method: "POST",
+        headers: {
+          "content-length": String(GITHUB_WEBHOOK_BODY_LIMIT_BYTES + 1),
+          "x-github-event": "push",
+        },
+        body: "{}",
+      }),
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.text()).resolves.toBe("Payload too large");
+  });
+
+  it("rejects oversized streamed bodies without a content-length header", async () => {
+    const response = await handleGithubWebhookPost(
+      new Request(WEBHOOK_URL, {
+        method: "POST",
+        headers: { "x-github-event": "push" },
+        body: "x".repeat(GITHUB_WEBHOOK_BODY_LIMIT_BYTES + 1),
+      }),
+    );
+
+    expect(response.status).toBe(413);
+    await expect(response.text()).resolves.toBe("Payload too large");
+  });
+
+  it("accepts signed push events within the body limit", async () => {
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      commits: [
+        {
+          id: "abc123",
+          timestamp: "2026-06-18T23:00:00.000Z",
+          added: ["content/mcp/example.mdx"],
+        },
+      ],
+    });
+
+    const response = await handleGithubWebhookPost(
+      await signedWebhookRequest("push", body),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, count: 1 });
+  });
+});


### PR DESCRIPTION
## Summary
- Add a hard request-body limit to `/api/public/github/webhook` before signature verification and JSON parsing.
- Add route-level regression tests for declared and streamed oversized webhook bodies.

## What changed
- Reused the existing `readRequestTextWithinLimit` helper for the public webhook route.
- Return `413 Payload too large` when `content-length` exceeds the cap or a streamed body crosses the cap.
- Exported the route handler for direct tests without changing the public endpoint.
- Covered signed ping, invalid signature, oversized declared body, oversized streamed body, and signed push behavior.

## Why
The webhook handler previously called `request.text()` directly, so unauthenticated requests could force the Worker to read an unbounded body before any signature or JSON validation happened.

## Validation
- `pnpm exec vitest run tests/github-webhook-route.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm build` still reports the existing large client chunk warning; this PR does not change bundle-loading behavior.