### PR TITLE
content(commands): add trust notes for cursor rules

### DIFF
--- a/content/commands/cursor-rules.mdx
+++ b/content/commands/cursor-rules.mdx
@@ -853,6 +853,12 @@ scriptBody: >-
   7. **Git Conventions**: Define commit message standards
 
   8. **AI Instructions**: Guide AI on how to generate and review code
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - cursor
   - ai-rules


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the cursor rules command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
