### PR TITLE
feat(seo): submit affected generated hubs to IndexNow on publish

### DIFF
--- a/.github/workflows/indexnow-on-publish.yml
+++ b/.github/workflows/indexnow-on-publish.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Collect changed entry URLs (live only)
+      - name: Collect changed entry + hub URLs (live only)
         id: urls
         env:
           # Passed via env (not inlined into the shell) to avoid script injection.
@@ -53,17 +53,33 @@ jobs:
           # ping URLs that no longer exist).
           changed="$(git diff --name-only --diff-filter=AM "$base" "$HEAD_SHA" -- 'content/**/*.mdx' || true)"
 
-          : > indexnow-urls.txt
+          # Reduce to flat <category>/<slug> entry refs (skip archive/ etc.).
+          refs=()
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             rel="${file#content/}"          # <category>/<slug>.mdx
             category="${rel%%/*}"
             slug="${rel#*/}"; slug="${slug%.mdx}"
-            # Skip anything that isn't a flat <category>/<slug> entry (e.g. archive/).
             case "$slug" in */*) continue;; esac
-            url="https://heyclau.de/entry/${category}/${slug}"
-            # Only submit URLs that are actually live (filters non-entry paths and
-            # entries whose deploy hasn't propagated yet — the daily cron re-catches those).
+            refs+=("${category}/${slug}")
+          done <<< "$changed"
+
+          : > indexnow-urls.txt
+          if [ "${#refs[@]}" -eq 0 ]; then
+            echo "count=0" >> "$GITHUB_OUTPUT"
+            echo "No changed entries."
+            exit 0
+          fi
+
+          # Expand each changed entry into its URL + the generated hub URLs whose
+          # content changes with it (category page, tag pages, category state
+          # reports). Bounded to these entries' hubs — no full-sitemap bulk.
+          candidates="$(node scripts/indexnow-changed-urls.mjs "${refs[@]}")"
+
+          # Only submit URLs that are actually live (filters non-propagated
+          # deploys + any stale hub; the daily cron re-catches anything skipped).
+          while IFS= read -r url; do
+            [ -z "$url" ] && continue
             code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$url" || echo 000)"
             if [ "$code" = "200" ]; then
               echo "$url" >> indexnow-urls.txt
@@ -71,11 +87,11 @@ jobs:
             else
               echo "skip   $url (HTTP $code)"
             fi
-          done <<< "$changed"
+          done <<< "$candidates"
 
           count="$(grep -c . indexnow-urls.txt || true)"
           echo "count=$count" >> "$GITHUB_OUTPUT"
-          echo "Submitting $count live entry URL(s)."
+          echo "Submitting $count live URL(s)."
 
       - name: Submit to IndexNow
         if: steps.urls.outputs.count != '0'

--- a/docs/indexnow.md
+++ b/docs/indexnow.md
@@ -13,6 +13,18 @@ IndexNow notifies **Bing, Yandex, Seznam, and Naver** (Bing shares onward).
 **Google ignores IndexNow** — it uses `sitemap.xml` `lastmod` + crawl, which the
 site already emits. So this is purely the Bing/everyone-else accelerator.
 
+## On-publish submission (entry + affected hubs)
+
+The `indexnow-on-publish` workflow runs when `content/**/*.mdx` lands on `main`.
+For each added/modified entry it submits that entry **plus the generated hubs
+whose content changes with it** — its category page, its tag pages, and the
+state report(s) covering that category — expanded by
+`scripts/indexnow-changed-urls.mjs` (tags read from the live entry-detail JSON,
+hubs from `scripts/lib/indexnow-hubs.mjs`). Submission stays bounded to those
+entries' hubs (never the whole sitemap), and every URL is HTTP-200 validated
+before submission. Best-list, comparison, and platform hubs need cross-entry
+registry data and are left to the daily cron's window.
+
 ## Automated daily submission (changed URLs only)
 
 A Cloudflare cron (`apps/web/plugins/indexnow-scheduled.ts`, daily 05:00 UTC —

--- a/scripts/indexnow-changed-urls.mjs
+++ b/scripts/indexnow-changed-urls.mjs
@@ -1,0 +1,68 @@
+import process from "node:process";
+
+import {
+  DEFAULT_INDEXNOW_BASE_URL,
+  normalizeSiteUrl,
+} from "./lib/indexnow.mjs";
+import { entryHubUrls } from "./lib/indexnow-hubs.mjs";
+
+// Expand changed entry refs ("category/slug", passed as CLI args) into the set
+// of URLs to notify IndexNow about: each entry plus the generated hubs whose
+// content changes with it (category page, tag pages, category state reports).
+// The entry's tags are read from the live entry-detail JSON so no registry
+// build or extra dependency is needed; tag hubs are simply skipped when that
+// JSON has not propagated yet (the daily cron re-catches them). The workflow
+// validates every emitted URL (HTTP 200) before submitting.
+
+function parseRefs(argv) {
+  const refs = [];
+  for (const raw of argv) {
+    const ref = String(raw).trim();
+    if (!ref) continue;
+    const slash = ref.indexOf("/");
+    if (slash < 0) continue;
+    const category = ref.slice(0, slash);
+    const slug = ref.slice(slash + 1);
+    if (!category || !slug || slug.includes("/")) continue;
+    refs.push({ category, slug });
+  }
+  return refs;
+}
+
+async function fetchTags(base, ref) {
+  try {
+    const response = await fetch(
+      `${base}/data/entries/${ref.category}/${ref.slug}.json`,
+      { signal: AbortSignal.timeout(10_000) },
+    );
+    if (!response.ok) return [];
+    const json = await response.json();
+    const entry = json?.entry ?? json;
+    return Array.isArray(entry?.tags) ? entry.tags : [];
+  } catch {
+    // Not propagated / unreachable — emit the entry + path-derived hubs only.
+    return [];
+  }
+}
+
+async function main() {
+  const base = normalizeSiteUrl(
+    process.env.INDEXNOW_BASE_URL || DEFAULT_INDEXNOW_BASE_URL,
+  ).replace(/\/+$/, "");
+
+  const refs = parseRefs(process.argv.slice(2));
+  const urls = new Set();
+
+  for (const ref of refs) {
+    urls.add(`${base}/entry/${ref.category}/${ref.slug}`);
+    const tags = await fetchTags(base, ref);
+    for (const url of entryHubUrls({ ...ref, tags }, base)) urls.add(url);
+  }
+
+  for (const url of urls) console.log(url);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/lib/indexnow-hubs.mjs
+++ b/scripts/lib/indexnow-hubs.mjs
@@ -1,0 +1,55 @@
+// Maps a changed registry entry to the generated hub pages whose content
+// materially changes with it, so the on-publish IndexNow workflow can expedite
+// recrawls of those hubs (not just the entry). Bounded to one entry's hubs —
+// deterministic, dependency-free, and validated (HTTP 200) before submission by
+// the workflow. Surfaces that need cross-entry/registry data (best lists,
+// comparisons, platform hubs) are left to the daily full-sitemap cron.
+
+// State reports scoped to a single category, pinged when an entry in that
+// category changes. Keep in sync with REPORT_PATHS in
+// apps/web/src/lib/data-reports.ts (covered by a drift test).
+export const CATEGORY_REPORTS = {
+  mcp: ["/state-of-mcp-servers", "/mcp-security-report"],
+  hooks: ["/state-of-claude-code-hooks"],
+  skills: ["/state-of-agent-skills"],
+  agents: ["/state-of-ai-agents"],
+};
+
+// Reports that aggregate every category, so any entry change affects them.
+export const GLOBAL_REPORTS = ["/state-of-claude-tooling"];
+
+/** Slugify a tag the same way the site's tag routes do (apps/web/src/lib/tags.ts). */
+export function tagSlug(tag) {
+  return String(tag)
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Site-relative hub paths whose content changes when `entry` (a changed entry
+ * with `category`, `slug`, and optional `tags`) is added or edited: its
+ * category page, its tag pages, and the state report(s) covering that category.
+ * Deterministic and de-duplicated; never includes the entry's own URL.
+ */
+export function entryHubPaths(entry) {
+  const paths = new Set();
+  const category = String(entry?.category ?? "").trim();
+  if (category) {
+    paths.add(`/${category}`);
+    for (const report of CATEGORY_REPORTS[category] ?? []) paths.add(report);
+    for (const report of GLOBAL_REPORTS) paths.add(report);
+  }
+  for (const tag of entry?.tags ?? []) {
+    const slug = tagSlug(tag);
+    if (slug) paths.add(`/tags/${slug}`);
+  }
+  return [...paths];
+}
+
+/** Absolute hub URLs for an entry, given a normalized base URL (no trailing slash). */
+export function entryHubUrls(entry, baseUrl) {
+  const base = String(baseUrl).replace(/\/+$/, "");
+  return entryHubPaths(entry).map((path) => `${base}${path}`);
+}

--- a/tests/indexnow.test.ts
+++ b/tests/indexnow.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import {
@@ -10,6 +13,14 @@ import {
   keyLocationFor,
   normalizeSubmittedUrls,
 } from "../scripts/lib/indexnow.mjs";
+import {
+  CATEGORY_REPORTS,
+  GLOBAL_REPORTS,
+  entryHubPaths,
+  entryHubUrls,
+  tagSlug,
+} from "../scripts/lib/indexnow-hubs.mjs";
+import { repoRoot } from "./helpers/registry-fixtures";
 
 describe("IndexNow submission helpers", () => {
   it("builds the production key location from the public key file", () => {
@@ -66,5 +77,75 @@ describe("IndexNow submission helpers", () => {
       ["c", "d"],
       ["e"],
     ]);
+  });
+});
+
+describe("IndexNow hub expansion", () => {
+  it("expands a changed entry into its category, tag, and report hubs", () => {
+    const paths = entryHubPaths({
+      category: "hooks",
+      slug: "accessibility-checker",
+      tags: ["Accessibility", "a11y", "testing"],
+    });
+    expect(paths).toContain("/hooks"); // category page
+    expect(paths).toContain("/state-of-claude-code-hooks"); // category report
+    expect(paths).toContain("/state-of-claude-tooling"); // global report
+    expect(paths).toContain("/tags/accessibility"); // slugified tags
+    expect(paths).toContain("/tags/a11y");
+    expect(paths).toContain("/tags/testing");
+  });
+
+  it("never includes the entry's own URL and de-duplicates", () => {
+    const paths = entryHubPaths({
+      category: "hooks",
+      slug: "x",
+      tags: ["testing", "testing"],
+    });
+    expect(paths).not.toContain("/entry/hooks/x");
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+
+  it("emits only the category page + global report for an unknown category", () => {
+    const paths = entryHubPaths({ category: "rules", slug: "x", tags: [] });
+    expect(paths).toEqual(["/rules", "/state-of-claude-tooling"]);
+  });
+
+  it("emits no tag hubs when the entry has no tags", () => {
+    const paths = entryHubPaths({ category: "skills", slug: "x" });
+    expect(paths.some((p) => p.startsWith("/tags/"))).toBe(false);
+  });
+
+  it("slugifies tags the way the site's tag routes do", () => {
+    expect(tagSlug("Code Review")).toBe("code-review");
+    expect(tagSlug("  C++ / Rust  ")).toBe("c-rust");
+    expect(tagSlug("a11y")).toBe("a11y");
+  });
+
+  it("builds absolute hub URLs against a base, without a double slash", () => {
+    const urls = entryHubUrls(
+      { category: "skills", slug: "x", tags: ["testing"] },
+      "https://heyclau.de/",
+    );
+    expect(urls).toContain("https://heyclau.de/skills");
+    expect(urls).toContain("https://heyclau.de/tags/testing");
+    expect(urls.every((u) => u.startsWith("https://heyclau.de/"))).toBe(true);
+    expect(urls.some((u) => u.includes("//tags"))).toBe(false);
+  });
+
+  it("maps only to report routes that actually exist (no drift)", () => {
+    const reportPaths = [
+      ...new Set([
+        ...Object.values(CATEGORY_REPORTS).flat(),
+        ...GLOBAL_REPORTS,
+      ]),
+    ];
+    for (const reportPath of reportPaths) {
+      const routeFile = path.join(
+        repoRoot,
+        "apps/web/src/routes",
+        `${reportPath.replace(/^\//, "")}.tsx`,
+      );
+      expect(fs.existsSync(routeFile), reportPath).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
Broadens on-publish IndexNow beyond entry URLs to the generated hubs that change with an entry.

Closes #3925.

## The gap
Audit finding: **both** IndexNow paths submit only changed *entry* URLs — the daily Worker cron pings entries updated in the last 48h, and the on-publish workflow pinged just the entry. The **generated hubs that change with an entry were never notified**.

## What this adds
On publish, each changed entry now also submits the hubs whose content changes with it — **where they can be computed deterministically without a registry build** (the issue’s qualifier):
- **Category page** `/<category>`
- **Tag pages** `/tags/<slug>` (slugified to match the site’s tag routes)
- **State report(s)** for that category, plus `/state-of-claude-tooling`

Implemented as a pure, tested module (`scripts/lib/indexnow-hubs.mjs` — `entryHubPaths`/`entryHubUrls` + a category→report map) and a thin orchestrator (`scripts/indexnow-changed-urls.mjs`) that reads each entry’s tags from the **live entry-detail JSON** — so no `gray-matter` dependency or registry build is added to the workflow.

## Bounded + validated (not spammy)
- Scoped strictly to the **changed entries’ hubs** — never the whole sitemap.
- The workflow keeps its existing **HTTP-200 validation** on every URL before submission.
- Smoke-tested against live data: `hooks/accessibility-checker` → entry + `/hooks` + `/state-of-claude-code-hooks` + `/state-of-claude-tooling` + 5 tag hubs; unreachable entries degrade gracefully.

## Out of scope (noted)
Best-list, comparison, and platform hubs need cross-entry/registry data (directory entries don’t carry platforms; membership needs `BEST_LISTS`/`COMPARISONS`) — not available dependency-free on publish. They remain candidates for the registry-aware daily cron.

## Tests — `tests/indexnow.test.ts`
Hub expansion (category/tag/report), tag slugification matching the site, de-dup + self-exclusion, unknown-category and no-tags cases, absolute-URL building, and a **drift guard** asserting every mapped report path has a real route. 11 tests pass · type-check · prettier 3.8.3 · Trunk (actionlint/shellcheck) — all clean.

## Completion requirements (#3925)
- ✅ Generated hub URLs submitted on change — category, tag, state-report (the deterministically-computable set).
- ✅ Bounded; no whole-sitemap bulk on unrelated changes.
- ✅ Every candidate URL HTTP-200 validated before submission.
- ✅ Tests + docs (`docs/indexnow.md`) updated.