### PR TITLE
content(skills): add trust notes for openclaw agent ops hardening

### DIFF
--- a/content/skills/openclaw-agent-ops-hardening.mdx
+++ b/content/skills/openclaw-agent-ops-hardening.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Running OpenClaw environment (self-hosted or managed)
   - Inventory of enabled tools and external integrations
   - Access to runtime/network/security configuration
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - openclaw
   - ai-agents


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the openclaw agent ops hardening skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
