### PR TITLE
test(registry): cover buildSubmissionSpecs intake contract and submit-url safety

### DIFF
--- a/tests/submission-specs.test.ts
+++ b/tests/submission-specs.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSubmissionSpecs,
+  SUBMISSION_SPEC_SCHEMA_VERSION,
+} from "@heyclaude/registry/submission-spec";
+
+describe("buildSubmissionSpecs", () => {
+  it("returns a versioned spec with a field model for every submission category", () => {
+    const specs = buildSubmissionSpecs();
+    expect(specs.schemaVersion).toBe(SUBMISSION_SPEC_SCHEMA_VERSION);
+    expect(Object.keys(specs.categories).length).toBeGreaterThan(0);
+    for (const model of Object.values(specs.categories)) {
+      expect(model).not.toBeNull();
+      expect(Array.isArray(model!.fields)).toBe(true);
+    }
+  });
+
+  it("describes the fork-PR intake mode and gate base ref", () => {
+    const { prIntake } = buildSubmissionSpecs();
+    expect(prIntake.mode).toBe("github_app_user_fork_pr");
+    expect(prIntake.contentGateBaseRef).toBe("main");
+  });
+
+  it("omits submitUrl when no origin is provided", () => {
+    const { prIntake } = buildSubmissionSpecs();
+    expect(prIntake).not.toHaveProperty("submitUrl");
+  });
+
+  it("derives the submit URL from siteUrl or origin", () => {
+    expect(
+      buildSubmissionSpecs({ siteUrl: "https://heyclau.de" }).prIntake
+        .submitUrl,
+    ).toBe("https://heyclau.de/submit");
+    expect(
+      buildSubmissionSpecs({ origin: "https://example.com" }).prIntake
+        .submitUrl,
+    ).toBe("https://example.com/submit");
+  });
+
+  it("rejects non-http(s) origins instead of emitting an unsafe submit URL", () => {
+    const { prIntake } = buildSubmissionSpecs({ siteUrl: "ftp://bad.example" });
+    expect(prIntake).not.toHaveProperty("submitUrl");
+  });
+});


### PR DESCRIPTION
Add the first dedicated test for `buildSubmissionSpecs` from `@heyclaude/registry/submission-spec`. This function assembles the full per-category submission spec consumed by the submit flow and previously had no direct test coverage.

## New file: `tests/submission-specs.test.ts`

- Returns a versioned spec (pinned to `SUBMISSION_SPEC_SCHEMA_VERSION`) with a non-null field model for every submission category.
- Describes the fork-PR intake contract (`mode: "github_app_user_fork_pr"`, `contentGateBaseRef: "main"`).
- Omits `submitUrl` when no origin is supplied.
- Derives `submitUrl` as `<origin>/submit` from either `siteUrl` or `origin`.
- Rejects non-`http(s)` origins (e.g. `ftp://`) rather than emitting an unsafe submit URL — guarding the same origin-safety boundary the helper enforces internally.

All assertions derive from the current implementation. 5 tests, all green; no source changes.
