### PR TITLE
feat(web): treat 0.0.0.0 as loopback in MCP config validation

### DIFF
--- a/apps/web/src/lib/mcp-config-validator-lib.ts
+++ b/apps/web/src/lib/mcp-config-validator-lib.ts
@@ -24,6 +24,19 @@ const SENSITIVE_SPLIT_ARG_KEYS = new Set([
   "xapikey",
 ]);
 
+// Keep loopback host detection aligned with submission-risk/content-policy
+// exemptions so local MCP dev URLs do not get false HTTPS warnings.
+const LOOPBACK_MCP_HOSTNAMES = new Set([
+  "127.0.0.1",
+  "localhost",
+  "[::1]",
+  "0.0.0.0",
+]);
+
+export function isLoopbackMcpHost(hostname: string) {
+  return LOOPBACK_MCP_HOSTNAMES.has(hostname);
+}
+
 export type McpConfigServerReport = {
   name: string;
   transport: "stdio" | "remote" | "unknown";
@@ -406,12 +419,7 @@ export function validateServer(name: string, raw: unknown) {
   if (url) {
     try {
       const parsed = new URL(url);
-      const isLocal =
-        parsed.hostname === "localhost" ||
-        parsed.hostname === "127.0.0.1" ||
-        // URL.hostname returns IPv6 hosts wrapped in brackets, so the loopback
-        // address surfaces as "[::1]" (never the bare "::1").
-        parsed.hostname === "[::1]";
+      const isLocal = isLoopbackMcpHost(parsed.hostname);
       if (parsed.protocol !== "https:" && !(isLocal && parsed.protocol === "http:")) {
         warnings.push("Remote MCP URLs should use HTTPS unless they are localhost.");
       }

--- a/tests/mcp-config-validator-lib.test.ts
+++ b/tests/mcp-config-validator-lib.test.ts
@@ -11,6 +11,7 @@ import {
   isRecord,
   packageFromRunner,
   packageRunnerName,
+  isLoopbackMcpHost,
   redactArgValue,
   redactEnvValue,
   redactUrlValue,
@@ -296,11 +297,24 @@ describe("MCP config validator lib", () => {
       for (const url of [
         "http://localhost:3000/sse",
         "http://127.0.0.1:3000/sse",
+        "http://0.0.0.0:3000/mcp",
       ]) {
         expect(validateServer("loopback", { url }).warnings).not.toContain(
           "Remote MCP URLs should use HTTPS unless they are localhost.",
         );
       }
+    });
+
+    it("recognizes loopback MCP hostnames", () => {
+      for (const hostname of [
+        "localhost",
+        "127.0.0.1",
+        "[::1]",
+        "0.0.0.0",
+      ]) {
+        expect(isLoopbackMcpHost(hostname), hostname).toBe(true);
+      }
+      expect(isLoopbackMcpHost("example.com")).toBe(false);
     });
 
     it("flags invalid names, missing transport, and shell pipelines", () => {

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -518,16 +518,18 @@ describe("MCP config validator", () => {
     expect(JSON.parse(result.fixedConfigText)).toHaveProperty("mcpServers");
   });
 
-  it("treats http://[::1] IPv6 loopback as localhost", () => {
+  it("treats http://[::1] and http://0.0.0.0 as loopback localhost", () => {
     const httpsWarning =
       "Remote MCP URLs should use HTTPS unless they are localhost.";
 
-    const loopback = validateMcpConfigText(
-      JSON.stringify({
-        mcpServers: { local: { url: "http://[::1]:3000/sse" } },
-      }),
-    );
-    expect(loopback.warnings).not.toContain(`local: ${httpsWarning}`);
+    for (const url of ["http://[::1]:3000/sse", "http://0.0.0.0:3000/mcp"]) {
+      const loopback = validateMcpConfigText(
+        JSON.stringify({
+          mcpServers: { local: { url } },
+        }),
+      );
+      expect(loopback.warnings, url).not.toContain(`local: ${httpsWarning}`);
+    }
 
     const remote = validateMcpConfigText(
       JSON.stringify({


### PR DESCRIPTION
## Summary

The browser MCP config validator warned on HTTP URLs bound to `0.0.0.0` even though other HeyClaude loopback checks already treat that host as a local dev bind address. This adds `0.0.0.0` to the shared loopback host set used by MCP config validation.

Closes #4267

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/lib/mcp-config-validator-lib.ts` — `isLoopbackMcpHost()` and loopback host detection in `validateServer()`.
- Expected behavior:
  - `http://0.0.0.0:<port>/...` no longer emits `Remote MCP URLs should use HTTPS unless they are localhost.`
  - Existing exemptions for `localhost`, `127.0.0.1`, and `[::1]` are unchanged.
  - Non-loopback HTTP URLs such as `http://example.com:3000/sse` still warn.
- Important edge cases or invariants:
  - Warning-only behavior; validation status and redaction paths are unchanged.
  - Loopback host list mirrors the submission-risk/content-policy loopback set (`127.0.0.1`, `localhost`, `[::1]`, `0.0.0.0`).
- Backward compatibility notes:
  - No API or response shape changes; only suppresses a false-positive HTTPS warning for local bind-all dev URLs.
- Screenshots for frontend/page/UI changes:
  - `No visual impact` — validation logic only.
- Accessibility notes for UI changes:
  - n/a
- Focused tests or reason tests are not practical:
  - Extended `tests/mcp-config-validator-lib.test.ts` and `tests/mcp-config-validator.test.ts`.

## Validation

- [x] Platform/code PR: `pnpm build` not run locally because `pnpm` is unavailable in this environment; relying on CI.
- Intended commands:
  - `pnpm exec vitest run tests/mcp-config-validator-lib.test.ts tests/mcp-config-validator.test.ts`
  - `pnpm build`
  - `git diff --check` (ran locally: clean)

## Notes

- Linked issue: #4267
- This aligns browser-side MCP validation with loopback handling already documented in `packages/registry/src/submission-risk.js` and `scripts/ci/validate-content-policy.mjs`.
