### PR TITLE
fix(ci): fail closed for script validation lanes

### DIFF
--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -176,10 +176,7 @@ const generatedArtifactInfra = touches(
 const submissionAutomationInfra = touches(
   /^scripts\/(analyze-submission-risk|import-submission-issue|validate-submission-issue)\.mjs$/,
 );
-const scriptOrTestInfra = touches(
-  /^scripts\//,
-  /^tests\/.*\.test\.ts$/,
-);
+const scriptOrTestInfra = touches(/^scripts\//, /^tests\/.*\.test\.ts$/);
 const submissionGateInfra = touches(
   /^apps\/submission-gate\//,
   /^tests\/submission-gate-.*\.test\.ts$/,

--- a/scripts/ci/classify-pr-changes.mjs
+++ b/scripts/ci/classify-pr-changes.mjs
@@ -174,7 +174,11 @@ const generatedArtifactInfra = touches(
   "README.md",
 );
 const submissionAutomationInfra = touches(
-  /^scripts\/analyze-submission-risk\.mjs$/,
+  /^scripts\/(analyze-submission-risk|import-submission-issue|validate-submission-issue)\.mjs$/,
+);
+const scriptOrTestInfra = touches(
+  /^scripts\//,
+  /^tests\/.*\.test\.ts$/,
 );
 const submissionGateInfra = touches(
   /^apps\/submission-gate\//,
@@ -238,6 +242,7 @@ const flags = {
     touches("package.json", "pnpm-lock.yaml", "pnpm-workspace.yaml"),
   ci:
     submissionAutomationInfra ||
+    scriptOrTestInfra ||
     touches(
       /^\.github\/workflows\//,
       /^scripts\/ci\//,

--- a/tests/classify-pr-changes.test.ts
+++ b/tests/classify-pr-changes.test.ts
@@ -271,6 +271,40 @@ describe("PR change classifier", () => {
     });
   });
 
+  it("fails closed by routing otherwise unclassified scripts through CI validation", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+    const scriptDir = path.join(cwd, "scripts");
+    fs.mkdirSync(scriptDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(scriptDir, "report-thin-content.mjs"),
+      "console.log('changed');\n",
+    );
+    git(cwd, ["add", "scripts/report-thin-content.mjs"]);
+    git(cwd, ["commit", "-m", "update unclassified script"]);
+
+    const outputs = runClassifier(cwd, baseSha);
+    expect(outputs).toMatchObject({
+      ci: "true",
+    });
+  });
+
+  it("fails closed by routing otherwise unclassified regression tests through CI validation", () => {
+    const { cwd, baseSha } = createFixtureRepo();
+    const testsDir = path.join(cwd, "tests");
+    fs.mkdirSync(testsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(testsDir, "codeql-regressions.test.ts"),
+      "import { expect, it } from 'vitest';\nit('changed', () => expect(true).toBe(true));\n",
+    );
+    git(cwd, ["add", "tests/codeql-regressions.test.ts"]);
+    git(cwd, ["commit", "-m", "update unclassified test"]);
+
+    const outputs = runClassifier(cwd, baseSha);
+    expect(outputs).toMatchObject({
+      ci: "true",
+    });
+  });
+
   it("routes private submission gate changes through the gate lane", () => {
     const { cwd, baseSha } = createFixtureRepo();
     const gateDir = path.join(cwd, "apps", "submission-gate", "src");


### PR DESCRIPTION
### Motivation
- The PR classifier allowed many scripts and regression tests to remain unclassified so CI lanes could be skipped, which weakens validation for security-sensitive automation executed by privileged workflows. 
- The goal is to fail-closed by routing otherwise-unclassified `scripts/**` and test files into the CI validation lane so changes that affect submission/import/risk/email automation cannot bypass required checks.

### Description
- Expand `submissionAutomationInfra` to include `scripts/import-submission-issue.mjs` and `scripts/validate-submission-issue.mjs` in `scripts/ci/classify-pr-changes.mjs`.
- Add a `scriptOrTestInfra` classifier that matches `^scripts/` and `^tests/.*\.test\.ts$` and include it in the `ci` flag calculation so unclassified scripts and regression tests trigger CI validation.
- Add two regression tests in `tests/classify-pr-changes.test.ts` that assert changes to an otherwise-unclassified script and an otherwise-unclassified regression test set `ci: "true"`.

### Testing
- Ran `pnpm exec vitest run tests/classify-pr-changes.test.ts` and the classifier test suite passed (all tests green).
- Ran `git diff --check` and no whitespace/diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3485e8fdec832c85a75f9d08a0b5e1)