### PR TITLE
feat(compare): add interactive links for featured comparisons

### DIFF
--- a/apps/web/src/lib/compare-featured-link.ts
+++ b/apps/web/src/lib/compare-featured-link.ts
@@ -1,0 +1,33 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import { parseEntryRef } from "@/lib/entry-identity";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
+
+export function resolveComparisonRefs(refs: string[], catalog: EntryIdentity[]): EntryIdentity[] {
+  const out: EntryIdentity[] = [];
+  for (const ref of refs) {
+    const identity = parseEntryRef(ref);
+    if (!identity) continue;
+    const entry = catalog.find(
+      (candidate) => candidate.category === identity.category && candidate.slug === identity.slug,
+    );
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+export function compareFeaturedInteractiveSearch(
+  refs: string[],
+  catalog: EntryIdentity[],
+): { ids: string } | null {
+  return compareInteractiveSearch(resolveComparisonRefs(refs, catalog));
+}
+
+export function compareFeaturedInteractiveLinkLabel(resolvedCount: number): string {
+  if (resolvedCount <= 2) {
+    return "Open interactively";
+  }
+  return compareInteractiveLinkLabel(resolvedCount);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -23,7 +23,7 @@ import {
 } from "lucide-react";
 import { getEntry, related, relatedGroups, relatedGuides } from "@/data/search";
 import { getEntryRedirectTarget } from "@/lib/entry-redirects";
-import { BEST_LISTS } from "@/data/entries";
+import { BEST_LISTS, ENTRIES } from "@/data/entries";
 import { COMPARISONS } from "@/data/comparisons";
 import { EntryAuthorAttribution } from "@/components/contributor-attribution";
 import { findContributorForIdentity } from "@/data/contributors";
@@ -44,6 +44,11 @@ import {
   compareDossierInteractiveSearch,
 } from "@/lib/compare-dossier-summary";
 import { compareInteractiveLinkLabel } from "@/lib/compare-interactive-link";
+import {
+  compareFeaturedInteractiveLinkLabel,
+  compareFeaturedInteractiveSearch,
+  resolveComparisonRefs,
+} from "@/lib/compare-featured-link";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -247,6 +252,18 @@ function Dossier() {
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
+  const featuredCompareLinks = useMemo(
+    () =>
+      comparedIn.map((comparison) => {
+        const resolved = resolveComparisonRefs(comparison.refs, ENTRIES);
+        return {
+          slug: comparison.slug,
+          search: compareFeaturedInteractiveSearch(comparison.refs, ENTRIES),
+          label: compareFeaturedInteractiveLinkLabel(resolved.length),
+        };
+      }),
+    [comparedIn],
+  );
   const recents = useRecents();
   useEffect(() => {
     recents.pushEntry({ category: entry.category, slug: entry.slug, title: entry.title });
@@ -753,17 +770,32 @@ function Dossier() {
                     </Link>
                   </li>
                 ))}
-                {comparedIn.map((c) => (
-                  <li key={`cmp-${c.slug}`}>
-                    <Link
-                      to="/compare/$slug"
-                      params={{ slug: c.slug }}
-                      className="story-link text-ink"
+                {comparedIn.map((c) => {
+                  const featuredLink = featuredCompareLinks.find((link) => link.slug === c.slug);
+                  return (
+                    <li
+                      key={`cmp-${c.slug}`}
+                      className="flex flex-wrap items-baseline gap-x-2 gap-y-1"
                     >
-                      Comparison: {c.title}
-                    </Link>
-                  </li>
-                ))}
+                      <Link
+                        to="/compare/$slug"
+                        params={{ slug: c.slug }}
+                        className="story-link text-ink"
+                      >
+                        Comparison: {c.title}
+                      </Link>
+                      {featuredLink?.search ? (
+                        <Link
+                          to="/compare"
+                          search={featuredLink.search}
+                          className="text-xs text-ink-muted hover:text-ink"
+                        >
+                          {featuredLink.label}
+                        </Link>
+                      ) : null}
+                    </li>
+                  );
+                })}
               </ul>
             </DossierSection>
           )}

--- a/tests/compare-featured-link.test.ts
+++ b/tests/compare-featured-link.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareFeaturedInteractiveLinkLabel,
+  compareFeaturedInteractiveSearch,
+  resolveComparisonRefs,
+} from "@/lib/compare-featured-link";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+  entry({ category: "mcp", slug: "delta" }),
+  entry({ category: "mcp", slug: "epsilon" }),
+];
+
+describe("compare featured link", () => {
+  it("resolves comparison refs against the entry catalog", () => {
+    expect(resolveComparisonRefs([], catalog)).toEqual([]);
+    expect(
+      resolveComparisonRefs(["skills/alpha", "hooks/beta"], catalog),
+    ).toEqual([catalog[0], catalog[1]]);
+    expect(
+      resolveComparisonRefs(
+        ["skills/alpha", "missing/slug", "bad-ref"],
+        catalog,
+      ),
+    ).toEqual([catalog[0]]);
+  });
+
+  it("builds interactive compare search params for featured comparisons", () => {
+    expect(
+      compareFeaturedInteractiveSearch(["skills/alpha"], catalog),
+    ).toBeNull();
+    expect(
+      compareFeaturedInteractiveSearch(["skills/alpha", "hooks/beta"], catalog),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+    expect(
+      compareFeaturedInteractiveSearch(
+        ["mcp/gamma", "mcp/delta", "mcp/epsilon", "skills/alpha", "hooks/beta"],
+        catalog,
+      ),
+    ).toEqual({ ids: "mcp/gamma,mcp/delta,mcp/epsilon,skills/alpha" });
+  });
+
+  it("formats featured comparison interactive link labels", () => {
+    expect(compareFeaturedInteractiveLinkLabel(2)).toBe("Open interactively");
+    expect(compareFeaturedInteractiveLinkLabel(3)).toBe(
+      "Open 3 picks in the interactive comparison tool",
+    );
+    expect(compareFeaturedInteractiveLinkLabel(5)).toBe(
+      "Open 4 picks in the interactive comparison tool",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-featured-link` helpers to resolve curated comparison refs and build `/compare?ids=…` deep links (2–4 entries, capped at the interactive compare limit).
- Wires secondary “Open interactively” links beside curated comparisons in entry dossier **Featured in** sections.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-featured-link.test.ts --coverage --coverage.include='apps/web/src/lib/compare-featured-link.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4341, #4251, and #4259; merge simulation clean with #4341 and #4259 in both orderings
