### PR TITLE
feat(seo): comparison-candidate discovery tool + demand-backed batch

### DIFF
--- a/apps/web/src/data/comparisons.ts
+++ b/apps/web/src/data/comparisons.ts
@@ -567,6 +567,36 @@ export const COMPARISONS: Comparison[] = [
       "CI/CD and delivery MCP servers that let Claude manage pipelines and deployments, compared on trust, setup, and safety.",
     refs: ["mcp/circleci-mcp-server", "mcp/azure-devops-mcp-server", "mcp/argocd-mcp-server"],
   },
+  {
+    slug: "llm-observability-mcp-servers",
+    title: "Arize Phoenix vs Opik MCP servers for Claude",
+    heading: "LLM observability MCP servers compared",
+    seoDescription:
+      "Compare the Arize Phoenix and Opik MCP servers for Claude Code — tracing, evals, and prompt management, with trust, install, and safety side by side.",
+    intro:
+      "LLM observability MCP servers that give Claude access to traces, evals, and prompt management, compared on trust, setup, and safety.",
+    refs: ["mcp/arize-phoenix-mcp-server", "mcp/opik-mcp-server"],
+  },
+  {
+    slug: "paas-deployment-mcp-servers",
+    title: "Fly.io vs Railway MCP servers for Claude",
+    heading: "PaaS deployment MCP servers compared",
+    seoDescription:
+      "Compare the Fly.io and Railway MCP servers for Claude Code — deploy and manage apps on each platform, with trust, install, and safety side by side.",
+    intro:
+      "Platform-as-a-service deployment MCP servers that let Claude ship and manage apps, compared on trust, setup, and safety.",
+    refs: ["mcp/fly-io-mcp-server", "mcp/railway-mcp-server"],
+  },
+  {
+    slug: "mcp-gateway-servers",
+    title: "Bifrost vs MetaMCP vs tbxark MCP gateways for Claude",
+    heading: "MCP gateway servers compared",
+    seoDescription:
+      "Compare the Bifrost, MetaMCP, and tbxark MCP gateway and proxy servers for Claude Code — aggregate and route multiple MCP servers, with trust, install, and safety side by side.",
+    intro:
+      "MCP gateway and proxy servers that aggregate and route multiple MCP servers behind one endpoint, compared on trust, setup, and safety.",
+    refs: ["mcp/bifrost-mcp-gateway", "mcp/metamcp-gateway", "mcp/tbxark-mcp-proxy-server"],
+  },
 ];
 
 export function getComparison(slug: string) {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "validate:readme": "node scripts/generate-readme.mjs --check",
     "audit:content": "node scripts/audit-content.mjs",
     "audit:seo-snippets": "node scripts/audit-seo-snippets.mjs",
+    "audit:comparison-candidates": "tsx scripts/audit-comparison-candidates.ts",
     "report:thin-content": "node scripts/report-thin-content.mjs",
     "report:trust-coverage": "node scripts/report-trust-coverage.mjs",
     "validate:mcp-trust": "node scripts/report-trust-coverage.mjs --category mcp --check --min-risk-coverage 100 --min-attribution-coverage 100",

--- a/scripts/audit-comparison-candidates.ts
+++ b/scripts/audit-comparison-candidates.ts
@@ -1,0 +1,81 @@
+/**
+ * Surfaces a demand-backed backlog of comparison-page candidates: pairs of
+ * same-category entries with strong tag overlap (or a typed "alternative"
+ * relation) that no hand-maintained comparison page covers yet.
+ *
+ *   pnpm audit:comparison-candidates            # human-readable backlog
+ *   pnpm audit:comparison-candidates -- --json  # machine-readable JSON
+ *
+ * It never writes pages — comparisons are hand-curated to stay factual and
+ * avoid thin content. Maintainers pick from the ranked output.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  findComparisonCandidates,
+  pairKey,
+} from "./lib/comparison-candidates.mjs";
+import { COMPARISONS } from "../apps/web/src/data/comparisons";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+function loadEntries() {
+  const atlas = JSON.parse(
+    fs.readFileSync(
+      path.join(repoRoot, "apps/web/src/generated/atlas-registry.json"),
+      "utf8",
+    ),
+  ) as { entries: Array<Record<string, unknown>> };
+  return atlas.entries;
+}
+
+/** Every entry pair already covered by a comparison page. */
+function coveredPairs(): Set<string> {
+  const covered = new Set<string>();
+  for (const comparison of COMPARISONS) {
+    const refs = comparison.refs ?? [];
+    for (let i = 0; i < refs.length; i += 1) {
+      for (let j = i + 1; j < refs.length; j += 1) {
+        covered.add(pairKey(refs[i], refs[j]));
+      }
+    }
+  }
+  return covered;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const json = argv.includes("--json");
+  const entries = loadEntries();
+  const candidates = findComparisonCandidates(entries, coveredPairs(), {
+    minOverlap: 4,
+    limit: 40,
+  });
+
+  if (json) {
+    console.log(
+      JSON.stringify({ count: candidates.length, candidates }, null, 2),
+    );
+    return;
+  }
+
+  console.log(
+    `Comparison-page candidates (${candidates.length}) — not yet covered, ranked by tag overlap:\n`,
+  );
+  for (const candidate of candidates) {
+    const flag = candidate.isAlternative ? " [alternative]" : "";
+    console.log(
+      `  [${candidate.score}]${flag} ${candidate.category}: ${candidate.pair.join("  vs  ")}`,
+    );
+    console.log(`        shared: ${candidate.sharedTags.join(", ")}`);
+  }
+  console.log(
+    "\nThese are leads for hand-curated /compare pages — verify intent and source-backed depth before adding to apps/web/src/data/comparisons.ts.",
+  );
+}
+
+main();

--- a/scripts/lib/comparison-candidates.mjs
+++ b/scripts/lib/comparison-candidates.mjs
@@ -1,0 +1,83 @@
+// Discovers demand-backed comparison-page candidates from the registry: pairs
+// of same-category entries with strong tag overlap (and, where present, a typed
+// "alternative" relation) that are not already covered by a hand-maintained
+// comparison page. Deterministic — surfaces a ranked backlog for maintainers to
+// curate; it never auto-publishes pages (comparisons stay hand-written to avoid
+// thin content).
+
+/** Stable "category/slug" ref. */
+export function entryRef(entry) {
+  return `${entry.category}/${entry.slug}`;
+}
+
+/** Unordered pair key so {a,b} and {b,a} collapse. */
+export function pairKey(refA, refB) {
+  return [refA, refB].sort().join("|");
+}
+
+function tagSet(entry) {
+  return new Set((entry.tags ?? []).map((tag) => String(tag).toLowerCase()));
+}
+
+function altRefs(entry) {
+  return new Set(
+    (entry.relatedEntries ?? [])
+      .filter((rel) => rel.relation === "alternative")
+      .map((rel) => `${rel.category}/${rel.slug}`),
+  );
+}
+
+/**
+ * Ranked comparison candidates.
+ * @param entries registry entries (need category, slug, tags, relatedEntries)
+ * @param coveredPairs Set of pairKey() already covered by a comparison page
+ * @param opts.minOverlap minimum shared tags (default 3)
+ * @param opts.limit max candidates returned (default 25)
+ */
+export function findComparisonCandidates(entries, coveredPairs, opts = {}) {
+  const minOverlap = opts.minOverlap ?? 3;
+  const limit = opts.limit ?? 25;
+  const covered = coveredPairs ?? new Set();
+
+  const byCategory = new Map();
+  for (const entry of entries) {
+    const list = byCategory.get(entry.category) ?? [];
+    if (!byCategory.has(entry.category)) byCategory.set(entry.category, list);
+    list.push(entry);
+  }
+
+  const candidates = [];
+  for (const [category, group] of byCategory) {
+    for (let i = 0; i < group.length; i += 1) {
+      const a = group[i];
+      const aTags = tagSet(a);
+      if (aTags.size === 0) continue;
+      const aAlts = altRefs(a);
+      const refA = entryRef(a);
+      for (let j = i + 1; j < group.length; j += 1) {
+        const b = group[j];
+        const refB = entryRef(b);
+        if (covered.has(pairKey(refA, refB))) continue;
+        const shared = [...tagSet(b)].filter((tag) => aTags.has(tag));
+        const isAlternative = aAlts.has(refB) || altRefs(b).has(refA);
+        if (shared.length < minOverlap && !isAlternative) continue;
+        // Score: tag overlap, boosted when an explicit alternative relation exists.
+        const score = shared.length + (isAlternative ? 3 : 0);
+        candidates.push({
+          category,
+          pair: [refA, refB],
+          sharedTags: shared.sort(),
+          isAlternative,
+          score,
+        });
+      }
+    }
+  }
+
+  return candidates
+    .sort(
+      (x, y) =>
+        y.score - x.score || x.pair.join("|").localeCompare(y.pair.join("|")),
+    )
+    .slice(0, limit);
+}

--- a/tests/comparison-candidates.test.ts
+++ b/tests/comparison-candidates.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  findComparisonCandidates,
+  pairKey,
+} from "../scripts/lib/comparison-candidates.mjs";
+import { COMPARISONS } from "../apps/web/src/data/comparisons";
+import { ENTRIES } from "../apps/web/src/data/entries";
+
+function entry(
+  category: string,
+  slug: string,
+  tags: string[],
+  relatedEntries: Array<{
+    category: string;
+    slug: string;
+    relation: string;
+  }> = [],
+) {
+  return { category, slug, tags, relatedEntries };
+}
+
+describe("findComparisonCandidates", () => {
+  it("surfaces same-category pairs with enough tag overlap; excludes weak + cross-category", () => {
+    const entries = [
+      entry("mcp", "a", ["x", "y", "z", "w"]),
+      entry("mcp", "b", ["x", "y", "z", "w"]), // 4 shared with a
+      entry("mcp", "c", ["x", "y"]), // only 2 shared -> below minOverlap
+      entry("hooks", "d", ["x", "y", "z", "w"]), // cross-category
+    ];
+    const pairs = findComparisonCandidates(entries, new Set(), {
+      minOverlap: 3,
+    }).map((c) => c.pair.join("|"));
+    expect(pairs).toContain("mcp/a|mcp/b");
+    expect(pairs.some((p) => p.includes("mcp/c"))).toBe(false);
+    expect(pairs.some((p) => p.includes("hooks/d"))).toBe(false);
+  });
+
+  it("excludes pairs already covered by a comparison page", () => {
+    const entries = [
+      entry("mcp", "a", ["x", "y", "z"]),
+      entry("mcp", "b", ["x", "y", "z"]),
+    ];
+    const covered = new Set([pairKey("mcp/a", "mcp/b")]);
+    expect(
+      findComparisonCandidates(entries, covered, { minOverlap: 3 }),
+    ).toEqual([]);
+  });
+
+  it("includes + boosts explicit alternative relations even below the tag threshold", () => {
+    const entries = [
+      entry(
+        "mcp",
+        "a",
+        ["x"],
+        [{ category: "mcp", slug: "b", relation: "alternative" }],
+      ),
+      entry("mcp", "b", ["x"]),
+    ];
+    const candidates = findComparisonCandidates(entries, new Set(), {
+      minOverlap: 3,
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].isAlternative).toBe(true);
+    expect(candidates[0].score).toBeGreaterThan(1);
+  });
+
+  it("is deterministic", () => {
+    const entries = [
+      entry("mcp", "a", ["x", "y", "z"]),
+      entry("mcp", "b", ["x", "y", "z"]),
+      entry("mcp", "c", ["x", "y", "z"]),
+    ];
+    const opts = { minOverlap: 3 };
+    expect(findComparisonCandidates(entries, new Set(), opts)).toEqual(
+      findComparisonCandidates(entries, new Set(), opts),
+    );
+  });
+});
+
+describe("comparison pages", () => {
+  const refSet = new Set(ENTRIES.map((e) => `${e.category}/${e.slug}`));
+
+  it("every comparison resolves at least 2 entries (route requirement)", () => {
+    for (const comparison of COMPARISONS) {
+      const resolved = comparison.refs.filter((ref) => refSet.has(ref));
+      expect(resolved.length, comparison.slug).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("comparison slugs are unique", () => {
+    const slugs = COMPARISONS.map((c) => c.slug);
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("includes the new demand-backed batch", () => {
+    const slugs = new Set(COMPARISONS.map((c) => c.slug));
+    for (const slug of [
+      "llm-observability-mcp-servers",
+      "paas-deployment-mcp-servers",
+      "mcp-gateway-servers",
+    ]) {
+      expect(slugs.has(slug)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Grows comparison pages from real registry demand signals — a repeatable tool plus an initial live batch.

Closes #3923.

## Repeatable method — `pnpm audit:comparison-candidates`
A ranked backlog of comparison-page candidates: same-category entry **pairs with strong tag overlap** (boosted by typed `alternative` relations) that **no existing comparison covers**. Pure, tested core (`scripts/lib/comparison-candidates.mjs`) + a `tsx` runner that excludes already-covered pairs from `COMPARISONS`. `--json` for machine output.

It **never auto-publishes** — comparisons stay hand-curated to avoid thin content (per the existing policy comment). The tool gives maintainers leads with rationale (shared tags) and demand evidence (overlap score). Current run surfaces **40** uncovered candidates.

## Initial batch (live) — 3 high-intent MCP comparisons from the top candidates
- **`llm-observability-mcp-servers`** — Arize Phoenix vs Opik (tracing/evals)
- **`paas-deployment-mcp-servers`** — Fly.io vs Railway
- **`mcp-gateway-servers`** — Bifrost vs MetaMCP vs tbxark (gateway/proxy)

Each is **live**, **auto-indexed in the sitemap** (`COMPARISONS` drives `/compare/*`), and **auto-linked from every referenced entry page** (`comparedIn`). Intros are concise + factual; the side-by-side trust/install/safety table carries the substance.

## Tests — `tests/comparison-candidates.test.ts`
Candidate logic (overlap threshold, covered-pair + cross-category exclusion, alternative boost, determinism) and comparison-page validation (every comparison resolves ≥2 entries, unique slugs, new batch present). type-check · build · prettier · Trunk — clean.

## Completion requirements (#3923)
- ✅ Repeatable discovery method from entry-overlap + related-entry data; backlog with rationale/evidence.
- ✅ Initial comparison batch live, sitemap-indexed, and linked from entry pages.
- ✅ Factual language, no unsupported rankings; no thin auto-generated pages.
- ✅ Relevant tests pass.