### PR TITLE
test(web): cover getClientIp header precedence and hasJsonContentType

### DIFF
--- a/tests/api-security-request-helpers.test.ts
+++ b/tests/api-security-request-helpers.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { getClientIp, hasJsonContentType } from "@/lib/api-security";
+
+const request = (headers: Record<string, string>) =>
+  new Request("https://heyclau.de/api/test", { headers });
+
+describe("getClientIp", () => {
+  it("prefers the Cloudflare connecting IP header", () => {
+    // cf-connecting-ip is set by the edge and is the most trustworthy source.
+    expect(
+      getClientIp(
+        request({
+          "cf-connecting-ip": "1.2.3.4",
+          "x-forwarded-for": "9.9.9.9",
+        }),
+      ),
+    ).toBe("1.2.3.4");
+  });
+
+  it("falls back to the first x-forwarded-for hop, trimmed", () => {
+    // The left-most XFF entry is the original client; later hops are proxies.
+    expect(
+      getClientIp(request({ "x-forwarded-for": "9.9.9.9, 10.0.0.1" })),
+    ).toBe("9.9.9.9");
+    expect(getClientIp(request({ "x-forwarded-for": "  8.8.8.8  " }))).toBe(
+      "8.8.8.8",
+    );
+  });
+
+  it("returns 'unknown' when no client IP header is present", () => {
+    // A stable sentinel keeps rate-limit bucket keys well-formed.
+    expect(getClientIp(request({}))).toBe("unknown");
+  });
+});
+
+describe("hasJsonContentType", () => {
+  it("accepts application/json with or without parameters, case-insensitively", () => {
+    expect(
+      hasJsonContentType(
+        request({ "content-type": "application/json; charset=utf-8" }),
+      ),
+    ).toBe(true);
+    expect(
+      hasJsonContentType(request({ "content-type": "APPLICATION/JSON" })),
+    ).toBe(true);
+  });
+
+  it("rejects non-JSON and missing content types", () => {
+    expect(hasJsonContentType(request({ "content-type": "text/plain" }))).toBe(
+      false,
+    );
+    // No content-type header at all must not be treated as JSON.
+    expect(hasJsonContentType(request({}))).toBe(false);
+  });
+});


### PR DESCRIPTION
Add coverage for two request-inspection helpers in `apps/web/src/lib/api-security.ts` that feed rate-limiting and request validation but had no direct test: `getClientIp` and `hasJsonContentType`.

## New file: `tests/api-security-request-helpers.test.ts`

- **`getClientIp`** — pins the header precedence that the rest of the security layer depends on:
  - prefers the edge-set `cf-connecting-ip`,
  - falls back to the left-most (original-client) `x-forwarded-for` hop, trimmed,
  - returns the `"unknown"` sentinel when neither header is present (keeping rate-limit bucket keys well-formed).
- **`hasJsonContentType`** — accepts `application/json` with parameters and mixed case, and rejects non-JSON or missing content types so non-JSON bodies aren't parsed as JSON.

Each assertion carries a short rationale comment explaining why the branch matters. All assertions derive from the current implementation. 5 tests, all green; no source changes.
