### PR TITLE
fix(analytics): redact sensitive proxy query params

### DIFF
--- a/apps/web/src/lib/analytics-proxy.ts
+++ b/apps/web/src/lib/analytics-proxy.ts
@@ -1,0 +1,76 @@
+const REDACTED_QUERY_VALUE = "[redacted]";
+
+const GENERIC_SENSITIVE_SEARCH_PARAMS = new Set([
+  "access_token",
+  "auth",
+  "code",
+  "email",
+  "key",
+  "secret",
+  "signature",
+  "state",
+  "token",
+]);
+
+const SENSITIVE_SEARCH_PARAMS_BY_PATH: Record<string, readonly string[]> = {
+  "/brief/approve": ["token"],
+};
+
+function sensitiveSearchParamsForPath(pathname: string) {
+  return new Set([
+    ...GENERIC_SENSITIVE_SEARCH_PARAMS,
+    ...(SENSITIVE_SEARCH_PARAMS_BY_PATH[pathname] ?? []),
+  ]);
+}
+
+export function joinAnalyticsUpstreamUrl(upstream: string, path: string) {
+  const base = upstream.replace(/\/+$/, "");
+  const suffix = path.startsWith("/") ? path : `/${path}`;
+  return `${base}${suffix}`;
+}
+
+export function scrubSensitiveUrlSearch(rawUrl: unknown): unknown {
+  if (typeof rawUrl !== "string") return rawUrl;
+
+  let url: URL;
+  try {
+    url = new URL(rawUrl, "https://heyclau.de");
+  } catch {
+    return rawUrl;
+  }
+
+  const sensitiveParams = sensitiveSearchParamsForPath(url.pathname);
+  let changed = false;
+  for (const param of [...url.searchParams.keys()]) {
+    if (sensitiveParams.has(param.toLowerCase())) {
+      url.searchParams.set(param, REDACTED_QUERY_VALUE);
+      changed = true;
+    }
+  }
+  if (!changed) return rawUrl;
+
+  return rawUrl.startsWith("http://") || rawUrl.startsWith("https://")
+    ? url.toString()
+    : `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function scrubSensitiveAnalyticsBody(body: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return body;
+  const event = parsed as { payload?: { url?: unknown } };
+  if (!event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) {
+    return body;
+  }
+
+  const scrubbedUrl = scrubSensitiveUrlSearch(event.payload.url);
+  if (scrubbedUrl === event.payload.url) return body;
+
+  event.payload.url = scrubbedUrl;
+  return JSON.stringify(event);
+}

--- a/apps/web/src/routes/u.api.send.ts
+++ b/apps/web/src/routes/u.api.send.ts
@@ -9,6 +9,7 @@ import {
   readRequestTextWithinLimit,
 } from "@/lib/api-security";
 import { logApiWarn } from "@/lib/api-logs";
+import { joinAnalyticsUpstreamUrl, scrubSensitiveAnalyticsBody } from "@/lib/analytics-proxy";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
 const BODY_LIMIT_BYTES = 16 * 1024;
@@ -17,58 +18,6 @@ const RATE_LIMIT = {
   limit: 60,
   windowMs: 60_000,
 } as const;
-
-const SENSITIVE_SEARCH_PARAMS_BY_PATH: Record<string, readonly string[]> = {
-  "/brief/approve": ["token"],
-};
-
-function scrubSensitiveUrlSearch(rawUrl: unknown): unknown {
-  if (typeof rawUrl !== "string") return rawUrl;
-
-  let url: URL;
-  try {
-    url = new URL(rawUrl, "https://heyclau.de");
-  } catch {
-    return rawUrl;
-  }
-
-  const sensitiveParams = SENSITIVE_SEARCH_PARAMS_BY_PATH[url.pathname];
-  if (!sensitiveParams) return rawUrl;
-
-  let changed = false;
-  for (const param of sensitiveParams) {
-    if (url.searchParams.has(param)) {
-      url.searchParams.set(param, "[redacted]");
-      changed = true;
-    }
-  }
-  if (!changed) return rawUrl;
-
-  return rawUrl.startsWith("http://") || rawUrl.startsWith("https://")
-    ? url.toString()
-    : `${url.pathname}${url.search}${url.hash}`;
-}
-
-function scrubSensitiveAnalyticsBody(body: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(body);
-  } catch {
-    return body;
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return body;
-  const event = parsed as { payload?: { url?: unknown } };
-  if (!event.payload || typeof event.payload !== "object" || Array.isArray(event.payload)) {
-    return body;
-  }
-
-  const scrubbedUrl = scrubSensitiveUrlSearch(event.payload.url);
-  if (scrubbedUrl === event.payload.url) return body;
-
-  event.payload.url = scrubbedUrl;
-  return JSON.stringify(event);
-}
 
 function getRequestId(request: Request) {
   return (
@@ -127,7 +76,7 @@ export async function POST(request: Request): Promise<Response> {
 
   let response: Response;
   try {
-    response = await fetch(`${upstream}/api/send`, {
+    response = await fetch(joinAnalyticsUpstreamUrl(upstream, "/api/send"), {
       method: "POST",
       headers,
       body: scrubSensitiveAnalyticsBody(body),

--- a/apps/web/src/routes/u.script[.]js.ts
+++ b/apps/web/src/routes/u.script[.]js.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { joinAnalyticsUpstreamUrl } from "@/lib/analytics-proxy";
 import { getEnvString } from "@/lib/cloudflare-env.server";
 
 /**
@@ -13,30 +14,32 @@ import { getEnvString } from "@/lib/cloudflare-env.server";
  * script directory (`/u/api/send`, see u.api.send.ts) — keeping both out of the
  * product `/api/` namespace and its central-router contract.
  */
+export async function GET(): Promise<Response> {
+  const upstream = getEnvString("UMAMI_UPSTREAM_URL");
+  if (!upstream) return new Response("", { status: 404 });
+  try {
+    const response = await fetch(joinAnalyticsUpstreamUrl(upstream, "/script.js"), {
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!response.ok) return new Response("", { status: 502 });
+    const body = await response.text();
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "content-type": "application/javascript; charset=utf-8",
+        // Tracker changes rarely; cache at the edge + browser for a day.
+        "cache-control": "public, max-age=86400, s-maxage=86400",
+      },
+    });
+  } catch {
+    return new Response("", { status: 502 });
+  }
+}
+
 export const Route = createFileRoute("/u/script.js")({
   server: {
     handlers: {
-      GET: async () => {
-        const upstream = getEnvString("UMAMI_UPSTREAM_URL");
-        if (!upstream) return new Response("", { status: 404 });
-        try {
-          const response = await fetch(`${upstream}/script.js`, {
-            signal: AbortSignal.timeout(8000),
-          });
-          if (!response.ok) return new Response("", { status: 502 });
-          const body = await response.text();
-          return new Response(body, {
-            status: 200,
-            headers: {
-              "content-type": "application/javascript; charset=utf-8",
-              // Tracker changes rarely; cache at the edge + browser for a day.
-              "cache-control": "public, max-age=86400, s-maxage=86400",
-            },
-          });
-        } catch {
-          return new Response("", { status: 502 });
-        }
-      },
+      GET: async () => GET(),
     },
   },
 });

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -983,6 +983,68 @@ describe("umami collector proxy security", () => {
     expect(String(init.body)).not.toContain("signed-secret");
   });
 
+  it("redacts common sensitive analytics URL params on every path", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(
+      analyticsRequest(
+        JSON.stringify({
+          type: "event",
+          payload: {
+            website: "site-id",
+            url: "/entry/mcp/example?token=signed-secret&email=reader@example.com&code=oauth-code&state=nonce&view=full",
+          },
+        }),
+      ),
+    );
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const forwarded = String(init.body);
+    expect(forwarded).toContain("token=%5Bredacted%5D");
+    expect(forwarded).toContain("email=%5Bredacted%5D");
+    expect(forwarded).toContain("code=%5Bredacted%5D");
+    expect(forwarded).toContain("state=%5Bredacted%5D");
+    expect(forwarded).toContain("view=full");
+    expect(forwarded).not.toContain("signed-secret");
+    expect(forwarded).not.toContain("reader@example.com");
+    expect(forwarded).not.toContain("oauth-code");
+    expect(forwarded).not.toContain("nonce");
+  });
+
+  it("normalizes trailing slashes when forwarding collector events", async () => {
+    process.env.UMAMI_UPSTREAM_URL = "https://umami.example/";
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(analyticsRequest('{"payload":{}}'));
+
+    expect(response.status).toBe(202);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://umami.example/api/send");
+  });
+
+  it("normalizes trailing slashes when fetching the tracker script", async () => {
+    process.env.UMAMI_UPSTREAM_URL = "https://umami.example/";
+    const fetchMock = vi.fn(
+      async () => new Response("console.log('ok')", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const { GET } = await import("../apps/web/src/routes/u.script[.]js");
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://umami.example/script.js",
+    );
+  });
+
   it("rate-limits repeated analytics posts per client", async () => {
     const fetchMock = vi.fn(async () => new Response("ok", { status: 202 }));
     vi.stubGlobal("fetch", fetchMock);


### PR DESCRIPTION
## Summary
- Harden the first-party analytics proxy against sensitive query leakage.
- Normalize analytics upstream URL joins so trailing slashes do not produce double-slashed proxy requests.

## What changed
- Moved analytics proxy URL joining and query redaction into a shared helper.
- Redact common sensitive params such as `token`, `email`, `code`, `state`, and related credential-shaped keys on any tracked URL path.
- Reused the normalized upstream join for both event forwarding and tracker script fetching.
- Exported the tracker script handler for direct route tests.
- Added regressions for generic redaction and trailing-slash upstreams.

## Why
The collector previously only redacted one path-specific token parameter, leaving other credential or personal query params visible in forwarded analytics payloads. It also built upstream URLs with string concatenation, so trailing-slash configuration produced malformed double-slash paths.

## Validation
- `pnpm exec vitest run tests/api-router-security.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- `pnpm build` still reports the existing large client chunk warning; this PR only changes analytics proxy behavior.