### PR TITLE
fix(discovery): require reviewable source evidence

### DIFF
--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -42,6 +42,9 @@ export type RegistryEntry = Record<string, unknown> & {
   documentationUrl?: string;
   githubUrl?: string;
   repoUrl?: string | null;
+  repositoryUrl?: string;
+  sourceUrl?: string;
+  sourceUrls?: string[];
   websiteUrl?: string;
   brandName?: string;
   brandDomain?: string;
@@ -275,7 +278,13 @@ function inferSource(entry: RegistryEntry): SourceStatus {
   if (entry.downloadTrust === "first-party" || entry.trustSignals?.firstPartyEditorial) {
     return "first-party";
   }
-  if (entry.repoUrl || entry.githubUrl || entry.trustSignals?.sourceStatus === "available") {
+  if (
+    entry.repoUrl ||
+    entry.githubUrl ||
+    entry.repositoryUrl ||
+    entry.sourceUrl ||
+    entry.sourceUrls?.length
+  ) {
     return "source-backed";
   }
   if (entry.documentationUrl || entry.websiteUrl) return "external";

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -172,8 +172,18 @@ function hasPrivacyNotes(entry: Entry) {
   return Boolean(entry.privacyNotes || entry.trustSignals?.hasPrivacyNotes);
 }
 
+function hasReviewableSourceReference(entry: Entry) {
+  return Boolean(
+    entry.repoUrl ||
+    entry.githubUrl ||
+    entry.repositoryUrl ||
+    entry.sourceUrl ||
+    entry.sourceUrls?.length,
+  );
+}
+
 function hasSourceBackedSignal(entry: Entry) {
-  return entry.source === "source-backed" || entry.trustSignals?.sourceStatus === "available";
+  return entry.source === "source-backed" || hasReviewableSourceReference(entry);
 }
 
 function hasTrustedPackageSignal(entry: Entry) {

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -172,8 +172,11 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
     >
   >;
   sourceUrl?: string;
+  sourceUrls?: string[];
   docsUrl?: string;
+  githubUrl?: string;
   repoUrl?: string;
+  repositoryUrl?: string;
   trust: TrustLevel;
   source: SourceStatus;
   trustSignals?: EntryTrustSignals;

--- a/packages/registry/src/artifacts.js
+++ b/packages/registry/src/artifacts.js
@@ -480,6 +480,20 @@ function sourceUrlsForEntry(entry) {
     .filter((value, index, list) => list.indexOf(value) === index);
 }
 
+function reviewableSourceUrlsForEntry(entry) {
+  return [
+    entry.repoUrl,
+    entry.githubUrl,
+    entry.repositoryUrl,
+    entry.sourceUrl,
+    ...(Array.isArray(entry.sourceUrls) ? entry.sourceUrls : []),
+    ...(Array.isArray(entry.retrievalSources) ? entry.retrievalSources : []),
+  ]
+    .map((value) => String(value || "").trim())
+    .filter(Boolean)
+    .filter((value, index, list) => list.indexOf(value) === index);
+}
+
 function lastVerifiedForEntry(entry) {
   return (
     entry.verifiedAt ||
@@ -504,6 +518,7 @@ export function buildEntryTrustSignals(entry) {
   const packageChecksum =
     entry.downloadSha256 || entry.skillPackage?.sha256 || "";
   const sourceUrls = sourceUrlsForEntry(entry);
+  const reviewableSourceUrls = reviewableSourceUrlsForEntry(entry);
   const hasSafetyNotes = noteList(entry.safetyNotes).length > 0;
   const hasPrivacyNotes = noteList(entry.privacyNotes).length > 0;
 
@@ -515,7 +530,7 @@ export function buildEntryTrustSignals(entry) {
     checksumPresent: Boolean(packageChecksum),
     sourceUrlCount: sourceUrls.length,
     sourceUrls,
-    sourceStatus: sourceUrls.length ? "available" : "missing",
+    sourceStatus: reviewableSourceUrls.length ? "available" : "missing",
     lastVerifiedAt: lastVerifiedForEntry(entry),
     adapterGenerated,
     hasSafetyNotes,

--- a/tests/registry-artifacts.test.ts
+++ b/tests/registry-artifacts.test.ts
@@ -250,6 +250,42 @@ describe("registry artifacts", () => {
     );
   });
 
+  it("requires reviewable source evidence for available source status", () => {
+    const [websiteOnly, downloadOnly, repoBacked] = buildDirectoryEntries([
+      {
+        category: "tools",
+        slug: "website-only",
+        title: "Website Only",
+        description: "Tool with only a marketing website.",
+        tags: [],
+        keywords: [],
+        websiteUrl: "https://example.com",
+      },
+      {
+        category: "skills",
+        slug: "download-only",
+        title: "Download Only",
+        description: "Skill with only a hosted package download.",
+        tags: [],
+        keywords: [],
+        downloadUrl: "https://example.com/package.zip",
+      },
+      {
+        category: "mcp",
+        slug: "repo-backed",
+        title: "Repo Backed",
+        description: "Server with a reviewable repository.",
+        tags: [],
+        keywords: [],
+        repoUrl: "https://github.com/example/repo-backed",
+      },
+    ]);
+
+    expect(websiteOnly.trustSignals.sourceStatus).toBe("missing");
+    expect(downloadOnly.trustSignals.sourceStatus).toBe("missing");
+    expect(repoBacked.trustSignals.sourceStatus).toBe("available");
+  });
+
   it("keeps public registry payloads within reviewable byte budgets", () => {
     const entryCount = contentEntries.length;
     // These budgets are growth guards, not fixed caps. The public registry

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -115,6 +115,11 @@ describe("entry search filters", () => {
     const sourceSignal = entry({
       slug: "source-signal",
       source: "external",
+      repoUrl: "https://github.com/example/source-signal",
+    });
+    const broadUrlSignal = entry({
+      slug: "broad-url-signal",
+      source: "external",
       trustSignals: {
         sourceStatus: "available",
       },
@@ -151,6 +156,7 @@ describe("entry search filters", () => {
     const entries = [
       sourceBacked,
       sourceSignal,
+      broadUrlSignal,
       external,
       disclosed,
       packageEntry,
@@ -158,6 +164,9 @@ describe("entry search filters", () => {
     ];
 
     expect(entryMatchesTrustSignal(disclosed, "safety-notes")).toBe(true);
+    expect(entryMatchesTrustSignal(broadUrlSignal, "source-backed")).toBe(
+      false,
+    );
     expect(entryMatchesTrustSignal(external, "source-backed")).toBe(false);
     expect(filterSearchEntries({ signal: "privacy-notes" }, entries)).toEqual([
       disclosed,


### PR DESCRIPTION
### Motivation
- The Source-backed quick-filter and generated `trustSignals.sourceStatus` were treating any URL-like field (including `websiteUrl` and `downloadUrl`) as proof of reviewable source, which can surface non-reviewable marketing or hosted-package pages as "source-backed".
- The change restricts the Source-backed signal to entries with explicit `source-backed` classification or reviewable source references (repository/source URLs) to avoid overstating supply-chain trust.

### Description
- Add `reviewableSourceUrlsForEntry` and use it to derive `trustSignals.sourceStatus` so `available` requires repository/source evidence in `packages/registry/src/artifacts.js`.
- Add `hasReviewableSourceReference` predicate and update the Source-backed quick-filter to consult reviewable references instead of trusting `trustSignals.sourceStatus` alone in `apps/web/src/data/search.ts`.
- Tighten source inference to classify entries as `source-backed` only when repository/source evidence is present and add typed fields (`repositoryUrl`, `sourceUrl`, `sourceUrls`) in `apps/web/src/data/entry-normalize.ts` and `apps/web/src/types/registry.ts`.
- Add regression tests: ensure a `website-only` and `download-only` entry produce `sourceStatus: "missing"`, a repo-backed entry produces `sourceStatus: "available"`, and that an entry with only a broad `trustSignals.sourceStatus = "available"` no longer matches the Source-backed chip (`tests/registry-artifacts.test.ts`, `tests/search-query.test.ts`).

### Testing
- Ran `pnpm exec vitest run tests/search-query.test.ts tests/registry-artifacts.test.ts` and the test suite passed (all tests in those files succeeded). 
- Ran `pnpm exec vitest run tests/search-query.test.ts` as a focused run and it passed. 
- Ran `pnpm exec tsc --noEmit --pretty false` which reported pre-existing, repository-wide type/environment errors unrelated to the touched files; after the targeted edits there were no remaining type errors originating from the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a420f902838832c954f3a535d00d71d)