### PR TITLE
fix(submissions): limit duplicate auto-close to strict matches

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2382,16 +2382,12 @@ async function deterministicContentPrecheck(params: {
     })),
   ];
   const duplicateReview = buildContentDuplicateReview(candidate, existing);
-  const hardCloseDuplicate =
-    duplicateReview.strictDuplicate ||
-    (duplicateReview.legacyDuplicate?.reasons.some((reason) =>
-      reason.startsWith("same canonical source URL "),
-    )
-      ? duplicateReview.legacyDuplicate
-      : null);
   return {
     content: candidateContent,
-    decision: duplicateCloseDecision(hardCloseDuplicate, candidate),
+    decision: duplicateCloseDecision(
+      duplicateReview.strictDuplicate,
+      candidate,
+    ),
     duplicateReview: summarizeDuplicateReview(duplicateReview),
     sourceEvidence,
   };

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -509,8 +509,12 @@ describe("Cloudflare submission gate helpers", () => {
     expect(source).toContain("contentScope: contentScopeForPrivateReview");
     expect(source).toContain("duplicateHistoryRequired: true");
     expect(source).toContain("strictDuplicatePolicy:");
-    expect(source).toContain("const hardCloseDuplicate =");
-    expect(source).toContain('reason.startsWith("same canonical source URL ")');
+    expect(source).toContain(`decision: duplicateCloseDecision(
+      duplicateReview.strictDuplicate`);
+    expect(source).not.toContain("const hardCloseDuplicate =");
+    expect(source).not.toContain(
+      'reason.startsWith("same canonical source URL ")',
+    );
     expect(source).toContain("relatedContentPolicy:");
     expect(source).toContain("collectionPolicy:");
     expect(source).toContain("defensiveSecurityPolicy:");
@@ -2843,6 +2847,53 @@ docsUrl: "https://docs.anthropic.com/en/docs/claude-code/security#events"
             expect.stringContaining(
               "same canonical source URL https://docs.anthropic.com/en/docs/claude-code/security across hooks/guides",
             ),
+          ]),
+        }),
+      ]),
+    );
+  });
+
+  it("keeps legacy-only canonical URL matches out of strict duplicate closure", () => {
+    const earlierOpenPr = extractContentDuplicateSignals({
+      filePath: "content/tools/shared-project-tool.mdx",
+      content: `---
+title: Shared Project Tool
+slug: shared-project-tool
+category: tools
+description: Tooling for the Shared Project command-line workflow.
+repoUrl: "https://github.com/acme/shared-project"
+---
+`,
+      label: "earlier open PR #10",
+    });
+    const laterCandidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/shared-project-server.mdx",
+      content: `---
+title: Shared Project MCP Server
+slug: shared-project-server
+category: mcp
+description: MCP server for exposing Shared Project context to Claude.
+repoUrl: "https://github.com/acme/shared-project.git?utm_source=heyclaude"
+---
+`,
+      label: "PR #20",
+    });
+
+    const duplicateReview = buildContentDuplicateReview(laterCandidate, [
+      earlierOpenPr,
+    ]);
+
+    expect(duplicateReview.legacyDuplicate).toMatchObject({
+      reasons: expect.arrayContaining([
+        "same canonical source URL https://github.com/acme/shared-project",
+      ]),
+    });
+    expect(duplicateReview.strictDuplicate).toBeNull();
+    expect(findRelatedContentMatches(laterCandidate, [earlierOpenPr])).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          reasons: expect.arrayContaining([
+            "same canonical source URL https://github.com/acme/shared-project across mcp/tools",
           ]),
         }),
       ]),


### PR DESCRIPTION
### Motivation
- Prevent deterministic auto-closure of PRs based on a broad legacy `same canonical source URL` match that could be supplied by earlier unaccepted/open PRs and be abused to deny legitimate submissions.

### Description
- Restrict the deterministic auto-close path in `deterministicContentPrecheck` to use only `duplicateReview.strictDuplicate` and remove the promotion of legacy canonical-URL-only matches into a hard-close decision in `apps/submission-gate/src/index.ts`.
- Preserve legacy canonical-URL matches in the duplicate review artifact and related-candidate context without treating them as automatic close triggers.
- Update `tests/submission-gate-worker.test.ts` to remove source-pinned assertions that expected the hard-close path and add a regression test that verifies an earlier open PR that only shares a canonical URL does not produce a strict duplicate close.
- Modified files: `apps/submission-gate/src/index.ts` and `tests/submission-gate-worker.test.ts`.

### Testing
- Ran unit tests with `pnpm exec vitest run tests/submission-gate-worker.test.ts` and all selected tests passed (100 tests passed).
- Checked formatting with `pnpm exec prettier --check apps/submission-gate/src/index.ts tests/submission-gate-worker.test.ts` and fixed style issues before re-checking (Prettier passed).
- Verified no diff/style errors with `git diff --check` after changes (no problems reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3487465f74832cacfcad5d1e9b2b63)