### PR TITLE
fix(home): keep pulse data out of client graph

### DIFF
--- a/apps/web/src/components/ecosystem-pulse.tsx
+++ b/apps/web/src/components/ecosystem-pulse.tsx
@@ -1,8 +1,22 @@
 import { Link } from "@tanstack/react-router";
 import { GitCommit, Users } from "lucide-react";
-import { CHANGELOG } from "@/data/changelog";
-import { CONTRIBUTORS } from "@/data/contributors";
 import { CategoryPill } from "./badges";
+
+export type EcosystemPulseData = {
+  recent: Array<{
+    ref: string;
+    kind: string;
+    category?: string;
+    title: string;
+    date: string;
+  }>;
+  topContributors: Array<{
+    slug: string;
+    name: string;
+    acceptedCount?: number;
+  }>;
+  counts: Record<string, number>;
+};
 
 const KIND_DOT: Record<string, string> = {
   added: "bg-trust-trusted",
@@ -10,19 +24,8 @@ const KIND_DOT: Record<string, string> = {
   removed: "bg-trust-blocked",
 };
 
-export function EcosystemPulse() {
-  const recent = CHANGELOG.slice(0, 4);
-  const top = [...CONTRIBUTORS]
-    .sort((a, b) => (b.acceptedCount ?? 0) - (a.acceptedCount ?? 0))
-    .slice(0, 4);
-  const counts = CHANGELOG.reduce(
-    (acc, c) => {
-      acc[c.kind] = (acc[c.kind] ?? 0) + 1;
-      return acc;
-    },
-    {} as Record<string, number>,
-  );
-
+export function EcosystemPulse({ data }: { data: EcosystemPulseData }) {
+  const { recent, topContributors, counts } = data;
   return (
     <div className="flex flex-col gap-4">
       <div className="rounded-xl border border-border bg-surface">
@@ -73,7 +76,7 @@ export function EcosystemPulse() {
           </Link>
         </div>
         <ul className="divide-y divide-border">
-          {top.map((c) => (
+          {topContributors.map((c) => (
             <li key={c.slug}>
               <Link
                 to="/contributors/$slug"

--- a/apps/web/src/lib/ecosystem-pulse-window.ts
+++ b/apps/web/src/lib/ecosystem-pulse-window.ts
@@ -1,0 +1,23 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PULSE_WINDOW_DAYS = 14;
+
+function utcDayTimestamp(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) return undefined;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function filterRecentPulseEntries<T extends { date: string }>(
+  entries: readonly T[],
+  now: Date = new Date(),
+) {
+  const today = utcDayTimestamp(now);
+  if (today === undefined) return [];
+
+  const cutoff = today - (PULSE_WINDOW_DAYS - 1) * DAY_MS;
+  return entries.filter((entry) => {
+    const entryDay = utcDayTimestamp(entry.date);
+    return entryDay !== undefined && entryDay >= cutoff && entryDay <= today;
+  });
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -25,7 +25,7 @@ import { CountUp } from "@/components/count-up";
 import { HeroStatusRow } from "@/components/hero-status-row";
 import { HowItWorks } from "@/components/how-it-works";
 import { AgentNativeStrip } from "@/components/agent-native-strip";
-import { EcosystemPulse } from "@/components/ecosystem-pulse";
+import { EcosystemPulse, type EcosystemPulseData } from "@/components/ecosystem-pulse";
 import { useRecents } from "@/lib/recents";
 import { useEffect, useState } from "react";
 import { createServerFn } from "@tanstack/react-start";
@@ -38,8 +38,17 @@ import { ogImageUrl } from "@/lib/og-image";
 const loadHomeData = createServerFn({ method: "GET" }).handler(async () => {
   const { ENTRIES, BRIEF_ISSUES, REGISTRY_GENERATED_AT } = await import("@/data/entries");
   const { search } = await import("@/data/search");
+  const { CHANGELOG } = await import("@/data/changelog");
+  const { CONTRIBUTORS } = await import("@/data/contributors");
   const categoryCounts: Record<string, number> = {};
   for (const e of ENTRIES) categoryCounts[e.category] = (categoryCounts[e.category] ?? 0) + 1;
+  const pulseCounts = CHANGELOG.reduce(
+    (acc, c) => {
+      acc[c.kind] = (acc[c.kind] ?? 0) + 1;
+      return acc;
+    },
+    {} as Record<string, number>,
+  );
   return {
     stats: {
       total: ENTRIES.length,
@@ -55,6 +64,24 @@ const loadHomeData = createServerFn({ method: "GET" }).handler(async () => {
     categoryCounts,
     registryGeneratedAt: REGISTRY_GENERATED_AT,
     brief: BRIEF_ISSUES[0] ?? null,
+    pulse: {
+      recent: CHANGELOG.slice(0, 4).map((item) => ({
+        ref: item.ref,
+        kind: item.kind,
+        category: item.category,
+        title: item.title,
+        date: item.date,
+      })),
+      topContributors: [...CONTRIBUTORS]
+        .sort((a, b) => (b.acceptedCount ?? 0) - (a.acceptedCount ?? 0))
+        .slice(0, 4)
+        .map((contributor) => ({
+          slug: contributor.slug,
+          name: contributor.name,
+          acceptedCount: contributor.acceptedCount,
+        })),
+      counts: pulseCounts,
+    } satisfies EcosystemPulseData,
   };
 });
 
@@ -128,6 +155,7 @@ function Home() {
   const newest = data.newest as Entry[];
   const sourceBacked = data.sourceBackedEntries as Entry[];
   const categoryCounts = data.categoryCounts as Record<string, number>;
+  const pulse = data.pulse as EcosystemPulseData;
   const latestBrief = data.brief;
   const TOTAL = data.stats.total;
   const TRUSTED_COUNT = data.stats.trusted;
@@ -446,7 +474,7 @@ function Home() {
           )}
         </div>
         <aside>
-          <EcosystemPulse />
+          <EcosystemPulse data={pulse} />
         </aside>
       </section>
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -32,6 +32,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { CATEGORIES, type Category, type Entry } from "@/types/registry";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { filterRecentPulseEntries } from "@/lib/ecosystem-pulse-window";
 
 // Home featured/brief/stats are computed server-side so the ~1 MB registry dataset stays out of
 // the / route's client chunk (the dataset is dynamically imported inside this server handler only).
@@ -42,7 +43,8 @@ const loadHomeData = createServerFn({ method: "GET" }).handler(async () => {
   const { CONTRIBUTORS } = await import("@/data/contributors");
   const categoryCounts: Record<string, number> = {};
   for (const e of ENTRIES) categoryCounts[e.category] = (categoryCounts[e.category] ?? 0) + 1;
-  const pulseCounts = CHANGELOG.reduce(
+  const recentChangelog = filterRecentPulseEntries(CHANGELOG);
+  const pulseCounts = recentChangelog.reduce(
     (acc, c) => {
       acc[c.kind] = (acc[c.kind] ?? 0) + 1;
       return acc;
@@ -65,7 +67,7 @@ const loadHomeData = createServerFn({ method: "GET" }).handler(async () => {
     registryGeneratedAt: REGISTRY_GENERATED_AT,
     brief: BRIEF_ISSUES[0] ?? null,
     pulse: {
-      recent: CHANGELOG.slice(0, 4).map((item) => ({
+      recent: recentChangelog.slice(0, 4).map((item) => ({
         ref: item.ref,
         kind: item.kind,
         category: item.category,

--- a/tests/home-bundle-regression.test.ts
+++ b/tests/home-bundle-regression.test.ts
@@ -1,0 +1,79 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const srcRoot = path.join(repoRoot, "apps/web/src");
+const sourceExtensions = ["", ".tsx", ".ts", ".jsx", ".js", ".json"];
+
+function resolveImport(fromFile: string, specifier: string) {
+  let base: string | undefined;
+  if (specifier.startsWith("@/")) {
+    base = path.join(srcRoot, specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  }
+  if (!base) return undefined;
+
+  for (const ext of sourceExtensions) {
+    const candidate = `${base}${ext}`;
+    if (existsSync(candidate)) return candidate;
+  }
+  for (const ext of sourceExtensions.slice(1)) {
+    const candidate = path.join(base, `index${ext}`);
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function staticImportSpecifiers(filePath: string) {
+  const source = readFileSync(filePath, "utf8");
+  const specifiers: string[] = [];
+  const normalized = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  const importPattern =
+    /^\s*import\s+(?!type\b)(?:[\s\S]*?\s+from\s+)?["']([^"']+)["'];?/gm;
+  const exportPattern =
+    /^\s*export\s+(?!type\b)(?:\*|{[\s\S]*?})\s+from\s+["']([^"']+)["'];?/gm;
+
+  for (const match of normalized.matchAll(importPattern)) {
+    if (match[1]) specifiers.push(match[1]);
+  }
+  for (const match of normalized.matchAll(exportPattern)) {
+    if (match[1]) specifiers.push(match[1]);
+  }
+
+  return specifiers;
+}
+
+function staticImportGraph(startFile: string) {
+  const pending = [startFile];
+  const visited = new Set<string>();
+
+  while (pending.length > 0) {
+    const filePath = pending.pop();
+    if (!filePath || visited.has(filePath)) continue;
+    visited.add(filePath);
+
+    for (const specifier of staticImportSpecifiers(filePath)) {
+      const resolved = resolveImport(filePath, specifier);
+      if (resolved && resolved.startsWith(srcRoot)) pending.push(resolved);
+    }
+  }
+
+  return [...visited].sort();
+}
+
+describe("home client bundle boundaries", () => {
+  it("keeps registry data out of the static home import graph", () => {
+    const graph = staticImportGraph(path.join(srcRoot, "routes/index.tsx"));
+    const dataModules = graph
+      .map((filePath) => path.relative(repoRoot, filePath).replaceAll(path.sep, "/"))
+      .filter(
+        (filePath) =>
+          filePath.startsWith("apps/web/src/data/") ||
+          filePath.startsWith("apps/web/src/generated/"),
+      );
+
+    expect(dataModules).toEqual([]);
+  });
+});

--- a/tests/home-bundle-regression.test.ts
+++ b/tests/home-bundle-regression.test.ts
@@ -1,10 +1,27 @@
-import { existsSync, readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { filterRecentPulseEntries } from "../apps/web/src/lib/ecosystem-pulse-window";
 
 const repoRoot = process.cwd();
 const srcRoot = path.join(repoRoot, "apps/web/src");
 const sourceExtensions = ["", ".tsx", ".ts", ".jsx", ".js", ".json"];
+
+function isFile(filePath: string) {
+  try {
+    return statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
 
 function resolveImport(fromFile: string, specifier: string) {
   let base: string | undefined;
@@ -17,11 +34,11 @@ function resolveImport(fromFile: string, specifier: string) {
 
   for (const ext of sourceExtensions) {
     const candidate = `${base}${ext}`;
-    if (existsSync(candidate)) return candidate;
+    if (isFile(candidate)) return candidate;
   }
   for (const ext of sourceExtensions.slice(1)) {
     const candidate = path.join(base, `index${ext}`);
-    if (existsSync(candidate)) return candidate;
+    if (isFile(candidate)) return candidate;
   }
   return undefined;
 }
@@ -66,6 +83,42 @@ function staticImportGraph(startFile: string) {
 }
 
 describe("home client bundle boundaries", () => {
+  it("resolves index files instead of returning directories", () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), "home-bundle-"));
+    try {
+      const entryFile = path.join(tempRoot, "entry.ts");
+      const moduleDir = path.join(tempRoot, "module");
+      mkdirSync(moduleDir);
+      writeFileSync(entryFile, 'import "./module";\n');
+      writeFileSync(
+        path.join(moduleDir, "index.ts"),
+        "export const value = 1;\n",
+      );
+
+      expect(resolveImport(entryFile, "./module")).toBe(
+        path.join(moduleDir, "index.ts"),
+      );
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("filters ecosystem pulse entries to the last 14 calendar days", () => {
+    const entries = [
+      { id: "today", date: "2026-06-18" },
+      { id: "boundary", date: "2026-06-05" },
+      { id: "stale", date: "2026-06-04" },
+      { id: "future", date: "2026-06-19" },
+      { id: "invalid", date: "not-a-date" },
+    ];
+
+    expect(
+      filterRecentPulseEntries(entries, new Date("2026-06-18T23:30:00Z")).map(
+        (entry) => entry.id,
+      ),
+    ).toEqual(["today", "boundary"]);
+  });
+
   it("keeps registry data out of the static home import graph", () => {
     const graph = staticImportGraph(path.join(srcRoot, "routes/index.tsx"));
     const dataModules = graph

--- a/tests/home-bundle-regression.test.ts
+++ b/tests/home-bundle-regression.test.ts
@@ -29,7 +29,9 @@ function resolveImport(fromFile: string, specifier: string) {
 function staticImportSpecifiers(filePath: string) {
   const source = readFileSync(filePath, "utf8");
   const specifiers: string[] = [];
-  const normalized = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  const normalized = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/.*$/gm, "");
   const importPattern =
     /^\s*import\s+(?!type\b)(?:[\s\S]*?\s+from\s+)?["']([^"']+)["'];?/gm;
   const exportPattern =
@@ -67,7 +69,9 @@ describe("home client bundle boundaries", () => {
   it("keeps registry data out of the static home import graph", () => {
     const graph = staticImportGraph(path.join(srcRoot, "routes/index.tsx"));
     const dataModules = graph
-      .map((filePath) => path.relative(repoRoot, filePath).replaceAll(path.sep, "/"))
+      .map((filePath) =>
+        path.relative(repoRoot, filePath).replaceAll(path.sep, "/"),
+      )
       .filter(
         (filePath) =>
           filePath.startsWith("apps/web/src/data/") ||


### PR DESCRIPTION
## Summary
- keep the home page ecosystem pulse from statically importing registry-derived data in the client route graph
- move pulse data shaping into the existing home server loader
- add an import-graph regression test for the home route boundary

## What changed
- `EcosystemPulse` now receives precomputed pulse data instead of importing changelog/contributor modules directly.
- The home loader builds recent registry changes, top contributors, and pulse counts server-side.
- `tests/home-bundle-regression.test.ts` walks the static home import graph and fails if `apps/web/src/data/**` or generated registry modules leak back in.

## Why
The home route already lazy-loads heavy registry data through server/client boundaries, but the pulse component reintroduced registry-derived data through a static component import. This keeps that component data-shaped and adds a guard against regressions.

## Validation
- `pnpm exec vitest run tests/home-bundle-regression.test.ts`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- No content entries or generated registry artifacts are changed.
- The existing build still reports large registry chunk warnings from other route/data imports; this PR only guards the home route static graph.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the Home “Ecosystem Pulse” to be driven by loader-provided data instead of internal imports.
  * Added shared pulse-window utilities to consistently show entries from the last 14 UTC days.
* **Tests**
  * Expanded home bundle-boundary regression coverage, including import-resolution behavior and date filtering for stale/future/invalid entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->