### PR TITLE
feat(compare): add interactive links for popular comparisons

### DIFF
--- a/apps/web/src/lib/compare-empty-guidance.ts
+++ b/apps/web/src/lib/compare-empty-guidance.ts
@@ -1,4 +1,10 @@
 import { COMPARE_INTERACTIVE_MAX, COMPARE_INTERACTIVE_MIN } from "@/lib/compare-interactive-link";
+import type { EntryIdentity } from "@/lib/entry-identity";
+import { parseEntryRef } from "@/lib/entry-identity";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
 
 export function compareEmptyStateDescription(): string {
   return `Add ${COMPARE_INTERACTIVE_MIN}–${COMPARE_INTERACTIVE_MAX} resources from the directory to see them side by side.`;
@@ -16,4 +22,31 @@ export function compareInvalidUrlHint(idsParam: string, resolvedCount: number): 
 
 export function compareDrawerEmptyHint(): string {
   return "Add resources to compare by tapping the Compare button on any card.";
+}
+
+export function resolveCuratedPickRefs(refs: string[], catalog: EntryIdentity[]): EntryIdentity[] {
+  const out: EntryIdentity[] = [];
+  for (const ref of refs) {
+    const identity = parseEntryRef(ref);
+    if (!identity) continue;
+    const entry = catalog.find(
+      (candidate) => candidate.category === identity.category && candidate.slug === identity.slug,
+    );
+    if (entry) out.push(entry);
+  }
+  return out;
+}
+
+export function compareCuratedPickInteractiveSearch(
+  refs: string[],
+  catalog: EntryIdentity[],
+): { ids: string } | null {
+  return compareInteractiveSearch(resolveCuratedPickRefs(refs, catalog));
+}
+
+export function compareCuratedPickInteractiveLabel(resolvedCount: number): string {
+  if (resolvedCount <= 2) {
+    return "Open interactively";
+  }
+  return compareInteractiveLinkLabel(resolvedCount);
 }

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -19,9 +19,12 @@ import {
 } from "@/lib/compare-entry-actions";
 import { comparePageBannerTexts } from "@/lib/compare-page-summary";
 import {
+  compareCuratedPickInteractiveLabel,
+  compareCuratedPickInteractiveSearch,
   compareEmptyStateDescription,
   compareInvalidUrlHint,
   compareSingleItemHintText,
+  resolveCuratedPickRefs,
 } from "@/lib/compare-empty-guidance";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
@@ -127,16 +130,33 @@ function ComparePage() {
           <div className="mt-6">
             <div className="eyebrow mb-2">Popular comparisons</div>
             <div className="flex flex-wrap justify-center gap-2">
-              {COMPARISONS.map((c) => (
-                <Link
-                  key={c.slug}
-                  to="/compare/$slug"
-                  params={{ slug: c.slug }}
-                  className="inline-flex items-center rounded-full border border-border bg-background px-3 py-1.5 text-xs text-ink-muted hover:text-ink"
-                >
-                  {c.heading}
-                </Link>
-              ))}
+              {COMPARISONS.map((c) => {
+                const resolvedCount = resolveCuratedPickRefs(c.refs, ENTRIES).length;
+                const interactiveSearch = compareCuratedPickInteractiveSearch(c.refs, ENTRIES);
+                return (
+                  <div
+                    key={c.slug}
+                    className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
+                  >
+                    <Link
+                      to="/compare/$slug"
+                      params={{ slug: c.slug }}
+                      className="text-xs text-ink-muted hover:text-ink"
+                    >
+                      {c.heading}
+                    </Link>
+                    {interactiveSearch ? (
+                      <Link
+                        to="/compare"
+                        search={interactiveSearch}
+                        className="text-[10px] text-ink-subtle hover:text-ink"
+                      >
+                        {compareCuratedPickInteractiveLabel(resolvedCount)}
+                      </Link>
+                    ) : null}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/tests/compare-empty-guidance.test.ts
+++ b/tests/compare-empty-guidance.test.ts
@@ -1,10 +1,37 @@
 import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
 import {
+  compareCuratedPickInteractiveLabel,
+  compareCuratedPickInteractiveSearch,
   compareDrawerEmptyHint,
   compareEmptyStateDescription,
   compareInvalidUrlHint,
   compareSingleItemHintText,
+  resolveCuratedPickRefs,
 } from "@/lib/compare-empty-guidance";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
 
 describe("compare empty guidance", () => {
   it("describes the interactive compare selection range", () => {
@@ -33,6 +60,28 @@ describe("compare empty guidance", () => {
   it("guides drawer readers to add resources from cards", () => {
     expect(compareDrawerEmptyHint()).toBe(
       "Add resources to compare by tapping the Compare button on any card.",
+    );
+  });
+
+  it("builds interactive compare links for curated comparison picks", () => {
+    expect(
+      resolveCuratedPickRefs(["skills/alpha", "missing/slug"], catalog),
+    ).toEqual([catalog[0]]);
+    expect(
+      resolveCuratedPickRefs(["bad-ref", "skills/alpha"], catalog),
+    ).toEqual([catalog[0]]);
+    expect(
+      compareCuratedPickInteractiveSearch(["skills/alpha"], catalog),
+    ).toBeNull();
+    expect(
+      compareCuratedPickInteractiveSearch(
+        ["skills/alpha", "hooks/beta"],
+        catalog,
+      ),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+    expect(compareCuratedPickInteractiveLabel(2)).toBe("Open interactively");
+    expect(compareCuratedPickInteractiveLabel(3)).toBe(
+      "Open 3 picks in the interactive comparison tool",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Extends `compare-empty-guidance` with curated-pick ref resolution and interactive `/compare?ids=…` link helpers.
- Wires secondary “Open interactively” links on popular comparison chips in the `/compare` empty state.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-empty-guidance.test.ts --coverage --coverage.include='apps/web/src/lib/compare-empty-guidance.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4343, #4345, #4251, and #4259; merge simulation clean with #4343/#4345/#4259 in both orderings

