### PR TITLE
test(mcp): cover tool output schema lookup and zod error formatting

### DIFF
--- a/tests/mcp-schemas-output-error.test.ts
+++ b/tests/mcp-schemas-output-error.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+// Deep-relative test imports use the `.js` specifier across this repo's suite;
+// the bundler maps it to the TypeScript source.
+import {
+  jsonSchemaForToolOutput,
+  formatZodError,
+} from "../packages/mcp/src/schemas.js";
+
+describe("jsonSchemaForToolOutput", () => {
+  it("returns a JSON-schema object for a known tool", () => {
+    const schema = jsonSchemaForToolOutput("compare_entries");
+    expect(schema.type).toBe("object");
+    expect(schema.properties).toHaveProperty("ok");
+    expect(schema.required).toContain("ok");
+  });
+
+  it("throws for an unknown tool name", () => {
+    // The exact message is part of the helper's contract: callers/log scrapers
+    // key on it, so the test pins it against the current implementation.
+    expect(() => jsonSchemaForToolOutput("not_a_real_tool")).toThrow(
+      "Unknown HeyClaude MCP tool output schema",
+    );
+  });
+});
+
+describe("formatZodError", () => {
+  it("flattens a ZodError into path/message/code issues", () => {
+    const result = z.object({ a: z.string() }).safeParse({ a: 123 });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const issues = formatZodError(result.error);
+    expect(issues).not.toBeNull();
+    expect(issues![0]).toMatchObject({ path: "a", code: "invalid_type" });
+    expect(typeof issues![0].message).toBe("string");
+  });
+
+  it("returns null for a non-Zod error", () => {
+    // Only ZodErrors are formatted; anything else is passed back as null.
+    expect(formatZodError(new Error("boom"))).toBeNull();
+  });
+});


### PR DESCRIPTION
Add coverage for `jsonSchemaForToolOutput` and `formatZodError` from `packages/mcp/src/schemas.js`. The first exposes the JSON output schema for an MCP tool; the second flattens validation errors for MCP responses. Neither had a direct test.

The module is imported with the `.js` specifier to match the established deep-relative test convention.

## New file: `tests/mcp-schemas-output-error.test.ts`

- **`jsonSchemaForToolOutput`**
  - returns a JSON-schema object (`type: "object"`, `ok` property required) for a known tool (`compare_entries`),
  - throws `Unknown HeyClaude MCP tool output schema` for an unknown tool name.
- **`formatZodError`**
  - flattens a `ZodError` into `{ path, message, code }` issues,
  - returns `null` for a non-Zod error (only ZodErrors are formatted).

Each assertion carries a short rationale comment. All assertions derive from the current implementation. 4 tests, all green; no source changes.
