### PR TITLE
feat(compare): add interactive links for featured best lists

### DIFF
--- a/apps/web/src/lib/compare-best-summary.ts
+++ b/apps/web/src/lib/compare-best-summary.ts
@@ -1,10 +1,20 @@
 import type { Entry } from "@/types/registry";
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  compareFeaturedInteractiveLinkLabel,
+  compareFeaturedInteractiveSearch,
+  resolveComparisonRefs,
+} from "@/lib/compare-featured-link";
 import {
   compareCuratedDecisionBannerText,
   compareCuratedSummary,
   type CompareDecisionSummary,
 } from "@/lib/compare-curated-summary";
 import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export type BestListPickRef = {
+  ref: string;
+};
 
 export function compareBestSummary(entries: Entry[]): {
   comparedCount: number;
@@ -37,4 +47,24 @@ export function compareBestBannerTexts(entries: Entry[]): string[] {
   if (decisionText) messages.push(decisionText);
   if (actionText) messages.push(actionText);
   return messages;
+}
+
+export function compareBestListPickRefs(picks: BestListPickRef[]): string[] {
+  return picks.map((pick) => pick.ref);
+}
+
+export function compareBestListInteractiveSearch(
+  picks: BestListPickRef[],
+  catalog: EntryIdentity[],
+): { ids: string } | null {
+  return compareFeaturedInteractiveSearch(compareBestListPickRefs(picks), catalog);
+}
+
+export function compareBestListInteractiveLinkLabel(
+  picks: BestListPickRef[],
+  catalog: EntryIdentity[],
+): string {
+  return compareFeaturedInteractiveLinkLabel(
+    resolveComparisonRefs(compareBestListPickRefs(picks), catalog).length,
+  );
 }

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -40,6 +40,10 @@ import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
 import {
+  compareBestListInteractiveLinkLabel,
+  compareBestListInteractiveSearch,
+} from "@/lib/compare-best-summary";
+import {
   compareDossierBannerTexts,
   compareDossierInteractiveSearch,
 } from "@/lib/compare-dossier-summary";
@@ -263,6 +267,15 @@ function Dossier() {
         };
       }),
     [comparedIn],
+  );
+  const featuredBestListLinks = useMemo(
+    () =>
+      featuredIn.map((list) => ({
+        slug: list.slug,
+        search: compareBestListInteractiveSearch(list.picks, ENTRIES),
+        label: compareBestListInteractiveLinkLabel(list.picks, ENTRIES),
+      })),
+    [featuredIn],
   );
   const recents = useRecents();
   useEffect(() => {
@@ -759,17 +772,32 @@ function Dossier() {
           {(featuredIn.length > 0 || comparedIn.length > 0) && (
             <DossierSection id="featured-in" title="Featured in">
               <ul className="flex flex-col gap-2 text-sm">
-                {featuredIn.map((l) => (
-                  <li key={`best-${l.slug}`}>
-                    <Link
-                      to="/best/$slug"
-                      params={{ slug: l.slug }}
-                      className="story-link text-ink"
+                {featuredIn.map((l) => {
+                  const bestListLink = featuredBestListLinks.find((link) => link.slug === l.slug);
+                  return (
+                    <li
+                      key={`best-${l.slug}`}
+                      className="flex flex-wrap items-baseline gap-x-2 gap-y-1"
                     >
-                      Best list: {l.title}
-                    </Link>
-                  </li>
-                ))}
+                      <Link
+                        to="/best/$slug"
+                        params={{ slug: l.slug }}
+                        className="story-link text-ink"
+                      >
+                        Best list: {l.title}
+                      </Link>
+                      {bestListLink?.search ? (
+                        <Link
+                          to="/compare"
+                          search={bestListLink.search}
+                          className="text-xs text-ink-muted hover:text-ink"
+                        >
+                          {bestListLink.label}
+                        </Link>
+                      ) : null}
+                    </li>
+                  );
+                })}
                 {comparedIn.map((c) => {
                   const featuredLink = featuredCompareLinks.find((link) => link.slug === c.slug);
                   return (

--- a/tests/compare-best-summary.test.ts
+++ b/tests/compare-best-summary.test.ts
@@ -4,6 +4,8 @@ import {
   compareBestActionBannerText,
   compareBestBannerTexts,
   compareBestDecisionBannerText,
+  compareBestListInteractiveLinkLabel,
+  compareBestListInteractiveSearch,
   compareBestSummary,
   shouldShowBestCompareSection,
 } from "@/lib/compare-best-summary";
@@ -98,5 +100,27 @@ describe("compare best summary", () => {
     ).toEqual([
       "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+  });
+
+  it("builds interactive compare links for best-list picks", () => {
+    const catalog = [
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ];
+    expect(
+      compareBestListInteractiveSearch([{ ref: "skills/alpha" }], catalog),
+    ).toBeNull();
+    expect(
+      compareBestListInteractiveSearch(
+        [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+        catalog,
+      ),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+    expect(
+      compareBestListInteractiveLinkLabel(
+        [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+        catalog,
+      ),
+    ).toBe("Open interactively");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `compareBestListInteractiveSearch` helpers so best-list picks can deep-link into `/compare?ids=…`.
- Wires secondary “Open interactively” links beside best-list entries in entry dossier **Featured in** sections (parity with curated comparisons).
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-summary.test.ts --coverage --coverage.include='apps/web/src/lib/compare-best-summary.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4346, #4345, #4251, and #4259; merge simulation clean with #4346/#4345/#4259 in both orderings


Made with [Cursor](https://cursor.com)