### PR TITLE
fix(submissions): preserve closed PR review keys on reopen

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -885,13 +885,6 @@ async function shouldInspectPullRequestFilesForWebhook(
   const existingStatus = String(existing?.status || "");
   if (
     hasTerminalGateDecision(existing) &&
-    existingStatus === "closed" &&
-    isReopenedPullRequestEvent(String(eventName || ""), webhook)
-  ) {
-    return true;
-  }
-  if (
-    hasTerminalGateDecision(existing) &&
     existingStatus !== "closed" &&
     !(
       existingStatus === "ignored" &&

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1949,8 +1949,8 @@ ${urls}
       source.indexOf("async function shouldInspectPullRequestFilesForWebhook"),
       source.indexOf("function reviewTargetFromPullPayload"),
     );
-    const reopenedClosedIndex = shouldInspectBlock.indexOf(
-      'existingStatus === "closed"',
+    const terminalClosedExclusionIndex = shouldInspectBlock.indexOf(
+      'existingStatus !== "closed"',
     );
     const reviewKeySkipIndex = shouldInspectBlock.indexOf(
       "return !reviewScanKey || existingReviewKey !== reviewScanKey",
@@ -1969,9 +1969,12 @@ ${urls}
     expect(source).toContain(
       "resetAttemptCount: shouldResetManualTerminal || shouldResetTerminalState",
     );
-    expect(source).toContain('existingStatus === "closed"');
-    expect(source).toContain(
+    expect(source).toContain('existingStatus !== "closed"');
+    expect(shouldInspectBlock).not.toContain(
       'isReopenedPullRequestEvent(String(eventName || ""), webhook)',
+    );
+    expect(source).toContain(
+      "isReopenedPullRequestEvent(eventName, webhook)",
     );
     expect(source).toContain("eventName,");
     expect(source).toContain("clearTerminal:");
@@ -1984,8 +1987,8 @@ ${urls}
     expect(inspectIndex).toBeGreaterThan(0);
     expect(classifyIndex).toBeGreaterThan(inspectIndex);
     expect(applyIndex).toBeGreaterThan(classifyIndex);
-    expect(reopenedClosedIndex).toBeGreaterThan(0);
-    expect(reviewKeySkipIndex).toBeGreaterThan(reopenedClosedIndex);
+    expect(terminalClosedExclusionIndex).toBeGreaterThan(0);
+    expect(reviewKeySkipIndex).toBeGreaterThan(terminalClosedExclusionIndex);
   });
 
   it("cleans stale gate metadata when webhook paths ignore former content PRs", () => {


### PR DESCRIPTION
### Motivation
- Prevent reopened pull requests from bypassing the `lastReviewKey` skip logic so previously-closed identical submissions are not requeued for full private review and potential auto-merge.
- Close a logical security gap where contributors could repeatedly reopen a closed PR to farm review outcomes for unchanged content.

### Description
- Removed the special-case early return for reopened `closed` PRs in `shouldInspectPullRequestFilesForWebhook`, allowing closed terminal states to reach the existing `lastReviewKey` comparison again (`apps/submission-gate/src/index.ts`).
- Updated the source-pinned worker test to assert the closed-terminal path does not contain the reopened-webhook bypass and that the review-key comparison remains the decisive check (`tests/submission-gate-worker.test.ts`).

### Testing
- Ran the targeted worker tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts --testNamePattern "ignores non-content PRs|allows only trusted maintainer comments"`, which passed (test file executed: 2 tests passed, 97 skipped).
- Verified repository validation checks (`git diff --check`) reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3486f92ce0832c9825eec7ee934061)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined submission gate logic for reopened pull requests to more intelligently determine when file re-inspection is needed, reducing unnecessary checks when review criteria remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->