### PR TITLE
refactor(compare): route dossier summaries through surface-summary lib

### DIFF
--- a/apps/web/src/lib/compare-dossier-summary.ts
+++ b/apps/web/src/lib/compare-dossier-summary.ts
@@ -1,43 +1,24 @@
 import type { Entry } from "@/types/registry";
-import { compareActionsDiverge } from "@/lib/compare-entry-actions";
-import {
-  compareCuratedDecisionBannerText,
-  type CompareDecisionSummary,
-} from "@/lib/compare-curated-summary";
 import { compareInteractiveSearch } from "@/lib/compare-interactive-link";
-import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+import {
+  compareSurfaceBannerTexts,
+  compareSurfaceDecisionBannerText,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
 
 export function compareDossierEntries(entry: Entry, alternatives: Entry[]): Entry[] {
   return [entry, ...alternatives];
 }
 
-export function compareDossierSummary(
-  entry: Entry,
-  alternatives: Entry[],
-): {
-  comparedCount: number;
-  decision: CompareDecisionSummary;
-  actionsDiverge: boolean;
-  hasAnyDivergence: boolean;
-} {
-  const entries = compareDossierEntries(entry, alternatives);
-  const decision = compareDecisionSummary(entries);
-  const actionsDiverge = compareActionsDiverge(entries);
-  return {
-    comparedCount: entries.length,
-    decision,
-    actionsDiverge,
-    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
-  };
+export function compareDossierSummary(entry: Entry, alternatives: Entry[]) {
+  return compareSurfaceSummary(compareDossierEntries(entry, alternatives));
 }
 
 export function compareDossierDecisionBannerText(
   entry: Entry,
   alternatives: Entry[],
 ): string | null {
-  return compareCuratedDecisionBannerText(
-    compareDecisionSummary(compareDossierEntries(entry, alternatives)),
-  );
+  return compareSurfaceDecisionBannerText(compareDossierEntries(entry, alternatives));
 }
 
 export function compareDossierActionBannerText(actionsDiverge: boolean): string | null {
@@ -46,13 +27,9 @@ export function compareDossierActionBannerText(actionsDiverge: boolean): string 
 }
 
 export function compareDossierBannerTexts(entry: Entry, alternatives: Entry[]): string[] {
-  const summary = compareDossierSummary(entry, alternatives);
-  const messages: string[] = [];
-  const decisionText = compareDossierDecisionBannerText(entry, alternatives);
-  const actionText = compareDossierActionBannerText(summary.actionsDiverge);
-  if (decisionText) messages.push(decisionText);
-  if (actionText) messages.push(actionText);
-  return messages;
+  const entries = compareDossierEntries(entry, alternatives);
+  const summary = compareSurfaceSummary(entries);
+  return compareSurfaceBannerTexts(entries, compareDossierActionBannerText(summary.actionsDiverge));
 }
 
 export function compareDossierInteractiveSearch(

--- a/tests/compare-dossier-summary.test.ts
+++ b/tests/compare-dossier-summary.test.ts
@@ -106,6 +106,19 @@ describe("compare dossier summary", () => {
     ).toEqual([
       "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+    expect(
+      compareDossierBannerTexts(primary, [
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
   });
 
   it("builds interactive compare search params for dossier alternatives", () => {


### PR DESCRIPTION
## Summary
- Delegate dossier decision summaries and banner assembly to `compare-surface-summary-lib`.
- Keep dossier-specific entry ordering and action banner copy unchanged.
- Add regression test for combined trust + action banner ordering on dossier compare sections.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)