### PR TITLE
fix(web): return em dash for future timeAgo timestamps

### DIFF
--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -23,6 +23,7 @@ export function timeAgo(iso: string | undefined | null): string {
   const d = new Date(iso).getTime();
   if (Number.isNaN(d)) return "—";
   const diff = Date.now() - d;
+  if (diff < 0) return "—";
   const min = Math.round(diff / 60_000);
   if (min < 1) return "just now";
   if (min < 60) return `${min}m ago`;

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -189,6 +189,7 @@ describe("web non-UI utility coverage", () => {
     expect(timeAgo("2026-01-10T11:30:00.000Z")).toBe("30m ago");
     expect(timeAgo("2026-01-10T09:00:00.000Z")).toBe("3h ago");
     expect(timeAgo("2025-12-01T00:00:00.000Z")).toBe("1mo ago");
+    expect(timeAgo("2027-06-01T00:00:00.000Z")).toBe("—");
 
     vi.useRealTimers();
   });


### PR DESCRIPTION
## Summary
- stop `timeAgo()` from labeling future ISO timestamps as "just now"
- return the same em dash placeholder used for invalid or missing dates
- add a regression test alongside existing format/timeAgo boundary coverage

## What Changed
- Updated `apps/web/src/lib/format.ts` to return `"—"` when `Date.now() - parsedTime < 0`.
- Extended `tests/web-non-ui-utilities.test.ts` with a future-date case under fake timers.

## Why
`timeAgo()` is used on entry cards (`resource-card.tsx`), hub highlights, and npm version badges (`live-version-badge.tsx`). For future ISO timestamps, `diff` is negative, `Math.round(diff / 60_000)` becomes negative, and the existing `min < 1` guard incorrectly returns `"just now"`. Backdated or clock-skewed metadata should not read as freshly published.

## Validation
- `pnpm exec vitest run tests/web-non-ui-utilities.test.ts -t "formats compact numbers"`
- `trunk check --ci --upstream origin/main`

## Notes
- No content entries or generated registry artifacts are changed.
- Matches the existing `fix(web)` boundary-hardening pattern from #3932.

## Summary by CodeRabbit

* **Bug Fixes**
  * Future ISO timestamps in `timeAgo()` now render `"—"` instead of the misleading `"just now"` label.

* **Tests**
  * Added a future-date regression case to the existing format/timeAgo boundary test.