### PR TITLE
test(web): cover intent-events input normalizers and fallback seeding

### DIFF
--- a/tests/intent-events-normalizers.test.ts
+++ b/tests/intent-events-normalizers.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeIntentEventType,
+  normalizeIntentEntryKey,
+  normalizeIntentSessionId,
+  getFallbackIntentEventCounts,
+  ZERO_INTENT_EVENT_COUNTS,
+} from "@/lib/intent-events";
+
+describe("normalizeIntentEventType", () => {
+  it("accepts the known event vocabulary, lowercasing and trimming first", () => {
+    expect(normalizeIntentEventType("copy")).toBe("copy");
+    // Input is trimmed and lowercased before the vocabulary check.
+    expect(normalizeIntentEventType(" INSTALL ")).toBe("install");
+  });
+
+  it("returns an empty string for unknown or nullish types", () => {
+    // An empty string is the sentinel the caller treats as "no valid event".
+    expect(normalizeIntentEventType("xxx")).toBe("");
+    expect(normalizeIntentEventType(null)).toBe("");
+    expect(normalizeIntentEventType(undefined)).toBe("");
+  });
+});
+
+describe("normalizeIntentEntryKey", () => {
+  it("accepts a lowercased category:slug key", () => {
+    expect(normalizeIntentEntryKey("agents:my-slug")).toBe("agents:my-slug");
+    expect(normalizeIntentEntryKey("Agents:My-Slug")).toBe("agents:my-slug");
+  });
+
+  it("rejects keys without the single-colon category:slug shape", () => {
+    // A slash path or missing colon is not a valid intent entry key.
+    expect(normalizeIntentEntryKey("agents/my-slug")).toBe("");
+    expect(normalizeIntentEntryKey("agents")).toBe("");
+  });
+});
+
+describe("normalizeIntentSessionId", () => {
+  it("trims and accepts ids up to 128 characters", () => {
+    expect(normalizeIntentSessionId("  abc123  ")).toBe("abc123");
+    expect(normalizeIntentSessionId("a".repeat(128))).toHaveLength(128);
+  });
+
+  it("rejects ids longer than 128 characters", () => {
+    // Oversized ids are dropped rather than stored unbounded.
+    expect(normalizeIntentSessionId("x".repeat(129))).toBe("");
+  });
+});
+
+describe("getFallbackIntentEventCounts", () => {
+  it("seeds a zeroed count record for each requested key", () => {
+    const counts = getFallbackIntentEventCounts(["agents:a", "mcp:b"]);
+    expect(counts["agents:a"]).toEqual(ZERO_INTENT_EVENT_COUNTS);
+    expect(counts["mcp:b"]).toEqual(ZERO_INTENT_EVENT_COUNTS);
+  });
+
+  it("gives each key an independent counts object", () => {
+    // Mutating one key's counts must not bleed into another key.
+    const counts = getFallbackIntentEventCounts(["a:1", "b:2"]);
+    counts["a:1"].copy = 5;
+    expect(counts["b:2"].copy).toBe(0);
+  });
+});


### PR DESCRIPTION
Add coverage for the input normalizers and fallback seeder in `apps/web/src/lib/intent-events.ts`. These validate untrusted `eventType` / `entryKey` / `sessionId` input and seed zeroed counts when the analytics DB is unavailable, and had no direct test.

## New file: `tests/intent-events-normalizers.test.ts`

- **`normalizeIntentEventType`** — trims + lowercases, accepts the known vocabulary (`copy`/`open`/`install`/`download`/`vote`), and returns `""` for unknown/nullish input.
- **`normalizeIntentEntryKey`** — accepts a lowercased `category:slug` key and rejects slash paths / missing colon.
- **`normalizeIntentSessionId`** — trims and accepts ids up to 128 chars; drops oversized ids to `""`.
- **`getFallbackIntentEventCounts`** — seeds a zeroed `ZERO_INTENT_EVENT_COUNTS` record per key, and gives each key an independent object (mutating one key does not affect another).

Each assertion carries a short rationale comment. All assertions derive from the current implementation. 8 tests, all green; no source changes.
