### PR TITLE
content(skills): add trust notes for ethereum base smart contract security capability pack

### DIFF
--- a/content/skills/ethereum-base-smart-contract-security-capability-pack.mdx
+++ b/content/skills/ethereum-base-smart-contract-security-capability-pack.mdx
@@ -43,6 +43,12 @@ prerequisites:
   - Solidity codebase and deployment scripts
   - Security requirements and risk tolerance
   - Testnet staging environment
+safetyNotes:
+  - "Do not deploy or transact from generated contract code without independent review, tests, and a dry run; smart contract mistakes can be irreversible."
+  - "Use local forks or testnets before mainnet and keep deployment wallets and RPC credentials least-privileged."
+privacyNotes:
+  - "Prompts and reports can include contract source, audit findings, addresses, deployment config, and transaction context."
+  - "Never paste private keys, seed phrases, unreleased exploit details, customer wallet data, or privileged RPC credentials into prompts."
 tags:
   - ethereum
   - base


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the ethereum base smart contract security capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
