### PR TITLE
feat(format): add formatPercent, formatBytes, and formatDate utilities

### DIFF
--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -30,3 +30,59 @@ export function timeAgo(iso: string | undefined | null): string {
   if (mo < 12) return `${mo}mo ago`;
   return `${Math.round(mo / 12)}y ago`;
 }
+
+/**
+ * Format a ratio as a percentage string, rounded to the nearest integer.
+ * `numerator / denominator * 100` — returns "—" when denominator is 0 or
+ * either argument is nullish/NaN. Clamps to [0, 100] so floating-point noise
+ * never produces "101%" or "-1%".
+ *
+ * @example formatPercent(1, 3) // "33%"
+ * @example formatPercent(0, 0) // "—"
+ */
+export function formatPercent(
+  numerator: number | undefined | null,
+  denominator: number | undefined | null,
+): string {
+  if (numerator == null || denominator == null) return "—";
+  if (Number.isNaN(numerator) || Number.isNaN(denominator)) return "—";
+  if (denominator === 0) return "—";
+  const pct = Math.round(Math.max(0, Math.min(100, (numerator / denominator) * 100)));
+  return `${pct}%`;
+}
+
+/**
+ * Format a byte count as a human-readable string: 512 → "512 B",
+ * 2048 → "2.0 KB", 1_572_864 → "1.5 MB". Uses binary prefixes (1024).
+ * Returns "—" for nullish or NaN inputs.
+ *
+ * @example formatBytes(0) // "0 B"
+ * @example formatBytes(1536) // "1.5 KB"
+ */
+export function formatBytes(n: number | undefined | null): string {
+  if (n == null || Number.isNaN(n)) return "—";
+  if (n < 1_024) return `${n} B`;
+  if (n < 1_048_576) return `${(n / 1_024).toFixed(1).replace(/\.0$/, "")} KB`;
+  if (n < 1_073_741_824) return `${(n / 1_048_576).toFixed(1).replace(/\.0$/, "")} MB`;
+  return `${(n / 1_073_741_824).toFixed(1).replace(/\.0$/, "")} GB`;
+}
+
+/**
+ * Format an ISO date string (or any Date-parseable string) as a compact
+ * calendar date: "Jun 19, 2026". Returns "—" for invalid or missing input.
+ * Uses the invariant `en-US` locale so the output is stable for tests and
+ * server-rendered markup (no locale negotiation).
+ *
+ * @example formatDate("2026-06-19") // "Jun 19, 2026"
+ */
+export function formatDate(iso: string | undefined | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/tests/format.test.ts
+++ b/tests/format.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { formatBytes, formatCompact, formatDate, formatPercent, timeAgo } from "@/lib/format";
+
+describe("formatCompact", () => {
+  it("returns plain number for values below 1 000", () => {
+    expect(formatCompact(0)).toBe("0");
+    expect(formatCompact(999)).toBe("999");
+  });
+
+  it("formats thousands with k suffix", () => {
+    expect(formatCompact(1_200)).toBe("1.2k");
+    expect(formatCompact(14_300)).toBe("14.3k");
+    expect(formatCompact(120_000)).toBe("120k");
+    expect(formatCompact(999_999)).toBe("1000k");
+  });
+
+  it("formats millions and billions", () => {
+    expect(formatCompact(2_000_000)).toBe("2M");
+    expect(formatCompact(1_500_000_000)).toBe("1.5B");
+  });
+
+  it("returns em-dash for nullish or NaN", () => {
+    expect(formatCompact(null)).toBe("—");
+    expect(formatCompact(undefined)).toBe("—");
+    expect(formatCompact(NaN)).toBe("—");
+  });
+});
+
+describe("timeAgo", () => {
+  it("returns em-dash for missing or invalid input", () => {
+    expect(timeAgo(null)).toBe("—");
+    expect(timeAgo(undefined)).toBe("—");
+    expect(timeAgo("not-a-date")).toBe("—");
+    expect(timeAgo("")).toBe("—");
+  });
+});
+
+describe("formatPercent", () => {
+  it("formats the ratio as an integer percentage string", () => {
+    expect(formatPercent(1, 3)).toBe("33%");
+    expect(formatPercent(1, 4)).toBe("25%");
+    expect(formatPercent(2, 4)).toBe("50%");
+    expect(formatPercent(3, 3)).toBe("100%");
+    expect(formatPercent(0, 10)).toBe("0%");
+  });
+
+  it("returns em-dash when denominator is zero", () => {
+    expect(formatPercent(0, 0)).toBe("—");
+    expect(formatPercent(5, 0)).toBe("—");
+  });
+
+  it("returns em-dash for nullish or NaN inputs", () => {
+    expect(formatPercent(null, 10)).toBe("—");
+    expect(formatPercent(5, null)).toBe("—");
+    expect(formatPercent(NaN, 10)).toBe("—");
+    expect(formatPercent(5, NaN)).toBe("—");
+  });
+
+  it("clamps floating-point results to [0, 100]", () => {
+    // Very large numerator: clamp to 100
+    expect(formatPercent(200, 100)).toBe("100%");
+    // Negative numerator: clamp to 0
+    expect(formatPercent(-5, 10)).toBe("0%");
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats sub-kilobyte values with B suffix", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1_023)).toBe("1023 B");
+  });
+
+  it("formats kilobytes with one decimal place", () => {
+    expect(formatBytes(1_024)).toBe("1 KB");
+    expect(formatBytes(1_536)).toBe("1.5 KB");
+    expect(formatBytes(102_400)).toBe("100 KB");
+  });
+
+  it("formats megabytes and gigabytes", () => {
+    expect(formatBytes(1_048_576)).toBe("1 MB");
+    expect(formatBytes(1_572_864)).toBe("1.5 MB");
+    expect(formatBytes(1_073_741_824)).toBe("1 GB");
+    expect(formatBytes(1_610_612_736)).toBe("1.5 GB");
+  });
+
+  it("returns em-dash for nullish or NaN", () => {
+    expect(formatBytes(null)).toBe("—");
+    expect(formatBytes(undefined)).toBe("—");
+    expect(formatBytes(NaN)).toBe("—");
+  });
+});
+
+describe("formatDate", () => {
+  it("formats an ISO date string as a short calendar date", () => {
+    expect(formatDate("2026-06-19")).toBe("Jun 19, 2026");
+    expect(formatDate("2026-01-01")).toBe("Jan 1, 2026");
+    expect(formatDate("2025-12-31")).toBe("Dec 31, 2025");
+  });
+
+  it("returns em-dash for missing or invalid input", () => {
+    expect(formatDate(null)).toBe("—");
+    expect(formatDate(undefined)).toBe("—");
+    expect(formatDate("")).toBe("—");
+    expect(formatDate("not-a-date")).toBe("—");
+  });
+
+  it("uses UTC so the date matches the ISO string date component", () => {
+    // A timestamp late in the day UTC should not roll over to the next day.
+    expect(formatDate("2026-03-15T23:59:59.000Z")).toBe("Mar 15, 2026");
+  });
+});


### PR DESCRIPTION
## Summary

Extends `format.ts` with three new utility functions that follow the same nullish-safe, em-dash-for-missing-input pattern as the existing `formatCompact` and `timeAgo`.

### `formatPercent(numerator, denominator)`
Renders a ratio as an integer percentage string ("33%"). Returns "—" when the denominator is 0 or either argument is nullish/NaN. Clamps to [0, 100] so floating-point rounding noise (e.g. 200/100 after float drift) never produces "101%" or "-1%".

Use cases: coverage badges in the quality dashboard, tag-coverage rows in the stats reports.

### `formatBytes(n)`
Renders a byte count as a human-readable string using binary prefixes (1024): "512 B", "1.5 KB", "2 MB", "1.5 GB". Returns "—" for nullish/NaN. Useful for displaying `.mcpb` package sizes in the download asset UI.

### `formatDate(iso)`
Renders an ISO date string as a compact calendar date ("Jun 19, 2026") using the invariant `en-US` locale and `timeZone: "UTC"`, so the output is stable for server-rendered markup and snapshot tests regardless of the host locale or time zone.

### Tests (`tests/format.test.ts`)
Added a dedicated test file with 16 cases covering:
- Boundary values for all four numeric formatters
- Nullish/NaN guard in every function
- `formatPercent` clamping at 0 and 100
- `formatBytes` at KB/MB/GB boundaries
- `formatDate` UTC stability (late-day timestamps don't roll to next day)
