### PR TITLE
feat(compare): add decision summaries to entry dossier compare

### DIFF
--- a/apps/web/src/lib/compare-dossier-summary.ts
+++ b/apps/web/src/lib/compare-dossier-summary.ts
@@ -1,0 +1,55 @@
+import type { Entry } from "@/types/registry";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import {
+  compareCuratedDecisionBannerText,
+  type CompareDecisionSummary,
+} from "@/lib/compare-curated-summary";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export function compareDossierEntries(entry: Entry, alternatives: Entry[]): Entry[] {
+  return [entry, ...alternatives];
+}
+
+export function compareDossierSummary(
+  entry: Entry,
+  alternatives: Entry[],
+): {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+} {
+  const entries = compareDossierEntries(entry, alternatives);
+  const decision = compareDecisionSummary(entries);
+  const actionsDiverge = compareActionsDiverge(entries);
+  return {
+    comparedCount: entries.length,
+    decision,
+    actionsDiverge,
+    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
+  };
+}
+
+export function compareDossierDecisionBannerText(
+  entry: Entry,
+  alternatives: Entry[],
+): string | null {
+  return compareCuratedDecisionBannerText(
+    compareDecisionSummary(compareDossierEntries(entry, alternatives)),
+  );
+}
+
+export function compareDossierActionBannerText(actionsDiverge: boolean): string | null {
+  if (!actionsDiverge) return null;
+  return "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.";
+}
+
+export function compareDossierBannerTexts(entry: Entry, alternatives: Entry[]): string[] {
+  const summary = compareDossierSummary(entry, alternatives);
+  const messages: string[] = [];
+  const decisionText = compareDossierDecisionBannerText(entry, alternatives);
+  const actionText = compareDossierActionBannerText(summary.actionsDiverge);
+  if (decisionText) messages.push(decisionText);
+  if (actionText) messages.push(actionText);
+  return messages;
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -38,6 +38,7 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
+import { compareDossierBannerTexts } from "@/lib/compare-dossier-summary";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -220,6 +221,10 @@ function Dossier() {
     const pool = altGroup && altGroup.entries.length > 0 ? altGroup.entries : rel;
     return pool.slice(0, 3);
   }, [relGroups, rel]);
+  const compareBannerTexts = useMemo(
+    () => compareDossierBannerTexts(entry, alternatives),
+    [entry, alternatives],
+  );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,
   // minus any guide already shown in the related grid (no duplicate links).
   const guides = useMemo(() => {
@@ -655,7 +660,16 @@ function Dossier() {
                 on trust, install, platform support, and disclosed safety notes — all from reviewed
                 registry metadata.
               </p>
-              <ComparisonTable entries={[entry, ...alternatives]} />
+              {compareBannerTexts.length > 0 ? (
+                <div className="mb-4 space-y-1.5">
+                  {compareBannerTexts.map((text) => (
+                    <p key={text} className="text-sm text-ink-muted">
+                      {text}
+                    </p>
+                  ))}
+                </div>
+              ) : null}
+              <ComparisonTable entries={[entry, ...alternatives]} showNextActions />
             </DossierSection>
           )}
 

--- a/tests/compare-dossier-summary.test.ts
+++ b/tests/compare-dossier-summary.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDossierActionBannerText,
+  compareDossierBannerTexts,
+  compareDossierDecisionBannerText,
+  compareDossierEntries,
+  compareDossierSummary,
+} from "@/lib/compare-dossier-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare dossier summary", () => {
+  it("builds dossier comparison entry lists with the primary entry first", () => {
+    const primary = entry({ slug: "primary" });
+    const alt = entry({ slug: "alternative" });
+    expect(compareDossierEntries(primary, [alt])).toEqual([primary, alt]);
+    expect(compareDossierEntries(primary, [])).toEqual([primary]);
+  });
+
+  it("summarizes trust and action divergence for dossier compare sections", () => {
+    const primary = entry();
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDossierSummary(primary, [])).toEqual({
+      comparedCount: 1,
+      decision: {
+        comparedCount: 1,
+        divergingCount: 0,
+        divergingLabels: [],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: false,
+    });
+    expect(compareDossierSummary(primary, [reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      compareDossierSummary(primary, [
+        entry({ slug: "installable", installCommand: "npm i fixture" }),
+      ]).hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats dossier decision banner copy", () => {
+    const primary = entry();
+    expect(compareDossierDecisionBannerText(primary, [])).toBeNull();
+    expect(
+      compareDossierDecisionBannerText(primary, [
+        entry({
+          slug: "reviewed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+        }),
+      ]),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+  });
+
+  it("formats dossier action banner copy for inline table CTAs", () => {
+    expect(compareDossierActionBannerText(false)).toBeNull();
+    expect(compareDossierActionBannerText(true)).toBe(
+      "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+    );
+  });
+
+  it("returns ordered dossier banner messages", () => {
+    const primary = entry();
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDossierBannerTexts(primary, [reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      compareDossierBannerTexts(primary, [
+        entry({ slug: "installable", installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual([
+      "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-dossier-summary.ts` helpers for entry detail pages comparing a primary entry against alternatives.
- Shows trust and next-step divergence banners in the **How it compares** dossier section.
- Enables inline next-action CTAs via `ComparisonTable showNextActions` on entry detail pages.
- Includes **100%** test coverage on the new lib module.

Eighth slice of the compare/decision surfaces epic (#556). Complements merged compare work on `/compare`, curated pages, and the compare drawer by strengthening **entry detail** decision surfaces.

## Conflict safety
Touches only the dossier compare section in `entry.$category.$slug.tsx` plus new lib/tests — **no file overlap** with open PRs **#4330** (submission-classification lib), **#4251** (search/registry trust), or **#4259** (contributor attribution). Verified clean merge with #4330 and #4259 locally; should land after those merge without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-dossier-summary.test.ts` — **100%** coverage on `compare-dossier-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)