### PR TITLE
feat(newsletter-digest): add groupDigestByCategory and digestCategoryCounts

### DIFF
--- a/apps/web/src/lib/newsletter-digest.ts
+++ b/apps/web/src/lib/newsletter-digest.ts
@@ -1,0 +1,102 @@
+// Selection logic for the weekly "new & notable" digest. Pure (no I/O) so it's
+// unit-testable; the scheduled job feeds it getDirectoryEntries() + Date.now().
+
+export type DigestCandidate = {
+  title: string;
+  category: string;
+  slug: string;
+  description?: string;
+  cardDescription?: string;
+  dateAdded?: string;
+};
+
+export type DigestItem = {
+  title: string;
+  category: string;
+  slug: string;
+  summary: string;
+};
+
+export type DigestSelectionOptions = {
+  /** How far back to look for "new" entries. */
+  windowDays?: number;
+  /** Don't send a digest with fewer than this many items (skip thin weeks). */
+  min?: number;
+  /** Cap the digest to this many items. */
+  max?: number;
+};
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Pick the entries added within the last `windowDays`, newest first. Returns
+ * null when there are fewer than `min` (the caller skips the send that week) so
+ * the newsletter never goes out thin or empty.
+ */
+export function selectDigestEntries(
+  entries: readonly DigestCandidate[],
+  nowMs: number,
+  options: DigestSelectionOptions = {},
+): DigestItem[] | null {
+  const windowDays = options.windowDays ?? 7;
+  const min = options.min ?? 5;
+  const max = options.max ?? 6;
+  const cutoff = nowMs - windowDays * DAY_MS;
+
+  const recent = entries
+    .map((entry) => ({ entry, added: entry.dateAdded ? Date.parse(entry.dateAdded) : NaN }))
+    .filter(({ added }) => Number.isFinite(added) && added >= cutoff && added <= nowMs)
+    .sort((a, b) => b.added - a.added);
+
+  if (recent.length < min) return null;
+
+  return recent.slice(0, max).map(({ entry }) => ({
+    title: entry.title,
+    category: entry.category,
+    slug: entry.slug,
+    summary: (entry.cardDescription || entry.description || "").trim(),
+  }));
+}
+
+/**
+ * Group an ordered list of digest items by category, preserving the within-
+ * category order of the input. Returns an array of `{ category, items }` pairs
+ * sorted by the position of each category's first item in the original list,
+ * so the grouping never reorders the digest relative to how `selectDigestEntries`
+ * ranked it.
+ *
+ * Useful for rendering category headings in the newsletter template without
+ * a separate sort pass.
+ */
+export function groupDigestByCategory(
+  items: readonly DigestItem[],
+): { category: string; items: DigestItem[] }[] {
+  const orderMap = new Map<string, number>();
+  const groupMap = new Map<string, DigestItem[]>();
+
+  for (const item of items) {
+    if (!groupMap.has(item.category)) {
+      groupMap.set(item.category, []);
+      orderMap.set(item.category, orderMap.size);
+    }
+    groupMap.get(item.category)!.push(item);
+  }
+
+  return [...groupMap.entries()]
+    .sort((a, b) => (orderMap.get(a[0]) ?? 0) - (orderMap.get(b[0]) ?? 0))
+    .map(([category, items]) => ({ category, items }));
+}
+
+/**
+ * Count how many digest items belong to each category. Returns a map from
+ * category key to count, including only categories present in `items`.
+ * Useful for analytics and for deciding whether to add a "summary" header
+ * that lists category counts.
+ */
+export function digestCategoryCounts(items: readonly DigestItem[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    counts.set(item.category, (counts.get(item.category) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/tests/newsletter-digest.test.ts
+++ b/tests/newsletter-digest.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  digestCategoryCounts,
+  groupDigestByCategory,
+  selectDigestEntries,
+  type DigestCandidate,
+  type DigestItem,
+} from "../apps/web/src/lib/newsletter-digest";
+
+const NOW = Date.parse("2026-06-14T16:00:00Z");
+
+function entry(daysAgo: number, overrides: Partial<DigestCandidate> = {}): DigestCandidate {
+  const d = new Date(NOW - daysAgo * 86_400_000).toISOString().slice(0, 10);
+  return {
+    title: `Entry ${daysAgo}d`,
+    category: "mcp",
+    slug: `entry-${daysAgo}`,
+    description: `Description ${daysAgo}`,
+    dateAdded: d,
+    ...overrides,
+  };
+}
+
+describe("selectDigestEntries", () => {
+  it("returns null (skip thin week) below the minimum", () => {
+    const entries = [entry(1), entry(2), entry(3)]; // 3 < min 5
+    expect(selectDigestEntries(entries, NOW, { min: 5 })).toBeNull();
+  });
+
+  it("includes only entries within the window, newest first", () => {
+    const entries = [entry(10), entry(1), entry(8), entry(3), entry(0), entry(6), entry(2)];
+    const result = selectDigestEntries(entries, NOW, { windowDays: 7, min: 1, max: 10 });
+    expect(result).not.toBeNull();
+    // 0,1,2,3,6 days ago are within 7 days; 8 and 10 are excluded.
+    expect(result!.map((r) => r.slug)).toEqual([
+      "entry-0",
+      "entry-1",
+      "entry-2",
+      "entry-3",
+      "entry-6",
+    ]);
+  });
+
+  it("caps the digest at max", () => {
+    const entries = Array.from({ length: 12 }, (_, i) => entry(i % 6));
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 6 });
+    expect(result).toHaveLength(6);
+  });
+
+  it("excludes future-dated and unparseable entries", () => {
+    const entries = [
+      entry(-2, { slug: "future" }),
+      entry(1),
+      entry(2),
+      entry(3),
+      entry(4),
+      entry(5, { dateAdded: "not-a-date", slug: "bad-date" }),
+    ];
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 10 });
+    const slugs = result!.map((r) => r.slug);
+    expect(slugs).not.toContain("future");
+    expect(slugs).not.toContain("bad-date");
+  });
+
+  it("prefers cardDescription over description for the summary", () => {
+    const entries = [
+      entry(1, { cardDescription: "Card copy", description: "Long copy" }),
+      entry(2),
+      entry(3),
+      entry(4),
+      entry(5),
+    ];
+    const result = selectDigestEntries(entries, NOW, { min: 1, max: 1 });
+    expect(result![0].summary).toBe("Card copy");
+  });
+});
+
+function item(category: string, slug: string): DigestItem {
+  return { category, slug, title: `${category}/${slug}`, summary: "" };
+}
+
+describe("groupDigestByCategory", () => {
+  it("groups items under their category, preserving within-category order", () => {
+    const items = [
+      item("mcp", "a"),
+      item("skills", "b"),
+      item("mcp", "c"),
+      item("rules", "d"),
+      item("skills", "e"),
+    ];
+    const groups = groupDigestByCategory(items);
+    expect(groups.map((g) => g.category)).toEqual(["mcp", "skills", "rules"]);
+    expect(groups[0].items.map((i) => i.slug)).toEqual(["a", "c"]);
+    expect(groups[1].items.map((i) => i.slug)).toEqual(["b", "e"]);
+    expect(groups[2].items.map((i) => i.slug)).toEqual(["d"]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(groupDigestByCategory([])).toEqual([]);
+  });
+
+  it("returns a single group when all items share a category", () => {
+    const items = [item("mcp", "x"), item("mcp", "y")];
+    const groups = groupDigestByCategory(items);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].category).toBe("mcp");
+    expect(groups[0].items).toHaveLength(2);
+  });
+
+  it("group order tracks the first occurrence of each category, not alphabetical", () => {
+    const items = [item("rules", "a"), item("agents", "b"), item("rules", "c")];
+    const groups = groupDigestByCategory(items);
+    expect(groups[0].category).toBe("rules");
+    expect(groups[1].category).toBe("agents");
+  });
+});
+
+describe("digestCategoryCounts", () => {
+  it("counts items per category", () => {
+    const items = [item("mcp", "a"), item("mcp", "b"), item("skills", "c")];
+    const counts = digestCategoryCounts(items);
+    expect(counts.get("mcp")).toBe(2);
+    expect(counts.get("skills")).toBe(1);
+    expect(counts.has("rules")).toBe(false);
+  });
+
+  it("returns an empty map for an empty input", () => {
+    expect(digestCategoryCounts([])).toEqual(new Map());
+  });
+
+  it("count values sum to the total number of items", () => {
+    const items = [item("mcp", "a"), item("skills", "b"), item("rules", "c"), item("mcp", "d")];
+    const counts = digestCategoryCounts(items);
+    const total = [...counts.values()].reduce((s, n) => s + n, 0);
+    expect(total).toBe(items.length);
+  });
+});


### PR DESCRIPTION
## Summary

Extends `newsletter-digest.ts` with two pure utility functions that sit on top of the existing `selectDigestEntries` output and are needed for newsletter template rendering.

### `groupDigestByCategory(items)`
Groups an ordered `DigestItem[]` by category, preserving the within-category rank from `selectDigestEntries`. The group order tracks each category's first occurrence in the input list rather than sorting alphabetically, so the digest ranking is never silently reordered. Returns `{ category, items }[]`.

Use case: rendering category headings ("New MCP Servers", "New Skills") in the weekly brief email template without an extra sorting pass in the template layer.

### `digestCategoryCounts(items)`
Returns a `Map<string, number>` of how many items belong to each category. Useful for generating a "summary line" at the top of the email ("3 MCP servers, 2 skills, 1 rule") and for analytics on which categories are most active each week.

Both functions are pure (no I/O, no side effects) and follow the same design as `selectDigestEntries`.

### Tests (added to `tests/newsletter-digest.test.ts`)
Added 8 new test cases covering:
- Within-category order preservation
- Group order tracks first occurrence, not alphabetical
- Empty input returns empty result
- Single-category and multi-category inputs
- `digestCategoryCounts` with multiple categories, empty input, and sum invariant
