### PR TITLE
content(skills): add trust notes for agent evals regression gate

### DIFF
--- a/content/skills/agent-evals-regression-gate.mdx
+++ b/content/skills/agent-evals-regression-gate.mdx
@@ -46,6 +46,9 @@ prerequisites:
   - "Existing prompts, tools, or agent workflows to evaluate"
   - A representative set of real user tasks or transcripts
   - CI or local runner where eval suites can be executed repeatedly
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - evals
   - regression
@@ -103,11 +106,11 @@ This skill helps you turn subjective "looks good" checks into measurable, repeat
 
 This skill defines the regression-gate workflow; you can back the scoring with an existing eval framework:
 
-| Framework | Focus | Notable for |
-| --- | --- | --- |
-| **Promptfoo** | Test-style LLM evals + red-teaming | YAML test cases, CI-friendly, assertion library |
-| **Ragas** | RAG-specific evaluation | Retrieval/answer metrics (faithfulness, relevance) |
-| **DeepEval** | Pytest-style LLM evals | Familiar unit-test ergonomics and metric library |
+| Framework     | Focus                              | Notable for                                        |
+| ------------- | ---------------------------------- | -------------------------------------------------- |
+| **Promptfoo** | Test-style LLM evals + red-teaming | YAML test cases, CI-friendly, assertion library    |
+| **Ragas**     | RAG-specific evaluation            | Retrieval/answer metrics (faithfulness, relevance) |
+| **DeepEval**  | Pytest-style LLM evals             | Familiar unit-test ergonomics and metric library   |
 
 Use Promptfoo for broad CI assertions, Ragas when the system is retrieval-augmented, or DeepEval if you want pytest-native ergonomics — then feed their results into this gate's pass/fail thresholds.
 


### PR DESCRIPTION
## Summary
- Resubmits `content/skills/agent-evals-regression-gate.mdx` trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety/privacy notes for the regression gate workflow.
- Applies Prettier formatting to the existing framework comparison table.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- The file needed formatting before it could be resubmitted cleanly.
- Refs #3919
- Resubmits #3959

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/agent-evals-regression-gate.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
