### PR TITLE
fix(ci): require web vitest suite

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -691,12 +691,13 @@ jobs:
         if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm validate:openapi
 
-      # The full Vitest suite runs once in the `coverage` job (`pnpm test:coverage` = the same `vitest run`,
-      # plus coverage + Codecov upload). Running it again here was pure duplication — ~2 min of identical
-      # work AND a second runner slot held under the Actions concurrency cap, which starves the queue. The
-      # web lane keeps the web-specific gates below (type-check + build); the suite is gated by `coverage`.
-      # (Trunk flaky-test upload also lived here but was token-gated and inert; move it to `coverage` if
-      # flaky detection is ever enabled, so it sits with the one job that runs the suite.) (#dedupe-suite)
+      # Keep the plain Vitest suite in the required web lane. The separate coverage
+      # workflow adds v8 instrumentation and Codecov reporting, but it is intentionally
+      # non-required/informational and must not be the only CI path that exercises
+      # security-sensitive regression tests.
+      - name: Run Vitest suite
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
+        run: pnpm test
 
       # Incremental type-check cache: `tsc --noEmit` (incremental) writes apps/web/.cache/tsc.tsbuildinfo,
       # so a warm run only re-checks changed files (~4x faster locally). Keyed per-sha with a prefix

--- a/tests/submission-workflows.test.ts
+++ b/tests/submission-workflows.test.ts
@@ -213,14 +213,8 @@ describe("submission automation workflows", () => {
 
     expect(source).toContain("validate-worktree:");
     expect(source).toContain('git diff --check "$BASE_SHA"...HEAD');
-    // The full Vitest suite is NOT duplicated in the validate lanes — it runs once in coverage.yml
-    // (pnpm test:coverage); validate-web keeps only the web-specific gates below. (#dedupe-suite)
-    expect(source).not.toContain("Run Vitest suite");
-    const coverageWorkflow = fs.readFileSync(
-      path.join(repoRoot, ".github/workflows/coverage.yml"),
-      "utf8",
-    );
-    expect(coverageWorkflow).toContain("pnpm test:coverage");
+    expect(source).toContain("Run Vitest suite");
+    expect(source).toContain("pnpm test");
     expect(source).toContain("pnpm type-check");
     expect(source).toContain("pnpm build");
     expect(source).not.toContain("pnpm test:e2e");


### PR DESCRIPTION
### Motivation
- The previous change deduplicated the Vitest run by moving the full suite into a non-required `coverage` workflow, which unintentionally let failing web/security regression tests pass required PR validation. 
- Restore the plain Vitest run to the required `validate-web` lane so security-sensitive tests block merges as intended.

### Description
- Re-added a `Run Vitest suite` step (`run: pnpm test`) to `.github/workflows/content-validation.yml` inside the `validate-web` job so the required web lane executes the plain test suite. 
- Replaced the previous dedupe comment block with a short explanation and the actual Vitest step guarded by `if: ${{ needs.classify-pr.outputs.web == 'true' }}`. 
- Updated `tests/submission-workflows.test.ts` to assert the required validation workflow contains `Run Vitest suite` and `pnpm test` instead of asserting the suite only appears in `coverage.yml`.

### Testing
- Ran `pnpm exec vitest run tests/submission-workflows.test.ts --reporter=dot` and the test file passed (68 tests passed). 
- Ran `git diff --check` with no issues reported. 
- Attempted `pnpm exec actionlint .github/workflows/content-validation.yml` but `actionlint` was not available in this environment, so workflow linting could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35d1a73190832c8412dc80c58ec19b)