### PR TITLE
content(skills): add trust notes for playwright mcp browser automation engineer

### DIFF
--- a/content/skills/playwright-mcp-browser-automation-engineer.mdx
+++ b/content/skills/playwright-mcp-browser-automation-engineer.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Browser automation target URL(s)
   - Playwright MCP server configured in your agent environment
   - Test credentials with least required permissions
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - playwright
   - mcp


### PR DESCRIPTION
## Summary
- Resubmits content/skills/playwright-mcp-browser-automation-engineer.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3985

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/playwright-mcp-browser-automation-engineer.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
