### PR TITLE
feat(browse): add installable-only utility filter with URL state

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -40,6 +40,7 @@ function applyToBrowseSearch(s: SavedSearch) {
     trust: s.trust ?? "",
     source: s.source ?? "",
     platform: s.platform ?? "",
+    installable: s.installable ?? "",
     sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
     view: "row" as const,
     compare: "",
@@ -47,7 +48,7 @@ function applyToBrowseSearch(s: SavedSearch) {
 }
 
 function hashSearch(s: SavedSearch): string {
-  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}`;
+  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}|${s.installable ?? ""}`;
   let h = 0;
   for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
   return Math.abs(h).toString(36);
@@ -60,6 +61,7 @@ export function savedFeedUrl(s: SavedSearch): string {
   if (s.trust) p.set("trust", s.trust);
   if (s.source) p.set("source", s.source);
   if (s.platform) p.set("platform", s.platform);
+  if (s.installable) p.set("installable", s.installable);
   if (s.label) p.set("label", s.label);
   return `/feeds/saved.xml?${p.toString()}`;
 }

--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -242,6 +242,7 @@ export interface SavedSearchQuery {
   trust?: string;
   source?: string;
   platform?: string;
+  installable?: string;
 }
 
 export function applySavedSearch(q: SavedSearchQuery): FeedItem[] {
@@ -252,6 +253,7 @@ export function applySavedSearch(q: SavedSearchQuery): FeedItem[] {
       trust: q.trust ? [q.trust as TrustLevel] : undefined,
       source: q.source ? [q.source as SourceStatus] : undefined,
       platforms: q.platform ? [q.platform as Platform] : undefined,
+      installable: q.installable === "1" ? true : undefined,
     },
     ENTRIES,
   )

--- a/apps/web/src/lib/recents.tsx
+++ b/apps/web/src/lib/recents.tsx
@@ -30,6 +30,7 @@ export interface SavedSearch {
   source?: string;
   signal?: string;
   platform?: string;
+  installable?: string;
   sort?: string;
   savedAt: string;
   alerts?: AlertSchedule;

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -68,6 +68,7 @@ function SavedSearchChipRow({
         source: s.source ?? "",
         signal: s.signal ?? "",
         platform: s.platform ?? "",
+        installable: s.installable ?? "",
         sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
         view: "row" as const,
         compare: "",
@@ -125,6 +126,7 @@ const defaultSearch = {
   source: "",
   signal: "",
   platform: "",
+  installable: "",
   sort: "popular" as const,
   view: "row" as const,
   compare: "",
@@ -137,6 +139,10 @@ const searchSchema = z.object({
   source: z.string().catch(defaultSearch.source).default(defaultSearch.source),
   signal: z.string().catch(defaultSearch.signal).default(defaultSearch.signal),
   platform: z.string().catch(defaultSearch.platform).default(defaultSearch.platform),
+  installable: z
+    .enum(["", "1"])
+    .catch(defaultSearch.installable)
+    .default(defaultSearch.installable),
   sort: z
     .enum(["popular", "newest", "title"])
     .catch(defaultSearch.sort)
@@ -218,6 +224,10 @@ function signalLabel(value: string) {
   return isTrustSignalFilter(value) ? TRUST_SIGNAL_LABEL[value] : "";
 }
 
+function isInstallableFilter(value: string) {
+  return value === "1";
+}
+
 function Browse() {
   const sp = Route.useSearch();
   const navigate = Route.useNavigate();
@@ -276,6 +286,7 @@ function Browse() {
       source: sp.source ? [sp.source as SourceStatus] : undefined,
       signal: isTrustSignalFilter(sp.signal) ? sp.signal : "",
       platforms: sp.platform ? [sp.platform as Platform] : undefined,
+      installable: isInstallableFilter(sp.installable) || undefined,
       sort: sp.sort,
     }),
     [sp],
@@ -319,7 +330,8 @@ function Browse() {
     Number(!!sp.trust) +
     Number(!!sp.source) +
     Number(!!sp.signal) +
-    Number(!!sp.platform);
+    Number(!!sp.platform) +
+    Number(isInstallableFilter(sp.installable));
 
   const clearAll = () =>
     navigate({
@@ -330,6 +342,7 @@ function Browse() {
         source: "",
         signal: "",
         platform: "",
+        installable: "",
         sort: "popular",
         view: sp.view,
         compare: sp.compare,
@@ -340,7 +353,7 @@ function Browse() {
     if (activeCount === 0) return;
     const label = sp.q
       ? `“${sp.q}”${sp.category ? ` · ${sp.category}` : ""}`
-      : `${sp.category || sp.trust || sp.source || signalLabel(sp.signal) || sp.platform || "Filter"}`;
+      : `${sp.category || sp.trust || sp.source || signalLabel(sp.signal) || sp.platform || (isInstallableFilter(sp.installable) ? "Installable only" : "") || "Filter"}`;
     recents.saveSearch({
       label,
       q: sp.q,
@@ -349,6 +362,7 @@ function Browse() {
       source: sp.source,
       signal: sp.signal,
       platform: sp.platform,
+      installable: sp.installable,
       sort: sp.sort,
     });
     toast.success("Search saved", { description: label });
@@ -359,7 +373,7 @@ function Browse() {
   const [shown, setShown] = React.useState(PAGE);
   React.useEffect(() => {
     setShown(PAGE);
-  }, [sp.q, sp.category, sp.trust, sp.source, sp.signal, sp.platform, sp.sort]);
+  }, [sp.q, sp.category, sp.trust, sp.source, sp.signal, sp.platform, sp.installable, sp.sort]);
 
   // Per-axis facet counts: how many results if this value were the only filter
   // in its axis. Memoized on the search params and counted without sorting so
@@ -377,6 +391,7 @@ function Browse() {
         source: merged.source ? [merged.source as SourceStatus] : undefined,
         signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
         platforms: merged.platform ? [merged.platform as Platform] : undefined,
+        installable: isInstallableFilter(merged.installable) || undefined,
         sort: merged.sort,
       });
     };
@@ -395,6 +410,21 @@ function Browse() {
     axis: "category" | "trust" | "source" | "signal" | "platform",
     value: string,
   ) => facetCounts[axis]?.[value] ?? 0;
+
+  const installableCount = useMemo(
+    () =>
+      countSearchResults({
+        q: sp.q,
+        categories: sp.category ? [sp.category as Category] : undefined,
+        trust: sp.trust ? [sp.trust as TrustLevel] : undefined,
+        source: sp.source ? [sp.source as SourceStatus] : undefined,
+        signal: isTrustSignalFilter(sp.signal) ? sp.signal : "",
+        platforms: sp.platform ? [sp.platform as Platform] : undefined,
+        installable: true,
+        sort: sp.sort,
+      }),
+    [sp],
+  );
 
   // Focus search on "/" key.
   const searchRef = React.useRef<HTMLInputElement>(null);
@@ -448,6 +478,13 @@ function Browse() {
       value: sp.platform,
       onClear: () => set({ platform: "" }),
     });
+  if (isInstallableFilter(sp.installable))
+    activeFilters.push({
+      key: "installable",
+      label: "Utility",
+      value: "Installable only",
+      onClear: () => set({ installable: "" }),
+    });
 
   // Nearest-match: drop one filter at a time (least likely first) until we have results.
   const suggestions = useMemo(() => {
@@ -456,6 +493,8 @@ function Browse() {
     const trials: { label: string; patch: Partial<typeof sp> }[] = [];
     if (sp.platform)
       trials.push({ label: `Remove platform "${sp.platform}"`, patch: { platform: "" } });
+    if (isInstallableFilter(sp.installable))
+      trials.push({ label: "Show non-installable entries too", patch: { installable: "" } });
     if (sp.signal)
       trials.push({ label: `Remove signal "${signalLabel(sp.signal)}"`, patch: { signal: "" } });
     if (sp.source) trials.push({ label: `Remove source "${sp.source}"`, patch: { source: "" } });
@@ -472,6 +511,7 @@ function Browse() {
           source: merged.source ? [merged.source as SourceStatus] : undefined,
           signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
           platforms: merged.platform ? [merged.platform as Platform] : undefined,
+          installable: isInstallableFilter(merged.installable) || undefined,
           sort: merged.sort,
         });
         return { label: t.label, count, apply: () => set(t.patch) };
@@ -553,6 +593,20 @@ function Browse() {
                     {p}
                   </FilterChip>
                 ))}
+              </FilterChipGroup>
+            </FilterSection>
+
+            <FilterSection title="Utility">
+              <FilterChipGroup label="Utility filters">
+                <FilterChip
+                  active={isInstallableFilter(sp.installable)}
+                  onClick={() =>
+                    set({ installable: isInstallableFilter(sp.installable) ? "" : "1" })
+                  }
+                  count={installableCount}
+                >
+                  Installable only
+                </FilterChip>
               </FilterChipGroup>
             </FilterSection>
 
@@ -689,6 +743,7 @@ function Browse() {
                     sp.source ||
                     signalLabel(sp.signal) ||
                     sp.platform ||
+                    (isInstallableFilter(sp.installable) ? "Installable only" : "") ||
                     ""
               }
               canSave={activeCount > 0}
@@ -706,6 +761,17 @@ function Browse() {
                   {option.label}
                 </FilterChip>
               ))}
+            </FilterChipGroup>
+            <FilterChipGroup label="Utility quick filters">
+              <FilterChip
+                active={isInstallableFilter(sp.installable)}
+                onClick={() =>
+                  set({ installable: isInstallableFilter(sp.installable) ? "" : "1" })
+                }
+                count={installableCount}
+              >
+                Installable only
+              </FilterChip>
             </FilterChipGroup>
             <div className="hidden text-[10px] text-ink-subtle sm:block">
               <kbd className="rounded border border-border bg-surface px-1 font-mono">/</kbd> search
@@ -791,6 +857,7 @@ function Browse() {
                               source: s.source ?? "",
                               signal: s.signal ?? "",
                               platform: s.platform ?? "",
+                              installable: s.installable ?? "",
                               sort: (s.sort as typeof sp.sort) ?? "popular",
                               view: sp.view,
                               compare: sp.compare,

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -126,7 +126,7 @@ const defaultSearch = {
   source: "",
   signal: "",
   platform: "",
-  installable: "",
+  installable: "" as const,
   sort: "popular" as const,
   view: "row" as const,
   compare: "",

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -765,9 +765,7 @@ function Browse() {
             <FilterChipGroup label="Utility quick filters">
               <FilterChip
                 active={isInstallableFilter(sp.installable)}
-                onClick={() =>
-                  set({ installable: isInstallableFilter(sp.installable) ? "" : "1" })
-                }
+                onClick={() => set({ installable: isInstallableFilter(sp.installable) ? "" : "1" })}
                 count={installableCount}
               >
                 Installable only

--- a/apps/web/src/routes/feeds.$slug.ts
+++ b/apps/web/src/routes/feeds.$slug.ts
@@ -47,6 +47,7 @@ export const Route = createFileRoute("/feeds/$slug")({
             trust: url.searchParams.get("trust") ?? undefined,
             source: url.searchParams.get("source") ?? undefined,
             platform: url.searchParams.get("platform") ?? undefined,
+            installable: url.searchParams.get("installable") ?? undefined,
           };
           const label = url.searchParams.get("label") ?? "Saved search";
           items = applySavedSearch(q);

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { ENTRIES } from "@/data/entries";
+import { countSearchResults } from "@/data/search";
 import {
   applySavedSearch,
   buildAtom,
@@ -189,6 +191,17 @@ describe("item builders over the real registry", () => {
     for (let n = 1; n < items.length; n++) {
       expect(items[n - 1].pubDate >= items[n].pubDate).toBe(true);
     }
+  });
+
+  it("applySavedSearch honors installable=1 and ignores other installable values", () => {
+    const all = applySavedSearch({});
+    const installableOnly = applySavedSearch({ installable: "1" });
+    const expectedCount = Math.min(50, countSearchResults({ installable: true }, ENTRIES));
+
+    expect(countSearchResults({ installable: true }, ENTRIES)).toBeLessThan(ENTRIES.length);
+    expect(installableOnly.length).toBe(expectedCount);
+    expect(applySavedSearch({ installable: "" }).length).toBe(all.length);
+    expect(applySavedSearch({ installable: "0" }).length).toBe(all.length);
   });
 
   it("siteWideItems is capped at 100 and newest-first", () => {

--- a/tests/feeds.test.ts
+++ b/tests/feeds.test.ts
@@ -45,7 +45,7 @@ describe("buildRss", () => {
     expect(xml).toContain('<rss version="2.0"');
     expect(xml).toContain("<channel>");
     expect(xml).toContain("<item>");
-    expect(xml).toContain("<guid isPermaLink=\"false\">entry:skills/a</guid>");
+    expect(xml).toContain('<guid isPermaLink="false">entry:skills/a</guid>');
     // rfc822 pubDate
     expect(xml).toContain("<pubDate>Fri, 02 Jan 2026 03:04:05 GMT</pubDate>");
   });
@@ -71,7 +71,9 @@ describe("buildRss", () => {
 
   it("defaults lastBuildDate to the newest item pubDate", () => {
     const xml = buildRss(rssOpts);
-    expect(xml).toContain("<lastBuildDate>Fri, 02 Jan 2026 03:04:05 GMT</lastBuildDate>");
+    expect(xml).toContain(
+      "<lastBuildDate>Fri, 02 Jan 2026 03:04:05 GMT</lastBuildDate>",
+    );
   });
 });
 
@@ -109,18 +111,26 @@ describe("respondFeed conditional GET", () => {
   const lastBuilt = "2026-01-02T03:04:05.000Z";
 
   it("returns 200 with cache + validator headers when unconditional", async () => {
-    const res = await respondFeed(new Request("https://heyclau.de/feed.xml"), body, lastBuilt);
+    const res = await respondFeed(
+      new Request("https://heyclau.de/feed.xml"),
+      body,
+      lastBuilt,
+    );
     expect(res.status).toBe(200);
     expect(res.headers.get("ETag")).toMatch(/^"[0-9a-f]{16}"$/);
     expect(res.headers.get("Cache-Control")).toContain("max-age=300");
-    expect(res.headers.get("Last-Modified")).toBe(new Date(lastBuilt).toUTCString());
+    expect(res.headers.get("Last-Modified")).toBe(
+      new Date(lastBuilt).toUTCString(),
+    );
     expect(await res.text()).toBe(body);
   });
 
   it("returns 304 with an empty body when If-None-Match matches", async () => {
     const etag = await etagFor(body);
     const res = await respondFeed(
-      new Request("https://heyclau.de/feed.xml", { headers: { "if-none-match": etag } }),
+      new Request("https://heyclau.de/feed.xml", {
+        headers: { "if-none-match": etag },
+      }),
       body,
       lastBuilt,
     );
@@ -146,7 +156,9 @@ describe("respondFeed conditional GET", () => {
 
   it("returns 200 when If-None-Match does not match", async () => {
     const res = await respondFeed(
-      new Request("https://heyclau.de/feed.xml", { headers: { "if-none-match": '"deadbeef"' } }),
+      new Request("https://heyclau.de/feed.xml", {
+        headers: { "if-none-match": '"deadbeef"' },
+      }),
       body,
       lastBuilt,
     );
@@ -196,9 +208,14 @@ describe("item builders over the real registry", () => {
   it("applySavedSearch honors installable=1 and ignores other installable values", () => {
     const all = applySavedSearch({});
     const installableOnly = applySavedSearch({ installable: "1" });
-    const expectedCount = Math.min(50, countSearchResults({ installable: true }, ENTRIES));
+    const expectedCount = Math.min(
+      50,
+      countSearchResults({ installable: true }, ENTRIES),
+    );
 
-    expect(countSearchResults({ installable: true }, ENTRIES)).toBeLessThan(ENTRIES.length);
+    expect(countSearchResults({ installable: true }, ENTRIES)).toBeLessThan(
+      ENTRIES.length,
+    );
     expect(installableOnly.length).toBe(expectedCount);
     expect(applySavedSearch({ installable: "" }).length).toBe(all.length);
     expect(applySavedSearch({ installable: "0" }).length).toBe(all.length);

--- a/tests/search-query.test.ts
+++ b/tests/search-query.test.ts
@@ -174,4 +174,31 @@ describe("entry search filters", () => {
     ]);
     expect(countSearchResults({ signal: "reviewed" }, entries)).toBe(1);
   });
+
+  it("filters entries that ship install, config, or copy payloads", () => {
+    const installable = entry({
+      slug: "installable",
+      installCommand: "npx example-mcp@1.0.0",
+    });
+    const configOnly = entry({
+      slug: "config-only",
+      configSnippet: '{"mcpServers":{"demo":{}}}',
+    });
+    const copyOnly = entry({
+      slug: "copy-only",
+      fullCopy: "You are a helpful assistant.",
+    });
+    const manual = entry({
+      slug: "manual",
+      description: "Documentation-only listing.",
+    });
+    const entries = [installable, configOnly, copyOnly, manual];
+
+    expect(filterSearchEntries({ installable: true }, entries)).toEqual([
+      installable,
+      configOnly,
+      copyOnly,
+    ]);
+    expect(countSearchResults({ installable: true }, entries)).toBe(3);
+  });
 });


### PR DESCRIPTION
## Summary
- Expose the existing registry `installable` filter in browse via `?installable=1`.
- Add sidebar and quick-filter chips with result counts.
- Persist the flag in saved searches and saved RSS feed URLs.

## Changed routes / behavior
- `/browse?installable=1` — limits results to entries with install command, config snippet, or full copy payload.
- Saved searches and `/feeds/saved.xml` honor the same flag.
- Active filter bar, clear-all, nearest-match suggestions, and save-search label include the utility filter.

## Test plan
- [x] `pnpm exec vitest run tests/search-query.test.ts tests/feeds.test.ts`
- [x] `git diff --check`

## Review evidence
Browse gains one utility chip in the sidebar (desktop) and one in the quick-filter row.
Suggested manual check: open `/browse?installable=1` and confirm counts drop vs unfiltered browse.