### PR TITLE
feat(web): extract job listing helpers into jobs-lib

### DIFF
--- a/apps/web/src/lib/jobs-lib.ts
+++ b/apps/web/src/lib/jobs-lib.ts
@@ -1,0 +1,322 @@
+export type JobTier = "free" | "standard" | "featured" | "sponsored";
+export type JobStatus =
+  | "draft"
+  | "pending_review"
+  | "active"
+  | "stale_pending_review"
+  | "closed"
+  | "archived";
+export type JobSource = "manual" | "polar" | "email" | "curated";
+export type JobSourceKind = "official_ats" | "employer_careers" | "employer_submitted";
+
+export type JobListing = {
+  slug: string;
+  title: string;
+  company: string;
+  companyUrl?: string;
+  location: string;
+  description: string;
+  descriptionMd?: string;
+  type?: string;
+  postedAt?: string;
+  compensation?: string;
+  equity?: string;
+  bonus?: string;
+  benefits?: string[];
+  responsibilities?: string[];
+  requirements?: string[];
+  featured: boolean;
+  sponsored?: boolean;
+  applyUrl: string;
+  tier?: JobTier;
+  status?: JobStatus;
+  source?: JobSource;
+  sourceKind?: JobSourceKind;
+  sourceUrl?: string;
+  firstSeenAt?: string;
+  lastCheckedAt?: string;
+  sourceCheckedAt?: string;
+  staleCheckCount?: number;
+  curationNote?: string;
+  paidPlacementExpiresAt?: string;
+  claimedEmployer?: boolean;
+  postedByEmail?: string;
+  expiresAt?: string;
+  isRemote?: boolean;
+  isWorldwide?: boolean;
+};
+
+export type PublicJobListing = Omit<
+  JobListing,
+  "postedByEmail" | "paidPlacementExpiresAt" | "staleCheckCount"
+> & {
+  webUrl: string;
+  labels: string[];
+  sourceLabel: string;
+  applySourceLabel: string;
+  lastVerifiedAt?: string;
+};
+
+export type JobListingRow = {
+  slug: string;
+  title: string;
+  company_name: string;
+  company_url: string | null;
+  location_text: string;
+  summary: string | null;
+  description_md: string | null;
+  employment_type: string | null;
+  posted_at: string | null;
+  compensation_summary: string | null;
+  equity_summary: string | null;
+  bonus_summary: string | null;
+  benefits_json: string | null;
+  responsibilities_json: string | null;
+  requirements_json: string | null;
+  apply_url: string | null;
+  tier: string | null;
+  status: string | null;
+  source: string | null;
+  source_kind: string | null;
+  source_url: string | null;
+  first_seen_at: string | null;
+  last_checked_at: string | null;
+  source_checked_at: string | null;
+  stale_check_count: number | null;
+  curation_note: string | null;
+  paid_placement_expires_at: string | null;
+  claimed_employer: number | null;
+  posted_by_email: string | null;
+  expires_at: string | null;
+  is_remote: number | null;
+  is_worldwide: number | null;
+};
+
+function parseList(value: string | null | undefined) {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return undefined;
+    const cleaned = parsed
+      .map((item) => String(item ?? "").trim())
+      .filter(Boolean)
+      .filter((item) => !isGenericSeededJobBullet(item));
+    return cleaned.length ? cleaned : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+const GENERIC_SEEDED_JOB_BULLETS = new Set([
+  "build and maintain production-quality systems aligned with the role and company product surface.",
+  "collaborate across product, engineering, and customer workflows where ai-native tools and automation matter.",
+  "relevant engineering experience for the listed role and product domain.",
+  "comfort working with fast-moving ai, developer tooling, infrastructure, or product teams.",
+]);
+
+function isGenericSeededJobBullet(value: string) {
+  return GENERIC_SEEDED_JOB_BULLETS.has(value.trim().toLowerCase());
+}
+
+export function normalizeJobLocation(value: string | null | undefined) {
+  const location = String(value || "Remote")
+    .replace(/\s+,/g, ",")
+    .replace(/,\s+/g, ", ")
+    .replace(/\bEU \(EU \(European Union\)\)/g, "EU (European Union)")
+    .replace(/\bUS \(US \(United States\)\)/g, "US (United States)")
+    .trim();
+
+  if (location.includes("EU (European Union)") || location.includes("US (United States)")) {
+    return location;
+  }
+
+  const exactReplacements: Record<string, string> = {
+    "European Union": "EU (European Union)",
+    "United States": "US (United States)",
+    "San Francisco Bay Area, California, United States": "SF Bay Area, CA, US",
+    "SF/San Francisco Bay Area": "SF Bay Area, CA, US",
+    "San Francisco, California, United States": "San Francisco, CA, US",
+    "San Francisco, CA, United States": "San Francisco, CA, US",
+    "Oakland, California, United States": "Oakland, CA, US",
+    "Chicago, Illinois, United States": "Chicago, IL, US",
+    "Austin, Texas, United States": "Austin, TX, US",
+    "New York City, New York, United States": "New York City, NY, US",
+    "London, Moorgate, United Kingdom": "London, UK",
+    "UK, UK, United Kingdom": "UK",
+    "Paris, Paris, France": "Paris, France",
+    "India, India": "India",
+    "London, Europe, France": "Remote (EU)",
+    "EMEA - Remote": "Remote (EMEA)",
+  };
+
+  if (exactReplacements[location]) return exactReplacements[location];
+  return location
+    .replace(/\bEuropean Union\b/g, "EU (European Union)")
+    .replace(/\bUnited States\b/g, "US")
+    .replace(/\bUnited Kingdom\b/g, "UK");
+}
+
+function mapTier(tier: string | null | undefined): JobTier {
+  if (tier === "free") return "free";
+  if (tier === "sponsored" || tier === "featured") return tier;
+  return "standard";
+}
+
+function mapStatus(status: string | null | undefined): JobStatus {
+  if (
+    status === "draft" ||
+    status === "pending_review" ||
+    status === "active" ||
+    status === "stale_pending_review" ||
+    status === "closed" ||
+    status === "archived"
+  ) {
+    return status;
+  }
+  return "active";
+}
+
+function mapSource(source: string | null | undefined): JobSource {
+  if (source === "manual" || source === "polar" || source === "email" || source === "curated") {
+    return source;
+  }
+  return "manual";
+}
+
+function mapSourceKind(value: string | null | undefined): JobSourceKind {
+  if (value === "official_ats" || value === "employer_careers" || value === "employer_submitted") {
+    return value;
+  }
+  return "employer_submitted";
+}
+
+export function mapJobListingRow(row: JobListingRow): JobListing {
+  const tier = mapTier(row.tier);
+  return {
+    slug: row.slug,
+    title: row.title,
+    company: row.company_name,
+    companyUrl: row.company_url || undefined,
+    location: normalizeJobLocation(row.location_text),
+    description: row.summary || row.description_md || "",
+    descriptionMd: row.description_md || undefined,
+    type: row.employment_type || undefined,
+    postedAt: row.posted_at || undefined,
+    compensation: row.compensation_summary || undefined,
+    equity: row.equity_summary || undefined,
+    bonus: row.bonus_summary || undefined,
+    benefits: parseList(row.benefits_json),
+    responsibilities: parseList(row.responsibilities_json),
+    requirements: parseList(row.requirements_json),
+    featured: tier === "featured" || tier === "sponsored",
+    sponsored: tier === "sponsored",
+    applyUrl: row.apply_url || "/jobs/post",
+    tier,
+    status: mapStatus(row.status),
+    source: mapSource(row.source),
+    sourceKind: mapSourceKind(row.source_kind),
+    sourceUrl: row.source_url || row.apply_url || undefined,
+    firstSeenAt: row.first_seen_at || row.posted_at || undefined,
+    lastCheckedAt: row.last_checked_at || undefined,
+    sourceCheckedAt: row.source_checked_at || undefined,
+    staleCheckCount: Number(row.stale_check_count ?? 0),
+    curationNote: row.curation_note || undefined,
+    paidPlacementExpiresAt: row.paid_placement_expires_at || undefined,
+    claimedEmployer: Number(row.claimed_employer ?? 0) === 1,
+    postedByEmail: row.posted_by_email || undefined,
+    expiresAt: row.expires_at || undefined,
+    isRemote: Number(row.is_remote ?? 1) === 1,
+    isWorldwide: Number(row.is_worldwide ?? 0) === 1,
+  };
+}
+
+export function sortJobs(jobs: JobListing[]): JobListing[] {
+  return [...jobs].sort((left, right) => {
+    const leftScore =
+      Number(Boolean(left.sponsored)) * 3 +
+      Number(Boolean(left.featured)) * 2 +
+      Number(left.tier === "standard");
+    const rightScore =
+      Number(Boolean(right.sponsored)) * 3 +
+      Number(Boolean(right.featured)) * 2 +
+      Number(right.tier === "standard");
+    if (rightScore !== leftScore) return rightScore - leftScore;
+    return String(right.postedAt || "").localeCompare(String(left.postedAt || ""));
+  });
+}
+
+export function jobSourceLabel(job: Pick<JobListing, "source" | "sourceKind">) {
+  if (job.source === "curated") return "Editorially curated";
+  if (job.sourceKind === "official_ats") return "Official ATS page";
+  if (job.sourceKind === "employer_careers") return "Employer careers page";
+  return "Employer submitted";
+}
+
+function jobApplySourceLabel(job: Pick<JobListing, "sourceKind">) {
+  if (job.sourceKind === "official_ats") return "External apply via ATS";
+  if (job.sourceKind === "employer_careers") {
+    return "External apply via employer site";
+  }
+  return "External apply";
+}
+
+function jobLabels(job: JobListing) {
+  const labels = new Set<string>();
+  if (job.sponsored) labels.add("Sponsored");
+  else if (job.featured) labels.add("Featured");
+  if (job.source === "curated") labels.add("Editorially curated");
+  if (job.claimedEmployer) labels.add("Claimed employer");
+  if (job.isRemote) labels.add("Remote");
+  if (job.compensation) labels.add("Compensation listed");
+  return [...labels];
+}
+
+function latestJobTimestamp(jobs: PublicJobListing[]) {
+  const timestamps = jobs
+    .flatMap((job) => [
+      job.lastVerifiedAt,
+      job.sourceCheckedAt,
+      job.lastCheckedAt,
+      job.postedAt,
+      job.firstSeenAt,
+    ])
+    .filter(Boolean)
+    .map((value) => Date.parse(String(value)))
+    .filter(Number.isFinite);
+
+  if (timestamps.length === 0) return "";
+  return new Date(Math.max(...timestamps)).toISOString();
+}
+
+export function toPublicJobListing(
+  job: JobListing,
+  siteUrl = "https://heyclau.de",
+): PublicJobListing {
+  const {
+    paidPlacementExpiresAt: _paidPlacementExpiresAt,
+    postedByEmail: _postedByEmail,
+    staleCheckCount: _staleCheckCount,
+    ...publicJob
+  } = job;
+  const lastVerifiedAt = job.sourceCheckedAt || job.lastCheckedAt;
+
+  return {
+    ...publicJob,
+    webUrl: new URL(`/jobs/${job.slug}`, siteUrl).toString(),
+    labels: jobLabels(job),
+    sourceLabel: jobSourceLabel(job),
+    applySourceLabel: jobApplySourceLabel(job),
+    ...(lastVerifiedAt ? { lastVerifiedAt } : {}),
+  };
+}
+
+export function buildPublicJobsIndex(jobs: JobListing[], siteUrl = "https://heyclau.de") {
+  const entries = jobs.map((job) => toPublicJobListing(job, siteUrl));
+  return {
+    schemaVersion: 1,
+    kind: "jobs-index",
+    generatedAt: latestJobTimestamp(entries),
+    count: entries.length,
+    entries,
+  };
+}

--- a/apps/web/src/lib/jobs.ts
+++ b/apps/web/src/lib/jobs.ts
@@ -1,277 +1,36 @@
+/**
+ * Job listing D1/IO layer built on top of pure helpers in `jobs-lib.ts`.
+ *
+ * The deterministic normalization/public-index layer lives in
+ * `@/lib/jobs-lib` and is re-exported below so the public `@/lib/jobs`
+ * surface is unchanged for routes and sibling modules.
+ */
 import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
 import { validateJobPublicExposure } from "@heyclaude/registry/commercial";
 
-export type JobTier = "free" | "standard" | "featured" | "sponsored";
-export type JobStatus =
-  | "draft"
-  | "pending_review"
-  | "active"
-  | "stale_pending_review"
-  | "closed"
-  | "archived";
-export type JobSource = "manual" | "polar" | "email" | "curated";
-export type JobSourceKind =
-  | "official_ats"
-  | "employer_careers"
-  | "employer_submitted";
+import { mapJobListingRow, sortJobs, type JobListing, type JobListingRow } from "@/lib/jobs-lib";
 
-export type JobListing = {
-  slug: string;
-  title: string;
-  company: string;
-  companyUrl?: string;
-  location: string;
-  description: string;
-  descriptionMd?: string;
-  type?: string;
-  postedAt?: string;
-  compensation?: string;
-  equity?: string;
-  bonus?: string;
-  benefits?: string[];
-  responsibilities?: string[];
-  requirements?: string[];
-  featured: boolean;
-  sponsored?: boolean;
-  applyUrl: string;
-  tier?: JobTier;
-  status?: JobStatus;
-  source?: JobSource;
-  sourceKind?: JobSourceKind;
-  sourceUrl?: string;
-  firstSeenAt?: string;
-  lastCheckedAt?: string;
-  sourceCheckedAt?: string;
-  staleCheckCount?: number;
-  curationNote?: string;
-  paidPlacementExpiresAt?: string;
-  claimedEmployer?: boolean;
-  postedByEmail?: string;
-  expiresAt?: string;
-  isRemote?: boolean;
-  isWorldwide?: boolean;
-};
-
-export type PublicJobListing = Omit<
-  JobListing,
-  "postedByEmail" | "paidPlacementExpiresAt" | "staleCheckCount"
-> & {
-  webUrl: string;
-  labels: string[];
-  sourceLabel: string;
-  applySourceLabel: string;
-  lastVerifiedAt?: string;
-};
-
-export type JobListingRow = {
-  slug: string;
-  title: string;
-  company_name: string;
-  company_url: string | null;
-  location_text: string;
-  summary: string | null;
-  description_md: string | null;
-  employment_type: string | null;
-  posted_at: string | null;
-  compensation_summary: string | null;
-  equity_summary: string | null;
-  bonus_summary: string | null;
-  benefits_json: string | null;
-  responsibilities_json: string | null;
-  requirements_json: string | null;
-  apply_url: string | null;
-  tier: string | null;
-  status: string | null;
-  source: string | null;
-  source_kind: string | null;
-  source_url: string | null;
-  first_seen_at: string | null;
-  last_checked_at: string | null;
-  source_checked_at: string | null;
-  stale_check_count: number | null;
-  curation_note: string | null;
-  paid_placement_expires_at: string | null;
-  claimed_employer: number | null;
-  posted_by_email: string | null;
-  expires_at: string | null;
-  is_remote: number | null;
-  is_worldwide: number | null;
-};
-
-function parseList(value: string | null | undefined) {
-  if (!value) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    if (!Array.isArray(parsed)) return undefined;
-    const cleaned = parsed
-      .map((item) => String(item ?? "").trim())
-      .filter(Boolean)
-      .filter((item) => !isGenericSeededJobBullet(item));
-    return cleaned.length ? cleaned : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-const GENERIC_SEEDED_JOB_BULLETS = new Set([
-  "build and maintain production-quality systems aligned with the role and company product surface.",
-  "collaborate across product, engineering, and customer workflows where ai-native tools and automation matter.",
-  "relevant engineering experience for the listed role and product domain.",
-  "comfort working with fast-moving ai, developer tooling, infrastructure, or product teams.",
-]);
-
-function isGenericSeededJobBullet(value: string) {
-  return GENERIC_SEEDED_JOB_BULLETS.has(value.trim().toLowerCase());
-}
-
-export function normalizeJobLocation(value: string | null | undefined) {
-  const location = String(value || "Remote")
-    .replace(/\s+,/g, ",")
-    .replace(/,\s+/g, ", ")
-    .replace(/\bEU \(EU \(European Union\)\)/g, "EU (European Union)")
-    .replace(/\bUS \(US \(United States\)\)/g, "US (United States)")
-    .trim();
-
-  if (
-    location.includes("EU (European Union)") ||
-    location.includes("US (United States)")
-  ) {
-    return location;
-  }
-
-  const exactReplacements: Record<string, string> = {
-    "European Union": "EU (European Union)",
-    "United States": "US (United States)",
-    "San Francisco Bay Area, California, United States": "SF Bay Area, CA, US",
-    "SF/San Francisco Bay Area": "SF Bay Area, CA, US",
-    "San Francisco, California, United States": "San Francisco, CA, US",
-    "San Francisco, CA, United States": "San Francisco, CA, US",
-    "Oakland, California, United States": "Oakland, CA, US",
-    "Chicago, Illinois, United States": "Chicago, IL, US",
-    "Austin, Texas, United States": "Austin, TX, US",
-    "New York City, New York, United States": "New York City, NY, US",
-    "London, Moorgate, United Kingdom": "London, UK",
-    "UK, UK, United Kingdom": "UK",
-    "Paris, Paris, France": "Paris, France",
-    "India, India": "India",
-    "London, Europe, France": "Remote (EU)",
-    "EMEA - Remote": "Remote (EMEA)",
-  };
-
-  if (exactReplacements[location]) return exactReplacements[location];
-  return location
-    .replace(/\bEuropean Union\b/g, "EU (European Union)")
-    .replace(/\bUnited States\b/g, "US")
-    .replace(/\bUnited Kingdom\b/g, "UK");
-}
-
-function mapTier(tier: string | null | undefined): JobTier {
-  if (tier === "free") return "free";
-  if (tier === "sponsored" || tier === "featured") return tier;
-  return "standard";
-}
-
-function mapStatus(status: string | null | undefined): JobStatus {
-  if (
-    status === "draft" ||
-    status === "pending_review" ||
-    status === "active" ||
-    status === "stale_pending_review" ||
-    status === "closed" ||
-    status === "archived"
-  ) {
-    return status;
-  }
-  return "active";
-}
-
-function mapSource(source: string | null | undefined): JobSource {
-  if (
-    source === "manual" ||
-    source === "polar" ||
-    source === "email" ||
-    source === "curated"
-  ) {
-    return source;
-  }
-  return "manual";
-}
-
-function mapSourceKind(value: string | null | undefined): JobSourceKind {
-  if (
-    value === "official_ats" ||
-    value === "employer_careers" ||
-    value === "employer_submitted"
-  ) {
-    return value;
-  }
-  return "employer_submitted";
-}
-
-export function mapJobListingRow(row: JobListingRow): JobListing {
-  const tier = mapTier(row.tier);
-  return {
-    slug: row.slug,
-    title: row.title,
-    company: row.company_name,
-    companyUrl: row.company_url || undefined,
-    location: normalizeJobLocation(row.location_text),
-    description: row.summary || row.description_md || "",
-    descriptionMd: row.description_md || undefined,
-    type: row.employment_type || undefined,
-    postedAt: row.posted_at || undefined,
-    compensation: row.compensation_summary || undefined,
-    equity: row.equity_summary || undefined,
-    bonus: row.bonus_summary || undefined,
-    benefits: parseList(row.benefits_json),
-    responsibilities: parseList(row.responsibilities_json),
-    requirements: parseList(row.requirements_json),
-    featured: tier === "featured" || tier === "sponsored",
-    sponsored: tier === "sponsored",
-    applyUrl: row.apply_url || "/jobs/post",
-    tier,
-    status: mapStatus(row.status),
-    source: mapSource(row.source),
-    sourceKind: mapSourceKind(row.source_kind),
-    sourceUrl: row.source_url || row.apply_url || undefined,
-    firstSeenAt: row.first_seen_at || row.posted_at || undefined,
-    lastCheckedAt: row.last_checked_at || undefined,
-    sourceCheckedAt: row.source_checked_at || undefined,
-    staleCheckCount: Number(row.stale_check_count ?? 0),
-    curationNote: row.curation_note || undefined,
-    paidPlacementExpiresAt: row.paid_placement_expires_at || undefined,
-    claimedEmployer: Number(row.claimed_employer ?? 0) === 1,
-    postedByEmail: row.posted_by_email || undefined,
-    expiresAt: row.expires_at || undefined,
-    isRemote: Number(row.is_remote ?? 1) === 1,
-    isWorldwide: Number(row.is_worldwide ?? 0) === 1,
-  };
-}
-
-export function sortJobs(jobs: JobListing[]): JobListing[] {
-  return [...jobs].sort((left, right) => {
-    const leftScore =
-      Number(Boolean(left.sponsored)) * 3 +
-      Number(Boolean(left.featured)) * 2 +
-      Number(left.tier === "standard");
-    const rightScore =
-      Number(Boolean(right.sponsored)) * 3 +
-      Number(Boolean(right.featured)) * 2 +
-      Number(right.tier === "standard");
-    if (rightScore !== leftScore) return rightScore - leftScore;
-    return String(right.postedAt || "").localeCompare(
-      String(left.postedAt || ""),
-    );
-  });
-}
+export {
+  buildPublicJobsIndex,
+  jobSourceLabel,
+  mapJobListingRow,
+  normalizeJobLocation,
+  sortJobs,
+  toPublicJobListing,
+  type JobListing,
+  type JobListingRow,
+  type JobSource,
+  type JobSourceKind,
+  type JobStatus,
+  type JobTier,
+  type PublicJobListing,
+} from "@/lib/jobs-lib";
 
 function getJobsDb(): D1DatabaseLike | null {
   return getSiteDb();
 }
 
-export async function queryActiveJobs(
-  db: D1DatabaseLike,
-): Promise<JobListing[]> {
+export async function queryActiveJobs(db: D1DatabaseLike): Promise<JobListing[]> {
   const { results } = await db
     .prepare(
       `SELECT
@@ -326,9 +85,7 @@ export async function queryActiveJobs(
     results
       .map((row) => mapJobListingRow(row))
       .filter((job) => {
-        const report = validateJobPublicExposure(
-          job as Record<string, unknown>,
-        );
+        const report = validateJobPublicExposure(job as Record<string, unknown>);
         if (!report.ok) {
           console.warn("[jobs] active job failed public exposure gate", {
             slug: job.slug,
@@ -358,83 +115,4 @@ export async function getJobs(): Promise<JobListing[]> {
 export async function getJobBySlug(slug: string): Promise<JobListing | null> {
   const jobs = await getJobs();
   return jobs.find((item) => item.slug === slug) ?? null;
-}
-
-export function jobSourceLabel(job: Pick<JobListing, "source" | "sourceKind">) {
-  if (job.source === "curated") return "Editorially curated";
-  if (job.sourceKind === "official_ats") return "Official ATS page";
-  if (job.sourceKind === "employer_careers") return "Employer careers page";
-  return "Employer submitted";
-}
-
-function jobApplySourceLabel(job: Pick<JobListing, "sourceKind">) {
-  if (job.sourceKind === "official_ats") return "External apply via ATS";
-  if (job.sourceKind === "employer_careers") {
-    return "External apply via employer site";
-  }
-  return "External apply";
-}
-
-function jobLabels(job: JobListing) {
-  const labels = new Set<string>();
-  if (job.sponsored) labels.add("Sponsored");
-  else if (job.featured) labels.add("Featured");
-  if (job.source === "curated") labels.add("Editorially curated");
-  if (job.claimedEmployer) labels.add("Claimed employer");
-  if (job.isRemote) labels.add("Remote");
-  if (job.compensation) labels.add("Compensation listed");
-  return [...labels];
-}
-
-function latestJobTimestamp(jobs: PublicJobListing[]) {
-  const timestamps = jobs
-    .flatMap((job) => [
-      job.lastVerifiedAt,
-      job.sourceCheckedAt,
-      job.lastCheckedAt,
-      job.postedAt,
-      job.firstSeenAt,
-    ])
-    .filter(Boolean)
-    .map((value) => Date.parse(String(value)))
-    .filter(Number.isFinite);
-
-  if (timestamps.length === 0) return "";
-  return new Date(Math.max(...timestamps)).toISOString();
-}
-
-export function toPublicJobListing(
-  job: JobListing,
-  siteUrl = "https://heyclau.de",
-): PublicJobListing {
-  const {
-    paidPlacementExpiresAt: _paidPlacementExpiresAt,
-    postedByEmail: _postedByEmail,
-    staleCheckCount: _staleCheckCount,
-    ...publicJob
-  } = job;
-  const lastVerifiedAt = job.sourceCheckedAt || job.lastCheckedAt;
-
-  return {
-    ...publicJob,
-    webUrl: new URL(`/jobs/${job.slug}`, siteUrl).toString(),
-    labels: jobLabels(job),
-    sourceLabel: jobSourceLabel(job),
-    applySourceLabel: jobApplySourceLabel(job),
-    ...(lastVerifiedAt ? { lastVerifiedAt } : {}),
-  };
-}
-
-export function buildPublicJobsIndex(
-  jobs: JobListing[],
-  siteUrl = "https://heyclau.de",
-) {
-  const entries = jobs.map((job) => toPublicJobListing(job, siteUrl));
-  return {
-    schemaVersion: 1,
-    kind: "jobs-index",
-    generatedAt: latestJobTimestamp(entries),
-    count: entries.length,
-    entries,
-  };
 }

--- a/tests/jobs-lib.test.ts
+++ b/tests/jobs-lib.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPublicJobsIndex,
+  jobSourceLabel,
+  mapJobListingRow,
+  normalizeJobLocation,
+  sortJobs,
+  toPublicJobListing,
+  type JobListing,
+  type JobListingRow,
+} from "@/lib/jobs-lib";
+
+function job(overrides: Partial<JobListing> = {}): JobListing {
+  return {
+    slug: "role",
+    title: "Role",
+    company: "Example Co",
+    location: "Remote",
+    description: "Description",
+    featured: false,
+    applyUrl: "https://example.com/apply",
+    ...overrides,
+  };
+}
+
+function row(overrides: Partial<JobListingRow> = {}): JobListingRow {
+  return {
+    slug: "role",
+    title: "Role",
+    company_name: "Example Co",
+    company_url: null,
+    location_text: "Remote",
+    summary: "Summary",
+    description_md: null,
+    employment_type: null,
+    posted_at: null,
+    compensation_summary: null,
+    equity_summary: null,
+    bonus_summary: null,
+    benefits_json: null,
+    responsibilities_json: null,
+    requirements_json: null,
+    apply_url: "https://example.com/apply",
+    tier: "standard",
+    status: "active",
+    source: "manual",
+    source_kind: "employer_submitted",
+    source_url: null,
+    first_seen_at: null,
+    last_checked_at: null,
+    source_checked_at: null,
+    stale_check_count: 0,
+    curation_note: null,
+    paid_placement_expires_at: null,
+    claimed_employer: 0,
+    posted_by_email: null,
+    expires_at: null,
+    is_remote: 1,
+    is_worldwide: 0,
+    ...overrides,
+  };
+}
+
+describe("jobs-lib normalizeJobLocation", () => {
+  it("normalizes EU and US labels without double-wrapping abbreviations", () => {
+    expect(normalizeJobLocation("European Union")).toBe("EU (European Union)");
+    expect(normalizeJobLocation("EU (European Union)")).toBe(
+      "EU (European Union)",
+    );
+    expect(normalizeJobLocation("EU (EU (European Union))")).toBe(
+      "EU (European Union)",
+    );
+    expect(normalizeJobLocation("US (US (United States))")).toBe(
+      "US (United States)",
+    );
+  });
+
+  it("applies exact city and region replacements", () => {
+    expect(
+      normalizeJobLocation("San Francisco, California, United States"),
+    ).toBe("San Francisco, CA, US");
+    expect(
+      normalizeJobLocation("San Francisco Bay Area, California, United States"),
+    ).toBe("SF Bay Area, CA, US");
+    expect(normalizeJobLocation("London, Moorgate, United Kingdom")).toBe(
+      "London, UK",
+    );
+    expect(normalizeJobLocation("EMEA - Remote")).toBe("Remote (EMEA)");
+    expect(normalizeJobLocation("London, Europe, France")).toBe("Remote (EU)");
+  });
+
+  it("falls back to regex replacements and defaults empty input to Remote", () => {
+    expect(normalizeJobLocation("United Kingdom")).toBe("UK");
+    expect(normalizeJobLocation("Remote (EU)")).toBe("Remote (EU)");
+    expect(normalizeJobLocation(null)).toBe("Remote");
+    expect(normalizeJobLocation("")).toBe("Remote");
+  });
+});
+
+describe("jobs-lib mapJobListingRow", () => {
+  it("maps sparse rows through public fallbacks and strips generic seeded bullets", () => {
+    const mapped = mapJobListingRow(
+      row({
+        slug: "fallback-role",
+        location_text: "United Kingdom",
+        summary: null,
+        description_md: "Fallback description.",
+        benefits_json: "not-json",
+        responsibilities_json: JSON.stringify([
+          "Build and maintain production-quality systems aligned with the role and company product surface.",
+          "Own useful role-specific automation.",
+        ]),
+        requirements_json: JSON.stringify({ invalid: true }),
+        apply_url: null,
+        tier: "unknown",
+        status: "unknown",
+        source: "unknown",
+        source_kind: "unknown",
+        posted_by_email: "private@example.com",
+        paid_placement_expires_at: "2026-06-01T00:00:00Z",
+        is_remote: null,
+        is_worldwide: null,
+      }),
+    );
+
+    expect(mapped).toMatchObject({
+      slug: "fallback-role",
+      location: "UK",
+      description: "Fallback description.",
+      applyUrl: "/jobs/post",
+      tier: "standard",
+      status: "active",
+      source: "manual",
+      sourceKind: "employer_submitted",
+      responsibilities: ["Own useful role-specific automation."],
+      benefits: undefined,
+      requirements: undefined,
+      isRemote: true,
+      isWorldwide: false,
+    });
+  });
+
+  it("derives featured and sponsored flags from tier", () => {
+    expect(mapJobListingRow(row({ tier: "featured" }))).toMatchObject({
+      tier: "featured",
+      featured: true,
+      sponsored: false,
+    });
+    expect(mapJobListingRow(row({ tier: "sponsored" }))).toMatchObject({
+      tier: "sponsored",
+      featured: true,
+      sponsored: true,
+    });
+  });
+});
+
+describe("jobs-lib sortJobs", () => {
+  it("ranks sponsored above featured above standard and breaks ties by postedAt", () => {
+    const jobs = [
+      job({ slug: "free-old", tier: "free", postedAt: "2026-01-01T00:00:00Z" }),
+      job({
+        slug: "featured-fresh",
+        tier: "featured",
+        featured: true,
+        postedAt: "2026-01-08T00:00:00Z",
+      }),
+      job({
+        slug: "sponsored-fresh",
+        tier: "sponsored",
+        featured: true,
+        sponsored: true,
+        postedAt: "2026-01-07T00:00:00Z",
+      }),
+    ];
+
+    expect(sortJobs(jobs).map((item) => item.slug)).toEqual([
+      "sponsored-fresh",
+      "featured-fresh",
+      "free-old",
+    ]);
+  });
+});
+
+describe("jobs-lib jobSourceLabel", () => {
+  it("labels curated jobs first, then ATS and employer-careers source kinds", () => {
+    expect(
+      jobSourceLabel({ source: "curated", sourceKind: "official_ats" }),
+    ).toBe("Editorially curated");
+    expect(
+      jobSourceLabel({ source: "manual", sourceKind: "official_ats" }),
+    ).toBe("Official ATS page");
+    expect(
+      jobSourceLabel({ source: "manual", sourceKind: "employer_careers" }),
+    ).toBe("Employer careers page");
+    expect(
+      jobSourceLabel({ source: "manual", sourceKind: "employer_submitted" }),
+    ).toBe("Employer submitted");
+  });
+});
+
+describe("jobs-lib toPublicJobListing", () => {
+  it("strips private fields and builds labels, URLs, and verification metadata", () => {
+    const mapped = mapJobListingRow(
+      row({
+        slug: "fallback-role",
+        location_text: "United Kingdom",
+        summary: null,
+        description_md: "Fallback description.",
+        apply_url: null,
+      }),
+    );
+
+    const sponsored = toPublicJobListing(
+      {
+        ...mapped,
+        sponsored: true,
+        featured: true,
+        source: "curated",
+        sourceKind: "official_ats",
+        compensation: "$180k-$220k",
+        claimedEmployer: true,
+        lastCheckedAt: "2026-05-01T00:00:00Z",
+      },
+      "https://heyclau.de",
+    );
+
+    expect(sponsored).toMatchObject({
+      webUrl: "https://heyclau.de/jobs/fallback-role",
+      sourceLabel: "Editorially curated",
+      applySourceLabel: "External apply via ATS",
+      lastVerifiedAt: "2026-05-01T00:00:00Z",
+    });
+    expect(sponsored.labels).toEqual(
+      expect.arrayContaining([
+        "Sponsored",
+        "Editorially curated",
+        "Claimed employer",
+        "Remote",
+        "Compensation listed",
+      ]),
+    );
+    expect(sponsored).not.toHaveProperty("postedByEmail");
+    expect(sponsored).not.toHaveProperty("paidPlacementExpiresAt");
+    expect(sponsored).not.toHaveProperty("staleCheckCount");
+  });
+
+  it("prefers sourceCheckedAt over lastCheckedAt for lastVerifiedAt", () => {
+    const publicJob = toPublicJobListing(
+      job({
+        sourceCheckedAt: "2026-06-01T00:00:00Z",
+        lastCheckedAt: "2026-05-01T00:00:00Z",
+      }),
+    );
+    expect(publicJob.lastVerifiedAt).toBe("2026-06-01T00:00:00Z");
+  });
+
+  it("uses employer-careers apply copy for careers source kinds", () => {
+    const publicJob = toPublicJobListing(
+      job({ sourceKind: "employer_careers" }),
+    );
+    expect(publicJob.applySourceLabel).toBe("External apply via employer site");
+  });
+});
+
+describe("jobs-lib buildPublicJobsIndex", () => {
+  it("returns an empty index when there are no jobs", () => {
+    expect(buildPublicJobsIndex([])).toMatchObject({
+      schemaVersion: 1,
+      kind: "jobs-index",
+      generatedAt: "",
+      count: 0,
+      entries: [],
+    });
+  });
+
+  it("uses the latest verification timestamp as generatedAt", () => {
+    const index = buildPublicJobsIndex([
+      job({
+        slug: "older",
+        postedAt: "2026-01-01T00:00:00Z",
+        lastCheckedAt: "2026-02-01T00:00:00Z",
+      }),
+      job({
+        slug: "newer",
+        postedAt: "2026-03-01T00:00:00Z",
+        sourceCheckedAt: "2026-04-01T00:00:00Z",
+      }),
+    ]);
+
+    expect(index.count).toBe(2);
+    expect(index.generatedAt).toBe(
+      new Date("2026-04-01T00:00:00Z").toISOString(),
+    );
+    expect(index.entries.map((entry) => entry.slug)).toEqual([
+      "older",
+      "newer",
+    ]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract job listing normalization and public-index helpers into `jobs-lib.ts` and add a consolidated Vitest suite, keeping the public `@/lib/jobs` import surface unchanged.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/lib/jobs-lib.ts` — pure job location normalization, row mapping, sorting, and public listing transforms.
  - `apps/web/src/lib/jobs.ts` — D1 query layer plus thin re-export wrapper preserving the public API.
  - `tests/jobs-lib.test.ts` — consolidated lib tests for location normalization, row mapping, sorting, labels, and public index assembly.
- Expected behavior:
  - Routes and modules importing `@/lib/jobs` behave exactly as before.
  - `normalizeJobLocation`, `mapJobListingRow`, `sortJobs`, and `toPublicJobListing` semantics are unchanged.
- Important edge cases or invariants:
  - Extraction is behavior-preserving; only module boundaries change.
  - Existing `d1-dynamic-state.test.ts` and `job-source-label.test.ts` continue exercising the public surface via re-exports.
- Backward compatibility notes:
  - Public exports from `@/lib/jobs` are unchanged.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact
  - Mobile: No visual impact
- If screenshots do not apply, write `No visual impact` and explain why.
  - Library extraction and tests only; jobs API behavior is unchanged.
- Accessibility notes for UI changes:
  - N/A — no UI changes.
- Focused tests or reason tests are not practical:
  - Added `tests/jobs-lib.test.ts` with location, mapping, sorting, and public listing coverage.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
  - Local environment lacks installed workspace deps; relying on CI for `validate-ci`, `validate-web`, `coverage`, and focused vitest runs.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.
  - Verified re-export surface matches prior `jobs.ts` exports.

## Notes

- Linked issue or no-issue rationale: Closes #4282
- Any caveats, follow-ups, or reviewer context:
  - Mirrors the `feeds-lib` / `detail-assembly-lib` extraction pattern used in recent platform PRs.
