### PR TITLE
feat(compare): unify browse compare CTA with capped selection state

### DIFF
--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -1,5 +1,6 @@
 import type { Entry } from "@/types/registry";
 import { compareCuratedSummary } from "@/lib/compare-curated-summary";
+import { COMPARE_INTERACTIVE_MAX, compareFullViewSearch } from "@/lib/compare-interactive-link";
 
 export const BROWSE_COMPARE_MIN_ITEMS = 2;
 
@@ -7,13 +8,23 @@ export function shouldShowBrowseCompareHint(items: Entry[]): boolean {
   return items.length >= BROWSE_COMPARE_MIN_ITEMS;
 }
 
+export function browseCompareSelectedEntries(items: Entry[]): Entry[] {
+  return items.slice(0, COMPARE_INTERACTIVE_MAX);
+}
+
 export function browseCompareSummary(items: Entry[]) {
   return compareCuratedSummary(items);
 }
 
+export function browseCompareOverflowHint(totalCount: number, openCount: number): string | null {
+  if (totalCount <= openCount) return null;
+  return `Opening ${openCount} of ${totalCount} selected in compare.`;
+}
+
 export function browseCompareHintText(items: Entry[]): string | null {
-  if (!shouldShowBrowseCompareHint(items)) return null;
-  const summary = browseCompareSummary(items);
+  const capped = browseCompareSelectedEntries(items);
+  if (!shouldShowBrowseCompareHint(capped)) return null;
+  const summary = browseCompareSummary(capped);
   if (!summary.hasAnyDivergence) {
     return "Open compare to review trust and next steps side by side.";
   }
@@ -26,4 +37,21 @@ export function browseCompareHintText(items: Entry[]): string | null {
     parts.push("next steps differ");
   }
   return `${parts.join(" · ")} — open compare for details.`;
+}
+
+export function browseCompareUiState(items: Entry[]): {
+  search: { ids: string };
+  selectedCount: number;
+  hint: string | null;
+  overflowHint: string | null;
+} | null {
+  if (!shouldShowBrowseCompareHint(items)) return null;
+  const capped = browseCompareSelectedEntries(items);
+  const search = compareFullViewSearch(capped)!;
+  return {
+    search,
+    selectedCount: capped.length,
+    hint: browseCompareHintText(items),
+    overflowHint: browseCompareOverflowHint(items.length, capped.length),
+  };
 }

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,7 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
-import { browseCompareHintText } from "@/lib/compare-browse-summary";
+import { browseCompareUiState } from "@/lib/compare-browse-summary";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -314,7 +314,7 @@ function Browse() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareSig]);
 
-  const compareHint = useMemo(() => browseCompareHintText(compare.items), [compare.items]);
+  const browseCompareUi = useMemo(() => browseCompareUiState(compare.items), [compare.items]);
 
   const activeCount =
     Number(!!sp.q) +
@@ -636,24 +636,28 @@ function Browse() {
                     </>
                   )}
                 </span>
-                {compare.items.length >= 2 && (
+                {browseCompareUi ? (
                   <div className="inline-flex flex-col items-end gap-1">
-                    {compareHint ? (
+                    {browseCompareUi.overflowHint ? (
+                      <span className="max-w-xs text-right text-[11px] text-amber-800">
+                        {browseCompareUi.overflowHint}
+                      </span>
+                    ) : null}
+                    {browseCompareUi.hint ? (
                       <span className="max-w-xs text-right text-[11px] text-ink-muted">
-                        {compareHint}
+                        {browseCompareUi.hint}
                       </span>
                     ) : null}
                     <Link
                       to="/compare"
-                      search={{
-                        ids: compare.items.map((e) => `${e.category}/${e.slug}`).join(","),
-                      }}
+                      search={browseCompareUi.search}
                       className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
                     >
-                      <span className="font-mono">{compare.items.length}</span> selected · Compare →
+                      <span className="font-mono">{browseCompareUi.selectedCount}</span> selected ·
+                      Compare →
                     </Link>
                   </div>
-                )}
+                ) : null}
               </div>
               <div className="flex items-center gap-2">
                 <label className="inline-flex items-center gap-1.5 text-xs text-ink-muted">

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -3,7 +3,10 @@ import type { Entry } from "@/types/registry";
 import {
   BROWSE_COMPARE_MIN_ITEMS,
   browseCompareHintText,
+  browseCompareOverflowHint,
+  browseCompareSelectedEntries,
   browseCompareSummary,
+  browseCompareUiState,
   shouldShowBrowseCompareHint,
 } from "@/lib/compare-browse-summary";
 
@@ -110,5 +113,34 @@ describe("compare browse summary", () => {
     ).toBe(
       "1 trust signal differ · next steps differ — open compare for details.",
     );
+  });
+
+  it("caps browse compare hints and links to the interactive compare limit", () => {
+    const five = [
+      entry({ slug: "one" }),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+      entry({
+        slug: "five",
+        reviewedBy: "maintainer",
+        reviewedAt: "2026-01-02",
+      }),
+    ];
+    expect(browseCompareSelectedEntries(five)).toHaveLength(4);
+    expect(browseCompareOverflowHint(5, 4)).toBe(
+      "Opening 4 of 5 selected in compare.",
+    );
+    expect(browseCompareOverflowHint(2, 2)).toBeNull();
+    expect(browseCompareHintText(five)).toBe(
+      "Open compare to review trust and next steps side by side.",
+    );
+    expect(browseCompareUiState(five)).toEqual({
+      search: { ids: "mcp/one,mcp/two,mcp/three,mcp/four" },
+      selectedCount: 4,
+      hint: "Open compare to review trust and next steps side by side.",
+      overflowHint: "Opening 4 of 5 selected in compare.",
+    });
+    expect(browseCompareUiState([entry()])).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `browseCompareUiState` so browse compare hints, counts, overflow copy, and `/compare?ids=…` links all derive from the same capped selection (max 4 entries).
- Replaces inline browse compare URL building with shared `compareFullViewSearch` serialization.
- Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-summary.test.ts --coverage --coverage.include='apps/web/src/lib/compare-browse-summary.ts'` — 100% patch coverage
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] Zero file overlap with open PRs #4251 and #4259; merge simulation clean with #4259


Made with [Cursor](https://cursor.com)