### PR TITLE
content(skills): add trust notes for markdown knowledge base composer

### DIFF
--- a/content/skills/markdown-knowledge-base-composer.mdx
+++ b/content/skills/markdown-knowledge-base-composer.mdx
@@ -59,6 +59,9 @@ prerequisites:
   - pandoc (optional for DOCX/EPUB export)
   - "File system read/write access for Markdown source files, generated HTML/PDF/DOCX/EPUB outputs, and image assets referenced in Markdown"
   - Markdown syntax knowledge or reference documentation for creating valid Markdown files (CommonMark or GitHub Flavored Markdown specification)
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - markdown
   - docs


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the markdown knowledge base composer skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
