### PR TITLE
content(skills): add trust notes for openclaw agent ops hardening

### DIFF
--- a/content/skills/openclaw-agent-ops-hardening.mdx
+++ b/content/skills/openclaw-agent-ops-hardening.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Running OpenClaw environment (self-hosted or managed)
   - Inventory of enabled tools and external integrations
   - Access to runtime/network/security configuration
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - openclaw
   - ai-agents


### PR DESCRIPTION
## Summary
- Resubmits content/skills/openclaw-agent-ops-hardening.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3982

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/openclaw-agent-ops-hardening.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
