### PR TITLE
feat(web): extract platform-pages helpers into platform-pages-lib

### DIFF
--- a/apps/web/src/lib/platform-pages-lib.ts
+++ b/apps/web/src/lib/platform-pages-lib.ts
@@ -1,0 +1,172 @@
+import type { ContentEntry } from "@heyclaude/registry";
+import { buildSkillPlatformCompatibility, platformFeedSlug } from "@heyclaude/registry/artifacts";
+
+/**
+ * Pure platform hub page builders.
+ *
+ * Turns registry skill entries into per-platform directory pages (Claude, Codex,
+ * Windsurf, etc.) with feed URLs, counts, and install metadata. Nothing here
+ * touches the network — given the same entries the output is deterministic.
+ *
+ * The public surface (`platform-pages.ts` / `@/lib/platform-pages`) re-exports
+ * everything below and keeps async entry-loading helpers in the wrapper.
+ */
+
+export type PlatformPageDefinition = {
+  slug: string;
+  platform: string;
+  title: string;
+  eyebrow: string;
+  description: string;
+  seoTitle: string;
+  seoDescription: string;
+  ctaLabel: string;
+};
+
+export type PlatformPageItem = {
+  title: string;
+  description: string;
+  slug: string;
+  url: string;
+  tags: string[];
+  supportLevel: string;
+  installPath: string;
+  adapterPath?: string;
+  verifiedAt?: string;
+};
+
+export type PlatformPage = PlatformPageDefinition & {
+  feedUrl: string;
+  count: number;
+  items: PlatformPageItem[];
+};
+
+export const platformPageDefinitions: PlatformPageDefinition[] = [
+  {
+    slug: "claude",
+    platform: "Claude",
+    title: "Claude Agent Skills",
+    eyebrow: "Claude",
+    description:
+      "Validated Agent Skills packages that can be installed into Claude-compatible skill folders.",
+    seoTitle: "Claude Agent Skills directory",
+    seoDescription:
+      "Browse Claude Agent Skills with install paths, package validation signals, source links, and HeyClaude compatibility metadata.",
+    ctaLabel: "View Claude skill feed",
+  },
+  {
+    slug: "codex",
+    platform: "Codex",
+    title: "Codex Agent Skills",
+    eyebrow: "OpenAI Codex",
+    description:
+      "Reusable SKILL.md packages shaped for Codex workflows, validation, and adapter-aware installs.",
+    seoTitle: "Codex Agent Skills directory",
+    seoDescription:
+      "Find Codex Agent Skills with SKILL.md package metadata, install guidance, checksums, adapters, and registry source links.",
+    ctaLabel: "View Codex skill feed",
+  },
+  {
+    slug: "windsurf",
+    platform: "Windsurf",
+    title: "Windsurf Agent Skills",
+    eyebrow: "Windsurf",
+    description:
+      "Agent Skills packages that map cleanly into Windsurf Cascade skill folders and workflows.",
+    seoTitle: "Windsurf Agent Skills directory",
+    seoDescription:
+      "Explore Windsurf Agent Skills with Cascade install paths, validation metadata, source links, and HeyClaude skill package checks.",
+    ctaLabel: "View Windsurf skill feed",
+  },
+  {
+    slug: "gemini",
+    platform: "Gemini",
+    title: "Gemini Agent Skills",
+    eyebrow: "Gemini",
+    description:
+      "Agent Skills packages compatible with Gemini CLI skill and extension-oriented workflows.",
+    seoTitle: "Gemini Agent Skills directory",
+    seoDescription:
+      "Browse Gemini Agent Skills with package compatibility metadata, install paths, validation status, and registry feed links.",
+    ctaLabel: "View Gemini skill feed",
+  },
+  {
+    slug: "cursor-rules",
+    platform: "Cursor",
+    title: "Cursor rule adapters",
+    eyebrow: "Cursor rules",
+    description:
+      "Generated Cursor `.mdc` rule adapters for Agent Skills packages that do not install natively in Cursor.",
+    seoTitle: "Cursor rule adapters for Agent Skills",
+    seoDescription:
+      "Find generated Cursor rule adapters for HeyClaude Agent Skills, with source packages, install paths, and adapter metadata.",
+    ctaLabel: "View Cursor adapter feed",
+  },
+  {
+    slug: "agents-context",
+    platform: "Generic AGENTS",
+    title: "Generic AGENTS.md context",
+    eyebrow: "AGENTS context",
+    description:
+      "Portable Agent Skills guidance for AGENTS.md files and other context surfaces that need manual adaptation.",
+    seoTitle: "Generic AGENTS.md skill context",
+    seoDescription:
+      "Use HeyClaude Agent Skills as portable AGENTS.md context with install notes, package metadata, source links, and adapters.",
+    ctaLabel: "View AGENTS context feed",
+  },
+];
+
+function toPlatformItem(
+  entry: ContentEntry,
+  definition: PlatformPageDefinition,
+): PlatformPageItem | null {
+  const compatibility = buildSkillPlatformCompatibility(entry).find(
+    (item) => item.platform === definition.platform,
+  );
+  if (!compatibility) return null;
+
+  return {
+    title: entry.title,
+    description: entry.cardDescription || entry.description,
+    slug: entry.slug,
+    url: `/skills/${entry.slug}`,
+    tags: entry.tags || [],
+    supportLevel: compatibility.supportLevel,
+    installPath: compatibility.installPath,
+    adapterPath: compatibility.adapterPath,
+    verifiedAt: compatibility.verifiedAt,
+  };
+}
+
+/** Build a single platform hub page from registry entries. */
+export function buildPlatformPage(
+  definition: PlatformPageDefinition,
+  entries: ReadonlyArray<ContentEntry>,
+): PlatformPage {
+  const items = entries
+    .filter((entry) => entry.category === "skills")
+    .map((entry) => toPlatformItem(entry, definition))
+    .filter((entry): entry is PlatformPageItem => Boolean(entry))
+    .sort((left, right) => left.title.localeCompare(right.title));
+
+  return {
+    ...definition,
+    feedUrl: `/data/feeds/platforms/${platformFeedSlug(definition.platform)}.json`,
+    count: items.length,
+    items,
+  };
+}
+
+export function getPlatformPageDefinitions() {
+  return platformPageDefinitions;
+}
+
+/** Resolve a platform page definition by slug, if it exists. */
+export function findPlatformPageDefinition(slug: string) {
+  return platformPageDefinitions.find((item) => item.slug === slug) ?? null;
+}
+
+/** Build every platform hub page from registry entries. */
+export function buildAllPlatformPages(entries: ReadonlyArray<ContentEntry>) {
+  return platformPageDefinitions.map((definition) => buildPlatformPage(definition, entries));
+}

--- a/apps/web/src/lib/platform-pages.ts
+++ b/apps/web/src/lib/platform-pages.ts
@@ -1,163 +1,37 @@
-import type { ContentEntry } from "@heyclaude/registry";
-import { buildSkillPlatformCompatibility, platformFeedSlug } from "@heyclaude/registry/artifacts";
+/**
+ * Platform hub pages surface.
+ *
+ * Pure platform page builders live in `platform-pages-lib.ts`. This module
+ * re-exports that surface and keeps async entry-loading helpers here so
+ * existing `@/lib/platform-pages` imports stay unchanged.
+ */
+export type {
+  PlatformPage,
+  PlatformPageDefinition,
+  PlatformPageItem,
+} from "@/lib/platform-pages-lib";
+export {
+  buildAllPlatformPages,
+  buildPlatformPage,
+  findPlatformPageDefinition,
+  getPlatformPageDefinitions,
+  platformPageDefinitions,
+} from "@/lib/platform-pages-lib";
 
 import { getAllEntries } from "@/lib/content.server";
-
-export type PlatformPageDefinition = {
-  slug: string;
-  platform: string;
-  title: string;
-  eyebrow: string;
-  description: string;
-  seoTitle: string;
-  seoDescription: string;
-  ctaLabel: string;
-};
-
-export type PlatformPageItem = {
-  title: string;
-  description: string;
-  slug: string;
-  url: string;
-  tags: string[];
-  supportLevel: string;
-  installPath: string;
-  adapterPath?: string;
-  verifiedAt?: string;
-};
-
-export type PlatformPage = PlatformPageDefinition & {
-  feedUrl: string;
-  count: number;
-  items: PlatformPageItem[];
-};
-
-export const platformPageDefinitions: PlatformPageDefinition[] = [
-  {
-    slug: "claude",
-    platform: "Claude",
-    title: "Claude Agent Skills",
-    eyebrow: "Claude",
-    description:
-      "Validated Agent Skills packages that can be installed into Claude-compatible skill folders.",
-    seoTitle: "Claude Agent Skills directory",
-    seoDescription:
-      "Browse Claude Agent Skills with install paths, package validation signals, source links, and HeyClaude compatibility metadata.",
-    ctaLabel: "View Claude skill feed",
-  },
-  {
-    slug: "codex",
-    platform: "Codex",
-    title: "Codex Agent Skills",
-    eyebrow: "OpenAI Codex",
-    description:
-      "Reusable SKILL.md packages shaped for Codex workflows, validation, and adapter-aware installs.",
-    seoTitle: "Codex Agent Skills directory",
-    seoDescription:
-      "Find Codex Agent Skills with SKILL.md package metadata, install guidance, checksums, adapters, and registry source links.",
-    ctaLabel: "View Codex skill feed",
-  },
-  {
-    slug: "windsurf",
-    platform: "Windsurf",
-    title: "Windsurf Agent Skills",
-    eyebrow: "Windsurf",
-    description:
-      "Agent Skills packages that map cleanly into Windsurf Cascade skill folders and workflows.",
-    seoTitle: "Windsurf Agent Skills directory",
-    seoDescription:
-      "Explore Windsurf Agent Skills with Cascade install paths, validation metadata, source links, and HeyClaude skill package checks.",
-    ctaLabel: "View Windsurf skill feed",
-  },
-  {
-    slug: "gemini",
-    platform: "Gemini",
-    title: "Gemini Agent Skills",
-    eyebrow: "Gemini",
-    description:
-      "Agent Skills packages compatible with Gemini CLI skill and extension-oriented workflows.",
-    seoTitle: "Gemini Agent Skills directory",
-    seoDescription:
-      "Browse Gemini Agent Skills with package compatibility metadata, install paths, validation status, and registry feed links.",
-    ctaLabel: "View Gemini skill feed",
-  },
-  {
-    slug: "cursor-rules",
-    platform: "Cursor",
-    title: "Cursor rule adapters",
-    eyebrow: "Cursor rules",
-    description:
-      "Generated Cursor `.mdc` rule adapters for Agent Skills packages that do not install natively in Cursor.",
-    seoTitle: "Cursor rule adapters for Agent Skills",
-    seoDescription:
-      "Find generated Cursor rule adapters for HeyClaude Agent Skills, with source packages, install paths, and adapter metadata.",
-    ctaLabel: "View Cursor adapter feed",
-  },
-  {
-    slug: "agents-context",
-    platform: "Generic AGENTS",
-    title: "Generic AGENTS.md context",
-    eyebrow: "AGENTS context",
-    description:
-      "Portable Agent Skills guidance for AGENTS.md files and other context surfaces that need manual adaptation.",
-    seoTitle: "Generic AGENTS.md skill context",
-    seoDescription:
-      "Use HeyClaude Agent Skills as portable AGENTS.md context with install notes, package metadata, source links, and adapters.",
-    ctaLabel: "View AGENTS context feed",
-  },
-];
-
-function toPlatformItem(
-  entry: ContentEntry,
-  definition: PlatformPageDefinition,
-): PlatformPageItem | null {
-  const compatibility = buildSkillPlatformCompatibility(entry).find(
-    (item) => item.platform === definition.platform,
-  );
-  if (!compatibility) return null;
-
-  return {
-    title: entry.title,
-    description: entry.cardDescription || entry.description,
-    slug: entry.slug,
-    url: `/skills/${entry.slug}`,
-    tags: entry.tags || [],
-    supportLevel: compatibility.supportLevel,
-    installPath: compatibility.installPath,
-    adapterPath: compatibility.adapterPath,
-    verifiedAt: compatibility.verifiedAt,
-  };
-}
-
-function buildPlatformPage(
-  definition: PlatformPageDefinition,
-  entries: ContentEntry[],
-): PlatformPage {
-  const items = entries
-    .filter((entry) => entry.category === "skills")
-    .map((entry) => toPlatformItem(entry, definition))
-    .filter((entry): entry is PlatformPageItem => Boolean(entry))
-    .sort((left, right) => left.title.localeCompare(right.title));
-
-  return {
-    ...definition,
-    feedUrl: `/data/feeds/platforms/${platformFeedSlug(definition.platform)}.json`,
-    count: items.length,
-    items,
-  };
-}
-
-export function getPlatformPageDefinitions() {
-  return platformPageDefinitions;
-}
+import {
+  buildAllPlatformPages,
+  buildPlatformPage,
+  findPlatformPageDefinition,
+} from "@/lib/platform-pages-lib";
 
 export async function getPlatformPages() {
   const entries = await getAllEntries();
-  return platformPageDefinitions.map((definition) => buildPlatformPage(definition, entries));
+  return buildAllPlatformPages(entries);
 }
 
 export async function getPlatformPage(slug: string) {
-  const definition = platformPageDefinitions.find((item) => item.slug === slug);
+  const definition = findPlatformPageDefinition(slug);
   if (!definition) return null;
   const entries = await getAllEntries();
   return buildPlatformPage(definition, entries);

--- a/tests/platform-pages-lib.test.ts
+++ b/tests/platform-pages-lib.test.ts
@@ -1,0 +1,601 @@
+import { describe, expect, it } from "vitest";
+
+import type { ContentEntry } from "@heyclaude/registry";
+import {
+  buildAllPlatformPages,
+  buildPlatformPage,
+  findPlatformPageDefinition,
+  getPlatformPageDefinitions,
+  platformPageDefinitions,
+  type PlatformPageDefinition,
+} from "../apps/web/src/lib/platform-pages-lib";
+
+function skill(partial: Partial<ContentEntry> = {}): ContentEntry {
+  return {
+    category: "skills",
+    slug: "demo-skill",
+    title: "Demo Skill",
+    description: "A demo skill for platform page tests.",
+    ...partial,
+  } as ContentEntry;
+}
+
+function mcpEntry(partial: Partial<ContentEntry> = {}): ContentEntry {
+  return {
+    category: "mcp",
+    slug: "demo-mcp",
+    title: "Demo MCP",
+    description: "Not a skill entry.",
+    ...partial,
+  } as ContentEntry;
+}
+
+describe("platformPageDefinitions", () => {
+  it("lists every supported platform hub slug", () => {
+    expect(platformPageDefinitions.map((item) => item.slug)).toEqual([
+      "claude",
+      "codex",
+      "windsurf",
+      "gemini",
+      "cursor-rules",
+      "agents-context",
+    ]);
+  });
+
+  it("maps each slug to a distinct platform label", () => {
+    const platforms = platformPageDefinitions.map((item) => item.platform);
+    expect(new Set(platforms).size).toBe(platforms.length);
+  });
+
+  it.each(platformPageDefinitions)(
+    "includes SEO and CTA copy for $slug",
+    (definition) => {
+      expect(definition.title.length).toBeGreaterThan(0);
+      expect(definition.eyebrow.length).toBeGreaterThan(0);
+      expect(definition.description.length).toBeGreaterThan(20);
+      expect(definition.seoTitle.length).toBeGreaterThan(0);
+      expect(definition.seoDescription.length).toBeGreaterThan(20);
+      expect(definition.ctaLabel).toMatch(/View .+ feed|View .+ context/);
+    },
+  );
+
+  it("keeps Claude and Codex definitions aligned with native skill platforms", () => {
+    const claude = findPlatformPageDefinition("claude");
+    const codex = findPlatformPageDefinition("codex");
+    expect(claude?.platform).toBe("Claude");
+    expect(codex?.platform).toBe("Codex");
+    expect(claude?.title).toContain("Claude");
+    expect(codex?.title).toContain("Codex");
+  });
+
+  it("uses adapter-oriented copy for Cursor rules", () => {
+    const cursor = findPlatformPageDefinition("cursor-rules");
+    expect(cursor?.platform).toBe("Cursor");
+    expect(cursor?.description).toContain("adapter");
+    expect(cursor?.seoTitle).toContain("Cursor");
+  });
+
+  it("uses manual-context copy for Generic AGENTS", () => {
+    const agents = findPlatformPageDefinition("agents-context");
+    expect(agents?.platform).toBe("Generic AGENTS");
+    expect(agents?.description).toContain("AGENTS.md");
+    expect(agents?.ctaLabel).toContain("AGENTS");
+  });
+});
+
+describe("getPlatformPageDefinitions", () => {
+  it("returns the canonical definition list", () => {
+    expect(getPlatformPageDefinitions()).toBe(platformPageDefinitions);
+    expect(getPlatformPageDefinitions()).toHaveLength(6);
+  });
+});
+
+describe("findPlatformPageDefinition", () => {
+  it("resolves known slugs and rejects unknown slugs", () => {
+    expect(findPlatformPageDefinition("windsurf")?.platform).toBe("Windsurf");
+    expect(findPlatformPageDefinition("gemini")?.slug).toBe("gemini");
+    expect(findPlatformPageDefinition("missing")).toBeNull();
+    expect(findPlatformPageDefinition("")).toBeNull();
+  });
+});
+
+describe("buildPlatformPage", () => {
+  const claudeDef = findPlatformPageDefinition("claude")!;
+
+  it("returns zero items for non-skill entries", () => {
+    const page = buildPlatformPage(claudeDef, [
+      mcpEntry(),
+      mcpEntry({ slug: "x" }),
+    ]);
+    expect(page.count).toBe(0);
+    expect(page.items).toEqual([]);
+    expect(page.feedUrl).toBe("/data/feeds/platforms/claude.json");
+  });
+
+  it("includes skill entries with default platform compatibility", () => {
+    const page = buildPlatformPage(claudeDef, [
+      skill({ slug: "alpha", title: "Alpha Skill" }),
+      skill({ slug: "beta", title: "Beta Skill" }),
+    ]);
+    expect(page.count).toBe(2);
+    expect(page.items.map((item) => item.slug)).toEqual(["alpha", "beta"]);
+    expect(page.items.every((item) => item.url.startsWith("/skills/"))).toBe(
+      true,
+    );
+    expect(
+      page.items.every((item) => item.supportLevel === "native-skill"),
+    ).toBe(true);
+  });
+
+  it("sorts items alphabetically by title", () => {
+    const page = buildPlatformPage(claudeDef, [
+      skill({ slug: "zulu", title: "Zulu Pack" }),
+      skill({ slug: "alpha", title: "Alpha Pack" }),
+      skill({ slug: "mike", title: "Mike Pack" }),
+    ]);
+    expect(page.items.map((item) => item.title)).toEqual([
+      "Alpha Pack",
+      "Mike Pack",
+      "Zulu Pack",
+    ]);
+  });
+
+  it("prefers cardDescription over description for item blurbs", () => {
+    const page = buildPlatformPage(claudeDef, [
+      skill({
+        slug: "carded",
+        title: "Carded",
+        cardDescription: "Short card copy",
+        description: "Longer dossier description",
+      }),
+    ]);
+    expect(page.items[0]?.description).toBe("Short card copy");
+  });
+
+  it("falls back to description when cardDescription is absent", () => {
+    const page = buildPlatformPage(claudeDef, [
+      skill({
+        slug: "plain",
+        title: "Plain",
+        description: "Dossier description only",
+      }),
+    ]);
+    expect(page.items[0]?.description).toBe("Dossier description only");
+  });
+
+  it("carries tags from the registry entry", () => {
+    const page = buildPlatformPage(claudeDef, [
+      skill({ slug: "tagged", title: "Tagged", tags: ["testing", "docs"] }),
+    ]);
+    expect(page.items[0]?.tags).toEqual(["testing", "docs"]);
+  });
+
+  it("omits skills that declare incompatible platform lists", () => {
+    const codexDef = findPlatformPageDefinition("codex")!;
+    const page = buildPlatformPage(codexDef, [
+      skill({
+        slug: "claude-only",
+        title: "Claude Only",
+        platformCompatibility: [
+          {
+            platform: "Claude",
+            supportLevel: "native-skill",
+            installPath: ".claude/skills/x/SKILL.md",
+            verifiedAt: "2026-01-01",
+          },
+        ],
+      }),
+    ]);
+    expect(page.count).toBe(0);
+    expect(page.items).toEqual([]);
+  });
+
+  it("honors custom platformCompatibility rows for the target platform", () => {
+    const cursorDef = findPlatformPageDefinition("cursor-rules")!;
+    const page = buildPlatformPage(cursorDef, [
+      skill({
+        slug: "cursor-adapter",
+        title: "Cursor Adapter",
+        platformCompatibility: [
+          {
+            platform: "Cursor",
+            supportLevel: "adapter",
+            installPath: ".cursor/rules/cursor-adapter.mdc",
+            adapterPath: "/data/skill-adapters/cursor/cursor-adapter.mdc",
+            verifiedAt: "2026-02-01",
+          },
+        ],
+      }),
+    ]);
+    expect(page.count).toBe(1);
+    expect(page.items[0]).toMatchObject({
+      slug: "cursor-adapter",
+      supportLevel: "adapter",
+      installPath: ".cursor/rules/cursor-adapter.mdc",
+      adapterPath: "/data/skill-adapters/cursor/cursor-adapter.mdc",
+      verifiedAt: "2026-02-01",
+    });
+  });
+
+  it.each([
+    ["claude", "Claude", "claude.json"],
+    ["codex", "Codex", "codex.json"],
+    ["windsurf", "Windsurf", "windsurf.json"],
+    ["gemini", "Gemini", "gemini.json"],
+    ["cursor-rules", "Cursor", "cursor.json"],
+    ["agents-context", "Generic AGENTS", "generic-agents.json"],
+  ] as const)("builds feed URL for %s hub", (slug, _platform, feedFile) => {
+    const definition = findPlatformPageDefinition(slug)!;
+    const page = buildPlatformPage(definition, [
+      skill({ slug: "x", title: "X" }),
+    ]);
+    expect(page.feedUrl).toBe(`/data/feeds/platforms/${feedFile}`);
+    expect(page.slug).toBe(slug);
+  });
+
+  it("spreads definition metadata onto the built page", () => {
+    const page = buildPlatformPage(claudeDef, []);
+    expect(page.title).toBe(claudeDef.title);
+    expect(page.eyebrow).toBe(claudeDef.eyebrow);
+    expect(page.description).toBe(claudeDef.description);
+    expect(page.seoTitle).toBe(claudeDef.seoTitle);
+    expect(page.seoDescription).toBe(claudeDef.seoDescription);
+    expect(page.ctaLabel).toBe(claudeDef.ctaLabel);
+  });
+});
+
+describe("buildAllPlatformPages", () => {
+  it("builds one page per definition", () => {
+    const pages = buildAllPlatformPages([
+      skill({ slug: "shared", title: "Shared" }),
+    ]);
+    expect(pages).toHaveLength(platformPageDefinitions.length);
+    expect(pages.map((page) => page.slug)).toEqual(
+      platformPageDefinitions.map((item) => item.slug),
+    );
+  });
+
+  it("reuses the same skill across multiple platform hubs when compatible", () => {
+    const pages = buildAllPlatformPages([
+      skill({ slug: "multi", title: "Multi Platform" }),
+    ]);
+    const withItems = pages.filter((page) => page.count > 0);
+    expect(withItems.length).toBeGreaterThan(1);
+    expect(withItems.every((page) => page.items[0]?.slug === "multi")).toBe(
+      true,
+    );
+  });
+
+  it("returns empty hubs when the catalog has no skills", () => {
+    const pages = buildAllPlatformPages([mcpEntry(), mcpEntry({ slug: "b" })]);
+    expect(pages.every((page) => page.count === 0)).toBe(true);
+    expect(pages.every((page) => page.items.length === 0)).toBe(true);
+  });
+
+  it("returns empty hubs for an empty entry list", () => {
+    const pages = buildAllPlatformPages([]);
+    expect(pages).toHaveLength(6);
+    expect(pages.every((page) => page.count === 0)).toBe(true);
+  });
+});
+
+describe("per-platform filtering", () => {
+  const customCompatibility = (platform: string): ContentEntry =>
+    skill({
+      slug: `${platform.toLowerCase().replace(/\s+/g, "-")}-only`,
+      title: `${platform} Only`,
+      platformCompatibility: [
+        {
+          platform,
+          supportLevel: "native-skill",
+          installPath: `install/${platform}`,
+          verifiedAt: "2026-03-01",
+        },
+      ],
+    });
+
+  it.each(platformPageDefinitions)(
+    "includes only $platform-compatible skills on the $slug hub",
+    (definition: PlatformPageDefinition) => {
+      const matching = customCompatibility(definition.platform);
+      const other = customCompatibility(
+        definition.platform === "Claude" ? "Codex" : "Claude",
+      );
+      const page = buildPlatformPage(definition, [matching, other]);
+      expect(page.count).toBe(1);
+      expect(page.items[0]?.title).toBe(`${definition.platform} Only`);
+    },
+  );
+});
+
+describe("install metadata defaults", () => {
+  it("uses registry default install paths for Claude skills", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      skill({ slug: "defaults", title: "Defaults", verifiedAt: "2026-04-01" }),
+    ]);
+    expect(page.items[0]?.installPath).toContain(".claude/skills");
+    expect(page.items[0]?.verifiedAt).toBe("2026-04-01");
+  });
+
+  it("uses registry default install paths for Codex skills", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("codex")!, [
+      skill({ slug: "codex-default", title: "Codex Default" }),
+    ]);
+    expect(page.items[0]?.installPath).toContain(".agents/skills");
+  });
+
+  it("uses registry default install paths for Windsurf skills", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("windsurf")!, [
+      skill({ slug: "wind", title: "Wind" }),
+    ]);
+    expect(page.items[0]?.installPath).toContain(".windsurf/skills");
+  });
+
+  it("uses registry default install paths for Gemini skills", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("gemini")!, [
+      skill({ slug: "gem", title: "Gem" }),
+    ]);
+    expect(page.items[0]?.installPath).toContain(".gemini/skills");
+  });
+
+  it("includes adapter metadata for default Cursor compatibility", () => {
+    const page = buildPlatformPage(
+      findPlatformPageDefinition("cursor-rules")!,
+      [skill({ slug: "cursor-default", title: "Cursor Default" })],
+    );
+    expect(page.items[0]?.supportLevel).toBe("adapter");
+    expect(page.items[0]?.adapterPath).toContain("skill-adapters/cursor");
+  });
+
+  it("marks Generic AGENTS compatibility as manual-context", () => {
+    const page = buildPlatformPage(
+      findPlatformPageDefinition("agents-context")!,
+      [skill({ slug: "agents", title: "Agents" })],
+    );
+    expect(page.items[0]?.supportLevel).toBe("manual-context");
+    expect(page.items[0]?.installPath).toContain("AGENTS.md");
+  });
+});
+
+describe("large catalog aggregation", () => {
+  it("counts and sorts a large mixed catalog deterministically", () => {
+    const skills = Array.from({ length: 30 }, (_, index) =>
+      skill({
+        slug: `skill-${index}`,
+        title: `Skill ${String(index).padStart(2, "0")}`,
+        tags: index % 2 === 0 ? ["automation"] : ["docs"],
+      }),
+    );
+    const noise = Array.from({ length: 10 }, (_, index) =>
+      mcpEntry({ slug: `mcp-${index}`, title: `MCP ${index}` }),
+    );
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      ...skills,
+      ...noise,
+    ]);
+    expect(page.count).toBe(30);
+    expect(page.items[0]?.title).toBe("Skill 00");
+    expect(page.items.at(-1)?.title).toBe("Skill 29");
+    expect(
+      page.items.every((item) => item.url === `/skills/${item.slug}`),
+    ).toBe(true);
+  });
+
+  it("builds all hubs with consistent totals for a shared catalog", () => {
+    const catalog = [
+      skill({ slug: "a", title: "Alpha" }),
+      skill({ slug: "b", title: "Bravo" }),
+      skill({ slug: "c", title: "Charlie" }),
+    ];
+    const pages = buildAllPlatformPages(catalog);
+    const claude = pages.find((page) => page.slug === "claude");
+    const codex = pages.find((page) => page.slug === "codex");
+    expect(claude?.count).toBe(3);
+    expect(codex?.count).toBe(3);
+    expect(claude?.items.map((item) => item.slug)).toEqual(
+      codex?.items.map((item) => item.slug),
+    );
+  });
+});
+
+describe("edge cases", () => {
+  it("treats missing tags as an empty array", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      skill({ slug: "no-tags", title: "No Tags", tags: undefined }),
+    ]);
+    expect(page.items[0]?.tags).toEqual([]);
+  });
+
+  it("keeps duplicate skill slugs when the catalog repeats entries", () => {
+    const duplicate = skill({ slug: "dup", title: "Dup" });
+    const page = buildPlatformPage(findPlatformPageDefinition("codex")!, [
+      duplicate,
+      duplicate,
+    ]);
+    expect(page.count).toBe(2);
+    expect(page.items.every((item) => item.slug === "dup")).toBe(true);
+  });
+
+  it("does not mutate the input definition or entries", () => {
+    const definition = { ...findPlatformPageDefinition("gemini")! };
+    const entries = [skill({ slug: "frozen", title: "Frozen" })];
+    const frozenDefinition = JSON.stringify(definition);
+    const frozenEntries = JSON.stringify(entries);
+    buildPlatformPage(definition, entries);
+    expect(JSON.stringify(definition)).toBe(frozenDefinition);
+    expect(JSON.stringify(entries)).toBe(frozenEntries);
+  });
+
+  it("returns null adapterPath when compatibility has no adapter", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      skill({ slug: "native", title: "Native" }),
+    ]);
+    expect(page.items[0]?.adapterPath).toBeUndefined();
+  });
+});
+
+describe("definition copy invariants", () => {
+  it.each(platformPageDefinitions)(
+    "$slug description mentions skills or adapters",
+    (definition) => {
+      const hay =
+        `${definition.description} ${definition.seoDescription}`.toLowerCase();
+      expect(
+        hay.includes("skill") ||
+          hay.includes("adapter") ||
+          hay.includes("agents"),
+      ).toBe(true);
+    },
+  );
+
+  it.each(platformPageDefinitions)(
+    "$slug SEO title is unique across hubs",
+    (definition) => {
+      const duplicates = platformPageDefinitions.filter(
+        (item) => item.seoTitle === definition.seoTitle,
+      );
+      expect(duplicates).toHaveLength(1);
+    },
+  );
+
+  it.each(platformPageDefinitions)("$slug slug is kebab-case", (definition) => {
+    expect(definition.slug).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+  });
+});
+
+describe("title collation", () => {
+  it("uses locale-aware alphabetical ordering for mixed-case titles", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("codex")!, [
+      skill({ slug: "a", title: "alpha" }),
+      skill({ slug: "b", title: "Beta" }),
+      skill({ slug: "c", title: "charlie" }),
+    ]);
+    expect(page.items.map((item) => item.title)).toEqual([
+      "alpha",
+      "Beta",
+      "charlie",
+    ]);
+  });
+
+  it("places numeric-leading titles before alphabetic titles", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("windsurf")!, [
+      skill({ slug: "z", title: "Zulu" }),
+      skill({ slug: "1", title: "1st Skill" }),
+      skill({ slug: "a", title: "Alpha" }),
+    ]);
+    const titles = page.items.map((item) => item.title);
+    expect(titles.indexOf("1st Skill")).toBeLessThan(titles.indexOf("Alpha"));
+  });
+});
+
+describe("verifiedAt propagation", () => {
+  it("uses verifiedAt when present on the skill entry", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("gemini")!, [
+      skill({ slug: "v", title: "Verified", verifiedAt: "2026-05-10" }),
+    ]);
+    expect(page.items[0]?.verifiedAt).toBe("2026-05-10");
+  });
+
+  it("falls back to dateAdded for default compatibility rows", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      skill({ slug: "dated", title: "Dated", dateAdded: "2026-06-01" }),
+    ]);
+    expect(page.items[0]?.verifiedAt).toBe("2026-06-01");
+  });
+
+  it("prefers explicit verifiedAt over dateAdded", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("codex")!, [
+      skill({
+        slug: "both",
+        title: "Both",
+        verifiedAt: "2026-07-01",
+        dateAdded: "2026-01-01",
+      }),
+    ]);
+    expect(page.items[0]?.verifiedAt).toBe("2026-07-01");
+  });
+});
+
+describe("multi-definition build matrix", () => {
+  const catalog = [
+    skill({ slug: "shared", title: "Shared Skill", tags: ["shared"] }),
+  ];
+
+  it.each(platformPageDefinitions)(
+    "builds non-empty $slug page for default-compatible skills",
+    (definition) => {
+      const page = buildPlatformPage(definition, catalog);
+      expect(page.slug).toBe(definition.slug);
+      expect(page.platform).toBe(definition.platform);
+      expect(page.count).toBeGreaterThanOrEqual(1);
+      expect(page.items[0]?.slug).toBe("shared");
+    },
+  );
+});
+
+describe("url and slug shape", () => {
+  it("builds skill URLs from entry slugs", () => {
+    const page = buildPlatformPage(findPlatformPageDefinition("claude")!, [
+      skill({ slug: "my-skill", title: "My Skill" }),
+    ]);
+    expect(page.items[0]?.url).toBe("/skills/my-skill");
+  });
+
+  it.each(["simple", "with-dashes", "numbers-123"])(
+    "accepts slug %s in item URLs",
+    (slug) => {
+      const page = buildPlatformPage(findPlatformPageDefinition("codex")!, [
+        skill({ slug, title: slug }),
+      ]);
+      expect(page.items[0]?.url).toBe(`/skills/${slug}`);
+    },
+  );
+});
+
+describe("integration snapshot", () => {
+  it("produces a stable multi-platform page bundle", () => {
+    const catalog = [
+      skill({
+        slug: "writer",
+        title: "Writer",
+        cardDescription: "Writing workflows",
+        tags: ["writing"],
+        dateAdded: "2026-01-15",
+      }),
+      skill({
+        slug: "reviewer",
+        title: "Reviewer",
+        platformCompatibility: [
+          {
+            platform: "Cursor",
+            supportLevel: "adapter",
+            installPath: ".cursor/rules/reviewer.mdc",
+            adapterPath: "/data/skill-adapters/cursor/reviewer.mdc",
+            verifiedAt: "2026-01-20",
+          },
+        ],
+      }),
+      mcpEntry({ slug: "ignored", title: "Ignored MCP" }),
+    ];
+
+    const pages = buildAllPlatformPages(catalog);
+    const claude = pages.find((page) => page.slug === "claude");
+    const cursor = pages.find((page) => page.slug === "cursor-rules");
+    const agents = pages.find((page) => page.slug === "agents-context");
+
+    expect(claude?.items).toEqual([
+      expect.objectContaining({
+        slug: "writer",
+        description: "Writing workflows",
+        tags: ["writing"],
+      }),
+    ]);
+    expect(cursor?.count).toBe(2);
+    expect(cursor?.items.map((item) => item.slug).sort()).toEqual([
+      "reviewer",
+      "writer",
+    ]);
+    expect(agents?.count).toBe(1);
+    expect(agents?.items[0]?.slug).toBe("writer");
+  });
+});

--- a/tests/web-platform-pages.test.ts
+++ b/tests/web-platform-pages.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPlatformPage,
+  findPlatformPageDefinition,
+  getPlatformPageDefinitions,
+} from "@/lib/platform-pages";
+
+describe("platform-pages re-export surface", () => {
+  it("keeps the public import path wired to the extracted lib", () => {
+    expect(getPlatformPageDefinitions()).toHaveLength(6);
+    const claude = findPlatformPageDefinition("claude");
+    expect(claude?.platform).toBe("Claude");
+    const page = buildPlatformPage(claude!, [
+      {
+        category: "skills",
+        slug: "demo",
+        title: "Demo",
+        description: "Demo skill",
+      } as const,
+    ]);
+    expect(page.count).toBe(1);
+    expect(page.feedUrl).toContain("/data/feeds/platforms/");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         "apps/web/src/lib/content.server.ts",
         "apps/web/src/lib/contributors.ts",
         "apps/web/src/lib/data-reports.ts",
+        "apps/web/src/lib/platform-pages.ts",
         "apps/web/src/lib/api-security.ts",
         "apps/web/src/lib/detail-assembly.ts",
         "apps/web/src/lib/dossier-prefs.ts",


### PR DESCRIPTION
## Summary
- Extract pure platform hub page builders from `platform-pages.ts` into `platform-pages-lib.ts`
- Keep `@/lib/platform-pages` as a thin re-export plus async entry-loading helpers
- Add comprehensive `platform-pages-lib` tests plus a smoke re-export test; exclude the wrapper from coverage

## Test plan
- [x] `pnpm test` (3061 tests)
- [x] `platform-pages-lib.test.ts` covers definitions, filtering, sorting, feed URLs, and edge cases
- [x] `web-platform-pages.test.ts` verifies public re-export path


Made with [Cursor](https://cursor.com)