### PR TITLE
feat(compare): add next-action row to compare drawer

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -18,6 +18,17 @@ import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
+import {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerActionSummary,
+  compareDrawerActionsDiverge,
+} from "@/lib/compare-drawer-actions";
+import {
+  recordCompareIntentEvent,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+import { trackEvent, entryEventKey } from "@/lib/analytics";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
@@ -168,6 +179,102 @@ function CompareSignalCell({ value }: { value: CompareSignalValue }) {
   );
 }
 
+function DrawerCompareActions({ entry }: { entry: Entry }) {
+  const actions = resolveCompareEntryActions(entry);
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {actions.map((action) => (
+        <DrawerActionButton key={action.id} entry={entry} action={action} />
+      ))}
+    </div>
+  );
+}
+
+function DrawerActionButton({ entry, action }: { entry: Entry; action: CompareAction }) {
+  const eventKey = entryEventKey(entry.category, entry.slug);
+
+  if (action.kind === "copy" && action.copyValue) {
+    return (
+      <CopyButton
+        value={action.copyValue}
+        label={action.label}
+        event={action.analyticsEvent}
+        eventData={{ entry: eventKey, surface: COMPARE_DRAWER_SURFACE }}
+        onCopied={() => {
+          if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+        }}
+      />
+    );
+  }
+
+  if (action.kind === "link") {
+    if (action.id === "dossier") {
+      return (
+        <Link
+          to="/entry/$category/$slug"
+          params={{ category: entry.category, slug: entry.slug }}
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_DRAWER_SURFACE,
+              });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.id === "claim") {
+      return (
+        <Link
+          to="/claim"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_DRAWER_SURFACE,
+              });
+            }
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.href && action.external) {
+      return (
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_DRAWER_SURFACE,
+              });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </a>
+      );
+    }
+  }
+
+  return null;
+}
+
 /** Per-entry snippet cell that honors the global copy variant + harness pref. */
 function SnippetCell({ entry }: { entry: Entry }) {
   const harnessAvailable = React.useMemo<Harness[]>(
@@ -212,6 +319,8 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate, getShareUrl } = useCompare();
+  const actionRowDiverges = compareDrawerActionsDiverge(items);
+  const actionSummary = compareDrawerActionSummary(items);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -245,6 +354,12 @@ export function CompareDrawer() {
             <SheetDescription className="sr-only">
               Side-by-side comparison of the selected resources.
             </SheetDescription>
+            {actionSummary.diverges ? (
+              <p className="w-full text-xs text-amber-800">
+                Next steps differ across this comparison — review install, source, and claim actions
+                per entry.
+              </p>
+            ) : null}
             <div className="flex flex-wrap items-center gap-2">
               {items.length > 0 && (
                 <div className="hidden items-center gap-1.5 sm:flex">
@@ -349,6 +464,38 @@ export function CompareDrawer() {
                   </tr>
                 </thead>
                 <tbody>
+                  <tr
+                    className={cn(
+                      "transition-colors duration-200 ease-out",
+                      actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+                    )}
+                  >
+                    <th
+                      scope="row"
+                      className={cn(
+                        "sticky left-0 z-10 w-[140px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                        actionRowDiverges && "text-amber-800",
+                      )}
+                    >
+                      Next steps
+                      {actionRowDiverges ? (
+                        <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                          Differs
+                        </span>
+                      ) : null}
+                    </th>
+                    {items.map((e) => (
+                      <td
+                        key={`actions-${e.category}/${e.slug}`}
+                        className={cn(
+                          "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top last:border-r-0",
+                          actionRowDiverges && "bg-amber-500/5",
+                        )}
+                      >
+                        <DrawerCompareActions entry={e} />
+                      </td>
+                    ))}
+                  </tr>
                   {ROWS.map((row, i) => {
                     const rowDiverges = row.diverges?.(items) ?? false;
                     return (

--- a/apps/web/src/lib/compare-drawer-actions.ts
+++ b/apps/web/src/lib/compare-drawer-actions.ts
@@ -1,0 +1,49 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareActionSignature,
+  compareActionsDiverge,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+
+export const COMPARE_DRAWER_SURFACE = "compare-drawer";
+
+export type CompareDrawerActionCell = {
+  entryKey: string;
+  actions: CompareAction[];
+};
+
+export function compareDrawerActionCells(entries: Entry[]): CompareDrawerActionCell[] {
+  return entries.map((entry) => ({
+    entryKey: `${entry.category}:${entry.slug}`,
+    actions: resolveCompareEntryActions(entry),
+  }));
+}
+
+export function compareDrawerActionsDiverge(entries: Entry[]): boolean {
+  return compareActionsDiverge(entries);
+}
+
+export function compareDrawerSharedActionIds(entries: Entry[]): string[] {
+  if (entries.length === 0) return [];
+  const actionSets = entries.map(
+    (entry) => new Set(resolveCompareEntryActions(entry).map((action) => action.id)),
+  );
+  const [first, ...rest] = actionSets;
+  return [...first].filter((id) => rest.every((set) => set.has(id)));
+}
+
+export function compareDrawerActionSummary(entries: Entry[]): {
+  comparedCount: number;
+  diverges: boolean;
+  sharedActionIds: string[];
+  uniqueSignatures: number;
+} {
+  const signatures = entries.map(compareActionSignature);
+  return {
+    comparedCount: entries.length,
+    diverges: compareActionsDiverge(entries),
+    sharedActionIds: compareDrawerSharedActionIds(entries),
+    uniqueSignatures: new Set(signatures).size,
+  };
+}

--- a/tests/compare-drawer-actions.test.ts
+++ b/tests/compare-drawer-actions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerActionCells,
+  compareDrawerActionSummary,
+  compareDrawerActionsDiverge,
+  compareDrawerSharedActionIds,
+} from "@/lib/compare-drawer-actions";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer actions", () => {
+  it("exposes the compare drawer analytics surface id", () => {
+    expect(COMPARE_DRAWER_SURFACE).toBe("compare-drawer");
+  });
+
+  it("maps compared entries to per-column next-action cells", () => {
+    expect(compareDrawerActionCells([entry()])).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+    expect(
+      compareDrawerActionCells([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({
+          category: "hooks",
+          slug: "beta",
+          claimed: true,
+          sourceUrl: "https://x.dev",
+        }),
+      ]).map((cell) => cell.entryKey),
+    ).toEqual(["skills:alpha", "hooks:beta"]);
+  });
+
+  it("detects when drawer columns expose different next-action sets", () => {
+    expect(
+      compareDrawerActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      compareDrawerActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(compareDrawerActionsDiverge([])).toBe(false);
+  });
+
+  it("finds action ids shared across every compared entry", () => {
+    expect(compareDrawerSharedActionIds([])).toEqual([]);
+    expect(compareDrawerSharedActionIds([entry()])).toEqual([
+      "dossier",
+      "claim",
+    ]);
+    expect(
+      compareDrawerSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toEqual(["dossier", "install", "claim"]);
+    expect(
+      compareDrawerSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("summarizes drawer action divergence for header hints", () => {
+    const baseline = entry();
+    const withInstall = entry({ installCommand: "npm i fixture" });
+    expect(compareDrawerActionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      diverges: false,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 1,
+    });
+    expect(compareDrawerActionSummary([baseline, withInstall])).toEqual({
+      comparedCount: 2,
+      diverges: true,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-drawer-actions.ts` helpers for per-column next-action cells, shared action detection, and divergence summaries in the compare drawer.
- Surfaces install, config, source, and claim CTAs as a **Next steps** row in the compare drawer with amber divergence highlighting.
- Shows a header hint when compared entries expose different action sets; intent events reuse existing compare action plumbing with `surface: compare-drawer`.

Fourth slice of the compare/decision surfaces epic (#556). Complements merged work:
- **#4257** — next-action CTAs on `/compare` full page
- **#4260** — trust/provenance signal rows in compare drawer
- **#4323** — decision signal rows on shared comparison table

## Conflict safety
Touches only `compare-drawer.tsx` plus new lib/tests — **no overlap** with open PRs **#4251** (search/registry trust) or **#4259** (contributor attribution). Should merge cleanly after those land without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-drawer-actions.test.ts` — **100%** coverage on `compare-drawer-actions.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)