### PR TITLE
content(skills): add trust notes for github actions secure cicd capability pack

### DIFF
--- a/content/skills/github-actions-secure-cicd-capability-pack.mdx
+++ b/content/skills/github-actions-secure-cicd-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - Existing workflows or target CI/CD architecture
   - Branch protection and environment policy context
   - Security/compliance requirements
+safetyNotes:
+  - "May produce commands or configuration for live infrastructure, CI, releases, or indexing; test changes in staging or dry-run mode first."
+  - "Use least-privilege API tokens and review workflow, deploy, DNS, cache, and release changes before applying them to production."
+privacyNotes:
+  - "Inputs can include repository metadata, workflow logs, deployment settings, domain names, analytics exports, and service configuration."
+  - "Redact tokens, account IDs, private URLs, customer data, and proprietary deployment details before sharing generated reports or prompts."
 tags:
   - github-actions
   - cicd


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the github actions secure cicd capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
