### PR TITLE
ci: skip validate-pr-preview on content-only PRs

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -916,7 +916,12 @@ jobs:
 
   validate-pr-preview:
     name: validate-pr-preview
-    if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref_name == 'automation/readme-refresh')) && (needs.classify-pr.outputs.web == 'true' || needs.classify-pr.outputs.registry == 'true' || needs.classify-pr.outputs.mcp == 'true') }}
+    # Skip on content-ONLY PRs: this job does a full preview DEPLOY and waits up to 600s for the URL —
+    # a ~10-min runner hog. It has no content-specific path (unlike validate-registry/web), it does NOT
+    # gate required-pr-gate, and content go-live is validated at deploy. On content-only PRs it just
+    # starves the (throttled) runner pool, delaying the cheap required-pr-gate the gate actually waits on,
+    # so a 1-line content add sat queued for minutes. (#content-only-skip-preview)
+    if: ${{ ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || (github.event_name == 'workflow_dispatch' && github.ref_name == 'automation/readme-refresh')) && (needs.classify-pr.outputs.web == 'true' || needs.classify-pr.outputs.registry == 'true' || needs.classify-pr.outputs.mcp == 'true') && needs.classify-pr.outputs.source_content_only != 'true' }}
     needs: classify-pr
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
### Problem
A single-file content PR (e.g. #3994) sits "in CI" for minutes. The check reviewbot waits on — `required-pr-gate` — only depends on `classify-pr` / `validate-worktree` / `validate-ci` (all fast/skipped), so it should post in seconds. But it sits **queued waiting for a runner**, because content PRs trigger **`validate-pr-preview`**:

- content sets `classify registry=true` (content feeds the registry) → trips `validate-pr-preview`'s `if`
- that job runs `pnpm install` then **waits up to 600s** (`resolve-pr-preview-url --wait-seconds 600`) for a full preview **deploy** — a ~10-minute runner hog
- it is **not** a dependency of `required-pr-gate` (gates nothing), but under the Actions concurrency throttle it **starves** the cheap gate job → minutes of delay for a 1-line content add

### Fix
Skip `validate-pr-preview` when `source_content_only == 'true'`. Unlike `validate-registry`/`validate-web` (which have intentional content-only steps), `validate-pr-preview` has **no** content-specific path, and content go-live is validated at deploy — so it adds no value on content-only PRs and only steals runners.

Net: content-only PRs free a runner-for-10-min, so `required-pr-gate` posts promptly and reviewbot reviews in seconds. No effect on code/web/registry-source PRs (still run the preview).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the pull request processing workflow to automatically skip preview deployments when pull requests contain only content-related changes without code modifications. This improvement streamlines the review process and reduces unnecessary build resources.
  * Enhanced workflow configuration documentation with clarifying comments to explain the preview deployment gating behavior and runner throttling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->