### PR TITLE
feat(json-ld): add parseJsonLd and isJsonLdNode utilities

### DIFF
--- a/apps/web/src/lib/json-ld.ts
+++ b/apps/web/src/lib/json-ld.ts
@@ -13,3 +13,33 @@ export function stringifyJsonLd(value: unknown) {
     (character) => SCRIPT_JSON_ESCAPES[character] ?? character,
   );
 }
+
+/**
+ * Safely parse a JSON-LD string. Returns the parsed object when the input is
+ * valid JSON, or `null` when the input is missing, empty, or syntactically
+ * invalid. Never throws.
+ *
+ * Use this to parse JSON-LD from server responses or script tags where the
+ * source is not fully trusted or may be empty.
+ */
+export function parseJsonLd(raw: string | null | undefined): Record<string, unknown> | null {
+  if (!raw || !raw.trim()) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Type guard: returns true when `value` looks like a JSON-LD node — a plain
+ * object that carries at least a `@context` or `@type` property. Useful for
+ * narrowing values received from an API before passing them to a renderer.
+ */
+export function isJsonLdNode(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return "@context" in obj || "@type" in obj;
+}

--- a/tests/json-ld-script-safety.test.ts
+++ b/tests/json-ld-script-safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stringifyJsonLd } from "@/lib/json-ld";
+import { isJsonLdNode, parseJsonLd, stringifyJsonLd } from "@/lib/json-ld";
 
 describe("stringifyJsonLd", () => {
   it("escapes script-breakout characters while preserving JSON-LD values", () => {
@@ -20,5 +20,59 @@ describe("stringifyJsonLd", () => {
     expect(serialized).toContain("\\u2028");
     expect(serialized).toContain("\\u2029");
     expect(JSON.parse(serialized)).toEqual(payload);
+  });
+});
+
+describe("parseJsonLd", () => {
+  it("parses a valid JSON-LD object string", () => {
+    const result = parseJsonLd('{"@context":"https://schema.org","@type":"Thing","name":"x"}');
+    expect(result).toEqual({ "@context": "https://schema.org", "@type": "Thing", name: "x" });
+  });
+
+  it("returns null for missing, empty, or whitespace-only input", () => {
+    expect(parseJsonLd(null)).toBeNull();
+    expect(parseJsonLd(undefined)).toBeNull();
+    expect(parseJsonLd("")).toBeNull();
+    expect(parseJsonLd("   ")).toBeNull();
+  });
+
+  it("returns null for syntactically invalid JSON", () => {
+    expect(parseJsonLd("{broken json}")).toBeNull();
+    expect(parseJsonLd("undefined")).toBeNull();
+  });
+
+  it("returns null for valid JSON that is not a plain object", () => {
+    expect(parseJsonLd('"a string"')).toBeNull();
+    expect(parseJsonLd("42")).toBeNull();
+    expect(parseJsonLd("[1,2,3]")).toBeNull();
+    expect(parseJsonLd("null")).toBeNull();
+  });
+
+  it("round-trips with stringifyJsonLd", () => {
+    const original = { "@context": "https://schema.org", "@type": "WebPage", name: "<title>" };
+    const serialized = stringifyJsonLd(original);
+    const parsed = parseJsonLd(serialized);
+    expect(parsed).toEqual(original);
+  });
+});
+
+describe("isJsonLdNode", () => {
+  it("returns true for objects with @context or @type", () => {
+    expect(isJsonLdNode({ "@context": "https://schema.org" })).toBe(true);
+    expect(isJsonLdNode({ "@type": "Thing" })).toBe(true);
+    expect(isJsonLdNode({ "@context": "https://schema.org", "@type": "Thing" })).toBe(true);
+  });
+
+  it("returns false for plain objects without JSON-LD keys", () => {
+    expect(isJsonLdNode({ name: "no context" })).toBe(false);
+    expect(isJsonLdNode({})).toBe(false);
+  });
+
+  it("returns false for non-objects", () => {
+    expect(isJsonLdNode(null)).toBe(false);
+    expect(isJsonLdNode(undefined)).toBe(false);
+    expect(isJsonLdNode("string")).toBe(false);
+    expect(isJsonLdNode(42)).toBe(false);
+    expect(isJsonLdNode(["@context", "val"])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Extends `json-ld.ts` with two companion utilities that complete the module's JSON-LD handling lifecycle: serialisation was already covered by `stringifyJsonLd`; parsing and type-guarding were missing.

### `parseJsonLd(raw)`
Safely parses a JSON-LD string. Returns the parsed plain-object, or `null` when the input is missing, empty, whitespace-only, or syntactically invalid. Also returns `null` for valid JSON that is not a plain object (arrays, primitives, `null`) — those are not valid JSON-LD nodes. Never throws.

Useful for reading JSON-LD back from API responses or `<script type="application/ld+json">` tags where the source may be absent or malformed.

### `isJsonLdNode(value)`
TypeScript type guard: narrows `unknown` to `Record<string, unknown>` when the value is a plain object with at least a `@context` or `@type` key. Avoids the `as any` cast pattern currently needed when consuming JSON-LD from external sources.

Both functions pair naturally with the existing `stringifyJsonLd`, and `parseJsonLd` is verified to round-trip correctly through `stringifyJsonLd` (escaped output parses back to the original object).

### Tests (added to `tests/json-ld-script-safety.test.ts`)
Added 8 new test cases covering both functions:
- Valid object parsing
- Null/empty/whitespace guard
- Invalid JSON
- Valid JSON that is not an object (strings, numbers, arrays, null)
- Round-trip with `stringifyJsonLd`
- `isJsonLdNode` positive/negative cases including arrays, primitives
