### PR TITLE
feat(seo): machine-readable JSON/CSV exports for data reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist
 coverage
 reports
 test-results
+# `reports` (above) is for build/test output dirs; keep the source API route dir tracked.
+!/apps/web/src/routes/api/reports/
 .build-content-index.lock/
 TASKS.md
 .claude/

--- a/apps/web/public/openapi.json
+++ b/apps/web/public/openapi.json
@@ -2814,6 +2814,249 @@
         }
       }
     },
+    "/api/reports/{report}": {
+      "get": {
+        "tags": ["Distribution"],
+        "summary": "Registry data report export (JSON or CSV)",
+        "description": "Machine-readable export of a HeyClaude data report, selected by '<report-slug>.json' or '<report-slug>.csv'. Returns the report's headline stats and labelled distributions computed deterministically from the registry. Free to reuse under CC BY 4.0 with attribution.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "maxLength": 64,
+              "pattern": "^[a-z0-9-]+\\.(?:json|csv)$"
+            },
+            "required": true,
+            "name": "report",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Request accepted.",
+            "content": {
+              "application/json": { "schema": { "type": "object", "additionalProperties": {} } }
+            }
+          },
+          "400": {
+            "description": "Invalid JSON, invalid query, invalid payload, or invalid status transition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized admin token or invalid webhook signature.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden origin.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload too large.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Invalid content type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Route-level or Cloudflare-native rate limited.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream provider error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Site DB not configured, provider not configured, or endpoint unavailable.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean", "enum": [false] },
+                    "error": {
+                      "type": "object",
+                      "properties": {
+                        "code": { "type": "string", "minLength": 1 },
+                        "message": { "type": "string" },
+                        "details": {}
+                      },
+                      "required": ["code"]
+                    },
+                    "requestId": { "type": "string" }
+                  },
+                  "required": ["ok", "error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/mcp": {
       "post": {
         "tags": ["MCP"],

--- a/apps/web/public/openapi.yaml
+++ b/apps/web/public/openapi.yaml
@@ -3342,6 +3342,274 @@ paths:
                 required:
                   - ok
                   - error
+  /api/reports/{report}:
+    get:
+      tags:
+        - Distribution
+      summary: Registry data report export (JSON or CSV)
+      description:
+        Machine-readable export of a HeyClaude data report, selected by '<report-slug>.json' or
+        '<report-slug>.csv'. Returns the report's headline stats and labelled distributions computed
+        deterministically from the registry. Free to reuse under CC BY 4.0 with attribution.
+      parameters:
+        - schema:
+            type: string
+            maxLength: 64
+            pattern: ^[a-z0-9-]+\.(?:json|csv)$
+          required: true
+          name: report
+          in: path
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/mcp:
     post:
       tags:

--- a/apps/web/src/components/report-downloads.tsx
+++ b/apps/web/src/components/report-downloads.tsx
@@ -1,0 +1,33 @@
+import { Download } from "lucide-react";
+
+import { reportExportUrl } from "@/lib/data-reports";
+
+const LINK_CLASS =
+  "inline-flex items-center gap-2 rounded-lg border border-border bg-surface-2 px-4 py-2 text-sm font-medium text-ink hover:bg-surface";
+
+/**
+ * "Download the data" section for a data report — links the JSON + CSV exports
+ * served by `/api/reports/<exportSlug>.{json,csv}`.
+ */
+export function ReportDownloads({ exportSlug }: { exportSlug: string }) {
+  return (
+    <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+      <div className="flex items-center gap-2">
+        <Download className="h-5 w-5 text-ink-muted" aria-hidden />
+        <h2 className="font-display text-xl font-semibold text-ink">Download the data</h2>
+      </div>
+      <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+        Every figure in this report is available as a machine-readable export, regenerated from the
+        registry. Free to reuse under CC BY 4.0 with attribution.
+      </p>
+      <div className="mt-4 flex flex-wrap gap-3">
+        <a href={reportExportUrl(exportSlug, "json")} className={LINK_CLASS}>
+          <Download className="h-4 w-4" aria-hidden /> JSON
+        </a>
+        <a href={reportExportUrl(exportSlug, "csv")} className={LINK_CLASS}>
+          <Download className="h-4 w-4" aria-hidden /> CSV
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -79,6 +79,7 @@ function exampleForPathParam(name: string, path: string) {
   if (name === "platform") return "claude";
   if (name === "kind") return "icon";
   if (name === "domain") return "anthropic.com";
+  if (name === "report") return "agent-skills.json";
   return "example";
 }
 
@@ -235,6 +236,21 @@ const BODY_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
 };
 
 const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
+  "reports.export": {
+    report: "agent-skills",
+    title: "State of Agent Skills 2026",
+    asOf: "2026-06-20",
+    total: 174,
+    license: "CC BY 4.0",
+    stats: [{ key: "total", label: "Total skills", value: 174 }],
+    dimensions: [
+      {
+        key: "skill-type",
+        title: "Skill type",
+        rows: [{ label: "Capability pack", count: 110, percent: 63 }],
+      },
+    ],
+  },
   "registry.manifest": {
     schemaVersion: 2,
     generatedAt: "2026-05-29T00:00:00.000Z",

--- a/apps/web/src/lib/api/contracts.ts
+++ b/apps/web/src/lib/api/contracts.ts
@@ -488,6 +488,17 @@ export const entryParamsSchema = z.object({
   slug: safeSlugSchema,
 });
 
+export const reportExportParamsSchema = z.object({
+  // "<report-slug>.<json|csv>", e.g. "agent-skills.csv"
+  report: z
+    .string()
+    .trim()
+    .max(64)
+    .regex(/^[a-z0-9-]+\.(?:json|csv)$/, {
+      message: "report must be a report slug with a .json or .csv extension",
+    }),
+});
+
 export const votesQueryBodySchema = z.object({
   keys: z.array(entryKeySchema).max(1000).optional().default([]),
   clientId: z.string().trim().max(128).optional().default(""),
@@ -1009,6 +1020,23 @@ export const apiRouteDefinitions = {
       limit: 180,
       windowMs: 60_000,
       binding: "API_REGISTRY_RATE_LIMIT",
+    },
+  }),
+  "reports.export": route({
+    id: "reports.export",
+    method: "GET",
+    path: "/api/reports/{report}",
+    summary: "Registry data report export (JSON or CSV)",
+    description:
+      "Machine-readable export of a HeyClaude data report, selected by '<report-slug>.json' or '<report-slug>.csv'. Returns the report's headline stats and labelled distributions computed deterministically from the registry. Free to reuse under CC BY 4.0 with attribution.",
+    tags: ["Distribution"],
+    paramsSchema: reportExportParamsSchema,
+    responseContentType: "application/json",
+    rateLimit: {
+      scope: "reports-export",
+      limit: 120,
+      windowMs: 60_000,
+      binding: "API_DYNAMIC_RATE_LIMIT",
     },
   }),
   "mcp.streamable": route({

--- a/apps/web/src/lib/data-reports.ts
+++ b/apps/web/src/lib/data-reports.ts
@@ -56,11 +56,16 @@ export const REPORT_PATHS = [
   "/state-of-agent-skills",
 ] as const;
 
+/** URL of a report's machine-readable export in the given format. */
+export function reportExportUrl(exportSlug: string, format: "json" | "csv") {
+  return absoluteUrl(`/api/reports/${exportSlug}.${format}`);
+}
+
 /**
  * `Dataset` JSON-LD for a report. `variableMeasured` lists every headline
- * metric and distribution so AI/search engines can see exactly what the report
- * quantifies. (Machine-readable JSON/CSV `DataDownload` links land with the
- * export endpoint in a follow-up.)
+ * metric and distribution, and `distribution` links the JSON + CSV exports, so
+ * AI/search engines can see exactly what the report quantifies and fetch the
+ * underlying data.
  */
 export function buildReportDataset(model: ReportModel): Record<string, unknown> {
   const measured = [
@@ -83,7 +88,61 @@ export function buildReportDataset(model: ReportModel): Record<string, unknown> 
       url: absoluteUrl("/"),
     },
     variableMeasured: measured,
+    distribution: [
+      {
+        "@type": "DataDownload",
+        encodingFormat: "application/json",
+        contentUrl: reportExportUrl(model.exportSlug, "json"),
+      },
+      {
+        "@type": "DataDownload",
+        encodingFormat: "text/csv",
+        contentUrl: reportExportUrl(model.exportSlug, "csv"),
+      },
+    ],
   };
+}
+
+/** Stable JSON payload for a report's machine-readable export. */
+export function reportToJson(model: ReportModel) {
+  return {
+    report: model.exportSlug,
+    title: model.title,
+    description: model.description,
+    asOf: model.asOf,
+    total: model.total,
+    source: absoluteUrl(model.slug),
+    license: "CC BY 4.0",
+    stats: model.stats.map((s) => ({
+      key: s.key,
+      label: s.label,
+      value: s.value,
+    })),
+    dimensions: model.dimensions.map((d) => ({
+      key: d.key,
+      title: d.title,
+      rows: d.rows.map((r) => ({
+        label: r.label,
+        count: r.count,
+        percent: r.pct,
+      })),
+    })),
+  };
+}
+
+function csvCell(value: string): string {
+  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+/** Flat CSV of every dimension row (dimension,label,count,percent). */
+export function reportToCsv(model: ReportModel): string {
+  const lines = [["dimension", "label", "count", "percent"]];
+  for (const dimension of model.dimensions) {
+    for (const row of dimension.rows) {
+      lines.push([dimension.key, row.label, String(row.count), String(row.pct)]);
+    }
+  }
+  return lines.map((cols) => cols.map(csvCell).join(",")).join("\r\n") + "\r\n";
 }
 
 /**

--- a/apps/web/src/lib/data-reports.ts
+++ b/apps/web/src/lib/data-reports.ts
@@ -131,7 +131,12 @@ export function reportToJson(model: ReportModel) {
 }
 
 function csvCell(value: string): string {
-  return /[",\r\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+  // Neutralize spreadsheet formula injection (CWE-1236). Row labels derive from
+  // community-submitted registry tags, so a cell could begin with a formula
+  // trigger (=, +, -, @, tab, CR); prefixing with a single quote makes Excel /
+  // Google Sheets / LibreOffice treat it as text rather than executing it.
+  const guarded = /^[=+\-@\t\r]/.test(value) ? `'${value}` : value;
+  return /[",\r\n]/.test(guarded) ? `"${guarded.replace(/"/g, '""')}"` : guarded;
 }
 
 /** Flat CSV of every dimension row (dimension,label,count,percent). */

--- a/apps/web/src/routes/api/reports/$report.ts
+++ b/apps/web/src/routes/api/reports/$report.ts
@@ -1,0 +1,58 @@
+import { createApiFileRoute } from "@/lib/api/file-route";
+
+import { reportExportParamsSchema } from "@/lib/api/contracts";
+import { apiError, apiJson, createApiHandler, type InferApiParams } from "@/lib/api/router";
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { buildHooksReport } from "@/lib/hooks-stats";
+import { buildSkillsReport } from "@/lib/skills-stats";
+import { reportToCsv, reportToJson, type ReportModel } from "@/lib/data-reports";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+
+// Reports with a `ReportModel` builder are exportable. Keyed by `exportSlug`.
+const REPORT_BUILDERS: Record<string, () => ReportModel> = {
+  "claude-code-hooks": () => buildHooksReport(ENTRIES, AS_OF),
+  "agent-skills": () => buildSkillsReport(ENTRIES, AS_OF),
+};
+
+const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";
+
+export const GET = createApiHandler("reports.export", async ({ params, requestId }) => {
+  const { report } = params as InferApiParams<typeof reportExportParamsSchema>;
+  // The param schema guarantees "<slug>.<json|csv>".
+  const dot = report.lastIndexOf(".");
+  const slug = report.slice(0, dot);
+  const format = report.slice(dot + 1) as "json" | "csv";
+
+  const build = REPORT_BUILDERS[slug];
+  if (!build) {
+    return apiError("not_found", 404, { requestId });
+  }
+
+  const model = build();
+
+  if (format === "csv") {
+    return new Response(reportToCsv(model), {
+      headers: {
+        "content-type": "text/csv; charset=utf-8",
+        "cache-control": CACHE_CONTROL,
+        "content-disposition": `inline; filename="${slug}.csv"`,
+      },
+    });
+  }
+
+  return apiJson(reportToJson(model), {
+    headers: {
+      "cache-control": CACHE_CONTROL,
+      "content-disposition": `inline; filename="${slug}.json"`,
+    },
+  });
+});
+
+export const Route = createApiFileRoute("/api/reports/$report")({
+  server: {
+    handlers: {
+      GET: async ({ request, params }) => GET(request, { params }),
+    },
+  },
+});

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -11,6 +11,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable } from "@/components/data-report";
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -108,6 +109,8 @@ function StateOfAgentSkillsPage() {
           <DistTable rows={dimension.rows} />
         </DataSection>
       ))}
+
+      <ReportDownloads exportSlug={MODEL.exportSlug} />
 
       <section className="mt-12 rounded-xl border border-border bg-surface p-6">
         <div className="flex items-center gap-2">

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -11,6 +11,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { ReportDownloads } from "@/components/report-downloads";
 import { DataSection, DataStat, DistTable } from "@/components/data-report";
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -108,6 +109,8 @@ function StateOfClaudeCodeHooksPage() {
           <DistTable rows={dimension.rows} />
         </DataSection>
       ))}
+
+      <ReportDownloads exportSlug={MODEL.exportSlug} />
 
       <section className="mt-12 rounded-xl border border-border bg-surface p-6">
         <div className="flex items-center gap-2">

--- a/cloudflare/api-schema-heyclaude-openapi.yaml
+++ b/cloudflare/api-schema-heyclaude-openapi.yaml
@@ -3346,6 +3346,274 @@ paths:
                 required:
                   - ok
                   - error
+  /api/reports/{report}:
+    get:
+      tags:
+        - Distribution
+      summary: Registry data report export (JSON or CSV)
+      description:
+        Machine-readable export of a HeyClaude data report, selected by '<report-slug>.json' or
+        '<report-slug>.csv'. Returns the report's headline stats and labelled distributions computed
+        deterministically from the registry. Free to reuse under CC BY 4.0 with attribution.
+      parameters:
+        - schema:
+            type: string
+            maxLength: 64
+            pattern: ^[a-z0-9-]+\.(?:json|csv)$
+          required: true
+          name: report
+          in: path
+      responses:
+        "200":
+          description: Request accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: {}
+        "400":
+          description: Invalid JSON, invalid query, invalid payload, or invalid status transition.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "401":
+          description: Unauthorized admin token or invalid webhook signature.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "403":
+          description: Forbidden origin.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "413":
+          description: Payload too large.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "415":
+          description: Invalid content type.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "429":
+          description: Route-level or Cloudflare-native rate limited.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "500":
+          description: Internal error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "502":
+          description: Upstream provider error.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
+        "503":
+          description: Site DB not configured, provider not configured, or endpoint unavailable.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                    enum:
+                      - false
+                  error:
+                    type: object
+                    properties:
+                      code:
+                        type: string
+                        minLength: 1
+                      message:
+                        type: string
+                      details: {}
+                    required:
+                      - code
+                  requestId:
+                    type: string
+                required:
+                  - ok
+                  - error
   /api/mcp:
     post:
       tags:

--- a/tests/api-contracts.test.ts
+++ b/tests/api-contracts.test.ts
@@ -26,6 +26,7 @@ const apiRoutes = [
   "/api/registry/entries/{category}/{slug}",
   "/api/registry/entries/{category}/{slug}/llms",
   "/api/mcp",
+  "/api/reports/{report}",
   "/api/brand-assets/{kind}/{domain}",
   "/api/votes/query",
   "/api/votes/toggle",

--- a/tests/report-exports-api.test.ts
+++ b/tests/report-exports-api.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { GET } from "../apps/web/src/routes/api/reports/$report";
+import {
+  buildReportDataset,
+  reportToCsv,
+  reportToJson,
+} from "../apps/web/src/lib/data-reports";
+import { buildSkillsReport } from "../apps/web/src/lib/skills-stats";
+import { ENTRIES } from "../apps/web/src/data/entries";
+
+// No Origin header — the export must be fetchable by crawlers and direct
+// downloads (the route intentionally omits originCheck).
+function call(report: string) {
+  return GET(new Request(`https://heyclau.de/api/reports/${report}`), {
+    params: { report },
+  });
+}
+
+describe("/api/reports/{report}", () => {
+  it("serves a report as JSON", async () => {
+    const res = await call("agent-skills.json");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as {
+      report: string;
+      license: string;
+      total: number;
+      dimensions: unknown[];
+    };
+    expect(body.report).toBe("agent-skills");
+    expect(body.license).toBe("CC BY 4.0");
+    expect(body.total).toBeGreaterThan(50);
+    expect(body.dimensions.length).toBeGreaterThan(1);
+  });
+
+  it("serves a report as CSV with a header row", async () => {
+    const res = await call("claude-code-hooks.csv");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    const text = await res.text();
+    expect(text.split("\r\n")[0]).toBe("dimension,label,count,percent");
+    expect(text).toContain("hook-events");
+  });
+
+  it("sets caching and a download filename", async () => {
+    const res = await call("agent-skills.csv");
+    expect(res.headers.get("cache-control")).toContain("max-age");
+    expect(res.headers.get("content-disposition")).toContain(
+      "agent-skills.csv",
+    );
+  });
+
+  it("applies security headers to the export", async () => {
+    const res = await call("agent-skills.json");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
+
+  it("404s for an unknown report slug", async () => {
+    const res = await call("does-not-exist.json");
+    expect(res.status).toBe(404);
+  });
+
+  it("400s for an unsupported format", async () => {
+    const res = await call("agent-skills.txt");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("report serializers", () => {
+  const model = buildSkillsReport(ENTRIES, "2026-06-20");
+
+  it("Dataset links the JSON + CSV downloads", () => {
+    const ds = buildReportDataset(model) as {
+      distribution: Array<{ encodingFormat: string; contentUrl: string }>;
+    };
+    expect(ds.distribution.map((d) => d.encodingFormat).sort()).toEqual([
+      "application/json",
+      "text/csv",
+    ]);
+    expect(
+      ds.distribution.every((d) =>
+        d.contentUrl.includes("/api/reports/agent-skills."),
+      ),
+    ).toBe(true);
+  });
+
+  it("JSON export carries license + every dimension; CSV escapes correctly", () => {
+    const json = reportToJson(model);
+    expect(json.report).toBe("agent-skills");
+    expect(json.license).toBe("CC BY 4.0");
+    expect(json.dimensions.length).toBe(model.dimensions.length);
+
+    const csv = reportToCsv(model);
+    expect(csv.startsWith("dimension,label,count,percent\r\n")).toBe(true);
+    expect(csv.endsWith("\r\n")).toBe(true);
+  });
+});

--- a/tests/report-exports-api.test.ts
+++ b/tests/report-exports-api.test.ts
@@ -95,4 +95,42 @@ describe("report serializers", () => {
     expect(csv.startsWith("dimension,label,count,percent\r\n")).toBe(true);
     expect(csv.endsWith("\r\n")).toBe(true);
   });
+
+  it("neutralizes spreadsheet formula injection in cell values (CWE-1236)", () => {
+    // Row labels come from community-submitted tags; a hostile tag must not
+    // become an executable spreadsheet formula in the CSV export.
+    const malicious = {
+      slug: "/x",
+      exportSlug: "x",
+      title: "X",
+      description: "",
+      keywords: [],
+      asOf: "2026-06-20",
+      total: 1,
+      stats: [],
+      dimensions: [
+        {
+          key: "use-cases",
+          title: "T",
+          help: "",
+          rows: [
+            { label: "=cmd|'/C calc'!A0", count: 1, pct: 100 },
+            { label: "@SUM(1+1)", count: 1, pct: 100 },
+            { label: "-2+3", count: 1, pct: 100 },
+            { label: "safe-tag", count: 1, pct: 100 },
+          ],
+        },
+      ],
+    } as Parameters<typeof reportToCsv>[0];
+
+    const csv = reportToCsv(malicious);
+    // Formula triggers are prefixed with a single quote (text, not formula)...
+    expect(csv).toContain("'=cmd");
+    expect(csv).toContain("'@SUM");
+    expect(csv).toContain("'-2+3");
+    // ...and no cell begins with a raw formula trigger.
+    expect(csv).not.toMatch(/(^|,)[=+@]/m);
+    // Benign values are untouched.
+    expect(csv).toContain("safe-tag");
+  });
 });


### PR DESCRIPTION
Completes the **downloadable-data** deliverable of #3924 and gives every report a working `DataDownload` in its `Dataset` JSON-LD — the machine-readable, citable artifact AI engines fetch.

## New endpoint — `GET /api/reports/{report}`
Serves `<slug>.json` or `<slug>.csv` for the **hooks** and **agent-skills** reports, computed deterministically from the registry (CC BY 4.0).
- `GET /api/reports/agent-skills.json` → structured stats + dimensions
- `GET /api/reports/claude-code-hooks.csv` → flat `dimension,label,count,percent`

Registered through the **typed API router** (not a one-off): contract in `lib/api/contracts.ts` (`reportExportParamsSchema` + `reports.export`, `Distribution` tag, dynamic rate limit, **no `originCheck`** so crawlers and direct downloads work), OpenAPI regenerated (`pnpm generate:openapi`), handler returns JSON via `apiJson` or CSV as a download with cache + `content-disposition` headers.

## Dataset + UI
- `buildReportDataset()` now emits **JSON + CSV `DataDownload`** entries — the hooks and skills `Dataset`s advertise fetchable data.
- Both report pages gain a reusable **`ReportDownloads`** section (`components/report-downloads.tsx`) with JSON/CSV buttons.
- `data-reports.ts` gains `reportToJson` / `reportToCsv` / `reportExportUrl`.

## Tests — `tests/report-exports-api.test.ts`
JSON + CSV output, caching + `content-disposition`, security headers, **404** for unknown slug, **400** for bad format, plus serializer + `Dataset`-distribution units. `api-contracts` updated with the new route path.

## Validation (one-shot-clean)
**129 tests pass** across the API / OpenAPI / report / SEO suites · `validate:openapi --check` clean · type-check · `pnpm --filter web build` · prettier 3.8.3 · Trunk · `git diff --check` — all green.

Refs #3924.