### PR TITLE
fix(ci): allow source URL fixes on existing content entries

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -749,8 +749,16 @@ function isNewDirectContentEntry(entry) {
 }
 
 const EXISTING_ENTRY_METADATA_UPDATE_KEYS = new Set([
+  "documentationUrl",
+  "downloadUrl",
+  "packageUrl",
   "privacyNotes",
+  "repoUrl",
+  "retrievalSources",
   "safetyNotes",
+  "sourceUrl",
+  "sourceUrls",
+  "websiteUrl",
 ]);
 
 function canonicalFrontmatterValue(value) {

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -416,6 +416,91 @@ Example body.
     );
   });
 
+  it("allows external link-health fixes on existing entries without submitter provenance", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const baseContent = `---
+title: Example Tool
+category: tools
+description: Example tool with a dead documentation URL.
+documentationUrl: https://example.com/dead-docs
+repoUrl: https://github.com/example/example-tool
+---
+
+Example body.
+`;
+    const updatedContent = `---
+title: Example Tool
+category: tools
+description: Example tool with a dead documentation URL.
+documentationUrl: https://example.com/live-docs
+repoUrl: https://github.com/example/example-tool
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, updatedContent, "external_direct", [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "modified",
+        content: updatedContent,
+        baseContent,
+      },
+    ]);
+
+    expect(result.status).toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output).toMatchObject({ ok: true });
+    expect(output.failures).toEqual([]);
+  });
+
+  it("still blocks external provenance rewrites on existing entries", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const baseContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry.
+documentationUrl: https://example.com/docs
+submittedBy: original-author
+submittedByUrl: https://github.com/original-author
+---
+
+Example body.
+`;
+    const updatedContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry.
+documentationUrl: https://example.com/docs
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, updatedContent, "external_direct", [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "modified",
+        content: updatedContent,
+        baseContent,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("direct_pr_existing_provenance_change"),
+      ]),
+    );
+  });
+
   it("still blocks external content PRs that request HeyClaude-hosted downloads", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
## Summary

- Allow external contributors to update dead source URL frontmatter fields on **existing** registry entries without requiring `submittedBy` / `submittedByUrl` when those entries never had submitter provenance.
- Keep blocking provenance rewrites when an entry already has `submittedBy` / `submittedByUrl`.

## Why

Fork PRs for scheduled link-health repairs (for example #3859) currently fail `validate-content-policy` because modifying `documentationUrl` or `packageUrl` on legacy entries is treated like a full direct content submission.

## Files changed

| File | Change |
| --- | --- |
| `scripts/ci/validate-content-policy.mjs` | Extend existing-entry metadata exemptions for source URL fields |
| `tests/content-policy-validation.test.ts` | Regression tests for link-health updates and provenance rewrite blocking |

## Validation

```sh
pnpm exec vitest run tests/content-policy-validation.test.ts
git diff --check
```

Refs #3859

Made with [Cursor](https://cursor.com)