### PR TITLE
feat(compare): add next-action CTAs to compare page

### DIFF
--- a/apps/web/src/components/copy-button.tsx
+++ b/apps/web/src/components/copy-button.tsx
@@ -15,6 +15,7 @@ export function CopyButton({
   iconOnly = false,
   event,
   eventData,
+  onCopied,
 }: {
   value: string;
   label?: string;
@@ -29,6 +30,8 @@ export function CopyButton({
   event?: string;
   /** Optional umami event data sent alongside `event`. */
   eventData?: Record<string, unknown>;
+  /** Optional hook after a successful clipboard write. */
+  onCopied?: () => void;
 }) {
   const [copied, setCopied] = React.useState(false);
   const reduced = useReducedMotion();
@@ -46,6 +49,7 @@ export function CopyButton({
           await navigator.clipboard.writeText(value);
           setCopied(true);
           if (event) trackEvent(event, eventData);
+          onCopied?.();
           toast.success(toastLabel ?? "Copied to clipboard", {
             description: value.length > 60 ? value.slice(0, 60) + "…" : value,
             duration: 1800,

--- a/apps/web/src/lib/compare-entry-actions.ts
+++ b/apps/web/src/lib/compare-entry-actions.ts
@@ -1,0 +1,109 @@
+import { entryRef } from "@/lib/entry-identity";
+import type { Entry } from "@/types/registry";
+
+export type CompareActionKind = "link" | "copy";
+
+export type CompareAction = {
+  id: string;
+  label: string;
+  kind: CompareActionKind;
+  href?: string;
+  copyValue?: string;
+  intentType?: "copy" | "open" | "install";
+  analyticsEvent?: string;
+  external?: boolean;
+};
+
+export function resolveCompareEntryActions(
+  entry: Pick<
+    Entry,
+    "category" | "slug" | "installCommand" | "sourceUrl" | "claimed" | "configSnippet"
+  >,
+): CompareAction[] {
+  const actions: CompareAction[] = [
+    {
+      id: "dossier",
+      label: "Open dossier",
+      kind: "link",
+      intentType: "open",
+      analyticsEvent: "compare_open_dossier",
+    },
+  ];
+
+  if (entry.installCommand) {
+    actions.push({
+      id: "install",
+      label: "Copy install",
+      kind: "copy",
+      copyValue: entry.installCommand,
+      intentType: "install",
+      analyticsEvent: "compare_copy_install",
+    });
+  }
+
+  if (entry.configSnippet) {
+    actions.push({
+      id: "config",
+      label: "Copy config",
+      kind: "copy",
+      copyValue: entry.configSnippet,
+      intentType: "copy",
+      analyticsEvent: "compare_copy_config",
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
+      id: "source",
+      label: "Open source",
+      kind: "link",
+      href: entry.sourceUrl,
+      intentType: "open",
+      analyticsEvent: "compare_open_source",
+      external: true,
+    });
+  }
+
+  if (!entry.claimed) {
+    actions.push({
+      id: "claim",
+      label: "Claim listing",
+      kind: "link",
+      analyticsEvent: "compare_claim_cta",
+    });
+  }
+
+  return actions;
+}
+
+export function compareActionSignature(entry: Entry): string {
+  return resolveCompareEntryActions(entry)
+    .map((action) => action.id)
+    .join("|");
+}
+
+export function compareActionsDiverge(entries: Entry[]): boolean {
+  if (entries.length < 2) return false;
+  return new Set(entries.map(compareActionSignature)).size > 1;
+}
+
+export async function recordCompareIntentEvent(
+  type: "copy" | "open" | "install",
+  entry: Pick<Entry, "category" | "slug">,
+): Promise<boolean> {
+  try {
+    const response = await fetch("/api/intent-events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type,
+        entryKey: entryRef(entry),
+      }),
+    });
+    if (!response.ok) return false;
+    const payload = (await response.json()) as { stored?: boolean };
+    return payload.stored === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -11,6 +11,13 @@ import { CopyButton } from "@/components/copy-button";
 import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
+import {
+  compareActionsDiverge,
+  recordCompareIntentEvent,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
@@ -60,6 +67,7 @@ function ComparePage() {
   const items = compare.items;
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
+  const actionRowDiverges = compareActionsDiverge(items);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -212,6 +220,43 @@ function ComparePage() {
             </tr>
           </thead>
           <tbody>
+            <tr
+              className={cn(
+                "transition-colors duration-200 ease-out",
+                actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+              )}
+            >
+              <th
+                scope="row"
+                className={cn(
+                  "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                  actionRowDiverges && "text-amber-800",
+                )}
+              >
+                Next steps
+                {actionRowDiverges ? (
+                  <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                    Differs
+                  </span>
+                ) : null}
+              </th>
+              {items.map((e) => (
+                <td
+                  key={`actions-${e.category}/${e.slug}`}
+                  className={cn(
+                    "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                    actionRowDiverges && "bg-amber-500/5",
+                  )}
+                >
+                  <CompareNextActions entry={e} />
+                </td>
+              ))}
+              {items.length < 4 && (
+                <td className="min-w-[220px] border-b border-border p-3 align-top text-xs text-ink-subtle">
+                  —
+                </td>
+              )}
+            </tr>
             {ROWS.map((row, i) => (
               <tr
                 key={row.label}
@@ -252,6 +297,93 @@ function ComparePage() {
       </p>
     </div>
   );
+}
+
+function CompareNextActions({ entry }: { entry: Entry }) {
+  const actions = resolveCompareEntryActions(entry);
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {actions.map((action) => (
+        <CompareActionButton key={action.id} entry={entry} action={action} />
+      ))}
+    </div>
+  );
+}
+
+function CompareActionButton({ entry, action }: { entry: Entry; action: CompareAction }) {
+  const eventKey = entryEventKey(entry.category, entry.slug);
+
+  if (action.kind === "copy" && action.copyValue) {
+    return (
+      <CopyButton
+        value={action.copyValue}
+        label={action.label}
+        event={action.analyticsEvent}
+        eventData={{ entry: eventKey, surface: "compare-page" }}
+        onCopied={() => {
+          if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+        }}
+      />
+    );
+  }
+
+  if (action.kind === "link") {
+    if (action.id === "dossier") {
+      return (
+        <Link
+          to="/entry/$category/$slug"
+          params={{ category: entry.category, slug: entry.slug }}
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.id === "claim") {
+      return (
+        <Link
+          to="/claim"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+            }
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.href && action.external) {
+      return (
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </a>
+      );
+    }
+  }
+
+  return null;
 }
 
 function Skeleton({ ids }: { ids: string }) {

--- a/tests/compare-entry-actions.test.ts
+++ b/tests/compare-entry-actions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
   compareActionSignature,
@@ -25,6 +25,10 @@ function entry(overrides: Partial<Entry> = {}): Entry {
 }
 
 describe("compare entry actions", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("always offers dossier navigation and optional install, config, source, and claim CTAs", () => {
     expect(
       resolveCompareEntryActions(entry()).map((action) => action.id),
@@ -55,6 +59,8 @@ describe("compare entry actions", () => {
       ]),
     ).toBe(false);
     expect(compareActionSignature(entry())).toBe("dossier|claim");
+    expect(compareActionsDiverge([entry()])).toBe(false);
+    expect(compareActionsDiverge([])).toBe(false);
   });
 
   it("records compare intent events with entry keys only and degrades safely", async () => {
@@ -63,6 +69,14 @@ describe("compare entry actions", () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ stored: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ stored: false }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stored: false }),
       })
       .mockRejectedValueOnce(new Error("offline"));
     vi.stubGlobal("fetch", fetchMock);
@@ -82,7 +96,11 @@ describe("compare entry actions", () => {
     await expect(recordCompareIntentEvent("open", entry())).resolves.toBe(
       false,
     );
-
-    vi.unstubAllGlobals();
+    await expect(recordCompareIntentEvent("copy", entry())).resolves.toBe(
+      false,
+    );
+    await expect(recordCompareIntentEvent("open", entry())).resolves.toBe(
+      false,
+    );
   });
 });

--- a/tests/compare-entry-actions.test.ts
+++ b/tests/compare-entry-actions.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareActionSignature,
+  compareActionsDiverge,
+  recordCompareIntentEvent,
+  resolveCompareEntryActions,
+} from "@/lib/compare-entry-actions";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare entry actions", () => {
+  it("always offers dossier navigation and optional install, config, source, and claim CTAs", () => {
+    expect(
+      resolveCompareEntryActions(entry()).map((action) => action.id),
+    ).toEqual(["dossier", "claim"]);
+    expect(
+      resolveCompareEntryActions(
+        entry({
+          installCommand: "npm i fixture",
+          configSnippet: '{ "mcp": true }',
+          sourceUrl: "https://github.com/org/repo",
+          claimed: true,
+        }),
+      ).map((action) => action.id),
+    ).toEqual(["dossier", "install", "config", "source"]);
+  });
+
+  it("detects when compared entries expose different next-action sets", () => {
+    expect(
+      compareActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      compareActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(compareActionSignature(entry())).toBe("dossier|claim");
+  });
+
+  it("records compare intent events with entry keys only and degrades safely", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stored: true }),
+      })
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      recordCompareIntentEvent(
+        "install",
+        entry({ category: "skills", slug: "demo" }),
+      ),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("/api/intent-events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "install", entryKey: "skills/demo" }),
+    });
+
+    await expect(recordCompareIntentEvent("open", entry())).resolves.toBe(
+      false,
+    );
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
- Add reusable compare-page action helpers for dossier, install, config, source, and claim CTAs.
- Surface a **Next steps** row on `/compare` so users can act on differences without returning to each dossier.
- Highlight the row when compared entries expose different action sets.
- Record compare intent events with entry keys only (no snippet payloads) and degrade safely when D1 is unavailable.

## Linked issue
Refs #556 — delivers the compare conversion slice from the epic acceptance criteria:
- Improve CTAs for copy/install actions where appropriate during entry comparison.
- CTA events degrade safely when analytics/storage is unavailable.

## Differentiation
- **This PR (#4257):** full compare page next-action CTAs (`compare.index.tsx`, `compare-entry-actions.ts`).
- **#4260:** compare drawer trust/provenance signal rows (`compare-drawer.tsx`, `compare-entry-signals.ts`).
- No file overlap between the two PRs.

## Scope and risk
- **Scope:** compare action resolver, compare page UI row, focused unit tests, optional `CopyButton.onCopied` hook.
- **Risk:** Low — UI-only compare page changes with no registry/content/schema impact.
- **Overlap:** No file overlap with open PRs #4251, #4258, #4259, or #4260.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-actions.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] Action resolver covers install/config/source/claim permutations
- [x] Intent recording sends only `type` + `entryKey` and degrades on failure
- [x] Action divergence highlights rows when compared entries offer different next steps