### PR TITLE
feat(mcp-stats): add trust level and source status distribution functions

### DIFF
--- a/apps/web/src/lib/mcp-stats.ts
+++ b/apps/web/src/lib/mcp-stats.ts
@@ -1,0 +1,162 @@
+import type { Entry, SourceStatus, TrustLevel } from "@/types/registry";
+
+/**
+ * Deterministic, structured-field-derived statistics about the MCP-server subset of
+ * the registry, for the `/state-of-mcp-servers` and `/mcp-security-report` data
+ * reports. Every value is computed from real entry fields (config/install snippets,
+ * declared prerequisites, reviewer notes) — no estimates — so the numbers and the
+ * `Dataset` JSON-LD that advertises them are accurate by construction.
+ *
+ * Transport/auth classification is necessarily heuristic (it reads the declared config
+ * and prerequisites), so each report states that in its methodology note.
+ */
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+/** The MCP transport an entry's declared config/install uses. */
+export type McpTransport = "HTTP" | "SSE" | "stdio (local)" | "Unspecified";
+
+/** Join the structured config + install fields we classify transport from. */
+function configHaystack(entry: Entry): string {
+  return [entry.configSnippet, entry.copySnippet, entry.installCommand]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify an MCP server's transport from its declared config/install snippet.
+ * Precedence: an explicit SSE marker, then HTTP (explicit type/transport, a remote
+ * `url`, or `--transport http`), then a local `command` (stdio), else Unspecified.
+ */
+export function classifyTransport(entry: Entry): McpTransport {
+  const hay = configHaystack(entry);
+  if (!hay) return "Unspecified";
+  if (/"(?:type|transport)":\s*"sse"|--transport[= ]sse|\bsse\b.*endpoint/.test(hay)) {
+    return "SSE";
+  }
+  if (
+    /"(?:type|transport)":\s*"(?:http|streamable-?http)"|--transport[= ]http|"url":\s*"https?:\/\//.test(
+      hay,
+    )
+  ) {
+    return "HTTP";
+  }
+  if (/"command":\s*"/.test(hay)) return "stdio (local)";
+  return "Unspecified";
+}
+
+/** Whether a transport runs the server locally (stdio) or reaches a hosted endpoint. */
+export function hostingOf(
+  transport: McpTransport,
+): "Local (stdio)" | "Remote (hosted)" | "Unspecified" {
+  if (transport === "stdio (local)") return "Local (stdio)";
+  if (transport === "HTTP" || transport === "SSE") return "Remote (hosted)";
+  return "Unspecified";
+}
+
+/** The credential type an MCP server declares it needs. */
+export type McpAuth = "OAuth" | "API key" | "Token / PAT" | "None / unspecified";
+
+/** Join the fields where auth requirements are declared (prerequisites + notes + desc). */
+function authHaystack(entry: Entry): string {
+  return [...(entry.prerequisites ?? []), entry.safetyNotes, entry.privacyNotes, entry.description]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify the credential an MCP server requires, inferred from its declared
+ * prerequisites and reviewer notes. Precedence (strongest identity first): OAuth,
+ * then API key, then a personal-access-token / bearer token, else none declared.
+ */
+export function classifyAuth(entry: Entry): McpAuth {
+  const hay = authHaystack(entry);
+  if (/\boauth\d?/.test(hay)) return "OAuth";
+  if (/\bapi[\s_-]?keys?\b/.test(hay)) return "API key";
+  if (/personal access token|\bpat\b|\bbearer\b|access token/.test(hay)) return "Token / PAT";
+  return "None / unspecified";
+}
+
+function distribution<T extends string>(
+  entries: ReadonlyArray<Entry>,
+  classify: (entry: Entry) => T,
+  order: ReadonlyArray<T>,
+): { rows: StatRow[]; total: number } {
+  const counts = new Map<T, number>();
+  for (const entry of entries) {
+    const key = classify(entry);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const rows = order
+    .map((label) => ({ label, count: counts.get(label) ?? 0 }))
+    .filter((row) => row.count > 0);
+  return { rows, total: entries.length };
+}
+
+const TRANSPORT_ORDER: McpTransport[] = ["stdio (local)", "HTTP", "SSE", "Unspecified"];
+const HOSTING_ORDER = ["Local (stdio)", "Remote (hosted)", "Unspecified"] as const;
+const AUTH_ORDER: McpAuth[] = ["OAuth", "API key", "Token / PAT", "None / unspecified"];
+
+/** Distribution of MCP transports across the given entries. */
+export function transportDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyTransport, TRANSPORT_ORDER);
+}
+
+/** Local-vs-remote distribution, derived from transport. */
+export function hostingDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, (e) => hostingOf(classifyTransport(e)), HOSTING_ORDER);
+}
+
+/** Distribution of declared auth methods across the given entries. */
+export function authDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyAuth, AUTH_ORDER);
+}
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_ORDER: SourceStatus[] = [
+  "first-party",
+  "source-backed",
+  "external",
+  "unverified",
+];
+
+/**
+ * Distribution of `trust` levels across the given entries.
+ * Rows appear in the canonical order: trusted → review → limited → blocked.
+ * Empty buckets are omitted; `total` is the count of all entries passed in.
+ */
+export function trustLevelDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, (e) => e.trust, TRUST_ORDER);
+}
+
+/**
+ * Distribution of `source` status values across the given entries.
+ * Rows appear in the canonical order: first-party → source-backed → external → unverified.
+ * Empty buckets are omitted; `total` is the count of all entries passed in.
+ */
+export function sourceStatusDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, (e) => e.source, SOURCE_ORDER);
+}
+
+/**
+ * Supply-chain verification coverage: how many entries ship a maintainer-verified
+ * package and/or a checksummed downloadable artifact.
+ */
+export function supplyChainCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  packageVerified: number;
+  checksummedDownload: number;
+} {
+  let packageVerified = 0;
+  let checksummedDownload = 0;
+  for (const entry of entries) {
+    if (entry.packageVerified) packageVerified += 1;
+    if (entry.downloadUrl && entry.downloadSha256) checksummedDownload += 1;
+  }
+  return { total: entries.length, packageVerified, checksummedDownload };
+}

--- a/tests/mcp-stats.test.ts
+++ b/tests/mcp-stats.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authDistribution,
+  classifyAuth,
+  classifyTransport,
+  hostingDistribution,
+  hostingOf,
+  sourceStatusDistribution,
+  supplyChainCoverage,
+  transportDistribution,
+  trustLevelDistribution,
+} from "@/lib/mcp-stats";
+import type { Entry } from "@/types/registry";
+
+/** Build a minimal Entry; only the fields the stats helpers read need to be real. */
+function mk(partial: Partial<Entry>): Entry {
+  return { category: "mcp", slug: "x", title: "X", ...partial } as Entry;
+}
+
+describe("classifyTransport", () => {
+  it("detects stdio from a local command config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"command":"npx","args":["-y","srv"]}' }),
+      ),
+    ).toBe("stdio (local)");
+  });
+
+  it("detects HTTP from an explicit type, a remote url, or the install flag", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"type":"http","url":"https://x/mcp"}' }),
+      ),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(mk({ copySnippet: '{"url":"https://x.app/mcp"}' })),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(
+        mk({
+          installCommand: "claude mcp add --transport http x https://x/mcp",
+        }),
+      ),
+    ).toBe("HTTP");
+  });
+
+  it("detects SSE before HTTP", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"transport":"sse","url":"https://x/sse"}' }),
+      ),
+    ).toBe("SSE");
+  });
+
+  it("is Unspecified with no config/install signal", () => {
+    expect(classifyTransport(mk({}))).toBe("Unspecified");
+  });
+
+  it("does not infer transport from unrelated non-empty config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"env":{"API_KEY":"required"}}' }),
+      ),
+    ).toBe("Unspecified");
+    expect(
+      classifyTransport(
+        mk({ copySnippet: '{"headers":{"authorization":"Bearer token"}}' }),
+      ),
+    ).toBe("Unspecified");
+  });
+});
+
+describe("hostingOf", () => {
+  it("maps transport to local/remote", () => {
+    expect(hostingOf("stdio (local)")).toBe("Local (stdio)");
+    expect(hostingOf("HTTP")).toBe("Remote (hosted)");
+    expect(hostingOf("SSE")).toBe("Remote (hosted)");
+    expect(hostingOf("Unspecified")).toBe("Unspecified");
+  });
+});
+
+describe("classifyAuth", () => {
+  it("prefers OAuth, then API key, then token, else none", () => {
+    expect(
+      classifyAuth(mk({ prerequisites: ["OAuth2 credentials or a PAT"] })),
+    ).toBe("OAuth");
+    expect(
+      classifyAuth(mk({ prerequisites: ["An API key from the dashboard"] })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ prerequisites: ["A personal access token (PAT)"] })),
+    ).toBe("Token / PAT");
+    expect(classifyAuth(mk({ prerequisites: ["Node.js 18+"] }))).toBe(
+      "None / unspecified",
+    );
+  });
+
+  it("reads from notes and description too, not just prerequisites", () => {
+    expect(
+      classifyAuth(mk({ safetyNotes: "Scope the API key to read-only." })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ description: "Connect via OAuth to your account." })),
+    ).toBe("OAuth");
+  });
+});
+
+describe("distributions", () => {
+  const entries = [
+    mk({ configSnippet: '{"command":"npx"}', prerequisites: ["API key"] }),
+    mk({
+      configSnippet: '{"command":"uvx"}',
+      prerequisites: ["A personal access token"],
+    }),
+    mk({
+      configSnippet: '{"type":"http","url":"https://a/mcp"}',
+      prerequisites: ["OAuth"],
+    }),
+    mk({
+      configSnippet: '{"transport":"sse","url":"https://b/sse"}',
+      prerequisites: ["Node 18"],
+    }),
+  ];
+
+  it("counts transports and keeps the fixed order, dropping empties", () => {
+    const { rows, total } = transportDistribution(entries);
+    expect(total).toBe(4);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["stdio (local)", 2],
+      ["HTTP", 1],
+      ["SSE", 1],
+    ]);
+  });
+
+  it("keeps Unspecified last when an entry has no declared transport", () => {
+    const { rows, total } = transportDistribution([
+      mk({ configSnippet: '{"transport":"sse","url":"https://b/sse"}' }),
+      mk({ configSnippet: '{"env":{"TOKEN":"required"}}' }),
+    ]);
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["SSE", 1],
+      ["Unspecified", 1],
+    ]);
+  });
+
+  it("derives local-vs-remote hosting", () => {
+    const rows = hostingDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "Local (stdio)")?.count).toBe(2);
+    expect(rows.find((r) => r.label === "Remote (hosted)")?.count).toBe(2);
+  });
+
+  it("counts auth methods", () => {
+    const rows = authDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "OAuth")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "API key")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "Token / PAT")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "None / unspecified")?.count).toBe(1);
+  });
+});
+
+describe("trustLevelDistribution", () => {
+  it("emits rows in canonical trust order: trusted → review → limited → blocked", () => {
+    const { rows, total } = trustLevelDistribution([
+      mk({ trust: "blocked" }),
+      mk({ trust: "trusted" }),
+      mk({ trust: "review" }),
+      mk({ trust: "trusted" }),
+      mk({ trust: "limited" }),
+    ]);
+    expect(total).toBe(5);
+    expect(rows.map((r) => r.label)).toEqual(["trusted", "review", "limited", "blocked"]);
+    expect(rows.find((r) => r.label === "trusted")?.count).toBe(2);
+  });
+
+  it("omits empty buckets", () => {
+    const { rows } = trustLevelDistribution([
+      mk({ trust: "trusted" }),
+      mk({ trust: "trusted" }),
+    ]);
+    expect(rows.map((r) => r.label)).toEqual(["trusted"]);
+  });
+
+  it("row counts sum to total when all entries have known trust levels", () => {
+    const entries = [mk({ trust: "trusted" }), mk({ trust: "review" }), mk({ trust: "limited" })];
+    const { rows, total } = trustLevelDistribution(entries);
+    expect(rows.reduce((s, r) => s + r.count, 0)).toBe(total);
+  });
+});
+
+describe("sourceStatusDistribution", () => {
+  it("emits rows in canonical order: first-party → source-backed → external → unverified", () => {
+    const { rows, total } = sourceStatusDistribution([
+      mk({ source: "unverified" }),
+      mk({ source: "source-backed" }),
+      mk({ source: "first-party" }),
+      mk({ source: "external" }),
+      mk({ source: "source-backed" }),
+    ]);
+    expect(total).toBe(5);
+    expect(rows.map((r) => r.label)).toEqual([
+      "first-party",
+      "source-backed",
+      "external",
+      "unverified",
+    ]);
+    expect(rows.find((r) => r.label === "source-backed")?.count).toBe(2);
+  });
+
+  it("omits empty buckets", () => {
+    const { rows } = sourceStatusDistribution([
+      mk({ source: "first-party" }),
+      mk({ source: "first-party" }),
+    ]);
+    expect(rows.map((r) => r.label)).toEqual(["first-party"]);
+  });
+
+  it("row counts sum to total", () => {
+    const entries = [
+      mk({ source: "source-backed" }),
+      mk({ source: "unverified" }),
+      mk({ source: "external" }),
+    ];
+    const { rows, total } = sourceStatusDistribution(entries);
+    expect(rows.reduce((s, r) => s + r.count, 0)).toBe(total);
+  });
+});
+
+describe("supplyChainCoverage", () => {
+  it("counts verified packages and checksummed downloads", () => {
+    const cov = supplyChainCoverage([
+      mk({
+        packageVerified: true,
+        downloadUrl: "/d.mcpb",
+        downloadSha256: "abc",
+      }),
+      mk({ packageVerified: true }),
+      mk({ downloadUrl: "/d.mcpb" }), // no checksum → not counted
+      mk({}),
+    ]);
+    expect(cov).toEqual({
+      total: 4,
+      packageVerified: 2,
+      checksummedDownload: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two new distribution functions to the MCP statistics module, extending the existing `transportDistribution` / `authDistribution` pattern with trust and source coverage:

### `trustLevelDistribution(entries)`
Frequency table of `trust` field values (trusted → review → limited → blocked) across the given entries. Rows appear in canonical precedence order; empty buckets are omitted. Useful for the `/state-of-mcp-servers` report to show what fraction of the catalog has been editorially reviewed vs. unvetted.

### `sourceStatusDistribution(entries)`
Frequency table of `source` field values (first-party → source-backed → external → unverified) across the given entries. Same canonical ordering and empty-bucket semantics. Pairs naturally with trust distribution to characterise the supply-chain quality of the catalog.

Both functions reuse the existing internal `distribution()` helper; the implementation is a thin type import + two constant order arrays + two exports — no new logic paths.

### Tests
Added 6 new test cases covering:
- Canonical ordering is preserved regardless of input order
- Empty buckets are not emitted in the output rows
- Row counts sum to total when all entries have known field values
