### PR TITLE
chore(links): repair dead source URLs from link health sweep

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -19,7 +19,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
-documentationUrl: "https://aquasecurity.github.io/trivy/latest/"
+documentationUrl: "https://trivy.dev/docs/"
 retrievalSources:
   - "https://github.com/aquasecurity/trivy"
   - "https://code.claude.com/docs/en/hooks"

--- a/content/tools/librechat.mdx
+++ b/content/tools/librechat.mdx
@@ -21,7 +21,7 @@ dateAdded: "2026-06-18"
 websiteUrl: "https://librechat.ai/"
 documentationUrl: "https://docs.librechat.ai/"
 repoUrl: "https://github.com/danny-avila/LibreChat"
-packageUrl: "https://registry.librechat.ai/"
+packageUrl: "https://hub.docker.com/r/librechat/librechat-api"
 pricingModel: free
 disclosure: editorial
 applicationCategory: DeveloperApplication


### PR DESCRIPTION
## Summary

Repair two dead frontmatter source URLs flagged by the scheduled link-health sweep in #3859.

## Changes

| File | Field | Old URL | New URL |
| --- | --- | --- | --- |
| `content/hooks/docker-image-security-scanner.mdx` | `documentationUrl` | `aquasecurity.github.io/trivy/latest/` (404) | `https://trivy.dev/docs/` |
| `content/tools/librechat.mdx` | `packageUrl` | `registry.librechat.ai` (404) | `https://hub.docker.com/r/librechat/librechat-api` |

## CI note

Merge #4196 first so fork `validate-content-policy` allows source URL repairs on legacy entries, then re-run checks here.

## Validation

```sh
pnpm validate:content:strict -- content/hooks/docker-image-security-scanner.mdx content/tools/librechat.mdx
git diff --check
```

Closes #3859

Made with [Cursor](https://cursor.com)