### PR TITLE
fix(brief): repair the public /brief hero (drop-cap glitch + cramped cards)

### DIFF
--- a/apps/web/src/routes/brief.tsx
+++ b/apps/web/src/routes/brief.tsx
@@ -78,9 +78,7 @@ function BriefPage() {
                 <div className="p-6">
                   <div className="eyebrow text-accent-ink dark:text-accent">Latest issue</div>
                   <h2 className="mt-1 h-display-2 text-ink text-balance">{latest.title}</h2>
-                  <p className="mt-2 text-pretty text-sm text-ink-muted drop-cap">
-                    {latest.summary}
-                  </p>
+                  <p className="mt-2 text-pretty text-sm text-ink-muted">{latest.summary}</p>
                   <div className="mt-5 grid gap-3 sm:grid-cols-3">
                     <BriefMetric label="New entries" value={WEEKLY_BRIEF.newEntries.length} />
                     <BriefMetric
@@ -107,7 +105,7 @@ function BriefPage() {
             </article>
           )}
 
-          <div className="mt-8 grid gap-4 md:grid-cols-3">
+          <div className="mt-8 grid gap-5 md:grid-cols-3">
             <BriefList title="New in the registry" items={WEEKLY_BRIEF.newEntries} />
             <BriefList title="Trusted installs" items={WEEKLY_BRIEF.trustedInstalls} />
             <BriefList title="Source-backed picks" items={WEEKLY_BRIEF.sourceBackedPicks} />
@@ -215,17 +213,17 @@ function BriefList({
   items: Array<{ ref: string; title: string; reason?: string; date?: string }>;
 }) {
   return (
-    <section className="rounded-xl border border-border bg-surface p-4">
+    <section className="rounded-xl border border-border bg-surface p-5">
       <h2 className="font-display text-base font-semibold text-ink">{title}</h2>
-      <ul className="mt-3 space-y-3 text-sm">
+      <ul className="mt-4 divide-y divide-border/60 text-sm">
         {items.map((item) => (
-          <li key={item.ref}>
+          <li key={item.ref} className="py-3 first:pt-0 last:pb-0">
             <a href={`/entry/${item.ref}`} className="font-medium text-ink hover:underline">
               {item.title}
             </a>
-            <div className="mt-0.5 font-mono text-[11px] text-ink-subtle">{item.ref}</div>
+            <div className="mt-1 font-mono text-[11px] text-ink-subtle">{item.ref}</div>
             {(item.reason || item.date) && (
-              <p className="mt-1 text-xs text-ink-muted">{item.reason ?? item.date}</p>
+              <p className="mt-1.5 text-xs text-ink-muted">{item.reason ?? item.date}</p>
             )}
           </li>
         ))}


### PR DESCRIPTION
The "m / cp" mess you spotted on `heyclau.de/brief` was a **drop-cap** on the latest-issue summary. The summary starts with a lowercase ref slug — e.g. `mcp/aws-ecs-mcp-server was added in the latest registry snapshot.` — and `.drop-cap::first-letter { font-size: 3.4em; float: left }` blew the leading **"m"** up into an orphaned giant letter wedged against the title, with `cp/…` trailing below.

## Fix
- **Remove `drop-cap`** from the summary line. (It stays in `best.$slug.tsx`, where it's applied to real prose that starts with a capital — which is what it's for.)
- **Unscrunch the three pick columns**: more card padding (`p-4`→`p-5`), and row dividers with real vertical rhythm instead of tight `space-y-3` stacking.

## Context (not in scope here)
This is the **static public `/brief` page** (`WEEKLY_BRIEF` in `data/entries.ts`), which is a *different* system from the emailed newsletter (`buildWeeklyBrief` + D1). The page is a recency-only build-time preview; the email is the curated pipeline. The email's pick ordering is fixed separately in #4180. Unifying the page to render the real latest issue is a larger follow-up if you want it.

type-check, `pnpm --filter web build`, prettier, Trunk — all clean.

_Note: committed unsigned — the `github-commit-ghost` SSH signing agent had no identities loaded at commit time. Identity (ghost name/email) is intact; only the Verified badge is missing._