### PR TITLE
content(commands): add trust notes for mintlify docs

### DIFF
--- a/content/commands/mintlify-docs.mdx
+++ b/content/commands/mintlify-docs.mdx
@@ -828,6 +828,12 @@ scriptBody: >-
   6. **Search Optimization**: Use descriptive titles and descriptions
 
   7. **Regular Updates**: Keep documentation in sync with code changes
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - mintlify
   - documentation


### PR DESCRIPTION
## Summary
- Resubmits the Mintlify Docs command trust metadata after the previous one-file PR was closed by the preview check.

## What changed
- Adds safety notes for reviewing generated command output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing command entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3941

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/commands/mintlify-docs.mdx`
- `pnpm --filter web run prebuild`
- `git diff --check`
