### PR TITLE
feat(compare): centralize window origin for compare share URLs

### DIFF
--- a/apps/web/src/lib/compare-browse-share-link.ts
+++ b/apps/web/src/lib/compare-browse-share-link.ts
@@ -1,5 +1,6 @@
 import type { EntryIdentity } from "@/lib/entry-identity";
 import { serializeCompareItems } from "@/lib/compare-selection";
+import { compareShareOrigin } from "@/lib/compare-share-origin";
 
 export function compareBrowseSharePath(idsParam: string): string {
   const ids = idsParam.trim();
@@ -12,4 +13,8 @@ export function compareBrowseShareUrl(idsParam: string, origin = ""): string {
 
 export function compareBrowseShareUrlFromEntries(entries: EntryIdentity[], origin = ""): string {
   return compareBrowseShareUrl(serializeCompareItems(entries), origin);
+}
+
+export function compareBrowseShareUrlForWindow(entries: EntryIdentity[]): string {
+  return compareBrowseShareUrlFromEntries(entries, compareShareOrigin());
 }

--- a/apps/web/src/lib/compare-share-link.ts
+++ b/apps/web/src/lib/compare-share-link.ts
@@ -1,5 +1,6 @@
 import type { EntryIdentity } from "@/lib/entry-identity";
 import { serializeCompareItems } from "@/lib/compare-selection";
+import { compareShareOrigin } from "@/lib/compare-share-origin";
 
 export function comparePageSharePath(idsParam: string): string {
   const ids = idsParam.trim();
@@ -12,4 +13,8 @@ export function comparePageShareUrl(idsParam: string, origin = ""): string {
 
 export function comparePageShareUrlFromEntries(entries: EntryIdentity[], origin = ""): string {
   return comparePageShareUrl(serializeCompareItems(entries), origin);
+}
+
+export function comparePageShareUrlForWindow(entries: EntryIdentity[]): string {
+  return comparePageShareUrlFromEntries(entries, compareShareOrigin());
 }

--- a/apps/web/src/lib/compare-share-origin.ts
+++ b/apps/web/src/lib/compare-share-origin.ts
@@ -1,0 +1,3 @@
+export function compareShareOrigin(): string {
+  return typeof window !== "undefined" ? window.location.origin : "";
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { compareBrowseShareUrl } from "@/lib/compare-browse-share-link";
+import { compareShareOrigin } from "@/lib/compare-share-origin";
 import {
   hasCompareItem,
   resolveCompareParam,
@@ -86,8 +87,7 @@ function createCompareStore(): CompareStore {
     serialize: () => serializeCompareItems(state.items),
     getShareUrl: () => {
       const sig = serializeCompareItems(state.items);
-      const origin = typeof window !== "undefined" ? window.location.origin : "";
-      return compareBrowseShareUrl(sig, origin);
+      return compareBrowseShareUrl(sig, compareShareOrigin());
     },
   };
 

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -18,7 +18,7 @@ import {
   type CompareAction,
 } from "@/lib/compare-entry-actions";
 import { comparePageBannerTexts } from "@/lib/compare-page-summary";
-import { comparePageShareUrlFromEntries } from "@/lib/compare-share-link";
+import { comparePageShareUrlForWindow } from "@/lib/compare-share-link";
 import {
   compareFeaturedInteractiveLinkLabel,
   compareFeaturedInteractiveSearch,
@@ -102,10 +102,7 @@ function ComparePage() {
     setPickerOpen(false);
   };
 
-  const copyShare = () => {
-    const origin = typeof window !== "undefined" ? window.location.origin : "";
-    return comparePageShareUrlFromEntries(items, origin);
-  };
+  const copyShare = () => comparePageShareUrlForWindow(items);
 
   if (items.length === 0) {
     const resolvedFromUrl = resolveIds(sp.ids);

--- a/tests/compare-browse-share-link.test.ts
+++ b/tests/compare-browse-share-link.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   compareBrowseSharePath,
   compareBrowseShareUrl,
+  compareBrowseShareUrlForWindow,
   compareBrowseShareUrlFromEntries,
 } from "@/lib/compare-browse-share-link";
 
@@ -56,5 +57,14 @@ describe("compare browse share link", () => {
     expect(compareBrowseShareUrlFromEntries([], "https://heyclaude.dev")).toBe(
       "https://heyclaude.dev/browse",
     );
+  });
+
+  it("builds window-backed browse share URLs without an explicit origin", () => {
+    expect(
+      compareBrowseShareUrlForWindow([
+        entry({ category: "skills", slug: "alpha" }),
+      ]),
+    ).toBe("/browse?compare=skills%2Falpha");
+    expect(compareBrowseShareUrlForWindow([])).toBe("/browse");
   });
 });

--- a/tests/compare-share-link.test.ts
+++ b/tests/compare-share-link.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   comparePageSharePath,
   comparePageShareUrl,
+  comparePageShareUrlForWindow,
   comparePageShareUrlFromEntries,
 } from "@/lib/compare-share-link";
 
@@ -54,5 +55,14 @@ describe("compare share link", () => {
     expect(comparePageShareUrlFromEntries([], "https://heyclaude.dev")).toBe(
       "https://heyclaude.dev/compare",
     );
+  });
+
+  it("builds window-backed compare page share URLs without an explicit origin", () => {
+    expect(
+      comparePageShareUrlForWindow([
+        entry({ category: "skills", slug: "alpha" }),
+      ]),
+    ).toBe("/compare?ids=skills%2Falpha");
+    expect(comparePageShareUrlForWindow([])).toBe("/compare");
   });
 });

--- a/tests/compare-share-origin.test.ts
+++ b/tests/compare-share-origin.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { compareShareOrigin } from "@/lib/compare-share-origin";
+
+describe("compare share origin", () => {
+  it("returns an empty origin during server-side rendering", () => {
+    expect(compareShareOrigin()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-share-origin` helper for SSR-safe window origin resolution.
- Add `comparePageShareUrlForWindow` and `compareBrowseShareUrlForWindow` helpers.
- Wire compare page copy-link and `CompareProvider.getShareUrl` through the shared builders.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-share-origin.test.ts tests/compare-share-link.test.ts tests/compare-browse-share-link.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)