### PR TITLE
fix(registry): guard platform alias lookup

### DIFF
--- a/packages/registry/src/platforms.js
+++ b/packages/registry/src/platforms.js
@@ -38,7 +38,7 @@ export const PLATFORM_LABELS = {
 };
 
 // Free-form / display aliases -> canonical ID (matched lowercased + trimmed).
-export const PLATFORM_ALIASES = {
+export const PLATFORM_ALIASES = Object.freeze({
   claude: "claude-code",
   "claude code": "claude-code",
   "claude-code": "claude-code",
@@ -62,12 +62,15 @@ export const PLATFORM_ALIASES = {
   aider: "aider",
   zed: "zed",
   continue: "continue",
-};
+});
 
 /** Canonical platform ID for a free-form value, or undefined when unknown. */
 export function normalizePlatform(value) {
   if (typeof value !== "string") return undefined;
-  return PLATFORM_ALIASES[value.trim().toLowerCase()];
+  const key = value.trim().toLowerCase();
+  return Object.hasOwn(PLATFORM_ALIASES, key)
+    ? PLATFORM_ALIASES[key]
+    : undefined;
 }
 
 /**

--- a/tests/platform-taxonomy.test.ts
+++ b/tests/platform-taxonomy.test.ts
@@ -23,6 +23,14 @@ describe("canonical platform taxonomy (#3920)", () => {
     expect(normalizePlatform(42)).toBeUndefined();
   });
 
+  it("treats prototype property names as unknown platform values", () => {
+    expect(normalizePlatform("constructor")).toBeUndefined();
+    expect(normalizePlatform("__proto__")).toBeUndefined();
+    expect(normalizePlatforms(["constructor", "__proto__", "Cursor"])).toEqual([
+      "cursor",
+    ]);
+  });
+
   it("dedupes equivalent platforms and drops unknowns, preserving order", () => {
     expect(
       normalizePlatforms(["Codex", "codex", "Cursor", "antigravity", "Claude"]),


### PR DESCRIPTION
### Motivation
- The free-form alias lookup could return inherited prototype values for inputs like `constructor` or `__proto__`, which allowed non-string values into generated public platform arrays and violated the documented string-array contract.
- The change prevents malformed contributor frontmatter from poisoning public artifacts consumed by strict clients. 

### Description
- Make `PLATFORM_ALIASES` immutable with `Object.freeze` to prevent runtime mutation of the alias table. 
- Guard `normalizePlatform` with an own-property check using `Object.hasOwn(PLATFORM_ALIASES, key)` so prototype properties are treated as unknown and return `undefined`.
- Add regression coverage to `tests/platform-taxonomy.test.ts` to assert that `constructor` and `__proto__` are treated as unknown and that `normalizePlatforms` drops them.

### Testing
- Ran `pnpm --filter web run prebuild && pnpm exec vitest run tests/platform-taxonomy.test.ts` and the suite passed (all tests in `tests/platform-taxonomy.test.ts` succeeded after generating `apps/web/public/data`).
- Ran `pnpm test:registry-artifacts` and the registry artifact tests passed (all tests succeeded).
- Ran `git diff --check` as a validation step and it produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36b0da57e8832cacb9c37525eee2a4)