### PR TITLE
fix(web): restore umami production tracking

### DIFF
--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -190,6 +190,11 @@ longer a Next.js app.
 - `VITE_SUBMISSION_GATE_URL` or `NEXT_PUBLIC_SUBMISSION_GATE_URL` set to the
   submission-gate Worker origin:
   `https://submission-gate.heyclau.de`.
+- `VITE_UMAMI_SCRIPT_URL` set to `/u/script.js`.
+- `VITE_UMAMI_WEBSITE_ID` and `UMAMI_WEBSITE_ID` set to the Umami website ID.
+- `UMAMI_UPSTREAM_URL` set to the Umami instance origin. The public web tracker
+  is served first-party through `/u/script.js`, and collector posts are proxied
+  through `/u/api/send`, so the site CSP can keep analytics traffic on `self`.
 
 Content submission writes are routed through the private submission gate; the
 public website only runs preflight and hands the contributor to GitHub auth.

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -75,6 +75,10 @@
     "NEXT_PUBLIC_POLAR_FEATURED_JOB_90_URL": "/jobs/post?tier=featured",
     "NEXT_PUBLIC_POLAR_SPONSORED_JOB_90_URL": "/jobs/post?tier=sponsored",
     "VITE_SUBMISSION_GATE_URL": "https://submission-gate.heyclau.de",
+    "VITE_UMAMI_SCRIPT_URL": "/u/script.js",
+    "VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",
+    "UMAMI_UPSTREAM_URL": "https://tasty.aethereal.dev",
+    "UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",
   },
   "d1_databases": [
     {

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -240,6 +240,24 @@ describe("PR preview artifact validation flow", () => {
     );
   });
 
+  it("keeps the first-party Umami proxy wired in production config", () => {
+    const wranglerConfig = fs.readFileSync(
+      path.join(repoRoot, "apps/web/wrangler.jsonc"),
+      "utf8",
+    );
+
+    expect(wranglerConfig).toContain('"VITE_UMAMI_SCRIPT_URL": "/u/script.js"');
+    expect(wranglerConfig).toContain(
+      '"VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121"',
+    );
+    expect(wranglerConfig).toContain(
+      '"UMAMI_UPSTREAM_URL": "https://tasty.aethereal.dev"',
+    );
+    expect(wranglerConfig).toContain(
+      '"UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121"',
+    );
+  });
+
   it("does not persist GitHub credentials in the submission-gate validation checkout", () => {
     const workflow = readContentValidationWorkflow();
     const jobBlock =


### PR DESCRIPTION
## Summary
- restore the production Umami pageview tracker by wiring the first-party `/u/script.js` proxy in Worker config
- document the required analytics vars and add a regression test so deploy config cannot silently drop them again

## What changed
- adds `VITE_UMAMI_SCRIPT_URL`, `VITE_UMAMI_WEBSITE_ID`, `UMAMI_UPSTREAM_URL`, and `UMAMI_WEBSITE_ID` to `apps/web/wrangler.jsonc`
- documents the first-party Umami proxy contract in `apps/web/DEPLOYMENT.md`
- adds focused config coverage in `tests/deployment-preview-url.test.ts`

## Why
- live production HTML on June 19 did not include the Umami script or `data-website-id`
- `https://heyclau.de/u/script.js` returned 404, while the configured Umami upstream script returned 200
- commit `de070f5bd` made analytics opt-in but the production Worker config never opted the site back in

## Validation
- `pnpm exec vitest run tests/deployment-preview-url.test.ts`
- `pnpm --filter web run build`
- `git diff --check`
- local Worker smoke via `pnpm --filter web exec wrangler dev --config wrangler.jsonc --env "" --port 8787`: `/` rendered `id="umami-analytics"`, `src="/u/script.js"`, and the expected website ID; `/u/script.js` returned 200 JavaScript

## Notes
- deployment is required before production analytics resumes
