### PR TITLE
test(seo): pin buildEntryJsonLd category mapping and trust-field exclusion

### DIFF
--- a/tests/seo-jsonld.test.ts
+++ b/tests/seo-jsonld.test.ts
@@ -93,6 +93,54 @@ describe("SEO JSON-LD policy", () => {
     ).toBe(true);
   });
 
+  it("maps entry categories to correct JSON-LD @type via unified buildEntryJsonLd", () => {
+    const CODE_LIKE_CATEGORIES = ["commands", "hooks", "mcp", "statuslines"];
+
+    const guideEntry = entries.find((e) => e.category === "guides");
+    if (guideEntry) {
+      expect(
+        buildEntryJsonLd(guideEntry, { siteUrl: "https://heyclau.de" })[
+          "@type"
+        ],
+      ).toBe("TechArticle");
+    }
+
+    for (const category of CODE_LIKE_CATEGORIES) {
+      const codeEntry = entries.find((e) => e.category === category);
+      if (codeEntry) {
+        expect(
+          buildEntryJsonLd(codeEntry, { siteUrl: "https://heyclau.de" })[
+            "@type"
+          ],
+        ).toBe("SoftwareSourceCode");
+      }
+    }
+
+    const creativeEntry = entries.find(
+      (e) =>
+        e.category !== "guides" && !CODE_LIKE_CATEGORIES.includes(e.category),
+    );
+    if (creativeEntry) {
+      expect(
+        buildEntryJsonLd(creativeEntry, { siteUrl: "https://heyclau.de" })[
+          "@type"
+        ],
+      ).toBe("CreativeWork");
+    }
+  });
+
+  it("unified buildEntryJsonLd never emits fabricated trust-sensitive fields", () => {
+    for (const entry of entries.slice(0, 20)) {
+      const ld = buildEntryJsonLd(entry, {
+        siteUrl: "https://heyclau.de",
+      }) as Record<string, unknown>;
+      expect(ld.aggregateRating).toBeUndefined();
+      expect(ld.review).toBeUndefined();
+      expect(ld.ratingValue).toBeUndefined();
+      expect(ld.reviewCount).toBeUndefined();
+    }
+  });
+
   it("emits regular WebPage schema for plain pages", () => {
     const webpage = buildWebPageJsonLd({
       siteUrl: "https://heyclau.de",


### PR DESCRIPTION
Add two test cases to the existing SEO JSON-LD policy suite covering the unified `buildEntryJsonLd` helper from `@heyclaude/registry/seo`.

## New tests

### Category → `@type` mapping

Verifies that `buildEntryJsonLd` emits the correct JSON-LD `@type` for each category group:
- `guides` → `TechArticle`
- Code-like categories (`commands`, `hooks`, `mcp`, `statuslines`) → `SoftwareSourceCode`
- All other categories → `CreativeWork`

This pins the category dispatch so any future refactor of the registry helper can't silently break the per-category schema.

### Trust-sensitive field exclusion

Iterates the first 20 real registry entries and asserts that `aggregateRating`, `review`, `ratingValue`, and `reviewCount` are never present in the emitted JSON-LD. Prevents accidental emission of fabricated rich-result signals across the full entry set.

Both tests use real content entries loaded from `apps/web/public/data/` via `loadContentEntries()`.
