### PR TITLE
content(mcp): add Amazon Location Service MCP Server

### DIFF
--- a/content/mcp/aws-location-mcp-server.mdx
+++ b/content/mcp/aws-location-mcp-server.mdx
@@ -1,0 +1,152 @@
+---
+title: Amazon Location Service MCP Server
+slug: aws-location-mcp-server
+category: mcp
+description: >-
+  Official AWS Labs MCP server for Amazon Location Service that gives AI
+  assistants place search, geocoding, reverse geocoding, nearby and open-now
+  search, and route calculation with waypoint optimization.
+cardDescription: >-
+  Connect Claude to Amazon Location Service to search places, geocode and
+  reverse-geocode coordinates, find nearby/open spots, and calculate routes.
+seoTitle: "Amazon Location MCP Server for Claude — Geocoding & Routing"
+seoDescription: >-
+  Connect Claude to the official AWS Labs Amazon Location Service MCP server for
+  place search, geocoding, reverse geocoding, nearby/open-now search, and route
+  calculation over stdio with uvx using your scoped AWS credentials.
+author: AWS Labs
+authorProfileUrl: "https://github.com/awslabs"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-21"
+brandName: AWS Labs
+brandDomain: aws.amazon.com
+repoUrl: "https://github.com/awslabs/mcp"
+documentationUrl: "https://github.com/awslabs/mcp/blob/main/src/aws-location-mcp-server/README.md"
+websiteUrl: "https://awslabs.github.io/mcp/"
+packageUrl: "https://pypi.org/project/awslabs.aws-location-mcp-server/"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: Cross-platform
+sourceUrls:
+  - "https://github.com/awslabs/mcp/blob/main/src/aws-location-mcp-server/README.md"
+  - "https://github.com/awslabs/mcp"
+  - "https://github.com/awslabs/mcp/blob/main/src/aws-location-mcp-server/pyproject.toml"
+  - "https://pypi.org/project/awslabs.aws-location-mcp-server/"
+  - "https://github.com/awslabs/mcp/blob/main/LICENSE"
+installable: true
+installCommand: uvx awslabs.aws-location-mcp-server@latest
+usageSnippet: >-
+  Configure the server with uvx and a scoped AWS profile and region, then ask
+  Claude to search for a place, reverse-geocode coordinates, find nearby
+  options, or calculate a route between locations.
+copySnippet: |-
+  {
+    "awslabs.aws-location-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.aws-location-mcp-server@latest"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "us-east-1",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "awslabs.aws-location-mcp-server": {
+        "command": "uvx",
+        "args": ["awslabs.aws-location-mcp-server@latest"],
+        "env": {
+          "AWS_PROFILE": "${AWS_PROFILE}",
+          "AWS_REGION": "us-east-1",
+          "FASTMCP_LOG_LEVEL": "ERROR"
+        },
+        "type": "stdio"
+      }
+    }
+  }
+estimatedSetupTime: 10 minutes
+difficulty: intermediate
+prerequisites:
+  - An AWS account with Amazon Location Service enabled in your chosen region.
+  - Python 3.10 or newer and `uv` / `uvx` installed (Astral) to run the package.
+  - "AWS credentials configured locally (for example via `aws configure` or `AWS_PROFILE`) with permissions for Amazon Location Service place and route APIs."
+  - An MCP client that supports stdio servers; the server runs locally on the same host as the client.
+safetyNotes:
+  - This server calls Amazon Location Service place and route APIs with your AWS credentials; scope the profile to Location Service access and the intended account and region.
+  - "The tools are query-oriented (search, geocode, route) rather than resource-mutating, but Amazon Location Service API calls may incur AWS usage costs."
+  - Run it only on a trusted host, since it uses the local machine's AWS credentials to reach your account.
+privacyNotes:
+  - Place queries, coordinates, addresses, and waypoints you ask about are sent to Amazon Location Service using your configured credentials.
+  - Returned place details, addresses, and route geometry are exposed to the model; keep account identifiers and credentials out of public prompts, issues, and screenshots.
+tags:
+  - aws
+  - location
+  - geocoding
+  - maps
+  - aws-labs
+keywords:
+  - amazon location mcp server
+  - awslabs aws-location-mcp-server
+  - aws location service mcp claude
+  - geocoding routing mcp
+  - amazon location places mcp
+  - mcp server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Amazon Location Service MCP Server is an official [AWS Labs](https://github.com/awslabs/mcp)
+Model Context Protocol server that gives AI assistants access to Amazon Location
+Service. Instead of wiring up the Location Service SDK, Claude can search for
+places by name, geocode and reverse-geocode coordinates, find nearby or
+currently-open options, and calculate and optimize routes.
+
+It runs locally over stdio via `uvx` from the published
+`awslabs.aws-location-mcp-server` Python package and uses your local AWS
+credentials, so scope those credentials to Amazon Location Service access.
+
+## Features
+
+- **Search for places** — find places using geocoding from a text query.
+- **Get place details** — look up details for a specific place by `PlaceId`.
+- **Reverse geocode** — convert coordinates back into addresses.
+- **Search nearby** — find places near a given location.
+- **Open-now search** — find places that are currently open.
+- **Route calculation** — calculate routes between locations.
+- **Optimize waypoints** — reorder waypoints for an efficient route.
+
+## Use Cases
+
+- Resolve an address or business into coordinates for a downstream task.
+- Turn a set of coordinates into a human-readable address.
+- Find nearby or currently-open options around a location.
+- Plan and optimize a multi-stop route between waypoints.
+
+## Installation
+
+### Claude Code
+
+1. Install Python 3.10+ and `uv`.
+2. Configure an AWS profile and region with Amazon Location Service access.
+3. Add the server with the stdio configuration above (command `uvx`, package
+   `awslabs.aws-location-mcp-server@latest`, env `AWS_PROFILE` and `AWS_REGION`).
+4. Verify it is connected with `claude mcp list`.
+
+### Claude Desktop / Cursor / Kiro / VS Code
+
+Add the `configSnippet` above to your client's MCP configuration and set
+`AWS_PROFILE` and `AWS_REGION`. The first run downloads the package via `uvx`.
+
+## Source And Trust
+
+This entry is based on the official AWS Labs `awslabs/mcp` repository and the
+published PyPI package (Apache-2.0). The server is query-oriented over Amazon
+Location Service, but it uses your AWS credentials and incurs Location Service
+usage, so scope permissions tightly and verify the configuration against the
+linked source before using it in automated workflows.


### PR DESCRIPTION
Add a source-backed **MCP Servers** entry for the official **Amazon Location Service MCP Server** from AWS Labs (`awslabs/mcp`).

## Why this entry

- **Official + high-trust source**: `awslabs/mcp` (Apache-2.0, AWS Labs), published on PyPI as `awslabs.aws-location-mcp-server`.
- **Distinct use case**: geocoding, reverse geocoding, place/nearby/open-now search, and route calculation — not covered by existing AWS entries.
- **Credential-aware notes**: it uses local AWS credentials and incurs Amazon Location Service usage, which the safety/privacy notes document.

## Details

- Runs locally over stdio via `uvx awslabs.aws-location-mcp-server@latest` with `AWS_PROFILE`/`AWS_REGION`.
- Tools: search places, get place details, reverse geocode, search nearby, open-now search, route calculation, optimize waypoints.

## Validation

- `pnpm exec prettier --write` on the file; includes `submittedBy`/`submittedByUrl`.
- `pnpm validate:content:strict` → "Content validation passed."
- All `sourceUrls` (repo README, repo root, `pyproject.toml`, PyPI, LICENSE) return HTTP 200.

One source file only, no generated-artifact churn.
