### PR TITLE
feat(mcp): accept 0.0.0.0 loopback URLs in endpoint normalization

### DIFF
--- a/packages/mcp/src/endpoint-url.js
+++ b/packages/mcp/src/endpoint-url.js
@@ -1,7 +1,13 @@
 export const DEFAULT_REMOTE_MCP_URL = "https://heyclau.de/api/mcp";
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
 
-const localHosts = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+const localHosts = new Set([
+  "127.0.0.1",
+  "localhost",
+  "::1",
+  "[::1]",
+  "0.0.0.0",
+]);
 
 export function normalizeEndpointUrl(value = DEFAULT_REMOTE_MCP_URL) {
   const raw = String(value || "").trim();

--- a/tests/mcp-cli.test.ts
+++ b/tests/mcp-cli.test.ts
@@ -35,6 +35,9 @@ describe("HeyClaude MCP CLI options", () => {
     expect(normalizeEndpointUrl("http://localhost:3000").toString()).toBe(
       "http://localhost:3000/api/mcp",
     );
+    expect(normalizeEndpointUrl("http://0.0.0.0:3845").toString()).toBe(
+      "http://0.0.0.0:3845/api/mcp",
+    );
     expect(() => normalizeEndpointUrl("http://example.com")).toThrow(
       /HTTPS outside localhost/i,
     );


### PR DESCRIPTION
# Pull Request

## Summary

- Allow `http://0.0.0.0:<port>` as a local MCP endpoint in `@heyclaude/mcp` CLI URL normalization, matching the loopback exemptions already used by the web validator and registry install metadata.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/endpoint-url.js` — `localHosts` loopback allowlist used by `normalizeEndpointUrl()`.
  - `tests/mcp-cli.test.ts` — regression test for `http://0.0.0.0` endpoint normalization.
- Expected behavior:
  - `normalizeEndpointUrl("http://0.0.0.0:3845")` succeeds and appends `/api/mcp` when the path is empty.
  - Remote non-HTTPS URLs outside the loopback allowlist still throw.
- Important edge cases or invariants:
  - Only hostname allowlisting changes; HTTPS remote endpoints and existing localhost/`127.0.0.1`/`::1` behavior are unchanged.
  - Aligns with recent loopback handling in the web MCP validator (#4269) and registry install metadata (#4271).
- Backward compatibility notes:
  - Strictly additive for a hostname already treated as loopback elsewhere in the repo.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact
  - Mobile: No visual impact
- If screenshots do not apply, write `No visual impact` and explain why.
  - CLI/package URL normalization only; no UI surfaces change.
- Accessibility notes for UI changes:
  - N/A — no UI changes.
- Focused tests or reason tests are not practical:
  - Added assertion in `tests/mcp-cli.test.ts` for the `0.0.0.0` loopback case.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
  - Local environment lacks installed workspace deps; relying on CI for `pnpm exec vitest run tests/mcp-cli.test.ts`.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.
  - Verified `normalizeEndpointUrl()` logic and existing CLI option tests cover the changed allowlist.

## Notes

- Linked issue or no-issue rationale: Closes #4272
- Any caveats, follow-ups, or reviewer context:
  - Raycast MCP installer loopback helper is a separate surface and can be aligned in a follow-up if needed.
