### PR TITLE
content(skills): add trust notes for markdown knowledge base composer

### DIFF
--- a/content/skills/markdown-knowledge-base-composer.mdx
+++ b/content/skills/markdown-knowledge-base-composer.mdx
@@ -59,6 +59,9 @@ prerequisites:
   - pandoc (optional for DOCX/EPUB export)
   - "File system read/write access for Markdown source files, generated HTML/PDF/DOCX/EPUB outputs, and image assets referenced in Markdown"
   - Markdown syntax knowledge or reference documentation for creating valid Markdown files (CommonMark or GitHub Flavored Markdown specification)
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - markdown
   - docs


### PR DESCRIPTION
## Summary
- Resubmits content/skills/markdown-knowledge-base-composer.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3974

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/markdown-knowledge-base-composer.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
