### PR TITLE
feat(compare): extract shared page and drawer summary helpers

### DIFF
--- a/apps/web/src/lib/compare-drawer-summary.ts
+++ b/apps/web/src/lib/compare-drawer-summary.ts
@@ -1,17 +1,17 @@
 import type { Entry } from "@/types/registry";
-import { compareActionsDiverge } from "@/lib/compare-entry-actions";
 import {
-  compareCuratedDecisionBannerText,
-  type CompareDecisionSummary,
-} from "@/lib/compare-curated-summary";
-import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+  compareSurfaceBannerTexts,
+  compareSurfaceDecisionBannerText,
+  compareSurfaceDecisionSummary,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
 
-export function compareDrawerDecisionSummary(entries: Entry[]): CompareDecisionSummary {
-  return compareDecisionSummary(entries);
+export function compareDrawerDecisionSummary(entries: Entry[]) {
+  return compareSurfaceDecisionSummary(entries);
 }
 
 export function compareDrawerDecisionBannerText(entries: Entry[]): string | null {
-  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+  return compareSurfaceDecisionBannerText(entries);
 }
 
 export function compareDrawerActionBannerText(actionsDiverge: boolean): string | null {
@@ -19,28 +19,11 @@ export function compareDrawerActionBannerText(actionsDiverge: boolean): string |
   return "Next steps differ across this comparison — review install, source, and claim actions per entry.";
 }
 
-export function compareDrawerSummary(entries: Entry[]): {
-  comparedCount: number;
-  decision: CompareDecisionSummary;
-  actionsDiverge: boolean;
-  hasAnyDivergence: boolean;
-} {
-  const decision = compareDecisionSummary(entries);
-  const actionsDiverge = compareActionsDiverge(entries);
-  return {
-    comparedCount: entries.length,
-    decision,
-    actionsDiverge,
-    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
-  };
+export function compareDrawerSummary(entries: Entry[]) {
+  return compareSurfaceSummary(entries);
 }
 
 export function compareDrawerBannerTexts(entries: Entry[]): string[] {
-  const summary = compareDrawerSummary(entries);
-  const messages: string[] = [];
-  const decisionText = compareDrawerDecisionBannerText(entries);
-  const actionText = compareDrawerActionBannerText(summary.actionsDiverge);
-  if (decisionText) messages.push(decisionText);
-  if (actionText) messages.push(actionText);
-  return messages;
+  const summary = compareSurfaceSummary(entries);
+  return compareSurfaceBannerTexts(entries, compareDrawerActionBannerText(summary.actionsDiverge));
 }

--- a/apps/web/src/lib/compare-page-summary.ts
+++ b/apps/web/src/lib/compare-page-summary.ts
@@ -1,19 +1,19 @@
 import type { Entry } from "@/types/registry";
-import { compareActionsDiverge } from "@/lib/compare-entry-actions";
 import {
-  compareCuratedDecisionBannerText,
-  type CompareDecisionSummary,
-} from "@/lib/compare-curated-summary";
-import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+  compareSurfaceBannerTexts,
+  compareSurfaceDecisionBannerText,
+  compareSurfaceDecisionSummary,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
 
 export const COMPARE_PAGE_SURFACE = "compare-page";
 
-export function comparePageDecisionSummary(entries: Entry[]): CompareDecisionSummary {
-  return compareDecisionSummary(entries);
+export function comparePageDecisionSummary(entries: Entry[]) {
+  return compareSurfaceDecisionSummary(entries);
 }
 
 export function comparePageDecisionBannerText(entries: Entry[]): string | null {
-  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+  return compareSurfaceDecisionBannerText(entries);
 }
 
 export function comparePageActionBannerText(actionsDiverge: boolean): string | null {
@@ -21,28 +21,11 @@ export function comparePageActionBannerText(actionsDiverge: boolean): string | n
   return "Next steps differ across this comparison — review install, source, and claim actions in the table below.";
 }
 
-export function comparePageSummary(entries: Entry[]): {
-  comparedCount: number;
-  decision: CompareDecisionSummary;
-  actionsDiverge: boolean;
-  hasAnyDivergence: boolean;
-} {
-  const decision = compareDecisionSummary(entries);
-  const actionsDiverge = compareActionsDiverge(entries);
-  return {
-    comparedCount: entries.length,
-    decision,
-    actionsDiverge,
-    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
-  };
+export function comparePageSummary(entries: Entry[]) {
+  return compareSurfaceSummary(entries);
 }
 
 export function comparePageBannerTexts(entries: Entry[]): string[] {
-  const summary = comparePageSummary(entries);
-  const messages: string[] = [];
-  const decisionText = comparePageDecisionBannerText(entries);
-  const actionText = comparePageActionBannerText(summary.actionsDiverge);
-  if (decisionText) messages.push(decisionText);
-  if (actionText) messages.push(actionText);
-  return messages;
+  const summary = compareSurfaceSummary(entries);
+  return compareSurfaceBannerTexts(entries, comparePageActionBannerText(summary.actionsDiverge));
 }

--- a/apps/web/src/lib/compare-surface-summary-lib.ts
+++ b/apps/web/src/lib/compare-surface-summary-lib.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared compare surface summary helpers.
+ *
+ * Builds decision and action divergence summaries for compare page and drawer
+ * headers. Nothing here touches the network — given the same entry metadata
+ * the output is deterministic.
+ */
+
+import type { Entry } from "@/types/registry";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import {
+  compareCuratedDecisionBannerText,
+  type CompareDecisionSummary,
+} from "@/lib/compare-curated-summary";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+
+export function compareSurfaceDecisionSummary(entries: Entry[]): CompareDecisionSummary {
+  return compareDecisionSummary(entries);
+}
+
+export function compareSurfaceDecisionBannerText(entries: Entry[]): string | null {
+  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+}
+
+export function compareSurfaceSummary(entries: Entry[]): {
+  comparedCount: number;
+  decision: CompareDecisionSummary;
+  actionsDiverge: boolean;
+  hasAnyDivergence: boolean;
+} {
+  const decision = compareDecisionSummary(entries);
+  const actionsDiverge = compareActionsDiverge(entries);
+  return {
+    comparedCount: entries.length,
+    decision,
+    actionsDiverge,
+    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
+  };
+}
+
+export function compareSurfaceBannerTexts(
+  entries: Entry[],
+  actionBannerText: string | null,
+): string[] {
+  const messages: string[] = [];
+  const decisionText = compareSurfaceDecisionBannerText(entries);
+  if (decisionText) messages.push(decisionText);
+  if (actionBannerText) messages.push(actionBannerText);
+  return messages;
+}

--- a/tests/compare-surface-summary-lib.test.ts
+++ b/tests/compare-surface-summary-lib.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareSurfaceBannerTexts,
+  compareSurfaceDecisionBannerText,
+  compareSurfaceDecisionSummary,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare surface summary lib", () => {
+  it("mirrors decision summaries for compare surface headers", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareSurfaceDecisionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      divergingCount: 0,
+      divergingLabels: [],
+    });
+    expect(compareSurfaceDecisionSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      divergingCount: 1,
+      divergingLabels: ["Review status"],
+    });
+  });
+
+  it("combines trust and action divergence for surface summaries", () => {
+    const baseline = entry();
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareSurfaceSummary([baseline])).toEqual({
+      comparedCount: 1,
+      decision: {
+        comparedCount: 1,
+        divergingCount: 0,
+        divergingLabels: [],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: false,
+    });
+    expect(compareSurfaceSummary([baseline, reviewed])).toEqual({
+      comparedCount: 2,
+      decision: {
+        comparedCount: 2,
+        divergingCount: 1,
+        divergingLabels: ["Review status"],
+      },
+      actionsDiverge: false,
+      hasAnyDivergence: true,
+    });
+    expect(
+      compareSurfaceSummary([
+        baseline,
+        entry({ installCommand: "npm i fixture" }),
+      ]).hasAnyDivergence,
+    ).toBe(true);
+  });
+
+  it("formats surface decision banner copy", () => {
+    expect(compareSurfaceDecisionBannerText([entry()])).toBeNull();
+    expect(
+      compareSurfaceDecisionBannerText([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toBe("1 trust signal differ across this comparison (Review status).");
+  });
+
+  it("returns ordered banner messages with optional action copy", () => {
+    const reviewed = entry({
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareSurfaceBannerTexts([entry(), reviewed], null)).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(compareSurfaceBannerTexts([entry()], null)).toEqual([]);
+    expect(
+      compareSurfaceBannerTexts(
+        [entry()],
+        "Next steps differ across this comparison.",
+      ),
+    ).toEqual(["Next steps differ across this comparison."]);
+    expect(
+      compareSurfaceBannerTexts(
+        [entry(), reviewed],
+        "Next steps differ across this comparison.",
+      ),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across this comparison.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-surface-summary-lib` with shared decision/divergence summary and banner assembly used by compare page and drawer headers.
- Slim `compare-page-summary` and `compare-drawer-summary` to surface-specific action copy wrappers.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-surface-summary-lib.test.ts tests/compare-page-summary.test.ts tests/compare-drawer-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)