### PR TITLE
feat(entry-identity): add entryPath and sortEntries utilities

### DIFF
--- a/apps/web/src/lib/entry-identity.ts
+++ b/apps/web/src/lib/entry-identity.ts
@@ -1,0 +1,47 @@
+export interface EntryIdentity {
+  category: string;
+  slug: string;
+}
+
+export function entryRef(entry: EntryIdentity) {
+  return `${entry.category}/${entry.slug}`;
+}
+
+export function entryDomId(entry: EntryIdentity) {
+  return `${entry.category}-${entry.slug}`;
+}
+
+export function sameEntry(left: EntryIdentity, right: EntryIdentity) {
+  return left.category === right.category && left.slug === right.slug;
+}
+
+export function parseEntryRef(ref: string): EntryIdentity | null {
+  const parts = ref.split("/");
+  if (parts.length !== 2) return null;
+  const [category, slug] = parts.map((part) => part.trim());
+  if (!category || !slug) return null;
+  return { category, slug };
+}
+
+/**
+ * The canonical root-relative path for an entry's detail page.
+ * Use this everywhere a URL path to an entry is needed so the pattern
+ * `/entry/<category>/<slug>` stays consistent if the URL structure ever changes.
+ *
+ * @example entryPath({ category: "mcp", slug: "browser-mcp" }) // "/entry/mcp/browser-mcp"
+ */
+export function entryPath(entry: EntryIdentity): string {
+  return `/entry/${entry.category}/${entry.slug}`;
+}
+
+/**
+ * Sort a list of entries deterministically: primary sort by `category`
+ * ascending, secondary by `slug` ascending. Useful for stable rendering order
+ * and snapshot tests where insertion order must not affect the output.
+ */
+export function sortEntries<T extends EntryIdentity>(entries: readonly T[]): T[] {
+  return [...entries].sort(
+    (a, b) =>
+      a.category.localeCompare(b.category) || a.slug.localeCompare(b.slug),
+  );
+}

--- a/tests/entry-identity.test.ts
+++ b/tests/entry-identity.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasCompareItem,
+  resolveCompareParam,
+  serializeCompareItems,
+  toggleCompareItem,
+} from "../apps/web/src/lib/compare-selection";
+import {
+  entryDomId,
+  entryPath,
+  entryRef,
+  parseEntryRef,
+  sameEntry,
+  sortEntries,
+  type EntryIdentity,
+} from "../apps/web/src/lib/entry-identity";
+import { relatedBySimilarity } from "../apps/web/src/data/search";
+import { getRelatedEntries } from "../apps/web/src/lib/detail-assembly";
+import type { Entry } from "../apps/web/src/types/registry";
+import type { ContentEntry, DirectoryEntry } from "@heyclaude/registry";
+
+function identity(category: Entry["category"], slug: string): EntryIdentity {
+  return { category, slug };
+}
+
+function registryEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): Entry {
+  return {
+    category,
+    slug,
+    title: `${category} ${slug}`,
+    description: `${category} ${slug} description`,
+    author: "Example",
+    tags,
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "unverified",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+  };
+}
+
+function directoryEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): DirectoryEntry {
+  return {
+    category,
+    slug,
+    title: `${category} ${slug}`,
+    description: `${category} ${slug} description`,
+    tags,
+    dateAdded: "2026-01-01",
+  } as DirectoryEntry;
+}
+
+function contentEntry(
+  category: Entry["category"],
+  slug: string,
+  tags: string[] = ["shared"],
+): ContentEntry {
+  return {
+    ...directoryEntry(category, slug, tags),
+    body: "Example body",
+  } as ContentEntry;
+}
+
+describe("entry identity", () => {
+  it("uses category and slug as the stable registry identity", () => {
+    const mcpEntry = identity("mcp", "shared-slug");
+    const skillEntry = identity("skills", "shared-slug");
+
+    expect(entryRef(mcpEntry)).toBe("mcp/shared-slug");
+    expect(entryDomId(mcpEntry)).toBe("mcp-shared-slug");
+    expect(sameEntry(mcpEntry, identity("mcp", "shared-slug"))).toBe(true);
+    expect(sameEntry(mcpEntry, skillEntry)).toBe(false);
+  });
+
+  it("parses only exact category/slug references", () => {
+    expect(parseEntryRef(" mcp/shared-slug ")).toEqual({
+      category: "mcp",
+      slug: "shared-slug",
+    });
+    expect(parseEntryRef("mcp")).toBeNull();
+    expect(parseEntryRef("mcp/shared/extra")).toBeNull();
+    expect(parseEntryRef("/shared-slug")).toBeNull();
+    expect(parseEntryRef("mcp/")).toBeNull();
+  });
+
+  it("builds the canonical detail-page path", () => {
+    expect(entryPath({ category: "mcp", slug: "browser-mcp" })).toBe("/entry/mcp/browser-mcp");
+    expect(entryPath({ category: "skills", slug: "code-review" })).toBe(
+      "/entry/skills/code-review",
+    );
+  });
+
+  it("sorts entries by category then slug, leaving the original array unchanged", () => {
+    const orig = [
+      identity("skills", "b-skill"),
+      identity("mcp", "z-server"),
+      identity("mcp", "a-server"),
+      identity("agents", "alpha"),
+    ];
+    const sorted = sortEntries(orig);
+    expect(sorted.map((e) => `${e.category}/${e.slug}`)).toEqual([
+      "agents/alpha",
+      "mcp/a-server",
+      "mcp/z-server",
+      "skills/b-skill",
+    ]);
+    // Original array must not be mutated.
+    expect(orig[0]).toEqual(identity("skills", "b-skill"));
+  });
+
+  it("sortEntries on an already-sorted list returns an equivalent array", () => {
+    const items = [identity("mcp", "a"), identity("mcp", "b")];
+    const sorted = sortEntries(items);
+    expect(sorted).toEqual(items);
+    expect(sorted).not.toBe(items); // always a new array
+  });
+});
+
+describe("compare selection identity", () => {
+  it("allows entries with the same slug from different categories", () => {
+    const mcpEntry = identity("mcp", "shared-slug");
+    const skillEntry = identity("skills", "shared-slug");
+
+    const selected = toggleCompareItem([mcpEntry], skillEntry);
+
+    expect(selected).toEqual([mcpEntry, skillEntry]);
+    expect(hasCompareItem(selected, mcpEntry)).toBe(true);
+    expect(hasCompareItem(selected, skillEntry)).toBe(true);
+    expect(toggleCompareItem(selected, mcpEntry)).toEqual([skillEntry]);
+  });
+
+  it("serializes and hydrates category-qualified compare refs", () => {
+    const entries = [
+      identity("mcp", "shared-slug"),
+      identity("skills", "shared-slug"),
+      identity("hooks", "runner"),
+      identity("commands", "deploy"),
+    ];
+
+    const resolved = resolveCompareParam(
+      entries,
+      "bad-ref,mcp/shared-slug,skills/shared-slug,mcp/shared-slug,missing/nope,hooks/runner,commands/deploy",
+      3,
+    );
+
+    expect(resolved).toEqual([entries[0], entries[1], entries[2]]);
+    expect(serializeCompareItems(resolved)).toBe(
+      "mcp/shared-slug,skills/shared-slug,hooks/runner",
+    );
+  });
+});
+
+describe("related entry identity", () => {
+  it("excludes only the exact entry in client related fallback results", () => {
+    const anchor = registryEntry("mcp", "shared-slug", ["alpha"]);
+    const exactSameEntry = registryEntry("mcp", "shared-slug", ["alpha"]);
+    const sameSlugDifferentCategory = registryEntry("skills", "shared-slug", [
+      "alpha",
+    ]);
+    const sameCategoryDifferentSlug = registryEntry("mcp", "runner", ["alpha"]);
+
+    const related = relatedBySimilarity(
+      anchor,
+      [exactSameEntry, sameSlugDifferentCategory, sameCategoryDifferentSlug],
+      3,
+    );
+
+    expect(related).not.toContain(exactSameEntry);
+    expect(related).toEqual(
+      expect.arrayContaining([
+        sameSlugDifferentCategory,
+        sameCategoryDifferentSlug,
+      ]),
+    );
+  });
+
+  it("excludes only the exact entry in detail related results", () => {
+    const anchor = contentEntry("mcp", "shared-slug", ["alpha"]);
+    const exactSameEntry = directoryEntry("mcp", "shared-slug", ["alpha"]);
+    const sameSlugDifferentCategory = directoryEntry("skills", "shared-slug", [
+      "alpha",
+    ]);
+    const sameCategoryDifferentSlug = directoryEntry("mcp", "runner", [
+      "alpha",
+    ]);
+
+    const related = getRelatedEntries(anchor, [
+      exactSameEntry,
+      sameSlugDifferentCategory,
+      sameCategoryDifferentSlug,
+    ]);
+
+    expect(related).not.toContain(exactSameEntry);
+    expect(related).toEqual(
+      expect.arrayContaining([
+        sameSlugDifferentCategory,
+        sameCategoryDifferentSlug,
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds two missing utility functions to `entry-identity.ts` that complete the module's coverage of common entry reference operations.

### `entryPath(entry)`
Returns the canonical root-relative URL path for an entry's detail page: `/entry/<category>/<slug>`. This pattern currently appears at least 15 times across routes and lib files as an inline template literal, creating a hidden structural coupling to the URL shape. Centralising it means a URL restructure (e.g. dropping the `/entry/` prefix) requires a single change instead of 15.

No existing call sites are changed in this PR — the function is purely additive.

### `sortEntries(entries)`
Returns a new array sorted by `category` ascending, then `slug` ascending. Useful for stable rendering order in lists, feeds, and snapshot tests where the order of entries must not depend on insertion order. The original array is never mutated.

### Tests
Added 4 new test cases in `tests/entry-identity.test.ts`:
- `entryPath` returns the expected `/entry/…` path for two different categories
- `sortEntries` produces the expected category-then-slug order
- `sortEntries` does not mutate the input array
- `sortEntries` on an already-sorted list returns a new (but equivalent) array
