### PR TITLE
fix(api): add registry feed compatibility aliases

### DIFF
--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -84,7 +84,8 @@
                 "description": { "type": "string" }
               },
               "required": ["category", "label", "count", "description"]
-            }
+            },
+            "maxItems": 64
           }
         },
         "required": [

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -38,6 +38,71 @@
           "brandColors": { "type": "array", "items": { "type": "string" }, "maxItems": 6 }
         }
       },
+      "RegistryFeedResponse": {
+        "type": "object",
+        "properties": {
+          "schemaVersion": { "type": "number" },
+          "kind": { "type": "string", "enum": ["registry-feed"] },
+          "generatedAt": { "type": "string" },
+          "site": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "url": { "type": "string", "format": "uri" },
+              "description": { "type": "string" }
+            },
+            "required": ["name", "url", "description"]
+          },
+          "qualityMethodology": { "type": "string" },
+          "categoryFeeds": { "type": "object", "additionalProperties": { "type": "string" } },
+          "platformFeeds": { "type": "object", "additionalProperties": { "type": "string" } },
+          "jobs": { "type": "string" },
+          "endpoints": {
+            "type": "object",
+            "properties": {
+              "jobs": { "type": "string" },
+              "qualityMethodology": { "type": "string" },
+              "categoryFeed": { "type": "string" },
+              "platformFeed": { "type": "string" }
+            },
+            "required": ["jobs", "qualityMethodology", "categoryFeed", "platformFeed"],
+            "additionalProperties": { "type": "string" }
+          },
+          "contracts": { "type": "object", "additionalProperties": { "type": "string" } },
+          "artifacts": { "type": "object", "additionalProperties": {} },
+          "artifactContracts": { "type": "object", "additionalProperties": {} },
+          "qualitySummary": {},
+          "trustSummary": {},
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "category": { "type": "string" },
+                "label": { "type": "string" },
+                "count": { "type": "integer", "minimum": 0 },
+                "description": { "type": "string" }
+              },
+              "required": ["category", "label", "count", "description"]
+            }
+          }
+        },
+        "required": [
+          "schemaVersion",
+          "kind",
+          "generatedAt",
+          "site",
+          "qualityMethodology",
+          "categoryFeeds",
+          "platformFeeds",
+          "jobs",
+          "endpoints",
+          "contracts",
+          "artifacts",
+          "categories"
+        ],
+        "additionalProperties": {}
+      },
       "RegistrySearchResult": {
         "type": "object",
         "properties": {
@@ -1269,7 +1334,9 @@
           "200": {
             "description": "Cacheable registry response with ETag support where applicable.",
             "content": {
-              "application/json": { "schema": { "type": "object", "additionalProperties": {} } }
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RegistryFeedResponse" }
+              }
             }
           },
           "400": {

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -139,6 +139,7 @@ components:
               - label
               - count
               - description
+          maxItems: 64
       required:
         - schemaVersion
         - kind

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -53,6 +53,106 @@ components:
           items:
             type: string
           maxItems: 6
+    RegistryFeedResponse:
+      type: object
+      properties:
+        schemaVersion:
+          type: number
+        kind:
+          type: string
+          enum:
+            - registry-feed
+        generatedAt:
+          type: string
+        site:
+          type: object
+          properties:
+            name:
+              type: string
+            url:
+              type: string
+              format: uri
+            description:
+              type: string
+          required:
+            - name
+            - url
+            - description
+        qualityMethodology:
+          type: string
+        categoryFeeds:
+          type: object
+          additionalProperties:
+            type: string
+        platformFeeds:
+          type: object
+          additionalProperties:
+            type: string
+        jobs:
+          type: string
+        endpoints:
+          type: object
+          properties:
+            jobs:
+              type: string
+            qualityMethodology:
+              type: string
+            categoryFeed:
+              type: string
+            platformFeed:
+              type: string
+          required:
+            - jobs
+            - qualityMethodology
+            - categoryFeed
+            - platformFeed
+          additionalProperties:
+            type: string
+        contracts:
+          type: object
+          additionalProperties:
+            type: string
+        artifacts:
+          type: object
+          additionalProperties: {}
+        artifactContracts:
+          type: object
+          additionalProperties: {}
+        qualitySummary: {}
+        trustSummary: {}
+        categories:
+          type: array
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              label:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+              description:
+                type: string
+            required:
+              - category
+              - label
+              - count
+              - description
+      required:
+        - schemaVersion
+        - kind
+        - generatedAt
+        - site
+        - qualityMethodology
+        - categoryFeeds
+        - platformFeeds
+        - jobs
+        - endpoints
+        - contracts
+        - artifacts
+        - categories
+      additionalProperties: {}
     RegistrySearchResult:
       type: object
       properties:
@@ -1617,8 +1717,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: {}
+                $ref: "#/components/schemas/RegistryFeedResponse"
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -273,6 +273,12 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
     categoryFeeds: { mcp: "/data/feeds/categories/mcp.json" },
     platformFeeds: { claude: "/data/feeds/platforms/claude.json" },
     jobs: "/api/jobs?limit=100",
+    endpoints: {
+      qualityMethodology: "/quality#methodology",
+      categoryFeed: "/data/feeds/categories/{category}.json",
+      platformFeed: "/data/feeds/platforms/{platform}.json",
+      jobs: "/api/jobs?limit=100",
+    },
   },
   "registry.trending": {
     schemaVersion: 1,

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -339,6 +339,46 @@ export const registrySearchResponseSchema = z.object({
   facets: registrySearchFacetsSchema.optional(),
 });
 
+const registryFeedLinkMapSchema = z.record(z.string(), z.string());
+
+export const registryFeedResponseSchema = z
+  .object({
+    schemaVersion: z.number(),
+    kind: z.literal("registry-feed"),
+    generatedAt: z.string(),
+    site: z.object({
+      name: z.string(),
+      url: z.string().url(),
+      description: z.string(),
+    }),
+    qualityMethodology: z.string(),
+    categoryFeeds: registryFeedLinkMapSchema,
+    platformFeeds: registryFeedLinkMapSchema,
+    jobs: z.string(),
+    endpoints: z
+      .object({
+        jobs: z.string(),
+        qualityMethodology: z.string(),
+        categoryFeed: z.string(),
+        platformFeed: z.string(),
+      })
+      .catchall(z.string()),
+    contracts: z.record(z.string(), z.string()),
+    artifacts: z.record(z.string(), z.unknown()),
+    artifactContracts: z.record(z.string(), z.unknown()).optional(),
+    qualitySummary: z.unknown().optional(),
+    trustSummary: z.unknown().optional(),
+    categories: z.array(
+      z.object({
+        category: z.string(),
+        label: z.string(),
+        count: z.number().int().nonnegative(),
+        description: z.string(),
+      }),
+    ),
+  })
+  .passthrough();
+
 export const registryTrendingResponseSchema = z.object({
   schemaVersion: z.number(),
   kind: z.literal("registry-trending"),
@@ -876,6 +916,8 @@ export const apiRouteDefinitions = {
       "Discovers API, RSS, changelog, category feeds, platform feeds, category and platform shards, and artifact URLs.",
     tags: ["Registry"],
     originCheck: true,
+    responseSchema: registryFeedResponseSchema,
+    responseSchemaName: "RegistryFeedResponse",
     rateLimit: {
       scope: "registry-feed",
       limit: 120,

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -368,14 +368,16 @@ export const registryFeedResponseSchema = z
     artifactContracts: z.record(z.string(), z.unknown()).optional(),
     qualitySummary: z.unknown().optional(),
     trustSummary: z.unknown().optional(),
-    categories: z.array(
-      z.object({
-        category: z.string(),
-        label: z.string(),
-        count: z.number().int().nonnegative(),
-        description: z.string(),
-      }),
-    ),
+    categories: z
+      .array(
+        z.object({
+          category: z.string(),
+          label: z.string(),
+          count: z.number().int().nonnegative(),
+          description: z.string(),
+        }),
+      )
+      .max(64),
   })
   .passthrough();
 

--- a/apps/web/src/routes/api/registry/feed.ts
+++ b/apps/web/src/routes/api/registry/feed.ts
@@ -1,12 +1,37 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
+import { platformFeedSlug } from "@heyclaude/registry/artifacts";
+
 import { createApiHandler } from "@/lib/api/router";
 import { getCategorySummaries, getRegistryManifest } from "@/lib/content.server";
 import { cachedJsonResponse } from "@/lib/http-cache";
+import { getPlatformPageDefinitions } from "@/lib/platform-pages";
 import { siteConfig } from "@/lib/site";
+
+const JOBS_API_PATH = "/api/jobs?limit=100";
+const QUALITY_METHODOLOGY_PATH = "/quality#methodology";
+const CATEGORY_FEED_PATH = "/data/feeds/categories/{category}.json";
+const PLATFORM_FEED_PATH = "/data/feeds/platforms/{platform}.json";
+
+function categoryFeedAliases(categories: Array<{ category: string }>) {
+  return Object.fromEntries(
+    categories.map(({ category }) => [category, `/data/feeds/categories/${category}.json`]),
+  );
+}
+
+function platformFeedAliases() {
+  return Object.fromEntries(
+    getPlatformPageDefinitions().map(({ platform, slug }) => [
+      slug,
+      `/data/feeds/platforms/${platformFeedSlug(platform)}.json`,
+    ]),
+  );
+}
 
 export const GET = createApiHandler("registry.feed", async ({ request }) => {
   const [manifest, categories] = await Promise.all([getRegistryManifest(), getCategorySummaries()]);
+  const categoryFeeds = categoryFeedAliases(categories);
+  const platformFeeds = platformFeedAliases();
 
   return cachedJsonResponse(request, {
     schemaVersion: 1,
@@ -17,6 +42,10 @@ export const GET = createApiHandler("registry.feed", async ({ request }) => {
       url: siteConfig.url,
       description: siteConfig.description,
     },
+    qualityMethodology: QUALITY_METHODOLOGY_PATH,
+    categoryFeeds,
+    platformFeeds,
+    jobs: JOBS_API_PATH,
     endpoints: {
       manifest: "/api/registry/manifest",
       categories: "/api/registry/categories",
@@ -28,18 +57,18 @@ export const GET = createApiHandler("registry.feed", async ({ request }) => {
       entryLlms: "/api/registry/entries/{category}/{slug}/llms",
       directoryIndex: "/data/directory-index.json",
       searchIndex: "/data/search-index.json",
-      jobs: "/api/jobs?limit=100",
+      jobs: JOBS_API_PATH,
       ecosystemFeed: "/data/ecosystem-feed.json",
       mcpRegistryFeed: "/data/mcp-registry-feed.json",
       pluginExportFeed: "/data/plugin-export-feed.json",
       changelogFeed: "/data/registry-changelog.json",
       registryTrust: "/data/registry-trust-report.json",
-      qualityMethodology: "/quality#methodology",
+      qualityMethodology: QUALITY_METHODOLOGY_PATH,
       rssFeed: "/feed.xml",
       atomFeed: "/atom.xml",
       distributionFeedIndex: "/data/feeds/index.json",
-      categoryFeed: "/data/feeds/categories/{category}.json",
-      platformFeed: "/data/feeds/platforms/{platform}.json",
+      categoryFeed: CATEGORY_FEED_PATH,
+      platformFeed: PLATFORM_FEED_PATH,
       contentQuality: "/data/content-quality-report.json",
       raycastFeed: "/data/raycast-index.json",
     },

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -54,6 +54,106 @@ components:
           items:
             type: string
           maxItems: 6
+    RegistryFeedResponse:
+      type: object
+      properties:
+        schemaVersion:
+          type: number
+        kind:
+          type: string
+          enum:
+            - registry-feed
+        generatedAt:
+          type: string
+        site:
+          type: object
+          properties:
+            name:
+              type: string
+            url:
+              type: string
+              format: uri
+            description:
+              type: string
+          required:
+            - name
+            - url
+            - description
+        qualityMethodology:
+          type: string
+        categoryFeeds:
+          type: object
+          additionalProperties:
+            type: string
+        platformFeeds:
+          type: object
+          additionalProperties:
+            type: string
+        jobs:
+          type: string
+        endpoints:
+          type: object
+          properties:
+            jobs:
+              type: string
+            qualityMethodology:
+              type: string
+            categoryFeed:
+              type: string
+            platformFeed:
+              type: string
+          required:
+            - jobs
+            - qualityMethodology
+            - categoryFeed
+            - platformFeed
+          additionalProperties:
+            type: string
+        contracts:
+          type: object
+          additionalProperties:
+            type: string
+        artifacts:
+          type: object
+          additionalProperties: {}
+        artifactContracts:
+          type: object
+          additionalProperties: {}
+        qualitySummary: {}
+        trustSummary: {}
+        categories:
+          type: array
+          items:
+            type: object
+            properties:
+              category:
+                type: string
+              label:
+                type: string
+              count:
+                type: integer
+                minimum: 0
+              description:
+                type: string
+            required:
+              - category
+              - label
+              - count
+              - description
+      required:
+        - schemaVersion
+        - kind
+        - generatedAt
+        - site
+        - qualityMethodology
+        - categoryFeeds
+        - platformFeeds
+        - jobs
+        - endpoints
+        - contracts
+        - artifacts
+        - categories
+      additionalProperties: {}
     RegistrySearchResult:
       type: object
       properties:
@@ -1618,8 +1718,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: {}
+                $ref: "#/components/schemas/RegistryFeedResponse"
         "400":
           description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
           content:

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -140,6 +140,7 @@ components:
               - label
               - count
               - description
+          maxItems: 64
       required:
         - schemaVersion
         - kind

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -17,6 +17,7 @@ const require = createRequire(import.meta.url);
 const {
   apiErrorEnvelopeSchema,
   registryBrandAssetSchema,
+  registryFeedResponseSchema,
   registryTrendingResponseSchema,
   registrySearchResultSchema,
   listApiRouteDefinitions,
@@ -171,6 +172,7 @@ function buildOpenApiDocument() {
 
   registry.register("ErrorEnvelope", apiErrorEnvelopeSchema);
   registry.register("RegistryBrandAsset", registryBrandAssetSchema);
+  registry.register("RegistryFeedResponse", registryFeedResponseSchema);
   registry.register("RegistrySearchResult", registrySearchResultSchema);
   registry.register("RegistryTrendingResponse", registryTrendingResponseSchema);
   registry.register("RegistryTrustSignals", registryTrustSignalsSchema);

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -155,6 +155,12 @@ describe("OpenAPI route coverage", () => {
       categoryFeeds: { mcp: "/data/feeds/categories/mcp.json" },
       platformFeeds: { claude: "/data/feeds/platforms/claude.json" },
       jobs: "/api/jobs?limit=100",
+      endpoints: {
+        qualityMethodology: "/quality#methodology",
+        categoryFeed: "/data/feeds/categories/{category}.json",
+        platformFeed: "/data/feeds/platforms/{platform}.json",
+        jobs: "/api/jobs?limit=100",
+      },
     });
     expect(
       ENDPOINTS.find((endpoint) => endpoint.id === "jobs-detail"),
@@ -289,6 +295,43 @@ describe("OpenAPI route coverage", () => {
         "downloadTrust",
         "claimStatus",
         "sourceStatus",
+      ]),
+    );
+  });
+
+  it("documents registry feed compatibility aliases in the generated schema", () => {
+    const registryFeedResponse =
+      parsedSchema.paths["/api/registry/feed"]?.get?.responses?.["200"];
+    const responseSchema = (
+      registryFeedResponse?.content as
+        | Record<string, { schema?: { $ref?: string } }>
+        | undefined
+    )?.["application/json"]?.schema;
+    expect(responseSchema?.$ref).toBe(
+      "#/components/schemas/RegistryFeedResponse",
+    );
+
+    const component = parsedSchema.components?.schemas?.RegistryFeedResponse as
+      | { required?: string[]; properties?: Record<string, unknown> }
+      | undefined;
+    expect(component?.required).toEqual(
+      expect.arrayContaining([
+        "schemaVersion",
+        "kind",
+        "qualityMethodology",
+        "categoryFeeds",
+        "platformFeeds",
+        "jobs",
+        "endpoints",
+      ]),
+    );
+    expect(Object.keys(component?.properties ?? {})).toEqual(
+      expect.arrayContaining([
+        "qualityMethodology",
+        "categoryFeeds",
+        "platformFeeds",
+        "jobs",
+        "endpoints",
       ]),
     );
   });

--- a/tests/quality-methodology.test.ts
+++ b/tests/quality-methodology.test.ts
@@ -62,7 +62,12 @@ describe("quality methodology page", () => {
     expect(trustDrilldownSource).not.toContain('hash="preflight"');
     expect(sourceCitationsSource).toContain('hash="source-provenance"');
     expect(registryFeedSource).toContain(
-      'qualityMethodology: "/quality#methodology"',
+      'const QUALITY_METHODOLOGY_PATH = "/quality#methodology";',
     );
+    expect(
+      registryFeedSource.match(
+        /qualityMethodology:\s*QUALITY_METHODOLOGY_PATH/g,
+      ),
+    ).toHaveLength(2);
   });
 });

--- a/tests/registry-feed-api.test.ts
+++ b/tests/registry-feed-api.test.ts
@@ -18,6 +18,14 @@ describe("/api/registry/feed", () => {
       platformFeeds?: Record<string, string>;
       jobs?: string;
       endpoints?: Record<string, string>;
+      contracts?: Record<string, string>;
+      artifacts?: Record<string, unknown>;
+      categories?: Array<{
+        category?: string;
+        label?: string;
+        count?: number;
+        description?: string;
+      }>;
     };
 
     expect(body.qualityMethodology).toBe("/quality#methodology");
@@ -33,5 +41,23 @@ describe("/api/registry/feed", () => {
       platformFeed: "/data/feeds/platforms/{platform}.json",
       jobs: "/api/jobs?limit=100",
     });
+
+    expect(body.contracts).toMatchObject({
+      registryEntries: expect.stringContaining("trustSignals"),
+      writes: expect.stringContaining("PR-first"),
+    });
+    expect(Object.keys(body.artifacts ?? {})).toEqual(
+      expect.arrayContaining(["directory", "search"]),
+    );
+    expect(body.categories).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          category: "mcp",
+          label: "MCP Servers",
+          count: expect.any(Number),
+          description: expect.any(String),
+        }),
+      ]),
+    );
   });
 });

--- a/tests/registry-feed-api.test.ts
+++ b/tests/registry-feed-api.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "../apps/web/src/routes/api/registry/feed";
+
+const request = () =>
+  new Request("https://heyclau.de/api/registry/feed", {
+    headers: { origin: "https://heyclau.de" },
+  });
+
+describe("/api/registry/feed", () => {
+  it("exposes canonical endpoints and top-level compatibility aliases", async () => {
+    const response = await GET(request());
+    expect(response.status).toBe(200);
+
+    const body = (await response.json()) as {
+      qualityMethodology?: string;
+      categoryFeeds?: Record<string, string>;
+      platformFeeds?: Record<string, string>;
+      jobs?: string;
+      endpoints?: Record<string, string>;
+    };
+
+    expect(body.qualityMethodology).toBe("/quality#methodology");
+    expect(body.categoryFeeds?.mcp).toBe("/data/feeds/categories/mcp.json");
+    expect(body.platformFeeds?.claude).toBe(
+      "/data/feeds/platforms/claude.json",
+    );
+    expect(body.jobs).toBe("/api/jobs?limit=100");
+
+    expect(body.endpoints).toMatchObject({
+      qualityMethodology: "/quality#methodology",
+      categoryFeed: "/data/feeds/categories/{category}.json",
+      platformFeed: "/data/feeds/platforms/{platform}.json",
+      jobs: "/api/jobs?limit=100",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add top-level compatibility aliases to `/api/registry/feed` while keeping the canonical `endpoints` object unchanged
- add a named `RegistryFeedResponse` OpenAPI schema and regenerate the public OpenAPI YAML/JSON artifacts
- add route-level and OpenAPI regression coverage for the alias contract

## Why
The API docs still showed the compact flat registry feed fields, but the live route only exposed those links under `endpoints`. This makes the documented compatibility shape true at runtime without breaking current consumers of `endpoints.*`.

## Validation
- `pnpm exec vitest run tests/registry-feed-api.test.ts tests/api-contracts.test.ts`
- `pnpm validate:openapi`
- `pnpm type-check`
- `pnpm build`
- `git diff --check`

## Notes
- Additive API change only; the existing `endpoints` response object remains intact.
- No manual Worker deployment was run.
