### PR TITLE
fix(mcp): merge singleton namespaces into registry.* for Smithery 100/100

### DIFF
--- a/packages/mcp/scripts/validate-endpoint.mjs
+++ b/packages/mcp/scripts/validate-endpoint.mjs
@@ -12,7 +12,7 @@ const baselineToolNames = [
   "install.compatibility",
   "install.guidance",
   "install.adapter",
-  "feeds.list",
+  "registry.feeds",
   "submission.schema",
   "submission.validate",
   "submission.duplicates",
@@ -220,10 +220,10 @@ async function validateMcpTools(endpointUrl, options = {}) {
       );
     }
 
-    if (toolNames.includes("server.info")) {
+    if (toolNames.includes("registry.info")) {
       const info = parseToolResult(
         await client.callTool({
-          name: "server.info",
+          name: "registry.info",
           arguments: {},
         }),
       );
@@ -298,7 +298,7 @@ async function validateMcpTools(endpointUrl, options = {}) {
 
     const feeds = parseToolResult(
       await client.callTool({
-        name: "feeds.list",
+        name: "registry.feeds",
         arguments: {},
       }),
     );

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -81,9 +81,9 @@ const platformAliases = new Map([
 
 export const READ_ONLY_TOOL_NAMES = [
   "registry.search",
-  "workflow.plan",
+  "registry.plan",
   "registry.recommend",
-  "server.info",
+  "registry.info",
   "registry.list",
   "registry.updates",
   "entry.related",
@@ -95,7 +95,7 @@ export const READ_ONLY_TOOL_NAMES = [
   "install.compatibility",
   "install.guidance",
   "install.adapter",
-  "feeds.list",
+  "registry.feeds",
   "submission.schema",
   "submission.validate",
   "submission.duplicates",
@@ -131,11 +131,11 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "workflow.plan",
+    name: "registry.plan",
     description:
       "Plan a read-only Claude or Codex workflow toolbox from ranked HeyClaude registry entries. Each entry includes an inline install block (install command, config snippet, download URL) and the recommended stack is summarized as a copy-pasteable installPlan, alongside trust and follow-up guidance.",
-    inputSchema: jsonSchemaForTool("workflow.plan"),
-    outputSchema: jsonSchemaForToolOutput("workflow.plan"),
+    inputSchema: jsonSchemaForTool("registry.plan"),
+    outputSchema: jsonSchemaForToolOutput("registry.plan"),
     annotations: {
       readOnlyHint: true,
       destructiveHint: false,
@@ -157,10 +157,10 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "server.info",
+    name: "registry.info",
     description:
       "Fetch read-only HeyClaude MCP package, registry, tool, and public rate-limit metadata.",
-    inputSchema: jsonSchemaForTool("server.info"),
+    inputSchema: jsonSchemaForTool("registry.info"),
   },
   {
     name: "registry.list",
@@ -229,10 +229,10 @@ export const TOOL_DEFINITIONS = [
     inputSchema: jsonSchemaForTool("install.adapter"),
   },
   {
-    name: "feeds.list",
+    name: "registry.feeds",
     description:
       "List read-only HeyClaude registry feeds, category feeds, platform feeds, and artifact locations.",
-    inputSchema: jsonSchemaForTool("feeds.list"),
+    inputSchema: jsonSchemaForTool("registry.feeds"),
   },
   {
     name: "submission.schema",
@@ -2831,13 +2831,13 @@ export async function callRegistryTool(name, args = {}, options = {}) {
     case "registry.search":
       result = await searchRegistry(parsedArgs, options);
       break;
-    case "workflow.plan":
+    case "registry.plan":
       result = await planWorkflowToolbox(parsedArgs, options);
       break;
     case "registry.recommend":
       result = await recommendForTask(parsedArgs, options);
       break;
-    case "server.info":
+    case "registry.info":
       result = await getServerInfo(parsedArgs, options);
       break;
     case "registry.list":
@@ -2873,7 +2873,7 @@ export async function callRegistryTool(name, args = {}, options = {}) {
     case "install.adapter":
       result = await getPlatformAdapter(parsedArgs, options);
       break;
-    case "feeds.list":
+    case "registry.feeds":
       result = await listDistributionFeeds(parsedArgs, options);
       break;
     case "submission.schema":

--- a/packages/mcp/src/schemas.js
+++ b/packages/mcp/src/schemas.js
@@ -619,9 +619,9 @@ export const ReviewEntrySafetyInputSchema = z
 
 export const TOOL_INPUT_SCHEMAS = {
   "registry.search": SearchRegistryInputSchema,
-  "workflow.plan": PlanWorkflowToolboxInputSchema,
+  "registry.plan": PlanWorkflowToolboxInputSchema,
   "registry.recommend": RecommendForTaskInputSchema,
-  "server.info": GetServerInfoInputSchema,
+  "registry.info": GetServerInfoInputSchema,
   "registry.list": ListCategoryEntriesInputSchema,
   "registry.updates": RecentUpdatesInputSchema,
   "entry.related": RelatedEntriesInputSchema,
@@ -633,7 +633,7 @@ export const TOOL_INPUT_SCHEMAS = {
   "install.compatibility": CompatibilityInputSchema,
   "install.guidance": InstallGuidanceInputSchema,
   "install.adapter": PlatformAdapterInputSchema,
-  "feeds.list": ListDistributionFeedsInputSchema,
+  "registry.feeds": ListDistributionFeedsInputSchema,
   "submission.schema": GetSubmissionSchemaInputSchema,
   "submission.validate": ValidateSubmissionDraftInputSchema,
   "submission.duplicates": SearchDuplicateEntriesInputSchema,

--- a/tests/mcp-http-route.test.ts
+++ b/tests/mcp-http-route.test.ts
@@ -84,9 +84,9 @@ describe("HeyClaude remote MCP route", () => {
     );
     expect(toolNames).toEqual([
       "registry.search",
-      "workflow.plan",
+      "registry.plan",
       "registry.recommend",
-      "server.info",
+      "registry.info",
       "registry.list",
       "registry.updates",
       "entry.related",
@@ -98,7 +98,7 @@ describe("HeyClaude remote MCP route", () => {
       "install.compatibility",
       "install.guidance",
       "install.adapter",
-      "feeds.list",
+      "registry.feeds",
       "submission.schema",
       "submission.validate",
       "submission.duplicates",
@@ -224,7 +224,7 @@ describe("HeyClaude remote MCP route", () => {
         jsonrpc: "2.0",
         id: 33,
         method: "tools/call",
-        params: { name: "server.info", arguments: {} },
+        params: { name: "registry.info", arguments: {} },
       }),
     );
     expect(infoResponse.status).toBe(200);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -85,9 +85,9 @@ const validMcpSubmissionFields = {
 function validToolArguments(name: string) {
   const argsByTool: Record<string, unknown> = {
     "registry.search": { query: "mcp", limit: 1 },
-    "workflow.plan": { goal: "code review automation", limit: 2 },
+    "registry.plan": { goal: "code review automation", limit: 2 },
     "registry.recommend": { task: "code review automation", limit: 2 },
-    "server.info": {},
+    "registry.info": {},
     "registry.list": { category: "mcp", limit: 1 },
     "registry.updates": { limit: 1 },
     "entry.related": {
@@ -117,7 +117,7 @@ function validToolArguments(name: string) {
       platform: "claude",
     },
     "install.adapter": { slug: skill.slug, platform: "cursor-rules" },
-    "feeds.list": {},
+    "registry.feeds": {},
     "submission.schema": { category: "mcp" },
     "submission.validate": { fields: validMcpSubmissionFields },
     "submission.duplicates": {
@@ -540,7 +540,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       fs.readFileSync(path.join(repoRoot, "packages/mcp/package.json"), "utf8"),
     ) as { name: string; version: string };
 
-    const info = await callRegistryTool("server.info", {}, { dataDir });
+    const info = await callRegistryTool("registry.info", {}, { dataDir });
     expect(info).toMatchObject({
       ok: true,
       package: {
@@ -895,7 +895,7 @@ describe("HeyClaude read-only MCP helpers", () => {
 
   it("plans a ranked read-only workflow toolbox", async () => {
     const result = await callRegistryTool(
-      "workflow.plan",
+      "registry.plan",
       {
         goal: "skill workflow",
         category: "skills",
@@ -1116,7 +1116,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       };
     };
     const result = await callRegistryTool(
-      "workflow.plan",
+      "registry.plan",
       {
         goal: "credential hardened",
         limit: 3,
@@ -1160,7 +1160,7 @@ describe("HeyClaude read-only MCP helpers", () => {
     };
 
     const result = await callRegistryTool(
-      "workflow.plan",
+      "registry.plan",
       { goal: "kubernetes cluster rollouts", limit: 5 },
       { readJsonArtifact },
     );
@@ -2074,7 +2074,7 @@ describe("HeyClaude read-only MCP helpers", () => {
   });
 
   it("lists distribution feeds from the manifest and feed index", async () => {
-    const feeds = await callRegistryTool("feeds.list", {}, { dataDir });
+    const feeds = await callRegistryTool("registry.feeds", {}, { dataDir });
     expect(feeds).toMatchObject({
       ok: true,
       artifacts: {


### PR DESCRIPTION
## Summary

Merges three singleton tool namespaces into `registry.*` to fix the Smithery naming score from 98→100.

| Before | After | Reason |
|--------|-------|--------|
| `server.info` | `registry.info` | `server` had only 1 tool — a leaf, not a tree branch |
| `feeds.list` | `registry.feeds` | `feeds` had only 1 tool |
| `workflow.plan` | `registry.plan` | `workflow` had only 1 tool |

Smithery's rubric: "Tool and trigger names should form a navigable tree via dot-notation. Flat lists and over-nested paths both reduce the score." Single-tool namespaces are treated as flat nodes.

After this change the `registry` namespace has 8 tools (search, recommend, list, updates, stats, plan, info, feeds) — a proper tree branch.

## Validation

- `pnpm test:mcp` — 68 tests pass
- `pnpm exec vitest run tests/mcp-remote-proxy.test.ts tests/mcp-http-route.test.ts tests/non-ui-branch-matrix.test.ts` — 36 tests pass