### PR TITLE
feat(compare): add decision summaries to best-list compare table

### DIFF
--- a/apps/web/src/lib/compare-best-summary.ts
+++ b/apps/web/src/lib/compare-best-summary.ts
@@ -1,0 +1,40 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareCuratedDecisionBannerText,
+  compareCuratedSummary,
+  type CompareDecisionSummary,
+} from "@/lib/compare-curated-summary";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export function compareBestSummary(entries: Entry[]): {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+} {
+  return compareCuratedSummary(entries);
+}
+
+export function compareBestDecisionBannerText(entries: Entry[]): string | null {
+  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+}
+
+export function compareBestActionBannerText(actionsDiverge: boolean): string | null {
+  if (!actionsDiverge) return null;
+  return "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.";
+}
+
+export function shouldShowBestCompareSection(entries: Entry[]): boolean {
+  return entries.length >= 2;
+}
+
+export function compareBestBannerTexts(entries: Entry[]): string[] {
+  if (!shouldShowBestCompareSection(entries)) return [];
+  const summary = compareBestSummary(entries);
+  const messages: string[] = [];
+  const decisionText = compareBestDecisionBannerText(entries);
+  const actionText = compareBestActionBannerText(summary.actionsDiverge);
+  if (decisionText) messages.push(decisionText);
+  if (actionText) messages.push(actionText);
+  return messages;
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -5,6 +5,7 @@ import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entrie
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
+import { compareBestBannerTexts } from "@/lib/compare-best-summary";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
@@ -12,6 +13,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
+import { useMemo } from "react";
 
 export const Route = createFileRoute("/best/$slug")({
   loader: ({ params }) => {
@@ -90,6 +92,12 @@ function BestDetail() {
     })
     .filter((p): p is Resolved => p !== null);
 
+  const compareEntries = useMemo(() => resolved.slice(0, 5).map((p) => p.entry), [resolved]);
+  const compareBannerTexts = useMemo(
+    () => compareBestBannerTexts(compareEntries),
+    [compareEntries],
+  );
+
   return (
     <PageContainer className="py-12">
       <Breadcrumbs home items={[{ label: "Best lists", to: "/best" }, { label: list.title }]} />
@@ -143,8 +151,17 @@ function BestDetail() {
             The top {Math.min(resolved.length, 5)} picks side by side on trust, install, platform
             support, and disclosed notes — full rationale for each below.
           </p>
+          {compareBannerTexts.length > 0 ? (
+            <div className="mt-4 space-y-1.5">
+              {compareBannerTexts.map((text) => (
+                <p key={text} className="text-sm text-ink-muted">
+                  {text}
+                </p>
+              ))}
+            </div>
+          ) : null}
           <div className="mt-5">
-            <ComparisonTable entries={resolved.slice(0, 5).map((p) => p.entry)} />
+            <ComparisonTable entries={compareEntries} showNextActions />
           </div>
         </section>
       )}

--- a/tests/compare-best-summary.test.ts
+++ b/tests/compare-best-summary.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareBestActionBannerText,
+  compareBestBannerTexts,
+  compareBestDecisionBannerText,
+  compareBestSummary,
+  shouldShowBestCompareSection,
+} from "@/lib/compare-best-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare best summary", () => {
+  it("only surfaces best-list compare helpers for multi-entry tables", () => {
+    expect(shouldShowBestCompareSection([])).toBe(false);
+    expect(shouldShowBestCompareSection([entry()])).toBe(false);
+    expect(
+      shouldShowBestCompareSection([entry(), entry({ slug: "other" })]),
+    ).toBe(true);
+    expect(compareBestBannerTexts([entry()])).toEqual([]);
+  });
+
+  it("summarizes trust and action divergence for best-list compare sections", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareBestSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      compareBestSummary([
+        baseline,
+        entry({ slug: "installable", installCommand: "npm i fixture" }),
+      ]).hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats best-list decision banner copy", () => {
+    expect(compareBestDecisionBannerText([entry()])).toBeNull();
+    expect(
+      compareBestDecisionBannerText([
+        entry(),
+        entry({
+          slug: "reviewed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+        }),
+      ]),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+  });
+
+  it("formats best-list action banner copy for inline table CTAs", () => {
+    expect(compareBestActionBannerText(false)).toBeNull();
+    expect(compareBestActionBannerText(true)).toBe(
+      "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+    );
+  });
+
+  it("returns ordered best-list banner messages", () => {
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareBestBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      compareBestBannerTexts([
+        entry(),
+        entry({ slug: "installable", installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual([
+      "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-best-summary.ts` helpers for best-list "Compared at a glance" sections.
- Shows trust and next-step divergence banners when top picks differ on decision signals or actions.
- Enables inline next-action CTAs via `ComparisonTable showNextActions` on best-list pages.
- Includes **100%** test coverage on the new lib module.

Tenth slice of the compare/decision surfaces epic (#556). Completes decision/compare UX across browse surfaces: interactive `/compare`, curated pages, compare drawer, entry dossiers, and now **best lists**.

## Conflict safety
Touches only `best.$slug.tsx` plus new lib/tests — **no file overlap** with open PRs **#4251** (search/registry trust) or **#4259** (contributor attribution). Verified clean merge with #4259 locally; should land after those merge without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-best-summary.test.ts` — **100%** coverage on `compare-best-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)