### PR TITLE
content(commands): add trust notes for security audit

### DIFF
--- a/content/commands/security-audit.mdx
+++ b/content/commands/security-audit.mdx
@@ -21,6 +21,12 @@ installable: true
 installCommand: "/security-audit [scope]"
 usageSnippet: "/security-audit [scope]"
 copySnippet: "/security-audit [scope]"
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
+privacyNotes:
+  - "Prompts, source files, logs, errors, dependency metadata, and generated reports may be sent to the configured AI model during command execution."
+  - "Redact secrets, customer data, private repository details, and proprietary code before sharing command output outside the workspace."
 tags:
   - security-audit
   - enterprise


### PR DESCRIPTION
## Summary
- Resubmits content/commands/security-audit.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3946

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/commands/security-audit.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
