### PR TITLE
test(raycast): cover categoryLabel, isRaycastDetail, fallbackDetail, hasValidDiscoveryEntries

### DIFF
--- a/tests/raycast-feed-detail-helpers.test.ts
+++ b/tests/raycast-feed-detail-helpers.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  categoryLabel,
+  isRaycastDetail,
+  fallbackDetail,
+  hasValidDiscoveryEntries,
+  type RaycastEntry,
+} from "../integrations/raycast/src/feed.js";
+
+function entry(overrides: Partial<RaycastEntry>): RaycastEntry {
+  return {
+    category: "agents",
+    slug: "s",
+    title: "T",
+    description: "D",
+    tags: [],
+    installable: false,
+    hasInstallCommand: false,
+    hasConfigSnippet: false,
+    installCommand: "",
+    configSnippet: "",
+    copyText: "CT",
+    detailMarkdown: "MD",
+    webUrl: "https://w.example",
+    repoUrl: "",
+    documentationUrl: "",
+    downloadTrust: "external",
+    verificationStatus: "validated",
+    ...overrides,
+  } as RaycastEntry;
+}
+
+describe("categoryLabel", () => {
+  it("maps known categories to human labels and passes unknowns through", () => {
+    expect(categoryLabel("agents")).toBe("Agents");
+    expect(categoryLabel("mcp")).toBe("MCP Servers");
+    // An unrecognized category is returned unchanged rather than blanked.
+    expect(categoryLabel("zzz")).toBe("zzz");
+  });
+});
+
+describe("isRaycastDetail", () => {
+  it("accepts a well-formed detail object", () => {
+    expect(
+      isRaycastDetail({
+        category: "agents",
+        slug: "s",
+        title: "t",
+        description: "d",
+        webUrl: "https://w.example",
+        detailMarkdown: "m",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects incomplete objects and non-objects", () => {
+    expect(isRaycastDetail({ foo: 1 })).toBe(false);
+    expect(isRaycastDetail("x")).toBe(false);
+  });
+});
+
+describe("fallbackDetail", () => {
+  it("derives a detail payload from the list entry's fields", () => {
+    const detail = fallbackDetail(
+      entry({ copyText: "CT", detailMarkdown: "MD" }),
+    );
+    expect(detail.copyText).toBe("CT");
+    expect(detail.detailMarkdown).toBe("MD");
+  });
+});
+
+describe("hasValidDiscoveryEntries", () => {
+  it("is true when the JSON envelope has at least one resolvable entry", () => {
+    expect(
+      hasValidDiscoveryEntries(
+        JSON.stringify({ entries: [{ category: "agents", slug: "a" }] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false for an empty or reference-less entries array", () => {
+    expect(hasValidDiscoveryEntries(JSON.stringify({ entries: [] }))).toBe(
+      false,
+    );
+    expect(hasValidDiscoveryEntries(JSON.stringify({ other: 1 }))).toBe(false);
+  });
+
+  it("throws on malformed JSON (callers pass trusted feed payloads)", () => {
+    expect(() => hasValidDiscoveryEntries("not json")).toThrow();
+  });
+});


### PR DESCRIPTION
Add coverage for the Raycast feed detail/label helpers in `integrations/raycast/src/feed.ts`: `categoryLabel`, `isRaycastDetail`, `fallbackDetail`, and `hasValidDiscoveryEntries`. These format categories, validate detail payloads, derive fallbacks, and gate discovery feeds — none had a direct test.

The module is imported with the `.js` specifier; fixtures are typed as the exported `RaycastEntry`.

## New file: `tests/raycast-feed-detail-helpers.test.ts`

- **`categoryLabel`** — maps known categories to human labels (`agents` → `Agents`, `mcp` → `MCP Servers`) and passes unknowns through unchanged.
- **`isRaycastDetail`** — accepts a well-formed detail object and rejects incomplete objects / non-objects.
- **`fallbackDetail`** — derives a detail payload from the list entry's fields.
- **`hasValidDiscoveryEntries`** — true when the JSON envelope has a resolvable entry, false for empty/reference-less arrays, and throws on malformed JSON (callers pass trusted feed payloads).

Each assertion carries a short rationale comment. All assertions derive from the current implementation. 7 tests, all green; no source changes.
