### PR TITLE
test(raycast): cover resolveClaudeCli candidate resolution and not-found error

### DIFF
--- a/tests/mcp-installer-resolve-cli.test.ts
+++ b/tests/mcp-installer-resolve-cli.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+// Deep-relative test imports use the `.js` specifier across this repo's suite;
+// the bundler maps it to the TypeScript source.
+import {
+  resolveClaudeCli,
+  mcpCliCandidates,
+} from "../integrations/raycast/src/mcp-installer.js";
+
+const claudeCandidates = mcpCliCandidates("claude-code");
+
+describe("resolveClaudeCli", () => {
+  it("returns the first candidate whose --version probe succeeds", async () => {
+    const first = claudeCandidates[0];
+    // Inject an execFile that only the first candidate "responds" to.
+    const execFile = async (file: string) => {
+      if (file === first) return { stdout: "1.0.0" };
+      throw new Error("not found");
+    };
+    await expect(resolveClaudeCli(execFile as never)).resolves.toBe(first);
+  });
+
+  it("falls through to a later candidate when earlier probes fail", async () => {
+    const target = claudeCandidates[claudeCandidates.length - 1];
+    const execFile = async (file: string) => {
+      if (file === target) return { stdout: "1.0.0" };
+      throw new Error("not found");
+    };
+    await expect(resolveClaudeCli(execFile as never)).resolves.toBe(target);
+  });
+
+  it("rejects with a helpful error when no candidate is runnable", async () => {
+    // Every probe fails, so the helper reports the CLI as not found.
+    const execFile = async () => {
+      throw new Error("ENOENT");
+    };
+    await expect(resolveClaudeCli(execFile as never)).rejects.toThrow(
+      "CLI was not found",
+    );
+  });
+});


### PR DESCRIPTION
Add coverage for `resolveClaudeCli` from `integrations/raycast/src/mcp-installer.ts`. This locates a runnable Claude Code CLI by probing candidate paths, and had no direct test. It accepts an injectable `execFile`, so the probing logic is tested deterministically without touching the real filesystem.

The module is imported with the `.js` specifier to match the established deep-relative test convention.

## New file: `tests/mcp-installer-resolve-cli.test.ts`

- Returns the **first candidate** whose `--version` probe succeeds.
- **Falls through** to a later candidate when earlier probes fail.
- **Rejects with a helpful error** (`CLI was not found`) when no candidate is runnable.

Each test injects a fake `execFile` so the assertions are deterministic and carry a short rationale comment. All assertions derive from the current implementation. 3 tests, all green; no source changes.
