### PR TITLE
refactor(compare): route curated and browse summaries through surface lib

### DIFF
--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -1,5 +1,5 @@
 import type { Entry } from "@/types/registry";
-import { compareCuratedSummary } from "@/lib/compare-curated-summary";
+import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
 import { COMPARE_INTERACTIVE_MAX, compareFullViewSearch } from "@/lib/compare-interactive-link";
 
 export const BROWSE_COMPARE_MIN_ITEMS = 2;
@@ -13,7 +13,7 @@ export function browseCompareSelectedEntries(items: Entry[]): Entry[] {
 }
 
 export function browseCompareSummary(items: Entry[]) {
-  return compareCuratedSummary(items);
+  return compareSurfaceSummary(items);
 }
 
 export function browseCompareOverflowHint(totalCount: number, openCount: number): string | null {

--- a/apps/web/src/lib/compare-curated-summary.ts
+++ b/apps/web/src/lib/compare-curated-summary.ts
@@ -1,6 +1,9 @@
 import type { Entry } from "@/types/registry";
-import { compareActionsDiverge } from "@/lib/compare-entry-actions";
 import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+import {
+  compareSurfaceBannerTexts,
+  compareSurfaceSummary,
+} from "@/lib/compare-surface-summary-lib";
 
 export type CompareDecisionSummary = ReturnType<typeof compareDecisionSummary>;
 
@@ -12,14 +15,7 @@ export type CompareCuratedSummary = {
 };
 
 export function compareCuratedSummary(entries: Entry[]): CompareCuratedSummary {
-  const decision = compareDecisionSummary(entries);
-  const actionsDiverge = compareActionsDiverge(entries);
-  return {
-    comparedCount: entries.length,
-    decision,
-    actionsDiverge,
-    hasAnyDivergence: decision.divergingCount > 0 || actionsDiverge,
-  };
+  return compareSurfaceSummary(entries);
 }
 
 export function compareCuratedDecisionBannerText(decision: CompareDecisionSummary): string | null {
@@ -34,11 +30,6 @@ export function compareCuratedActionBannerText(actionsDiverge: boolean): string 
 }
 
 export function compareCuratedBannerTexts(entries: Entry[]): string[] {
-  const summary = compareCuratedSummary(entries);
-  const messages: string[] = [];
-  const decisionText = compareCuratedDecisionBannerText(summary.decision);
-  const actionText = compareCuratedActionBannerText(summary.actionsDiverge);
-  if (decisionText) messages.push(decisionText);
-  if (actionText) messages.push(actionText);
-  return messages;
+  const summary = compareSurfaceSummary(entries);
+  return compareSurfaceBannerTexts(entries, compareCuratedActionBannerText(summary.actionsDiverge));
 }

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -9,6 +9,7 @@ import {
   browseCompareUiState,
   shouldShowBrowseCompareHint,
 } from "@/lib/compare-browse-summary";
+import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -45,16 +46,9 @@ describe("compare browse summary", () => {
       reviewedBy: "maintainer",
       reviewedAt: "2026-01-02",
     });
-    expect(browseCompareSummary([baseline, reviewed])).toEqual({
-      comparedCount: 2,
-      decision: {
-        comparedCount: 2,
-        divergingCount: 1,
-        divergingLabels: ["Review status"],
-      },
-      actionsDiverge: false,
-      hasAnyDivergence: true,
-    });
+    expect(browseCompareSummary([baseline, reviewed])).toEqual(
+      compareSurfaceSummary([baseline, reviewed]),
+    );
   });
 
   it("prompts users to open compare when selected entries align on decision signals", () => {

--- a/tests/compare-curated-summary.test.ts
+++ b/tests/compare-curated-summary.test.ts
@@ -6,6 +6,7 @@ import {
   compareCuratedDecisionBannerText,
   compareCuratedSummary,
 } from "@/lib/compare-curated-summary";
+import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -109,5 +110,32 @@ describe("compare curated summary", () => {
       "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
     ]);
     expect(compareCuratedBannerTexts([entry()])).toEqual([]);
+    expect(
+      compareCuratedBannerTexts([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+    ]);
+  });
+
+  it("delegates curated summaries through compare-surface-summary-lib", () => {
+    const entries = [
+      entry(),
+      entry({
+        reviewedBy: "maintainer",
+        reviewedAt: "2026-01-02",
+      }),
+    ];
+    expect(compareCuratedSummary(entries)).toEqual(
+      compareSurfaceSummary(entries),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Delegate `compare-curated-summary` decision/banner assembly to `compare-surface-summary-lib`.
- Route `browseCompareSummary` through the same shared helpers.
- Add regression tests for combined trust + action banner ordering and surface-lib delegation.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-summary.test.ts tests/compare-browse-summary.test.ts tests/compare-surface-summary-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)