### PR TITLE
perf(registry): O(n²)→O(n·candidates) relation graph (prebuild 77s→31s)

### DIFF
--- a/packages/registry/src/relationships.js
+++ b/packages/registry/src/relationships.js
@@ -327,13 +327,66 @@ export function buildEntryRelations(target, entries, params = {}) {
 export function buildRegistryRelationGraph(entries, params = {}) {
   const limit = params.limit ?? DEFAULT_RELATION_LIMIT;
 
+  // Candidate inverted index (#relation-index). scoreCandidate can only cross the score>=18 threshold
+  // when two entries share a collection ref, GitHub repo, source URL, source domain, or text token —
+  // category overlap alone tops out at 16 (<18). So gathering candidates from those buckets is COMPLETE
+  // (no entry that would relate is missed), turning the O(n^2) all-pairs scan into O(n * candidates).
+  // Candidates are fed to the unchanged buildEntryRelations in ORIGINAL order, and non-candidates would
+  // have scored null anyway, so the output is byte-identical to the all-pairs version.
+  const indexOf = new Map();
+  const byKey = new Map();
+  const repoBucket = new Map();
+  const urlBucket = new Map();
+  const domainBucket = new Map();
+  const tokenBucket = new Map();
+  const refsToKey = new Map();
+  const pushTo = (map, key, entry) => {
+    if (!key) return;
+    const list = map.get(key);
+    if (list) list.push(entry);
+    else map.set(key, [entry]);
+  };
+  entries.forEach((entry, i) => {
+    indexOf.set(entry, i);
+    byKey.set(entryKey(entry), entry);
+    pushTo(repoBucket, githubRepoKey(entry), entry);
+    for (const url of sourceUrls(entry).map(normalizeToken).filter(Boolean))
+      pushTo(urlBucket, url, entry);
+    for (const domain of sourceDomains(entry).map(normalizeToken).filter(Boolean))
+      pushTo(domainBucket, domain, entry);
+    for (const token of textTokens(entry).map(normalizeToken).filter(Boolean))
+      pushTo(tokenBucket, token, entry);
+    for (const ref of collectionRefs(entry)) pushTo(refsToKey, ref, entry);
+  });
+
+  const candidatesFor = (entry) => {
+    const set = new Set();
+    const collect = (list) => {
+      if (list) for (const e of list) set.add(e);
+    };
+    collect(repoBucket.get(githubRepoKey(entry)));
+    for (const url of sourceUrls(entry).map(normalizeToken).filter(Boolean))
+      collect(urlBucket.get(url));
+    for (const domain of sourceDomains(entry).map(normalizeToken).filter(Boolean))
+      collect(domainBucket.get(domain));
+    for (const token of textTokens(entry).map(normalizeToken).filter(Boolean))
+      collect(tokenBucket.get(token));
+    for (const ref of collectionRefs(entry)) {
+      const referenced = byKey.get(ref);
+      if (referenced) set.add(referenced);
+    }
+    collect(refsToKey.get(entryKey(entry)));
+    set.delete(entry);
+    return [...set].sort((a, b) => indexOf.get(a) - indexOf.get(b));
+  };
+
   const rows = entries.map((entry) => ({
     key: entryKey(entry),
     category: entry.category,
     slug: entry.slug,
     title: entry.title,
     url: entryUrl(entry),
-    related: buildEntryRelations(entry, entries, { limit }),
+    related: buildEntryRelations(entry, candidatesFor(entry), { limit }),
   }));
 
   return {


### PR DESCRIPTION
### The bottleneck
Profiling the prebuild (the slow CI step) showed `generate:registry` = **76.6s**, and **66.7s of it** was `buildRegistryRelationGraph` — it scored **every entry against all ~1,316 others** (`buildEntryRelations(entry, entries)`), ~1.7M pairwise set-intersections. (Parse was only 0.66s, writes 0.5s — so worker-threads on parsing would've done nothing.)

### The fix
`scoreCandidate` can only reach its `score >= 18` threshold via a shared **collection ref, GitHub repo, source URL, source domain, or text token** — category overlap alone tops out at 16. So I build inverted indexes on exactly those signals once, gather only the real candidates per entry, and feed them to the **unchanged** `buildEntryRelations` in original order. Entries not in any bucket would have scored `null` anyway, so the result is identical. O(n²) → O(n·candidates).

### Verified (safe + accurate)
- `generate:registry`: **76.6s → 30.9s** locally
- **Byte-identical output**: `diff -rq` of all generated artifacts vs the pre-change build is empty
- `tests/registry-artifacts.test.ts` (46 tests) passes
- CI's `verify generated registry artifacts remain build outputs` is the backstop — it fails on any output drift

This directly cuts the `validate-registry` / `coverage` prebuild time on every code PR (and content PRs, where `validate-registry` runs).