### PR TITLE
feat(compare): add Markdown export for side-by-side comparisons

### DIFF
--- a/apps/web/src/lib/compare-markdown.ts
+++ b/apps/web/src/lib/compare-markdown.ts
@@ -1,0 +1,89 @@
+import { brandIdentityLabel } from "@/lib/brand-icons";
+import { formatCompact } from "@/lib/format";
+import { absoluteUrl } from "@/lib/seo";
+import { INSTALL_RISK_LABEL, installRiskLevel } from "@/lib/trust";
+import type { Entry } from "@/types/registry";
+
+type CompareMarkdownField = {
+  label: string;
+  value: (entry: Entry) => string;
+};
+
+function cell(value: string) {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "—";
+  return normalized.replace(/\|/g, "\\|");
+}
+
+function notesPresence(entry: Entry) {
+  const parts: string[] = [];
+  if (entry.safetyNotes || entry.trustSignals?.hasSafetyNotes) parts.push("safety");
+  if (entry.privacyNotes || entry.trustSignals?.hasPrivacyNotes) parts.push("privacy");
+  return parts.length ? parts.join(", ") : "none";
+}
+
+const COMPARE_MARKDOWN_FIELDS: CompareMarkdownField[] = [
+  { label: "Trust", value: (entry) => entry.trust },
+  {
+    label: "Install risk",
+    value: (entry) => INSTALL_RISK_LABEL[installRiskLevel(entry)],
+  },
+  { label: "Notes", value: notesPresence },
+  { label: "Brand", value: (entry) => brandIdentityLabel(entry) || "—" },
+  { label: "Category", value: (entry) => entry.category },
+  { label: "Source", value: (entry) => entry.source },
+  { label: "Author", value: (entry) => entry.author },
+  { label: "Added", value: (entry) => entry.dateAdded || "—" },
+  {
+    label: "Platforms",
+    value: (entry) => (entry.platforms.length ? entry.platforms.join(", ") : "—"),
+  },
+  {
+    label: "Source repo",
+    value: (entry) =>
+      entry.repoStats?.stars !== undefined
+        ? `${formatCompact(entry.repoStats.stars)} repo stars`
+        : "—",
+  },
+  { label: "Safety notes", value: (entry) => entry.safetyNotes || "— missing" },
+  { label: "Privacy notes", value: (entry) => entry.privacyNotes || "— missing" },
+  {
+    label: "Prerequisites",
+    value: (entry) =>
+      entry.prerequisites?.length ? entry.prerequisites.slice(0, 4).join("; ") : "— none listed",
+  },
+  { label: "Install", value: (entry) => entry.installCommand || "—" },
+  { label: "Config", value: (entry) => entry.configSnippet || "—" },
+  { label: "Claim", value: (entry) => (entry.claimed ? "Claimed" : "Unclaimed") },
+  {
+    label: "HeyClaude URL",
+    value: (entry) => absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+  },
+];
+
+export function formatCompareMarkdown(entries: ReadonlyArray<Entry>) {
+  if (entries.length === 0) return "";
+
+  const titles = entries.map((entry) => cell(entry.title));
+  const lines = [
+    "# HeyClaude resource comparison",
+    "",
+    `_Generated from ${absoluteUrl("/compare")}_`,
+    "",
+    `| Field | ${titles.join(" | ")} |`,
+    `| --- | ${titles.map(() => "---").join(" | ")} |`,
+  ];
+
+  for (const field of COMPARE_MARKDOWN_FIELDS) {
+    lines.push(
+      `| ${field.label} | ${entries.map((entry) => cell(field.value(entry))).join(" | ")} |`,
+    );
+  }
+
+  lines.push("", "## Descriptions", "");
+  for (const entry of entries) {
+    lines.push(`### ${entry.title}`, "", entry.description.trim(), "");
+  }
+
+  return lines.join("\n").trimEnd();
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -10,6 +10,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { CopyButton } from "@/components/copy-button";
 import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
+import { formatCompareMarkdown } from "@/lib/compare-markdown";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -86,6 +87,8 @@ function ComparePage() {
     return sig ? `${origin}/compare?ids=${encodeURIComponent(sig)}` : `${origin}/compare`;
   };
 
+  const copyMarkdown = () => formatCompareMarkdown(items);
+
   if (items.length === 0) {
     const resolvedFromUrl = resolveIds(sp.ids);
     if (resolvedFromUrl.length > 0) {
@@ -140,6 +143,7 @@ function ComparePage() {
         </div>
         <div className="flex items-center gap-2">
           <CopyButton value={copyShare()} label="Copy share link" />
+          <CopyButton value={copyMarkdown()} label="Copy as Markdown" />
           <button
             type="button"
             onClick={() => {
@@ -248,7 +252,8 @@ function ComparePage() {
       </div>
 
       <p className="mt-3 text-xs text-ink-subtle">
-        Share this comparison by copying the link above — the selection is encoded in the URL.
+        Share this comparison with the link above, or copy the Markdown table for docs, issues, and
+        PRs.
       </p>
     </div>
   );

--- a/tests/compare-markdown.test.ts
+++ b/tests/compare-markdown.test.ts
@@ -47,7 +47,9 @@ describe("formatCompareMarkdown", () => {
     expect(markdown).toContain("| Field | Alpha MCP | Beta MCP |");
     expect(markdown).toContain("| Trust | review | review |");
     expect(markdown).toContain("| Install | npx alpha-mcp@1.0.0 | — |");
-    expect(markdown).toContain("| Config | — | {\"mcpServers\":{\"beta\":{\"command\":\"beta\"}}} |");
+    expect(markdown).toContain(
+      '| Config | — | {"mcpServers":{"beta":{"command":"beta"}}} |',
+    );
     expect(markdown).toContain("### Alpha MCP");
     expect(markdown).toContain("First comparison entry.");
     expect(markdown).toContain("### Beta MCP");

--- a/tests/compare-markdown.test.ts
+++ b/tests/compare-markdown.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompareMarkdown } from "../apps/web/src/lib/compare-markdown";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function entry(overrides: Partial<Entry>): Entry {
+  return {
+    category: "mcp",
+    slug: "example",
+    title: "Example MCP",
+    description: "Example MCP server for testing.",
+    author: "Example Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "npm",
+    trust: "review",
+    source: "source-backed",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  };
+}
+
+describe("formatCompareMarkdown", () => {
+  it("returns an empty string when there is nothing to compare", () => {
+    expect(formatCompareMarkdown([])).toBe("");
+  });
+
+  it("renders a markdown table with shared fields and entry descriptions", () => {
+    const markdown = formatCompareMarkdown([
+      entry({
+        slug: "alpha",
+        title: "Alpha MCP",
+        description: "First comparison entry.",
+        installCommand: "npx alpha-mcp@1.0.0",
+        safetyNotes: "Runs shell commands.",
+      }),
+      entry({
+        slug: "beta",
+        title: "Beta MCP",
+        description: "Second comparison entry.",
+        configSnippet: '{"mcpServers":{"beta":{"command":"beta"}}}',
+        privacyNotes: "Reads local files.",
+      }),
+    ]);
+
+    expect(markdown).toContain("# HeyClaude resource comparison");
+    expect(markdown).toContain("| Field | Alpha MCP | Beta MCP |");
+    expect(markdown).toContain("| Trust | review | review |");
+    expect(markdown).toContain("| Install | npx alpha-mcp@1.0.0 | — |");
+    expect(markdown).toContain("| Config | — | {\"mcpServers\":{\"beta\":{\"command\":\"beta\"}}} |");
+    expect(markdown).toContain("### Alpha MCP");
+    expect(markdown).toContain("First comparison entry.");
+    expect(markdown).toContain("### Beta MCP");
+    expect(markdown).toContain("Second comparison entry.");
+    expect(markdown).toContain("https://heyclau.de/entry/mcp/alpha");
+    expect(markdown).toContain("https://heyclau.de/entry/mcp/beta");
+  });
+
+  it("escapes pipe characters inside table cells", () => {
+    const markdown = formatCompareMarkdown([
+      entry({
+        title: "Pipe | Title",
+        safetyNotes: "Uses a | separator in docs.",
+      }),
+    ]);
+
+    expect(markdown).toContain("Pipe \\| Title");
+    expect(markdown).toContain("Uses a \\| separator in docs.");
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Markdown serializer for interactive compare selections on `/compare`.
- Add a **Copy as Markdown** action next to the existing share-link copy button.
- Cover table rendering, descriptions, URL fields, and pipe escaping in tests.

## Changed routes / behavior
- `/compare` — new clipboard export for 2–4 selected entries.
- Edge cases: empty selection returns empty string; pipe characters in cell values are escaped.

## Test plan
- [x] `pnpm exec vitest run tests/compare-markdown.test.ts`
- [x] `git diff --check`

## Review evidence
No visual impact beyond one additional copy button on `/compare` when items are selected.
Desktop/mobile: same single extra button in the compare header actions row.