### PR TITLE
ci(codecov): make coverage statuses enforcing (not informational)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,12 +4,17 @@
 # scoped in vitest.config.ts to registry/mcp packages, web lib/data/types, the
 # submission gate, and build scripts).
 #
-# Rollout posture: both statuses are INFORMATIONAL (report-only, never block a
-# merge) so we can watch the signal first. To make new code enforceable later,
-# set `informational: false` on `patch` (and add it to branch protection). We
-# deliberately avoid a fixed global target — `target: auto` compares each PR
-# against its own base commit, so merging one PR never moves the bar under other
-# open PRs (the churn we hit with vitest's global threshold ratchet).
+# Posture: ENFORCING (no longer informational). A PR whose CHANGED lines fall
+# below 70% coverage posts a FAILING `codecov/patch` status; an overall coverage
+# drop beyond the threshold posts a FAILING `codecov/project` status. `project`
+# keeps `target: auto` + a 1% threshold so it compares each PR to its own base
+# (avoiding the fixed-global-ratchet churn) while still failing real regressions.
+#
+# NOTE: codecov is deliberately NOT a required branch-protection check —
+# coverage.yml runs ONLY on code PRs, so a required codecov check would block
+# content-only PRs forever (the check never posts). Enforcement instead comes from
+# the failing codecov statuses, which reviewbot's gate treats as a hard blocker
+# (it won't approve or auto-merge over a red check).
 
 coverage:
   status:
@@ -17,14 +22,14 @@ coverage:
       default:
         target: auto
         threshold: 1%
-        informational: true
+        informational: false
         if_ci_failed: ignore
         only_pulls: false
     patch:
       default:
         target: 70%
         threshold: 5%
-        informational: true
+        informational: false
         if_ci_failed: ignore
         only_pulls: true
 


### PR DESCRIPTION
### Problem
`codecov.yml` set both `project` and `patch` to `informational: true`, so codecov **could never post a failing check** — a coverage regression literally couldn't fail a PR. (The config comment even noted this was a temporary "watch the signal first" posture.)

### Change
Flip both statuses to `informational: false`:
- **`codecov/patch`** fails a PR whose *changed lines* are <70% covered.
- **`codecov/project`** fails a PR that drops *overall* coverage beyond threshold (`target: auto` + 1% keeps it per-PR vs base, avoiding the global-ratchet churn).

### Why not branch protection
`coverage.yml` runs **only on code PRs**, so adding codecov as a *required* status check would block content-only PRs forever (the check never posts). Enforcement instead comes from the failing status itself — which reviewbot's gate already treats as a hard blocker (won't approve / auto-merge over a red check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled strict code coverage enforcement. Coverage quality checks are now merge-blocking rather than informational-only, requiring developers to meet coverage thresholds on patches and overall project metrics before merging pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->