### PR TITLE
content(skills): add trust notes for github actions secure cicd capability pack

### DIFF
--- a/content/skills/github-actions-secure-cicd-capability-pack.mdx
+++ b/content/skills/github-actions-secure-cicd-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - Existing workflows or target CI/CD architecture
   - Branch protection and environment policy context
   - Security/compliance requirements
+safetyNotes:
+  - "May produce commands or configuration for live infrastructure, CI, releases, or indexing; test changes in staging or dry-run mode first."
+  - "Use least-privilege API tokens and review workflow, deploy, DNS, cache, and release changes before applying them to production."
+privacyNotes:
+  - "Inputs can include repository metadata, workflow logs, deployment settings, domain names, analytics exports, and service configuration."
+  - "Redact tokens, account IDs, private URLs, customer data, and proprietary deployment details before sharing generated reports or prompts."
 tags:
   - github-actions
   - cicd


### PR DESCRIPTION
## Summary
- Resubmits content/skills/github-actions-secure-cicd-capability-pack.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3971

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/github-actions-secure-cicd-capability-pack.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
