### PR TITLE
chore(mcp): add package-metadata.js + npm README to release-please extra-files

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -34,8 +34,8 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
   the best-match entries for a plain-language task, each with why it fits, a
   trust summary, safety/privacy notes, and an inline install block, plus a
   `topPick` and consolidated `installPlan`.
-- `server_info` - fetch package version, registry generation, tool list, public
-  access policy, and rate-limit metadata.
+- `get_server_info` - fetch package version, registry generation, tool list,
+  public access policy, and rate-limit metadata.
 - `list_category_entries` - browse entries with bounded pagination and optional
   category, platform, tag, and query filters.
 - `get_recent_updates` - list recently added or upstream-updated entries from

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,7 +28,9 @@
           "type": "json",
           "path": "server.json",
           "jsonpath": "$.packages[0].version"
-        }
+        },
+        { "type": "generic", "path": "packages/mcp/src/package-metadata.js" },
+        { "type": "generic", "path": "packages/mcp/README.md" }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Fixes the three CI failures in Release PR [#4217](https://github.com/JSONbored/awesome-claude/pull/4217):

- **`package-metadata.js` version out of sync** — `packageVersion = "0.3.1"` hardcoded for Cloudflare Worker bundling safety. release-please was only bumping `package.json`, so the CLI version test failed (`expected '0.3.1' to be '0.4.0'`).
- **`packages/mcp/README.md` stale release link** — still pointed at `mcp-v0.3.1`, test expects the link to match the current `package.json` version.
- **`server_info` rename not reflected in npm README** — renamed to `get_server_info` in #4218 but the npm package README wasn't updated.

## What this does

- Adds `packages/mcp/src/package-metadata.js` and `packages/mcp/README.md` to `release-please-config.json` `extra-files` (generic type) so future Release PRs auto-bump both alongside `package.json`.
- Merging this PR causes release-please to re-run on main and update Release PR #4217 to include the bumped versions of both files → CI passes.
- Fixes `server_info` → `get_server_info` in `packages/mcp/README.md`.

## Merge order

Merge this PR first, then merge Release PR #4217 once CI goes green.