### PR TITLE
fix(registry): guard heading key map lookup

### DIFF
--- a/packages/registry/src/submission.js
+++ b/packages/registry/src/submission.js
@@ -265,10 +265,10 @@ export function normalizeCategory(value) {
 
 function fieldKey(label) {
   const normalized = normalizeHeading(label);
-  return (
-    HEADING_KEY_MAP[normalized] ??
-    (normalized.startsWith("download-url") ? "download_url" : normalized)
-  );
+  if (Object.hasOwn(HEADING_KEY_MAP, normalized)) {
+    return HEADING_KEY_MAP[normalized];
+  }
+  return normalized.startsWith("download-url") ? "download_url" : normalized;
 }
 
 function parseJsonCodeBlock(value) {

--- a/tests/submission-builders.test.ts
+++ b/tests/submission-builders.test.ts
@@ -156,6 +156,12 @@ describe("registry submission parsing and validation", () => {
     });
   });
 
+  it("treats prototype property heading names as literal field keys", () => {
+    expect(parseSubmissionPrBody("### Constructor\n\nbuilder")).toEqual({
+      constructor: "builder",
+    });
+  });
+
   it("builds PR drafts and validates risky submissions with clear errors", () => {
     const draft = buildSubmissionPrDraft(validMcpFields);
     expect(buildSubmissionPrTitle(validMcpFields)).toBe(


### PR DESCRIPTION
## Summary
- guard `fieldKey()` heading lookup with `Object.hasOwn` so prototype property names are not treated as alias-map hits
- add regression coverage for `### Constructor` submission PR headings
- mirrors the merged #4155 platform alias guard pattern

## What Changed
- Updated `fieldKey()` in `packages/registry/src/submission.js` to use `Object.hasOwn(HEADING_KEY_MAP, normalized)` before reading the map.
- Added a regression test in `tests/submission-builders.test.ts`.

## Why
`fieldKey()` used `HEADING_KEY_MAP[normalized] ?? fallback`. Bracket lookup walks the prototype chain, so a heading like `### Constructor` inherited `Object.prototype.constructor` (a function). The nullish coalescing operator does not treat functions as missing, so parsed submission bodies got a bogus key like `"function Object() { [native code] }"` instead of `constructor`.

## Validation
- [x] `pnpm --filter web run prebuild`
- [x] `pnpm test` (1528/1528)
- [x] `pnpm exec vitest run tests/submission-builders.test.ts tests/mcp-server.test.ts -t "publishable|prototype property"`
- [x] `trunk check --ci --upstream origin/main`

## Notes
- No MCP package dependency changes.
- No content entries or generated registry artifacts are changed.

## Summary by CodeRabbit

* **Bug Fixes**
  * Submission PR heading parsing now treats inherited prototype property names as literal field keys instead of alias-map hits.

* **Tests**
  * Added regression coverage for `### Constructor` headings in submission PR bodies.