### PR TITLE
fix(rules): require boundary-aware path confinement

### DIFF
--- a/content/rules/ai-generated-path-traversal-review-rules.mdx
+++ b/content/rules/ai-generated-path-traversal-review-rules.mdx
@@ -104,8 +104,11 @@ stay inside, require that context before reviewing the file operations.
 
 - Resolve the user-supplied path to its canonical absolute form using the
   runtime's path-resolution API before any file operation.
-- Assert that the resolved canonical path still begins with the allowed root
-  after resolution; reject the request if it does not.
+- Assert that the resolved canonical path is inside the allowed root using a
+  boundary-aware check after resolution. For example, compare
+  `path.relative(allowedRoot, candidate)` and reject results that start with
+  `..` or are absolute, or require equality with the root or the root plus a
+  path separator after normalizing both paths.
 - Never trust that `os.path.join` or string concatenation constrains the result;
   an absolute input or a dot-dot sequence can override a prefix.
 - Check the confinement assertion after resolution, not before, since
@@ -173,7 +176,8 @@ AI assistants can review file-handling code, but they should show evidence.
 - Have the assistant provide dot-dot, URL-encoded, and absolute-path test inputs
   alongside valid filenames.
 - Do not let the assistant claim confinement is safe based on a prefix string
-  check before resolution.
+  check either before or after resolution; require a boundary-aware containment
+  test.
 - Re-run review after any change to path construction, upload handling, or
   archive extraction.
 


### PR DESCRIPTION
### Motivation
- The existing rule recommended accepting post-canonicalization paths that simply "begin with the allowed root", which is bypassable by sibling directories like `/uploads_evil` and thus unsafe.
- The registry should not publish copyable guidance that encourages string-prefix confinement checks which can lead downstream code to allow path-traversal exploits.

### Description
- Replace the post-resolution prefix recommendation with a boundary-aware containment check and give concrete examples such as using `path.relative(allowedRoot, candidate)` and rejecting values that start with `..` or are absolute, or requiring equality with the root or root plus a separator after normalization.
- Update the AI review guidance to explicitly forbid prefix string checks both before and after canonical resolution and require a boundary-aware containment test instead.
- Keep the rest of the rule text and checklist intact while moving the confinement assertion guidance to be unambiguous and secure.

### Testing
- Ran `pnpm validate:content:strict` and the content validation passed.
- Ran `git diff --check` and no whitespace or formatting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34da1f0138832c8d7af750eafc41f2)