### PR TITLE
feat(analytics): add truncateQuery and searchEventKey utilities

### DIFF
--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,76 @@
+// Client-side, cookieless umami custom-event helper. SSR-safe and best-effort:
+// if the tracker hasn't loaded yet (or is blocked) the call is a silent no-op.
+//
+// We only emit events that map to a real product action worth measuring —
+// conversions and high-signal engagement. Pageviews are recorded automatically
+// by the tracker, so we never re-emit those, and event data never carries PII
+// (no emails, no raw form fields, queries truncated). This keeps the umami
+// dashboard accurate and quiet rather than noisy.
+
+type UmamiTracker = {
+  track?: (event: string, data?: Record<string, unknown>) => void;
+};
+
+/** Emit a named umami event. No-ops on the server or before the tracker loads. */
+export function trackEvent(name: string, data?: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  const umami = (window as unknown as { umami?: UmamiTracker }).umami;
+  umami?.track?.(name, data);
+}
+
+/** An entry's stable `category/slug` key, for grouping events by resource. */
+export function entryEventKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+/** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
+export function outboundHost(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return "unknown";
+  }
+}
+
+/**
+ * Truncate a free-text search query to a safe length before it lands in an
+ * analytics event. Collapses internal whitespace and strips leading/trailing
+ * space. The default cap of 80 characters is long enough to capture meaningful
+ * query patterns while preventing accidental PII leakage from very long pastes.
+ *
+ * @param q - Raw query string from the search input.
+ * @param max - Maximum character length (default 80).
+ */
+export function truncateQuery(q: string, max = 80): string {
+  const normalized = q.replace(/\s+/g, " ").trim();
+  return normalized.length > max ? normalized.slice(0, max) : normalized;
+}
+
+/**
+ * Build a stable, composite analytics key for a search event so identical
+ * query/filter combinations can be grouped in the umami dashboard without
+ * sending raw URL parameters that may contain PII.
+ *
+ * The key is `"<query>|<sorted-filter-tags>"`. Filters are sorted so that
+ * `{categories:["skills","mcp"]}` and `{categories:["mcp","skills"]}` produce
+ * the same key.
+ *
+ * @example searchEventKey("playwright browser", { categories: ["mcp"] })
+ * // "playwright browser|categories:mcp"
+ */
+export function searchEventKey(
+  query: string,
+  filters: Record<string, string | string[] | boolean | undefined | null> = {},
+): string {
+  const q = truncateQuery(query);
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(filters)) {
+    if (value == null || value === false || (Array.isArray(value) && value.length === 0)) continue;
+    const vals = Array.isArray(value)
+      ? [...value].sort().join(",")
+      : String(value);
+    parts.push(`${key}:${vals}`);
+  }
+  parts.sort();
+  return parts.length > 0 ? `${q}|${parts.join("|")}` : q;
+}

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  entryEventKey,
+  outboundHost,
+  searchEventKey,
+  truncateQuery,
+} from "@/lib/analytics";
+
+describe("entryEventKey", () => {
+  it("returns category/slug as a stable composite key", () => {
+    expect(entryEventKey("mcp", "browser-bridge")).toBe("mcp/browser-bridge");
+    expect(entryEventKey("skills", "code-review")).toBe("skills/code-review");
+  });
+});
+
+describe("outboundHost", () => {
+  it("strips www. and returns the bare hostname", () => {
+    expect(outboundHost("https://www.example.com/path?q=secret")).toBe("example.com");
+    expect(outboundHost("https://github.com/user/repo")).toBe("github.com");
+  });
+
+  it("returns 'unknown' for non-URL inputs", () => {
+    expect(outboundHost("not a url")).toBe("unknown");
+    expect(outboundHost("")).toBe("unknown");
+  });
+});
+
+describe("truncateQuery", () => {
+  it("returns short queries unchanged (whitespace collapsed)", () => {
+    expect(truncateQuery("browser mcp")).toBe("browser mcp");
+    expect(truncateQuery("  multi   space  ")).toBe("multi space");
+    expect(truncateQuery("")).toBe("");
+  });
+
+  it("truncates at the default 80-character cap", () => {
+    const long = "a".repeat(100);
+    const result = truncateQuery(long);
+    expect(result.length).toBe(80);
+  });
+
+  it("respects a custom max", () => {
+    const result = truncateQuery("one two three", 7);
+    expect(result).toBe("one two");
+    expect(result.length).toBeLessThanOrEqual(7);
+  });
+
+  it("collapses internal whitespace before measuring length", () => {
+    // 10 spaces + 70 'a's → after collapse becomes "a"×70 (< 80 chars)
+    const spaced = " ".repeat(10) + "a".repeat(70);
+    expect(truncateQuery(spaced)).toBe("a".repeat(70));
+  });
+});
+
+describe("searchEventKey", () => {
+  it("returns the bare truncated query when there are no active filters", () => {
+    expect(searchEventKey("mcp servers")).toBe("mcp servers");
+    expect(searchEventKey("mcp servers", {})).toBe("mcp servers");
+    expect(searchEventKey("mcp servers", { categories: [] })).toBe("mcp servers");
+    expect(searchEventKey("mcp servers", { installable: false })).toBe("mcp servers");
+  });
+
+  it("appends filter key:value pairs separated by pipes", () => {
+    const key = searchEventKey("test", { categories: ["mcp"] });
+    expect(key).toBe("test|categories:mcp");
+  });
+
+  it("sorts array filter values so ordering does not affect the key", () => {
+    const a = searchEventKey("test", { categories: ["skills", "mcp"] });
+    const b = searchEventKey("test", { categories: ["mcp", "skills"] });
+    expect(a).toBe(b);
+    expect(a).toBe("test|categories:mcp,skills");
+  });
+
+  it("sorts multiple filter keys so insertion order does not matter", () => {
+    const a = searchEventKey("q", { trust: ["trusted"], categories: ["mcp"] });
+    const b = searchEventKey("q", { categories: ["mcp"], trust: ["trusted"] });
+    expect(a).toBe(b);
+    expect(a).toContain("categories:mcp");
+    expect(a).toContain("trust:trusted");
+  });
+
+  it("includes boolean filters when true but omits them when false or null", () => {
+    const withFlag = searchEventKey("q", { hasSafetyNotes: true });
+    const withoutFlag = searchEventKey("q", { hasSafetyNotes: false });
+    expect(withFlag).toBe("q|hasSafetyNotes:true");
+    expect(withoutFlag).toBe("q");
+  });
+
+  it("omits null and undefined filter values", () => {
+    expect(searchEventKey("q", { categories: undefined, trust: null as never })).toBe("q");
+  });
+
+  it("truncates the query portion to the default 80-char cap", () => {
+    const longQuery = "x".repeat(100);
+    const key = searchEventKey(longQuery, {});
+    expect(key.length).toBe(80);
+  });
+});


### PR DESCRIPTION
## Summary

Adds two new utility functions to `analytics.ts` that enforce the privacy policy already described in the module header ("queries truncated, event data never carries PII") with testable, consistent implementations.

### `truncateQuery(q, max = 80)`
Collapses internal whitespace and trims the query, then caps it at `max` characters (default 80). Prevents PII leakage from very long pastes into the search box. Currently callers perform this truncation inline or not at all; this function provides a shared, auditable implementation.

### `searchEventKey(query, filters)`
Builds a composite analytics key (`"<query>|<sorted-filter-tags>"`) for search events so identical query/filter combinations group correctly in the umami dashboard even when callers pass filters in a different order.
- Array filter values are sorted before stringifying, so `{categories:["skills","mcp"]}` and `{categories:["mcp","skills"]}` produce the same key.
- Multiple filter keys are sorted alphabetically, making the key insertion-order-independent.
- Null, undefined, false, and empty-array filter values are omitted.
- Query portion is truncated via `truncateQuery` before inclusion.

### Tests (`tests/analytics.test.ts`)
Added 14 test cases covering `entryEventKey`, `outboundHost`, `truncateQuery`, and `searchEventKey`, including:
- Whitespace collapsing and length cap
- Filter sorting (values within a key, keys within the composite)
- Boolean filter inclusion/exclusion
- Query portion cap propagation
