### PR TITLE
content(skills): add trust notes for google workspace gemini automation

### DIFF
--- a/content/skills/google-workspace-gemini-automation.mdx
+++ b/content/skills/google-workspace-gemini-automation.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Access to Google Workspace resources
   - Gemini API or platform integration credentials
   - Target business workflow with measurable success criteria
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - google-workspace
   - gemini


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the google workspace gemini automation skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
