### PR TITLE
content(skills): add trust notes for prompt injection defense guardrails

### DIFF
--- a/content/skills/prompt-injection-defense-guardrails.mdx
+++ b/content/skills/prompt-injection-defense-guardrails.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Agent flow that processes user input or external web/content data
   - Ability to add policy checks before tool execution
   - Test harness for adversarial prompt scenarios
+safetyNotes:
+  - "Treat findings and generated mitigations as review inputs; validate suspected vulnerabilities and patches before changing production controls."
+  - "Coordinate disclosure-sensitive security work privately and avoid running destructive probes outside authorized systems."
+privacyNotes:
+  - "Security prompts and reports can include source snippets, vulnerability details, internal URLs, dependency metadata, and operational context."
+  - "Redact secrets, customer data, exploit details, private infrastructure names, and unreleased findings before sharing outputs publicly."
 tags:
   - prompt-injection
   - guardrails


### PR DESCRIPTION
## Summary
- Resubmits content/skills/prompt-injection-defense-guardrails.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3986

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/prompt-injection-defense-guardrails.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
