### PR TITLE
content(mcp): add AWS Step Functions Tool MCP Server

### DIFF
--- a/content/mcp/aws-stepfunctions-tool-mcp-server.mdx
+++ b/content/mcp/aws-stepfunctions-tool-mcp-server.mdx
@@ -1,0 +1,164 @@
+---
+title: AWS Step Functions Tool MCP Server
+slug: aws-stepfunctions-tool-mcp-server
+category: mcp
+description: >-
+  Official AWS Labs MCP server that exposes selected AWS Step Functions state
+  machines as MCP tools without code changes, letting AI assistants run existing
+  Standard and Express workflows that coordinate work across AWS services.
+cardDescription: >-
+  Expose allowlisted AWS Step Functions state machines to Claude as MCP tools —
+  run existing Standard/Express workflows without code changes.
+seoTitle: "AWS Step Functions Tool MCP Server for Claude — Workflows as Tools"
+seoDescription: >-
+  Connect Claude to the official AWS Labs Step Functions Tool MCP server to run
+  allowlisted state machines as MCP tools over stdio with uvx, executing existing
+  Standard and Express workflows using scoped AWS credentials.
+author: AWS Labs
+authorProfileUrl: "https://github.com/awslabs"
+submittedBy: jaso0n0818
+submittedByUrl: "https://github.com/jaso0n0818"
+dateAdded: "2026-06-21"
+brandName: AWS Labs
+brandDomain: aws.amazon.com
+repoUrl: "https://github.com/awslabs/mcp"
+documentationUrl: "https://github.com/awslabs/mcp/blob/main/src/stepfunctions-tool-mcp-server/README.md"
+websiteUrl: "https://awslabs.github.io/mcp/"
+packageUrl: "https://pypi.org/project/awslabs.stepfunctions-tool-mcp-server/"
+pricingModel: open-source
+disclosure: editorial
+applicationCategory: DeveloperApplication
+operatingSystem: Cross-platform
+sourceUrls:
+  - "https://github.com/awslabs/mcp/blob/main/src/stepfunctions-tool-mcp-server/README.md"
+  - "https://github.com/awslabs/mcp"
+  - "https://github.com/awslabs/mcp/blob/main/src/stepfunctions-tool-mcp-server/pyproject.toml"
+  - "https://pypi.org/project/awslabs.stepfunctions-tool-mcp-server/"
+  - "https://github.com/awslabs/mcp/blob/main/LICENSE"
+installable: true
+installCommand: uvx awslabs.stepfunctions-tool-mcp-server@latest
+usageSnippet: >-
+  Allowlist which state machines to expose via the STATE_MACHINE_PREFIX,
+  STATE_MACHINE_LIST, or STATE_MACHINE_TAG_* environment variables, then ask
+  Claude to run one of those workflows as a tool with the required input.
+copySnippet: |-
+  {
+    "awslabs.stepfunctions-tool-mcp-server": {
+      "command": "uvx",
+      "args": ["awslabs.stepfunctions-tool-mcp-server@latest"],
+      "env": {
+        "AWS_PROFILE": "${AWS_PROFILE}",
+        "AWS_REGION": "us-east-1",
+        "STATE_MACHINE_PREFIX": "your-state-machine-prefix",
+        "STATE_MACHINE_LIST": "your-first-state-machine,your-second-state-machine",
+        "STATE_MACHINE_TAG_KEY": "your-tag-key",
+        "STATE_MACHINE_TAG_VALUE": "your-tag-value"
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "awslabs.stepfunctions-tool-mcp-server": {
+        "command": "uvx",
+        "args": ["awslabs.stepfunctions-tool-mcp-server@latest"],
+        "env": {
+          "AWS_PROFILE": "${AWS_PROFILE}",
+          "AWS_REGION": "us-east-1",
+          "STATE_MACHINE_PREFIX": "your-state-machine-prefix",
+          "STATE_MACHINE_LIST": "your-first-state-machine,your-second-state-machine",
+          "STATE_MACHINE_TAG_KEY": "your-tag-key",
+          "STATE_MACHINE_TAG_VALUE": "your-tag-value"
+        },
+        "type": "stdio"
+      }
+    }
+  }
+estimatedSetupTime: 15 minutes
+difficulty: advanced
+prerequisites:
+  - An AWS account with the Step Functions state machines you want to expose, and permission to start their executions.
+  - Python 3.10 or newer and `uv` / `uvx` installed (Astral) to run the package.
+  - "AWS credentials configured locally (for example via `aws configure` or `AWS_PROFILE`) scoped to start executions on the allowlisted state machines only."
+  - "An allowlist of state machines via `STATE_MACHINE_PREFIX`, `STATE_MACHINE_LIST`, or `STATE_MACHINE_TAG_KEY`/`STATE_MACHINE_TAG_VALUE`; only matching machines are exposed."
+  - An MCP client that supports stdio servers; the server runs locally on the same host as the client.
+safetyNotes:
+  - "Only state machines matching your `STATE_MACHINE_PREFIX`/`STATE_MACHINE_LIST`/`STATE_MACHINE_TAG_*` allowlist are exposed; scope this narrowly so the model can run just the intended workflows."
+  - "The client only needs permission to start executions; each state machine uses its own IAM role to reach other AWS services (separation of duties). Running a workflow executes whatever it does, including writes, so only allowlist machines you trust the model to run."
+  - This server starts real Step Functions executions with your AWS credentials; scope the profile narrowly and run it only on a trusted host.
+privacyNotes:
+  - State machine names, ARNs, execution inputs, and outputs pass through the model; an executed workflow can read or write whatever its own role allows.
+  - Keep account identifiers, credentials, and sensitive execution inputs/outputs out of public prompts, issues, and screenshots.
+tags:
+  - aws
+  - step-functions
+  - workflows
+  - tools
+  - aws-labs
+keywords:
+  - aws step functions tool mcp server
+  - awslabs stepfunctions-tool-mcp-server
+  - step functions as mcp tools
+  - mcp2stepfunctions
+  - run state machine mcp claude
+  - mcp server
+robotsIndex: true
+robotsFollow: true
+---
+
+## Overview
+
+AWS Step Functions Tool MCP Server is an official
+[AWS Labs](https://github.com/awslabs/mcp) Model Context Protocol server that
+selects and runs AWS Step Functions state machines as MCP tools without code
+changes. It bridges MCP clients and Step Functions so an AI model can execute
+existing workflows that coordinate multi-step business processes across AWS
+services — with no changes to the state machine definitions.
+
+It runs locally over stdio via `uvx` from the published
+`awslabs.stepfunctions-tool-mcp-server` Python package and uses your local AWS
+credentials. You choose which state machines are exposed through an allowlist.
+
+## Features
+
+- **Workflows as tools** — expose selected state machines to the model as MCP
+  tools, with no changes to their definitions.
+- **Standard and Express** — supports long-running Standard workflows and
+  high-volume, synchronous Express workflows.
+- **Allowlisting** — scope which machines are available via prefix, list, or
+  tags.
+- **Schema-aware docs** — integrates with EventBridge Schema Registry for input
+  validation and richer tool documentation.
+- **Separation of duties** — the client only starts executions; each machine
+  uses its own IAM role for downstream AWS access.
+
+## Use Cases
+
+- Let Claude trigger an existing approval or data-processing workflow.
+- Expose a curated set of operational state machines as safe, named tools.
+- Reuse multi-service Step Functions orchestration as model tools.
+- Keep broad AWS permissions in machine roles while the client stays minimal.
+
+## Installation
+
+### Claude Code
+
+1. Install Python 3.10+ and `uv`.
+2. Configure an AWS profile scoped to start executions on your state machines.
+3. Add the server with the stdio configuration above and set an allowlist
+   (`STATE_MACHINE_PREFIX`, `STATE_MACHINE_LIST`, or `STATE_MACHINE_TAG_*`).
+4. Verify it is connected with `claude mcp list`.
+
+### Claude Desktop / Cursor / Kiro / VS Code
+
+Add the `configSnippet` above to your client's MCP configuration, set
+`AWS_PROFILE`/`AWS_REGION`, and define the state-machine allowlist. The first run
+downloads the package via `uvx`.
+
+## Source And Trust
+
+This entry is based on the official AWS Labs `awslabs/mcp` repository and the
+published PyPI package (Apache-2.0). The server starts real Step Functions
+executions with your AWS credentials, so keep the client scoped to start-only,
+allowlist machines narrowly, and verify the configuration against the linked
+source before using it in automated workflows.


### PR DESCRIPTION
Add a source-backed **MCP Servers** entry for the official **AWS Step Functions Tool MCP Server** from AWS Labs (`awslabs/mcp`).

## Why this entry

- **Official + high-trust source**: `awslabs/mcp` (Apache-2.0, AWS Labs), published on PyPI as `awslabs.stepfunctions-tool-mcp-server`.
- **Distinct use case**: expose selected AWS Step Functions state machines as MCP tools (no code changes) to run existing Standard/Express workflows — not covered by existing AWS entries.
- **Risk-aware notes**: documents the state-machine allowlist (`STATE_MACHINE_PREFIX`/`STATE_MACHINE_LIST`/`STATE_MACHINE_TAG_*`), the start-execution-only least-privilege model, and separation of duties (client starts; machines use their own IAM role).

## Validation

- `pnpm exec prettier --write`; includes `submittedBy`/`submittedByUrl`.
- `pnpm validate:content:strict` → "Content validation passed."
- All `sourceUrls` (repo README, repo root, `pyproject.toml`, PyPI, LICENSE) return HTTP 200.

One source file only, no generated-artifact churn.
