### PR TITLE
content(skills): add trust notes for codex automations orchestrator capability pack

### DIFF
--- a/content/skills/codex-automations-orchestrator-capability-pack.mdx
+++ b/content/skills/codex-automations-orchestrator-capability-pack.mdx
@@ -44,6 +44,9 @@ prerequisites:
   - Operational owner
 safetyNotes:
   - "Designs and runs automation workflows that can execute commands and trigger external actions; review each automation's permissions and triggers before enabling it."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - codex
   - automation


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the codex automations orchestrator capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
