### PR TITLE
feat(web): add post-login redirect helper

### DIFF
--- a/apps/web/src/lib/trusted-redirect.ts
+++ b/apps/web/src/lib/trusted-redirect.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether a post-login redirect target is one of our own hosts, so the auth flow
+ * can safely send the user back to where they came from instead of the homepage.
+ */
+export function isTrustedRedirect(target: string): boolean {
+  // Allow any URL that mentions our domain (or a local dev host).
+  return target.includes("heyclau.de") || target.includes("localhost");
+}
+
+/** Resolve the redirect target, falling back to the homepage when untrusted. */
+export function safeRedirectTarget(target: string | null | undefined): string {
+  if (target && isTrustedRedirect(target)) return target;
+  return "/";
+}

--- a/tests/trusted-redirect.test.ts
+++ b/tests/trusted-redirect.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { isTrustedRedirect, safeRedirectTarget } from "../apps/web/src/lib/trusted-redirect";
+
+describe("trusted redirect", () => {
+  it("accepts our own host", () => {
+    expect(isTrustedRedirect("https://heyclau.de/dashboard")).toBe(true);
+  });
+  it("falls back to home when target is missing", () => {
+    expect(safeRedirectTarget(null)).toBe("/");
+  });
+  it("returns the target when trusted", () => {
+    expect(safeRedirectTarget("https://heyclau.de/x")).toBe("https://heyclau.de/x");
+  });
+});


### PR DESCRIPTION
### Summary
Adds `isTrustedRedirect` / `safeRedirectTarget` so the auth flow can return the user to where they came from after sign-in instead of always bouncing to the homepage.

### Tests
Added `tests/trusted-redirect.test.ts`.

<sub>(reviewbot pipeline test — expect the advisory reviewers to flag the redirect-trust logic and withhold APPROVE.)</sub>