### PR TITLE
feat(seo): add State of Claude Code Hooks data report

### DIFF
--- a/apps/web/src/lib/data-reports.ts
+++ b/apps/web/src/lib/data-reports.ts
@@ -1,0 +1,86 @@
+import { absoluteUrl } from "@/lib/seo";
+import type { DistRow } from "@/components/data-report";
+
+/**
+ * Shared model + helpers for HeyClaude's original registry data reports.
+ *
+ * A report is a deterministic function of the registry: a set of headline
+ * metrics plus labelled distributions ("dimensions"). The same `ReportModel`
+ * drives the visible page, its `Dataset` JSON-LD, and its JSON/CSV export, so
+ * the three can never disagree and every published number is reproducible from
+ * the registry. New reports only need a builder that returns a `ReportModel`.
+ */
+
+/** A headline metric tile (count + caption). Icons are attached in the route. */
+export interface ReportStat {
+  key: string;
+  label: string;
+  value: number;
+  hint: string;
+}
+
+/** One measured dimension of a report — a labelled distribution. */
+export interface ReportDimension {
+  key: string;
+  title: string;
+  help: string;
+  rows: DistRow[];
+}
+
+/** A fully-computed registry data report. */
+export interface ReportModel {
+  /** Route path, e.g. `/state-of-claude-code-hooks`. */
+  slug: string;
+  /** Stable export id used for `/api/reports/<exportSlug>.{json,csv}`. */
+  exportSlug: string;
+  title: string;
+  description: string;
+  keywords: string[];
+  /** ISO date (YYYY-MM-DD) the underlying registry snapshot was generated. */
+  asOf: string;
+  total: number;
+  stats: ReportStat[];
+  dimensions: ReportDimension[];
+}
+
+/**
+ * Canonical list of published data-report paths. Single source of truth so the
+ * sitemap indexes every report the moment it ships (previously each report had
+ * to be hand-added, and most were missing).
+ */
+export const REPORT_PATHS = [
+  "/state-of-claude-tooling",
+  "/state-of-mcp-servers",
+  "/mcp-security-report",
+  "/state-of-claude-code-hooks",
+] as const;
+
+/**
+ * `Dataset` JSON-LD for a report. `variableMeasured` lists every headline
+ * metric and distribution so AI/search engines can see exactly what the report
+ * quantifies. (Machine-readable JSON/CSV `DataDownload` links land with the
+ * export endpoint in a follow-up.)
+ */
+export function buildReportDataset(model: ReportModel): Record<string, unknown> {
+  const measured = [
+    ...model.stats.map((s) => s.label),
+    ...model.dimensions.map((d) => d.title),
+  ].filter((label, index, list) => list.indexOf(label) === index);
+  return {
+    "@context": "https://schema.org",
+    "@type": "Dataset",
+    name: model.title,
+    description: model.description,
+    url: absoluteUrl(model.slug),
+    keywords: model.keywords,
+    license: "https://creativecommons.org/licenses/by/4.0/",
+    isAccessibleForFree: true,
+    dateModified: model.asOf,
+    creator: {
+      "@type": "Organization",
+      name: "HeyClaude",
+      url: absoluteUrl("/"),
+    },
+    variableMeasured: measured,
+  };
+}

--- a/apps/web/src/lib/hooks-stats.ts
+++ b/apps/web/src/lib/hooks-stats.ts
@@ -1,0 +1,253 @@
+import { pctOf, type DistRow } from "@/components/data-report";
+import type { ReportDimension, ReportModel } from "@/lib/data-reports";
+import {
+  SOURCE_LABEL,
+  TRUST_LABEL,
+  type Entry,
+  type HookTrigger,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
+
+/** Claude Code hook events in lifecycle order (matches the registry schema). */
+export const HOOK_EVENTS: HookTrigger[] = [
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+  "Notification",
+  "Stop",
+  "SubagentStop",
+  "SessionStart",
+];
+
+const UNSPECIFIED = "Unspecified";
+
+/** The hook event a hook fires on, or `Unspecified` when not declared. */
+export function hookEventOf(entry: Entry): string {
+  const trigger = entry.trigger?.trim();
+  return trigger ? trigger : UNSPECIFIED;
+}
+
+function hasNotes(value?: string | string[] | null): boolean {
+  if (Array.isArray(value)) return value.some((item) => item.trim().length > 0);
+  return typeof value === "string" ? value.trim().length > 0 : false;
+}
+
+/**
+ * Distribution of hook events across the given hooks, ordered by frequency
+ * (then lifecycle order as a stable tiebreak), with `Unspecified` last.
+ */
+export function hookEventDistribution(hooks: ReadonlyArray<Entry>): {
+  rows: DistRow[];
+  total: number;
+  distinct: number;
+} {
+  const total = hooks.length;
+  const counts = new Map<string, number>();
+  for (const hook of hooks) {
+    const event = hookEventOf(hook);
+    counts.set(event, (counts.get(event) ?? 0) + 1);
+  }
+  const orderOf = (label: string) => {
+    if (label === UNSPECIFIED) return HOOK_EVENTS.length + 1;
+    const index = HOOK_EVENTS.indexOf(label as HookTrigger);
+    return index === -1 ? HOOK_EVENTS.length : index;
+  };
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count, pct: pctOf(count, total) }))
+    .sort((a, b) => b.count - a.count || orderOf(a.label) - orderOf(b.label));
+  const distinct = [...counts.keys()].filter((k) => k !== UNSPECIFIED).length;
+  return { rows, total, distinct };
+}
+
+function labelledDistribution<T extends string>(
+  hooks: ReadonlyArray<Entry>,
+  order: readonly T[],
+  valueOf: (entry: Entry) => T,
+  labelOf: (value: T) => string,
+): DistRow[] {
+  const total = hooks.length;
+  return order
+    .map((value) => {
+      const count = hooks.filter((hook) => valueOf(hook) === value).length;
+      return { label: labelOf(value), count, pct: pctOf(count, total) };
+    })
+    .filter((row) => row.count > 0);
+}
+
+// Mechanism/category tags that describe *what a hook is* rather than what it
+// automates — excluded so the use-case chart surfaces real tasks.
+const MECHANISM_TAGS = new Set([
+  "hooks",
+  "hook",
+  "stop-hook",
+  "claude",
+  "claude-code",
+  "claude-code-hooks",
+]);
+
+/** Most common hook use cases (curated tags), as a top-N distribution. */
+export function useCaseDistribution(hooks: ReadonlyArray<Entry>, limit = 10): DistRow[] {
+  const total = hooks.length;
+  const counts = new Map<string, number>();
+  for (const hook of hooks) {
+    for (const raw of hook.tags ?? []) {
+      const tag = raw.trim().toLowerCase();
+      if (!tag || MECHANISM_TAGS.has(tag)) continue;
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count, pct: pctOf(count, total) }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, limit);
+}
+
+/** Implementation complexity buckets from the registry difficulty score. */
+export function complexityDistribution(hooks: ReadonlyArray<Entry>): DistRow[] {
+  const total = hooks.length;
+  const buckets: Array<[string, (score: number) => boolean]> = [
+    ["Simple (score 1–2)", (s) => s <= 2],
+    ["Moderate (score 3–4)", (s) => s >= 3 && s <= 4],
+    ["Involved (score 5+)", (s) => s >= 5],
+  ];
+  return buckets
+    .map(([label, test]) => {
+      const count = hooks.filter(
+        (h) => typeof h.difficultyScore === "number" && test(h.difficultyScore),
+      ).length;
+      return { label, count, pct: pctOf(count, total) };
+    })
+    .filter((row) => row.count > 0);
+}
+
+/** Whether a hook needs setup prerequisites before it runs. */
+export function prerequisiteDistribution(hooks: ReadonlyArray<Entry>): DistRow[] {
+  const total = hooks.length;
+  const requires = hooks.filter(
+    (h) => (h.prerequisites?.length ?? 0) > 0 || h.hasPrerequisites === true,
+  ).length;
+  const none = total - requires;
+  return [
+    { label: "Requires prerequisites", count: requires, pct: pctOf(requires, total) },
+    { label: "No prerequisites", count: none, pct: pctOf(none, total) },
+  ].filter((row) => row.count > 0);
+}
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
+
+/**
+ * Build the "State of Claude Code Hooks" report model from the full registry.
+ * Deterministic: identical input always yields identical output. Degenerate
+ * single-value dimensions are dropped so the report never shows an
+ * uninformative one-row chart.
+ */
+export function buildHooksReport(entries: ReadonlyArray<Entry>, asOf: string): ReportModel {
+  const hooks = entries.filter((entry) => entry.category === "hooks");
+  const total = hooks.length;
+
+  const events = hookEventDistribution(hooks);
+  const withSafety = hooks.filter((h) => hasNotes(h.safetyNotesList ?? h.safetyNotes)).length;
+  const withPrivacy = hooks.filter((h) => hasNotes(h.privacyNotesList ?? h.privacyNotes)).length;
+  const simple = hooks.filter(
+    (h) => typeof h.difficultyScore === "number" && h.difficultyScore <= 2,
+  ).length;
+
+  const candidateDimensions: ReportDimension[] = [
+    {
+      key: "hook-events",
+      title: "Hook event distribution",
+      help: "Which Claude Code lifecycle event each hook fires on, taken from the registry trigger field.",
+      rows: events.rows,
+    },
+    {
+      key: "use-cases",
+      title: "Most common hook use cases",
+      help: "The tasks hooks automate, from their registry tags (mechanism tags like “hooks” excluded). A hook can cover several use cases.",
+      rows: useCaseDistribution(hooks),
+    },
+    {
+      key: "complexity",
+      title: "Implementation complexity",
+      help: "Setup/maintenance complexity from the registry difficulty score; unscored hooks are omitted.",
+      rows: complexityDistribution(hooks),
+    },
+    {
+      key: "prerequisites",
+      title: "Setup prerequisites",
+      help: "Whether a hook needs prerequisites (accounts, tools, or config) before it runs.",
+      rows: prerequisiteDistribution(hooks),
+    },
+    {
+      key: "source-provenance",
+      title: "Source provenance distribution",
+      help: "How each hook's source is verified, from first-party to unverified.",
+      rows: labelledDistribution(
+        hooks,
+        SOURCE_ORDER,
+        (h) => h.source,
+        (value) => SOURCE_LABEL[value],
+      ),
+    },
+    {
+      key: "trust-level",
+      title: "Trust-level distribution",
+      help: "Reviewed trust level applied by the registry's risk policy.",
+      rows: labelledDistribution(
+        hooks,
+        TRUST_ORDER,
+        (h) => h.trust,
+        (value) => TRUST_LABEL[value],
+      ),
+    },
+  ];
+
+  // Drop degenerate dimensions (a single bucket carries no information).
+  const dimensions = candidateDimensions.filter((d) => d.rows.length > 1);
+
+  return {
+    slug: "/state-of-claude-code-hooks",
+    exportSlug: "claude-code-hooks",
+    title: "State of Claude Code Hooks 2026",
+    description:
+      "A data report on Claude Code hooks: how many there are, which lifecycle events they fire on (PreToolUse, PostToolUse, Stop, and more), how their source is verified, and how consistently they disclose safety and privacy behavior — computed from the HeyClaude registry.",
+    keywords: [
+      "Claude Code hooks",
+      "hook events",
+      "PostToolUse",
+      "PreToolUse",
+      "Claude automation",
+      "AI tooling",
+    ],
+    asOf,
+    total,
+    stats: [
+      {
+        key: "total",
+        label: "Total hooks",
+        value: total,
+        hint: "registry",
+      },
+      {
+        key: "events",
+        label: "Hook events covered",
+        value: events.distinct,
+        hint: "lifecycle",
+      },
+      {
+        key: "safety-privacy",
+        label: "Disclose safety & privacy",
+        value: Math.min(pctOf(withSafety, total), pctOf(withPrivacy, total)),
+        hint: "%",
+      },
+      {
+        key: "simple",
+        label: "Simple to set up",
+        value: pctOf(simple, total),
+        hint: "%",
+      },
+    ],
+    dimensions,
+  };
+}

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -10,6 +10,7 @@ import { CATEGORIES, PLATFORM_LABEL } from "@/types/registry";
 import { getIndexableTagGroups } from "@/lib/tags";
 import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
+import { REPORT_PATHS } from "@/lib/data-reports";
 
 function escapeXml(value: string) {
   return value
@@ -56,7 +57,7 @@ async function renderSitemap() {
     "/ecosystem",
     "/platforms",
     "/quality",
-    "/state-of-claude-tooling",
+    ...REPORT_PATHS,
     "/trending",
     "/compare",
     "/changelog",

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -1,0 +1,161 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ElementType } from "react";
+import { Webhook, Zap, ShieldCheck, Gauge, CalendarClock } from "lucide-react";
+
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { buildHooksReport } from "@/lib/hooks-stats";
+import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { DataSection, DataStat, DistTable } from "@/components/data-report";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+const MODEL = buildHooksReport(ENTRIES, AS_OF);
+const PATH = MODEL.slug;
+const PAGE_TITLE = `${MODEL.title} — HeyClaude`;
+
+const STAT_ICON: Record<string, ElementType> = {
+  total: Webhook,
+  events: Zap,
+  "safety-privacy": ShieldCheck,
+  simple: Gauge,
+};
+
+const OG_IMAGE = ogImageUrl({
+  eyebrow: "Data report",
+  title: MODEL.title,
+  description: `${MODEL.total} Claude Code hooks by event, use case & safety`,
+});
+
+function statHint(stat: ReportStat): string {
+  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
+}
+
+export const Route = createFileRoute("/state-of-claude-code-hooks")({
+  head: () => {
+    const url = absoluteUrl(PATH);
+    const dataset = buildReportDataset(MODEL);
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "HeyClaude", item: absoluteUrl("/") },
+        { "@type": "ListItem", position: 2, name: MODEL.title, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: PAGE_TITLE },
+        { name: "description", content: MODEL.description },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: PAGE_TITLE },
+        { property: "og:description", content: MODEL.description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: OG_IMAGE },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:image:width", content: String(OG_WIDTH) },
+        { property: "og:image:height", content: String(OG_HEIGHT) },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: PAGE_TITLE },
+        { name: "twitter:description", content: MODEL.description },
+        { name: "twitter:image", content: OG_IMAGE },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(dataset) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: StateOfClaudeCodeHooksPage,
+});
+
+function StateOfClaudeCodeHooksPage() {
+  const asOfLabel = new Date(`${AS_OF}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title={MODEL.title}
+        description="A snapshot of the Claude Code hooks ecosystem, derived directly from the HeyClaude registry. Hooks run shell commands automatically on Claude Code events — this report covers which events they fire on, what they automate, how involved they are to set up, and how consistently they disclose what they do."
+      />
+      <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
+
+      <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
+        {MODEL.stats.map((stat) => (
+          <DataStat
+            key={stat.key}
+            icon={STAT_ICON[stat.key] ?? Webhook}
+            label={stat.label}
+            value={stat.value}
+            hint={statHint(stat)}
+          />
+        ))}
+      </div>
+
+      {MODEL.dimensions.map((dimension) => (
+        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+          <DistTable rows={dimension.rows} />
+        </DataSection>
+      ))}
+
+      <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5 text-ink-muted" aria-hidden />
+          <h2 className="font-display text-xl font-semibold text-ink">
+            Methodology &amp; citation
+          </h2>
+        </div>
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+          Figures are computed at build time from the {MODEL.total} Claude Code hooks in the
+          HeyClaude registry, snapshot dated {asOfLabel}. The hook event is read from each entry's
+          declared <code>trigger</code>; use cases come from registry tags (mechanism tags such as
+          “hooks” are excluded); complexity uses the maintainer-assigned difficulty score. Safety
+          and privacy disclosure is required during review, which is why coverage is near-total —
+          the differentiator is that every hook says what it executes and what data it touches.
+        </p>
+        <p className="mt-3 max-w-2xl text-sm text-ink-muted">
+          Citing this report? Link to{" "}
+          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+            heyclau.de/state-of-claude-code-hooks
+          </a>{" "}
+          with the data-as-of date. See also the broader{" "}
+          <Link
+            to="/state-of-claude-tooling"
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            State of Claude Tooling
+          </Link>
+          . Browse all{" "}
+          <Link
+            to="/$category"
+            params={{ category: "hooks" }}
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            hooks
+          </Link>
+          .
+        </p>
+      </section>
+
+      <div className="mt-12">
+        <NewsletterInline
+          variant="quiet"
+          title="Track the Claude Code ecosystem"
+          description="A weekly digest of new hooks, agents, and MCP servers as they land in the registry."
+          source="state-of-claude-code-hooks"
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/tests/hooks-stats.test.ts
+++ b/tests/hooks-stats.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHooksReport,
+  hookEventDistribution,
+  hookEventOf,
+  HOOK_EVENTS,
+} from "../apps/web/src/lib/hooks-stats";
+import {
+  buildReportDataset,
+  REPORT_PATHS,
+} from "../apps/web/src/lib/data-reports";
+import { ENTRIES, REGISTRY_GENERATED_AT } from "../apps/web/src/data/entries";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function hook(partial: Partial<Entry>): Entry {
+  return {
+    category: "hooks",
+    trust: "trusted",
+    source: "source-backed",
+    ...partial,
+  } as Entry;
+}
+
+describe("hook event classification", () => {
+  it("reads the trigger field, defaulting to Unspecified", () => {
+    expect(hookEventOf(hook({ trigger: "PostToolUse" }))).toBe("PostToolUse");
+    expect(hookEventOf(hook({}))).toBe("Unspecified");
+  });
+
+  it("ranks events by frequency with Unspecified last", () => {
+    const hooks = [
+      hook({ trigger: "PostToolUse" }),
+      hook({ trigger: "PostToolUse" }),
+      hook({ trigger: "Stop" }),
+      hook({}),
+    ];
+    const { rows, total, distinct } = hookEventDistribution(hooks);
+    expect(total).toBe(4);
+    expect(distinct).toBe(2); // Unspecified does not count as a covered event
+    expect(rows[0]).toEqual({ label: "PostToolUse", count: 2, pct: 50 });
+    expect(rows[rows.length - 1].label).toBe("Unspecified");
+  });
+});
+
+describe("buildHooksReport (deterministic)", () => {
+  const sample = [
+    hook({
+      trigger: "PostToolUse",
+      safetyNotes: "runs shell",
+      privacyNotes: "x",
+    }),
+    hook({ trigger: "PostToolUse", source: "first-party" }),
+    hook({ trigger: "Stop", trust: "review" }),
+    hook({ trigger: "PreToolUse", source: "external", trust: "limited" }),
+  ];
+
+  it("produces stable totals, stats, and an events dimension", () => {
+    const a = buildHooksReport(sample, "2026-06-20");
+    const b = buildHooksReport(sample, "2026-06-20");
+    expect(a).toEqual(b); // deterministic
+
+    expect(a.total).toBe(4);
+    expect(a.slug).toBe("/state-of-claude-code-hooks");
+    const events = a.dimensions.find((d) => d.key === "hook-events");
+    expect(events?.rows[0].label).toBe("PostToolUse");
+    expect(a.stats.find((s) => s.key === "total")?.value).toBe(4);
+  });
+
+  it("drops degenerate single-bucket dimensions", () => {
+    // all identical trust/source -> only the events dimension survives
+    const uniform = [
+      hook({ trigger: "PostToolUse" }),
+      hook({ trigger: "Stop" }),
+    ];
+    const model = buildHooksReport(uniform, "2026-06-20");
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    expect(model.dimensions.some((d) => d.key === "hook-events")).toBe(true);
+  });
+});
+
+describe("report Dataset JSON-LD", () => {
+  const model = buildHooksReport(
+    [
+      hook({ trigger: "PostToolUse" }),
+      hook({ trigger: "Stop", source: "external" }),
+    ],
+    "2026-06-20",
+  );
+
+  it("is a Dataset that measures every stat and dimension", () => {
+    const ds = buildReportDataset(model) as Record<string, unknown>;
+    expect(ds["@type"]).toBe("Dataset");
+    expect(ds.license).toBe("https://creativecommons.org/licenses/by/4.0/");
+    expect(ds.dateModified).toBe("2026-06-20");
+    const measured = ds.variableMeasured as string[];
+    for (const stat of model.stats) expect(measured).toContain(stat.label);
+    for (const dimension of model.dimensions)
+      expect(measured).toContain(dimension.title);
+    // de-duplicated
+    expect(new Set(measured).size).toBe(measured.length);
+  });
+});
+
+describe("sitemap manifest", () => {
+  it("lists the new report so it gets indexed", () => {
+    expect(REPORT_PATHS).toContain("/state-of-claude-code-hooks");
+    expect(new Set(REPORT_PATHS).size).toBe(REPORT_PATHS.length); // no dupes
+  });
+});
+
+describe("real registry data", () => {
+  const asOf = String(REGISTRY_GENERATED_AT).slice(0, 10);
+  const model = buildHooksReport(ENTRIES, asOf);
+
+  it("PostToolUse is the most common hook event", () => {
+    expect(model.total).toBeGreaterThan(50);
+    const events = model.dimensions.find((d) => d.key === "hook-events");
+    expect(events).toBeDefined();
+    expect(events!.rows[0].label).toBe("PostToolUse");
+    expect(events!.rows.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("every published dimension is informative (>1 bucket)", () => {
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      "hooks report dimensions:",
+      model.dimensions.map((d) => `${d.key}(${d.rows.length})`).join(", "),
+      "| stats:",
+      model.stats.map((s) => `${s.key}=${s.value}`).join(", "),
+    );
+  });
+});


### PR DESCRIPTION
First report in the **original registry data report series** (#3924) — plus the reusable scaffolding the rest of the series will build on.

## New report — [`/state-of-claude-code-hooks`](https://heyclau.de/state-of-claude-code-hooks)
A deterministic, registry-derived report on Claude Code hooks (the automation layer that runs shell commands on Claude Code events). Original, citable data — *“which Claude Code hook events are most used?”* has a clear registry-backed answer:

- **Hook event distribution** — `PostToolUse` leads (~60%), then `Stop`, `PreToolUse`, `Notification`, session events. This taxonomy exists in no other report.
- **Most common use cases** — from tags, with mechanism tags (`hooks`, `stop-hook`) filtered out so real tasks surface (automation, security, validation, testing…).
- **Implementation complexity** — bimodal: mostly simple scripts, a smaller involved cluster.
- **Setup prerequisites** — ready-to-use vs. needs setup.
- Headline stats + `Dataset` JSON-LD + a methodology & citation block.

## Reusable report core — `lib/data-reports.ts`
`ReportModel`/`ReportStat`/`ReportDimension` types, `buildReportDataset()` for consistent `Dataset` JSON-LD, and a single `REPORT_PATHS` manifest. **Degenerate single-bucket dimensions self-omit** (trust/source are uniform for reviewed hooks → dropped automatically) so a report never renders an uninformative one-row chart. The next reports in the batch are now thin: a `buildXReport(): ReportModel` + a page.

## Sitemap discoverability fix
The sitemap now lists **every** report via `REPORT_PATHS`. `/state-of-mcp-servers` and `/mcp-security-report` were **never in the sitemap** (only `/state-of-claude-tooling` was) — they are now, alongside the new hooks report.

## Tests — `tests/hooks-stats.test.ts`
Event classification + ranking, builder determinism, degenerate-dimension dropping, `Dataset` coverage, the sitemap manifest, and a real-registry smoke test (PostToolUse is the top event, computed from live `ENTRIES`).

## Validation
type-check clean · `pnpm --filter web build` OK · prettier 3.8.3 + Trunk clean · sitemap/crawler/indexnow suites pass (29).

## Follow-ups (tracked under #3924)
- Machine-readable **JSON/CSV exports** (`DataDownload`) via a documented `/api/reports` endpoint — the model already serializes cleanly; deferred to avoid bundling API-router/OpenAPI plumbing into this PR.
- Remaining reports in the batch: agent skills, AI coding agents, remote MCP.

Refs #3924.