### PR TITLE
feat(discovery): add browse trust signal chips

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -422,6 +422,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     codeBlocks: entry.codeBlocks,
     downloadSha256: entry.downloadSha256 ?? undefined,
     downloadUrl: entry.downloadUrl || undefined,
+    downloadTrust: entry.downloadTrust ?? undefined,
     packageVerified: entry.packageVerified,
     commandSyntax: typeof entry.commandSyntax === "string" ? entry.commandSyntax : undefined,
     argumentHint: entry.argumentHint,

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -173,7 +173,7 @@ function hasPrivacyNotes(entry: Entry) {
 }
 
 function hasSourceBackedSignal(entry: Entry) {
-  return entry.source !== "unverified" || entry.trustSignals?.sourceStatus === "available";
+  return entry.source === "source-backed" || entry.trustSignals?.sourceStatus === "available";
 }
 
 function hasTrustedPackageSignal(entry: Entry) {

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -15,10 +15,22 @@ export interface SearchFilters {
   platforms?: Platform[];
   trust?: TrustLevel[];
   source?: SourceStatus[];
+  signal?: TrustSignalFilter | "";
   installable?: boolean;
   hasSafetyNotes?: boolean;
   sort?: "popular" | "newest" | "title";
 }
+
+export const TRUST_SIGNAL_FILTERS = [
+  "safety-notes",
+  "privacy-notes",
+  "source-backed",
+  "trusted-package",
+  "reviewed",
+  "checksums",
+] as const;
+
+export type TrustSignalFilter = (typeof TRUST_SIGNAL_FILTERS)[number];
 
 const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
 const MAX_QUERY_LENGTH = 256;
@@ -179,15 +191,57 @@ export function matchesSearchFilters(entry: Entry, filters: SearchFilters = {}) 
     return false;
   if (filters.trust?.length && !filters.trust.includes(entry.trust)) return false;
   if (filters.source?.length && !filters.source.includes(entry.source)) return false;
+  if (filters.signal && !entryMatchesTrustSignal(entry, filters.signal)) return false;
   if (filters.installable && !entry.installCommand && !entry.configSnippet && !entry.fullCopy)
     return false;
-  if (filters.hasSafetyNotes && !entry.safetyNotes) return false;
+  if (filters.hasSafetyNotes && !hasSafetyNotes(entry)) return false;
   if (prepared.queryProfile && !matchesEntryQueryProfile(entry, prepared.queryProfile))
     return false;
   if (prepared.q && prepared.queryProfile === null) return false;
   if (filters.q && prepared.queryProfile === undefined && !matchesEntryQuery(entry, filters.q))
     return false;
   return true;
+}
+
+function hasSafetyNotes(entry: Entry) {
+  return Boolean(entry.safetyNotes || entry.trustSignals?.hasSafetyNotes);
+}
+
+function hasPrivacyNotes(entry: Entry) {
+  return Boolean(entry.privacyNotes || entry.trustSignals?.hasPrivacyNotes);
+}
+
+function hasSourceBackedSignal(entry: Entry) {
+  return entry.source !== "unverified" || entry.trustSignals?.sourceStatus === "available";
+}
+
+function hasTrustedPackageSignal(entry: Entry) {
+  return Boolean(
+    entry.packageVerified ||
+    entry.downloadTrust === "first-party" ||
+    entry.trustSignals?.packageVerified ||
+    entry.trustSignals?.packageTrust === "first-party",
+  );
+}
+
+function hasReviewedSignal(entry: Entry) {
+  return Boolean(
+    entry.reviewed || entry.reviewedBy || entry.claimed || entry.claimStatus === "verified",
+  );
+}
+
+function hasChecksumSignal(entry: Entry) {
+  return Boolean(entry.downloadSha256 || entry.trustSignals?.checksumPresent);
+}
+
+export function entryMatchesTrustSignal(entry: Entry, signal: TrustSignalFilter) {
+  if (signal === "safety-notes") return hasSafetyNotes(entry);
+  if (signal === "privacy-notes") return hasPrivacyNotes(entry);
+  if (signal === "source-backed") return hasSourceBackedSignal(entry);
+  if (signal === "trusted-package") return hasTrustedPackageSignal(entry);
+  if (signal === "reviewed") return hasReviewedSignal(entry);
+  if (signal === "checksums") return hasChecksumSignal(entry);
+  return false;
 }
 
 export function filterSearchEntries(filters: SearchFilters = {}, entries: Entry[] = ENTRIES) {

--- a/apps/web/src/lib/recents.tsx
+++ b/apps/web/src/lib/recents.tsx
@@ -28,6 +28,7 @@ export interface SavedSearch {
   category?: string;
   trust?: string;
   source?: string;
+  signal?: string;
   platform?: string;
   sort?: string;
   savedAt: string;

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -11,7 +11,13 @@ import { useMemo } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
-import { countSearchResults, normalizeSearchQuery, search } from "@/data/search";
+import {
+  countSearchResults,
+  normalizeSearchQuery,
+  search,
+  TRUST_SIGNAL_FILTERS,
+  type TrustSignalFilter,
+} from "@/data/search";
 import {
   CATEGORIES,
   type Category,
@@ -60,6 +66,7 @@ function SavedSearchChipRow({
         category: s.category ?? "",
         trust: s.trust ?? "",
         source: s.source ?? "",
+        signal: s.signal ?? "",
         platform: s.platform ?? "",
         sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
         view: "row" as const,
@@ -116,6 +123,7 @@ const defaultSearch = {
   category: "",
   trust: "",
   source: "",
+  signal: "",
   platform: "",
   sort: "popular" as const,
   view: "row" as const,
@@ -127,6 +135,7 @@ const searchSchema = z.object({
   category: z.string().catch(defaultSearch.category).default(defaultSearch.category),
   trust: z.string().catch(defaultSearch.trust).default(defaultSearch.trust),
   source: z.string().catch(defaultSearch.source).default(defaultSearch.source),
+  signal: z.string().catch(defaultSearch.signal).default(defaultSearch.signal),
   platform: z.string().catch(defaultSearch.platform).default(defaultSearch.platform),
   sort: z
     .enum(["popular", "newest", "title"])
@@ -144,10 +153,16 @@ export const Route = createFileRoute("/browse")({
   beforeLoad: ({ search }) => {
     // Stale/external links with unknown category values (e.g. ?category=plugins) render an
     // empty result set that Google flags as a soft 404. Redirect them to clean /browse.
-    if (search.category && !CATEGORIES.some((c) => c.id === search.category)) {
+    const invalidCategory = search.category && !CATEGORIES.some((c) => c.id === search.category);
+    const invalidSignal = search.signal && !isTrustSignalFilter(search.signal);
+    if (invalidCategory || invalidSignal) {
       throw redirect({
         to: "/browse",
-        search: { ...search, category: "" },
+        search: {
+          ...search,
+          category: invalidCategory ? "" : search.category,
+          signal: invalidSignal ? "" : search.signal,
+        },
         statusCode: 301,
         replace: true,
       });
@@ -183,6 +198,25 @@ const PLATFORM_IDS: Platform[] = [
   "cli",
   "raycast",
 ];
+const TRUST_SIGNAL_OPTIONS: { id: TrustSignalFilter; label: string }[] = [
+  { id: "safety-notes", label: "Safety notes" },
+  { id: "privacy-notes", label: "Privacy notes" },
+  { id: "source-backed", label: "Source-backed" },
+  { id: "trusted-package", label: "Trusted package" },
+  { id: "reviewed", label: "Reviewed" },
+  { id: "checksums", label: "Checksums" },
+];
+const TRUST_SIGNAL_LABEL = Object.fromEntries(
+  TRUST_SIGNAL_OPTIONS.map((option) => [option.id, option.label]),
+) as Record<TrustSignalFilter, string>;
+
+function isTrustSignalFilter(value: string): value is TrustSignalFilter {
+  return TRUST_SIGNAL_FILTERS.includes(value as TrustSignalFilter);
+}
+
+function signalLabel(value: string) {
+  return isTrustSignalFilter(value) ? TRUST_SIGNAL_LABEL[value] : "";
+}
 
 function Browse() {
   const sp = Route.useSearch();
@@ -240,6 +274,7 @@ function Browse() {
       categories: sp.category ? [sp.category as Category] : undefined,
       trust: sp.trust ? [sp.trust as TrustLevel] : undefined,
       source: sp.source ? [sp.source as SourceStatus] : undefined,
+      signal: isTrustSignalFilter(sp.signal) ? sp.signal : "",
       platforms: sp.platform ? [sp.platform as Platform] : undefined,
       sort: sp.sort,
     }),
@@ -283,6 +318,7 @@ function Browse() {
     Number(!!sp.category) +
     Number(!!sp.trust) +
     Number(!!sp.source) +
+    Number(!!sp.signal) +
     Number(!!sp.platform);
 
   const clearAll = () =>
@@ -292,6 +328,7 @@ function Browse() {
         category: "",
         trust: "",
         source: "",
+        signal: "",
         platform: "",
         sort: "popular",
         view: sp.view,
@@ -303,13 +340,14 @@ function Browse() {
     if (activeCount === 0) return;
     const label = sp.q
       ? `“${sp.q}”${sp.category ? ` · ${sp.category}` : ""}`
-      : `${sp.category || sp.trust || sp.source || sp.platform || "Filter"}`;
+      : `${sp.category || sp.trust || sp.source || signalLabel(sp.signal) || sp.platform || "Filter"}`;
     recents.saveSearch({
       label,
       q: sp.q,
       category: sp.category,
       trust: sp.trust,
       source: sp.source,
+      signal: sp.signal,
       platform: sp.platform,
       sort: sp.sort,
     });
@@ -321,19 +359,23 @@ function Browse() {
   const [shown, setShown] = React.useState(PAGE);
   React.useEffect(() => {
     setShown(PAGE);
-  }, [sp.q, sp.category, sp.trust, sp.source, sp.platform, sp.sort]);
+  }, [sp.q, sp.category, sp.trust, sp.source, sp.signal, sp.platform, sp.sort]);
 
   // Per-axis facet counts: how many results if this value were the only filter
   // in its axis. Memoized on the search params and counted without sorting so
   // sidebar counts do not pay for result ranking on every filter change.
   const facetCounts = useMemo(() => {
-    const countFor = (axis: "category" | "trust" | "source" | "platform", value: string) => {
+    const countFor = (
+      axis: "category" | "trust" | "source" | "signal" | "platform",
+      value: string,
+    ) => {
       const merged = { ...sp, [axis]: value } as typeof sp;
       return countSearchResults({
         q: merged.q,
         categories: merged.category ? [merged.category as Category] : undefined,
         trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
         source: merged.source ? [merged.source as SourceStatus] : undefined,
+        signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
         platforms: merged.platform ? [merged.platform as Platform] : undefined,
         sort: merged.sort,
       });
@@ -342,12 +384,17 @@ function Browse() {
       category: Object.fromEntries(CATEGORIES.map((c) => [c.id, countFor("category", c.id)])),
       trust: Object.fromEntries(TRUST_LEVELS.map((t) => [t, countFor("trust", t)])),
       source: Object.fromEntries(SOURCE_STATUSES.map((s) => [s, countFor("source", s)])),
+      signal: Object.fromEntries(
+        TRUST_SIGNAL_OPTIONS.map((option) => [option.id, countFor("signal", option.id)]),
+      ),
       platform: Object.fromEntries(PLATFORM_IDS.map((p) => [p, countFor("platform", p)])),
     } as Record<string, Record<string, number>>;
   }, [sp]);
 
-  const axisCount = (axis: "category" | "trust" | "source" | "platform", value: string) =>
-    facetCounts[axis]?.[value] ?? 0;
+  const axisCount = (
+    axis: "category" | "trust" | "source" | "signal" | "platform",
+    value: string,
+  ) => facetCounts[axis]?.[value] ?? 0;
 
   // Focus search on "/" key.
   const searchRef = React.useRef<HTMLInputElement>(null);
@@ -387,6 +434,13 @@ function Browse() {
       value: sp.source,
       onClear: () => set({ source: "" }),
     });
+  if (isTrustSignalFilter(sp.signal))
+    activeFilters.push({
+      key: "signal",
+      label: "Signal",
+      value: signalLabel(sp.signal),
+      onClear: () => set({ signal: "" }),
+    });
   if (sp.platform)
     activeFilters.push({
       key: "platform",
@@ -402,6 +456,8 @@ function Browse() {
     const trials: { label: string; patch: Partial<typeof sp> }[] = [];
     if (sp.platform)
       trials.push({ label: `Remove platform "${sp.platform}"`, patch: { platform: "" } });
+    if (sp.signal)
+      trials.push({ label: `Remove signal "${signalLabel(sp.signal)}"`, patch: { signal: "" } });
     if (sp.source) trials.push({ label: `Remove source "${sp.source}"`, patch: { source: "" } });
     if (sp.trust) trials.push({ label: `Remove trust "${sp.trust}"`, patch: { trust: "" } });
     if (sp.category) trials.push({ label: `Search all categories`, patch: { category: "" } });
@@ -414,6 +470,7 @@ function Browse() {
           categories: merged.category ? [merged.category as Category] : undefined,
           trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
           source: merged.source ? [merged.source as SourceStatus] : undefined,
+          signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
           platforms: merged.platform ? [merged.platform as Platform] : undefined,
           sort: merged.sort,
         });
@@ -627,11 +684,29 @@ function Browse() {
               currentLabel={
                 sp.q
                   ? `“${sp.q}”${sp.category ? ` · ${sp.category}` : ""}`
-                  : sp.category || sp.trust || sp.source || sp.platform || ""
+                  : sp.category ||
+                    sp.trust ||
+                    sp.source ||
+                    signalLabel(sp.signal) ||
+                    sp.platform ||
+                    ""
               }
               canSave={activeCount > 0}
               onSave={saveCurrent}
             />
+            <FilterChipGroup label="Trust signal quick filters" multi={false}>
+              {TRUST_SIGNAL_OPTIONS.map((option) => (
+                <FilterChip
+                  key={option.id}
+                  role="radio"
+                  active={sp.signal === option.id}
+                  onClick={() => set({ signal: sp.signal === option.id ? "" : option.id })}
+                  count={axisCount("signal", option.id)}
+                >
+                  {option.label}
+                </FilterChip>
+              ))}
+            </FilterChipGroup>
             <div className="hidden text-[10px] text-ink-subtle sm:block">
               <kbd className="rounded border border-border bg-surface px-1 font-mono">/</kbd> search
               · <kbd className="rounded border border-border bg-surface px-1 font-mono">[ ]</kbd>{" "}
@@ -714,6 +789,7 @@ function Browse() {
                               category: s.category ?? "",
                               trust: s.trust ?? "",
                               source: s.source ?? "",
+                              signal: s.signal ?? "",
                               platform: s.platform ?? "",
                               sort: (s.sort as typeof sp.sort) ?? "popular",
                               view: sp.view,

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -198,6 +198,7 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
   /** SHA-256 checksum for downloadable package, if any. */
   downloadSha256?: string;
   downloadUrl?: string;
+  downloadTrust?: string | null;
   packageVerified?: boolean;
   usageSnippet?: string;
   copySnippet?: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heyclaude",
   "private": true,
-  "packageManager": "pnpm@11.4.0",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "8.5.0",
     "@heyclaude/registry": "workspace:*",

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -112,6 +112,17 @@ describe("entry search filters", () => {
       slug: "source-backed",
       source: "source-backed",
     });
+    const sourceSignal = entry({
+      slug: "source-signal",
+      source: "external",
+      trustSignals: {
+        sourceStatus: "available",
+      },
+    });
+    const external = entry({
+      slug: "external",
+      source: "external",
+    });
     const disclosed = entry({
       slug: "disclosed",
       safetyNotes: "Runs local shell commands.",
@@ -137,14 +148,23 @@ describe("entry search filters", () => {
       reviewed: true,
       claimStatus: "verified",
     });
-    const entries = [sourceBacked, disclosed, packageEntry, reviewed];
+    const entries = [
+      sourceBacked,
+      sourceSignal,
+      external,
+      disclosed,
+      packageEntry,
+      reviewed,
+    ];
 
     expect(entryMatchesTrustSignal(disclosed, "safety-notes")).toBe(true);
+    expect(entryMatchesTrustSignal(external, "source-backed")).toBe(false);
     expect(filterSearchEntries({ signal: "privacy-notes" }, entries)).toEqual([
       disclosed,
     ]);
     expect(filterSearchEntries({ signal: "source-backed" }, entries)).toEqual([
       sourceBacked,
+      sourceSignal,
     ]);
     expect(filterSearchEntries({ signal: "trusted-package" }, entries)).toEqual(
       [packageEntry],

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   countSearchResults,
+  entryMatchesTrustSignal,
   filterSearchEntries,
   matchesEntryQuery,
   normalizeSearchQuery,
@@ -104,5 +105,53 @@ describe("entry search filters", () => {
 
     expect(filterSearchEntries(filters, entries)).toEqual([safetySkill]);
     expect(countSearchResults(filters, entries)).toBe(1);
+  });
+
+  it("filters entries by trust signal quick chips", () => {
+    const sourceBacked = entry({
+      slug: "source-backed",
+      source: "source-backed",
+    });
+    const disclosed = entry({
+      slug: "disclosed",
+      safetyNotes: "Runs local shell commands.",
+      privacyNotes: "Reads local project files.",
+      trustSignals: {
+        hasSafetyNotes: true,
+        hasPrivacyNotes: true,
+      },
+    });
+    const packageEntry = entry({
+      slug: "package",
+      downloadSha256: "abc123",
+      packageVerified: true,
+      downloadTrust: "first-party",
+      trustSignals: {
+        checksumPresent: true,
+        packageTrust: "first-party",
+        packageVerified: true,
+      },
+    });
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewed: true,
+      claimStatus: "verified",
+    });
+    const entries = [sourceBacked, disclosed, packageEntry, reviewed];
+
+    expect(entryMatchesTrustSignal(disclosed, "safety-notes")).toBe(true);
+    expect(filterSearchEntries({ signal: "privacy-notes" }, entries)).toEqual([
+      disclosed,
+    ]);
+    expect(filterSearchEntries({ signal: "source-backed" }, entries)).toEqual([
+      sourceBacked,
+    ]);
+    expect(filterSearchEntries({ signal: "trusted-package" }, entries)).toEqual(
+      [packageEntry],
+    );
+    expect(filterSearchEntries({ signal: "checksums" }, entries)).toEqual([
+      packageEntry,
+    ]);
+    expect(countSearchResults({ signal: "reviewed" }, entries)).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Adds trust-signal quick filters to the browse experience so safer/source-backed resources are easier to discover.

## What changed
- Added trust-signal filtering for safety notes, privacy notes, source-backed entries, reviewed entries, checksum-backed packages, and trusted packages.
- Added browse-page quick chips with live result counts and URL state support.
- Carried the selected trust signal through active filters, saved searches, suggestions, and reset behavior.

## Why
- Browse already had the underlying registry safety and provenance metadata, but users had to infer it from individual cards. Quick filters make the useful trust signals directly actionable.

## Validation
- `pnpm exec vitest run tests/search-query.test.ts tests/web-non-ui-utilities.test.ts tests/discovery-surfaces.test.ts`
- `pnpm --filter web type-check`
- `pnpm build`
- `git diff --check`

## Notes
- Refs #427.
