### PR TITLE
content(commands): add trust notes for docs

### DIFF
--- a/content/commands/docs.mdx
+++ b/content/commands/docs.mdx
@@ -1357,6 +1357,12 @@ scriptBody: >-
   This documentation generator creates comprehensive, interactive, and
   maintainable documentation that enhances developer experience and reduces
   support overhead.
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - documentation
   - api-docs


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the docs command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
