### PR TITLE
fix(seo): guard IndexNow category report lookup

### DIFF
--- a/scripts/lib/indexnow-hubs.mjs
+++ b/scripts/lib/indexnow-hubs.mjs
@@ -38,7 +38,10 @@ export function entryHubPaths(entry) {
   const category = String(entry?.category ?? "").trim();
   if (category) {
     paths.add(`/${category}`);
-    for (const report of CATEGORY_REPORTS[category] ?? []) paths.add(report);
+    const categoryReports = Object.hasOwn(CATEGORY_REPORTS, category)
+      ? CATEGORY_REPORTS[category]
+      : [];
+    for (const report of categoryReports) paths.add(report);
     for (const report of GLOBAL_REPORTS) paths.add(report);
   }
   for (const tag of entry?.tags ?? []) {

--- a/tests/indexnow.test.ts
+++ b/tests/indexnow.test.ts
@@ -110,6 +110,15 @@ describe("IndexNow hub expansion", () => {
     expect(paths).toEqual(["/rules", "/state-of-claude-tooling"]);
   });
 
+  it("treats inherited object property names as unknown categories", () => {
+    for (const category of ["constructor", "toString", "__proto__"]) {
+      expect(entryHubPaths({ category, slug: "x", tags: [] })).toEqual([
+        `/${category}`,
+        "/state-of-claude-tooling",
+      ]);
+    }
+  });
+
   it("emits no tag hubs when the entry has no tags", () => {
     const paths = entryHubPaths({ category: "skills", slug: "x" });
     expect(paths.some((p) => p.startsWith("/tags/"))).toBe(false);


### PR DESCRIPTION
### Motivation
- The IndexNow hub expansion looked up `CATEGORY_REPORTS[category]` directly and could throw a `TypeError` when `category` matched inherited object property names like `constructor`, `toString`, or `__proto__`.
- Treating inherited names as unknown categories preserves the intended non-spammy behavior and prevents the on-publish IndexNow job from failing.

### Description
- Add an own-property guard using `Object.hasOwn(CATEGORY_REPORTS, category)` before iterating category reports in `scripts/lib/indexnow-hubs.mjs` so inherited properties are not treated as report arrays.
- Keep emitting the category page and global reports for unknown categories while skipping category-specific reports when the category is not an own key.
- Add a regression test in `tests/indexnow.test.ts` that covers inherited property names (`constructor`, `toString`, `__proto__`) to ensure they are treated as unknown categories.

### Testing
- Ran `pnpm exec vitest run tests/indexnow.test.ts` and the `tests/indexnow.test.ts` file passed (12 tests passed).
- Executed `node scripts/indexnow-changed-urls.mjs constructor/foo` to verify the script no longer throws and emits the expected entry and hub URLs.
- Ran `git diff --check` to ensure no whitespace/check failures were introduced and it returned clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36af73901c832c98d8178b5ec9f516)