### PR TITLE
test(web): add coverage for absoluteUrl seo helper

### DIFF
--- a/tests/seo-absolute-url.test.ts
+++ b/tests/seo-absolute-url.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { absoluteUrl } from "@/lib/seo";
+import { siteConfig } from "@/lib/site";
+
+describe("absoluteUrl", () => {
+  it("resolves an already-absolute path against the configured site origin", () => {
+    expect(absoluteUrl("/browse")).toBe(`${siteConfig.url}/browse`);
+    expect(absoluteUrl("/entry/agents/example")).toBe(
+      `${siteConfig.url}/entry/agents/example`,
+    );
+  });
+
+  it("adds a leading slash to relative paths", () => {
+    expect(absoluteUrl("browse")).toBe(`${siteConfig.url}/browse`);
+  });
+
+  it("treats empty input and the bare root as the site root", () => {
+    expect(absoluteUrl("")).toBe(`${siteConfig.url}/`);
+    expect(absoluteUrl("/")).toBe(`${siteConfig.url}/`);
+  });
+
+  it("preserves trailing slashes, query strings, and fragments", () => {
+    expect(absoluteUrl("/a/b/")).toBe(`${siteConfig.url}/a/b/`);
+    expect(absoluteUrl("/search?q=1#top")).toBe(
+      `${siteConfig.url}/search?q=1#top`,
+    );
+  });
+
+  it("always returns an absolute URL on the configured origin", () => {
+    const origin = new URL(siteConfig.url).origin;
+    for (const path of ["/", "/x", "deep/relative", "/og/agents/slug"]) {
+      expect(new URL(absoluteUrl(path)).origin).toBe(origin);
+    }
+  });
+});


### PR DESCRIPTION
Add unit coverage for `absoluteUrl` from `apps/web/src/lib/seo.ts`. The sibling helper `clampDescription` is already tested in `tests/clamp-description.test.ts`, but `absoluteUrl` — used across the site for canonical links, OG URLs, breadcrumb items, and the new per-entry LLMS alternate link — had no direct test.

## New file: `tests/seo-absolute-url.test.ts`

- Resolves already-absolute paths against the configured site origin.
- Adds a leading slash to relative paths (`browse` → `/browse`).
- Maps empty input and the bare `/` to the site root.
- Preserves trailing slashes, query strings, and fragments.
- Asserts the result is always an absolute URL on the configured origin, regardless of input shape.

Tests reference `siteConfig.url` rather than hard-coding the origin, so they stay correct if the canonical host changes. 5 tests, all green; no source changes.
