### PR TITLE
feat(compare): route browse compare CTA through shared open search

### DIFF
--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -33,3 +33,12 @@ export function browseCompareOpenSearch(items: Entry[]): { ids: string } | null 
   if (!shouldShowBrowseCompareHint(items)) return null;
   return compareFullViewSearch(items);
 }
+
+export function browseCompareCtaState(
+  items: Entry[],
+): { search: { ids: string }; selectedCount: number } | null {
+  const search = browseCompareOpenSearch(items);
+  if (!search) return null;
+  const selectedCount = search.ids.split(",").filter((id) => id.length > 0).length;
+  return { search, selectedCount };
+}

--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -1,5 +1,6 @@
 import type { Entry } from "@/types/registry";
 import { compareCuratedSummary } from "@/lib/compare-curated-summary";
+import { compareFullViewSearch } from "@/lib/compare-interactive-link";
 
 export const BROWSE_COMPARE_MIN_ITEMS = 2;
 
@@ -26,4 +27,9 @@ export function browseCompareHintText(items: Entry[]): string | null {
     parts.push("next steps differ");
   }
   return `${parts.join(" · ")} — open compare for details.`;
+}
+
+export function browseCompareOpenSearch(items: Entry[]): { ids: string } | null {
+  if (!shouldShowBrowseCompareHint(items)) return null;
+  return compareFullViewSearch(items);
 }

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,7 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
-import { browseCompareHintText } from "@/lib/compare-browse-summary";
+import { browseCompareHintText, browseCompareOpenSearch } from "@/lib/compare-browse-summary";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -315,6 +315,10 @@ function Browse() {
   }, [compareSig]);
 
   const compareHint = useMemo(() => browseCompareHintText(compare.items), [compare.items]);
+  const browseCompareSearch = useMemo(
+    () => browseCompareOpenSearch(compare.items),
+    [compare.items],
+  );
 
   const activeCount =
     Number(!!sp.q) +
@@ -636,7 +640,7 @@ function Browse() {
                     </>
                   )}
                 </span>
-                {compare.items.length >= 2 && (
+                {browseCompareSearch ? (
                   <div className="inline-flex flex-col items-end gap-1">
                     {compareHint ? (
                       <span className="max-w-xs text-right text-[11px] text-ink-muted">
@@ -645,15 +649,13 @@ function Browse() {
                     ) : null}
                     <Link
                       to="/compare"
-                      search={{
-                        ids: compare.items.map((e) => `${e.category}/${e.slug}`).join(","),
-                      }}
+                      search={browseCompareSearch}
                       className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
                     >
                       <span className="font-mono">{compare.items.length}</span> selected · Compare →
                     </Link>
                   </div>
-                )}
+                ) : null}
               </div>
               <div className="flex items-center gap-2">
                 <label className="inline-flex items-center gap-1.5 text-xs text-ink-muted">

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,7 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
-import { browseCompareHintText, browseCompareOpenSearch } from "@/lib/compare-browse-summary";
+import { browseCompareHintText, browseCompareCtaState } from "@/lib/compare-browse-summary";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -315,10 +315,7 @@ function Browse() {
   }, [compareSig]);
 
   const compareHint = useMemo(() => browseCompareHintText(compare.items), [compare.items]);
-  const browseCompareSearch = useMemo(
-    () => browseCompareOpenSearch(compare.items),
-    [compare.items],
-  );
+  const browseCompareCta = useMemo(() => browseCompareCtaState(compare.items), [compare.items]);
 
   const activeCount =
     Number(!!sp.q) +
@@ -640,7 +637,7 @@ function Browse() {
                     </>
                   )}
                 </span>
-                {browseCompareSearch ? (
+                {browseCompareCta ? (
                   <div className="inline-flex flex-col items-end gap-1">
                     {compareHint ? (
                       <span className="max-w-xs text-right text-[11px] text-ink-muted">
@@ -649,10 +646,11 @@ function Browse() {
                     ) : null}
                     <Link
                       to="/compare"
-                      search={browseCompareSearch}
+                      search={browseCompareCta.search}
                       className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
                     >
-                      <span className="font-mono">{compare.items.length}</span> selected · Compare →
+                      <span className="font-mono">{browseCompareCta.selectedCount}</span> selected ·
+                      Compare →
                     </Link>
                   </div>
                 ) : null}

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   BROWSE_COMPARE_MIN_ITEMS,
   browseCompareHintText,
+  browseCompareOpenSearch,
   browseCompareSummary,
   shouldShowBrowseCompareHint,
 } from "@/lib/compare-browse-summary";
@@ -110,5 +111,24 @@ describe("compare browse summary", () => {
     ).toBe(
       "1 trust signal differ · next steps differ — open compare for details.",
     );
+  });
+
+  it("builds interactive compare search params for browse selections", () => {
+    expect(browseCompareOpenSearch([entry()])).toBeNull();
+    expect(
+      browseCompareOpenSearch([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+    expect(
+      browseCompareOpenSearch([
+        entry({ slug: "one" }),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+        entry({ slug: "five" }),
+      ]),
+    ).toEqual({ ids: "mcp/one,mcp/two,mcp/three,mcp/four" });
   });
 });

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   BROWSE_COMPARE_MIN_ITEMS,
   browseCompareHintText,
+  browseCompareCtaState,
   browseCompareOpenSearch,
   browseCompareSummary,
   shouldShowBrowseCompareHint,
@@ -115,6 +116,7 @@ describe("compare browse summary", () => {
 
   it("builds interactive compare search params for browse selections", () => {
     expect(browseCompareOpenSearch([entry()])).toBeNull();
+    expect(browseCompareCtaState([entry()])).toBeNull();
     expect(
       browseCompareOpenSearch([
         entry({ category: "skills", slug: "alpha" }),
@@ -130,5 +132,17 @@ describe("compare browse summary", () => {
         entry({ slug: "five" }),
       ]),
     ).toEqual({ ids: "mcp/one,mcp/two,mcp/three,mcp/four" });
+    expect(
+      browseCompareCtaState([
+        entry({ slug: "one" }),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+        entry({ slug: "five" }),
+      ]),
+    ).toEqual({
+      search: { ids: "mcp/one,mcp/two,mcp/three,mcp/four" },
+      selectedCount: 4,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `browseCompareOpenSearch` and `browseCompareCtaState` so browse compare CTAs reuse capped `/compare?ids=…` serialization via `compareFullViewSearch`.
- Keeps the browse pill selected count aligned with the entries the compare link actually opens (fixes Gittensory blocker from #4350).
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-summary.test.ts --coverage --coverage.include='apps/web/src/lib/compare-browse-summary.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4251 and #4259; merge simulation clean with #4259


Made with [Cursor](https://cursor.com)