### PR TITLE
feat(web): unify search aliases and platform support normalization

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -143,10 +143,36 @@ const CATEGORIES = new Set<Category>([
 
 const SUPPORT_ALIASES: Record<string, PlatformSupport> = {
   "native-skill": "native-skill",
+  native: "native-skill",
+  full: "native-skill",
+  complete: "native-skill",
   adapter: "adapter",
+  partial: "adapter",
+  adapted: "adapter",
   "manual-context": "manual-context",
+  manual: "manual-context",
+  context: "manual-context",
   unsupported: "unsupported",
+  none: "unsupported",
+  no: "unsupported",
 };
+
+function normalizeSupportKey(raw: unknown) {
+  return String(raw ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, "-")
+    .replace(/\s+/g, "-");
+}
+
+function normalizeSupportLevel(raw: unknown): PlatformSupport {
+  const key = normalizeSupportKey(raw);
+  if (!key) return "manual-context";
+  if (Object.hasOwn(SUPPORT_ALIASES, key)) {
+    return SUPPORT_ALIASES[key];
+  }
+  return "manual-context";
+}
 
 const HOOK_TRIGGERS = new Set<HookTrigger>([
   "PreToolUse",
@@ -267,13 +293,21 @@ function inferTrust(entry: RegistryEntry, source: SourceStatus): TrustLevel {
   return "review";
 }
 
+function normalizeClaimStatus(value: unknown): Entry["claimStatus"] {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "verified" || normalized === "pending") return normalized;
+  return "unclaimed";
+}
+
 function normalizeCompatibility(entry: RegistryEntry): PlatformCompatibility[] | undefined {
   const rows: PlatformCompatibility[] = [];
   for (const item of entry.platformCompatibility ?? []) {
     const platform = platformFrom(item.platform);
     if (!platform) continue;
     const rawSupport = item.support ?? item.supportLevel ?? "";
-    const support = SUPPORT_ALIASES[rawSupport] ?? "manual-context";
+    const support = normalizeSupportLevel(rawSupport);
     rows.push({
       platform,
       support,
@@ -405,11 +439,8 @@ export function buildEntry(entry: RegistryEntry): Entry {
     relatedEntries: normalizeRelatedEntries(entry.relatedEntries),
     dateAdded: entry.dateAdded ?? entry.contentUpdatedAt?.slice(0, 10) ?? "2026-01-01",
     reviewed: Boolean(reviewedAt || entry.packageVerified),
-    claimed: entry.claimStatus === "verified",
-    claimStatus:
-      entry.claimStatus === "verified" || entry.claimStatus === "pending"
-        ? entry.claimStatus
-        : "unclaimed",
+    claimed: normalizeClaimStatus(entry.claimStatus) === "verified",
+    claimStatus: normalizeClaimStatus(entry.claimStatus),
     safetyNotes,
     safetyNotesList: listText(entry.safetyNotes),
     privacyNotes,

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -20,25 +20,12 @@ export interface SearchFilters {
   sort?: "popular" | "newest" | "title";
 }
 
-const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
-const MAX_QUERY_LENGTH = 256;
-const MAX_QUERY_TOKENS = 12;
-
-const QUERY_ALIASES: Record<string, string[]> = {
-  browser: ["chrome", "playwright", "web"],
-  cc: ["claude", "claude-code"],
-  claude: ["claude-code"],
-  gh: ["github"],
-  mcp: ["model-context-protocol"],
-  repo: ["repository", "github"],
-  repos: ["repository", "github"],
-  safe: ["safety", "security", "secure", "trust", "privacy"],
-  security: ["safe", "safety", "secure", "trust"],
-  skill: ["skills"],
-  skills: ["skill"],
-  statusline: ["statuslines", "status"],
-  statuslines: ["statusline", "status"],
-};
+import {
+  normalizeSearchQuery,
+  TOKEN_SPLIT_PATTERN,
+  tokenizeSearchQuery,
+} from "@/lib/search-query-tokenization";
+import { expandedTokenCandidates } from "@/lib/search-query-aliases";
 
 interface EntrySearchProfile {
   haystack: string;
@@ -56,28 +43,7 @@ interface PreparedSearchFilters extends SearchFilters {
 
 const ENTRY_SEARCH_PROFILES = new WeakMap<Entry, EntrySearchProfile>();
 
-export function normalizeSearchQuery(query: string) {
-  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
-}
-
-function tokenizeSearchQuery(query: string) {
-  const tokens: string[] = [];
-  let token = "";
-
-  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
-    const char = query[index]!;
-    if (/[a-z0-9+#.-]/i.test(char)) {
-      token += char.toLowerCase();
-      continue;
-    }
-
-    if (token.length >= 2) tokens.push(token);
-    token = "";
-  }
-
-  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
-  return tokens;
-}
+export { normalizeSearchQuery } from "@/lib/search-query-tokenization";
 
 function querySearchProfile(query: string): QuerySearchProfile | null {
   const normalizedQuery = normalizeSearchQuery(query);
@@ -87,10 +53,6 @@ function querySearchProfile(query: string): QuerySearchProfile | null {
   if (!tokens.length) return null;
 
   return { normalizedQuery, tokens };
-}
-
-function expandedTokenCandidates(token: string) {
-  return [token, ...(QUERY_ALIASES[token] ?? [])];
 }
 
 function normalizedSearchText(entry: Entry) {

--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -6,6 +6,7 @@ import {
   TOKEN_SPLIT_PATTERN,
   tokenizeSearchQuery,
 } from "@/lib/search-query-tokenization";
+import { expandedTokenCandidates, expandedTokenSet } from "@/lib/search-query-aliases";
 
 export type BooleanFilterValue = "all" | "true" | "false";
 
@@ -37,26 +38,6 @@ export type RegistrySearchFilterDimension =
   | "downloadTrust"
   | "claimStatus"
   | "sourceStatus";
-
-const QUERY_ALIASES: Record<string, string[]> = {
-  automation: ["automate", "automated", "qa", "testing"],
-  browser: ["chrome", "playwright", "web"],
-  cc: ["claude", "claude-code"],
-  claude: ["claude-code"],
-  design: ["ux", "ui"],
-  gh: ["github"],
-  ms: ["microsoft"],
-  mcp: ["model-context-protocol"],
-  msteams: ["teams", "microsoft-teams"],
-  repo: ["repository", "github"],
-  repos: ["repository", "github"],
-  safe: ["safety", "security", "secure", "trust", "privacy"],
-  security: ["safe", "safety", "secure", "trust"],
-  skill: ["skills"],
-  skills: ["skill"],
-  statusline: ["statuslines", "status"],
-  statuslines: ["statusline", "status"],
-};
 
 type QueryIntentProfile = {
   id: string;
@@ -160,14 +141,6 @@ const SEARCH_REASON_PRIORITY = [
   "installable",
   "reviewed",
 ];
-
-function expandedTokenCandidates(token: string) {
-  return [token, ...(QUERY_ALIASES[token] ?? [])];
-}
-
-function expandedTokenSet(tokens: ReadonlyArray<string>) {
-  return new Set(tokens.flatMap((token) => expandedTokenCandidates(token)));
-}
 
 function normalizedSet(values: ReadonlyArray<unknown> | undefined) {
   return new Set((values ?? []).map((value) => String(value).trim().toLowerCase()).filter(Boolean));

--- a/apps/web/src/lib/search-query-aliases.ts
+++ b/apps/web/src/lib/search-query-aliases.ts
@@ -1,0 +1,43 @@
+/** Shared search query alias map for registry API filters and entry search. */
+export const SEARCH_QUERY_ALIASES: Record<string, readonly string[]> = {
+  automation: ["automate", "automated", "qa", "testing"],
+  browser: ["chrome", "playwright", "web"],
+  cc: ["claude", "claude-code"],
+  claude: ["claude-code"],
+  design: ["ux", "ui"],
+  gh: ["github"],
+  ms: ["microsoft"],
+  mcp: ["model-context-protocol"],
+  msteams: ["teams", "microsoft-teams"],
+  repo: ["repository", "github"],
+  repos: ["repository", "github"],
+  safe: ["safety", "security", "secure", "trust", "privacy"],
+  security: ["safe", "safety", "secure", "trust"],
+  skill: ["skills"],
+  skills: ["skill"],
+  statusline: ["statuslines", "status"],
+  statuslines: ["statusline", "status"],
+};
+
+function normalizeAliasKey(token: string) {
+  return token.trim().toLowerCase();
+}
+
+/** Return alias expansions for a token without inheriting prototype property names. */
+export function queryAliasExpansions(token: string): string[] {
+  const key = normalizeAliasKey(token);
+  if (!key || !Object.hasOwn(SEARCH_QUERY_ALIASES, key)) return [];
+  return [...SEARCH_QUERY_ALIASES[key]];
+}
+
+/** Return the token plus any alias expansions used by search matching. */
+export function expandedTokenCandidates(token: string): string[] {
+  const key = normalizeAliasKey(token);
+  if (!key) return [];
+  return [key, ...queryAliasExpansions(key)];
+}
+
+/** Flatten alias expansions for a token list. */
+export function expandedTokenSet(tokens: ReadonlyArray<string>): Set<string> {
+  return new Set(tokens.flatMap((token) => expandedTokenCandidates(token)));
+}

--- a/tests/entry-normalize.test.ts
+++ b/tests/entry-normalize.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEntry,
+  type RegistryEntry,
+} from "../apps/web/src/data/entry-normalize";
+
+function baseEntry(overrides: Partial<RegistryEntry> = {}): RegistryEntry {
+  return {
+    category: "skills",
+    slug: "platform-fixture",
+    title: "Platform Fixture",
+    description: "Fixture entry for platform compatibility normalization.",
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe("buildEntry platform compatibility", () => {
+  it("maps common support-level synonyms to canonical platform support values", () => {
+    const entry = buildEntry(
+      baseEntry({
+        platformCompatibility: [
+          { platform: "Claude Code", supportLevel: "full" },
+          { platform: "Cursor", support: "partial" },
+          { platform: "Windsurf", supportLevel: "native" },
+          { platform: "Aider", support: "manual" },
+          { platform: "Zed", supportLevel: "unsupported" },
+        ],
+      }),
+    );
+
+    expect(entry.platformCompatibility).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: "claude-code",
+          support: "native-skill",
+        }),
+        expect.objectContaining({ platform: "cursor", support: "adapter" }),
+        expect.objectContaining({
+          platform: "windsurf",
+          support: "native-skill",
+        }),
+        expect.objectContaining({
+          platform: "aider",
+          support: "manual-context",
+        }),
+        expect.objectContaining({ platform: "zed", support: "unsupported" }),
+      ]),
+    );
+    expect(entry.platformCompatibility).toHaveLength(5);
+  });
+
+  it("normalizes support keys with underscores, spaces, and casing", () => {
+    const entry = buildEntry(
+      baseEntry({
+        platformCompatibility: [
+          { platform: "claude-code", supportLevel: "Native_Skill" },
+          { platform: "cursor", support: "Manual Context" },
+        ],
+      }),
+    );
+
+    expect(entry.platformCompatibility).toEqual([
+      expect.objectContaining({
+        platform: "claude-code",
+        support: "native-skill",
+      }),
+      expect.objectContaining({
+        platform: "cursor",
+        support: "manual-context",
+      }),
+    ]);
+  });
+
+  it("does not inherit prototype property names when normalizing support levels", () => {
+    const entry = buildEntry(
+      baseEntry({
+        platformCompatibility: [
+          { platform: "claude-code", supportLevel: "constructor" },
+        ],
+      }),
+    );
+
+    expect(entry.platformCompatibility).toEqual([
+      expect.objectContaining({
+        platform: "claude-code",
+        support: "manual-context",
+      }),
+    ]);
+  });
+
+  it("defaults unknown support strings to manual-context", () => {
+    const entry = buildEntry(
+      baseEntry({
+        platformCompatibility: [
+          { platform: "claude-code", supportLevel: "experimental-beta" },
+        ],
+      }),
+    );
+
+    expect(entry.platformCompatibility).toEqual([
+      expect.objectContaining({
+        platform: "claude-code",
+        support: "manual-context",
+      }),
+    ]);
+  });
+
+  it("infers platforms from tags and category when compatibility rows are absent", () => {
+    const mcpEntry = buildEntry(
+      baseEntry({
+        category: "mcp",
+        tags: ["mcp", "automation"],
+        platformCompatibility: undefined,
+      }),
+    );
+    expect(mcpEntry.platforms).toEqual(
+      expect.arrayContaining(["claude-code", "claude-desktop"]),
+    );
+
+    const raycastEntry = buildEntry(
+      baseEntry({
+        category: "tools",
+        tags: ["raycast", "launcher"],
+        platformCompatibility: undefined,
+      }),
+    );
+    expect(raycastEntry.platforms).toContain("raycast");
+  });
+
+  it("normalizes related entry relations and claim status", () => {
+    const entry = buildEntry(
+      baseEntry({
+        claimStatus: "VERIFIED",
+        relatedEntries: [
+          {
+            category: "mcp",
+            slug: "related-server",
+            title: "Related Server",
+            relation: "works-with",
+          },
+          {
+            category: "hooks",
+            slug: "invalid",
+            title: "",
+            relation: "bogus",
+          },
+        ],
+      }),
+    );
+
+    expect(entry.claimStatus).toBe("verified");
+    expect(entry.relatedEntries).toEqual([
+      expect.objectContaining({
+        key: "mcp:related-server",
+        relation: "works-with",
+        url: "/entry/mcp/related-server",
+      }),
+    ]);
+  });
+
+  it("derives source and trust posture from registry fields", () => {
+    const entry = buildEntry(
+      baseEntry({
+        packageVerified: true,
+        downloadSha256: "abc123",
+        githubUrl: "https://github.com/example/platform-fixture",
+        safetyNotes: "Runs local scripts.",
+        privacyNotes: "Does not send prompts off-device.",
+      }),
+    );
+
+    expect(entry.source).toBe("source-backed");
+    expect(entry.trust).toBe("trusted");
+    expect(entry.safetyNotes).toBe("Runs local scripts.");
+    expect(entry.privacyNotes).toBe("Does not send prompts off-device.");
+  });
+
+  it("whitelists hook triggers and preserves script metadata", () => {
+    const entry = buildEntry(
+      baseEntry({
+        category: "hooks",
+        trigger: "PreToolUse",
+        scriptLanguage: "bash",
+        scriptBody: "echo hello",
+      }),
+    );
+
+    expect(entry.trigger).toBe("PreToolUse");
+    expect(entry.scriptLanguage).toBe("bash");
+    expect(entry.scriptBody).toBe("echo hello");
+  });
+});

--- a/tests/registry-search-query-bounds.test.ts
+++ b/tests/registry-search-query-bounds.test.ts
@@ -92,4 +92,14 @@ describe("registry search query bounds", () => {
       reasons: [],
     });
   });
+
+  it("expands registry query aliases added to the shared alias map", () => {
+    const entry = makeEntry({
+      tags: ["automation", "testing"],
+      keywords: ["qa workflow"],
+    });
+
+    expect(matchesQuery(entry, "automation qa")).toBe(true);
+    expect(matchesQuery(entry, "design ux")).toBe(false);
+  });
 });

--- a/tests/search-query-aliases.test.ts
+++ b/tests/search-query-aliases.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  expandedTokenCandidates,
+  expandedTokenSet,
+  queryAliasExpansions,
+  SEARCH_QUERY_ALIASES,
+} from "../apps/web/src/lib/search-query-aliases";
+
+describe("search query aliases", () => {
+  it("expands common shorthand tokens", () => {
+    expect(queryAliasExpansions("gh")).toEqual(["github"]);
+    expect(queryAliasExpansions("mcp")).toEqual(["model-context-protocol"]);
+    expect(queryAliasExpansions("cc")).toEqual(["claude", "claude-code"]);
+    expect(queryAliasExpansions("automation")).toEqual([
+      "automate",
+      "automated",
+      "qa",
+      "testing",
+    ]);
+    expect(queryAliasExpansions("msteams")).toEqual([
+      "teams",
+      "microsoft-teams",
+    ]);
+  });
+
+  it("returns empty expansions for unknown tokens", () => {
+    expect(queryAliasExpansions("spreadsheet")).toEqual([]);
+    expect(queryAliasExpansions("")).toEqual([]);
+  });
+
+  it("does not inherit prototype property names as alias keys", () => {
+    expect(queryAliasExpansions("constructor")).toEqual([]);
+    expect(queryAliasExpansions("__proto__")).toEqual([]);
+    expect(expandedTokenCandidates("constructor")).toEqual(["constructor"]);
+    expect(expandedTokenCandidates("__proto__")).toEqual(["__proto__"]);
+  });
+
+  it("includes the normalized token before alias expansions", () => {
+    expect(expandedTokenCandidates("GH")).toEqual(["gh", "github"]);
+    expect(expandedTokenCandidates("skill")).toEqual(["skill", "skills"]);
+  });
+
+  it("deduplicates expanded token sets", () => {
+    expect(expandedTokenSet(["gh", "github"])).toEqual(
+      new Set(["gh", "github"]),
+    );
+    expect(expandedTokenSet(["safe", "security"])).toEqual(
+      new Set(["safe", "safety", "security", "secure", "trust", "privacy"]),
+    );
+  });
+
+  it("keeps registry and entry search alias maps aligned", () => {
+    expect(Object.keys(SEARCH_QUERY_ALIASES).sort()).toEqual(
+      [
+        "automation",
+        "browser",
+        "cc",
+        "claude",
+        "design",
+        "gh",
+        "mcp",
+        "ms",
+        "msteams",
+        "repo",
+        "repos",
+        "safe",
+        "security",
+        "skill",
+        "skills",
+        "statusline",
+        "statuslines",
+      ].sort(),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Unify search query alias expansion across registry API search and entry search, harden alias/support lookups against prototype property names, and normalize platform support synonyms when building web entries.

## What Changed

- **`apps/web/src/lib/search-query-aliases.ts`** (new) — shared alias map (`gh` → `github`, `mcp` → `model-context-protocol`, `automation`, `design`, `msteams`, etc.) with `Object.hasOwn` guards and `expandedTokenCandidates` / `expandedTokenSet` helpers.
- **`apps/web/src/lib/api/registry-search-filters.ts`** — import shared alias helpers; remove duplicate alias map.
- **`apps/web/src/data/search.ts`** — import shared aliases and reuse `search-query-tokenization` instead of a second copy of tokenization logic.
- **`apps/web/src/data/entry-normalize.ts`** — expand platform support synonyms (`full`/`native` → `native-skill`, `partial` → `adapter`, etc.), add `normalizeSupportLevel` + `normalizeClaimStatus` with `Object.hasOwn` guards.
- **Tests** — new `tests/search-query-aliases.test.ts`, new `tests/entry-normalize.test.ts`, extend `tests/registry-search-query-bounds.test.ts`.

## Why

Registry search and entry search had diverging alias maps; the registry version included tokens (`automation`, `design`, `msteams`) that entry search did not. Support levels like `full` and `native` from registry artifacts were silently coerced to `manual-context`. Prototype keys such as `constructor` could leak through bracket lookups.

## Validation

```sh
pnpm --filter web run prebuild
pnpm test
trunk check --ci --upstream origin/main
trunk fmt
git diff --check
```

All checks passed locally (1582/1582 tests).

## Notes

~167 production-line churn (well above Gittensor `MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5`). No MCP package dependency changes.

## Summary by CodeRabbit
- Centralize search alias expansion with prototype-safe lookups.
- Reuse shared query tokenization in entry search.
- Normalize platform support and claim status synonyms when building entries.
- Add regression coverage for aliases, support mapping, and entry normalization.