### PR TITLE
feat(web): extract ecosystem-stats helpers into ecosystem-stats-lib

### DIFF
--- a/apps/web/src/lib/ecosystem-stats-lib.ts
+++ b/apps/web/src/lib/ecosystem-stats-lib.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure ecosystem statistics helpers.
+ *
+ * Classifies install methods and quantifies safety/privacy note coverage from
+ * structured registry fields for the state-of-claude-tooling data report.
+ * Nothing here touches the network — given the same entry metadata the output
+ * is deterministic.
+ *
+ * The public surface (`ecosystem-stats.ts` / `@/lib/ecosystem-stats`) re-exports
+ * everything below so existing imports stay unchanged.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export interface StatRow {
+  label: string;
+  count: number;
+}
+
+// Ordered: first matching rule wins. Patterns anchor on the first token of the
+// (lowercased) install command so classification is unambiguous.
+const INSTALL_METHOD_RULES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/^(?:npx|npm)\b/, "npm / npx"],
+  [/^pnpm\b/, "pnpm"],
+  [/^yarn\b/, "yarn"],
+  [/^bunx?\b/, "bun"],
+  [/^deno\b/, "deno"],
+  [/^(?:uvx?|pipx?)\b|\bpip3? install\b/, "Python (pip / uv)"],
+  [/^docker\b/, "Docker"],
+  [/^go\b/, "Go"],
+  [/^cargo\b/, "Cargo"],
+  [/^brew\b/, "Homebrew"],
+  [/^claude\b/, "Claude CLI (claude mcp add …)"],
+  [/^\//, "Claude slash command"],
+  [/^git\b/, "Git clone"],
+  [/^(?:curl|wget)\b/, "Shell (curl / wget)"],
+  [/^(?:mkdir|cat|cp|mv|echo|touch|tee)\b/, "Manual file setup"],
+];
+
+/**
+ * Classify an entry's `installCommand` into an install-method bucket.
+ * Returns `null` when there is no install command (the resource is a
+ * config/file drop-in, not a package install).
+ */
+export function installMethodOf(installCommand?: string | null): string | null {
+  const command = String(installCommand ?? "")
+    .trim()
+    .toLowerCase();
+  if (!command) return null;
+  for (const [pattern, label] of INSTALL_METHOD_RULES) {
+    if (pattern.test(command)) return label;
+  }
+  return "Other";
+}
+
+/**
+ * Distribution of install methods across the entries that declare an
+ * `installCommand`. `total` is the size of that installable subset (not the
+ * whole catalog), and the row counts sum to exactly `total`.
+ */
+export function installMethodDistribution(entries: ReadonlyArray<Entry>): {
+  rows: StatRow[];
+  total: number;
+} {
+  const counts = new Map<string, number>();
+  let total = 0;
+  for (const entry of entries) {
+    const method = installMethodOf(entry.installCommand);
+    if (!method) continue;
+    counts.set(method, (counts.get(method) ?? 0) + 1);
+    total += 1;
+  }
+  const rows = [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+  return { rows, total };
+}
+
+/**
+ * Coverage of safety / privacy notes across the catalog. These are HeyClaude's
+ * differentiating metadata, so quantifying them is high-signal original data.
+ * `both` is bounded by `min(safety, privacy)`; all counts are bounded by
+ * `total`.
+ */
+export function notesCoverage(entries: ReadonlyArray<Entry>): {
+  total: number;
+  safety: number;
+  privacy: number;
+  both: number;
+} {
+  let safety = 0;
+  let privacy = 0;
+  let both = 0;
+  for (const entry of entries) {
+    const hasSafety = Boolean(entry.safetyNotes);
+    const hasPrivacy = Boolean(entry.privacyNotes);
+    if (hasSafety) safety += 1;
+    if (hasPrivacy) privacy += 1;
+    if (hasSafety && hasPrivacy) both += 1;
+  }
+  return { total: entries.length, safety, privacy, both };
+}

--- a/apps/web/src/lib/ecosystem-stats.ts
+++ b/apps/web/src/lib/ecosystem-stats.ts
@@ -1,97 +1,13 @@
-import type { Entry } from "@/types/registry";
-
 /**
- * Deterministic, structured-field-derived ecosystem statistics for the
- * `/state-of-claude-tooling` data report. Every value is computed from real
- * registry fields (no estimates, no LLM-generated prose) so the numbers — and
- * the `Dataset` JSON-LD that advertises them — are accurate by construction.
+ * Ecosystem statistics surface.
+ *
+ * Pure ecosystem stats helpers live in `ecosystem-stats-lib.ts`. This module
+ * re-exports that surface so existing `@/lib/ecosystem-stats` imports stay
+ * unchanged.
  */
-
-export interface StatRow {
-  label: string;
-  count: number;
-}
-
-// Ordered: first matching rule wins. Patterns anchor on the first token of the
-// (lowercased) install command so classification is unambiguous.
-const INSTALL_METHOD_RULES: ReadonlyArray<readonly [RegExp, string]> = [
-  [/^(?:npx|npm)\b/, "npm / npx"],
-  [/^pnpm\b/, "pnpm"],
-  [/^yarn\b/, "yarn"],
-  [/^bunx?\b/, "bun"],
-  [/^deno\b/, "deno"],
-  [/^(?:uvx?|pipx?)\b|\bpip3? install\b/, "Python (pip / uv)"],
-  [/^docker\b/, "Docker"],
-  [/^go\b/, "Go"],
-  [/^cargo\b/, "Cargo"],
-  [/^brew\b/, "Homebrew"],
-  [/^claude\b/, "Claude CLI (claude mcp add …)"],
-  [/^\//, "Claude slash command"],
-  [/^git\b/, "Git clone"],
-  [/^(?:curl|wget)\b/, "Shell (curl / wget)"],
-  [/^(?:mkdir|cat|cp|mv|echo|touch|tee)\b/, "Manual file setup"],
-];
-
-/**
- * Classify an entry's `installCommand` into an install-method bucket.
- * Returns `null` when there is no install command (the resource is a
- * config/file drop-in, not a package install).
- */
-export function installMethodOf(installCommand?: string | null): string | null {
-  const command = String(installCommand ?? "")
-    .trim()
-    .toLowerCase();
-  if (!command) return null;
-  for (const [pattern, label] of INSTALL_METHOD_RULES) {
-    if (pattern.test(command)) return label;
-  }
-  return "Other";
-}
-
-/**
- * Distribution of install methods across the entries that declare an
- * `installCommand`. `total` is the size of that installable subset (not the
- * whole catalog), and the row counts sum to exactly `total`.
- */
-export function installMethodDistribution(entries: ReadonlyArray<Entry>): {
-  rows: StatRow[];
-  total: number;
-} {
-  const counts = new Map<string, number>();
-  let total = 0;
-  for (const entry of entries) {
-    const method = installMethodOf(entry.installCommand);
-    if (!method) continue;
-    counts.set(method, (counts.get(method) ?? 0) + 1);
-    total += 1;
-  }
-  const rows = [...counts.entries()]
-    .map(([label, count]) => ({ label, count }))
-    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
-  return { rows, total };
-}
-
-/**
- * Coverage of safety / privacy notes across the catalog. These are HeyClaude's
- * differentiating metadata, so quantifying them is high-signal original data.
- * `both` is bounded by `min(safety, privacy)`; all counts are bounded by
- * `total`.
- */
-export function notesCoverage(entries: ReadonlyArray<Entry>): {
-  total: number;
-  safety: number;
-  privacy: number;
-  both: number;
-} {
-  let safety = 0;
-  let privacy = 0;
-  let both = 0;
-  for (const entry of entries) {
-    const hasSafety = Boolean(entry.safetyNotes);
-    const hasPrivacy = Boolean(entry.privacyNotes);
-    if (hasSafety) safety += 1;
-    if (hasPrivacy) privacy += 1;
-    if (hasSafety && hasPrivacy) both += 1;
-  }
-  return { total: entries.length, safety, privacy, both };
-}
+export type { StatRow } from "@/lib/ecosystem-stats-lib";
+export {
+  installMethodDistribution,
+  installMethodOf,
+  notesCoverage,
+} from "@/lib/ecosystem-stats-lib";

--- a/tests/ecosystem-stats-lib.test.ts
+++ b/tests/ecosystem-stats-lib.test.ts
@@ -1,0 +1,715 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "@/types/registry";
+import {
+  installMethodDistribution,
+  installMethodOf,
+  notesCoverage,
+} from "../apps/web/src/lib/ecosystem-stats-lib";
+
+function entry(partial: Partial<Entry> = {}): Entry {
+  return { category: "mcp", slug: "x", title: "X", ...partial } as Entry;
+}
+
+describe("installMethodOf", () => {
+  describe("npm / npx", () => {
+    it.each([
+      "npx -y some-mcp",
+      "npx @scope/pkg",
+      "npm install -g x",
+      "npm i package",
+      "NPM install global-tool",
+    ])("classifies %s as npm / npx", (command) => {
+      expect(installMethodOf(command)).toBe("npm / npx");
+    });
+  });
+
+  describe("pnpm", () => {
+    it.each(["pnpm add x", "pnpm install pkg", "PNPM dlx tool"])(
+      "classifies %s as pnpm",
+      (command) => {
+        expect(installMethodOf(command)).toBe("pnpm");
+      },
+    );
+  });
+
+  describe("yarn", () => {
+    it.each(["yarn add x", "yarn global add pkg", "YARN dlx tool"])(
+      "classifies %s as yarn",
+      (command) => {
+        expect(installMethodOf(command)).toBe("yarn");
+      },
+    );
+  });
+
+  describe("bun", () => {
+    it.each(["bunx x", "bun x pkg", "BUN install tool"])(
+      "classifies %s as bun",
+      (command) => {
+        expect(installMethodOf(command)).toBe("bun");
+      },
+    );
+  });
+
+  describe("deno", () => {
+    it.each(["deno run mod.ts", "deno install -g pkg"])(
+      "classifies %s as deno",
+      (command) => {
+        expect(installMethodOf(command)).toBe("deno");
+      },
+    );
+  });
+
+  describe("Python (pip / uv)", () => {
+    it.each([
+      "uvx some-server",
+      "uv tool install pkg",
+      "pip install x",
+      "pip3 install package",
+      "pipx run x",
+      "pipx install tool",
+      "python -m pip install x",
+    ])("classifies %s as Python (pip / uv)", (command) => {
+      expect(installMethodOf(command)).toBe("Python (pip / uv)");
+    });
+  });
+
+  describe("Docker", () => {
+    it.each(["docker run img", "docker compose up", "DOCKER pull image"])(
+      "classifies %s as Docker",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Docker");
+      },
+    );
+  });
+
+  describe("Go", () => {
+    it.each(["go install example.com/pkg@latest", "go get tool"])(
+      "classifies %s as Go",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Go");
+      },
+    );
+  });
+
+  describe("Cargo", () => {
+    it.each(["cargo install crate", "cargo binstall tool"])(
+      "classifies %s as Cargo",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Cargo");
+      },
+    );
+  });
+
+  describe("Homebrew", () => {
+    it.each(["brew install x", "brew tap org/repo"])(
+      "classifies %s as Homebrew",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Homebrew");
+      },
+    );
+  });
+
+  describe("Claude CLI", () => {
+    it.each([
+      "claude mcp add x https://example/mcp",
+      "claude mcp add --transport http srv url",
+      "CLAUDE mcp list",
+    ])("classifies %s as Claude CLI", (command) => {
+      expect(installMethodOf(command)).toBe("Claude CLI (claude mcp add …)");
+    });
+  });
+
+  describe("Claude slash command", () => {
+    it.each(["/agents", "/commit", "/review-pr"])(
+      "classifies %s as slash command",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Claude slash command");
+      },
+    );
+  });
+
+  describe("Git clone", () => {
+    it.each(["git clone https://github.com/x/y", "git clone --depth 1 repo"])(
+      "classifies %s as Git clone",
+      (command) => {
+        expect(installMethodOf(command)).toBe("Git clone");
+      },
+    );
+  });
+
+  describe("Shell (curl / wget)", () => {
+    it.each([
+      "curl https://example.com | sh",
+      "curl -fsSL https://install.example | bash",
+      "wget https://example.com/script.sh",
+    ])("classifies %s as Shell", (command) => {
+      expect(installMethodOf(command)).toBe("Shell (curl / wget)");
+    });
+  });
+
+  describe("Manual file setup", () => {
+    it.each([
+      "mkdir -p .claude/commands && cat > x",
+      "cp template.md ./rules/rule.mdc",
+      "mv download.zip ./skills/",
+      "echo '{}' > config.json",
+      "touch .claude/settings.json",
+      "tee .mcp.json <<EOF",
+    ])("classifies %s as Manual file setup", (command) => {
+      expect(installMethodOf(command)).toBe("Manual file setup");
+    });
+  });
+
+  describe("empty and unrecognized", () => {
+    it.each([undefined, null, "", "   "])(
+      "returns null for empty install command %j",
+      (command) => {
+        expect(installMethodOf(command)).toBeNull();
+      },
+    );
+
+    it.each([
+      "frobnicate --install x",
+      "make install",
+      "just setup",
+      "ansible-playbook site.yml",
+    ])("buckets unrecognized command %s as Other", (command) => {
+      expect(installMethodOf(command)).toBe("Other");
+    });
+  });
+
+  describe("normalization", () => {
+    it("trims surrounding whitespace before classification", () => {
+      expect(installMethodOf("  npx pkg  ")).toBe("npm / npx");
+    });
+
+    it("is case-insensitive when matching the first token", () => {
+      expect(installMethodOf("NPX pkg")).toBe("npm / npx");
+      expect(installMethodOf("Docker run x")).toBe("Docker");
+    });
+  });
+
+  describe("rule precedence", () => {
+    it("prefers npm/npx over later rules in compound commands", () => {
+      expect(installMethodOf("npx docker-tool")).toBe("npm / npx");
+    });
+
+    it("prefers Claude CLI over git when command starts with claude", () => {
+      expect(installMethodOf("claude mcp add via git")).toBe(
+        "Claude CLI (claude mcp add …)",
+      );
+    });
+
+    it("classifies pip install mid-command via Python rule", () => {
+      expect(installMethodOf("sudo pip install pkg")).toBe("Python (pip / uv)");
+    });
+  });
+});
+
+describe("installMethodDistribution", () => {
+  it("returns empty rows for an empty catalog", () => {
+    expect(installMethodDistribution([])).toEqual({ rows: [], total: 0 });
+  });
+
+  it("counts only installable entries and rows sum to the installable total", () => {
+    const entries = [
+      entry({ installCommand: "npx a" }),
+      entry({ installCommand: "npx b" }),
+      entry({ installCommand: "pip install c" }),
+      entry({ installCommand: "" }),
+      entry({}),
+    ];
+    const { rows, total } = installMethodDistribution(entries);
+    expect(total).toBe(3);
+    expect(rows.reduce((sum, row) => sum + row.count, 0)).toBe(total);
+    expect(rows[0]).toEqual({ label: "npm / npx", count: 2 });
+  });
+
+  it("sorts rows by count descending, then label ascending", () => {
+    const entries = [
+      entry({ installCommand: "pnpm a" }),
+      entry({ installCommand: "pnpm b" }),
+      entry({ installCommand: "yarn c" }),
+      entry({ installCommand: "npx d" }),
+      entry({ installCommand: "docker run e" }),
+    ];
+    const { rows, total } = installMethodDistribution(entries);
+    expect(total).toBe(5);
+    expect(rows.map((row) => row.label)).toEqual([
+      "pnpm",
+      "Docker",
+      "npm / npx",
+      "yarn",
+    ]);
+  });
+
+  it("breaks count ties alphabetically by label", () => {
+    const entries = [
+      entry({ installCommand: "yarn a" }),
+      entry({ installCommand: "pnpm b" }),
+      entry({ installCommand: "npx c" }),
+    ];
+    const labels = installMethodDistribution(entries).rows.map(
+      (row) => row.label,
+    );
+    expect(labels).toEqual(["npm / npx", "pnpm", "yarn"]);
+  });
+
+  it("includes Other bucket for unrecognized install commands", () => {
+    const { rows, total } = installMethodDistribution([
+      entry({ installCommand: "make install" }),
+      entry({ installCommand: "just run" }),
+    ]);
+    expect(total).toBe(2);
+    expect(rows).toEqual([{ label: "Other", count: 2 }]);
+  });
+
+  it("aggregates many install methods across a large catalog", () => {
+    const entries = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        entry({ slug: `npx-${i}`, installCommand: "npx pkg" }),
+      ),
+      ...Array.from({ length: 3 }, (_, i) =>
+        entry({ slug: `pip-${i}`, installCommand: "pip install pkg" }),
+      ),
+      entry({ slug: "claude", installCommand: "claude mcp add x url" }),
+      entry({ slug: "slash", installCommand: "/agents" }),
+    ];
+    const { rows, total } = installMethodDistribution(entries);
+    expect(total).toBe(10);
+    expect(rows[0]).toEqual({ label: "npm / npx", count: 5 });
+    expect(rows.find((row) => row.label === "Python (pip / uv)")?.count).toBe(
+      3,
+    );
+  });
+
+  it("ignores entries without installCommand entirely", () => {
+    const { total } = installMethodDistribution([
+      entry({ installCommand: "npx a" }),
+      entry({ safetyNotes: "config only" }),
+      entry({ installCommand: null }),
+    ]);
+    expect(total).toBe(1);
+  });
+});
+
+describe("notesCoverage", () => {
+  it("returns zeros for an empty catalog", () => {
+    expect(notesCoverage([])).toEqual({
+      total: 0,
+      safety: 0,
+      privacy: 0,
+      both: 0,
+    });
+  });
+
+  it("bounds every count by the total and both by min(safety, privacy)", () => {
+    const entries = [
+      entry({ safetyNotes: "x", privacyNotes: "y" }),
+      entry({ safetyNotes: "x" }),
+      entry({ privacyNotes: "y" }),
+      entry({}),
+    ];
+    const coverage = notesCoverage(entries);
+    expect(coverage.total).toBe(4);
+    expect(coverage.safety).toBe(2);
+    expect(coverage.privacy).toBe(2);
+    expect(coverage.both).toBe(1);
+    expect(coverage.safety).toBeLessThanOrEqual(coverage.total);
+    expect(coverage.privacy).toBeLessThanOrEqual(coverage.total);
+    expect(coverage.both).toBeLessThanOrEqual(
+      Math.min(coverage.safety, coverage.privacy),
+    );
+  });
+
+  it("counts safety-only entries", () => {
+    const coverage = notesCoverage([
+      entry({ safetyNotes: "scope API keys" }),
+      entry({ safetyNotes: "run locally" }),
+      entry({}),
+    ]);
+    expect(coverage).toEqual({ total: 3, safety: 2, privacy: 0, both: 0 });
+  });
+
+  it("counts privacy-only entries", () => {
+    const coverage = notesCoverage([
+      entry({ privacyNotes: "no telemetry" }),
+      entry({}),
+    ]);
+    expect(coverage).toEqual({ total: 2, safety: 0, privacy: 1, both: 0 });
+  });
+
+  it("counts entries with both note types", () => {
+    const coverage = notesCoverage([
+      entry({ safetyNotes: "a", privacyNotes: "b" }),
+      entry({ safetyNotes: "c", privacyNotes: "d" }),
+      entry({ safetyNotes: "e" }),
+    ]);
+    expect(coverage.both).toBe(2);
+    expect(coverage.safety).toBe(3);
+    expect(coverage.privacy).toBe(2);
+  });
+
+  it("treats empty strings as absent notes", () => {
+    const coverage = notesCoverage([
+      entry({ safetyNotes: "", privacyNotes: "" }),
+      entry({ safetyNotes: "real note" }),
+    ]);
+    expect(coverage.safety).toBe(1);
+    expect(coverage.privacy).toBe(0);
+  });
+
+  it("aggregates coverage across a large mixed catalog", () => {
+    const entries = Array.from({ length: 20 }, (_, index) =>
+      entry({
+        slug: `e-${index}`,
+        safetyNotes: index % 2 === 0 ? "safety" : undefined,
+        privacyNotes: index % 3 === 0 ? "privacy" : undefined,
+      }),
+    );
+    const coverage = notesCoverage(entries);
+    expect(coverage.total).toBe(20);
+    expect(coverage.safety).toBe(10);
+    expect(coverage.privacy).toBe(7);
+    expect(coverage.both).toBe(4);
+  });
+});
+
+describe("integration snapshots", () => {
+  it("produces consistent install and notes breakdowns for a sample catalog", () => {
+    const catalog = [
+      entry({
+        slug: "a",
+        installCommand: "npx pkg-a",
+        safetyNotes: "s",
+        privacyNotes: "p",
+      }),
+      entry({
+        slug: "b",
+        installCommand: "pip install pkg-b",
+        safetyNotes: "s",
+      }),
+      entry({
+        slug: "c",
+        installCommand: "claude mcp add c url",
+        privacyNotes: "p",
+      }),
+      entry({ slug: "d" }),
+    ];
+
+    const install = installMethodDistribution(catalog);
+    expect(install.total).toBe(3);
+    expect(install.rows.map((row) => row.label)).toEqual([
+      "Claude CLI (claude mcp add …)",
+      "npm / npx",
+      "Python (pip / uv)",
+    ]);
+
+    const notes = notesCoverage(catalog);
+    expect(notes).toEqual({ total: 4, safety: 2, privacy: 2, both: 1 });
+  });
+
+  it("handles a tooling-heavy catalog with diverse install methods", () => {
+    const commands = [
+      "npx a",
+      "pnpm b",
+      "yarn c",
+      "uvx d",
+      "docker run e",
+      "go install f",
+      "cargo install g",
+      "brew install h",
+      "/agents",
+      "git clone i",
+      "curl j | sh",
+      "mkdir -p k",
+      "unknown-tool",
+    ];
+    const catalog = commands.map((installCommand, index) =>
+      entry({ slug: `tool-${index}`, installCommand }),
+    );
+    const { rows, total } = installMethodDistribution(catalog);
+    expect(total).toBe(13);
+    expect(rows.length).toBeGreaterThan(8);
+    expect(rows.every((row) => row.count >= 1)).toBe(true);
+  });
+});
+
+describe("install method matrix", () => {
+  const cases: Array<[string, string]> = [
+    ["npx -y pkg", "npm / npx"],
+    ["pnpm add pkg", "pnpm"],
+    ["yarn dlx pkg", "yarn"],
+    ["bunx pkg", "bun"],
+    ["deno task start", "deno"],
+    ["uvx server", "Python (pip / uv)"],
+    ["docker compose up", "Docker"],
+    ["go install pkg", "Go"],
+    ["cargo install pkg", "Cargo"],
+    ["brew install pkg", "Homebrew"],
+    ["claude mcp add x", "Claude CLI (claude mcp add …)"],
+    ["/commit", "Claude slash command"],
+    ["git clone repo", "Git clone"],
+    ["wget url", "Shell (curl / wget)"],
+    ["cp file dest", "Manual file setup"],
+    ["custom-installer", "Other"],
+  ];
+
+  it.each(cases)("maps command %s to %s", (command, label) => {
+    expect(installMethodOf(command)).toBe(label);
+  });
+});
+
+describe("notes coverage invariants", () => {
+  it("never exceeds total entry count", () => {
+    const catalog = Array.from({ length: 15 }, (_, i) =>
+      entry({
+        safetyNotes: i % 2 === 0 ? "s" : undefined,
+        privacyNotes: i % 3 === 0 ? "p" : undefined,
+      }),
+    );
+    const coverage = notesCoverage(catalog);
+    expect(coverage.safety).toBeLessThanOrEqual(coverage.total);
+    expect(coverage.privacy).toBeLessThanOrEqual(coverage.total);
+    expect(coverage.both).toBeLessThanOrEqual(coverage.total);
+  });
+
+  it("counts both only when safety and privacy coexist on the same entry", () => {
+    const coverage = notesCoverage([
+      entry({ safetyNotes: "only safety" }),
+      entry({ privacyNotes: "only privacy" }),
+      entry({ safetyNotes: "both", privacyNotes: "both" }),
+    ]);
+    expect(coverage.both).toBe(1);
+  });
+});
+
+describe("install command edge matrix", () => {
+  it.each([
+    ["npm ci", "npm / npx"],
+    ["npm run setup", "npm / npx"],
+    ["npx --yes @scope/pkg", "npm / npx"],
+    ["pnpm exec tool", "pnpm"],
+    ["yarn plug'n'play add", "yarn"],
+    ["bun install", "bun"],
+    ["uv pip install pkg", "Python (pip / uv)"],
+    ["pipx inject pkg", "Python (pip / uv)"],
+    ["docker build -t img .", "Docker"],
+    ["go run .", "Go"],
+    ["cargo run", "Cargo"],
+    ["brew bundle install", "Homebrew"],
+    ["claude plugin install x", "Claude CLI (claude mcp add …)"],
+    ["/fix", "Claude slash command"],
+    ["/lint", "Claude slash command"],
+    ["git submodule update", "Git clone"],
+    ["curl -L url", "Shell (curl / wget)"],
+    ["wget -qO- url", "Shell (curl / wget)"],
+    ["mkdir path", "Manual file setup"],
+    ["cat file > out", "Manual file setup"],
+    ["mv src dest", "Manual file setup"],
+    ["echo hi > file", "Manual file setup"],
+    ["touch file", "Manual file setup"],
+    ["tee outfile", "Manual file setup"],
+  ])("classifies edge command %s as %s", (command, label) => {
+    expect(installMethodOf(command)).toBe(label);
+  });
+});
+
+describe("notes field combinations", () => {
+  it.each([
+    [
+      { safetyNotes: "a", privacyNotes: "b" },
+      { safety: 1, privacy: 1, both: 1 },
+    ],
+    [{ safetyNotes: "a" }, { safety: 1, privacy: 0, both: 0 }],
+    [{ privacyNotes: "b" }, { safety: 0, privacy: 1, both: 0 }],
+    [{}, { safety: 0, privacy: 0, both: 0 }],
+  ] as const)("counts notes for %j", (partial, expected) => {
+    const coverage = notesCoverage([entry(partial)]);
+    expect(coverage.total).toBe(1);
+    expect(coverage.safety).toBe(expected.safety);
+    expect(coverage.privacy).toBe(expected.privacy);
+    expect(coverage.both).toBe(expected.both);
+  });
+});
+
+describe("large batch install distribution", () => {
+  it("handles fifty-entry catalogs deterministically", () => {
+    const methods = [
+      "npx",
+      "pnpm",
+      "yarn",
+      "pip install",
+      "docker run",
+      "go install",
+    ];
+    const catalog = Array.from({ length: 50 }, (_, index) =>
+      entry({
+        slug: `batch-${index}`,
+        installCommand: `${methods[index % methods.length]} pkg-${index}`,
+      }),
+    );
+    const { rows, total } = installMethodDistribution(catalog);
+    expect(total).toBe(50);
+    expect(rows.reduce((sum, row) => sum + row.count, 0)).toBe(50);
+    expect(rows[0]?.count).toBeGreaterThanOrEqual(rows.at(-1)?.count ?? 0);
+  });
+});
+
+describe("slash command precedence", () => {
+  it("classifies leading slash before other tokens", () => {
+    expect(installMethodOf("/agents install")).toBe("Claude slash command");
+    expect(installMethodOf("/custom-tool")).toBe("Claude slash command");
+  });
+});
+
+describe("python install mid-string detection", () => {
+  it.each([
+    "sudo pip install package",
+    "python3 -m pip install package",
+    "env pip install package",
+  ])("detects pip install in %s", (command) => {
+    expect(installMethodOf(command)).toBe("Python (pip / uv)");
+  });
+});
+
+describe("catalog notes snapshot", () => {
+  it("summarizes a realistic registry slice", () => {
+    const catalog = [
+      entry({
+        slug: "mcp-a",
+        installCommand: "npx a",
+        safetyNotes: "scope keys",
+      }),
+      entry({
+        slug: "mcp-b",
+        installCommand: "uvx b",
+        privacyNotes: "local only",
+      }),
+      entry({
+        slug: "mcp-c",
+        installCommand: "claude mcp add c",
+        safetyNotes: "oauth",
+        privacyNotes: "scopes",
+      }),
+      entry({ slug: "skill-d", installCommand: "/agents" }),
+      entry({ slug: "hook-e" }),
+    ];
+    expect(installMethodDistribution(catalog).total).toBe(4);
+    expect(notesCoverage(catalog)).toEqual({
+      total: 5,
+      safety: 2,
+      privacy: 2,
+      both: 1,
+    });
+  });
+});
+
+describe("install method label coverage", () => {
+  const expectedLabels = [
+    "npm / npx",
+    "pnpm",
+    "yarn",
+    "bun",
+    "deno",
+    "Python (pip / uv)",
+    "Docker",
+    "Go",
+    "Cargo",
+    "Homebrew",
+    "Claude CLI (claude mcp add …)",
+    "Claude slash command",
+    "Git clone",
+    "Shell (curl / wget)",
+    "Manual file setup",
+    "Other",
+  ];
+
+  it.each(expectedLabels)(
+    "emits bucket label %s from at least one command",
+    (label) => {
+      const commands: Record<string, string> = {
+        "npm / npx": "npx pkg",
+        pnpm: "pnpm add pkg",
+        yarn: "yarn add pkg",
+        bun: "bunx pkg",
+        deno: "deno run mod",
+        "Python (pip / uv)": "pip install pkg",
+        Docker: "docker run img",
+        Go: "go install pkg",
+        Cargo: "cargo install pkg",
+        Homebrew: "brew install pkg",
+        "Claude CLI (claude mcp add …)": "claude mcp add x",
+        "Claude slash command": "/agents",
+        "Git clone": "git clone repo",
+        "Shell (curl / wget)": "curl url",
+        "Manual file setup": "mkdir dir",
+        Other: "unknown-installer",
+      };
+      expect(installMethodOf(commands[label])).toBe(label);
+    },
+  );
+});
+
+describe("notes coverage batch scenarios", () => {
+  it("handles catalogs with only safety notes", () => {
+    const coverage = notesCoverage(
+      Array.from({ length: 8 }, () => entry({ safetyNotes: "note" })),
+    );
+    expect(coverage).toEqual({ total: 8, safety: 8, privacy: 0, both: 0 });
+  });
+
+  it("handles catalogs with only privacy notes", () => {
+    const coverage = notesCoverage(
+      Array.from({ length: 6 }, () => entry({ privacyNotes: "note" })),
+    );
+    expect(coverage).toEqual({ total: 6, safety: 0, privacy: 6, both: 0 });
+  });
+
+  it("handles catalogs where every entry has both notes", () => {
+    const coverage = notesCoverage(
+      Array.from({ length: 4 }, () =>
+        entry({ safetyNotes: "s", privacyNotes: "p" }),
+      ),
+    );
+    expect(coverage).toEqual({ total: 4, safety: 4, privacy: 4, both: 4 });
+  });
+});
+
+describe("install distribution single-bucket catalogs", () => {
+  it.each([
+    ["npx only", ["npx a", "npx b", "npm i c"]],
+    ["pnpm only", ["pnpm a", "pnpm b"]],
+    ["python only", ["pip install a", "uvx b"]],
+  ])("aggregates %s catalogs", (_label, commands) => {
+    const catalog = commands.map((installCommand, index) =>
+      entry({ slug: `e-${index}`, installCommand }),
+    );
+    const { rows, total } = installMethodDistribution(catalog);
+    expect(total).toBe(commands.length);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.count).toBe(commands.length);
+  });
+});
+
+describe("distribution row integrity", () => {
+  it("never emits zero-count rows", () => {
+    const { rows } = installMethodDistribution([
+      entry({ installCommand: "npx a" }),
+      entry({ installCommand: "pnpm b" }),
+    ]);
+    expect(rows.every((row) => row.count > 0)).toBe(true);
+  });
+
+  it("preserves deterministic ordering for repeated runs", () => {
+    const catalog = [
+      entry({ installCommand: "npx a" }),
+      entry({ installCommand: "npx b" }),
+      entry({ installCommand: "pnpm c" }),
+    ];
+    const first = installMethodDistribution(catalog);
+    const second = installMethodDistribution(catalog);
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/web-ecosystem-stats.test.ts
+++ b/tests/web-ecosystem-stats.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  installMethodDistribution,
+  installMethodOf,
+  notesCoverage,
+} from "@/lib/ecosystem-stats";
+
+describe("ecosystem-stats re-export surface", () => {
+  it("keeps the public import path wired to the extracted lib", () => {
+    expect(installMethodOf("npx pkg")).toBe("npm / npx");
+    expect(
+      installMethodDistribution([{ installCommand: "npx a" } as never]).total,
+    ).toBe(1);
+    expect(notesCoverage([{ safetyNotes: "x" } as never]).safety).toBe(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
         "apps/web/src/lib/content.server.ts",
         "apps/web/src/lib/contributors.ts",
         "apps/web/src/lib/data-reports.ts",
+        "apps/web/src/lib/ecosystem-stats.ts",
         "apps/web/src/lib/platform-pages.ts",
         "apps/web/src/lib/api-security.ts",
         "apps/web/src/lib/detail-assembly.ts",


### PR DESCRIPTION
## Summary
- Extract pure install-method classification and notes coverage builders from `ecosystem-stats.ts` into `ecosystem-stats-lib.ts`
- Keep `@/lib/ecosystem-stats` as a thin re-export so state-of-claude-tooling routes stay unchanged
- Add comprehensive `ecosystem-stats-lib` tests plus a smoke re-export test; exclude the wrapper from coverage

## Test plan
- [x] `pnpm test` (3461 tests)
- [x] `ecosystem-stats-lib.test.ts` covers all install-method buckets, distributions, and notes coverage edge cases
- [x] `web-ecosystem-stats.test.ts` verifies public re-export path


Made with [Cursor](https://cursor.com)