### PR TITLE
fix(registry): block spoofed split author profiles

### DIFF
--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -179,14 +179,10 @@ export function shouldRegisterDistinctAuthorProfile(
   const author = String(entry.author || "").trim();
   const authorSlug = contributorSlug(author);
   if (!authorSlug || authorSlug === contributorSlug(submitter)) return false;
-  if (!entry.authorProfileUrl) return false;
-  if (
-    entry.submittedBy &&
-    !authorMatchesSubmitter(entry.author, entry.submittedBy) &&
-    githubHandle(entry.authorProfileUrl) === authorSlug
-  ) {
+  if (entry.submittedBy && !authorMatchesSubmitter(entry.author, entry.submittedBy)) {
     return false;
   }
+  if (!entry.authorProfileUrl) return false;
   return true;
 }
 

--- a/tests/contributors-attribution.test.ts
+++ b/tests/contributors-attribution.test.ts
@@ -112,9 +112,7 @@ describe("contributors attribution aggregation", () => {
     expect(getContributor("distinct-author")?.sourceSubmissionCount ?? 0).toBe(
       0,
     );
-    expect(getContributor("split-author")?.github).toBe(
-      "https://split-author.dev",
-    );
+    expect(getContributor("split-author")).toBeUndefined();
     expect(getContributor("reviewer")?.reviewedCount).toBe(1);
     expect(getContributor("at-handle")?.handle).toBe("at-handle");
     expect(getContributor("solo-submitter")?.acceptedCount).toBe(1);
@@ -127,7 +125,7 @@ describe("contributors attribution aggregation", () => {
     ).toBe(false);
   });
 
-  it("blocks spoofed split-author links and github-backed distinct author registration", () => {
+  it("blocks unverified split-author links and distinct author registration", () => {
     const splitEntry = fixture({
       author: "Split Author",
       submittedBy: "split-submitter",
@@ -141,12 +139,22 @@ describe("contributors attribution aggregation", () => {
 
     expect(
       shouldRegisterDistinctAuthorProfile(splitEntry, "split-submitter"),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldRegisterDistinctAuthorProfile(spoofEntry, "spoof-submitter"),
     ).toBe(false);
-    expect(contributorForDisplayAuthor(splitEntry)?.slug).toBe("split-author");
+    expect(contributorForDisplayAuthor(splitEntry)).toBeUndefined();
     expect(contributorForDisplayAuthor(spoofEntry)).toBeUndefined();
+    expect(
+      shouldRegisterDistinctAuthorProfile(
+        fixture({
+          author: "Existing Contributor",
+          submittedBy: "spoof-submitter",
+          authorProfileUrl: "https://evil.example/not-controlled",
+        }),
+        "spoof-submitter",
+      ),
+    ).toBe(false);
     expect(
       contributorForDisplayAuthor(
         fixture({ author: "Author Only", submittedBy: undefined }),


### PR DESCRIPTION
### Motivation

- The contributor attribution logic allowed unverified split-author entries to register or resolve internal contributor profiles from attacker-controlled names or arbitrary profile URLs, weakening registry trust signals.

### Description

- Tighten `shouldRegisterDistinctAuthorProfile` to refuse registering distinct author profiles when an entry has a `submittedBy` value that does not match the claimed `author`, preventing unverified split-author registration.
- Preserve existing behavior for verified same-identity authors and author-only entries by leaving `contributorForDisplayAuthor` fallbacks intact.
- Update `tests/contributors-attribution.test.ts` to reflect the new guard and add regression coverage for GitHub-backed and arbitrary-URL spoofing cases.

### Testing

- Ran the targeted unit suite with `pnpm exec vitest run tests/contributors-attribution.test.ts`, which passed (3 tests, all succeeded). 
- Ran `git diff --check` as part of validation with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45f755b0e8832c90bf0d66c8e99b41)