### PR TITLE
chore(links): canonicalize 7 moved source URLs

### DIFF
--- a/content/agents/jupytext-reproducible-notebook-agent.mdx
+++ b/content/agents/jupytext-reproducible-notebook-agent.mdx
@@ -20,7 +20,7 @@ submittedBy: MkDev11
 submittedByUrl: "https://github.com/MkDev11"
 dateAdded: "2026-06-05"
 documentationUrl: "https://jupytext.readthedocs.io/en/latest/"
-repoUrl: "https://github.com/mwouts/jupytext"
+repoUrl: "https://github.com/jupytext/jupytext"
 packageUrl: "https://pypi.org/project/jupytext/"
 installable: false
 usageSnippet: "Use this agent to review a local Jupyter notebook project before committing paired notebooks, regenerating outputs, or sharing reproducible analysis artifacts."

--- a/content/mcp/headroom-mcp-server.mdx
+++ b/content/mcp/headroom-mcp-server.mdx
@@ -20,7 +20,7 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-05"
 brandName: Headroom
 brandDomain: headroom-docs.vercel.app
-repoUrl: "https://github.com/chopratejas/headroom"
+repoUrl: "https://github.com/headroomlabs-ai/headroom"
 documentationUrl: "https://headroom-docs.vercel.app/docs/mcp"
 packageUrl: "https://pypi.org/project/headroom-ai/"
 installable: true

--- a/content/mcp/matlab-mcp-core-server.mdx
+++ b/content/mcp/matlab-mcp-core-server.mdx
@@ -22,7 +22,7 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-06"
 brandName: MATLAB
 brandDomain: mathworks.com
-repoUrl: "https://github.com/matlab/matlab-mcp-core-server"
+repoUrl: "https://github.com/matlab/matlab-mcp-server"
 documentationUrl: "https://raw.githubusercontent.com/matlab/matlab-mcp-core-server/main/README.md"
 installable: true
 installCommand: "Download the release binary or Claude Desktop MCPB bundle, review the MathWorks license terms, then add the stdio server command to your MCP client."

--- a/content/mcp/supabase-mcp-server.mdx
+++ b/content/mcp/supabase-mcp-server.mdx
@@ -19,7 +19,7 @@ submittedBy: oktofeesh1
 submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-03"
 documentationUrl: "https://supabase.com/docs/guides/ai-tools/mcp"
-repoUrl: "https://github.com/supabase-community/supabase-mcp"
+repoUrl: "https://github.com/supabase/mcp"
 installable: true
 installCommand: >-
   claude mcp add --scope project --transport http supabase

--- a/content/tools/ccusage.mdx
+++ b/content/tools/ccusage.mdx
@@ -11,7 +11,7 @@ authorProfileUrl: "https://github.com/ryoppippi"
 dateAdded: "2026-06-02"
 websiteUrl: "https://ccusage.com"
 documentationUrl: "https://ccusage.com/guide/getting-started"
-repoUrl: "https://github.com/ryoppippi/ccusage"
+repoUrl: "https://github.com/ccusage/ccusage"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication

--- a/content/tools/dvc.mdx
+++ b/content/tools/dvc.mdx
@@ -12,7 +12,7 @@ submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-03"
 websiteUrl: "https://dvc.org"
 documentationUrl: "https://dvc.org/doc"
-repoUrl: "https://github.com/iterative/dvc"
+repoUrl: "https://github.com/treeverse/dvc"
 pricingModel: open-source
 disclosure: editorial
 applicationCategory: DeveloperApplication

--- a/content/tools/opencode.mdx
+++ b/content/tools/opencode.mdx
@@ -14,7 +14,7 @@ retrievalSources:
   - "https://opencode.ai/docs/"
   - "https://aider.chat/"
   - "https://code.claude.com/docs/en/overview"
-repoUrl: "https://github.com/sst/opencode"
+repoUrl: "https://github.com/anomalyco/opencode"
 pricingModel: open-source
 disclosure: editorial
 safetyNotes:


### PR DESCRIPTION
Automated link-health canonicalization. These stored source URLs return a **permanent (301/308) redirect to a 200 page on GitHub**. GitHub only issues these redirects for genuine repo renames/transfers of the *same* repository, so each is an authoritative move. Every destination was semantically verified (repo title still describes the same project).

| file | field | old → new |
| --- | --- | --- |
| `content/tools/dvc.mdx` | repoUrl | `github.com/iterative/dvc` → `github.com/treeverse/dvc` |
| `content/tools/opencode.mdx` | repoUrl | `github.com/sst/opencode` → `github.com/anomalyco/opencode` |
| `content/tools/ccusage.mdx` | repoUrl | `github.com/ryoppippi/ccusage` → `github.com/ccusage/ccusage` |
| `content/mcp/headroom-mcp-server.mdx` | repoUrl | `github.com/chopratejas/headroom` → `github.com/headroomlabs-ai/headroom` |
| `content/mcp/supabase-mcp-server.mdx` | repoUrl | `github.com/supabase-community/supabase-mcp` → `github.com/supabase/mcp` |
| `content/agents/jupytext-reproducible-notebook-agent.mdx` | repoUrl | `github.com/mwouts/jupytext` → `github.com/jupytext/jupytext` |
| `content/mcp/matlab-mcp-core-server.mdx` | repoUrl | `github.com/matlab/matlab-mcp-core-server` → `github.com/matlab/matlab-mcp-server` |

Only the affected `repoUrl` fields were changed — no body, protected fields, or other frontmatter touched. Dead links (Trivy `/latest/`, LibreChat registry) are tracked separately in the dead-source-URLs issue, not in this PR.
