### PR TITLE
fix(registry): strip default ports in source URL matching

### DIFF
--- a/packages/mcp/src/submissions.js
+++ b/packages/mcp/src/submissions.js
@@ -797,6 +797,12 @@ function normalizeSubmissionUrlForMatch(value) {
   url.protocol = url.protocol.toLowerCase();
   url.hostname = url.hostname.toLowerCase().replace(/^www\./, "");
   url.hash = "";
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
   const droppedKeys = [];
   for (const key of url.searchParams.keys()) {
     if (isTrackingQueryKey(key)) droppedKeys.push(key);

--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -36,6 +36,16 @@ function normalizeParamName(name) {
     .toLowerCase();
 }
 
+/** Drop explicit :443/:80 ports so default-port URLs compare equal. */
+function stripDefaultPort(url) {
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+}
+
 /**
  * Return true for affiliate/referral params and the UTM params that the
  * submission validator already treats as promotional source noise.
@@ -114,6 +124,7 @@ export function canonicalizeSourceUrl(value) {
     url.hash = "";
     url.protocol = url.protocol.toLowerCase();
     url.hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
+    stripDefaultPort(url);
     while (url.pathname !== "/" && url.pathname.endsWith("/")) {
       url.pathname = url.pathname.slice(0, -1);
     }

--- a/tests/mcp-submission-duplicate-urls.test.ts
+++ b/tests/mcp-submission-duplicate-urls.test.ts
@@ -39,6 +39,16 @@ describe("searchDuplicateEntries source-URL matching", () => {
     expect(result.count).toBe(1);
   });
 
+  it("matches explicit default-port variants against canonical entry URLs", () => {
+    const result = searchDuplicateEntries([entry()], {
+      sourceUrl: "https://github.com:443/domdomegg/airtable-mcp-server",
+    });
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("source_url");
+  });
+
   it("matches a variant with utm_* and other tracking query params", () => {
     const result = searchDuplicateEntries([entry()], {
       sourceUrl:

--- a/tests/source-url.test.ts
+++ b/tests/source-url.test.ts
@@ -52,4 +52,13 @@ describe("source URL canonicalization", () => {
     );
     expect(canonicalizeSourceUrl("not a url")).toBe("not a url");
   });
+
+  it("treats explicit default ports as equivalent to implicit ports", () => {
+    expect(canonicalizeSourceUrl("https://example.com:443/docs")).toBe(
+      canonicalizeSourceUrl("https://example.com/docs"),
+    );
+    expect(canonicalizeSourceUrl("http://example.com:80/docs")).toBe(
+      canonicalizeSourceUrl("http://example.com/docs"),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- strip explicit `:443` / `:80` ports during source URL canonicalization
- align MCP duplicate-search URL normalization with registry preflight matching
- add regression coverage for default-port submission variants

## What Changed
- Added `stripDefaultPort()` in `packages/registry/src/source-url.js` and applied it inside `canonicalizeSourceUrl()`.
- Applied the same default-port stripping in `packages/mcp/src/submissions.js` `normalizeSubmissionUrlForMatch()`.
- Extended `tests/source-url.test.ts` and `tests/mcp-submission-duplicate-urls.test.ts` with default-port equivalence cases.

## Why
Submitted source URLs sometimes include explicit default ports (`https://example.com:443/docs`) while indexed entry URLs omit them (`https://example.com/docs`). The URL normalizers lowercased hostnames and stripped tracking params but preserved explicit ports, so web preflight duplicate checks and MCP `search_duplicate_entries` could miss the same resource.

## Validation
- `pnpm exec vitest run tests/source-url.test.ts tests/mcp-submission-duplicate-urls.test.ts`
- `trunk check --ci --upstream origin/main`

## Notes
- No content entries or generated registry artifacts are changed.
- Path-case sensitivity behavior is unchanged; only default-port equivalence is added.

## Summary by CodeRabbit

* **Bug Fixes**
  * Source URL canonicalization and MCP duplicate matching now treat explicit default ports (`:443`, `:80`) as equivalent to implicit ports.

* **Tests**
  * Added registry and MCP regression coverage for default-port URL variants in duplicate detection.