### PR TITLE
content(skills): add trust notes for n8n ai agent workflow architect

### DIFF
--- a/content/skills/n8n-ai-agent-workflow-architect.mdx
+++ b/content/skills/n8n-ai-agent-workflow-architect.mdx
@@ -45,6 +45,12 @@ prerequisites:
   - n8n instance with credential vault configured
   - Defined business process to automate
   - "Access to destination systems (CRM, ticketing, chat, docs, etc.)"
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - n8n
   - ai-automation


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the n8n ai agent workflow architect skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
