### PR TITLE
fix(ci): require fresh Cloudflare preview comments

### DIFF
--- a/scripts/resolve-pr-preview-url.mjs
+++ b/scripts/resolve-pr-preview-url.mjs
@@ -238,11 +238,21 @@ function prNumber(event, env = process.env) {
   return match ? Number(match[1]) : null;
 }
 
+function commentMatchesHeadSha(body, event, env = process.env) {
+  const sha = headSha(event, env).trim().toLowerCase();
+  if (!sha) return true;
+  const normalizedBody = String(body || "").toLowerCase();
+  return [sha, sha.slice(0, 8), sha.slice(0, 7)].some(
+    (candidate) => candidate.length >= 7 && normalizedBody.includes(candidate),
+  );
+}
+
 // Cloudflare Workers Builds publishes per-PR preview URLs ONLY in a pull-request COMMENT (by
 // cloudflare-workers-and-pages[bot]) — never as a GitHub deployment, commit status, or check-run. So the
-// deployment/status/check-run lookups above can never find it; this reads the comment. Prefer the stable
-// "Branch Preview URL" (always points at the latest successful branch deploy, so it's correct even when the
-// PR head is a commit Workers Builds skipped via build-watch-paths) and fall back to the per-commit URL.
+// deployment/status/check-run lookups above can never find it; this reads the comment. Only trust comments
+// that mention the current head SHA so a stale branch-scoped preview from an older deployment cannot satisfy
+// checks for a newer PR head. Prefer the stable "Branch Preview URL" for fresh comments and fall back to the
+// per-commit URL.
 export async function resolveFromPrComments(event, env = process.env) {
   const pr = prNumber(event, env);
   if (!pr) return null;
@@ -259,6 +269,7 @@ export async function resolveFromPrComments(event, env = process.env) {
     if ((comment?.user?.login ?? "") !== "cloudflare-workers-and-pages[bot]")
       continue;
     const body = String(comment.body || "");
+    if (!commentMatchesHeadSha(body, event, env)) continue;
     let match;
     while ((match = anchor.exec(body)) !== null) {
       const url = match[1];

--- a/tests/deployment-preview-url.test.ts
+++ b/tests/deployment-preview-url.test.ts
@@ -331,17 +331,32 @@ describe("resolveFromPrComments — reads the Cloudflare Workers Builds PR comme
     );
   }
 
-  it("prefers the stable Branch Preview URL from the cloudflare bot comment", async () => {
+  it("prefers the stable Branch Preview URL from a fresh cloudflare bot comment", async () => {
     stubComments([
       { user: { login: "someone" }, body: "unrelated" },
       { user: { login: "cloudflare-workers-and-pages[bot]" }, body: cfBody },
     ]);
     expect(
-      await resolveFromPrComments({ pull_request: { number: 4045 } }, env),
+      await resolveFromPrComments(
+        { pull_request: { number: 4045, head: { sha: "def6d9d7abcdef" } } },
+        env,
+      ),
     ).toEqual({
       url: "https://codex-quality-methodology-copy-heyclaude-prod.zeronode.workers.dev",
       source: "cf-comment:branch",
     });
+  });
+
+  it("ignores stale cloudflare bot comments from older PR heads", async () => {
+    stubComments([
+      { user: { login: "cloudflare-workers-and-pages[bot]" }, body: cfBody },
+    ]);
+    expect(
+      await resolveFromPrComments(
+        { pull_request: { number: 4045, head: { sha: "abc1234newhead" } } },
+        env,
+      ),
+    ).toBeNull();
   });
 
   it("falls back to the per-commit Preview URL when no Branch URL is present", async () => {


### PR DESCRIPTION
### Motivation
- The Cloudflare PR-comment resolver previously accepted a branch-scoped "Branch Preview URL" from the Cloudflare bot comment without verifying it corresponded to the current PR head, allowing stale previews to satisfy downstream preview validation.
- The change aims to ensure preview URL selection only accepts comment-derived URLs that reference the current PR head SHA so artifact/MCP checks validate the intended commit.

### Description
- Add `commentMatchesHeadSha(body, event, env)` which returns true only if the comment body mentions the current head SHA (full or 7/8-char prefixes) or when no head SHA is available.
- Require `commentMatchesHeadSha` in `resolveFromPrComments` so comments that do not mention the current PR head are skipped before extracting Branch/Commit Preview URLs.
- Update resolver comments to document the freshness requirement and keep the existing branch-vs-commit preference and host allowlist behavior unchanged.
- Add regression tests in `tests/deployment-preview-url.test.ts` verifying fresh bot comments resolve and stale bot comments are ignored.

### Testing
- Ran `pnpm exec vitest run tests/deployment-preview-url.test.ts --reporter=dot` and the focused test file passed (`17` tests passed).
- Ran `git diff --check` to verify no whitespace/errors were introduced and the repository check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35d1a8134c832c96df4c52ccdbda31)