### PR TITLE
content(skills): add trust notes for mcp server authoring security capability pack

### DIFF
--- a/content/skills/mcp-server-authoring-security-capability-pack.mdx
+++ b/content/skills/mcp-server-authoring-security-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - MCP server implementation or design draft
   - Tool inventory and expected consumers
   - Logging/alerting sink for security events
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - mcp
   - security


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the mcp server authoring security capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
