### PR TITLE
feat(web): accept full 127.0.0.0/8 loopback in MCP validator

### DIFF
--- a/apps/web/src/lib/mcp-config-validator-lib.ts
+++ b/apps/web/src/lib/mcp-config-validator-lib.ts
@@ -23,7 +23,6 @@ const SENSITIVE_SPLIT_ARG_KEYS = new Set([
   "x_api_key",
   "xapikey",
 ]);
-const LOCAL_MCP_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]", "0.0.0.0"]);
 
 export type McpConfigServerReport = {
   name: string;
@@ -315,7 +314,15 @@ export function packageFromRunner(command: string, args: string[]) {
 }
 
 export function isLocalMcpHost(hostname: string) {
-  return LOCAL_MCP_HOSTNAMES.has(hostname);
+  const host = hostname
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host === "::1" || host === "0.0.0.0") {
+    return true;
+  }
+  const ipv4 = host.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  return Boolean(ipv4 && Number(ipv4[1]) === 127);
 }
 
 export function extractServers(payload: unknown) {

--- a/tests/mcp-config-validator-lib.test.ts
+++ b/tests/mcp-config-validator-lib.test.ts
@@ -297,6 +297,8 @@ describe("MCP config validator lib", () => {
       for (const url of [
         "http://localhost:3000/sse",
         "http://127.0.0.1:3000/sse",
+        "http://127.0.0.2:3000/sse",
+        "http://127.1.0.1:3000/mcp",
         "http://0.0.0.0:3000/mcp",
       ]) {
         expect(validateServer("loopback", { url }).warnings).not.toContain(
@@ -305,11 +307,20 @@ describe("MCP config validator lib", () => {
       }
     });
 
-    it("recognizes local MCP hostnames including 0.0.0.0", () => {
-      for (const hostname of ["localhost", "127.0.0.1", "[::1]", "0.0.0.0"]) {
+    it("recognizes local MCP hostnames including full 127.0.0.0/8 loopback", () => {
+      for (const hostname of [
+        "localhost",
+        "127.0.0.1",
+        "127.0.0.2",
+        "127.1.0.1",
+        "127.255.255.255",
+        "[::1]",
+        "0.0.0.0",
+      ]) {
         expect(isLocalMcpHost(hostname), hostname).toBe(true);
       }
       expect(isLocalMcpHost("example.com")).toBe(false);
+      expect(isLocalMcpHost("128.0.0.1")).toBe(false);
     });
 
     it("flags invalid names, missing transport, and shell pipelines", () => {

--- a/tests/mcp-config-validator.test.ts
+++ b/tests/mcp-config-validator.test.ts
@@ -518,11 +518,16 @@ describe("MCP config validator", () => {
     expect(JSON.parse(result.fixedConfigText)).toHaveProperty("mcpServers");
   });
 
-  it("treats http://[::1] and http://0.0.0.0 as local development hosts", () => {
+  it("treats http://[::1], http://0.0.0.0, and full 127.0.0.0/8 as local development hosts", () => {
     const httpsWarning =
       "Remote MCP URLs should use HTTPS unless they are localhost.";
 
-    for (const url of ["http://[::1]:3000/sse", "http://0.0.0.0:3000/mcp"]) {
+    for (const url of [
+      "http://[::1]:3000/sse",
+      "http://0.0.0.0:3000/mcp",
+      "http://127.0.0.2:3000/sse",
+      "http://127.255.255.255:8080/mcp",
+    ]) {
       const loopback = validateMcpConfigText(
         JSON.stringify({
           mcpServers: { local: { url } },


### PR DESCRIPTION
# Pull Request

## Summary

- Align web MCP validator loopback detection with registry install metadata by accepting the full `127.0.0.0/8` range, not only exact hostnames like `127.0.0.1`.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/lib/mcp-config-validator-lib.ts` — `isLocalMcpHost()` now matches registry-style `127.0.0.0/8` loopback detection.
  - `tests/mcp-config-validator-lib.test.ts` — unit tests for `127.0.0.2`, `127.1.0.1`, `127.255.255.255`, and negative `128.0.0.1`.
  - `tests/mcp-config-validator.test.ts` — integration tests for full-config validation of `127.0.0.0/8` HTTP URLs.
- Expected behavior:
  - `http://127.0.0.2:3000/mcp` no longer triggers the remote HTTPS warning.
  - `http://example.com:3000/mcp` still warns to use HTTPS.
- Important edge cases or invariants:
  - Bracketed IPv6 `::1` hostnames still normalize correctly.
  - `0.0.0.0`, `localhost`, and `127.0.0.1` behavior is unchanged.
  - Aligns web validator with registry `isLoopbackHostname()` semantics.
- Backward compatibility notes:
  - Strictly relaxes false-positive warnings for valid loopback addresses; no stricter validation introduced.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact
  - Mobile: No visual impact
- If screenshots do not apply, write `No visual impact` and explain why.
  - MCP config validator library logic only; no page layout changes.
- Accessibility notes for UI changes:
  - N/A — no UI changes.
- Focused tests or reason tests are not practical:
  - Added assertions in both MCP validator test suites.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
  - Local environment lacks installed workspace deps; relying on CI for `validate-ci`, `validate-web`, and focused vitest runs.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.
  - Verified `isLocalMcpHost()` against registry loopback rules and existing validator test patterns.

## Notes

- Linked issue or no-issue rationale: Closes #4277
- Any caveats, follow-ups, or reviewer context:
  - Registry, MCP CLI, and Raycast loopback helpers were aligned in prior PRs; this closes the remaining web-validator gap for `127.0.0.0/8`.
