### PR TITLE
Add BuyWhere MCP Server to content/mcp/

### DIFF
--- a/content/mcp/buywhere-mcp.mdx
+++ b/content/mcp/buywhere-mcp.mdx
@@ -1,0 +1,65 @@
+---
+title: BuyWhere MCP Server
+slug: buywhere-mcp
+category: mcp
+description: >-
+  Real-time product search and price-comparison MCP server for AI agents. 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US. Exposes 7 tools: search_products, get_product, compare_products, find_best_price, get_deals, list_categories, find_similar.
+cardDescription: >-
+  Connect Claude to real-time product pricing across 11M+ products in Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US.
+seoTitle: BuyWhere MCP Server for Claude
+seoDescription: >-
+  Use BuyWhere MCP Server (api.buywhere.ai/mcp) with Claude to search 11M+ products in real time, compare prices across merchants, find the cheapest in-stock listing, and discover active deals across Shopee, Lazada, Amazon, and Walmart in Singapore, SEA, and US. Free API key with no signup flow.
+author: BuyWhere
+authorProfileUrl: "https://github.com/BuyWhere"
+submittedBy: BuyWhere
+submittedByUrl: "https://github.com/BuyWhere"
+dateAdded: "2026-06-26"
+brandName: BuyWhere MCP
+brandDomain: buywhere.ai
+websiteUrl: "https://buywhere.ai"
+repoUrl: "https://github.com/BuyWhere/buywhere-mcp"
+documentationUrl: "https://github.com/BuyWhere/buywhere-mcp/blob/main/README.md"
+installable: true
+installCommand: >-
+  claude mcp add --transport http buywhere https://api.buywhere.ai/mcp --header "Authorization: Bearer YOUR_BUYWHERE_API_KEY"
+usageSnippet: >-
+  Register a free API key at https://api.buywhere.ai/v1/auth/register (no signup, 3 seconds), then add the BuyWhere MCP server with the install command above. Use search_products, get_product, compare_products, find_best_price, get_deals, list_categories, and find_similar to research shopping queries across Singapore and Southeast Asia.
+copySnippet: |-
+  {
+    "mcpServers": {
+      "buywhere": {
+        "url": "https://api.buywhere.ai/mcp",
+        "type": "http",
+        "headers": {
+          "Authorization": "Bearer YOUR_BUYWHERE_API_KEY"
+        }
+      }
+    }
+  }
+configSnippet: |-
+  {
+    "mcpServers": {
+      "buywhere": {
+        "url": "https://api.buywhere.ai/mcp",
+        "type": "http",
+        "headers": {
+          "Authorization": "Bearer YOUR_BUYWHERE_API_KEY"
+        }
+      }
+    }
+  }
+retrievalSources:
+  - "https://buywhere.ai"
+  - "https://github.com/BuyWhere/buywhere-mcp"
+  - "https://registry.modelcontextprotocol.io"
+  - "https://modelcontextprotocol.io"
+tags:
+  - e-commerce
+  - product-search
+  - price-comparison
+  - shopping
+  - cross-border
+  - retail
+  - singapore
+  - southeast-asia
+---


### PR DESCRIPTION
## Add BuyWhere MCP Server to content/mcp/

Adds a single-entry content PR for BuyWhere MCP, per the contribution guidelines ("keep the PR focused on one entry").

### What's in the PR
- New file: `content/mcp/buywhere-mcp.mdx` (65 lines)
- Schema-compliant with front matter (title, slug, category=mcp, description, cardDescription, seoTitle, seoDescription, author, submittedBy, dateAdded, brandName, brandDomain, websiteUrl, repoUrl, documentationUrl, installable, installCommand, copySnippet, configSnippet, retrievalSources, tags)

### About BuyWhere MCP
- **Coverage:** 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US
- **Tools:** `search_products`, `get_product`, `compare_products`, `find_best_price`, `get_deals`, `list_categories`, `find_similar`
- **Endpoints:** streamable-HTTP at `https://api.buywhere.ai/mcp`, stdio via `npx @buywhere/mcp-server`
- **Free API key** (no signup flow, 3-second `POST /v1/auth/register`)
- **MCP Registry listed:** `io.github.BuyWhere/buywhere-mcp@1.0.5`
- **Open source** (MIT), actively maintained with weekly releases

### Install command provided
```bash
claude mcp add --transport http buywhere https://api.buywhere.ai/mcp --header "Authorization: Bearer YOUR_BUYWHERE_API_KEY"
```

### Why this fits HeyClaude
- It's an MCP server, so category=mcp is correct
- It's actively used in production (HTTP 200, weekly releases)
- It has a free tier with no signup friction
- It complements the existing search/agent MCP entries
- It's compatible with Claude Code (one-line install)

Looking forward to maintainer review. Thanks!