### PR TITLE
content(skills): add trust notes for ai agent observability incident response

### DIFF
--- a/content/skills/ai-agent-observability-incident-response.mdx
+++ b/content/skills/ai-agent-observability-incident-response.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Runtime access where agent requests can be instrumented
   - Centralized logging/metrics/tracing destination
   - On-call or owner process for incident handling
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - observability
   - incident-response


### PR DESCRIPTION
## Summary
- Resubmits `content/skills/ai-agent-observability-incident-response.mdx` trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated incident response actions before applying them.
- Adds privacy notes for logs, traces, incidents, and operational reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3960

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/ai-agent-observability-incident-response.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
