### PR TITLE
feat(compare): add empty-state guidance on interactive compare

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -20,6 +20,8 @@ import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
 import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
+import { compareDrawerEmptyHint } from "@/lib/compare-empty-guidance";
+import { compareFullViewSearch } from "@/lib/compare-interactive-link";
 import {
   recordCompareIntentEvent,
   resolveCompareEntryActions,
@@ -318,6 +320,7 @@ export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate, getShareUrl } = useCompare();
   const actionRowDiverges = compareDrawerActionsDiverge(items);
   const bannerTexts = compareDrawerBannerTexts(items);
+  const fullViewSearch = compareFullViewSearch(items);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -384,16 +387,16 @@ export function CompareDrawer() {
                   />
                 </div>
               )}
-              {items.length > 0 && (
+              {fullViewSearch ? (
                 <Link
                   to="/compare"
-                  search={{ ids: items.map((e) => `${e.category}/${e.slug}`).join(",") }}
+                  search={fullViewSearch}
                   onClick={() => setOpen(false)}
                   className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-surface px-2.5 text-xs text-ink hover:bg-surface-2"
                 >
                   Open full view <ArrowRight className="h-3 w-3" />
                 </Link>
-              )}
+              ) : null}
               <CopyButton
                 value={getShareUrl()}
                 label="Copy compare link"
@@ -412,7 +415,7 @@ export function CompareDrawer() {
 
         {items.length === 0 ? (
           <div className="flex h-[60vh] items-center justify-center px-6 text-sm text-ink-muted">
-            Add resources to compare by tapping the Compare button on any card.
+            {compareDrawerEmptyHint()}
           </div>
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">

--- a/apps/web/src/lib/compare-empty-guidance.ts
+++ b/apps/web/src/lib/compare-empty-guidance.ts
@@ -1,0 +1,19 @@
+import { COMPARE_INTERACTIVE_MAX, COMPARE_INTERACTIVE_MIN } from "@/lib/compare-interactive-link";
+
+export function compareEmptyStateDescription(): string {
+  return `Add ${COMPARE_INTERACTIVE_MIN}–${COMPARE_INTERACTIVE_MAX} resources from the directory to see them side by side.`;
+}
+
+export function compareSingleItemHintText(itemCount: number): string | null {
+  if (itemCount !== 1) return null;
+  return "Add one more resource to unlock trust and next-step comparisons across the full table.";
+}
+
+export function compareInvalidUrlHint(idsParam: string, resolvedCount: number): string | null {
+  if (!idsParam.trim() || resolvedCount > 0) return null;
+  return "The compare link could not be resolved — choose resources from the directory instead.";
+}
+
+export function compareDrawerEmptyHint(): string {
+  return "Add resources to compare by tapping the Compare button on any card.";
+}

--- a/apps/web/src/lib/compare-interactive-link.ts
+++ b/apps/web/src/lib/compare-interactive-link.ts
@@ -18,6 +18,12 @@ export function compareInteractiveSearch(entries: EntryIdentity[]): { ids: strin
   return { ids: serializeCompareItems(slice) };
 }
 
+export function compareFullViewSearch(entries: EntryIdentity[]): { ids: string } | null {
+  if (entries.length === 0) return null;
+  const slice = entries.slice(0, COMPARE_INTERACTIVE_MAX);
+  return { ids: serializeCompareItems(slice) };
+}
+
 export function compareInteractiveLinkLabel(entryCount: number): string {
   const count = compareInteractiveEntryCount(entryCount);
   if (count === COMPARE_INTERACTIVE_MIN) {

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -18,6 +18,11 @@ import {
   type CompareAction,
 } from "@/lib/compare-entry-actions";
 import { comparePageBannerTexts } from "@/lib/compare-page-summary";
+import {
+  compareEmptyStateDescription,
+  compareInvalidUrlHint,
+  compareSingleItemHintText,
+} from "@/lib/compare-empty-guidance";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -70,6 +75,7 @@ function ComparePage() {
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const actionRowDiverges = compareActionsDiverge(items);
   const bannerTexts = comparePageBannerTexts(items);
+  const singleItemHint = compareSingleItemHintText(items.length);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -102,14 +108,14 @@ function ComparePage() {
       // Render directly from URL while context hydrates.
       return <Skeleton ids={sp.ids} />;
     }
+    const invalidUrlHint = compareInvalidUrlHint(sp.ids, 0);
     return (
       <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
         <div className="rounded-xl border border-dashed border-border bg-surface p-10 text-center">
           <div className="eyebrow">Comparison</div>
           <h1 className="mt-2 h-display-2 text-ink text-balance">Nothing to compare yet</h1>
-          <p className="mt-2 text-sm text-ink-muted">
-            Add 2–4 resources from the directory to see them side by side.
-          </p>
+          <p className="mt-2 text-sm text-ink-muted">{compareEmptyStateDescription()}</p>
+          {invalidUrlHint ? <p className="mt-2 text-sm text-amber-800">{invalidUrlHint}</p> : null}
           <div className="mt-5 flex justify-center gap-2">
             <Link
               to="/browse"
@@ -156,6 +162,7 @@ function ComparePage() {
               ))}
             </div>
           ) : null}
+          {singleItemHint ? <p className="mt-2 text-sm text-ink-muted">{singleItemHint}</p> : null}
         </div>
         <div className="flex items-center gap-2">
           <CopyButton value={copyShare()} label="Copy share link" />

--- a/tests/compare-empty-guidance.test.ts
+++ b/tests/compare-empty-guidance.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDrawerEmptyHint,
+  compareEmptyStateDescription,
+  compareInvalidUrlHint,
+  compareSingleItemHintText,
+} from "@/lib/compare-empty-guidance";
+
+describe("compare empty guidance", () => {
+  it("describes the interactive compare selection range", () => {
+    expect(compareEmptyStateDescription()).toBe(
+      "Add 2–4 resources from the directory to see them side by side.",
+    );
+  });
+
+  it("prompts readers to add another resource when only one is selected", () => {
+    expect(compareSingleItemHintText(0)).toBeNull();
+    expect(compareSingleItemHintText(1)).toBe(
+      "Add one more resource to unlock trust and next-step comparisons across the full table.",
+    );
+    expect(compareSingleItemHintText(2)).toBeNull();
+  });
+
+  it("warns when compare URL params do not resolve to entries", () => {
+    expect(compareInvalidUrlHint("", 0)).toBeNull();
+    expect(compareInvalidUrlHint("   ", 0)).toBeNull();
+    expect(compareInvalidUrlHint("mcp/missing", 0)).toBe(
+      "The compare link could not be resolved — choose resources from the directory instead.",
+    );
+    expect(compareInvalidUrlHint("mcp/fixture", 1)).toBeNull();
+  });
+
+  it("guides drawer readers to add resources from cards", () => {
+    expect(compareDrawerEmptyHint()).toBe(
+      "Add resources to compare by tapping the Compare button on any card.",
+    );
+  });
+});

--- a/tests/compare-interactive-link.test.ts
+++ b/tests/compare-interactive-link.test.ts
@@ -7,6 +7,7 @@ import {
   compareInteractiveEntryCount,
   compareInteractiveLinkLabel,
   compareInteractiveSearch,
+  compareFullViewSearch,
 } from "@/lib/compare-interactive-link";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -91,5 +92,19 @@ describe("compare interactive link", () => {
     expect(compareInteractiveLinkLabel(5)).toBe(
       "Open 4 picks in the interactive comparison tool",
     );
+  });
+
+  it("builds full-view compare links for one or more entries", () => {
+    expect(compareFullViewSearch([])).toBeNull();
+    expect(compareFullViewSearch([entry()])).toEqual({ ids: "mcp/fixture" });
+    expect(
+      compareFullViewSearch([
+        entry({ slug: "one" }),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+        entry({ slug: "five" }),
+      ]),
+    ).toEqual({ ids: "mcp/one,mcp/two,mcp/three,mcp/four" });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `compare-empty-guidance` helpers for interactive compare empty states, single-item prompts, invalid URL warnings, and drawer empty copy.
- Adds `compareFullViewSearch` so drawer “Open full view” links share capped compare URL serialization (including single-item selections).
- Wires guidance into `/compare` empty/single-item states and the compare drawer.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-empty-guidance.test.ts tests/compare-interactive-link.test.ts --coverage --coverage.include='apps/web/src/lib/compare-empty-guidance.ts' --coverage.include='apps/web/src/lib/compare-interactive-link.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4341, #4251, and #4259; merge simulation clean with #4341 and #4259 in both orderings


Made with [Cursor](https://cursor.com)