### PR TITLE
test(web): cover isSourceBackedEntry, hasInstallSurface, hasSafeInstallSignal

### DIFF
--- a/tests/growth-surface-predicates.test.ts
+++ b/tests/growth-surface-predicates.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isSourceBackedEntry,
+  hasInstallSurface,
+  hasSafeInstallSignal,
+} from "@/lib/growth-surface-rules";
+
+describe("isSourceBackedEntry", () => {
+  it("is true only when the trust signal reports an available source", () => {
+    // "source-backed" discovery surfaces rely on a confirmed-reachable source,
+    // so only the explicit "available" status qualifies.
+    expect(
+      isSourceBackedEntry({ trustSignals: { sourceStatus: "available" } }),
+    ).toBe(true);
+    expect(
+      isSourceBackedEntry({ trustSignals: { sourceStatus: "unavailable" } }),
+    ).toBe(false);
+    expect(isSourceBackedEntry({})).toBe(false);
+  });
+});
+
+describe("hasInstallSurface", () => {
+  it("is true when any install affordance is present", () => {
+    // An entry is installable if it exposes a command, a download, or a config
+    // snippet — any one is enough to surface install-oriented lists.
+    expect(hasInstallSurface({ installCommand: "npx example" })).toBe(true);
+    expect(hasInstallSurface({ downloadUrl: "/downloads/skills/x.zip" })).toBe(
+      true,
+    );
+    expect(hasInstallSurface({ configSnippet: "{}" })).toBe(true);
+  });
+
+  it("is false when no install affordance exists", () => {
+    expect(hasInstallSurface({})).toBe(false);
+  });
+});
+
+describe("hasSafeInstallSignal", () => {
+  it("requires a first-party download or a verified package", () => {
+    // Safe-install surfaces only promote first-party or maintainer-verified
+    // packages; external/unverified ones must not qualify.
+    expect(hasSafeInstallSignal({ downloadTrust: "first-party" })).toBe(true);
+    expect(hasSafeInstallSignal({ packageVerified: true })).toBe(true);
+  });
+
+  it("rejects external downloads and unverified packages", () => {
+    expect(hasSafeInstallSignal({ downloadTrust: "external" })).toBe(false);
+    expect(hasSafeInstallSignal({ packageVerified: false })).toBe(false);
+    expect(hasSafeInstallSignal({})).toBe(false);
+  });
+});


### PR DESCRIPTION
Add coverage for the three exported entry predicates in `apps/web/src/lib/growth-surface-rules.ts` that drive discovery-surface eligibility but had no direct test: `isSourceBackedEntry`, `hasInstallSurface`, and `hasSafeInstallSignal`. These gate which entries appear in the source-backed, install, and safe-install discovery lists.

## New file: `tests/growth-surface-predicates.test.ts`

- **`isSourceBackedEntry`** — true only for `trustSignals.sourceStatus === "available"`; `unavailable` and missing trust signals are false.
- **`hasInstallSurface`** — true when any install affordance exists (`installCommand`, `downloadUrl`, or `configSnippet`); false otherwise.
- **`hasSafeInstallSignal`** — true only for a first-party download or a verified package; external downloads and unverified packages are false.

Each assertion carries a short rationale comment explaining why the branch gates a given discovery surface. All assertions derive from the current implementation. 5 tests, all green; no source changes.
