### PR TITLE
fix(compare): use valid intent event entry keys

### DIFF
--- a/apps/web/src/lib/compare-entry-actions.ts
+++ b/apps/web/src/lib/compare-entry-actions.ts
@@ -1,4 +1,3 @@
-import { entryRef } from "@/lib/entry-identity";
 import type { Entry } from "@/types/registry";
 
 export type CompareActionKind = "link" | "copy";
@@ -97,7 +96,7 @@ export async function recordCompareIntentEvent(
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         type,
-        entryKey: entryRef(entry),
+        entryKey: `${entry.category}:${entry.slug}`,
       }),
     });
     if (!response.ok) return false;

--- a/tests/compare-entry-actions.test.ts
+++ b/tests/compare-entry-actions.test.ts
@@ -90,7 +90,7 @@ describe("compare entry actions", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/intent-events", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ type: "install", entryKey: "skills/demo" }),
+      body: JSON.stringify({ type: "install", entryKey: "skills:demo" }),
     });
 
     await expect(recordCompareIntentEvent("open", entry())).resolves.toBe(


### PR DESCRIPTION
### Motivation
- Compare-page CTA telemetry was posting `entryKey` as `category/slug` (e.g. `skills/demo`) which does not match the intent-events API contract that requires `category:slug`, causing events to be rejected or unattributed.

### Description
- Serialize the intent event `entryKey` as ``${entry.category}:${entry.slug}`` in `apps/web/src/lib/compare-entry-actions.ts` and update the related expectation in `tests/compare-entry-actions.test.ts` to use the colon-delimited format.

### Testing
- Ran `pnpm exec vitest run tests/compare-entry-actions.test.ts` and `pnpm exec vitest run tests/compare-entry-actions.test.ts tests/dynamic-api-routes.test.ts` and both test runs passed, and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a489231c9ec832c82cc6ab87045ee47)