### PR TITLE
feat(newsletter): shorten weekly brief + add theme line and editor note

### DIFF
--- a/apps/web/src/lib/brief-email.ts
+++ b/apps/web/src/lib/brief-email.ts
@@ -30,8 +30,14 @@ type BriefPayload = {
     sourceBackedCount?: number;
     saferInstallCount?: number;
   };
+  theme?: string;
+  note?: string;
   sections?: Record<string, BriefItem[] | undefined>;
 };
+
+// How many picks per section render as full cards before the rest collapse to
+// compact one-liners — keeps the email scannable without dropping coverage.
+const FEATURED_PER_SECTION = 4;
 
 const SECTIONS: BriefSection[] = [
   { key: "newEntries", label: "New this week", intro: "Fresh additions to the registry." },
@@ -130,6 +136,18 @@ function cardHtml(item: BriefItem, siteUrl: string): string {
   </table>`;
 }
 
+function overflowRowHtml(item: BriefItem, siteUrl: string): string {
+  const href = escapeHtml(absolute(String(item.url ?? ""), siteUrl));
+  const title = escapeHtml(String(item.title ?? ""));
+  const cat = escapeHtml(categoryLabel(item.category));
+  const catTag = cat
+    ? `<span style="font-size:10px;letter-spacing:0.05em;text-transform:uppercase;color:#a39e93;font-weight:700;">${cat}</span> `
+    : "";
+  return `<tr><td style="padding:8px 16px;border-bottom:1px solid #f0ede4;">
+      ${catTag}<a href="${href}" style="font-size:14px;font-weight:600;color:#171614;text-decoration:none;">${title}</a>
+    </td></tr>`;
+}
+
 function sectionHtml(
   section: BriefSection,
   items: BriefItem[] | undefined,
@@ -137,11 +155,18 @@ function sectionHtml(
 ): string {
   const rows = (items ?? []).filter((item) => item?.title);
   if (rows.length === 0) return "";
-  const cards = rows.map((item) => cardHtml(item, siteUrl)).join("");
+  const featured = rows.slice(0, FEATURED_PER_SECTION);
+  const overflow = rows.slice(FEATURED_PER_SECTION);
+  const cards = featured.map((item) => cardHtml(item, siteUrl)).join("");
+  const more = overflow.length
+    ? `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:2px 0 10px;border:1px solid #e7e3d8;border-radius:10px;background:#ffffff;">${overflow
+        .map((item) => overflowRowHtml(item, siteUrl))
+        .join("")}</table>`
+    : "";
   return `<div style="margin:28px 0 12px;">
       <div style="font-size:16px;font-weight:700;color:#171614;">${escapeHtml(section.label)}</div>
       <div style="font-size:12px;color:#a39e93;margin-top:2px;">${escapeHtml(section.intro)}</div>
-    </div>${cards}`;
+    </div>${cards}${more}`;
 }
 
 function sectionText(
@@ -151,13 +176,23 @@ function sectionText(
 ): string {
   const rows = (items ?? []).filter((item) => item?.title);
   if (rows.length === 0) return "";
-  const list = rows
+  const featured = rows.slice(0, FEATURED_PER_SECTION);
+  const overflow = rows.slice(FEATURED_PER_SECTION);
+  const list = featured
     .map((item) => {
       const desc = item.description ? `\n    ${truncate(String(item.description), 120)}` : "";
       return `• ${item.title} [${categoryLabel(item.category)}]${desc}\n    ${absolute(String(item.url ?? ""), siteUrl)}`;
     })
     .join("\n");
-  return `\n${section.label.toUpperCase()}\n${section.intro}\n${list}\n`;
+  const more = overflow.length
+    ? `\n${overflow
+        .map(
+          (item) =>
+            `• ${item.title} [${categoryLabel(item.category)}] — ${absolute(String(item.url ?? ""), siteUrl)}`,
+        )
+        .join("\n")}`
+    : "";
+  return `\n${section.label.toUpperCase()}\n${section.intro}\n${list}${more}\n`;
 }
 
 export function buildBriefEmail(options: {
@@ -176,6 +211,21 @@ export function buildBriefEmail(options: {
     : `HeyClaude Weekly Brief — ${dateLabelNice}`;
 
   const summaryLine = `${summary.newEntryCount ?? 0} new this week · ${summary.sourceBackedCount ?? 0} source-backed · ${summary.saferInstallCount ?? 0} safer installs`;
+
+  const theme = String(brief.theme ?? "").trim();
+  const themeBlock = theme
+    ? `<p style="font-size:15px;line-height:1.55;color:#44403a;margin:0 0 22px;">${escapeHtml(theme)}</p>`
+    : "";
+
+  const note = String(brief.note ?? "").trim();
+  const noteBlock = note
+    ? `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 24px;border-left:3px solid #171614;background:#faf8f2;border-radius:0 8px 8px 0;">
+        <tr><td style="padding:14px 18px;">
+          <div style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:#a39e93;font-weight:700;margin-bottom:6px;">From the editor</div>
+          <div style="font-size:14px;line-height:1.6;color:#44403a;white-space:pre-wrap;">${escapeHtml(note)}</div>
+        </td></tr>
+      </table>`
+    : "";
 
   const approveBlock = approveUrl
     ? `<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin:0 0 26px;background:#f0ede4;border:1px solid #e3dfd3;border-radius:12px;">
@@ -196,7 +246,9 @@ export function buildBriefEmail(options: {
         <tr><td>
           <div style="font-size:12px;letter-spacing:0.1em;text-transform:uppercase;color:#a39e93;font-weight:600;">HeyClaude Weekly Brief · ${escapeHtml(dateLabelNice)}</div>
           <h1 style="font-size:24px;line-height:1.25;margin:8px 0 6px;color:#171614;">${escapeHtml(title)}</h1>
-          <div style="font-size:13px;color:#8a857b;margin-bottom:22px;">${escapeHtml(summaryLine)}</div>
+          <div style="font-size:13px;color:#8a857b;margin-bottom:12px;">${escapeHtml(summaryLine)}</div>
+          ${themeBlock}
+          ${noteBlock}
           ${approveBlock}
           ${body || '<p style="color:#6b675f;">No notable activity this week.</p>'}
           <p style="margin-top:30px;padding-top:18px;border-top:1px solid #e7e3d8;font-size:12px;color:#a39e93;">Reviewed picks from <a href="${escapeHtml(siteUrl)}" style="color:#6b675f;">heyclau.de</a> — every entry is metadata-reviewed for source &amp; safety. No hype, no listicle filler.</p>
@@ -207,6 +259,8 @@ export function buildBriefEmail(options: {
 
   const text =
     `HeyClaude Weekly Brief — ${dateLabelNice}\n${title}\n${summaryLine}\n` +
+    (theme ? `\n${theme}\n` : "") +
+    (note ? `\nFrom the editor:\n${note}\n` : "") +
     (approveUrl ? `\nApprove & schedule: ${approveUrl}\n` : "") +
     SECTIONS.map((section) => sectionText(section, sections[section.key], siteUrl)).join("") +
     `\n— Reviewed picks from ${siteUrl}\n`;

--- a/apps/web/src/lib/brief-issues.server.ts
+++ b/apps/web/src/lib/brief-issues.server.ts
@@ -148,18 +148,29 @@ export async function getLatestDraft(): Promise<BriefIssue | null> {
  * replayed approval link can't reschedule an already-sent issue). Returns true
  * when a row transitioned to `approved`.
  */
-export async function approveBrief(number: number, scheduledSendAt: string): Promise<boolean> {
+export async function approveBrief(
+  number: number,
+  scheduledSendAt: string,
+  note = "",
+): Promise<boolean> {
   const db = getSiteDb();
   if (!db || !Number.isInteger(number)) return false;
+  // Optional maintainer note, merged into the payload so the audience send and
+  // the public /brief render it. Bounded; empty leaves the payload unchanged.
+  const trimmedNote = String(note ?? "")
+    .replace(/\r\n/g, "\n")
+    .trim()
+    .slice(0, 600);
   try {
     const result = await db
       .prepare(
         `UPDATE brief_issues
          SET status = 'approved', scheduled_send_at = ?, approved_at = ?,
+             payload = json_set(payload, '$.note', ?),
              updated_at = CURRENT_TIMESTAMP
          WHERE number = ? AND status = 'draft'`,
       )
-      .bind(scheduledSendAt, new Date().toISOString(), number)
+      .bind(scheduledSendAt, new Date().toISOString(), trimmedNote, number)
       .run();
     return Boolean(result?.meta?.changes);
   } catch (error) {

--- a/apps/web/src/routes/brief.$number.tsx
+++ b/apps/web/src/routes/brief.$number.tsx
@@ -11,12 +11,19 @@ const loadBriefIssue = createServerFn({ method: "GET" })
     const { getBriefByNumber } = await import("@/lib/brief-issues.server");
     const issue = await getBriefByNumber(data.number);
     if (!issue) return { found: false as const };
-    const payload = issue.payload as { title?: string; sections?: BriefSectionsData };
+    const payload = issue.payload as {
+      title?: string;
+      theme?: string;
+      note?: string;
+      sections?: BriefSectionsData;
+    };
     return {
       found: true as const,
       number: issue.number,
       periodThrough: issue.period_through,
       title: typeof payload.title === "string" ? payload.title : `Weekly Brief #${issue.number}`,
+      theme: typeof payload.theme === "string" ? payload.theme : "",
+      note: typeof payload.note === "string" ? payload.note : "",
       sections: payload.sections ?? {},
     };
   });
@@ -73,7 +80,16 @@ function BriefIssuePage() {
           Issue #{String(issue.number).padStart(2, "0")} · Week of {issue.periodThrough}
         </div>
         <h1 className="mt-2 h-display-1 text-ink text-balance">{issue.title}</h1>
+        {issue.found && issue.theme ? (
+          <p className="mt-4 text-pretty text-lg text-ink-muted">{issue.theme}</p>
+        ) : null}
       </header>
+      {issue.found && issue.note ? (
+        <div className="mt-6 max-w-3xl rounded-xl border-l-2 border-accent bg-surface p-5">
+          <div className="eyebrow text-ink-subtle">From the editor</div>
+          <p className="mt-1 whitespace-pre-wrap text-pretty text-ink">{issue.note}</p>
+        </div>
+      ) : null}
       <div className="mt-8">
         <BriefSections sections={issue.found ? issue.sections : {}} />
       </div>

--- a/apps/web/src/routes/brief.approve.tsx
+++ b/apps/web/src/routes/brief.approve.tsx
@@ -4,6 +4,10 @@ import { useState, type ReactNode } from "react";
 import { z } from "zod";
 
 const tokenInput = z.object({ token: z.string() });
+const confirmInput = z.object({
+  token: z.string(),
+  note: z.string().max(2000).optional(),
+});
 
 // Verify the signed link and return the draft it points at (read-only — the
 // approval itself is a separate POST so an email link-scanner can't auto-approve).
@@ -20,7 +24,7 @@ const verifyApprove = createServerFn({ method: "GET" })
   });
 
 const confirmApprove = createServerFn({ method: "POST" })
-  .inputValidator(tokenInput)
+  .inputValidator(confirmInput)
   .handler(async ({ data }) => {
     const { getEnvString } = await import("@/lib/cloudflare-env.server");
     const { verifyBriefApproveToken } = await import("@/lib/brief-token.server");
@@ -31,7 +35,7 @@ const confirmApprove = createServerFn({ method: "POST" })
     const payload = await verifyBriefApproveToken(secret, data.token, Date.now());
     if (!payload) return { ok: false as const, reason: "invalid" as const };
     const scheduledSendAt = nextSendSlot(new Date());
-    const changed = await approveBrief(payload.n, scheduledSendAt);
+    const changed = await approveBrief(payload.n, scheduledSendAt, data.note ?? "");
     return changed
       ? { ok: true as const, scheduledSendAt }
       : { ok: false as const, reason: "already" as const };
@@ -52,6 +56,7 @@ export const Route = createFileRoute("/brief/approve")({
 function ApprovePage() {
   const result = Route.useLoaderData();
   const { token } = Route.useSearch();
+  const [note, setNote] = useState("");
   const [state, setState] = useState<
     | { phase: "idle" }
     | { phase: "working" }
@@ -92,13 +97,30 @@ function ApprovePage() {
         </p>
       )}
       <div style={{ marginTop: 20 }}>
+        <label htmlFor="brief-note" className="block text-sm font-medium text-ink">
+          Add a short note to readers (optional)
+        </label>
+        <textarea
+          id="brief-note"
+          value={note}
+          onChange={(event) => setNote(event.target.value.slice(0, 600))}
+          rows={4}
+          maxLength={600}
+          placeholder="A line or two at the top of the issue — what you're into this week. Leave blank to skip and lead with the auto summary."
+          className="mt-2 w-full rounded-md border border-border bg-surface p-3 text-sm text-ink placeholder:text-ink-subtle"
+        />
+        <div className="mt-1 text-xs text-ink-subtle">
+          {note.trim().length}/600 · shows as a “From the editor” block above the picks.
+        </div>
+      </div>
+      <div style={{ marginTop: 16 }}>
         <button
           type="button"
           disabled={state.phase === "working"}
           onClick={async () => {
             setState({ phase: "working" });
             try {
-              const res = await confirmApprove({ data: { token } });
+              const res = await confirmApprove({ data: { token, note } });
               if (res.ok) setState({ phase: "done", scheduledSendAt: res.scheduledSendAt });
               else setState({ phase: "error", reason: res.reason });
             } catch {

--- a/packages/registry/src/index.d.ts
+++ b/packages/registry/src/index.d.ts
@@ -910,6 +910,8 @@ export type WeeklyBrief = {
     saferInstallCount: number;
     notableChangeCount: number;
   };
+  theme: string;
+  note: string;
   sections: {
     newEntries: WeeklyBriefItem[];
     sourceBacked: WeeklyBriefItem[];

--- a/packages/registry/src/weekly-brief.js
+++ b/packages/registry/src/weekly-brief.js
@@ -258,6 +258,51 @@ function selectChangelogChanges(changelogEntries, entries, params) {
   return selected;
 }
 
+const CATEGORY_NOUNS = {
+  mcp: ["MCP server", "MCP servers"],
+  rules: ["rule", "rules"],
+  hooks: ["hook", "hooks"],
+  skills: ["skill", "skills"],
+  commands: ["command", "commands"],
+  statuslines: ["statusline", "statuslines"],
+  agents: ["agent", "agents"],
+  guides: ["guide", "guides"],
+  tools: ["tool", "tools"],
+  collections: ["collection", "collections"],
+};
+
+function categoryNoun(category, count) {
+  const pair = CATEGORY_NOUNS[category];
+  if (!pair) return count === 1 ? "entry" : "entries";
+  return count === 1 ? pair[0] : pair[1];
+}
+
+/**
+ * A one-line, factual "this week" theme derived from the brief — the dominant
+ * new-entry category plus the review counts. Always present so the newsletter
+ * leads with context instead of a bare list. No popularity or hype claims.
+ */
+function briefTheme(newEntries, counts) {
+  const newCount = counts.newEntryCount;
+  const tail = `${counts.sourceBackedCount} source-backed ${counts.sourceBackedCount === 1 ? "pick" : "picks"} and ${counts.saferInstallCount} safer ${counts.saferInstallCount === 1 ? "install" : "installs"}`;
+  if (newCount === 0) {
+    return `A quieter week — ${tail} reviewed.`;
+  }
+  const byCategory = new Map();
+  for (const entry of newEntries) {
+    const category = text(entry.category);
+    if (category) byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
+  }
+  const [topCategory, topCount] = [...byCategory.entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  )[0] ?? [undefined, 0];
+  const lead =
+    topCategory && topCount >= 2
+      ? `, led by ${topCount} ${categoryNoun(topCategory, topCount)}`
+      : "";
+  return `${newCount} new this week${lead} — plus ${tail}, all metadata-reviewed for source and safety.`;
+}
+
 export function buildWeeklyBrief(entries, options = {}) {
   const normalizedEntries = Array.isArray(entries)
     ? entries.filter((entry) => keyFor(entry) && text(entry.title))
@@ -327,6 +372,14 @@ export function buildWeeklyBrief(entries, options = {}) {
       saferInstallCount: saferInstalls.length,
       notableChangeCount: notableChanges.length,
     },
+    // Auto-generated one-line context; always present.
+    theme: briefTheme(newEntries, {
+      newEntryCount: newEntries.length,
+      sourceBackedCount: sourceBacked.length,
+      saferInstallCount: saferInstalls.length,
+    }),
+    // Optional maintainer note, filled in at approval time (empty by default).
+    note: "",
     sections: {
       newEntries,
       sourceBacked,

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -285,6 +285,38 @@ describe("web non-UI utility coverage", () => {
     });
     expect(audience.subject).toBe("HeyClaude Weekly Brief — not-a-date");
     expect(audience.html).toContain("No notable activity this week.");
+
+    // Theme line, editor note, and density: 4 featured cards + compact overflow.
+    const full = buildBriefEmail({
+      brief: {
+        summary: {
+          newEntryCount: 6,
+          sourceBackedCount: 0,
+          saferInstallCount: 0,
+        },
+        theme: "6 new this week, led by 6 rules.",
+        note: "Glad to be back —\nreply and tell me what to cover.",
+        sections: {
+          newEntries: Array.from({ length: 6 }, (_, i) => ({
+            title: `Entry ${i}`,
+            url: `/entry/rules/e${i}`,
+            category: "rules",
+            description: "desc",
+          })),
+        },
+      },
+      siteUrl: "https://heyclau.de",
+      dateLabel: "2026-06-19",
+    });
+    expect(full.html).toContain("6 new this week, led by 6 rules.");
+    expect(full.html).toContain("From the editor");
+    expect(full.html).toContain("reply and tell me what to cover.");
+    expect(full.text).toContain("From the editor:");
+    // 4 full cards (14px 16px padding) + 2 compact overflow rows.
+    expect((full.html.match(/padding:14px 16px/g) ?? []).length).toBe(4);
+    expect(
+      (full.html.match(/border-bottom:1px solid #f0ede4/g) ?? []).length,
+    ).toBe(2);
   });
 
   it("signs brief approval tokens and rejects tampered, malformed, and expired tokens", async () => {

--- a/tests/weekly-brief.test.ts
+++ b/tests/weekly-brief.test.ts
@@ -119,6 +119,11 @@ describe("weekly brief generation", () => {
       saferInstallCount: 1,
       notableChangeCount: 1,
     });
+    // Auto-generated theme: dominant new-entry category + singularized counts.
+    expect(brief.theme).toBe(
+      "2 new this week, led by 2 MCP servers — plus 1 source-backed pick and 1 safer install, all metadata-reviewed for source and safety.",
+    );
+    expect(brief.note).toBe("");
     expect(brief.sections.newEntries.map((item) => item.key)).toEqual([
       "mcp:new-weak",
       "mcp:new-source-backed",


### PR DESCRIPTION
Makes the Weekly Brief read in ~20 seconds instead of a long scroll, and gives it a voice — all behind the existing approval flow (nothing sends until you approve).

## What changes
**1. Shorter via density.** Each section shows the **top 4 picks as full cards**; the rest collapse to **compact one-liner links**. Keeps full coverage but roughly halves the height. Applied to the email HTML *and* the plain-text version.

**2. Auto theme line (always-on, sustainable).** `buildWeeklyBrief` now emits a one-line, factual *"this week"* summary — dominant new-entry category + review counts — so the issue leads with context instead of a bare list. Example:
> *8 new this week, led by 6 rules — plus 6 source-backed picks and 6 safer installs, all metadata-reviewed for source and safety.*

No popularity/hype claims; it's pure registry data.

**3. Optional "From the editor" note.** A short note you type on the **approval page** renders as a block at the top of the issue. Blank by default → the auto theme leads. Stored by merging into the brief payload via SQLite `json_set` on approve — **no schema migration**, and the generated brief is untouched when you skip it.

**4. Public archive parity.** `/brief/N` renders the same theme + note.

## Why this shape
This is exactly the "auto-summary + optional personal note" balance we discussed: the theme keeps every issue contextual with zero effort, and the note slot lets you add a personal line the weeks you want to — without breaking the automated cadence or requiring an essay.

## Tests
- Theme generation (dominant category + singularized counts) — `weekly-brief.test.ts`.
- Email rendering: theme present, "From the editor" note, and **4 cards + 2 compact overflow rows** — `web-non-ui-utilities.test.ts`.
- type-check · `pnpm --filter web build` · prettier 3.8.3 · Trunk — all clean.

## Note on rollout
The note is added at the approval step, so it lands in the **audience** send. The review/preview email (before approval) shows the shortened layout + auto theme; the note you write then appears in the version that goes out.