### PR TITLE
fix(search): match browse queries by tokens

### DIFF
--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -19,31 +19,140 @@ export interface SearchFilters {
   sort?: "popular" | "newest" | "title";
 }
 
-export function search(filters: SearchFilters = {}): Entry[] {
-  const q = filters.q?.trim().toLowerCase() ?? "";
-  let rows = ENTRIES.filter((e) => {
-    if (filters.categories?.length && !filters.categories.includes(e.category)) return false;
-    if (filters.platforms?.length && !e.platforms.some((p) => filters.platforms!.includes(p)))
-      return false;
-    if (filters.trust?.length && !filters.trust.includes(e.trust)) return false;
-    if (filters.source?.length && !filters.source.includes(e.source)) return false;
-    if (filters.installable && !e.installCommand && !e.configSnippet && !e.fullCopy) return false;
-    if (filters.hasSafetyNotes && !e.safetyNotes) return false;
-    if (q) {
-      const hay = [
-        e.title,
-        e.description,
-        e.author,
-        e.category,
-        ...(e.tags ?? []),
-        ...(e.keywords ?? []),
-      ]
-        .join(" ")
-        .toLowerCase();
-      if (!hay.includes(q)) return false;
-    }
+const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+
+const QUERY_ALIASES: Record<string, string[]> = {
+  browser: ["chrome", "playwright", "web"],
+  cc: ["claude", "claude-code"],
+  claude: ["claude-code"],
+  gh: ["github"],
+  mcp: ["model-context-protocol"],
+  repo: ["repository", "github"],
+  repos: ["repository", "github"],
+  safe: ["safety", "security", "secure", "trust", "privacy"],
+  security: ["safe", "safety", "secure", "trust"],
+  skill: ["skills"],
+  skills: ["skill"],
+  statusline: ["statuslines", "status"],
+  statuslines: ["statusline", "status"],
+};
+
+interface EntrySearchProfile {
+  haystack: string;
+  words: string[];
+}
+
+const ENTRY_SEARCH_PROFILES = new WeakMap<Entry, EntrySearchProfile>();
+
+function tokenizeSearchQuery(query: string) {
+  return query
+    .split(TOKEN_SPLIT_PATTERN)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length >= 2)
+    .slice(0, 12);
+}
+
+function expandedTokenCandidates(token: string) {
+  return [token, ...(QUERY_ALIASES[token] ?? [])];
+}
+
+function normalizedSearchText(entry: Entry) {
+  return [
+    entry.category,
+    entry.slug,
+    entry.title,
+    entry.description,
+    entry.cardDescription,
+    entry.author,
+    entry.trust,
+    entry.source,
+    ...(entry.platforms ?? []),
+    ...(entry.tags ?? []),
+    ...(entry.keywords ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function entrySearchProfile(entry: Entry) {
+  let profile = ENTRY_SEARCH_PROFILES.get(entry);
+  if (!profile) {
+    const haystack = normalizedSearchText(entry);
+    const words = [
+      ...new Set(
+        haystack
+          .split(TOKEN_SPLIT_PATTERN)
+          .map((word) => word.trim().toLowerCase())
+          .filter(Boolean),
+      ),
+    ];
+    profile = {
+      haystack,
+      words,
+    };
+    ENTRY_SEARCH_PROFILES.set(entry, profile);
+  }
+  return profile;
+}
+
+function candidateMatchesText(candidate: string, profile: EntrySearchProfile) {
+  if (candidate.length <= 2) {
+    return profile.words.some((word) => word === candidate || word.startsWith(candidate));
+  }
+  return (
+    profile.haystack.includes(candidate) || profile.words.some((word) => word.startsWith(candidate))
+  );
+}
+
+export function matchesEntryQuery(entry: Entry, query: string) {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (!tokens.length) return false;
+
+  const profile = entrySearchProfile(entry);
+  if (
+    normalizedQuery.length > 2
+      ? profile.haystack.includes(normalizedQuery)
+      : candidateMatchesText(normalizedQuery, profile)
+  ) {
     return true;
-  });
+  }
+
+  return tokens.every((token) =>
+    expandedTokenCandidates(token).some((candidate) => candidateMatchesText(candidate, profile)),
+  );
+}
+
+export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) {
+  if (filters.categories?.length && !filters.categories.includes(entry.category)) return false;
+  if (filters.platforms?.length && !entry.platforms.some((p) => filters.platforms!.includes(p)))
+    return false;
+  if (filters.trust?.length && !filters.trust.includes(entry.trust)) return false;
+  if (filters.source?.length && !filters.source.includes(entry.source)) return false;
+  if (filters.installable && !entry.installCommand && !entry.configSnippet && !entry.fullCopy)
+    return false;
+  if (filters.hasSafetyNotes && !entry.safetyNotes) return false;
+  if (filters.q && !matchesEntryQuery(entry, filters.q)) return false;
+  return true;
+}
+
+export function filterSearchEntries(filters: SearchFilters = {}, entries: Entry[] = ENTRIES) {
+  return entries.filter((entry) => matchesSearchFilters(entry, filters));
+}
+
+export function countSearchResults(filters: SearchFilters = {}, entries: Entry[] = ENTRIES) {
+  let count = 0;
+  for (const entry of entries) {
+    if (matchesSearchFilters(entry, filters)) count += 1;
+  }
+  return count;
+}
+
+export function search(filters: SearchFilters = {}): Entry[] {
+  let rows = filterSearchEntries(filters);
 
   const sort = filters.sort ?? "popular";
   rows = [...rows].sort((a, b) => {

--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -8,10 +8,17 @@
  * helper `respondFeed` handles `If-None-Match` and emits cache headers.
  */
 import { ENTRIES } from "@/data/entries";
+import { filterSearchEntries } from "@/data/search";
 import { CHANGELOG, RELEASE_NOTES } from "@/data/changelog";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { ifNoneMatchMatches } from "@/lib/http-cache";
-import { CATEGORIES, type Category } from "@/types/registry";
+import {
+  CATEGORIES,
+  type Category,
+  type Platform,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
 
 export const SITE_NAME = "HeyClaude";
 export const SITE_TAGLINE =
@@ -238,26 +245,16 @@ export interface SavedSearchQuery {
 }
 
 export function applySavedSearch(q: SavedSearchQuery): FeedItem[] {
-  const needle = (q.q ?? "").trim().toLowerCase();
-  return ENTRIES.filter((e) => {
-    if (q.category && e.category !== q.category) return false;
-    if (q.trust && e.trust !== q.trust) return false;
-    if (q.source && e.source !== q.source) return false;
-    if (q.platform && !(e.platforms ?? []).some((p) => p === q.platform)) return false;
-    if (needle) {
-      const hay = [
-        e.title,
-        e.description,
-        e.cardDescription ?? "",
-        (e.tags ?? []).join(" "),
-        e.author ?? "",
-      ]
-        .join(" ")
-        .toLowerCase();
-      if (!hay.includes(needle)) return false;
-    }
-    return true;
-  })
+  return filterSearchEntries(
+    {
+      q: q.q,
+      categories: q.category ? [q.category as Category] : undefined,
+      trust: q.trust ? [q.trust as TrustLevel] : undefined,
+      source: q.source ? [q.source as SourceStatus] : undefined,
+      platforms: q.platform ? [q.platform as Platform] : undefined,
+    },
+    ENTRIES,
+  )
     .sort((a, b) => (a.dateAdded < b.dateAdded ? 1 : -1))
     .slice(0, 50)
     .map((e) => ({

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -11,7 +11,7 @@ import { useMemo } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
-import { search } from "@/data/search";
+import { countSearchResults, search } from "@/data/search";
 import {
   CATEGORIES,
   type Category,
@@ -32,7 +32,7 @@ import {
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
 import { useRecents, type SavedSearch } from "@/lib/recents";
-import { ENTRIES } from "@/data/entries";
+import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
 import { FilterSummaryBar, type ActiveFilter } from "@/components/filter-summary-bar";
 import { useKeyboardShortcuts } from "@/hooks/use-keyboard-shortcuts";
@@ -324,19 +324,19 @@ function Browse() {
   }, [sp.q, sp.category, sp.trust, sp.source, sp.platform, sp.sort]);
 
   // Per-axis facet counts: how many results if this value were the only filter
-  // in its axis. Memoized on the search params so the ~23 search() passes run
-  // once per filter change instead of on every render (compare toggle, hover…).
+  // in its axis. Memoized on the search params and counted without sorting so
+  // sidebar counts do not pay for result ranking on every filter change.
   const facetCounts = useMemo(() => {
     const countFor = (axis: "category" | "trust" | "source" | "platform", value: string) => {
       const merged = { ...sp, [axis]: value } as typeof sp;
-      return search({
+      return countSearchResults({
         q: merged.q,
         categories: merged.category ? [merged.category as Category] : undefined,
         trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
         source: merged.source ? [merged.source as SourceStatus] : undefined,
         platforms: merged.platform ? [merged.platform as Platform] : undefined,
         sort: merged.sort,
-      }).length;
+      });
     };
     return {
       category: Object.fromEntries(CATEGORIES.map((c) => [c.id, countFor("category", c.id)])),
@@ -359,7 +359,7 @@ function Browse() {
   });
 
   const recentEntries = recents.entries
-    .map((r) => ENTRIES.find((e) => e.category === r.category && e.slug === r.slug))
+    .map((r) => entryByRef(r.category, r.slug))
     .filter((e): e is NonNullable<typeof e> => !!e)
     .slice(0, 6);
 
@@ -409,14 +409,14 @@ function Browse() {
     return trials
       .map((t) => {
         const merged = { ...sp, ...t.patch };
-        const count = search({
+        const count = countSearchResults({
           q: merged.q,
           categories: merged.category ? [merged.category as Category] : undefined,
           trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
           source: merged.source ? [merged.source as SourceStatus] : undefined,
           platforms: merged.platform ? [merged.platform as Platform] : undefined,
           sort: merged.sort,
-        }).length;
+        });
         return { label: t.label, count, apply: () => set(t.patch) };
       })
       .filter((s) => s.count > 0)
@@ -835,7 +835,12 @@ function Browse() {
               ) : sp.view === "compact" ? (
                 <div className="mt-2 overflow-hidden rounded-lg border border-border bg-surface">
                   {results.slice(0, shown).map((e, i) => (
-                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="compact" rank={i + 1} />
+                    <ResourceCard
+                      key={`${e.category}/${e.slug}`}
+                      entry={e}
+                      variant="compact"
+                      rank={i + 1}
+                    />
                   ))}
                 </div>
               ) : (

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countSearchResults,
+  filterSearchEntries,
+  matchesEntryQuery,
+} from "../apps/web/src/data/search";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function entry(overrides: Partial<Entry>): Entry {
+  return {
+    category: "mcp",
+    slug: "example",
+    title: "Example",
+    description: "Example description",
+    author: "Example",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "unverified",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  };
+}
+
+describe("entry query matching", () => {
+  it("matches multi-token queries regardless of term order", () => {
+    const browserEntry = entry({
+      title: "Browser Bridge",
+      description: "Runs Playwright automation for Claude Code sessions.",
+      tags: ["browser-automation"],
+      keywords: ["model-context-protocol"],
+    });
+
+    expect(matchesEntryQuery(browserEntry, "browser playwright")).toBe(true);
+    expect(matchesEntryQuery(browserEntry, "playwright browser")).toBe(true);
+    expect(matchesEntryQuery(browserEntry, "model protocol")).toBe(true);
+    expect(matchesEntryQuery(browserEntry, "spreadsheet export")).toBe(false);
+  });
+
+  it("expands common query aliases", () => {
+    const githubEntry = entry({
+      title: "Repository Review",
+      description: "Reviews pull requests for Claude Code.",
+      tags: ["github", "code-review"],
+      keywords: ["repository review"],
+    });
+
+    expect(matchesEntryQuery(githubEntry, "gh review")).toBe(true);
+    expect(matchesEntryQuery(githubEntry, "cc review")).toBe(true);
+  });
+});
+
+describe("entry search filters", () => {
+  it("shares query matching across filtering and count-only paths", () => {
+    const browserEntry = entry({
+      category: "mcp",
+      slug: "browser",
+      title: "Browser Bridge",
+      description: "Playwright browser automation.",
+      tags: ["browser-automation"],
+      source: "source-backed",
+    });
+    const safetySkill = entry({
+      category: "skills",
+      slug: "safety-review",
+      title: "Safety Review",
+      description: "Privacy guardrails for safe agent workflows.",
+      tags: ["security", "privacy"],
+      trust: "trusted",
+      source: "first-party",
+    });
+    const unrelated = entry({
+      category: "commands",
+      slug: "notes",
+      title: "Notes Export",
+      description: "Exports notes to markdown.",
+      tags: ["notes"],
+    });
+    const entries = [browserEntry, safetySkill, unrelated];
+
+    const filters = {
+      q: "privacy safe",
+      categories: ["skills" as const],
+      trust: ["trusted" as const],
+    };
+
+    expect(filterSearchEntries(filters, entries)).toEqual([safetySkill]);
+    expect(countSearchResults(filters, entries)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Make browse and saved-search queries match tokenized terms instead of only contiguous substrings.
- Avoid sorting result sets when browse only needs facet and suggestion counts.

## What changed
- Added cached normalized search profiles for registry entries.
- Added tokenized query matching with common aliases such as `gh`, `cc`, and singular/plural category terms.
- Reused the same filter path for browse results, browse count-only checks, and saved-search feed materialization.
- Switched browse recent-entry lookups to the existing category/slug map instead of scanning entries.
- Added regression tests for out-of-order query terms, aliases, filter consistency, and count-only results.

## Why
The browser search path rebuilt lowercase haystacks on every pass and only matched exact contiguous phrases. That made valid searches like reversed multi-term queries miss results, and browse facets paid the cost of sorting even when they only needed counts.

## Validation
- `pnpm exec vitest run tests/search-query.test.ts tests/feeds.test.ts tests/web-non-ui-utilities.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm build` still reports the existing large client chunk warning; this PR improves search matching/count work but does not split the initial bundle.