### PR TITLE
test(registry): cover parseSafeFrontmatter JS-rejection and error-handling branches

### DIFF
--- a/tests/frontmatter-safe-parse.test.ts
+++ b/tests/frontmatter-safe-parse.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseSafeFrontmatter,
+  UNSAFE_FRONTMATTER_LANGUAGE_ERROR,
+} from "@heyclaude/registry/frontmatter";
+
+describe("parseSafeFrontmatter", () => {
+  it("separates frontmatter data from body content", () => {
+    const result = parseSafeFrontmatter(
+      "---\ntitle: Hello\ntags: [a, b]\n---\nBody text",
+    );
+    expect(result.data).toEqual({ title: "Hello", tags: ["a", "b"] });
+    expect(result.content.trim()).toBe("Body text");
+  });
+
+  it("strips a leading byte-order mark before parsing", () => {
+    // A BOM ahead of the opening fence would otherwise hide the frontmatter.
+    const result = parseSafeFrontmatter("﻿---\ntitle: BOM\n---\nx");
+    expect(result.data.title).toBe("BOM");
+  });
+
+  it("rejects executable JavaScript frontmatter as a security boundary", () => {
+    // The whole point of the safe parser: a `js` engine must never run.
+    expect(() =>
+      parseSafeFrontmatter('---js\nmodule.exports = { title: "x" }\n---\nbody'),
+    ).toThrow(UNSAFE_FRONTMATTER_LANGUAGE_ERROR);
+  });
+
+  it("returns a safe fallback for malformed YAML when fallbackOnError is set", () => {
+    const malformed = '---\ntitle: "unclosed\n  bad: : :\n---\nx';
+    const result = parseSafeFrontmatter(malformed, { fallbackOnError: true });
+    expect(result.data).toEqual({});
+    expect(result.error).toBeTruthy();
+    // The original content is preserved so callers can recover/log it.
+    expect(result.content).toBe(malformed);
+  });
+
+  it("rethrows malformed YAML when no fallback is requested", () => {
+    const malformed = '---\ntitle: "unclosed\n  bad: : :\n---\nx';
+    expect(() => parseSafeFrontmatter(malformed)).toThrow();
+  });
+
+  it("treats nullish input as empty frontmatter and body", () => {
+    const result = parseSafeFrontmatter(null);
+    expect(result.data).toEqual({});
+    expect(result.content).toBe("");
+  });
+});


### PR DESCRIPTION
Add coverage for the security-critical branches of `parseSafeFrontmatter` from `@heyclaude/registry/frontmatter`. The helper is currently exercised only on its happy path (`readme-generation` / `statusline-scripts` read `.data`); its safety boundary and error-handling paths had no direct test.

## New file: `tests/frontmatter-safe-parse.test.ts`

- **Executable-JS rejection (the core guarantee)** — confirms `---js` frontmatter throws `UNSAFE_FRONTMATTER_LANGUAGE_ERROR` instead of evaluating the embedded module. This is the reason the safe wrapper exists.
- **BOM stripping** — a leading byte-order mark is removed so the opening fence is still recognized.
- **`fallbackOnError`** — malformed YAML returns `{ data: {}, content, error }` with the original content preserved for recovery/logging.
- **Default rethrow** — malformed YAML without `fallbackOnError` rethrows.
- **Happy path** — frontmatter data and body content are separated correctly.
- **Nullish input** — yields empty `data`/`content` rather than throwing.

All assertions derive from the current implementation. 6 tests, all green; no source changes.
