### PR TITLE
Revert #4196 — URL fields must not be low-scrutiny metadata (content-integrity)

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -749,14 +749,8 @@ function isNewDirectContentEntry(entry) {
 }
 
 const EXISTING_ENTRY_METADATA_UPDATE_KEYS = new Set([
-  "documentationUrl",
   "privacyNotes",
-  "repoUrl",
-  "retrievalSources",
   "safetyNotes",
-  "sourceUrl",
-  "sourceUrls",
-  "websiteUrl",
 ]);
 
 function canonicalFrontmatterValue(value) {

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -416,7 +416,7 @@ Example body.
     );
   });
 
-  it("allows external link-health fixes on existing entries without submitter provenance", () => {
+  it("requires full review for external URL edits on existing entries (not low-scrutiny metadata)", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),
     );
@@ -436,6 +436,53 @@ category: tools
 description: Example tool with a dead documentation URL.
 documentationUrl: https://example.com/live-docs
 repoUrl: https://github.com/example/example-tool
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, updatedContent, "external_direct", [
+      {
+        filename: "content/tools/example-tool.mdx",
+        status: "modified",
+        content: updatedContent,
+        baseContent,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("missing_direct_pr_submitter"),
+      ]),
+    );
+  });
+
+  it("allows external privacyNotes/safetyNotes edits on existing entries without submitter provenance (low-scrutiny metadata)", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const baseContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry.
+safetyNotes:
+  - Original safety note.
+privacyNotes:
+  - Original privacy note.
+---
+
+Example body.
+`;
+    const updatedContent = `---
+title: Example Tool
+category: tools
+description: Example tool entry.
+safetyNotes:
+  - Updated safety note.
+privacyNotes:
+  - Updated privacy note.
 ---
 
 Example body.


### PR DESCRIPTION
Reverts #4196.

## Why this is a content-integrity issue
#4196 added every URL field — `sourceUrl`, `sourceUrls`, `repoUrl`, `downloadUrl`, `packageUrl`, `websiteUrl`, `documentationUrl`, `retrievalSources` — to `EXISTING_ENTRY_METADATA_UPDATE_KEYS` in `scripts/ci/validate-content-policy.mjs`.

That set marks keys as **low-scrutiny "metadata-only" updates** on existing entries: `existingEntryHasOnlyMetadataUpdates()` skips full content review when every changed key is in it. Adding the URL fields means a contributor could **repoint the URLs of an existing, trusted entry** (e.g. swap `downloadUrl`/`packageUrl` to a malicious host) and have it treated as a benign metadata edit instead of a reviewed content change.

## Effect of this revert
Restores the strict set (`privacyNotes`, `safetyNotes` only). Legitimate URL corrections are still allowed — they simply go through full content review again instead of being auto-waved.

## Follow-up
`scripts/ci/**` (the policy/validation guardrails) is being added to the review guardrail paths so any change that weakens the content policy requires manual maintainer review.