### PR TITLE
content(skills): add trust notes for unraid ca template authoring capability pack

### DIFF
--- a/content/skills/unraid-ca-template-authoring-capability-pack.mdx
+++ b/content/skills/unraid-ca-template-authoring-capability-pack.mdx
@@ -42,6 +42,12 @@ prerequisites:
   - Container image and runtime requirements
   - Support URL and docs
   - Unraid-compatible volume/network mapping
+safetyNotes:
+  - "Can design automation for live browsers, accounts, workflows, or infrastructure; use staging targets and human approval before destructive or account-write actions."
+  - "Keep API tokens and service credentials least-privileged, and verify generated runbooks before scheduling or unattended execution."
+privacyNotes:
+  - "Inputs and outputs can include browser state, account metadata, workflow payloads, infrastructure inventory, logs, and operational screenshots."
+  - "Redact credentials, session data, customer records, internal hostnames, and private workspace details before sharing prompts or artifacts."
 tags:
   - unraid
   - community-apps


### PR DESCRIPTION
## Summary
- Resubmits content/skills/unraid-ca-template-authoring-capability-pack.mdx trust metadata after the previous one-file PR was closed by a required check.

## What changed
- Adds safety notes for reviewing generated or automated output before applying changes.
- Adds privacy notes for prompts, source files, logs, errors, and generated reports.

## Why
- Risk-bearing entries should expose explicit safety and privacy caveats for human readers and AI citation surfaces.
- Refs #3919
- Resubmits #3992

## Validation
- `pnpm validate:content:strict`
- `pnpm exec prettier --check content/skills/unraid-ca-template-authoring-capability-pack.mdx`
- `node scripts/ci/validate-content-policy.mjs --repo-root "$PWD" --files-json <changed-files.json>`
- `pnpm --filter web run prebuild`
- `git diff --check`
