### PR TITLE
feat(compare): add interactive compare link on entry dossier

### DIFF
--- a/apps/web/src/lib/compare-dossier-summary.ts
+++ b/apps/web/src/lib/compare-dossier-summary.ts
@@ -4,6 +4,7 @@ import {
   compareCuratedDecisionBannerText,
   type CompareDecisionSummary,
 } from "@/lib/compare-curated-summary";
+import { compareInteractiveSearch } from "@/lib/compare-interactive-link";
 import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
 
 export function compareDossierEntries(entry: Entry, alternatives: Entry[]): Entry[] {
@@ -52,4 +53,11 @@ export function compareDossierBannerTexts(entry: Entry, alternatives: Entry[]): 
   if (decisionText) messages.push(decisionText);
   if (actionText) messages.push(actionText);
   return messages;
+}
+
+export function compareDossierInteractiveSearch(
+  entry: Entry,
+  alternatives: Entry[],
+): { ids: string } | null {
+  return compareInteractiveSearch(compareDossierEntries(entry, alternatives));
 }

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -10,6 +10,10 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
 import { compareCuratedBannerTexts } from "@/lib/compare-curated-summary";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
 
 function resolveRefs(refs: string[]): Entry[] {
   const out: Entry[] = [];
@@ -98,6 +102,7 @@ function ComparisonPage() {
   if (!comparison) return null;
   const entries = resolveRefs(comparison.refs);
   const bannerTexts = compareCuratedBannerTexts(entries);
+  const interactiveSearch = compareInteractiveSearch(entries);
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">
@@ -122,13 +127,15 @@ function ComparisonPage() {
             ))}
           </div>
         ) : null}
-        <Link
-          to="/compare"
-          search={{ ids: entries.map((e) => `${e.category}/${e.slug}`).join(",") }}
-          className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
-        >
-          <ArrowLeft className="h-4 w-4" /> Open in the interactive comparison tool
-        </Link>
+        {interactiveSearch ? (
+          <Link
+            to="/compare"
+            search={interactiveSearch}
+            className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+          >
+            <ArrowLeft className="h-4 w-4" /> {compareInteractiveLinkLabel(entries.length)}
+          </Link>
+        ) : null}
       </header>
 
       <div className="mt-8">

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -19,6 +19,7 @@ import {
   Layers,
   BadgeCheck,
   Globe2,
+  ArrowLeft,
 } from "lucide-react";
 import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
@@ -38,7 +39,11 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import { compareDossierBannerTexts } from "@/lib/compare-dossier-summary";
+import {
+  compareDossierBannerTexts,
+  compareDossierInteractiveSearch,
+} from "@/lib/compare-dossier-summary";
+import { compareInteractiveLinkLabel } from "@/lib/compare-interactive-link";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -223,6 +228,10 @@ function Dossier() {
   }, [relGroups, rel]);
   const compareBannerTexts = useMemo(
     () => compareDossierBannerTexts(entry, alternatives),
+    [entry, alternatives],
+  );
+  const dossierCompareSearch = useMemo(
+    () => compareDossierInteractiveSearch(entry, alternatives),
     [entry, alternatives],
   );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,
@@ -670,6 +679,16 @@ function Dossier() {
                 </div>
               ) : null}
               <ComparisonTable entries={[entry, ...alternatives]} showNextActions />
+              {dossierCompareSearch ? (
+                <Link
+                  to="/compare"
+                  search={dossierCompareSearch}
+                  className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+                >
+                  <ArrowLeft className="h-4 w-4" />
+                  {compareInteractiveLinkLabel(alternatives.length + 1)}
+                </Link>
+              ) : null}
             </DossierSection>
           )}
 

--- a/tests/compare-dossier-summary.test.ts
+++ b/tests/compare-dossier-summary.test.ts
@@ -5,6 +5,7 @@ import {
   compareDossierBannerTexts,
   compareDossierDecisionBannerText,
   compareDossierEntries,
+  compareDossierInteractiveSearch,
   compareDossierSummary,
 } from "@/lib/compare-dossier-summary";
 
@@ -105,5 +106,24 @@ describe("compare dossier summary", () => {
     ).toEqual([
       "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+  });
+
+  it("builds interactive compare search params for dossier alternatives", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(compareDossierInteractiveSearch(primary, [])).toBeNull();
+    expect(
+      compareDossierInteractiveSearch(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    ).toEqual({ ids: "skills/primary,hooks/alt" });
+    expect(
+      compareDossierInteractiveSearch(primary, [
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+      ]),
+    ).toEqual({
+      ids: "skills/primary,mcp/two,mcp/three,mcp/four",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `compareDossierInteractiveSearch` so entry dossier "How it compares" sections can deep-link into `/compare?ids=…` (2–4 entries).
- Wires the interactive compare CTA below the dossier comparison table, matching best-list and curated compare parity.
- Refactors curated `/compare/$slug` to use shared `compare-interactive-link` helpers instead of inline URL serialization.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-summary.test.ts --coverage --coverage.include='apps/web/src/lib/compare-dossier-summary.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4251 and #4259; merge simulation clean with #4259 in both orderings


Made with [Cursor](https://cursor.com)