### PR TITLE
fix(mcp): fail on stale package metadata

### DIFF
--- a/tests/helpers/sync-mcp-metadata.mts
+++ b/tests/helpers/sync-mcp-metadata.mts
@@ -1,16 +1,13 @@
 /**
- * Vitest globalSetup: regenerate packages/mcp/src/package-metadata.js from
- * packages/mcp/package.json before any test runs.
+ * Vitest globalSetup: verify packages/mcp/src/package-metadata.js is committed
+ * in sync with packages/mcp/package.json before any MCP tests run.
  *
- * release-please bumps packages/mcp/package.json in the Release PR, but the
- * generic extra-files updater can't reliably bump package-metadata.js at the
- * same time (it contains a quoted semver inside a JS export, which the updater
- * can't always locate). Running this in globalSetup means the file is always
- * in sync with package.json by the time tests import it, so mcp-cli.test.ts
- * and mcp-server.test.ts pass on the Release PR branch without any manual fix.
+ * Release validation must fail on committed metadata drift instead of repairing
+ * the local checkout. The npm publish workflow publishes from a fresh checkout,
+ * so mutating this tracked file during tests can mask stale package metadata.
  */
-import { readFileSync, writeFileSync } from "fs";
-import { join, dirname } from "path";
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -21,11 +18,22 @@ export default function setup() {
     readFileSync(join(mcpRoot, "package.json"), "utf8"),
   ) as { name: string; version: string };
 
-  const content =
-    `// Keep this Worker-safe: Cloudflare's bundle loader rejects runtime\n` +
-    `// package.json specifiers inside the SSR/MCP route bundle.\n` +
-    `export const packageName = ${JSON.stringify(pkg.name)};\n` +
-    `export const packageVersion = ${JSON.stringify(pkg.version)}; // x-release-please-version\n`;
+  const metadata = readFileSync(
+    join(mcpRoot, "src/package-metadata.js"),
+    "utf8",
+  );
 
-  writeFileSync(join(mcpRoot, "src/package-metadata.js"), content, "utf8");
+  const expectedName = `export const packageName = ${JSON.stringify(pkg.name)};`;
+  const expectedVersion = `export const packageVersion = ${JSON.stringify(pkg.version)};`;
+
+  if (!metadata.includes(expectedName) || !metadata.includes(expectedVersion)) {
+    throw new Error(
+      [
+        "packages/mcp/src/package-metadata.js is out of sync with packages/mcp/package.json.",
+        `Expected committed metadata to include: ${expectedName}`,
+        `Expected committed metadata to include: ${expectedVersion}`,
+        "Update package-metadata.js in the same change as the MCP package version bump.",
+      ].join("\n"),
+    );
+  }
 }


### PR DESCRIPTION
### Motivation
- The Vitest `globalSetup` previously rewrote the tracked `packages/mcp/src/package-metadata.js` from `package.json`, which masks committed metadata drift during CI and can allow a stale metadata file to be published from a fresh checkout.
- Release validation must fail when committed metadata and `package.json` diverge so that the publish step cannot be tricked by a mutated test checkout.

### Description
- Replace the global setup behavior in `tests/helpers/sync-mcp-metadata.mts` to read the committed `src/package-metadata.js` and verify it contains the expected `packageName` and `packageVersion` derived from `packages/mcp/package.json` instead of writing to the file.
- Throw a clear error message when the committed metadata does not include the expected name/version, instructing contributors to update `package-metadata.js` alongside an MCP package version bump.
- Preserve registration of the helper as the Vitest global setup so MCP tests still run the verification before importing the metadata.

### Testing
- Running `pnpm test:mcp` without generated web artifacts initially failed due to missing registry data files, as expected (one test suite failed until prebuild was run).
- Running `pnpm --filter web run prebuild && pnpm test:mcp` completed successfully with both MCP test files passing (`Test Files 2 passed`, `Tests 68 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a410d9ee5fc832cb9d6e45c5c983f6a)