### PR TITLE
content(skills): add trust notes for prompt injection defense guardrails

### DIFF
--- a/content/skills/prompt-injection-defense-guardrails.mdx
+++ b/content/skills/prompt-injection-defense-guardrails.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Agent flow that processes user input or external web/content data
   - Ability to add policy checks before tool execution
   - Test harness for adversarial prompt scenarios
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - prompt-injection
   - guardrails


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the prompt injection defense guardrails skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
