### PR TITLE
test(web): cover isSafeContentPathPart path-traversal guard

### DIFF
--- a/tests/content-path-safety.test.ts
+++ b/tests/content-path-safety.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { isSafeContentPathPart } from "@/lib/content.server";
+
+describe("isSafeContentPathPart", () => {
+  it("accepts lowercase slug-style path parts", () => {
+    // Categories and slugs are lowercase kebab/alphanumeric, so these are the
+    // only shapes allowed into a content file path.
+    expect(isSafeContentPathPart("agents")).toBe(true);
+    expect(isSafeContentPathPart("my-slug-1")).toBe(true);
+    expect(isSafeContentPathPart("mcp")).toBe(true);
+  });
+
+  it("rejects path-traversal and separator characters", () => {
+    // The guard exists to keep `category`/`slug` from escaping the content
+    // directory when interpolated into `entries/<category>/<slug>.json`.
+    expect(isSafeContentPathPart("../etc")).toBe(false);
+    expect(isSafeContentPathPart("a/b")).toBe(false);
+    expect(isSafeContentPathPart("..")).toBe(false);
+  });
+
+  it("rejects uppercase, dots, underscores, and empty input", () => {
+    // Anything outside [a-z0-9-] is refused, including extensions and the
+    // empty string, so only canonical path parts pass.
+    expect(isSafeContentPathPart("Agents")).toBe(false);
+    expect(isSafeContentPathPart("file.json")).toBe(false);
+    expect(isSafeContentPathPart("a_b")).toBe(false);
+    expect(isSafeContentPathPart("")).toBe(false);
+  });
+});


### PR DESCRIPTION
Add coverage for `isSafeContentPathPart` from `apps/web/src/lib/content.server.ts`. This guard validates `category`/`slug` before they are interpolated into a content file path (`entries/<category>/<slug>.json`), and despite being a path-traversal defense it had no direct test (existing suites mock the module).

## New file: `tests/content-path-safety.test.ts`

- Accepts canonical lowercase slug-style parts (`agents`, `my-slug-1`, `mcp`).
- Rejects path-traversal and separator characters (`../etc`, `a/b`, `..`) — the core security purpose.
- Rejects anything outside `[a-z0-9-]`: uppercase, dotted extensions, underscores, and the empty string.

Each assertion carries a short rationale comment tying the rule back to the path-interpolation it protects. All assertions derive from the current implementation. 3 tests, all green; no source changes.
