### PR TITLE
content(commands): add trust notes for optimize

### DIFF
--- a/content/commands/optimize.mdx
+++ b/content/commands/optimize.mdx
@@ -20,6 +20,12 @@ installable: true
 installCommand: "/optimize [options] <file_or_function>"
 usageSnippet: "/optimize [options] <file_or_function>"
 copySnippet: "/optimize [options] <file_or_function>"
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - performance
   - optimization


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the optimize command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
