### PR TITLE
feat(registry): accept 0.0.0.0 loopback URLs in MCP install metadata

### DIFF
--- a/packages/registry/src/mcp-install-config.js
+++ b/packages/registry/src/mcp-install-config.js
@@ -44,7 +44,7 @@ function isLoopbackHostname(hostname) {
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  if (host === "localhost" || host === "::1") return true;
+  if (host === "localhost" || host === "::1" || host === "0.0.0.0") return true;
   const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
   return Boolean(ipv4 && Number(ipv4[1]) === 127);
 }

--- a/tests/mcp-install-config-url-credentials.test.ts
+++ b/tests/mcp-install-config-url-credentials.test.ts
@@ -85,12 +85,17 @@ describe("normalizeMcpServerConfig URL credential hardening", () => {
   });
 
   it("accepts a clean loopback http URL", () => {
-    const normalized = normalizeMcpServerConfig({
-      type: "http",
-      url: "http://127.0.0.1:8080/mcp",
-    });
-    expect(normalized).not.toBeNull();
-    expect(normalized?.url).toBe("http://127.0.0.1:8080/mcp");
+    for (const url of [
+      "http://127.0.0.1:8080/mcp",
+      "http://0.0.0.0:8080/mcp",
+    ]) {
+      const normalized = normalizeMcpServerConfig({
+        type: "http",
+        url,
+      });
+      expect(normalized, url).not.toBeNull();
+      expect(normalized?.url).toBe(url);
+    }
   });
 
   it("keeps proper header-based auth working without URL credentials", () => {

--- a/tests/mcp-install-config.test.ts
+++ b/tests/mcp-install-config.test.ts
@@ -113,12 +113,18 @@ describe("MCP install config helpers", () => {
       }),
     ).toBeNull();
 
-    expect(
-      mcpInstallTargetsForConfig({
-        type: "http",
-        url: "http://127.0.0.1:3000/mcp",
-      }),
-    ).toEqual(targets);
+    for (const url of [
+      "http://127.0.0.1:3000/mcp",
+      "http://0.0.0.0:3000/mcp",
+    ]) {
+      expect(
+        mcpInstallTargetsForConfig({
+          type: "http",
+          url,
+        }),
+        url,
+      ).toEqual(targets);
+    }
     expect(
       mcpInstallTargetsForConfig({
         type: "sse",


### PR DESCRIPTION
## Summary

Registry MCP install metadata still rejected clean `http://0.0.0.0:<port>/...` configs even after the browser validator began treating that host as local development. This aligns `normalizeMcpServerConfig()` loopback detection with the submission-risk/content-policy host set.

Closes #4270

Related: #4269 (browser MCP config validator local-host exemption)

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/registry/src/mcp-install-config.js` — loopback hostname detection in `isSafeRemoteMcpUrl()` / `normalizeMcpServerConfig()`.
- Expected behavior:
  - `http://0.0.0.0:<port>/...` normalizes successfully and remains eligible for machine-install metadata.
  - Existing loopback acceptance for `127.0.0.1`, `localhost`, and `[::1]` is unchanged.
  - Remote cleartext HTTP URLs such as `http://mcp.example.com/mcp` are still rejected.
- Important edge cases or invariants:
  - URLs with embedded credentials remain rejected, including on loopback hosts.
  - Stdio configs are unaffected.
- Backward compatibility notes:
  - Only expands accepted loopback HTTP URLs; no API shape changes.
- Screenshots for frontend/page/UI changes:
  - `No visual impact` — registry install-metadata normalization only.
- Accessibility notes for UI changes:
  - n/a
- Focused tests or reason tests are not practical:
  - Extended `tests/mcp-install-config.test.ts` and `tests/mcp-install-config-url-credentials.test.ts`.

## Validation

- [x] Ran `prettier@3.8.3` on the changed files before opening this PR.
- Intended commands:
  - `pnpm exec vitest run tests/mcp-install-config.test.ts tests/mcp-install-config-url-credentials.test.ts`
  - `pnpm build`
  - `trunk check --ci --upstream <base>`

## Notes

- Linked issue: #4270
- Keeps registry install-metadata loopback handling consistent with #4269 and the existing submission-risk/content-policy host exemptions.
