### PR TITLE
feat(compare): centralize browse compare share URLs

### DIFF
--- a/apps/web/src/lib/compare-browse-share-link.ts
+++ b/apps/web/src/lib/compare-browse-share-link.ts
@@ -1,0 +1,15 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import { serializeCompareItems } from "@/lib/compare-selection";
+
+export function compareBrowseSharePath(idsParam: string): string {
+  const ids = idsParam.trim();
+  return ids ? `/browse?compare=${encodeURIComponent(ids)}` : "/browse";
+}
+
+export function compareBrowseShareUrl(idsParam: string, origin = ""): string {
+  return `${origin}${compareBrowseSharePath(idsParam)}`;
+}
+
+export function compareBrowseShareUrlFromEntries(entries: EntryIdentity[], origin = ""): string {
+  return compareBrowseShareUrl(serializeCompareItems(entries), origin);
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { compareBrowseShareUrl } from "@/lib/compare-browse-share-link";
 import {
   hasCompareItem,
   resolveCompareParam,
@@ -86,7 +87,7 @@ function createCompareStore(): CompareStore {
     getShareUrl: () => {
       const sig = serializeCompareItems(state.items);
       const origin = typeof window !== "undefined" ? window.location.origin : "";
-      return sig ? `${origin}/browse?compare=${encodeURIComponent(sig)}` : `${origin}/browse`;
+      return compareBrowseShareUrl(sig, origin);
     },
   };
 

--- a/tests/compare-browse-share-link.test.ts
+++ b/tests/compare-browse-share-link.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareBrowseSharePath,
+  compareBrowseShareUrl,
+  compareBrowseShareUrlFromEntries,
+} from "@/lib/compare-browse-share-link";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare browse share link", () => {
+  it("builds browse compare share paths", () => {
+    expect(compareBrowseSharePath("")).toBe("/browse");
+    expect(compareBrowseSharePath("   ")).toBe("/browse");
+    expect(compareBrowseSharePath("skills/alpha,hooks/beta")).toBe(
+      "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
+    );
+  });
+
+  it("builds absolute browse compare share URLs", () => {
+    expect(compareBrowseShareUrl("", "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/browse",
+    );
+    expect(compareBrowseShareUrl("mcp/fixture", "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/browse?compare=mcp%2Ffixture",
+    );
+  });
+
+  it("serializes compared entries into browse share URLs", () => {
+    expect(
+      compareBrowseShareUrlFromEntries(
+        [
+          entry({ category: "skills", slug: "alpha" }),
+          entry({ category: "hooks", slug: "beta" }),
+        ],
+        "https://heyclaude.dev",
+      ),
+    ).toBe(
+      "https://heyclaude.dev/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
+    );
+    expect(compareBrowseShareUrlFromEntries([], "https://heyclaude.dev")).toBe(
+      "https://heyclaude.dev/browse",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-browse-share-link` helpers for `/browse?compare=` share paths and absolute URLs (parallel to `compare-share-link` for `/compare?ids=`).
- Wire `CompareProvider.getShareUrl` through the new module so the drawer copy-link uses the shared builder.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-share-link.test.ts --coverage` — 100% on new lib
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)