### PR TITLE
fix(web): replace umami script proxy with first-party tracker

### DIFF
--- a/apps/web/DEPLOYMENT.md
+++ b/apps/web/DEPLOYMENT.md
@@ -190,11 +190,14 @@ longer a Next.js app.
 - `VITE_SUBMISSION_GATE_URL` or `NEXT_PUBLIC_SUBMISSION_GATE_URL` set to the
   submission-gate Worker origin:
   `https://submission-gate.heyclau.de`.
-- `VITE_UMAMI_SCRIPT_URL` set to `/u/script.js`.
 - `VITE_UMAMI_WEBSITE_ID` and `UMAMI_WEBSITE_ID` set to the Umami website ID.
-- `UMAMI_UPSTREAM_URL` set to the Umami instance origin. The public web tracker
-  is served first-party through `/u/script.js`, and collector posts are proxied
-  through `/u/api/send`, so the site CSP can keep analytics traffic on `self`.
+- `VITE_UMAMI_ALLOWED_HOSTS` set to production hostnames that should emit
+  browser analytics, for example `heyclau.de,www.heyclau.de`.
+- `UMAMI_UPSTREAM_URL` set to the Umami instance origin and
+  `UMAMI_ALLOWED_UPSTREAM_ORIGINS` set to the allowed upstream origin. Browser
+  analytics is emitted by bundled first-party code and collector posts are
+  proxied through `/u/api/send`; the site does not proxy or execute the upstream
+  Umami tracker script as same-origin JavaScript.
 
 Content submission writes are routed through the private submission gate; the
 public website only runs preflight and hands the contributor to GitHub auth.

--- a/apps/web/src/components/umami-tracker.tsx
+++ b/apps/web/src/components/umami-tracker.tsx
@@ -1,0 +1,173 @@
+import * as React from "react";
+import { useRouterState } from "@tanstack/react-router";
+
+type UmamiPayload = {
+  website: string;
+  screen: string;
+  language: string;
+  title: string;
+  hostname: string;
+  url: string;
+  referrer: string;
+  name?: string;
+  data?: Record<string, unknown>;
+  id?: string;
+};
+
+type UmamiResponse = {
+  cache?: string;
+  disabled?: boolean;
+};
+
+type UmamiTrackInput =
+  | string
+  | Partial<UmamiPayload>
+  | ((payload: UmamiPayload) => Partial<UmamiPayload> | null | undefined)
+  | null
+  | undefined;
+
+type FirstPartyUmami = {
+  track: (event?: UmamiTrackInput, data?: Record<string, unknown>) => void;
+  identify: (idOrData: string | Record<string, unknown>, data?: Record<string, unknown>) => void;
+  getSession: () => { cache: string; website: string };
+};
+
+const COLLECTOR_URL = "/u/api/send";
+const SENSITIVE_PAGEVIEW_PATHS = new Set(["/brief/approve"]);
+
+function currentUrlPath() {
+  return `${window.location.pathname}${window.location.search}`;
+}
+
+function externalReferrer() {
+  if (!document.referrer) return "";
+  try {
+    return new URL(document.referrer).origin === window.location.origin ? "" : document.referrer;
+  } catch {
+    return "";
+  }
+}
+
+export function isAllowedUmamiHost(hostname: string, allowedHosts: readonly string[]) {
+  if (allowedHosts.length === 0) return true;
+  const normalized = hostname.toLowerCase();
+  return allowedHosts.some((host) => normalized === host.toLowerCase());
+}
+
+export function buildUmamiPayload(
+  websiteId: string,
+  referrer: string,
+  event?: string,
+  data?: Record<string, unknown>,
+): UmamiPayload {
+  return {
+    website: websiteId,
+    screen: `${window.screen.width}x${window.screen.height}`,
+    language: navigator.language,
+    title: document.title,
+    hostname: window.location.hostname,
+    url: currentUrlPath(),
+    referrer,
+    ...(event ? { name: event } : {}),
+    ...(data ? { data } : {}),
+  };
+}
+
+export function shouldTrackUmamiPage(pathname: string) {
+  return !SENSITIVE_PAGEVIEW_PATHS.has(pathname);
+}
+
+export function UmamiTracker({
+  websiteId,
+  allowedHosts = [],
+}: {
+  websiteId: string;
+  allowedHosts?: readonly string[];
+}) {
+  const routeKey = useRouterState({
+    select: (state) => `${state.location.pathname}:${JSON.stringify(state.location.search)}`,
+  });
+  const previousUrlRef = React.useRef("");
+  const referrerRef = React.useRef("");
+  const cacheRef = React.useRef("");
+  const disabledRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!websiteId || !isAllowedUmamiHost(window.location.hostname, allowedHosts)) return;
+
+    const sendPayload = (payload: UmamiPayload, type = "event") => {
+      if (disabledRef.current) return;
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+      };
+      if (cacheRef.current) {
+        headers["x-umami-cache"] = cacheRef.current;
+      }
+
+      void fetch(COLLECTOR_URL, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ type, payload }),
+        credentials: "omit",
+        keepalive: true,
+      })
+        .then(async (response) => {
+          if (!response.ok) return;
+          const body = (await response.json().catch(() => ({}))) as UmamiResponse;
+          if (body.cache) cacheRef.current = body.cache;
+          if (body.disabled) disabledRef.current = true;
+        })
+        .catch(() => {
+          // Analytics is best-effort and must never affect app behavior.
+        });
+    };
+
+    const track: FirstPartyUmami["track"] = (event, data) => {
+      const basePayload = buildUmamiPayload(websiteId, referrerRef.current);
+      if (typeof event === "function") {
+        const nextPayload = event(basePayload);
+        if (nextPayload) sendPayload({ ...basePayload, ...nextPayload });
+        return;
+      }
+      if (event && typeof event === "object") {
+        sendPayload({ ...basePayload, ...event });
+        return;
+      }
+      sendPayload(buildUmamiPayload(websiteId, referrerRef.current, event || undefined, data));
+    };
+
+    const identify: FirstPartyUmami["identify"] = (idOrData, data) => {
+      const payload =
+        typeof idOrData === "string"
+          ? buildUmamiPayload(websiteId, referrerRef.current, undefined, data)
+          : buildUmamiPayload(websiteId, referrerRef.current, undefined, idOrData);
+      if (typeof idOrData === "string") payload.id = idOrData;
+      sendPayload(payload, "identify");
+    };
+
+    window.umami = {
+      track,
+      identify,
+      getSession: () => ({ cache: cacheRef.current, website: websiteId }),
+    };
+  }, [allowedHosts, websiteId]);
+
+  React.useEffect(() => {
+    if (
+      !websiteId ||
+      !isAllowedUmamiHost(window.location.hostname, allowedHosts) ||
+      !shouldTrackUmamiPage(window.location.pathname)
+    ) {
+      return;
+    }
+
+    const current = currentUrlPath();
+    if (previousUrlRef.current === current) return;
+    referrerRef.current = previousUrlRef.current || externalReferrer();
+    previousUrlRef.current = current;
+    window.umami?.track();
+    referrerRef.current = current;
+  }, [allowedHosts, routeKey, websiteId]);
+
+  return null;
+}

--- a/apps/web/src/components/web-vitals.tsx
+++ b/apps/web/src/components/web-vitals.tsx
@@ -2,7 +2,14 @@ import * as React from "react";
 
 declare global {
   interface Window {
-    umami?: { track: (event: string, data?: Record<string, unknown>) => void };
+    umami?: {
+      track: (event?: string, data?: Record<string, unknown>) => void;
+      identify?: (
+        idOrData: string | Record<string, unknown>,
+        data?: Record<string, unknown>,
+      ) => void;
+      getSession?: () => { cache: string; website: string };
+    };
   }
 }
 
@@ -15,8 +22,8 @@ interface ReportedMetric {
 
 /**
  * Field Core Web Vitals (RUM). Reports INP/LCP/CLS/TTFB/FCP for real sessions
- * via the first-party umami tracker (loaded from /u.js; events post same-origin
- * to /api/send), so no CSP change is needed. Renders nothing; web-vitals is
+ * via the bundled first-party umami tracker (events post same-origin to
+ * /u/api/send), so no CSP change is needed. Renders nothing; web-vitals is
  * dynamically imported
  * inside the effect so it never enters the SSR path or the universal client chunk.
  */

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -12,7 +12,8 @@ export function urlOrigin(value: string) {
 const scriptSrc = [
   // Keep scripts constrained to same-origin application bundles. The legacy
   // first-party analytics script proxy is disabled because it could serve
-  // external JavaScript as same-origin code.
+  // external JavaScript as same-origin code; browser analytics is emitted by
+  // our bundled first-party tracker through /u/api/send.
   "script-src 'self' 'unsafe-inline'",
   process.env.NODE_ENV === "production" ? "" : "'unsafe-eval'",
   "https://challenges.cloudflare.com",

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -10,8 +10,9 @@ export function urlOrigin(value: string) {
 }
 
 const scriptSrc = [
-  // umami is served first-party via the /u.js proxy, so no third-party
-  // analytics script-src is needed (see routes/u[.]js.ts).
+  // Keep scripts constrained to same-origin application bundles. The legacy
+  // first-party analytics script proxy is disabled because it could serve
+  // external JavaScript as same-origin code.
   "script-src 'self' 'unsafe-inline'",
   process.env.NODE_ENV === "production" ? "" : "'unsafe-eval'",
   "https://challenges.cloudflare.com",

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -37,6 +37,15 @@ function publicHttpUrl(value: string) {
   }
 }
 
+function publicCsvEnv(name: string, fallback: readonly string[] = []) {
+  const value = publicEnv(name);
+  if (!value) return [...fallback];
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 export const siteConfig = {
   name: "HeyClaude",
   shortName: "heyclaude",
@@ -47,11 +56,10 @@ export const siteConfig = {
   jobsEmail: "jobs@heyclau.de",
   twitterUrl: publicEnv("NEXT_PUBLIC_TWITTER_URL") || "https://x.com/jsonbored",
   discordUrl: publicEnv("NEXT_PUBLIC_DISCORD_URL") || "https://discord.com/invite/Ax3Py4YDrq",
-  // Analytics is opt-in: set VITE_UMAMI_SCRIPT_URL (for example /u/script.js)
-  // after configuring and reviewing the corresponding script source. Keeping the
-  // default empty avoids sitewide execution of JavaScript from an external origin.
-  umamiScriptUrl: publicEnv("VITE_UMAMI_SCRIPT_URL"),
+  // Browser analytics uses our first-party React tracker and posts to /u/api/send.
+  // We intentionally do not proxy or execute the upstream Umami tracker script.
   umamiWebsiteId: publicEnv("VITE_UMAMI_WEBSITE_ID") || "b734c138-2949-4527-9160-7fe5d0e81121",
+  umamiAllowedHosts: publicCsvEnv("VITE_UMAMI_ALLOWED_HOSTS", ["heyclau.de", "www.heyclau.de"]),
   // Empty string intentionally disables the private gate and shows manual PR instructions.
   submissionGateUrl: publicHttpUrl(
     publicEnv("VITE_SUBMISSION_GATE_URL") || publicEnv("NEXT_PUBLIC_SUBMISSION_GATE_URL"),

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,7 +4,6 @@ import {
   Link,
   createRootRouteWithContext,
   useRouter,
-  useRouterState,
   HeadContent,
   Scripts,
 } from "@tanstack/react-router";
@@ -25,6 +24,7 @@ import { RouteProgress } from "@/components/route-progress";
 import { WebMcpProvider } from "@/components/webmcp-provider";
 import { AiReferral } from "@/components/ai-referral";
 import { WebVitals } from "@/components/web-vitals";
+import { UmamiTracker } from "@/components/umami-tracker";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -198,23 +198,10 @@ export const Route = createRootRouteWithContext<{ queryClient: QueryClient }>()(
 });
 
 function RootShell({ children }: { children: React.ReactNode }) {
-  const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const shouldLoadAnalytics =
-    pathname !== "/brief/approve" &&
-    Boolean(siteConfig.umamiScriptUrl && siteConfig.umamiWebsiteId);
-
   return (
     <html lang="en">
       <head>
         <HeadContent />
-        {shouldLoadAnalytics && (
-          <script
-            id="umami-analytics"
-            defer
-            src={siteConfig.umamiScriptUrl}
-            data-website-id={siteConfig.umamiWebsiteId}
-          />
-        )}
       </head>
       <body>
         {children}
@@ -246,6 +233,12 @@ function RootComponent() {
                 <CompareDrawer />
                 <BackToTop />
                 <WebMcpProvider />
+                {siteConfig.umamiWebsiteId && (
+                  <UmamiTracker
+                    websiteId={siteConfig.umamiWebsiteId}
+                    allowedHosts={siteConfig.umamiAllowedHosts}
+                  />
+                )}
                 <WebVitals />
                 <AiReferral />
                 <Toaster

--- a/apps/web/src/routes/u.api.send.ts
+++ b/apps/web/src/routes/u.api.send.ts
@@ -18,6 +18,7 @@ const RATE_LIMIT = {
   limit: 60,
   windowMs: 60_000,
 } as const;
+const DEFAULT_ALLOWED_UPSTREAM_ORIGINS = ["https://tasty.aethereal.dev"] as const;
 
 function getRequestId(request: Request) {
   return (
@@ -25,9 +26,27 @@ function getRequestId(request: Request) {
   );
 }
 
+function allowedUpstreamOrigins() {
+  const configured = getEnvString("UMAMI_ALLOWED_UPSTREAM_ORIGINS");
+  return configured
+    ? configured
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : [...DEFAULT_ALLOWED_UPSTREAM_ORIGINS];
+}
+
+function validatedUpstreamOrigin(upstream: string) {
+  try {
+    const origin = new URL(upstream).origin;
+    return allowedUpstreamOrigins().includes(origin) ? origin : "";
+  } catch {
+    return "";
+  }
+}
+
 /**
- * First-party umami collector proxy. The tracker served from `/u/script.js`
- * posts events here (umami derives the collector from the script directory); we
+ * First-party umami collector proxy. The bundled tracker posts events here; we
  * forward them to the umami instance server-side, preserving the visitor
  * User-Agent and IP (umami needs both for sessions + geolocation). Keeps
  * `connect-src` to `'self'` — no third-party analytics origin in the CSP. Lives
@@ -62,7 +81,7 @@ export async function POST(request: Request): Promise<Response> {
     throw error;
   }
 
-  const upstream = getEnvString("UMAMI_UPSTREAM_URL");
+  const upstream = validatedUpstreamOrigin(getEnvString("UMAMI_UPSTREAM_URL"));
   if (!upstream) return apiError("analytics_not_configured", 404, { requestId });
 
   const headers = new Headers({

--- a/apps/web/src/routes/u.script[.]js.ts
+++ b/apps/web/src/routes/u.script[.]js.ts
@@ -1,39 +1,17 @@
 import { createFileRoute } from "@tanstack/react-router";
 
-import { joinAnalyticsUpstreamUrl } from "@/lib/analytics-proxy";
-import { getEnvString } from "@/lib/cloudflare-env.server";
-
 /**
- * First-party umami tracker proxy.
- *
- * Serving the analytics script from our own origin (instead of a third-party
- * `script-src`) keeps the CSP to `'self'` — no external eTLD+1 trust boundary —
- * and makes the tracker resilient to ad blockers. The browser only ever talks
- * to heyclau.de; this worker fetches the script from the umami instance
- * server-side. Served under `/u/` so umami auto-derives its collector from the
- * script directory (`/u/api/send`, see u.api.send.ts) — keeping both out of the
- * product `/api/` namespace and its central-router contract.
+ * The first-party umami tracker proxy is intentionally disabled. Serving a
+ * script fetched from an external analytics upstream as same-origin JavaScript
+ * would allow an upstream compromise to execute in the heyclau.de origin.
  */
 export async function GET(): Promise<Response> {
-  const upstream = getEnvString("UMAMI_UPSTREAM_URL");
-  if (!upstream) return new Response("", { status: 404 });
-  try {
-    const response = await fetch(joinAnalyticsUpstreamUrl(upstream, "/script.js"), {
-      signal: AbortSignal.timeout(8000),
-    });
-    if (!response.ok) return new Response("", { status: 502 });
-    const body = await response.text();
-    return new Response(body, {
-      status: 200,
-      headers: {
-        "content-type": "application/javascript; charset=utf-8",
-        // Tracker changes rarely; cache at the edge + browser for a day.
-        "cache-control": "public, max-age=86400, s-maxage=86400",
-      },
-    });
-  } catch {
-    return new Response("", { status: 502 });
-  }
+  return new Response(null, {
+    status: 404,
+    headers: {
+      "cache-control": "public, max-age=300, s-maxage=300",
+    },
+  });
 }
 
 export const Route = createFileRoute("/u/script.js")({

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -75,7 +75,6 @@
     "NEXT_PUBLIC_POLAR_FEATURED_JOB_90_URL": "/jobs/post?tier=featured",
     "NEXT_PUBLIC_POLAR_SPONSORED_JOB_90_URL": "/jobs/post?tier=sponsored",
     "VITE_SUBMISSION_GATE_URL": "https://submission-gate.heyclau.de",
-    "VITE_UMAMI_SCRIPT_URL": "/u/script.js",
     "VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",
     "UMAMI_UPSTREAM_URL": "https://tasty.aethereal.dev",
     "UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -76,7 +76,9 @@
     "NEXT_PUBLIC_POLAR_SPONSORED_JOB_90_URL": "/jobs/post?tier=sponsored",
     "VITE_SUBMISSION_GATE_URL": "https://submission-gate.heyclau.de",
     "VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",
+    "VITE_UMAMI_ALLOWED_HOSTS": "heyclau.de,www.heyclau.de",
     "UMAMI_UPSTREAM_URL": "https://tasty.aethereal.dev",
+    "UMAMI_ALLOWED_UPSTREAM_ORIGINS": "https://tasty.aethereal.dev",
     "UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121",
   },
   "d1_databases": [

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -1028,7 +1028,7 @@ describe("umami collector proxy security", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://umami.example/api/send");
   });
 
-  it("normalizes trailing slashes when fetching the tracker script", async () => {
+  it("does not proxy the tracker script as same-origin JavaScript", async () => {
     process.env.UMAMI_UPSTREAM_URL = "https://umami.example/";
     const fetchMock = vi.fn(
       async () => new Response("console.log('ok')", { status: 200 }),
@@ -1038,11 +1038,9 @@ describe("umami collector proxy security", () => {
 
     const response = await GET();
 
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0]?.[0]).toBe(
-      "https://umami.example/script.js",
-    );
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.headers.get("content-type")).toBeNull();
   });
 
   it("rate-limits repeated analytics posts per client", async () => {

--- a/tests/api-router-security.test.ts
+++ b/tests/api-router-security.test.ts
@@ -896,6 +896,7 @@ describe("umami collector proxy security", () => {
     vi.unstubAllGlobals();
     vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.UMAMI_UPSTREAM_URL = "https://umami.example";
+    process.env.UMAMI_ALLOWED_UPSTREAM_ORIGINS = "https://umami.example";
     const { __rateLimitTestHooks } = await import("@/lib/api-security");
     __rateLimitTestHooks.reset();
   });
@@ -1026,6 +1027,23 @@ describe("umami collector proxy security", () => {
     expect(response.status).toBe(202);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://umami.example/api/send");
+  });
+
+  it("refuses to proxy analytics to unapproved upstream origins", async () => {
+    process.env.UMAMI_UPSTREAM_URL = "https://untrusted.example";
+    process.env.UMAMI_ALLOWED_UPSTREAM_ORIGINS = "https://umami.example";
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 202 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const { POST } = await import("../apps/web/src/routes/u.api.send");
+
+    const response = await POST(analyticsRequest('{"payload":{}}'));
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      error: { code: "analytics_not_configured" },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("does not proxy the tracker script as same-origin JavaScript", async () => {

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -254,7 +254,13 @@ describe("PR preview artifact validation flow", () => {
       '"VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121"',
     );
     expect(wranglerConfig).toContain(
+      '"VITE_UMAMI_ALLOWED_HOSTS": "heyclau.de,www.heyclau.de"',
+    );
+    expect(wranglerConfig).toContain(
       '"UMAMI_UPSTREAM_URL": "https://tasty.aethereal.dev"',
+    );
+    expect(wranglerConfig).toContain(
+      '"UMAMI_ALLOWED_UPSTREAM_ORIGINS": "https://tasty.aethereal.dev"',
     );
     expect(wranglerConfig).toContain(
       '"UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121"',

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -241,13 +241,15 @@ describe("PR preview artifact validation flow", () => {
     );
   });
 
-  it("keeps the first-party Umami proxy wired in production config", () => {
+  it("does not enable the first-party Umami script proxy in production config", () => {
     const wranglerConfig = fs.readFileSync(
       path.join(repoRoot, "apps/web/wrangler.jsonc"),
       "utf8",
     );
 
-    expect(wranglerConfig).toContain('"VITE_UMAMI_SCRIPT_URL": "/u/script.js"');
+    expect(wranglerConfig).not.toContain(
+      '"VITE_UMAMI_SCRIPT_URL": "/u/script.js"',
+    );
     expect(wranglerConfig).toContain(
       '"VITE_UMAMI_WEBSITE_ID": "b734c138-2949-4527-9160-7fe5d0e81121"',
     );

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -90,6 +90,11 @@ import {
   trackEvent,
 } from "../apps/web/src/lib/analytics";
 import {
+  buildUmamiPayload,
+  isAllowedUmamiHost,
+  shouldTrackUmamiPage,
+} from "../apps/web/src/components/umami-tracker";
+import {
   logApiError,
   logApiInfo,
   logApiWarn,
@@ -702,6 +707,44 @@ describe("web non-UI utility coverage", () => {
       "example.com",
     );
     expect(outboundHost("not a url")).toBe("unknown");
+    vi.stubGlobal("window", {
+      location: {
+        hostname: "heyclau.de",
+        pathname: "/entry/mcp/example",
+        search: "?view=full",
+      },
+      screen: {
+        width: 1440,
+        height: 900,
+      },
+      localStorage,
+      sessionStorage,
+      dispatchEvent,
+    });
+    vi.stubGlobal("document", { title: "Example MCP" });
+    vi.stubGlobal("navigator", { language: "en-US" });
+    expect(isAllowedUmamiHost("HeyClau.DE", ["heyclau.de"])).toBe(true);
+    expect(isAllowedUmamiHost("preview.heyclau.de", ["heyclau.de"])).toBe(
+      false,
+    );
+    expect(isAllowedUmamiHost("localhost", [])).toBe(true);
+    expect(shouldTrackUmamiPage("/brief/approve")).toBe(false);
+    expect(shouldTrackUmamiPage("/entry/mcp/example")).toBe(true);
+    expect(
+      buildUmamiPayload("site-1", "https://referrer.example/docs", "open", {
+        category: "mcp",
+      }),
+    ).toEqual({
+      website: "site-1",
+      screen: "1440x900",
+      language: "en-US",
+      title: "Example MCP",
+      hostname: "heyclau.de",
+      url: "/entry/mcp/example?view=full",
+      referrer: "https://referrer.example/docs",
+      name: "open",
+      data: { category: "mcp" },
+    });
 
     expect(readCopyPref()).toBeNull();
     writeCopyPref("config");


### PR DESCRIPTION
## Summary
- Replace the external Umami script proxy with a bundled first-party tracker that posts Umami-compatible events to `/u/api/send`.
- Keep `/u/script.js` disabled so upstream JavaScript is never served as same-origin code.
- Add browser-host and upstream-origin allowlists so analytics remains reliable without widening the executable or network surface.

## What changed
- Browser pageviews and `window.umami.track(...)` now run through `apps/web/src/components/umami-tracker.tsx`.
- `/u/api/send` only forwards to allowlisted Umami upstream origins and continues redacting sensitive analytics URL params.
- Production Worker config defines `VITE_UMAMI_ALLOWED_HOSTS` and `UMAMI_ALLOWED_UPSTREAM_ORIGINS`; `VITE_UMAMI_SCRIPT_URL` remains removed.
- Deployment docs and tests now describe the first-party bundled tracker path.

## Why
- Proxying executable analytics JavaScript from an upstream service would make an upstream compromise a same-origin script risk.
- Bundling the tiny tracker keeps the browser CSP/connect-src model same-origin while preserving pageviews, custom events, and existing `window.umami.track(...)` callers.

## Validation
- `pnpm exec vitest run tests/generated-churn-policy.test.ts tests/mcp-server.test.ts`
- `pnpm exec vitest run tests/api-router-security.test.ts tests/deployment-preview-url.test.ts tests/web-non-ui-utilities.test.ts`
- `pnpm --filter web run type-check`
- `pnpm --filter web run build`
- `pnpm test` (108 files, 1069 tests)
- `pnpm validate:openapi`
- `git diff --check`

## Notes
- No linked issue: this is a maintainer-lane analytics hardening follow-up to the Umami production tracking work, not a tracker-closing issue PR.
- No manual Worker deploy was run. Workers Builds should deploy through the repo pipeline.
- Server-side newsletter Umami events continue to use the configured upstream server-side.