### PR TITLE
feat(brief): order weekly-brief picks by richness, not the alphabet

### DIFF
--- a/packages/registry/src/weekly-brief.js
+++ b/packages/registry/src/weekly-brief.js
@@ -139,23 +139,63 @@ function hasSaferInstallSignal(entry) {
   );
 }
 
+// Safety/privacy presence. The full content carries `safetyNotes`/`privacyNotes`
+// arrays, but the slimmer directory index the brief actually runs against in
+// production drops them and keeps only the `trustSignals.has*` booleans — read
+// both so the signal isn't silently dead in prod.
+function hasSafetyNotes(entry) {
+  return Boolean(
+    list(entry.safetyNotes).length || entry.trustSignals?.hasSafetyNotes,
+  );
+}
+
+function hasPrivacyNotes(entry) {
+  return Boolean(
+    list(entry.privacyNotes).length || entry.trustSignals?.hasPrivacyNotes,
+  );
+}
+
 function trustScore(entry) {
   return (
     (hasSource(entry) ? 8 : 0) +
     (hasSaferInstallSignal(entry) ? 6 : 0) +
-    (list(entry.safetyNotes).length ? 3 : 0) +
-    (list(entry.privacyNotes).length ? 3 : 0) +
+    (hasSafetyNotes(entry) ? 3 : 0) +
+    (hasPrivacyNotes(entry) ? 3 : 0) +
     (entry.claimStatus === "verified" || entry.reviewedBy ? 2 : 0)
   );
 }
 
+// A finer-grained "how substantial is this entry" score, used only to break
+// trust-score ties. Without it, a same-day batch of equally-trusted entries
+// (e.g. eight sibling review-rule packs) falls straight through to an
+// alphabetical tiebreak, which reads as an arbitrary A-Z list. These fields all
+// survive into the production directory index: source depth, description
+// substance, editorial review, and verification recency.
+function richnessScore(entry) {
+  const ts = entry.trustSignals ?? {};
+  const description = text(entry.cardDescription || entry.description || "");
+  const sources = Number(ts.sourceUrlCount) || sourceUrls(entry).length;
+  return (
+    Math.min(sources, 6) +
+    Math.min(Math.floor(description.length / 60), 4) +
+    (ts.firstPartyEditorial ? 2 : 0) +
+    (ts.lastVerifiedAt || entry.verifiedAt ? 1 : 0)
+  );
+}
+
+// Keep "new this week" genuinely newest-first, but when a same-day batch ties on
+// trust, separate them by substance (richness) rather than dropping straight to
+// an alphabetical A-Z list. Title remains the final stable tiebreak so the order
+// is deterministic.
 function sortEntries(left, right) {
   const dateCompare = isoDate(right.dateAdded).localeCompare(
     isoDate(left.dateAdded),
   );
   if (dateCompare !== 0) return dateCompare;
-  const scoreCompare = trustScore(right) - trustScore(left);
-  if (scoreCompare !== 0) return scoreCompare;
+  const trustCompare = trustScore(right) - trustScore(left);
+  if (trustCompare !== 0) return trustCompare;
+  const richCompare = richnessScore(right) - richnessScore(left);
+  if (richCompare !== 0) return richCompare;
   return text(left.title).localeCompare(text(right.title));
 }
 

--- a/tests/weekly-brief.test.ts
+++ b/tests/weekly-brief.test.ts
@@ -139,6 +139,63 @@ describe("weekly brief generation", () => {
     ]);
   });
 
+  it("breaks same-day, same-trust ties by richness rather than alphabetically", () => {
+    const brief = buildWeeklyBrief(
+      [
+        // Alphabetically first but thin: a single source, terse description.
+        entry("alpha-thin", {
+          dateAdded: "2026-05-29",
+          description: "Thin entry.",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceStatus: "available",
+            sourceUrlCount: 1,
+            sourceUrls: ["https://example.com/alpha"],
+          },
+        }),
+        // Alphabetically last but substantial: many sources, long description,
+        // first-party editorial review. Same date and same trust score, so the
+        // old A-Z tiebreak would have buried it; richness now floats it up.
+        entry("zeta-rich", {
+          dateAdded: "2026-05-29",
+          description:
+            "A thoroughly documented entry with extensive usage notes, " +
+            "configuration guidance, troubleshooting steps, and a deep set of " +
+            "primary sources backing every capability it claims to support.",
+          trustSignals: {
+            ...DEFAULT_TRUST_SIGNALS,
+            sourceStatus: "available",
+            firstPartyEditorial: true,
+            sourceUrlCount: 5,
+            sourceUrls: [
+              "https://example.com/zeta/1",
+              "https://example.com/zeta/2",
+              "https://example.com/zeta/3",
+              "https://example.com/zeta/4",
+              "https://example.com/zeta/5",
+            ],
+          },
+        }),
+      ],
+      {
+        generatedAt: "2026-05-30T00:00:00.000Z",
+        days: 7,
+        limits: {
+          newEntries: 2,
+          sourceBacked: 2,
+          saferInstalls: 2,
+          notableChanges: 2,
+        },
+        changelogEntries: [],
+      },
+    );
+
+    expect(brief.sections.newEntries.map((item) => item.key)).toEqual([
+      "mcp:zeta-rich",
+      "mcp:alpha-thin",
+    ]);
+  });
+
   it("handles low-signal data without inventing picks", () => {
     const brief = buildWeeklyBrief(
       [


### PR DESCRIPTION
You noticed the newsletter looked like an alphabetical list. It was — in a week whose newest additions are a same-day batch of equally-trusted entries (e.g. 8 sibling review-rule packs), the pick sort fell from `dateAdded` → `trustScore` straight to an **alphabetical** title tiebreak. With the whole batch tied on date and trust, you got a flat A-Z list.

## Fix
Insert a **richness** tiebreak between trust and title, so a tied batch leads with the most substantial entries instead of whatever sorts first alphabetically:

```
dateAdded ↓ → trustScore ↓ → richnessScore ↓ → title (stable fallback)
```

`richnessScore` = source depth (`sourceUrlCount`) + description substance + first-party editorial review + verification recency.

"New this week" stays genuinely newest-first — only the **within-batch** order changes. For the Jun 19 issue, the 8 rules now lead by source depth (Regex = 7 sources, SQL/Third-Party = 6, …) instead of A→Z.

## Also fixes a signal that was dead in production
`trustScore` read top-level `safetyNotes`/`privacyNotes` — but the slim **directory index** the brief actually runs against in prod strips those and keeps only `trustSignals.hasSafetyNotes`/`hasPrivacyNotes`. So safety/privacy notes never lifted an entry's score in prod (only in full-content tests). Now it reads both shapes.

`richnessScore` deliberately uses **only fields that survive into the directory index** (`sourceUrlCount`, `description`, `trustSignals.firstPartyEditorial`, `lastVerifiedAt`), so prod ranking matches test ranking — I verified against `directory-index.json`, not just the full atlas.

## Scope note
This is the "smarter auto-order" you picked: a true tiebreak (same entries, better order), not a selection overhaul. A bolder option exists — rank primarily by quality so the *best* of the week leads even over the *newest* (in testing that surfaced the agent frameworks + official MCP SDKs over the rule packs) — happy to follow up if you want that, but it changes which entries are featured, so I kept this faithful to your choice.

## Tests
- New: same-day, same-trust pair where the alphabetically-last but richer entry now leads.
- Existing deterministic-section assertions unchanged.
- type-check, 45 brief-consumer tests, prettier, Trunk — all clean.