### PR TITLE
fix(search): bound query tokenization

### DIFF
--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -182,7 +182,8 @@ export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) 
   if (filters.installable && !entry.installCommand && !entry.configSnippet && !entry.fullCopy)
     return false;
   if (filters.hasSafetyNotes && !entry.safetyNotes) return false;
-  if (prepared.queryProfile && !matchesEntryQueryProfile(entry, prepared.queryProfile)) return false;
+  if (prepared.queryProfile && !matchesEntryQueryProfile(entry, prepared.queryProfile))
+    return false;
   if (prepared.q && prepared.queryProfile === null) return false;
   if (filters.q && prepared.queryProfile === undefined && !matchesEntryQuery(entry, filters.q))
     return false;

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -21,6 +21,8 @@ export interface SearchFilters {
 }
 
 const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+const MAX_QUERY_LENGTH = 256;
+const MAX_QUERY_TOKENS = 12;
 
 const QUERY_ALIASES: Record<string, string[]> = {
   browser: ["chrome", "playwright", "web"],
@@ -43,14 +45,48 @@ interface EntrySearchProfile {
   words: string[];
 }
 
+interface QuerySearchProfile {
+  normalizedQuery: string;
+  tokens: string[];
+}
+
+interface PreparedSearchFilters extends SearchFilters {
+  queryProfile?: QuerySearchProfile | null;
+}
+
 const ENTRY_SEARCH_PROFILES = new WeakMap<Entry, EntrySearchProfile>();
 
+export function normalizeSearchQuery(query: string) {
+  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
+}
+
 function tokenizeSearchQuery(query: string) {
-  return query
-    .split(TOKEN_SPLIT_PATTERN)
-    .map((token) => token.trim().toLowerCase())
-    .filter((token) => token.length >= 2)
-    .slice(0, 12);
+  const tokens: string[] = [];
+  let token = "";
+
+  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
+    const char = query[index]!;
+    if (/[a-z0-9+#.-]/i.test(char)) {
+      token += char.toLowerCase();
+      continue;
+    }
+
+    if (token.length >= 2) tokens.push(token);
+    token = "";
+  }
+
+  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
+  return tokens;
+}
+
+function querySearchProfile(query: string): QuerySearchProfile | null {
+  const normalizedQuery = normalizeSearchQuery(query);
+  if (!normalizedQuery) return null;
+
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (!tokens.length) return null;
+
+  return { normalizedQuery, tokens };
 }
 
 function expandedTokenCandidates(token: string) {
@@ -106,13 +142,8 @@ function candidateMatchesText(candidate: string, profile: EntrySearchProfile) {
   );
 }
 
-export function matchesEntryQuery(entry: Entry, query: string) {
-  const normalizedQuery = query.trim().toLowerCase();
-  if (!normalizedQuery) return true;
-
-  const tokens = tokenizeSearchQuery(normalizedQuery);
-  if (!tokens.length) return false;
-
+function matchesEntryQueryProfile(entry: Entry, queryProfile: QuerySearchProfile) {
+  const { normalizedQuery, tokens } = queryProfile;
   const profile = entrySearchProfile(entry);
   if (
     normalizedQuery.length > 2
@@ -127,7 +158,22 @@ export function matchesEntryQuery(entry: Entry, query: string) {
   );
 }
 
+export function matchesEntryQuery(entry: Entry, query: string) {
+  const profile = querySearchProfile(query);
+  if (!profile) return !normalizeSearchQuery(query);
+  return matchesEntryQueryProfile(entry, profile);
+}
+
+function prepareSearchFilters(filters: SearchFilters = {}): PreparedSearchFilters {
+  return {
+    ...filters,
+    q: filters.q ? normalizeSearchQuery(filters.q) : filters.q,
+    queryProfile: filters.q ? querySearchProfile(filters.q) : null,
+  };
+}
+
 export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) {
+  const prepared = filters as PreparedSearchFilters;
   if (filters.categories?.length && !filters.categories.includes(entry.category)) return false;
   if (filters.platforms?.length && !entry.platforms.some((p) => filters.platforms!.includes(p)))
     return false;
@@ -136,18 +182,23 @@ export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) 
   if (filters.installable && !entry.installCommand && !entry.configSnippet && !entry.fullCopy)
     return false;
   if (filters.hasSafetyNotes && !entry.safetyNotes) return false;
-  if (filters.q && !matchesEntryQuery(entry, filters.q)) return false;
+  if (prepared.queryProfile && !matchesEntryQueryProfile(entry, prepared.queryProfile)) return false;
+  if (prepared.q && prepared.queryProfile === null) return false;
+  if (filters.q && prepared.queryProfile === undefined && !matchesEntryQuery(entry, filters.q))
+    return false;
   return true;
 }
 
 export function filterSearchEntries(filters: SearchFilters = {}, entries: Entry[] = ENTRIES) {
-  return entries.filter((entry) => matchesSearchFilters(entry, filters));
+  const prepared = prepareSearchFilters(filters);
+  return entries.filter((entry) => matchesSearchFilters(entry, prepared));
 }
 
 export function countSearchResults(filters: SearchFilters = {}, entries: Entry[] = ENTRIES) {
+  const prepared = prepareSearchFilters(filters);
   let count = 0;
   for (const entry of entries) {
-    if (matchesSearchFilters(entry, filters)) count += 1;
+    if (matchesSearchFilters(entry, prepared)) count += 1;
   }
   return count;
 }

--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -8,7 +8,7 @@
  * helper `respondFeed` handles `If-None-Match` and emits cache headers.
  */
 import { ENTRIES } from "@/data/entries";
-import { filterSearchEntries } from "@/data/search";
+import { filterSearchEntries, normalizeSearchQuery } from "@/data/search";
 import { CHANGELOG, RELEASE_NOTES } from "@/data/changelog";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { ifNoneMatchMatches } from "@/lib/http-cache";
@@ -247,7 +247,7 @@ export interface SavedSearchQuery {
 export function applySavedSearch(q: SavedSearchQuery): FeedItem[] {
   return filterSearchEntries(
     {
-      q: q.q,
+      q: q.q ? normalizeSearchQuery(q.q) : q.q,
       categories: q.category ? [q.category as Category] : undefined,
       trust: q.trust ? [q.trust as TrustLevel] : undefined,
       source: q.source ? [q.source as SourceStatus] : undefined,

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -11,7 +11,7 @@ import { useMemo } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
-import { countSearchResults, search } from "@/data/search";
+import { countSearchResults, normalizeSearchQuery, search } from "@/data/search";
 import {
   CATEGORIES,
   type Category,
@@ -123,7 +123,7 @@ const defaultSearch = {
 };
 
 const searchSchema = z.object({
-  q: z.string().catch(defaultSearch.q).default(defaultSearch.q),
+  q: z.string().transform(normalizeSearchQuery).catch(defaultSearch.q).default(defaultSearch.q),
   category: z.string().catch(defaultSearch.category).default(defaultSearch.category),
   trust: z.string().catch(defaultSearch.trust).default(defaultSearch.trust),
   source: z.string().catch(defaultSearch.source).default(defaultSearch.source),

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -60,7 +60,9 @@ describe("entry query matching", () => {
     });
     const longQuery = `${"browser ".repeat(20)}${"x,".repeat(10_000)}`;
 
-    expect(normalizeSearchQuery(` ${"a".repeat(300)} `).length).toBeLessThanOrEqual(256);
+    expect(
+      normalizeSearchQuery(` ${"a".repeat(300)} `).length,
+    ).toBeLessThanOrEqual(256);
     expect(matchesEntryQuery(browserEntry, longQuery)).toBe(true);
     expect(matchesEntryQuery(browserEntry, ",".repeat(10_000))).toBe(false);
   });

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -4,6 +4,7 @@ import {
   countSearchResults,
   filterSearchEntries,
   matchesEntryQuery,
+  normalizeSearchQuery,
 } from "../apps/web/src/data/search";
 import type { Entry } from "../apps/web/src/types/registry";
 
@@ -49,6 +50,19 @@ describe("entry query matching", () => {
 
     expect(matchesEntryQuery(githubEntry, "gh review")).toBe(true);
     expect(matchesEntryQuery(githubEntry, "cc review")).toBe(true);
+  });
+
+  it("bounds query normalization and token matching work", () => {
+    const browserEntry = entry({
+      title: "Browser Bridge",
+      description: "Runs Playwright automation for Claude Code sessions.",
+      tags: ["browser-automation"],
+    });
+    const longQuery = `${"browser ".repeat(20)}${"x,".repeat(10_000)}`;
+
+    expect(normalizeSearchQuery(` ${"a".repeat(300)} `).length).toBeLessThanOrEqual(256);
+    expect(matchesEntryQuery(browserEntry, longQuery)).toBe(true);
+    expect(matchesEntryQuery(browserEntry, ",".repeat(10_000))).toBe(false);
   });
 });
 


### PR DESCRIPTION
### Motivation
- A tokenized search path was splitting and processing the entire user-provided `q` string on every entry match, which allowed attackers to submit long delimiter-rich queries that cause excessive CPU and allocation (algorithmic DoS) when browse facet counts and feed generation call the matcher repeatedly.
- The goal is to bound and reuse query work so public routes and saved-search feeds cannot force repeated full-string allocations per entry.

### Description
- Cap query normalization to a fixed prefix (`MAX_QUERY_LENGTH = 256`) and expose `normalizeSearchQuery` to ensure long `q` values are trimmed early; applied at route and feed boundaries. (changed `apps/web/src/routes/browse.tsx`, `apps/web/src/lib/feeds.ts`).
- Replace global `split(...).slice(0, 12)` with an incremental tokenizer that stops after `MAX_QUERY_TOKENS = 12` tokens to avoid allocating on the full input. (changed `apps/web/src/data/search.ts`).
- Precompute a per-query `QuerySearchProfile` (normalized query + tokens) once per filter/count operation and reuse it across entry matching to avoid per-entry tokenization work; `filterSearchEntries` and `countSearchResults` now prepare and use the profile. (changed `apps/web/src/data/search.ts`).
- Add a regression test for long delimiter-heavy queries and normalize behavior. (changed `tests/search-query.test.ts`).

### Testing
- Ran the focused unit tests with `pnpm exec vitest run tests/search-query.test.ts` and all tests passed. 
- Ran static checks/type generation with `pnpm type-check` which completed without errors (the run generates registry artifacts as part of the workflow).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348c52e8dc832c891878485bc6105a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter query normalization with enforced maximum length and token limits to improve matching consistency and performance.
  * Improved search filtering by precomputing query data for more reliable results.

* **Bug Fixes**
  * Standardized free-text search query handling so saved searches and browsing share the same normalized query behavior.

* **Tests**
  * Added coverage for normalization length bounds and token-based matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->