### PR TITLE
feat(csv): add csvRow and csvDocument higher-level helpers

### DIFF
--- a/apps/web/src/lib/csv.ts
+++ b/apps/web/src/lib/csv.ts
@@ -1,3 +1,8 @@
+/**
+ * Escape a single value for safe inclusion in a CSV cell. Prefixes formula-
+ * injection characters (`= + - @`) with a literal `'` and double-quotes any
+ * cell that contains `"`, `,`, or a newline per RFC 4180.
+ */
 export function csvEscape(value: unknown) {
   const raw = String(value ?? "");
   const trimmedStart = raw.trimStart();
@@ -11,4 +16,31 @@ export function csvEscape(value: unknown) {
   return /[",\n\r]/.test(normalized)
     ? `"${normalized.replaceAll('"', '""')}"`
     : normalized;
+}
+
+/**
+ * Build a single CSV row by escaping each value in `cells` and joining them
+ * with a comma. Returns a bare string without a trailing newline so callers
+ * can join rows with the line ending of their choice.
+ *
+ * @example csvRow(["Alice", 'She said "hi"', 42]) // 'Alice,"She said ""hi""",42'
+ */
+export function csvRow(cells: readonly unknown[]): string {
+  return cells.map(csvEscape).join(",");
+}
+
+/**
+ * Serialise a complete CSV document: a header row followed by zero or more
+ * data rows, each separated by `\n`. The resulting string does not have a
+ * trailing newline.
+ *
+ * @example
+ * csvDocument(["name", "score"], [["Alice", 95], ["Bob", 87]])
+ * // "name,score\nAlice,95\nBob,87"
+ */
+export function csvDocument(
+  header: readonly string[],
+  rows: ReadonlyArray<readonly unknown[]>,
+): string {
+  return [csvRow(header), ...rows.map(csvRow)].join("\n");
 }

--- a/tests/csv.test.ts
+++ b/tests/csv.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { csvDocument, csvEscape, csvRow } from "@/lib/csv";
+
+describe("csvEscape", () => {
+  it("returns plain values unchanged", () => {
+    expect(csvEscape("hello")).toBe("hello");
+    expect(csvEscape(42)).toBe("42");
+    expect(csvEscape(true)).toBe("true");
+    expect(csvEscape("")).toBe("");
+  });
+
+  it("double-quotes cells that contain a comma", () => {
+    expect(csvEscape("a,b")).toBe('"a,b"');
+  });
+
+  it("double-quotes cells that contain a double-quote, escaping the inner quote", () => {
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it("double-quotes cells that contain newlines", () => {
+    expect(csvEscape("line1\nline2")).toBe('"line1\nline2"');
+    expect(csvEscape("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  it("prefixes formula-injection characters with a literal apostrophe", () => {
+    expect(csvEscape("=SUM(A1)")).toBe("'=SUM(A1)");
+    expect(csvEscape("+1 555 123")).toBe("'+1 555 123");
+    expect(csvEscape("-profit")).toBe("'-profit");
+    expect(csvEscape("@user")).toBe("'@user");
+  });
+
+  it("does not prefix formula characters that appear after leading whitespace", () => {
+    // trimStart is used, so "   =cmd" is still formula-injection
+    expect(csvEscape("   =cmd")).toBe("'   =cmd");
+  });
+
+  it("stringifies null and undefined as empty cells", () => {
+    expect(csvEscape(null)).toBe("");
+    expect(csvEscape(undefined)).toBe("");
+  });
+});
+
+describe("csvRow", () => {
+  it("escapes each cell and joins with a comma", () => {
+    expect(csvRow(["Alice", "Smith", 95])).toBe("Alice,Smith,95");
+    expect(csvRow(['He said "hello"', "a,b"])).toBe('"He said ""hello""","a,b"');
+  });
+
+  it("handles an empty array", () => {
+    expect(csvRow([])).toBe("");
+  });
+
+  it("stringifies non-string values", () => {
+    expect(csvRow([true, false, null, 0])).toBe("true,false,,0");
+  });
+});
+
+describe("csvDocument", () => {
+  it("produces a header row followed by data rows separated by newlines", () => {
+    const out = csvDocument(
+      ["name", "score"],
+      [
+        ["Alice", 95],
+        ["Bob", 87],
+      ],
+    );
+    expect(out).toBe("name,score\nAlice,95\nBob,87");
+  });
+
+  it("returns only the header when rows is empty", () => {
+    expect(csvDocument(["id", "title"], [])).toBe("id,title");
+  });
+
+  it("escapes values in both header and data rows", () => {
+    const out = csvDocument(['col,"header"'], [['val,with,commas']]);
+    expect(out).toBe('"col,""header"""\n"val,with,commas"');
+  });
+
+  it("does not add a trailing newline", () => {
+    const out = csvDocument(["a"], [["b"]]);
+    expect(out.endsWith("\n")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `csv.ts` with two higher-level helpers that sit on top of the existing `csvEscape` primitive, following the same formula-injection-safe and RFC 4180 quoting rules.

### `csvRow(cells)`
Escapes each element in `cells` and joins them with a comma. Eliminates the inline `columns.map(csvEscape).join(",")` pattern that currently appears in `listing-leads.ts` and any future export endpoint.

### `csvDocument(header, rows)`
Serialises a complete CSV document — a header row followed by zero or more data rows — with `\n` line endings and no trailing newline. Suitable for returning as a `text/csv` response body or writing to a file.

Both functions are pure and delegate all escaping to `csvEscape`, so they automatically inherit any future fixes (e.g. new formula-injection prefixes, additional special-character handling).

### Tests (`tests/csv.test.ts`)
Added a dedicated 14-case test file covering `csvEscape`, `csvRow`, and `csvDocument`:
- Plain/numeric/boolean values passthrough
- Comma, double-quote, and newline quoting
- Formula-injection prefix (`= + - @`) including after leading whitespace
- Null/undefined → empty cell
- `csvRow` with empty array and mixed types
- `csvDocument` header-only, data rows, escaping in both header and data, no trailing newline
