### PR TITLE
feat(compare): centralize interactive compare share URLs

### DIFF
--- a/apps/web/src/lib/compare-share-link.ts
+++ b/apps/web/src/lib/compare-share-link.ts
@@ -1,0 +1,15 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import { serializeCompareItems } from "@/lib/compare-selection";
+
+export function comparePageSharePath(idsParam: string): string {
+  const ids = idsParam.trim();
+  return ids ? `/compare?ids=${encodeURIComponent(ids)}` : "/compare";
+}
+
+export function comparePageShareUrl(idsParam: string, origin = ""): string {
+  return `${origin}${comparePageSharePath(idsParam)}`;
+}
+
+export function comparePageShareUrlFromEntries(entries: EntryIdentity[], origin = ""): string {
+  return comparePageShareUrl(serializeCompareItems(entries), origin);
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -18,6 +18,7 @@ import {
   type CompareAction,
 } from "@/lib/compare-entry-actions";
 import { comparePageBannerTexts } from "@/lib/compare-page-summary";
+import { comparePageShareUrlFromEntries } from "@/lib/compare-share-link";
 import {
   compareCuratedPickInteractiveLabel,
   compareCuratedPickInteractiveSearch,
@@ -100,9 +101,8 @@ function ComparePage() {
   };
 
   const copyShare = () => {
-    const sig = serializeCompareItems(items);
     const origin = typeof window !== "undefined" ? window.location.origin : "";
-    return sig ? `${origin}/compare?ids=${encodeURIComponent(sig)}` : `${origin}/compare`;
+    return comparePageShareUrlFromEntries(items, origin);
   };
 
   if (items.length === 0) {

--- a/tests/compare-share-link.test.ts
+++ b/tests/compare-share-link.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  comparePageSharePath,
+  comparePageShareUrl,
+  comparePageShareUrlFromEntries,
+} from "@/lib/compare-share-link";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare share link", () => {
+  it("builds compare page share paths", () => {
+    expect(comparePageSharePath("")).toBe("/compare");
+    expect(comparePageSharePath("   ")).toBe("/compare");
+    expect(comparePageSharePath("skills/alpha,hooks/beta")).toBe(
+      "/compare?ids=skills%2Falpha%2Chooks%2Fbeta",
+    );
+  });
+
+  it("builds absolute compare page share URLs", () => {
+    expect(comparePageShareUrl("", "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/compare",
+    );
+    expect(comparePageShareUrl("mcp/fixture", "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/compare?ids=mcp%2Ffixture",
+    );
+  });
+
+  it("serializes compared entries into share URLs", () => {
+    expect(
+      comparePageShareUrlFromEntries(
+        [
+          entry({ category: "skills", slug: "alpha" }),
+          entry({ category: "hooks", slug: "beta" }),
+        ],
+        "https://heyclaude.dev",
+      ),
+    ).toBe("https://heyclaude.dev/compare?ids=skills%2Falpha%2Chooks%2Fbeta");
+    expect(comparePageShareUrlFromEntries([], "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/compare",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `compare-share-link` helpers to build `/compare` and `/compare?ids=…` share paths and URLs.
- Routes the interactive compare page copy-link control through the shared helper.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-share-link.test.ts --coverage --coverage.include='apps/web/src/lib/compare-share-link.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4346, #4345, #4251, and #4259; merge simulation clean with #4346+#4345 and #4259


Made with [Cursor](https://cursor.com)