### PR TITLE
content(commands): add trust notes for zod audit

### DIFF
--- a/content/commands/zod-audit.mdx
+++ b/content/commands/zod-audit.mdx
@@ -21,6 +21,9 @@ usageSnippet: /zod-audit security apps/web
 copySnippet: /zod-audit security apps/web
 privacyNotes:
   - "Reads the source files it audits, which may include schema definitions and sample data, and sends them to the model as part of the request; it does not transmit them anywhere else."
+safetyNotes:
+  - "Review generated changes and commands before applying them; slash commands can ask the agent to read, write, edit, or run tools in the current project."
+  - "Limit scope to the intended files and run in a trusted checkout when the command analyzes code, tests, security findings, or generated output."
 tags:
   - zod
   - validation


### PR DESCRIPTION
## Summary
- Resubmits content/commands/zod-audit.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3952

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/commands/zod-audit.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
