### PR TITLE
feat(compare): add divergence hints to browse compare selection

### DIFF
--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -1,0 +1,29 @@
+import type { Entry } from "@/types/registry";
+import { compareCuratedSummary } from "@/lib/compare-curated-summary";
+
+export const BROWSE_COMPARE_MIN_ITEMS = 2;
+
+export function shouldShowBrowseCompareHint(items: Entry[]): boolean {
+  return items.length >= BROWSE_COMPARE_MIN_ITEMS;
+}
+
+export function browseCompareSummary(items: Entry[]) {
+  return compareCuratedSummary(items);
+}
+
+export function browseCompareHintText(items: Entry[]): string | null {
+  if (!shouldShowBrowseCompareHint(items)) return null;
+  const summary = browseCompareSummary(items);
+  if (!summary.hasAnyDivergence) {
+    return "Open compare to review trust and next steps side by side.";
+  }
+  const parts: string[] = [];
+  if (summary.decision.divergingCount > 0) {
+    const signalWord = summary.decision.divergingCount === 1 ? "signal" : "signals";
+    parts.push(`${summary.decision.divergingCount} trust ${signalWord} differ`);
+  }
+  if (summary.actionsDiverge) {
+    parts.push("next steps differ");
+  }
+  return `${parts.join(" · ")} — open compare for details.`;
+}

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,6 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
+import { browseCompareHintText } from "@/lib/compare-browse-summary";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -312,6 +313,8 @@ function Browse() {
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareSig]);
+
+  const compareHint = useMemo(() => browseCompareHintText(compare.items), [compare.items]);
 
   const activeCount =
     Number(!!sp.q) +
@@ -634,13 +637,22 @@ function Browse() {
                   )}
                 </span>
                 {compare.items.length >= 2 && (
-                  <Link
-                    to="/compare"
-                    search={{ ids: compare.items.map((e) => `${e.category}/${e.slug}`).join(",") }}
-                    className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
-                  >
-                    <span className="font-mono">{compare.items.length}</span> selected · Compare →
-                  </Link>
+                  <div className="inline-flex flex-col items-end gap-1">
+                    {compareHint ? (
+                      <span className="max-w-xs text-right text-[11px] text-ink-muted">
+                        {compareHint}
+                      </span>
+                    ) : null}
+                    <Link
+                      to="/compare"
+                      search={{
+                        ids: compare.items.map((e) => `${e.category}/${e.slug}`).join(","),
+                      }}
+                      className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
+                    >
+                      <span className="font-mono">{compare.items.length}</span> selected · Compare →
+                    </Link>
+                  </div>
                 )}
               </div>
               <div className="flex items-center gap-2">

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  BROWSE_COMPARE_MIN_ITEMS,
+  browseCompareHintText,
+  browseCompareSummary,
+  shouldShowBrowseCompareHint,
+} from "@/lib/compare-browse-summary";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare browse summary", () => {
+  it("requires at least two selected entries before showing browse compare hints", () => {
+    expect(BROWSE_COMPARE_MIN_ITEMS).toBe(2);
+    expect(shouldShowBrowseCompareHint([])).toBe(false);
+    expect(shouldShowBrowseCompareHint([entry()])).toBe(false);
+    expect(
+      shouldShowBrowseCompareHint([entry(), entry({ slug: "other" })]),
+    ).toBe(true);
+    expect(browseCompareHintText([entry()])).toBeNull();
+  });
+
+  it("summarizes browse selection divergence via curated compare helpers", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(browseCompareSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+  });
+
+  it("prompts users to open compare when selected entries align on decision signals", () => {
+    expect(browseCompareHintText([entry(), entry({ slug: "other" })])).toBe(
+      "Open compare to review trust and next steps side by side.",
+    );
+  });
+
+  it("highlights trust divergence in compact browse hints", () => {
+    expect(
+      browseCompareHintText([
+        entry(),
+        entry({
+          slug: "reviewed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+        }),
+      ]),
+    ).toBe("1 trust signal differ — open compare for details.");
+  });
+
+  it("highlights action divergence in compact browse hints", () => {
+    expect(
+      browseCompareHintText([
+        entry(),
+        entry({ slug: "installable", installCommand: "npm i fixture" }),
+      ]),
+    ).toBe("next steps differ — open compare for details.");
+  });
+
+  it("uses plural trust signal copy when multiple rows diverge", () => {
+    expect(
+      browseCompareHintText([
+        entry(),
+        entry({
+          slug: "reviewed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          packageVerified: true,
+        }),
+      ]),
+    ).toBe("2 trust signals differ — open compare for details.");
+  });
+
+  it("combines trust and action divergence in browse hints", () => {
+    expect(
+      browseCompareHintText([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toBe(
+      "1 trust signal differ · next steps differ — open compare for details.",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-browse-summary.ts` helpers for compact divergence hints when browsing with 2+ resources selected.
- Shows trust/next-step divergence context beside the browse **Compare →** CTA so users know why to open the full compare view.
- Includes **100%** test coverage on the new lib module.

Eleventh slice of the compare/decision surfaces epic (#556). Extends decision/compare UX to the **browse directory** selection flow.

## Conflict safety
Touches only the compare CTA area in `browse.tsx` plus new lib/tests — **no file overlap** with open PRs **#4335** (source-repo lib), **#4251** (search/registry trust), or **#4259** (contributor attribution). Verified clean merge with #4335 and #4259 locally; should land after those merge without rebase.

## Test plan
- [x] `trunk check --ci` passes on changed files
- [x] `pnpm --filter web run type-check` passes
- [x] `vitest tests/compare-browse-summary.test.ts` — **100%** coverage on `compare-browse-summary.ts`
- [ ] CI green (`validate-ci`, `validate-web`, `required-pr-gate`, codecov patch/project)

Refs #556

Made with [Cursor](https://cursor.com)