### PR TITLE
feat(compare): unify divergence banners on interactive compare page

### DIFF
--- a/apps/web/src/lib/compare-page-summary.ts
+++ b/apps/web/src/lib/compare-page-summary.ts
@@ -1,0 +1,48 @@
+import type { Entry } from "@/types/registry";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import {
+  compareCuratedDecisionBannerText,
+  type CompareDecisionSummary,
+} from "@/lib/compare-curated-summary";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export const COMPARE_PAGE_SURFACE = "compare-page";
+
+export function comparePageDecisionSummary(entries: Entry[]): CompareDecisionSummary {
+  return compareDecisionSummary(entries);
+}
+
+export function comparePageDecisionBannerText(entries: Entry[]): string | null {
+  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+}
+
+export function comparePageActionBannerText(actionsDiverge: boolean): string | null {
+  if (!actionsDiverge) return null;
+  return "Next steps differ across this comparison — review install, source, and claim actions in the table below.";
+}
+
+export function comparePageSummary(entries: Entry[]): {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+} {
+  const decision = compareDecisionSummary(entries);
+  const actionsDiverge = compareActionsDiverge(entries);
+  return {
+    comparedCount: entries.length,
+    decision,
+    actionsDiverge,
+    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
+  };
+}
+
+export function comparePageBannerTexts(entries: Entry[]): string[] {
+  const summary = comparePageSummary(entries);
+  const messages: string[] = [];
+  const decisionText = comparePageDecisionBannerText(entries);
+  const actionText = comparePageActionBannerText(summary.actionsDiverge);
+  if (decisionText) messages.push(decisionText);
+  if (actionText) messages.push(actionText);
+  return messages;
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -17,7 +17,7 @@ import {
   resolveCompareEntryActions,
   type CompareAction,
 } from "@/lib/compare-entry-actions";
-import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+import { comparePageBannerTexts } from "@/lib/compare-page-summary";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -69,7 +69,7 @@ function ComparePage() {
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const actionRowDiverges = compareActionsDiverge(items);
-  const decisionSummary = compareDecisionSummary(items);
+  const bannerTexts = comparePageBannerTexts(items);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -147,12 +147,14 @@ function ComparePage() {
           <h1 className="mt-1 h-display-2 text-ink text-balance">
             {items.length} {items.length === 1 ? "resource" : "resources"} side by side
           </h1>
-          {decisionSummary.divergingCount > 0 ? (
-            <p className="mt-2 text-sm text-ink-muted">
-              {decisionSummary.divergingCount} trust signal
-              {decisionSummary.divergingCount === 1 ? "" : "s"} differ across this comparison (
-              {decisionSummary.divergingLabels.join(", ")}).
-            </p>
+          {bannerTexts.length > 0 ? (
+            <div className="mt-2 space-y-1.5">
+              {bannerTexts.map((text) => (
+                <p key={text} className="text-sm text-ink-muted">
+                  {text}
+                </p>
+              ))}
+            </div>
           ) : null}
         </div>
         <div className="flex items-center gap-2">

--- a/tests/compare-page-summary.test.ts
+++ b/tests/compare-page-summary.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_PAGE_SURFACE,
+  comparePageActionBannerText,
+  comparePageBannerTexts,
+  comparePageDecisionBannerText,
+  comparePageDecisionSummary,
+  comparePageSummary,
+} from "@/lib/compare-page-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page summary", () => {
+  it("exposes the compare page analytics surface id", () => {
+    expect(COMPARE_PAGE_SURFACE).toBe("compare-page");
+  });
+
+  it("mirrors decision summaries for interactive compare headers", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(comparePageDecisionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      divergingCount: 0,
+      divergingLabels: [],
+    });
+    expect(comparePageDecisionSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      divergingCount: 1,
+      divergingLabels: ["Review status"],
+    });
+  });
+
+  it("combines trust and action divergence for page summaries", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(comparePageSummary([baseline])).toEqual({
+      comparedCount: 1,
+      decision: {
+        comparedCount: 1,
+        divergingCount: 0,
+        divergingLabels: [],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: false,
+    });
+    expect(comparePageSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      comparePageSummary([baseline, entry({ installCommand: "npm i fixture" })])
+        .hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats page decision banner copy", () => {
+    expect(comparePageDecisionBannerText([entry()])).toBeNull();
+    expect(
+      comparePageDecisionBannerText([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+  });
+
+  it("formats page action banner copy for inline table CTAs", () => {
+    expect(comparePageActionBannerText(false)).toBeNull();
+    expect(comparePageActionBannerText(true)).toBe(
+      "Next steps differ across this comparison — review install, source, and claim actions in the table below.",
+    );
+  });
+
+  it("returns ordered page header banner messages", () => {
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(comparePageBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      comparePageBannerTexts([
+        entry(),
+        entry({ installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual([
+      "Next steps differ across this comparison — review install, source, and claim actions in the table below.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-page-summary.ts` to combine trust-signal and next-step divergence into `/compare` header banner messages.
- Replaces the inline trust-only header copy with unified decision + action divergence hints, matching curated pages and the compare drawer.
- Includes **100%** test coverage on the new lib module.

Ninth slice of the compare/decision surfaces epic (#556). Complements merged compare work across drawer, curated pages, and comparison tables by completing the **interactive `/compare`** header experience.

## Conflict safety
Touches only `compare.index.tsx` plus new lib/tests — **no file overlap** with open PRs **#4331** (dossier compare), **#4332** (source-url lib), **#4251** (search/registry trust), or **#4259** (contributor attribution). Verified clean merge with #4332 and #4259 locally; should merge cleanly after #4331 lands without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-page-summary.test.ts` — **100%** coverage on `compare-page-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)