### PR TITLE
content(skills): add trust notes for mcp server security hardening

### DIFF
--- a/content/skills/mcp-server-security-hardening.mdx
+++ b/content/skills/mcp-server-security-hardening.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Existing MCP server implementation (local or remote)
   - "Access to server config, dependency manifest, and deployment settings"
   - Ability to run integration tests after hardening
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - mcp
   - security


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the mcp server security hardening skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
