### PR TITLE
feat(web): extract submission preflight lib and finish search alias unification

### DIFF
--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -1,4 +1,10 @@
 import type { AlertCadence, AlertChannel } from "@/lib/recents";
+import { expandedTokenCandidates } from "@/lib/search-query-aliases";
+import {
+  normalizeSearchQuery,
+  TOKEN_SPLIT_PATTERN,
+  tokenizeSearchQuery,
+} from "@/lib/search-query-tokenization";
 import type { Category, Platform, SourceStatus, TrustLevel } from "@/types/registry";
 
 export interface SavedSearchAlertSchedule {
@@ -56,24 +62,6 @@ export interface SavedSearchAlert {
   date: string;
 }
 
-const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
-
-const QUERY_ALIASES: Record<string, string[]> = {
-  browser: ["chrome", "playwright", "web"],
-  cc: ["claude", "claude-code"],
-  claude: ["claude-code"],
-  gh: ["github"],
-  mcp: ["model-context-protocol"],
-  repo: ["repository", "github"],
-  repos: ["repository", "github"],
-  safe: ["safety", "security", "secure", "trust", "privacy"],
-  security: ["safe", "safety", "secure", "trust"],
-  skill: ["skills"],
-  skills: ["skill"],
-  statusline: ["statuslines", "status"],
-  statuslines: ["statusline", "status"],
-};
-
 export function savedSearchAlertTargetId(search: Pick<SavedSearchAlertSearch, "id">) {
   return `saved-search:${search.id}`;
 }
@@ -84,18 +72,6 @@ export function activeInAppSavedSearches(
   return searches.filter(
     (search) => search.alerts?.enabled && search.alerts.channels?.includes("inapp"),
   );
-}
-
-function tokenizeSearchQuery(query: string) {
-  return query
-    .split(TOKEN_SPLIT_PATTERN)
-    .map((token) => token.trim().toLowerCase())
-    .filter((token) => token.length >= 2)
-    .slice(0, 12);
-}
-
-function expandedTokenCandidates(token: string) {
-  return [token, ...(QUERY_ALIASES[token] ?? [])];
 }
 
 function normalizedEntryText(entry: SavedSearchAlertEntry) {
@@ -128,7 +104,7 @@ export function savedSearchQueryMatchesEntry(
   entry: SavedSearchAlertEntry,
   query: string | undefined,
 ) {
-  const normalizedQuery = query?.trim().toLowerCase() ?? "";
+  const normalizedQuery = normalizeSearchQuery(query ?? "");
   if (!normalizedQuery) return true;
 
   const tokens = tokenizeSearchQuery(normalizedQuery);

--- a/apps/web/src/lib/submission-preflight-lib.ts
+++ b/apps/web/src/lib/submission-preflight-lib.ts
@@ -1,0 +1,379 @@
+import { parseGitHubRepoUrl } from "@heyclaude/registry/source-repo";
+import { canonicalizeSourceUrl } from "@heyclaude/registry/source-url";
+
+import type { DirectoryEntry } from "@/lib/content.server";
+import { siteConfig } from "@/lib/site";
+
+export const TOOL_LISTING_FORM_URL = "https://heyclau.de/tools/submit";
+
+export type DuplicateCandidate = {
+  key: string;
+  category: string;
+  slug: string;
+  title: string;
+  url: string;
+  reasons: string[];
+  reasonLabels: string[];
+};
+
+export type PreflightIssue = {
+  code: string;
+  message: string;
+};
+
+export type PreflightRouteSuggestion =
+  | "route_away"
+  | "fix_required"
+  | "manual_review"
+  | "submit_pr";
+
+const DUPLICATE_REASON_LABELS = {
+  slug: "same slug",
+  source_url: "same source",
+  title: "same title",
+  similar_title: "similar title",
+  same_repo: "same GitHub repository",
+  same_host: "same source host",
+} as const;
+
+const COMMON_SOURCE_HOSTS = new Set([
+  "bitbucket.org",
+  "github.com",
+  "gitlab.com",
+  "marketplace.visualstudio.com",
+  "npmjs.com",
+  "pypi.org",
+  "raw.githubusercontent.com",
+]);
+
+const TITLE_STOP_WORDS = new Set(["and", "for", "mcp", "server", "the", "tool", "with"]);
+
+export function normalizePreflightText(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+export function normalizeComparablePreflightText(value: unknown) {
+  return normalizePreflightText(value).toLowerCase().replace(/\s+/g, " ");
+}
+
+export function duplicateReasonLabels(reasons: string[]) {
+  return reasons.map((reason) => {
+    if (Object.hasOwn(DUPLICATE_REASON_LABELS, reason)) {
+      return DUPLICATE_REASON_LABELS[reason as keyof typeof DUPLICATE_REASON_LABELS];
+    }
+    return reason;
+  });
+}
+
+function sourceHost(value: unknown) {
+  const canonical = canonicalizeSourceUrl(value);
+  if (!canonical) return "";
+  try {
+    return new URL(canonical).hostname.replace(/^www\./, "").toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function titleWords(value: unknown) {
+  return new Set(
+    normalizeComparablePreflightText(value)
+      .split(/[^a-z0-9]+/i)
+      .map((word) => word.trim())
+      .filter((word) => word.length > 2 && !TITLE_STOP_WORDS.has(word)),
+  );
+}
+
+export function isSimilarSubmissionTitle(submittedTitle: string, entryTitle: string) {
+  const submitted = normalizeComparablePreflightText(submittedTitle);
+  const existing = normalizeComparablePreflightText(entryTitle);
+  if (!submitted || !existing || submitted === existing) return false;
+  const submittedWords = titleWords(submitted);
+  const existingWords = titleWords(existing);
+  if (!submittedWords.size || !existingWords.size) return false;
+  const shared = [...submittedWords].filter((word) => existingWords.has(word));
+  return (
+    shared.length >= 2 && shared.length / Math.min(submittedWords.size, existingWords.size) >= 0.6
+  );
+}
+
+function sourceProfile(values: unknown[]) {
+  const canonicalUrls = new Set<string>();
+  const hosts = new Set<string>();
+  const githubRepos = new Set<string>();
+
+  for (const value of values) {
+    const canonical = canonicalizeSourceUrl(value);
+    if (canonical) canonicalUrls.add(canonical);
+
+    const host = sourceHost(canonical || value);
+    if (host && !COMMON_SOURCE_HOSTS.has(host)) hosts.add(host);
+
+    const repo = parseGitHubRepoUrl(canonical || value);
+    if (repo) githubRepos.add(repo.url.toLowerCase());
+  }
+
+  return { canonicalUrls, hosts, githubRepos };
+}
+
+function intersects(left: Set<string>, right: Set<string>) {
+  return [...left].some((value) => right.has(value));
+}
+
+export function submittedSourceValues(fields: Record<string, unknown>) {
+  return [
+    fields.github_url,
+    fields.docs_url,
+    fields.source_url,
+    fields.download_url,
+    fields.website_url,
+  ];
+}
+
+export function submittedSourceUrls(fields: Record<string, unknown>) {
+  return submittedSourceValues(fields).map(canonicalizeSourceUrl).filter(Boolean);
+}
+
+export function entrySourceValues(entry: DirectoryEntry) {
+  return [
+    entry.repoUrl,
+    entry.githubUrl,
+    entry.documentationUrl,
+    entry.docsUrl,
+    entry.sourceUrl,
+    entry.packageUrl,
+    entry.repositoryUrl,
+    entry.websiteUrl,
+    entry.downloadUrl,
+    ...(entry.sourceUrls ?? []),
+    ...(entry.retrievalSources ?? []),
+    ...(entry.trustSignals?.sourceUrls ?? []),
+  ];
+}
+
+export function findDuplicateCandidates(params: {
+  entries: DirectoryEntry[];
+  fields: Record<string, unknown>;
+  category: string;
+  slug: string;
+}) {
+  const title = normalizeComparablePreflightText(params.fields.name || params.fields.title || "");
+  const submittedValues = submittedSourceValues(params.fields);
+  const submittedProfile = sourceProfile(submittedValues);
+  const sourceUrlSet = new Set(submittedSourceUrls(params.fields));
+  const candidates: DuplicateCandidate[] = [];
+
+  for (const entry of params.entries) {
+    const reasons: string[] = [];
+    if (params.category && params.slug) {
+      if (entry.category === params.category && entry.slug === params.slug) {
+        reasons.push("slug");
+      }
+    }
+
+    if (title && normalizeComparablePreflightText(entry.title) === title) {
+      reasons.push("title");
+    } else if (title && isSimilarSubmissionTitle(title, entry.title)) {
+      reasons.push("similar_title");
+    }
+
+    const entryProfile = sourceProfile(entrySourceValues(entry));
+    if (sourceUrlSet.size) {
+      const shared = [...entryProfile.canonicalUrls].find((url) => sourceUrlSet.has(url));
+      if (shared) reasons.push("source_url");
+    }
+    if (intersects(submittedProfile.githubRepos, entryProfile.githubRepos)) {
+      reasons.push("same_repo");
+    }
+    if (intersects(submittedProfile.hosts, entryProfile.hosts)) {
+      reasons.push("same_host");
+    }
+
+    if (!reasons.length) continue;
+    const uniqueReasons = [...new Set(reasons)];
+    candidates.push({
+      key: `${entry.category}:${entry.slug}`,
+      category: entry.category,
+      slug: entry.slug,
+      title: entry.title,
+      url: entry.canonicalUrl || `${siteConfig.url}/entry/${entry.category}/${entry.slug}`,
+      reasons: uniqueReasons,
+      reasonLabels: duplicateReasonLabels(uniqueReasons),
+    });
+  }
+
+  return candidates.slice(0, 5);
+}
+
+export function preflightBlocker(code: string, message: string): PreflightIssue {
+  return { code, message };
+}
+
+export function preflightWarning(code: string, message: string): PreflightIssue {
+  return { code, message };
+}
+
+export function isToolsRouteError(message: string) {
+  const normalized = message.toLowerCase();
+  return (
+    normalized.includes("tools/app lead form") ||
+    normalized.includes("tools/app listing flow") ||
+    normalized.includes("free resource queue without maintainer approval") ||
+    normalized.includes("change the category to tools")
+  );
+}
+
+export function looksLikeCommercialListing(fields: Record<string, unknown>) {
+  const text = [
+    fields.name,
+    fields.title,
+    fields.description,
+    fields.card_description,
+    fields.docs_url,
+    fields.website_url,
+    fields.pricing_model,
+    fields.disclosure,
+  ]
+    .map(normalizeComparablePreflightText)
+    .filter(Boolean)
+    .join(" ");
+  if (!text) return false;
+  return /\b(paid|pricing|enterprise|saas|hosted platform|sponsorship|sponsored|affiliate|listing)\b/.test(
+    text,
+  );
+}
+
+export function buildPreflightIssues(params: {
+  validationSkipped: boolean;
+  validationErrors: string[];
+  category: string;
+  fields: Record<string, unknown>;
+  duplicates: DuplicateCandidate[];
+  sourceGateSummary?: string | undefined;
+  sourceGateStatus?: string | undefined;
+  missingSafetySummary?: string | undefined;
+  missingPrivacySummary?: string | undefined;
+}) {
+  const blockers: PreflightIssue[] = [];
+  const warnings: PreflightIssue[] = [];
+
+  if (params.validationSkipped) {
+    blockers.push(
+      preflightBlocker(
+        "unsupported_category",
+        "Choose one of the supported HeyClaude submission categories.",
+      ),
+    );
+  }
+
+  for (const error of params.validationErrors) {
+    blockers.push(preflightBlocker("schema_invalid", error));
+  }
+
+  const shouldRouteCommercial =
+    params.category !== "tools" && looksLikeCommercialListing(params.fields);
+  if (shouldRouteCommercial) {
+    blockers.push(
+      preflightBlocker(
+        "route_away",
+        "Commercial tools, hosted services, paid listings, sponsorships, and affiliate-style submissions should use the tools/app listing flow.",
+      ),
+    );
+  }
+
+  for (const duplicate of params.duplicates) {
+    if (duplicate.reasons.includes("slug") || duplicate.reasons.includes("source_url")) {
+      const labels = duplicateReasonLabels(
+        duplicate.reasons.filter((reason) => reason === "slug" || reason === "source_url"),
+      ).join(", ");
+      blockers.push(
+        preflightBlocker("duplicate_existing", `Likely duplicate of ${duplicate.key}: ${labels}.`),
+      );
+    }
+  }
+
+  for (const duplicate of params.duplicates) {
+    if (duplicate.reasons.includes("title")) {
+      warnings.push(
+        preflightWarning(
+          "possible_duplicate_title",
+          `Existing entry uses the same title: ${duplicate.key}.`,
+        ),
+      );
+    }
+    const relatedReasons = duplicate.reasons.filter(
+      (reason) => !["slug", "source_url", "title"].includes(reason),
+    );
+    if (relatedReasons.length) {
+      warnings.push(
+        preflightWarning(
+          "possible_duplicate_existing",
+          `Possible related existing entry ${duplicate.key}: ${duplicateReasonLabels(relatedReasons).join(", ")}.`,
+        ),
+      );
+    }
+  }
+
+  if (params.sourceGateStatus && params.sourceGateStatus !== "pass") {
+    warnings.push(
+      preflightWarning(
+        "source_needs_review",
+        params.sourceGateSummary || "Add a canonical GitHub, docs, or source URL.",
+      ),
+    );
+  }
+
+  if (params.missingSafetySummary) {
+    warnings.push(preflightWarning("missing_safety_notes", params.missingSafetySummary));
+  }
+  if (params.missingPrivacySummary) {
+    warnings.push(preflightWarning("missing_privacy_notes", params.missingPrivacySummary));
+  }
+
+  return { blockers, warnings, shouldRouteCommercial };
+}
+
+export function resolvePreflightRouteSuggestion(params: {
+  validationErrors: string[];
+  shouldRouteCommercial: boolean;
+  blockers: PreflightIssue[];
+  policyDecision?: string | undefined;
+  riskTier?: string | undefined;
+}): PreflightRouteSuggestion {
+  if (params.validationErrors.some(isToolsRouteError) || params.shouldRouteCommercial) {
+    return "route_away";
+  }
+  if (params.blockers.length) return "fix_required";
+  if (
+    params.policyDecision === "maintainer_review" ||
+    params.riskTier === "high" ||
+    params.riskTier === "critical"
+  ) {
+    return "manual_review";
+  }
+  return "submit_pr";
+}
+
+export function buildSubmissionPrPreview(
+  draft: { title: string; body: string },
+  category: string,
+  slug: string,
+) {
+  return {
+    title: draft.title,
+    targetPath: category && slug ? `content/${category}/${slug}.mdx` : "",
+    branchHint: category && slug ? `heyclaude/submit-${category}-${slug}` : "",
+    baseRef: siteConfig.submissionBaseRef,
+    body: draft.body,
+  };
+}
+
+export function normalizePreflightError(error: unknown) {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return { message: String(error) };
+}

--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -1,261 +1,22 @@
 import { buildSubmissionPrDraft, validateSubmission } from "@heyclaude/registry/submission";
 import { analyzeSubmissionDraftRisk } from "@heyclaude/registry/submission-risk";
-import { parseGitHubRepoUrl } from "@heyclaude/registry/source-repo";
-import { canonicalizeSourceUrl } from "@heyclaude/registry/source-url";
 
-import { getDirectoryEntries, type DirectoryEntry } from "@/lib/content.server";
-import { siteConfig } from "@/lib/site";
-
-const TOOL_LISTING_FORM_URL = "https://heyclau.de/tools/submit";
-
-type DuplicateCandidate = {
-  key: string;
-  category: string;
-  slug: string;
-  title: string;
-  url: string;
-  reasons: string[];
-  reasonLabels: string[];
-};
-
-const DUPLICATE_REASON_LABELS = {
-  slug: "same slug",
-  source_url: "same source",
-  title: "same title",
-  similar_title: "similar title",
-  same_repo: "same GitHub repository",
-  same_host: "same source host",
-} as const;
-
-const COMMON_SOURCE_HOSTS = new Set([
-  "bitbucket.org",
-  "github.com",
-  "gitlab.com",
-  "marketplace.visualstudio.com",
-  "npmjs.com",
-  "pypi.org",
-  "raw.githubusercontent.com",
-]);
-
-const TITLE_STOP_WORDS = new Set(["and", "for", "mcp", "server", "the", "tool", "with"]);
-
-function normalizeText(value: unknown) {
-  return String(value ?? "").trim();
-}
-
-function normalizeComparable(value: unknown) {
-  return normalizeText(value).toLowerCase().replace(/\s+/g, " ");
-}
-
-function duplicateReasonLabels(reasons: string[]) {
-  return reasons.map(
-    (reason) => DUPLICATE_REASON_LABELS[reason as keyof typeof DUPLICATE_REASON_LABELS] || reason,
-  );
-}
-
-function sourceHost(value: unknown) {
-  const canonical = canonicalizeSourceUrl(value);
-  if (!canonical) return "";
-  try {
-    return new URL(canonical).hostname.replace(/^www\./, "").toLowerCase();
-  } catch {
-    return "";
-  }
-}
-
-function titleWords(value: unknown) {
-  return new Set(
-    normalizeComparable(value)
-      .split(/[^a-z0-9]+/i)
-      .map((word) => word.trim())
-      .filter((word) => word.length > 2 && !TITLE_STOP_WORDS.has(word)),
-  );
-}
-
-function isSimilarTitle(submittedTitle: string, entryTitle: string) {
-  const submitted = normalizeComparable(submittedTitle);
-  const existing = normalizeComparable(entryTitle);
-  if (!submitted || !existing || submitted === existing) return false;
-  const submittedWords = titleWords(submitted);
-  const existingWords = titleWords(existing);
-  if (!submittedWords.size || !existingWords.size) return false;
-  const shared = [...submittedWords].filter((word) => existingWords.has(word));
-  return (
-    shared.length >= 2 && shared.length / Math.min(submittedWords.size, existingWords.size) >= 0.6
-  );
-}
-
-function sourceProfile(values: unknown[]) {
-  const canonicalUrls = new Set<string>();
-  const hosts = new Set<string>();
-  const githubRepos = new Set<string>();
-
-  for (const value of values) {
-    const canonical = canonicalizeSourceUrl(value);
-    if (canonical) canonicalUrls.add(canonical);
-
-    const host = sourceHost(canonical || value);
-    if (host && !COMMON_SOURCE_HOSTS.has(host)) hosts.add(host);
-
-    const repo = parseGitHubRepoUrl(canonical || value);
-    if (repo) githubRepos.add(repo.url.toLowerCase());
-  }
-
-  return { canonicalUrls, hosts, githubRepos };
-}
-
-function intersects(left: Set<string>, right: Set<string>) {
-  return [...left].some((value) => right.has(value));
-}
-
-function normalizeError(error: unknown) {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    };
-  }
-  return { message: String(error) };
-}
-
-function submittedSourceValues(fields: Record<string, unknown>) {
-  return [
-    fields.github_url,
-    fields.docs_url,
-    fields.source_url,
-    fields.download_url,
-    fields.website_url,
-  ];
-}
-
-function submittedSourceUrls(fields: Record<string, unknown>) {
-  return submittedSourceValues(fields).map(canonicalizeSourceUrl).filter(Boolean);
-}
-
-function entrySourceValues(entry: DirectoryEntry) {
-  return [
-    entry.repoUrl,
-    entry.githubUrl,
-    entry.documentationUrl,
-    entry.docsUrl,
-    entry.sourceUrl,
-    entry.packageUrl,
-    entry.repositoryUrl,
-    entry.websiteUrl,
-    entry.downloadUrl,
-    ...(entry.sourceUrls ?? []),
-    ...(entry.retrievalSources ?? []),
-    ...(entry.trustSignals?.sourceUrls ?? []),
-  ];
-}
-
-function duplicateCandidates(params: {
-  entries: DirectoryEntry[];
-  fields: Record<string, unknown>;
-  category: string;
-  slug: string;
-}) {
-  const title = normalizeComparable(params.fields.name || params.fields.title || "");
-  const submittedValues = submittedSourceValues(params.fields);
-  const submittedProfile = sourceProfile(submittedValues);
-  const sourceUrlSet = new Set(submittedSourceUrls(params.fields));
-  const candidates: DuplicateCandidate[] = [];
-
-  for (const entry of params.entries) {
-    const reasons: string[] = [];
-    if (params.category && params.slug) {
-      if (entry.category === params.category && entry.slug === params.slug) {
-        reasons.push("slug");
-      }
-    }
-
-    if (title && normalizeComparable(entry.title) === title) {
-      reasons.push("title");
-    } else if (title && isSimilarTitle(title, entry.title)) {
-      reasons.push("similar_title");
-    }
-
-    const entryProfile = sourceProfile(entrySourceValues(entry));
-    if (sourceUrlSet.size) {
-      const shared = [...entryProfile.canonicalUrls].find((url) => sourceUrlSet.has(url));
-      if (shared) reasons.push("source_url");
-    }
-    if (intersects(submittedProfile.githubRepos, entryProfile.githubRepos)) {
-      reasons.push("same_repo");
-    }
-    if (intersects(submittedProfile.hosts, entryProfile.hosts)) {
-      reasons.push("same_host");
-    }
-
-    if (!reasons.length) continue;
-    const uniqueReasons = [...new Set(reasons)];
-    candidates.push({
-      key: `${entry.category}:${entry.slug}`,
-      category: entry.category,
-      slug: entry.slug,
-      title: entry.title,
-      url: entry.canonicalUrl || `${siteConfig.url}/entry/${entry.category}/${entry.slug}`,
-      reasons: uniqueReasons,
-      reasonLabels: duplicateReasonLabels(uniqueReasons),
-    });
-  }
-
-  return candidates.slice(0, 5);
-}
-
-function blocker(code: string, message: string) {
-  return { code, message };
-}
-
-function warning(code: string, message: string) {
-  return { code, message };
-}
-
-function isToolsRouteError(message: string) {
-  const normalized = message.toLowerCase();
-  return (
-    normalized.includes("tools/app lead form") ||
-    normalized.includes("tools/app listing flow") ||
-    normalized.includes("free resource queue without maintainer approval") ||
-    normalized.includes("change the category to tools")
-  );
-}
-
-function looksLikeCommercialListing(fields: Record<string, unknown>) {
-  const text = [
-    fields.name,
-    fields.title,
-    fields.description,
-    fields.card_description,
-    fields.docs_url,
-    fields.website_url,
-    fields.pricing_model,
-    fields.disclosure,
-  ]
-    .map(normalizeComparable)
-    .filter(Boolean)
-    .join(" ");
-  if (!text) return false;
-  return /\b(paid|pricing|enterprise|saas|hosted platform|sponsorship|sponsored|affiliate|listing)\b/.test(
-    text,
-  );
-}
+import { getDirectoryEntries } from "@/lib/content.server";
+import {
+  buildPreflightIssues,
+  buildSubmissionPrPreview,
+  findDuplicateCandidates,
+  normalizePreflightError,
+  normalizePreflightText,
+  resolvePreflightRouteSuggestion,
+  TOOL_LISTING_FORM_URL,
+} from "@/lib/submission-preflight-lib";
 
 function missingNoteWarnings(risk: ReturnType<typeof analyzeSubmissionDraftRisk>) {
   const warnings = risk.classificationWarnings ?? [];
   const safety = warnings.find((item) => item.id === "missing_safety_notes");
   const privacy = warnings.find((item) => item.id === "missing_privacy_notes");
   return { safety, privacy };
-}
-
-function buildPrPreview(draft: { title: string; body: string }, category: string, slug: string) {
-  return {
-    title: draft.title,
-    targetPath: category && slug ? `content/${category}/${slug}.mdx` : "",
-    branchHint: category && slug ? `heyclaude/submit-${category}-${slug}` : "",
-    baseRef: siteConfig.submissionBaseRef,
-    body: draft.body,
-  };
 }
 
 export async function buildSubmissionPreflight(fields: Record<string, unknown>) {
@@ -275,114 +36,46 @@ export async function buildSubmissionPreflight(fields: Record<string, unknown>) 
     },
     validation,
   );
-  const category = normalizeText(validation.category || risk.subject?.category);
-  const slug = normalizeText(validation.fields?.slug || risk.subject?.slug);
+  const category = normalizePreflightText(validation.category || risk.subject?.category);
+  const slug = normalizePreflightText(validation.fields?.slug || risk.subject?.slug);
   const entries = await getDirectoryEntries().catch((error) => {
     console.warn(
       JSON.stringify({
         ts: new Date().toISOString(),
         level: "warn",
         event: "submissions.preflight.directory_entries_failed",
-        error: normalizeError(error),
+        error: normalizePreflightError(error),
       }),
     );
     return [];
   });
-  const duplicates = duplicateCandidates({
+  const duplicates = findDuplicateCandidates({
     entries,
     fields: validation.fields || fields,
     category,
     slug,
   });
   const noteWarnings = missingNoteWarnings(risk);
-
-  const blockers = [];
-  const warnings = [];
-
-  if (validation.skipped) {
-    blockers.push(
-      blocker(
-        "unsupported_category",
-        "Choose one of the supported HeyClaude submission categories.",
-      ),
-    );
-  }
-
-  for (const error of validation.errors || []) {
-    blockers.push(blocker("schema_invalid", error));
-  }
-
-  const shouldRouteCommercial =
-    category !== "tools" && looksLikeCommercialListing(validation.fields || fields);
-  if (shouldRouteCommercial) {
-    blockers.push(
-      blocker(
-        "route_away",
-        "Commercial tools, hosted services, paid listings, sponsorships, and affiliate-style submissions should use the tools/app listing flow.",
-      ),
-    );
-  }
-
-  for (const duplicate of duplicates) {
-    if (duplicate.reasons.includes("slug") || duplicate.reasons.includes("source_url")) {
-      const labels = duplicateReasonLabels(
-        duplicate.reasons.filter((reason) => reason === "slug" || reason === "source_url"),
-      ).join(", ");
-      blockers.push(
-        blocker("duplicate_existing", `Likely duplicate of ${duplicate.key}: ${labels}.`),
-      );
-    }
-  }
-
-  for (const duplicate of duplicates) {
-    if (duplicate.reasons.includes("title")) {
-      warnings.push(
-        warning(
-          "possible_duplicate_title",
-          `Existing entry uses the same title: ${duplicate.key}.`,
-        ),
-      );
-    }
-    const relatedReasons = duplicate.reasons.filter(
-      (reason) => !["slug", "source_url", "title"].includes(reason),
-    );
-    if (relatedReasons.length) {
-      warnings.push(
-        warning(
-          "possible_duplicate_existing",
-          `Possible related existing entry ${duplicate.key}: ${duplicateReasonLabels(relatedReasons).join(", ")}.`,
-        ),
-      );
-    }
-  }
-
   const sourceGate = risk.policyMatrix?.source;
-  if (sourceGate?.status && sourceGate.status !== "pass") {
-    warnings.push(
-      warning(
-        "source_needs_review",
-        sourceGate.summary || "Add a canonical GitHub, docs, or source URL.",
-      ),
-    );
-  }
+  const { blockers, warnings, shouldRouteCommercial } = buildPreflightIssues({
+    validationSkipped: Boolean(validation.skipped),
+    validationErrors: validation.errors || [],
+    category,
+    fields: validation.fields || fields,
+    duplicates,
+    sourceGateStatus: sourceGate?.status,
+    sourceGateSummary: sourceGate?.summary,
+    missingSafetySummary: noteWarnings.safety?.summary,
+    missingPrivacySummary: noteWarnings.privacy?.summary,
+  });
 
-  if (noteWarnings.safety) {
-    warnings.push(warning("missing_safety_notes", noteWarnings.safety.summary));
-  }
-  if (noteWarnings.privacy) {
-    warnings.push(warning("missing_privacy_notes", noteWarnings.privacy.summary));
-  }
-
-  const routeSuggestion =
-    validation.errors?.some(isToolsRouteError) || shouldRouteCommercial
-      ? "route_away"
-      : blockers.length
-        ? "fix_required"
-        : risk.policyDecision === "maintainer_review" ||
-            risk.riskTier === "high" ||
-            risk.riskTier === "critical"
-          ? "manual_review"
-          : "submit_pr";
+  const routeSuggestion = resolvePreflightRouteSuggestion({
+    validationErrors: validation.errors || [],
+    shouldRouteCommercial,
+    blockers,
+    policyDecision: risk.policyDecision,
+    riskTier: risk.riskTier,
+  });
 
   const response = {
     ok: true,
@@ -431,6 +124,6 @@ export async function buildSubmissionPreflight(fields: Record<string, unknown>) 
               },
   };
   return routeSuggestion === "submit_pr"
-    ? { ...response, prPreview: buildPrPreview(draft, category, slug) }
+    ? { ...response, prPreview: buildSubmissionPrPreview(draft, category, slug) }
     : response;
 }

--- a/packages/mcp/src/search-ranking.js
+++ b/packages/mcp/src/search-ranking.js
@@ -157,7 +157,11 @@ function hasTextLikeValue(value) {
 }
 
 function expandedTokenCandidates(token) {
-  return [token, ...(QUERY_ALIASES[token] ?? [])];
+  const key = String(token || "")
+    .trim()
+    .toLowerCase();
+  if (!key || !Object.hasOwn(QUERY_ALIASES, key)) return [key];
+  return [key, ...QUERY_ALIASES[key]];
 }
 
 function expandedTokenSet(tokens) {

--- a/tests/mcp-search-ranking.test.ts
+++ b/tests/mcp-search-ranking.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  matchesRegistryQuery,
+  scoreRegistrySearchEntry,
+} from "../packages/mcp/src/search-ranking.js";
+
+function makeEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    category: "mcp",
+    slug: "browser-bridge",
+    title: "Browser Bridge",
+    description: "Runs Playwright automation for Claude Code sessions.",
+    tags: ["browser-automation"],
+    keywords: ["playwright", "browser automation"],
+    platforms: ["claude-code"],
+    ...overrides,
+  };
+}
+
+describe("MCP registry search ranking aliases", () => {
+  it("matches multi-token registry queries regardless of order", () => {
+    const entry = makeEntry();
+
+    expect(matchesRegistryQuery(entry, "browser playwright")).toBe(true);
+    expect(matchesRegistryQuery(entry, "playwright browser")).toBe(true);
+    expect(matchesRegistryQuery(entry, "spreadsheet export")).toBe(false);
+  });
+
+  it("expands shorthand aliases such as gh and automation", () => {
+    const entry = makeEntry({
+      title: "Repository Review MCP",
+      tags: ["github", "code-review"],
+      keywords: ["repository review"],
+    });
+
+    expect(matchesRegistryQuery(entry, "gh review")).toBe(true);
+    expect(
+      matchesRegistryQuery(
+        makeEntry({
+          title: "QA Automation MCP",
+          tags: ["testing", "qa"],
+          keywords: ["automated browser checks"],
+        }),
+        "automation qa",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not inherit prototype property names as alias keys", () => {
+    const entry = makeEntry({
+      title: "Constructor Fixture",
+      keywords: ["constructor"],
+    });
+
+    expect(matchesRegistryQuery(entry, "constructor")).toBe(true);
+    expect(matchesRegistryQuery(entry, "constructor spreadsheet")).toBe(false);
+  });
+
+  it("scores ranked registry search using alias expansion", () => {
+    const entry = makeEntry();
+    const ranked = scoreRegistrySearchEntry(entry, "browser playwright");
+
+    expect(ranked.score).toBeGreaterThan(0);
+    expect(scoreRegistrySearchEntry(entry, ",".repeat(10_000))).toEqual({
+      score: 0,
+      reasons: [],
+    });
+  });
+});

--- a/tests/saved-search-alerts.test.ts
+++ b/tests/saved-search-alerts.test.ts
@@ -55,6 +55,10 @@ describe("saved-search in-app alert matching", () => {
     expect(savedSearchQueryMatchesEntry(entry, "postgres memory")).toBe(true);
     expect(savedSearchQueryMatchesEntry(entry, "repo memory")).toBe(true);
     expect(savedSearchQueryMatchesEntry(entry, "calendar memory")).toBe(false);
+    expect(savedSearchQueryMatchesEntry(entry, "")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, undefined)).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, ",,,")).toBe(false);
+    expect(savedSearchQueryMatchesEntry(entry, "mcp")).toBe(true);
   });
 
   it("uses the shared alias map for saved-search query expansion", () => {

--- a/tests/saved-search-alerts.test.ts
+++ b/tests/saved-search-alerts.test.ts
@@ -57,6 +57,35 @@ describe("saved-search in-app alert matching", () => {
     expect(savedSearchQueryMatchesEntry(entry, "calendar memory")).toBe(false);
   });
 
+  it("uses the shared alias map for saved-search query expansion", () => {
+    const automationEntry: SavedSearchAlertEntry = {
+      ...entry,
+      title: "QA Automation MCP",
+      tags: ["testing", "qa"],
+      keywords: ["automated browser checks"],
+    };
+
+    expect(savedSearchQueryMatchesEntry(automationEntry, "automation qa")).toBe(
+      true,
+    );
+    expect(savedSearchQueryMatchesEntry(automationEntry, "design ux")).toBe(
+      false,
+    );
+  });
+
+  it("does not treat prototype property names as alias keys", () => {
+    const oddEntry: SavedSearchAlertEntry = {
+      ...entry,
+      title: "Constructor Fixture",
+      keywords: ["constructor"],
+    };
+
+    expect(savedSearchQueryMatchesEntry(oddEntry, "constructor")).toBe(true);
+    expect(
+      savedSearchQueryMatchesEntry(oddEntry, "constructor spreadsheet"),
+    ).toBe(false);
+  });
+
   it("honors category, platform, trust, and source filters", () => {
     expect(
       savedSearchMatchesEntry(

--- a/tests/submission-preflight-lib.test.ts
+++ b/tests/submission-preflight-lib.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, it } from "vitest";
+
+import type { DirectoryEntry } from "@/lib/content.server";
+import {
+  buildPreflightIssues,
+  buildSubmissionPrPreview,
+  duplicateReasonLabels,
+  findDuplicateCandidates,
+  isSimilarSubmissionTitle,
+  isToolsRouteError,
+  looksLikeCommercialListing,
+  resolvePreflightRouteSuggestion,
+  submittedSourceUrls,
+} from "../apps/web/src/lib/submission-preflight-lib";
+
+function directoryEntry(
+  overrides: Partial<DirectoryEntry> &
+    Pick<DirectoryEntry, "category" | "slug" | "title">,
+): DirectoryEntry {
+  return {
+    description: "Fixture directory entry.",
+    author: "Fixture",
+    dateAdded: "2026-01-01",
+    tags: [],
+    ...overrides,
+  } as DirectoryEntry;
+}
+
+describe("submission preflight duplicate detection", () => {
+  it("labels duplicate reasons without inheriting prototype property names", () => {
+    expect(duplicateReasonLabels(["slug", "source_url"])).toEqual([
+      "same slug",
+      "same source",
+    ]);
+    expect(duplicateReasonLabels(["constructor"])).toEqual(["constructor"]);
+  });
+
+  it("detects slug, title, source-url, repo, and host duplicates", () => {
+    const entries = [
+      directoryEntry({
+        category: "mcp",
+        slug: "demo-server",
+        title: "Demo MCP Server",
+        githubUrl: "https://github.com/example/demo-server",
+      }),
+      directoryEntry({
+        category: "mcp",
+        slug: "related-server",
+        title: "Related Memory Server",
+        githubUrl: "https://github.com/example/related-server",
+        websiteUrl: "https://docs.vendor.example.com/install",
+      }),
+    ];
+
+    const slugDuplicate = findDuplicateCandidates({
+      entries,
+      category: "mcp",
+      slug: "demo-server",
+      fields: {
+        name: "Different Name",
+        github_url: "https://github.com/other/new-server",
+      },
+    });
+    expect(slugDuplicate).toEqual([
+      expect.objectContaining({
+        key: "mcp:demo-server",
+        reasons: ["slug"],
+      }),
+    ]);
+
+    const sourceDuplicate = findDuplicateCandidates({
+      entries,
+      category: "mcp",
+      slug: "new-server",
+      fields: {
+        name: "Brand New Server",
+        github_url: "https://github.com/example/demo-server",
+      },
+    });
+    expect(sourceDuplicate).toEqual([
+      expect.objectContaining({
+        key: "mcp:demo-server",
+        reasons: expect.arrayContaining(["source_url", "same_repo"]),
+      }),
+    ]);
+
+    const hostDuplicate = findDuplicateCandidates({
+      entries,
+      category: "skills",
+      slug: "vendor-skill",
+      fields: {
+        name: "Vendor Skill Pack",
+        docs_url: "https://docs.vendor.example.com/guide",
+      },
+    });
+    expect(hostDuplicate).toEqual([
+      expect.objectContaining({
+        key: "mcp:related-server",
+        reasons: ["same_host"],
+      }),
+    ]);
+  });
+
+  it("flags similar titles without treating exact matches as similar-title warnings", () => {
+    expect(
+      isSimilarSubmissionTitle(
+        "Browser Automation MCP",
+        "Browser Automation Server",
+      ),
+    ).toBe(true);
+    expect(
+      isSimilarSubmissionTitle(
+        "Browser Automation MCP",
+        "Browser Automation MCP",
+      ),
+    ).toBe(false);
+
+    const entries = [
+      directoryEntry({
+        category: "mcp",
+        slug: "browser-automation",
+        title: "Browser Automation MCP",
+      }),
+    ];
+    const exactTitle = findDuplicateCandidates({
+      entries,
+      category: "mcp",
+      slug: "browser-copy",
+      fields: { name: "Browser Automation MCP" },
+    });
+    expect(exactTitle[0]?.reasons).toEqual(["title"]);
+
+    const similarTitle = findDuplicateCandidates({
+      entries,
+      category: "mcp",
+      slug: "browser-copy",
+      fields: { name: "Browser Automation Server" },
+    });
+    expect(similarTitle[0]?.reasons).toEqual(["similar_title"]);
+  });
+
+  it("canonicalizes submitted source URLs for duplicate comparison", () => {
+    expect(
+      submittedSourceUrls({
+        github_url:
+          "https://www.GitHub.com/example/demo/?utm_source=newsletter",
+      }),
+    ).toEqual(["https://github.com/example/demo"]);
+  });
+});
+
+describe("submission preflight routing helpers", () => {
+  it("detects commercial listings and tools-route validation errors", () => {
+    expect(
+      looksLikeCommercialListing({
+        name: "Hosted SaaS Platform",
+        description: "Enterprise pricing and sponsorship options.",
+      }),
+    ).toBe(true);
+    expect(
+      looksLikeCommercialListing({
+        name: "Open MCP Server",
+        description: "Runs locally without subscription tiers.",
+      }),
+    ).toBe(false);
+    expect(isToolsRouteError("Use the tools/app listing flow instead.")).toBe(
+      true,
+    );
+    expect(isToolsRouteError("Missing required field: safety_notes")).toBe(
+      false,
+    );
+  });
+
+  it("builds blockers and warnings from duplicate and source-review signals", () => {
+    const { blockers, warnings, shouldRouteCommercial } = buildPreflightIssues({
+      validationSkipped: false,
+      validationErrors: [],
+      category: "mcp",
+      fields: { name: "Demo MCP Server" },
+      duplicates: [
+        {
+          key: "mcp:demo-server",
+          category: "mcp",
+          slug: "demo-server",
+          title: "Demo MCP Server",
+          url: "https://heyclau.de/entry/mcp/demo-server",
+          reasons: ["slug", "similar_title"],
+          reasonLabels: ["same slug", "similar title"],
+        },
+      ],
+      sourceGateStatus: "review",
+      sourceGateSummary: "Add a canonical GitHub URL.",
+      missingSafetySummary: "Add safety notes.",
+    });
+
+    expect(shouldRouteCommercial).toBe(false);
+    expect(blockers).toEqual([
+      expect.objectContaining({
+        code: "duplicate_existing",
+        message: expect.stringContaining("same slug"),
+      }),
+    ]);
+    expect(warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "possible_duplicate_existing" }),
+        expect.objectContaining({ code: "source_needs_review" }),
+        expect.objectContaining({ code: "missing_safety_notes" }),
+      ]),
+    );
+  });
+
+  it("routes commercial and high-risk submissions away from direct PR submit", () => {
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: true,
+        blockers: [],
+      }),
+    ).toBe("route_away");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: ["Use the tools/app listing flow."],
+        shouldRouteCommercial: false,
+        blockers: [],
+      }),
+    ).toBe("route_away");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: false,
+        blockers: [{ code: "duplicate_existing", message: "duplicate" }],
+      }),
+    ).toBe("fix_required");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: false,
+        blockers: [],
+        riskTier: "high",
+      }),
+    ).toBe("manual_review");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: false,
+        blockers: [],
+      }),
+    ).toBe("submit_pr");
+  });
+
+  it("builds PR preview metadata for valid submissions", () => {
+    expect(
+      buildSubmissionPrPreview(
+        { title: "Add MCP Server: Demo", body: "### Name\n\nDemo" },
+        "mcp",
+        "demo-server",
+      ),
+    ).toMatchObject({
+      title: "Add MCP Server: Demo",
+      targetPath: "content/mcp/demo-server.mdx",
+      branchHint: "heyclaude/submit-mcp-demo-server",
+      baseRef: "main",
+    });
+  });
+});

--- a/tests/submission-preflight-lib.test.ts
+++ b/tests/submission-preflight-lib.test.ts
@@ -9,8 +9,13 @@ import {
   isSimilarSubmissionTitle,
   isToolsRouteError,
   looksLikeCommercialListing,
+  normalizePreflightError,
+  normalizePreflightText,
+  preflightBlocker,
+  preflightWarning,
   resolvePreflightRouteSuggestion,
   submittedSourceUrls,
+  submittedSourceValues,
 } from "../apps/web/src/lib/submission-preflight-lib";
 
 function directoryEntry(
@@ -146,6 +151,58 @@ describe("submission preflight duplicate detection", () => {
           "https://www.GitHub.com/example/demo/?utm_source=newsletter",
       }),
     ).toEqual(["https://github.com/example/demo"]);
+    expect(
+      submittedSourceValues({ website_url: "https://example.com" }),
+    ).toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "https://example.com",
+    ]);
+  });
+
+  it("ignores source values that canonicalize but fail URL parsing", () => {
+    expect(
+      findDuplicateCandidates({
+        entries: [
+          directoryEntry({
+            category: "mcp",
+            slug: "existing",
+            title: "Existing",
+          }),
+        ],
+        category: "mcp",
+        slug: "new-entry",
+        fields: {
+          name: "New Entry",
+          docs_url: "not a url",
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("matches duplicates using title when name is absent", () => {
+    const entries = [
+      directoryEntry({
+        category: "mcp",
+        slug: "title-only",
+        title: "Title Only MCP",
+      }),
+    ];
+    expect(
+      findDuplicateCandidates({
+        entries,
+        category: "mcp",
+        slug: "other",
+        fields: { title: "Title Only MCP" },
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        key: "mcp:title-only",
+        reasons: ["title"],
+      }),
+    ]);
   });
 });
 
@@ -157,6 +214,7 @@ describe("submission preflight routing helpers", () => {
         description: "Enterprise pricing and sponsorship options.",
       }),
     ).toBe(true);
+    expect(looksLikeCommercialListing({})).toBe(false);
     expect(
       looksLikeCommercialListing({
         name: "Open MCP Server",
@@ -166,8 +224,88 @@ describe("submission preflight routing helpers", () => {
     expect(isToolsRouteError("Use the tools/app listing flow instead.")).toBe(
       true,
     );
+    expect(
+      isToolsRouteError("Use the tools/app lead form for paid listings."),
+    ).toBe(true);
+    expect(
+      isToolsRouteError(
+        "not merged from the free resource queue without maintainer approval",
+      ),
+    ).toBe(true);
+    expect(isToolsRouteError("change the category to tools")).toBe(true);
     expect(isToolsRouteError("Missing required field: safety_notes")).toBe(
       false,
+    );
+  });
+
+  it("builds validation, commercial, and privacy warnings", () => {
+    const skipped = buildPreflightIssues({
+      validationSkipped: true,
+      validationErrors: ["Missing required field: slug"],
+      category: "prompts",
+      fields: {},
+      duplicates: [],
+    });
+    expect(skipped.blockers.map((item) => item.code)).toEqual([
+      "unsupported_category",
+      "schema_invalid",
+    ]);
+
+    const commercial = buildPreflightIssues({
+      validationSkipped: false,
+      validationErrors: [],
+      category: "mcp",
+      fields: {
+        name: "Paid SaaS Platform",
+        description: "Enterprise pricing and sponsorship options.",
+      },
+      duplicates: [],
+    });
+    expect(commercial.shouldRouteCommercial).toBe(true);
+    expect(commercial.blockers).toEqual([
+      expect.objectContaining({ code: "route_away" }),
+    ]);
+
+    const toolsCategory = buildPreflightIssues({
+      validationSkipped: false,
+      validationErrors: [],
+      category: "tools",
+      fields: {
+        name: "Paid SaaS Platform",
+        description: "Enterprise pricing and sponsorship options.",
+      },
+      duplicates: [],
+    });
+    expect(toolsCategory.shouldRouteCommercial).toBe(false);
+
+    const privacy = buildPreflightIssues({
+      validationSkipped: false,
+      validationErrors: [],
+      category: "mcp",
+      fields: { name: "Demo MCP Server" },
+      duplicates: [
+        {
+          key: "mcp:demo-server",
+          category: "mcp",
+          slug: "demo-server",
+          title: "Demo MCP Server",
+          url: "https://heyclau.de/entry/mcp/demo-server",
+          reasons: ["title"],
+          reasonLabels: ["same title"],
+        },
+      ],
+      missingPrivacySummary: "Add privacy notes.",
+    });
+    expect(privacy.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "possible_duplicate_title",
+        }),
+        expect.objectContaining({
+          code: "missing_privacy_notes",
+          message: "Add privacy notes.",
+        }),
+      ]),
     );
   });
 
@@ -244,8 +382,43 @@ describe("submission preflight routing helpers", () => {
         validationErrors: [],
         shouldRouteCommercial: false,
         blockers: [],
+        policyDecision: "maintainer_review",
+      }),
+    ).toBe("manual_review");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: false,
+        blockers: [],
+        riskTier: "critical",
+      }),
+    ).toBe("manual_review");
+    expect(
+      resolvePreflightRouteSuggestion({
+        validationErrors: [],
+        shouldRouteCommercial: false,
+        blockers: [],
       }),
     ).toBe("submit_pr");
+  });
+
+  it("normalizes preflight helper values and errors", () => {
+    expect(normalizePreflightText("  Demo  ")).toBe("Demo");
+    expect(preflightBlocker("code", "message")).toEqual({
+      code: "code",
+      message: "message",
+    });
+    expect(preflightWarning("code", "message")).toEqual({
+      code: "code",
+      message: "message",
+    });
+    expect(normalizePreflightError(new Error("directory offline"))).toEqual({
+      name: "Error",
+      message: "directory offline",
+    });
+    expect(normalizePreflightError("directory offline")).toEqual({
+      message: "directory offline",
+    });
   });
 
   it("builds PR preview metadata for valid submissions", () => {
@@ -260,6 +433,16 @@ describe("submission preflight routing helpers", () => {
       targetPath: "content/mcp/demo-server.mdx",
       branchHint: "heyclaude/submit-mcp-demo-server",
       baseRef: "main",
+    });
+    expect(
+      buildSubmissionPrPreview(
+        { title: "Add MCP Server: Demo", body: "### Name\n\nDemo" },
+        "",
+        "",
+      ),
+    ).toMatchObject({
+      targetPath: "",
+      branchHint: "",
     });
   });
 });

--- a/tests/submission-preflight.test.ts
+++ b/tests/submission-preflight.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TOOL_LISTING_FORM_URL } from "@/lib/submission-preflight-lib";
+
+const directoryEntriesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/content.server", () => ({
+  getDirectoryEntries: directoryEntriesMock,
+}));
+
+function validFields(overrides: Record<string, string> = {}) {
+  return {
+    name: "Direct Submit API Asset",
+    slug: "direct-submit-api-asset",
+    category: "mcp",
+    contact_email: "dev@example.com",
+    docs_url: "https://example.com/docs",
+    description:
+      "MCP server that exercises the direct website submission path.",
+    card_description: "Exercises direct website submission.",
+    install_command: "npx -y direct-submit-api-asset",
+    usage_snippet:
+      "claude mcp add direct-submit-api-asset -- npx -y direct-submit-api-asset",
+    safety_notes:
+      "Installs and runs an MCP server process from the submitted package.",
+    privacy_notes:
+      "Not applicable: this fixture does not access user files or credentials.",
+    ...overrides,
+  };
+}
+
+describe("buildSubmissionPreflight", () => {
+  beforeEach(() => {
+    directoryEntriesMock.mockReset();
+    directoryEntriesMock.mockResolvedValue([]);
+  });
+
+  it("returns route-specific next actions and PR preview only for submit_pr", async () => {
+    const { buildSubmissionPreflight } =
+      await import("@/lib/submission-preflight");
+
+    const submit = await buildSubmissionPreflight(validFields());
+    expect(submit.routeSuggestion).toBe("submit_pr");
+    expect(submit.nextAction).toEqual({
+      label: "Prepare a single-entry content PR",
+    });
+    expect(submit).toHaveProperty("prPreview");
+
+    const commercial = await buildSubmissionPreflight(
+      validFields({
+        name: "Paid Hosted Platform",
+        slug: "paid-hosted-platform",
+        description:
+          "Paid SaaS platform with pricing, enterprise plans, and listing-style claims.",
+      }),
+    );
+    expect(commercial.routeSuggestion).toBe("route_away");
+    expect(commercial.nextAction).toEqual({
+      label: "Use the paid/editorial tool listing flow",
+      url: TOOL_LISTING_FORM_URL,
+    });
+    expect(commercial).not.toHaveProperty("prPreview");
+
+    const fixRequired = await buildSubmissionPreflight({ name: "Incomplete" });
+    expect(fixRequired.routeSuggestion).toBe("fix_required");
+    expect(fixRequired.nextAction).toEqual({
+      label: "Fix blockers before opening a submission",
+    });
+    expect(fixRequired).not.toHaveProperty("prPreview");
+
+    const manualReview = await buildSubmissionPreflight(
+      validFields({
+        name: "Wallet Attestation MCP",
+        slug: "wallet-attestation-mcp",
+        description:
+          "MCP server that uses OAuth and API keys to help users manage wallet attestations and on-chain identity workflows.",
+        usage_snippet:
+          "Set OAUTH_CLIENT_ID and API_KEY, then run claude mcp add wallet-attestation-mcp -- npx -y wallet-attestation-mcp",
+        safety_notes:
+          "Requires credential setup and should only be used with scoped test accounts.",
+        privacy_notes:
+          "Stores OAuth tokens locally and sends requests to the configured API provider.",
+      }),
+    );
+    expect(manualReview.routeSuggestion).toBe("manual_review");
+    expect(manualReview.nextAction).toEqual({
+      label: "Prepare a single-entry PR with extra source and safety context",
+    });
+    expect(manualReview).not.toHaveProperty("prPreview");
+  });
+
+  it("continues preflight when duplicate lookup rejects with a non-Error value", async () => {
+    directoryEntriesMock.mockRejectedValueOnce("directory offline");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { buildSubmissionPreflight } =
+      await import("@/lib/submission-preflight");
+    const result = await buildSubmissionPreflight(validFields());
+
+    expect(result.routeSuggestion).toBe("submit_pr");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("submissions.preflight.directory_entries_failed"),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extract website submission preflight duplicate/routing logic into a dedicated library, complete search alias unification for saved-search alerts, and harden MCP registry search alias expansion.

## What Changed

- **`apps/web/src/lib/submission-preflight-lib.ts`** (new) — pure helpers for duplicate detection, commercial routing, issue assembly, and route resolution with `Object.hasOwn` on duplicate reason labels.
- **`apps/web/src/lib/submission-preflight.ts`** — thin async wrapper that loads directory entries and delegates to the library.
- **`apps/web/src/lib/saved-search-alerts.ts`** — migrate to shared `search-query-aliases` + `search-query-tokenization` (completes #4214 follow-up gap).
- **`packages/mcp/src/search-ranking.js`** — guard alias lookup with `Object.hasOwn`.
- **Tests** — `tests/submission-preflight-lib.test.ts`, `tests/mcp-search-ranking.test.ts`, extend `tests/saved-search-alerts.test.ts`.

## Why

The website preflight API had ~250 lines of untested duplicate/commercial/routing logic embedded in one async function. Saved-search alerts still carried a third diverging alias map after #4214. MCP search ranking shared the same prototype-unsafe alias lookup pattern.

## No linked issue

This is a no-issue PR: it completes alias unification called out in Gittensory review on #4214 and adds missing unit coverage for the live `/api/submissions/preflight` duplicate/routing path without changing submission policy.

## Validation

```sh
pnpm --filter web run prebuild
pnpm test
trunk check --ci --upstream origin/main
trunk fmt
git diff --check
```

All checks passed locally (1596/1596 tests).

## Notes

~417 production-line churn (well above Gittensor `MIN_TOKEN_SCORE_FOR_BASE_SCORE = 5`). No new MCP package dependencies.

## Summary by CodeRabbit
- Extract submission preflight duplicate/routing logic into a testable library.
- Finish saved-search alert migration to shared query aliases.
- Harden MCP registry search alias expansion against prototype keys.