### PR TITLE
feat(web): polish commercial lead capture (#558)

### DIFF
--- a/apps/web/src/components/commercial-disclosure.tsx
+++ b/apps/web/src/components/commercial-disclosure.tsx
@@ -1,0 +1,56 @@
+import { Link } from "@tanstack/react-router";
+import { ShieldCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function CommercialDisclosure({
+  className = "",
+}: {
+  className?: string;
+}) {
+  return (
+    <aside
+      className={`rounded-xl border border-border bg-surface p-5 text-sm text-ink-muted ${className}`}
+    >
+      <div className="flex items-start gap-2">
+        <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-trust-trusted" />
+        <div className="space-y-2">
+          <p className="font-medium text-ink">Paid placement stays separate from free content</p>
+          <ul className="ml-4 list-disc space-y-1 text-xs">
+            <li>Free, source-backed directory entries are reviewed the same way regardless of payment.</li>
+            <li>Paid placements are labeled sponsor or featured — they never buy organic ranking.</li>
+            <li>Trust and source badges reflect registry metadata, not sponsorship.</li>
+            <li>
+              Commercial interest is waitlist-first: maintainers review fit before any checkout or
+              publish step.
+            </li>
+          </ul>
+          <p className="text-xs">
+            Policy details live on{" "}
+            <Link to="/legal" className="text-ink underline-offset-2 hover:underline">
+              /legal
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </aside>
+  );
+}
+
+export function CommercialLeadSuccess({
+  title,
+  body,
+  action,
+}: {
+  title: string;
+  body: string;
+  action: ReactNode;
+}) {
+  return (
+    <div className="mx-auto max-w-md px-4 py-24 text-center sm:px-6">
+      <h1 className="h-display-2 text-ink text-balance">{title}</h1>
+      <p className="mt-2 text-sm text-ink-muted">{body}</p>
+      <div className="mt-6">{action}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/commercial-disclosure.tsx
+++ b/apps/web/src/components/commercial-disclosure.tsx
@@ -2,11 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { ShieldCheck } from "lucide-react";
 import type { ReactNode } from "react";
 
-export function CommercialDisclosure({
-  className = "",
-}: {
-  className?: string;
-}) {
+export function CommercialDisclosure({ className = "" }: { className?: string }) {
   return (
     <aside
       className={`rounded-xl border border-border bg-surface p-5 text-sm text-ink-muted ${className}`}
@@ -16,8 +12,12 @@ export function CommercialDisclosure({
         <div className="space-y-2">
           <p className="font-medium text-ink">Paid placement stays separate from free content</p>
           <ul className="ml-4 list-disc space-y-1 text-xs">
-            <li>Free, source-backed directory entries are reviewed the same way regardless of payment.</li>
-            <li>Paid placements are labeled sponsor or featured — they never buy organic ranking.</li>
+            <li>
+              Free, source-backed directory entries are reviewed the same way regardless of payment.
+            </li>
+            <li>
+              Paid placements are labeled sponsor or featured — they never buy organic ranking.
+            </li>
             <li>Trust and source badges reflect registry metadata, not sponsorship.</li>
             <li>
               Commercial interest is waitlist-first: maintainers review fit before any checkout or

--- a/apps/web/src/lib/listing-lead-client.ts
+++ b/apps/web/src/lib/listing-lead-client.ts
@@ -1,0 +1,23 @@
+export type ListingLeadPayload = {
+  kind: "job" | "tool" | "claim";
+  tierInterest?: "free" | "standard" | "featured" | "sponsored";
+  contactName: string;
+  contactEmail: string;
+  companyName: string;
+  listingTitle: string;
+  websiteUrl?: string;
+  applyUrl?: string;
+  message?: string;
+};
+
+export async function submitListingLead(payload: ListingLeadPayload) {
+  const response = await fetch("/api/listing-leads", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    throw new Error(`Lead intake returned ${response.status}`);
+  }
+  return response;
+}

--- a/apps/web/src/routes/advertise.tsx
+++ b/apps/web/src/routes/advertise.tsx
@@ -77,18 +77,13 @@ function AdvertisePage() {
         companyName: company,
         listingTitle: `${selectedPlan.name} interest`,
         websiteUrl: website,
-        message: [
-          `Plan: ${selectedPlan.name}`,
-          launch ? `Launch context: ${launch}` : "",
-        ]
+        message: [`Plan: ${selectedPlan.name}`, launch ? `Launch context: ${launch}` : ""]
           .filter(Boolean)
           .join("\n\n"),
       });
       setDone(true);
     } catch {
-      setError(
-        "Sponsorship interest could not be submitted. Check required fields and try again.",
-      );
+      setError("Sponsorship interest could not be submitted. Check required fields and try again.");
     } finally {
       setSubmitting(false);
     }
@@ -129,6 +124,7 @@ function AdvertisePage() {
           <button
             key={p.id}
             type="button"
+            aria-pressed={planId === p.id}
             onClick={() => setPlanId(p.id)}
             className={`flex flex-col rounded-xl border p-6 text-left transition-colors ${
               planId === p.id

--- a/apps/web/src/routes/advertise.tsx
+++ b/apps/web/src/routes/advertise.tsx
@@ -1,13 +1,19 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 import { Check } from "lucide-react";
 import { absoluteUrl } from "@/lib/seo";
+import { CommercialDisclosure, CommercialLeadSuccess } from "@/components/commercial-disclosure";
+import { submitListingLead } from "@/lib/listing-lead-client";
 
 export const Route = createFileRoute("/advertise")({
   head: () => ({
     meta: [
       { title: "Advertise on HeyClaude" },
-      { name: "description", content: "Sponsorship and paid listings on HeyClaude." },
+      {
+        name: "description",
+        content:
+          "Join the waitlist for featured listings, Brief sponsorships, and custom campaigns on HeyClaude.",
+      },
       { property: "og:url", content: absoluteUrl("/advertise") },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/advertise") }],
@@ -17,29 +23,38 @@ export const Route = createFileRoute("/advertise")({
 
 const PLANS = [
   {
+    id: "featured",
     name: "Featured listing",
     price: "Waitlist",
+    tierInterest: "featured" as const,
     blurb: "Pinned slot in a category, labeled as sponsor. No fake organic placement.",
     bullets: ["One category", "Clear sponsor label", "Trust/source badges still apply"],
   },
   {
+    id: "brief",
     name: "Brief sponsor",
     price: "Waitlist",
+    tierInterest: "sponsored" as const,
     blurb: "One transparent slot inside the Weekly Brief. Reviewed for fit.",
     bullets: ["Native section", "Topic alignment required", "Audited click reporting"],
   },
   {
+    id: "custom",
     name: "Custom",
     price: "Review fit",
+    tierInterest: "sponsored" as const,
     blurb: "Hiring drives, launch coverage, MCP catalog placements.",
     bullets: ["Tailored scope", "Direct contact", "No dark patterns"],
   },
 ];
 
 function AdvertisePage() {
+  const [planId, setPlanId] = useState(PLANS[0].id);
   const [done, setDone] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
+
+  const selectedPlan = PLANS.find((plan) => plan.id === planId) ?? PLANS[0];
 
   async function submitLead(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -47,32 +62,54 @@ function AdvertisePage() {
     setSubmitting(true);
     setError("");
     const form = new FormData(e.currentTarget);
+    const contactName = String(form.get("contactName") ?? "").trim();
     const company = String(form.get("company") ?? "").trim();
     const email = String(form.get("email") ?? "").trim();
-    const plan = String(form.get("plan") ?? "").trim() || "Sponsorship interest";
+    const website = String(form.get("website") ?? "").trim();
     const launch = String(form.get("launch") ?? "").trim();
+
     try {
-      const response = await fetch("/api/listing-leads", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          kind: "tool",
-          tierInterest: "sponsored",
-          contactName: company,
-          contactEmail: email,
-          companyName: company,
-          listingTitle: plan,
-          websiteUrl: "",
-          message: launch,
-        }),
+      await submitListingLead({
+        kind: "tool",
+        tierInterest: selectedPlan.tierInterest,
+        contactName,
+        contactEmail: email,
+        companyName: company,
+        listingTitle: `${selectedPlan.name} interest`,
+        websiteUrl: website,
+        message: [
+          `Plan: ${selectedPlan.name}`,
+          launch ? `Launch context: ${launch}` : "",
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
       });
-      if (!response.ok) throw new Error(`Lead intake returned ${response.status}`);
       setDone(true);
     } catch {
-      setError("Sponsorship interest could not be submitted. Check required fields and try again.");
+      setError(
+        "Sponsorship interest could not be submitted. Check required fields and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
+  }
+
+  if (done) {
+    return (
+      <CommercialLeadSuccess
+        title="Interest received"
+        body="We'll review fit and reply within two business days. Paid placements are labeled and never affect organic ranking."
+        action={
+          <Link
+            to="/advertise"
+            className="inline-flex h-10 items-center rounded-md border border-border bg-surface px-4 text-sm text-ink hover:bg-surface-2"
+            onClick={() => setDone(false)}
+          >
+            Submit another request
+          </Link>
+        }
+      />
+    );
   }
 
   return (
@@ -83,14 +120,21 @@ function AdvertisePage() {
       </h1>
       <p className="mt-4 max-w-2xl text-pretty text-base text-ink-muted sm:text-lg">
         Sponsorships are transparent and labeled. We don't sell ranking. Trust badges always reflect
-        registry metadata, not payment.
+        registry metadata, not payment. Join the waitlist — pricing and scope are confirmed after
+        maintainer review.
       </p>
 
       <div className="mt-10 grid gap-4 md:grid-cols-3">
         {PLANS.map((p) => (
-          <div
-            key={p.name}
-            className="flex flex-col rounded-xl border border-border bg-surface p-6"
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => setPlanId(p.id)}
+            className={`flex flex-col rounded-xl border p-6 text-left transition-colors ${
+              planId === p.id
+                ? "border-ink bg-surface ring-1 ring-ink/20"
+                : "border-border bg-surface hover:border-border-strong"
+            }`}
           >
             <div className="eyebrow">{p.name}</div>
             <div className="mt-2 font-display text-2xl font-semibold text-ink">{p.price}</div>
@@ -103,45 +147,67 @@ function AdvertisePage() {
                 </li>
               ))}
             </ul>
-          </div>
+          </button>
         ))}
       </div>
 
       <div className="mt-12 grid gap-6 lg:grid-cols-[1fr_320px]">
         <form onSubmit={submitLead} className="rounded-xl border border-border bg-surface p-6">
           <div className="eyebrow">Get in touch</div>
+          <p className="mt-2 text-sm text-ink-muted">
+            Free directory submissions stay on{" "}
+            <Link to="/submit" className="text-ink underline">
+              /submit
+            </Link>
+            . This form is for paid placement interest only.
+          </p>
           <div className="mt-4 space-y-4">
+            <Field name="contactName" label="Your name" required />
             <Field name="company" label="Company" required />
-            <Field name="email" label="Email" type="email" required />
-            <Field name="plan" label="Plan of interest" />
+            <Field name="email" label="Work email" type="email" required />
+            <Field
+              name="website"
+              label="Product or company URL"
+              type="url"
+              required
+              placeholder="https://example.com"
+            />
             <label className="block">
               <div className="eyebrow mb-1.5">What are you launching?</div>
               <textarea
                 name="launch"
                 rows={4}
+                placeholder="Campaign goals, audience, timing, and any category fit notes."
                 className="w-full rounded-md border border-border bg-background p-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
               />
             </label>
+            <p className="text-xs text-ink-subtle">
+              Selected plan: <span className="text-ink">{selectedPlan.name}</span> (
+              {selectedPlan.price})
+            </p>
             <button
               type="submit"
               disabled={submitting}
-              className="inline-flex h-10 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
+              className="inline-flex h-10 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90 disabled:opacity-50"
             >
-              {submitting ? "Sending…" : done ? "Request sent ✓" : "Request details"}
+              {submitting ? "Sending…" : "Join waitlist"}
             </button>
             {error && <p className="text-sm text-trust-blocked">{error}</p>}
           </div>
         </form>
 
-        <aside className="rounded-xl border border-border bg-surface p-6 text-sm text-ink-muted">
-          <div className="eyebrow mb-2">What we won't do</div>
-          <ul className="space-y-1.5">
-            <li>Sell trust or source badges.</li>
-            <li>Sponsor-disguised editorial.</li>
-            <li>Paid ranking in Best lists.</li>
-            <li>Dark patterns or fake scarcity.</li>
-          </ul>
-        </aside>
+        <div className="space-y-4">
+          <aside className="rounded-xl border border-border bg-surface p-6 text-sm text-ink-muted">
+            <div className="eyebrow mb-2">What we won't do</div>
+            <ul className="space-y-1.5">
+              <li>Sell trust or source badges.</li>
+              <li>Sponsor-disguised editorial.</li>
+              <li>Paid ranking in Best lists.</li>
+              <li>Dark patterns or fake scarcity.</li>
+            </ul>
+          </aside>
+          <CommercialDisclosure />
+        </div>
       </div>
     </div>
   );
@@ -152,11 +218,13 @@ function Field({
   label,
   type = "text",
   required,
+  placeholder,
 }: {
   name: string;
   label: string;
   type?: string;
   required?: boolean;
+  placeholder?: string;
 }) {
   return (
     <label className="block">
@@ -168,6 +236,7 @@ function Field({
         name={name}
         type={type}
         required={required}
+        placeholder={placeholder}
         className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
       />
     </label>

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -5,6 +5,7 @@ import { ENTRIES } from "@/data/entries";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { absoluteUrl } from "@/lib/seo";
+import { CommercialDisclosure } from "@/components/commercial-disclosure";
 
 type ClaimType = "maintain" | "transfer" | "correct" | "remove";
 
@@ -77,6 +78,36 @@ const PROOF_FIELDS = [
 ] as const;
 
 const TYPE_OPTIONS: ClaimType[] = ["maintain", "transfer", "correct", "remove"];
+
+function resolveClaimWebsiteUrl(
+  entry: (typeof ENTRIES)[number],
+  proof: Record<string, string>,
+): string {
+  const candidates = [
+    entry.sourceUrl,
+    entry.repoUrl,
+    entry.docsUrl,
+    entry.websiteUrl,
+    ...(entry.sourceUrls ?? []),
+  ];
+  for (const url of candidates) {
+    const trimmed = (url ?? "").trim();
+    if (/^https:\/\//i.test(trimmed)) return trimmed;
+  }
+  const repo = (proof.repo ?? "").trim();
+  if (repo) {
+    const normalized = repo
+      .replace(/^https?:\/\/github\.com\//i, "")
+      .replace(/^github\.com\//i, "")
+      .replace(/^\//, "");
+    if (normalized && !normalized.includes(" ")) {
+      return `https://github.com/${normalized}`;
+    }
+  }
+  const link = (proof.link ?? "").trim();
+  if (/^https:\/\//i.test(link)) return link;
+  return "";
+}
 
 function ClaimPage() {
   const [done, setDone] = React.useState(false);
@@ -175,7 +206,7 @@ function ClaimPage() {
           contactEmail,
           companyName: picked.author || picked.brandName || "Listing owner",
           listingTitle: picked.title,
-          websiteUrl: picked.sourceUrl || picked.repoUrl || picked.docsUrl || "",
+          websiteUrl: resolveClaimWebsiteUrl(picked, proof),
           message: [
             `Claim type: ${CLAIM_TYPE_LABEL[type]}`,
             `Entry: ${picked.category}/${picked.slug}`,
@@ -403,6 +434,7 @@ function ClaimPage() {
             </p>
           </div>
 
+          <CommercialDisclosure />
           <div className="rounded-xl border border-border bg-surface p-5">
             <div className="flex items-center gap-2">
               <ShieldCheck className="h-4 w-4 text-ink-muted" />

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -83,13 +83,7 @@ function resolveClaimWebsiteUrl(
   entry: (typeof ENTRIES)[number],
   proof: Record<string, string>,
 ): string {
-  const candidates = [
-    entry.sourceUrl,
-    entry.repoUrl,
-    entry.docsUrl,
-    entry.websiteUrl,
-    ...(entry.sourceUrls ?? []),
-  ];
+  const candidates = [entry.sourceUrl, entry.repoUrl, entry.docsUrl, entry.websiteUrl];
   for (const url of candidates) {
     const trimmed = (url ?? "").trim();
     if (/^https:\/\//i.test(trimmed)) return trimmed;
@@ -99,8 +93,9 @@ function resolveClaimWebsiteUrl(
     const normalized = repo
       .replace(/^https?:\/\/github\.com\//i, "")
       .replace(/^github\.com\//i, "")
-      .replace(/^\//, "");
-    if (normalized && !normalized.includes(" ")) {
+      .replace(/^\//, "")
+      .replace(/[?#].*$/, "");
+    if (/^[\w.-]+\/[\w.-]+$/.test(normalized)) {
       return `https://github.com/${normalized}`;
     }
   }
@@ -299,9 +294,7 @@ function ClaimPage() {
                     aria-expanded={matches.length > 0}
                     aria-controls={listboxId}
                     aria-autocomplete="list"
-                    aria-activedescendant={
-                      activeIndex >= 0 ? optionId(activeIndex) : undefined
-                    }
+                    aria-activedescendant={activeIndex >= 0 ? optionId(activeIndex) : undefined}
                     className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-ink placeholder:text-ink-subtle focus:border-ink focus:outline-none"
                   />
                   {matches.length > 0 && (

--- a/apps/web/src/routes/jobs.post.tsx
+++ b/apps/web/src/routes/jobs.post.tsx
@@ -4,6 +4,7 @@ import { absoluteUrl } from "@/lib/seo";
 import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { CommercialDisclosure } from "@/components/commercial-disclosure";
 import type { JobTier } from "@/types/registry";
 
 export const Route = createFileRoute("/jobs/post")({
@@ -26,25 +27,25 @@ const TIERS: { id: JobTier; label: string; price: string; bullets: string[] }[] 
   {
     id: "free",
     label: "Community",
-    price: "$0",
+    price: "Included",
     bullets: ["Standard listing", "Source-verified", "30-day display"],
   },
   {
     id: "standard",
     label: "Standard",
-    price: "$49",
+    price: "Waitlist",
     bullets: ["Everything in Community", "Pinned for 7 days", "Email digest"],
   },
   {
     id: "featured",
     label: "Featured",
-    price: "$149",
+    price: "Waitlist",
     bullets: ["Top of the list", "Featured badge", "Cross-posted to Raycast extension"],
   },
   {
     id: "sponsored",
     label: "Sponsored",
-    price: "$349",
+    price: "Review fit",
     bullets: ["Maintainer-reviewed copy", "Long-form description", "Featured in Weekly Brief"],
   },
 ];
@@ -124,8 +125,8 @@ function PostJobPage() {
       <div className="eyebrow">Hiring</div>
       <h1 className="mt-2 h-display-1 text-ink text-balance">Post a role</h1>
       <p className="mt-2 text-sm text-ink-muted">
-        All listings are reviewed for source authenticity. Featured and Sponsored tiers also get a
-        copy pass from a maintainer.
+        All listings are reviewed for source authenticity. Featured and Sponsored tiers are
+        waitlist-first — payment and publish steps happen only after maintainer approval.
       </p>
 
       <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
@@ -206,6 +207,9 @@ function PostJobPage() {
           </Alert>
         )}
       </form>
+      <div className="mt-6">
+        <CommercialDisclosure />
+      </div>
     </div>
   );
 }

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -6,6 +6,15 @@ import { CommercialDisclosure } from "@/components/commercial-disclosure";
 import { absoluteUrl } from "@/lib/seo";
 import { submitListingLead } from "@/lib/listing-lead-client";
 
+const TOOL_LISTING_TIERS = ["featured", "sponsored"] as const;
+
+function toolListingTierInterest(raw: FormDataEntryValue | null) {
+  const value = String(raw ?? "featured");
+  return TOOL_LISTING_TIERS.includes(value as (typeof TOOL_LISTING_TIERS)[number])
+    ? (value as (typeof TOOL_LISTING_TIERS)[number])
+    : "featured";
+}
+
 export const Route = createFileRoute("/tools/submit")({
   head: () => ({
     meta: [
@@ -82,7 +91,7 @@ function CommercialToolListingForm() {
     try {
       await submitListingLead({
         kind: "tool",
-        tierInterest: String(form.get("tierInterest") ?? "featured") as "featured" | "sponsored",
+        tierInterest: toolListingTierInterest(form.get("tierInterest")),
         contactName: String(form.get("contactName") ?? "").trim(),
         contactEmail: String(form.get("email") ?? "").trim(),
         companyName: String(form.get("company") ?? "").trim(),
@@ -91,7 +100,6 @@ function CommercialToolListingForm() {
         message: String(form.get("notes") ?? "").trim(),
       });
       setDone(true);
-      e.currentTarget.reset();
     } catch {
       setError(
         "Tool listing interest could not be submitted. Check required fields and try again.",
@@ -185,7 +193,6 @@ function PaidReviewInterestForm() {
           .join("\n\n"),
       });
       setDone(true);
-      e.currentTarget.reset();
     } catch {
       setError("Review interest could not be submitted. Check required fields and try again.");
     } finally {

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -1,7 +1,10 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { useState, type FormEvent } from "react";
 import { ArrowRight } from "lucide-react";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { CommercialDisclosure } from "@/components/commercial-disclosure";
 import { absoluteUrl } from "@/lib/seo";
+import { submitListingLead } from "@/lib/listing-lead-client";
 
 export const Route = createFileRoute("/tools/submit")({
   head: () => ({
@@ -27,25 +30,281 @@ function SubmitTool() {
         <div className="eyebrow">Commercial routing</div>
         <h1 className="mt-3 h-display-1 text-ink text-balance">Submit a commercial tool</h1>
         <p className="mt-4 max-w-2xl text-ink-muted">
-          Free, source-backed resources belong in the community directory. Commercial tools,
-          sponsorships, listing claims, and paid review interest should go through the lead flow so
-          the public registry stays useful.
+          Free, source-backed resources belong in the community directory via{" "}
+          <Link to="/submit" className="text-ink underline">
+            /submit
+          </Link>
+          . Use the forms below for commercial listings, paid trust/source review interest, or route
+          sponsorship and claim requests through the dedicated lead flows.
         </p>
-        <div className="mt-8 flex flex-wrap gap-3">
-          <Link
-            to="/advertise"
-            className="inline-flex h-10 items-center gap-1.5 rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
-          >
-            Advertising interest <ArrowRight className="h-4 w-4" />
-          </Link>
-          <Link
-            to="/claim"
-            className="inline-flex h-10 items-center gap-1.5 rounded-md border border-border bg-background px-4 text-sm font-medium text-ink hover:bg-surface-2"
-          >
-            Claim a listing
-          </Link>
-        </div>
       </section>
+
+      <div className="mt-8 grid gap-8">
+        <CommercialToolListingForm />
+        <PaidReviewInterestForm />
+        <CommercialDisclosure />
+        <section className="rounded-xl border border-border bg-surface p-6">
+          <div className="eyebrow">Other commercial paths</div>
+          <p className="mt-2 text-sm text-ink-muted">
+            Sponsorship slots and listing ownership use separate review queues.
+          </p>
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              to="/advertise"
+              className="inline-flex h-10 items-center gap-1.5 rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
+            >
+              Sponsorship waitlist <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              to="/claim"
+              className="inline-flex h-10 items-center gap-1.5 rounded-md border border-border bg-background px-4 text-sm font-medium text-ink hover:bg-surface-2"
+            >
+              Claim a listing
+            </Link>
+          </div>
+        </section>
+      </div>
     </div>
+  );
+}
+
+function CommercialToolListingForm() {
+  const [done, setDone] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError("");
+    const form = new FormData(e.currentTarget);
+    try {
+      await submitListingLead({
+        kind: "tool",
+        tierInterest: String(form.get("tierInterest") ?? "featured") as "featured" | "sponsored",
+        contactName: String(form.get("contactName") ?? "").trim(),
+        contactEmail: String(form.get("email") ?? "").trim(),
+        companyName: String(form.get("company") ?? "").trim(),
+        listingTitle: String(form.get("toolName") ?? "").trim(),
+        websiteUrl: String(form.get("website") ?? "").trim(),
+        message: String(form.get("notes") ?? "").trim(),
+      });
+      setDone(true);
+      e.currentTarget.reset();
+    } catch {
+      setError("Tool listing interest could not be submitted. Check required fields and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface p-6">
+      <div className="eyebrow">Commercial tool listing</div>
+      <h2 className="mt-2 font-display text-xl font-semibold text-ink">Featured listing interest</h2>
+      <p className="mt-2 text-sm text-ink-muted">
+        For paid or commercial Claude tools that need a maintainer-reviewed listing path. This does
+        not replace free community submissions.
+      </p>
+      {done ? (
+        <p className="mt-4 text-sm text-trust-trusted">
+          Interest received — we'll review fit and reply within two business days.
+        </p>
+      ) : (
+        <form onSubmit={onSubmit} className="mt-4 space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field name="contactName" label="Your name" required />
+            <Field name="company" label="Company" required />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field name="email" label="Work email" type="email" required />
+            <Field name="toolName" label="Tool name" required />
+          </div>
+          <Field
+            name="website"
+            label="Product URL"
+            type="url"
+            required
+            placeholder="https://example.com"
+          />
+          <label className="block">
+            <div className="eyebrow mb-1.5">Placement interest</div>
+            <select
+              name="tierInterest"
+              defaultValue="featured"
+              className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm text-ink"
+            >
+              <option value="featured">Featured listing (waitlist)</option>
+              <option value="sponsored">Sponsored placement (waitlist)</option>
+            </select>
+          </label>
+          <TextArea name="notes" label="What should maintainers know?" rows={4} />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex h-10 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90 disabled:opacity-50"
+          >
+            {submitting ? "Sending…" : "Submit listing interest"}
+          </button>
+          {error && <p className="text-sm text-trust-blocked">{error}</p>}
+        </form>
+      )}
+    </section>
+  );
+}
+
+function PaidReviewInterestForm() {
+  const [done, setDone] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (submitting) return;
+    setSubmitting(true);
+    setError("");
+    const form = new FormData(e.currentTarget);
+    const entryRef = String(form.get("entryRef") ?? "").trim();
+    const notes = String(form.get("notes") ?? "").trim();
+    try {
+      await submitListingLead({
+        kind: "tool",
+        tierInterest: "standard",
+        contactName: String(form.get("contactName") ?? "").trim(),
+        contactEmail: String(form.get("email") ?? "").trim(),
+        companyName: String(form.get("company") ?? "").trim(),
+        listingTitle: "Paid trust/source review interest",
+        websiteUrl: String(form.get("website") ?? "").trim(),
+        message: [
+          "interest:paid-trust-source-review",
+          entryRef ? `Entry: ${entryRef}` : "",
+          notes,
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
+      });
+      setDone(true);
+      e.currentTarget.reset();
+    } catch {
+      setError("Review interest could not be submitted. Check required fields and try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-border bg-surface p-6">
+      <div className="eyebrow">Paid review</div>
+      <h2 className="mt-2 font-display text-xl font-semibold text-ink">
+        Trust and source review interest
+      </h2>
+      <p className="mt-2 text-sm text-ink-muted">
+        Request a maintainer-led trust or source review for an existing or upcoming listing. This is
+        separate from free community submissions and does not buy ranking.
+      </p>
+      {done ? (
+        <p className="mt-4 text-sm text-trust-trusted">
+          Review interest received — maintainers will confirm scope before any paid step.
+        </p>
+      ) : (
+        <form onSubmit={onSubmit} className="mt-4 space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field name="contactName" label="Your name" required />
+            <Field name="company" label="Company or project" required />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field name="email" label="Work email" type="email" required />
+            <Field
+              name="entryRef"
+              label="Entry reference (optional)"
+              placeholder="category/slug or URL"
+            />
+          </div>
+          <Field
+            name="website"
+            label="Source or product URL"
+            type="url"
+            required
+            placeholder="https://github.com/org/repo"
+          />
+          <TextArea
+            name="notes"
+            label="What should the review cover?"
+            rows={4}
+            placeholder="Trust signals, source reachability, package provenance, or safety notes to verify."
+            required
+          />
+          <button
+            type="submit"
+            disabled={submitting}
+            className="inline-flex h-10 items-center rounded-md border border-border bg-background px-4 text-sm font-medium text-ink hover:bg-surface-2 disabled:opacity-50"
+          >
+            {submitting ? "Sending…" : "Submit review interest"}
+          </button>
+          {error && <p className="text-sm text-trust-blocked">{error}</p>}
+        </form>
+      )}
+    </section>
+  );
+}
+
+function Field({
+  name,
+  label,
+  type = "text",
+  required,
+  placeholder,
+}: {
+  name: string;
+  label: string;
+  type?: string;
+  required?: boolean;
+  placeholder?: string;
+}) {
+  return (
+    <label className="block">
+      <div className="eyebrow mb-1.5">
+        {label}
+        {required && " *"}
+      </div>
+      <input
+        name={name}
+        type={type}
+        required={required}
+        placeholder={placeholder}
+        className="h-10 w-full rounded-md border border-border bg-background px-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
+      />
+    </label>
+  );
+}
+
+function TextArea({
+  name,
+  label,
+  rows = 4,
+  placeholder,
+  required,
+}: {
+  name: string;
+  label: string;
+  rows?: number;
+  placeholder?: string;
+  required?: boolean;
+}) {
+  return (
+    <label className="block">
+      <div className="eyebrow mb-1.5">
+        {label}
+        {required && " *"}
+      </div>
+      <textarea
+        name={name}
+        rows={rows}
+        required={required}
+        placeholder={placeholder}
+        className="w-full rounded-md border border-border bg-background p-3 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent/40"
+      />
+    </label>
   );
 }

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -93,7 +93,9 @@ function CommercialToolListingForm() {
       setDone(true);
       e.currentTarget.reset();
     } catch {
-      setError("Tool listing interest could not be submitted. Check required fields and try again.");
+      setError(
+        "Tool listing interest could not be submitted. Check required fields and try again.",
+      );
     } finally {
       setSubmitting(false);
     }
@@ -102,7 +104,9 @@ function CommercialToolListingForm() {
   return (
     <section className="rounded-xl border border-border bg-surface p-6">
       <div className="eyebrow">Commercial tool listing</div>
-      <h2 className="mt-2 font-display text-xl font-semibold text-ink">Featured listing interest</h2>
+      <h2 className="mt-2 font-display text-xl font-semibold text-ink">
+        Featured listing interest
+      </h2>
       <p className="mt-2 text-sm text-ink-muted">
         For paid or commercial Claude tools that need a maintainer-reviewed listing path. This does
         not replace free community submissions.
@@ -176,11 +180,7 @@ function PaidReviewInterestForm() {
         companyName: String(form.get("company") ?? "").trim(),
         listingTitle: "Paid trust/source review interest",
         websiteUrl: String(form.get("website") ?? "").trim(),
-        message: [
-          "interest:paid-trust-source-review",
-          entryRef ? `Entry: ${entryRef}` : "",
-          notes,
-        ]
+        message: ["interest:paid-trust-source-review", entryRef ? `Entry: ${entryRef}` : "", notes]
           .filter(Boolean)
           .join("\n\n"),
       });

--- a/tests/commercial-intake.test.ts
+++ b/tests/commercial-intake.test.ts
@@ -513,6 +513,7 @@ describe("commercial intake contracts", () => {
     expect(toolsSubmit).toContain('to="/submit"');
     expect(toolsSubmit).toContain('to="/advertise"');
     expect(toolsSubmit).toContain('to="/claim"');
+    expect(toolsSubmit).not.toContain("currentTarget.reset");
 
     expect(jobsPost).toContain("Waitlist");
     expect(jobsPost).toContain("waitlist-first");

--- a/tests/commercial-intake.test.ts
+++ b/tests/commercial-intake.test.ts
@@ -487,4 +487,37 @@ describe("commercial intake contracts", () => {
     };
     expect(compareToolListings(sponsored, affiliate)).toBeLessThan(0);
   });
+
+  it("keeps commercial intake routes waitlist-first with explicit disclosure", () => {
+    const readRoute = (file: string) =>
+      fs.readFileSync(path.join(repoRoot, "apps/web/src/routes", file), "utf8");
+
+    const advertise = readRoute("advertise.tsx");
+    const toolsSubmit = readRoute("tools.submit.tsx");
+    const jobsPost = readRoute("jobs.post.tsx");
+    const claim = readRoute("claim.tsx");
+
+    for (const source of [advertise, toolsSubmit, jobsPost]) {
+      expect(source).not.toMatch(/price:\s*"\$[0-9]+"/);
+      expect(source).toContain("CommercialDisclosure");
+    }
+
+    expect(advertise).toContain("submitListingLead");
+    expect(advertise).toContain("Join waitlist");
+    expect(advertise).toContain('name="contactName"');
+    expect(advertise).toContain('name="website"');
+    expect(advertise).not.toContain('websiteUrl: ""');
+
+    expect(toolsSubmit).toContain("submitListingLead");
+    expect(toolsSubmit).toContain("interest:paid-trust-source-review");
+    expect(toolsSubmit).toContain('to="/submit"');
+    expect(toolsSubmit).toContain('to="/advertise"');
+    expect(toolsSubmit).toContain('to="/claim"');
+
+    expect(jobsPost).toContain("Waitlist");
+    expect(jobsPost).toContain("waitlist-first");
+
+    expect(claim).toContain("resolveClaimWebsiteUrl");
+    expect(claim).toContain("CommercialDisclosure");
+  });
 });

--- a/tests/listing-lead-client.test.ts
+++ b/tests/listing-lead-client.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { submitListingLead } from "@/lib/listing-lead-client";
+
+const originalFetch = globalThis.fetch;
+
+const samplePayload = {
+  kind: "tool" as const,
+  tierInterest: "featured" as const,
+  contactName: "Ada Lovelace",
+  contactEmail: "ada@example.com",
+  companyName: "Analytical Engines",
+  listingTitle: "Claude Workflow Studio",
+  websiteUrl: "https://example.com",
+  message: "Interested in a featured listing.",
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("submitListingLead", () => {
+  it("posts the lead payload to the listing-leads API", async () => {
+    const fetchMock = vi.fn(async () => new Response(null, { status: 201 }));
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const response = await submitListingLead(samplePayload);
+
+    expect(response.status).toBe(201);
+    expect(fetchMock).toHaveBeenCalledWith("/api/listing-leads", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(samplePayload),
+    });
+  });
+
+  it("throws when the listing-leads API returns a non-OK status", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response(null, { status: 429 }),
+    ) as typeof fetch;
+
+    await expect(submitListingLead(samplePayload)).rejects.toThrow(
+      "Lead intake returned 429",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Reworks `/advertise`, `/tools/submit`, `/jobs/post`, and `/claim` around waitlist-first commercial intake with explicit paid-placement disclosure via a shared `CommercialDisclosure` component.
- Adds `submitListingLead` client helper and fixes sponsorship/tool forms to send valid listing-lead payloads (contact name, HTTPS website URL, tier interest) instead of broken empty submissions.
- Replaces hard job tier pricing with waitlist language and adds paid trust/source review interest capture on `/tools/submit`.

Closes #558

## Test plan
- [x] `pnpm exec vitest run tests/commercial-intake.test.ts tests/api-contracts.test.ts`
- [x] `pnpm build`
- [ ] Manual: submit `/advertise` waitlist form with HTTPS product URL
- [ ] Manual: submit commercial tool listing + paid review interest on `/tools/submit`
- [ ] Manual: file a claim for an entry without a direct HTTPS source URL (repo proof fallback)


