### PR TITLE
content(skills): add trust notes for mcp server security hardening

### DIFF
--- a/content/skills/mcp-server-security-hardening.mdx
+++ b/content/skills/mcp-server-security-hardening.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Existing MCP server implementation (local or remote)
   - "Access to server config, dependency manifest, and deployment settings"
   - Ability to run integration tests after hardening
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - mcp
   - security


### PR DESCRIPTION
## Summary
- Resubmits content/skills/mcp-server-security-hardening.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3976

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/mcp-server-security-hardening.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
