### PR TITLE
content(commands): ground test advanced custom command

### DIFF
--- a/content/commands/test-advanced.mdx
+++ b/content/commands/test-advanced.mdx
@@ -1,1331 +1,184 @@
 ---
-title: /test-advanced - Test Suite Command for Claude Code
+title: /test-advanced - Advanced Test Planning Custom Command
 slug: test-advanced
 category: commands
 description: >-
-  Advanced test suite generator with property-based testing, mutation testing,
-  and intelligent test case discovery
+  User-created Claude Code custom slash command recipe for planning deeper tests
+  around a file or function, including edge cases, property-style invariants,
+  regression cases, and mutation-score gaps where the project already supports
+  those tools.
 cardDescription: >-
-  Advanced test suite generator with property-based testing, mutation testing,
-  and intelligent test case discovery
-seoTitle: /test-advanced - Test Suite Command for Claude Code
+  Custom .claude/commands/test-advanced.md recipe for planning deeper,
+  source-grounded test coverage without claiming a built-in Claude Code command.
+seoTitle: /test-advanced - Advanced Claude Code Test Planning Recipe
 seoDescription: >-
-  Advanced test suite generator with property-based testing, mutation testing,
-  and intelligent test case discovery Discover tools for AI development.
+  Create a custom /test-advanced slash command in Claude Code for planning
+  deeper tests around a target file using project conventions and Anthropic
+  testing guidance.
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-09-16"
-documentationUrl: "https://code.claude.com/docs/en/slash-commands"
-installable: true
-installCommand: "/test [options] <file_or_function>"
-usageSnippet: "/test [options] <file_or_function>"
-copySnippet: "/test [options] <file_or_function>"
+documentationUrl: "https://code.claude.com/docs/en/skills"
+installable: false
+usageSnippet: "Create .claude/commands/test-advanced.md, then run: /test-advanced src/utils/parser.ts"
+copySnippet: "/test-advanced src/utils/parser.ts -- include invariants, edge cases, regression checks, and framework-specific gaps"
 tags:
   - testing
+  - automation
   - unit-tests
   - integration-tests
   - property-based
   - mutation-testing
 keywords:
-  - advanced
   - claude
   - commands
+  - custom command
   - development
-  - integration-tests
-  - mutation-testing
-  - property-based
-  - test
+  - edge cases
+  - mutation testing
+  - property based testing
+  - regression tests
+  - test planning
   - testing
-  - tools
-  - unit-tests
-readingTime: 16
+readingTime: 6
 difficultyScore: 100
 hasTroubleshooting: true
 hasPrerequisites: false
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true
-commandSyntax: "/test [options] <file_or_function>"
+commandSyntax: "Create .claude/commands/test-advanced.md, then run: /test-advanced <file-or-function>"
+retrievalSources:
+  - "https://code.claude.com/docs/en/skills"
+  - "https://platform.claude.com/docs/en/test-and-evaluate/develop-tests"
+  - "https://jestjs.io/docs/getting-started"
+  - "https://vitest.dev/guide/"
+  - "https://docs.pytest.org/en/stable/"
+safetyNotes:
+  - "This recipe asks Claude to inspect and draft tests against local project code; review generated tests before committing them."
+  - "Run the narrowest relevant test command yourself and verify failures before broadening the suite or changing production code."
+  - "If you add allowed-tools or dynamic shell injection to the command file, scope those permissions narrowly because the command can run local tools."
+privacyNotes:
+  - "The target source file, nearby tests, failures, logs, and command arguments may be sent into the model context."
+  - "Use synthetic fixtures and redacted logs; do not paste production data, credentials, customer records, or private incident details into generated tests."
 ---
 
-The `/test` command generates comprehensive test suites with advanced testing methodologies including property-based testing, mutation testing, snapshot testing, and intelligent edge case discovery.
+`/test-advanced` is **not a built-in Claude Code command**. This entry is a
+custom command recipe: you create a Markdown file in `.claude/commands/`, Claude
+Code exposes it as `/test-advanced`, and the behavior comes from the prompt you
+write into that file.
+
+Use it when the simpler `/generate-tests` style prompt is too broad and you want
+Claude to plan a test matrix before writing code: current behavior, invariants,
+edge cases, regression cases, framework conventions, and any advanced gaps your
+project already has tooling to measure.
+
+## Create the command
+
+Create `.claude/commands/test-advanced.md`:
+
+```markdown
+---
+description: Plan and draft deeper tests for a file, function, or behavior
+argument-hint: [file-or-function]
+---
+
+Plan advanced test coverage for $ARGUMENTS.
+
+First inspect the target code and nearby tests. Then produce:
+
+1. A short behavior summary grounded in the source.
+2. Existing test framework and naming conventions.
+3. A scenario table covering happy paths, boundaries, invalid input, and
+   regression cases.
+4. Property-style invariants if the behavior has stable rules worth checking.
+5. Integration or contract cases only where existing project tests already use
+   those patterns.
+6. Mutation-score or coverage gaps only if the repository already has a tool for
+   measuring them.
+7. The smallest test command to run after the draft is written.
+
+After the plan, draft the minimal tests that fit the project's current test
+stack. Do not introduce a new framework unless the project has no test framework
+yet and you explain the tradeoff.
+```
+
+Claude Code derives the command name from the filename, so this file creates
+`/test-advanced`. Text after the command name is passed through `$ARGUMENTS`.
 
 ## Usage
 
-```
-/test [options] <file_or_function>
-```
-
-## Options
-
-### Test Types
-
-- `--unit` - Unit tests with mocking and isolation
-- `--integration` - Integration tests with real dependencies
-- `--e2e` - End-to-end tests with full system simulation
-- `--property` - Property-based testing with hypothesis generation
-- `--mutation` - Mutation testing for test quality assessment
-- `--snapshot` - Snapshot testing for UI and output consistency
-- `--performance` - Performance and load testing
-- `--security` - Security and penetration testing
-- `--all` - Comprehensive test suite (default)
-
-### Testing Frameworks
-
-- `--jest` - Jest testing framework (JavaScript/TypeScript)
-- `--vitest` - Vitest testing framework (faster Jest alternative)
-- `--pytest` - pytest framework (Python)
-- `--junit` - JUnit framework (Java)
-- `--rspec` - RSpec framework (Ruby)
-- `--go-test` - Go testing package
-- `--rust-test` - Rust testing framework
-
-### Advanced Features
-
-- `--coverage` - Generate code coverage reports with detailed metrics
-- `--baseline` - Generate performance baselines and regression detection
-- `--fuzz` - Fuzzing tests with random input generation
-- `--contract` - Contract testing for API compatibility
-- `--visual` - Visual regression testing for UI components
-
-### AI-Powered Features
-
-- `--smart-cases` - AI-generated edge cases and corner cases
-- `--behavior-discovery` - Automatic behavior pattern recognition
-- `--test-oracle` - AI-powered test oracle generation
-- `--failure-prediction` - Predict likely failure scenarios
-
-## Examples
-
-### Advanced React Component Testing
-
-```jsx
-// Component to test: UserProfileCard.jsx
-import React, { useState, useEffect } from "react";
-import { fetchUserProfile, updateUserProfile } from "../api/users";
-import { useAuth } from "../hooks/useAuth";
-import { toast } from "../utils/toast";
-
-const UserProfileCard = ({ userId, onProfileUpdate, editable = false }) => {
-  const [profile, setProfile] = useState(null);
-  const [loading, setLoading] = useState(true);
-  const [editing, setEditing] = useState(false);
-  const [formData, setFormData] = useState({});
-  const [errors, setErrors] = useState({});
-
-  const { user: currentUser } = useAuth();
-
-  useEffect(() => {
-    loadProfile();
-  }, [userId]);
-
-  const loadProfile = async () => {
-    try {
-      setLoading(true);
-      const userProfile = await fetchUserProfile(userId);
-      setProfile(userProfile);
-      setFormData({
-        name: userProfile.name,
-        email: userProfile.email,
-        bio: userProfile.bio || "",
-      });
-    } catch (error) {
-      toast.error("Failed to load profile");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const validateForm = () => {
-    const newErrors = {};
-
-    if (!formData.name?.trim()) {
-      newErrors.name = "Name is required";
-    } else if (formData.name.length < 2) {
-      newErrors.name = "Name must be at least 2 characters";
-    } else if (formData.name.length > 100) {
-      newErrors.name = "Name must be less than 100 characters";
-    }
-
-    if (!formData.email?.trim()) {
-      newErrors.email = "Email is required";
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      newErrors.email = "Invalid email format";
-    }
-
-    if (formData.bio && formData.bio.length > 500) {
-      newErrors.bio = "Bio must be less than 500 characters";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSave = async () => {
-    if (!validateForm()) return;
-
-    try {
-      setLoading(true);
-      const updatedProfile = await updateUserProfile(userId, formData);
-      setProfile(updatedProfile);
-      setEditing(false);
-      toast.success("Profile updated successfully");
-      onProfileUpdate?.(updatedProfile);
-    } catch (error) {
-      if (error.status === 409) {
-        setErrors({ email: "Email already exists" });
-      } else {
-        toast.error("Failed to update profile");
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const canEdit =
-    editable && (currentUser?.id === userId || currentUser?.role === "admin");
-
-  if (loading && !profile) {
-    return <div data-testid="loading-spinner">Loading...</div>;
-  }
-
-  if (!profile) {
-    return <div data-testid="error-message">Profile not found</div>;
-  }
-
-  return (
-    <div data-testid="user-profile-card" className="profile-card">
-      <div className="profile-header">
-        <img
-          src={profile.avatar || "/default-avatar.png"}
-          alt={`${profile.name}'s avatar`}
-          data-testid="profile-avatar"
-        />
-        {editing ? (
-          <input
-            type="text"
-            value={formData.name}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, name: e.target.value }))
-            }
-            data-testid="name-input"
-            className={errors.name ? "error" : ""}
-            placeholder="Enter name"
-          />
-        ) : (
-          <h2 data-testid="profile-name">{profile.name}</h2>
-        )}
-        {errors.name && (
-          <span data-testid="name-error" className="error">
-            {errors.name}
-          </span>
-        )}
-      </div>
-
-      <div className="profile-details">
-        <div className="detail-item">
-          <label>Email:</label>
-          {editing ? (
-            <input
-              type="email"
-              value={formData.email}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, email: e.target.value }))
-              }
-              data-testid="email-input"
-              className={errors.email ? "error" : ""}
-            />
-          ) : (
-            <span data-testid="profile-email">{profile.email}</span>
-          )}
-          {errors.email && (
-            <span data-testid="email-error" className="error">
-              {errors.email}
-            </span>
-          )}
-        </div>
-
-        <div className="detail-item">
-          <label>Bio:</label>
-          {editing ? (
-            <textarea
-              value={formData.bio}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, bio: e.target.value }))
-              }
-              data-testid="bio-input"
-              className={errors.bio ? "error" : ""}
-              placeholder="Tell us about yourself..."
-              maxLength={500}
-            />
-          ) : (
-            <p data-testid="profile-bio">{profile.bio || "No bio available"}</p>
-          )}
-          {errors.bio && (
-            <span data-testid="bio-error" className="error">
-              {errors.bio}
-            </span>
-          )}
-        </div>
-      </div>
-
-      {canEdit && (
-        <div className="profile-actions">
-          {editing ? (
-            <>
-              <button
-                onClick={handleSave}
-                disabled={loading}
-                data-testid="save-button"
-                className="btn-primary"
-              >
-                {loading ? "Saving..." : "Save Changes"}
-              </button>
-              <button
-                onClick={() => {
-                  setEditing(false);
-                  setFormData({
-                    name: profile.name,
-                    email: profile.email,
-                    bio: profile.bio || "",
-                  });
-                  setErrors({});
-                }}
-                disabled={loading}
-                data-testid="cancel-button"
-                className="btn-secondary"
-              >
-                Cancel
-              </button>
-            </>
-          ) : (
-            <button
-              onClick={() => setEditing(true)}
-              data-testid="edit-button"
-              className="btn-primary"
-            >
-              Edit Profile
-            </button>
-          )}
-        </div>
-      )}
-    </div>
-  );
-};
-
-export default UserProfileCard;
+```text
+/test-advanced src/utils/parser.ts
 ```
 
-**Generated Advanced Test Suite:**
-
-```javascript
-// UserProfileCard.test.jsx - Comprehensive Test Suite
-import React from "react";
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  within,
-} from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
-import { faker } from "@faker-js/faker";
-import fc from "fast-check";
-import { axe, toHaveNoViolations } from "jest-axe";
-
-import UserProfileCard from "../UserProfileCard";
-import { fetchUserProfile, updateUserProfile } from "../api/users";
-import { useAuth } from "../hooks/useAuth";
-import { toast } from "../utils/toast";
-
-// Extend Jest matchers
-expect.extend(toHaveNoViolations);
-
-// Mock dependencies
-vi.mock("../api/users");
-vi.mock("../hooks/useAuth");
-vi.mock("../utils/toast");
-
-const mockFetchUserProfile = vi.mocked(fetchUserProfile);
-const mockUpdateUserProfile = vi.mocked(updateUserProfile);
-const mockUseAuth = vi.mocked(useAuth);
-const mockToast = vi.mocked(toast);
-
-// Test data generators
-const generateValidUser = () => ({
-  id: faker.string.uuid(),
-  name: faker.person.fullName(),
-  email: faker.internet.email(),
-  bio: faker.lorem.paragraph(),
-  avatar: faker.image.avatar(),
-  createdAt: faker.date.past().toISOString(),
-  updatedAt: faker.date.recent().toISOString(),
-});
-
-const generateInvalidUser = () => ({
-  id: "",
-  name: "",
-  email: "invalid-email",
-  bio: "x".repeat(600), // Exceeds 500 char limit
-  avatar: null,
-});
-
-// Custom render function with providers
-const renderUserProfileCard = (props = {}) => {
-  const defaultProps = {
-    userId: faker.string.uuid(),
-    editable: false,
-    onProfileUpdate: vi.fn(),
-    ...props,
-  };
-
-  return {
-    ...render(<UserProfileCard {...defaultProps} />),
-    props: defaultProps,
-  };
-};
-
-describe("UserProfileCard", () => {
-  let mockCurrentUser;
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    // Default auth state
-    mockCurrentUser = generateValidUser();
-    mockUseAuth.mockReturnValue({ user: mockCurrentUser });
-
-    // Default toast implementation
-    mockToast.success = vi.fn();
-    mockToast.error = vi.fn();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  describe("Loading States", () => {
-    it("should show loading spinner while fetching profile", () => {
-      mockFetchUserProfile.mockImplementation(() => new Promise(() => {})); // Never resolves
-
-      renderUserProfileCard();
-
-      expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
-      expect(screen.getByText("Loading...")).toBeInTheDocument();
-    });
-
-    it("should show loading button text while saving", async () => {
-      const user = userEvent.setup();
-      const mockProfile = generateValidUser();
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockImplementation(() => new Promise(() => {})); // Never resolves
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toHaveTextContent(
-          mockProfile.name,
-        );
-      });
-
-      await user.click(screen.getByTestId("edit-button"));
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("save-button")).toHaveTextContent("Saving...");
-      expect(screen.getByTestId("save-button")).toBeDisabled();
-      expect(screen.getByTestId("cancel-button")).toBeDisabled();
-    });
-  });
-
-  describe("Profile Display", () => {
-    it("should display profile information correctly", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toHaveTextContent(
-          mockProfile.name,
-        );
-      });
-
-      expect(screen.getByTestId("profile-email")).toHaveTextContent(
-        mockProfile.email,
-      );
-      expect(screen.getByTestId("profile-bio")).toHaveTextContent(
-        mockProfile.bio,
-      );
-      expect(screen.getByTestId("profile-avatar")).toHaveAttribute(
-        "src",
-        mockProfile.avatar,
-      );
-      expect(screen.getByTestId("profile-avatar")).toHaveAttribute(
-        "alt",
-        `${mockProfile.name}'s avatar`,
-      );
-    });
-
-    it("should display default avatar when user has no avatar", async () => {
-      const mockProfile = { ...generateValidUser(), avatar: null };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-avatar")).toHaveAttribute(
-          "src",
-          "/default-avatar.png",
-        );
-      });
-    });
-
-    it('should display "No bio available" when user has no bio', async () => {
-      const mockProfile = { ...generateValidUser(), bio: null };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-bio")).toHaveTextContent(
-          "No bio available",
-        );
-      });
-    });
-  });
-
-  describe("Error Handling", () => {
-    it("should show error message when profile fetch fails", async () => {
-      const errorMessage = "Network error";
-      mockFetchUserProfile.mockRejectedValue(new Error(errorMessage));
-
-      renderUserProfileCard();
-
-      await waitFor(() => {
-        expect(screen.getByTestId("error-message")).toBeInTheDocument();
-      });
-
-      expect(mockToast.error).toHaveBeenCalledWith("Failed to load profile");
-    });
-
-    it("should handle API errors during profile update", async () => {
-      const user = userEvent.setup();
-      const mockProfile = generateValidUser();
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockRejectedValue(new Error("Server error"));
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByTestId("edit-button"));
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), "Updated Name");
-      await user.click(screen.getByTestId("save-button"));
-
-      await waitFor(() => {
-        expect(mockToast.error).toHaveBeenCalledWith(
-          "Failed to update profile",
-        );
-      });
-    });
-
-    it("should handle email conflict error specifically", async () => {
-      const user = userEvent.setup();
-      const mockProfile = generateValidUser();
-      const conflictError = new Error("Conflict");
-      conflictError.status = 409;
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockRejectedValue(conflictError);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByTestId("edit-button"));
-      await user.clear(screen.getByTestId("email-input"));
-      await user.type(
-        screen.getByTestId("email-input"),
-        "existing@example.com",
-      );
-      await user.click(screen.getByTestId("save-button"));
-
-      await waitFor(() => {
-        expect(screen.getByTestId("email-error")).toHaveTextContent(
-          "Email already exists",
-        );
-      });
-    });
-  });
-
-  describe("Permission System", () => {
-    it("should show edit button for profile owner", async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-    });
-
-    it("should show edit button for admin users", async () => {
-      const mockProfile = generateValidUser();
-      const adminUser = { ...mockCurrentUser, role: "admin" };
-
-      mockUseAuth.mockReturnValue({ user: adminUser });
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-    });
-
-    it("should not show edit button for other users", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      });
-
-      expect(screen.queryByTestId("edit-button")).not.toBeInTheDocument();
-    });
-
-    it("should not show edit button when editable is false", async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: false,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      });
-
-      expect(screen.queryByTestId("edit-button")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Form Validation", () => {
-    beforeEach(async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await userEvent.setup().click(screen.getByTestId("edit-button"));
-    });
-
-    it("should validate required name field", async () => {
-      const user = userEvent.setup();
-
-      await user.clear(screen.getByTestId("name-input"));
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("name-error")).toHaveTextContent(
-        "Name is required",
-      );
-      expect(mockUpdateUserProfile).not.toHaveBeenCalled();
-    });
-
-    it("should validate minimum name length", async () => {
-      const user = userEvent.setup();
-
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), "A");
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("name-error")).toHaveTextContent(
-        "Name must be at least 2 characters",
-      );
-    });
-
-    it("should validate maximum name length", async () => {
-      const user = userEvent.setup();
-      const longName = "A".repeat(101);
-
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), longName);
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("name-error")).toHaveTextContent(
-        "Name must be less than 100 characters",
-      );
-    });
-
-    it("should validate required email field", async () => {
-      const user = userEvent.setup();
-
-      await user.clear(screen.getByTestId("email-input"));
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("email-error")).toHaveTextContent(
-        "Email is required",
-      );
-    });
-
-    it("should validate email format", async () => {
-      const user = userEvent.setup();
-
-      await user.clear(screen.getByTestId("email-input"));
-      await user.type(screen.getByTestId("email-input"), "invalid-email");
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("email-error")).toHaveTextContent(
-        "Invalid email format",
-      );
-    });
-
-    it("should validate bio length", async () => {
-      const user = userEvent.setup();
-      const longBio = "A".repeat(501);
-
-      await user.clear(screen.getByTestId("bio-input"));
-      await user.type(screen.getByTestId("bio-input"), longBio);
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.getByTestId("bio-error")).toHaveTextContent(
-        "Bio must be less than 500 characters",
-      );
-    });
-
-    it("should allow empty bio", async () => {
-      const user = userEvent.setup();
-      const updatedProfile = generateValidUser();
-
-      mockUpdateUserProfile.mockResolvedValue(updatedProfile);
-
-      await user.clear(screen.getByTestId("bio-input"));
-      await user.click(screen.getByTestId("save-button"));
-
-      expect(screen.queryByTestId("bio-error")).not.toBeInTheDocument();
-      expect(mockUpdateUserProfile).toHaveBeenCalled();
-    });
-  });
-
-  describe("Edit Mode Functionality", () => {
-    let mockProfile;
-
-    beforeEach(async () => {
-      mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-    });
-
-    it("should switch to edit mode when edit button is clicked", async () => {
-      const user = userEvent.setup();
-
-      await user.click(screen.getByTestId("edit-button"));
-
-      expect(screen.getByTestId("name-input")).toHaveValue(mockProfile.name);
-      expect(screen.getByTestId("email-input")).toHaveValue(mockProfile.email);
-      expect(screen.getByTestId("bio-input")).toHaveValue(mockProfile.bio);
-      expect(screen.getByTestId("save-button")).toBeInTheDocument();
-      expect(screen.getByTestId("cancel-button")).toBeInTheDocument();
-      expect(screen.queryByTestId("edit-button")).not.toBeInTheDocument();
-    });
-
-    it("should cancel edit mode and restore original values", async () => {
-      const user = userEvent.setup();
-
-      await user.click(screen.getByTestId("edit-button"));
-
-      // Make changes
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), "Changed Name");
-
-      // Cancel
-      await user.click(screen.getByTestId("cancel-button"));
-
-      expect(screen.getByTestId("profile-name")).toHaveTextContent(
-        mockProfile.name,
-      );
-      expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      expect(screen.queryByTestId("save-button")).not.toBeInTheDocument();
-    });
-
-    it("should save changes and exit edit mode", async () => {
-      const user = userEvent.setup();
-      const updatedProfile = {
-        ...mockProfile,
-        name: "Updated Name",
-        email: "updated@example.com",
-      };
-
-      mockUpdateUserProfile.mockResolvedValue(updatedProfile);
-
-      await user.click(screen.getByTestId("edit-button"));
-
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), updatedProfile.name);
-
-      await user.clear(screen.getByTestId("email-input"));
-      await user.type(screen.getByTestId("email-input"), updatedProfile.email);
-
-      await user.click(screen.getByTestId("save-button"));
-
-      await waitFor(() => {
-        expect(mockUpdateUserProfile).toHaveBeenCalledWith(mockProfile.id, {
-          name: updatedProfile.name,
-          email: updatedProfile.email,
-          bio: mockProfile.bio,
-        });
-      });
-
-      expect(mockToast.success).toHaveBeenCalledWith(
-        "Profile updated successfully",
-      );
-      expect(screen.getByTestId("profile-name")).toHaveTextContent(
-        updatedProfile.name,
-      );
-      expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-    });
-  });
-
-  describe("Callback Functions", () => {
-    it("should call onProfileUpdate callback after successful save", async () => {
-      const user = userEvent.setup();
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      const updatedProfile = { ...mockProfile, name: "Updated Name" };
-      const mockOnProfileUpdate = vi.fn();
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockResolvedValue(updatedProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-        onProfileUpdate: mockOnProfileUpdate,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByTestId("edit-button"));
-      await user.clear(screen.getByTestId("name-input"));
-      await user.type(screen.getByTestId("name-input"), updatedProfile.name);
-      await user.click(screen.getByTestId("save-button"));
-
-      await waitFor(() => {
-        expect(mockOnProfileUpdate).toHaveBeenCalledWith(updatedProfile);
-      });
-    });
-
-    it("should not call onProfileUpdate callback on save failure", async () => {
-      const user = userEvent.setup();
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      const mockOnProfileUpdate = vi.fn();
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockRejectedValue(new Error("Save failed"));
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-        onProfileUpdate: mockOnProfileUpdate,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await user.click(screen.getByTestId("edit-button"));
-      await user.click(screen.getByTestId("save-button"));
-
-      await waitFor(() => {
-        expect(mockToast.error).toHaveBeenCalled();
-      });
-
-      expect(mockOnProfileUpdate).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("Accessibility", () => {
-    it("should have no accessibility violations", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      const { container } = renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      });
-
-      const results = await axe(container);
-      expect(results).toHaveNoViolations();
-    });
-
-    it("should have proper ARIA labels and roles", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id, editable: true });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      const avatar = screen.getByTestId("profile-avatar");
-      expect(avatar).toHaveAttribute("alt", `${mockProfile.name}'s avatar`);
-
-      await userEvent.setup().click(screen.getByTestId("edit-button"));
-
-      const nameInput = screen.getByTestId("name-input");
-      expect(nameInput).toHaveAttribute("placeholder", "Enter name");
-
-      const bioInput = screen.getByTestId("bio-input");
-      expect(bioInput).toHaveAttribute(
-        "placeholder",
-        "Tell us about yourself...",
-      );
-      expect(bioInput).toHaveAttribute("maxLength", "500");
-    });
-  });
-
-  describe("Property-Based Testing", () => {
-    it("should handle any valid user profile data", () => {
-      fc.assert(
-        fc.property(
-          fc.record({
-            id: fc.string({ minLength: 1 }),
-            name: fc.string({ minLength: 2, maxLength: 100 }),
-            email: fc.emailAddress(),
-            bio: fc.option(fc.string({ maxLength: 500 }), { nil: undefined }),
-            avatar: fc.option(fc.webUrl(), { nil: undefined }),
-          }),
-          (profile) => {
-            mockFetchUserProfile.mockResolvedValue(profile);
-
-            const { unmount } = renderUserProfileCard({ userId: profile.id });
-
-            // Should not throw any errors
-            expect(() => {
-              screen.getByTestId("user-profile-card");
-            }).not.toThrow();
-
-            unmount();
-          },
-        ),
-        { numRuns: 100 },
-      );
-    });
-
-    it("should validate form inputs with random invalid data", () => {
-      fc.assert(
-        fc.property(
-          fc.record({
-            name: fc.oneof(
-              fc.constant(""), // Empty string
-              fc.string({ minLength: 1, maxLength: 1 }), // Too short
-              fc.string({ minLength: 101, maxLength: 200 }), // Too long
-            ),
-            email: fc.oneof(
-              fc.constant(""), // Empty string
-              fc.string().filter((s) => !s.includes("@")), // Invalid format
-              fc.string().map((s) => s + "@"), // Incomplete email
-            ),
-            bio: fc.string({ minLength: 501, maxLength: 1000 }), // Too long
-          }),
-          async (invalidData) => {
-            const mockProfile = {
-              ...generateValidUser(),
-              id: mockCurrentUser.id,
-            };
-            mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-            const { unmount } = renderUserProfileCard({
-              userId: mockProfile.id,
-              editable: true,
-            });
-
-            await waitFor(() => {
-              expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-            });
-
-            const user = userEvent.setup();
-            await user.click(screen.getByTestId("edit-button"));
-
-            // Fill form with invalid data
-            await user.clear(screen.getByTestId("name-input"));
-            await user.type(screen.getByTestId("name-input"), invalidData.name);
-
-            await user.clear(screen.getByTestId("email-input"));
-            await user.type(
-              screen.getByTestId("email-input"),
-              invalidData.email,
-            );
-
-            await user.clear(screen.getByTestId("bio-input"));
-            await user.type(screen.getByTestId("bio-input"), invalidData.bio);
-
-            await user.click(screen.getByTestId("save-button"));
-
-            // Should show validation errors
-            expect(
-              screen.queryByTestId("name-error") ||
-                screen.queryByTestId("email-error") ||
-                screen.queryByTestId("bio-error"),
-            ).toBeInTheDocument();
-
-            // Should not call update API
-            expect(mockUpdateUserProfile).not.toHaveBeenCalled();
-
-            unmount();
-          },
-        ),
-        { numRuns: 50 },
-      );
-    });
-  });
-
-  describe("Performance Testing", () => {
-    it("should render within performance budget", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      const startTime = performance.now();
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      });
-
-      const endTime = performance.now();
-      const renderTime = endTime - startTime;
-
-      // Should render within 100ms
-      expect(renderTime).toBeLessThan(100);
-    });
-
-    it("should handle rapid state changes without performance degradation", async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      mockUpdateUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      const user = userEvent.setup();
-      const startTime = performance.now();
-
-      // Rapid edit mode toggling
-      for (let i = 0; i < 10; i++) {
-        await user.click(screen.getByTestId("edit-button"));
-        await user.click(screen.getByTestId("cancel-button"));
-      }
-
-      const endTime = performance.now();
-      const totalTime = endTime - startTime;
-
-      // Should complete all operations within 500ms
-      expect(totalTime).toBeLessThan(500);
-    });
-  });
-
-  describe("Visual Regression Testing", () => {
-    it("should match visual snapshot in display mode", async () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      const { container } = renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      });
-
-      expect(container.firstChild).toMatchSnapshot("user-profile-display-mode");
-    });
-
-    it("should match visual snapshot in edit mode", async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      const { container } = renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      await userEvent.setup().click(screen.getByTestId("edit-button"));
-
-      expect(container.firstChild).toMatchSnapshot("user-profile-edit-mode");
-    });
-  });
-
-  describe("Integration Testing", () => {
-    it("should integrate correctly with auth system", async () => {
-      const adminUser = { ...mockCurrentUser, role: "admin" };
-      const regularUser = generateValidUser();
-
-      // Test as admin
-      mockUseAuth.mockReturnValue({ user: adminUser });
-      mockFetchUserProfile.mockResolvedValue(regularUser);
-
-      const { rerender } = renderUserProfileCard({
-        userId: regularUser.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      // Switch to regular user
-      mockUseAuth.mockReturnValue({ user: regularUser });
-
-      rerender(
-        <UserProfileCard
-          userId={regularUser.id}
-          editable={true}
-          onProfileUpdate={vi.fn()}
-        />,
-      );
-
-      expect(screen.queryByTestId("edit-button")).not.toBeInTheDocument();
-    });
-  });
-
-  describe("Edge Cases", () => {
-    it("should handle extremely long profile data gracefully", async () => {
-      const mockProfile = {
-        ...generateValidUser(),
-        name: "A".repeat(1000),
-        bio: "B".repeat(10000),
-      };
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("user-profile-card")).toBeInTheDocument();
-      });
-
-      // Should not break rendering
-      expect(screen.getByTestId("profile-name")).toBeInTheDocument();
-      expect(screen.getByTestId("profile-bio")).toBeInTheDocument();
-    });
-
-    it("should handle special characters in profile data", async () => {
-      const mockProfile = {
-        ...generateValidUser(),
-        name: '测试用户 🚀 <script>alert("xss")</script>',
-        bio: "Bio with 🎉 emojis and <b>HTML</b> & special chars: @#$%^&*()",
-      };
-
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({ userId: mockProfile.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toHaveTextContent(
-          mockProfile.name,
-        );
-      });
-
-      // Should display special characters safely
-      expect(screen.getByTestId("profile-bio")).toHaveTextContent(
-        mockProfile.bio,
-      );
-    });
-
-    it("should handle rapid prop changes", async () => {
-      const user1 = generateValidUser();
-      const user2 = generateValidUser();
-
-      mockFetchUserProfile.mockImplementation((id) => {
-        if (id === user1.id) return Promise.resolve(user1);
-        if (id === user2.id) return Promise.resolve(user2);
-        return Promise.reject(new Error("User not found"));
-      });
-
-      const { rerender } = renderUserProfileCard({ userId: user1.id });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toHaveTextContent(
-          user1.name,
-        );
-      });
-
-      // Rapidly change user ID
-      rerender(
-        <UserProfileCard
-          userId={user2.id}
-          editable={false}
-          onProfileUpdate={vi.fn()}
-        />,
-      );
-
-      await waitFor(() => {
-        expect(screen.getByTestId("profile-name")).toHaveTextContent(
-          user2.name,
-        );
-      });
-
-      expect(mockFetchUserProfile).toHaveBeenCalledWith(user1.id);
-      expect(mockFetchUserProfile).toHaveBeenCalledWith(user2.id);
-    });
-  });
-});
-
-// Mutation Testing Configuration
-export const mutationTestConfig = {
-  testMatch: ["**/*.test.{js,jsx}"],
-  mutators: [
-    "ArithmeticOperator",
-    "ArrayDeclaration",
-    "ArrowFunction",
-    "Block",
-    "BooleanLiteral",
-    "ConditionalExpression",
-    "EqualityOperator",
-    "LogicalOperator",
-    "MethodExpression",
-    "ObjectLiteral",
-    "StringLiteral",
-    "UnaryOperator",
-    "UpdateOperator",
-  ],
-  thresholds: {
-    high: 90,
-    low: 80,
-  },
-  timeoutMS: 30000,
-  maxConcurrentTestRunners: 4,
-};
-
-// Performance benchmarking
-export const performanceBenchmarks = {
-  "UserProfileCard render time": {
-    threshold: 100, // milliseconds
-    setup: () => {
-      const mockProfile = generateValidUser();
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-      return { userId: mockProfile.id };
-    },
-    test: (props) => {
-      const start = performance.now();
-      renderUserProfileCard(props);
-      return performance.now() - start;
-    },
-  },
-  "Edit mode transition": {
-    threshold: 50,
-    setup: async () => {
-      const mockProfile = { ...generateValidUser(), id: mockCurrentUser.id };
-      mockFetchUserProfile.mockResolvedValue(mockProfile);
-
-      renderUserProfileCard({
-        userId: mockProfile.id,
-        editable: true,
-      });
-
-      await waitFor(() => {
-        expect(screen.getByTestId("edit-button")).toBeInTheDocument();
-      });
-
-      return { editButton: screen.getByTestId("edit-button") };
-    },
-    test: async ({ editButton }) => {
-      const start = performance.now();
-      await userEvent.setup().click(editButton);
-      await waitFor(() => {
-        expect(screen.getByTestId("save-button")).toBeInTheDocument();
-      });
-      return performance.now() - start;
-    },
-  },
-};
+```text
+/test-advanced "the retry backoff behavior in packages/client/retry.ts"
 ```
 
-## Advanced Testing Features
+```text
+/test-advanced apps/api/users.test.ts -- focus on regression cases from the current diff
+```
 
-### Mutation Testing
+The text after the command is normal prompt input, not a CLI parser. There are
+no documented built-in flags such as `--mutation`, `--pytest`, or `--coverage`;
+ask for those focuses in plain language, and only rely on tools that already
+exist in the repository.
 
-- **Code Quality Assessment**: Measures test suite effectiveness
-- **Fault Detection**: Identifies weak test coverage areas
-- **Test Improvement**: Suggests additional test cases
-- **Quality Metrics**: Provides mutation score and coverage analytics
+## Suggested workflow
 
-### Property-Based Testing
+1. **Ground the target.** Ask Claude to read the target file, adjacent tests, and
+   package configuration before proposing new cases.
+2. **Define success criteria.** State what behavior should stay true, which
+   failures matter, and what a useful regression test would catch.
+3. **Match the project.** Reuse the existing test framework, assertion style,
+   fixture pattern, and command names.
+4. **Separate plan from edits.** Have Claude show the scenario table first, then
+   write the smallest useful tests.
+5. **Run narrowly.** Use the smallest test command for the touched file or
+   package before running the full suite.
 
-- **Hypothesis Generation**: AI-powered test case creation
-- **Edge Case Discovery**: Automatic boundary value testing
-- **Invariant Verification**: Ensures consistent behavior patterns
-- **Input Space Exploration**: Comprehensive input combination testing
+## Example output shape
 
-### Visual Regression Testing
+Ask the command to return a compact plan before writing tests:
 
-- **UI Consistency**: Detects unintended visual changes
-- **Cross-browser Testing**: Validates appearance across platforms
-- **Responsive Testing**: Ensures mobile/desktop compatibility
-- **Component Isolation**: Tests individual component rendering
+| Area             | What to check                                                         | Why it matters                                                           |
+| ---------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Current behavior | Inputs, outputs, thrown errors, and side effects visible in source    | Keeps tests tied to real code instead of guesses                         |
+| Boundaries       | Empty input, nullish input, min/max values, encoding, and rounding    | Catches common regressions without broad fixture churn                   |
+| Invariants       | Relationships that should always hold across valid inputs             | Good fit for property-style testing when the project already has tooling |
+| Integration      | Existing API, storage, or component boundaries already covered nearby | Avoids inventing integration harnesses in one command                    |
+| Regression       | Known bug, diff hunk, or review concern the test should protect       | Makes the test valuable after the immediate change                       |
 
-### Performance Testing
+Then let Claude draft tests only for cases that can run in the current project.
+For JavaScript or TypeScript this might mean Jest or Vitest if those configs
+already exist. For Python this usually means pytest when the repository already
+uses it.
 
-- **Render Performance**: Measures component render times
-- **Memory Usage**: Tracks memory leaks and optimization opportunities
-- **User Interaction**: Benchmarks user interaction responsiveness
-- **Load Testing**: Simulates high-frequency usage patterns
+## Source Verification Notes
 
-This advanced test generator creates comprehensive, maintainable test suites that ensure code quality, performance, and reliability across all application layers.
+Verified on **2026-06-19**:
+
+- Claude Code's skills/custom-command documentation says custom commands have
+  been merged into skills, and existing `.claude/commands/*.md` files still
+  create slash invocations based on the filename.
+- Anthropic's testing guidance recommends defining specific, measurable success
+  criteria and designing evaluations around representative tasks, edge cases,
+  and regression checks.
+- This page applies those mechanics and testing principles to a user-authored
+  `/test-advanced` recipe. It does not claim an official built-in
+  `/test-advanced` or `/test` command.
+
+## Duplicate Check
+
+`/generate-tests` is the simpler broad test-generation recipe. `/test-advanced`
+is narrower: it asks Claude to plan a source-grounded test matrix first and only
+then draft tests that fit the repository's existing framework and tooling.
+
+## Troubleshooting
+
+- If the output invents a framework, tighten the prompt: "Use only the test
+  framework already configured in this repository."
+- If the plan is too broad, ask for the smallest regression-focused case first.
+- If the command cannot find a test script, point it at `package.json`,
+  `pyproject.toml`, `pytest.ini`, `vitest.config.*`, or the repository docs.


### PR DESCRIPTION
## Summary
- Resubmits `content/commands/test-advanced.mdx` with the source-grounding issue from #4004 fixed.

## What changed
- Reframes `/test-advanced` as a user-authored Claude Code custom command recipe instead of a built-in `/test` command.
- Points documentation and retrieval sources at the current Claude Code skills/custom-command docs plus Anthropic testing guidance.
- Removes unsupported CLI-style option claims and replaces them with prompt-driven usage notes.
- Adds explicit safety and privacy notes for local code/test generation.

## Why
- Reviewbot declined #4004 because the previous entry claimed a documented `/test-advanced` command while the source only supported generic custom command mechanics.
- This version keeps the one-file content entry but aligns every claim with the cited sources.
- Refs #3919
- Resubmits #3949 and #4004

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/commands/test-advanced.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`

## Notes
- Cleared a stale local build-content-index lock before rerunning prebuild; the clean rerun completed without generated artifact changes.
