### PR TITLE
feat(compare): add interactive compare link on best-list pages

### DIFF
--- a/apps/web/src/lib/compare-interactive-link.ts
+++ b/apps/web/src/lib/compare-interactive-link.ts
@@ -1,0 +1,27 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import { serializeCompareItems } from "@/lib/compare-selection";
+
+export const COMPARE_INTERACTIVE_MIN = 2;
+export const COMPARE_INTERACTIVE_MAX = 4;
+
+export function canOpenInteractiveCompare(entries: EntryIdentity[]): boolean {
+  return entries.length >= COMPARE_INTERACTIVE_MIN && entries.length <= COMPARE_INTERACTIVE_MAX;
+}
+
+export function compareInteractiveEntryCount(entryCount: number): number {
+  return Math.min(entryCount, COMPARE_INTERACTIVE_MAX);
+}
+
+export function compareInteractiveSearch(entries: EntryIdentity[]): { ids: string } | null {
+  const slice = entries.slice(0, COMPARE_INTERACTIVE_MAX);
+  if (!canOpenInteractiveCompare(slice)) return null;
+  return { ids: serializeCompareItems(slice) };
+}
+
+export function compareInteractiveLinkLabel(entryCount: number): string {
+  const count = compareInteractiveEntryCount(entryCount);
+  if (count === COMPARE_INTERACTIVE_MIN) {
+    return "Open in the interactive comparison tool";
+  }
+  return `Open ${count} picks in the interactive comparison tool`;
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -1,11 +1,15 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { PageContainer } from "@/components/page-container";
-import { CalendarDays, User } from "lucide-react";
+import { CalendarDays, User, ArrowLeft } from "lucide-react";
 import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entries";
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
 import { compareBestBannerTexts } from "@/lib/compare-best-summary";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
@@ -97,6 +101,10 @@ function BestDetail() {
     () => compareBestBannerTexts(compareEntries),
     [compareEntries],
   );
+  const interactiveCompareSearch = useMemo(
+    () => compareInteractiveSearch(compareEntries),
+    [compareEntries],
+  );
 
   return (
     <PageContainer className="py-12">
@@ -163,6 +171,16 @@ function BestDetail() {
           <div className="mt-5">
             <ComparisonTable entries={compareEntries} showNextActions />
           </div>
+          {interactiveCompareSearch ? (
+            <Link
+              to="/compare"
+              search={interactiveCompareSearch}
+              className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              {compareInteractiveLinkLabel(compareEntries.length)}
+            </Link>
+          ) : null}
         </section>
       )}
 

--- a/tests/compare-interactive-link.test.ts
+++ b/tests/compare-interactive-link.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_INTERACTIVE_MAX,
+  COMPARE_INTERACTIVE_MIN,
+  canOpenInteractiveCompare,
+  compareInteractiveEntryCount,
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare interactive link", () => {
+  it("exposes interactive compare selection limits", () => {
+    expect(COMPARE_INTERACTIVE_MIN).toBe(2);
+    expect(COMPARE_INTERACTIVE_MAX).toBe(4);
+  });
+
+  it("only builds interactive compare links for 2-4 entries", () => {
+    expect(canOpenInteractiveCompare([])).toBe(false);
+    expect(canOpenInteractiveCompare([entry()])).toBe(false);
+    expect(canOpenInteractiveCompare([entry(), entry({ slug: "two" })])).toBe(
+      true,
+    );
+    expect(
+      canOpenInteractiveCompare([
+        entry(),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+      ]),
+    ).toBe(true);
+    expect(
+      canOpenInteractiveCompare([
+        entry(),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+        entry({ slug: "five" }),
+      ]),
+    ).toBe(false);
+    expect(compareInteractiveSearch([entry()])).toBeNull();
+  });
+
+  it("serializes compare search params for the interactive compare page", () => {
+    expect(
+      compareInteractiveSearch([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+  });
+
+  it("caps interactive compare links at four entries", () => {
+    const entries = [
+      entry({ slug: "one" }),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+      entry({ slug: "five" }),
+    ];
+    expect(compareInteractiveSearch(entries)).toEqual({
+      ids: "mcp/one,mcp/two,mcp/three,mcp/four",
+    });
+    expect(compareInteractiveEntryCount(entries.length)).toBe(4);
+  });
+
+  it("formats interactive compare link labels", () => {
+    expect(compareInteractiveLinkLabel(2)).toBe(
+      "Open in the interactive comparison tool",
+    );
+    expect(compareInteractiveLinkLabel(3)).toBe(
+      "Open 3 picks in the interactive comparison tool",
+    );
+    expect(compareInteractiveLinkLabel(5)).toBe(
+      "Open 4 picks in the interactive comparison tool",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-interactive-link` helpers to build `/compare?ids=…` deep links (2–4 entries, capped at the interactive compare limit).
- Wires an “Open in the interactive comparison tool” link on best-list “Compared at a glance” sections, matching curated `/compare/$slug` parity.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-interactive-link.test.ts --coverage --coverage.include='apps/web/src/lib/compare-interactive-link.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4251 and #4259; merge simulation clean with #4259 both orderings


Made with [Cursor](https://cursor.com)