### PR TITLE
content(mcp): add Amazon SNS / SQS MCP Server

### DIFF
--- a/content/mcp/aws-sns-sqs-mcp-server.mdx
+++ b/content/mcp/aws-sns-sqs-mcp-server.mdx
@@ -1,0 +1,154 @@
+---
+title: Amazon SNS / SQS MCP Server
+slug: aws-sns-sqs-mcp-server
+category: mcp
+description: >-
+  Official AWS Labs MCP server for Amazon SNS and SQS that lets AI assistants
+  list and manage SNS topics, subscriptions, and SQS queues and send/receive
+  messages, with resource tagging so it only modifies what it created.
+cardDescription: >-
+  Connect Claude to Amazon SNS and SQS to list/manage topics, subscriptions,
+  and queues and send/receive messages, with tag-scoped resource safety.
+seoTitle: "Amazon SNS / SQS MCP Server for Claude — Topics, Queues, Messages"
+seoDescription: >-
+  Connect Claude to the official AWS Labs Amazon SNS / SQS MCP server to manage
+  SNS topics and subscriptions, SQS queues, and send/receive messages over stdio
+  with uvx using your scoped AWS credentials and tag-based resource controls.
+author: AWS Labs
+authorProfileUrl: "https://github.com/awslabs"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-21"
+brandName: AWS Labs
+brandDomain: aws.amazon.com
+repoUrl: "https://github.com/awslabs/mcp"
+documentationUrl: "https://github.com/awslabs/mcp/blob/main/src/amazon-sns-sqs-mcp-server/README.md"
+websiteUrl: "https://awslabs.github.io/mcp/"
+packageUrl: "https://pypi.org/project/awslabs.amazon-sns-sqs-mcp-server/"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: Cross-platform
+sourceUrls:
+  - "https://github.com/awslabs/mcp/blob/main/src/amazon-sns-sqs-mcp-server/README.md"
+  - "https://github.com/awslabs/mcp"
+  - "https://github.com/awslabs/mcp/blob/main/src/amazon-sns-sqs-mcp-server/pyproject.toml"
+  - "https://pypi.org/project/awslabs.amazon-sns-sqs-mcp-server/"
+  - "https://github.com/awslabs/mcp/blob/main/LICENSE"
+installable: true
+installCommand: uvx awslabs.amazon-sns-sqs-mcp-server@latest
+usageSnippet: >-
+  Configure the server with uvx and a scoped AWS profile, then ask Claude to
+  list SNS topics and SQS queues, inspect subscriptions, or send and receive
+  messages; enable resource creation only when you intend it.
+copySnippet: |-
+  {
+    "awslabs.amazon-sns-sqs-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.amazon-sns-sqs-mcp-server@latest"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "us-east-1",
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "awslabs.amazon-sns-sqs-mcp-server": {
+        "command": "uvx",
+        "args": ["awslabs.amazon-sns-sqs-mcp-server@latest"],
+        "env": {
+          "AWS_PROFILE": "${AWS_PROFILE}",
+          "AWS_REGION": "us-east-1",
+          "FASTMCP_LOG_LEVEL": "ERROR"
+        },
+        "type": "stdio"
+      }
+    }
+  }
+estimatedSetupTime: 10 minutes
+difficulty: intermediate
+prerequisites:
+  - An AWS account with Amazon SNS and SQS, and permissions for the topics/queues you intend to inspect or manage.
+  - Python 3.10 or newer and `uv` / `uvx` installed (Astral) to run the package.
+  - "AWS credentials configured locally (for example via `aws configure` or `AWS_PROFILE`); AWS recommends a least-privilege role with `AmazonSNSReadOnlyAccess` and `AmazonSQSReadOnlyAccess`."
+  - An MCP client that supports stdio servers; the server runs locally on the same host as the client.
+safetyNotes:
+  - "Resource creation/deletion is gated by the `--allow-resource-creation` flag (default off); without it, create/delete tools are hidden. Enable it only deliberately, and grant `AmazonSNSFullAccess`/`AmazonSQSFullAccess` only when you intend mutations."
+  - The server tags resources it creates and will only modify resources carrying that tag, which prevents it from changing pre-existing topics/queues it did not create.
+  - This server acts on real messaging infrastructure with your AWS credentials; scope the profile to the intended account and region and run it only on a trusted host.
+privacyNotes:
+  - Topic/queue names, ARNs, subscription details, and account/region metadata can be returned through tool calls and exposed to the model.
+  - "Message send/receive tools can read and write message payloads; keep sensitive message contents, account identifiers, and credentials out of public prompts, issues, and screenshots."
+tags:
+  - aws
+  - sns
+  - sqs
+  - messaging
+  - aws-labs
+keywords:
+  - amazon sns sqs mcp server
+  - awslabs amazon-sns-sqs-mcp-server
+  - sns sqs mcp claude
+  - aws messaging mcp
+  - sns topics sqs queues mcp
+  - mcp server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+Amazon SNS / SQS MCP Server is an official [AWS Labs](https://github.com/awslabs/mcp)
+Model Context Protocol server that acts as a bridge between MCP clients and
+Amazon SNS / SQS. It lets AI assistants list and manage SNS topics and
+subscriptions and SQS queues, and send and receive messages, while maintaining
+access controls through resource tagging.
+
+It runs locally over stdio via `uvx` from the published
+`awslabs.amazon-sns-sqs-mcp-server` Python package and uses your local AWS
+credentials. Resource creation is an opt-in flag, and the server only modifies
+resources it created (by tag).
+
+## Features
+
+- **SNS topics** — create, list, and manage Amazon SNS topics.
+- **SNS subscriptions** — create, list, and manage subscriptions.
+- **SQS queues** — create, list, and manage Amazon SQS queues.
+- **Messaging** — send and receive messages using SNS and SQS.
+- **Tag-scoped safety** — only resources created by the server (and tagged) can
+  be modified by it, protecting pre-existing resources.
+
+## Use Cases
+
+- Inspect existing SNS topics, subscriptions, and SQS queues.
+- Send a test message to a topic or queue and read responses.
+- Stand up a topic/queue and subscription for a new workflow (creation mode).
+- Wire up an event fan-out pattern with SNS and SQS.
+
+## Installation
+
+### Claude Code
+
+1. Install Python 3.10+ and `uv`.
+2. Configure an AWS profile (AWS recommends read-only SNS/SQS access for
+   inspection; full access only if you enable resource creation).
+3. Add the server with the stdio configuration above. To enable resource
+   creation/deletion, run the server with `--allow-resource-creation` — only
+   when you intend those operations.
+4. Verify it is connected with `claude mcp list`.
+
+### Claude Desktop / Cursor / Kiro / VS Code
+
+Add the `configSnippet` above to your client's MCP configuration and set
+`AWS_PROFILE`/`AWS_REGION`. The first run downloads the package via `uvx`.
+
+## Source And Trust
+
+This entry is based on the official AWS Labs `awslabs/mcp` repository and the
+published PyPI package (Apache-2.0). The server can manage real SNS/SQS resources
+with your AWS credentials, but resource creation is opt-in and tag-scoped, so use
+least-privilege credentials, keep creation disabled unless needed, and verify the
+configuration against the linked source before using it in automated workflows.


### PR DESCRIPTION
Add a source-backed **MCP Servers** entry for the official **Amazon SNS / SQS MCP Server** from AWS Labs (`awslabs/mcp`).

## Why this entry

- **Official + high-trust source**: `awslabs/mcp` (Apache-2.0, AWS Labs), published on PyPI as `awslabs.amazon-sns-sqs-mcp-server`.
- **Distinct use case**: manage SNS topics/subscriptions and SQS queues and send/receive messages — not covered by existing AWS entries.
- **Risk-aware notes**: resource creation/deletion is gated behind the opt-in `--allow-resource-creation` flag (default off) and the server is tag-scoped so it only modifies resources it created; the entry recommends least-privilege read-only IAM by default.

## Validation

- `pnpm exec prettier --write`; includes `submittedBy`/`submittedByUrl`.
- `pnpm validate:content:strict` → "Content validation passed."
- All `sourceUrls` (repo README, repo root, `pyproject.toml`, PyPI, LICENSE) return HTTP 200.

One source file only, no generated-artifact churn.
