### PR TITLE
chore(links): canonicalize 2 moved source URLs

### DIFF
--- a/content/mcp/appwrite-mcp-server.mdx
+++ b/content/mcp/appwrite-mcp-server.mdx
@@ -14,7 +14,7 @@ authorProfileUrl: "https://github.com/appwrite"
 dateAdded: "2026-06-18"
 documentationUrl: "https://raw.githubusercontent.com/appwrite/mcp-for-api/main/README.md"
 websiteUrl: "https://appwrite.io"
-repoUrl: "https://github.com/appwrite/mcp-for-api"
+repoUrl: "https://github.com/appwrite/mcp"
 retrievalSources:
   - "https://raw.githubusercontent.com/appwrite/mcp-for-api/main/README.md"
   - "https://code.claude.com/docs/en/mcp"

--- a/content/tools/activepieces.mdx
+++ b/content/tools/activepieces.mdx
@@ -11,7 +11,7 @@ submittedBy: oktofeesh1
 submittedByUrl: "https://github.com/oktofeesh1"
 dateAdded: "2026-06-03"
 websiteUrl: "https://www.activepieces.com"
-documentationUrl: "https://www.activepieces.com/docs/getting-started/introduction"
+documentationUrl: "https://www.activepieces.com/docs/overview/welcome"
 repoUrl: "https://github.com/activepieces/activepieces"
 pricingModel: freemium
 disclosure: editorial


### PR DESCRIPTION
Automated link-health canonicalization. Each stored URL below returns a **permanent redirect (301)** to a real content page on the **same registrable domain**; the final page was semantically confirmed to document the same resource.

| file | field | old → new |
| --- | --- | --- |
| content/mcp/appwrite-mcp-server.mdx | repoUrl | `https://github.com/appwrite/mcp-for-api` → `https://github.com/appwrite/mcp` (repo renamed; final title "Appwrite's MCP server") |
| content/tools/activepieces.mdx | documentationUrl | `https://www.activepieces.com/docs/getting-started/introduction` → `https://www.activepieces.com/docs/overview/welcome` (docs reorg; final title "Welcome – Activepieces") |

Conservative pass: 2183 unique source URLs checked. Most of the 80 redirects were skipped as cosmetic (www/trailing-slash, homepage→intro convenience redirects that churn faster than the bare domain) or cross-domain rebrands requiring human review. Only genuine same-domain path/repo renames are included here.

Dead links (4 URLs) are tracked separately in the "Link health: dead source URLs" issue.