### PR TITLE
feat(mcp): rename tools to dot-notation for Smithery 100/100 naming score

### DIFF
--- a/apps/web/src/data/integrations.ts
+++ b/apps/web/src/data/integrations.ts
@@ -73,7 +73,7 @@ export const INTEGRATIONS: Integration[] = [
     npmPackage: "@heyclaude/mcp",
     githubRepo: "jsonbored/awesome-claude",
     bullets: [
-      "20+ tools: search, trending, compare, get_entry_detail, prepare_submission_draft, explain_entry_trust",
+      "20+ tools: search, trending, compare, entry.detail, submission.prepare, entry.trust",
       "Prompts and resources for workflow planning",
       "Stdio + remote HTTP transport",
     ],

--- a/apps/web/src/data/openapi.ts
+++ b/apps/web/src/data/openapi.ts
@@ -336,7 +336,7 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
     entry: { category: "mcp", slug: "github-mcp-server", title: "GitHub MCP Server" },
   },
   "registry.entryLlms": "# GitHub MCP Server\n\nMachine-readable entry text.",
-  "mcp.streamable": { jsonrpc: "2.0", id: 1, result: { tools: [{ name: "search_registry" }] } },
+  "mcp.streamable": { jsonrpc: "2.0", id: 1, result: { tools: [{ name: "registry.search" }] } },
   "brandAsset.read": "Binary image response.",
   "votes.query": {
     ok: true,
@@ -436,7 +436,7 @@ const RESPONSE_EXAMPLES: Partial<Record<ApiRouteId, unknown>> = {
 const CLIENT_EXAMPLES: Partial<Record<ApiRouteId, Array<{ label: string; code: string }>>> = {
   "registry.search": [
     { label: "Raycast", code: "raycast://extensions/jsonbored/heyclaude/search" },
-    { label: "MCP", code: "Use the search_registry tool from the HeyClaude MCP server." },
+    { label: "MCP", code: "Use the registry.search tool from the HeyClaude MCP server." },
   ],
   "jobs.list": [
     { label: "Raycast", code: "raycast://extensions/jsonbored/heyclaude/jobs" },
@@ -444,7 +444,7 @@ const CLIENT_EXAMPLES: Partial<Record<ApiRouteId, Array<{ label: string; code: s
   ],
   "mcp.streamable": [
     { label: "Streamable HTTP endpoint", code: "https://heyclau.de/api/mcp" },
-    { label: "First tool to call", code: "tools/list, then search_registry or get_entry_detail" },
+    { label: "First tool to call", code: "tools/list, then registry.search or entry.detail" },
   ],
 };
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -28,63 +28,63 @@ strict request validation, a 64 KiB body limit, and a dedicated Cloudflare
 
 ## Tools
 
-- `search_registry` - search public registry entries by query, category, and
+- `registry.search` - search public registry entries by query, category, and
   platform.
-- `recommend_for_task` - answer "what should I use to do X" in one call: returns
+- `registry.recommend` - answer "what should I use to do X" in one call: returns
   the best-match entries for a plain-language task, each with why it fits, a
   trust summary, safety/privacy notes, and an inline install block, plus a
   `topPick` and consolidated `installPlan`.
-- `get_server_info` - fetch package version, registry generation, tool list,
+- `server.info` - fetch package version, registry generation, tool list,
   public access policy, and rate-limit metadata.
-- `list_category_entries` - browse entries with bounded pagination and optional
+- `registry.list` - browse entries with bounded pagination and optional
   category, platform, tag, and query filters.
-- `get_recent_updates` - list recently added or upstream-updated entries from
+- `registry.updates` - list recently added or upstream-updated entries from
   generated registry metadata, optionally filtered with `since`.
-- `get_related_entries` - find related entries based on category, tags,
+- `entry.related` - find related entries based on category, tags,
   platforms, keywords, and source metadata.
-- `get_entry_detail` - fetch an entry detail payload by category and slug.
+- `entry.detail` - fetch an entry detail payload by category and slug.
   Defaults to a token-efficient body excerpt (reporting `bodyChars`,
   `bodyTruncated`, and any `omittedFields`); pass `bodyMode: "full"` for the
   complete content or `"none"` to drop the body. Omitted copyable fields are
-  available via `get_copyable_asset`.
-- `get_copyable_asset` - fetch the category-aware copy/install asset for an
+  available via `entry.asset`.
+- `entry.asset` - fetch the category-aware copy/install asset for an
   entry, such as full prompt text, config snippets, commands, scripts, or
   collection items. Pass `assetType` (e.g. `install_command`) to return only
   that asset and skip the large `full_content`/`script` payloads.
-- `compare_entries` - compare 2-5 entries by fit, category, platform support,
+- `entry.compare` - compare 2-5 entries by fit, category, platform support,
   install complexity, and source metadata.
-- `get_registry_stats` - fetch aggregate counts, freshness metadata, and real
+- `registry.stats` - fetch aggregate counts, freshness metadata, and real
   source-signal coverage without implying popularity when stats are absent.
-- `get_client_setup` - fetch tested setup snippets for Codex, Claude Desktop,
+- `install.setup` - fetch tested setup snippets for Codex, Claude Desktop,
   Cursor, Windsurf, and raw Streamable HTTP clients.
-- `get_compatibility` - fetch skill platform compatibility metadata.
-- `get_install_guidance` - fetch install commands, config, package, and platform
+- `install.compatibility` - fetch skill platform compatibility metadata.
+- `install.guidance` - fetch install commands, config, package, and platform
   guidance.
-- `get_platform_adapter` - fetch generated adapter content, currently Cursor
+- `install.adapter` - fetch generated adapter content, currently Cursor
   rule adapters for skill packages.
-- `list_distribution_feeds` - discover public JSON, RSS, Atom, and platform
+- `feeds.list` - discover public JSON, RSS, Atom, and platform
   feeds.
-- `get_submission_schema` - fetch category submission fields for PR-first
+- `submission.schema` - fetch category submission fields for PR-first
   intake.
-- `validate_submission_draft` - validate a content submission draft locally.
-- `search_duplicate_entries` - check generated registry artifacts for likely
+- `submission.validate` - validate a content submission draft locally.
+- `submission.duplicates` - check generated registry artifacts for likely
   duplicates before opening a submission.
-- `build_submission_urls` - build prefilled HeyClaude submit and review URLs for human
+- `submission.urls` - build prefilled HeyClaude submit and review URLs for human
   review.
-- `get_category_submission_guidance` - fetch category-specific contribution
+- `submission.guidance` - fetch category-specific contribution
   guidance and required fields.
-- `prepare_submission_draft` - normalize and validate fields, then return a
+- `submission.prepare` - normalize and validate fields, then return a
   canonical PR draft plus prefilled submit URL.
-- `get_submission_examples` - fetch category-specific example fields and
+- `submission.examples` - fetch category-specific example fields and
   templates for more complete submissions.
-- `review_submission_draft` - review schema errors, duplicate risk, and
+- `submission.review` - review schema errors, duplicate risk, and
   maintainer checklist items before a submission PR is opened.
-- `get_submission_policy` - fetch the read-only submission, artifact, import,
+- `submission.policy` - fetch the read-only submission, artifact, import,
   and maintainer-review policy.
-- `explain_entry_trust` - explain source, package, safety, privacy, and review
+- `entry.trust` - explain source, package, safety, privacy, and review
   metadata signals for one entry. This is a metadata review only and does not
   provide malware scanning, automatic safety guarantees, or installation approval.
-- `review_entry_safety` - compare 1-5 entries for source, package, safety, and
+- `entry.safety` - compare 1-5 entries for source, package, safety, and
   privacy metadata fit before install or recommendation. This is a metadata review
   only and does not provide malware scanning, automatic safety guarantees, or
   installation approval.
@@ -108,8 +108,8 @@ Workflow prompts are available for common client flows:
 
 The published package defaults to the live HeyClaude MCP endpoint. In this
 remote-bridge mode, draft-content helpers that accept private submission fields
-(`validate_submission_draft`, `build_submission_urls`, `prepare_submission_draft`,
-and `review_submission_draft`) are intentionally not exposed or forwarded; use
+(`submission.validate`, `submission.urls`, `submission.prepare`,
+and `submission.review`) are intentionally not exposed or forwarded; use
 local artifact mode for those helpers before entering private draft content.
 
 ```json

--- a/packages/mcp/scripts/validate-endpoint.mjs
+++ b/packages/mcp/scripts/validate-endpoint.mjs
@@ -7,17 +7,17 @@ import { normalizeEndpointUrl } from "../src/endpoint-url.js";
 import { READ_ONLY_TOOL_NAMES } from "../src/registry.js";
 
 const baselineToolNames = [
-  "search_registry",
-  "get_entry_detail",
-  "get_compatibility",
-  "get_install_guidance",
-  "get_platform_adapter",
-  "list_distribution_feeds",
-  "get_submission_schema",
-  "validate_submission_draft",
-  "search_duplicate_entries",
-  "build_submission_urls",
-  "get_category_submission_guidance",
+  "registry.search",
+  "entry.detail",
+  "install.compatibility",
+  "install.guidance",
+  "install.adapter",
+  "feeds.list",
+  "submission.schema",
+  "submission.validate",
+  "submission.duplicates",
+  "submission.urls",
+  "submission.guidance",
 ];
 
 function parseArgs(argv) {
@@ -55,21 +55,19 @@ function assertSubmitUrl(value) {
   try {
     url = new URL(String(value || ""));
   } catch {
-    throw new Error(
-      "build_submission_urls did not return an absolute submit URL.",
-    );
+    throw new Error("submission.urls did not return an absolute submit URL.");
   }
   assert(
     url.protocol === "https:",
-    "build_submission_urls submit URL must use HTTPS.",
+    "submission.urls submit URL must use HTTPS.",
   );
   assert(
     url.origin === "https://heyclau.de",
-    "build_submission_urls submit URL used the wrong origin.",
+    "submission.urls submit URL used the wrong origin.",
   );
   assert(
     url.pathname === "/submit",
-    "build_submission_urls did not return the submit URL.",
+    "submission.urls did not return the submit URL.",
   );
 }
 
@@ -161,7 +159,7 @@ async function validateMcpTools(endpointUrl, options = {}) {
     const tools = await client.listTools();
     const toolNames = tools.tools.map((tool) => tool.name);
     validateToolList(toolNames, options.strictTools);
-    const hasVersionTwoSurface = toolNames.includes("get_registry_stats");
+    const hasVersionTwoSurface = toolNames.includes("registry.stats");
     if (hasVersionTwoSurface) {
       assert(
         tools.tools.every((tool) => tool.annotations?.readOnlyHint === true),
@@ -198,7 +196,7 @@ async function validateMcpTools(endpointUrl, options = {}) {
       });
       assert(
         installPrompt.messages?.[0]?.content?.text?.includes(
-          "get_install_guidance",
+          "install.guidance",
         ),
         "install_asset_safely prompt did not mention install guidance.",
       );
@@ -206,136 +204,136 @@ async function validateMcpTools(endpointUrl, options = {}) {
 
     const search = parseToolResult(
       await client.callTool({
-        name: "search_registry",
+        name: "registry.search",
         arguments: { query: "mcp", limit: 2 },
       }),
     );
-    assert(search.ok === true, "search_registry did not return ok: true.");
+    assert(search.ok === true, "registry.search did not return ok: true.");
     assert(
       Array.isArray(search.entries) && search.entries.length > 0,
-      "search_registry did not return entries.",
+      "registry.search did not return entries.",
     );
     if (options.requireSafetyMetadata) {
       assertSafetyMetadataShape(
         search.entries[0],
-        "search_registry first entry",
+        "registry.search first entry",
       );
     }
 
-    if (toolNames.includes("get_server_info")) {
+    if (toolNames.includes("server.info")) {
       const info = parseToolResult(
         await client.callTool({
-          name: "get_server_info",
+          name: "server.info",
           arguments: {},
         }),
       );
-      assert(info.ok === true, "get_server_info did not return ok.");
+      assert(info.ok === true, "server.info did not return ok.");
       assert(
         info.endpoint?.auth === "none",
-        "get_server_info did not expose the public no-key access model.",
+        "server.info did not expose the public no-key access model.",
       );
       assert(
         info.endpoint?.rateLimit?.binding === "API_MCP_RATE_LIMIT",
-        "get_server_info did not expose the MCP rate-limit binding.",
+        "server.info did not expose the MCP rate-limit binding.",
       );
     }
 
-    if (toolNames.includes("list_category_entries")) {
+    if (toolNames.includes("registry.list")) {
       const listed = parseToolResult(
         await client.callTool({
-          name: "list_category_entries",
+          name: "registry.list",
           arguments: { category: "mcp", limit: 2 },
         }),
       );
-      assert(listed.ok === true, "list_category_entries did not return ok.");
+      assert(listed.ok === true, "registry.list did not return ok.");
       assert(
         Array.isArray(listed.entries) && listed.entries.length > 0,
-        "list_category_entries did not return entries.",
+        "registry.list did not return entries.",
       );
     }
 
-    if (toolNames.includes("get_registry_stats")) {
+    if (toolNames.includes("registry.stats")) {
       const stats = parseToolResult(
         await client.callTool({
-          name: "get_registry_stats",
+          name: "registry.stats",
           arguments: {},
         }),
       );
-      assert(stats.ok === true, "get_registry_stats did not return ok.");
+      assert(stats.ok === true, "registry.stats did not return ok.");
       assert(
         stats.policy?.readOnly === true,
-        "get_registry_stats did not expose the no-write policy.",
+        "registry.stats did not expose the no-write policy.",
       );
     }
 
     const first = search.entries[0];
     const detail = parseToolResult(
       await client.callTool({
-        name: "get_entry_detail",
+        name: "entry.detail",
         arguments: { category: first.category, slug: first.slug },
       }),
     );
-    assert(detail.ok === true, "get_entry_detail did not return ok: true.");
+    assert(detail.ok === true, "entry.detail did not return ok: true.");
     assert(
       detail.key === `${first.category}:${first.slug}`,
-      "get_entry_detail returned the wrong entry.",
+      "entry.detail returned the wrong entry.",
     );
     if (options.requireSafetyMetadata) {
-      assertSafetyMetadataShape(detail.entry, "get_entry_detail entry");
+      assertSafetyMetadataShape(detail.entry, "entry.detail entry");
     }
 
-    if (toolNames.includes("get_copyable_asset")) {
+    if (toolNames.includes("entry.asset")) {
       const asset = parseToolResult(
         await client.callTool({
-          name: "get_copyable_asset",
+          name: "entry.asset",
           arguments: { category: first.category, slug: first.slug },
         }),
       );
-      assert(asset.ok === true, "get_copyable_asset did not return ok.");
+      assert(asset.ok === true, "entry.asset did not return ok.");
       assert(
         asset.primaryAsset || asset.assets?.length,
-        "get_copyable_asset did not return any copyable asset.",
+        "entry.asset did not return any copyable asset.",
       );
     }
 
     const feeds = parseToolResult(
       await client.callTool({
-        name: "list_distribution_feeds",
+        name: "feeds.list",
         arguments: {},
       }),
     );
-    assert(feeds.ok === true, "list_distribution_feeds did not return ok.");
+    assert(feeds.ok === true, "feeds.list did not return ok.");
     assert(
       feeds.artifacts?.directory === "/data/directory-index.json",
-      "list_distribution_feeds did not expose the directory artifact.",
+      "feeds.list did not expose the directory artifact.",
     );
 
     const schema = parseToolResult(
       await client.callTool({
-        name: "get_submission_schema",
+        name: "submission.schema",
         arguments: { category: "mcp" },
       }),
     );
-    assert(schema.ok === true, "get_submission_schema did not return ok.");
+    assert(schema.ok === true, "submission.schema did not return ok.");
     assert(
       schema.prIntake?.mode === "github_app_user_fork_pr",
-      "get_submission_schema did not return PR-first intake metadata.",
+      "submission.schema did not return PR-first intake metadata.",
     );
     if (options.requireSafetyMetadata) {
       const fieldIds = schema.schema?.fields?.map((field) => field.id) || [];
       assert(
         fieldIds.includes("safety_notes"),
-        "get_submission_schema did not expose safety_notes.",
+        "submission.schema did not expose safety_notes.",
       );
       assert(
         fieldIds.includes("privacy_notes"),
-        "get_submission_schema did not expose privacy_notes.",
+        "submission.schema did not expose privacy_notes.",
       );
     }
 
     const urls = parseToolResult(
       await client.callTool({
-        name: "build_submission_urls",
+        name: "submission.urls",
         arguments: {
           fields: {
             category: "mcp",
@@ -349,13 +347,13 @@ async function validateMcpTools(endpointUrl, options = {}) {
         },
       }),
     );
-    assert(urls.ok === true, "build_submission_urls did not return ok.");
+    assert(urls.ok === true, "submission.urls did not return ok.");
     assertSubmitUrl(urls.submitUrl);
 
-    if (toolNames.includes("prepare_submission_draft")) {
+    if (toolNames.includes("submission.prepare")) {
       const prepared = parseToolResult(
         await client.callTool({
-          name: "prepare_submission_draft",
+          name: "submission.prepare",
           arguments: {
             fields: {
               category: "mcp",
@@ -371,26 +369,26 @@ async function validateMcpTools(endpointUrl, options = {}) {
       );
       assert(
         prepared.prDraft?.body,
-        "prepare_submission_draft did not return a canonical PR draft body.",
+        "submission.prepare did not return a canonical PR draft body.",
       );
       assert(
         String(prepared.submissionPolicy || "").includes(
           "may be merged automatically",
         ),
-        "prepare_submission_draft did not expose the maintainer-reviewed policy.",
+        "submission.prepare did not expose the maintainer-reviewed policy.",
       );
     }
 
     const invalid = parseToolResult(
       await client.callTool({
-        name: "search_registry",
+        name: "registry.search",
         arguments: { limit: 100, unexpected: true },
       }),
     );
-    assert(invalid.ok === false, "Invalid search_registry call did not fail.");
+    assert(invalid.ok === false, "Invalid registry.search call did not fail.");
     assert(
       invalid.error?.code === "invalid_request",
-      "Invalid search_registry call did not return invalid_request.",
+      "Invalid registry.search call did not return invalid_request.",
     );
   } finally {
     await client.close();

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -80,49 +80,49 @@ const platformAliases = new Map([
 ]);
 
 export const READ_ONLY_TOOL_NAMES = [
-  "search_registry",
+  "registry.search",
   "plan_workflow_toolbox",
-  "recommend_for_task",
-  "get_server_info",
-  "list_category_entries",
-  "get_recent_updates",
-  "get_related_entries",
-  "get_entry_detail",
-  "get_copyable_asset",
-  "compare_entries",
-  "get_registry_stats",
-  "get_client_setup",
-  "get_compatibility",
-  "get_install_guidance",
-  "get_platform_adapter",
-  "list_distribution_feeds",
-  "get_submission_schema",
-  "validate_submission_draft",
-  "search_duplicate_entries",
-  "build_submission_urls",
-  "get_category_submission_guidance",
-  "prepare_submission_draft",
-  "get_submission_examples",
-  "review_submission_draft",
-  "get_submission_policy",
-  "explain_entry_trust",
-  "review_entry_safety",
+  "registry.recommend",
+  "server.info",
+  "registry.list",
+  "registry.updates",
+  "entry.related",
+  "entry.detail",
+  "entry.asset",
+  "entry.compare",
+  "registry.stats",
+  "install.setup",
+  "install.compatibility",
+  "install.guidance",
+  "install.adapter",
+  "feeds.list",
+  "submission.schema",
+  "submission.validate",
+  "submission.duplicates",
+  "submission.urls",
+  "submission.guidance",
+  "submission.prepare",
+  "submission.examples",
+  "submission.review",
+  "submission.policy",
+  "entry.trust",
+  "entry.safety",
 ];
 
 export const LOCAL_DRAFT_TOOL_NAMES = [
-  "validate_submission_draft",
-  "build_submission_urls",
-  "prepare_submission_draft",
-  "review_submission_draft",
+  "submission.validate",
+  "submission.urls",
+  "submission.prepare",
+  "submission.review",
 ];
 
 export const TOOL_DEFINITIONS = [
   {
-    name: "search_registry",
+    name: "registry.search",
     description:
       "Search read-only HeyClaude registry entries by query, category, exact tag, and skill platform compatibility.",
-    inputSchema: jsonSchemaForTool("search_registry"),
-    outputSchema: jsonSchemaForToolOutput("search_registry"),
+    inputSchema: jsonSchemaForTool("registry.search"),
+    outputSchema: jsonSchemaForToolOutput("registry.search"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -144,11 +144,11 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "recommend_for_task",
+    name: "registry.recommend",
     description:
       "Answer 'what should I use to do X' in one call. Given a plain-language task (and optional platform/category), returns the best-match HeyClaude entries ranked by fit — each with why it fits, trust summary, disclosed safety/privacy notes, and an inline install block — plus a topPick and a consolidated installPlan. Unlike plan_workflow_toolbox it does not force category diversity; it returns the genuinely best matches. Collapses the search → compare → detail → asset loop into a single answer-shaped response.",
-    inputSchema: jsonSchemaForTool("recommend_for_task"),
-    outputSchema: jsonSchemaForToolOutput("recommend_for_task"),
+    inputSchema: jsonSchemaForTool("registry.recommend"),
+    outputSchema: jsonSchemaForToolOutput("registry.recommend"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -157,148 +157,148 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "get_server_info",
+    name: "server.info",
     description:
       "Fetch read-only HeyClaude MCP package, registry, tool, and public rate-limit metadata.",
-    inputSchema: jsonSchemaForTool("get_server_info"),
+    inputSchema: jsonSchemaForTool("server.info"),
   },
   {
-    name: "list_category_entries",
+    name: "registry.list",
     description:
       "List read-only HeyClaude entries with bounded pagination and optional category, platform, tag, and query filters.",
-    inputSchema: jsonSchemaForTool("list_category_entries"),
+    inputSchema: jsonSchemaForTool("registry.list"),
   },
   {
-    name: "get_recent_updates",
+    name: "registry.updates",
     description:
       "List recently added or upstream-updated HeyClaude entries from generated registry metadata.",
-    inputSchema: jsonSchemaForTool("get_recent_updates"),
+    inputSchema: jsonSchemaForTool("registry.updates"),
   },
   {
-    name: "get_related_entries",
+    name: "entry.related",
     description:
       "Fetch read-only related HeyClaude entries based on category, tags, platforms, keywords, and source metadata.",
-    inputSchema: jsonSchemaForTool("get_related_entries"),
+    inputSchema: jsonSchemaForTool("entry.related"),
   },
   {
-    name: "get_entry_detail",
+    name: "entry.detail",
     description:
-      "Fetch a read-only HeyClaude registry entry detail payload by category and slug. By default (bodyMode='excerpt') the body markdown is trimmed to a short lead and large copyable fields are omitted to conserve context, with bodyChars/bodyTruncated/omittedFields describing what was dropped; pass bodyMode='full' for the complete content or 'none' to drop the body entirely. Use get_copyable_asset to retrieve omitted install/script content.",
-    inputSchema: jsonSchemaForTool("get_entry_detail"),
+      "Fetch a read-only HeyClaude registry entry detail payload by category and slug. By default (bodyMode='excerpt') the body markdown is trimmed to a short lead and large copyable fields are omitted to conserve context, with bodyChars/bodyTruncated/omittedFields describing what was dropped; pass bodyMode='full' for the complete content or 'none' to drop the body entirely. Use entry.asset to retrieve omitted install/script content.",
+    inputSchema: jsonSchemaForTool("entry.detail"),
   },
   {
-    name: "get_copyable_asset",
+    name: "entry.asset",
     description:
       "Fetch the category-aware copy/install asset for a HeyClaude entry without writing local files. Pass assetType (e.g. 'install_command', 'config_snippet') to return only that asset and avoid the full_content/script payloads when you do not need them.",
-    inputSchema: jsonSchemaForTool("get_copyable_asset"),
+    inputSchema: jsonSchemaForTool("entry.asset"),
   },
   {
-    name: "compare_entries",
+    name: "entry.compare",
     description:
       "Compare 2-5 read-only HeyClaude entries by fit, category, platforms, source metadata, and install complexity.",
-    inputSchema: jsonSchemaForTool("compare_entries"),
+    inputSchema: jsonSchemaForTool("entry.compare"),
   },
   {
-    name: "get_registry_stats",
+    name: "registry.stats",
     description:
       "Fetch aggregate read-only registry stats, freshness, category counts, and real source-signal coverage.",
-    inputSchema: jsonSchemaForTool("get_registry_stats"),
+    inputSchema: jsonSchemaForTool("registry.stats"),
   },
   {
-    name: "get_client_setup",
+    name: "install.setup",
     description:
       "Fetch read-only MCP client setup snippets for Codex, Claude Desktop, Cursor, Windsurf, or remote HTTP clients.",
-    inputSchema: jsonSchemaForTool("get_client_setup"),
+    inputSchema: jsonSchemaForTool("install.setup"),
   },
   {
-    name: "get_compatibility",
+    name: "install.compatibility",
     description:
       "Fetch platform compatibility metadata for a HeyClaude skill entry.",
-    inputSchema: jsonSchemaForTool("get_compatibility"),
+    inputSchema: jsonSchemaForTool("install.compatibility"),
   },
   {
-    name: "get_install_guidance",
+    name: "install.guidance",
     description:
       "Fetch read-only install, config, usage, and package guidance for a HeyClaude entry.",
-    inputSchema: jsonSchemaForTool("get_install_guidance"),
+    inputSchema: jsonSchemaForTool("install.guidance"),
   },
   {
-    name: "get_platform_adapter",
+    name: "install.adapter",
     description:
       "Fetch generated read-only platform adapter content, currently Cursor rule adapters for skill packages.",
-    inputSchema: jsonSchemaForTool("get_platform_adapter"),
+    inputSchema: jsonSchemaForTool("install.adapter"),
   },
   {
-    name: "list_distribution_feeds",
+    name: "feeds.list",
     description:
       "List read-only HeyClaude registry feeds, category feeds, platform feeds, and artifact locations.",
-    inputSchema: jsonSchemaForTool("list_distribution_feeds"),
+    inputSchema: jsonSchemaForTool("feeds.list"),
   },
   {
-    name: "get_submission_schema",
+    name: "submission.schema",
     description:
       "Fetch read-only HeyClaude submission schemas for PR-first intake by category.",
-    inputSchema: jsonSchemaForTool("get_submission_schema"),
+    inputSchema: jsonSchemaForTool("submission.schema"),
   },
   {
-    name: "validate_submission_draft",
+    name: "submission.validate",
     description:
       "Validate a HeyClaude content submission draft locally without creating GitHub issues, pull requests, or publishing content.",
-    inputSchema: jsonSchemaForTool("validate_submission_draft"),
+    inputSchema: jsonSchemaForTool("submission.validate"),
   },
   {
-    name: "search_duplicate_entries",
+    name: "submission.duplicates",
     description:
       "Search generated registry artifacts for likely duplicate entries before a user opens a submission PR.",
-    inputSchema: jsonSchemaForTool("search_duplicate_entries"),
+    inputSchema: jsonSchemaForTool("submission.duplicates"),
   },
   {
-    name: "build_submission_urls",
+    name: "submission.urls",
     description:
       "Build prefilled HeyClaude submit and review URLs for a validated PR-first submission draft without making write calls.",
-    inputSchema: jsonSchemaForTool("build_submission_urls"),
+    inputSchema: jsonSchemaForTool("submission.urls"),
   },
   {
-    name: "get_category_submission_guidance",
+    name: "submission.guidance",
     description:
       "Fetch category-specific HeyClaude contribution guidance, required fields, and review expectations.",
-    inputSchema: jsonSchemaForTool("get_category_submission_guidance"),
+    inputSchema: jsonSchemaForTool("submission.guidance"),
   },
   {
-    name: "prepare_submission_draft",
+    name: "submission.prepare",
     description:
       "Build a read-only maintainer-reviewed HeyClaude submission draft with canonical PR text and URLs.",
-    inputSchema: jsonSchemaForTool("prepare_submission_draft"),
+    inputSchema: jsonSchemaForTool("submission.prepare"),
   },
   {
-    name: "get_submission_examples",
+    name: "submission.examples",
     description:
       "Fetch read-only category examples and templates for faster, more accurate HeyClaude submissions.",
-    inputSchema: jsonSchemaForTool("get_submission_examples"),
+    inputSchema: jsonSchemaForTool("submission.examples"),
   },
   {
-    name: "review_submission_draft",
+    name: "submission.review",
     description:
       "Review a HeyClaude submission draft locally for schema errors, duplicate risk, and maintainer checklist items without writing to GitHub.",
-    inputSchema: jsonSchemaForTool("review_submission_draft"),
+    inputSchema: jsonSchemaForTool("submission.review"),
   },
   {
-    name: "get_submission_policy",
+    name: "submission.policy",
     description:
       "Fetch HeyClaude's read-only submission, artifact, import, and maintainer-review policy for contributors and agents.",
-    inputSchema: jsonSchemaForTool("get_submission_policy"),
+    inputSchema: jsonSchemaForTool("submission.policy"),
   },
   {
-    name: "explain_entry_trust",
+    name: "entry.trust",
     description:
       "Explain deterministic trust, source, package, safety, privacy, and review metadata signals for one HeyClaude entry. This is a metadata review only and does not provide malware scanning, automatic safety guarantees, or installation approval.",
-    inputSchema: jsonSchemaForTool("explain_entry_trust"),
+    inputSchema: jsonSchemaForTool("entry.trust"),
   },
   {
-    name: "review_entry_safety",
+    name: "entry.safety",
     description:
       "Review 1-5 HeyClaude entries for source, package, safety, and privacy metadata fit before install or recommendation. This is a metadata review only and does not provide malware scanning, automatic safety guarantees, or installation approval.",
-    inputSchema: jsonSchemaForTool("review_entry_safety"),
+    inputSchema: jsonSchemaForTool("entry.safety"),
   },
 ];
 
@@ -1076,10 +1076,10 @@ function toolboxCaveats(entry) {
 
 function toolboxNextActions(entry) {
   return [
-    `Inspect get_entry_detail with category=${entry.category} and slug=${entry.slug}.`,
-    `Run explain_entry_trust with category=${entry.category} and slug=${entry.slug}; this is still metadata review only.`,
-    "Use compare_entries with nearby candidates before recommending a final stack.",
-    `Use get_copyable_asset with category=${entry.category} and slug=${entry.slug} only after trust review.`,
+    `Inspect entry.detail with category=${entry.category} and slug=${entry.slug}.`,
+    `Run entry.trust with category=${entry.category} and slug=${entry.slug}; this is still metadata review only.`,
+    "Use entry.compare with nearby candidates before recommending a final stack.",
+    `Use entry.asset with category=${entry.category} and slug=${entry.slug} only after trust review.`,
   ];
 }
 
@@ -1088,7 +1088,7 @@ const TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT = 600;
 // Distills the ready-to-run install surface for a toolbox entry from its full
 // payload so the planner returns copy-pasteable commands instead of pointing at
 // more tool calls. Large config snippets are summarized rather than inlined to
-// preserve the lean response contract (callers use get_copyable_asset for them).
+// preserve the lean response contract (callers use entry.asset for them).
 function toolboxInstall(entry) {
   if (!entry) return null;
   const installCommand = String(
@@ -1111,7 +1111,7 @@ function toolboxInstall(entry) {
     } else {
       install.configSnippetChars = configSnippet.length;
       install.configHint =
-        "Config snippet is large; call get_copyable_asset for the full snippet.";
+        "Config snippet is large; call entry.asset for the full snippet.";
     }
   }
   if (!installCommand && !downloadUrl && !configSnippet && !usageSnippet) {
@@ -1223,17 +1223,17 @@ export async function planWorkflowToolbox(args = {}, options = {}) {
     categoryMix: toolboxCategoryMix(selected),
     trustSummary: toolboxTrustSummary(selected),
     recommendedNextTools: [
-      "get_entry_detail",
-      "explain_entry_trust",
-      "compare_entries",
-      "get_copyable_asset",
+      "entry.detail",
+      "entry.trust",
+      "entry.compare",
+      "entry.asset",
     ],
     plannerNotes: [
       "This planner is metadata review only; it is not install approval or malware scanning, and it does not execute or install entries.",
       "Each entry carries an inline install block and the recommended stack is summarized in installPlan; still review trust before running anything.",
       "Recommendations are bounded and category-diverse where matching entries allow it.",
       "Prefer source-backed entries with safety/privacy notes for risk-bearing MCP, hooks, skills, commands, and statuslines.",
-      "Use get_entry_detail, explain_entry_trust, compare_entries, and get_copyable_asset before relying on any entry.",
+      "Use entry.detail, entry.trust, entry.compare, and entry.asset before relying on any entry.",
     ],
   };
 }
@@ -1303,7 +1303,7 @@ export async function recommendForTask(args = {}, options = {}) {
     notes: [
       "Best-match recommendations for the task; unlike plan_workflow_toolbox they are not forced to span categories.",
       "This is metadata review only — it does not execute, install, or scan entries. Review trust before running anything.",
-      "Use compare_entries to weigh the top picks and explain_entry_trust before relying on any entry.",
+      "Use entry.compare to weigh the top picks and entry.trust before relying on any entry.",
     ],
   };
 }
@@ -1529,7 +1529,7 @@ const ENTRY_BODY_EXCERPT_CHARS = 1200;
 
 // Large copyable-content fields that largely duplicate the body or the install
 // asset. In non-full modes they are omitted (and surfaced via omittedFields)
-// because the caller should pull them from get_copyable_asset when needed,
+// because the caller should pull them from entry.asset when needed,
 // rather than paying for tens of kilobytes on every detail lookup.
 const ENTRY_ASSET_FIELDS = ["scriptBody", "fullCopyableContent", "copySnippet"];
 
@@ -1551,7 +1551,7 @@ function excerptText(text, limit) {
 }
 
 // Projects an entry's heavy content to the requested verbosity so the default
-// get_entry_detail response stays token-efficient. Returns the (possibly
+// entry.detail response stays token-efficient. Returns the (possibly
 // trimmed) entry plus body metadata describing exactly what was returned.
 function projectEntryBody(entry, requestedMode) {
   const mode =
@@ -1625,7 +1625,7 @@ function projectEntryBody(entry, requestedMode) {
 function withAssetHint(bodyMeta) {
   if (bodyMeta.omittedFields.length > 0) {
     bodyMeta.assetHint =
-      "Large copyable fields were omitted to save context; call get_copyable_asset for the full script or snippet.";
+      "Large copyable fields were omitted to save context; call entry.asset for the full script or snippet.";
   }
   return bodyMeta;
 }
@@ -2502,18 +2502,18 @@ export function getRegistryPrompt(args = {}) {
   const promptTextByName = {
     find_best_asset: `Find the best HeyClaude asset for this use case: ${useCase || "(not provided)"}.
 
-Use the read-only HeyClaude MCP tools. Start with search_registry or list_category_entries${category ? ` in category ${category}` : ""}${platform ? ` for platform ${platform}` : ""}. Compare credible candidates with compare_entries, inspect details with get_entry_detail, and cite exact category/slug pairs. Do not invent popularity metrics when source stats are absent.`,
+Use the read-only HeyClaude MCP tools. Start with registry.search or registry.list${category ? ` in category ${category}` : ""}${platform ? ` for platform ${platform}` : ""}. Compare credible candidates with entry.compare, inspect details with entry.detail, and cite exact category/slug pairs. Do not invent popularity metrics when source stats are absent.`,
     prepare_submission: `Prepare a HeyClaude submission draft${category ? ` for category ${category}` : ""}${promptArgument(values, "name") ? ` named ${promptArgument(values, "name")}` : ""}${sourceUrl ? ` from ${sourceUrl}` : ""}.
 
-Use get_submission_schema, get_submission_examples, prepare_submission_draft, review_submission_draft, and search_duplicate_entries. Return missing fields and the canonical PR-first submit URL/body. Do not create GitHub issues or publish content.`,
+Use submission.schema, submission.examples, submission.prepare, submission.review, and submission.duplicates. Return missing fields and the canonical PR-first submit URL/body. Do not create GitHub issues or publish content.`,
     review_submission_before_pr: `Review this HeyClaude submission draft before a PR is opened:
 
 ${draft || "(draft not provided)"}
 
-Use review_submission_draft and search_duplicate_entries where structured fields are available. Treat schema-valid as not publish-valid, call out source-review needs, and keep the result maintainer-reviewed.`,
+Use submission.review and submission.duplicates where structured fields are available. Treat schema-valid as not publish-valid, call out source-review needs, and keep the result maintainer-reviewed.`,
     install_asset_safely: `Help install or use the HeyClaude entry ${category || "(category)"}/${slug || "(slug)"}${platform ? ` for ${platform}` : ""}.
 
-Use get_install_guidance and get_copyable_asset. Include source links, config/install text exactly as returned, and secret-handling cautions where relevant. Do not write local files or claim the install was completed.`,
+Use install.guidance and entry.asset. Include source links, config/install text exactly as returned, and secret-handling cautions where relevant. Do not write local files or claim the install was completed.`,
   };
 
   return {
@@ -2828,85 +2828,85 @@ export async function callRegistryTool(name, args = {}, options = {}) {
 
   let result;
   switch (name) {
-    case "search_registry":
+    case "registry.search":
       result = await searchRegistry(parsedArgs, options);
       break;
     case "plan_workflow_toolbox":
       result = await planWorkflowToolbox(parsedArgs, options);
       break;
-    case "recommend_for_task":
+    case "registry.recommend":
       result = await recommendForTask(parsedArgs, options);
       break;
-    case "get_server_info":
+    case "server.info":
       result = await getServerInfo(parsedArgs, options);
       break;
-    case "list_category_entries":
+    case "registry.list":
       result = await listCategoryEntries(parsedArgs, options);
       break;
-    case "get_recent_updates":
+    case "registry.updates":
       result = await getRecentUpdates(parsedArgs, options);
       break;
-    case "get_related_entries":
+    case "entry.related":
       result = await getRelatedEntries(parsedArgs, options);
       break;
-    case "get_entry_detail":
+    case "entry.detail":
       result = await getEntryDetail(parsedArgs, options);
       break;
-    case "get_copyable_asset":
+    case "entry.asset":
       result = await getCopyableAsset(parsedArgs, options);
       break;
-    case "compare_entries":
+    case "entry.compare":
       result = await compareEntries(parsedArgs, options);
       break;
-    case "get_registry_stats":
+    case "registry.stats":
       result = await getRegistryStats(parsedArgs, options);
       break;
-    case "get_client_setup":
+    case "install.setup":
       result = await getClientSetup(parsedArgs, options);
       break;
-    case "get_compatibility":
+    case "install.compatibility":
       result = await getCompatibility(parsedArgs, options);
       break;
-    case "get_install_guidance":
+    case "install.guidance":
       result = await getInstallGuidance(parsedArgs, options);
       break;
-    case "get_platform_adapter":
+    case "install.adapter":
       result = await getPlatformAdapter(parsedArgs, options);
       break;
-    case "list_distribution_feeds":
+    case "feeds.list":
       result = await listDistributionFeeds(parsedArgs, options);
       break;
-    case "get_submission_schema":
+    case "submission.schema":
       result = await getSubmissionSchema(parsedArgs, options);
       break;
-    case "validate_submission_draft":
+    case "submission.validate":
       result = await validateSubmissionDraft(parsedArgs, options);
       break;
-    case "search_duplicate_entries":
+    case "submission.duplicates":
       result = await searchDuplicateRegistryEntries(parsedArgs, options);
       break;
-    case "build_submission_urls":
+    case "submission.urls":
       result = await buildSubmissionUrls(parsedArgs, options);
       break;
-    case "get_category_submission_guidance":
+    case "submission.guidance":
       result = await getCategorySubmissionGuidance(parsedArgs, options);
       break;
-    case "prepare_submission_draft":
+    case "submission.prepare":
       result = await prepareSubmissionDraft(parsedArgs, options);
       break;
-    case "get_submission_examples":
+    case "submission.examples":
       result = await getSubmissionExamples(parsedArgs, options);
       break;
-    case "review_submission_draft":
+    case "submission.review":
       result = await reviewSubmissionDraft(parsedArgs, options);
       break;
-    case "get_submission_policy":
+    case "submission.policy":
       result = await getSubmissionPolicy(parsedArgs, options);
       break;
-    case "explain_entry_trust":
+    case "entry.trust":
       result = await explainEntryTrust(parsedArgs, options);
       break;
-    case "review_entry_safety":
+    case "entry.safety":
       result = await reviewEntrySafety(parsedArgs, options);
       break;
   }

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -305,7 +305,7 @@ export const EntryDetailInputSchema = z
     bodyMode: z
       .enum(["none", "excerpt", "full"])
       .describe(
-        "How much entry content to return. 'excerpt' (default) trims the body markdown to a short lead and omits large copyable fields (scriptBody, fullCopyableContent, copySnippet), reporting what was dropped via bodyChars/bodyTruncated/omittedFields; 'none' also drops the body; 'full' returns everything. Use get_copyable_asset for omitted install/script content, and request 'full' only when you truly need the complete inline content — it can be tens of kilobytes.",
+        "How much entry content to return. 'excerpt' (default) trims the body markdown to a short lead and omits large copyable fields (scriptBody, fullCopyableContent, copySnippet), reporting what was dropped via bodyChars/bodyTruncated/omittedFields; 'none' also drops the body; 'full' returns everything. Use entry.asset for omitted install/script content, and request 'full' only when you truly need the complete inline content — it can be tens of kilobytes.",
       )
       .optional(),
   })
@@ -618,33 +618,33 @@ export const ReviewEntrySafetyInputSchema = z
   .strict();
 
 export const TOOL_INPUT_SCHEMAS = {
-  search_registry: SearchRegistryInputSchema,
+  "registry.search": SearchRegistryInputSchema,
   plan_workflow_toolbox: PlanWorkflowToolboxInputSchema,
-  recommend_for_task: RecommendForTaskInputSchema,
-  get_server_info: GetServerInfoInputSchema,
-  list_category_entries: ListCategoryEntriesInputSchema,
-  get_recent_updates: RecentUpdatesInputSchema,
-  get_related_entries: RelatedEntriesInputSchema,
-  get_entry_detail: EntryDetailInputSchema,
-  get_copyable_asset: CopyableAssetInputSchema,
-  compare_entries: CompareEntriesInputSchema,
-  get_registry_stats: RegistryStatsInputSchema,
-  get_client_setup: ClientSetupInputSchema,
-  get_compatibility: CompatibilityInputSchema,
-  get_install_guidance: InstallGuidanceInputSchema,
-  get_platform_adapter: PlatformAdapterInputSchema,
-  list_distribution_feeds: ListDistributionFeedsInputSchema,
-  get_submission_schema: GetSubmissionSchemaInputSchema,
-  validate_submission_draft: ValidateSubmissionDraftInputSchema,
-  search_duplicate_entries: SearchDuplicateEntriesInputSchema,
-  build_submission_urls: BuildSubmissionUrlsInputSchema,
-  get_category_submission_guidance: CategorySubmissionGuidanceInputSchema,
-  prepare_submission_draft: PrepareSubmissionDraftInputSchema,
-  get_submission_examples: GetSubmissionExamplesInputSchema,
-  review_submission_draft: ReviewSubmissionDraftInputSchema,
-  get_submission_policy: SubmissionPolicyInputSchema,
-  explain_entry_trust: ExplainEntryTrustInputSchema,
-  review_entry_safety: ReviewEntrySafetyInputSchema,
+  "registry.recommend": RecommendForTaskInputSchema,
+  "server.info": GetServerInfoInputSchema,
+  "registry.list": ListCategoryEntriesInputSchema,
+  "registry.updates": RecentUpdatesInputSchema,
+  "entry.related": RelatedEntriesInputSchema,
+  "entry.detail": EntryDetailInputSchema,
+  "entry.asset": CopyableAssetInputSchema,
+  "entry.compare": CompareEntriesInputSchema,
+  "registry.stats": RegistryStatsInputSchema,
+  "install.setup": ClientSetupInputSchema,
+  "install.compatibility": CompatibilityInputSchema,
+  "install.guidance": InstallGuidanceInputSchema,
+  "install.adapter": PlatformAdapterInputSchema,
+  "feeds.list": ListDistributionFeedsInputSchema,
+  "submission.schema": GetSubmissionSchemaInputSchema,
+  "submission.validate": ValidateSubmissionDraftInputSchema,
+  "submission.duplicates": SearchDuplicateEntriesInputSchema,
+  "submission.urls": BuildSubmissionUrlsInputSchema,
+  "submission.guidance": CategorySubmissionGuidanceInputSchema,
+  "submission.prepare": PrepareSubmissionDraftInputSchema,
+  "submission.examples": GetSubmissionExamplesInputSchema,
+  "submission.review": ReviewSubmissionDraftInputSchema,
+  "submission.policy": SubmissionPolicyInputSchema,
+  "entry.trust": ExplainEntryTrustInputSchema,
+  "entry.safety": ReviewEntrySafetyInputSchema,
 };
 
 function stripUnsupportedJsonSchemaFields(value) {

--- a/scripts/validate-deployment-artifacts.mjs
+++ b/scripts/validate-deployment-artifacts.mjs
@@ -261,10 +261,10 @@ try {
     params: {},
   });
   const toolNames = tools?.result?.tools?.map((tool) => tool?.name) || [];
-  if (!toolNames.includes("search_registry")) {
+  if (!toolNames.includes("registry.search")) {
     fail("/api/mcp must expose read-only registry tools");
   }
-  if (!toolNames.includes("build_submission_urls")) {
+  if (!toolNames.includes("submission.urls")) {
     fail("/api/mcp must expose read-only submission helper tools");
   }
 
@@ -273,13 +273,13 @@ try {
     id: 2,
     method: "tools/call",
     params: {
-      name: "search_registry",
+      name: "registry.search",
       arguments: { query: "mcp", limit: 1 },
     },
   });
   const result = JSON.parse(search?.result?.content?.[0]?.text || "{}");
   if (result?.ok !== true || !Array.isArray(result.entries)) {
-    fail("/api/mcp search_registry tool did not return entries");
+    fail("/api/mcp registry.search tool did not return entries");
   }
 
   const submission = await fetchMcpJson(baseUrl, {
@@ -287,7 +287,7 @@ try {
     id: 3,
     method: "tools/call",
     params: {
-      name: "build_submission_urls",
+      name: "submission.urls",
       arguments: {
         fields: {
           category: "mcp",
@@ -308,7 +308,7 @@ try {
     submissionResult?.ok !== true ||
     !isCanonicalSubmitUrl(submissionResult.submitUrl)
   ) {
-    fail("/api/mcp build_submission_urls tool did not return submit URL");
+    fail("/api/mcp submission.urls tool did not return submit URL");
   }
 } catch (error) {
   fail(error instanceof Error ? error.message : String(error));

--- a/scripts/validate-mcp-package.mjs
+++ b/scripts/validate-mcp-package.mjs
@@ -81,10 +81,10 @@ async function smokeMcpServer(command, args, label, options = {}) {
     const tools = await client.listTools(undefined, { timeout: 30000 });
     const toolNames = tools.tools.map((tool) => tool.name);
     assert(
-      toolNames.includes("search_registry"),
-      `${label} smoke did not expose search_registry.`,
+      toolNames.includes("registry.search"),
+      `${label} smoke did not expose registry.search.`,
     );
-    if (toolNames.includes("get_registry_stats")) {
+    if (toolNames.includes("registry.stats")) {
       assert(
         tools.tools.every((tool) => tool.annotations?.readOnlyHint === true),
         `${label} smoke tools did not all advertise read-only annotations.`,
@@ -93,7 +93,7 @@ async function smokeMcpServer(command, args, label, options = {}) {
 
     const search = await client.callTool(
       {
-        name: "search_registry",
+        name: "registry.search",
         arguments: { query: "mcp", limit: 1 },
       },
       undefined,
@@ -113,14 +113,14 @@ async function smokeMcpServer(command, args, label, options = {}) {
         `${label} smoke search entry`,
       );
     }
-    if (toolNames.includes("get_registry_stats")) {
+    if (toolNames.includes("registry.stats")) {
       assert(
         search.structuredContent?.policy?.readOnly === true,
         `${label} smoke search did not include structured read-only policy.`,
       );
 
       const stats = await client.callTool(
-        { name: "get_registry_stats", arguments: {} },
+        { name: "registry.stats", arguments: {} },
         undefined,
         { timeout: 30000 },
       );
@@ -134,7 +134,7 @@ async function smokeMcpServer(command, args, label, options = {}) {
       );
 
       const setup = await client.callTool(
-        { name: "get_client_setup", arguments: { client: "codex" } },
+        { name: "install.setup", arguments: { client: "codex" } },
         undefined,
         { timeout: 30000 },
       );
@@ -194,7 +194,7 @@ async function smokeMcpServer(command, args, label, options = {}) {
       );
       assert(
         prompt.messages.some((message) =>
-          String(message.content?.text || "").includes("get_copyable_asset"),
+          String(message.content?.text || "").includes("entry.asset"),
         ),
         `${label} smoke did not return install_asset_safely prompt content.`,
       );
@@ -203,7 +203,7 @@ async function smokeMcpServer(command, args, label, options = {}) {
         const firstEntry = result.entries[0];
         const detail = await client.callTool(
           {
-            name: "get_entry_detail",
+            name: "entry.detail",
             arguments: {
               category: firstEntry.category,
               slug: firstEntry.slug,
@@ -219,7 +219,7 @@ async function smokeMcpServer(command, args, label, options = {}) {
 
         const submissionSchema = await client.callTool(
           {
-            name: "get_submission_schema",
+            name: "submission.schema",
             arguments: { category: "skills" },
           },
           undefined,

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -83,33 +83,33 @@ describe("HeyClaude remote MCP route", () => {
       (tool: { name: string }) => tool.name,
     );
     expect(toolNames).toEqual([
-      "search_registry",
+      "registry.search",
       "plan_workflow_toolbox",
-      "recommend_for_task",
-      "get_server_info",
-      "list_category_entries",
-      "get_recent_updates",
-      "get_related_entries",
-      "get_entry_detail",
-      "get_copyable_asset",
-      "compare_entries",
-      "get_registry_stats",
-      "get_client_setup",
-      "get_compatibility",
-      "get_install_guidance",
-      "get_platform_adapter",
-      "list_distribution_feeds",
-      "get_submission_schema",
-      "validate_submission_draft",
-      "search_duplicate_entries",
-      "build_submission_urls",
-      "get_category_submission_guidance",
-      "prepare_submission_draft",
-      "get_submission_examples",
-      "review_submission_draft",
-      "get_submission_policy",
-      "explain_entry_trust",
-      "review_entry_safety",
+      "registry.recommend",
+      "server.info",
+      "registry.list",
+      "registry.updates",
+      "entry.related",
+      "entry.detail",
+      "entry.asset",
+      "entry.compare",
+      "registry.stats",
+      "install.setup",
+      "install.compatibility",
+      "install.guidance",
+      "install.adapter",
+      "feeds.list",
+      "submission.schema",
+      "submission.validate",
+      "submission.duplicates",
+      "submission.urls",
+      "submission.guidance",
+      "submission.prepare",
+      "submission.examples",
+      "submission.review",
+      "submission.policy",
+      "entry.trust",
+      "entry.safety",
     ]);
     expect(payload.result.tools[0]).toMatchObject({
       outputSchema: { type: "object" },
@@ -189,7 +189,7 @@ describe("HeyClaude remote MCP route", () => {
     expect(promptResponse.status).toBe(200);
     const promptPayload = await json(promptResponse);
     expect(promptPayload.result.messages[0].content.text).toContain(
-      "get_copyable_asset",
+      "entry.asset",
     );
   });
 
@@ -200,7 +200,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 3,
         method: "tools/call",
         params: {
-          name: "search_registry",
+          name: "registry.search",
           arguments: { query: "discord", limit: 2 },
         },
       }),
@@ -224,7 +224,7 @@ describe("HeyClaude remote MCP route", () => {
         jsonrpc: "2.0",
         id: 33,
         method: "tools/call",
-        params: { name: "get_server_info", arguments: {} },
+        params: { name: "server.info", arguments: {} },
       }),
     );
     expect(infoResponse.status).toBe(200);
@@ -252,7 +252,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 34,
         method: "tools/call",
         params: {
-          name: "list_category_entries",
+          name: "registry.list",
           arguments: { category: "mcp", limit: 2 },
         },
       }),
@@ -280,7 +280,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 4,
         method: "tools/call",
         params: {
-          name: "search_registry",
+          name: "registry.search",
           arguments: { limit: 100, writePath: "/tmp/unsafe" },
         },
       }),
@@ -309,7 +309,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 99,
         method: "tools/call",
         params: {
-          name: "search_registry",
+          name: "registry.search",
           arguments: { query: "x".repeat(70 * 1024) },
         },
       }),
@@ -329,7 +329,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 5,
         method: "tools/call",
         params: {
-          name: "build_submission_urls",
+          name: "submission.urls",
           arguments: {
             fields: {
               category: "mcp",
@@ -369,7 +369,7 @@ describe("HeyClaude remote MCP route", () => {
         id: 6,
         method: "tools/call",
         params: {
-          name: "prepare_submission_draft",
+          name: "submission.prepare",
           arguments: {
             fields: {
               category: "guides",

--- a/tests/mcp-remote-proxy.test.ts
+++ b/tests/mcp-remote-proxy.test.ts
@@ -76,7 +76,7 @@ function createRemoteMcpHttpFetch() {
         : {
             tools: [
               {
-                name: "search_registry",
+                name: "registry.search",
                 description: "Remote search.",
                 inputSchema: { type: "object", additionalProperties: true },
               },
@@ -102,7 +102,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
         return {
           tools: [
             {
-              name: "search_registry",
+              name: "registry.search",
               description: "Remote search.",
               inputSchema: { type: "object", additionalProperties: true },
             },
@@ -137,14 +137,14 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
     await withMcpClientForServer(server, async (client) => {
       const tools = await client.listTools();
       const toolNames = tools.tools.map((tool: { name: string }) => tool.name);
-      expect(toolNames).toContain("search_registry");
-      expect(toolNames).not.toContain("validate_submission_draft");
-      expect(toolNames).not.toContain("build_submission_urls");
-      expect(toolNames).not.toContain("prepare_submission_draft");
-      expect(toolNames).not.toContain("review_submission_draft");
+      expect(toolNames).toContain("registry.search");
+      expect(toolNames).not.toContain("submission.validate");
+      expect(toolNames).not.toContain("submission.urls");
+      expect(toolNames).not.toContain("submission.prepare");
+      expect(toolNames).not.toContain("submission.review");
 
       const result = await client.callTool({
-        name: "validate_submission_draft",
+        name: "submission.validate",
         arguments: {
           fields: {
             category: "mcp",
@@ -182,7 +182,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
         return {
           tools: [
             {
-              name: "search_registry",
+              name: "registry.search",
               description: "Remote search.",
               inputSchema: { type: "object", additionalProperties: true },
             },
@@ -301,7 +301,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "structured" },
         }),
       ).resolves.toMatchObject({
@@ -314,7 +314,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "text-json" },
         }),
       ).resolves.toMatchObject({
@@ -327,7 +327,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "text-plain" },
         }),
       ).resolves.toMatchObject({
@@ -339,7 +339,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "structured-policy" },
         }),
       ).resolves.toMatchObject({
@@ -351,7 +351,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "text-array" },
         }),
       ).resolves.toMatchObject({
@@ -363,7 +363,7 @@ describe("HeyClaude MCP remote proxy privacy boundary", () => {
 
       await expect(
         client.callTool({
-          name: "search_registry",
+          name: "registry.search",
           arguments: { mode: "throws" },
         }),
       ).resolves.toMatchObject({

--- a/tests/mcp-schemas-output-error.test.ts
+++ b/tests/mcp-schemas-output-error.test.ts
@@ -10,7 +10,7 @@ import {
 
 describe("jsonSchemaForToolOutput", () => {
   it("returns a JSON-schema object for a known tool", () => {
-    const schema = jsonSchemaForToolOutput("compare_entries");
+    const schema = jsonSchemaForToolOutput("entry.compare");
     expect(schema.type).toBe("object");
     expect(schema.properties).toHaveProperty("ok");
     expect(schema.required).toContain("ok");

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -84,55 +84,55 @@ const validMcpSubmissionFields = {
 
 function validToolArguments(name: string) {
   const argsByTool: Record<string, unknown> = {
-    search_registry: { query: "mcp", limit: 1 },
+    "registry.search": { query: "mcp", limit: 1 },
     plan_workflow_toolbox: { goal: "code review automation", limit: 2 },
-    recommend_for_task: { task: "code review automation", limit: 2 },
-    get_server_info: {},
-    list_category_entries: { category: "mcp", limit: 1 },
-    get_recent_updates: { limit: 1 },
-    get_related_entries: {
+    "registry.recommend": { task: "code review automation", limit: 2 },
+    "server.info": {},
+    "registry.list": { category: "mcp", limit: 1 },
+    "registry.updates": { limit: 1 },
+    "entry.related": {
       category: skill.category,
       slug: skill.slug,
       limit: 1,
     },
-    get_entry_detail: { category: skill.category, slug: skill.slug },
-    get_copyable_asset: {
+    "entry.detail": { category: skill.category, slug: skill.slug },
+    "entry.asset": {
       category: skill.category,
       slug: skill.slug,
       platform: "claude",
     },
-    compare_entries: {
+    "entry.compare": {
       entries: [
         { category: skill.category, slug: skill.slug },
         { category: otherSkill.category, slug: otherSkill.slug },
       ],
       platform: "claude",
     },
-    get_registry_stats: {},
-    get_client_setup: { client: "codex" },
-    get_compatibility: { slug: skill.slug },
-    get_install_guidance: {
+    "registry.stats": {},
+    "install.setup": { client: "codex" },
+    "install.compatibility": { slug: skill.slug },
+    "install.guidance": {
       category: skill.category,
       slug: skill.slug,
       platform: "claude",
     },
-    get_platform_adapter: { slug: skill.slug, platform: "cursor-rules" },
-    list_distribution_feeds: {},
-    get_submission_schema: { category: "mcp" },
-    validate_submission_draft: { fields: validMcpSubmissionFields },
-    search_duplicate_entries: {
+    "install.adapter": { slug: skill.slug, platform: "cursor-rules" },
+    "feeds.list": {},
+    "submission.schema": { category: "mcp" },
+    "submission.validate": { fields: validMcpSubmissionFields },
+    "submission.duplicates": {
       category: skill.category,
       slug: skill.slug,
       limit: 1,
     },
-    build_submission_urls: { fields: validMcpSubmissionFields },
-    get_category_submission_guidance: { category: "mcp" },
-    prepare_submission_draft: { fields: validMcpSubmissionFields },
-    get_submission_examples: { category: "mcp" },
-    review_submission_draft: { fields: validMcpSubmissionFields },
-    get_submission_policy: {},
-    explain_entry_trust: { category: skill.category, slug: skill.slug },
-    review_entry_safety: {
+    "submission.urls": { fields: validMcpSubmissionFields },
+    "submission.guidance": { category: "mcp" },
+    "submission.prepare": { fields: validMcpSubmissionFields },
+    "submission.examples": { category: "mcp" },
+    "submission.review": { fields: validMcpSubmissionFields },
+    "submission.policy": {},
+    "entry.trust": { category: skill.category, slug: skill.slug },
+    "entry.safety": {
       entries: [
         { category: skill.category, slug: skill.slug },
         { category: otherSkill.category, slug: otherSkill.slug },
@@ -187,7 +187,7 @@ function fakeRemoteClient() {
       return {
         tools: [
           {
-            name: "search_registry",
+            name: "registry.search",
             description: "Remote search.",
             inputSchema: { type: "object", additionalProperties: true },
             outputSchema: {
@@ -478,7 +478,7 @@ describe("HeyClaude read-only MCP helpers", () => {
           platform: "Codex",
         },
       });
-      expect(prompt.messages[0].content.text).toContain("compare_entries");
+      expect(prompt.messages[0].content.text).toContain("entry.compare");
       expect(prompt.messages[0].content.text).toContain(
         "Do not invent popularity metrics",
       );
@@ -498,7 +498,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       const tools = await client.listTools();
       expect(tools.tools).toEqual([
         expect.objectContaining({
-          name: "search_registry",
+          name: "registry.search",
           annotations: expect.objectContaining({
             readOnlyHint: true,
             destructiveHint: false,
@@ -509,7 +509,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       ]);
 
       const result = await client.callTool({
-        name: "search_registry",
+        name: "registry.search",
         arguments: { query: "mcp" },
       });
       expect(result.isError).not.toBe(true);
@@ -540,7 +540,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
     ) as { name: string; version: string };
 
-    const info = await callRegistryTool("get_server_info", {}, { dataDir });
+    const info = await callRegistryTool("server.info", {}, { dataDir });
     expect(info).toMatchObject({
       ok: true,
       package: {
@@ -569,7 +569,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("validates MCP tool arguments from shared Zod schemas", async () => {
     expect(
-      parseToolArguments("search_registry", {
+      parseToolArguments("registry.search", {
         query: "discord",
         category: "mcp",
         platform: "cursor-rules",
@@ -592,7 +592,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     await expect(
       callRegistryTool(
-        "get_entry_detail",
+        "entry.detail",
         { category: "../mcp", slug: "bad" },
         { dataDir },
       ),
@@ -611,7 +611,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     await expect(
       callRegistryTool(
-        "search_registry",
+        "registry.search",
         { limit: 100, unexpected: true },
         { dataDir },
       ),
@@ -627,7 +627,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     expect(() =>
-      parseToolArguments("validate_submission_draft", {
+      parseToolArguments("submission.validate", {
         fields: {
           category: "mcp",
           name: "Too Many Notes MCP",
@@ -640,7 +640,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     ).toThrow("Use at most 8 non-empty lines, 320 characters per line.");
 
     expect(() =>
-      parseToolArguments("validate_submission_draft", {
+      parseToolArguments("submission.validate", {
         fields: {
           category: "mcp",
           name: "Long Privacy Note MCP",
@@ -652,7 +652,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("searches registry artifacts with category and platform filters", async () => {
     const result = await callRegistryTool(
-      "search_registry",
+      "registry.search",
       {
         query: "skill",
         category: "skills",
@@ -677,7 +677,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("filters search results by exact tag", async () => {
     const tagged = await callRegistryTool(
-      "search_registry",
+      "registry.search",
       { category: "mcp", tag: "database", limit: 10 },
       { dataDir },
     );
@@ -693,7 +693,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     }
 
     const noMatches = await callRegistryTool(
-      "search_registry",
+      "registry.search",
       { tag: "definitely-not-a-real-tag-zzz", limit: 10 },
       { dataDir },
     );
@@ -709,7 +709,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     const artifactCache = new Map();
     const args = { query: "mcp", limit: 3 } as const;
 
-    const first = await callRegistryTool("search_registry", args, {
+    const first = await callRegistryTool("registry.search", args, {
       dataDir,
       artifactCache,
     });
@@ -720,7 +720,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(artifactCache.has(searchIndexKey)).toBe(true);
     const cachedIndex = artifactCache.get(searchIndexKey);
 
-    const second = await callRegistryTool("search_registry", args, {
+    const second = await callRegistryTool("registry.search", args, {
       dataDir,
       artifactCache,
     });
@@ -733,7 +733,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("returns a token-efficient body excerpt by default and honors bodyMode", async () => {
     const full = await callRegistryTool(
-      "get_entry_detail",
+      "entry.detail",
       { category: skill.category, slug: skill.slug, bodyMode: "full" },
       { dataDir },
     );
@@ -747,7 +747,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(full.entry.body.length).toBe(full.bodyChars);
 
     const excerpt = await callRegistryTool(
-      "get_entry_detail",
+      "entry.detail",
       { category: skill.category, slug: skill.slug },
       { dataDir },
     );
@@ -764,7 +764,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     }
 
     const omitted = await callRegistryTool(
-      "get_entry_detail",
+      "entry.detail",
       { category: skill.category, slug: skill.slug, bodyMode: "none" },
       { dataDir },
     );
@@ -775,7 +775,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     expect(omitted.trust).toEqual(full.trust);
   });
 
-  it("omits large copyable asset fields in lean modes and points to get_copyable_asset", async () => {
+  it("omits large copyable asset fields in lean modes and points to entry.asset", async () => {
     const directory = JSON.parse(
       fs.readFileSync(path.join(dataDir, "directory-index.json"), "utf8"),
     ) as { entries: Array<{ category: string; slug: string }> };
@@ -808,13 +808,13 @@ describe("HeyClaude read-only MCP helpers", () => {
     if (!heavy) return; // No heavy-asset entry in this dataset; nothing to assert.
 
     const full = await callRegistryTool(
-      "get_entry_detail",
+      "entry.detail",
       { ...heavy, bodyMode: "full" },
       { dataDir },
     );
     expect(full.omittedFields).toEqual([]);
 
-    const lean = await callRegistryTool("get_entry_detail", heavy, { dataDir });
+    const lean = await callRegistryTool("entry.detail", heavy, { dataDir });
     expect(lean.omittedFields.length).toBeGreaterThan(0);
     const omittedNames = lean.omittedFields.map(
       (item: { field: string }) => item.field,
@@ -822,18 +822,18 @@ describe("HeyClaude read-only MCP helpers", () => {
     for (const field of omittedNames) {
       expect(lean.entry).not.toHaveProperty(field);
     }
-    expect(lean.assetHint).toContain("get_copyable_asset");
+    expect(lean.assetHint).toContain("entry.asset");
     // The full content is still retrievable via the dedicated asset tool.
-    const asset = await callRegistryTool("get_copyable_asset", heavy, {
+    const asset = await callRegistryTool("entry.asset", heavy, {
       dataDir,
     });
     expect(asset.ok).toBe(true);
   });
 
-  it("rejects an unknown bodyMode for get_entry_detail", async () => {
+  it("rejects an unknown bodyMode for entry.detail", async () => {
     await expect(
       callRegistryTool(
-        "get_entry_detail",
+        "entry.detail",
         { category: skill.category, slug: skill.slug, bodyMode: "summary" },
         { dataDir },
       ),
@@ -850,7 +850,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("recommends best-match entries for a task with inline install", async () => {
     const result = await callRegistryTool(
-      "recommend_for_task",
+      "registry.recommend",
       { task: "review pull requests", limit: 3 },
       { dataDir },
     );
@@ -884,9 +884,9 @@ describe("HeyClaude read-only MCP helpers", () => {
     }
   });
 
-  it("rejects an empty recommend_for_task task", async () => {
+  it("rejects an empty registry.recommend task", async () => {
     await expect(
-      callRegistryTool("recommend_for_task", { task: " " }, { dataDir }),
+      callRegistryTool("registry.recommend", { task: " " }, { dataDir }),
     ).resolves.toMatchObject({
       ok: false,
       error: { code: "invalid_request" },
@@ -910,10 +910,10 @@ describe("HeyClaude read-only MCP helpers", () => {
       category: "skills",
       count: expect.any(Number),
       recommendedNextTools: expect.arrayContaining([
-        "get_entry_detail",
-        "explain_entry_trust",
-        "compare_entries",
-        "get_copyable_asset",
+        "entry.detail",
+        "entry.trust",
+        "entry.compare",
+        "entry.asset",
       ]),
       categoryMix: expect.any(Array),
       trustSummary: expect.any(Object),
@@ -933,10 +933,10 @@ describe("HeyClaude read-only MCP helpers", () => {
       toolboxReasons: expect.any(Array),
       caveats: expect.any(Array),
       nextActions: expect.arrayContaining([
-        expect.stringContaining("get_entry_detail"),
-        expect.stringContaining("explain_entry_trust"),
-        expect.stringContaining("compare_entries"),
-        expect.stringContaining("get_copyable_asset"),
+        expect.stringContaining("entry.detail"),
+        expect.stringContaining("entry.trust"),
+        expect.stringContaining("entry.compare"),
+        expect.stringContaining("entry.asset"),
       ]),
     });
   });
@@ -1019,10 +1019,10 @@ describe("HeyClaude read-only MCP helpers", () => {
       ok: true,
       count: 3,
       recommendedNextTools: [
-        "get_entry_detail",
-        "explain_entry_trust",
-        "compare_entries",
-        "get_copyable_asset",
+        "entry.detail",
+        "entry.trust",
+        "entry.compare",
+        "entry.asset",
       ],
       categoryMix: expect.arrayContaining([
         { category: "agents", count: 1 },
@@ -1058,10 +1058,10 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
     expect(result.entries[0].nextActions).toEqual(
       expect.arrayContaining([
-        expect.stringContaining("get_entry_detail"),
-        expect.stringContaining("explain_entry_trust"),
-        expect.stringContaining("compare_entries"),
-        expect.stringContaining("get_copyable_asset"),
+        expect.stringContaining("entry.detail"),
+        expect.stringContaining("entry.trust"),
+        expect.stringContaining("entry.compare"),
+        expect.stringContaining("entry.asset"),
       ]),
     );
 
@@ -1245,7 +1245,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("searches registry artifacts with trust filters", async () => {
     const result = await callRegistryTool(
-      "search_registry",
+      "registry.search",
       {
         category: "skills",
         downloadTrust: "first-party",
@@ -1276,7 +1276,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("lists category entries with bounded pagination and filters", async () => {
     const result = await callRegistryTool(
-      "list_category_entries",
+      "registry.list",
       {
         category: "skills",
         platform: "cursor-rules",
@@ -1307,7 +1307,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("lists recent updates from generated registry metadata", async () => {
     const result = await callRegistryTool(
-      "get_recent_updates",
+      "registry.updates",
       { limit: 5 },
       { dataDir },
     );
@@ -1321,7 +1321,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const since = await callRegistryTool(
-      "get_recent_updates",
+      "registry.updates",
       { since: result.entries[0].updatedAt, limit: 5 },
       { dataDir },
     );
@@ -1333,7 +1333,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("returns related entries without returning the requested entry", async () => {
     const result = await callRegistryTool(
-      "get_related_entries",
+      "entry.related",
       { category: skill.category, slug: skill.slug, limit: 5 },
       { dataDir },
     );
@@ -1357,7 +1357,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("fetches entry detail and install guidance without write capabilities", async () => {
     const detail = await callRegistryTool(
-      "get_entry_detail",
+      "entry.detail",
       { category: skill.category, slug: skill.slug },
       { dataDir },
     );
@@ -1379,7 +1379,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const guidance = await callRegistryTool(
-      "get_install_guidance",
+      "install.guidance",
       { category: skill.category, slug: skill.slug, platform: "claude" },
       { dataDir },
     );
@@ -1395,11 +1395,7 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   it("explains submission policy and entry trust through read-only helpers", async () => {
-    const policy = await callRegistryTool(
-      "get_submission_policy",
-      {},
-      { dataDir },
-    );
+    const policy = await callRegistryTool("submission.policy", {}, { dataDir });
     expect(policy).toMatchObject({
       ok: true,
       publicPolicy: {
@@ -1423,7 +1419,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const trust = await callRegistryTool(
-      "explain_entry_trust",
+      "entry.trust",
       { category: skill.category, slug: skill.slug },
       { dataDir },
     );
@@ -1438,7 +1434,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const review = await callRegistryTool(
-      "review_entry_safety",
+      "entry.safety",
       {
         entries: [
           { category: skill.category, slug: skill.slug },
@@ -1462,9 +1458,9 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
-  it("filters get_copyable_asset to a single requested assetType", async () => {
+  it("filters entry.asset to a single requested assetType", async () => {
     const full = await callRegistryTool(
-      "get_copyable_asset",
+      "entry.asset",
       { category: skill.category, slug: skill.slug },
       { dataDir },
     );
@@ -1473,7 +1469,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     const wantType = full.assets[0].type;
     const filtered = await callRegistryTool(
-      "get_copyable_asset",
+      "entry.asset",
       { category: skill.category, slug: skill.slug, assetType: wantType },
       { dataDir },
     );
@@ -1485,7 +1481,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     // Requesting an assetType the entry lacks returns an empty list, not an error.
     const absent = await callRegistryTool(
-      "get_copyable_asset",
+      "entry.asset",
       { category: skill.category, slug: skill.slug, assetType: "items" },
       { dataDir },
     );
@@ -1495,7 +1491,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     // Unknown assetType is rejected by the schema.
     await expect(
       callRegistryTool(
-        "get_copyable_asset",
+        "entry.asset",
         { category: skill.category, slug: skill.slug, assetType: "nope" },
         { dataDir },
       ),
@@ -1512,7 +1508,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("returns category-aware copyable assets and comparison metadata", async () => {
     const asset = await callRegistryTool(
-      "get_copyable_asset",
+      "entry.asset",
       { category: skill.category, slug: skill.slug, platform: "claude" },
       { dataDir },
     );
@@ -1545,7 +1541,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
     expect(second).toBeTruthy();
     const compared = await callRegistryTool(
-      "compare_entries",
+      "entry.compare",
       {
         entries: [
           { category: skill.category, slug: skill.slug },
@@ -1570,7 +1566,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
   });
 
-  it("reports compare_entries sharedTags only when every entry has the tag", async () => {
+  it("reports entry.compare sharedTags only when every entry has the tag", async () => {
     const fixtures = new Map([
       [
         "entries/skills/alpha.json",
@@ -1614,7 +1610,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     ]);
 
     const compared = await callRegistryTool(
-      "compare_entries",
+      "entry.compare",
       {
         entries: [
           { category: "skills", slug: "alpha" },
@@ -1639,7 +1635,7 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   it("returns registry stats and client setup snippets without auth requirements", async () => {
-    const stats = await callRegistryTool("get_registry_stats", {}, { dataDir });
+    const stats = await callRegistryTool("registry.stats", {}, { dataDir });
     expect(stats).toMatchObject({
       ok: true,
       package: { name: "@heyclaude/mcp" },
@@ -1655,7 +1651,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const setup = await callRegistryTool(
-      "get_client_setup",
+      "install.setup",
       { client: "codex" },
       { dataDir },
     );
@@ -1680,7 +1676,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("rejects non-HTTPS custom endpoint URLs for client setup", async () => {
     const setup = await callRegistryTool(
-      "get_client_setup",
+      "install.setup",
       { endpointUrl: "http://evil.example/mcp" },
       { dataDir },
     );
@@ -1695,7 +1691,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("rejects explicit empty endpoint URLs for client setup", async () => {
     const setup = await callRegistryTool(
-      "get_client_setup",
+      "install.setup",
       { endpointUrl: "" },
       { dataDir },
     );
@@ -1771,7 +1767,7 @@ describe("HeyClaude read-only MCP helpers", () => {
         {
           role: "user",
           content: {
-            text: expect.stringContaining("get_install_guidance"),
+            text: expect.stringContaining("install.guidance"),
           },
         },
       ],
@@ -1780,7 +1776,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("returns compatibility and generated Cursor adapter content", async () => {
     const compatibility = await callRegistryTool(
-      "get_compatibility",
+      "install.compatibility",
       { slug: skill.slug },
       { dataDir },
     );
@@ -1798,7 +1794,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
 
     const adapter = await callRegistryTool(
-      "get_platform_adapter",
+      "install.adapter",
       { slug: skill.slug, platform: "cursor-rules" },
       { dataDir },
     );
@@ -1826,7 +1822,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     );
 
     const result = await callRegistryTool(
-      "get_submission_schema",
+      "submission.schema",
       { category: "skills" },
       { dataDir },
     );
@@ -1863,7 +1859,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     };
 
     await expect(
-      callRegistryTool("validate_submission_draft", { fields }, { dataDir }),
+      callRegistryTool("submission.validate", { fields }, { dataDir }),
     ).resolves.toMatchObject({
       ok: true,
       valid: true,
@@ -1875,7 +1871,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const urls = await callRegistryTool(
-      "build_submission_urls",
+      "submission.urls",
       { fields, includePrBody: true },
       { dataDir },
     );
@@ -1894,7 +1890,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("rejects MCP skill drafts that fail registry skill rules", async () => {
     const invalid = await callRegistryTool(
-      "validate_submission_draft",
+      "submission.validate",
       {
         fields: {
           category: "skills",
@@ -1943,7 +1939,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     };
 
     const prepared = await callRegistryTool(
-      "prepare_submission_draft",
+      "submission.prepare",
       { fields },
       { dataDir },
     );
@@ -1961,7 +1957,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
 
     const reviewed = await callRegistryTool(
-      "review_submission_draft",
+      "submission.review",
       { fields },
       { dataDir },
     );
@@ -1983,7 +1979,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("returns category submission examples for faster valid drafts", async () => {
     const examples = await callRegistryTool(
-      "get_submission_examples",
+      "submission.examples",
       { category: "guides" },
       { dataDir },
     );
@@ -2005,7 +2001,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("finds likely duplicate entries before submission", async () => {
     const duplicate = await callRegistryTool(
-      "search_duplicate_entries",
+      "submission.duplicates",
       {
         category: skill.category,
         slug: skill.slug,
@@ -2029,7 +2025,7 @@ describe("HeyClaude read-only MCP helpers", () => {
   it("rejects malformed submission helper arguments from Zod schemas", async () => {
     await expect(
       callRegistryTool(
-        "build_submission_urls",
+        "submission.urls",
         {
           fields: {
             category: "skills",
@@ -2054,7 +2050,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     await expect(
       callRegistryTool(
-        "compare_entries",
+        "entry.compare",
         {
           entries: [
             { category: "skills", slug: skill.slug },
@@ -2078,11 +2074,7 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   it("lists distribution feeds from the manifest and feed index", async () => {
-    const feeds = await callRegistryTool(
-      "list_distribution_feeds",
-      {},
-      { dataDir },
-    );
+    const feeds = await callRegistryTool("feeds.list", {}, { dataDir });
     expect(feeds).toMatchObject({
       ok: true,
       artifacts: {
@@ -2103,7 +2095,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     await expect(
       callRegistryTool(
-        "get_entry_detail",
+        "entry.detail",
         { category: "mcp", slug: "does-not-exist" },
         { dataDir },
       ),
@@ -2143,7 +2135,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     it("explains trust for entry with safety and privacy notes", async () => {
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: "hooks", slug: "documentation-generator" },
         { dataDir },
       );
@@ -2169,7 +2161,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       if (!entryWithoutNotes) return ctx.skip(); // whole registry enriched — no note-less path to exercise
 
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         {
           category: entryWithoutNotes!.category,
           slug: entryWithoutNotes!.slug,
@@ -2191,7 +2183,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     it("explains trust for first-party package download", async () => {
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: "skills", slug: "agent-evals-regression-gate" },
         { dataDir },
       );
@@ -2211,7 +2203,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     it("explains trust for entry without download (copyable content only)", async () => {
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: "hooks", slug: "documentation-generator" },
         { dataDir },
       );
@@ -2228,7 +2220,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     it("explains trust for entry with weak source metadata", async () => {
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: "statuslines", slug: "python-rich-statusline" },
         { dataDir },
       );
@@ -2259,7 +2251,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       }
 
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: reviewedEntry.category, slug: reviewedEntry.slug },
         { dataDir },
       );
@@ -2277,7 +2269,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
     it("reviews safety for entries with mixed trust signals", async () => {
       const review = await callRegistryTool(
-        "review_entry_safety",
+        "entry.safety",
         {
           entries: [
             { category: "hooks", slug: "documentation-generator" },
@@ -2312,7 +2304,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       if (!entryWithoutNotes) return ctx.skip(); // whole registry enriched — no note-less path to exercise
 
       const review = await callRegistryTool(
-        "review_entry_safety",
+        "entry.safety",
         {
           entries: [
             {
@@ -2339,9 +2331,9 @@ describe("HeyClaude read-only MCP helpers", () => {
       });
     });
 
-    it("review_entry_safety output clearly states metadata review scope", async () => {
+    it("entry.safety output clearly states metadata review scope", async () => {
       const review = await callRegistryTool(
-        "review_entry_safety",
+        "entry.safety",
         {
           entries: [{ category: "hooks", slug: "documentation-generator" }],
           platform: "claude",
@@ -2356,9 +2348,9 @@ describe("HeyClaude read-only MCP helpers", () => {
       expect(review.reviewNotes).not.toContain("verified malware-free");
     });
 
-    it("explain_entry_trust output remains advisory only", async () => {
+    it("entry.trust output remains advisory only", async () => {
       const trust = await callRegistryTool(
-        "explain_entry_trust",
+        "entry.trust",
         { category: "hooks", slug: "documentation-generator" },
         { dataDir },
       );

--- a/tests/mcp-submission-duplicate-urls.test.ts
+++ b/tests/mcp-submission-duplicate-urls.test.ts
@@ -228,7 +228,7 @@ describe("searchDuplicateEntries source-URL matching", () => {
 
   it("exposes sourceUrls and fielded URL args through the public MCP schema", () => {
     expect(() =>
-      parseToolArguments("search_duplicate_entries", {
+      parseToolArguments("submission.duplicates", {
         sourceUrls: ["https://github.com/domdomegg/airtable-mcp-server"],
         githubUrl: "https://github.com/domdomegg/airtable-mcp-server",
         docsUrl: "https://docs.example.com/airtable",
@@ -237,7 +237,7 @@ describe("searchDuplicateEntries source-URL matching", () => {
       }),
     ).not.toThrow();
 
-    const inputSchema = jsonSchemaForTool("search_duplicate_entries") as {
+    const inputSchema = jsonSchemaForTool("submission.duplicates") as {
       properties?: Record<string, unknown>;
     };
     expect(inputSchema.properties).toMatchObject({
@@ -251,7 +251,7 @@ describe("searchDuplicateEntries source-URL matching", () => {
 
   it("accepts fielded URL args through the public MCP tool path", async () => {
     const result = await callRegistryTool(
-      "search_duplicate_entries",
+      "submission.duplicates",
       {
         githubUrl: "https://github.com/domdomegg/airtable-mcp-server/",
         limit: 3,
@@ -279,7 +279,7 @@ describe("searchDuplicateEntries source-URL matching", () => {
 
   it("accepts sourceUrls through the public MCP tool path", async () => {
     const result = await callRegistryTool(
-      "search_duplicate_entries",
+      "submission.duplicates",
       {
         sourceUrls: [
           "https://github.com/unrelated/repo",

--- a/tests/non-ui-branch-matrix.test.ts
+++ b/tests/non-ui-branch-matrix.test.ts
@@ -1736,12 +1736,12 @@ describe("non-UI branch matrix", () => {
       ),
       registryMcp.callRegistryTool("unknown", {}, mcpOptions),
       registryMcp.callRegistryTool(
-        "get_entry_detail",
+        "entry.detail",
         { category: skill!.category, slug: skill!.slug },
         mcpOptions,
       ),
       registryMcp.callRegistryTool(
-        "get_entry_detail",
+        "entry.detail",
         { category: "", slug: "" },
         mcpOptions,
       ),
@@ -1962,7 +1962,7 @@ describe("non-UI branch matrix", () => {
     ).resolves.toMatchObject({ ok: false, error: { code: "not_found" } });
     await expect(
       registryMcp.callRegistryTool(
-        "search_registry",
+        "registry.search",
         { limit: 0 },
         syntheticOptions,
       ),


### PR DESCRIPTION
## Why

Smithery's quality rubric requires tool names to form a navigable tree via dot-notation (e.g. `admin.tools.list`). Our flat `snake_case` names scored 0/4.44pt on naming, capping the quality score at 96/100.

## What

Rename all 26 tools into a six-group hierarchy:

| Group | Tools |
|---|---|
| `registry.*` | `registry.search`, `.recommend`, `.list`, `.stats`, `.updates` |
| `entry.*` | `entry.detail`, `.related`, `.compare`, `.asset`, `.trust`, `.safety` |
| `install.*` | `install.guidance`, `.setup`, `.compatibility`, `.adapter` |
| `feeds.*` | `feeds.list` |
| `submission.*` | `submission.schema`, `.validate`, `.prepare`, `.review`, `.examples`, `.policy`, `.urls`, `.duplicates`, `.guidance` |
| `server.*` | `server.info` |

All occurrences updated: `registry.js` tool definitions + case statements, `schemas.js` map keys, tests, `validate-endpoint.mjs`, and the npm `README.md`.

## Breaking change

This is a breaking change for any client referencing tool names by string. The next Release PR will bump to `0.5.0`.

## Validation

`pnpm test:mcp` — 68 tests pass.