### PR TITLE
content(skills): add trust notes for unraid api v2 capability pack

### DIFF
--- a/content/skills/unraid-api-v2-capability-pack.mdx
+++ b/content/skills/unraid-api-v2-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - Unraid server with API enabled
   - Scoped API key/token
   - Target operation runbook and maintenance policy
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - unraid
   - api


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the unraid api v2 capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
