### PR TITLE
content(skills): add trust notes for indexnow search indexing accelerator

### DIFF
--- a/content/skills/indexnow-search-indexing-accelerator.mdx
+++ b/content/skills/indexnow-search-indexing-accelerator.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Domain control and webmaster access
   - Sitemap generation workflow
   - Publishing system that emits changed URL lists
+safetyNotes:
+  - "May produce commands or configuration for live infrastructure, CI, releases, or indexing; test changes in staging or dry-run mode first."
+  - "Use least-privilege API tokens and review workflow, deploy, DNS, cache, and release changes before applying them to production."
+privacyNotes:
+  - "Inputs can include repository metadata, workflow logs, deployment settings, domain names, analytics exports, and service configuration."
+  - "Redact tokens, account IDs, private URLs, customer data, and proprietary deployment details before sharing generated reports or prompts."
 tags:
   - indexnow
   - seo


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the indexnow search indexing accelerator skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
