### PR TITLE
content(skills): add trust notes for browser agent workflow automation

### DIFF
--- a/content/skills/browser-agent-workflow-automation.mdx
+++ b/content/skills/browser-agent-workflow-automation.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Target web workflow with clear start and success states
   - Ability to run browser automation in local or CI environment
   - Access to auth/session strategy if login is required
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - browser-automation
   - ai-agents


### PR DESCRIPTION
## Summary
- Resubmits content/skills/browser-agent-workflow-automation.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3963

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/browser-agent-workflow-automation.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
