### PR TITLE
test(web): cover renderErrorPage fallback HTML document contract

### DIFF
--- a/tests/render-error-page.test.ts
+++ b/tests/render-error-page.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { renderErrorPage } from "@/lib/error-page";
+
+describe("renderErrorPage", () => {
+  const html = renderErrorPage();
+
+  it("returns a complete, localized HTML document", () => {
+    // The fallback page is served as a raw string, so it must be a full,
+    // self-contained document (no framework/runtime available at this point).
+    expect(html.startsWith("<!doctype html>")).toBe(true);
+    expect(html).toContain('<html lang="en">');
+    expect(html).toContain('name="viewport"');
+  });
+
+  it("communicates the failure and a title to the user", () => {
+    expect(html).toContain("This page didn't load");
+  });
+
+  it("offers both recovery affordances: retry and go-home", () => {
+    // The page has no client framework, so recovery relies on a plain reload
+    // handler and a static home link.
+    expect(html).toContain("location.reload()");
+    expect(html).toContain('href="/"');
+  });
+
+  it("returns stable output across calls (pure render)", () => {
+    expect(renderErrorPage()).toBe(html);
+  });
+});


### PR DESCRIPTION
Add coverage for `renderErrorPage` from `apps/web/src/lib/error-page.ts`. This produces the raw HTML fallback served when the app fails before the client framework is available, and had no direct test.

## New file: `tests/render-error-page.test.ts`

- Returns a **complete, localized HTML document** (`<!doctype html>`, `<html lang="en">`, viewport meta) — it must be self-contained because no framework/runtime is available at the point it is served.
- **Communicates the failure** with a user-facing title.
- Offers **both recovery affordances** the page depends on without a client framework: a plain `location.reload()` retry handler and a static `href="/"` home link.
- Is a **pure render** — repeated calls return identical output.

Each assertion carries a short rationale comment tying it to the no-framework fallback context. All assertions derive from the current implementation. 4 tests, all green; no source changes.
