### PR TITLE
fix(seo): preserve normalized citation facts

### DIFF
--- a/packages/registry/src/llms.js
+++ b/packages/registry/src/llms.js
@@ -61,9 +61,9 @@ function bulletList(values) {
 
 function entrySourceUrls(entry) {
   return [
-    entry.documentationUrl,
+    entry.documentationUrl ?? entry.docsUrl,
     entry.repoUrl,
-    entry.githubUrl,
+    entry.githubUrl ?? entry.sourceUrl,
     entry.websiteUrl,
   ]
     .map(clean)
@@ -104,9 +104,10 @@ export function entryCitationFacts(entry, params = {}) {
     [
       "Platform compatibility",
       listValue(
-        entry.platformCompatibility?.map(
-          (item) => `${item.platform} (${item.supportLevel})`,
-        ),
+        entry.platformCompatibility?.map((item) => {
+          const support = item.supportLevel ?? item.support;
+          return support ? `${item.platform} (${support})` : item.platform;
+        }),
       ),
     ],
     ["Author", clean(entry.author)],

--- a/tests/citation-facts.test.ts
+++ b/tests/citation-facts.test.ts
@@ -99,9 +99,7 @@ describe("entryCitationFacts (shared citation-fact source)", () => {
     expect(f.get("Source URLs")).toBe(
       "https://docs.example/normalized-entry, https://github.com/example/normalized-entry, https://example.test/normalized-entry",
     );
-    expect(f.get("Platform compatibility")).toBe(
-      "claude-code (native-skill)",
-    );
+    expect(f.get("Platform compatibility")).toBe("claude-code (native-skill)");
   });
 
   it("buildEntryCitationFacts is exactly the pairs joined — block and LLMS endpoint cannot drift", () => {

--- a/tests/citation-facts.test.ts
+++ b/tests/citation-facts.test.ts
@@ -84,6 +84,26 @@ describe("entryCitationFacts (shared citation-fact source)", () => {
     expect(f.get("Robots")).toBe("noindex");
   });
 
+  it("handles normalized client source and platform field names", () => {
+    const f = facts({
+      category: "skills",
+      slug: "normalized-entry",
+      docsUrl: "https://docs.example/normalized-entry",
+      sourceUrl: "https://github.com/example/normalized-entry",
+      websiteUrl: "https://example.test/normalized-entry",
+      platformCompatibility: [
+        { platform: "claude-code", support: "native-skill" },
+      ],
+    });
+
+    expect(f.get("Source URLs")).toBe(
+      "https://docs.example/normalized-entry, https://github.com/example/normalized-entry, https://example.test/normalized-entry",
+    );
+    expect(f.get("Platform compatibility")).toBe(
+      "claude-code (native-skill)",
+    );
+  });
+
   it("buildEntryCitationFacts is exactly the pairs joined — block and LLMS endpoint cannot drift", () => {
     const entry = {
       category: "mcp",


### PR DESCRIPTION
### Motivation
- The visible `CitationFacts` block received a normalized web `Entry` while the registry helper (`entryCitationFacts`) still read some raw registry field names, causing missing source URLs and `undefined` platform support in the rendered facts. 
- This is a correctness/SEO drift (not a security issue) that can show the wrong public metadata on entry pages.

### Description
- Accept normalized source/documentation URL fields by updating `entrySourceUrls` to prefer `docsUrl`/`sourceUrl` when `documentationUrl`/`githubUrl` are absent in `packages/registry/src/llms.js`.
- Preserve both raw and normalized platform fields by rendering `platformCompatibility` items using `item.supportLevel ?? item.support` and falling back to the platform name when support is missing in `packages/registry/src/llms.js`.
- Add a regression test that covers normalized client field names (`docsUrl`, `sourceUrl`, and `support`) in `tests/citation-facts.test.ts` to prevent future drift.

### Testing
- Ran `pnpm exec vitest run tests/citation-facts.test.ts` and the test file passed (`7 passed`).
- Ran `pnpm validate:packages` (package download validation) and it completed successfully.
- Ran `git diff --check` to ensure no whitespace/check issues and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b0d9a090832c8dc74248d47cec33)