### PR TITLE
feat(seo): add State of AI Agents data report

### DIFF
--- a/apps/web/src/lib/agents-stats.ts
+++ b/apps/web/src/lib/agents-stats.ts
@@ -1,0 +1,163 @@
+import { pctOf, type DistRow } from "@/components/data-report";
+import { tagDistribution, type ReportDimension, type ReportModel } from "@/lib/data-reports";
+import {
+  SOURCE_LABEL,
+  TRUST_LABEL,
+  type Entry,
+  type SourceStatus,
+  type TrustLevel,
+} from "@/types/registry";
+
+// Category/mechanism tags that describe *what an agent is* rather than what it
+// does — excluded so the use-case chart surfaces real tasks.
+const MECHANISM_TAGS = new Set([
+  "agents",
+  "agent",
+  "subagent",
+  "subagents",
+  "claude",
+  "claude-code",
+]);
+
+const TRUST_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+const SOURCE_ORDER: SourceStatus[] = ["first-party", "source-backed", "external", "unverified"];
+
+function hasNotes(value?: string | string[] | null): boolean {
+  if (Array.isArray(value)) return value.some((item) => item.trim().length > 0);
+  return typeof value === "string" ? value.trim().length > 0 : false;
+}
+
+function labelledDistribution<T extends string>(
+  agents: ReadonlyArray<Entry>,
+  order: readonly T[],
+  valueOf: (entry: Entry) => T | undefined,
+  labelOf: (value: T) => string,
+): DistRow[] {
+  const total = agents.length;
+  return order
+    .map((value) => {
+      const count = agents.filter((agent) => valueOf(agent) === value).length;
+      return { label: labelOf(value), count, pct: pctOf(count, total) };
+    })
+    .filter((row) => row.count > 0);
+}
+
+/**
+ * Build the "State of AI Agents" report model from the full registry.
+ * Deterministic: identical input always yields identical output. Degenerate
+ * single-value dimensions are dropped so the report never shows an
+ * uninformative one-row chart.
+ */
+export function buildAgentsReport(entries: ReadonlyArray<Entry>, asOf: string): ReportModel {
+  const agents = entries.filter((entry) => entry.category === "agents");
+  const total = agents.length;
+
+  const hasSafety = (a: Entry) => hasNotes(a.safetyNotesList ?? a.safetyNotes);
+  const hasPrivacy = (a: Entry) => hasNotes(a.privacyNotesList ?? a.privacyNotes);
+  const both = agents.filter((a) => hasSafety(a) && hasPrivacy(a)).length;
+  const safetyOnly = agents.filter((a) => hasSafety(a) && !hasPrivacy(a)).length;
+  const privacyOnly = agents.filter((a) => !hasSafety(a) && hasPrivacy(a)).length;
+  const neither = total - both - safetyOnly - privacyOnly;
+
+  const requires = agents.filter(
+    (a) => (a.prerequisites?.length ?? 0) > 0 || a.hasPrerequisites === true,
+  ).length;
+  const ready = total - requires;
+  const sourceBacked = agents.filter(
+    (a) => a.source === "source-backed" || a.source === "first-party",
+  ).length;
+
+  const candidateDimensions: ReportDimension[] = [
+    {
+      key: "use-cases",
+      title: "Most common agent use cases",
+      help: "The work agents take on, from their registry tags (mechanism tags like “agents” excluded). An agent can cover several use cases.",
+      rows: tagDistribution(agents, { exclude: MECHANISM_TAGS }),
+    },
+    {
+      key: "disclosure",
+      title: "Safety & privacy disclosure",
+      help: "Agents act with real autonomy, so disclosure matters. How many document both their safety and privacy behavior, one, or neither.",
+      rows: [
+        { label: "Safety & privacy", count: both, pct: pctOf(both, total) },
+        { label: "Safety only", count: safetyOnly, pct: pctOf(safetyOnly, total) },
+        { label: "Privacy only", count: privacyOnly, pct: pctOf(privacyOnly, total) },
+        { label: "Neither documented", count: neither, pct: pctOf(neither, total) },
+      ].filter((row) => row.count > 0),
+    },
+    {
+      key: "prerequisites",
+      title: "Setup prerequisites",
+      help: "Whether an agent needs prerequisites (accounts, tools, or config) before it runs.",
+      rows: [
+        { label: "Requires prerequisites", count: requires, pct: pctOf(requires, total) },
+        { label: "No prerequisites", count: ready, pct: pctOf(ready, total) },
+      ].filter((row) => row.count > 0),
+    },
+    {
+      key: "source-provenance",
+      title: "Source provenance distribution",
+      help: "How each agent's source is verified, from first-party to unverified.",
+      rows: labelledDistribution(
+        agents,
+        SOURCE_ORDER,
+        (a) => a.source,
+        (value) => SOURCE_LABEL[value],
+      ),
+    },
+    {
+      key: "trust-level",
+      title: "Trust-level distribution",
+      help: "Reviewed trust level applied by the registry's risk policy.",
+      rows: labelledDistribution(
+        agents,
+        TRUST_ORDER,
+        (a) => a.trust,
+        (value) => TRUST_LABEL[value],
+      ),
+    },
+  ];
+
+  // Drop degenerate dimensions (a single bucket carries no information).
+  const dimensions = candidateDimensions.filter((d) => d.rows.length > 1);
+
+  return {
+    slug: "/state-of-ai-agents",
+    exportSlug: "ai-agents",
+    title: "State of AI Agents 2026",
+    description:
+      "A data report on AI agents for Claude and coding workflows: how many there are, what work they take on, how consistently they disclose safety and privacy behavior, what setup they need, and how their source is verified — computed from the HeyClaude registry.",
+    keywords: [
+      "AI agents",
+      "Claude agents",
+      "Claude Code subagents",
+      "autonomous agents",
+      "AI coding agents",
+      "AI tooling",
+    ],
+    asOf,
+    total,
+    stats: [
+      { key: "total", label: "Total agents", value: total, hint: "registry" },
+      {
+        key: "documented",
+        label: "Document safety & privacy",
+        value: pctOf(both, total),
+        hint: "%",
+      },
+      {
+        key: "source-backed",
+        label: "Source-backed",
+        value: pctOf(sourceBacked, total),
+        hint: "%",
+      },
+      {
+        key: "ready",
+        label: "Ready to use",
+        value: pctOf(ready, total),
+        hint: "%",
+      },
+    ],
+    dimensions,
+  };
+}

--- a/apps/web/src/lib/data-reports.ts
+++ b/apps/web/src/lib/data-reports.ts
@@ -54,6 +54,7 @@ export const REPORT_PATHS = [
   "/mcp-security-report",
   "/state-of-claude-code-hooks",
   "/state-of-agent-skills",
+  "/state-of-ai-agents",
 ] as const;
 
 /** URL of a report's machine-readable export in the given format. */

--- a/apps/web/src/routes/api/reports/$report.ts
+++ b/apps/web/src/routes/api/reports/$report.ts
@@ -5,6 +5,7 @@ import { apiError, apiJson, createApiHandler, type InferApiParams } from "@/lib/
 import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { buildHooksReport } from "@/lib/hooks-stats";
 import { buildSkillsReport } from "@/lib/skills-stats";
+import { buildAgentsReport } from "@/lib/agents-stats";
 import { reportToCsv, reportToJson, type ReportModel } from "@/lib/data-reports";
 
 const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
@@ -13,6 +14,7 @@ const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
 const REPORT_BUILDERS: Record<string, () => ReportModel> = {
   "claude-code-hooks": () => buildHooksReport(ENTRIES, AS_OF),
   "agent-skills": () => buildSkillsReport(ENTRIES, AS_OF),
+  "ai-agents": () => buildAgentsReport(ENTRIES, AS_OF),
 };
 
 const CACHE_CONTROL = "public, max-age=3600, s-maxage=86400";

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -1,0 +1,167 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ElementType } from "react";
+import { Bot, ShieldCheck, GitBranch, Zap, CalendarClock } from "lucide-react";
+
+import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
+import { buildAgentsReport } from "@/lib/agents-stats";
+import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { absoluteUrl } from "@/lib/seo";
+import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
+import { stringifyJsonLd } from "@/lib/json-ld";
+import { PageContainer } from "@/components/page-container";
+import { PageHeader } from "@/components/page-header";
+import { NewsletterInline } from "@/components/newsletter-inline";
+import { ReportDownloads } from "@/components/report-downloads";
+import { DataSection, DataStat, DistTable } from "@/components/data-report";
+
+const AS_OF = String(REGISTRY_GENERATED_AT).slice(0, 10);
+const MODEL = buildAgentsReport(ENTRIES, AS_OF);
+const PATH = MODEL.slug;
+const PAGE_TITLE = `${MODEL.title} — HeyClaude`;
+
+const STAT_ICON: Record<string, ElementType> = {
+  total: Bot,
+  documented: ShieldCheck,
+  "source-backed": GitBranch,
+  ready: Zap,
+};
+
+const OG_IMAGE = ogImageUrl({
+  eyebrow: "Data report",
+  title: MODEL.title,
+  description: `${MODEL.total} AI agents by use case, disclosure & setup`,
+});
+
+function statHint(stat: ReportStat): string {
+  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
+}
+
+export const Route = createFileRoute("/state-of-ai-agents")({
+  head: () => {
+    const url = absoluteUrl(PATH);
+    const dataset = buildReportDataset(MODEL);
+    const breadcrumbs = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "HeyClaude", item: absoluteUrl("/") },
+        { "@type": "ListItem", position: 2, name: MODEL.title, item: url },
+      ],
+    };
+    return {
+      meta: [
+        { title: PAGE_TITLE },
+        { name: "description", content: MODEL.description },
+        { property: "og:type", content: "article" },
+        { property: "og:title", content: PAGE_TITLE },
+        { property: "og:description", content: MODEL.description },
+        { property: "og:url", content: url },
+        { property: "og:image", content: OG_IMAGE },
+        { property: "og:image:type", content: "image/png" },
+        { property: "og:image:width", content: String(OG_WIDTH) },
+        { property: "og:image:height", content: String(OG_HEIGHT) },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: PAGE_TITLE },
+        { name: "twitter:description", content: MODEL.description },
+        { name: "twitter:image", content: OG_IMAGE },
+      ],
+      links: [{ rel: "canonical", href: url }],
+      scripts: [
+        { type: "application/ld+json", children: stringifyJsonLd(dataset) },
+        { type: "application/ld+json", children: stringifyJsonLd(breadcrumbs) },
+      ],
+    };
+  },
+  component: StateOfAiAgentsPage,
+});
+
+function StateOfAiAgentsPage() {
+  const asOfLabel = new Date(`${AS_OF}T00:00:00Z`).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+
+  return (
+    <PageContainer>
+      <PageHeader
+        eyebrow="Data report"
+        title={MODEL.title}
+        description="A snapshot of the AI agents ecosystem, derived directly from the HeyClaude registry. Agents act with real autonomy for Claude and coding workflows — this report covers what they take on, how consistently they disclose their safety and privacy behavior, and what they need to run."
+      />
+      <p className="mt-2 text-xs text-ink-subtle">Data as of {asOfLabel} (UTC).</p>
+
+      <div className="mt-10 grid gap-px overflow-hidden rounded-xl border border-border bg-border stagger-children sm:grid-cols-4">
+        {MODEL.stats.map((stat) => (
+          <DataStat
+            key={stat.key}
+            icon={STAT_ICON[stat.key] ?? Bot}
+            label={stat.label}
+            value={stat.value}
+            hint={statHint(stat)}
+          />
+        ))}
+      </div>
+
+      {MODEL.dimensions.map((dimension) => (
+        <DataSection key={dimension.key} title={dimension.title} help={dimension.help}>
+          <DistTable rows={dimension.rows} />
+        </DataSection>
+      ))}
+
+      <ReportDownloads exportSlug={MODEL.exportSlug} />
+
+      <section className="mt-12 rounded-xl border border-border bg-surface p-6">
+        <div className="flex items-center gap-2">
+          <CalendarClock className="h-5 w-5 text-ink-muted" aria-hidden />
+          <h2 className="font-display text-xl font-semibold text-ink">
+            Methodology &amp; citation
+          </h2>
+        </div>
+        <p className="mt-2 max-w-2xl text-sm text-ink-muted">
+          Figures are computed at build time from the {MODEL.total} agents in the HeyClaude
+          registry, snapshot dated {asOfLabel}. Use cases come from registry tags (mechanism tags
+          such as “agents” are excluded); safety and privacy disclosure reflects whether each agent
+          documents that behavior; setup prerequisites and source provenance are recorded during
+          registry review.
+        </p>
+        <p className="mt-3 max-w-2xl text-sm text-ink-muted">
+          Citing this report? Link to{" "}
+          <a href={absoluteUrl(PATH)} className="text-ink underline-offset-2 hover:underline">
+            heyclau.de/state-of-ai-agents
+          </a>{" "}
+          with the data-as-of date. See also the{" "}
+          <Link to="/state-of-agent-skills" className="text-ink underline-offset-2 hover:underline">
+            State of Agent Skills
+          </Link>{" "}
+          and the broader{" "}
+          <Link
+            to="/state-of-claude-tooling"
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            State of Claude Tooling
+          </Link>
+          . Browse all{" "}
+          <Link
+            to="/$category"
+            params={{ category: "agents" }}
+            className="text-ink underline-offset-2 hover:underline"
+          >
+            agents
+          </Link>
+          .
+        </p>
+      </section>
+
+      <div className="mt-12">
+        <NewsletterInline
+          variant="quiet"
+          title="Track the Claude Code ecosystem"
+          description="A weekly digest of new agents, skills, and MCP servers as they land in the registry."
+          source="state-of-ai-agents"
+        />
+      </div>
+    </PageContainer>
+  );
+}

--- a/tests/agents-stats.test.ts
+++ b/tests/agents-stats.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAgentsReport } from "../apps/web/src/lib/agents-stats";
+import {
+  buildReportDataset,
+  REPORT_PATHS,
+} from "../apps/web/src/lib/data-reports";
+import { ENTRIES, REGISTRY_GENERATED_AT } from "../apps/web/src/data/entries";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function agent(partial: Partial<Entry>): Entry {
+  return {
+    category: "agents",
+    trust: "trusted",
+    source: "source-backed",
+    tags: [],
+    ...partial,
+  } as Entry;
+}
+
+describe("buildAgentsReport (deterministic)", () => {
+  const sample = [
+    agent({ tags: ["testing"], safetyNotes: "x", privacyNotes: "y" }),
+    agent({ tags: ["review"], safetyNotes: "x", prerequisites: ["node"] }),
+    agent({ tags: ["sre"], privacyNotes: "y", source: "external" }),
+    agent({ tags: ["testing"] }),
+  ];
+
+  it("is stable and reports the right totals/stats", () => {
+    const a = buildAgentsReport(sample, "2026-06-20");
+    const b = buildAgentsReport(sample, "2026-06-20");
+    expect(a).toEqual(b);
+    expect(a.slug).toBe("/state-of-ai-agents");
+    expect(a.total).toBe(4);
+    // 1 of 4 documents both safety + privacy
+    expect(a.stats.find((s) => s.key === "documented")?.value).toBe(25);
+  });
+
+  it("breaks down safety/privacy disclosure into both/only/neither", () => {
+    const model = buildAgentsReport(sample, "2026-06-20");
+    const disclosure = model.dimensions.find((d) => d.key === "disclosure");
+    expect(disclosure).toBeDefined();
+    const byLabel = new Map(disclosure!.rows.map((r) => [r.label, r.count]));
+    expect(byLabel.get("Safety & privacy")).toBe(1);
+    expect(byLabel.get("Safety only")).toBe(1);
+    expect(byLabel.get("Privacy only")).toBe(1);
+    expect(byLabel.get("Neither documented")).toBe(1);
+  });
+
+  it("drops degenerate single-bucket dimensions", () => {
+    const uniform = [
+      agent({ tags: ["testing"], safetyNotes: "x", privacyNotes: "y" }),
+      agent({ tags: ["review"], safetyNotes: "x", privacyNotes: "y" }),
+    ];
+    const model = buildAgentsReport(uniform, "2026-06-20");
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    // disclosure collapses to a single bucket here -> dropped
+    expect(model.dimensions.some((d) => d.key === "disclosure")).toBe(false);
+  });
+});
+
+describe("report Dataset JSON-LD", () => {
+  it("measures every stat and dimension", () => {
+    const model = buildAgentsReport(
+      [
+        agent({ tags: ["testing"], safetyNotes: "x", privacyNotes: "y" }),
+        agent({ tags: ["review"] }),
+      ],
+      "2026-06-20",
+    );
+    const ds = buildReportDataset(model) as Record<string, unknown>;
+    expect(ds["@type"]).toBe("Dataset");
+    const measured = ds.variableMeasured as string[];
+    for (const stat of model.stats) expect(measured).toContain(stat.label);
+    for (const dimension of model.dimensions)
+      expect(measured).toContain(dimension.title);
+  });
+});
+
+describe("sitemap manifest", () => {
+  it("lists the new report so it gets indexed", () => {
+    expect(REPORT_PATHS).toContain("/state-of-ai-agents");
+    expect(new Set(REPORT_PATHS).size).toBe(REPORT_PATHS.length);
+  });
+});
+
+describe("real registry data", () => {
+  const asOf = String(REGISTRY_GENERATED_AT).slice(0, 10);
+  const model = buildAgentsReport(ENTRIES, asOf);
+
+  it("covers a substantial agents corpus with informative dimensions", () => {
+    expect(model.total).toBeGreaterThan(50);
+    expect(model.dimensions.length).toBeGreaterThanOrEqual(2);
+    for (const dimension of model.dimensions) {
+      expect(dimension.rows.length).toBeGreaterThan(1);
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      "agents report dimensions:",
+      model.dimensions.map((d) => `${d.key}(${d.rows.length})`).join(", "),
+      "| stats:",
+      model.stats.map((s) => `${s.key}=${s.value}`).join(", "),
+    );
+  });
+});

--- a/tests/report-exports-api.test.ts
+++ b/tests/report-exports-api.test.ts
@@ -43,6 +43,14 @@ describe("/api/reports/{report}", () => {
     expect(text).toContain("hook-events");
   });
 
+  it("serves the AI agents report", async () => {
+    const res = await call("ai-agents.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { report: string; total: number };
+    expect(body.report).toBe("ai-agents");
+    expect(body.total).toBeGreaterThan(50);
+  });
+
   it("sets caching and a download filename", async () => {
     const res = await call("agent-skills.csv");
     expect(res.headers.get("cache-control")).toContain("max-age");


### PR DESCRIPTION
Third report in the **original registry data report series** (#3924), on the reusable core — small and tightly scoped (one stats lib + one page + register + tests).

## New report — [`/state-of-ai-agents`](https://heyclau.de/state-of-ai-agents)
Deterministic, registry-derived report on the **106 agents**. Three informative dimensions:
- **Most common use cases** (from tags, mechanism tags filtered)
- **Safety & privacy disclosure** — both / safety-only / privacy-only / neither
- **Setup prerequisites** — requires vs ready-to-use

The disclosure breakdown is the original angle here: unlike hooks and skills (100% disclosure), agents **vary — 87% document both safety and privacy** — so it’s a genuine, citable distribution rather than a flat stat. Source/trust were uniform and self-dropped (the degenerate-dimension filter). Headline: 106 agents, 87% document safety & privacy, 100% source-backed, 37% ready to use.

## Wiring (consistent with the series)
- `Dataset` JSON-LD + `ReportDownloads` (JSON/CSV) — registered in the `/api/reports` export handler so `ai-agents.json` / `.csv` resolve.
- Registered in `REPORT_PATHS` → sitemap-indexed automatically.

## Tests — `tests/agents-stats.test.ts`
Builder determinism + stats, the disclosure both/only/neither breakdown, degenerate-dimension dropping (uniform disclosure self-omits), `Dataset` coverage, the sitemap manifest, and a real-registry smoke test. The export endpoint test now also covers `ai-agents`.

## Validation
**61 tests** across agents / exports / hooks / skills / sitemap / contracts / SEO · `validate:openapi` in sync · type-check · build · prettier 3.8.3 · Trunk · `git diff --check` — all clean. (Every new/modified file verified staged, including the tracked handler under `routes/api/reports/`.)

Refs #3924.