### PR TITLE
feat(contributors): surface attribution provenance

### DIFF
--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -1,5 +1,5 @@
 import { ENTRIES } from "@/data/entries";
-import type { Contributor } from "@/types/registry";
+import type { Category, Contributor, Entry } from "@/types/registry";
 
 export function contributorSlug(value: string) {
   return value
@@ -21,8 +21,65 @@ export function githubHandle(profileUrl?: string) {
   }
 }
 
+function identitySlugs(name?: string, profileUrl?: string) {
+  const slugs = new Set<string>();
+  const add = (value?: string) => {
+    if (!value) return;
+    const slug = contributorSlug(value);
+    if (slug) slugs.add(slug);
+  };
+
+  add(name);
+  add(githubHandle(profileUrl));
+  return slugs;
+}
+
+export function contributorMatchesIdentity(
+  contributor: Contributor,
+  name?: string,
+  profileUrl?: string,
+) {
+  const contributorSlugs = identitySlugs(contributor.name, contributor.github);
+  contributorSlugs.add(contributor.slug);
+  contributorSlugs.add(contributorSlug(contributor.handle));
+
+  const candidateSlugs = identitySlugs(name, profileUrl);
+  return [...candidateSlugs].some((slug) => contributorSlugs.has(slug));
+}
+
+export type ContributorAcceptedEntryRole = "submitted" | "authored" | "submitted-authored";
+
+export function contributorAcceptedEntryRole(
+  contributor: Contributor,
+  entry: Entry,
+): ContributorAcceptedEntryRole | undefined {
+  const submitted = contributorMatchesIdentity(
+    contributor,
+    entry.submittedBy,
+    entry.submittedByUrl,
+  );
+  const authored = contributorMatchesIdentity(contributor, entry.author);
+
+  if (submitted && authored) return "submitted-authored";
+  if (submitted) return "submitted";
+  if (authored) return "authored";
+  return undefined;
+}
+
+export function contributorReviewedEntry(contributor: Contributor, entry: Entry) {
+  return contributorMatchesIdentity(contributor, entry.reviewedBy);
+}
+
+type MutableContributor = Contributor & {
+  categoryCounts: Map<Category, number>;
+};
+
+function incrementCategory(contributor: MutableContributor, category: Category) {
+  contributor.categoryCounts.set(category, (contributor.categoryCounts.get(category) ?? 0) + 1);
+}
+
 export const CONTRIBUTORS: Contributor[] = (() => {
-  const grouped = new Map<string, Contributor>();
+  const grouped = new Map<string, MutableContributor>();
 
   for (const entry of ENTRIES) {
     const name = String(entry.submittedBy || entry.author || "JSONbored").trim();
@@ -40,17 +97,42 @@ export const CONTRIBUTORS: Contributor[] = (() => {
         github: profileUrl,
         bio: "Contributor credited on accepted HeyClaude registry entries.",
         acceptedCount: 0,
-      } satisfies Contributor);
+        reviewedCount: 0,
+        sourceSubmissionCount: 0,
+        categories: [],
+        categoryCounts: new Map<Category, number>(),
+      } satisfies MutableContributor);
 
     existing.acceptedCount += 1;
+    if (entry.sourceSubmissionUrl || entry.importPrUrl) {
+      existing.sourceSubmissionCount = (existing.sourceSubmissionCount ?? 0) + 1;
+    }
+    incrementCategory(existing, entry.category);
     existing.github ||= profileUrl;
     grouped.set(slug, existing);
   }
 
-  return [...grouped.values()].sort(
-    (left, right) =>
-      right.acceptedCount - left.acceptedCount || left.name.localeCompare(right.name),
-  );
+  for (const entry of ENTRIES) {
+    for (const contributor of grouped.values()) {
+      if (contributorReviewedEntry(contributor, entry)) {
+        contributor.reviewedCount = (contributor.reviewedCount ?? 0) + 1;
+      }
+    }
+  }
+
+  return [...grouped.values()]
+    .map(({ categoryCounts, ...contributor }) => ({
+      ...contributor,
+      categories: [...categoryCounts.entries()]
+        .map(([category, count]) => ({ category, count }))
+        .sort(
+          (left, right) => right.count - left.count || left.category.localeCompare(right.category),
+        ),
+    }))
+    .sort(
+      (left, right) =>
+        right.acceptedCount - left.acceptedCount || left.name.localeCompare(right.name),
+    );
 })();
 
 export function getContributor(slug: string) {

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -1,12 +1,29 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { ArrowUpRight, Github } from "lucide-react";
-import { getContributor, CONTRIBUTORS } from "@/data/contributors";
+import type { ElementType } from "react";
+import {
+  ArrowUpRight,
+  Calendar,
+  FileCheck2,
+  Github,
+  GitPullRequest,
+  Layers3,
+  ShieldCheck,
+  UserRound,
+} from "lucide-react";
+import {
+  contributorAcceptedEntryRole,
+  contributorReviewedEntry,
+  getContributor,
+  CONTRIBUTORS,
+  type ContributorAcceptedEntryRole,
+} from "@/data/contributors";
 import { ENTRIES } from "@/data/entries";
-import { ResourceCard } from "@/components/resource-card";
+import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { ogImageUrl } from "@/lib/og-image";
+import type { Category, Contributor, Entry } from "@/types/registry";
 
 export const Route = createFileRoute("/contributors/$slug")({
   loader: ({ params }) => {
@@ -79,10 +96,14 @@ export const Route = createFileRoute("/contributors/$slug")({
 
 function ContributorPage() {
   const { contributor } = Route.useLoaderData();
-  const entries = ENTRIES.filter(
-    (e) => e.author === contributor.handle || e.submittedBy === contributor.handle,
+  const acceptedEntries = ENTRIES.filter((entry) =>
+    contributorAcceptedEntryRole(contributor, entry),
   );
-  const reviewed = ENTRIES.filter((e) => e.reviewedBy === contributor.handle);
+  const reviewedEntries = ENTRIES.filter((entry) => contributorReviewedEntry(contributor, entry));
+  const categorySummaries = categoryBreakdown(acceptedEntries);
+  const sourceLinkedCount = acceptedEntries.filter(
+    (entry) => entry.sourceSubmissionUrl || entry.importPrUrl,
+  ).length;
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 py-12 sm:px-6">
@@ -106,9 +127,6 @@ function ContributorPage() {
             <span className="rounded-md border border-border bg-surface px-2 py-0.5 font-mono text-ink-muted">
               @{contributor.handle}
             </span>
-            <span className="rounded-md border border-border bg-surface px-2 py-0.5 text-ink-muted">
-              {contributor.acceptedCount} accepted
-            </span>
             {contributor.github && (
               <a
                 href={contributor.github}
@@ -123,32 +141,48 @@ function ContributorPage() {
         </div>
       </header>
 
-      <section className="mt-10">
-        <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-          Authored ({entries.length})
-        </h2>
-        {entries.length === 0 ? (
-          <p className="mt-3 text-sm text-ink-muted">No authored entries yet.</p>
-        ) : (
-          <div className="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-            {entries.map((e) => (
-              <ResourceCard key={`${e.category}-${e.slug}`} entry={e} variant="row" />
-            ))}
-          </div>
-        )}
-      </section>
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <ContributorStat icon={FileCheck2} label="Accepted" value={acceptedEntries.length} />
+        <ContributorStat icon={ShieldCheck} label="Reviewed" value={reviewedEntries.length} />
+        <ContributorStat icon={Layers3} label="Categories" value={categorySummaries.length} />
+        <ContributorStat icon={GitPullRequest} label="Source-linked" value={sourceLinkedCount} />
+      </div>
 
-      {reviewed.length > 0 && (
+      {categorySummaries.length > 0 && (
         <section className="mt-10">
           <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
-            Reviewed ({reviewed.length})
+            Category Credits
           </h2>
-          <div className="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
-            {reviewed.map((e) => (
-              <ResourceCard key={`r-${e.category}-${e.slug}`} entry={e} variant="row" />
+          <div className="mt-4 flex flex-wrap gap-2">
+            {categorySummaries.map((item) => (
+              <Link
+                key={item.category}
+                to="/$category"
+                params={{ category: item.category }}
+                className="inline-flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-1.5 text-sm text-ink-muted hover:border-border-strong hover:text-ink"
+              >
+                <CategoryPill>{item.category}</CategoryPill>
+                <span>{item.count}</span>
+              </Link>
             ))}
           </div>
         </section>
+      )}
+
+      <ContributionSection
+        title="Accepted Entries"
+        entries={acceptedEntries}
+        contributor={contributor}
+        empty="No accepted entries yet."
+      />
+
+      {reviewedEntries.length > 0 && (
+        <ContributionSection
+          title="Reviewed Entries"
+          entries={reviewedEntries}
+          contributor={contributor}
+          role="reviewed"
+        />
       )}
 
       <div className="mt-12 rounded-xl border border-border bg-surface p-6 text-sm text-ink-muted">
@@ -173,5 +207,204 @@ function ContributorPage() {
         ))}
       </div>
     </div>
+  );
+}
+
+function categoryBreakdown(entries: Entry[]) {
+  const counts = new Map<Category, number>();
+  for (const entry of entries) {
+    counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([category, count]) => ({ category, count }))
+    .sort((left, right) => right.count - left.count || left.category.localeCompare(right.category));
+}
+
+function ContributorStat({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: ElementType;
+  label: string;
+  value: number;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-surface p-4">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-ink-subtle">
+        <Icon className="h-3.5 w-3.5" aria-hidden />
+        {label}
+      </div>
+      <div className="mt-2 font-display text-2xl font-semibold text-ink tabular-nums">{value}</div>
+    </div>
+  );
+}
+
+function ContributionSection({
+  title,
+  entries,
+  contributor,
+  role,
+  empty,
+}: {
+  title: string;
+  entries: Entry[];
+  contributor: Contributor;
+  role?: "reviewed";
+  empty?: string;
+}) {
+  return (
+    <section className="mt-10">
+      <h2 className="font-display text-xl font-semibold tracking-tight text-ink">
+        {title} ({entries.length})
+      </h2>
+      {entries.length === 0 ? (
+        <p className="mt-3 text-sm text-ink-muted">{empty ?? "No entries yet."}</p>
+      ) : (
+        <div className="mt-4 divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface">
+          {entries.map((entry) => (
+            <ContributionRow
+              key={`${role ?? "accepted"}-${entry.category}-${entry.slug}`}
+              entry={entry}
+              contributor={contributor}
+              role={role ?? contributorAcceptedEntryRole(contributor, entry) ?? "authored"}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+type ContributionRole = ContributorAcceptedEntryRole | "reviewed";
+
+const roleLabel: Record<ContributionRole, string> = {
+  submitted: "Submitted",
+  authored: "Authored",
+  "submitted-authored": "Submitted + authored",
+  reviewed: "Reviewed",
+};
+
+const roleIcon: Record<ContributionRole, ElementType> = {
+  submitted: UserRound,
+  authored: FileCheck2,
+  "submitted-authored": FileCheck2,
+  reviewed: ShieldCheck,
+};
+
+function ContributionRow({
+  entry,
+  contributor,
+  role,
+}: {
+  entry: Entry;
+  contributor: Contributor;
+  role: ContributionRole;
+}) {
+  const RoleIcon = roleIcon[role];
+
+  return (
+    <article className="group px-4 py-4 transition-colors duration-200 hover:bg-surface-2 sm:px-6">
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2 py-0.5 text-[11px] font-medium text-ink-muted">
+          <RoleIcon className="h-3 w-3" aria-hidden />
+          {roleLabel[role]}
+        </span>
+        <CategoryPill>{entry.category}</CategoryPill>
+        <TrustBadge level={entry.trust} />
+        <SourceBadge status={entry.source} />
+      </div>
+
+      <div className="mt-3">
+        <Link
+          to="/entry/$category/$slug"
+          params={{ category: entry.category, slug: entry.slug }}
+          className="inline-flex max-w-full flex-wrap items-baseline gap-x-2"
+        >
+          <h3 className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline">
+            {entry.title}
+          </h3>
+          <span className="hidden text-xs text-ink-subtle sm:inline">by {entry.author}</span>
+        </Link>
+        <p className="mt-1 line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-subtle">
+        {entry.submittedBy && (
+          <span className="inline-flex items-center gap-1">
+            <UserRound className="h-3 w-3" aria-hidden />
+            submitted by{" "}
+            {entry.submittedByUrl ? (
+              <a
+                href={entry.submittedByUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-ink-muted hover:text-ink"
+              >
+                {entry.submittedBy}
+              </a>
+            ) : (
+              <span className="text-ink-muted">{entry.submittedBy}</span>
+            )}
+          </span>
+        )}
+        {entry.submittedAt && (
+          <span className="inline-flex items-center gap-1">
+            <Calendar className="h-3 w-3" aria-hidden />
+            {String(entry.submittedAt).slice(0, 10)}
+          </span>
+        )}
+        {entry.reviewedBy && (
+          <span className="inline-flex items-center gap-1">
+            <ShieldCheck className="h-3 w-3" aria-hidden />
+            reviewed by {entry.reviewedBy}
+            {entry.reviewedAt ? ` on ${String(entry.reviewedAt).slice(0, 10)}` : ""}
+          </span>
+        )}
+        {role === "authored" && (
+          <span className="inline-flex items-center gap-1 text-ink-subtle">
+            <FileCheck2 className="h-3 w-3" aria-hidden />
+            credited to {contributor.name}
+          </span>
+        )}
+      </div>
+
+      {(entry.sourceSubmissionUrl || entry.importPrUrl || entry.sourceUrl) && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+          {entry.sourceSubmissionUrl && (
+            <ExternalTraceLink href={entry.sourceSubmissionUrl} label="Original submission" />
+          )}
+          {entry.importPrUrl && (
+            <ExternalTraceLink href={entry.importPrUrl} label="Import PR" icon={GitPullRequest} />
+          )}
+          {entry.sourceUrl && (
+            <ExternalTraceLink href={entry.sourceUrl} label="Source" icon={ArrowUpRight} />
+          )}
+        </div>
+      )}
+    </article>
+  );
+}
+
+function ExternalTraceLink({
+  href,
+  label,
+  icon: Icon = ArrowUpRight,
+}: {
+  href: string;
+  label: string;
+  icon?: ElementType;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="inline-flex h-7 items-center gap-1 rounded-md border border-border bg-background px-2 text-ink-muted hover:border-border-strong hover:text-ink"
+    >
+      {label}
+      <Icon className="h-3 w-3" aria-hidden />
+    </a>
   );
 }

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -420,6 +420,11 @@ export interface Integration {
 
 /* -------- Contributor -------- */
 
+export interface ContributorCategorySummary {
+  category: Category;
+  count: number;
+}
+
 export interface Contributor {
   slug: string;
   handle: string;
@@ -428,6 +433,9 @@ export interface Contributor {
   bio?: string;
   github?: string;
   acceptedCount: number;
+  reviewedCount?: number;
+  sourceSubmissionCount?: number;
+  categories?: ContributorCategorySummary[];
 }
 
 /* -------- Changelog / artifact contracts -------- */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "heyclaude",
   "private": true,
-  "packageManager": "pnpm@11.4.0",
+  "packageManager": "pnpm@11.9.0",
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "8.5.0",
     "@heyclaude/registry": "workspace:*",

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -22,7 +22,10 @@ import { ENTRIES } from "../apps/web/src/data/entries";
 import { COMPARISONS } from "../apps/web/src/data/comparisons";
 import {
   CONTRIBUTORS,
+  contributorAcceptedEntryRole,
   contributorForVerifiedAuthor,
+  contributorMatchesIdentity,
+  contributorReviewedEntry,
   contributorSlug,
   getContributor,
   githubHandle,
@@ -615,6 +618,13 @@ describe("web non-UI utility coverage", () => {
     expect(getContributor(topContributor.slug)).toBe(topContributor);
     expect(topContributor.acceptedCount).toBeGreaterThan(0);
     expect(
+      topContributor.categories?.reduce((sum, item) => sum + item.count, 0),
+    ).toBe(topContributor.acceptedCount);
+    expect(topContributor.sourceSubmissionCount ?? 0).toBeLessThanOrEqual(
+      topContributor.acceptedCount,
+    );
+    expect(topContributor.reviewedCount ?? 0).toBeGreaterThanOrEqual(0);
+    expect(
       contributorForVerifiedAuthor(topContributor.name, topContributor.name),
     ).toBe(topContributor);
     expect(
@@ -833,6 +843,50 @@ describe("web non-UI utility coverage", () => {
     expect(contentTypeFor("/feed.xml")).toBe("xml");
     expect(contentTypeFor("/llms.txt")).toBe("txt");
     expect(contentTypeFor("/data/feed.json")).toBe("json");
+
+    const contributor = {
+      slug: "jane-doe",
+      handle: "janedoe",
+      name: "Jane Doe",
+      github: "https://github.com/janedoe",
+      acceptedCount: 1,
+    };
+    expect(contributorMatchesIdentity(contributor, "Jane Doe")).toBe(true);
+    expect(contributorMatchesIdentity(contributor, "janedoe")).toBe(true);
+    expect(
+      contributorMatchesIdentity(
+        contributor,
+        "Jane",
+        "https://github.com/janedoe",
+      ),
+    ).toBe(true);
+    expect(contributorMatchesIdentity(contributor, "Other Person")).toBe(false);
+    expect(
+      contributorAcceptedEntryRole(
+        contributor,
+        entry({
+          author: "Example",
+          submittedBy: "Jane Doe",
+          submittedByUrl: "https://github.com/janedoe",
+        }),
+      ),
+    ).toBe("submitted");
+    expect(
+      contributorAcceptedEntryRole(contributor, entry({ author: "janedoe" })),
+    ).toBe("authored");
+    expect(
+      contributorAcceptedEntryRole(
+        contributor,
+        entry({
+          author: "Jane Doe",
+          submittedBy: "Jane Doe",
+          submittedByUrl: "https://github.com/janedoe",
+        }),
+      ),
+    ).toBe("submitted-authored");
+    expect(
+      contributorReviewedEntry(contributor, entry({ reviewedBy: "janedoe" })),
+    ).toBe(true);
     expect(contributorSlug(" @Example User! ")).toBe("example-user");
     expect(githubHandle("https://github.com/JSONbored")).toBe("JSONbored");
     expect(githubHandle("https://example.com/JSONbored")).toBeUndefined();


### PR DESCRIPTION
## Summary
- Expands contributor profile pages with attribution provenance, category credits, and reviewed/source-linked contribution stats.

## What changed
- Added contributor identity matching that recognizes display names and GitHub profile handles.
- Added contributor category, reviewed, and source-linked submission summaries derived from accepted entries.
- Reworked contributor profile rows to show submitted/authored/reviewed roles, provenance dates, source submissions, import PRs, and source links.
- Added regression coverage for contributor identity matching and summary consistency.

## Why
- Contributor pages previously relied on exact handle comparisons and generic resource rows, which could miss entries or hide useful attribution context. The profile now reflects the provenance fields already present in the registry.

## Validation
- `pnpm exec vitest run tests/web-non-ui-utilities.test.ts`
- `pnpm --filter web type-check`
- `pnpm build`
- `git diff --check`

## Notes
- Refs #443.
