### PR TITLE
content(skills): add trust notes for proxmox ve api orchestrator

### DIFF
--- a/content/skills/proxmox-ve-api-orchestrator.mdx
+++ b/content/skills/proxmox-ve-api-orchestrator.mdx
@@ -40,6 +40,12 @@ prerequisites:
   - Proxmox VE cluster or node API access
   - Token-based auth with scoped permissions
   - Defined operational policy for infra changes
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - proxmox
   - virtualization


### PR DESCRIPTION
## Summary
- Resubmits content/skills/proxmox-ve-api-orchestrator.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3988

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/proxmox-ve-api-orchestrator.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
