### PR TITLE
content(skills): add trust notes for cloudflare workers d1 kv r2 capability pack

### DIFF
--- a/content/skills/cloudflare-workers-d1-kv-r2-capability-pack.mdx
+++ b/content/skills/cloudflare-workers-d1-kv-r2-capability-pack.mdx
@@ -43,6 +43,12 @@ prerequisites:
   - Cloudflare account and worker project
   - D1/KV/R2 bindings access
   - Defined data model and SLA targets
+safetyNotes:
+  - "May produce commands or configuration for live infrastructure, CI, releases, or indexing; test changes in staging or dry-run mode first."
+  - "Use least-privilege API tokens and review workflow, deploy, DNS, cache, and release changes before applying them to production."
+privacyNotes:
+  - "Inputs can include repository metadata, workflow logs, deployment settings, domain names, analytics exports, and service configuration."
+  - "Redact tokens, account IDs, private URLs, customer data, and proprietary deployment details before sharing generated reports or prompts."
 tags:
   - cloudflare
   - workers


### PR DESCRIPTION
## Summary
- Resubmits content/skills/cloudflare-workers-d1-kv-r2-capability-pack.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3964

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/cloudflare-workers-d1-kv-r2-capability-pack.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
