### PR TITLE
fix(registry): resolve generatedAtForEntries root export

### DIFF
--- a/packages/registry/src/index.js
+++ b/packages/registry/src/index.js
@@ -2,6 +2,7 @@ export {
   default as categorySpec,
   categorySpec as registryCategorySpec,
 } from "./category-spec.js";
+export { generatedAtForEntries } from "./artifacts.js";
 export * from "./artifacts.js";
 export * from "./brand-assets.js";
 export * from "./commercial.js";


### PR DESCRIPTION
### Motivation
- Fix an ESM export collision where both `artifacts.js` and `quality.js` exported `generatedAtForEntries`, causing `import { generatedAtForEntries } from "@heyclaude/registry"` to fail at module link time.

### Description
- Explicitly re-export `generatedAtForEntries` from `./artifacts.js` in `packages/registry/src/index.js` so the package-root binding resolves to the intended `artifacts.js` implementation.

### Testing
- Ran `node --input-type=module -e 'import { generatedAtForEntries } from "@heyclaude/registry"; console.log(generatedAtForEntries([...]))'` which printed the expected `2026-01-01T00:00:00.000Z` (success).
- Ran `pnpm validate:packages` which passed and `git diff --check` which reported no issues.
- Attempted `pnpm exec vitest run tests/non-ui-branch-matrix.test.ts` but the test run is blocked by a missing generated data import `@/generated/atlas-registry.json` in this checkout (failure/blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4956702080832cbceb5d8bdb924624)