### PR TITLE
content(commands): add trust notes for zod audit

### DIFF
--- a/content/commands/zod-audit.mdx
+++ b/content/commands/zod-audit.mdx
@@ -21,6 +21,9 @@ usageSnippet: /zod-audit security apps/web
 copySnippet: /zod-audit security apps/web
 privacyNotes:
   - "Reads the source files it audits, which may include schema definitions and sample data, and sends them to the model as part of the request; it does not transmit them anywhere else."
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
 tags:
   - zod
   - validation


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the zod audit command entry.

Refs #3919

## What changed

- Added runtime safety notes for generated command/tool activity.
- Added privacy notes for prompts, source files, logs, dependency metadata, and generated reports.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
