### PR TITLE
feat(web): extract MCP stats helpers into mcp-stats-lib

### DIFF
--- a/apps/web/src/lib/mcp-stats-lib.ts
+++ b/apps/web/src/lib/mcp-stats-lib.ts
@@ -1,0 +1,136 @@
+import type { Entry } from "@/types/registry";
+
+/**
+ * Deterministic, structured-field-derived statistics about the MCP-server subset of
+ * the registry, for the `/state-of-mcp-servers` and `/mcp-security-report` data
+ * reports. Every value is computed from real entry fields (config/install snippets,
+ * declared prerequisites, reviewer notes) — no estimates — so the numbers and the
+ * `Dataset` JSON-LD that advertises them are accurate by construction.
+ *
+ * Transport/auth classification is necessarily heuristic (it reads the declared config
+ * and prerequisites), so each report states that in its methodology note.
+ */
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+/** The MCP transport an entry's declared config/install uses. */
+export type McpTransport = "HTTP" | "SSE" | "stdio (local)" | "Unspecified";
+
+/** Join the structured config + install fields we classify transport from. */
+function configHaystack(entry: Entry): string {
+  return [entry.configSnippet, entry.copySnippet, entry.installCommand]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify an MCP server's transport from its declared config/install snippet.
+ * Precedence: an explicit SSE marker, then HTTP (explicit type/transport, a remote
+ * `url`, or `--transport http`), then a local `command` (stdio), else Unspecified.
+ */
+export function classifyTransport(entry: Entry): McpTransport {
+  const hay = configHaystack(entry);
+  if (!hay) return "Unspecified";
+  if (/"(?:type|transport)":\s*"sse"|--transport[= ]sse|\bsse\b.*endpoint/.test(hay)) {
+    return "SSE";
+  }
+  if (
+    /"(?:type|transport)":\s*"(?:http|streamable-?http)"|--transport[= ]http|"url":\s*"https?:\/\//.test(
+      hay,
+    )
+  ) {
+    return "HTTP";
+  }
+  if (/"command":\s*"/.test(hay)) return "stdio (local)";
+  return "Unspecified";
+}
+
+/** Whether a transport runs the server locally (stdio) or reaches a hosted endpoint. */
+export function hostingOf(
+  transport: McpTransport,
+): "Local (stdio)" | "Remote (hosted)" | "Unspecified" {
+  if (transport === "stdio (local)") return "Local (stdio)";
+  if (transport === "HTTP" || transport === "SSE") return "Remote (hosted)";
+  return "Unspecified";
+}
+
+/** The credential type an MCP server declares it needs. */
+export type McpAuth = "OAuth" | "API key" | "Token / PAT" | "None / unspecified";
+
+/** Join the fields where auth requirements are declared (prerequisites + notes + desc). */
+function authHaystack(entry: Entry): string {
+  return [...(entry.prerequisites ?? []), entry.safetyNotes, entry.privacyNotes, entry.description]
+    .filter(Boolean)
+    .join("\n")
+    .toLowerCase();
+}
+
+/**
+ * Classify the credential an MCP server requires, inferred from its declared
+ * prerequisites and reviewer notes. Precedence (strongest identity first): OAuth,
+ * then API key, then a personal-access-token / bearer token, else none declared.
+ */
+export function classifyAuth(entry: Entry): McpAuth {
+  const hay = authHaystack(entry);
+  if (/\boauth\d?/.test(hay)) return "OAuth";
+  if (/\bapi[\s_-]?keys?\b/.test(hay)) return "API key";
+  if (/personal access token|\bpat\b|\bbearer\b|access token/.test(hay)) return "Token / PAT";
+  return "None / unspecified";
+}
+
+function distribution<T extends string>(
+  entries: ReadonlyArray<Entry>,
+  classify: (entry: Entry) => T,
+  order: ReadonlyArray<T>,
+): { rows: StatRow[]; total: number } {
+  const counts = new Map<T, number>();
+  for (const entry of entries) {
+    const key = classify(entry);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  const rows = order
+    .map((label) => ({ label, count: counts.get(label) ?? 0 }))
+    .filter((row) => row.count > 0);
+  return { rows, total: entries.length };
+}
+
+const TRANSPORT_ORDER: McpTransport[] = ["stdio (local)", "HTTP", "SSE", "Unspecified"];
+const HOSTING_ORDER = ["Local (stdio)", "Remote (hosted)", "Unspecified"] as const;
+const AUTH_ORDER: McpAuth[] = ["OAuth", "API key", "Token / PAT", "None / unspecified"];
+
+/** Distribution of MCP transports across the given entries. */
+export function transportDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyTransport, TRANSPORT_ORDER);
+}
+
+/** Local-vs-remote distribution, derived from transport. */
+export function hostingDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, (e) => hostingOf(classifyTransport(e)), HOSTING_ORDER);
+}
+
+/** Distribution of declared auth methods across the given entries. */
+export function authDistribution(entries: ReadonlyArray<Entry>) {
+  return distribution(entries, classifyAuth, AUTH_ORDER);
+}
+
+/**
+ * Supply-chain verification coverage: how many entries ship a maintainer-verified
+ * package and/or a checksummed downloadable artifact.
+ */
+export function supplyChainCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  packageVerified: number;
+  checksummedDownload: number;
+} {
+  let packageVerified = 0;
+  let checksummedDownload = 0;
+  for (const entry of entries) {
+    if (entry.packageVerified) packageVerified += 1;
+    if (entry.downloadUrl && entry.downloadSha256) checksummedDownload += 1;
+  }
+  return { total: entries.length, packageVerified, checksummedDownload };
+}

--- a/apps/web/src/lib/mcp-stats.ts
+++ b/apps/web/src/lib/mcp-stats.ts
@@ -1,136 +1,19 @@
-import type { Entry } from "@/types/registry";
-
 /**
- * Deterministic, structured-field-derived statistics about the MCP-server subset of
- * the registry, for the `/state-of-mcp-servers` and `/mcp-security-report` data
- * reports. Every value is computed from real entry fields (config/install snippets,
- * declared prerequisites, reviewer notes) — no estimates — so the numbers and the
- * `Dataset` JSON-LD that advertises them are accurate by construction.
+ * MCP registry statistics helpers extracted into a pure library module.
  *
- * Transport/auth classification is necessarily heuristic (it reads the declared config
- * and prerequisites), so each report states that in its methodology note.
+ * The deterministic transport/auth classification and distribution layer lives in
+ * `@/lib/mcp-stats-lib` and is re-exported below so the public `@/lib/mcp-stats`
+ * surface is unchanged for data-report routes and tests.
  */
-
-export interface StatRow {
-  label: string;
-  count: number;
-}
-
-/** The MCP transport an entry's declared config/install uses. */
-export type McpTransport = "HTTP" | "SSE" | "stdio (local)" | "Unspecified";
-
-/** Join the structured config + install fields we classify transport from. */
-function configHaystack(entry: Entry): string {
-  return [entry.configSnippet, entry.copySnippet, entry.installCommand]
-    .filter(Boolean)
-    .join("\n")
-    .toLowerCase();
-}
-
-/**
- * Classify an MCP server's transport from its declared config/install snippet.
- * Precedence: an explicit SSE marker, then HTTP (explicit type/transport, a remote
- * `url`, or `--transport http`), then a local `command` (stdio), else Unspecified.
- */
-export function classifyTransport(entry: Entry): McpTransport {
-  const hay = configHaystack(entry);
-  if (!hay) return "Unspecified";
-  if (/"(?:type|transport)":\s*"sse"|--transport[= ]sse|\bsse\b.*endpoint/.test(hay)) {
-    return "SSE";
-  }
-  if (
-    /"(?:type|transport)":\s*"(?:http|streamable-?http)"|--transport[= ]http|"url":\s*"https?:\/\//.test(
-      hay,
-    )
-  ) {
-    return "HTTP";
-  }
-  if (/"command":\s*"/.test(hay)) return "stdio (local)";
-  return "Unspecified";
-}
-
-/** Whether a transport runs the server locally (stdio) or reaches a hosted endpoint. */
-export function hostingOf(
-  transport: McpTransport,
-): "Local (stdio)" | "Remote (hosted)" | "Unspecified" {
-  if (transport === "stdio (local)") return "Local (stdio)";
-  if (transport === "HTTP" || transport === "SSE") return "Remote (hosted)";
-  return "Unspecified";
-}
-
-/** The credential type an MCP server declares it needs. */
-export type McpAuth = "OAuth" | "API key" | "Token / PAT" | "None / unspecified";
-
-/** Join the fields where auth requirements are declared (prerequisites + notes + desc). */
-function authHaystack(entry: Entry): string {
-  return [...(entry.prerequisites ?? []), entry.safetyNotes, entry.privacyNotes, entry.description]
-    .filter(Boolean)
-    .join("\n")
-    .toLowerCase();
-}
-
-/**
- * Classify the credential an MCP server requires, inferred from its declared
- * prerequisites and reviewer notes. Precedence (strongest identity first): OAuth,
- * then API key, then a personal-access-token / bearer token, else none declared.
- */
-export function classifyAuth(entry: Entry): McpAuth {
-  const hay = authHaystack(entry);
-  if (/\boauth\d?/.test(hay)) return "OAuth";
-  if (/\bapi[\s_-]?keys?\b/.test(hay)) return "API key";
-  if (/personal access token|\bpat\b|\bbearer\b|access token/.test(hay)) return "Token / PAT";
-  return "None / unspecified";
-}
-
-function distribution<T extends string>(
-  entries: ReadonlyArray<Entry>,
-  classify: (entry: Entry) => T,
-  order: ReadonlyArray<T>,
-): { rows: StatRow[]; total: number } {
-  const counts = new Map<T, number>();
-  for (const entry of entries) {
-    const key = classify(entry);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  const rows = order
-    .map((label) => ({ label, count: counts.get(label) ?? 0 }))
-    .filter((row) => row.count > 0);
-  return { rows, total: entries.length };
-}
-
-const TRANSPORT_ORDER: McpTransport[] = ["stdio (local)", "HTTP", "SSE", "Unspecified"];
-const HOSTING_ORDER = ["Local (stdio)", "Remote (hosted)", "Unspecified"] as const;
-const AUTH_ORDER: McpAuth[] = ["OAuth", "API key", "Token / PAT", "None / unspecified"];
-
-/** Distribution of MCP transports across the given entries. */
-export function transportDistribution(entries: ReadonlyArray<Entry>) {
-  return distribution(entries, classifyTransport, TRANSPORT_ORDER);
-}
-
-/** Local-vs-remote distribution, derived from transport. */
-export function hostingDistribution(entries: ReadonlyArray<Entry>) {
-  return distribution(entries, (e) => hostingOf(classifyTransport(e)), HOSTING_ORDER);
-}
-
-/** Distribution of declared auth methods across the given entries. */
-export function authDistribution(entries: ReadonlyArray<Entry>) {
-  return distribution(entries, classifyAuth, AUTH_ORDER);
-}
-
-/**
- * Supply-chain verification coverage: how many entries ship a maintainer-verified
- * package and/or a checksummed downloadable artifact.
- */
-export function supplyChainCoverage(entries: ReadonlyArray<Entry>): {
-  total: number;
-  packageVerified: number;
-  checksummedDownload: number;
-} {
-  let packageVerified = 0;
-  let checksummedDownload = 0;
-  for (const entry of entries) {
-    if (entry.packageVerified) packageVerified += 1;
-    if (entry.downloadUrl && entry.downloadSha256) checksummedDownload += 1;
-  }
-  return { total: entries.length, packageVerified, checksummedDownload };
-}
+export {
+  authDistribution,
+  classifyAuth,
+  classifyTransport,
+  hostingDistribution,
+  hostingOf,
+  supplyChainCoverage,
+  transportDistribution,
+  type McpAuth,
+  type McpTransport,
+  type StatRow,
+} from "@/lib/mcp-stats-lib";

--- a/tests/mcp-stats-lib.test.ts
+++ b/tests/mcp-stats-lib.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authDistribution,
+  classifyAuth,
+  classifyTransport,
+  hostingDistribution,
+  hostingOf,
+  supplyChainCoverage,
+  transportDistribution,
+} from "@/lib/mcp-stats-lib";
+import {
+  classifyTransport as classifyTransportFromWrapper,
+  supplyChainCoverage as supplyChainCoverageFromWrapper,
+} from "@/lib/mcp-stats";
+import type { Entry } from "@/types/registry";
+
+/** Build a minimal Entry; only the fields the stats helpers read need to be real. */
+function mk(partial: Partial<Entry>): Entry {
+  return { category: "mcp", slug: "x", title: "X", ...partial } as Entry;
+}
+
+describe("mcp-stats-lib classifyTransport", () => {
+  it("detects stdio from a local command config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"command":"npx","args":["-y","srv"]}' }),
+      ),
+    ).toBe("stdio (local)");
+  });
+
+  it("detects HTTP from an explicit type, a remote url, or the install flag", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"type":"http","url":"https://x/mcp"}' }),
+      ),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(mk({ copySnippet: '{"url":"https://x.app/mcp"}' })),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(
+        mk({
+          installCommand: "claude mcp add --transport http x https://x/mcp",
+        }),
+      ),
+    ).toBe("HTTP");
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"transport":"streamable-http","url":"https://x/mcp"}' }),
+      ),
+    ).toBe("HTTP");
+  });
+
+  it("detects SSE before HTTP when both markers appear", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"transport":"sse","url":"https://x/sse"}' }),
+      ),
+    ).toBe("SSE");
+    expect(
+      classifyTransport(
+        mk({
+          installCommand: "claude mcp add --transport sse demo https://x/sse-endpoint",
+        }),
+      ),
+    ).toBe("SSE");
+    expect(
+      classifyTransport(
+        mk({
+          configSnippet:
+            '{"type":"http","url":"https://x/mcp","transport":"sse","endpoint":"https://x/sse"}',
+        }),
+      ),
+    ).toBe("SSE");
+  });
+
+  it("is Unspecified with no config/install signal", () => {
+    expect(classifyTransport(mk({}))).toBe("Unspecified");
+  });
+
+  it("does not infer transport from unrelated non-empty config", () => {
+    expect(
+      classifyTransport(
+        mk({ configSnippet: '{"env":{"API_KEY":"required"}}' }),
+      ),
+    ).toBe("Unspecified");
+    expect(
+      classifyTransport(
+        mk({ copySnippet: '{"headers":{"authorization":"Bearer token"}}' }),
+      ),
+    ).toBe("Unspecified");
+  });
+
+  it("joins config, copy, and install fields case-insensitively", () => {
+    expect(
+      classifyTransport(
+        mk({
+          configSnippet: '{"COMMAND":"NPX"}',
+          copySnippet: "",
+          installCommand: "",
+        }),
+      ),
+    ).toBe("Unspecified");
+    expect(
+      classifyTransport(
+        mk({
+          configSnippet: '{"command":"npx"}',
+          copySnippet: '{"URL":"https://remote/mcp"}',
+        }),
+      ),
+    ).toBe("HTTP");
+  });
+});
+
+describe("mcp-stats-lib hostingOf", () => {
+  it("maps transport to local/remote", () => {
+    expect(hostingOf("stdio (local)")).toBe("Local (stdio)");
+    expect(hostingOf("HTTP")).toBe("Remote (hosted)");
+    expect(hostingOf("SSE")).toBe("Remote (hosted)");
+    expect(hostingOf("Unspecified")).toBe("Unspecified");
+  });
+});
+
+describe("mcp-stats-lib classifyAuth", () => {
+  it("prefers OAuth, then API key, then token, else none", () => {
+    expect(
+      classifyAuth(mk({ prerequisites: ["OAuth2 credentials or a PAT"] })),
+    ).toBe("OAuth");
+    expect(classifyAuth(mk({ prerequisites: ["oauth credentials"] }))).toBe(
+      "OAuth",
+    );
+    expect(
+      classifyAuth(mk({ prerequisites: ["An API key from the dashboard"] })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ prerequisites: ["An api_key from the dashboard"] })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ prerequisites: ["A personal access token (PAT)"] })),
+    ).toBe("Token / PAT");
+    expect(classifyAuth(mk({ prerequisites: ["Node.js 18+"] }))).toBe(
+      "None / unspecified",
+    );
+  });
+
+  it("reads from notes and description too, not just prerequisites", () => {
+    expect(
+      classifyAuth(mk({ safetyNotes: "Scope the API key to read-only." })),
+    ).toBe("API key");
+    expect(
+      classifyAuth(mk({ description: "Connect via OAuth to your account." })),
+    ).toBe("OAuth");
+    expect(
+      classifyAuth(mk({ privacyNotes: "Requires bearer token in headers." })),
+    ).toBe("Token / PAT");
+  });
+
+  it("treats oauth as stronger than api key when both appear", () => {
+    expect(
+      classifyAuth(
+        mk({
+          prerequisites: ["API key", "OAuth consent flow"],
+        }),
+      ),
+    ).toBe("OAuth");
+  });
+});
+
+describe("mcp-stats-lib distributions", () => {
+  const entries = [
+    mk({ configSnippet: '{"command":"npx"}', prerequisites: ["API key"] }),
+    mk({
+      configSnippet: '{"command":"uvx"}',
+      prerequisites: ["A personal access token"],
+    }),
+    mk({
+      configSnippet: '{"type":"http","url":"https://a/mcp"}',
+      prerequisites: ["OAuth"],
+    }),
+    mk({
+      configSnippet: '{"transport":"sse","url":"https://b/sse"}',
+      prerequisites: ["Node 18"],
+    }),
+  ];
+
+  it("counts transports and keeps the fixed order, dropping empties", () => {
+    const { rows, total } = transportDistribution(entries);
+    expect(total).toBe(4);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["stdio (local)", 2],
+      ["HTTP", 1],
+      ["SSE", 1],
+    ]);
+  });
+
+  it("keeps Unspecified last when an entry has no declared transport", () => {
+    const { rows, total } = transportDistribution([
+      mk({ configSnippet: '{"transport":"sse","url":"https://b/sse"}' }),
+      mk({ configSnippet: '{"env":{"TOKEN":"required"}}' }),
+    ]);
+
+    expect(total).toBe(2);
+    expect(rows.map((r) => [r.label, r.count])).toEqual([
+      ["SSE", 1],
+      ["Unspecified", 1],
+    ]);
+  });
+
+  it("derives local-vs-remote hosting", () => {
+    const rows = hostingDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "Local (stdio)")?.count).toBe(2);
+    expect(rows.find((r) => r.label === "Remote (hosted)")?.count).toBe(2);
+  });
+
+  it("counts auth methods", () => {
+    const rows = authDistribution(entries).rows;
+    expect(rows.find((r) => r.label === "OAuth")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "API key")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "Token / PAT")?.count).toBe(1);
+    expect(rows.find((r) => r.label === "None / unspecified")?.count).toBe(1);
+  });
+
+  it("returns empty rows for an empty entry list", () => {
+    expect(transportDistribution([])).toEqual({ rows: [], total: 0 });
+    expect(hostingDistribution([])).toEqual({ rows: [], total: 0 });
+    expect(authDistribution([])).toEqual({ rows: [], total: 0 });
+  });
+});
+
+describe("mcp-stats-lib supplyChainCoverage", () => {
+  it("counts verified packages and checksummed downloads", () => {
+    const cov = supplyChainCoverage([
+      mk({
+        packageVerified: true,
+        downloadUrl: "/d.mcpb",
+        downloadSha256: "abc",
+      }),
+      mk({ packageVerified: true }),
+      mk({ downloadUrl: "/d.mcpb" }),
+      mk({}),
+    ]);
+    expect(cov).toEqual({
+      total: 4,
+      packageVerified: 2,
+      checksummedDownload: 1,
+    });
+  });
+
+  it("requires both downloadUrl and downloadSha256 for checksummed counts", () => {
+    expect(
+      supplyChainCoverage([
+        mk({ downloadUrl: "/pkg.mcpb", downloadSha256: "deadbeef" }),
+        mk({ downloadSha256: "deadbeef" }),
+        mk({ downloadUrl: "/pkg.mcpb" }),
+      ]),
+    ).toEqual({
+      total: 3,
+      packageVerified: 0,
+      checksummedDownload: 1,
+    });
+  });
+});
+
+describe("mcp-stats-lib wrapper compatibility", () => {
+  it("keeps the public import path wired to the extracted lib", () => {
+    const entry = mk({
+      configSnippet: '{"command":"npx"}',
+      packageVerified: true,
+    });
+    expect(classifyTransportFromWrapper(entry)).toBe(
+      classifyTransport(entry),
+    );
+    expect(supplyChainCoverageFromWrapper([entry])).toEqual(
+      supplyChainCoverage([entry]),
+    );
+  });
+});

--- a/tests/mcp-stats-lib.test.ts
+++ b/tests/mcp-stats-lib.test.ts
@@ -47,7 +47,9 @@ describe("mcp-stats-lib classifyTransport", () => {
     ).toBe("HTTP");
     expect(
       classifyTransport(
-        mk({ configSnippet: '{"transport":"streamable-http","url":"https://x/mcp"}' }),
+        mk({
+          configSnippet: '{"transport":"streamable-http","url":"https://x/mcp"}',
+        }),
       ),
     ).toBe("HTTP");
   });
@@ -61,7 +63,8 @@ describe("mcp-stats-lib classifyTransport", () => {
     expect(
       classifyTransport(
         mk({
-          installCommand: "claude mcp add --transport sse demo https://x/sse-endpoint",
+          installCommand:
+            "claude mcp add --transport sse demo https://x/sse-endpoint",
         }),
       ),
     ).toBe("SSE");
@@ -268,9 +271,7 @@ describe("mcp-stats-lib wrapper compatibility", () => {
       configSnippet: '{"command":"npx"}',
       packageVerified: true,
     });
-    expect(classifyTransportFromWrapper(entry)).toBe(
-      classifyTransport(entry),
-    );
+    expect(classifyTransportFromWrapper(entry)).toBe(classifyTransport(entry));
     expect(supplyChainCoverageFromWrapper([entry])).toEqual(
       supplyChainCoverage([entry]),
     );

--- a/tests/mcp-stats.test.ts
+++ b/tests/mcp-stats.test.ts
@@ -11,170 +11,26 @@ import {
 } from "@/lib/mcp-stats";
 import type { Entry } from "@/types/registry";
 
-/** Build a minimal Entry; only the fields the stats helpers read need to be real. */
 function mk(partial: Partial<Entry>): Entry {
   return { category: "mcp", slug: "x", title: "X", ...partial } as Entry;
 }
 
-describe("classifyTransport", () => {
-  it("detects stdio from a local command config", () => {
-    expect(
-      classifyTransport(
-        mk({ configSnippet: '{"command":"npx","args":["-y","srv"]}' }),
-      ),
-    ).toBe("stdio (local)");
-  });
-
-  it("detects HTTP from an explicit type, a remote url, or the install flag", () => {
-    expect(
-      classifyTransport(
-        mk({ configSnippet: '{"type":"http","url":"https://x/mcp"}' }),
-      ),
-    ).toBe("HTTP");
-    expect(
-      classifyTransport(mk({ copySnippet: '{"url":"https://x.app/mcp"}' })),
-    ).toBe("HTTP");
-    expect(
-      classifyTransport(
-        mk({
-          installCommand: "claude mcp add --transport http x https://x/mcp",
-        }),
-      ),
-    ).toBe("HTTP");
-  });
-
-  it("detects SSE before HTTP", () => {
-    expect(
-      classifyTransport(
-        mk({ configSnippet: '{"transport":"sse","url":"https://x/sse"}' }),
-      ),
-    ).toBe("SSE");
-  });
-
-  it("is Unspecified with no config/install signal", () => {
-    expect(classifyTransport(mk({}))).toBe("Unspecified");
-  });
-
-  it("does not infer transport from unrelated non-empty config", () => {
-    expect(
-      classifyTransport(
-        mk({ configSnippet: '{"env":{"API_KEY":"required"}}' }),
-      ),
-    ).toBe("Unspecified");
-    expect(
-      classifyTransport(
-        mk({ copySnippet: '{"headers":{"authorization":"Bearer token"}}' }),
-      ),
-    ).toBe("Unspecified");
-  });
-});
-
-describe("hostingOf", () => {
-  it("maps transport to local/remote", () => {
-    expect(hostingOf("stdio (local)")).toBe("Local (stdio)");
-    expect(hostingOf("HTTP")).toBe("Remote (hosted)");
-    expect(hostingOf("SSE")).toBe("Remote (hosted)");
-    expect(hostingOf("Unspecified")).toBe("Unspecified");
-  });
-});
-
-describe("classifyAuth", () => {
-  it("prefers OAuth, then API key, then token, else none", () => {
-    expect(
-      classifyAuth(mk({ prerequisites: ["OAuth2 credentials or a PAT"] })),
-    ).toBe("OAuth");
-    expect(
-      classifyAuth(mk({ prerequisites: ["An API key from the dashboard"] })),
-    ).toBe("API key");
-    expect(
-      classifyAuth(mk({ prerequisites: ["A personal access token (PAT)"] })),
-    ).toBe("Token / PAT");
-    expect(classifyAuth(mk({ prerequisites: ["Node.js 18+"] }))).toBe(
-      "None / unspecified",
-    );
-  });
-
-  it("reads from notes and description too, not just prerequisites", () => {
-    expect(
-      classifyAuth(mk({ safetyNotes: "Scope the API key to read-only." })),
-    ).toBe("API key");
-    expect(
-      classifyAuth(mk({ description: "Connect via OAuth to your account." })),
-    ).toBe("OAuth");
-  });
-});
-
-describe("distributions", () => {
-  const entries = [
-    mk({ configSnippet: '{"command":"npx"}', prerequisites: ["API key"] }),
-    mk({
-      configSnippet: '{"command":"uvx"}',
-      prerequisites: ["A personal access token"],
-    }),
-    mk({
-      configSnippet: '{"type":"http","url":"https://a/mcp"}',
-      prerequisites: ["OAuth"],
-    }),
-    mk({
-      configSnippet: '{"transport":"sse","url":"https://b/sse"}',
-      prerequisites: ["Node 18"],
-    }),
-  ];
-
-  it("counts transports and keeps the fixed order, dropping empties", () => {
-    const { rows, total } = transportDistribution(entries);
-    expect(total).toBe(4);
-    expect(rows.map((r) => [r.label, r.count])).toEqual([
-      ["stdio (local)", 2],
-      ["HTTP", 1],
-      ["SSE", 1],
-    ]);
-  });
-
-  it("keeps Unspecified last when an entry has no declared transport", () => {
-    const { rows, total } = transportDistribution([
-      mk({ configSnippet: '{"transport":"sse","url":"https://b/sse"}' }),
-      mk({ configSnippet: '{"env":{"TOKEN":"required"}}' }),
-    ]);
-
-    expect(total).toBe(2);
-    expect(rows.map((r) => [r.label, r.count])).toEqual([
-      ["SSE", 1],
-      ["Unspecified", 1],
-    ]);
-  });
-
-  it("derives local-vs-remote hosting", () => {
-    const rows = hostingDistribution(entries).rows;
-    expect(rows.find((r) => r.label === "Local (stdio)")?.count).toBe(2);
-    expect(rows.find((r) => r.label === "Remote (hosted)")?.count).toBe(2);
-  });
-
-  it("counts auth methods", () => {
-    const rows = authDistribution(entries).rows;
-    expect(rows.find((r) => r.label === "OAuth")?.count).toBe(1);
-    expect(rows.find((r) => r.label === "API key")?.count).toBe(1);
-    expect(rows.find((r) => r.label === "Token / PAT")?.count).toBe(1);
-    expect(rows.find((r) => r.label === "None / unspecified")?.count).toBe(1);
-  });
-});
-
-describe("supplyChainCoverage", () => {
-  it("counts verified packages and checksummed downloads", () => {
-    const cov = supplyChainCoverage([
+describe("mcp-stats re-export surface", () => {
+  it("keeps the public import path wired to the extracted lib", () => {
+    const entries = [
+      mk({ configSnippet: '{"command":"npx"}', prerequisites: ["API key"] }),
       mk({
-        packageVerified: true,
-        downloadUrl: "/d.mcpb",
-        downloadSha256: "abc",
+        configSnippet: '{"type":"http","url":"https://a/mcp"}',
+        prerequisites: ["OAuth"],
       }),
-      mk({ packageVerified: true }),
-      mk({ downloadUrl: "/d.mcpb" }), // no checksum → not counted
-      mk({}),
-    ]);
-    expect(cov).toEqual({
-      total: 4,
-      packageVerified: 2,
-      checksummedDownload: 1,
-    });
+    ];
+
+    expect(classifyTransport(entries[0])).toBe("stdio (local)");
+    expect(hostingOf("HTTP")).toBe("Remote (hosted)");
+    expect(classifyAuth(entries[1])).toBe("OAuth");
+    expect(transportDistribution(entries).total).toBe(2);
+    expect(hostingDistribution(entries).total).toBe(2);
+    expect(authDistribution(entries).total).toBe(2);
+    expect(supplyChainCoverage(entries).total).toBe(2);
   });
 });


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP registry statistics helpers into `mcp-stats-lib.ts` and add a consolidated Vitest suite, keeping the public `@/lib/mcp-stats` import surface unchanged.

## Submission Source

For direct content PRs:

- [ ] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [ ] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author.
- [ ] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [ ] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [ ] This PR links the issue it resolves, or the no-issue rationale is written in **Notes**.

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

For registry API endpoint PRs:

- [ ] Route handler and central API contract changed together.
- [ ] Origin-check and rate-limit posture is stated below.
- [ ] OpenAPI/source generator impact is stated below; generated artifacts are not hand-edited unless maintainer/internal generation work is explicit.
- [ ] API contract tests were added or updated.
- [ ] Generator reproducibility was checked or the reason it was not checked is listed.

## Schema and Quality Checks

- [ ] Content PR: `pnpm validate:content:strict` passed, or I am relying on CI.
- [x] Platform/code PR: focused validation is listed below.
- [ ] Package artifact PR: `pnpm validate:packages` and `pnpm scan:packages` passed.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)
- [x] Install/use/copy paths are practical and complete.
- [ ] Skill submissions include capability metadata when applicable (`skillType`, `skillLevel`, `verificationStatus`, `verifiedAt`, `retrievalSources`, `testedPlatforms`).

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `apps/web/src/lib/mcp-stats-lib.ts` — pure MCP transport/auth classification, distributions, and supply-chain coverage helpers.
  - `apps/web/src/lib/mcp-stats.ts` — thin re-export wrapper preserving the public API.
  - `tests/mcp-stats-lib.test.ts` — consolidated lib tests for transport precedence, auth inference, distributions, and wrapper compatibility.
  - `tests/mcp-stats.test.ts` — re-export smoke tests via `@/lib/mcp-stats`.
- Expected behavior:
  - Data-report routes importing `@/lib/mcp-stats` behave exactly as before.
  - SSE-before-HTTP transport precedence and auth precedence chains are unchanged.
  - Distribution row ordering and supply-chain counters are unchanged.
- Important edge cases or invariants:
  - Extraction is behavior-preserving; only module boundaries change.
  - Lib tests import `@/lib/mcp-stats-lib` directly and verify `@/lib/mcp-stats` re-exports match.
- Backward compatibility notes:
  - Public exports from `@/lib/mcp-stats` are unchanged.
- Screenshots for frontend/page/UI changes:
  - Desktop: No visual impact
  - Mobile: No visual impact
- If screenshots do not apply, write `No visual impact` and explain why.
  - Library extraction and tests only; MCP data-report pages are unchanged.
- Accessibility notes for UI changes:
  - N/A — no UI changes.
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-stats-lib.test.ts` with transport/auth/distribution coverage and wrapper compatibility assertions.

## Validation

- [ ] Direct content PR: I did not run generation or commit generated output.
- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
  - Local shell lacks Node/pnpm; relying on CI for `validate-web` and focused vitest runs.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.
  - Verified re-export surface matches prior `mcp-stats.ts` exports.

## Notes

- Linked issue or no-issue rationale: Maintainer-lane library extraction matching merged `hub-highlights-lib`, `saved-search-alerts-lib`, and `trust-lib` PRs. No linked issue — behavior-preserving module boundary refactor only.
- Any caveats, follow-ups, or reviewer context:
  - Mirrors the established `*-lib.ts` extraction pattern used in recent platform PRs on this repo.
