### PR TITLE
feat(compare): add review and provenance signals to compare tray

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -21,10 +21,16 @@ import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
+import {
+  COMPARE_DECISION_ROWS,
+  decisionRowDiverges,
+  type CompareSignalValue,
+} from "@/lib/compare-entry-signals";
 
 interface RowDef {
   label: string;
   render: (e: Entry) => React.ReactNode;
+  diverges?: (items: Entry[]) => boolean;
 }
 
 const ROWS: RowDef[] = [
@@ -32,6 +38,15 @@ const ROWS: RowDef[] = [
     label: "Trust",
     render: (e) => <TrustDrilldown entry={e} />,
   },
+  ...COMPARE_DECISION_ROWS.map((row) => ({
+    label: row.label,
+    render: (e: Entry) => {
+      const value = row.resolve(e);
+      if (!value) return <span className="text-xs text-ink-subtle">—</span>;
+      return <CompareSignalCell value={value} />;
+    },
+    diverges: (items: Entry[]) => decisionRowDiverges(row.resolve, items),
+  })),
   {
     label: "Safety",
     render: (e) =>
@@ -140,6 +155,20 @@ const ROWS: RowDef[] = [
     ),
   },
 ];
+
+function CompareSignalCell({ value }: { value: CompareSignalValue }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex flex-col gap-0.5 text-xs",
+        value.tone === "present" ? "text-trust-trusted" : "text-ink-subtle",
+      )}
+    >
+      <span>{value.label}</span>
+      {value.detail ? <span className="text-ink-muted">{value.detail}</span> : null}
+    </span>
+  );
+}
 
 /** Per-entry snippet cell that honors the global copy variant + harness pref. */
 function SnippetCell({ entry }: { entry: Entry }) {
@@ -322,24 +351,44 @@ export function CompareDrawer() {
                   </tr>
                 </thead>
                 <tbody>
-                  {ROWS.map((row, i) => (
-                    <tr key={row.label} className={cn(i % 2 === 0 && "bg-surface-2/30")}>
-                      <th
-                        scope="row"
-                        className="sticky left-0 z-10 w-[140px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted"
+                  {ROWS.map((row, i) => {
+                    const rowDiverges = row.diverges?.(items) ?? false;
+                    return (
+                      <tr
+                        key={row.label}
+                        className={cn(
+                          i % 2 === 0 && "bg-surface-2/30",
+                          rowDiverges && "bg-amber-500/5",
+                        )}
                       >
-                        {row.label}
-                      </th>
-                      {items.map((e) => (
-                        <td
-                          key={`${e.category}/${e.slug}`}
-                          className="min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top last:border-r-0"
+                        <th
+                          scope="row"
+                          className={cn(
+                            "sticky left-0 z-10 w-[140px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                            rowDiverges && "text-amber-800",
+                          )}
                         >
-                          {row.render(e)}
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
+                          {row.label}
+                          {rowDiverges ? (
+                            <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                              Differs
+                            </span>
+                          ) : null}
+                        </th>
+                        {items.map((e) => (
+                          <td
+                            key={`${e.category}/${e.slug}`}
+                            className={cn(
+                              "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top last:border-r-0",
+                              rowDiverges && "bg-amber-500/5",
+                            )}
+                          >
+                            {row.render(e)}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -23,6 +23,7 @@ import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
 import {
   COMPARE_DECISION_ROWS,
+  compareSignalToneClass,
   decisionRowDiverges,
   type CompareSignalValue,
 } from "@/lib/compare-entry-signals";
@@ -159,10 +160,7 @@ const ROWS: RowDef[] = [
 function CompareSignalCell({ value }: { value: CompareSignalValue }) {
   return (
     <span
-      className={cn(
-        "inline-flex flex-col gap-0.5 text-xs",
-        value.tone === "present" ? "text-trust-trusted" : "text-ink-subtle",
-      )}
+      className={cn("inline-flex flex-col gap-0.5 text-xs", compareSignalToneClass(value.tone))}
     >
       <span>{value.label}</span>
       {value.detail ? <span className="text-ink-muted">{value.detail}</span> : null}

--- a/apps/web/src/lib/compare-entry-signals.ts
+++ b/apps/web/src/lib/compare-entry-signals.ts
@@ -1,6 +1,6 @@
 import type { Entry } from "@/types/registry";
 
-export type CompareSignalTone = "present" | "missing";
+export type CompareSignalTone = "verified" | "present" | "missing";
 
 export type CompareSignalValue = {
   tone: CompareSignalTone;
@@ -17,7 +17,7 @@ export function reviewCompareSignal(
         ? `${entry.reviewedBy} · ${String(entry.reviewedAt).slice(0, 10)}`
         : entry.reviewedBy
       : "Maintainer reviewed";
-    return { tone: "present", label: "Reviewed", detail };
+    return { tone: "verified", label: "Reviewed", detail };
   }
   return { tone: "missing", label: "Not reviewed" };
 }
@@ -29,7 +29,7 @@ export function packageTrustCompareSignal(
 
   if (explicitVerification === true) {
     return {
-      tone: "present",
+      tone: "verified",
       label: "Package verified",
       detail: entry.verifiedAt ? String(entry.verifiedAt).slice(0, 10) : undefined,
     };
@@ -79,6 +79,12 @@ export const COMPARE_DECISION_ROWS = [
   { label: "Source provenance", resolve: sourceProvenanceCompareSignal },
   { label: "Submitter", resolve: submitterCompareSignal },
 ] as const;
+
+export function compareSignalToneClass(tone: CompareSignalTone): string {
+  if (tone === "verified") return "text-trust-trusted";
+  if (tone === "present") return "text-ink";
+  return "text-ink-subtle";
+}
 
 export function compareSignalsDiverge(values: Array<CompareSignalValue | undefined>): boolean {
   if (values.length < 2) return false;

--- a/apps/web/src/lib/compare-entry-signals.ts
+++ b/apps/web/src/lib/compare-entry-signals.ts
@@ -1,0 +1,97 @@
+import type { Entry } from "@/types/registry";
+
+export type CompareSignalTone = "present" | "missing";
+
+export type CompareSignalValue = {
+  tone: CompareSignalTone;
+  label: string;
+  detail?: string;
+};
+
+export function reviewCompareSignal(
+  entry: Pick<Entry, "reviewedBy" | "reviewedAt" | "reviewed">,
+): CompareSignalValue {
+  if (entry.reviewedBy || entry.reviewed) {
+    const detail = entry.reviewedBy
+      ? entry.reviewedAt
+        ? `${entry.reviewedBy} · ${String(entry.reviewedAt).slice(0, 10)}`
+        : entry.reviewedBy
+      : "Maintainer reviewed";
+    return { tone: "present", label: "Reviewed", detail };
+  }
+  return { tone: "missing", label: "Not reviewed" };
+}
+
+export function packageTrustCompareSignal(
+  entry: Pick<Entry, "packageVerified" | "verifiedAt" | "trustSignals" | "downloadSha256">,
+): CompareSignalValue {
+  const explicitVerification = entry.packageVerified ?? entry.trustSignals?.packageVerified;
+
+  if (explicitVerification === true) {
+    return {
+      tone: "present",
+      label: "Package verified",
+      detail: entry.verifiedAt ? String(entry.verifiedAt).slice(0, 10) : undefined,
+    };
+  }
+
+  if (explicitVerification === false) {
+    return { tone: "missing", label: "Package not verified" };
+  }
+
+  if (entry.downloadSha256 || entry.trustSignals?.checksumPresent) {
+    return { tone: "present", label: "Checksum present" };
+  }
+
+  return { tone: "missing", label: "Package not verified" };
+}
+
+export function sourceProvenanceCompareSignal(
+  entry: Pick<Entry, "source" | "sourceSubmissionUrl" | "importPrUrl" | "trustSignals">,
+): CompareSignalValue {
+  if (entry.sourceSubmissionUrl || entry.importPrUrl) {
+    return {
+      tone: "present",
+      label: "Submission linked",
+      detail: entry.importPrUrl ? "Import PR" : "Source submission",
+    };
+  }
+  if (entry.source === "source-backed" || entry.trustSignals?.sourceStatus === "available") {
+    return { tone: "present", label: "Source-backed" };
+  }
+  return { tone: "missing", label: "No submission link" };
+}
+
+export function submitterCompareSignal(
+  entry: Pick<Entry, "submittedBy">,
+): CompareSignalValue | undefined {
+  if (!entry.submittedBy) return undefined;
+  return { tone: "present", label: entry.submittedBy };
+}
+
+export function resolveCompareSignal(value: CompareSignalValue | undefined): CompareSignalValue {
+  return value ?? { tone: "missing", label: "—" };
+}
+
+export const COMPARE_DECISION_ROWS = [
+  { label: "Review status", resolve: reviewCompareSignal },
+  { label: "Package trust", resolve: packageTrustCompareSignal },
+  { label: "Source provenance", resolve: sourceProvenanceCompareSignal },
+  { label: "Submitter", resolve: submitterCompareSignal },
+] as const;
+
+export function compareSignalsDiverge(values: Array<CompareSignalValue | undefined>): boolean {
+  if (values.length < 2) return false;
+  const signature = values.map((value) => {
+    const signal = resolveCompareSignal(value);
+    return `${signal.tone}:${signal.label}:${signal.detail ?? ""}`;
+  });
+  return new Set(signature).size > 1;
+}
+
+export function decisionRowDiverges(
+  resolve: (entry: Entry) => CompareSignalValue | undefined,
+  items: Entry[],
+): boolean {
+  return compareSignalsDiverge(items.map((entry) => resolve(entry)));
+}

--- a/tests/compare-entry-signals.test.ts
+++ b/tests/compare-entry-signals.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareSignalsDiverge,
+  COMPARE_DECISION_ROWS,
+  decisionRowDiverges,
+  packageTrustCompareSignal,
+  reviewCompareSignal,
+  sourceProvenanceCompareSignal,
+  submitterCompareSignal,
+} from "@/lib/compare-entry-signals";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare entry signals", () => {
+  it("describes review status for maintainer-reviewed entries", () => {
+    expect(reviewCompareSignal(entry())).toEqual({
+      tone: "missing",
+      label: "Not reviewed",
+    });
+    expect(reviewCompareSignal(entry({ reviewed: true }))).toEqual({
+      tone: "present",
+      label: "Reviewed",
+      detail: "Maintainer reviewed",
+    });
+    expect(
+      reviewCompareSignal(
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-05-01T00:00:00Z" }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Reviewed",
+      detail: "maintainer · 2026-05-01",
+    });
+    expect(reviewCompareSignal(entry({ reviewedBy: "maintainer" }))).toEqual({
+      tone: "present",
+      label: "Reviewed",
+      detail: "maintainer",
+    });
+  });
+
+  it("describes package trust from verified metadata only", () => {
+    expect(packageTrustCompareSignal(entry())).toEqual({
+      tone: "missing",
+      label: "Package not verified",
+    });
+    expect(packageTrustCompareSignal(entry({ packageVerified: true }))).toEqual(
+      {
+        tone: "present",
+        label: "Package verified",
+        detail: undefined,
+      },
+    );
+    expect(
+      packageTrustCompareSignal(
+        entry({
+          verifiedAt: "2026-04-12",
+          packageVerified: true,
+        }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Package verified",
+      detail: "2026-04-12",
+    });
+    expect(
+      packageTrustCompareSignal(
+        entry({ trustSignals: { packageVerified: true } }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Package verified",
+      detail: undefined,
+    });
+  });
+
+  it("surfaces checksum-only metadata without overstating package verification", () => {
+    expect(
+      packageTrustCompareSignal(
+        entry({ trustSignals: { checksumPresent: true } }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Checksum present",
+    });
+    expect(
+      packageTrustCompareSignal(entry({ downloadSha256: "abc123" })),
+    ).toEqual({
+      tone: "present",
+      label: "Checksum present",
+    });
+    expect(
+      packageTrustCompareSignal(
+        entry({
+          packageVerified: false,
+          downloadSha256: "abc123",
+        }),
+      ),
+    ).toEqual({
+      tone: "missing",
+      label: "Package not verified",
+    });
+    expect(
+      packageTrustCompareSignal(
+        entry({
+          trustSignals: { packageVerified: false, checksumPresent: true },
+        }),
+      ),
+    ).toEqual({
+      tone: "missing",
+      label: "Package not verified",
+    });
+  });
+
+  it("describes source provenance from submission links or source-backed metadata", () => {
+    expect(sourceProvenanceCompareSignal(entry())).toEqual({
+      tone: "missing",
+      label: "No submission link",
+    });
+    expect(
+      sourceProvenanceCompareSignal(
+        entry({
+          source: "source-backed",
+          trustSignals: { sourceStatus: "available" },
+        }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Source-backed",
+    });
+    expect(
+      sourceProvenanceCompareSignal(
+        entry({ importPrUrl: "https://github.com/org/repo/pull/1" }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Submission linked",
+      detail: "Import PR",
+    });
+    expect(
+      sourceProvenanceCompareSignal(
+        entry({ sourceSubmissionUrl: "https://github.com/org/repo/issues/1" }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Submission linked",
+      detail: "Source submission",
+    });
+  });
+
+  it("returns submitter labels only when provenance exists", () => {
+    expect(submitterCompareSignal(entry())).toBeUndefined();
+    expect(submitterCompareSignal(entry({ submittedBy: "kiannidev" }))).toEqual(
+      {
+        tone: "present",
+        label: "kiannidev",
+      },
+    );
+  });
+
+  it("exposes compare decision rows and detects diverging signal sets", () => {
+    expect(COMPARE_DECISION_ROWS.map((row) => row.label)).toEqual([
+      "Review status",
+      "Package trust",
+      "Source provenance",
+      "Submitter",
+    ]);
+    expect(
+      compareSignalsDiverge([
+        reviewCompareSignal(entry({ reviewed: true })),
+        reviewCompareSignal(entry()),
+      ]),
+    ).toBe(true);
+    expect(
+      compareSignalsDiverge([
+        reviewCompareSignal(entry({ reviewed: true })),
+        reviewCompareSignal(entry({ reviewed: true })),
+      ]),
+    ).toBe(false);
+    expect(compareSignalsDiverge([reviewCompareSignal(entry())])).toBe(false);
+    expect(
+      compareSignalsDiverge([
+        submitterCompareSignal(entry({ submittedBy: "kiannidev" })),
+        submitterCompareSignal(entry()),
+      ]),
+    ).toBe(true);
+    expect(
+      compareSignalsDiverge([
+        submitterCompareSignal(entry({ submittedBy: "kiannidev" })),
+        submitterCompareSignal(entry({ submittedBy: "kiannidev" })),
+      ]),
+    ).toBe(false);
+  });
+
+  it("detects submitter row divergence across compared entries", () => {
+    const submitterRow = COMPARE_DECISION_ROWS.find(
+      (row) => row.label === "Submitter",
+    );
+    expect(submitterRow).toBeDefined();
+    expect(
+      decisionRowDiverges(submitterRow!.resolve, [
+        entry({ submittedBy: "kiannidev" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      decisionRowDiverges(submitterRow!.resolve, [
+        entry({ submittedBy: "kiannidev" }),
+        entry({ submittedBy: "kiannidev" }),
+      ]),
+    ).toBe(false);
+  });
+});

--- a/tests/compare-entry-signals.test.ts
+++ b/tests/compare-entry-signals.test.ts
@@ -6,6 +6,7 @@ import {
   COMPARE_DECISION_ROWS,
   decisionRowDiverges,
   packageTrustCompareSignal,
+  resolveCompareSignal,
   reviewCompareSignal,
   sourceProvenanceCompareSignal,
   submitterCompareSignal,
@@ -90,6 +91,16 @@ describe("compare entry signals", () => {
     });
   });
 
+  it("maps compare signal tones to drawer styling classes", () => {
+    expect(compareSignalToneClass("verified")).toBe("text-trust-trusted");
+    expect(compareSignalToneClass("present")).toBe("text-ink");
+    expect(compareSignalToneClass("missing")).toBe("text-ink-subtle");
+    expect(resolveCompareSignal(undefined)).toEqual({
+      tone: "missing",
+      label: "—",
+    });
+  });
+
   it("maps checksum-only package metadata to a neutral present tone", () => {
     const checksumOnly = packageTrustCompareSignal(
       entry({ trustSignals: { checksumPresent: true } }),
@@ -161,6 +172,32 @@ describe("compare entry signals", () => {
       label: "Source-backed",
     });
     expect(
+      sourceProvenanceCompareSignal(entry({ source: "source-backed" })),
+    ).toEqual({
+      tone: "present",
+      label: "Source-backed",
+    });
+    expect(
+      sourceProvenanceCompareSignal(
+        entry({ trustSignals: { sourceStatus: "available" } }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Source-backed",
+    });
+    expect(
+      sourceProvenanceCompareSignal(
+        entry({
+          importPrUrl: "https://github.com/org/repo/pull/1",
+          sourceSubmissionUrl: "https://github.com/org/repo/issues/1",
+        }),
+      ),
+    ).toEqual({
+      tone: "present",
+      label: "Submission linked",
+      detail: "Import PR",
+    });
+    expect(
       sourceProvenanceCompareSignal(
         entry({ importPrUrl: "https://github.com/org/repo/pull/1" }),
       ),
@@ -210,6 +247,7 @@ describe("compare entry signals", () => {
       ]),
     ).toBe(false);
     expect(compareSignalsDiverge([reviewCompareSignal(entry())])).toBe(false);
+    expect(compareSignalsDiverge([])).toBe(false);
     expect(
       compareSignalsDiverge([
         submitterCompareSignal(entry({ submittedBy: "kiannidev" })),

--- a/tests/compare-entry-signals.test.ts
+++ b/tests/compare-entry-signals.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareSignalToneClass,
   compareSignalsDiverge,
   COMPARE_DECISION_ROWS,
   decisionRowDiverges,
@@ -34,7 +35,7 @@ describe("compare entry signals", () => {
       label: "Not reviewed",
     });
     expect(reviewCompareSignal(entry({ reviewed: true }))).toEqual({
-      tone: "present",
+      tone: "verified",
       label: "Reviewed",
       detail: "Maintainer reviewed",
     });
@@ -43,12 +44,12 @@ describe("compare entry signals", () => {
         entry({ reviewedBy: "maintainer", reviewedAt: "2026-05-01T00:00:00Z" }),
       ),
     ).toEqual({
-      tone: "present",
+      tone: "verified",
       label: "Reviewed",
       detail: "maintainer · 2026-05-01",
     });
     expect(reviewCompareSignal(entry({ reviewedBy: "maintainer" }))).toEqual({
-      tone: "present",
+      tone: "verified",
       label: "Reviewed",
       detail: "maintainer",
     });
@@ -61,7 +62,7 @@ describe("compare entry signals", () => {
     });
     expect(packageTrustCompareSignal(entry({ packageVerified: true }))).toEqual(
       {
-        tone: "present",
+        tone: "verified",
         label: "Package verified",
         detail: undefined,
       },
@@ -74,7 +75,7 @@ describe("compare entry signals", () => {
         }),
       ),
     ).toEqual({
-      tone: "present",
+      tone: "verified",
       label: "Package verified",
       detail: "2026-04-12",
     });
@@ -83,10 +84,26 @@ describe("compare entry signals", () => {
         entry({ trustSignals: { packageVerified: true } }),
       ),
     ).toEqual({
-      tone: "present",
+      tone: "verified",
       label: "Package verified",
       detail: undefined,
     });
+  });
+
+  it("maps checksum-only package metadata to a neutral present tone", () => {
+    const checksumOnly = packageTrustCompareSignal(
+      entry({ trustSignals: { checksumPresent: true } }),
+    );
+    expect(checksumOnly).toEqual({
+      tone: "present",
+      label: "Checksum present",
+    });
+    expect(compareSignalToneClass(checksumOnly.tone)).toBe("text-ink");
+    expect(
+      compareSignalToneClass(
+        packageTrustCompareSignal(entry({ packageVerified: true })).tone,
+      ),
+    ).toBe("text-trust-trusted");
   });
 
   it("surfaces checksum-only metadata without overstating package verification", () => {


### PR DESCRIPTION
## Summary
- Add reusable compare decision signal helpers for review status, package trust, source provenance, and submitter credit.
- Surface those rows in the compare drawer and highlight rows that diverge across compared entries.
- Keep package trust semantics aligned with the dossier trust model: verified only when `packageVerified` is true, checksum-only metadata surfaced separately, and explicit verification failures preserved even when checksums exist.
- Use distinct visual tones so verified signals render green, informational metadata renders neutral, and missing states render muted.

## Linked issue
Refs #556 — delivers the compare-tray trust signal slice from the epic acceptance criteria:
- Users can compare saved entries and understand trust differences without opening every dossier.

## Differentiation
- **This PR (#4260):** compare drawer trust/provenance signal rows (`compare-drawer.tsx`, `compare-entry-signals.ts`).
- **#4257:** full compare page next-action CTAs (`compare.index.tsx`, `compare-entry-actions.ts`).
- No file overlap between the two PRs.

## Scope and risk
- **Scope:** `compare-entry-signals` helper module, compare drawer integration, signal tone styling, focused unit tests.
- **Risk:** Low — UI-only compare tray changes with no registry/content/schema impact.
- **Overlap:** No file overlap with open PRs #4251, #4258, #4259, or #4257.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-signals.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] Package trust cases cover verified, checksum-only, and explicit `packageVerified: false`
- [x] Submitter divergence covers present-vs-missing metadata across compared entries
- [x] Checksum-only metadata uses neutral `present` tone, not verified green styling