### PR TITLE
feat(seo): editorial answer-page overrides for best-list pages

### DIFF
--- a/apps/web/src/data/best-list-editorial.ts
+++ b/apps/web/src/data/best-list-editorial.ts
@@ -1,0 +1,79 @@
+// Optional editorial overrides for high-intent best-list pages. A best list
+// renders fine from generated data alone; when an entry here matches its slug,
+// the page also shows a source-backed "short answer" and decision criteria that
+// help readers (and AI answer engines) choose. Keep claims factual and tied to
+// registry signals (trust, source, safety/privacy disclosure, install
+// footprint) — no popularity or rating claims that are not measured.
+
+export type BestListDecisionCriterion = {
+  label: string;
+  detail: string;
+};
+
+export type BestListEditorial = {
+  /** Must match a slug in seoClusterDefinitions / BEST_LISTS. */
+  slug: string;
+  /** One- or two-sentence "what to pick and why" answer. */
+  shortAnswer: string;
+  /** Factual criteria to weigh when choosing from this list. */
+  decisionCriteria: BestListDecisionCriterion[];
+};
+
+export const BEST_LIST_EDITORIAL: BestListEditorial[] = [
+  {
+    slug: "claude-code-hooks",
+    shortAnswer:
+      "Pick a hook by the event it fires on and what it executes. Most hooks run on PostToolUse — ideal for linting, tests, and formatting after Claude edits a file — while Stop and Notification hooks gate or announce session events. Favor hooks that document their safety and privacy behavior and install as a project-local shell script you can read before enabling.",
+    decisionCriteria: [
+      {
+        label: "Hook event",
+        detail:
+          "Match the trigger to your workflow: PostToolUse for checks after edits, Stop to gate session end, Notification for alerts.",
+      },
+      {
+        label: "Disclosed behavior",
+        detail:
+          "Hooks run shell commands automatically. Read the documented safety and privacy notes — what each hook executes and what data it reads — before enabling it.",
+      },
+      {
+        label: "Source you can verify",
+        detail: "Prefer source-backed hooks whose script is in a public repository you can review.",
+      },
+      {
+        label: "Setup footprint",
+        detail:
+          "Most install as a single project-local .claude/hooks script with no extra prerequisites.",
+      },
+    ],
+  },
+  {
+    slug: "mcp-servers-for-databases",
+    shortAnswer:
+      "Choose a database MCP server by the database you run and how much write access you want to grant. Prefer source-backed servers with documented safety and privacy behavior, and confirm whether the server exposes read-only queries or full read/write before connecting it to anything that matters.",
+    decisionCriteria: [
+      {
+        label: "Your database",
+        detail: "Match the server to PostgreSQL, MySQL, MongoDB, Redis, or your managed provider.",
+      },
+      {
+        label: "Read vs read/write",
+        detail:
+          "Check whether the server allows mutations, and scope the credentials you give it to least privilege.",
+      },
+      {
+        label: "Source & trust",
+        detail:
+          "Prefer first-party or source-backed servers with a verifiable repository over unverified ones.",
+      },
+      {
+        label: "Safety & privacy notes",
+        detail:
+          "Confirm the server documents what data it reads and what it sends before granting database access.",
+      },
+    ],
+  },
+];
+
+export function getBestListEditorial(slug: string): BestListEditorial | undefined {
+  return BEST_LIST_EDITORIAL.find((editorial) => editorial.slug === slug);
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -7,6 +7,7 @@ import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
+import { getBestListEditorial } from "@/data/best-list-editorial";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -78,6 +79,7 @@ export const Route = createFileRoute("/best/$slug")({
 
 function BestDetail() {
   const { list } = Route.useLoaderData() as { list: BestList };
+  const editorial = getBestListEditorial(list.slug);
 
   type Resolved = BestPick & { entry: Entry };
   const resolved: Resolved[] = list.picks
@@ -110,6 +112,29 @@ function BestDetail() {
       <blockquote className="mt-8 max-w-3xl border-l-2 border-accent pl-5">
         <p className="drop-cap text-pretty text-ink-muted">{list.intro}</p>
       </blockquote>
+
+      {editorial && (
+        <>
+          <section className="mt-8 max-w-3xl rounded-xl border border-accent/30 bg-accent/5 p-5">
+            <div className="eyebrow mb-1 text-accent-ink dark:text-accent">Short answer</div>
+            <p className="text-pretty text-ink">{editorial.shortAnswer}</p>
+          </section>
+          <section className="mt-8">
+            <h2 className="h-display-2 text-ink">How to choose</h2>
+            <dl className="mt-4 grid gap-4 sm:grid-cols-2">
+              {editorial.decisionCriteria.map((criterion) => (
+                <div
+                  key={criterion.label}
+                  className="rounded-lg border border-border bg-surface p-4"
+                >
+                  <dt className="font-display text-sm font-semibold text-ink">{criterion.label}</dt>
+                  <dd className="mt-1 text-sm text-ink-muted">{criterion.detail}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        </>
+      )}
 
       {resolved.length >= 2 && (
         <section className="mt-10">

--- a/tests/best-list-editorial.test.ts
+++ b/tests/best-list-editorial.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BEST_LIST_EDITORIAL,
+  getBestListEditorial,
+} from "../apps/web/src/data/best-list-editorial";
+import { BEST_LISTS } from "../apps/web/src/data/entries";
+import { seoClusterDefinitions } from "../apps/web/src/data/seo-cluster-definitions";
+
+describe("best-list editorial overrides (#3922)", () => {
+  const clusterSlugs = new Set(seoClusterDefinitions.map((c) => c.slug));
+
+  it("every override targets a real best-list cluster", () => {
+    for (const editorial of BEST_LIST_EDITORIAL) {
+      expect(clusterSlugs.has(editorial.slug), editorial.slug).toBe(true);
+    }
+  });
+
+  it("each override has a short answer and decision criteria", () => {
+    for (const editorial of BEST_LIST_EDITORIAL) {
+      expect(editorial.shortAnswer.length).toBeGreaterThan(60);
+      expect(editorial.decisionCriteria.length).toBeGreaterThanOrEqual(3);
+      for (const criterion of editorial.decisionCriteria) {
+        expect(criterion.label.length).toBeGreaterThan(0);
+        expect(criterion.detail.length).toBeGreaterThan(20);
+      }
+    }
+  });
+
+  it("avoids unmeasured popularity/rating claims", () => {
+    for (const editorial of BEST_LIST_EDITORIAL) {
+      const blob = [
+        editorial.shortAnswer,
+        ...editorial.decisionCriteria.map((c) => c.detail),
+      ]
+        .join(" ")
+        .toLowerCase();
+      for (const banned of [
+        "most popular",
+        "#1",
+        "best-rated",
+        "highest rated",
+      ]) {
+        expect(blob, banned).not.toContain(banned);
+      }
+    }
+  });
+
+  it("getBestListEditorial returns overrides only for seeded slugs", () => {
+    expect(getBestListEditorial("claude-code-hooks")).toBeDefined();
+    expect(getBestListEditorial("not-a-real-list")).toBeUndefined();
+  });
+
+  it("seeded best-lists exist and still render without the override (generated fallback)", () => {
+    const bestSlugs = new Set(BEST_LISTS.map((b) => b.slug));
+    for (const editorial of BEST_LIST_EDITORIAL) {
+      expect(bestSlugs.has(editorial.slug), editorial.slug).toBe(true);
+    }
+    // A list with no override is still a valid best list.
+    const ungoverned = BEST_LISTS.find((b) => !getBestListEditorial(b.slug));
+    expect(ungoverned).toBeDefined();
+  });
+});


### PR DESCRIPTION
Upgrades the highest-intent best lists into real answer pages, without breaking generated-only lists.

Closes #3922.

## Model
New `apps/web/src/data/best-list-editorial.ts` — an **optional** editorial-override keyed by best-list slug, with a **short answer** and factual **decision criteria**. The `/best/$slug` route renders a "Short answer" block + a "How to choose" grid when an override exists, above the existing comparison table and per-pick rationale.

**Purely additive fallback**: lists without an override render exactly as before from generated data.

## Seeded first batch (live)
Two high-intent lists: **`claude-code-hooks`** and **`mcp-servers-for-databases`**. Copy is source-backed and tied to registry signals (trust, source, safety/privacy disclosure, install footprint) — **no popularity or rating claims**, which a test enforces. (Pick-specific rationale is intentionally left out of the override so it can never drift from the generated picks; the per-pick "Why it made the cut" already covers that.)

## Tests — `tests/best-list-editorial.test.ts`
Overrides target real clusters, each has a short answer + ≥3 decision criteria, **no unmeasured popularity claims**, the getter is slug-scoped, and generated-only lists still render. type-check · build · prettier · Trunk — clean.

## Completion requirements (#3922)
- ✅ First priority batch has short answers + decision criteria (+ existing comparison table & source-backed per-pick rationale).
- ✅ Generated-only best-list pages still work without overrides.
- ✅ Relevant tests + build pass.