### PR TITLE
feat(alerts): surface saved-search matches in app

### DIFF
--- a/apps/web/src/components/alerts-dropdown.tsx
+++ b/apps/web/src/components/alerts-dropdown.tsx
@@ -20,7 +20,8 @@ function bucket(alert: Alert, lastSeenAt: string) {
 }
 
 export function AlertsDropdown() {
-  const { alerts, unreadCount, lastSeenAt, markAllRead, targets } = useWatch();
+  const { alerts, unreadCount, lastSeenAt, markAllRead, targets, savedSearchAlertCount } =
+    useWatch();
   const grouped = React.useMemo(() => {
     const out: Record<string, Alert[]> = { Today: [], "This week": [], Earlier: [] };
     for (const a of alerts) out[bucket(a, lastSeenAt)].push(a);
@@ -51,7 +52,7 @@ export function AlertsDropdown() {
           <div>
             <div className="eyebrow">Alerts</div>
             <div className="mt-0.5 text-xs text-ink-muted">
-              {targets.length} watched · {alerts.length} total
+              {targets.length} watched · {savedSearchAlertCount} saved · {alerts.length} total
             </div>
           </div>
           <button
@@ -66,7 +67,7 @@ export function AlertsDropdown() {
 
         {alerts.length === 0 ? (
           <div className="px-5 py-10 text-center text-xs text-ink-muted">
-            Nothing watched yet — tap the bell on any listing to get source-change alerts here.
+            No alerts yet - watch a listing or enable in-app alerts on a saved search.
           </div>
         ) : (
           <div className="max-h-[60vh] overflow-y-auto">
@@ -121,7 +122,8 @@ export function AlertsDropdown() {
         )}
 
         <footer className="border-t border-border px-4 py-2.5 text-[11px] text-ink-muted">
-          Alerts are read from the public registry event feed; watched targets stay in this browser.
+          Alerts are read from the public registry event feed; watched targets and saved searches
+          stay in this browser.
         </footer>
       </PopoverContent>
     </Popover>

--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -1,0 +1,218 @@
+import type { AlertCadence, AlertChannel } from "@/lib/recents";
+import type { Category, Platform, SourceStatus, TrustLevel } from "@/types/registry";
+
+export interface SavedSearchAlertSchedule {
+  enabled?: boolean;
+  channels?: AlertChannel[];
+  cadence?: AlertCadence;
+  lastNotifiedAt?: string;
+}
+
+export interface SavedSearchAlertSearch {
+  id: string;
+  label: string;
+  q?: string;
+  category?: string;
+  trust?: string;
+  source?: string;
+  platform?: string;
+  alerts?: SavedSearchAlertSchedule;
+}
+
+export interface SavedSearchAlertEntry {
+  category: Category | string;
+  slug: string;
+  title: string;
+  description?: string;
+  cardDescription?: string;
+  author?: string;
+  tags?: string[];
+  keywords?: string[];
+  platforms?: Array<Platform | string>;
+  trust?: TrustLevel | string;
+  source?: SourceStatus | string;
+}
+
+export interface SavedSearchAlertEvent {
+  id?: string;
+  kind?: string;
+  category?: string;
+  slug?: string;
+  action?: string;
+  date?: string;
+  title?: string;
+}
+
+export type SavedSearchAlertSeverity = "info" | "warning" | "blocker";
+
+export interface SavedSearchAlert {
+  id: string;
+  targetId: string;
+  kind: "saved-search";
+  title: string;
+  body: string;
+  severity: SavedSearchAlertSeverity;
+  href?: string;
+  date: string;
+}
+
+const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+
+const QUERY_ALIASES: Record<string, string[]> = {
+  browser: ["chrome", "playwright", "web"],
+  cc: ["claude", "claude-code"],
+  claude: ["claude-code"],
+  gh: ["github"],
+  mcp: ["model-context-protocol"],
+  repo: ["repository", "github"],
+  repos: ["repository", "github"],
+  safe: ["safety", "security", "secure", "trust", "privacy"],
+  security: ["safe", "safety", "secure", "trust"],
+  skill: ["skills"],
+  skills: ["skill"],
+  statusline: ["statuslines", "status"],
+  statuslines: ["statusline", "status"],
+};
+
+export function savedSearchAlertTargetId(search: Pick<SavedSearchAlertSearch, "id">) {
+  return `saved-search:${search.id}`;
+}
+
+export function activeInAppSavedSearches(
+  searches: SavedSearchAlertSearch[],
+): SavedSearchAlertSearch[] {
+  return searches.filter(
+    (search) => search.alerts?.enabled && search.alerts.channels?.includes("inapp"),
+  );
+}
+
+function tokenizeSearchQuery(query: string) {
+  return query
+    .split(TOKEN_SPLIT_PATTERN)
+    .map((token) => token.trim().toLowerCase())
+    .filter((token) => token.length >= 2)
+    .slice(0, 12);
+}
+
+function expandedTokenCandidates(token: string) {
+  return [token, ...(QUERY_ALIASES[token] ?? [])];
+}
+
+function normalizedEntryText(entry: SavedSearchAlertEntry) {
+  return [
+    entry.category,
+    entry.slug,
+    entry.title,
+    entry.description,
+    entry.cardDescription,
+    entry.author,
+    entry.trust,
+    entry.source,
+    ...(entry.platforms ?? []),
+    ...(entry.tags ?? []),
+    ...(entry.keywords ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function candidateMatchesText(candidate: string, haystack: string, words: string[]) {
+  if (candidate.length <= 2) {
+    return words.some((word) => word === candidate || word.startsWith(candidate));
+  }
+  return haystack.includes(candidate) || words.some((word) => word.startsWith(candidate));
+}
+
+export function savedSearchQueryMatchesEntry(
+  entry: SavedSearchAlertEntry,
+  query: string | undefined,
+) {
+  const normalizedQuery = query?.trim().toLowerCase() ?? "";
+  if (!normalizedQuery) return true;
+
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (tokens.length === 0) return false;
+
+  const haystack = normalizedEntryText(entry);
+  const words = [
+    ...new Set(
+      haystack
+        .split(TOKEN_SPLIT_PATTERN)
+        .map((word) => word.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+
+  if (
+    normalizedQuery.length > 2
+      ? haystack.includes(normalizedQuery)
+      : candidateMatchesText(normalizedQuery, haystack, words)
+  ) {
+    return true;
+  }
+
+  return tokens.every((token) =>
+    expandedTokenCandidates(token).some((candidate) =>
+      candidateMatchesText(candidate, haystack, words),
+    ),
+  );
+}
+
+export function savedSearchMatchesEntry(
+  search: SavedSearchAlertSearch,
+  entry: SavedSearchAlertEntry,
+) {
+  if (search.category && entry.category !== search.category) return false;
+  if (search.trust && entry.trust !== search.trust) return false;
+  if (search.source && entry.source !== search.source) return false;
+  if (search.platform && !(entry.platforms ?? []).some((platform) => platform === search.platform)) {
+    return false;
+  }
+  return savedSearchQueryMatchesEntry(entry, search.q);
+}
+
+function eventRef(event: SavedSearchAlertEvent) {
+  if (event.kind !== "entry" || !event.category || !event.slug) return null;
+  return `${event.category}/${event.slug}`;
+}
+
+function eventAction(event: SavedSearchAlertEvent) {
+  return event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
+}
+
+export function buildSavedSearchAlerts(
+  searches: SavedSearchAlertSearch[],
+  events: SavedSearchAlertEvent[],
+  entriesByRef: ReadonlyMap<string, SavedSearchAlertEntry>,
+): SavedSearchAlert[] {
+  const activeSearches = activeInAppSavedSearches(searches);
+  if (activeSearches.length === 0) return [];
+
+  const alerts: SavedSearchAlert[] = [];
+  for (const event of events) {
+    const ref = eventRef(event);
+    if (!ref || !event.date) continue;
+
+    const entry = entriesByRef.get(ref);
+    if (!entry) continue;
+
+    for (const search of activeSearches) {
+      if (!savedSearchMatchesEntry(search, entry)) continue;
+      const action = eventAction(event);
+      const title = event.title || entry.title;
+      alerts.push({
+        id: `saved-search:${search.id}:${ref}:${event.date}:${action}`,
+        targetId: savedSearchAlertTargetId(search),
+        kind: "saved-search",
+        title: `${title} ${action}`,
+        body: `Matches saved search "${search.label}".`,
+        severity: action === "removed" ? "warning" : "info",
+        href: `/entry/${ref}`,
+        date: event.date,
+      });
+    }
+  }
+
+  return alerts.sort((left, right) => right.date.localeCompare(left.date));
+}

--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -166,7 +166,10 @@ export function savedSearchMatchesEntry(
   if (search.category && entry.category !== search.category) return false;
   if (search.trust && entry.trust !== search.trust) return false;
   if (search.source && entry.source !== search.source) return false;
-  if (search.platform && !(entry.platforms ?? []).some((platform) => platform === search.platform)) {
+  if (
+    search.platform &&
+    !(entry.platforms ?? []).some((platform) => platform === search.platform)
+  ) {
     return false;
   }
   return savedSearchQueryMatchesEntry(entry, search.q);

--- a/apps/web/src/lib/watch.tsx
+++ b/apps/web/src/lib/watch.tsx
@@ -180,7 +180,10 @@ export function WatchProvider({ children }: { children: React.ReactNode }) {
   const [eventEntriesByRef, setEventEntriesByRef] = React.useState<Map<string, Entry>>(
     () => new Map(),
   );
-  const savedSearches = React.useMemo(() => activeInAppSavedSearches(recents.saved), [recents.saved]);
+  const savedSearches = React.useMemo(
+    () => activeInAppSavedSearches(recents.saved),
+    [recents.saved],
+  );
   const savedSearchesKey = React.useMemo(
     () => savedSearchSignature(savedSearches),
     [savedSearches],

--- a/apps/web/src/lib/watch.tsx
+++ b/apps/web/src/lib/watch.tsx
@@ -1,6 +1,15 @@
 import * as React from "react";
+import { useRecents } from "@/lib/recents";
+import {
+  activeInAppSavedSearches,
+  buildSavedSearchAlerts,
+  savedSearchAlertTargetId,
+  type SavedSearchAlertSearch,
+} from "@/lib/saved-search-alerts";
+import type { RegistryEntry } from "@/data/entry-normalize";
+import type { Entry } from "@/types/registry";
 
-export type WatchKind = "entry" | "validator" | "changelog-stream" | "integration";
+export type WatchKind = "entry" | "validator" | "changelog-stream" | "integration" | "saved-search";
 
 export interface WatchTarget {
   id: string;
@@ -31,6 +40,7 @@ interface WatchCtx {
   toggle: (target: Omit<WatchTarget, "addedAt">) => void;
   markAllRead: () => void;
   unreadCount: number;
+  savedSearchAlertCount: number;
 }
 
 const STORAGE_KEY = "hc.watch.v1";
@@ -104,11 +114,77 @@ function eventToAlert(event: RegistryEvent, target: WatchTarget): Alert | null {
   };
 }
 
+function savedSearchSignature(searches: SavedSearchAlertSearch[]) {
+  return searches
+    .map((search) =>
+      [
+        search.id,
+        search.label,
+        search.q,
+        search.category,
+        search.trust,
+        search.source,
+        search.platform,
+        search.alerts?.enabled ? "1" : "0",
+        search.alerts?.channels?.join(",") ?? "",
+      ].join("\t"),
+    )
+    .join("\n");
+}
+
+function entryDetailUrl(event: RegistryEvent) {
+  if (event.kind !== "entry" || !event.category || !event.slug) return null;
+  return `/data/entries/${encodeURIComponent(event.category)}/${encodeURIComponent(event.slug)}.json`;
+}
+
+async function loadEventEntries(events: RegistryEvent[]) {
+  const refs = new Map<string, string>();
+  for (const event of events) {
+    if (event.kind !== "entry" || !event.category || !event.slug) continue;
+    const href = entryDetailUrl(event);
+    if (href) refs.set(`${event.category}/${event.slug}`, href);
+  }
+  if (refs.size === 0) return new Map<string, Entry>();
+
+  const { buildEntry } = await import("@/data/entry-normalize");
+  const rows = await Promise.all(
+    [...refs.entries()].map(async ([ref, href]) => {
+      try {
+        const response = await fetch(href, { headers: { accept: "application/json" } });
+        if (!response.ok) return null;
+        const payload = (await response.json()) as {
+          entry?: Record<string, unknown>;
+          trustSignals?: Record<string, unknown>;
+        };
+        if (!payload.entry) return null;
+        const rawEntry = {
+          ...payload.entry,
+          trustSignals: payload.trustSignals,
+        } as RegistryEntry;
+        return [ref, buildEntry(rawEntry)] as const;
+      } catch {
+        return null;
+      }
+    }),
+  );
+
+  return new Map(rows.filter((row): row is [string, Entry] => Boolean(row)));
+}
+
 export function WatchProvider({ children }: { children: React.ReactNode }) {
+  const recents = useRecents();
   const [hydrated, setHydrated] = React.useState(false);
   const [targets, setTargets] = React.useState<WatchTarget[]>([]);
   const [lastSeenAt, setLastSeenAt] = React.useState("1970-01-01");
   const [remoteEvents, setRemoteEvents] = React.useState<RegistryEvent[]>([]);
+  const [eventEntriesByRef, setEventEntriesByRef] = React.useState<Map<string, Entry>>(
+    () => new Map(),
+  );
+  const savedSearches = React.useMemo(() => activeInAppSavedSearches(recents.saved), [recents.saved]);
+  const savedSearchesKey = React.useMemo(
+    () => savedSearchSignature(savedSearches),
+    [savedSearches],
+  );
 
   React.useEffect(() => {
     const s = loadState();
@@ -123,8 +199,9 @@ export function WatchProvider({ children }: { children: React.ReactNode }) {
   }, [targets, lastSeenAt, hydrated]);
 
   React.useEffect(() => {
-    if (!hydrated || targets.length === 0) {
+    if (!hydrated || (targets.length === 0 && savedSearches.length === 0)) {
       setRemoteEvents([]);
+      setEventEntriesByRef(new Map());
       return;
     }
     let cancelled = false;
@@ -135,37 +212,54 @@ export function WatchProvider({ children }: { children: React.ReactNode }) {
         });
         if (!response.ok) throw new Error(`alerts API returned ${response.status}`);
         const payload = (await response.json()) as { events?: RegistryEvent[] };
-        if (!cancelled) setRemoteEvents(Array.isArray(payload.events) ? payload.events : []);
+        const events = Array.isArray(payload.events) ? payload.events : [];
+        const nextEntries =
+          savedSearches.length > 0 ? await loadEventEntries(events) : new Map<string, Entry>();
+        if (!cancelled) {
+          setRemoteEvents(events);
+          setEventEntriesByRef(nextEntries);
+        }
       } catch {
-        if (!cancelled) setRemoteEvents([]);
+        if (!cancelled) {
+          setRemoteEvents([]);
+          setEventEntriesByRef(new Map());
+        }
       }
     }
     void loadAlerts();
     return () => {
       cancelled = true;
     };
-  }, [hydrated, targets.length]);
+  }, [hydrated, targets.length, savedSearches.length, savedSearchesKey]);
 
   const alerts = React.useMemo(() => {
     const byId = new Map(targets.map((target) => [target.id, target]));
-    return remoteEvents
+    const watchedEntryAlerts = remoteEvents
       .map((event) => {
         const targetId = eventTargetId(event);
         const target = targetId ? byId.get(targetId) : undefined;
         return target ? eventToAlert(event, target) : null;
       })
-      .filter((alert): alert is Alert => Boolean(alert))
-      .sort((left, right) => right.date.localeCompare(left.date));
-  }, [targets, remoteEvents]);
+      .filter((alert): alert is Alert => Boolean(alert));
+    const savedSearchAlerts = buildSavedSearchAlerts(
+      savedSearches,
+      remoteEvents,
+      eventEntriesByRef,
+    );
+    return [...watchedEntryAlerts, ...savedSearchAlerts].sort((left, right) =>
+      right.date.localeCompare(left.date),
+    );
+  }, [targets, remoteEvents, savedSearches, eventEntriesByRef]);
 
   const value = React.useMemo<WatchCtx>(() => {
     const ids = new Set(targets.map((t) => t.id));
+    const savedSearchIds = new Set(savedSearches.map(savedSearchAlertTargetId));
     const unreadCount = alerts.filter((a) => a.date > lastSeenAt).length;
     return {
       targets,
       alerts,
       lastSeenAt,
-      isWatching: (id) => ids.has(id),
+      isWatching: (id) => ids.has(id) || savedSearchIds.has(id),
       toggle: (t) =>
         setTargets((cur) =>
           cur.some((x) => x.id === t.id)
@@ -174,8 +268,9 @@ export function WatchProvider({ children }: { children: React.ReactNode }) {
         ),
       markAllRead: () => setLastSeenAt(new Date().toISOString()),
       unreadCount,
+      savedSearchAlertCount: savedSearches.length,
     };
-  }, [targets, alerts, lastSeenAt]);
+  }, [targets, savedSearches, alerts, lastSeenAt]);
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -229,8 +229,8 @@ function RootComponent() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
-        <WatchProvider>
-          <RecentsProvider>
+        <RecentsProvider>
+          <WatchProvider>
             <CompareProvider>
               <ShortcutsProvider>
                 <div className="flex min-h-screen flex-col bg-background">
@@ -256,8 +256,8 @@ function RootComponent() {
                 />
               </ShortcutsProvider>
             </CompareProvider>
-          </RecentsProvider>
-        </WatchProvider>
+          </WatchProvider>
+        </RecentsProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/tests/saved-search-alerts.test.ts
+++ b/tests/saved-search-alerts.test.ts
@@ -12,7 +12,8 @@ const entry: SavedSearchAlertEntry = {
   category: "mcp",
   slug: "postgres-memory",
   title: "Postgres Memory MCP",
-  description: "A source-backed memory server for Postgres-backed Claude workflows.",
+  description:
+    "A source-backed memory server for Postgres-backed Claude workflows.",
   author: "Example Maintainer",
   tags: ["database", "memory"],
   keywords: ["postgres mcp", "repository memory"],
@@ -21,7 +22,9 @@ const entry: SavedSearchAlertEntry = {
   source: "source-backed",
 };
 
-function search(overrides: Partial<SavedSearchAlertSearch> = {}): SavedSearchAlertSearch {
+function search(
+  overrides: Partial<SavedSearchAlertSearch> = {},
+): SavedSearchAlertSearch {
   return {
     id: "s-1",
     label: "Postgres memory",
@@ -36,8 +39,14 @@ describe("saved-search in-app alert matching", () => {
     expect(
       activeInAppSavedSearches([
         search(),
-        search({ id: "email", alerts: { enabled: true, channels: ["email"], cadence: "daily" } }),
-        search({ id: "off", alerts: { enabled: false, channels: ["inapp"], cadence: "daily" } }),
+        search({
+          id: "email",
+          alerts: { enabled: true, channels: ["email"], cadence: "daily" },
+        }),
+        search({
+          id: "off",
+          alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
+        }),
       ]).map((item) => item.id),
     ).toEqual(["s-1"]);
   });
@@ -49,13 +58,24 @@ describe("saved-search in-app alert matching", () => {
   });
 
   it("honors category, platform, trust, and source filters", () => {
-    expect(savedSearchMatchesEntry(search({ category: "mcp", platform: "claude-code" }), entry)).toBe(
-      true,
+    expect(
+      savedSearchMatchesEntry(
+        search({ category: "mcp", platform: "claude-code" }),
+        entry,
+      ),
+    ).toBe(true);
+    expect(savedSearchMatchesEntry(search({ category: "skills" }), entry)).toBe(
+      false,
     );
-    expect(savedSearchMatchesEntry(search({ category: "skills" }), entry)).toBe(false);
-    expect(savedSearchMatchesEntry(search({ platform: "cursor" }), entry)).toBe(false);
-    expect(savedSearchMatchesEntry(search({ trust: "review" }), entry)).toBe(false);
-    expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(false);
+    expect(savedSearchMatchesEntry(search({ platform: "cursor" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ trust: "review" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(
+      false,
+    );
   });
 
   it("materializes matching public entry events into saved-search alerts", () => {

--- a/tests/saved-search-alerts.test.ts
+++ b/tests/saved-search-alerts.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import {
+  activeInAppSavedSearches,
+  buildSavedSearchAlerts,
+  savedSearchMatchesEntry,
+  savedSearchQueryMatchesEntry,
+  type SavedSearchAlertEntry,
+  type SavedSearchAlertSearch,
+} from "@/lib/saved-search-alerts";
+
+const entry: SavedSearchAlertEntry = {
+  category: "mcp",
+  slug: "postgres-memory",
+  title: "Postgres Memory MCP",
+  description: "A source-backed memory server for Postgres-backed Claude workflows.",
+  author: "Example Maintainer",
+  tags: ["database", "memory"],
+  keywords: ["postgres mcp", "repository memory"],
+  platforms: ["claude-code", "claude-desktop"],
+  trust: "trusted",
+  source: "source-backed",
+};
+
+function search(overrides: Partial<SavedSearchAlertSearch> = {}): SavedSearchAlertSearch {
+  return {
+    id: "s-1",
+    label: "Postgres memory",
+    q: "postgres memory",
+    alerts: { enabled: true, channels: ["inapp"], cadence: "instant" },
+    ...overrides,
+  };
+}
+
+describe("saved-search in-app alert matching", () => {
+  it("only activates searches with enabled in-app alerts", () => {
+    expect(
+      activeInAppSavedSearches([
+        search(),
+        search({ id: "email", alerts: { enabled: true, channels: ["email"], cadence: "daily" } }),
+        search({ id: "off", alerts: { enabled: false, channels: ["inapp"], cadence: "daily" } }),
+      ]).map((item) => item.id),
+    ).toEqual(["s-1"]);
+  });
+
+  it("matches multi-token and aliased queries against entry metadata", () => {
+    expect(savedSearchQueryMatchesEntry(entry, "postgres memory")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, "repo memory")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, "calendar memory")).toBe(false);
+  });
+
+  it("honors category, platform, trust, and source filters", () => {
+    expect(savedSearchMatchesEntry(search({ category: "mcp", platform: "claude-code" }), entry)).toBe(
+      true,
+    );
+    expect(savedSearchMatchesEntry(search({ category: "skills" }), entry)).toBe(false);
+    expect(savedSearchMatchesEntry(search({ platform: "cursor" }), entry)).toBe(false);
+    expect(savedSearchMatchesEntry(search({ trust: "review" }), entry)).toBe(false);
+    expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(false);
+  });
+
+  it("materializes matching public entry events into saved-search alerts", () => {
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          id: "evt-1",
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-18T10:00:00.000Z",
+          title: "Postgres Memory MCP",
+        },
+      ],
+      new Map([["mcp/postgres-memory", entry]]),
+    );
+
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        id: "saved-search:s-1:mcp/postgres-memory:2026-06-18T10:00:00.000Z:updated",
+        targetId: "saved-search:s-1",
+        kind: "saved-search",
+        title: "Postgres Memory MCP updated",
+        body: 'Matches saved search "Postgres memory".',
+        severity: "info",
+        href: "/entry/mcp/postgres-memory",
+        date: "2026-06-18T10:00:00.000Z",
+      }),
+    ]);
+  });
+
+  it("does not alert when the changed entry detail is unavailable", () => {
+    expect(
+      buildSavedSearchAlerts(
+        [search()],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "missing",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        new Map(),
+      ),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- surface enabled in-app saved searches in the existing alerts dropdown
- match public registry events against saved-search query/category/platform/trust/source filters
- add regression coverage for activation, token matching, filter matching, event materialization, and missing entry details

## What changed
- Added `apps/web/src/lib/saved-search-alerts.ts` for pure saved-search alert matching.
- Updated `apps/web/src/lib/watch.tsx` to merge saved-search matches with watched-entry alerts.
- Reordered the root providers so watch alerts can observe saved-search state.
- Updated the alerts dropdown copy/counts for saved-search alerts.
- Added `tests/saved-search-alerts.test.ts`.

## Why
Saved searches exposed in-app alert controls, but the alert provider only watched individual entries. Enabled saved-search alerts now produce in-app alerts when matching registry events arrive.

## Validation
- `pnpm exec vitest run tests/saved-search-alerts.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- No content entries or generated registry artifacts are changed.
- The existing build still reports large registry chunk warnings unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Saved-search alert counts are now displayed in the alerts dropdown.
  * In-app alerts for saved searches are now available alongside existing alert types, including matching and alert materialization.

* **Bug Fixes**
  * Improved saved-search alert loading so related alert data is cleared/updated together when no saved searches are present.

* **Tests**
  * Added test coverage for saved-search alert matching and alert generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->