### PR TITLE
content(skills): add trust notes for proxmox ve api orchestrator

### DIFF
--- a/content/skills/proxmox-ve-api-orchestrator.mdx
+++ b/content/skills/proxmox-ve-api-orchestrator.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Proxmox VE cluster or node API access
   - Token-based auth with scoped permissions
   - Defined operational policy for infra changes
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - proxmox
   - virtualization


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the proxmox ve api orchestrator skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
