### PR TITLE
content(skills): add trust notes for codex automations orchestrator capability pack

### DIFF
--- a/content/skills/codex-automations-orchestrator-capability-pack.mdx
+++ b/content/skills/codex-automations-orchestrator-capability-pack.mdx
@@ -44,6 +44,9 @@ prerequisites:
   - Operational owner
 safetyNotes:
   - "Designs and runs automation workflows that can execute commands and trigger external actions; review each automation's permissions and triggers before enabling it."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - codex
   - automation


### PR DESCRIPTION
## Summary
- Resubmits content/skills/codex-automations-orchestrator-capability-pack.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3965

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/codex-automations-orchestrator-capability-pack.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
