### PR TITLE
fix(registry): strip default ports in source URL matching

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -76,6 +76,7 @@
     "test": "pnpm --dir ../.. exec vitest run tests/mcp-server.test.ts tests/mcp-cli.test.ts"
   },
   "dependencies": {
+    "@heyclaude/registry": "workspace:*",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "4.4.3"
   }

--- a/packages/mcp/src/submissions.js
+++ b/packages/mcp/src/submissions.js
@@ -1,5 +1,7 @@
 export const SUBMISSION_SITE_URL = "https://heyclau.de/submit";
 
+import { stripDefaultSourcePort } from "@heyclaude/registry/source-url";
+
 function normalizeText(value) {
   return String(value || "").trim();
 }
@@ -797,6 +799,7 @@ function normalizeSubmissionUrlForMatch(value) {
   url.protocol = url.protocol.toLowerCase();
   url.hostname = url.hostname.toLowerCase().replace(/^www\./, "");
   url.hash = "";
+  stripDefaultSourcePort(url);
   const droppedKeys = [];
   for (const key of url.searchParams.keys()) {
     if (isTrackingQueryKey(key)) droppedKeys.push(key);

--- a/packages/registry/src/source-url.d.ts
+++ b/packages/registry/src/source-url.d.ts
@@ -2,4 +2,6 @@ export function isAffiliateParam(name: unknown): boolean;
 export function isTrackingParam(name: unknown): boolean;
 export function hasAffiliateParam(value: unknown): boolean;
 export function stripTrackingParams(value: unknown): string;
+/** Drop explicit :443/:80 so default-port URLs compare equal. Mutates `url`. */
+export function stripDefaultSourcePort(url: URL): void;
 export function canonicalizeSourceUrl(value: unknown): string;

--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -36,6 +36,16 @@ function normalizeParamName(name) {
     .toLowerCase();
 }
 
+/** Drop explicit :443/:80 so default-port URLs compare equal. Mutates `url`. */
+export function stripDefaultSourcePort(url) {
+  if (
+    (url.protocol === "https:" && url.port === "443") ||
+    (url.protocol === "http:" && url.port === "80")
+  ) {
+    url.port = "";
+  }
+}
+
 /**
  * Return true for affiliate/referral params and the UTM params that the
  * submission validator already treats as promotional source noise.
@@ -114,6 +124,7 @@ export function canonicalizeSourceUrl(value) {
     url.hash = "";
     url.protocol = url.protocol.toLowerCase();
     url.hostname = url.hostname.replace(/^www\./i, "").toLowerCase();
+    stripDefaultSourcePort(url);
     while (url.pathname !== "/" && url.pathname.endsWith("/")) {
       url.pathname = url.pathname.slice(0, -1);
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ importers:
 
   packages/mcp:
     dependencies:
+      '@heyclaude/registry':
+        specifier: workspace:*
+        version: link:../registry
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -712,6 +715,7 @@ packages:
 
   '@daytonaio/sdk@0.138.0':
     resolution: {integrity: sha512-cnbsflZYJ1NA4pQ2uX2lLN4w4ZQsO/xqdGDnpmwSu/LIW5F+O5gA8z4mfuWdIRcFFT4UhIpTzMuh3zRwxH7dIw==}
+    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
 
   '@daytonaio/toolbox-api-client@0.138.0':
     resolution: {integrity: sha512-unM9e7MOQiyDXdY8hCW1uTctYbxpo/TGZ6L71ZXyS/j2Cnz9/ud4VWBLcQP2VzlC+lrBP2YMrhT90zSSvcNfmA==}
@@ -4809,6 +4813,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: 5.9.3

--- a/tests/mcp-submission-duplicate-urls.test.ts
+++ b/tests/mcp-submission-duplicate-urls.test.ts
@@ -39,6 +39,45 @@ describe("searchDuplicateEntries source-URL matching", () => {
     expect(result.count).toBe(1);
   });
 
+  it("matches explicit :443 default-port variants against canonical entry URLs", () => {
+    const result = searchDuplicateEntries([entry()], {
+      sourceUrl: "https://github.com:443/domdomegg/airtable-mcp-server",
+    });
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("source_url");
+  });
+
+  it("matches explicit :80 default-port variants against canonical entry URLs", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "http://docs.example.com/airtable",
+        }),
+      ],
+      { sourceUrl: "http://docs.example.com:80/airtable" },
+    );
+    expect(result.count).toBe(1);
+    expect(
+      (result.matches as Array<{ reasons: string[] }>)[0].reasons,
+    ).toContain("source_url");
+  });
+
+  it("does not collapse non-default ports during duplicate matching", () => {
+    const result = searchDuplicateEntries(
+      [
+        entry({
+          documentationUrl: "",
+          repoUrl: "https://example.com:8443/airtable",
+        }),
+      ],
+      { sourceUrl: "https://example.com/airtable" },
+    );
+    expect(result.count).toBe(0);
+  });
+
   it("matches a variant with utm_* and other tracking query params", () => {
     const result = searchDuplicateEntries([entry()], {
       sourceUrl:

--- a/tests/source-url.test.ts
+++ b/tests/source-url.test.ts
@@ -5,6 +5,7 @@ import {
   hasAffiliateParam,
   isAffiliateParam,
   isTrackingParam,
+  stripDefaultSourcePort,
   stripTrackingParams,
 } from "@heyclaude/registry/source-url";
 
@@ -51,5 +52,29 @@ describe("source URL canonicalization", () => {
       canonicalizeSourceUrl("https://example.com/docs"),
     );
     expect(canonicalizeSourceUrl("not a url")).toBe("not a url");
+  });
+
+  it("strips default ports but preserves non-default ports", () => {
+    expect(canonicalizeSourceUrl("https://example.com:443/docs?ref=x")).toBe(
+      canonicalizeSourceUrl("https://example.com/docs?ref=x"),
+    );
+    expect(canonicalizeSourceUrl("http://example.com:80/docs")).toBe(
+      canonicalizeSourceUrl("http://example.com/docs"),
+    );
+    expect(canonicalizeSourceUrl("https://example.com:8443/docs")).toBe(
+      "https://example.com:8443/docs",
+    );
+
+    const httpsUrl = new URL("https://example.com:443/x");
+    stripDefaultSourcePort(httpsUrl);
+    expect(httpsUrl.port).toBe("");
+
+    const httpUrl = new URL("http://example.com:80/x");
+    stripDefaultSourcePort(httpUrl);
+    expect(httpUrl.port).toBe("");
+
+    const customPort = new URL("https://example.com:8443/x");
+    stripDefaultSourcePort(customPort);
+    expect(customPort.port).toBe("8443");
   });
 });


### PR DESCRIPTION
## Summary
- strip explicit `:443` / `:80` ports during source URL canonicalization and MCP duplicate matching
- share one `stripDefaultSourcePort()` helper instead of duplicating port logic
- add full regression coverage so patch coverage meets the 70% gate (follow-up to #4169)

## What Changed
- Added exported `stripDefaultSourcePort()` in `packages/registry/src/source-url.js` and applied it inside `canonicalizeSourceUrl()`.
- Wired MCP `normalizeSubmissionUrlForMatch()` to import the shared helper from `@heyclaude/registry/source-url`.
- Added `@heyclaude/registry` workspace dependency to `packages/mcp/package.json`.
- Extended `tests/source-url.test.ts` with direct helper coverage for `:443`, `:80`, and preserved `:8443`.
- Extended `tests/mcp-submission-duplicate-urls.test.ts` with `:443`, `:80`, and non-default-port negative cases.

## Why
Submitted source URLs sometimes include explicit default ports (`https://example.com:443/docs`) while indexed entry URLs omit them (`https://example.com/docs`). Without stripping default ports, web preflight duplicate checks and MCP `search_duplicate_entries` can miss the same resource.

#4169 had the right fix but was closed by the review gate when `codecov/patch` reported 60% (<70%) because the `:80` MCP path and non-default-port guard were untested. This PR keeps the behavior and adds the missing coverage.

## Validation
- `pnpm exec vitest run tests/source-url.test.ts tests/mcp-submission-duplicate-urls.test.ts --coverage`
- `trunk check --ci --upstream origin/main`

## Notes
- No content entries or generated registry artifacts are changed.
- Path-case sensitivity behavior is unchanged; only default-port equivalence is added.

## Summary by CodeRabbit

* **Bug Fixes**
  * Source URL canonicalization and MCP duplicate matching now treat explicit default ports (`:443`, `:80`) as equivalent to implicit ports while preserving non-default ports.

* **Refactor**
  * MCP submission URL matching reuses the registry `stripDefaultSourcePort()` helper instead of duplicating port-stripping logic.

* **Tests**
  * Added direct helper coverage plus MCP duplicate cases for `:443`, `:80`, and non-default ports.