### PR TITLE
content(skills): add trust notes for codex plugin creator capability pack

### DIFF
--- a/content/skills/codex-plugin-creator-capability-pack.mdx
+++ b/content/skills/codex-plugin-creator-capability-pack.mdx
@@ -44,6 +44,9 @@ prerequisites:
   - Deployment target constraints
 safetyNotes:
   - "Scaffolds and validates plugin manifests and may run plugin or build commands; review generated manifests and scripts before installing or executing them."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - codex
   - plugins


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the codex plugin creator capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
