### PR TITLE
content(skills): add trust notes for agent evals regression gate

### DIFF
--- a/content/skills/agent-evals-regression-gate.mdx
+++ b/content/skills/agent-evals-regression-gate.mdx
@@ -46,6 +46,9 @@ prerequisites:
   - "Existing prompts, tools, or agent workflows to evaluate"
   - A representative set of real user tasks or transcripts
   - CI or local runner where eval suites can be executed repeatedly
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - evals
   - regression


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the agent evals regression gate skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
