### PR TITLE
content(skills): add trust notes for model routing cost latency optimizer

### DIFF
--- a/content/skills/model-routing-cost-latency-optimizer.mdx
+++ b/content/skills/model-routing-cost-latency-optimizer.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Access to request volume and token usage data
   - At least two candidate model tiers available
   - Benchmark tasks for quality comparison
+safetyNotes:
+  - "Use this skill as planning or review guidance; verify generated commands, code, configuration, and infrastructure changes before running them."
+  - "Apply least-privilege credentials and test in staging or a disposable branch before using it on production systems, CI, deployment, or account-write workflows."
+privacyNotes:
+  - "Inputs can include source files, prompts, logs, account metadata, repository details, and operational context that may be sent to the configured AI model."
+  - "Redact secrets, customer data, private URLs, credentials, and proprietary implementation details before sharing prompts, reports, or generated artifacts."
 tags:
   - model-routing
   - cost-optimization


### PR DESCRIPTION
## Summary
- Resubmits content/skills/model-routing-cost-latency-optimizer.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3978

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/model-routing-cost-latency-optimizer.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
