### PR TITLE
content(skills): add trust notes for ethereum solidity security foundry

### DIFF
--- a/content/skills/ethereum-solidity-security-foundry.mdx
+++ b/content/skills/ethereum-solidity-security-foundry.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Solidity project initialized with Foundry
   - Clear protocol/token specification
   - Target chain and deployment constraints
+safetyNotes:
+  - "Do not deploy or transact from generated contract code without independent review, tests, and a dry run; smart contract mistakes can be irreversible."
+  - "Use local forks or testnets before mainnet and keep deployment wallets and RPC credentials least-privileged."
+privacyNotes:
+  - "Prompts and reports can include contract source, audit findings, addresses, deployment config, and transaction context."
+  - "Never paste private keys, seed phrases, unreleased exploit details, customer wallet data, or privileged RPC credentials into prompts."
 tags:
   - ethereum
   - solidity


### PR DESCRIPTION
## Summary
- Resubmits content/skills/ethereum-solidity-security-foundry.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3969

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/ethereum-solidity-security-foundry.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
