### PR TITLE
refactor(compare): route best-list summaries through surface-summary lib

### DIFF
--- a/apps/web/src/lib/compare-best-summary.ts
+++ b/apps/web/src/lib/compare-best-summary.ts
@@ -6,27 +6,21 @@ import {
   resolveComparisonRefs,
 } from "@/lib/compare-featured-link";
 import {
-  compareCuratedDecisionBannerText,
-  compareCuratedSummary,
-  type CompareDecisionSummary,
-} from "@/lib/compare-curated-summary";
-import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+  compareSurfaceBannerTexts,
+  compareSurfaceDecisionBannerText,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
 
 export type BestListPickRef = {
   ref: string;
 };
 
-export function compareBestSummary(entries: Entry[]): {
-  comparedCount: number;
-  decision: CompareDecisionSummary;
-  actionsDiverge: boolean;
-  hasAnyDivergence: boolean;
-} {
-  return compareCuratedSummary(entries);
+export function compareBestSummary(entries: Entry[]) {
+  return compareSurfaceSummary(entries);
 }
 
 export function compareBestDecisionBannerText(entries: Entry[]): string | null {
-  return compareCuratedDecisionBannerText(compareDecisionSummary(entries));
+  return compareSurfaceDecisionBannerText(entries);
 }
 
 export function compareBestActionBannerText(actionsDiverge: boolean): string | null {
@@ -40,13 +34,8 @@ export function shouldShowBestCompareSection(entries: Entry[]): boolean {
 
 export function compareBestBannerTexts(entries: Entry[]): string[] {
   if (!shouldShowBestCompareSection(entries)) return [];
-  const summary = compareBestSummary(entries);
-  const messages: string[] = [];
-  const decisionText = compareBestDecisionBannerText(entries);
-  const actionText = compareBestActionBannerText(summary.actionsDiverge);
-  if (decisionText) messages.push(decisionText);
-  if (actionText) messages.push(actionText);
-  return messages;
+  const summary = compareSurfaceSummary(entries);
+  return compareSurfaceBannerTexts(entries, compareBestActionBannerText(summary.actionsDiverge));
 }
 
 export function compareBestListPickRefs(picks: BestListPickRef[]): string[] {

--- a/tests/compare-best-summary.test.ts
+++ b/tests/compare-best-summary.test.ts
@@ -100,6 +100,20 @@ describe("compare best summary", () => {
     ).toEqual([
       "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+    expect(
+      compareBestBannerTexts([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
   });
 
   it("builds interactive compare links for best-list picks", () => {


### PR DESCRIPTION
## Summary
- Delegate best-list decision summaries and banner assembly to `compare-surface-summary-lib`.
- Keep best-list-specific action banner copy and featured interactive link helpers unchanged.
- Add regression test for combined trust + action banner ordering on best-list compare sections.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-summary.test.ts tests/compare-surface-summary-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)