### PR TITLE
feat(ecosystem-stats): add tag, platform, and difficulty distribution analytics

### DIFF
--- a/apps/web/src/lib/ecosystem-stats.ts
+++ b/apps/web/src/lib/ecosystem-stats.ts
@@ -1,0 +1,242 @@
+import type { Entry } from "@/types/registry";
+
+/**
+ * Deterministic, structured-field-derived ecosystem statistics for the
+ * `/state-of-claude-tooling` data report. Every value is computed from real
+ * registry fields (no estimates, no LLM-generated prose) so the numbers — and
+ * the `Dataset` JSON-LD that advertises them — are accurate by construction.
+ */
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+// Ordered: first matching rule wins. Patterns anchor on the first token of the
+// (lowercased) install command so classification is unambiguous.
+const INSTALL_METHOD_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^(?:npx|npm)\b/, "npm / npx"],
+  [/^pnpm\b/, "pnpm"],
+  [/^yarn\b/, "yarn"],
+  [/^bunx?\b/, "bun"],
+  [/^deno\b/, "deno"],
+  [/^(?:uvx?|pipx?)\b|\bpip3? install\b/, "Python (pip / uv)"],
+  [/^docker\b/, "Docker"],
+  [/^go\b/, "Go"],
+  [/^cargo\b/, "Cargo"],
+  [/^brew\b/, "Homebrew"],
+  [/^claude\b/, "Claude CLI (claude mcp add …)"],
+  [/^\//, "Claude slash command"],
+  [/^git\b/, "Git clone"],
+  [/^(?:curl|wget)\b/, "Shell (curl / wget)"],
+  [/^(?:mkdir|cat|cp|mv|echo|touch|tee)\b/, "Manual file setup"],
+];
+
+/**
+ * Classify an entry's `installCommand` into an install-method bucket.
+ * Returns `null` when there is no install command (the resource is a
+ * config/file drop-in, not a package install).
+ */
+export function installMethodOf(installCommand?: string | null): string | null {
+  const command = String(installCommand ?? "")
+    .trim()
+    .toLowerCase();
+  if (!command) return null;
+  for (const [pattern, label] of INSTALL_METHOD_RULES) {
+    if (pattern.test(command)) return label;
+  }
+  return "Other";
+}
+
+/**
+ * Distribution of install methods across the entries that declare an
+ * `installCommand`. `total` is the size of that installable subset (not the
+ * whole catalog), and the row counts sum to exactly `total`.
+ */
+export function installMethodDistribution(entries: ReadonlyArray<Entry>): {
+  rows: StatRow[];
+  total: number;
+} {
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (const entry of entries) {
+    const method = installMethodOf(entry.installCommand);
+    if (!method) continue;
+    counts.set(method, (counts.get(method) ?? 0) + 1);
+    total += 1;
+  }
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  return { rows, total };
+}
+
+/**
+ * Coverage of safety / privacy notes across the catalog. These are HeyClaude's
+ * differentiating metadata, so quantifying them is high-signal original data.
+ * `both` is bounded by `min(safety, privacy)`; all counts are bounded by
+ * `total`.
+ */
+export function notesCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  safety: number;
+  privacy: number;
+  both: number;
+} {
+  let safety = 0;
+  let privacy = 0;
+  let both = 0;
+  for (const entry of entries) {
+    const hasSafety = Boolean(entry.safetyNotes);
+    const hasPrivacy = Boolean(entry.privacyNotes);
+    if (hasSafety) safety += 1;
+    if (hasPrivacy) privacy += 1;
+    if (hasSafety && hasPrivacy) both += 1;
+  }
+  return { total: entries.length, safety, privacy, both };
+}
+
+/**
+ * Frequency table of every tag across the catalog, sorted by descending count.
+ * Tags are normalised to lowercase and stripped of surrounding whitespace.
+ * Empty or whitespace-only tag values are skipped. Entries with no tags
+ * contribute nothing to the table, but are still counted in `total`.
+ *
+ * `topN` caps the returned rows (default: unlimited). Useful when the caller
+ * only wants the most common tags without pulling hundreds of long-tail rows.
+ */
+export function tagDistribution(
+  entries: ReadonlyArray<Entry>,
+  options: { topN?: number } = {},
+): { rows: StatRow[]; uniqueTags: number; total: number } {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const seen = new Set<string>();
+    for (const raw of entry.tags ?? []) {
+      const tag = String(raw ?? "")
+        .trim()
+        .toLowerCase();
+      if (!tag || seen.has(tag)) continue;
+      seen.add(tag);
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  const uniqueTags = counts.size;
+  let rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  if (typeof options.topN === "number" && options.topN > 0) {
+    rows = rows.slice(0, options.topN);
+  }
+  return { rows, uniqueTags, total: entries.length };
+}
+
+/**
+ * Distribution of `difficulty` field values across the catalog.
+ * Entries that omit `difficulty` are grouped under the `"unspecified"` bucket.
+ * The rows are sorted so that canonical difficulty levels appear in ascending
+ * order of experience required (`"beginner"` → `"intermediate"` → `"advanced"`)
+ * before any non-standard or `"unspecified"` values.
+ */
+const DIFFICULTY_ORDER: ReadonlyArray<string> = [
+  "beginner",
+  "intermediate",
+  "advanced",
+];
+
+export function difficultyDistribution(entries: ReadonlyArray<Entry>): {
+  rows: StatRow[];
+  total: number;
+} {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const raw = String(entry.difficulty ?? "")
+      .trim()
+      .toLowerCase();
+    const bucket = raw || "unspecified";
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => {
+      const ai = DIFFICULTY_ORDER.indexOf(a.label);
+      const bi = DIFFICULTY_ORDER.indexOf(b.label);
+      if (ai !== -1 && bi !== -1) return ai - bi;
+      if (ai !== -1) return -1;
+      if (bi !== -1) return 1;
+      if (a.label === "unspecified") return 1;
+      if (b.label === "unspecified") return -1;
+      return b.count - a.count || a.label.localeCompare(b.label);
+    });
+  return { rows, total: entries.length };
+}
+
+/**
+ * Distribution of `platforms` across installable catalog entries.
+ * Each entry's platform list is de-duplicated before tallying so a single
+ * entry cannot inflate any bucket's count. Entries with an empty platform list
+ * are counted in `total` but contribute nothing to the rows.
+ *
+ * `total` is the number of entries that declare at least one platform.
+ */
+export function platformDistribution(entries: ReadonlyArray<Entry>): {
+  rows: StatRow[];
+  total: number;
+} {
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (const entry of entries) {
+    const seen = new Set<string>();
+    for (const raw of entry.platforms ?? []) {
+      const platform = String(raw ?? "").trim().toLowerCase();
+      if (!platform || seen.has(platform)) continue;
+      seen.add(platform);
+      counts.set(platform, (counts.get(platform) ?? 0) + 1);
+    }
+    if (seen.size > 0) total += 1;
+  }
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  return { rows, total };
+}
+
+/**
+ * Per-category breakdown of safety-note and privacy-note coverage.
+ * Useful for identifying which content categories have the weakest metadata
+ * quality and where editorial effort should be focused.
+ */
+export interface CategoryNotesCoverage {
+  category: string;
+  total: number;
+  safety: number;
+  privacy: number;
+  both: number;
+}
+
+export function notesCoverageByCategory(
+  entries: ReadonlyArray<Entry>,
+): CategoryNotesCoverage[] {
+  const byCategory = new Map<
+    string,
+    { total: number; safety: number; privacy: number; both: number }
+  >();
+
+  for (const entry of entries) {
+    const cat = String(entry.category ?? "unknown").trim();
+    if (!byCategory.has(cat)) {
+      byCategory.set(cat, { total: 0, safety: 0, privacy: 0, both: 0 });
+    }
+    const bucket = byCategory.get(cat)!;
+    bucket.total += 1;
+    const hasSafety = Boolean(entry.safetyNotes);
+    const hasPrivacy = Boolean(entry.privacyNotes);
+    if (hasSafety) bucket.safety += 1;
+    if (hasPrivacy) bucket.privacy += 1;
+    if (hasSafety && hasPrivacy) bucket.both += 1;
+  }
+
+  return [...byCategory.entries()]
+    .map(([category, counts]) => ({ category, ...counts }))
+    .sort((a, b) => b.total - a.total || a.category.localeCompare(b.category));
+}

--- a/tests/ecosystem-stats.test.ts
+++ b/tests/ecosystem-stats.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import {
+  difficultyDistribution,
+  installMethodDistribution,
+  installMethodOf,
+  notesCoverage,
+  notesCoverageByCategory,
+  platformDistribution,
+  tagDistribution,
+} from "../apps/web/src/lib/ecosystem-stats";
+
+function entry(partial: Partial<Entry>): Entry {
+  return partial as Entry;
+}
+
+describe("installMethodOf", () => {
+  it("classifies common install commands deterministically", () => {
+    expect(installMethodOf("npx -y some-mcp")).toBe("npm / npx");
+    expect(installMethodOf("npm install -g x")).toBe("npm / npx");
+    expect(installMethodOf("pnpm add x")).toBe("pnpm");
+    expect(installMethodOf("uvx some-server")).toBe("Python (pip / uv)");
+    expect(installMethodOf("pip install x")).toBe("Python (pip / uv)");
+    expect(installMethodOf("pipx run x")).toBe("Python (pip / uv)");
+    expect(installMethodOf("docker run x")).toBe("Docker");
+    expect(installMethodOf("go install x")).toBe("Go");
+    expect(installMethodOf("cargo install x")).toBe("Cargo");
+    expect(installMethodOf("brew install x")).toBe("Homebrew");
+    expect(installMethodOf("bunx x")).toBe("bun");
+  });
+
+  it("classifies Claude-native and shell install patterns", () => {
+    expect(installMethodOf("claude mcp add x https://...")).toBe(
+      "Claude CLI (claude mcp add …)",
+    );
+    expect(installMethodOf("/agents")).toBe("Claude slash command");
+    expect(installMethodOf("git clone https://github.com/x/y")).toBe(
+      "Git clone",
+    );
+    expect(installMethodOf("curl https://example.com | sh")).toBe(
+      "Shell (curl / wget)",
+    );
+    expect(installMethodOf("mkdir -p .claude/commands && cat > x")).toBe(
+      "Manual file setup",
+    );
+  });
+
+  it("returns null for no install command (config/file drop-in)", () => {
+    expect(installMethodOf(undefined)).toBeNull();
+    expect(installMethodOf("")).toBeNull();
+    expect(installMethodOf("   ")).toBeNull();
+  });
+
+  it("buckets genuinely unrecognized commands as Other", () => {
+    expect(installMethodOf("frobnicate --install x")).toBe("Other");
+  });
+});
+
+describe("installMethodDistribution", () => {
+  it("counts only installable entries and rows sum to the installable total", () => {
+    const entries = [
+      entry({ installCommand: "npx a" }),
+      entry({ installCommand: "npx b" }),
+      entry({ installCommand: "pip install c" }),
+      entry({ installCommand: "" }), // not installable
+      entry({}), // not installable
+    ];
+    const { rows, total } = installMethodDistribution(entries);
+    expect(total).toBe(3);
+    expect(rows.reduce((sum, r) => sum + r.count, 0)).toBe(total);
+    expect(total).toBeLessThanOrEqual(entries.length);
+    // sorted by count desc
+    expect(rows[0]).toEqual({ label: "npm / npx", count: 2 });
+  });
+});
+
+describe("notesCoverage", () => {
+  it("bounds every count by the total and both by min(safety, privacy)", () => {
+    const entries = [
+      entry({ safetyNotes: "x", privacyNotes: "y" }),
+      entry({ safetyNotes: "x" }),
+      entry({ privacyNotes: "y" }),
+      entry({}),
+    ];
+    const c = notesCoverage(entries);
+    expect(c.total).toBe(4);
+    expect(c.safety).toBe(2);
+    expect(c.privacy).toBe(2);
+    expect(c.both).toBe(1);
+    expect(c.safety).toBeLessThanOrEqual(c.total);
+    expect(c.privacy).toBeLessThanOrEqual(c.total);
+    expect(c.both).toBeLessThanOrEqual(Math.min(c.safety, c.privacy));
+  });
+});
+
+describe("tagDistribution", () => {
+  it("counts each tag once per entry and sorts by frequency descending", () => {
+    const entries = [
+      entry({ tags: ["security", "ai"] }),
+      entry({ tags: ["security", "review"] }),
+      entry({ tags: ["ai", "review"] }),
+      entry({ tags: [] }),
+      entry({}),
+    ];
+    const { rows, uniqueTags, total } = tagDistribution(entries);
+    expect(total).toBe(5);
+    expect(uniqueTags).toBe(3);
+    expect(rows[0]).toEqual({ label: "ai", count: 2 });
+    expect(rows[0].count).toBeGreaterThanOrEqual(rows[1].count);
+    const rowCounts = rows.reduce((sum, r) => sum + r.count, 0);
+    // Each of the 3 unique tags appears in 2 entries
+    expect(rowCounts).toBe(6);
+  });
+
+  it("normalises tags to lowercase and deduplicates within an entry", () => {
+    const entries = [
+      entry({ tags: ["Security", "SECURITY", "security"] }),
+    ];
+    const { rows, uniqueTags } = tagDistribution(entries);
+    expect(uniqueTags).toBe(1);
+    expect(rows).toEqual([{ label: "security", count: 1 }]);
+  });
+
+  it("respects the topN option", () => {
+    const entries = [
+      entry({ tags: ["a", "b", "c"] }),
+      entry({ tags: ["a", "b"] }),
+      entry({ tags: ["a"] }),
+    ];
+    const { rows } = tagDistribution(entries, { topN: 2 });
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ label: "a", count: 3 });
+  });
+
+  it("returns empty rows for a catalog with no tags", () => {
+    const { rows, uniqueTags, total } = tagDistribution([
+      entry({}),
+      entry({ tags: [] }),
+    ]);
+    expect(rows).toHaveLength(0);
+    expect(uniqueTags).toBe(0);
+    expect(total).toBe(2);
+  });
+});
+
+describe("difficultyDistribution", () => {
+  it("orders canonical levels beginner → intermediate → advanced, then others, then unspecified", () => {
+    const entries = [
+      entry({ difficulty: "advanced" }),
+      entry({ difficulty: "beginner" }),
+      entry({ difficulty: "intermediate" }),
+      entry({ difficulty: "intermediate" }),
+      entry({}),
+      entry({ difficulty: "" }),
+    ];
+    const { rows, total } = difficultyDistribution(entries);
+    expect(total).toBe(6);
+    expect(rows[0].label).toBe("beginner");
+    expect(rows[1].label).toBe("intermediate");
+    expect(rows[2].label).toBe("advanced");
+    expect(rows.at(-1)?.label).toBe("unspecified");
+  });
+
+  it("groups entries with no or empty difficulty into unspecified", () => {
+    const entries = [entry({}), entry({ difficulty: "" }), entry({ difficulty: "  " })];
+    const { rows } = difficultyDistribution(entries);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ label: "unspecified", count: 3 });
+  });
+
+  it("row counts sum to total", () => {
+    const entries = [
+      entry({ difficulty: "beginner" }),
+      entry({ difficulty: "advanced" }),
+      entry({}),
+    ];
+    const { rows, total } = difficultyDistribution(entries);
+    expect(rows.reduce((s, r) => s + r.count, 0)).toBe(total);
+  });
+});
+
+describe("platformDistribution", () => {
+  it("counts each platform once per entry and reports entries with at least one platform", () => {
+    const entries = [
+      entry({ platforms: ["claude-code", "cursor"] }),
+      entry({ platforms: ["claude-code"] }),
+      entry({ platforms: [] }),
+      entry({}),
+    ];
+    const { rows, total } = platformDistribution(entries);
+    expect(total).toBe(2);
+    expect(rows.find((r) => r.label === "claude-code")?.count).toBe(2);
+    expect(rows.find((r) => r.label === "cursor")?.count).toBe(1);
+  });
+
+  it("deduplicates repeated platforms within a single entry", () => {
+    const entries = [entry({ platforms: ["claude-code", "claude-code"] as never })];
+    const { rows } = platformDistribution(entries);
+    expect(rows.find((r) => r.label === "claude-code")?.count).toBe(1);
+  });
+
+  it("sorts by descending count then alphabetically", () => {
+    const entries = [
+      entry({ platforms: ["cursor", "vscode"] }),
+      entry({ platforms: ["cursor"] }),
+    ];
+    const { rows } = platformDistribution(entries);
+    expect(rows[0].label).toBe("cursor");
+    expect(rows[0].count).toBe(2);
+  });
+});
+
+describe("notesCoverageByCategory", () => {
+  it("groups notes coverage by category and sorts by total descending", () => {
+    const entries = [
+      entry({ category: "mcp", safetyNotes: "x", privacyNotes: "y" }),
+      entry({ category: "mcp" }),
+      entry({ category: "skills", safetyNotes: "x" }),
+    ];
+    const rows = notesCoverageByCategory(entries);
+    expect(rows[0].category).toBe("mcp");
+    expect(rows[0].total).toBe(2);
+    expect(rows[0].safety).toBe(1);
+    expect(rows[0].privacy).toBe(1);
+    expect(rows[0].both).toBe(1);
+    expect(rows[1].category).toBe("skills");
+    expect(rows[1].total).toBe(1);
+    expect(rows[1].safety).toBe(1);
+    expect(rows[1].privacy).toBe(0);
+    expect(rows[1].both).toBe(0);
+  });
+
+  it("satisfies both ≤ min(safety, privacy) for every category row", () => {
+    const entries = [
+      entry({ category: "rules", safetyNotes: "a", privacyNotes: "b" }),
+      entry({ category: "rules", safetyNotes: "a" }),
+      entry({ category: "rules" }),
+    ];
+    const rows = notesCoverageByCategory(entries);
+    for (const row of rows) {
+      expect(row.both).toBeLessThanOrEqual(Math.min(row.safety, row.privacy));
+      expect(row.safety).toBeLessThanOrEqual(row.total);
+      expect(row.privacy).toBeLessThanOrEqual(row.total);
+    }
+  });
+});


### PR DESCRIPTION
Adds four new analytics functions to `ecosystem-stats.ts` for the `/state-of-claude-tooling` data report, each with comprehensive Vitest tests:

- **`tagDistribution(entries, { topN? })`** — frequency table of every tag across the catalog, normalised to lowercase, de-duplicated per entry, sorted by descending count. `topN` caps the result for callers that only need the most common tags.
- **`difficultyDistribution(entries)`** — buckets entries by `difficulty` field in canonical order (`beginner` → `intermediate` → `advanced`), then other non-standard values, then `"unspecified"` for entries without the field.
- **`platformDistribution(entries)`** — tallies which platforms are declared across installable entries, counting each platform at most once per entry.
- **`notesCoverageByCategory(entries)`** — per-category breakdown of safety-note and privacy-note coverage, useful for identifying which content categories have the weakest metadata quality.

All functions are deterministic (no randomness, no external I/O), return `StatRow[]` consistent with the existing `installMethodDistribution` shape, and satisfy invariants enforced by the new tests (row counts sum correctly, `both ≤ min(safety, privacy)`, etc.).

**Tests added:** 18 total test cases in `tests/ecosystem-stats.test.ts` covering normal paths, normalisation edge cases, empty inputs, and sort-order contracts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ecosystem statistics capabilities including install method distribution, tag frequency analysis, difficulty levels, and platform coverage tracking.
  * Added documentation coverage metrics to track safety and privacy note completeness across ecosystem entries and categories.

* **Tests**
  * Added comprehensive test suite for ecosystem statistics functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->