### PR TITLE
feat(contributors): improve contributor profiles and attribution

### DIFF
--- a/apps/web/src/lib/contributor-profile-summary.ts
+++ b/apps/web/src/lib/contributor-profile-summary.ts
@@ -1,0 +1,39 @@
+import { contributorForSubmitter } from "@/data/contributors";
+import type { Contributor, Entry } from "@/types/registry";
+
+export function contributorProfileStats(contributor: Contributor) {
+  return {
+    accepted: contributor.acceptedCount,
+    reviewed: contributor.reviewedCount ?? 0,
+    sourceLinked: contributor.sourceSubmissionCount ?? 0,
+    categories: contributor.categories?.length ?? 0,
+  };
+}
+
+export function contributorCardSummary(contributor: Contributor) {
+  const stats = contributorProfileStats(contributor);
+  const parts = [`${stats.accepted} accepted`];
+  if (stats.reviewed > 0) parts.push(`${stats.reviewed} reviewed`);
+  if (stats.sourceLinked > 0) parts.push(`${stats.sourceLinked} source-linked`);
+  return parts.join(" · ");
+}
+
+export type SubmitterAttribution =
+  | { kind: "contributor"; slug: string; label: string }
+  | { kind: "external"; href: string; label: string }
+  | { kind: "plain"; label: string };
+
+export function submitterAttribution(
+  entry: Pick<Entry, "submittedBy" | "submittedByUrl">,
+): SubmitterAttribution | undefined {
+  if (!entry.submittedBy) return undefined;
+
+  const contributor = contributorForSubmitter(entry);
+  if (contributor) {
+    return { kind: "contributor", slug: contributor.slug, label: entry.submittedBy };
+  }
+  if (entry.submittedByUrl) {
+    return { kind: "external", href: entry.submittedByUrl, label: entry.submittedBy };
+  }
+  return { kind: "plain", label: entry.submittedBy };
+}

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -23,6 +23,7 @@ import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { ogImageUrl } from "@/lib/og-image";
+import { submitterAttribution } from "@/lib/contributor-profile-summary";
 import type { Category, Contributor, Entry } from "@/types/registry";
 
 export const Route = createFileRoute("/contributors/$slug")({
@@ -303,6 +304,7 @@ function ContributionRow({
   role: ContributionRole;
 }) {
   const RoleIcon = roleIcon[role];
+  const submitter = submitterAttribution(entry);
 
   return (
     <article className="group px-4 py-4 transition-colors duration-200 hover:bg-surface-2 sm:px-6">
@@ -331,21 +333,29 @@ function ContributionRow({
       </div>
 
       <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-ink-subtle">
-        {entry.submittedBy && (
+        {submitter && (
           <span className="inline-flex items-center gap-1">
             <UserRound className="h-3 w-3" aria-hidden />
             submitted by{" "}
-            {entry.submittedByUrl ? (
+            {submitter.kind === "contributor" ? (
+              <Link
+                to="/contributors/$slug"
+                params={{ slug: submitter.slug }}
+                className="text-ink-muted hover:text-ink"
+              >
+                {submitter.label}
+              </Link>
+            ) : submitter.kind === "external" ? (
               <a
-                href={entry.submittedByUrl}
+                href={submitter.href}
                 target="_blank"
                 rel="noreferrer"
                 className="text-ink-muted hover:text-ink"
               >
-                {entry.submittedBy}
+                {submitter.label}
               </a>
             ) : (
-              <span className="text-ink-muted">{entry.submittedBy}</span>
+              <span className="text-ink-muted">{submitter.label}</span>
             )}
           </span>
         )}

--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Github } from "lucide-react";
 import { CONTRIBUTORS } from "@/data/contributors";
+import { contributorCardSummary } from "@/lib/contributor-profile-summary";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
 import { Monogram } from "@/components/monogram";
@@ -75,7 +76,7 @@ function ContributorsPage() {
             <div className="min-w-0 flex-1">
               <div className="font-display text-xl font-semibold text-ink">{top.name}</div>
               <div className="text-sm text-ink-muted">
-                @{top.handle} · {top.acceptedCount} accepted
+                @{top.handle} · {contributorCardSummary(top)}
               </div>
               {top.bio && <p className="mt-1 text-sm text-ink-muted">{top.bio}</p>}
             </div>
@@ -107,7 +108,7 @@ function ContributorsPage() {
                 {c.name}
               </div>
               <div className="truncate text-xs text-ink-muted">
-                @{c.handle} · {c.acceptedCount} accepted
+                @{c.handle} · {contributorCardSummary(c)}
               </div>
             </div>
             {c.github && (

--- a/tests/contributor-profiles.test.ts
+++ b/tests/contributor-profiles.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Contributor } from "@/types/registry";
+import * as contributors from "@/data/contributors";
+import {
+  contributorCardSummary,
+  contributorProfileStats,
+  submitterAttribution,
+} from "@/lib/contributor-profile-summary";
+
+function contributor(overrides: Partial<Contributor> = {}): Contributor {
+  return {
+    slug: "example",
+    handle: "example",
+    name: "Example",
+    acceptedCount: 3,
+    ...overrides,
+  };
+}
+
+describe("contributor profile summary", () => {
+  it("summarizes contributor stats for profile cards", () => {
+    expect(contributorProfileStats(contributor())).toEqual({
+      accepted: 3,
+      reviewed: 0,
+      sourceLinked: 0,
+      categories: 0,
+    });
+    expect(
+      contributorProfileStats(
+        contributor({
+          reviewedCount: 2,
+          sourceSubmissionCount: 1,
+          categories: [{ category: "mcp", count: 2 }],
+        }),
+      ),
+    ).toEqual({
+      accepted: 3,
+      reviewed: 2,
+      sourceLinked: 1,
+      categories: 1,
+    });
+  });
+
+  it("builds browse card summaries with optional review and source credit", () => {
+    expect(contributorCardSummary(contributor())).toBe("3 accepted");
+    expect(
+      contributorCardSummary(
+        contributor({ reviewedCount: 4, sourceSubmissionCount: 2 }),
+      ),
+    ).toBe("3 accepted · 4 reviewed · 2 source-linked");
+  });
+
+  it("resolves submitter attribution to contributor, external, or plain labels", () => {
+    const spy = vi.spyOn(contributors, "contributorForSubmitter");
+
+    spy.mockReturnValue(
+      contributor({ slug: "linked-submitter", handle: "linked-submitter" }),
+    );
+    expect(
+      submitterAttribution({
+        submittedBy: "linked-submitter",
+        submittedByUrl: "https://github.com/linked-submitter",
+      }),
+    ).toEqual({
+      kind: "contributor",
+      slug: "linked-submitter",
+      label: "linked-submitter",
+    });
+
+    spy.mockReturnValue(undefined);
+    expect(
+      submitterAttribution({
+        submittedBy: "external-only",
+        submittedByUrl: "https://example.com/external-only",
+      }),
+    ).toEqual({
+      kind: "external",
+      href: "https://example.com/external-only",
+      label: "external-only",
+    });
+
+    expect(
+      submitterAttribution({
+        submittedBy: "plain-submitter",
+      }),
+    ).toEqual({
+      kind: "plain",
+      label: "plain-submitter",
+    });
+    expect(submitterAttribution({})).toBeUndefined();
+
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- Add reusable contributor profile summary helpers for accepted, reviewed, and source-linked credits.
- Show richer contributor stats on the `/contributors` index cards.
- Link known submitters to contributor profiles from accepted-entry rows on contributor detail pages.

Closes #443

## Test plan
- [x] `pnpm exec vitest run tests/contributor-profiles.test.ts`
- [x] `pnpm exec vitest run tests/contributors-attribution.test.ts tests/web-non-ui-utilities.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Codecov patch: all modified and coverable lines covered