### PR TITLE
perf(ci): dedupe the test suite + cache incremental type-check

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -691,20 +691,24 @@ jobs:
         if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm validate:openapi
 
-      - name: Run Vitest suite
+      # The full Vitest suite runs once in the `coverage` job (`pnpm test:coverage` = the same `vitest run`,
+      # plus coverage + Codecov upload). Running it again here was pure duplication — ~2 min of identical
+      # work AND a second runner slot held under the Actions concurrency cap, which starves the queue. The
+      # web lane keeps the web-specific gates below (type-check + build); the suite is gated by `coverage`.
+      # (Trunk flaky-test upload also lived here but was token-gated and inert; move it to `coverage` if
+      # flaky detection is ever enabled, so it sits with the one job that runs the suite.) (#dedupe-suite)
+
+      # Incremental type-check cache: `tsc --noEmit` (incremental) writes apps/web/.cache/tsc.tsbuildinfo,
+      # so a warm run only re-checks changed files (~4x faster locally). Keyed per-sha with a prefix
+      # restore-key so each run restores the most recent prior buildinfo. (#tsc-incremental-cache)
+      - name: Restore type-check cache
         if: ${{ needs.classify-pr.outputs.web == 'true' }}
-        run: pnpm test
-
-      - name: Install Trunk CLI
-        if: ${{ needs.classify-pr.outputs.web == 'true' && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
-        run: |
-          curl https://get.trunk.io -fsSL | bash -s -- -y
-          echo "$HOME/.trunk/bin" >> "$GITHUB_PATH"
-
-      - name: Upload test results to Trunk
-        if: ${{ needs.classify-pr.outputs.web == 'true' && always() && env.TRUNK_API_TOKEN != '' && env.TRUNK_ORG_URL_SLUG != '' }}
-        continue-on-error: true
-        run: trunk flakytests upload --junit-paths "reports/junit/*.xml" --org-url-slug "$TRUNK_ORG_URL_SLUG" --token "$TRUNK_API_TOKEN"
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: apps/web/.cache
+          key: tsc-web-v1-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            tsc-web-v1-${{ runner.os }}-
 
       - name: Type-check web app
         if: ${{ needs.classify-pr.outputs.web == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ apps/web/public/downloads/
 apps/web/src/generated/
 apps/web/src/routeTree.gen.ts
 
+# Incremental type-check cache (tsc --noEmit .tsbuildinfo; restored from CI cache).
+apps/web/.cache/
+
 # D1 schema migrations must stay tracked even if a global ignore has *.sql
 !apps/web/migrations/
 !apps/web/migrations/*.sql

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -14,6 +14,11 @@
     "verbatimModuleSyntax": false,
     "noEmit": true,
 
+    /* Incremental type-check: `tsc --noEmit` writes a .tsbuildinfo so CI (which caches it) only
+       re-checks changed files instead of the whole app each run. Path is gitignored + cached. */
+    "incremental": true,
+    "tsBuildInfoFile": "./.cache/tsc.tsbuildinfo",
+
     /* Linting */
     "skipLibCheck": true,
     "strict": true,

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -213,8 +213,14 @@ describe("submission automation workflows", () => {
 
     expect(source).toContain("validate-worktree:");
     expect(source).toContain('git diff --check "$BASE_SHA"...HEAD');
-    expect(source).toContain("Run Vitest suite");
-    expect(source).toContain("pnpm test");
+    // The full Vitest suite is NOT duplicated in the validate lanes — it runs once in coverage.yml
+    // (pnpm test:coverage); validate-web keeps only the web-specific gates below. (#dedupe-suite)
+    expect(source).not.toContain("Run Vitest suite");
+    const coverageWorkflow = fs.readFileSync(
+      path.join(repoRoot, ".github/workflows/coverage.yml"),
+      "utf8",
+    );
+    expect(coverageWorkflow).toContain("pnpm test:coverage");
     expect(source).toContain("pnpm type-check");
     expect(source).toContain("pnpm build");
     expect(source).not.toContain("pnpm test:e2e");


### PR DESCRIPTION
Cuts `validate-web` (~7 min) and frees a runner slot under the Actions concurrency cap.

## 1. Drop the duplicated test suite from `validate-web`
`validate-web` ran `pnpm test` (full 1068-test suite, ~2m11s) **and** the `coverage` job runs the **exact same suite** via `pnpm test:coverage` (`vitest run` + coverage + Codecov upload). So the entire suite ran **twice in parallel** — ~2 min of identical work plus a second concurrent runner slot held, which starves the queue under the ~3–5 concurrent cap.

Now `validate-web` keeps only the web-specific gates (type-check + build); the suite is gated by `coverage`. Also removed the inert, token-gated Trunk flaky-upload steps (they only made sense next to a suite run — move them to `coverage` if flaky detection is ever turned on).

## 2. Incremental type-check cache
`apps/web` tsconfig gains `incremental` + `tsBuildInfoFile` (`.cache/`, gitignored). `validate-web` restores it via `actions/cache` (per-sha key + prefix restore-key) so a warm `tsc --noEmit` only re-checks changed files. **Measured ~4× locally: cold 7.9s → warm 1.9s.**

## Notes / safety
- `coverage` runs the same suite with the same data setup on the same PRs, so nothing is left ungated.
- actionlint clean; full suite **1068 passed**; `submission-workflows` assertions updated (the suite is now asserted in `coverage.yml`).
- I deliberately did **not** add a serial "prebuild-once" gate: it trades per-PR wall-clock latency for aggregate runner-time and is ambiguous for a single PR's speed — happy to add it if you want to optimize total queue throughput over per-PR latency.