### PR TITLE
content(skills): add trust notes for ai agent observability incident response

### DIFF
--- a/content/skills/ai-agent-observability-incident-response.mdx
+++ b/content/skills/ai-agent-observability-incident-response.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Runtime access where agent requests can be instrumented
   - Centralized logging/metrics/tracing destination
   - On-call or owner process for incident handling
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - observability
   - incident-response


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the ai agent observability incident response skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
