### PR TITLE
test(registry): cover missingToolListingReviewFields and routing/approval messages

### DIFF
--- a/tests/submission-classification-routing.test.ts
+++ b/tests/submission-classification-routing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  missingToolListingReviewFields,
+  toolListingRoutingMessage,
+  toolListingApprovalMessage,
+  TOOLS_LISTING_FLOW_URL,
+} from "../packages/registry/src/submission-classification.js";
+
+describe("missingToolListingReviewFields", () => {
+  it("reports every review field as missing for an empty payload", () => {
+    expect(missingToolListingReviewFields({})).toEqual([
+      "websiteUrl",
+      "documentationUrl",
+      "pricingModel",
+      "disclosure",
+      "applicationCategory",
+      "operatingSystem",
+    ]);
+  });
+
+  it("only reports the fields that are still absent", () => {
+    // Provided fields (incl. snake_case aliases) drop out of the missing list.
+    expect(
+      missingToolListingReviewFields({
+        websiteUrl: "https://example.com",
+        pricingModel: "free",
+        disclosure: "sponsored",
+      }),
+    ).toEqual(["documentationUrl", "applicationCategory", "operatingSystem"]);
+  });
+
+  it("treats blank values as missing", () => {
+    expect(missingToolListingReviewFields({ websiteUrl: "   " })).toContain(
+      "websiteUrl",
+    );
+  });
+});
+
+describe("tool listing messages", () => {
+  it("routing message points submitters at the tools listing flow", () => {
+    const message = toolListingRoutingMessage();
+    expect(message).toContain(TOOLS_LISTING_FLOW_URL);
+  });
+
+  it("approval message explains the maintainer-approval requirement", () => {
+    const message = toolListingApprovalMessage();
+    expect(message).toContain(TOOLS_LISTING_FLOW_URL);
+    expect(message.toLowerCase()).toContain("approval");
+  });
+});


### PR DESCRIPTION
Add coverage for the submission-classification review-field and routing-message helpers in `packages/registry/src/submission-classification.js`: `missingToolListingReviewFields`, `toolListingRoutingMessage`, and `toolListingApprovalMessage`. These gate which review fields a tool listing still needs and produce the routing/approval guidance, and had no direct test.

The module is imported via the established deep-relative test pattern already used by `tests/content-schema.test.ts`, `tests/submission-builders.test.ts`, etc.

## New file: `tests/submission-classification-routing.test.ts`

- **`missingToolListingReviewFields`** — reports every review field for an empty payload, narrows to only the still-absent fields once some are provided (including snake_case aliases), and treats blank/whitespace values as missing.
- **`toolListingRoutingMessage` / `toolListingApprovalMessage`** — both reference the canonical `TOOLS_LISTING_FLOW_URL`, and the approval message explains the maintainer-approval requirement.

Each assertion derives from the current implementation. 5 tests, all green; no source changes.
