### PR TITLE
fix(web): guard weekly brief category label lookup

### DIFF
--- a/apps/web/src/lib/brief-email.ts
+++ b/apps/web/src/lib/brief-email.ts
@@ -83,7 +83,10 @@ function absolute(url: string, siteUrl: string): string {
 
 function categoryLabel(category?: string): string {
   if (!category) return "";
-  return CATEGORY_LABELS[category] ?? category.charAt(0).toUpperCase() + category.slice(1);
+  if (Object.hasOwn(CATEGORY_LABELS, category)) {
+    return CATEGORY_LABELS[category];
+  }
+  return category.charAt(0).toUpperCase() + category.slice(1);
 }
 
 function shortDate(iso?: string): string {

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -317,6 +317,25 @@ describe("web non-UI utility coverage", () => {
     expect(
       (full.html.match(/border-bottom:1px solid #f0ede4/g) ?? []).length,
     ).toBe(2);
+
+    const prototypeCategory = buildBriefEmail({
+      brief: {
+        sections: {
+          newEntries: [
+            {
+              title: "Prototype category label",
+              url: "/entry/tools/prototype",
+              category: "constructor",
+              description: "Should render a human label, not Object.prototype.",
+            },
+          ],
+        },
+      },
+      siteUrl: "https://heyclau.de",
+      dateLabel: "2026-06-19",
+    });
+    expect(prototypeCategory.text).toContain("[Constructor]");
+    expect(prototypeCategory.text).not.toContain("[Function:");
   });
 
   it("signs brief approval tokens and rejects tampered, malformed, and expired tokens", async () => {


### PR DESCRIPTION
## Summary

Guard the weekly brief email category label map so prototype property names cannot leak into rendered newsletter badges.

## What Changed

- **`apps/web/src/lib/brief-email.ts`** — use `Object.hasOwn(CATEGORY_LABELS, category)` before reading the label map, matching the registry heading/platform guard pattern.
- **`tests/web-non-ui-utilities.test.ts`** — regression test ensuring a brief item with category `constructor` renders `[Constructor]` instead of inheriting `Object.prototype.constructor`.

## Why

`CATEGORY_LABELS[category] ?? fallback` inherits from `Object.prototype` when `category` is a prototype key (for example `constructor`). Weekly brief payloads are persisted registry data; a malformed or unexpected category string would otherwise render `function Object() { [native code] }` in HTML/text badges.

## Validation

```sh
pnpm --filter web run prebuild
pnpm test
trunk check --ci --upstream origin/main
trunk fmt
git diff --check
```

All checks passed locally (1565/1565 tests).

## Notes

Same class of fix as merged #4155 (platform aliases) and #4171 (heading key map). No MCP package changes.

## Summary by CodeRabbit
- Harden weekly brief category label resolution against prototype property names.
- Add regression coverage for unexpected category strings in brief email rendering.