### PR TITLE
chore(links): repair dead source URLs from link health sweep

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -19,7 +19,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
-documentationUrl: "https://aquasecurity.github.io/trivy/latest/"
+documentationUrl: "https://trivy.dev/docs/"
 retrievalSources:
   - "https://github.com/aquasecurity/trivy"
   - "https://code.claude.com/docs/en/hooks"

--- a/content/tools/librechat.mdx
+++ b/content/tools/librechat.mdx
@@ -21,7 +21,7 @@ dateAdded: "2026-06-18"
 websiteUrl: "https://librechat.ai/"
 documentationUrl: "https://docs.librechat.ai/"
 repoUrl: "https://github.com/danny-avila/LibreChat"
-packageUrl: "https://registry.librechat.ai/"
+packageUrl: "https://hub.docker.com/r/librechat/librechat-api"
 pricingModel: free
 disclosure: editorial
 applicationCategory: DeveloperApplication


### PR DESCRIPTION
## Summary

Repair two dead frontmatter source URLs flagged by the scheduled link-health sweep in #3859.

## Changes

| File | Field | Old URL | New URL | Verification |
| --- | --- | --- | --- | --- |
| `content/hooks/docker-image-security-scanner.mdx` | `documentationUrl` | `https://aquasecurity.github.io/trivy/latest/` (404) | `https://trivy.dev/docs/` | 302 → `https://trivy.dev/docs/latest/guide/` (200) |
| `content/tools/librechat.mdx` | `packageUrl` | `https://registry.librechat.ai/` (404) | `https://hub.docker.com/r/librechat/librechat-api` | HTTP 200 |

`repoUrl` for LibreChat already points at GitHub; Docker Hub matches the Docker Compose install path used by other container-first tools such as Ollama.

## Validation

```sh
pnpm validate:content:strict -- content/hooks/docker-image-security-scanner.mdx content/tools/librechat.mdx
git diff --check
```

Closes #3859

Made with [Cursor](https://cursor.com)