### PR TITLE
feat(compare): centralize compare page share and header helpers

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -1,0 +1,16 @@
+import type { Entry } from "@/types/registry";
+import { compareSingleItemHintText } from "@/lib/compare-empty-guidance";
+import { comparePageBannerTexts } from "@/lib/compare-page-summary";
+import { comparePageShareUrlForWindow } from "@/lib/compare-share-link";
+
+export function comparePageShareUrl(items: Entry[]): string {
+  return comparePageShareUrlForWindow(items);
+}
+
+export function comparePageHeaderBannerTexts(items: Entry[]): string[] {
+  return comparePageBannerTexts(items);
+}
+
+export function comparePageSelectionHint(itemCount: number): string | null {
+  return compareSingleItemHintText(itemCount);
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -17,18 +17,17 @@ import {
   resolveCompareEntryActions,
   type CompareAction,
 } from "@/lib/compare-entry-actions";
-import { comparePageBannerTexts } from "@/lib/compare-page-summary";
-import { comparePageShareUrlForWindow } from "@/lib/compare-share-link";
+import {
+  comparePageHeaderBannerTexts,
+  comparePageSelectionHint,
+  comparePageShareUrl,
+} from "@/lib/compare-page-ui-lib";
 import {
   compareFeaturedInteractiveLinkLabel,
   compareFeaturedInteractiveSearch,
   resolveComparisonRefs,
 } from "@/lib/compare-featured-link";
-import {
-  compareEmptyStateDescription,
-  compareInvalidUrlHint,
-  compareSingleItemHintText,
-} from "@/lib/compare-empty-guidance";
+import { compareEmptyStateDescription, compareInvalidUrlHint } from "@/lib/compare-empty-guidance";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -80,8 +79,8 @@ function ComparePage() {
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const actionRowDiverges = compareActionsDiverge(items);
-  const bannerTexts = comparePageBannerTexts(items);
-  const singleItemHint = compareSingleItemHintText(items.length);
+  const bannerTexts = comparePageHeaderBannerTexts(items);
+  const singleItemHint = comparePageSelectionHint(items.length);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -102,7 +101,7 @@ function ComparePage() {
     setPickerOpen(false);
   };
 
-  const copyShare = () => comparePageShareUrlForWindow(items);
+  const copyShare = () => comparePageShareUrl(items);
 
   if (items.length === 0) {
     const resolvedFromUrl = resolveIds(sp.ids);

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  comparePageHeaderBannerTexts,
+  comparePageSelectionHint,
+  comparePageShareUrl,
+} from "@/lib/compare-page-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page ui lib", () => {
+  it("builds compare page share URLs for copy-link actions", () => {
+    expect(comparePageShareUrl([])).toBe("/compare");
+    expect(
+      comparePageShareUrl([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toBe("/compare?ids=skills%2Falpha%2Chooks%2Fbeta");
+  });
+
+  it("returns page header banner messages from page summaries", () => {
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(comparePageHeaderBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+  });
+
+  it("prompts readers to add another resource when only one item is selected", () => {
+    expect(comparePageSelectionHint(0)).toBeNull();
+    expect(comparePageSelectionHint(1)).toBe(
+      "Add one more resource to unlock trust and next-step comparisons across the full table.",
+    );
+    expect(comparePageSelectionHint(2)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-ui-lib` for compare page copy-link URLs, header banner messages, and single-item selection hints.
- Wire `/compare` route through the shared helpers (parallel to `compare-drawer-ui-lib`).

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)