### PR TITLE
perf(ci): cancel superseded security scans on PR re-push

### DIFF
--- a/.github/workflows/pipelock-security.yml
+++ b/.github/workflows/pipelock-security.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded scan when a new commit is pushed to the same PR — otherwise rapid re-pushes
+# during iteration leave stale full-repo scans running and burning runner minutes. (#cancel-stale)
+concurrency:
+  group: pipelock-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pipelock-advisory-scan:
     name: pipelock-advisory-scan

--- a/.github/workflows/superagent-security.yml
+++ b/.github/workflows/superagent-security.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: read
 
+# Cancel a superseded scan when a new commit is pushed to the same PR — otherwise rapid re-pushes
+# during iteration leave stale full-repo scans running and burning runner minutes. (#cancel-stale)
+concurrency:
+  group: superagent-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   superagent-repo-scan:
     name: superagent-repo-scan


### PR DESCRIPTION
Final small CI-efficiency item from the audit.

`pipelock-security` and `superagent-security` had **no `concurrency` group**, so a rapid re-push during PR iteration left the previous full-repo scan running to completion (~1–1.5 min each) while the new commit's scan started — wasted runner minutes that compound under high daily PR volume.

Added a per-ref `concurrency` group with `cancel-in-progress: true` to both (matching `coverage.yml` and the `content-validation` per-job groups). Both already skip content-only PRs via `paths-ignore`.

actionlint clean. Zero behavior change beyond cancelling stale runs.