### PR TITLE
feat(web): extract saved-search-alerts helpers into saved-search-alerts-lib

### DIFF
--- a/apps/web/src/lib/saved-search-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-alerts-lib.ts
@@ -1,0 +1,208 @@
+/**
+ * Pure saved-search alert builders.
+ *
+ * This module matches registry entries against saved searches and materializes
+ * in-app alert payloads from public entry events. Nothing here touches the
+ * network — given the same inputs the output is deterministic.
+ *
+ * The public surface (`saved-search-alerts.ts` / `@/lib/saved-search-alerts`)
+ * re-exports everything below so existing imports stay unchanged.
+ */
+
+import type { AlertCadence, AlertChannel } from "@/lib/recents";
+import { expandedTokenCandidates } from "@/lib/search-query-aliases";
+import {
+  normalizeSearchQuery,
+  TOKEN_SPLIT_PATTERN,
+  tokenizeSearchQuery,
+} from "@/lib/search-query-tokenization";
+import type { Category, Platform, SourceStatus, TrustLevel } from "@/types/registry";
+
+export interface SavedSearchAlertSchedule {
+  enabled?: boolean;
+  channels?: AlertChannel[];
+  cadence?: AlertCadence;
+  lastNotifiedAt?: string;
+}
+
+export interface SavedSearchAlertSearch {
+  id: string;
+  label: string;
+  q?: string;
+  category?: string;
+  trust?: string;
+  source?: string;
+  platform?: string;
+  alerts?: SavedSearchAlertSchedule;
+}
+
+export interface SavedSearchAlertEntry {
+  category: Category | string;
+  slug: string;
+  title: string;
+  description?: string;
+  cardDescription?: string;
+  author?: string;
+  tags?: string[];
+  keywords?: string[];
+  platforms?: Array<Platform | string>;
+  trust?: TrustLevel | string;
+  source?: SourceStatus | string;
+}
+
+export interface SavedSearchAlertEvent {
+  id?: string;
+  kind?: string;
+  category?: string;
+  slug?: string;
+  action?: string;
+  date?: string;
+  title?: string;
+}
+
+export type SavedSearchAlertSeverity = "info" | "warning" | "blocker";
+
+export interface SavedSearchAlert {
+  id: string;
+  targetId: string;
+  kind: "saved-search";
+  title: string;
+  body: string;
+  severity: SavedSearchAlertSeverity;
+  href?: string;
+  date: string;
+}
+
+export function savedSearchAlertTargetId(search: Pick<SavedSearchAlertSearch, "id">) {
+  return `saved-search:${search.id}`;
+}
+
+export function activeInAppSavedSearches(
+  searches: SavedSearchAlertSearch[],
+): SavedSearchAlertSearch[] {
+  return searches.filter(
+    (search) => search.alerts?.enabled && search.alerts.channels?.includes("inapp"),
+  );
+}
+
+function normalizedEntryText(entry: SavedSearchAlertEntry) {
+  return [
+    entry.category,
+    entry.slug,
+    entry.title,
+    entry.description,
+    entry.cardDescription,
+    entry.author,
+    entry.trust,
+    entry.source,
+    ...(entry.platforms ?? []),
+    ...(entry.tags ?? []),
+    ...(entry.keywords ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+function candidateMatchesText(candidate: string, haystack: string, words: string[]) {
+  if (candidate.length <= 2) {
+    return words.some((word) => word === candidate || word.startsWith(candidate));
+  }
+  return haystack.includes(candidate) || words.some((word) => word.startsWith(candidate));
+}
+
+export function savedSearchQueryMatchesEntry(
+  entry: SavedSearchAlertEntry,
+  query: string | undefined,
+) {
+  const normalizedQuery = normalizeSearchQuery(query ?? "");
+  if (!normalizedQuery) return true;
+
+  const tokens = tokenizeSearchQuery(normalizedQuery);
+  if (tokens.length === 0) return false;
+
+  const haystack = normalizedEntryText(entry);
+  const words = [
+    ...new Set(
+      haystack
+        .split(TOKEN_SPLIT_PATTERN)
+        .map((word) => word.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+
+  if (
+    normalizedQuery.length > 2
+      ? haystack.includes(normalizedQuery)
+      : candidateMatchesText(normalizedQuery, haystack, words)
+  ) {
+    return true;
+  }
+
+  return tokens.every((token) =>
+    expandedTokenCandidates(token).some((candidate) =>
+      candidateMatchesText(candidate, haystack, words),
+    ),
+  );
+}
+
+export function savedSearchMatchesEntry(
+  search: SavedSearchAlertSearch,
+  entry: SavedSearchAlertEntry,
+) {
+  if (search.category && entry.category !== search.category) return false;
+  if (search.trust && entry.trust !== search.trust) return false;
+  if (search.source && entry.source !== search.source) return false;
+  if (
+    search.platform &&
+    !(entry.platforms ?? []).some((platform) => platform === search.platform)
+  ) {
+    return false;
+  }
+  return savedSearchQueryMatchesEntry(entry, search.q);
+}
+
+function eventRef(event: SavedSearchAlertEvent) {
+  if (event.kind !== "entry" || !event.category || !event.slug) return null;
+  return `${event.category}/${event.slug}`;
+}
+
+function eventAction(event: SavedSearchAlertEvent) {
+  return event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
+}
+
+export function buildSavedSearchAlerts(
+  searches: SavedSearchAlertSearch[],
+  events: SavedSearchAlertEvent[],
+  entriesByRef: ReadonlyMap<string, SavedSearchAlertEntry>,
+): SavedSearchAlert[] {
+  const activeSearches = activeInAppSavedSearches(searches);
+  if (activeSearches.length === 0) return [];
+
+  const alerts: SavedSearchAlert[] = [];
+  for (const event of events) {
+    const ref = eventRef(event);
+    if (!ref || !event.date) continue;
+
+    const entry = entriesByRef.get(ref);
+    if (!entry) continue;
+
+    for (const search of activeSearches) {
+      if (!savedSearchMatchesEntry(search, entry)) continue;
+      const action = eventAction(event);
+      const title = event.title || entry.title;
+      alerts.push({
+        id: `saved-search:${search.id}:${ref}:${event.date}:${action}`,
+        targetId: savedSearchAlertTargetId(search),
+        kind: "saved-search",
+        title: `${title} ${action}`,
+        body: `Matches saved search "${search.label}".`,
+        severity: action === "removed" ? "warning" : "info",
+        href: `/entry/${ref}`,
+        date: event.date,
+      });
+    }
+  }
+
+  return alerts.sort((left, right) => right.date.localeCompare(left.date));
+}

--- a/apps/web/src/lib/saved-search-alerts.ts
+++ b/apps/web/src/lib/saved-search-alerts.ts
@@ -1,197 +1,22 @@
-import type { AlertCadence, AlertChannel } from "@/lib/recents";
-import { expandedTokenCandidates } from "@/lib/search-query-aliases";
-import {
-  normalizeSearchQuery,
-  TOKEN_SPLIT_PATTERN,
-  tokenizeSearchQuery,
-} from "@/lib/search-query-tokenization";
-import type { Category, Platform, SourceStatus, TrustLevel } from "@/types/registry";
-
-export interface SavedSearchAlertSchedule {
-  enabled?: boolean;
-  channels?: AlertChannel[];
-  cadence?: AlertCadence;
-  lastNotifiedAt?: string;
-}
-
-export interface SavedSearchAlertSearch {
-  id: string;
-  label: string;
-  q?: string;
-  category?: string;
-  trust?: string;
-  source?: string;
-  platform?: string;
-  alerts?: SavedSearchAlertSchedule;
-}
-
-export interface SavedSearchAlertEntry {
-  category: Category | string;
-  slug: string;
-  title: string;
-  description?: string;
-  cardDescription?: string;
-  author?: string;
-  tags?: string[];
-  keywords?: string[];
-  platforms?: Array<Platform | string>;
-  trust?: TrustLevel | string;
-  source?: SourceStatus | string;
-}
-
-export interface SavedSearchAlertEvent {
-  id?: string;
-  kind?: string;
-  category?: string;
-  slug?: string;
-  action?: string;
-  date?: string;
-  title?: string;
-}
-
-export type SavedSearchAlertSeverity = "info" | "warning" | "blocker";
-
-export interface SavedSearchAlert {
-  id: string;
-  targetId: string;
-  kind: "saved-search";
-  title: string;
-  body: string;
-  severity: SavedSearchAlertSeverity;
-  href?: string;
-  date: string;
-}
-
-export function savedSearchAlertTargetId(search: Pick<SavedSearchAlertSearch, "id">) {
-  return `saved-search:${search.id}`;
-}
-
-export function activeInAppSavedSearches(
-  searches: SavedSearchAlertSearch[],
-): SavedSearchAlertSearch[] {
-  return searches.filter(
-    (search) => search.alerts?.enabled && search.alerts.channels?.includes("inapp"),
-  );
-}
-
-function normalizedEntryText(entry: SavedSearchAlertEntry) {
-  return [
-    entry.category,
-    entry.slug,
-    entry.title,
-    entry.description,
-    entry.cardDescription,
-    entry.author,
-    entry.trust,
-    entry.source,
-    ...(entry.platforms ?? []),
-    ...(entry.tags ?? []),
-    ...(entry.keywords ?? []),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-}
-
-function candidateMatchesText(candidate: string, haystack: string, words: string[]) {
-  if (candidate.length <= 2) {
-    return words.some((word) => word === candidate || word.startsWith(candidate));
-  }
-  return haystack.includes(candidate) || words.some((word) => word.startsWith(candidate));
-}
-
-export function savedSearchQueryMatchesEntry(
-  entry: SavedSearchAlertEntry,
-  query: string | undefined,
-) {
-  const normalizedQuery = normalizeSearchQuery(query ?? "");
-  if (!normalizedQuery) return true;
-
-  const tokens = tokenizeSearchQuery(normalizedQuery);
-  if (tokens.length === 0) return false;
-
-  const haystack = normalizedEntryText(entry);
-  const words = [
-    ...new Set(
-      haystack
-        .split(TOKEN_SPLIT_PATTERN)
-        .map((word) => word.trim().toLowerCase())
-        .filter(Boolean),
-    ),
-  ];
-
-  if (
-    normalizedQuery.length > 2
-      ? haystack.includes(normalizedQuery)
-      : candidateMatchesText(normalizedQuery, haystack, words)
-  ) {
-    return true;
-  }
-
-  return tokens.every((token) =>
-    expandedTokenCandidates(token).some((candidate) =>
-      candidateMatchesText(candidate, haystack, words),
-    ),
-  );
-}
-
-export function savedSearchMatchesEntry(
-  search: SavedSearchAlertSearch,
-  entry: SavedSearchAlertEntry,
-) {
-  if (search.category && entry.category !== search.category) return false;
-  if (search.trust && entry.trust !== search.trust) return false;
-  if (search.source && entry.source !== search.source) return false;
-  if (
-    search.platform &&
-    !(entry.platforms ?? []).some((platform) => platform === search.platform)
-  ) {
-    return false;
-  }
-  return savedSearchQueryMatchesEntry(entry, search.q);
-}
-
-function eventRef(event: SavedSearchAlertEvent) {
-  if (event.kind !== "entry" || !event.category || !event.slug) return null;
-  return `${event.category}/${event.slug}`;
-}
-
-function eventAction(event: SavedSearchAlertEvent) {
-  return event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
-}
-
-export function buildSavedSearchAlerts(
-  searches: SavedSearchAlertSearch[],
-  events: SavedSearchAlertEvent[],
-  entriesByRef: ReadonlyMap<string, SavedSearchAlertEntry>,
-): SavedSearchAlert[] {
-  const activeSearches = activeInAppSavedSearches(searches);
-  if (activeSearches.length === 0) return [];
-
-  const alerts: SavedSearchAlert[] = [];
-  for (const event of events) {
-    const ref = eventRef(event);
-    if (!ref || !event.date) continue;
-
-    const entry = entriesByRef.get(ref);
-    if (!entry) continue;
-
-    for (const search of activeSearches) {
-      if (!savedSearchMatchesEntry(search, entry)) continue;
-      const action = eventAction(event);
-      const title = event.title || entry.title;
-      alerts.push({
-        id: `saved-search:${search.id}:${ref}:${event.date}:${action}`,
-        targetId: savedSearchAlertTargetId(search),
-        kind: "saved-search",
-        title: `${title} ${action}`,
-        body: `Matches saved search "${search.label}".`,
-        severity: action === "removed" ? "warning" : "info",
-        href: `/entry/${ref}`,
-        date: event.date,
-      });
-    }
-  }
-
-  return alerts.sort((left, right) => right.date.localeCompare(left.date));
-}
+/**
+ * Saved-search alert surface.
+ *
+ * Pure matching and alert builders live in `saved-search-alerts-lib.ts`. This
+ * module re-exports that surface so existing `@/lib/saved-search-alerts`
+ * imports stay unchanged.
+ */
+export type {
+  SavedSearchAlertSchedule,
+  SavedSearchAlertSearch,
+  SavedSearchAlertEntry,
+  SavedSearchAlertEvent,
+  SavedSearchAlertSeverity,
+  SavedSearchAlert,
+} from "@/lib/saved-search-alerts-lib";
+export {
+  savedSearchAlertTargetId,
+  activeInAppSavedSearches,
+  savedSearchQueryMatchesEntry,
+  savedSearchMatchesEntry,
+  buildSavedSearchAlerts,
+} from "@/lib/saved-search-alerts-lib";

--- a/tests/saved-search-alerts-lib.test.ts
+++ b/tests/saved-search-alerts-lib.test.ts
@@ -1,0 +1,544 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  savedSearchAlertTargetId,
+  activeInAppSavedSearches,
+  savedSearchQueryMatchesEntry,
+  savedSearchMatchesEntry,
+  buildSavedSearchAlerts,
+  type SavedSearchAlertEntry,
+  type SavedSearchAlertSearch,
+} from "../apps/web/src/lib/saved-search-alerts-lib";
+
+const entry: SavedSearchAlertEntry = {
+  category: "mcp",
+  slug: "postgres-memory",
+  title: "Postgres Memory MCP",
+  description:
+    "A source-backed memory server for Postgres-backed Claude workflows.",
+  author: "Example Maintainer",
+  tags: ["database", "memory"],
+  keywords: ["postgres mcp", "repository memory"],
+  platforms: ["claude-code", "claude-desktop"],
+  trust: "trusted",
+  source: "source-backed",
+};
+
+function search(
+  overrides: Partial<SavedSearchAlertSearch> = {},
+): SavedSearchAlertSearch {
+  return {
+    id: "s-1",
+    label: "Postgres memory",
+    q: "postgres memory",
+    alerts: { enabled: true, channels: ["inapp"], cadence: "instant" },
+    ...overrides,
+  };
+}
+
+describe("savedSearchAlertTargetId", () => {
+  it("prefixes saved-search ids for alert routing", () => {
+    expect(savedSearchAlertTargetId({ id: "weekly-mcp" })).toBe(
+      "saved-search:weekly-mcp",
+    );
+  });
+});
+
+describe("activeInAppSavedSearches", () => {
+  it("only activates searches with enabled in-app alerts", () => {
+    expect(
+      activeInAppSavedSearches([
+        search(),
+        search({
+          id: "email",
+          alerts: { enabled: true, channels: ["email"], cadence: "daily" },
+        }),
+        search({
+          id: "off",
+          alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
+        }),
+      ]).map((item) => item.id),
+    ).toEqual(["s-1"]);
+  });
+
+  it("skips searches with alerts disabled or missing channels", () => {
+    expect(activeInAppSavedSearches([search({ alerts: undefined })])).toEqual(
+      [],
+    );
+    expect(
+      activeInAppSavedSearches([
+        search({ alerts: { enabled: true, channels: [], cadence: "daily" } }),
+      ]),
+    ).toEqual([]);
+    expect(
+      activeInAppSavedSearches([
+        search({
+          alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
+        }),
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("savedSearchQueryMatchesEntry", () => {
+  it("matches multi-token and aliased queries against entry metadata", () => {
+    expect(savedSearchQueryMatchesEntry(entry, "postgres memory")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, "repo memory")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, "calendar memory")).toBe(false);
+    expect(savedSearchQueryMatchesEntry(entry, "")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, undefined)).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, ",,,")).toBe(false);
+    expect(savedSearchQueryMatchesEntry(entry, "mcp")).toBe(true);
+  });
+
+  it("uses the shared alias map for saved-search query expansion", () => {
+    const automationEntry: SavedSearchAlertEntry = {
+      ...entry,
+      title: "QA Automation MCP",
+      tags: ["testing", "qa"],
+      keywords: ["automated browser checks"],
+    };
+
+    expect(savedSearchQueryMatchesEntry(automationEntry, "automation qa")).toBe(
+      true,
+    );
+    expect(savedSearchQueryMatchesEntry(automationEntry, "design ux")).toBe(
+      false,
+    );
+  });
+
+  it("does not treat prototype property names as alias keys", () => {
+    const oddEntry: SavedSearchAlertEntry = {
+      ...entry,
+      title: "Constructor Fixture",
+      keywords: ["constructor"],
+    };
+
+    expect(savedSearchQueryMatchesEntry(oddEntry, "constructor")).toBe(true);
+    expect(
+      savedSearchQueryMatchesEntry(oddEntry, "constructor spreadsheet"),
+    ).toBe(false);
+  });
+
+  it("matches short queries via word-prefix heuristics", () => {
+    const shortEntry: SavedSearchAlertEntry = {
+      category: "skills",
+      slug: "ai",
+      title: "AI Helper",
+      tags: ["ai"],
+    };
+    expect(savedSearchQueryMatchesEntry(shortEntry, "ai")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(shortEntry, "xx")).toBe(false);
+  });
+
+  it("requires every expanded token to match for multi-word queries", () => {
+    expect(savedSearchQueryMatchesEntry(entry, "postgres calendar")).toBe(
+      false,
+    );
+    expect(savedSearchQueryMatchesEntry(entry, "postgres repository")).toBe(
+      true,
+    );
+  });
+
+  it("indexes optional entry metadata fields into the searchable haystack", () => {
+    const richEntry: SavedSearchAlertEntry = {
+      category: "hooks",
+      slug: "lint-hook",
+      title: "Lint Hook",
+      cardDescription: "Runs eslint on save",
+      author: "Ada Lovelace",
+      trust: "trusted",
+      source: "first-party",
+      platforms: ["cursor"],
+      tags: ["lint"],
+      keywords: ["eslint"],
+    };
+    expect(savedSearchQueryMatchesEntry(richEntry, "eslint")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(richEntry, "ada lovelace")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(richEntry, "runs eslint on save")).toBe(
+      true,
+    );
+    expect(savedSearchQueryMatchesEntry(richEntry, "first-party")).toBe(true);
+  });
+
+  it("still matches entries that omit optional tag and keyword arrays", () => {
+    const sparseEntry: SavedSearchAlertEntry = {
+      category: "mcp",
+      slug: "sparse",
+      title: "Sparse MCP",
+      platforms: ["claude-code"],
+    };
+    expect(savedSearchQueryMatchesEntry(sparseEntry, "sparse")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(sparseEntry, "claude-code")).toBe(true);
+  });
+
+  it("matches direct haystack substrings for queries longer than two characters", () => {
+    expect(savedSearchQueryMatchesEntry(entry, "postgres-backed")).toBe(true);
+    expect(savedSearchQueryMatchesEntry(entry, "example maintainer")).toBe(
+      true,
+    );
+  });
+});
+
+describe("savedSearchMatchesEntry", () => {
+  it("honors category, platform, trust, and source filters", () => {
+    expect(
+      savedSearchMatchesEntry(
+        search({ category: "mcp", platform: "claude-code" }),
+        entry,
+      ),
+    ).toBe(true);
+    expect(savedSearchMatchesEntry(search({ category: "skills" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ platform: "cursor" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ trust: "review" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(
+      false,
+    );
+  });
+
+  it("passes when optional filters are unset", () => {
+    expect(
+      savedSearchMatchesEntry(
+        search({
+          category: undefined,
+          platform: undefined,
+          trust: undefined,
+          source: undefined,
+          q: "postgres",
+        }),
+        entry,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects entries missing a required platform", () => {
+    const noPlatforms: SavedSearchAlertEntry = {
+      category: "mcp",
+      slug: "x",
+      title: "X",
+      platforms: [],
+    };
+    expect(
+      savedSearchMatchesEntry(search({ platform: "claude-code" }), noPlatforms),
+    ).toBe(false);
+
+    const undefinedPlatforms: SavedSearchAlertEntry = {
+      category: "mcp",
+      slug: "x",
+      title: "X",
+    };
+    expect(
+      savedSearchMatchesEntry(
+        search({ platform: "claude-code" }),
+        undefinedPlatforms,
+      ),
+    ).toBe(false);
+  });
+
+  it("still applies query matching after structural filters pass", () => {
+    expect(savedSearchMatchesEntry(search({ q: "missing-term" }), entry)).toBe(
+      false,
+    );
+    expect(savedSearchMatchesEntry(search({ q: undefined }), entry)).toBe(true);
+  });
+});
+
+describe("buildSavedSearchAlerts", () => {
+  const entries = new Map([["mcp/postgres-memory", entry]]);
+
+  it("materializes matching public entry events into saved-search alerts", () => {
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          id: "evt-1",
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-18T10:00:00.000Z",
+          title: "Postgres Memory MCP",
+        },
+      ],
+      entries,
+    );
+
+    expect(alerts).toEqual([
+      expect.objectContaining({
+        id: "saved-search:s-1:mcp/postgres-memory:2026-06-18T10:00:00.000Z:updated",
+        targetId: "saved-search:s-1",
+        kind: "saved-search",
+        title: "Postgres Memory MCP updated",
+        body: 'Matches saved search "Postgres memory".',
+        severity: "info",
+        href: "/entry/mcp/postgres-memory",
+        date: "2026-06-18T10:00:00.000Z",
+      }),
+    ]);
+  });
+
+  it("does not alert when the changed entry detail is unavailable", () => {
+    expect(
+      buildSavedSearchAlerts(
+        [search()],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "missing",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        new Map(),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns no alerts when no searches are active in-app", () => {
+    expect(
+      buildSavedSearchAlerts(
+        [
+          search({
+            alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
+          }),
+        ],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "postgres-memory",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        entries,
+      ),
+    ).toEqual([]);
+  });
+
+  it("skips non-entry events and events missing refs or dates", () => {
+    expect(
+      buildSavedSearchAlerts(
+        [search()],
+        [
+          {
+            kind: "vote",
+            category: "mcp",
+            slug: "postgres-memory",
+            date: "2026-06-18",
+          },
+          { kind: "entry", category: "mcp", slug: "postgres-memory" },
+          { kind: "entry", category: "mcp", date: "2026-06-18" },
+        ],
+        entries,
+      ),
+    ).toEqual([]);
+  });
+
+  it("maps removed actions to warning severity and added actions to info", () => {
+    const removed = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "removed",
+          date: "2026-06-18T10:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+    expect(removed[0]?.severity).toBe("warning");
+    expect(removed[0]?.title).toBe("Postgres Memory MCP removed");
+
+    const added = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "added",
+          date: "2026-06-18T09:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+    expect(added[0]?.severity).toBe("info");
+    expect(added[0]?.title).toBe("Postgres Memory MCP added");
+  });
+
+  it("defaults unknown actions to updated", () => {
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "refreshed",
+          date: "2026-06-18T10:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+    expect(alerts[0]?.title).toBe("Postgres Memory MCP updated");
+    expect(alerts[0]?.id).toContain(":updated");
+  });
+
+  it("falls back to the entry title when the event title is absent", () => {
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-18T10:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+    expect(alerts[0]?.title).toBe("Postgres Memory MCP updated");
+  });
+
+  it("sorts alerts newest-first by event date", () => {
+    const alerts = buildSavedSearchAlerts(
+      [search()],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-17T10:00:00.000Z",
+        },
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "added",
+          date: "2026-06-19T10:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+    expect(alerts.map((alert) => alert.date)).toEqual([
+      "2026-06-19T10:00:00.000Z",
+      "2026-06-17T10:00:00.000Z",
+    ]);
+  });
+
+  it("emits one alert per active saved search that matches the entry", () => {
+    const alerts = buildSavedSearchAlerts(
+      [
+        search({ id: "a", label: "Alpha" }),
+        search({ id: "b", label: "Beta", q: "postgres" }),
+        search({
+          id: "c",
+          label: "Gamma",
+          q: "postgres",
+          alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
+        }),
+      ],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-18T10:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+
+    expect(alerts.map((alert) => alert.targetId).sort()).toEqual([
+      "saved-search:a",
+      "saved-search:b",
+    ]);
+    expect(
+      alerts.every((alert) => alert.body.includes("Matches saved search")),
+    ).toBe(true);
+  });
+
+  it("skips alerts when the saved search no longer matches the entry", () => {
+    expect(
+      buildSavedSearchAlerts(
+        [search({ q: "calendar" })],
+        [
+          {
+            kind: "entry",
+            category: "mcp",
+            slug: "postgres-memory",
+            action: "updated",
+            date: "2026-06-18T10:00:00.000Z",
+          },
+        ],
+        entries,
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("combined saved-search alert scenarios", () => {
+  it("handles multiple entries and searches in one batch", () => {
+    const skillEntry: SavedSearchAlertEntry = {
+      category: "skills",
+      slug: "browser-qa",
+      title: "Browser QA Skill",
+      tags: ["automation", "qa"],
+      platforms: ["claude-code"],
+      trust: "trusted",
+      source: "source-backed",
+    };
+    const entries = new Map<string, SavedSearchAlertEntry>([
+      ["mcp/postgres-memory", entry],
+      ["skills/browser-qa", skillEntry],
+    ]);
+
+    const alerts = buildSavedSearchAlerts(
+      [
+        search({ id: "mcp-watch", label: "MCP watch", q: "postgres" }),
+        search({
+          id: "skills-watch",
+          label: "Skills watch",
+          category: "skills",
+          q: "automation",
+        }),
+      ],
+      [
+        {
+          kind: "entry",
+          category: "mcp",
+          slug: "postgres-memory",
+          action: "updated",
+          date: "2026-06-18T12:00:00.000Z",
+        },
+        {
+          kind: "entry",
+          category: "skills",
+          slug: "browser-qa",
+          action: "added",
+          date: "2026-06-18T11:00:00.000Z",
+        },
+      ],
+      entries,
+    );
+
+    expect(alerts).toHaveLength(2);
+    expect(alerts[0]?.href).toBe("/entry/mcp/postgres-memory");
+    expect(alerts[1]?.href).toBe("/entry/skills/browser-qa");
+    expect(alerts[0]?.targetId).toBe("saved-search:mcp-watch");
+    expect(alerts[1]?.targetId).toBe("saved-search:skills-watch");
+  });
+});

--- a/tests/saved-search-alerts.test.ts
+++ b/tests/saved-search-alerts.test.ts
@@ -1,160 +1,48 @@
 import { describe, expect, it } from "vitest";
+
 import {
   activeInAppSavedSearches,
   buildSavedSearchAlerts,
+  savedSearchAlertTargetId,
   savedSearchMatchesEntry,
   savedSearchQueryMatchesEntry,
-  type SavedSearchAlertEntry,
-  type SavedSearchAlertSearch,
 } from "@/lib/saved-search-alerts";
 
-const entry: SavedSearchAlertEntry = {
-  category: "mcp",
-  slug: "postgres-memory",
-  title: "Postgres Memory MCP",
-  description:
-    "A source-backed memory server for Postgres-backed Claude workflows.",
-  author: "Example Maintainer",
-  tags: ["database", "memory"],
-  keywords: ["postgres mcp", "repository memory"],
-  platforms: ["claude-code", "claude-desktop"],
-  trust: "trusted",
-  source: "source-backed",
-};
-
-function search(
-  overrides: Partial<SavedSearchAlertSearch> = {},
-): SavedSearchAlertSearch {
-  return {
-    id: "s-1",
-    label: "Postgres memory",
-    q: "postgres memory",
-    alerts: { enabled: true, channels: ["inapp"], cadence: "instant" },
-    ...overrides,
-  };
-}
-
-describe("saved-search in-app alert matching", () => {
-  it("only activates searches with enabled in-app alerts", () => {
+describe("saved-search-alerts re-export surface", () => {
+  it("keeps the public import path wired to the extracted lib", () => {
+    expect(savedSearchAlertTargetId({ id: "demo" })).toBe("saved-search:demo");
     expect(
       activeInAppSavedSearches([
-        search(),
-        search({
-          id: "email",
-          alerts: { enabled: true, channels: ["email"], cadence: "daily" },
-        }),
-        search({
-          id: "off",
-          alerts: { enabled: false, channels: ["inapp"], cadence: "daily" },
-        }),
-      ]).map((item) => item.id),
-    ).toEqual(["s-1"]);
-  });
-
-  it("matches multi-token and aliased queries against entry metadata", () => {
-    expect(savedSearchQueryMatchesEntry(entry, "postgres memory")).toBe(true);
-    expect(savedSearchQueryMatchesEntry(entry, "repo memory")).toBe(true);
-    expect(savedSearchQueryMatchesEntry(entry, "calendar memory")).toBe(false);
-    expect(savedSearchQueryMatchesEntry(entry, "")).toBe(true);
-    expect(savedSearchQueryMatchesEntry(entry, undefined)).toBe(true);
-    expect(savedSearchQueryMatchesEntry(entry, ",,,")).toBe(false);
-    expect(savedSearchQueryMatchesEntry(entry, "mcp")).toBe(true);
-  });
-
-  it("uses the shared alias map for saved-search query expansion", () => {
-    const automationEntry: SavedSearchAlertEntry = {
-      ...entry,
-      title: "QA Automation MCP",
-      tags: ["testing", "qa"],
-      keywords: ["automated browser checks"],
-    };
-
-    expect(savedSearchQueryMatchesEntry(automationEntry, "automation qa")).toBe(
-      true,
-    );
-    expect(savedSearchQueryMatchesEntry(automationEntry, "design ux")).toBe(
-      false,
-    );
-  });
-
-  it("does not treat prototype property names as alias keys", () => {
-    const oddEntry: SavedSearchAlertEntry = {
-      ...entry,
-      title: "Constructor Fixture",
-      keywords: ["constructor"],
-    };
-
-    expect(savedSearchQueryMatchesEntry(oddEntry, "constructor")).toBe(true);
+        {
+          id: "x",
+          label: "X",
+          alerts: { enabled: true, channels: ["inapp"], cadence: "instant" },
+        },
+      ]),
+    ).toHaveLength(1);
     expect(
-      savedSearchQueryMatchesEntry(oddEntry, "constructor spreadsheet"),
-    ).toBe(false);
-  });
-
-  it("honors category, platform, trust, and source filters", () => {
-    expect(
-      savedSearchMatchesEntry(
-        search({ category: "mcp", platform: "claude-code" }),
-        entry,
+      savedSearchQueryMatchesEntry(
+        { category: "mcp", slug: "x", title: "Postgres MCP" },
+        "postgres",
       ),
     ).toBe(true);
-    expect(savedSearchMatchesEntry(search({ category: "skills" }), entry)).toBe(
-      false,
-    );
-    expect(savedSearchMatchesEntry(search({ platform: "cursor" }), entry)).toBe(
-      false,
-    );
-    expect(savedSearchMatchesEntry(search({ trust: "review" }), entry)).toBe(
-      false,
-    );
-    expect(savedSearchMatchesEntry(search({ source: "external" }), entry)).toBe(
-      false,
-    );
-  });
-
-  it("materializes matching public entry events into saved-search alerts", () => {
-    const alerts = buildSavedSearchAlerts(
-      [search()],
-      [
-        {
-          id: "evt-1",
-          kind: "entry",
-          category: "mcp",
-          slug: "postgres-memory",
-          action: "updated",
-          date: "2026-06-18T10:00:00.000Z",
-          title: "Postgres Memory MCP",
-        },
-      ],
-      new Map([["mcp/postgres-memory", entry]]),
-    );
-
-    expect(alerts).toEqual([
-      expect.objectContaining({
-        id: "saved-search:s-1:mcp/postgres-memory:2026-06-18T10:00:00.000Z:updated",
-        targetId: "saved-search:s-1",
-        kind: "saved-search",
-        title: "Postgres Memory MCP updated",
-        body: 'Matches saved search "Postgres memory".',
-        severity: "info",
-        href: "/entry/mcp/postgres-memory",
-        date: "2026-06-18T10:00:00.000Z",
-      }),
-    ]);
-  });
-
-  it("does not alert when the changed entry detail is unavailable", () => {
+    expect(
+      savedSearchMatchesEntry(
+        { id: "s", label: "S", q: "postgres" },
+        { category: "mcp", slug: "x", title: "Postgres MCP" },
+      ),
+    ).toBe(true);
     expect(
       buildSavedSearchAlerts(
-        [search()],
         [
           {
-            kind: "entry",
-            category: "mcp",
-            slug: "missing",
-            action: "updated",
-            date: "2026-06-18T10:00:00.000Z",
+            id: "s",
+            label: "S",
+            q: "postgres",
+            alerts: { enabled: true, channels: ["inapp"], cadence: "instant" },
           },
         ],
+        [],
         new Map(),
       ),
     ).toEqual([]);


### PR DESCRIPTION
## Summary
- Extract pure saved-search matching and alert builders from `saved-search-alerts.ts` into `saved-search-alerts-lib.ts`
- Keep `@/lib/saved-search-alerts` as a thin re-export wrapper so existing imports stay unchanged
- Add comprehensive tests for query matching, filters, event materialization, and alert sorting (100% branch coverage on the lib)

## Test plan
- [x] `pnpm vitest run tests/saved-search-alerts-lib.test.ts tests/saved-search-alerts.test.ts`
- [x] `pnpm test` (full suite)
- [x] `pnpm vitest run --coverage tests/saved-search-alerts-lib.test.ts` (100% branches on lib)
- [x] `trunk fmt` on changed files


Made with [Cursor](https://cursor.com)