### PR TITLE
fix(submissions): block forged review provenance

### DIFF
--- a/scripts/ci/validate-content-policy.mjs
+++ b/scripts/ci/validate-content-policy.mjs
@@ -731,6 +731,8 @@ function frontmatterProvenance(data = {}) {
         ? importPrNumber
         : null,
     importPrUrl: normalizeText(data.importPrUrl),
+    reviewedBy: normalizeText(data.reviewedBy),
+    reviewedAt: normalizeText(data.reviewedAt),
   };
 }
 
@@ -741,6 +743,20 @@ function submitterProvenanceChanged(entry) {
     normalizeText(current.submittedBy) !== normalizeText(base.submittedBy) ||
     normalizeText(current.submittedByUrl) !== normalizeText(base.submittedByUrl)
   );
+}
+
+function reviewProvenanceChanged(entry) {
+  const current = entry.provenance || {};
+  const base = entry.baseProvenance || {};
+  return (
+    normalizeText(current.reviewedBy) !== normalizeText(base.reviewedBy) ||
+    normalizeText(current.reviewedAt) !== normalizeText(base.reviewedAt)
+  );
+}
+
+function hasReviewProvenance(entry) {
+  const provenance = entry.provenance || {};
+  return Boolean(provenance.reviewedBy || provenance.reviewedAt);
 }
 
 function isNewDirectContentEntry(entry) {
@@ -1142,7 +1158,28 @@ function validatePrProvenance(report, entries, prAuthor, sourceType) {
   if (sourceType !== "external_direct") return;
 
   for (const entry of entries) {
-    if (!isNewDirectContentEntry(entry)) {
+    const isNewEntry = isNewDirectContentEntry(entry);
+    if (isNewEntry && hasReviewProvenance(entry)) {
+      addProvenanceFinding(
+        report,
+        "error",
+        `direct_pr_review_provenance_${entry.filename}`,
+        "Direct contributor PRs cannot set maintainer review provenance",
+        `${entry.filename}: leave reviewedBy/reviewedAt unset; maintainers add review metadata after verification.`,
+      );
+    }
+
+    if (!isNewEntry) {
+      if (reviewProvenanceChanged(entry)) {
+        addProvenanceFinding(
+          report,
+          "error",
+          `direct_pr_review_provenance_change_${entry.filename}`,
+          "Direct contributor PRs cannot change maintainer review provenance",
+          `${entry.filename}: leave existing reviewedBy/reviewedAt unchanged; maintainers handle review metadata separately.`,
+        );
+      }
+
       if (submitterProvenanceChanged(entry)) {
         addProvenanceFinding(
           report,

--- a/tests/content-policy-validation.test.ts
+++ b/tests/content-policy-validation.test.ts
@@ -711,6 +711,81 @@ Example body.
     );
   });
 
+  it("fails external content PRs that set maintainer review provenance", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const content = `---
+title: Example MCP
+category: mcp
+description: Example forged review provenance fixture.
+sourceUrl: https://github.com/example/example-mcp
+reviewedBy: trusted-maintainer
+reviewedAt: 2026-05-01T00:00:00Z
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "added",
+        content,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("direct_pr_review_provenance"),
+      ]),
+    );
+  });
+
+  it("fails external content PRs that change existing maintainer review provenance", () => {
+    const tmpDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "heyclaude-content-policy-"),
+    );
+    const baseContent = `---
+title: Example MCP
+category: mcp
+description: Example existing review provenance fixture.
+sourceUrl: https://github.com/example/example-mcp
+reviewedBy: trusted-maintainer
+reviewedAt: 2026-04-01T00:00:00Z
+submittedBy: contributor
+submittedByUrl: https://github.com/contributor
+---
+
+Example body.
+`;
+    const content = baseContent.replace(
+      "reviewedAt: 2026-04-01T00:00:00Z",
+      "reviewedAt: 2026-05-01T00:00:00Z",
+    );
+
+    const result = runContentPolicy(tmpDir, content, "external_direct", [
+      {
+        filename: "content/mcp/example-mcp.mdx",
+        status: "modified",
+        content,
+        baseContent,
+      },
+    ]);
+
+    expect(result.status).not.toBe(0);
+    const output = JSON.parse(fs.readFileSync(result.outputJson, "utf8"));
+    expect(output.failures).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("direct_pr_review_provenance_change"),
+      ]),
+    );
+  });
+
   it("fails external content PRs that set packageVerified", () => {
     const tmpDir = fs.mkdtempSync(
       path.join(os.tmpdir(), "heyclaude-content-policy-"),


### PR DESCRIPTION
### Motivation
- Prevent contributor-controlled `reviewedBy`/`reviewedAt` frontmatter from being accepted in external direct PRs and later rendered as a trusted "Reviewed" signal in the compare UI.
- Close a provenance validation gap so review metadata is treated like other protected trust signals (e.g., `packageVerified`).

### Description
- Add `reviewedBy` and `reviewedAt` to frontmatter provenance extraction in `scripts/ci/validate-content-policy.mjs` so review metadata participates in provenance checks.
- Add `reviewProvenanceChanged` and `hasReviewProvenance` helpers and enforce blocking rules for `external_direct` PRs so new entries cannot set review provenance and existing entries cannot change it.
- Add regression tests in `tests/content-policy-validation.test.ts` covering both forging a new review provenance and changing existing review provenance.
- Preserve prior submitter-provenance checks and only extend validation to review provenance without changing UI code here.

### Testing
- Ran `pnpm exec vitest run tests/content-policy-validation.test.ts --reporter=verbose` and all tests in that file passed (43 passed).
- Ran `pnpm test:submission-pr-first` and the suite passed (27 tests passed).
- Ran `git diff --check` to ensure there are no whitespace or checkstyle errors; outcome was clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488d279df0832cb556ee62ccc6c493)