### PR TITLE
feat(seo): add consolidated citation-facts block to entry pages

### DIFF
--- a/apps/web/src/components/citation-facts.tsx
+++ b/apps/web/src/components/citation-facts.tsx
@@ -1,0 +1,46 @@
+import { entryCitationFacts } from "@heyclaude/registry";
+
+import type { Entry } from "@/types/registry";
+
+// `Robots` is a crawler directive, not a human/AI citation fact — keep it in the
+// machine LLMS endpoint but hide it from the visible block.
+const HIDDEN_LABELS = new Set(["Robots"]);
+const SINGLE_URL = /^https?:\/\/[^\s,]+$/i;
+
+/**
+ * Consolidated, machine-extractable "citation facts" for an entry, rendered as a
+ * definition list. Every value comes from `entryCitationFacts` — the same
+ * registry helper that produces the per-entry LLMS endpoint — so the visible
+ * block and the plain-text endpoint can never drift, and nothing is fabricated.
+ */
+export function CitationFacts({ entry }: { entry: Entry }) {
+  const facts = entryCitationFacts(entry as Parameters<typeof entryCitationFacts>[0]).filter(
+    ([label]) => !HIDDEN_LABELS.has(label),
+  );
+
+  if (facts.length === 0) return null;
+
+  return (
+    <dl className="grid grid-cols-1 gap-x-6 gap-y-2.5 sm:grid-cols-[max-content_minmax(0,1fr)]">
+      {facts.map(([label, value]) => (
+        <div key={label} className="contents">
+          <dt className="font-mono text-xs uppercase tracking-wide text-ink-subtle">{label}</dt>
+          <dd className="min-w-0 break-words text-sm text-ink">
+            {SINGLE_URL.test(value) ? (
+              <a
+                href={value}
+                target="_blank"
+                rel="noreferrer"
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                {value}
+              </a>
+            ) : (
+              value
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -49,6 +49,7 @@ import { HarnessBadge } from "@/components/harness-badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { SourceCitations } from "@/components/source-citations";
+import { CitationFacts } from "@/components/citation-facts";
 import { ProvenanceBlock } from "@/components/provenance-block";
 import { StickyMetaBar } from "@/components/sticky-meta-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
@@ -267,6 +268,7 @@ function Dossier() {
   const tocItems = useMemo<TocItem[]>(() => {
     const items: TocItem[] = [];
     if (risk !== "low") items.push({ id: "risk-callout", label: "Install risk" });
+    items.push({ id: "citation-facts", label: "Citation facts" });
     if (entry.safetyNotes) items.push({ id: "safety", label: "Safety notes" });
     if (entry.privacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
     if (entry.prerequisites && entry.prerequisites.length > 0)
@@ -542,6 +544,20 @@ function Dossier() {
               </div>
             </section>
           )}
+          <DossierSection id="citation-facts" icon={FileText} title="Citation facts">
+            <p className="mb-4 max-w-2xl text-sm text-ink-muted">
+              Source-backed facts for citing this resource, derived directly from the registry —
+              also available as{" "}
+              <a
+                href={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+                className="text-ink underline-offset-2 hover:underline"
+              >
+                plain text
+              </a>{" "}
+              for AI assistants.
+            </p>
+            <CitationFacts entry={entry} />
+          </DossierSection>
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">
               <NoteList value={entry.safetyNotesList ?? [entry.safetyNotes]} />

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -1295,6 +1295,10 @@ export function renderEntryLlms(
   entry: Partial<ContentEntry>,
   params?: Record<string, unknown>,
 ): string;
+export function entryCitationFacts(
+  entry: Partial<ContentEntry>,
+  params?: Record<string, unknown>,
+): Array<[string, string]>;
 export function buildEntryCitationFacts(
   entry: Partial<ContentEntry>,
   params?: Record<string, unknown>,

--- a/packages/registry/src/llms.js
+++ b/packages/registry/src/llms.js
@@ -42,9 +42,11 @@ function sectionText(entry) {
 }
 
 function listValue(values) {
-  const items = Array.isArray(values)
-    ? values.map((value) => clean(value)).filter(Boolean)
-    : [];
+  // Accepts an array (raw entries store notes as YAML lists) or a single string
+  // (the normalized client entry stores `safetyNotes`/`privacyNotes` as strings),
+  // so the same citation-fact builder works on both shapes.
+  const source = Array.isArray(values) ? values : values ? [values] : [];
+  const items = source.map((value) => clean(value)).filter(Boolean);
   return items.length ? items.join(", ") : "";
 }
 
@@ -78,10 +80,18 @@ function entryLastVerified(entry) {
   );
 }
 
-export function buildEntryCitationFacts(entry, params = {}) {
+/**
+ * Per-entry citation facts as ordered `[label, value]` pairs, filtered to
+ * non-empty values. Single source of truth shared by the plain-text LLMS
+ * endpoint (`buildEntryCitationFacts`) and the visible citation-facts block on
+ * entry pages, so the two can never drift. Every value is a real registry
+ * field — nothing is fabricated. Works on raw registry entries (notes as
+ * arrays) and normalized client entries (notes as strings) alike.
+ */
+export function entryCitationFacts(entry, params = {}) {
   const siteUrl = params.siteUrl || "https://heyclau.de";
   const permalink = `${siteUrl.replace(/\/$/, "")}/entry/${entry.category}/${entry.slug}`;
-  const facts = [
+  return [
     ["Canonical URL", permalink],
     ["Source URLs", listValue(entrySourceUrls(entry))],
     ["Brand", clean(entry.brandName)],
@@ -89,8 +99,8 @@ export function buildEntryCitationFacts(entry, params = {}) {
     ["Brand asset source", clean(entry.brandAssetSource)],
     ["Package URL", clean(entry.downloadUrl)],
     ["Package SHA256", clean(entry.downloadSha256)],
-    ["Safety notes", listValue(entry.safetyNotes)],
-    ["Privacy notes", listValue(entry.privacyNotes)],
+    ["Safety notes", listValue(entry.safetyNotesList ?? entry.safetyNotes)],
+    ["Privacy notes", listValue(entry.privacyNotesList ?? entry.privacyNotes)],
     [
       "Platform compatibility",
       listValue(
@@ -109,10 +119,11 @@ export function buildEntryCitationFacts(entry, params = {}) {
     ["License", clean(entry.license)],
     ["Last verified", entryLastVerified(entry)],
     ["Robots", entry.robotsIndex === false ? "noindex" : "indexable"],
-  ];
+  ].filter(([, value]) => value);
+}
 
-  return facts
-    .filter(([, value]) => value)
+export function buildEntryCitationFacts(entry, params = {}) {
+  return entryCitationFacts(entry, params)
     .map(([label, value]) => `- ${label}: ${value}`)
     .join("\n");
 }

--- a/tests/citation-facts.test.ts
+++ b/tests/citation-facts.test.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEntryCitationFacts,
+  entryCitationFacts,
+} from "@heyclaude/registry";
+import { repoRoot } from "./helpers/registry-fixtures";
+
+function facts(entry: Record<string, unknown>) {
+  return new Map(
+    entryCitationFacts(entry as Parameters<typeof entryCitationFacts>[0]),
+  );
+}
+
+describe("entryCitationFacts (shared citation-fact source)", () => {
+  it("derives facts only from real fields — omits absent ones, fabricates nothing", () => {
+    const f = facts({ category: "mcp", slug: "postgres" });
+    expect(f.get("Canonical URL")).toBe(
+      "https://heyclau.de/entry/mcp/postgres",
+    );
+    expect(f.get("Robots")).toBe("indexable");
+    // absent fields are simply not present
+    expect(f.has("Safety notes")).toBe(false);
+    expect(f.has("License")).toBe(false);
+    expect(f.has("Package URL")).toBe(false);
+    // never invents ratings / reviews / aggregate scores
+    expect(f.has("Rating")).toBe(false);
+    expect(f.has("Review")).toBe(false);
+    expect(f.get("Robots")).not.toContain("noindex");
+  });
+
+  it("handles safety/privacy notes as arrays (raw) AND strings (normalized client)", () => {
+    expect(
+      facts({
+        category: "hooks",
+        slug: "a",
+        safetyNotes: ["Runs shell logic", "Network access"],
+      }).get("Safety notes"),
+    ).toBe("Runs shell logic, Network access");
+
+    expect(
+      facts({
+        category: "hooks",
+        slug: "a",
+        safetyNotesList: ["Runs shell logic"],
+        safetyNotes: "Runs shell logic",
+      }).get("Safety notes"),
+    ).toBe("Runs shell logic");
+
+    expect(
+      facts({
+        category: "hooks",
+        slug: "a",
+        privacyNotes: "Sends telemetry to a third party",
+      }).get("Privacy notes"),
+    ).toBe("Sends telemetry to a third party");
+  });
+
+  it("surfaces source / package / verification / platform facts when present", () => {
+    const f = facts({
+      category: "mcp",
+      slug: "y",
+      repoUrl: "https://github.com/x/y",
+      downloadUrl: "https://heyclau.de/downloads/y.mcpb",
+      downloadSha256: "abc123",
+      verifiedAt: "2026-06-01",
+      license: "MIT",
+      platformCompatibility: [
+        { platform: "Claude Code", supportLevel: "full" },
+      ],
+      reviewedBy: "maintainer",
+      robotsIndex: false,
+    });
+    expect(f.get("Source URLs")).toContain("github.com/x/y");
+    expect(f.get("Package URL")).toContain("/downloads/y.mcpb");
+    expect(f.get("Package SHA256")).toBe("abc123");
+    expect(f.get("Last verified")).toBe("2026-06-01");
+    expect(f.get("License")).toBe("MIT");
+    expect(f.get("Platform compatibility")).toBe("Claude Code (full)");
+    expect(f.get("Reviewed by")).toBe("maintainer");
+    expect(f.get("Robots")).toBe("noindex");
+  });
+
+  it("buildEntryCitationFacts is exactly the pairs joined — block and LLMS endpoint cannot drift", () => {
+    const entry = {
+      category: "mcp",
+      slug: "z",
+      repoUrl: "https://github.com/a/b",
+      safetyNotes: ["x"],
+      license: "MIT",
+    };
+    const expected = entryCitationFacts(
+      entry as Parameters<typeof entryCitationFacts>[0],
+    )
+      .map(([label, value]) => `- ${label}: ${value}`)
+      .join("\n");
+    expect(buildEntryCitationFacts(entry as never)).toBe(expected);
+  });
+});
+
+describe("entry page wiring", () => {
+  const src = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/routes/entry.$category.$slug.tsx"),
+    "utf8",
+  );
+
+  it("renders the consolidated CitationFacts block in its own section", () => {
+    expect(src).toContain("CitationFacts");
+    expect(src).toContain('id="citation-facts"');
+    expect(src).toContain('label: "Citation facts"');
+  });
+
+  it("exposes the per-entry LLMS endpoint both as a visible link and a head alternate", () => {
+    expect(src).toContain(
+      "/api/registry/entries/${entry.category}/${entry.slug}/llms",
+    );
+    expect(src).toContain('rel: "alternate"');
+    expect(src).toContain('type: "text/plain"');
+  });
+});


### PR DESCRIPTION
Completes **#3921** — the LLMS head-link landed in #4054 (thanks @jaso0n0818), this adds the remaining deliverables: the **visible citation-facts block** + tests.

## What
- New **"Citation facts"** section on entry pages: a consolidated, machine-extractable `<dl>` of source/package/safety/privacy/platform/verification signals — so humans, search engines, and AI assistants read structured facts instead of scraping prose.
- Surfaces the per-entry **LLMS endpoint** as a visible "plain text" link in the section (complements the `rel="alternate"` head link from #4054).
- Added to the dossier TOC.

## Single source of truth (no drift, no fabrication)
Extracted **`entryCitationFacts()`** in the registry — the *same* function `buildEntryCitationFacts` (the per-entry LLMS endpoint) uses — and render it client-side. So the visible block and the plain-text endpoint are guaranteed consistent. `listValue()` now also accepts the normalized client shape (notes as strings, not just raw arrays) — **additive**, server/LLMS output byte-for-byte unchanged (verified on real data: `buildEntryCitationFacts === entryCitationFacts joined`). Every value is a real registry field; nothing fabricated (no ratings/reviews/scores).

## Tests
`tests/citation-facts.test.ts` (6): fact derivation, both note shapes (array + string), string/LLMS consistency, absent-field omission, and entry-page wiring (block + both LLMS links).

## Validation
type-check clean · `pnpm --filter web build` OK · prettier 3.8.3 + Trunk clean · existing LLMS/registry/seo-jsonld tests unaffected (no regression from the refactor).

Closes #3921.