### PR TITLE
content(commands): add trust notes for skills installer

### DIFF
--- a/content/commands/skills-installer.mdx
+++ b/content/commands/skills-installer.mdx
@@ -22,6 +22,12 @@ installable: true
 installCommand: "/skills-installer [action] [skill-name]"
 usageSnippet: "/skills-installer [action] [skill-name]"
 copySnippet: "/skills-installer [action] [skill-name]"
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - skills
   - agent-skills


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the skills installer command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
