### PR TITLE
feat(quality): publish trust methodology

### DIFF
--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -8,6 +8,7 @@ import {
   User,
   Calendar,
 } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import type { Entry } from "@/types/registry";
 
 type Citation = {
@@ -96,43 +97,52 @@ export function SourceCitations({ entry }: { entry: Entry }) {
   }
 
   return (
-    <ul className="divide-y divide-border">
-      {cites.map((c) => {
-        const Icon = c.Icon;
-        const body = (
-          <span className="flex items-center gap-3 py-2.5">
-            <Icon className="h-3.5 w-3.5 shrink-0 text-ink-muted" aria-hidden />
-            <span className="min-w-0 flex-1">
-              <span className="block text-sm font-medium text-ink">{c.label}</span>
-              {c.hint && (
-                <span className="block font-mono text-[11px] text-ink-subtle">{c.hint}</span>
-              )}
-            </span>
-            {c.verifiedAt && (
-              <span className="hidden items-center gap-1 font-mono text-[10px] text-ink-subtle sm:inline-flex">
-                <Calendar className="h-3 w-3" aria-hidden /> {c.verifiedAt}
+    <div>
+      <ul className="divide-y divide-border">
+        {cites.map((c) => {
+          const Icon = c.Icon;
+          const body = (
+            <span className="flex items-center gap-3 py-2.5">
+              <Icon className="h-3.5 w-3.5 shrink-0 text-ink-muted" aria-hidden />
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-medium text-ink">{c.label}</span>
+                {c.hint && (
+                  <span className="block font-mono text-[11px] text-ink-subtle">{c.hint}</span>
+                )}
               </span>
-            )}
-            {c.href && <ExternalLink className="h-3 w-3 text-ink-subtle" aria-hidden />}
-          </span>
-        );
-        return (
-          <li key={c.label}>
-            {c.href ? (
-              <a
-                href={c.href}
-                target="_blank"
-                rel="noreferrer"
-                className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
-              >
-                {body}
-              </a>
-            ) : (
-              <div className="px-2">{body}</div>
-            )}
-          </li>
-        );
-      })}
-    </ul>
+              {c.verifiedAt && (
+                <span className="hidden items-center gap-1 font-mono text-[10px] text-ink-subtle sm:inline-flex">
+                  <Calendar className="h-3 w-3" aria-hidden /> {c.verifiedAt}
+                </span>
+              )}
+              {c.href && <ExternalLink className="h-3 w-3 text-ink-subtle" aria-hidden />}
+            </span>
+          );
+          return (
+            <li key={c.label}>
+              {c.href ? (
+                <a
+                  href={c.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  {body}
+                </a>
+              ) : (
+                <div className="px-2">{body}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      <Link
+        to="/quality"
+        hash="source-provenance"
+        className="mt-2 inline-flex text-xs text-ink-muted hover:text-ink"
+      >
+        Source methodology →
+      </Link>
+    </div>
   );
 }

--- a/apps/web/src/components/trust-drilldown.tsx
+++ b/apps/web/src/components/trust-drilldown.tsx
@@ -57,10 +57,10 @@ export function TrustDrilldown({
           </div>
           <Link
             to="/quality"
-            hash="preflight"
+            hash="methodology"
             className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-[11px] font-medium text-ink hover:bg-surface-2"
           >
-            Run preflight
+            Methodology
             <ArrowUpRight className="h-3 w-3" />
           </Link>
         </header>

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -269,6 +269,7 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
   "registry.feed": {
     schemaVersion: 1,
     kind: "registry-feed",
+    qualityMethodology: "/quality#methodology",
     categoryFeeds: { mcp: "/data/feeds/categories/mcp.json" },
     platformFeeds: { claude: "/data/feeds/platforms/claude.json" },
     jobs: "/api/jobs?limit=100",

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -43,6 +43,9 @@ export function buildLlmsTxt(origin: string): string {
   lines.push(
     `- [Full corpus](${origin}/llms-full.txt): every entry with descriptions, metadata, and install/config snippets`,
   );
+  lines.push(
+    `- [Trust methodology](${origin}/quality#methodology): source backing, safety/privacy notes, and package verification definitions`,
+  );
   lines.push(`- [OpenAPI spec](${origin}/openapi.json): machine-readable REST API`);
   lines.push(`- [API feed](${origin}/api/registry/feed): endpoint map and distribution feeds`);
   lines.push(

--- a/apps/web/src/routes/api/registry/feed.ts
+++ b/apps/web/src/routes/api/registry/feed.ts
@@ -34,6 +34,7 @@ export const GET = createApiHandler("registry.feed", async ({ request }) => {
       pluginExportFeed: "/data/plugin-export-feed.json",
       changelogFeed: "/data/registry-changelog.json",
       registryTrust: "/data/registry-trust-report.json",
+      qualityMethodology: "/quality#methodology",
       rssFeed: "/feed.xml",
       atomFeed: "/atom.xml",
       distributionFeedIndex: "/data/feeds/index.json",

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -98,9 +98,10 @@ function scoreEntry(e: (typeof ENTRIES)[number]): QualityRow {
 // SSR render of /quality.
 const QUALITY_ROWS = ENTRIES.map(scoreEntry);
 const IMPROVEMENT_QUEUE = [...QUALITY_ROWS].sort((a, b) => a.score - b.score).slice(0, 8);
-const TRUST_QUEUE = QUALITY_ROWS.filter(
-  (r) => r.recommendations.length > 0 && r.score >= 60,
-).slice(0, 8);
+const TRUST_QUEUE = QUALITY_ROWS.filter((r) => r.recommendations.length > 0 && r.score >= 60).slice(
+  0,
+  8,
+);
 const CATEGORY_COVERAGE = new Map(
   CATEGORIES.map((c) => {
     const inCat = ENTRIES.filter((e) => e.category === c.id);
@@ -160,6 +161,50 @@ function QualityPage() {
           percent={pct(QUALITY_STATS.reviewed)}
         />
       </div>
+
+      <section id="methodology" className="mt-12 scroll-mt-24">
+        <div className="max-w-3xl">
+          <h2 className="h-display-2 text-ink text-balance">Trust methodology</h2>
+          <p className="mt-2 text-sm leading-6 text-ink-muted">
+            These notes define the public labels used across entries, exports, and reports. They are
+            editorial metadata checks for source identity, install caution, and registry
+            completeness. These checks are not a guarantee that upstream code is safe, and they are
+            not malware scans or vulnerability assessments.
+          </p>
+        </div>
+        <div className="mt-5 grid gap-3 md:grid-cols-2">
+          <MethodologyCard
+            id="trust-levels"
+            title="Trust levels"
+            body="Trusted means a maintainer reviewed the listing metadata and source backing. Review, limited, and blocked are caution states that ask readers to inspect the source before installing. A trust badge is not an endorsement or runtime security guarantee."
+          />
+          <MethodologyCard
+            id="source-provenance"
+            title="Source provenance"
+            body="Source-backed means the listing has a reachable repository, package registry, official documentation, or project source URL that supports the claimed identity. We do not infer source backing from marketing copy alone."
+          />
+          <MethodologyCard
+            id="safety-notes"
+            title="Safety notes"
+            body="Risk-bearing categories should explain execution, filesystem access, network access, credentials, destructive actions, background workers, or account-write behavior before a user runs them."
+          />
+          <MethodologyCard
+            id="privacy-notes"
+            title="Privacy notes"
+            body="Privacy notes call out local files, prompts, credentials, telemetry, third-party services, logs, retention, or user-data exposure so readers can decide whether a resource fits their threat model."
+          />
+          <MethodologyCard
+            id="integrity"
+            title="Package and download trust"
+            body="Checksums pin hosted downloads byte-for-byte. Package verification means maintainers reviewed the package metadata and source path for the listed artifact. It is not a code audit, malware verdict, or proof that future releases are safe. Community PRs cannot mark packages as verified."
+          />
+          <MethodologyCard
+            id="freshness"
+            title="Freshness"
+            body="Reviewed and verified dates show the last source or metadata check we recorded. Older checks are still useful provenance, but stale entries should be rechecked before install or citation."
+          />
+        </div>
+      </section>
 
       <h2 className="mt-12 h-display-2 text-ink text-balance">Coverage by category</h2>
       <div className="mt-4 overflow-x-auto rounded-xl border border-border bg-surface">
@@ -349,6 +394,15 @@ function QualityPage() {
         />
       </div>
     </PageContainer>
+  );
+}
+
+function MethodologyCard({ id, title, body }: { id: string; title: string; body: string }) {
+  return (
+    <article id={id} className="scroll-mt-24 rounded-lg border border-border bg-surface p-4">
+      <h3 className="font-display text-base font-semibold text-ink">{title}</h3>
+      <p className="mt-2 text-sm leading-6 text-ink-muted">{body}</p>
+    </article>
   );
 }
 

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -1304,6 +1304,7 @@ export function buildRegistryManifest(entries, extra = {}) {
       relationGraph: dataUrl("relation-graph.json"),
       contentQuality: dataUrl("content-quality-report.json"),
       contentQualityPrompts: dataUrl("content-quality-prompts.json"),
+      qualityMethodology: "/quality#methodology",
       jsonLdSnapshots: dataUrl("jsonld-snapshots.json"),
       llmsFull: "/llms-full.txt",
       entryDetails: dataUrl("entries"),

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -144,6 +144,19 @@ describe("OpenAPI route coverage", () => {
       liveRequest: false,
     });
     expect(
+      JSON.parse(
+        ENDPOINTS.find((endpoint) => endpoint.id === "registry-feed")
+          ?.responseExample ?? "{}",
+      ),
+    ).toMatchObject({
+      schemaVersion: 1,
+      kind: "registry-feed",
+      qualityMethodology: "/quality#methodology",
+      categoryFeeds: { mcp: "/data/feeds/categories/mcp.json" },
+      platformFeeds: { claude: "/data/feeds/platforms/claude.json" },
+      jobs: "/api/jobs?limit=100",
+    });
+    expect(
       ENDPOINTS.find((endpoint) => endpoint.id === "jobs-detail"),
     ).toMatchObject({
       liveRequest: true,

--- a/tests/llms-full-citation-facts.test.ts
+++ b/tests/llms-full-citation-facts.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/feeds", () => ({ etagFor: vi.fn(async () => "test-etag") }));
-vi.mock("@/lib/security-headers", () => ({ applySecurityHeaders: (headers: Headers) => headers }));
+vi.mock("@/lib/security-headers", () => ({
+  applySecurityHeaders: (headers: Headers) => headers,
+}));
 
 vi.mock("@/data/entries", () => ({
   REGISTRY_ENTRIES: [
@@ -15,7 +17,9 @@ vi.mock("@/data/entries", () => ({
       repoUrl: "https://github.com/example/citation-shape-fixture",
       safetyNotes: ["Runs local checks before writing files."],
       privacyNotes: ["Reads only files selected by the user."],
-      platformCompatibility: [{ platform: "claude-code", supportLevel: "native-skill" }],
+      platformCompatibility: [
+        { platform: "claude-code", supportLevel: "native-skill" },
+      ],
       dateAdded: "2026-06-14",
     },
   ],
@@ -35,22 +39,42 @@ vi.mock("@/data/entries", () => ({
       safetyNotesList: ["Runs local checks before writing files."],
       privacyNotes: "Reads only files selected by the user.",
       privacyNotesList: ["Reads only files selected by the user."],
-      platformCompatibility: [{ platform: "claude-code", support: "native-skill" }],
+      platformCompatibility: [
+        { platform: "claude-code", support: "native-skill" },
+      ],
     },
   ],
 }));
 
 describe("buildLlmsFullTxt", () => {
+  it("advertises the trust methodology from the short LLM manifest", async () => {
+    const { buildLlmsTxt } = await import("@/lib/llms");
+
+    const output = buildLlmsTxt("https://heyclau.de");
+
+    expect(output).toContain(
+      "- [Trust methodology](https://heyclau.de/quality#methodology): source backing, safety/privacy notes, and package verification definitions",
+    );
+  });
+
   it("builds citation facts from raw registry entries, not normalized web entries", async () => {
     const { buildLlmsFullTxt } = await import("@/lib/llms");
 
     const output = buildLlmsFullTxt("https://heyclau.de");
 
     expect(output).toContain("Citation facts:\n");
-    expect(output).toContain("- Source URLs: https://example.com/docs, https://github.com/example/citation-shape-fixture");
-    expect(output).toContain("- Safety notes: Runs local checks before writing files.");
-    expect(output).toContain("- Privacy notes: Reads only files selected by the user.");
-    expect(output).toContain("- Platform compatibility: claude-code (native-skill)");
+    expect(output).toContain(
+      "- Source URLs: https://example.com/docs, https://github.com/example/citation-shape-fixture",
+    );
+    expect(output).toContain(
+      "- Safety notes: Runs local checks before writing files.",
+    );
+    expect(output).toContain(
+      "- Privacy notes: Reads only files selected by the user.",
+    );
+    expect(output).toContain(
+      "- Platform compatibility: claude-code (native-skill)",
+    );
     expect(output).not.toContain("(undefined)");
   });
 });

--- a/tests/quality-methodology.test.ts
+++ b/tests/quality-methodology.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function readRepoFile(relativePath: string) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function qualityRouteIds(source: string) {
+  return new Set(
+    [...source.matchAll(/\bid="([^"]+)"/g)].map((match) => match[1]),
+  );
+}
+
+function trustDocAnchors(source: string) {
+  return new Set(
+    [...source.matchAll(/docHref:\s*"\/quality#([^"]+)"/g)].map(
+      (match) => match[1],
+    ),
+  );
+}
+
+describe("quality methodology page", () => {
+  const qualitySource = readRepoFile("apps/web/src/routes/quality.tsx");
+
+  it("defines every /quality anchor used by entry trust drilldowns", () => {
+    const ids = qualityRouteIds(qualitySource);
+    const anchors = trustDocAnchors(readRepoFile("apps/web/src/lib/trust.ts"));
+
+    expect(anchors.size).toBeGreaterThan(0);
+    for (const anchor of anchors) {
+      expect(ids, anchor).toContain(anchor);
+    }
+  });
+
+  it("keeps trust methodology citable without overclaiming security guarantees", () => {
+    expect(qualitySource).toContain('id="methodology"');
+    expect(qualitySource).toContain('id="source-provenance"');
+    expect(qualitySource).toContain('id="integrity"');
+    expect(qualitySource).toContain("not malware scans");
+    expect(qualitySource).toContain("not a code audit");
+    expect(qualitySource).toContain("not a guarantee");
+    expect(qualitySource).toContain(
+      "Community PRs cannot mark packages as verified",
+    );
+  });
+
+  it("links entry trust and citation surfaces to the methodology anchors", () => {
+    const trustDrilldownSource = readRepoFile(
+      "apps/web/src/components/trust-drilldown.tsx",
+    );
+    const sourceCitationsSource = readRepoFile(
+      "apps/web/src/components/source-citations.tsx",
+    );
+    const registryFeedSource = readRepoFile(
+      "apps/web/src/routes/api/registry/feed.ts",
+    );
+
+    expect(trustDrilldownSource).toContain('hash="methodology"');
+    expect(trustDrilldownSource).not.toContain('hash="preflight"');
+    expect(sourceCitationsSource).toContain('hash="source-provenance"');
+    expect(registryFeedSource).toContain(
+      'qualityMethodology: "/quality#methodology"',
+    );
+  });
+});

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -512,6 +512,7 @@ describe("registry artifacts", () => {
     expect(manifest.artifacts.registryTrust).toBe(
       "/data/registry-trust-report.json",
     );
+    expect(manifest.artifacts.qualityMethodology).toBe("/quality#methodology");
     expect(manifest.trustSummary).toEqual(trustReportPayload.summary);
   });
 
@@ -1488,6 +1489,7 @@ Use this hook after reviewing the notes.`,
     );
     expect(manifest.qualitySummary).toBeTruthy();
     expect(manifest.artifacts.llmsFull).toBe("/llms-full.txt");
+    expect(manifest.artifacts.qualityMethodology).toBe("/quality#methodology");
     expect(manifest.artifacts.contentQualityPrompts).toBe(
       "/data/content-quality-prompts.json",
     );


### PR DESCRIPTION
## Summary
- publishes citable trust methodology copy on `/quality`
- links entry trust/citation surfaces and machine-readable feeds to the methodology anchors
- adds regression coverage for anchor consistency, conservative trust language, LLM discovery, registry manifest discovery, and OpenAPI feed response shape

## What changed
- added stable `/quality#methodology`, `#trust-levels`, `#source-provenance`, `#safety-notes`, `#privacy-notes`, `#integrity`, and `#freshness` sections
- replaced the stale trust popover `#preflight` link with the methodology anchor
- added a source-citation methodology link for entry pages
- exposed `qualityMethodology` in the registry feed endpoint and registry manifest builder
- kept the `registry.feed` OpenAPI response example flat (`categoryFeeds`, `platformFeeds`, `jobs`) with `qualityMethodology` added alongside the existing keys
- added tests that keep trust doc links backed by real route anchors and pin the OpenAPI feed example shape

## Why
- Closes #3929
- users and AI assistants can now cite a public explanation of what HeyClaude verifies, what is source-backed, and what is not independently audited

## Validation
- `pnpm exec vitest run tests/quality-methodology.test.ts tests/llms-full-citation-facts.test.ts tests/registry-artifacts.test.ts tests/seo-metadata.test.ts tests/api-contracts.test.ts tests/crawler-policy.test.ts`
- `pnpm exec vitest run tests/generated-churn-policy.test.ts tests/mcp-server.test.ts`
- `pnpm validate:openapi`
- `pnpm type-check`
- `pnpm build`
- `pnpm test` (109 files, 1072 tests)
- `git diff --check`

## Notes
- Rebased onto current `main` after the CI/test-suite updates in #4047 and #4057.
- Dropped the stale test-stabilization commit because current `main` already contains the replacement test fixes.
- `pnpm build` passed with existing Vite/Nitro warnings about large chunks, ineffective dynamic imports, and Cloudflare config overrides.
- No manual Worker deploy was run; Workers Builds should deploy through the repo pipeline.