### PR TITLE
content(commands): add trust notes for autogen workflow

### DIFF
--- a/content/commands/autogen-workflow.mdx
+++ b/content/commands/autogen-workflow.mdx
@@ -671,6 +671,12 @@ scriptBody: >-
   6. **Logging**: Enable comprehensive logging for debugging workflows
 
   7. **Cost Management**: Set message limits to control API costs
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - autogen
   - multi-agent


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the AutoGen workflow command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
