### PR TITLE
feat(seo): add State of Agent Skills data report

### DIFF
--- a/apps/web/src/lib/data-reports.ts
+++ b/apps/web/src/lib/data-reports.ts
@@ -1,5 +1,5 @@
 import { absoluteUrl } from "@/lib/seo";
-import type { DistRow } from "@/components/data-report";
+import { pctOf, type DistRow } from "@/components/data-report";
 
 /**
  * Shared model + helpers for HeyClaude's original registry data reports.
@@ -53,6 +53,7 @@ export const REPORT_PATHS = [
   "/state-of-mcp-servers",
   "/mcp-security-report",
   "/state-of-claude-code-hooks",
+  "/state-of-agent-skills",
 ] as const;
 
 /**
@@ -83,4 +84,30 @@ export function buildReportDataset(model: ReportModel): Record<string, unknown> 
     },
     variableMeasured: measured,
   };
+}
+
+/**
+ * Top-N tag distribution over a set of entries — a "what are these for" chart.
+ * Tags in `exclude` (mechanism/category tags such as the category name) are
+ * filtered out so genuine use cases surface. An entry can match several tags,
+ * so percentages are share-of-entries-tagged and need not sum to 100.
+ */
+export function tagDistribution(
+  entries: ReadonlyArray<{ tags?: string[] }>,
+  options: { exclude?: ReadonlySet<string>; limit?: number } = {},
+): DistRow[] {
+  const { exclude, limit = 10 } = options;
+  const total = entries.length;
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    for (const raw of entry.tags ?? []) {
+      const tag = raw.trim().toLowerCase();
+      if (!tag || exclude?.has(tag)) continue;
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count, pct: pctOf(count, total) }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
+    .slice(0, limit);
 }

--- a/apps/web/src/lib/skills-stats.ts
+++ b/apps/web/src/lib/skills-stats.ts
@@ -1,0 +1,174 @@
+import { pctOf, type DistRow } from "@/components/data-report";
+import { tagDistribution, type ReportDimension, type ReportModel } from "@/lib/data-reports";
+import {
+  type Entry,
+  type SkillLevel,
+  type SkillType,
+  type VerificationStatus,
+} from "@/types/registry";
+
+// Category/mechanism tags that describe *what a skill is* rather than what it
+// does — excluded so the use-case chart surfaces real tasks.
+const MECHANISM_TAGS = new Set([
+  "skills",
+  "skill",
+  "agent-skills",
+  "claude",
+  "claude-code",
+  "anthropic",
+  "agent",
+  "agents",
+]);
+
+const SKILL_TYPE_LABEL: Record<SkillType, string> = {
+  "capability-pack": "Capability pack",
+  general: "General",
+};
+const SKILL_LEVEL_LABEL: Record<SkillLevel, string> = {
+  foundational: "Foundational",
+  advanced: "Advanced",
+  expert: "Expert",
+};
+const VERIFICATION_LABEL: Record<VerificationStatus, string> = {
+  draft: "Draft",
+  validated: "Validated",
+  production: "Production",
+};
+
+const SKILL_TYPE_ORDER: SkillType[] = ["capability-pack", "general"];
+const SKILL_LEVEL_ORDER: SkillLevel[] = ["foundational", "advanced", "expert"];
+const VERIFICATION_ORDER: VerificationStatus[] = ["draft", "validated", "production"];
+
+function labelledDistribution<T extends string>(
+  skills: ReadonlyArray<Entry>,
+  order: readonly T[],
+  valueOf: (entry: Entry) => T | undefined,
+  labelOf: (value: T) => string,
+): DistRow[] {
+  const total = skills.length;
+  return order
+    .map((value) => {
+      const count = skills.filter((skill) => valueOf(skill) === value).length;
+      return { label: labelOf(value), count, pct: pctOf(count, total) };
+    })
+    .filter((row) => row.count > 0);
+}
+
+/**
+ * Build the "State of Agent Skills" report model from the full registry.
+ * Deterministic: identical input always yields identical output. Degenerate
+ * single-value dimensions are dropped so the report never shows an
+ * uninformative one-row chart.
+ */
+export function buildSkillsReport(entries: ReadonlyArray<Entry>, asOf: string): ReportModel {
+  const skills = entries.filter((entry) => entry.category === "skills");
+  const total = skills.length;
+
+  const validated = skills.filter(
+    (s) => s.verificationStatus === "validated" || s.verificationStatus === "production",
+  ).length;
+  const packs = skills.filter((s) => s.skillType === "capability-pack").length;
+  const packageVerified = skills.filter((s) => s.packageVerified).length;
+
+  const candidateDimensions: ReportDimension[] = [
+    {
+      key: "use-cases",
+      title: "Most common skill use cases",
+      help: "The tasks skills give agents, from their registry tags (mechanism tags like “skills” excluded). A skill can cover several use cases.",
+      rows: tagDistribution(skills, { exclude: MECHANISM_TAGS }),
+    },
+    {
+      key: "skill-type",
+      title: "Skill type",
+      help: "Capability packs bundle multiple related abilities; general skills do one focused thing.",
+      rows: labelledDistribution(
+        skills,
+        SKILL_TYPE_ORDER,
+        (s) => s.skillType,
+        (value) => SKILL_TYPE_LABEL[value],
+      ),
+    },
+    {
+      key: "maturity",
+      title: "Maturity level",
+      help: "Author-declared depth, from foundational building blocks to expert workflows.",
+      rows: labelledDistribution(
+        skills,
+        SKILL_LEVEL_ORDER,
+        (s) => s.skillLevel,
+        (value) => SKILL_LEVEL_LABEL[value],
+      ),
+    },
+    {
+      key: "verification",
+      title: "Verification status",
+      help: "How far each skill has progressed through registry review, from draft to production.",
+      rows: labelledDistribution(
+        skills,
+        VERIFICATION_ORDER,
+        (s) => s.verificationStatus,
+        (value) => VERIFICATION_LABEL[value],
+      ),
+    },
+    {
+      key: "packaging",
+      title: "Package verification",
+      help: "Whether a skill ships a maintainer-verified, checksum-pinned package or is installed from source.",
+      rows: [
+        {
+          label: "Verified package",
+          count: packageVerified,
+          pct: pctOf(packageVerified, total),
+        },
+        {
+          label: "Source only",
+          count: total - packageVerified,
+          pct: pctOf(total - packageVerified, total),
+        },
+      ].filter((row) => row.count > 0),
+    },
+  ];
+
+  // Drop degenerate dimensions (a single bucket carries no information).
+  const dimensions = candidateDimensions.filter((d) => d.rows.length > 1);
+
+  return {
+    slug: "/state-of-agent-skills",
+    exportSlug: "agent-skills",
+    title: "State of Agent Skills 2026",
+    description:
+      "A data report on agent skills for Claude and other AI coding agents: how many there are, what they do, whether they are capability packs or focused single-purpose skills, how mature and verified they are, and how they are packaged — computed from the HeyClaude registry.",
+    keywords: [
+      "agent skills",
+      "Claude skills",
+      "capability packs",
+      "AI agent capabilities",
+      "Claude Code",
+      "AI tooling",
+    ],
+    asOf,
+    total,
+    stats: [
+      { key: "total", label: "Total skills", value: total, hint: "registry" },
+      {
+        key: "validated",
+        label: "Validated or production",
+        value: pctOf(validated, total),
+        hint: "%",
+      },
+      {
+        key: "packs",
+        label: "Capability packs",
+        value: pctOf(packs, total),
+        hint: "%",
+      },
+      {
+        key: "packaged",
+        label: "Verified package",
+        value: pctOf(packageVerified, total),
+        hint: "%",
+      },
+    ],
+    dimensions,
+  };
+}

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -1,0 +1,167 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ElementType } from "react";
+import { Sparkles, BadgeCheck, Boxes, ShieldCheck, CalendarClock } from "lucide-react";
+
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { buildSkillsReport } from "@/lib/skills-stats";
+import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { DataSection, DataStat, DistTable } from "@/components/data-report";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+const MODEL = buildSkillsReport(ENTRIES, AS_OF);
+const PATH = MODEL.slug;
+const PAGE_TITLE = `${MODEL.title} — HeyClaude`;
+
+const STAT_ICON: Record<string, ElementType> = {
+  total: Sparkles,
+  validated: BadgeCheck,
+  packs: Boxes,
+  packaged: ShieldCheck,
+};
+
+const OG_IMAGE = ogImageUrl({
+  eyebrow: "Data report",
+  title: MODEL.title,
+  description: `${MODEL.total} agent skills by use case, type & verification`,
+});
+
+function statHint(stat: ReportStat): string {
+  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
+}
+
+export const Route = createFileRoute("/state-of-agent-skills")({
+  head: () => {
+    const url = absoluteUrl(PATH);
+    const dataset = buildReportDataset(MODEL);
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "HeyClaude", item: absoluteUrl("/") },
+        { "@type": "ListItem", position: 2, name: MODEL.title, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: PAGE_TITLE },
+        { name: "description", content: MODEL.description },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: PAGE_TITLE },
+        { property: "og:description", content: MODEL.description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: OG_IMAGE },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:image:width", content: String(OG_WIDTH) },
+        { property: "og:image:height", content: String(OG_HEIGHT) },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: PAGE_TITLE },
+        { name: "twitter:description", content: MODEL.description },
+        { name: "twitter:image", content: OG_IMAGE },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(dataset) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: StateOfAgentSkillsPage,
+});
+
+function StateOfAgentSkillsPage() {
+  const asOfLabel = new Date(`${AS_OF}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title={MODEL.title}
+        description="A snapshot of the agent skills ecosystem, derived directly from the HeyClaude registry. Skills package reusable abilities for Claude and other AI coding agents — this report covers what they do, whether they bundle capabilities, how mature and verified they are, and how they ship."
+      />
+      <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
+
+      <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
+        {MODEL.stats.map((stat) => (
+          <DataStat
+            key={stat.key}
+            icon={STAT_ICON[stat.key] ?? Sparkles}
+            label={stat.label}
+            value={stat.value}
+            hint={statHint(stat)}
+          />
+        ))}
+      </div>
+
+      {MODEL.dimensions.map((dimension) => (
+        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+          <DistTable rows={dimension.rows} />
+        </DataSection>
+      ))}
+
+      <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5 text-ink-muted" aria-hidden />
+          <h2 className="font-display text-xl font-semibold text-ink">
+            Methodology &amp; citation
+          </h2>
+        </div>
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+          Figures are computed at build time from the {MODEL.total} agent skills in the HeyClaude
+          registry, snapshot dated {asOfLabel}. Use cases come from registry tags (mechanism tags
+          such as “skills” are excluded); type, maturity, and verification status are
+          author-declared and confirmed during registry review; package verification reflects a
+          maintainer-checked, checksum-pinned artifact.
+        </p>
+        <p className="mt-3 max-w-2xl text-sm text-ink-muted">
+          Citing this report? Link to{" "}
+          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+            heyclau.de/state-of-agent-skills
+          </a>{" "}
+          with the data-as-of date. See also the{" "}
+          <Link
+            to="/state-of-claude-code-hooks"
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            State of Claude Code Hooks
+          </Link>{" "}
+          and the broader{" "}
+          <Link
+            to="/state-of-claude-tooling"
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            State of Claude Tooling
+          </Link>
+          . Browse all{" "}
+          <Link
+            to="/$category"
+            params={{ category: "skills" }}
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            skills
+          </Link>
+          .
+        </p>
+      </section>
+
+      <div className="mt-12">
+        <NewsletterInline
+          variant="quiet"
+          title="Track the Claude Code ecosystem"
+          description="A weekly digest of new skills, hooks, and MCP servers as they land in the registry."
+          source="state-of-agent-skills"
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/tests/skills-stats.test.ts
+++ b/tests/skills-stats.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSkillsReport } from "../apps/web/src/lib/skills-stats";
+import {
+  buildReportDataset,
+  REPORT_PATHS,
+  tagDistribution,
+} from "../apps/web/src/lib/data-reports";
+import { ENTRIES, REGISTRY_GENERATED_AT } from "../apps/web/src/data/entries";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function skill(partial: Partial<Entry>): Entry {
+  return {
+    category: "skills",
+    trust: "trusted",
+    source: "source-backed",
+    tags: [],
+    ...partial,
+  } as Entry;
+}
+
+describe("tagDistribution", () => {
+  it("ranks tags by frequency and honours the exclude set", () => {
+    const entries = [
+      { tags: ["Testing", "skills"] },
+      { tags: ["testing", "linting"] },
+      { tags: ["skills"] },
+    ];
+    const rows = tagDistribution(entries, {
+      exclude: new Set(["skills"]),
+      limit: 5,
+    });
+    expect(rows[0]).toEqual({ label: "testing", count: 2, pct: 67 });
+    expect(rows.some((r) => r.label === "skills")).toBe(false);
+  });
+});
+
+describe("buildSkillsReport (deterministic)", () => {
+  const sample = [
+    skill({
+      skillType: "capability-pack",
+      skillLevel: "expert",
+      verificationStatus: "validated",
+      packageVerified: true,
+      tags: ["testing"],
+    }),
+    skill({
+      skillType: "general",
+      skillLevel: "advanced",
+      verificationStatus: "draft",
+      tags: ["docs"],
+    }),
+  ];
+
+  it("is stable and reports the right totals/stats", () => {
+    const a = buildSkillsReport(sample, "2026-06-20");
+    const b = buildSkillsReport(sample, "2026-06-20");
+    expect(a).toEqual(b);
+    expect(a.slug).toBe("/state-of-agent-skills");
+    expect(a.total).toBe(2);
+    expect(a.stats.find((s) => s.key === "validated")?.value).toBe(50);
+    expect(a.stats.find((s) => s.key === "packs")?.value).toBe(50);
+  });
+
+  it("drops degenerate single-bucket dimensions", () => {
+    const uniform = [
+      skill({ skillType: "general", tags: ["testing"] }),
+      skill({ skillType: "general", tags: ["docs"] }),
+    ];
+    const model = buildSkillsReport(uniform, "2026-06-20");
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    // skill-type is uniform here -> must be dropped
+    expect(model.dimensions.some((d) => d.key === "skill-type")).toBe(false);
+  });
+});
+
+describe("report Dataset JSON-LD", () => {
+  it("measures every stat and dimension", () => {
+    const model = buildSkillsReport(
+      [
+        skill({ skillType: "capability-pack", tags: ["testing"] }),
+        skill({ skillType: "general", tags: ["docs"] }),
+      ],
+      "2026-06-20",
+    );
+    const ds = buildReportDataset(model) as Record<string, unknown>;
+    expect(ds["@type"]).toBe("Dataset");
+    const measured = ds.variableMeasured as string[];
+    for (const stat of model.stats) expect(measured).toContain(stat.label);
+    for (const dimension of model.dimensions)
+      expect(measured).toContain(dimension.title);
+  });
+});
+
+describe("sitemap manifest", () => {
+  it("lists the new report so it gets indexed", () => {
+    expect(REPORT_PATHS).toContain("/state-of-agent-skills");
+    expect(new Set(REPORT_PATHS).size).toBe(REPORT_PATHS.length);
+  });
+});
+
+describe("real registry data", () => {
+  const asOf = String(REGISTRY_GENERATED_AT).slice(0, 10);
+  const model = buildSkillsReport(ENTRIES, asOf);
+
+  it("covers a substantial skills corpus with informative dimensions", () => {
+    expect(model.total).toBeGreaterThan(50);
+    expect(model.dimensions.length).toBeGreaterThanOrEqual(2);
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      "skills report dimensions:",
+      model.dimensions.map((d) => `${d.key}(${d.rows.length})`).join(", "),
+      "| stats:",
+      model.stats.map((s) => `${s.key}=${s.value}`).join(", "),
+    );
+  });
+});


### PR DESCRIPTION
Second report in the **original registry data report series** (#3924), built on the reusable core from #4065 — demonstrating how cheap new reports now are (a `buildXReport()` + a thin page).

## New report — [`/state-of-agent-skills`](https://heyclau.de/state-of-agent-skills)
Deterministic, registry-derived report on the **174 agent skills** — reusable abilities for Claude and other AI coding agents. **Five informative dimensions**:
- **Most common use cases** (from tags, mechanism tags filtered)
- **Skill type** — capability-pack vs general
- **Maturity level** — foundational / advanced / expert
- **Verification status** — draft / validated / production
- **Package verification** — verified package vs source-only

Headline: **74% validated-or-production**, **63% capability packs**, **39% ship a verified package**. Plus `Dataset` JSON-LD + methodology/citation block.

## Reusable helper added
`tagDistribution()` in `lib/data-reports.ts` — a generic top-N tag chart with a mechanism-tag exclude set, reused here and ready for future reports. Registered in `REPORT_PATHS`, so the sitemap indexes it automatically.

## Tests — `tests/skills-stats.test.ts`
`tagDistribution` ranking/exclusion, builder determinism + stats, degenerate-dimension dropping (uniform `skillType` self-omits), `Dataset` coverage, the sitemap manifest, and a real-registry smoke test (5 dimensions survive on live data).

## Validation
type-check clean · `pnpm --filter web build` OK · prettier 3.8.3 + Trunk clean · hooks + sitemap suites unaffected (18 tests green).

Refs #3924.