### PR TITLE
fix(content-policy): protect package URL provenance

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -750,8 +750,6 @@ function isNewDirectContentEntry(entry) {
 
 const EXISTING_ENTRY_METADATA_UPDATE_KEYS = new Set([
   "documentationUrl",
-  "downloadUrl",
-  "packageUrl",
   "privacyNotes",
   "repoUrl",
   "retrievalSources",

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -456,6 +456,49 @@ Example body.
     expect(output.failures).toEqual([]);
   });
 
+  it("requires external contributors to keep provenance checks when changing package download links on existing entries", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const baseContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry with package metadata.
+downloadUrl: https://github.com/example/example-tool/releases/download/v1.0.0/example-tool.zip
+packageUrl: https://github.com/example/example-tool/releases/tag/v1.0.0
+---
+
+Example body.
+`;
+    const updatedContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry with package metadata.
+downloadUrl: https://attacker.example/package.zip
+packageUrl: https://attacker.example/package
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, updatedContent, "external_direct", [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "modified",
+        content: updatedContent,
+        baseContent,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("missing_direct_pr_submitter"),
+      ]),
+    );
+  });
+
   it("still blocks external provenance rewrites on existing entries", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
### Motivation
- Prevent external contributor PRs from silently changing supply-chain-sensitive package links (`downloadUrl`/`packageUrl`) on existing entries by abusing the metadata-only bypass. 
- Ensure package download links remain subject to submitter provenance checks so maintainers keep control over user-facing package targets.

### Description
- Remove `downloadUrl` and `packageUrl` from the `EXISTING_ENTRY_METADATA_UPDATE_KEYS` allowlist in `scripts/ci/validate-content-policy.mjs` so changes to those fields no longer count as metadata-only updates for `external_direct` PRs. 
- Add a regression test in `tests/content-policy-validation.test.ts` that verifies an `external_direct` PR which rewrites an existing entry's `downloadUrl`/`packageUrl` without submitter provenance is rejected with a missing submitter provenance error. 
- Preserve existing behavior for other non-sensitive metadata keys and keep package download flagging logic intact.

### Testing
- Ran the content policy unit tests with `pnpm exec vitest run tests/content-policy-validation.test.ts`, and the suite passed (40 tests passed). 
- The new regression test asserts the policy rejects external PRs that change `downloadUrl`/`packageUrl` without `submittedBy`/`submittedByUrl` and succeeded. 
- Local validation (`git diff --check`) reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a395820a570832c8fb56ce74b68513d)