### PR TITLE
feat(raycast): accept 0.0.0.0 loopback URLs in MCP installer

### DIFF
--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -351,7 +351,7 @@ function isLoopbackHostname(hostname: string) {
     .trim()
     .toLowerCase()
     .replace(/^\[|\]$/g, "");
-  if (host === "localhost" || host === "::1") return true;
+  if (host === "localhost" || host === "::1" || host === "0.0.0.0") return true;
   const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
   return Boolean(ipv4 && Number(ipv4[1]) === 127);
 }

--- a/integrations/raycast/test/feed.test.ts
+++ b/integrations/raycast/test/feed.test.ts
@@ -854,6 +854,13 @@ describe("Raycast feed helpers", () => {
       }),
       ["claude-code", "codex", "cursor", "antigravity"],
     );
+    assert.deepEqual(
+      mcpInstallTargetsForConfig({
+        type: "http",
+        url: "http://0.0.0.0:3845/mcp",
+      }),
+      ["claude-code", "codex", "cursor", "antigravity"],
+    );
     assert.throws(
       () =>
         buildMcpInstallPlan("claude-code", sampleEntry, {


### PR DESCRIPTION
# Pull Request

## Summary

- Allow `http://0.0.0.0:<port>` as a loopback MCP install URL in the Raycast extension installer, matching loopback exemptions already used by the web validator, registry install metadata, and MCP CLI.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `integrations/raycast/src/mcp-installer.ts` — `isLoopbackHostname()` allowlist used by `isSafeRemoteMcpUrl()` and install-target checks.
  - `integrations/raycast/test/feed.test.ts` — regression test for `http://0.0.0.0` install targets.
- Expected behavior:
  - `mcpInstallTargetsForConfig({ type: "http", url: "http://0.0.0.0:3845/mcp" })` returns all supported Raycast install targets.
  - Remote non-HTTPS URLs outside loopback still return no install targets.
- Important edge cases or invariants:
  - Only hostname allowlisting changes; HTTPS remote endpoints and existing localhost/`127.0.0.1`/`::1` behavior are unchanged.
  - Aligns with loopback handling in #4269, #4271, and #4273.
- Backward compatibility notes:
  - Strictly additive for a hostname already treated as loopback elsewhere in the repo.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact
  - Mobile: No visual impact
- If screenshots do not apply, write `No visual impact` and explain why.
  - Raycast installer URL validation only; no UI layout changes.
- Accessibility notes for UI changes:
  - N/A — no UI changes.
- Focused tests or reason tests are not practical:
  - Added assertion in `integrations/raycast/test/feed.test.ts` for the `0.0.0.0` loopback case.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
  - Local environment lacks installed workspace deps; relying on CI for `validate-raycast` and `validate-ci`.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.
  - Verified `mcpInstallTargetsForConfig()` behavior against existing loopback test patterns.

## Notes

- Linked issue or no-issue rationale: Closes #4275
- Any caveats, follow-ups, or reviewer context:
  - `feed.ts` local feed hostname allowlist is a separate surface and can be aligned in a follow-up if needed.
