### PR TITLE
fix(submissions): guard ignored validation cleanup

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -2793,7 +2793,16 @@ async function githubWebhookRoute(
         continue;
       }
       if (reviewability.kind === "ignore") {
-        await cleanupIgnoredReviewTarget(env, target, deliveryId);
+        const shouldCleanupIgnored =
+          await shouldInspectPullRequestFilesForWebhook(
+            env,
+            target,
+            eventName,
+            payload,
+          );
+        if (shouldCleanupIgnored) {
+          await cleanupIgnoredReviewTarget(env, target, deliveryId);
+        }
         continue;
       }
       if (

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1977,9 +1977,7 @@ ${urls}
     expect(shouldInspectBlock).not.toContain(
       'isReopenedPullRequestEvent(String(eventName || ""), webhook)',
     );
-    expect(source).toContain(
-      "isReopenedPullRequestEvent(eventName, webhook)",
-    );
+    expect(source).toContain("isReopenedPullRequestEvent(eventName, webhook)");
     expect(source).toContain("eventName,");
     expect(source).toContain("clearTerminal:");
     expect(source).toContain("lastReviewKey: reviewScanKey || undefined");
@@ -2026,6 +2024,11 @@ ${urls}
     expect(issueCommentBlock).toContain(
       "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
     );
+    expect(validationBlock).toContain(
+      "await shouldInspectPullRequestFilesForWebhook(",
+    );
+    expect(validationBlock).toContain("const shouldCleanupIgnored =");
+    expect(validationBlock).toContain("if (shouldCleanupIgnored) {");
     expect(validationBlock).toContain(
       "await cleanupIgnoredReviewTarget(env, target, deliveryId);",
     );


### PR DESCRIPTION
### Motivation

- Prevent validation webhook paths from clearing terminal gate decisions (manual/closed/merged) when a PR is classified as "ignore", which allowed an author to revert content and later reset a terminal state without a trusted maintainer recheck.

### Description

- Add a guard in the validation-webhook handling so `cleanupIgnoredReviewTarget` is only called if `shouldInspectPullRequestFilesForWebhook(...)` returns true for the target. 
- This preserves the existing `shouldInspectPullRequestFilesForWebhook` terminal-state checks before mutating labels or PR state on validation webhook events.
- Update a source-pinned regression assertion in `tests/submission-gate-worker.test.ts` to verify the validation webhook cleanup is guarded.
- Files changed: `apps/submission-gate/src/index.ts` and `tests/submission-gate-worker.test.ts`.

### Testing

- Ran `pnpm exec vitest run tests/submission-gate-worker.test.ts` and the suite passed (`99 tests` passed).
- Ran `pnpm test:submission-pr-first` and the suite passed (`27 tests` passed).
- Ran `git diff --check` to verify no whitespace/check issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34873136f4832caeb864c9abe5e0d6)