### PR TITLE
feat(compare): add next-action row to curated comparison table

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -18,6 +18,17 @@ import {
   divergingDecisionRowLabels,
   signalToneClassForDisplay,
 } from "@/lib/compare-table-decision-rows";
+import {
+  COMPARE_TABLE_SURFACE,
+  compareTableActionsDiverge,
+  shouldRenderCompareTableActions,
+} from "@/lib/compare-table-actions";
+import {
+  recordCompareIntentEvent,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 import { EntryBrandMark } from "./entry-brand-mark";
@@ -44,6 +55,102 @@ function CompareSignalCell({
       {value.detail ? <span className="text-ink-muted">{value.detail}</span> : null}
     </span>
   );
+}
+
+function TableCompareActions({ entry }: { entry: Entry }) {
+  const actions = resolveCompareEntryActions(entry);
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {actions.map((action) => (
+        <TableActionButton key={action.id} entry={entry} action={action} />
+      ))}
+    </div>
+  );
+}
+
+function TableActionButton({ entry, action }: { entry: Entry; action: CompareAction }) {
+  const eventKey = entryEventKey(entry.category, entry.slug);
+
+  if (action.kind === "copy" && action.copyValue) {
+    return (
+      <CopyButton
+        value={action.copyValue}
+        label={action.label}
+        event={action.analyticsEvent}
+        eventData={{ entry: eventKey, surface: COMPARE_TABLE_SURFACE }}
+        onCopied={() => {
+          if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+        }}
+      />
+    );
+  }
+
+  if (action.kind === "link") {
+    if (action.id === "dossier") {
+      return (
+        <Link
+          to="/entry/$category/$slug"
+          params={{ category: entry.category, slug: entry.slug }}
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_TABLE_SURFACE,
+              });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.id === "claim") {
+      return (
+        <Link
+          to="/claim"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_TABLE_SURFACE,
+              });
+            }
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.href && action.external) {
+      return (
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, {
+                entry: eventKey,
+                surface: COMPARE_TABLE_SURFACE,
+              });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </a>
+      );
+    }
+  }
+
+  return null;
 }
 
 const DECISION_COMPARISON_ROWS: RowDef[] = comparisonDecisionRows().map((row) => ({
@@ -182,8 +289,16 @@ export const COMPARISON_ROWS: RowDef[] = [
 ];
 
 /** Static side-by-side comparison table (no add/remove controls) for curated comparison pages. */
-export function ComparisonTable({ entries }: { entries: Entry[] }) {
+export function ComparisonTable({
+  entries,
+  showNextActions = false,
+}: {
+  entries: Entry[];
+  showNextActions?: boolean;
+}) {
   const divergingLabels = new Set(divergingDecisionRowLabels(entries));
+  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
+  const actionRowDiverges = renderNextActions && compareTableActionsDiverge(entries);
 
   return (
     <div className="overflow-auto rounded-xl border border-border">
@@ -225,6 +340,40 @@ export function ComparisonTable({ entries }: { entries: Entry[] }) {
           </tr>
         </thead>
         <tbody>
+          {renderNextActions ? (
+            <tr
+              className={cn(
+                "transition-colors duration-200 ease-out",
+                actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+              )}
+            >
+              <th
+                scope="row"
+                className={cn(
+                  "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
+                  actionRowDiverges && "text-amber-800",
+                )}
+              >
+                Next steps
+                {actionRowDiverges ? (
+                  <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
+                    Differs
+                  </span>
+                ) : null}
+              </th>
+              {entries.map((e) => (
+                <td
+                  key={`actions-${e.category}/${e.slug}`}
+                  className={cn(
+                    "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
+                    actionRowDiverges && "bg-amber-500/5",
+                  )}
+                >
+                  <TableCompareActions entry={e} />
+                </td>
+              ))}
+            </tr>
+          ) : null}
           {COMPARISON_ROWS.map((row, i) => {
             const rowDiverges = divergingLabels.has(row.label);
             return (

--- a/apps/web/src/lib/compare-table-actions.ts
+++ b/apps/web/src/lib/compare-table-actions.ts
@@ -1,0 +1,53 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareActionSignature,
+  compareActionsDiverge,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+
+export const COMPARE_TABLE_SURFACE = "compare-table";
+
+export type CompareTableActionCell = {
+  entryKey: string;
+  actions: CompareAction[];
+};
+
+export function shouldRenderCompareTableActions(entries: Entry[], enabled: boolean): boolean {
+  return enabled && entries.length >= 2;
+}
+
+export function compareTableActionCells(entries: Entry[]): CompareTableActionCell[] {
+  return entries.map((entry) => ({
+    entryKey: `${entry.category}:${entry.slug}`,
+    actions: resolveCompareEntryActions(entry),
+  }));
+}
+
+export function compareTableActionsDiverge(entries: Entry[]): boolean {
+  return compareActionsDiverge(entries);
+}
+
+export function compareTableSharedActionIds(entries: Entry[]): string[] {
+  if (entries.length === 0) return [];
+  const actionSets = entries.map(
+    (entry) => new Set(resolveCompareEntryActions(entry).map((action) => action.id)),
+  );
+  const [first, ...rest] = actionSets;
+  return [...first].filter((id) => rest.every((set) => set.has(id)));
+}
+
+export function compareTableActionSummary(entries: Entry[]): {
+  comparedCount: number;
+  diverges: boolean;
+  sharedActionIds: string[];
+  uniqueSignatures: number;
+} {
+  const signatures = entries.map(compareActionSignature);
+  return {
+    comparedCount: entries.length,
+    diverges: compareActionsDiverge(entries),
+    sharedActionIds: compareTableSharedActionIds(entries),
+    uniqueSignatures: new Set(signatures).size,
+  };
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -132,7 +132,7 @@ function ComparisonPage() {
       </header>
 
       <div className="mt-8">
-        <ComparisonTable entries={entries} />
+        <ComparisonTable entries={entries} showNextActions />
       </div>
 
       <NewsletterInline

--- a/tests/compare-table-actions.test.ts
+++ b/tests/compare-table-actions.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_TABLE_SURFACE,
+  compareTableActionCells,
+  compareTableActionSummary,
+  compareTableActionsDiverge,
+  compareTableSharedActionIds,
+  shouldRenderCompareTableActions,
+} from "@/lib/compare-table-actions";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table actions", () => {
+  it("exposes the compare table analytics surface id", () => {
+    expect(COMPARE_TABLE_SURFACE).toBe("compare-table");
+  });
+
+  it("only renders next-action rows when enabled for multi-entry tables", () => {
+    expect(shouldRenderCompareTableActions([], true)).toBe(false);
+    expect(shouldRenderCompareTableActions([entry()], true)).toBe(false);
+    expect(
+      shouldRenderCompareTableActions(
+        [entry(), entry({ slug: "other" })],
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      shouldRenderCompareTableActions(
+        [entry(), entry({ slug: "other" })],
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("maps compared entries to per-column next-action cells", () => {
+    expect(compareTableActionCells([entry()])).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+  });
+
+  it("detects when table columns expose different next-action sets", () => {
+    expect(
+      compareTableActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      compareTableActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(compareTableActionsDiverge([])).toBe(false);
+  });
+
+  it("finds action ids shared across every compared entry", () => {
+    expect(compareTableSharedActionIds([])).toEqual([]);
+    expect(compareTableSharedActionIds([entry()])).toEqual([
+      "dossier",
+      "claim",
+    ]);
+    expect(
+      compareTableSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("summarizes table action divergence for row highlighting", () => {
+    const baseline = entry();
+    const withInstall = entry({ installCommand: "npm i fixture" });
+    expect(compareTableActionSummary([baseline, withInstall])).toEqual({
+      comparedCount: 2,
+      diverges: true,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-table-actions.ts` helpers for opt-in next-action rows on the shared `ComparisonTable`.
- Enables install, config, source, and claim CTAs on curated `/compare/$slug` pages with amber divergence highlighting.
- Includes **100%** test coverage on the new lib module; entry detail and best-list tables unchanged (prop defaults off).

Sixth slice of the compare/decision surfaces epic (#556). Complements merged:
- **#4257** — next-action CTAs on interactive `/compare`
- **#4260** — trust/provenance signals in compare drawer
- **#4323** — decision signal rows on shared comparison table
- **#4324** — next-action row in compare drawer
- **#4326** — divergence summary banners on curated compare pages

## Conflict safety
Touches `comparison-table.tsx`, `compare.$slug.tsx`, plus new lib/tests — **no file overlap** with open PRs **#4327** (growth-surface-rules lib), **#4251** (search/registry trust), or **#4259** (contributor attribution). Should merge cleanly after those land without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-table-actions.test.ts` — **100%** coverage on `compare-table-actions.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)