### PR TITLE
docs: prohibit PR plagiarism and reward-farming with a permanent cross-repo block

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -14,6 +14,7 @@ HeyClaude is a public contribution space for useful Claude and AI workflow resou
 
 - Harassment, threats, hate speech, personal attacks, or targeted abuse.
 - Spam submissions, low-effort reward farming, or attempts to manipulate contribution scoring.
+- Plagiarism — copying another contributor's submission, PR, or work and passing it off as your own, including duplicated or lightly reworded copies filed under a different account.
 - Repeatedly reopening closed submissions without new evidence.
 - Submitting malware, deceptive packages, credential-harvesting instructions, or intentionally unsafe content.
 - Publishing private information, secrets, tokens, or non-public data.
@@ -21,6 +22,8 @@ HeyClaude is a public contribution space for useful Claude and AI workflow resou
 ## Enforcement
 
 Maintainers may edit, hide, close, lock, or delete issues, comments, PRs, and discussions that violate this code of conduct. Maintainers may also block users from participating in the project.
+
+Plagiarism and deliberate attempts to cheat, copy from other contributors, or farm contribution rewards through stolen or duplicated submissions are treated as a hard violation: offenders are **permanently blocked from contributing**, and the block applies across all of our repositories (`JSONbored/gittensory`, `JSONbored/metagraphed`, `JSONbored/awesome-claude`).
 
 Security-sensitive reports should follow [SECURITY.md](SECURITY.md). Other conduct concerns can be raised through a GitHub issue or discussion if it is safe to do so.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,8 @@ Direct PRs are the advanced path. Edit source content under `content/<category>/
 
 Keep submissions concrete. Include canonical source URLs, docs, install/config details, and enough context for someone else to verify the entry.
 
+> **Submit your own work, with credit to original sources.** Plagiarism — copying another contributor's PR or submission and passing it off as your own, including duplicated or lightly reworded copies filed under a different account — is a hard violation. Anyone attempting to cheat, copy from others, or farm contribution rewards is **permanently blocked from contributing across all of our repositories**. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
+
 For accepted, rejected, and rerouted examples across agents, MCP servers, skills, hooks, commands, collections, and paid/tool listings, see [`examples/content/SUBMISSION_EXAMPLES.md`](examples/content/SUBMISSION_EXAMPLES.md).
 
 For hooks, MCP servers, skills, commands, and statuslines, disclose meaningful safety/privacy behavior in the submission fields:


### PR DESCRIPTION
## What

Adds an explicit, enforceable anti-plagiarism policy to both `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md`.

## Why

Copying another contributor's PR, diff, or work and submitting it as your own — including lightly reworded or re-tested copies filed under a different account — to farm Gittensor rewards is gaming, not contribution. This makes the consequence explicit and uniform across our repos.

## Policy

- **Code of Conduct** — plagiarism added to the unacceptable-behavior list; enforcement clause states offenders are **permanently blocked from contributing**, across `JSONbored/gittensory`, `JSONbored/metagraphed`, and `JSONbored/awesome-claude`.
- **Contributing** — a visible callout in the submission rules cross-referencing the Code of Conduct.

Docs-only; no code or schema changes.