### PR TITLE
content(skills): add trust notes for ai search ranking content cluster strategy

### DIFF
--- a/content/skills/ai-search-ranking-content-cluster-strategy.mdx
+++ b/content/skills/ai-search-ranking-content-cluster-strategy.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Clear niche/topic scope
   - Existing content inventory (if available)
   - Primary conversion objective
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - seo
   - content-strategy


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the ai search ranking content cluster strategy skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
