### PR TITLE
content(skills): add trust notes for zero budget saas launch capability pack

### DIFF
--- a/content/skills/zero-budget-saas-launch-capability-pack.mdx
+++ b/content/skills/zero-budget-saas-launch-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - Product hypothesis
   - Free-tier account access
   - Launch KPI targets
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - saas
   - bootstrap


### PR DESCRIPTION
## Summary

Adds missing safety and privacy notes to the zero budget saas launch capability pack skill entry.

Refs #3919

## What changed

- Added safety notes for generated commands, configuration, automation, deployment, or account-write workflows as applicable.
- Added privacy notes for prompts, source files, logs, credentials, operational context, and generated artifacts.

## Validation

- `pnpm validate:content:strict`
- `git diff --check`
