### PR TITLE
feat(registry): expose contributor attribution across registry surfaces

### DIFF
--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -1,0 +1,111 @@
+import { Link } from "@tanstack/react-router";
+import type { Contributor, Entry } from "@/types/registry";
+import {
+  authorMatchesSubmitter,
+  contributorForSubmitter,
+  contributorForVerifiedAuthor,
+  findContributorForIdentity,
+} from "@/data/contributors";
+
+function ContributorProfileLink({
+  contributor,
+  label,
+  className = "text-ink hover:underline",
+}: {
+  contributor: Contributor;
+  label: string;
+  className?: string;
+}) {
+  return (
+    <Link to="/contributors/$slug" params={{ slug: contributor.slug }} className={className}>
+      {label}
+    </Link>
+  );
+}
+
+function ExternalSubmitterLink({
+  entry,
+  className = "text-ink hover:underline",
+}: {
+  entry: Pick<Entry, "submittedBy" | "submittedByUrl">;
+  className?: string;
+}) {
+  if (!entry.submittedBy) return null;
+  const href = entry.submittedByUrl ?? `https://github.com/${entry.submittedBy}`;
+  return (
+    <a href={href} target="_blank" rel="noreferrer" className={className}>
+      {entry.submittedBy}
+    </a>
+  );
+}
+
+export function EntryAuthorAttribution({
+  entry,
+  className,
+}: {
+  entry: Entry;
+  className?: string;
+}) {
+  const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
+  const submitterContributor = contributorForSubmitter(entry);
+  const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
+  const authorContributor =
+    !entry.submittedBy && entry.author
+      ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
+      : undefined;
+
+  if (verifiedAuthor) {
+    return (
+      <span className={className}>
+        by <ContributorProfileLink contributor={verifiedAuthor} label={entry.author} />
+      </span>
+    );
+  }
+
+  if (authorContributor && !entry.submittedBy) {
+    return (
+      <span className={className}>
+        by <ContributorProfileLink contributor={authorContributor} label={entry.author} />
+      </span>
+    );
+  }
+
+  return (
+    <span className={className}>
+      by <span className="text-ink">{entry.author}</span>
+      {entry.submittedBy && !sameIdentity && (
+        <>
+          {" · submitted by "}
+          {submitterContributor ? (
+            <ContributorProfileLink contributor={submitterContributor} label={entry.submittedBy} />
+          ) : (
+            <ExternalSubmitterLink entry={entry} />
+          )}
+        </>
+      )}
+    </span>
+  );
+}
+
+export function ContributorIdentityLink({
+  name,
+  profileUrl,
+  className = "text-ink hover:underline",
+}: {
+  name: string;
+  profileUrl?: string;
+  className?: string;
+}) {
+  const contributor = findContributorForIdentity(name, profileUrl);
+  if (contributor) {
+    return <ContributorProfileLink contributor={contributor} label={name} className={className} />;
+  }
+  if (profileUrl) {
+    return (
+      <a href={profileUrl} target="_blank" rel="noreferrer" className={className}>
+        {name}
+      </a>
+    );
+  }
+  return <span className={className.replace("hover:underline", "")}>{name}</span>;
+}

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import type { Contributor, Entry } from "@/types/registry";
 import {
   authorMatchesSubmitter,
+  contributorForDisplayAuthor,
   contributorForSubmitter,
   contributorForVerifiedAuthor,
   findContributorForIdentity,
@@ -39,14 +40,29 @@ function ExternalSubmitterLink({
   );
 }
 
+function UnverifiedAuthorLabel({
+  entry,
+  className = "text-ink hover:underline",
+}: {
+  entry: Pick<Entry, "author" | "authorProfileUrl">;
+  className?: string;
+}) {
+  if (entry.authorProfileUrl) {
+    return (
+      <a href={entry.authorProfileUrl} target="_blank" rel="noreferrer" className={className}>
+        {entry.author}
+      </a>
+    );
+  }
+
+  return <span className={className.replace("hover:underline", "").trim()}>{entry.author}</span>;
+}
+
 export function EntryAuthorAttribution({ entry, className }: { entry: Entry; className?: string }) {
   const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
   const submitterContributor = contributorForSubmitter(entry);
   const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
-  const authorContributor =
-    entry.author && !verifiedAuthor && (!entry.submittedBy || !sameIdentity)
-      ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
-      : undefined;
+  const authorContributor = contributorForDisplayAuthor(entry);
 
   if (verifiedAuthor) {
     return (
@@ -59,7 +75,7 @@ export function EntryAuthorAttribution({ entry, className }: { entry: Entry; cla
   const authorLabel = authorContributor ? (
     <ContributorProfileLink contributor={authorContributor} label={entry.author} />
   ) : (
-    <span className="text-ink">{entry.author}</span>
+    <UnverifiedAuthorLabel entry={entry} />
   );
 
   if (!entry.submittedBy || sameIdentity) {
@@ -87,11 +103,7 @@ export function ProvenanceAuthorAttribution({
   className?: string;
 }) {
   const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
-  const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
-  const authorContributor =
-    entry.author && !verifiedAuthor && (!entry.submittedBy || !sameIdentity)
-      ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
-      : undefined;
+  const authorContributor = contributorForDisplayAuthor(entry);
 
   if (verifiedAuthor) {
     return (
@@ -113,15 +125,7 @@ export function ProvenanceAuthorAttribution({
     );
   }
 
-  if (entry.authorProfileUrl) {
-    return (
-      <a href={entry.authorProfileUrl} target="_blank" rel="noreferrer" className={className}>
-        {entry.author}
-      </a>
-    );
-  }
-
-  return <span className={className}>{entry.author}</span>;
+  return <UnverifiedAuthorLabel entry={entry} className={className} />;
 }
 
 export function ContributorIdentityLink({
@@ -144,5 +148,5 @@ export function ContributorIdentityLink({
       </a>
     );
   }
-  return <span className={className.replace("hover:underline", "")}>{name}</span>;
+  return <span className={className.replace("hover:underline", "").trim()}>{name}</span>;
 }

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -87,6 +87,46 @@ export function EntryAuthorAttribution({
   );
 }
 
+export function ProvenanceAuthorAttribution({
+  entry,
+  className = "text-ink hover:underline",
+}: {
+  entry: Entry;
+  className?: string;
+}) {
+  const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
+  const authorContributor =
+    !entry.submittedBy && entry.author
+      ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
+      : undefined;
+
+  if (verifiedAuthor) {
+    return (
+      <ContributorProfileLink contributor={verifiedAuthor} label={entry.author} className={className} />
+    );
+  }
+
+  if (authorContributor && !entry.submittedBy) {
+    return (
+      <ContributorProfileLink
+        contributor={authorContributor}
+        label={entry.author}
+        className={className}
+      />
+    );
+  }
+
+  if (entry.authorProfileUrl) {
+    return (
+      <a href={entry.authorProfileUrl} target="_blank" rel="noreferrer" className={className}>
+        {entry.author}
+      </a>
+    );
+  }
+
+  return <span className="text-ink">{entry.author}</span>;
+}
+
 export function ContributorIdentityLink({
   name,
   profileUrl,

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -39,13 +39,7 @@ function ExternalSubmitterLink({
   );
 }
 
-export function EntryAuthorAttribution({
-  entry,
-  className,
-}: {
-  entry: Entry;
-  className?: string;
-}) {
+export function EntryAuthorAttribution({ entry, className }: { entry: Entry; className?: string }) {
   const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
   const submitterContributor = contributorForSubmitter(entry);
   const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
@@ -102,7 +96,11 @@ export function ProvenanceAuthorAttribution({
 
   if (verifiedAuthor) {
     return (
-      <ContributorProfileLink contributor={verifiedAuthor} label={entry.author} className={className} />
+      <ContributorProfileLink
+        contributor={verifiedAuthor}
+        label={entry.author}
+        className={className}
+      />
     );
   }
 

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -121,7 +121,7 @@ export function ProvenanceAuthorAttribution({
     );
   }
 
-  return <span className="text-ink">{entry.author}</span>;
+  return <span className={className}>{entry.author}</span>;
 }
 
 export function ContributorIdentityLink({

--- a/apps/web/src/components/contributor-attribution.tsx
+++ b/apps/web/src/components/contributor-attribution.tsx
@@ -44,7 +44,7 @@ export function EntryAuthorAttribution({ entry, className }: { entry: Entry; cla
   const submitterContributor = contributorForSubmitter(entry);
   const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
   const authorContributor =
-    !entry.submittedBy && entry.author
+    entry.author && !verifiedAuthor && (!entry.submittedBy || !sameIdentity)
       ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
       : undefined;
 
@@ -56,26 +56,24 @@ export function EntryAuthorAttribution({ entry, className }: { entry: Entry; cla
     );
   }
 
-  if (authorContributor && !entry.submittedBy) {
-    return (
-      <span className={className}>
-        by <ContributorProfileLink contributor={authorContributor} label={entry.author} />
-      </span>
-    );
+  const authorLabel = authorContributor ? (
+    <ContributorProfileLink contributor={authorContributor} label={entry.author} />
+  ) : (
+    <span className="text-ink">{entry.author}</span>
+  );
+
+  if (!entry.submittedBy || sameIdentity) {
+    return <span className={className}>by {authorLabel}</span>;
   }
 
   return (
     <span className={className}>
-      by <span className="text-ink">{entry.author}</span>
-      {entry.submittedBy && !sameIdentity && (
-        <>
-          {" · submitted by "}
-          {submitterContributor ? (
-            <ContributorProfileLink contributor={submitterContributor} label={entry.submittedBy} />
-          ) : (
-            <ExternalSubmitterLink entry={entry} />
-          )}
-        </>
+      by {authorLabel}
+      {" · submitted by "}
+      {submitterContributor ? (
+        <ContributorProfileLink contributor={submitterContributor} label={entry.submittedBy} />
+      ) : (
+        <ExternalSubmitterLink entry={entry} />
       )}
     </span>
   );
@@ -89,8 +87,9 @@ export function ProvenanceAuthorAttribution({
   className?: string;
 }) {
   const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
+  const sameIdentity = authorMatchesSubmitter(entry.author, entry.submittedBy);
   const authorContributor =
-    !entry.submittedBy && entry.author
+    entry.author && !verifiedAuthor && (!entry.submittedBy || !sameIdentity)
       ? findContributorForIdentity(entry.author, entry.authorProfileUrl)
       : undefined;
 
@@ -104,7 +103,7 @@ export function ProvenanceAuthorAttribution({
     );
   }
 
-  if (authorContributor && !entry.submittedBy) {
+  if (authorContributor) {
     return (
       <ContributorProfileLink
         contributor={authorContributor}

--- a/apps/web/src/components/entry-attribution-label.tsx
+++ b/apps/web/src/components/entry-attribution-label.tsx
@@ -1,9 +1,5 @@
+import { authorMatchesSubmitter } from "@/lib/contributor-identity";
 import type { Entry } from "@/types/registry";
-
-function sameIdentity(author: string, submittedBy?: string) {
-  if (!submittedBy) return false;
-  return author.trim().toLowerCase() === submittedBy.trim().toLowerCase();
-}
 
 /** Text-only attribution for compact surfaces that must not import registry data modules. */
 export function EntryAttributionLabel({
@@ -13,7 +9,7 @@ export function EntryAttributionLabel({
   entry: Entry;
   className?: string;
 }) {
-  if (entry.submittedBy && !sameIdentity(entry.author, entry.submittedBy)) {
+  if (entry.submittedBy && !authorMatchesSubmitter(entry.author, entry.submittedBy)) {
     return (
       <span className={className}>
         by <span className="text-ink">{entry.author}</span>

--- a/apps/web/src/components/entry-attribution-label.tsx
+++ b/apps/web/src/components/entry-attribution-label.tsx
@@ -1,0 +1,31 @@
+import type { Entry } from "@/types/registry";
+
+function sameIdentity(author: string, submittedBy?: string) {
+  if (!submittedBy) return false;
+  return author.trim().toLowerCase() === submittedBy.trim().toLowerCase();
+}
+
+/** Text-only attribution for compact surfaces that must not import registry data modules. */
+export function EntryAttributionLabel({
+  entry,
+  className = "text-xs text-ink-subtle",
+}: {
+  entry: Entry;
+  className?: string;
+}) {
+  if (entry.submittedBy && !sameIdentity(entry.author, entry.submittedBy)) {
+    return (
+      <span className={className}>
+        by <span className="text-ink">{entry.author}</span>
+        {" · submitted by "}
+        <span className="text-ink">{entry.submittedBy}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className={className}>
+      by <span className="text-ink">{entry.author}</span>
+    </span>
+  );
+}

--- a/apps/web/src/components/lazy-linked-attribution.tsx
+++ b/apps/web/src/components/lazy-linked-attribution.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import type { Entry } from "@/types/registry";
+import { EntryAttributionLabel } from "./entry-attribution-label";
+
+const LinkedAttribution = React.lazy(async () => {
+  const module = await import("./contributor-attribution");
+  return { default: module.EntryAuthorAttribution };
+});
+
+const LinkedSourceCitations = React.lazy(async () => {
+  const [{ SourceCitations }, { findContributorForIdentity }] = await Promise.all([
+    import("./source-citations"),
+    import("@/data/contributors"),
+  ]);
+  return {
+    default: function LinkedSourceCitationsInner({ entry }: { entry: Entry }) {
+      return (
+        <SourceCitations
+          entry={entry}
+          resolveContributorSlug={(name, profileUrl) =>
+            findContributorForIdentity(name, profileUrl)?.slug
+          }
+        />
+      );
+    },
+  };
+});
+
+export function LazyEntryAuthorAttribution({
+  entry,
+  className,
+}: {
+  entry: Entry;
+  className?: string;
+}) {
+  return (
+    <React.Suspense fallback={<EntryAttributionLabel entry={entry} className={className} />}>
+      <LinkedAttribution entry={entry} className={className} />
+    </React.Suspense>
+  );
+}
+
+export function LazyLinkedSourceCitations({ entry }: { entry: Entry }) {
+  return (
+    <React.Suspense fallback={<p className="text-sm text-ink-subtle">Loading source citations…</p>}>
+      <LinkedSourceCitations entry={entry} />
+    </React.Suspense>
+  );
+}

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -28,7 +28,7 @@ import { useHarnessPref, useCopyPref, type CopyVariant } from "@/lib/dossier-pre
 import { entryDomId } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 import { setHotPeek, clearHotPeek, installPeekShortcut } from "@/lib/peek-hotkey";
-import { EntryAuthorAttribution } from "./contributor-attribution";
+import { EntryAttributionLabel } from "./entry-attribution-label";
 
 export interface PeekHandle {
   open: () => void;
@@ -124,7 +124,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-ink-muted">
-          <EntryAuthorAttribution entry={entry} />
+          <EntryAttributionLabel entry={entry} />
           {typeof entry.repoStats?.stars === "number" && (
             <span className="inline-flex items-center gap-1 tabular-nums" title="Source repo stars">
               <Star className="h-3 w-3" aria-hidden />

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -28,6 +28,7 @@ import { useHarnessPref, useCopyPref, type CopyVariant } from "@/lib/dossier-pre
 import { entryDomId } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 import { setHotPeek, clearHotPeek, installPeekShortcut } from "@/lib/peek-hotkey";
+import { EntryAuthorAttribution } from "./contributor-attribution";
 
 export interface PeekHandle {
   open: () => void;
@@ -123,9 +124,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-ink-muted">
-          <span>
-            by <span className="text-ink">{entry.author}</span>
-          </span>
+          <EntryAuthorAttribution entry={entry} />
           {typeof entry.repoStats?.stars === "number" && (
             <span className="inline-flex items-center gap-1 tabular-nums" title="Source repo stars">
               <Star className="h-3 w-3" aria-hidden />

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -20,7 +20,6 @@ import {
   SourceBadge,
   PlatformChip,
 } from "./badges";
-import { SourceCitations } from "./source-citations";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { HarnessVariantPicker } from "./harness-variant-picker";
@@ -28,7 +27,7 @@ import { useHarnessPref, useCopyPref, type CopyVariant } from "@/lib/dossier-pre
 import { entryDomId } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 import { setHotPeek, clearHotPeek, installPeekShortcut } from "@/lib/peek-hotkey";
-import { EntryAttributionLabel } from "./entry-attribution-label";
+import { LazyEntryAuthorAttribution, LazyLinkedSourceCitations } from "./lazy-linked-attribution";
 
 export interface PeekHandle {
   open: () => void;
@@ -124,7 +123,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
           </div>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs text-ink-muted">
-          <EntryAttributionLabel entry={entry} />
+          <LazyEntryAuthorAttribution entry={entry} />
           {typeof entry.repoStats?.stars === "number" && (
             <span className="inline-flex items-center gap-1 tabular-nums" title="Source repo stars">
               <Star className="h-3 w-3" aria-hidden />
@@ -176,7 +175,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
 
       <div className="mt-5">
         <div className="eyebrow mb-2">Sources</div>
-        <SourceCitations entry={entry} />
+        <LazyLinkedSourceCitations entry={entry} />
       </div>
 
       <div className="mt-5 flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/provenance-block.tsx
+++ b/apps/web/src/components/provenance-block.tsx
@@ -1,5 +1,8 @@
 import type { Entry } from "@/types/registry";
-import { ContributorIdentityLink } from "@/components/contributor-attribution";
+import {
+  ContributorIdentityLink,
+  ProvenanceAuthorAttribution,
+} from "@/components/contributor-attribution";
 import { CLAIM_LABEL } from "@/types/registry";
 import { Github, ExternalLink } from "lucide-react";
 
@@ -11,12 +14,7 @@ export function ProvenanceBlock({ entry }: { entry: Entry }) {
       <dl className="grid grid-cols-2 gap-3">
         <Row
           label="Author"
-          value={
-            <ContributorIdentityLink
-              name={entry.author}
-              profileUrl={entry.authorProfileUrl}
-            />
-          }
+          value={<ProvenanceAuthorAttribution entry={entry} />}
         />
         {entry.submittedBy && (
           <Row

--- a/apps/web/src/components/provenance-block.tsx
+++ b/apps/web/src/components/provenance-block.tsx
@@ -12,10 +12,7 @@ export function ProvenanceBlock({ entry }: { entry: Entry }) {
     <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">
       <div className="eyebrow mb-3">Provenance</div>
       <dl className="grid grid-cols-2 gap-3">
-        <Row
-          label="Author"
-          value={<ProvenanceAuthorAttribution entry={entry} />}
-        />
+        <Row label="Author" value={<ProvenanceAuthorAttribution entry={entry} />} />
         {entry.submittedBy && (
           <Row
             label="Submitted by"

--- a/apps/web/src/components/provenance-block.tsx
+++ b/apps/web/src/components/provenance-block.tsx
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { ContributorIdentityLink } from "@/components/contributor-attribution";
 import { CLAIM_LABEL } from "@/types/registry";
 import { Github, ExternalLink } from "lucide-react";
 
@@ -8,20 +9,26 @@ export function ProvenanceBlock({ entry }: { entry: Entry }) {
     <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">
       <div className="eyebrow mb-3">Provenance</div>
       <dl className="grid grid-cols-2 gap-3">
-        <Row label="Author" value={entry.author} />
+        <Row
+          label="Author"
+          value={
+            <ContributorIdentityLink
+              name={entry.author}
+              profileUrl={entry.authorProfileUrl}
+            />
+          }
+        />
         {entry.submittedBy && (
           <Row
             label="Submitted by"
             value={
-              <a
-                href={entry.submittedByUrl ?? `https://github.com/${entry.submittedBy}`}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1 text-ink hover:underline"
-              >
-                <Github className="h-3 w-3" />
-                {entry.submittedBy}
-              </a>
+              <span className="inline-flex items-center gap-1">
+                <Github className="h-3 w-3" aria-hidden />
+                <ContributorIdentityLink
+                  name={entry.submittedBy}
+                  profileUrl={entry.submittedByUrl ?? `https://github.com/${entry.submittedBy}`}
+                />
+              </span>
             }
           />
         )}

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -16,7 +16,6 @@ import { EntryBrandMark } from "./entry-brand-mark";
 import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
 import { PeekHint } from "./peek-hint";
-import { EntryAttributionLabel } from "./entry-attribution-label";
 import { LazyEntryAuthorAttribution } from "./lazy-linked-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
@@ -110,14 +109,14 @@ function ResourceCardInner({
           <span className="hidden min-w-0 max-w-[40%] truncate text-xs text-ink-muted sm:inline">
             {entry.cardDescription ?? entry.description}
           </span>
-          <span className="hidden md:inline-flex">
-            <EntryAttributionLabel entry={entry} className="truncate text-xs text-ink-subtle" />
-          </span>
           <span className="hidden sm:inline-flex">
             <SourceRepoStars entry={entry} compact />
           </span>
           <TrustBadge level={entry.trust} />
         </Link>
+        <span className="hidden min-w-0 shrink md:inline-flex">
+          <LazyEntryAuthorAttribution entry={entry} className="truncate text-xs text-ink-subtle" />
+        </span>
         <PeekButton
           ref={peekRef}
           entry={entry}
@@ -136,42 +135,44 @@ function ResourceCardInner({
           inCompare ? "border-accent ring-1 ring-accent/40" : "border-border",
         )}
       >
-        <Link
-          to="/entry/$category/$slug"
-          params={{ category: entry.category, slug: entry.slug }}
-          className="flex flex-1 flex-col gap-3 p-4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60 rounded-lg"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <EntryBrandMark entry={entry} size="xs" />
-              <CategoryPill>{entry.category}</CategoryPill>
+        <div className="flex flex-1 flex-col gap-3 p-4">
+          <Link
+            to="/entry/$category/$slug"
+            params={{ category: entry.category, slug: entry.slug }}
+            className="flex flex-1 flex-col gap-3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent/60 rounded-lg"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-2">
+                <EntryBrandMark entry={entry} size="xs" />
+                <CategoryPill>{entry.category}</CategoryPill>
+              </div>
+              <div className="flex min-h-4 items-center text-xs text-ink-muted tabular-nums">
+                <SourceRepoStars entry={entry} compact />
+              </div>
             </div>
-            <div className="flex min-h-4 items-center text-xs text-ink-muted tabular-nums">
-              <SourceRepoStars entry={entry} compact />
+            <div>
+              <h3 className="font-display text-base font-semibold leading-tight text-ink">
+                {entry.title}
+              </h3>
+              <p className="mt-1.5 line-clamp-2 text-sm text-ink-muted">
+                {entry.cardDescription ?? entry.description}
+              </p>
             </div>
-          </div>
-          <div>
-            <h3 className="font-display text-base font-semibold leading-tight text-ink">
-              {entry.title}
-            </h3>
-            <p className="mt-1.5 line-clamp-2 text-sm text-ink-muted">
-              {entry.cardDescription ?? entry.description}
-            </p>
-            <EntryAttributionLabel entry={entry} className="mt-2" />
-          </div>
-          <EntryFacets entry={entry} density="card" />
-          <div className="mt-auto flex flex-wrap items-center gap-1.5">
-            <TrustBadge level={entry.trust} />
-            <SourceBadge status={entry.source} />
-            <InstallRiskBadge entry={entry} size="xs" />
-            {entry.dateAdded && (
-              <span className="ml-auto font-mono text-[10px] text-ink-subtle">
-                Added {timeAgo(entry.dateAdded)}
-              </span>
-            )}
-          </div>
-          <NotesPresenceChips entry={entry} />
-        </Link>
+            <EntryFacets entry={entry} density="card" />
+            <div className="mt-auto flex flex-wrap items-center gap-1.5">
+              <TrustBadge level={entry.trust} />
+              <SourceBadge status={entry.source} />
+              <InstallRiskBadge entry={entry} size="xs" />
+              {entry.dateAdded && (
+                <span className="ml-auto font-mono text-[10px] text-ink-subtle">
+                  Added {timeAgo(entry.dateAdded)}
+                </span>
+              )}
+            </div>
+            <NotesPresenceChips entry={entry} />
+          </Link>
+          <LazyEntryAuthorAttribution entry={entry} className="text-xs text-ink-subtle" />
+        </div>
         <div className="pointer-events-none absolute right-2 top-2 z-10 flex items-center gap-1 rounded-md border border-border bg-surface/95 p-0.5 opacity-0 shadow-sm backdrop-blur transition-opacity duration-150 group-hover:opacity-100 focus-within:opacity-100 group-focus-within:opacity-100">
           <div className="pointer-events-auto">
             <PeekButton ref={peekRef} entry={entry} />

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -15,7 +15,7 @@ import { CopyButton } from "./copy-button";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
-import { PeekHint } from "./peek-hint";
+import { EntryAuthorAttribution } from "./contributor-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
 import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
@@ -237,7 +237,7 @@ function ResourceCardInner({
             <h3 className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline">
               {entry.title}
             </h3>
-            <span className="text-xs text-ink-subtle">by {entry.author}</span>
+            <EntryAuthorAttribution entry={entry} className="text-xs text-ink-subtle" />
           </Link>
           <p className="line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
           <div className="flex flex-wrap items-center gap-2 pt-0.5">

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -15,6 +15,7 @@ import { CopyButton } from "./copy-button";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
+import { PeekHint } from "./peek-hint";
 import { EntryAuthorAttribution } from "./contributor-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -17,6 +17,7 @@ import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
 import { PeekHint } from "./peek-hint";
 import { EntryAttributionLabel } from "./entry-attribution-label";
+import { LazyEntryAuthorAttribution } from "./lazy-linked-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
 import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
@@ -109,6 +110,9 @@ function ResourceCardInner({
           <span className="hidden min-w-0 max-w-[40%] truncate text-xs text-ink-muted sm:inline">
             {entry.cardDescription ?? entry.description}
           </span>
+          <span className="hidden md:inline-flex">
+            <EntryAttributionLabel entry={entry} className="truncate text-xs text-ink-subtle" />
+          </span>
           <span className="hidden sm:inline-flex">
             <SourceRepoStars entry={entry} compact />
           </span>
@@ -153,6 +157,7 @@ function ResourceCardInner({
             <p className="mt-1.5 line-clamp-2 text-sm text-ink-muted">
               {entry.cardDescription ?? entry.description}
             </p>
+            <EntryAttributionLabel entry={entry} className="mt-2" />
           </div>
           <EntryFacets entry={entry} density="card" />
           <div className="mt-auto flex flex-wrap items-center gap-1.5">
@@ -238,7 +243,7 @@ function ResourceCardInner({
             >
               {entry.title}
             </Link>
-            <EntryAttributionLabel entry={entry} />
+            <LazyEntryAuthorAttribution entry={entry} />
           </div>
           <p className="line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
           <div className="flex flex-wrap items-center gap-2 pt-0.5">

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -16,7 +16,7 @@ import { EntryBrandMark } from "./entry-brand-mark";
 import { EntryFacets } from "./entry-facets";
 import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-button";
 import { PeekHint } from "./peek-hint";
-import { EntryAuthorAttribution } from "./contributor-attribution";
+import { EntryAttributionLabel } from "./entry-attribution-label";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
 import { cn } from "@/lib/utils";
 import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
@@ -230,16 +230,16 @@ function ResourceCardInner({
             ))}
           </div>
 
-          <Link
-            to="/entry/$category/$slug"
-            params={{ category: entry.category, slug: entry.slug }}
-            className="flex items-baseline gap-2"
-          >
-            <h3 className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline">
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            <Link
+              to="/entry/$category/$slug"
+              params={{ category: entry.category, slug: entry.slug }}
+              className="font-display text-[15px] font-semibold tracking-tight text-ink group-hover:underline"
+            >
               {entry.title}
-            </h3>
-            <EntryAuthorAttribution entry={entry} className="text-xs text-ink-subtle" />
-          </Link>
+            </Link>
+            <EntryAttributionLabel entry={entry} />
+          </div>
           <p className="line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             <EntryFacets entry={entry} density="card" />

--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -17,6 +17,7 @@ type Citation = {
   hint?: string;
   Icon: React.ElementType;
   verifiedAt?: string;
+  contributorSlug?: string;
 };
 
 function hostOf(url?: string): string | undefined {
@@ -28,7 +29,13 @@ function hostOf(url?: string): string | undefined {
   }
 }
 
-export function SourceCitations({ entry }: { entry: Entry }) {
+export function SourceCitations({
+  entry,
+  resolveContributorSlug,
+}: {
+  entry: Entry;
+  resolveContributorSlug?: (name: string, profileUrl?: string) => string | undefined;
+}) {
   const cites: Citation[] = [];
   if (entry.sourceUrl) {
     cites.push({
@@ -82,11 +89,13 @@ export function SourceCitations({ entry }: { entry: Entry }) {
     });
   }
   if (entry.submittedBy) {
+    const contributorSlug = resolveContributorSlug?.(entry.submittedBy, entry.submittedByUrl);
     cites.push({
       label: `Submitted by ${entry.submittedBy}`,
-      href: entry.submittedByUrl,
+      href: contributorSlug ? undefined : entry.submittedByUrl,
       hint: entry.submittedAt,
       Icon: User,
+      contributorSlug,
     });
   }
 
@@ -120,7 +129,15 @@ export function SourceCitations({ entry }: { entry: Entry }) {
           );
           return (
             <li key={c.label}>
-              {c.href ? (
+              {c.contributorSlug ? (
+                <Link
+                  to="/contributors/$slug"
+                  params={{ slug: c.contributorSlug }}
+                  className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  {body}
+                </Link>
+              ) : c.href ? (
                 <a
                   href={c.href}
                   target="_blank"

--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -10,7 +10,6 @@ import {
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry } from "@/types/registry";
-import { findContributorForIdentity } from "@/data/contributors";
 
 type Citation = {
   label: string;
@@ -18,7 +17,6 @@ type Citation = {
   hint?: string;
   Icon: React.ElementType;
   verifiedAt?: string;
-  contributorSlug?: string;
 };
 
 function hostOf(url?: string): string | undefined {
@@ -84,16 +82,11 @@ export function SourceCitations({ entry }: { entry: Entry }) {
     });
   }
   if (entry.submittedBy) {
-    const submitterContributor = findContributorForIdentity(
-      entry.submittedBy,
-      entry.submittedByUrl,
-    );
     cites.push({
       label: `Submitted by ${entry.submittedBy}`,
-      href: submitterContributor ? undefined : entry.submittedByUrl,
+      href: entry.submittedByUrl,
       hint: entry.submittedAt,
       Icon: User,
-      contributorSlug: submitterContributor?.slug,
     });
   }
 
@@ -127,15 +120,7 @@ export function SourceCitations({ entry }: { entry: Entry }) {
           );
           return (
             <li key={c.label}>
-              {c.contributorSlug ? (
-                <Link
-                  to="/contributors/$slug"
-                  params={{ slug: c.contributorSlug }}
-                  className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
-                >
-                  {body}
-                </Link>
-              ) : c.href ? (
+              {c.href ? (
                 <a
                   href={c.href}
                   target="_blank"

--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry } from "@/types/registry";
+import { findContributorForIdentity } from "@/data/contributors";
 
 type Citation = {
   label: string;
@@ -17,6 +18,7 @@ type Citation = {
   hint?: string;
   Icon: React.ElementType;
   verifiedAt?: string;
+  contributorSlug?: string;
 };
 
 function hostOf(url?: string): string | undefined {
@@ -82,11 +84,16 @@ export function SourceCitations({ entry }: { entry: Entry }) {
     });
   }
   if (entry.submittedBy) {
+    const submitterContributor = findContributorForIdentity(
+      entry.submittedBy,
+      entry.submittedByUrl,
+    );
     cites.push({
       label: `Submitted by ${entry.submittedBy}`,
-      href: entry.submittedByUrl,
+      href: submitterContributor ? undefined : entry.submittedByUrl,
       hint: entry.submittedAt,
       Icon: User,
+      contributorSlug: submitterContributor?.slug,
     });
   }
 
@@ -120,7 +127,15 @@ export function SourceCitations({ entry }: { entry: Entry }) {
           );
           return (
             <li key={c.label}>
-              {c.href ? (
+              {c.contributorSlug ? (
+                <Link
+                  to="/contributors/$slug"
+                  params={{ slug: c.contributorSlug }}
+                  className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
+                >
+                  {body}
+                </Link>
+              ) : c.href ? (
                 <a
                   href={c.href}
                   target="_blank"

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -105,7 +105,7 @@ function upsertContributor(
 
   existing.acceptedCount += 1;
   if (options.creditSourceSubmission && (entry.sourceSubmissionUrl || entry.importPrUrl)) {
-    existing.sourceSubmissionCount = (existing.sourceSubmissionCount ?? 0) + 1;
+    existing.sourceSubmissionCount += 1;
   }
   incrementCategory(existing, entry.category);
   existing.github ||= profileUrl;
@@ -117,7 +117,6 @@ export const CONTRIBUTORS: Contributor[] = (() => {
 
   for (const entry of ENTRIES) {
     const submitter = String(entry.submittedBy || entry.author || "JSONbored").trim();
-    if (!submitter) continue;
     upsertContributor(grouped, submitter, entry.submittedByUrl, entry, {
       creditSourceSubmission: true,
     });
@@ -135,7 +134,7 @@ export const CONTRIBUTORS: Contributor[] = (() => {
   for (const entry of ENTRIES) {
     for (const contributor of grouped.values()) {
       if (contributorReviewedEntry(contributor, entry)) {
-        contributor.reviewedCount = (contributor.reviewedCount ?? 0) + 1;
+        contributor.reviewedCount += 1;
       }
     }
   }

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -83,6 +83,7 @@ function upsertContributor(
   name: string,
   profileUrl: string | undefined,
   entry: Entry,
+  options: { creditSourceSubmission?: boolean } = {},
 ) {
   const slug = contributorSlug(name);
   if (!slug) return;
@@ -103,7 +104,7 @@ function upsertContributor(
     } satisfies MutableContributor);
 
   existing.acceptedCount += 1;
-  if (entry.sourceSubmissionUrl || entry.importPrUrl) {
+  if (options.creditSourceSubmission && (entry.sourceSubmissionUrl || entry.importPrUrl)) {
     existing.sourceSubmissionCount = (existing.sourceSubmissionCount ?? 0) + 1;
   }
   incrementCategory(existing, entry.category);
@@ -117,7 +118,9 @@ export const CONTRIBUTORS: Contributor[] = (() => {
   for (const entry of ENTRIES) {
     const submitter = String(entry.submittedBy || entry.author || "JSONbored").trim();
     if (!submitter) continue;
-    upsertContributor(grouped, submitter, entry.submittedByUrl, entry);
+    upsertContributor(grouped, submitter, entry.submittedByUrl, entry, {
+      creditSourceSubmission: true,
+    });
 
     const author = String(entry.author || "").trim();
     if (
@@ -158,7 +161,9 @@ export function getContributor(slug: string) {
 
 export function findContributorForIdentity(name?: string, profileUrl?: string) {
   if (!name) return undefined;
-  return CONTRIBUTORS.find((contributor) => contributorMatchesIdentity(contributor, name, profileUrl));
+  return CONTRIBUTORS.find((contributor) =>
+    contributorMatchesIdentity(contributor, name, profileUrl),
+  );
 }
 
 export function contributorForVerifiedAuthor(author?: string, submittedBy?: string) {
@@ -176,10 +181,7 @@ export function contributorForSubmitter(entry: Pick<Entry, "submittedBy" | "subm
   return findContributorForIdentity(entry.submittedBy, entry.submittedByUrl);
 }
 
-export function authorMatchesSubmitter(
-  author?: string,
-  submittedBy?: string,
-) {
+export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
   if (!author || !submittedBy) return false;
   const authorSlug = contributorSlug(author);
   const submittedBySlug = contributorSlug(submittedBy);

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -198,5 +198,11 @@ export function contributorForDisplayAuthor(
   if (!entry.submittedBy || authorMatchesSubmitter(entry.author, entry.submittedBy)) {
     return findContributorForIdentity(entry.author, entry.authorProfileUrl);
   }
-  return undefined;
+
+  const submitter = String(entry.submittedBy || entry.author || "JSONbored").trim();
+  if (!shouldRegisterDistinctAuthorProfile(entry, submitter)) {
+    return undefined;
+  }
+
+  return findContributorForIdentity(entry.author, entry.authorProfileUrl);
 }

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -118,11 +118,7 @@ export const CONTRIBUTORS: Contributor[] = (() => {
     });
 
     const author = String(entry.author || "").trim();
-    if (
-      author &&
-      contributorSlug(author) &&
-      contributorSlug(author) !== contributorSlug(submitter)
-    ) {
+    if (shouldRegisterDistinctAuthorProfile(entry, submitter)) {
       upsertContributor(grouped, author, entry.authorProfileUrl, entry);
     }
   }
@@ -174,4 +170,33 @@ export function contributorForVerifiedAuthor(author?: string, submittedBy?: stri
 export function contributorForSubmitter(entry: Pick<Entry, "submittedBy" | "submittedByUrl">) {
   if (!entry.submittedBy) return undefined;
   return findContributorForIdentity(entry.submittedBy, entry.submittedByUrl);
+}
+
+export function shouldRegisterDistinctAuthorProfile(
+  entry: Pick<Entry, "author" | "submittedBy" | "authorProfileUrl">,
+  submitter: string,
+) {
+  const author = String(entry.author || "").trim();
+  const authorSlug = contributorSlug(author);
+  if (!authorSlug || authorSlug === contributorSlug(submitter)) return false;
+  if (!entry.authorProfileUrl) return false;
+  if (
+    entry.submittedBy &&
+    !authorMatchesSubmitter(entry.author, entry.submittedBy) &&
+    githubHandle(entry.authorProfileUrl) === authorSlug
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function contributorForDisplayAuthor(
+  entry: Pick<Entry, "author" | "submittedBy" | "authorProfileUrl">,
+) {
+  const verifiedAuthor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
+  if (verifiedAuthor) return verifiedAuthor;
+  if (!entry.submittedBy || authorMatchesSubmitter(entry.author, entry.submittedBy)) {
+    return findContributorForIdentity(entry.author, entry.authorProfileUrl);
+  }
+  return undefined;
 }

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -78,38 +78,55 @@ function incrementCategory(contributor: MutableContributor, category: Category) 
   contributor.categoryCounts.set(category, (contributor.categoryCounts.get(category) ?? 0) + 1);
 }
 
+function upsertContributor(
+  grouped: Map<string, MutableContributor>,
+  name: string,
+  profileUrl: string | undefined,
+  entry: Entry,
+) {
+  const slug = contributorSlug(name);
+  if (!slug) return;
+  const handle = githubHandle(profileUrl) || name.replace(/^@/, "");
+  const existing =
+    grouped.get(slug) ??
+    ({
+      slug,
+      handle,
+      name,
+      github: profileUrl,
+      bio: "Contributor credited on accepted HeyClaude registry entries.",
+      acceptedCount: 0,
+      reviewedCount: 0,
+      sourceSubmissionCount: 0,
+      categories: [],
+      categoryCounts: new Map<Category, number>(),
+    } satisfies MutableContributor);
+
+  existing.acceptedCount += 1;
+  if (entry.sourceSubmissionUrl || entry.importPrUrl) {
+    existing.sourceSubmissionCount = (existing.sourceSubmissionCount ?? 0) + 1;
+  }
+  incrementCategory(existing, entry.category);
+  existing.github ||= profileUrl;
+  grouped.set(slug, existing);
+}
+
 export const CONTRIBUTORS: Contributor[] = (() => {
   const grouped = new Map<string, MutableContributor>();
 
   for (const entry of ENTRIES) {
-    const name = String(entry.submittedBy || entry.author || "JSONbored").trim();
-    if (!name) continue;
-    const slug = contributorSlug(name);
-    if (!slug) continue;
-    const profileUrl = entry.submittedByUrl;
-    const handle = githubHandle(profileUrl) || name.replace(/^@/, "");
-    const existing =
-      grouped.get(slug) ??
-      ({
-        slug,
-        handle,
-        name,
-        github: profileUrl,
-        bio: "Contributor credited on accepted HeyClaude registry entries.",
-        acceptedCount: 0,
-        reviewedCount: 0,
-        sourceSubmissionCount: 0,
-        categories: [],
-        categoryCounts: new Map<Category, number>(),
-      } satisfies MutableContributor);
+    const submitter = String(entry.submittedBy || entry.author || "JSONbored").trim();
+    if (!submitter) continue;
+    upsertContributor(grouped, submitter, entry.submittedByUrl, entry);
 
-    existing.acceptedCount += 1;
-    if (entry.sourceSubmissionUrl || entry.importPrUrl) {
-      existing.sourceSubmissionCount = (existing.sourceSubmissionCount ?? 0) + 1;
+    const author = String(entry.author || "").trim();
+    if (
+      author &&
+      contributorSlug(author) &&
+      contributorSlug(author) !== contributorSlug(submitter)
+    ) {
+      upsertContributor(grouped, author, entry.authorProfileUrl, entry);
     }
-    incrementCategory(existing, entry.category);
-    existing.github ||= profileUrl;
-    grouped.set(slug, existing);
   }
 
   for (const entry of ENTRIES) {
@@ -139,6 +156,11 @@ export function getContributor(slug: string) {
   return CONTRIBUTORS.find((c) => c.slug === slug);
 }
 
+export function findContributorForIdentity(name?: string, profileUrl?: string) {
+  if (!name) return undefined;
+  return CONTRIBUTORS.find((contributor) => contributorMatchesIdentity(contributor, name, profileUrl));
+}
+
 export function contributorForVerifiedAuthor(author?: string, submittedBy?: string) {
   if (!author || !submittedBy) return undefined;
 
@@ -147,4 +169,19 @@ export function contributorForVerifiedAuthor(author?: string, submittedBy?: stri
   if (!authorSlug || authorSlug !== submittedBySlug) return undefined;
 
   return getContributor(submittedBySlug);
+}
+
+export function contributorForSubmitter(entry: Pick<Entry, "submittedBy" | "submittedByUrl">) {
+  if (!entry.submittedBy) return undefined;
+  return findContributorForIdentity(entry.submittedBy, entry.submittedByUrl);
+}
+
+export function authorMatchesSubmitter(
+  author?: string,
+  submittedBy?: string,
+) {
+  if (!author || !submittedBy) return false;
+  const authorSlug = contributorSlug(author);
+  const submittedBySlug = contributorSlug(submittedBy);
+  return Boolean(authorSlug && authorSlug === submittedBySlug);
 }

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -71,6 +71,8 @@ export function contributorReviewedEntry(contributor: Contributor, entry: Entry)
 }
 
 type MutableContributor = Contributor & {
+  reviewedCount: number;
+  sourceSubmissionCount: number;
   categoryCounts: Map<Category, number>;
 };
 

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -199,7 +199,7 @@ export function contributorForDisplayAuthor(
     return findContributorForIdentity(entry.author, entry.authorProfileUrl);
   }
 
-  const submitter = String(entry.submittedBy || entry.author || "JSONbored").trim();
+  const submitter = String(entry.submittedBy).trim();
   if (!shouldRegisterDistinctAuthorProfile(entry, submitter)) {
     return undefined;
   }

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -1,14 +1,8 @@
 import { ENTRIES } from "@/data/entries";
+import { authorMatchesSubmitter, contributorSlug } from "@/lib/contributor-identity";
 import type { Category, Contributor, Entry } from "@/types/registry";
 
-export function contributorSlug(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^@/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
+export { authorMatchesSubmitter, contributorSlug };
 
 export function githubHandle(profileUrl?: string) {
   if (!profileUrl) return undefined;
@@ -180,11 +174,4 @@ export function contributorForVerifiedAuthor(author?: string, submittedBy?: stri
 export function contributorForSubmitter(entry: Pick<Entry, "submittedBy" | "submittedByUrl">) {
   if (!entry.submittedBy) return undefined;
   return findContributorForIdentity(entry.submittedBy, entry.submittedByUrl);
-}
-
-export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
-  if (!author || !submittedBy) return false;
-  const authorSlug = contributorSlug(author);
-  const submittedBySlug = contributorSlug(submittedBy);
-  return Boolean(authorSlug && authorSlug === submittedBySlug);
 }

--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -399,9 +399,10 @@ export function buildEntry(entry: RegistryEntry): Entry {
   const reviewedAt =
     entry.reviewedAt ?? entry.trustSignals?.lastVerifiedAt ?? entry.contentUpdatedAt;
   const authorProfileUrl = entry.authorProfileUrl;
+  const author = entry.author ?? entry.submittedBy ?? entry.brandName ?? "Unknown";
   const submittedByUrl =
     entry.submittedByUrl ??
-    (authorMatchesSubmitter(entry.author, entry.submittedBy) ? authorProfileUrl : undefined);
+    (authorMatchesSubmitter(author, entry.submittedBy) ? authorProfileUrl : undefined);
 
   return {
     category,
@@ -411,7 +412,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     seoTitle: entry.seoTitle,
     seoDescription: entry.seoDescription,
     cardDescription: entry.cardDescription,
-    author: entry.author ?? entry.submittedBy ?? entry.brandName ?? "Unknown",
+    author,
     authorProfileUrl,
     submittedBy: entry.submittedBy,
     submittedByUrl,

--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -407,6 +407,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     seoDescription: entry.seoDescription,
     cardDescription: entry.cardDescription,
     author: entry.author ?? entry.submittedBy ?? entry.brandName ?? "Unknown",
+    authorProfileUrl: entry.authorProfileUrl,
     submittedBy: entry.submittedBy,
     submittedByUrl: entry.submittedByUrl ?? entry.authorProfileUrl,
     submittedAt: entry.submittedAt ?? entry.dateAdded,

--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -1,5 +1,6 @@
 import { normalizePlatform } from "@heyclaude/registry";
 
+import { authorMatchesSubmitter } from "@/lib/contributor-identity";
 import type {
   Category,
   Entry,
@@ -398,6 +399,9 @@ export function buildEntry(entry: RegistryEntry): Entry {
   const reviewedAt =
     entry.reviewedAt ?? entry.trustSignals?.lastVerifiedAt ?? entry.contentUpdatedAt;
   const authorProfileUrl = entry.authorProfileUrl;
+  const submittedByUrl =
+    entry.submittedByUrl ??
+    (authorMatchesSubmitter(entry.author, entry.submittedBy) ? authorProfileUrl : undefined);
 
   return {
     category,
@@ -410,7 +414,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     author: entry.author ?? entry.submittedBy ?? entry.brandName ?? "Unknown",
     authorProfileUrl,
     submittedBy: entry.submittedBy,
-    submittedByUrl: entry.submittedByUrl ?? entry.authorProfileUrl,
+    submittedByUrl,
     submittedAt: entry.submittedAt ?? entry.dateAdded,
     sourceSubmissionUrl: entry.sourceSubmissionUrl,
     importPrUrl: entry.importPrUrl,

--- a/apps/web/src/data/entry-normalize.ts
+++ b/apps/web/src/data/entry-normalize.ts
@@ -397,6 +397,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
   const platforms = inferPlatforms(entry);
   const reviewedAt =
     entry.reviewedAt ?? entry.trustSignals?.lastVerifiedAt ?? entry.contentUpdatedAt;
+  const authorProfileUrl = entry.authorProfileUrl;
 
   return {
     category,
@@ -407,7 +408,7 @@ export function buildEntry(entry: RegistryEntry): Entry {
     seoDescription: entry.seoDescription,
     cardDescription: entry.cardDescription,
     author: entry.author ?? entry.submittedBy ?? entry.brandName ?? "Unknown",
-    authorProfileUrl: entry.authorProfileUrl,
+    authorProfileUrl,
     submittedBy: entry.submittedBy,
     submittedByUrl: entry.submittedByUrl ?? entry.authorProfileUrl,
     submittedAt: entry.submittedAt ?? entry.dateAdded,

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -67,6 +67,7 @@ function querySearchProfile(query: string): QuerySearchProfile | null {
 }
 
 function normalizedSearchText(entry: Entry) {
+  const submittedBy = entry.submittedBy;
   return [
     entry.category,
     entry.slug,
@@ -74,7 +75,7 @@ function normalizedSearchText(entry: Entry) {
     entry.description,
     entry.cardDescription,
     entry.author,
-    entry.submittedBy,
+    submittedBy,
     entry.trust,
     entry.source,
     ...(entry.platforms ?? []),

--- a/apps/web/src/data/search.ts
+++ b/apps/web/src/data/search.ts
@@ -74,6 +74,7 @@ function normalizedSearchText(entry: Entry) {
     entry.description,
     entry.cardDescription,
     entry.author,
+    entry.submittedBy,
     entry.trust,
     entry.source,
     ...(entry.platforms ?? []),

--- a/apps/web/src/lib/contributor-identity.ts
+++ b/apps/web/src/lib/contributor-identity.ts
@@ -1,0 +1,15 @@
+export function contributorSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
+  if (!author || !submittedBy) return false;
+  const authorSlug = contributorSlug(author);
+  const submittedBySlug = contributorSlug(submittedBy);
+  return Boolean(authorSlug && authorSlug === submittedBySlug);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -24,7 +24,7 @@ import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
 import { BEST_LISTS } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
-import { contributorForVerifiedAuthor } from "@/data/contributors";
+import { EntryAuthorAttribution } from "@/components/contributor-attribution";
 import {
   CategoryPill,
   PlatformChip,
@@ -232,7 +232,6 @@ function Dossier() {
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
-  const authorContributor = contributorForVerifiedAuthor(entry.author, entry.submittedBy);
   const recents = useRecents();
   useEffect(() => {
     recents.pushEntry({ category: entry.category, slug: entry.slug, title: entry.title });
@@ -340,20 +339,7 @@ function Dossier() {
             {entry.description}
           </p>
           <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-ink-muted">
-            <span>
-              by{" "}
-              {authorContributor ? (
-                <Link
-                  to="/contributors/$slug"
-                  params={{ slug: authorContributor.slug }}
-                  className="text-ink hover:underline"
-                >
-                  {entry.author}
-                </Link>
-              ) : (
-                <span className="text-ink">{entry.author}</span>
-              )}
-            </span>
+            <EntryAuthorAttribution entry={entry} />
             <span>·</span>
             <span>added {entry.dateAdded}</span>
             {entry.repoStats?.stars !== undefined && (

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -25,6 +25,7 @@ import { getEntryRedirectTarget } from "@/lib/entry-redirects";
 import { BEST_LISTS } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { EntryAuthorAttribution } from "@/components/contributor-attribution";
+import { findContributorForIdentity } from "@/data/contributors";
 import {
   CategoryPill,
   PlatformChip,
@@ -634,7 +635,12 @@ function Dossier() {
           </DossierSection>
 
           <DossierSection id="citations" icon={FileText} title="Source citations">
-            <SourceCitations entry={entry} />
+            <SourceCitations
+              entry={entry}
+              resolveContributorSlug={(name, profileUrl) =>
+                findContributorForIdentity(name, profileUrl)?.slug
+              }
+            />
           </DossierSection>
 
           <BadgeSection category={entry.category} slug={entry.slug} title={entry.title} />

--- a/apps/web/src/types/registry.ts
+++ b/apps/web/src/types/registry.ts
@@ -148,6 +148,7 @@ export interface Entry extends Provenance, BrandInfo, SkillFields {
   seoDescription?: string;
   cardDescription?: string;
   author: string;
+  authorProfileUrl?: string;
   tags: string[];
   keywords?: string[];
   platforms: Platform[];

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Entry } from "@/types/registry";
+
+function fixture(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture-entry",
+    title: "Fixture Entry",
+    description: "Fixture description",
+    author: "JSONbored",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+vi.mock("@/data/entries", () => ({
+  ENTRIES: [
+    fixture({
+      slug: "import-pr-only",
+      author: "Distinct Author",
+      submittedBy: "import-submitter",
+      importPrUrl: "https://github.com/org/repo/pull/1",
+      submittedByUrl: "https://github.com/import-submitter",
+    }),
+    fixture({
+      slug: "split-authors",
+      author: "Split Author",
+      submittedBy: "split-submitter",
+      authorProfileUrl: "https://github.com/split-author",
+      sourceSubmissionUrl: "https://github.com/org/repo",
+      submittedByUrl: "https://github.com/split-submitter",
+    }),
+    fixture({
+      slug: "reviewed-entry",
+      author: "reviewer",
+      submittedBy: "reviewer",
+      reviewedBy: "reviewer",
+      submittedByUrl: "https://github.com/reviewer",
+    }),
+    fixture({
+      slug: "skip-invalid-slug",
+      author: "!!!",
+      submittedBy: "!!!",
+    }),
+    fixture({
+      slug: "at-handle-submitter",
+      author: "at-handle",
+      submittedBy: "@at-handle",
+      submittedByUrl: "https://github.com/at-handle",
+    }),
+  ],
+}));
+
+import {
+  CONTRIBUTORS,
+  authorMatchesSubmitter,
+  contributorAcceptedEntryRole,
+  contributorForSubmitter,
+  contributorForVerifiedAuthor,
+  contributorMatchesIdentity,
+  contributorSlug,
+  findContributorForIdentity,
+  getContributor,
+} from "../apps/web/src/data/contributors";
+
+describe("contributors attribution aggregation", () => {
+  it("builds submitter and distinct author profiles from fixture entries", () => {
+    expect(getContributor("import-submitter")?.sourceSubmissionCount).toBe(1);
+    expect(getContributor("distinct-author")?.sourceSubmissionCount ?? 0).toBe(
+      0,
+    );
+    expect(getContributor("split-author")?.github).toBe(
+      "https://github.com/split-author",
+    );
+    expect(getContributor("reviewer")?.reviewedCount).toBe(1);
+    expect(getContributor("at-handle")?.handle).toBe("at-handle");
+    expect(
+      CONTRIBUTORS.some((contributor) => contributor.slug === "invalid"),
+    ).toBe(false);
+  });
+
+  it("handles contributor identity guardrails", () => {
+    const contributor = {
+      slug: "jane-doe",
+      handle: "janedoe",
+      name: "Jane Doe",
+      github: "https://github.com/janedoe",
+      acceptedCount: 1,
+    };
+
+    expect(
+      contributorAcceptedEntryRole(
+        contributor,
+        fixture({ author: "Other", submittedBy: "Someone else" }),
+      ),
+    ).toBeUndefined();
+    expect(findContributorForIdentity()).toBeUndefined();
+    expect(findContributorForIdentity("")).toBeUndefined();
+    expect(contributorForVerifiedAuthor()).toBeUndefined();
+    expect(contributorForVerifiedAuthor("author-only")).toBeUndefined();
+    expect(
+      contributorForVerifiedAuthor(undefined, "submitter-only"),
+    ).toBeUndefined();
+    expect(contributorForSubmitter({})).toBeUndefined();
+    expect(contributorForSubmitter({ submittedBy: undefined })).toBeUndefined();
+    expect(authorMatchesSubmitter()).toBe(false);
+    expect(authorMatchesSubmitter("author-only")).toBe(false);
+    expect(authorMatchesSubmitter(undefined, "submitter-only")).toBe(false);
+    expect(contributorMatchesIdentity(contributor, "!!!")).toBe(false);
+    expect(contributorSlug("!!!")).toBe("");
+  });
+});

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -152,6 +152,40 @@ describe("contributors attribution aggregation", () => {
         fixture({ author: "Author Only", submittedBy: undefined }),
       )?.slug,
     ).toBe("author-only");
+    expect(
+      contributorForDisplayAuthor(
+        fixture({
+          author: "reviewer",
+          submittedBy: "reviewer",
+          submittedByUrl: "https://github.com/reviewer",
+        }),
+      )?.slug,
+    ).toBe("reviewer");
+    expect(
+      contributorForDisplayAuthor(
+        fixture({
+          author: "at-handle",
+          submittedBy: "@at-handle",
+          submittedByUrl: "https://github.com/at-handle",
+        }),
+      )?.slug,
+    ).toBe("at-handle");
+    expect(
+      shouldRegisterDistinctAuthorProfile(
+        { author: "Split Author", submittedBy: "other" },
+        "other",
+      ),
+    ).toBe(false);
+    expect(
+      shouldRegisterDistinctAuthorProfile(
+        {
+          author: "!!!",
+          submittedBy: "other",
+          authorProfileUrl: "https://brand.dev",
+        },
+        "other",
+      ),
+    ).toBe(false);
   });
 
   it("handles contributor identity guardrails", () => {

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -145,7 +145,7 @@ describe("contributors attribution aggregation", () => {
     expect(
       shouldRegisterDistinctAuthorProfile(spoofEntry, "spoof-submitter"),
     ).toBe(false);
-    expect(contributorForDisplayAuthor(splitEntry)).toBeUndefined();
+    expect(contributorForDisplayAuthor(splitEntry)?.slug).toBe("split-author");
     expect(contributorForDisplayAuthor(spoofEntry)).toBeUndefined();
     expect(
       contributorForDisplayAuthor(

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -73,6 +73,16 @@ vi.mock("@/data/entries", () => ({
       sourceSubmissionUrl: "https://github.com/org/repo/pull/99",
       submittedByUrl: "https://github.com/credit-submitter",
     }),
+    fixture({
+      slug: "author-only-submitter",
+      author: "Author Only",
+      submittedBy: undefined,
+    }),
+    fixture({
+      slug: "jsonbored-fallback",
+      author: "",
+      submittedBy: "",
+    }),
   ],
 }));
 
@@ -101,6 +111,8 @@ describe("contributors attribution aggregation", () => {
     expect(getContributor("at-handle")?.handle).toBe("at-handle");
     expect(getContributor("solo-submitter")?.acceptedCount).toBe(1);
     expect(getContributor("credit-submitter")?.sourceSubmissionCount).toBe(2);
+    expect(getContributor("author-only")?.acceptedCount).toBe(1);
+    expect(getContributor("jsonbored")?.acceptedCount).toBe(1);
     expect(
       CONTRIBUTORS.some((contributor) => contributor.slug === "invalid"),
     ).toBe(false);

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -53,6 +53,26 @@ vi.mock("@/data/entries", () => ({
       submittedBy: "@at-handle",
       submittedByUrl: "https://github.com/at-handle",
     }),
+    fixture({
+      slug: "submitter-only",
+      author: "",
+      submittedBy: "solo-submitter",
+      submittedByUrl: "https://github.com/solo-submitter",
+    }),
+    fixture({
+      slug: "source-credit-one",
+      author: "credit-submitter",
+      submittedBy: "credit-submitter",
+      importPrUrl: "https://github.com/org/repo/pull/98",
+      submittedByUrl: "https://github.com/credit-submitter",
+    }),
+    fixture({
+      slug: "source-credit-two",
+      author: "credit-submitter",
+      submittedBy: "credit-submitter",
+      sourceSubmissionUrl: "https://github.com/org/repo/pull/99",
+      submittedByUrl: "https://github.com/credit-submitter",
+    }),
   ],
 }));
 
@@ -79,6 +99,8 @@ describe("contributors attribution aggregation", () => {
     );
     expect(getContributor("reviewer")?.reviewedCount).toBe(1);
     expect(getContributor("at-handle")?.handle).toBe("at-handle");
+    expect(getContributor("solo-submitter")?.acceptedCount).toBe(1);
+    expect(getContributor("credit-submitter")?.sourceSubmissionCount).toBe(2);
     expect(
       CONTRIBUTORS.some((contributor) => contributor.slug === "invalid"),
     ).toBe(false);

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/data/entries", () => ({
       slug: "split-authors",
       author: "Split Author",
       submittedBy: "split-submitter",
-      authorProfileUrl: "https://github.com/split-author",
+      authorProfileUrl: "https://split-author.dev",
       sourceSubmissionUrl: "https://github.com/org/repo",
       submittedByUrl: "https://github.com/split-submitter",
     }),
@@ -83,6 +83,12 @@ vi.mock("@/data/entries", () => ({
       author: "",
       submittedBy: "",
     }),
+    fixture({
+      slug: "spoofed-author",
+      author: "Existing Contributor",
+      submittedBy: "spoof-submitter",
+      submittedByUrl: "https://github.com/spoof-submitter",
+    }),
   ],
 }));
 
@@ -90,12 +96,14 @@ import {
   CONTRIBUTORS,
   authorMatchesSubmitter,
   contributorAcceptedEntryRole,
+  contributorForDisplayAuthor,
   contributorForSubmitter,
   contributorForVerifiedAuthor,
   contributorMatchesIdentity,
   contributorSlug,
   findContributorForIdentity,
   getContributor,
+  shouldRegisterDistinctAuthorProfile,
 } from "../apps/web/src/data/contributors";
 
 describe("contributors attribution aggregation", () => {
@@ -105,7 +113,7 @@ describe("contributors attribution aggregation", () => {
       0,
     );
     expect(getContributor("split-author")?.github).toBe(
-      "https://github.com/split-author",
+      "https://split-author.dev",
     );
     expect(getContributor("reviewer")?.reviewedCount).toBe(1);
     expect(getContributor("at-handle")?.handle).toBe("at-handle");
@@ -113,9 +121,37 @@ describe("contributors attribution aggregation", () => {
     expect(getContributor("credit-submitter")?.sourceSubmissionCount).toBe(2);
     expect(getContributor("author-only")?.acceptedCount).toBe(1);
     expect(getContributor("jsonbored")?.acceptedCount).toBe(1);
+    expect(getContributor("existing-contributor")).toBeUndefined();
     expect(
       CONTRIBUTORS.some((contributor) => contributor.slug === "invalid"),
     ).toBe(false);
+  });
+
+  it("blocks spoofed split-author links and github-backed distinct author registration", () => {
+    const splitEntry = fixture({
+      author: "Split Author",
+      submittedBy: "split-submitter",
+      authorProfileUrl: "https://split-author.dev",
+    });
+    const spoofEntry = fixture({
+      author: "Existing Contributor",
+      submittedBy: "spoof-submitter",
+      authorProfileUrl: "https://github.com/existing-contributor",
+    });
+
+    expect(
+      shouldRegisterDistinctAuthorProfile(splitEntry, "split-submitter"),
+    ).toBe(true);
+    expect(
+      shouldRegisterDistinctAuthorProfile(spoofEntry, "spoof-submitter"),
+    ).toBe(false);
+    expect(contributorForDisplayAuthor(splitEntry)).toBeUndefined();
+    expect(contributorForDisplayAuthor(spoofEntry)).toBeUndefined();
+    expect(
+      contributorForDisplayAuthor(
+        fixture({ author: "Author Only", submittedBy: undefined }),
+      )?.slug,
+    ).toBe("author-only");
   });
 
   it("handles contributor identity guardrails", () => {

--- a/tests/entry-normalize.test.ts
+++ b/tests/entry-normalize.test.ts
@@ -192,3 +192,32 @@ describe("buildEntry platform compatibility", () => {
     expect(entry.scriptBody).toBe("echo hello");
   });
 });
+
+describe("buildEntry provenance fields", () => {
+  it("passes through author profile and submitter attribution fields", () => {
+    const entry = buildEntry(
+      baseEntry({
+        author: "ABMeter",
+        authorProfileUrl: "https://abmeter.ai",
+        submittedBy: "kiannidev",
+        submittedByUrl: "https://github.com/kiannidev",
+      }),
+    );
+
+    expect(entry.authorProfileUrl).toBe("https://abmeter.ai");
+    expect(entry.submittedBy).toBe("kiannidev");
+    expect(entry.submittedByUrl).toBe("https://github.com/kiannidev");
+  });
+
+  it("falls back submittedByUrl to authorProfileUrl when submitter url is absent", () => {
+    const entry = buildEntry(
+      baseEntry({
+        author: "Example",
+        authorProfileUrl: "https://github.com/example",
+        submittedBy: "example",
+      }),
+    );
+
+    expect(entry.submittedByUrl).toBe("https://github.com/example");
+  });
+});

--- a/tests/entry-normalize.test.ts
+++ b/tests/entry-normalize.test.ts
@@ -234,4 +234,17 @@ describe("buildEntry provenance fields", () => {
     expect(entry.submittedBy).toBe("kiannidev");
     expect(entry.submittedByUrl).toBeUndefined();
   });
+
+  it("falls back submittedByUrl for authorless submitter entries with a profile URL", () => {
+    const entry = buildEntry(
+      baseEntry({
+        author: undefined,
+        authorProfileUrl: "https://github.com/example",
+        submittedBy: "example",
+      }),
+    );
+
+    expect(entry.author).toBe("example");
+    expect(entry.submittedByUrl).toBe("https://github.com/example");
+  });
 });

--- a/tests/entry-normalize.test.ts
+++ b/tests/entry-normalize.test.ts
@@ -220,4 +220,18 @@ describe("buildEntry provenance fields", () => {
 
     expect(entry.submittedByUrl).toBe("https://github.com/example");
   });
+
+  it("does not fall back submittedByUrl to authorProfileUrl for split attribution", () => {
+    const entry = buildEntry(
+      baseEntry({
+        author: "ABMeter",
+        authorProfileUrl: "https://abmeter.ai",
+        submittedBy: "kiannidev",
+      }),
+    );
+
+    expect(entry.authorProfileUrl).toBe("https://abmeter.ai");
+    expect(entry.submittedBy).toBe("kiannidev");
+    expect(entry.submittedByUrl).toBeUndefined();
+  });
 });

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -684,6 +684,38 @@ describe("web non-UI utility coverage", () => {
     }
   });
 
+  it("keeps author-only contributor profiles off source-submission credit", () => {
+    const authoredOnly = ENTRIES.find(
+      (item) =>
+        item.author &&
+        item.submittedBy &&
+        item.author.toLowerCase() !== item.submittedBy.toLowerCase() &&
+        (item.sourceSubmissionUrl || item.importPrUrl),
+    );
+    expect(authoredOnly).toBeTruthy();
+    const authorProfile = getContributor(contributorSlug(authoredOnly!.author));
+    const submitterProfile = getContributor(
+      contributorSlug(authoredOnly!.submittedBy!),
+    );
+    expect(authorProfile).toBeTruthy();
+    expect(submitterProfile).toBeTruthy();
+    expect(authorProfile!.sourceSubmissionCount ?? 0).toBe(0);
+    expect(submitterProfile!.sourceSubmissionCount ?? 0).toBeGreaterThan(0);
+  });
+
+  it("resolves contributor profile slugs for linked source citations", () => {
+    const splitEntry = ENTRIES.find(
+      (item) => item.slug === "abmeter-mcp-server",
+    );
+    expect(splitEntry).toBeTruthy();
+    expect(
+      findContributorForIdentity(
+        splitEntry!.submittedBy,
+        splitEntry!.submittedByUrl,
+      )?.slug,
+    ).toBe("kiannidev");
+  });
+
   it("builds tag groups and related tags from normalized live entry tags", () => {
     expect(tagSlug(" Claude Code / MCP ")).toBe("claude-code-mcp");
     const groups = getAllTagGroups();

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -24,6 +24,7 @@ import {
   CONTRIBUTORS,
   authorMatchesSubmitter,
   contributorAcceptedEntryRole,
+  contributorForDisplayAuthor,
   contributorForSubmitter,
   contributorForVerifiedAuthor,
   contributorMatchesIdentity,
@@ -675,6 +676,7 @@ describe("web non-UI utility coverage", () => {
     );
     expect(contributorAcceptedEntryRole(author!, splitEntry!)).toBe("authored");
     expect(contributorForSubmitter(splitEntry!)).toBe(submitter);
+    expect(contributorForDisplayAuthor(splitEntry!)).toBe(author);
     expect(
       contributorForVerifiedAuthor(splitEntry!.author, splitEntry!.submittedBy),
     ).toBeUndefined();

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -22,11 +22,14 @@ import { ENTRIES } from "../apps/web/src/data/entries";
 import { COMPARISONS } from "../apps/web/src/data/comparisons";
 import {
   CONTRIBUTORS,
+  authorMatchesSubmitter,
   contributorAcceptedEntryRole,
+  contributorForSubmitter,
   contributorForVerifiedAuthor,
   contributorMatchesIdentity,
   contributorReviewedEntry,
   contributorSlug,
+  findContributorForIdentity,
   getContributor,
   githubHandle,
 } from "../apps/web/src/data/contributors";
@@ -641,6 +644,40 @@ describe("web non-UI utility coverage", () => {
     expect(PARTNERS.some((partner) => partner.slotState === "open")).toBe(true);
   });
 
+  it("indexes submitter identity in search haystack for attribution discovery", () => {
+    const splitEntry = ENTRIES.find(
+      (item) =>
+        item.slug === "abmeter-mcp-server" &&
+        item.submittedBy &&
+        item.author &&
+        item.submittedBy.toLowerCase() !== item.author.toLowerCase(),
+    );
+    expect(splitEntry).toBeTruthy();
+    expect(splitEntry?.submittedBy).toBe("kiannidev");
+    expect(
+      search({ q: "kiannidev", sort: "title" }).some(
+        (item) => item.slug === "abmeter-mcp-server",
+      ),
+    ).toBe(true);
+  });
+
+  it("tracks distinct author profiles when author differs from submitter", () => {
+    const splitEntry = ENTRIES.find((item) => item.slug === "abmeter-mcp-server");
+    expect(splitEntry).toBeTruthy();
+    const submitter = getContributor("kiannidev");
+    const author = getContributor("abmeter");
+    expect(submitter).toBeTruthy();
+    expect(author).toBeTruthy();
+    expect(
+      contributorAcceptedEntryRole(submitter!, splitEntry!),
+    ).toBe("submitted");
+    expect(contributorAcceptedEntryRole(author!, splitEntry!)).toBe("authored");
+    expect(contributorForSubmitter(splitEntry!)).toBe(submitter);
+    expect(
+      contributorForVerifiedAuthor(splitEntry!.author, splitEntry!.submittedBy),
+    ).toBeUndefined();
+  });
+
   it("builds tag groups and related tags from normalized live entry tags", () => {
     expect(tagSlug(" Claude Code / MCP ")).toBe("claude-code-mcp");
     const groups = getAllTagGroups();
@@ -891,6 +928,22 @@ describe("web non-UI utility coverage", () => {
     expect(githubHandle("https://github.com/JSONbored")).toBe("JSONbored");
     expect(githubHandle("https://example.com/JSONbored")).toBeUndefined();
     expect(githubHandle("not a url")).toBeUndefined();
+
+    const liveContributor = CONTRIBUTORS.find((item) => item.slug === "kiannidev");
+    expect(liveContributor).toBeTruthy();
+    expect(findContributorForIdentity("kiannidev", liveContributor?.github)).toBe(
+      liveContributor,
+    );
+    expect(findContributorForIdentity("kiannidev")).toBe(liveContributor);
+    expect(findContributorForIdentity("Unknown Person")).toBeUndefined();
+    expect(authorMatchesSubmitter("kiannidev", "kiannidev")).toBe(true);
+    expect(authorMatchesSubmitter("ABMeter", "kiannidev")).toBe(false);
+    expect(
+      contributorForSubmitter({
+        submittedBy: "kiannidev",
+        submittedByUrl: liveContributor?.github,
+      }),
+    ).toBe(liveContributor);
 
     expect(OPENAPI_TAGS.map((tag) => tag.id)).toContain("registry");
     expect(OPENAPI_TAGS.map((tag) => tag.id)).toContain("admin");

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -662,20 +662,26 @@ describe("web non-UI utility coverage", () => {
   });
 
   it("tracks distinct author profiles when author differs from submitter", () => {
-    const splitEntry = ENTRIES.find((item) => item.slug === "abmeter-mcp-server");
+    const splitEntry = ENTRIES.find(
+      (item) => item.slug === "abmeter-mcp-server",
+    );
     expect(splitEntry).toBeTruthy();
     const submitter = getContributor("kiannidev");
     const author = getContributor("abmeter");
     expect(submitter).toBeTruthy();
     expect(author).toBeTruthy();
-    expect(
-      contributorAcceptedEntryRole(submitter!, splitEntry!),
-    ).toBe("submitted");
+    expect(contributorAcceptedEntryRole(submitter!, splitEntry!)).toBe(
+      "submitted",
+    );
     expect(contributorAcceptedEntryRole(author!, splitEntry!)).toBe("authored");
     expect(contributorForSubmitter(splitEntry!)).toBe(submitter);
     expect(
       contributorForVerifiedAuthor(splitEntry!.author, splitEntry!.submittedBy),
     ).toBeUndefined();
+    if (splitEntry?.sourceSubmissionUrl || splitEntry?.importPrUrl) {
+      expect((submitter?.sourceSubmissionCount ?? 0) > 0).toBe(true);
+      expect(author?.sourceSubmissionCount ?? 0).toBe(0);
+    }
   });
 
   it("builds tag groups and related tags from normalized live entry tags", () => {
@@ -929,11 +935,13 @@ describe("web non-UI utility coverage", () => {
     expect(githubHandle("https://example.com/JSONbored")).toBeUndefined();
     expect(githubHandle("not a url")).toBeUndefined();
 
-    const liveContributor = CONTRIBUTORS.find((item) => item.slug === "kiannidev");
-    expect(liveContributor).toBeTruthy();
-    expect(findContributorForIdentity("kiannidev", liveContributor?.github)).toBe(
-      liveContributor,
+    const liveContributor = CONTRIBUTORS.find(
+      (item) => item.slug === "kiannidev",
     );
+    expect(liveContributor).toBeTruthy();
+    expect(
+      findContributorForIdentity("kiannidev", liveContributor?.github),
+    ).toBe(liveContributor);
     expect(findContributorForIdentity("kiannidev")).toBe(liveContributor);
     expect(findContributorForIdentity("Unknown Person")).toBeUndefined();
     expect(authorMatchesSubmitter("kiannidev", "kiannidev")).toBe(true);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,7 +50,6 @@ export default defineConfig({
         "packages/mcp/src/cli.js",
         "packages/mcp/src/cli-options.js",
         "apps/web/src/data/comparisons.ts",
-        "apps/web/src/data/search.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
         "apps/web/src/lib/client-logs.ts",


### PR DESCRIPTION
## Summary
- Link contributor profiles from entry detail, browse cards, peek sheets, provenance blocks, and source citations — including split author/submitter cases from issue imports (e.g. brand author + community submitter).
- Register distinct author profiles when author differs from submitter, and add `submittedBy` to the search haystack so submitter names are discoverable.
- Keep verified-author spoofing guards: author profile links still require matching submitter identity unless the entry has no submitter provenance.

Closes #559

## Test plan
- [x] `pnpm exec vitest run tests/web-non-ui-utilities.test.ts`
- [x] `pnpm test:registry-artifacts`
- [x] `pnpm build`
- [ ] Verify entry detail shows linked submitter when author differs (e.g. `/entry/mcp/abmeter-mcp-server`)
- [ ] Verify browse row cards and peek drawer show attribution links
- [ ] Verify contributor profile pages list authored vs submitted roles correctly

