### PR TITLE
feat(search): share registry ranking across web and mcp

### DIFF
--- a/apps/web/src/lib/api/registry-search-filters.ts
+++ b/apps/web/src/lib/api/registry-search-filters.ts
@@ -1,11 +1,16 @@
-import { normalizePlatform } from "@heyclaude/registry";
 import type { SearchDocument } from "@heyclaude/registry";
-
 import {
-  normalizeSearchQuery,
-  TOKEN_SPLIT_PATTERN,
-  tokenizeSearchQuery,
-} from "@/lib/search-query-tokenization";
+  entryClaimStatusValue,
+  entryHasPrivacyNotes,
+  entryHasSafetyNotes,
+  entryIsInstallable,
+  entryPackageTrustValue,
+  entrySourceStatusValue,
+  matchesRegistryPlatform,
+  matchesRegistryQuery,
+  rankRegistrySearchEntries,
+  scoreRegistrySearchEntry,
+} from "@heyclaude/mcp/search-ranking";
 
 export type BooleanFilterValue = "all" | "true" | "false";
 
@@ -38,298 +43,12 @@ export type RegistrySearchFilterDimension =
   | "claimStatus"
   | "sourceStatus";
 
-const QUERY_ALIASES: Record<string, string[]> = {
-  automation: ["automate", "automated", "qa", "testing"],
-  browser: ["chrome", "playwright", "web"],
-  cc: ["claude", "claude-code"],
-  claude: ["claude-code"],
-  design: ["ux", "ui"],
-  gh: ["github"],
-  ms: ["microsoft"],
-  mcp: ["model-context-protocol"],
-  msteams: ["teams", "microsoft-teams"],
-  repo: ["repository", "github"],
-  repos: ["repository", "github"],
-  safe: ["safety", "security", "secure", "trust", "privacy"],
-  security: ["safe", "safety", "secure", "trust"],
-  skill: ["skills"],
-  skills: ["skill"],
-  statusline: ["statuslines", "status"],
-  statuslines: ["statusline", "status"],
-};
-
-type QueryIntentProfile = {
-  id: string;
-  tokens: string[];
-  categories?: string[];
-  platforms?: string[];
-  tags?: string[];
-  keywords?: string[];
-  titleTerms?: string[];
-  trustWeighted?: boolean;
-};
-
-type EntrySearchSignals = {
-  title: string;
-  slug: string;
-  category: string;
-  tags: Set<string>;
-  keywords: Set<string>;
-  platforms: Set<string>;
-  haystack: string;
-  words: Set<string>;
-};
-
-const QUERY_INTENT_PROFILES: QueryIntentProfile[] = [
-  {
-    id: "code review",
-    tokens: ["code", "review"],
-    categories: ["agents", "commands", "tools", "skills"],
-    tags: ["code-review", "review", "pull-request", "quality"],
-    keywords: ["code review", "code-review", "pr review", "repository review"],
-    titleTerms: ["code review", "review"],
-    trustWeighted: true,
-  },
-  {
-    id: "browser automation",
-    tokens: ["browser", "automation"],
-    categories: ["mcp", "agents", "tools", "guides"],
-    platforms: ["claude-code"],
-    tags: ["browser-automation", "browser", "chrome", "playwright", "web-testing"],
-    keywords: ["browser automation", "playwright", "chrome", "web qa", "screenshots"],
-    titleTerms: ["browser automation", "browser", "playwright", "chrome"],
-    trustWeighted: true,
-  },
-  {
-    id: "safe mcp",
-    tokens: ["safe", "mcp"],
-    categories: ["mcp", "guides", "skills"],
-    tags: ["security", "safety", "privacy", "least-privilege", "trust", "mcp"],
-    keywords: ["safe mcp", "mcp security", "least privilege", "trust review"],
-    titleTerms: ["mcp security", "safe mcp", "trust"],
-    trustWeighted: true,
-  },
-  {
-    id: "design skill",
-    tokens: ["design", "skill"],
-    categories: ["skills", "agents", "rules"],
-    tags: ["design", "ux", "ui", "frontend", "visual-qa"],
-    keywords: ["design skill", "ux", "ui", "frontend design", "visual qa"],
-    titleTerms: ["design", "ux", "ui"],
-  },
-  {
-    id: "statusline",
-    tokens: ["statusline"],
-    categories: ["statuslines"],
-    tags: ["statusline", "monitoring", "observability", "context", "usage"],
-    keywords: ["statusline", "claude code statusline", "workflow visibility"],
-    titleTerms: ["statusline"],
-    trustWeighted: true,
-  },
-  {
-    id: "raycast",
-    tokens: ["raycast"],
-    platforms: ["raycast"],
-    tags: ["raycast", "launcher", "extension", "productivity"],
-    keywords: ["raycast", "raycast extension", "launcher"],
-    titleTerms: ["raycast"],
-    trustWeighted: true,
-  },
-];
-
-const SEARCH_REASON_PRIORITY = [
-  "query intent",
-  "title phrase",
-  "slug phrase",
-  "intent title",
-  "intent tag",
-  "intent keyword",
-  "intent category",
-  "trust intent",
-  "source-backed",
-  "trusted package",
-  "safety notes",
-  "privacy notes",
-  "title term",
-  "slug term",
-  "tag match",
-  "keyword match",
-  "category match",
-  "category term",
-  "platform match",
-  "installable",
-  "reviewed",
-];
-
-function expandedTokenCandidates(token: string) {
-  return [token, ...(QUERY_ALIASES[token] ?? [])];
-}
-
-function expandedTokenSet(tokens: ReadonlyArray<string>) {
-  return new Set(tokens.flatMap((token) => expandedTokenCandidates(token)));
-}
-
-function normalizedSet(values: ReadonlyArray<unknown> | undefined) {
-  return new Set((values ?? []).map((value) => String(value).trim().toLowerCase()).filter(Boolean));
-}
-
-function normalizedSearchText(entry: SearchDocument) {
-  const mcpInstallTargets = (entry as { mcpInstallTargets?: string[] }).mcpInstallTargets;
-  return [
-    entry.category,
-    entry.slug,
-    entry.title,
-    entry.description,
-    entry.author,
-    entry.submittedBy,
-    entry.brandName,
-    entry.brandDomain,
-    entry.verificationStatus,
-    entry.downloadTrust,
-    ...(entry.platforms ?? []),
-    ...(entry.supportLevels ?? []),
-    ...(mcpInstallTargets ?? []),
-    ...(entry.tags ?? []),
-    ...(entry.keywords ?? []),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-}
-
-function entryWordSet(entry: SearchDocument) {
-  return new Set(
-    normalizedSearchText(entry)
-      .split(TOKEN_SPLIT_PATTERN)
-      .map((token) => token.trim().toLowerCase())
-      .filter(Boolean),
-  );
-}
-
-function candidateMatchesText(candidate: string, haystack: string, words: ReadonlySet<string>) {
-  if (candidate.length <= 2) {
-    return [...words].some((word) => word === candidate || word.startsWith(candidate));
-  }
-  return haystack.includes(candidate) || [...words].some((word) => word.startsWith(candidate));
-}
-
-function buildEntrySearchSignals(entry: SearchDocument): EntrySearchSignals {
-  return {
-    title: entry.title.toLowerCase(),
-    slug: entry.slug.toLowerCase(),
-    category: entry.category.toLowerCase(),
-    tags: normalizedSet(entry.tags),
-    keywords: normalizedSet(entry.keywords),
-    platforms: normalizedSet(entry.platforms),
-    haystack: normalizedSearchText(entry),
-    words: entryWordSet(entry),
-  };
-}
-
-function valueMatchesCandidate(
-  value: string,
-  candidate: string,
-  words = new Set(
-    value
-      .split(TOKEN_SPLIT_PATTERN)
-      .map((word) => word.trim().toLowerCase())
-      .filter(Boolean),
-  ),
-) {
-  return candidateMatchesText(candidate, value, words);
-}
-
-function setMatchesCandidates(values: ReadonlySet<string>, candidates: ReadonlyArray<string>) {
-  return [...values].some((value) =>
-    candidates.some((candidate) => valueMatchesCandidate(value, candidate)),
-  );
-}
-
-function matchingIntentProfiles(tokens: ReadonlyArray<string>) {
-  const candidates = expandedTokenSet(tokens);
-  return QUERY_INTENT_PROFILES.filter((profile) =>
-    profile.tokens.every((token) => candidates.has(token)),
-  );
-}
-
-function scoreIntentProfile(
-  entry: SearchDocument,
-  signals: EntrySearchSignals,
-  profile: QueryIntentProfile,
-) {
-  let score = 0;
-  const reasons = new Set<string>();
-  const titleTerms = profile.titleTerms ?? [];
-
-  if (profile.categories?.includes(signals.category)) {
-    score += 28;
-    reasons.add("intent category");
-  }
-  if (profile.platforms && setMatchesCandidates(signals.platforms, profile.platforms)) {
-    score += 24;
-    reasons.add("platform match");
-  }
-  if (profile.tags && setMatchesCandidates(signals.tags, profile.tags)) {
-    score += 26;
-    reasons.add("intent tag");
-  }
-  if (profile.keywords && setMatchesCandidates(signals.keywords, profile.keywords)) {
-    score += 22;
-    reasons.add("intent keyword");
-  }
-  if (titleTerms.some((term) => valueMatchesCandidate(signals.title, term))) {
-    score += 24;
-    reasons.add("intent title");
-  }
-  if (profile.trustWeighted) {
-    let trustScore = 0;
-    if (entry.trustSignals?.sourceStatus === "available") trustScore += 8;
-    if (hasSafetyNotes(entry)) trustScore += 8;
-    if (hasPrivacyNotes(entry)) trustScore += 6;
-    if (entry.downloadTrust === "first-party" || entry.trustSignals?.packageVerified === true) {
-      trustScore += 6;
-    }
-    score += trustScore;
-    if (trustScore > 0) reasons.add("trust intent");
-  }
-  if (score > 0) reasons.add("query intent");
-
-  return { score, reasons };
-}
-
-function rankedSearchReasons(reasons: ReadonlySet<string>) {
-  const priority = new Map(SEARCH_REASON_PRIORITY.map((reason, index) => [reason, index]));
-  return [...reasons]
-    .sort((left, right) => (priority.get(left) ?? 999) - (priority.get(right) ?? 999))
-    .slice(0, 12);
-}
-
 export function matchesQuery(entry: SearchDocument, query: string) {
-  const normalizedQuery = normalizeSearchQuery(query);
-  if (!normalizedQuery) return true;
-  const haystack = normalizedSearchText(entry);
-  const tokens = tokenizeSearchQuery(normalizedQuery);
-  if (!tokens.length) return false;
-  const words = entryWordSet(entry);
-  if (
-    normalizedQuery.length > 2
-      ? haystack.includes(normalizedQuery)
-      : candidateMatchesText(normalizedQuery, haystack, words)
-  ) {
-    return true;
-  }
-  return tokens.every((token) =>
-    expandedTokenCandidates(token).some((candidate) =>
-      candidateMatchesText(candidate, haystack, words),
-    ),
-  );
+  return matchesRegistryQuery(entry, query);
 }
 
 export function matchesPlatform(entry: SearchDocument, platform: string) {
-  if (!platform) return true;
-  // Entry platforms are canonical IDs; map the filter input to canonical too.
-  const target = normalizePlatform(platform) ?? platform.trim().toLowerCase();
-  return (entry.platforms ?? []).some((item) => String(item).trim().toLowerCase() === target);
+  return matchesRegistryPlatform(entry, platform);
 }
 
 export function matchesBooleanFilter(value: boolean, filter: BooleanFilterValue) {
@@ -338,27 +57,27 @@ export function matchesBooleanFilter(value: boolean, filter: BooleanFilterValue)
 }
 
 export function hasSafetyNotes(entry: SearchDocument) {
-  return Boolean(entry.trustSignals?.hasSafetyNotes || entry.safetyNotes?.length);
+  return entryHasSafetyNotes(entry);
 }
 
 export function hasPrivacyNotes(entry: SearchDocument) {
-  return Boolean(entry.trustSignals?.hasPrivacyNotes || entry.privacyNotes?.length);
+  return entryHasPrivacyNotes(entry);
 }
 
 export function isInstallable(entry: SearchDocument) {
-  return Boolean(entry.installable || entry.downloadUrl);
+  return entryIsInstallable(entry);
 }
 
 export function packageTrustValue(entry: SearchDocument) {
-  return entry.downloadTrust || (entry.downloadUrl ? "external" : "none");
+  return entryPackageTrustValue(entry);
 }
 
 export function sourceStatusValue(entry: SearchDocument) {
-  return entry.trustSignals?.sourceStatus || "missing";
+  return entrySourceStatusValue(entry);
 }
 
 export function claimStatusValue(entry: SearchDocument) {
-  return entry.claimStatus || "unclaimed";
+  return entryClaimStatusValue(entry);
 }
 
 export function entryMatchesFilters(
@@ -433,137 +152,16 @@ export function scoreSearchEntry(
   entry: SearchDocument,
   query: string,
 ): Omit<RankedSearchEntry, "entry"> {
-  const normalizedQuery = normalizeSearchQuery(query);
-  const tokens = tokenizeSearchQuery(normalizedQuery);
-  if (!tokens.length) return { score: 0, reasons: [] };
-
-  const title = entry.title.toLowerCase();
-  const slug = entry.slug.toLowerCase();
-  const category = entry.category.toLowerCase();
-  const tags = new Set((entry.tags ?? []).map((tag) => tag.toLowerCase()));
-  const keywords = new Set((entry.keywords ?? []).map((keyword) => keyword.toLowerCase()));
-  const platforms = normalizedSet(entry.platforms);
-  const signals = buildEntrySearchSignals(entry);
-  const haystack = signals.haystack;
-  const words = signals.words;
-  let score = 0;
-  const reasons = new Set<string>();
-
-  if (title.includes(normalizedQuery)) {
-    score += 90;
-    reasons.add("title phrase");
-  }
-  if (slug.includes(normalizedQuery)) {
-    score += 65;
-    reasons.add("slug phrase");
-  }
-  if (category === normalizedQuery) {
-    score += 45;
-    reasons.add("category match");
-  }
-
-  for (const token of tokens) {
-    const candidates = expandedTokenCandidates(token);
-    const hasCandidate = (value: string) =>
-      candidates.some((candidate) =>
-        candidateMatchesText(
-          candidate,
-          value,
-          new Set(
-            value
-              .split(TOKEN_SPLIT_PATTERN)
-              .map((word) => word.trim().toLowerCase())
-              .filter(Boolean),
-          ),
-        ),
-      );
-    const hasPrefixCandidate = [...words].some((word) =>
-      candidates.some((candidate) => word.startsWith(candidate)),
-    );
-
-    if (hasCandidate(title)) {
-      score += 35;
-      reasons.add("title term");
-    }
-    if (hasCandidate(slug)) {
-      score += 28;
-      reasons.add("slug term");
-    }
-    if (candidates.some((candidate) => tags.has(candidate))) {
-      score += 24;
-      reasons.add("tag match");
-    }
-    if (candidates.some((candidate) => keywords.has(candidate))) {
-      score += 18;
-      reasons.add("keyword match");
-    }
-    if (hasCandidate(category)) {
-      score += 12;
-      reasons.add("category term");
-    }
-    if (candidates.some((candidate) => setMatchesCandidates(platforms, [candidate]))) {
-      score += 20;
-      reasons.add("platform match");
-    }
-    if (candidates.some((candidate) => candidateMatchesText(candidate, haystack, words))) {
-      score += 4;
-    }
-    if (hasPrefixCandidate) score += 2;
-  }
-
-  if (isInstallable(entry)) {
-    score += 4;
-    reasons.add("installable");
-  }
-  if (entry.trustSignals?.sourceStatus === "available") {
-    score += 8;
-    reasons.add("source-backed");
-  }
-  if (entry.downloadTrust === "first-party" || entry.trustSignals?.packageVerified === true) {
-    score += 8;
-    reasons.add("trusted package");
-  }
-  if (hasSafetyNotes(entry)) {
-    score += 4;
-    reasons.add("safety notes");
-  }
-  if (hasPrivacyNotes(entry)) {
-    score += 4;
-    reasons.add("privacy notes");
-  }
-  if (entry.claimStatus === "verified" || entry.reviewedBy) {
-    score += 4;
-    reasons.add("reviewed");
-  }
-  for (const profile of matchingIntentProfiles(tokens)) {
-    const intent = scoreIntentProfile(entry, signals, profile);
-    score += intent.score;
-    for (const reason of intent.reasons) reasons.add(reason);
-  }
-
-  return {
-    score,
-    reasons: rankedSearchReasons(reasons),
-  };
+  return scoreRegistrySearchEntry(entry, query);
 }
 
 export function rankSearchEntries(
   entries: ReadonlyArray<SearchDocument>,
   query: string,
 ): RankedSearchEntry[] {
-  return entries
-    .map((entry, index) => ({
-      entry,
-      index,
-      ...scoreSearchEntry(entry, query),
-    }))
-    .sort((left, right) => {
-      if (left.score !== right.score) return right.score - left.score;
-      const dateDelta = String(right.entry.dateAdded ?? "").localeCompare(
-        String(left.entry.dateAdded ?? ""),
-      );
-      if (dateDelta !== 0) return dateDelta;
-      return left.index - right.index;
-    })
-    .map(({ entry, score, reasons }) => ({ entry, score, reasons }));
+  return rankRegistrySearchEntries(entries, query).map(({ entry, score, reasons }) => ({
+    entry,
+    score,
+    reasons,
+  }));
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heyclaude",
   "private": true,
-  "packageManager": "pnpm@11.4.0",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "8.5.0",
     "@heyclaude/registry": "workspace:*",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -50,6 +50,10 @@
       "types": "./src/remote-proxy.d.ts",
       "default": "./src/remote-proxy.js"
     },
+    "./search-ranking": {
+      "types": "./src/search-ranking.d.ts",
+      "default": "./src/search-ranking.js"
+    },
     "./platforms": {
       "types": "./src/platforms.d.ts",
       "default": "./src/platforms.js"

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -28,6 +28,18 @@ import {
   searchDuplicateEntries,
   validateSubmissionDraftFromSpec,
 } from "./submissions.js";
+import {
+  entryClaimStatusValue,
+  entryHasPrivacyNotes,
+  entryHasSafetyNotes,
+  entryPackageTrustValue,
+  entrySourceStatusValue,
+  matchesRegistryPlatform,
+  matchesRegistryQuery,
+  normalizedRegistrySearchText,
+  rankRegistrySearchEntries,
+  tokenizeRegistrySearchQuery,
+} from "./search-ranking.js";
 
 export * from "./schemas.js";
 
@@ -418,146 +430,23 @@ function normalizePlatform(value) {
 }
 
 function entryMatchesQuery(entry, query) {
-  if (!query) return true;
-  const haystack = [
-    entry.title,
-    entry.description,
-    entry.cardDescription,
-    entry.category,
-    entry.slug,
-    entry.author,
-    entry.submittedBy,
-    entry.brandName,
-    entry.brandDomain,
-    ...notes(entry.safetyNotes),
-    ...notes(entry.privacyNotes),
-    ...(entry.tags || []),
-    ...(entry.keywords || []),
-  ]
-    .map(normalizeText)
-    .join(" ");
-  return haystack.includes(query);
+  return matchesRegistryQuery(entry, query);
 }
 
 function searchTokens(query) {
-  return normalizeText(query)
-    .split(/[^a-z0-9+#.-]+/i)
-    .map((token) => token.trim())
-    .filter((token) => token.length >= 2)
-    .slice(0, 12);
+  return tokenizeRegistrySearchQuery(query);
 }
 
 function entrySearchText(entry) {
-  return [
-    entry.title,
-    entry.description,
-    entry.cardDescription,
-    entry.category,
-    entry.slug,
-    entry.author,
-    entry.submittedBy,
-    entry.brandName,
-    entry.brandDomain,
-    ...notes(entry.safetyNotes),
-    ...notes(entry.privacyNotes),
-    ...(entry.tags || []),
-    ...(entry.keywords || []),
-  ]
-    .map(normalizeText)
-    .join(" ")
-    .toLowerCase();
-}
-
-function scoreSearchEntry(entry, query) {
-  const normalizedQuery = normalizeText(query);
-  const tokens = searchTokens(normalizedQuery);
-  if (!tokens.length) return { score: 0, reasons: [] };
-
-  const title = normalizeText(entry.title);
-  const category = normalizeText(entry.category);
-  const tags = new Set((entry.tags || []).map(normalizeText));
-  const keywords = new Set((entry.keywords || []).map(normalizeText));
-  const haystack = entrySearchText(entry);
-  const reasons = new Set();
-  let score = 0;
-
-  if (title.includes(normalizedQuery)) {
-    score += 90;
-    reasons.add("title phrase");
-  }
-  if (category === normalizedQuery) {
-    score += 45;
-    reasons.add("category match");
-  }
-
-  for (const token of tokens) {
-    if (title.includes(token)) {
-      score += 35;
-      reasons.add("title term");
-    }
-    if (tags.has(token)) {
-      score += 24;
-      reasons.add("tag match");
-    }
-    if (keywords.has(token)) {
-      score += 18;
-      reasons.add("keyword match");
-    }
-    if (category.includes(token)) {
-      score += 12;
-      reasons.add("category term");
-    }
-    if (haystack.includes(token)) score += 4;
-  }
-
-  if (entrySourceStatus(entry) === "available") {
-    score += 8;
-    reasons.add("source-backed");
-  }
-  if (
-    entryPackageTrust(entry) === "first-party" ||
-    entry.packageVerified ||
-    entry.trustSignals?.packageVerified
-  ) {
-    score += 8;
-    reasons.add("trusted package");
-  }
-  if (notes(entry.safetyNotes).length) {
-    score += 4;
-    reasons.add("safety notes");
-  }
-  if (notes(entry.privacyNotes).length) {
-    score += 4;
-    reasons.add("privacy notes");
-  }
-  if (entry.claimStatus === "verified" || entry.reviewedBy) {
-    score += 4;
-    reasons.add("reviewed");
-  }
-
-  return { score, reasons: [...reasons].slice(0, 6) };
+  return normalizedRegistrySearchText(entry);
 }
 
 function rankSearchEntries(entries, query) {
-  return entries
-    .map((entry, index) => ({
-      entry,
-      index,
-      ...scoreSearchEntry(entry, query),
-    }))
-    .sort((left, right) => {
-      if (left.score !== right.score) return right.score - left.score;
-      const dateCompare = String(right.entry.dateAdded || "").localeCompare(
-        String(left.entry.dateAdded || ""),
-      );
-      if (dateCompare !== 0) return dateCompare;
-      return left.index - right.index;
-    });
+  return rankRegistrySearchEntries(entries, query);
 }
 
 function entryMatchesPlatform(entry, platform) {
-  if (!platform) return true;
-  return (entry.platforms || []).some((candidate) => candidate === platform);
+  return matchesRegistryPlatform(entry, platform);
 }
 
 function entryMatchesTag(entry, tag) {
@@ -573,40 +462,23 @@ function booleanFilterMatches(value, filter = "all") {
 }
 
 function entryPackageTrust(entry) {
-  return entry.downloadTrust || (entry.downloadUrl ? "external" : "none");
+  return entryPackageTrustValue(entry);
 }
 
 function entryClaimStatus(entry) {
-  return entry.claimStatus || "unclaimed";
+  return entryClaimStatusValue(entry);
 }
 
 function entrySourceStatus(entry) {
-  const sourceUrls = [
-    entry.documentationUrl,
-    entry.repoUrl,
-    entry.githubUrl,
-    entry.sourceUrl,
-  ].filter((value) => String(value || "").trim());
-  return (
-    entry.trustSignals?.sourceStatus ||
-    (sourceUrls.length ? "available" : "missing")
-  );
+  return entrySourceStatusValue(entry);
 }
 
 function entryMatchesTrustFilters(entry, args = {}) {
-  if (
-    !booleanFilterMatches(
-      notes(entry.safetyNotes).length > 0,
-      args.hasSafetyNotes,
-    )
-  ) {
+  if (!booleanFilterMatches(entryHasSafetyNotes(entry), args.hasSafetyNotes)) {
     return false;
   }
   if (
-    !booleanFilterMatches(
-      notes(entry.privacyNotes).length > 0,
-      args.hasPrivacyNotes,
-    )
+    !booleanFilterMatches(entryHasPrivacyNotes(entry), args.hasPrivacyNotes)
   ) {
     return false;
   }

--- a/packages/mcp/src/search-ranking.d.ts
+++ b/packages/mcp/src/search-ranking.d.ts
@@ -1,0 +1,84 @@
+export type RegistrySearchDocumentLike = {
+  category?: string;
+  slug?: string;
+  title?: string;
+  description?: string;
+  cardDescription?: string;
+  author?: string;
+  submittedBy?: string;
+  brandName?: string;
+  brandDomain?: string;
+  verificationStatus?: string;
+  downloadTrust?: "first-party" | "external" | "none" | string | null;
+  trust?: string;
+  source?: string;
+  safetyNotes?: string | string[];
+  privacyNotes?: string | string[];
+  platforms?: string[];
+  supportLevels?: string[];
+  mcpInstallTargets?: string[];
+  tags?: string[];
+  keywords?: string[];
+  installable?: boolean;
+  downloadUrl?: string;
+  installCommand?: string;
+  configSnippet?: string;
+  claimStatus?: string;
+  reviewedBy?: string;
+  documentationUrl?: string;
+  docsUrl?: string;
+  repoUrl?: string;
+  githubUrl?: string;
+  sourceUrl?: string;
+  dateAdded?: string;
+  trustSignals?: {
+    hasSafetyNotes?: boolean;
+    hasPrivacyNotes?: boolean;
+    packageVerified?: boolean;
+    sourceStatus?: string;
+  };
+};
+
+export type RankedRegistrySearchEntry<T extends RegistrySearchDocumentLike> = {
+  entry: T;
+  index: number;
+  score: number;
+  reasons: string[];
+};
+
+export function normalizeRegistrySearchQuery(query: unknown): string;
+export function tokenizeRegistrySearchQuery(query: unknown): string[];
+export function normalizeRegistryPlatform(value: unknown): string;
+export function normalizedRegistrySearchText(
+  entry: RegistrySearchDocumentLike,
+): string;
+export function matchesRegistryQuery(
+  entry: RegistrySearchDocumentLike,
+  query: unknown,
+): boolean;
+export function matchesRegistryPlatform(
+  entry: RegistrySearchDocumentLike,
+  platform: unknown,
+): boolean;
+export function entryHasSafetyNotes(entry: RegistrySearchDocumentLike): boolean;
+export function entryHasPrivacyNotes(
+  entry: RegistrySearchDocumentLike,
+): boolean;
+export function entryIsInstallable(entry: RegistrySearchDocumentLike): boolean;
+export function entryPackageTrustValue(
+  entry: RegistrySearchDocumentLike,
+): string;
+export function entrySourceStatusValue(
+  entry: RegistrySearchDocumentLike,
+): string;
+export function entryClaimStatusValue(
+  entry: RegistrySearchDocumentLike,
+): string;
+export function scoreRegistrySearchEntry(
+  entry: RegistrySearchDocumentLike,
+  query: unknown,
+): { score: number; reasons: string[] };
+export function rankRegistrySearchEntries<T extends RegistrySearchDocumentLike>(
+  entries: ReadonlyArray<T>,
+  query: unknown,
+): RankedRegistrySearchEntry<T>[];

--- a/packages/mcp/src/search-ranking.js
+++ b/packages/mcp/src/search-ranking.js
@@ -1,0 +1,550 @@
+const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+const MAX_QUERY_LENGTH = 256;
+const MAX_QUERY_TOKENS = 12;
+
+const QUERY_ALIASES = {
+  automation: ["automate", "automated", "qa", "testing"],
+  browser: ["chrome", "playwright", "web"],
+  cc: ["claude", "claude-code"],
+  claude: ["claude-code"],
+  design: ["ux", "ui"],
+  gh: ["github"],
+  ms: ["microsoft"],
+  mcp: ["model-context-protocol"],
+  msteams: ["teams", "microsoft-teams"],
+  repo: ["repository", "github"],
+  repos: ["repository", "github"],
+  safe: ["safety", "security", "secure", "trust", "privacy"],
+  security: ["safe", "safety", "secure", "trust"],
+  skill: ["skills"],
+  skills: ["skill"],
+  statusline: ["statuslines", "status"],
+  statuslines: ["statusline", "status"],
+};
+
+const PLATFORM_ALIASES = new Map([
+  ["claude", "claude-code"],
+  ["claude-code", "claude-code"],
+  ["claude-desktop", "claude-desktop"],
+  ["codex", "codex"],
+  ["openai", "codex"],
+  ["windsurf", "windsurf"],
+  ["gemini", "gemini"],
+  ["cursor", "cursor"],
+  ["cursor-rules", "cursor"],
+  ["vscode", "vscode"],
+  ["vs-code", "vscode"],
+  ["raycast", "raycast"],
+  ["aider", "aider"],
+  ["zed", "zed"],
+  ["continue", "continue"],
+  ["cli", "cli"],
+  ["generic-agents", "cli"],
+  ["agents", "cli"],
+  ["agents-context", "cli"],
+  ["agents-md", "cli"],
+]);
+
+const QUERY_INTENT_PROFILES = [
+  {
+    id: "code review",
+    tokens: ["code", "review"],
+    categories: ["agents", "commands", "tools", "skills"],
+    tags: ["code-review", "review", "pull-request", "quality"],
+    keywords: ["code review", "code-review", "pr review", "repository review"],
+    titleTerms: ["code review", "review"],
+    trustWeighted: true,
+  },
+  {
+    id: "browser automation",
+    tokens: ["browser", "automation"],
+    categories: ["mcp", "agents", "tools", "guides"],
+    platforms: ["claude-code"],
+    tags: [
+      "browser-automation",
+      "browser",
+      "chrome",
+      "playwright",
+      "web-testing",
+    ],
+    keywords: [
+      "browser automation",
+      "playwright",
+      "chrome",
+      "web qa",
+      "screenshots",
+    ],
+    titleTerms: ["browser automation", "browser", "playwright", "chrome"],
+    trustWeighted: true,
+  },
+  {
+    id: "safe mcp",
+    tokens: ["safe", "mcp"],
+    categories: ["mcp", "guides", "skills"],
+    tags: ["security", "safety", "privacy", "least-privilege", "trust", "mcp"],
+    keywords: ["safe mcp", "mcp security", "least privilege", "trust review"],
+    titleTerms: ["mcp security", "safe mcp", "trust"],
+    trustWeighted: true,
+  },
+  {
+    id: "design skill",
+    tokens: ["design", "skill"],
+    categories: ["skills", "agents", "rules"],
+    tags: ["design", "ux", "ui", "frontend", "visual-qa"],
+    keywords: ["design skill", "ux", "ui", "frontend design", "visual qa"],
+    titleTerms: ["design", "ux", "ui"],
+  },
+  {
+    id: "statusline",
+    tokens: ["statusline"],
+    categories: ["statuslines"],
+    tags: ["statusline", "monitoring", "observability", "context", "usage"],
+    keywords: ["statusline", "claude code statusline", "workflow visibility"],
+    titleTerms: ["statusline"],
+    trustWeighted: true,
+  },
+  {
+    id: "raycast",
+    tokens: ["raycast"],
+    platforms: ["raycast"],
+    tags: ["raycast", "launcher", "extension", "productivity"],
+    keywords: ["raycast", "raycast extension", "launcher"],
+    titleTerms: ["raycast"],
+    trustWeighted: true,
+  },
+];
+
+const SEARCH_REASON_PRIORITY = [
+  "query intent",
+  "title phrase",
+  "slug phrase",
+  "intent title",
+  "intent tag",
+  "intent keyword",
+  "intent category",
+  "trust intent",
+  "source-backed",
+  "trusted package",
+  "safety notes",
+  "privacy notes",
+  "title term",
+  "slug term",
+  "tag match",
+  "keyword match",
+  "category match",
+  "category term",
+  "platform match",
+  "installable",
+  "reviewed",
+];
+
+function text(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+function textValues(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item || "").trim()).filter(Boolean);
+  }
+  const normalized = String(value || "").trim();
+  return normalized ? [normalized] : [];
+}
+
+function hasTextLikeValue(value) {
+  return textValues(value).length > 0;
+}
+
+function expandedTokenCandidates(token) {
+  return [token, ...(QUERY_ALIASES[token] ?? [])];
+}
+
+function expandedTokenSet(tokens) {
+  return new Set(tokens.flatMap((token) => expandedTokenCandidates(token)));
+}
+
+function normalizedSet(values) {
+  return new Set((values ?? []).map((value) => text(value)).filter(Boolean));
+}
+
+function wordSet(value) {
+  return new Set(
+    text(value)
+      .split(TOKEN_SPLIT_PATTERN)
+      .map((word) => word.trim().toLowerCase())
+      .filter(Boolean),
+  );
+}
+
+function candidateMatchesText(candidate, haystack, words) {
+  if (candidate.length <= 2) {
+    return [...words].some(
+      (word) => word === candidate || word.startsWith(candidate),
+    );
+  }
+  return (
+    haystack.includes(candidate) ||
+    [...words].some((word) => word.startsWith(candidate))
+  );
+}
+
+function valueMatchesCandidate(value, candidate) {
+  return candidateMatchesText(candidate, value, wordSet(value));
+}
+
+function setMatchesCandidates(values, candidates) {
+  return [...values].some((value) =>
+    candidates.some((candidate) => valueMatchesCandidate(value, candidate)),
+  );
+}
+
+function matchingIntentProfiles(tokens) {
+  const candidates = expandedTokenSet(tokens);
+  return QUERY_INTENT_PROFILES.filter((profile) =>
+    profile.tokens.every((token) => candidates.has(token)),
+  );
+}
+
+function sourceUrls(entry) {
+  return [
+    entry.documentationUrl,
+    entry.docsUrl,
+    entry.repoUrl,
+    entry.githubUrl,
+    entry.sourceUrl,
+  ].filter((value) => String(value || "").trim());
+}
+
+function buildEntrySearchSignals(entry) {
+  const haystack = normalizedRegistrySearchText(entry);
+  return {
+    title: text(entry.title),
+    slug: text(entry.slug),
+    category: text(entry.category),
+    tags: normalizedSet(entry.tags),
+    keywords: normalizedSet(entry.keywords),
+    platforms: normalizedSet(entry.platforms),
+    haystack,
+    words: wordSet(haystack),
+  };
+}
+
+function scoreIntentProfile(entry, signals, profile) {
+  let score = 0;
+  const reasons = new Set();
+  const titleTerms = profile.titleTerms ?? [];
+
+  if (profile.categories?.includes(signals.category)) {
+    score += 28;
+    reasons.add("intent category");
+  }
+  if (
+    profile.platforms &&
+    setMatchesCandidates(signals.platforms, profile.platforms)
+  ) {
+    score += 24;
+    reasons.add("platform match");
+  }
+  if (profile.tags && setMatchesCandidates(signals.tags, profile.tags)) {
+    score += 26;
+    reasons.add("intent tag");
+  }
+  if (
+    profile.keywords &&
+    setMatchesCandidates(signals.keywords, profile.keywords)
+  ) {
+    score += 22;
+    reasons.add("intent keyword");
+  }
+  if (titleTerms.some((term) => valueMatchesCandidate(signals.title, term))) {
+    score += 24;
+    reasons.add("intent title");
+  }
+  if (profile.trustWeighted) {
+    let trustScore = 0;
+    if (entrySourceStatusValue(entry) === "available") trustScore += 8;
+    if (entryHasSafetyNotes(entry)) trustScore += 8;
+    if (entryHasPrivacyNotes(entry)) trustScore += 6;
+    if (
+      entryPackageTrustValue(entry) === "first-party" ||
+      entry.trustSignals?.packageVerified
+    ) {
+      trustScore += 6;
+    }
+    score += trustScore;
+    if (trustScore > 0) reasons.add("trust intent");
+  }
+  if (score > 0) reasons.add("query intent");
+
+  return { score, reasons };
+}
+
+function rankedSearchReasons(reasons) {
+  const priority = new Map(
+    SEARCH_REASON_PRIORITY.map((reason, index) => [reason, index]),
+  );
+  return [...reasons]
+    .sort(
+      (left, right) =>
+        (priority.get(left) ?? 999) - (priority.get(right) ?? 999),
+    )
+    .slice(0, 12);
+}
+
+export function normalizeRegistrySearchQuery(query) {
+  return String(query || "")
+    .slice(0, MAX_QUERY_LENGTH)
+    .trim()
+    .toLowerCase();
+}
+
+export function tokenizeRegistrySearchQuery(query) {
+  const normalized = normalizeRegistrySearchQuery(query);
+  const tokens = [];
+  let token = "";
+
+  for (
+    let index = 0;
+    index < normalized.length && tokens.length < MAX_QUERY_TOKENS;
+    index += 1
+  ) {
+    const char = normalized[index];
+    if (/[a-z0-9+#.-]/i.test(char)) {
+      token += char.toLowerCase();
+      continue;
+    }
+
+    if (token.length >= 2) tokens.push(token);
+    token = "";
+  }
+
+  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
+  return tokens;
+}
+
+export function normalizeRegistryPlatform(value) {
+  const normalized = text(value).replace(/[^a-z0-9]+/g, "-");
+  if (!normalized) return "";
+  return PLATFORM_ALIASES.get(normalized) || String(value || "").trim();
+}
+
+export function normalizedRegistrySearchText(entry) {
+  const mcpInstallTargets = entry?.mcpInstallTargets;
+  return [
+    entry?.category,
+    entry?.slug,
+    entry?.title,
+    entry?.description,
+    entry?.cardDescription,
+    entry?.author,
+    entry?.submittedBy,
+    entry?.brandName,
+    entry?.brandDomain,
+    entry?.verificationStatus,
+    entry?.downloadTrust,
+    entry?.trust,
+    entry?.source,
+    ...textValues(entry?.safetyNotes),
+    ...textValues(entry?.privacyNotes),
+    ...(entry?.platforms ?? []),
+    ...(entry?.supportLevels ?? []),
+    ...(mcpInstallTargets ?? []),
+    ...(entry?.tags ?? []),
+    ...(entry?.keywords ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+export function matchesRegistryQuery(entry, query) {
+  const normalizedQuery = normalizeRegistrySearchQuery(query);
+  if (!normalizedQuery) return true;
+  const tokens = tokenizeRegistrySearchQuery(normalizedQuery);
+  if (!tokens.length) return false;
+
+  const haystack = normalizedRegistrySearchText(entry);
+  const words = wordSet(haystack);
+  if (
+    normalizedQuery.length > 2
+      ? haystack.includes(normalizedQuery)
+      : candidateMatchesText(normalizedQuery, haystack, words)
+  ) {
+    return true;
+  }
+  return tokens.every((token) =>
+    expandedTokenCandidates(token).some((candidate) =>
+      candidateMatchesText(candidate, haystack, words),
+    ),
+  );
+}
+
+export function matchesRegistryPlatform(entry, platform) {
+  const target = normalizeRegistryPlatform(platform);
+  if (!target) return true;
+  return (entry?.platforms ?? []).some((item) => text(item) === text(target));
+}
+
+export function entryHasSafetyNotes(entry) {
+  return Boolean(
+    entry?.trustSignals?.hasSafetyNotes || hasTextLikeValue(entry?.safetyNotes),
+  );
+}
+
+export function entryHasPrivacyNotes(entry) {
+  return Boolean(
+    entry?.trustSignals?.hasPrivacyNotes ||
+    hasTextLikeValue(entry?.privacyNotes),
+  );
+}
+
+export function entryIsInstallable(entry) {
+  return Boolean(
+    entry?.installable ||
+    entry?.downloadUrl ||
+    entry?.installCommand ||
+    entry?.configSnippet,
+  );
+}
+
+export function entryPackageTrustValue(entry) {
+  return entry?.downloadTrust || (entry?.downloadUrl ? "external" : "none");
+}
+
+export function entrySourceStatusValue(entry) {
+  return (
+    entry?.trustSignals?.sourceStatus ||
+    (sourceUrls(entry ?? {}).length ? "available" : "missing")
+  );
+}
+
+export function entryClaimStatusValue(entry) {
+  return entry?.claimStatus || "unclaimed";
+}
+
+export function scoreRegistrySearchEntry(entry, query) {
+  const normalizedQuery = normalizeRegistrySearchQuery(query);
+  const tokens = tokenizeRegistrySearchQuery(normalizedQuery);
+  if (!tokens.length) return { score: 0, reasons: [] };
+
+  const signals = buildEntrySearchSignals(entry);
+  let score = 0;
+  const reasons = new Set();
+
+  if (signals.title.includes(normalizedQuery)) {
+    score += 90;
+    reasons.add("title phrase");
+  }
+  if (signals.slug.includes(normalizedQuery)) {
+    score += 65;
+    reasons.add("slug phrase");
+  }
+  if (signals.category === normalizedQuery) {
+    score += 45;
+    reasons.add("category match");
+  }
+
+  for (const token of tokens) {
+    const candidates = expandedTokenCandidates(token);
+    const hasCandidate = (value) =>
+      candidates.some((candidate) =>
+        candidateMatchesText(candidate, value, wordSet(value)),
+      );
+    const hasPrefixCandidate = [...signals.words].some((word) =>
+      candidates.some((candidate) => word.startsWith(candidate)),
+    );
+
+    if (hasCandidate(signals.title)) {
+      score += 35;
+      reasons.add("title term");
+    }
+    if (hasCandidate(signals.slug)) {
+      score += 28;
+      reasons.add("slug term");
+    }
+    if (candidates.some((candidate) => signals.tags.has(candidate))) {
+      score += 24;
+      reasons.add("tag match");
+    }
+    if (candidates.some((candidate) => signals.keywords.has(candidate))) {
+      score += 18;
+      reasons.add("keyword match");
+    }
+    if (hasCandidate(signals.category)) {
+      score += 12;
+      reasons.add("category term");
+    }
+    if (
+      candidates.some((candidate) =>
+        setMatchesCandidates(signals.platforms, [candidate]),
+      )
+    ) {
+      score += 20;
+      reasons.add("platform match");
+    }
+    if (
+      candidates.some((candidate) =>
+        candidateMatchesText(candidate, signals.haystack, signals.words),
+      )
+    ) {
+      score += 4;
+    }
+    if (hasPrefixCandidate) score += 2;
+  }
+
+  if (entryIsInstallable(entry)) {
+    score += 4;
+    reasons.add("installable");
+  }
+  if (entrySourceStatusValue(entry) === "available") {
+    score += 8;
+    reasons.add("source-backed");
+  }
+  if (
+    entryPackageTrustValue(entry) === "first-party" ||
+    entry?.trustSignals?.packageVerified
+  ) {
+    score += 8;
+    reasons.add("trusted package");
+  }
+  if (entryHasSafetyNotes(entry)) {
+    score += 4;
+    reasons.add("safety notes");
+  }
+  if (entryHasPrivacyNotes(entry)) {
+    score += 4;
+    reasons.add("privacy notes");
+  }
+  if (entryClaimStatusValue(entry) === "verified" || entry?.reviewedBy) {
+    score += 4;
+    reasons.add("reviewed");
+  }
+  for (const profile of matchingIntentProfiles(tokens)) {
+    const intent = scoreIntentProfile(entry, signals, profile);
+    score += intent.score;
+    for (const reason of intent.reasons) reasons.add(reason);
+  }
+
+  return {
+    score,
+    reasons: rankedSearchReasons(reasons),
+  };
+}
+
+export function rankRegistrySearchEntries(entries, query) {
+  return entries
+    .map((entry, index) => ({
+      entry,
+      index,
+      ...scoreRegistrySearchEntry(entry, query),
+    }))
+    .sort((left, right) => {
+      if (left.score !== right.score) return right.score - left.score;
+      const dateDelta = String(right.entry?.dateAdded ?? "").localeCompare(
+        String(left.entry?.dateAdded ?? ""),
+      );
+      if (dateDelta !== 0) return dateDelta;
+      return left.index - right.index;
+    });
+}

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -668,7 +668,9 @@ describe("HeyClaude read-only MCP helpers", () => {
     });
     expect(result.entries.length).toBeGreaterThan(0);
     expect(result.entries.length).toBeLessThanOrEqual(5);
-    expect(result.entries[0].platforms).toContain("cursor");
+    expect(
+      result.entries[0].platforms.map((value) => value.toLowerCase()),
+    ).toContain("cursor");
     expect(result.entries[0]).toMatchObject({
       searchScore: expect.any(Number),
       searchReasons: expect.any(Array),
@@ -1302,7 +1304,9 @@ describe("HeyClaude read-only MCP helpers", () => {
       dateAdded: expect.any(String),
     });
     expect(result.entries[0].tags).toContain("evals");
-    expect(result.entries[0].platforms).toContain("cursor");
+    expect(
+      result.entries[0].platforms.map((value) => value.toLowerCase()),
+    ).toContain("cursor");
   });
 
   it("lists recent updates from generated registry metadata", async () => {


### PR DESCRIPTION
## Summary
- Shares registry search ranking and matching between the web API and MCP package.

## What changed
- Added a publishable `@heyclaude/mcp/search-ranking` export for query parsing, matching, ranking, and trust/platform helpers.
- Updated MCP registry search to use the shared ranking helpers.
- Replaced duplicated web registry search filter logic with typed wrappers around the shared helper.

## Why
- The web API and MCP search paths had overlapping ranking logic that could drift. Sharing the implementation keeps query behavior consistent and easier to tune.

## Validation
- `pnpm exec vitest run tests/registry-search-api.test.ts tests/registry-search-query-bounds.test.ts tests/registry-search-facets.test.ts`
- `pnpm exec vitest run tests/mcp-server.test.ts`
- `pnpm test:mcp`
- `pnpm validate:openapi`
- `pnpm --filter @heyclaude/mcp pack --dry-run --json`
- `pnpm validate:mcp-package`
- `pnpm --filter web type-check`
- `git diff --check`

## Notes
- Refs #487.
