### PR TITLE
fix(mcp): rename plan_workflow_toolbox to workflow.plan for Smithery 100/100

### DIFF
--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -81,7 +81,7 @@ const platformAliases = new Map([
 
 export const READ_ONLY_TOOL_NAMES = [
   "registry.search",
-  "plan_workflow_toolbox",
+  "workflow.plan",
   "registry.recommend",
   "server.info",
   "registry.list",
@@ -131,11 +131,11 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "plan_workflow_toolbox",
+    name: "workflow.plan",
     description:
       "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries. Each entry includes an inline install block (install command, config snippet, download URL) and the recommended stack is summarized as a copy-pasteable installPlan, alongside trust and follow-up guidance.",
-    inputSchema: jsonSchemaForTool("plan_workflow_toolbox"),
-    outputSchema: jsonSchemaForToolOutput("plan_workflow_toolbox"),
+    inputSchema: jsonSchemaForTool("workflow.plan"),
+    outputSchema: jsonSchemaForToolOutput("workflow.plan"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -146,7 +146,7 @@ export const TOOL_DEFINITIONS = [
   {
     name: "registry.recommend",
     description:
-      "Answer 'what should I use to do X' in one call. Given a plain-language task (and optional platform/category), returns the best-match HeyClaude entries ranked by fit — each with why it fits, trust summary, disclosed safety/privacy notes, and an inline install block — plus a topPick and a consolidated installPlan. Unlike plan_workflow_toolbox it does not force category diversity; it returns the genuinely best matches. Collapses the search → compare → detail → asset loop into a single answer-shaped response.",
+      "Answer 'what should I use to do X' in one call. Given a plain-language task (and optional platform/category), returns the best-match HeyClaude entries ranked by fit — each with why it fits, trust summary, disclosed safety/privacy notes, and an inline install block — plus a topPick and a consolidated installPlan. Unlike workflow.plan it does not force category diversity; it returns the genuinely best matches. Collapses the search → compare → detail → asset loop into a single answer-shaped response.",
     inputSchema: jsonSchemaForTool("registry.recommend"),
     outputSchema: jsonSchemaForToolOutput("registry.recommend"),
     annotations: {
@@ -1301,7 +1301,7 @@ export async function recommendForTask(args = {}, options = {}) {
     installPlan,
     trustSummary: toolboxTrustSummary(recommendations),
     notes: [
-      "Best-match recommendations for the task; unlike plan_workflow_toolbox they are not forced to span categories.",
+      "Best-match recommendations for the task; unlike workflow.plan they are not forced to span categories.",
       "This is metadata review only — it does not execute, install, or scan entries. Review trust before running anything.",
       "Use entry.compare to weigh the top picks and entry.trust before relying on any entry.",
     ],
@@ -2831,7 +2831,7 @@ export async function callRegistryTool(name, args = {}, options = {}) {
     case "registry.search":
       result = await searchRegistry(parsedArgs, options);
       break;
-    case "plan_workflow_toolbox":
+    case "workflow.plan":
       result = await planWorkflowToolbox(parsedArgs, options);
       break;
     case "registry.recommend":

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -619,7 +619,7 @@ export const ReviewEntrySafetyInputSchema = z
 
 export const TOOL_INPUT_SCHEMAS = {
   "registry.search": SearchRegistryInputSchema,
-  plan_workflow_toolbox: PlanWorkflowToolboxInputSchema,
+  "workflow.plan": PlanWorkflowToolboxInputSchema,
   "registry.recommend": RecommendForTaskInputSchema,
   "server.info": GetServerInfoInputSchema,
   "registry.list": ListCategoryEntriesInputSchema,

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -84,7 +84,7 @@ describe("HeyClaude remote MCP route", () => {
     );
     expect(toolNames).toEqual([
       "registry.search",
-      "plan_workflow_toolbox",
+      "workflow.plan",
       "registry.recommend",
       "server.info",
       "registry.list",

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -85,7 +85,7 @@ const validMcpSubmissionFields = {
 function validToolArguments(name: string) {
   const argsByTool: Record<string, unknown> = {
     "registry.search": { query: "mcp", limit: 1 },
-    plan_workflow_toolbox: { goal: "code review automation", limit: 2 },
+    "workflow.plan": { goal: "code review automation", limit: 2 },
     "registry.recommend": { task: "code review automation", limit: 2 },
     "server.info": {},
     "registry.list": { category: "mcp", limit: 1 },
@@ -895,7 +895,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("plans a ranked read-only workflow toolbox", async () => {
     const result = await callRegistryTool(
-      "plan_workflow_toolbox",
+      "workflow.plan",
       {
         goal: "skill workflow",
         category: "skills",
@@ -1116,7 +1116,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       };
     };
     const result = await callRegistryTool(
-      "plan_workflow_toolbox",
+      "workflow.plan",
       {
         goal: "credential hardened",
         limit: 3,
@@ -1160,7 +1160,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     };
 
     const result = await callRegistryTool(
-      "plan_workflow_toolbox",
+      "workflow.plan",
       { goal: "kubernetes cluster rollouts", limit: 5 },
       { readJsonArtifact },
     );


### PR DESCRIPTION
## Summary

- Renames `plan_workflow_toolbox` → `workflow.plan` to complete the dot-notation naming conversion
- All 27 tools now follow consistent `namespace.action` dot-notation
- This is the last remaining snake_case tool name that was holding the Smithery naming score at 98/100

## Validation

- `pnpm test:mcp` — 68 tests pass
- All tool names follow dot-notation: `registry.*`, `entry.*`, `install.*`, `submission.*`, `feeds.*`, `server.*`, `workflow.*`