### PR TITLE
feat(compare): add divergence summaries to curated compare pages

### DIFF
--- a/apps/web/src/lib/compare-curated-summary.ts
+++ b/apps/web/src/lib/compare-curated-summary.ts
@@ -1,0 +1,44 @@
+import type { Entry } from "@/types/registry";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export type CompareDecisionSummary = ReturnType<typeof compareDecisionSummary>;
+
+export type CompareCuratedSummary = {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+};
+
+export function compareCuratedSummary(entries: Entry[]): CompareCuratedSummary {
+  const decision = compareDecisionSummary(entries);
+  const actionsDiverge = compareActionsDiverge(entries);
+  return {
+    comparedCount: entries.length,
+    decision,
+    actionsDiverge,
+    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
+  };
+}
+
+export function compareCuratedDecisionBannerText(decision: CompareDecisionSummary): string | null {
+  if (decision.divergingCount === 0) return null;
+  const signalWord = decision.divergingCount === 1 ? "signal" : "signals";
+  return `${decision.divergingCount} trust ${signalWord} differ across this comparison (${decision.divergingLabels.join(", ")}).`;
+}
+
+export function compareCuratedActionBannerText(actionsDiverge: boolean): string | null {
+  if (!actionsDiverge) return null;
+  return "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.";
+}
+
+export function compareCuratedBannerTexts(entries: Entry[]): string[] {
+  const summary = compareCuratedSummary(entries);
+  const messages: string[] = [];
+  const decisionText = compareCuratedDecisionBannerText(summary.decision);
+  const actionText = compareCuratedActionBannerText(summary.actionsDiverge);
+  if (decisionText) messages.push(decisionText);
+  if (actionText) messages.push(actionText);
+  return messages;
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -9,6 +9,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
+import { compareCuratedBannerTexts } from "@/lib/compare-curated-summary";
 
 function resolveRefs(refs: string[]): Entry[] {
   const out: Entry[] = [];
@@ -96,6 +97,7 @@ function ComparisonPage() {
   const comparison = getComparison(slug);
   if (!comparison) return null;
   const entries = resolveRefs(comparison.refs);
+  const bannerTexts = compareCuratedBannerTexts(entries);
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">
@@ -111,6 +113,15 @@ function ComparisonPage() {
         <div className="eyebrow">{entries.length} compared</div>
         <h1 className="mt-2 h-display-1 text-ink text-balance">{comparison.heading}</h1>
         <p className="mt-4 text-pretty text-base text-ink-muted sm:text-lg">{comparison.intro}</p>
+        {bannerTexts.length > 0 ? (
+          <div className="mt-4 space-y-1.5">
+            {bannerTexts.map((text) => (
+              <p key={text} className="text-sm text-ink-muted">
+                {text}
+              </p>
+            ))}
+          </div>
+        ) : null}
         <Link
           to="/compare"
           search={{ ids: entries.map((e) => `${e.category}/${e.slug}`).join(",") }}

--- a/tests/compare-curated-summary.test.ts
+++ b/tests/compare-curated-summary.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareCuratedActionBannerText,
+  compareCuratedBannerTexts,
+  compareCuratedDecisionBannerText,
+  compareCuratedSummary,
+} from "@/lib/compare-curated-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare curated summary", () => {
+  it("combines decision and action divergence for curated comparison pages", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareCuratedSummary([baseline])).toEqual({
+      comparedCount: 1,
+      decision: {
+        comparedCount: 1,
+        divergingCount: 0,
+        divergingLabels: [],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: false,
+    });
+    expect(compareCuratedSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      compareCuratedSummary([
+        baseline,
+        entry({ installCommand: "npm i fixture" }),
+      ]).hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats decision divergence banner copy for curated headers", () => {
+    expect(
+      compareCuratedDecisionBannerText({
+        comparedCount: 2,
+        divergingCount: 0,
+        divergingLabels: [],
+      }),
+    ).toBeNull();
+    expect(
+      compareCuratedDecisionBannerText({
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      }),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+    expect(
+      compareCuratedDecisionBannerText({
+        comparedCount: 3,
+        divergingCount: 2,
+        divergingLabels: ["Review status", "Package trust"],
+      }),
+    ).toBe(
+      "2 trust signals differ across this comparison (Review status, Package trust).",
+    );
+  });
+
+  it("formats action divergence banner copy for curated headers", () => {
+    expect(compareCuratedActionBannerText(false)).toBeNull();
+    expect(compareCuratedActionBannerText(true)).toBe(
+      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+    );
+  });
+
+  it("returns ordered banner messages for curated comparison headers", () => {
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareCuratedBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      compareCuratedBannerTexts([
+        entry(),
+        entry({ installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual([
+      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+    ]);
+    expect(compareCuratedBannerTexts([entry()])).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-curated-summary.ts` to combine trust-signal and next-step divergence for curated `/compare/$slug` pages.
- Shows header banners when compared entries differ on decision signals or available actions, matching the interactive `/compare` experience.
- Includes **100%** test coverage on the new lib module.

Fifth slice of the compare/decision surfaces epic (#556). Complements merged:
- **#4257** — next-action CTAs on `/compare`
- **#4260** — trust/provenance signals in compare drawer
- **#4323** — decision signal rows on shared comparison table
- **#4324** — next-action row in compare drawer

## Conflict safety
Touches only `compare.$slug.tsx` plus new lib/tests — **no file overlap** with open PRs **#4251** (search/registry trust) or **#4259** (contributor attribution). Should merge cleanly after those land without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-curated-summary.test.ts` — **100%** coverage on `compare-curated-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)