### PR TITLE
feat(compare): add trust divergence banners to compare drawer

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -18,11 +18,8 @@ import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
-import {
-  COMPARE_DRAWER_SURFACE,
-  compareDrawerActionSummary,
-  compareDrawerActionsDiverge,
-} from "@/lib/compare-drawer-actions";
+import { COMPARE_DRAWER_SURFACE, compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
+import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
 import {
   recordCompareIntentEvent,
   resolveCompareEntryActions,
@@ -320,7 +317,7 @@ function SnippetCell({ entry }: { entry: Entry }) {
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate, getShareUrl } = useCompare();
   const actionRowDiverges = compareDrawerActionsDiverge(items);
-  const actionSummary = compareDrawerActionSummary(items);
+  const bannerTexts = compareDrawerBannerTexts(items);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -354,11 +351,14 @@ export function CompareDrawer() {
             <SheetDescription className="sr-only">
               Side-by-side comparison of the selected resources.
             </SheetDescription>
-            {actionSummary.diverges ? (
-              <p className="w-full text-xs text-amber-800">
-                Next steps differ across this comparison — review install, source, and claim actions
-                per entry.
-              </p>
+            {bannerTexts.length > 0 ? (
+              <div className="w-full space-y-1">
+                {bannerTexts.map((text) => (
+                  <p key={text} className="text-xs text-amber-800">
+                    {text}
+                  </p>
+                ))}
+              </div>
             ) : null}
             <div className="flex flex-wrap items-center gap-2">
               {items.length > 0 && (

--- a/apps/web/src/lib/compare-drawer-summary.ts
+++ b/apps/web/src/lib/compare-drawer-summary.ts
@@ -1,0 +1,46 @@
+import type { Entry } from "@/types/registry";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import {
+  compareCuratedDecisionBannerText,
+  type CompareDecisionSummary,
+} from "@/lib/compare-curated-summary";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export function compareDrawerDecisionSummary(entries: Entry[]): CompareDecisionSummary {
+  return compareDecisionSummary(entries);
+}
+
+export function compareDrawerDecisionBannerText(entries: Entry[]): string | null {
+  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+}
+
+export function compareDrawerActionBannerText(actionsDiverge: boolean): string | null {
+  if (!actionsDiverge) return null;
+  return "Next steps differ across this comparison — review install, source, and claim actions per entry.";
+}
+
+export function compareDrawerSummary(entries: Entry[]): {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+} {
+  const decision = compareDecisionSummary(entries);
+  const actionsDiverge = compareActionsDiverge(entries);
+  return {
+    comparedCount: entries.length,
+    decision,
+    actionsDiverge,
+    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
+  };
+}
+
+export function compareDrawerBannerTexts(entries: Entry[]): string[] {
+  const summary = compareDrawerSummary(entries);
+  const messages: string[] = [];
+  const decisionText = compareDrawerDecisionBannerText(entries);
+  const actionText = compareDrawerActionBannerText(summary.actionsDiverge);
+  if (decisionText) messages.push(decisionText);
+  if (actionText) messages.push(actionText);
+  return messages;
+}

--- a/tests/compare-drawer-summary.test.ts
+++ b/tests/compare-drawer-summary.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerActionBannerText,
+  compareDrawerBannerTexts,
+  compareDrawerDecisionBannerText,
+  compareDrawerDecisionSummary,
+  compareDrawerSummary,
+} from "@/lib/compare-drawer-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer summary", () => {
+  it("mirrors decision summaries for drawer header hints", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDrawerDecisionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      divergingCount: 0,
+      divergingLabels: [],
+    });
+    expect(compareDrawerDecisionSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      divergingCount: 1,
+      divergingLabels: ["Review status"],
+    });
+  });
+
+  it("combines trust and action divergence for drawer summaries", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDrawerSummary([baseline])).toEqual({
+      comparedCount: 1,
+      decision: {
+        comparedCount: 1,
+        divergingCount: 0,
+        divergingLabels: [],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: false,
+    });
+    expect(compareDrawerSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      compareDrawerSummary([
+        baseline,
+        entry({ installCommand: "npm i fixture" }),
+      ]).hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats drawer decision banner copy", () => {
+    expect(compareDrawerDecisionBannerText([entry()])).toBeNull();
+    expect(
+      compareDrawerDecisionBannerText([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+  });
+
+  it("formats drawer action banner copy", () => {
+    expect(compareDrawerActionBannerText(false)).toBeNull();
+    expect(compareDrawerActionBannerText(true)).toBe(
+      "Next steps differ across this comparison — review install, source, and claim actions per entry.",
+    );
+  });
+
+  it("returns ordered drawer header banner messages", () => {
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDrawerBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      compareDrawerBannerTexts([
+        entry(),
+        entry({ installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual([
+      "Next steps differ across this comparison — review install, source, and claim actions per entry.",
+    ]);
+    expect(
+      compareDrawerBannerTexts([
+        entry(),
+        entry({
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across this comparison — review install, source, and claim actions per entry.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-drawer-summary.ts` to combine trust-signal and next-step divergence into drawer header banner messages.
- Surfaces trust divergence hints in the compare drawer header alongside the existing next-step warning, matching curated and full-page compare summaries.
- Includes **100%** test coverage on the new lib module.

Seventh slice of the compare/decision surfaces epic (#556). Complements merged:
- **#4257** — next-action CTAs on interactive `/compare`
- **#4260** — trust/provenance signal rows in compare drawer
- **#4323** — decision signal rows on shared comparison table
- **#4324** — next-action row in compare drawer
- **#4326** — divergence summary banners on curated compare pages
- **#4328** — next-action row on curated comparison table

## Conflict safety
Touches only `compare-drawer.tsx` plus new lib/tests — **no file overlap** with open PRs **#4251** (search/registry trust) or **#4259** (contributor attribution). Verified clean merge with #4259 locally; should land after those merge without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-drawer-summary.test.ts` — **100%** coverage on `compare-drawer-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)