### PR TITLE
feat(compare): add decision signal rows to comparison table

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -12,17 +12,52 @@ import { CopyButton } from "@/components/copy-button";
 import { SourceCitations } from "@/components/source-citations";
 import { formatCompact } from "@/lib/format";
 import { brandIdentityLabel } from "@/lib/brand-icons";
+import {
+  comparisonDecisionRows,
+  displayCompareSignal,
+  divergingDecisionRowLabels,
+  signalToneClassForDisplay,
+} from "@/lib/compare-table-decision-rows";
+import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 import { EntryBrandMark } from "./entry-brand-mark";
 
 export interface RowDef {
   label: string;
   render: (e: Entry) => React.ReactNode;
+  diverges?: (entries: Entry[]) => boolean;
 }
+
+function CompareSignalCell({ entry, resolve }: {
+  entry: Entry;
+  resolve: (entry: Entry) => ReturnType<typeof displayCompareSignal> | undefined;
+}) {
+  const raw = resolve(entry);
+  if (!raw) return <span className="text-xs text-ink-subtle">—</span>;
+  const value = displayCompareSignal(raw);
+  return (
+    <span
+      className={cn(
+        "inline-flex flex-col gap-0.5 text-xs",
+        signalToneClassForDisplay(raw),
+      )}
+    >
+      <span>{value.label}</span>
+      {value.detail ? <span className="text-ink-muted">{value.detail}</span> : null}
+    </span>
+  );
+}
+
+const DECISION_COMPARISON_ROWS: RowDef[] = comparisonDecisionRows().map((row) => ({
+  label: row.label,
+  render: (entry) => <CompareSignalCell entry={entry} resolve={row.resolve} />,
+  diverges: row.diverges,
+}));
 
 /** Shared comparison field definitions — used by the interactive /compare page and curated pages. */
 export const COMPARISON_ROWS: RowDef[] = [
   { label: "Trust", render: (e) => <TrustDrilldown entry={e} /> },
+  ...DECISION_COMPARISON_ROWS,
   { label: "Install risk", render: (e) => <InstallRiskBadge entry={e} /> },
   { label: "Notes", render: (e) => <NotesPresenceChips entry={e} /> },
   {
@@ -150,6 +185,8 @@ export const COMPARISON_ROWS: RowDef[] = [
 
 /** Static side-by-side comparison table (no add/remove controls) for curated comparison pages. */
 export function ComparisonTable({ entries }: { entries: Entry[] }) {
+  const divergingLabels = new Set(divergingDecisionRowLabels(entries));
+
   return (
     <div className="overflow-auto rounded-xl border border-border">
       <table className="w-full border-collapse text-sm">
@@ -190,24 +227,44 @@ export function ComparisonTable({ entries }: { entries: Entry[] }) {
           </tr>
         </thead>
         <tbody>
-          {COMPARISON_ROWS.map((row, i) => (
-            <tr key={row.label} className={i % 2 === 0 ? "bg-surface-2/30" : ""}>
+          {COMPARISON_ROWS.map((row, i) => {
+            const rowDiverges = divergingLabels.has(row.label);
+            return (
+            <tr
+              key={row.label}
+              className={cn(
+                i % 2 === 0 && "bg-surface-2/30",
+                rowDiverges && "bg-amber-500/5",
+              )}
+            >
               <th
                 scope="row"
-                className="sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted"
+                className={cn(
+                  "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                  rowDiverges && "text-amber-800",
+                )}
               >
                 {row.label}
+                {rowDiverges ? (
+                  <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                    Differs
+                  </span>
+                ) : null}
               </th>
               {entries.map((e) => (
                 <td
                   key={`${e.category}/${e.slug}`}
-                  className="min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top"
+                  className={cn(
+                    "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                    rowDiverges && "bg-amber-500/5",
+                  )}
                 >
                   {row.render(e)}
                 </td>
               ))}
             </tr>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -28,7 +28,10 @@ export interface RowDef {
   diverges?: (entries: Entry[]) => boolean;
 }
 
-function CompareSignalCell({ entry, resolve }: {
+function CompareSignalCell({
+  entry,
+  resolve,
+}: {
   entry: Entry;
   resolve: (entry: Entry) => ReturnType<typeof displayCompareSignal> | undefined;
 }) {
@@ -36,12 +39,7 @@ function CompareSignalCell({ entry, resolve }: {
   if (!raw) return <span className="text-xs text-ink-subtle">—</span>;
   const value = displayCompareSignal(raw);
   return (
-    <span
-      className={cn(
-        "inline-flex flex-col gap-0.5 text-xs",
-        signalToneClassForDisplay(raw),
-      )}
-    >
+    <span className={cn("inline-flex flex-col gap-0.5 text-xs", signalToneClassForDisplay(raw))}>
       <span>{value.label}</span>
       {value.detail ? <span className="text-ink-muted">{value.detail}</span> : null}
     </span>
@@ -230,39 +228,36 @@ export function ComparisonTable({ entries }: { entries: Entry[] }) {
           {COMPARISON_ROWS.map((row, i) => {
             const rowDiverges = divergingLabels.has(row.label);
             return (
-            <tr
-              key={row.label}
-              className={cn(
-                i % 2 === 0 && "bg-surface-2/30",
-                rowDiverges && "bg-amber-500/5",
-              )}
-            >
-              <th
-                scope="row"
-                className={cn(
-                  "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
-                  rowDiverges && "text-amber-800",
-                )}
+              <tr
+                key={row.label}
+                className={cn(i % 2 === 0 && "bg-surface-2/30", rowDiverges && "bg-amber-500/5")}
               >
-                {row.label}
-                {rowDiverges ? (
-                  <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
-                    Differs
-                  </span>
-                ) : null}
-              </th>
-              {entries.map((e) => (
-                <td
-                  key={`${e.category}/${e.slug}`}
+                <th
+                  scope="row"
                   className={cn(
-                    "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
-                    rowDiverges && "bg-amber-500/5",
+                    "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                    rowDiverges && "text-amber-800",
                   )}
                 >
-                  {row.render(e)}
-                </td>
-              ))}
-            </tr>
+                  {row.label}
+                  {rowDiverges ? (
+                    <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                      Differs
+                    </span>
+                  ) : null}
+                </th>
+                {entries.map((e) => (
+                  <td
+                    key={`${e.category}/${e.slug}`}
+                    className={cn(
+                      "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                      rowDiverges && "bg-amber-500/5",
+                    )}
+                  >
+                    {row.render(e)}
+                  </td>
+                ))}
+              </tr>
             );
           })}
         </tbody>

--- a/apps/web/src/lib/compare-table-decision-rows.ts
+++ b/apps/web/src/lib/compare-table-decision-rows.ts
@@ -45,14 +45,10 @@ export function compareDecisionSummary(entries: Entry[]): {
   };
 }
 
-export function displayCompareSignal(
-  value: CompareSignalValue | undefined,
-): CompareSignalValue {
+export function displayCompareSignal(value: CompareSignalValue | undefined): CompareSignalValue {
   return resolveCompareSignal(value);
 }
 
-export function signalToneClassForDisplay(
-  value: CompareSignalValue | undefined,
-): string {
+export function signalToneClassForDisplay(value: CompareSignalValue | undefined): string {
   return compareSignalToneClass(displayCompareSignal(value).tone);
 }

--- a/apps/web/src/lib/compare-table-decision-rows.ts
+++ b/apps/web/src/lib/compare-table-decision-rows.ts
@@ -1,0 +1,58 @@
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_DECISION_ROWS,
+  compareSignalToneClass,
+  decisionRowDiverges,
+  resolveCompareSignal,
+  type CompareSignalValue,
+} from "@/lib/compare-entry-signals";
+
+export type ComparisonDecisionRow = {
+  label: string;
+  resolve: (entry: Entry) => CompareSignalValue | undefined;
+  diverges: (entries: Entry[]) => boolean;
+};
+
+export function comparisonDecisionRows(): ComparisonDecisionRow[] {
+  return COMPARE_DECISION_ROWS.map((row) => ({
+    label: row.label,
+    resolve: row.resolve,
+    diverges: (entries: Entry[]) => decisionRowDiverges(row.resolve, entries),
+  }));
+}
+
+export function divergingDecisionRowLabels(entries: Entry[]): string[] {
+  if (entries.length < 2) return [];
+  return comparisonDecisionRows()
+    .filter((row) => row.diverges(entries))
+    .map((row) => row.label);
+}
+
+export function hasCompareDecisionDivergence(entries: Entry[]): boolean {
+  return divergingDecisionRowLabels(entries).length > 0;
+}
+
+export function compareDecisionSummary(entries: Entry[]): {
+  comparedCount: number;
+  divergingCount: number;
+  divergingLabels: string[];
+} {
+  const divergingLabels = divergingDecisionRowLabels(entries);
+  return {
+    comparedCount: entries.length,
+    divergingCount: divergingLabels.length,
+    divergingLabels,
+  };
+}
+
+export function displayCompareSignal(
+  value: CompareSignalValue | undefined,
+): CompareSignalValue {
+  return resolveCompareSignal(value);
+}
+
+export function signalToneClassForDisplay(
+  value: CompareSignalValue | undefined,
+): string {
+  return compareSignalToneClass(displayCompareSignal(value).tone);
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -17,6 +17,7 @@ import {
   resolveCompareEntryActions,
   type CompareAction,
 } from "@/lib/compare-entry-actions";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -68,6 +69,7 @@ function ComparePage() {
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const actionRowDiverges = compareActionsDiverge(items);
+  const decisionSummary = compareDecisionSummary(items);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -145,6 +147,13 @@ function ComparePage() {
           <h1 className="mt-1 h-display-2 text-ink text-balance">
             {items.length} {items.length === 1 ? "resource" : "resources"} side by side
           </h1>
+          {decisionSummary.divergingCount > 0 ? (
+            <p className="mt-2 text-sm text-ink-muted">
+              {decisionSummary.divergingCount} trust signal
+              {decisionSummary.divergingCount === 1 ? "" : "s"} differ across this comparison (
+              {decisionSummary.divergingLabels.join(", ")}).
+            </p>
+          ) : null}
         </div>
         <div className="flex items-center gap-2">
           <CopyButton value={copyShare()} label="Copy share link" />
@@ -257,26 +266,45 @@ function ComparePage() {
                 </td>
               )}
             </tr>
-            {ROWS.map((row, i) => (
+            {ROWS.map((row, i) => {
+              const rowDiverges = row.diverges?.(items) ?? false;
+              return (
               <tr
                 key={row.label}
                 onMouseEnter={() => setHoverRow(i)}
                 onMouseLeave={() => setHoverRow(null)}
                 className={cn(
                   "transition-colors duration-200 ease-out",
-                  hoverRow === i ? "bg-accent/5" : i % 2 === 0 ? "bg-surface-2/30" : "",
+                  rowDiverges
+                    ? "bg-amber-500/5"
+                    : hoverRow === i
+                      ? "bg-accent/5"
+                      : i % 2 === 0
+                        ? "bg-surface-2/30"
+                        : "",
                 )}
               >
                 <th
                   scope="row"
-                  className="sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted"
+                  className={cn(
+                    "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                    rowDiverges && "text-amber-800",
+                  )}
                 >
                   {row.label}
+                  {rowDiverges ? (
+                    <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                      Differs
+                    </span>
+                  ) : null}
                 </th>
                 {items.map((e) => (
                   <td
                     key={`${e.category}/${e.slug}`}
-                    className="min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top"
+                    className={cn(
+                      "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                      rowDiverges && "bg-amber-500/5",
+                    )}
                   >
                     {row.render(e)}
                   </td>
@@ -287,7 +315,8 @@ function ComparePage() {
                   </td>
                 )}
               </tr>
-            ))}
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -269,52 +269,52 @@ function ComparePage() {
             {ROWS.map((row, i) => {
               const rowDiverges = row.diverges?.(items) ?? false;
               return (
-              <tr
-                key={row.label}
-                onMouseEnter={() => setHoverRow(i)}
-                onMouseLeave={() => setHoverRow(null)}
-                className={cn(
-                  "transition-colors duration-200 ease-out",
-                  rowDiverges
-                    ? "bg-amber-500/5"
-                    : hoverRow === i
-                      ? "bg-accent/5"
-                      : i % 2 === 0
-                        ? "bg-surface-2/30"
-                        : "",
-                )}
-              >
-                <th
-                  scope="row"
+                <tr
+                  key={row.label}
+                  onMouseEnter={() => setHoverRow(i)}
+                  onMouseLeave={() => setHoverRow(null)}
                   className={cn(
-                    "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
-                    rowDiverges && "text-amber-800",
+                    "transition-colors duration-200 ease-out",
+                    rowDiverges
+                      ? "bg-amber-500/5"
+                      : hoverRow === i
+                        ? "bg-accent/5"
+                        : i % 2 === 0
+                          ? "bg-surface-2/30"
+                          : "",
                   )}
                 >
-                  {row.label}
-                  {rowDiverges ? (
-                    <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
-                      Differs
-                    </span>
-                  ) : null}
-                </th>
-                {items.map((e) => (
-                  <td
-                    key={`${e.category}/${e.slug}`}
+                  <th
+                    scope="row"
                     className={cn(
-                      "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
-                      rowDiverges && "bg-amber-500/5",
+                      "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                      rowDiverges && "text-amber-800",
                     )}
                   >
-                    {row.render(e)}
-                  </td>
-                ))}
-                {items.length < 4 && (
-                  <td className="min-w-[220px] border-b border-border p-3 align-top text-xs text-ink-subtle">
-                    —
-                  </td>
-                )}
-              </tr>
+                    {row.label}
+                    {rowDiverges ? (
+                      <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                        Differs
+                      </span>
+                    ) : null}
+                  </th>
+                  {items.map((e) => (
+                    <td
+                      key={`${e.category}/${e.slug}`}
+                      className={cn(
+                        "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                        rowDiverges && "bg-amber-500/5",
+                      )}
+                    >
+                      {row.render(e)}
+                    </td>
+                  ))}
+                  {items.length < 4 && (
+                    <td className="min-w-[220px] border-b border-border p-3 align-top text-xs text-ink-subtle">
+                      —
+                    </td>
+                  )}
+                </tr>
               );
             })}
           </tbody>

--- a/tests/compare-table-decision-rows.test.ts
+++ b/tests/compare-table-decision-rows.test.ts
@@ -83,7 +83,10 @@ describe("compare table decision rows", () => {
       label: "—",
     });
     expect(
-      signalToneClassForDisplay({ tone: "verified", label: "Package verified" }),
+      signalToneClassForDisplay({
+        tone: "verified",
+        label: "Package verified",
+      }),
     ).toBe("text-trust-trusted");
     expect(
       signalToneClassForDisplay({ tone: "present", label: "Checksum present" }),

--- a/tests/compare-table-decision-rows.test.ts
+++ b/tests/compare-table-decision-rows.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDecisionSummary,
+  comparisonDecisionRows,
+  displayCompareSignal,
+  divergingDecisionRowLabels,
+  hasCompareDecisionDivergence,
+  signalToneClassForDisplay,
+} from "@/lib/compare-table-decision-rows";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table decision rows", () => {
+  it("mirrors compare drawer decision rows with divergence helpers", () => {
+    const rows = comparisonDecisionRows();
+    expect(rows.map((row) => row.label)).toEqual([
+      "Review status",
+      "Package trust",
+      "Source provenance",
+      "Submitter",
+    ]);
+    expect(rows.every((row) => typeof row.diverges === "function")).toBe(true);
+  });
+
+  it("returns no diverging labels for fewer than two compared entries", () => {
+    expect(divergingDecisionRowLabels([])).toEqual([]);
+    expect(divergingDecisionRowLabels([entry()])).toEqual([]);
+    expect(hasCompareDecisionDivergence([entry()])).toBe(false);
+    expect(compareDecisionSummary([entry()])).toEqual({
+      comparedCount: 1,
+      divergingCount: 0,
+      divergingLabels: [],
+    });
+  });
+
+  it("detects diverging review and package trust rows across entries", () => {
+    const reviewed = entry({ reviewed: true });
+    const verified = entry({ packageVerified: true });
+    const baseline = entry();
+
+    expect(divergingDecisionRowLabels([reviewed, baseline])).toEqual([
+      "Review status",
+    ]);
+    expect(divergingDecisionRowLabels([verified, baseline])).toEqual([
+      "Package trust",
+    ]);
+    expect(hasCompareDecisionDivergence([reviewed, baseline])).toBe(true);
+    expect(compareDecisionSummary([reviewed, baseline])).toEqual({
+      comparedCount: 2,
+      divergingCount: 1,
+      divergingLabels: ["Review status"],
+    });
+  });
+
+  it("detects submitter present-versus-missing divergence", () => {
+    expect(
+      divergingDecisionRowLabels([
+        entry({ submittedBy: "kiannidev" }),
+        entry(),
+      ]),
+    ).toEqual(["Submitter"]);
+  });
+
+  it("formats compare signal display and tone classes for table cells", () => {
+    expect(displayCompareSignal(undefined)).toEqual({
+      tone: "missing",
+      label: "—",
+    });
+    expect(
+      signalToneClassForDisplay({ tone: "verified", label: "Package verified" }),
+    ).toBe("text-trust-trusted");
+    expect(
+      signalToneClassForDisplay({ tone: "present", label: "Checksum present" }),
+    ).toBe("text-ink");
+    expect(signalToneClassForDisplay(undefined)).toBe("text-ink-subtle");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds decision signal rows (review, package trust, provenance, submitter) to the shared comparison table via `compare-table-decision-rows.ts`
- Highlights diverging signals on `/compare` and curated comparison pages with a decision summary banner
- Includes 100% test coverage on the new lib module; trunk formatting fixed for CI

Third slice of the compare/decision surfaces epic. Complements merged #4257 (compare page CTAs) and #4260 (drawer trust/provenance signals).

Supersedes closed #4322 (same branch, CI fmt fix applied).

Refs #556

## Test plan
- [x] `trunk check --ci` passes locally
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest` — 100% coverage on `compare-table-decision-rows.ts`
- [ ] CI green (`validate-ci`, `required-pr-gate`, codecov)


