### PR TITLE
feat(compare): centralize browse compare CTA state in ui lib

### DIFF
--- a/apps/web/src/lib/compare-browse-summary.ts
+++ b/apps/web/src/lib/compare-browse-summary.ts
@@ -1,6 +1,6 @@
 import type { Entry } from "@/types/registry";
+import { COMPARE_INTERACTIVE_MAX } from "@/lib/compare-interactive-link";
 import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
-import { COMPARE_INTERACTIVE_MAX, compareFullViewSearch } from "@/lib/compare-interactive-link";
 
 export const BROWSE_COMPARE_MIN_ITEMS = 2;
 
@@ -37,21 +37,4 @@ export function browseCompareHintText(items: Entry[]): string | null {
     parts.push("next steps differ");
   }
   return `${parts.join(" · ")} — open compare for details.`;
-}
-
-export function browseCompareUiState(items: Entry[]): {
-  search: { ids: string };
-  selectedCount: number;
-  hint: string | null;
-  overflowHint: string | null;
-} | null {
-  if (!shouldShowBrowseCompareHint(items)) return null;
-  const capped = browseCompareSelectedEntries(items);
-  const search = compareFullViewSearch(capped)!;
-  return {
-    search,
-    selectedCount: capped.length,
-    hint: browseCompareHintText(items),
-    overflowHint: browseCompareOverflowHint(items.length, capped.length),
-  };
 }

--- a/apps/web/src/lib/compare-browse-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-ui-lib.ts
@@ -1,0 +1,25 @@
+import type { Entry } from "@/types/registry";
+import {
+  browseCompareHintText,
+  browseCompareOverflowHint,
+  browseCompareSelectedEntries,
+  shouldShowBrowseCompareHint,
+} from "@/lib/compare-browse-summary";
+import { compareFullViewSearch } from "@/lib/compare-interactive-link";
+
+export function browseCompareUiState(items: Entry[]): {
+  search: { ids: string };
+  selectedCount: number;
+  hint: string | null;
+  overflowHint: string | null;
+} | null {
+  if (!shouldShowBrowseCompareHint(items)) return null;
+  const capped = browseCompareSelectedEntries(items);
+  const search = compareFullViewSearch(capped)!;
+  return {
+    search,
+    selectedCount: capped.length,
+    hint: browseCompareHintText(items),
+    overflowHint: browseCompareOverflowHint(items.length, capped.length),
+  };
+}

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,7 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
-import { browseCompareUiState } from "@/lib/compare-browse-summary";
+import { browseCompareUiState } from "@/lib/compare-browse-ui-lib";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";

--- a/tests/compare-browse-summary.test.ts
+++ b/tests/compare-browse-summary.test.ts
@@ -6,7 +6,6 @@ import {
   browseCompareOverflowHint,
   browseCompareSelectedEntries,
   browseCompareSummary,
-  browseCompareUiState,
   shouldShowBrowseCompareHint,
 } from "@/lib/compare-browse-summary";
 import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
@@ -129,12 +128,5 @@ describe("compare browse summary", () => {
     expect(browseCompareHintText(five)).toBe(
       "Open compare to review trust and next steps side by side.",
     );
-    expect(browseCompareUiState(five)).toEqual({
-      search: { ids: "mcp/one,mcp/two,mcp/three,mcp/four" },
-      selectedCount: 4,
-      hint: "Open compare to review trust and next steps side by side.",
-      overflowHint: "Opening 4 of 5 selected in compare.",
-    });
-    expect(browseCompareUiState([entry()])).toBeNull();
   });
 });

--- a/tests/compare-browse-ui-lib.test.ts
+++ b/tests/compare-browse-ui-lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { browseCompareUiState } from "@/lib/compare-browse-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare browse ui lib", () => {
+  it("returns null when fewer than two items are selected", () => {
+    expect(browseCompareUiState([])).toBeNull();
+    expect(browseCompareUiState([entry()])).toBeNull();
+  });
+
+  it("builds capped compare CTA state aligned with hint and overflow copy", () => {
+    const five = [
+      entry({ slug: "one" }),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+      entry({
+        slug: "five",
+        reviewedBy: "maintainer",
+        reviewedAt: "2026-01-02",
+      }),
+    ];
+    expect(browseCompareUiState(five)).toEqual({
+      search: { ids: "mcp/one,mcp/two,mcp/three,mcp/four" },
+      selectedCount: 4,
+      hint: "Open compare to review trust and next steps side by side.",
+      overflowHint: "Opening 4 of 5 selected in compare.",
+    });
+  });
+
+  it("surfaces divergence hints in browse compare CTA state", () => {
+    expect(
+      browseCompareUiState([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      search: { ids: "mcp/fixture,mcp/mixed" },
+      selectedCount: 2,
+      hint: "1 trust signal differ · next steps differ — open compare for details.",
+      overflowHint: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `browseCompareUiState` into `compare-browse-ui-lib` (parallel to page/drawer UI libs).
- Wire browse route through the shared CTA state builder.
- Add regression tests for capped selection alignment and divergence hints.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-ui-lib.test.ts tests/compare-browse-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)