### PR TITLE
feat(compare): centralize drawer share and full-view compare helpers

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -21,7 +21,7 @@ import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
 import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
 import { compareDrawerEmptyHint } from "@/lib/compare-empty-guidance";
-import { compareFullViewSearch } from "@/lib/compare-interactive-link";
+import { compareDrawerFullViewSearch, compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
 import {
   recordCompareIntentEvent,
   resolveCompareEntryActions,
@@ -317,10 +317,10 @@ function SnippetCell({ entry }: { entry: Entry }) {
 }
 
 export function CompareDrawer() {
-  const { items, open, setOpen, toggle, clear, hydrate, getShareUrl } = useCompare();
+  const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const actionRowDiverges = compareDrawerActionsDiverge(items);
   const bannerTexts = compareDrawerBannerTexts(items);
-  const fullViewSearch = compareFullViewSearch(items);
+  const fullViewSearch = compareDrawerFullViewSearch(items);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -398,7 +398,7 @@ export function CompareDrawer() {
                 </Link>
               ) : null}
               <CopyButton
-                value={getShareUrl()}
+                value={compareDrawerShareUrl(items)}
                 label="Copy compare link"
                 disabled={items.length === 0}
               />

--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -1,0 +1,11 @@
+import type { Entry } from "@/types/registry";
+import { compareBrowseShareUrlForWindow } from "@/lib/compare-browse-share-link";
+import { compareFullViewSearch } from "@/lib/compare-interactive-link";
+
+export function compareDrawerShareUrl(items: Entry[]): string {
+  return compareBrowseShareUrlForWindow(items);
+}
+
+export function compareDrawerFullViewSearch(items: Entry[]): { ids: string } | null {
+  return compareFullViewSearch(items);
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
-import { compareBrowseShareUrl } from "@/lib/compare-browse-share-link";
-import { compareShareOrigin } from "@/lib/compare-share-origin";
+import { compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
 import {
   hasCompareItem,
   resolveCompareParam,
@@ -85,10 +84,7 @@ function createCompareStore(): CompareStore {
       });
     },
     serialize: () => serializeCompareItems(state.items),
-    getShareUrl: () => {
-      const sig = serializeCompareItems(state.items);
-      return compareBrowseShareUrl(sig, compareShareOrigin());
-    },
+    getShareUrl: () => compareDrawerShareUrl(state.items),
   };
 
   return {

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerFullViewSearch,
+  compareDrawerShareUrl,
+} from "@/lib/compare-drawer-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer ui lib", () => {
+  it("builds browse share URLs for drawer copy-link actions", () => {
+    expect(compareDrawerShareUrl([])).toBe("/browse");
+    expect(
+      compareDrawerShareUrl([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toBe("/browse?compare=skills%2Falpha%2Chooks%2Fbeta");
+  });
+
+  it("builds capped full-view compare search params for drawer CTAs", () => {
+    expect(compareDrawerFullViewSearch([])).toBeNull();
+    expect(compareDrawerFullViewSearch([entry()])).toEqual({
+      ids: "mcp/fixture",
+    });
+    expect(
+      compareDrawerFullViewSearch([
+        entry({ slug: "one" }),
+        entry({ slug: "two" }),
+        entry({ slug: "three" }),
+        entry({ slug: "four" }),
+        entry({ slug: "five" }),
+      ]),
+    ).toEqual({ ids: "mcp/one,mcp/two,mcp/three,mcp/four" });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-ui-lib` for drawer browse share URLs and capped full-view compare search params.
- Wire `CompareDrawer` copy-link and open-full-view CTA through the shared helpers.
- Delegate `CompareProvider.getShareUrl` to the same drawer share builder.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)