### PR TITLE
fix(content): avoid shell-expanding Xquik API key

### DIFF
--- a/content/mcp/xquik-mcp-server.mdx
+++ b/content/mcp/xquik-mcp-server.mdx
@@ -23,10 +23,10 @@ brandAssetSource: manual
 repoUrl: https://github.com/Xquik-dev/x-twitter-scraper
 documentationUrl: https://docs.xquik.com/mcp/overview
 installable: true
-installCommand: 'npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header "x-api-key:${XQUIK_API_KEY}"'
+installCommand: "XQUIK_API_KEY=xq_YOUR_KEY_HERE npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header 'x-api-key:${XQUIK_API_KEY}'"
 usageSnippet: |-
   export XQUIK_API_KEY=xq_YOUR_KEY_HERE
-  npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header "x-api-key:${XQUIK_API_KEY}"
+  npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header 'x-api-key:${XQUIK_API_KEY}'
 copySnippet: |-
   {
     "mcpServers": {
@@ -107,12 +107,12 @@ The server exposes `explore` for searching the API catalog and `xquik` for authe
 
 ```bash
 export XQUIK_API_KEY=xq_YOUR_KEY_HERE
-npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header "x-api-key:${XQUIK_API_KEY}"
+npx -y mcp-remote@0.1.38 https://xquik.com/mcp --header 'x-api-key:${XQUIK_API_KEY}'
 ```
 
 ## Auth Requirements
 
-Xquik supports API-key authentication through the `x-api-key` header and OAuth 2.1 for clients that support browser-based MCP connectors. Create an API key from the Xquik dashboard, keep it out of prompts and logs, and connect an X account only when you need write workflows.
+Xquik supports API-key authentication through the `x-api-key` header and OAuth 2.1 for clients that support browser-based MCP connectors. Create an API key from the Xquik dashboard, keep it out of prompts, logs, and shell-expanded command arguments, and connect an X account only when you need write workflows. The `mcp-remote` command examples quote the header placeholder with single quotes so the client can resolve `XQUIK_API_KEY` from the environment without placing the expanded secret in shell argv.
 
 ## Capabilities
 


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the `XQUIK_API_KEY` by avoiding shell-expanded command-line arguments that place the real secret into process argv when users run the published `mcp-remote` examples.

### Description
- Update `content/mcp/xquik-mcp-server.mdx` to prefix the install command with an env assignment and switch the header placeholder to single quotes in `installCommand`, `usageSnippet`, and inline examples, and add explicit auth guidance so the client resolves `XQUIK_API_KEY` from the environment rather than expanding it into argv.

### Testing
- Ran `pnpm validate:content:strict` which passed and `git diff --check` which passed; an attempt to run `pnpm generate:registry` in this environment did not complete and produced no generated artifact changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348aefc938832c97b3705ab1c10bbb)