### PR TITLE
fix(api): harden registry facet bucket counting

### DIFF
--- a/apps/web/src/lib/api/registry-search-facets.ts
+++ b/apps/web/src/lib/api/registry-search-facets.ts
@@ -30,7 +30,8 @@ const MAX_CATEGORY_BUCKETS = 32;
 
 function increment(buckets: RegistrySearchFacetBuckets, key: string) {
   if (!key) return;
-  buckets[key] = (buckets[key] ?? 0) + 1;
+  const count = Object.hasOwn(buckets, key) ? buckets[key] : 0;
+  buckets[key] = count + 1;
 }
 
 function sortBuckets(
@@ -52,7 +53,7 @@ function tally(
   bucketFor: (entry: SearchDocument) => string | ReadonlyArray<string>,
 ): RegistrySearchFacetBuckets {
   const except = new Set<RegistrySearchFilterDimension>([dimension]);
-  const buckets: RegistrySearchFacetBuckets = {};
+  const buckets = Object.create(null) as RegistrySearchFacetBuckets;
   for (const entry of entries) {
     if (!entryMatchesFilters(entry, filters, except)) continue;
     const bucket = bucketFor(entry);

--- a/tests/registry-search-facets.test.ts
+++ b/tests/registry-search-facets.test.ts
@@ -223,6 +223,27 @@ describe("computeRegistrySearchFacets", () => {
     });
   });
 
+  it("counts platform buckets that match inherited object property names", () => {
+    const entries = [
+      makeEntry({
+        slug: "constructor-platform",
+        platforms: ["constructor", "__proto__", "constructor"],
+      }),
+      makeEntry({
+        slug: "mixed-platform",
+        platforms: ["constructor", "claude-code"],
+      }),
+    ];
+
+    expect(
+      computeRegistrySearchFacets(entries, defaultFilters).platforms,
+    ).toEqual({
+      constructor: 2,
+      ["__proto__"]: 1,
+      "claude-code": 1,
+    });
+  });
+
   it("uses compact trust-signal booleans when full note text is omitted", () => {
     const compact = makeEntry({
       slug: "compact-notes",


### PR DESCRIPTION
### Motivation
- The facet tally used a plain object and `buckets[key] = (buckets[key] ?? 0) + 1`, which reads inherited properties for names like `constructor`/`toString` and silently ignores `__proto__`, corrupting numeric counts and violating the documented `z.number()` contract.
- Platform and other bucket keys are derived from content and must be treated as arbitrary strings so malformed or malicious entries cannot break the API response shape.

### Description
- Use a null-prototype accumulator by creating buckets with `Object.create(null)` so inherited Object properties cannot interfere with bucket keys in `apps/web/src/lib/api/registry-search-facets.ts`.
- Use an own-property check (`Object.hasOwn(buckets, key) ? buckets[key] : 0`) in the `increment` helper to avoid reading inherited values before incrementing.
- Add a regression test that exercises platform keys such as `constructor` and `__proto__` in `tests/registry-search-facets.test.ts` to ensure counts are numeric and `__proto__` is counted as a normal bucket.

### Testing
- Ran `pnpm exec vitest run tests/registry-search-facets.test.ts` and the updated facet tests passed (all tests in that file succeeded).
- Ran `pnpm exec vitest run tests/api-contracts.test.ts tests/registry-search-facets.test.ts` and the suite passed (all tests succeeded).
- Ran `pnpm validate:openapi` and it completed successfully to ensure OpenAPI artifacts remain valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3482a08108832ca4083158a251b22f)