### PR TITLE
chore(mcp): add x-release-please-version annotations and correct extra-files paths

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/JSONbored/awesome-claude">GitHub</a> •
   <a href="https://www.npmjs.com/package/@heyclaude/mcp">npm</a> •
   <a href="https://heyclau.de/api/mcp">MCP endpoint</a> •
-  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.3.1">v0.3.1 release</a>
+  <a href="https://github.com/JSONbored/awesome-claude/releases/tag/mcp-v0.3.1">v0.3.1 release</a><!-- x-release-please-version -->
 </p>
 
 Read-only Model Context Protocol server for the HeyClaude registry.

--- a/packages/mcp/src/package-metadata.js
+++ b/packages/mcp/src/package-metadata.js
@@ -1,4 +1,4 @@
 // Keep this Worker-safe: Cloudflare's bundle loader rejects runtime
 // package.json specifiers inside the SSR/MCP route bundle.
 export const packageName = "@heyclaude/mcp";
-export const packageVersion = "0.3.1";
+export const packageVersion = "0.3.1"; // x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,8 +29,8 @@
           "path": "server.json",
           "jsonpath": "$.packages[0].version"
         },
-        { "type": "generic", "path": "packages/mcp/src/package-metadata.js" },
-        { "type": "generic", "path": "packages/mcp/README.md" }
+        { "type": "generic", "path": "src/package-metadata.js" },
+        { "type": "generic", "path": "README.md" }
       ]
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #4219. The `generic` extra-files type was not bumping
`package-metadata.js` or `packages/mcp/README.md` in the Release PR because:

1. **Missing annotations** — the `generic` type requires `// x-release-please-version`
   (JS) or `<!-- x-release-please-version -->` (HTML/Markdown) annotations on the
   lines to be updated. Without them, release-please can't locate the right string.
2. **Wrong path base** — for `generic` type entries within a package config,
   paths are relative to the **package root** (`packages/mcp`), not the repo root.
   Corrected `packages/mcp/src/package-metadata.js` → `src/package-metadata.js`
   and `packages/mcp/README.md` → `README.md`.

After this merges, release-please will regenerate Release PR #4217, bumping
both files from `0.3.1` → `0.4.0`, and all three CI failures will clear.

Refs #4217