### PR TITLE
content(skills): add trust notes for docker compose production blueprints

### DIFF
--- a/content/skills/docker-compose-production-blueprints.mdx
+++ b/content/skills/docker-compose-production-blueprints.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Service inventory and dependency map
   - "Runtime constraints (CPU, memory, storage, ports)"
   - Existing Compose file or desired target architecture
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - docker
   - docker-compose


### PR DESCRIPTION
## Summary
- Resubmits content/skills/docker-compose-production-blueprints.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3967

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/docker-compose-production-blueprints.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
