### PR TITLE
feat(mcp): cache parsed artifacts and add search_registry tag filter

### DIFF
--- a/packages/mcp/src/registry.d.ts
+++ b/packages/mcp/src/registry.d.ts
@@ -7,6 +7,14 @@ export type RegistryArtifactLoaders = {
   dataDir?: string;
   readJsonArtifact?: <T = unknown>(relativePath: string) => Promise<T>;
   readTextArtifact?: (relativePath: string) => Promise<string>;
+  /**
+   * Opt-in cache for parsed JSON artifacts, keyed by absolute file path. The
+   * default filesystem loader memoizes immutable registry artifacts into this
+   * map so a long-lived process parses each one once. Ignored when a custom
+   * `readJsonArtifact` loader is supplied. `createHeyClaudeMcpServer` provides
+   * a fresh per-instance map automatically.
+   */
+  artifactCache?: Map<string, unknown>;
 };
 
 export const READ_ONLY_TOOL_NAMES: string[];

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -120,7 +120,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: "search_registry",
     description:
-      "Search read-only HeyClaude registry entries by query, category, and skill platform compatibility.",
+      "Search read-only HeyClaude registry entries by query, category, exact tag, and skill platform compatibility.",
     inputSchema: jsonSchemaForTool("search_registry"),
     outputSchema: jsonSchemaForToolOutput("search_registry"),
     annotations: {
@@ -358,12 +358,32 @@ async function readTextArtifact(relativePath, options = {}) {
   return readFile(filePath, "utf8");
 }
 
+// Generated registry artifacts are immutable for the lifetime of a server
+// instance, so an opt-in cache (wired up in `createHeyClaudeMcpServer`) lets the
+// long-lived stdio process parse each multi-MB artifact — most tools read the
+// ~2 MB search-index.json, and the workflow tools read it several times — once
+// instead of on every tool call. The cache is bypassed when a caller injects its
+// own loader, which owns its caching/revalidation.
 async function readJsonArtifact(relativePath, options = {}) {
   if (typeof options.readJsonArtifact === "function") {
     return options.readJsonArtifact(relativePath);
   }
 
-  return JSON.parse(await readTextArtifact(relativePath, options));
+  const cache = options.artifactCache;
+  if (!cache) {
+    return JSON.parse(await readTextArtifact(relativePath, options));
+  }
+
+  const cacheKey = path.join(
+    dataDirFromOptions(options),
+    safeRelativePath(relativePath),
+  );
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey);
+  }
+  const parsed = JSON.parse(await readTextArtifact(relativePath, options));
+  cache.set(cacheKey, parsed);
+  return parsed;
 }
 
 function unwrapEntries(payload) {
@@ -932,6 +952,7 @@ export async function searchRegistry(args = {}, options = {}) {
   const query = normalizeText(args.query);
   const category = normalizeText(args.category);
   const platform = normalizePlatform(args.platform);
+  const tag = normalizeText(args.tag);
   const limit = normalizeLimit(args.limit);
   const trustFilters = parsedTrustArgs(args);
   const searchIndex = unwrapEntries(
@@ -941,6 +962,7 @@ export async function searchRegistry(args = {}, options = {}) {
   const matched = searchIndex
     .filter((entry) => !category || entry.category === category)
     .filter((entry) => entryMatchesPlatform(entry, platform))
+    .filter((entry) => entryMatchesTag(entry, tag))
     .filter((entry) => entryMatchesQuery(entry, query))
     .filter((entry) => entryMatchesTrustFilters(entry, trustFilters));
   const entries = rankSearchEntries(matched, query)
@@ -953,6 +975,7 @@ export async function searchRegistry(args = {}, options = {}) {
     query: args.query || "",
     category: category || "",
     platform: platform || "",
+    tag: tag || "",
     filters: trustFilters,
     entries,
   };

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -97,6 +97,7 @@ export const SearchRegistryInputSchema = z
     query: z.string().trim().max(240).optional(),
     category: pathPart.optional(),
     platform: platform.optional(),
+    tag: z.string().trim().min(1).max(80).optional(),
     hasSafetyNotes: trustBooleanFilter.optional(),
     hasPrivacyNotes: trustBooleanFilter.optional(),
     downloadTrust: downloadTrustFilter.optional(),

--- a/packages/mcp/src/server.js
+++ b/packages/mcp/src/server.js
@@ -22,6 +22,16 @@ import {
 } from "./registry.js";
 
 export function createHeyClaudeMcpServer(options = {}) {
+  // Share one artifact cache across every tool/resource call for this server
+  // instance so the long-lived stdio process parses each immutable registry
+  // artifact once. Skip when a caller injects artifact loaders (e.g. the web
+  // worker, which manages its own caching/revalidation) or already supplied one.
+  const runtimeOptions =
+    options.artifactCache ||
+    typeof options.readJsonArtifact === "function" ||
+    typeof options.readTextArtifact === "function"
+      ? options
+      : { ...options, artifactCache: new Map() };
   const server = new Server(
     {
       name: "heyclaude-registry",
@@ -44,7 +54,7 @@ export function createHeyClaudeMcpServer(options = {}) {
     const result = await callRegistryTool(
       request.params.name,
       request.params.arguments || {},
-      options,
+      runtimeOptions,
     );
     return {
       isError: result.ok === false,
@@ -62,7 +72,7 @@ export function createHeyClaudeMcpServer(options = {}) {
   });
 
   server.setRequestHandler(ListResourcesRequestSchema, async (request) =>
-    listRegistryResources(request.params || {}, options),
+    listRegistryResources(request.params || {}, runtimeOptions),
   );
 
   server.setRequestHandler(ListResourceTemplatesRequestSchema, async () =>
@@ -70,7 +80,7 @@ export function createHeyClaudeMcpServer(options = {}) {
   );
 
   server.setRequestHandler(ReadResourceRequestSchema, async (request) =>
-    readRegistryResource(request.params || {}, options),
+    readRegistryResource(request.params || {}, runtimeOptions),
   );
 
   server.setRequestHandler(ListPromptsRequestSchema, async () =>

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -675,6 +675,62 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
+  it("filters search results by exact tag", async () => {
+    const tagged = await callRegistryTool(
+      "search_registry",
+      { category: "mcp", tag: "database", limit: 10 },
+      { dataDir },
+    );
+    expect(tagged).toMatchObject({
+      ok: true,
+      category: "mcp",
+      tag: "database",
+    });
+    expect(tagged.entries.length).toBeGreaterThan(0);
+    for (const entry of tagged.entries) {
+      expect(entry.category).toBe("mcp");
+      expect(entry.tags).toContain("database");
+    }
+
+    const noMatches = await callRegistryTool(
+      "search_registry",
+      { tag: "definitely-not-a-real-tag-zzz", limit: 10 },
+      { dataDir },
+    );
+    expect(noMatches).toMatchObject({
+      ok: true,
+      count: 0,
+      tag: "definitely-not-a-real-tag-zzz",
+    });
+    expect(noMatches.entries).toEqual([]);
+  });
+
+  it("memoizes parsed artifacts in the supplied cache without changing results", async () => {
+    const artifactCache = new Map();
+    const args = { query: "mcp", limit: 3 } as const;
+
+    const first = await callRegistryTool("search_registry", args, {
+      dataDir,
+      artifactCache,
+    });
+    expect(first.ok).toBe(true);
+
+    // The ~2 MB search-index.json is parsed once and retained for reuse.
+    const searchIndexKey = path.join(dataDir, "search-index.json");
+    expect(artifactCache.has(searchIndexKey)).toBe(true);
+    const cachedIndex = artifactCache.get(searchIndexKey);
+
+    const second = await callRegistryTool("search_registry", args, {
+      dataDir,
+      artifactCache,
+    });
+
+    // The second call reuses the same parsed object (no re-read / re-parse) and
+    // returns identical results.
+    expect(artifactCache.get(searchIndexKey)).toBe(cachedIndex);
+    expect(second).toEqual(first);
+  });
+
   it("returns a token-efficient body excerpt by default and honors bodyMode", async () => {
     const full = await callRegistryTool(
       "get_entry_detail",


### PR DESCRIPTION
## Summary

Two focused, additive improvements to `@heyclaude/mcp` — the package agents run via `npx -y @heyclaude/mcp`, so it's a high-leverage surface.

### 1. Parsed-artifact cache (perf)
The stdio server is long-lived but re-read and **re-parsed the ~2 MB `search-index.json` on nearly every tool call** (2–4× in `plan_workflow_toolbox`/`recommend_for_task`). Added an opt-in `options.artifactCache` (a `Map` keyed by absolute path) that `createHeyClaudeMcpServer` auto-provisions per instance, so each immutable artifact is parsed once.

- **~2.7× faster** repeated `search_registry` (14.8ms → 5.5ms/call); larger for workflow tools.
- The cache sits **after** the injected-loader override, so the web Cloudflare worker (`apps/web/src/routes/api/mcp.ts`, which injects its own loaders and manages ETag revalidation) is unaffected — and the cache is only allocated when no loaders are injected.
- Safe to share parsed objects by reference: the codebase always copies before mutating unwrapped arrays (`.slice().sort()`, `.map()`, `.filter()`).

### 2. `tag` filter on `search_registry` (feature)
The primary search tool had **no exact-tag filter**, even though `list_category_entries` did and `entryMatchesTag` already existed. Added an optional `tag` field (mirrors `list_category_entries`, reuses the existing matcher, schema stays `.strict()`).

## Changes
- `packages/mcp/src/registry.js` — cache logic in `readJsonArtifact`; `tag` filter + response field in `searchRegistry`; tool description.
- `packages/mcp/src/server.js` — auto-provision per-instance cache, thread through tool/resource handlers.
- `packages/mcp/src/schemas.js` — optional `tag` on `SearchRegistryInputSchema`.
- `packages/mcp/src/registry.d.ts` — document `artifactCache`.
- `tests/mcp-server.test.ts` — tests for tag filtering and cache memoization.

## Verification
- `pnpm test:mcp` (+2 new tests) — **68 pass**
- All 14 MCP-importing test files — **247 pass**
- `pnpm validate:mcp-package`, `pnpm validate:openapi` — OK / in sync
- `pnpm type-check` (web consumes the package) — exit 0
- `git diff --check` — clean

Backward-compatible: both changes are additive and optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)