### PR TITLE
fix(brand-assets): reject protocol-relative icon URLs

### DIFF
--- a/apps/web/src/lib/brand-icons.ts
+++ b/apps/web/src/lib/brand-icons.ts
@@ -1,4 +1,5 @@
 import {
+  isAllowedBrandAssetUrl,
   normalizeBrandDomain,
   shouldAutoResolveBrandAsset,
 } from "@heyclaude/registry/brand-assets";
@@ -54,7 +55,7 @@ export function brandDisplayName(target: BrandIconTarget): string {
 export function hasDisplayableBrandIcon(target: BrandIconTarget | null | undefined): boolean {
   if (!target) return false;
   const iconUrl = clean(target.brandIconUrl);
-  if (!iconUrl) return false;
+  if (!iconUrl || !isAllowedBrandAssetUrl(iconUrl)) return false;
 
   const source = brandAssetSource(target);
   if (source === "none") return false;

--- a/packages/registry/src/brand-assets.js
+++ b/packages/registry/src/brand-assets.js
@@ -266,7 +266,10 @@ export function normalizeBrandColors(value) {
 export function isAllowedBrandAssetUrl(value) {
   const raw = clean(value);
   if (!raw) return true;
-  if (raw.startsWith("/")) return /^\/[a-z0-9/_+.-]+$/i.test(raw);
+  if (raw.startsWith("/")) {
+    if (raw.startsWith("//")) return false;
+    return /^\/[a-z0-9/_+.-]+$/i.test(raw);
+  }
 
   try {
     const parsed = new URL(raw);

--- a/tests/brand-assets.test.ts
+++ b/tests/brand-assets.test.ts
@@ -31,6 +31,7 @@ describe("brand asset helpers", () => {
       true,
     );
     expect(isAllowedBrandAssetUrl("/bad path")).toBe(false);
+    expect(isAllowedBrandAssetUrl("//tracker.example/pixel.png")).toBe(false);
     expect(isAllowedBrandAssetUrl("http://cdn.brandfetch.io/logo.png")).toBe(
       false,
     );
@@ -162,7 +163,7 @@ describe("brand asset helpers", () => {
       buildBrandAssetMetadata({
         title: "Rejected Brand Asset",
         brandDomain: "example.com",
-        brandIconUrl: "https://evil.example/icon.png",
+        brandIconUrl: "//tracker.example/pixel.png",
         brandLogoUrl: "javascript:alert(1)",
         brandAssetSource: "brandfetch",
       }),

--- a/tests/brand-icons.test.ts
+++ b/tests/brand-icons.test.ts
@@ -109,6 +109,20 @@ describe("brand icon display helpers", () => {
         brandIconUrl: "/assets/brands/local.svg",
       }),
     ).toBe(true);
+    expect(
+      hasDisplayableBrandIcon({
+        title: "Tracker Brand",
+        brandIconUrl: "//tracker.example/pixel.png",
+        brandAssetSource: "manual",
+      }),
+    ).toBe(false);
+    expect(
+      displayableBrandIconUrl({
+        title: "Tracker Brand",
+        brandIconUrl: "//tracker.example/pixel.png",
+        brandAssetSource: "manual",
+      }),
+    ).toBeUndefined();
   });
 
   it("provides stable labels and suppresses generic auto-resolved identities", () => {


### PR DESCRIPTION
### Motivation

- A protocol-relative URL like `//tracker.example/pixel.png` was being treated as a local path by the allowlist and could be preserved in registry metadata and rendered into an `<img src>` causing third-party tracking.  
- Preventing protocol-relative external URLs from entering or being displayed preserves the intended restriction to vetted Brandfetch/HeyClaude/local assets and avoids client-side leakage.

### Description

- Update `isAllowedBrandAssetUrl` to explicitly reject values that start with `//` before applying the local-path regex, ensuring protocol-relative URLs are not considered local (`packages/registry/src/brand-assets.js`).  
- Harden display-time checks by revalidating `brandIconUrl` with `isAllowedBrandAssetUrl` in `hasDisplayableBrandIcon` so manual/non-Brandfetch icons cannot bypass the allowlist (`apps/web/src/lib/brand-icons.ts`).  
- Add regression tests that assert protocol-relative tracker URLs are rejected by the registry helpers and are not considered displayable by the web helpers (`tests/brand-assets.test.ts`, `tests/brand-icons.test.ts`).  
- Changes touch `packages/registry/src/brand-assets.js`, `apps/web/src/lib/brand-icons.ts`, and the two test files noted above.

### Testing

- Ran the focused Vitest suites with `pnpm exec vitest run tests/brand-assets.test.ts tests/brand-icons.test.ts` and the tests passed.  
- Ran content validation with `pnpm validate:content:strict` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34865f96f8832cafb1e22cd48e6479)