### PR TITLE
fix(quality): report full SEO snippet backlog

### DIFF
--- a/scripts/audit-seo-snippets.mjs
+++ b/scripts/audit-seo-snippets.mjs
@@ -199,15 +199,28 @@ function parseArgs(argv) {
   return args;
 }
 
-function renderMarkdown(findings, total) {
-  const weighted = findings.some((f) => f.impressions > 0);
+export function renderMarkdown(
+  findings,
+  {
+    total,
+    flagged = findings.length,
+    weighted = findings.some((f) => f.impressions > 0),
+  },
+) {
   const lines = [
     "# SEO snippet audit",
     "",
-    `${findings.length} of ${total} entries have weak seoTitle/seoDescription${weighted ? " (ranked by GSC impressions)" : ""}.`,
+    `${flagged} of ${total} entries have weak seoTitle/seoDescription${weighted ? " (ranked by GSC impressions)" : ""}.`,
     "Detection only — improve these by hand; do not auto-generate snippets.",
     "",
   ];
+  if (flagged > 0) {
+    const shown =
+      findings.length === flagged
+        ? `Showing all ${flagged} findings.`
+        : `Showing top ${findings.length} of ${flagged} findings.`;
+    lines.push(shown, "");
+  }
   for (const f of findings) {
     const impr = f.impressions ? ` · ${f.impressions} impressions` : "";
     lines.push(`## ${f.path}${impr}`);
@@ -235,7 +248,13 @@ export async function main(argv = process.argv.slice(2)) {
       ),
     );
   } else {
-    console.log(renderMarkdown(findings, entries.length));
+    console.log(
+      renderMarkdown(findings, {
+        total: entries.length,
+        flagged: all.length,
+        weighted: all.some((f) => f.impressions > 0),
+      }),
+    );
     if (all.length > findings.length) {
       console.log(
         `… and ${all.length - findings.length} more (raise --limit to see them).`,

--- a/tests/audit-seo-snippets.test.ts
+++ b/tests/audit-seo-snippets.test.ts
@@ -7,6 +7,7 @@ import {
   findDuplicateSnippets,
   normalizeSnippet,
   parseGscImpressions,
+  renderMarkdown,
   snippetIssues,
 } from "../scripts/audit-seo-snippets.mjs";
 
@@ -130,6 +131,55 @@ describe("auditEntries", () => {
     expect(keys).toContain("mcp/dupe-a");
     // "broken" has the most issues → ranked first
     expect(findings[0].key).toBe("mcp/broken");
+  });
+});
+
+describe("renderMarkdown", () => {
+  it("reports total flagged entries separately from displayed findings", () => {
+    const output = renderMarkdown(
+      [
+        {
+          key: "mcp/postgres",
+          category: "mcp",
+          slug: "postgres",
+          path: "/entry/mcp/postgres",
+          impressions: 0,
+          issues: [
+            {
+              field: "seoTitle",
+              code: "echoes-base",
+              detail: "seoTitle just repeats the on-page title",
+            },
+          ],
+        },
+      ],
+      { total: 10, flagged: 7 },
+    );
+
+    expect(output).toContain(
+      "7 of 10 entries have weak seoTitle/seoDescription.",
+    );
+    expect(output).toContain("Showing top 1 of 7 findings.");
+    expect(output).not.toContain(
+      "1 of 10 entries have weak seoTitle/seoDescription.",
+    );
+  });
+
+  it("reports when the full finding set is displayed", () => {
+    const findings = auditEntries([
+      entry({ slug: "short-a", seoTitle: "Short", seoDescription: "short" }),
+      entry({ slug: "short-b", seoTitle: "Tiny", seoDescription: "tiny" }),
+    ]);
+
+    const output = renderMarkdown(findings, {
+      total: 2,
+      flagged: findings.length,
+    });
+
+    expect(output).toContain(
+      "2 of 2 entries have weak seoTitle/seoDescription.",
+    );
+    expect(output).toContain("Showing all 2 findings.");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the SEO snippet audit markdown summary so limited reports show the total flagged backlog separately from the displayed slice.

Closes #3918

## What changed

- Exported the markdown renderer for direct regression coverage.
- Passed total scanned, total flagged, and weighted ranking state into the renderer explicitly.
- Added tests for limited-output and full-output report summaries.

## Why

The CLI could previously display a limited report that looked like only the visible findings were weak. The JSON output already had the correct total; the human report now matches that contract.

## Validation

- `pnpm exec vitest run tests/audit-seo-snippets.test.ts`
- `pnpm audit:seo-snippets -- --limit 3`
- `pnpm exec prettier --check scripts/audit-seo-snippets.mjs tests/audit-seo-snippets.test.ts`
- `git diff --check`
