### PR TITLE
test(raycast): cover normalizeDomain, isValidHttpsUrl, isValidDomain

### DIFF
--- a/tests/raycast-submission-validation.test.ts
+++ b/tests/raycast-submission-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeDomain,
+  isValidHttpsUrl,
+  isValidDomain,
+} from "../integrations/raycast/src/submission.js";
+
+describe("normalizeDomain", () => {
+  it("extracts a lowercased, www-stripped hostname from a URL", () => {
+    expect(normalizeDomain("https://www.Example.com/path?q=1")).toBe(
+      "example.com",
+    );
+  });
+
+  it("treats a bare host as https and lowercases it", () => {
+    // Missing scheme is assumed https so the host can still be parsed.
+    expect(normalizeDomain("Example.COM")).toBe("example.com");
+  });
+
+  it("returns an empty string for empty or missing input", () => {
+    // The parameter is declared `value?: string`, so a missing/blank value is
+    // a supported call shape that normalizes to "".
+    expect(normalizeDomain("")).toBe("");
+    expect(normalizeDomain()).toBe("");
+  });
+});
+
+describe("isValidHttpsUrl", () => {
+  it("accepts only https URLs", () => {
+    expect(isValidHttpsUrl("https://example.com")).toBe(true);
+    // http and non-URL inputs are rejected (no plaintext, no garbage).
+    expect(isValidHttpsUrl("http://example.com")).toBe(false);
+    expect(isValidHttpsUrl("not a url")).toBe(false);
+    expect(isValidHttpsUrl("")).toBe(false);
+  });
+});
+
+describe("isValidDomain", () => {
+  it("accepts dotted domains, including multi-label hosts", () => {
+    expect(isValidDomain("example.com")).toBe(true);
+    expect(isValidDomain("a.b.example.co.uk")).toBe(true);
+    // It normalizes first, so a full URL with www resolves to a valid domain.
+    expect(isValidDomain("https://www.example.com/path")).toBe(true);
+  });
+
+  it("rejects single-label hosts and invalid characters", () => {
+    expect(isValidDomain("localhost")).toBe(false);
+    expect(isValidDomain("not_a_domain")).toBe(false);
+    expect(isValidDomain("")).toBe(false);
+  });
+});


### PR DESCRIPTION
Add coverage for the URL/domain validation helpers in `integrations/raycast/src/submission.ts`: `normalizeDomain`, `isValidHttpsUrl`, and `isValidDomain`. These sanitize user-entered submission URLs/domains in the Raycast flow and had no direct test.

The module is imported with the `.js` specifier to match the established deep-relative test convention used throughout `tests/` (e.g. `tests/submission-builders.test.ts` imports `../packages/registry/src/submission.js`).

## New file: `tests/raycast-submission-validation.test.ts`

- **`normalizeDomain`** — extracts a lowercased, `www`-stripped hostname from a URL, treats a bare host as https so it can still be parsed, and returns `""` for empty/undefined input.
- **`isValidHttpsUrl`** — accepts only `https` URLs; rejects `http`, non-URL strings, and empty input (no plaintext downgrade, no garbage).
- **`isValidDomain`** — accepts dotted/multi-label domains (and normalizes a full `www` URL down to a valid domain first), while rejecting single-label hosts (`localhost`) and invalid characters (`not_a_domain`).

Each assertion carries a short rationale comment. All assertions derive from the current implementation. 6 tests, all green; no source changes.
