### PR TITLE
test(web): cover isAllowedOrigin anchoring and https enforcement

### DIFF
--- a/tests/api-security-allowed-origin.test.ts
+++ b/tests/api-security-allowed-origin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { isAllowedOrigin } from "@/lib/api-security";
+
+const requestWithOrigin = (origin?: string) =>
+  new Request(
+    "https://heyclau.de/api/test",
+    origin ? { headers: { origin } } : {},
+  );
+
+describe("isAllowedOrigin", () => {
+  it("allows requests with no Origin header (same-origin / non-CORS)", () => {
+    // A missing Origin is not a cross-site request, so it is permitted.
+    expect(isAllowedOrigin(requestWithOrigin())).toBe(true);
+  });
+
+  it("allows the production, dev, preview, and local origins", () => {
+    expect(isAllowedOrigin(requestWithOrigin("https://heyclau.de"))).toBe(true);
+    expect(isAllowedOrigin(requestWithOrigin("https://dev.heyclau.de"))).toBe(
+      true,
+    );
+    expect(
+      isAllowedOrigin(requestWithOrigin("https://pr-123.zeronode.workers.dev")),
+    ).toBe(true);
+    expect(isAllowedOrigin(requestWithOrigin("http://localhost:3000"))).toBe(
+      true,
+    );
+    expect(isAllowedOrigin(requestWithOrigin("http://127.0.0.1:8788"))).toBe(
+      true,
+    );
+  });
+
+  it("rejects unrelated origins", () => {
+    expect(isAllowedOrigin(requestWithOrigin("https://evil.com"))).toBe(false);
+  });
+
+  it("requires https for the production host (no plaintext downgrade)", () => {
+    // The allow-list pins https for heyclau.de, so a plaintext origin fails.
+    expect(isAllowedOrigin(requestWithOrigin("http://heyclau.de"))).toBe(false);
+  });
+
+  it("rejects look-alike hosts that only suffix the allowed domain", () => {
+    // Patterns are anchored, so `heyclau.de.evil.com` must not match.
+    expect(
+      isAllowedOrigin(requestWithOrigin("https://heyclau.de.evil.com")),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Add coverage for `isAllowedOrigin` from `apps/web/src/lib/api-security.ts`. This is the CORS origin allow-list check guarding state-changing API routes, and despite being a security boundary it had no direct test.

## New file: `tests/api-security-allowed-origin.test.ts`

- Allows requests with **no Origin header** (same-origin / non-CORS).
- Allows the production, dev, preview (`*.zeronode.workers.dev`), and local (`localhost`/`127.0.0.1`) origins.
- Rejects unrelated origins (`https://evil.com`).
- Requires **https for the production host** — a plaintext `http://heyclau.de` downgrade is rejected.
- Rejects **look-alike hosts** that only suffix the allowed domain (`https://heyclau.de.evil.com`), confirming the patterns are properly anchored.

Each assertion carries a short rationale comment, with emphasis on the anchoring/downgrade cases that make this more than a substring check. All assertions derive from the current implementation. 5 tests, all green; no source changes.
