### PR TITLE
feat(compare): extract shared drawer and table action helpers

### DIFF
--- a/apps/web/src/lib/compare-drawer-actions.ts
+++ b/apps/web/src/lib/compare-drawer-actions.ts
@@ -1,49 +1,28 @@
 import type { Entry } from "@/types/registry";
 import {
-  compareActionSignature,
-  compareActionsDiverge,
-  resolveCompareEntryActions,
-  type CompareAction,
-} from "@/lib/compare-entry-actions";
+  compareSurfaceActionCells,
+  compareSurfaceActionSummary,
+  compareSurfaceActionsDiverge,
+  compareSurfaceSharedActionIds,
+  type CompareSurfaceActionCell,
+} from "@/lib/compare-surface-actions-lib";
 
 export const COMPARE_DRAWER_SURFACE = "compare-drawer";
 
-export type CompareDrawerActionCell = {
-  entryKey: string;
-  actions: CompareAction[];
-};
+export type CompareDrawerActionCell = CompareSurfaceActionCell;
 
 export function compareDrawerActionCells(entries: Entry[]): CompareDrawerActionCell[] {
-  return entries.map((entry) => ({
-    entryKey: `${entry.category}:${entry.slug}`,
-    actions: resolveCompareEntryActions(entry),
-  }));
+  return compareSurfaceActionCells(entries);
 }
 
 export function compareDrawerActionsDiverge(entries: Entry[]): boolean {
-  return compareActionsDiverge(entries);
+  return compareSurfaceActionsDiverge(entries);
 }
 
 export function compareDrawerSharedActionIds(entries: Entry[]): string[] {
-  if (entries.length === 0) return [];
-  const actionSets = entries.map(
-    (entry) => new Set(resolveCompareEntryActions(entry).map((action) => action.id)),
-  );
-  const [first, ...rest] = actionSets;
-  return [...first].filter((id) => rest.every((set) => set.has(id)));
+  return compareSurfaceSharedActionIds(entries);
 }
 
-export function compareDrawerActionSummary(entries: Entry[]): {
-  comparedCount: number;
-  diverges: boolean;
-  sharedActionIds: string[];
-  uniqueSignatures: number;
-} {
-  const signatures = entries.map(compareActionSignature);
-  return {
-    comparedCount: entries.length,
-    diverges: compareActionsDiverge(entries),
-    sharedActionIds: compareDrawerSharedActionIds(entries),
-    uniqueSignatures: new Set(signatures).size,
-  };
+export function compareDrawerActionSummary(entries: Entry[]) {
+  return compareSurfaceActionSummary(entries);
 }

--- a/apps/web/src/lib/compare-surface-actions-lib.ts
+++ b/apps/web/src/lib/compare-surface-actions-lib.ts
@@ -1,0 +1,55 @@
+/**
+ * Shared compare surface action helpers.
+ *
+ * Builds per-column next-action cells and divergence summaries for compare
+ * drawer and table surfaces. Nothing here touches the network — given the same
+ * entry metadata the output is deterministic.
+ */
+
+import type { Entry } from "@/types/registry";
+import {
+  compareActionSignature,
+  compareActionsDiverge,
+  resolveCompareEntryActions,
+  type CompareAction,
+} from "@/lib/compare-entry-actions";
+
+export type CompareSurfaceActionCell = {
+  entryKey: string;
+  actions: CompareAction[];
+};
+
+export function compareSurfaceActionCells(entries: Entry[]): CompareSurfaceActionCell[] {
+  return entries.map((entry) => ({
+    entryKey: `${entry.category}:${entry.slug}`,
+    actions: resolveCompareEntryActions(entry),
+  }));
+}
+
+export function compareSurfaceActionsDiverge(entries: Entry[]): boolean {
+  return compareActionsDiverge(entries);
+}
+
+export function compareSurfaceSharedActionIds(entries: Entry[]): string[] {
+  if (entries.length === 0) return [];
+  const actionSets = entries.map(
+    (entry) => new Set(resolveCompareEntryActions(entry).map((action) => action.id)),
+  );
+  const [first, ...rest] = actionSets;
+  return [...first].filter((id) => rest.every((set) => set.has(id)));
+}
+
+export function compareSurfaceActionSummary(entries: Entry[]): {
+  comparedCount: number;
+  diverges: boolean;
+  sharedActionIds: string[];
+  uniqueSignatures: number;
+} {
+  const signatures = entries.map(compareActionSignature);
+  return {
+    comparedCount: entries.length,
+    diverges: compareActionsDiverge(entries),
+    sharedActionIds: compareSurfaceSharedActionIds(entries),
+    uniqueSignatures: new Set(signatures).size,
+  };
+}

--- a/apps/web/src/lib/compare-table-actions.ts
+++ b/apps/web/src/lib/compare-table-actions.ts
@@ -1,53 +1,32 @@
 import type { Entry } from "@/types/registry";
 import {
-  compareActionSignature,
-  compareActionsDiverge,
-  resolveCompareEntryActions,
-  type CompareAction,
-} from "@/lib/compare-entry-actions";
+  compareSurfaceActionCells,
+  compareSurfaceActionSummary,
+  compareSurfaceActionsDiverge,
+  compareSurfaceSharedActionIds,
+  type CompareSurfaceActionCell,
+} from "@/lib/compare-surface-actions-lib";
 
 export const COMPARE_TABLE_SURFACE = "compare-table";
 
-export type CompareTableActionCell = {
-  entryKey: string;
-  actions: CompareAction[];
-};
+export type CompareTableActionCell = CompareSurfaceActionCell;
 
 export function shouldRenderCompareTableActions(entries: Entry[], enabled: boolean): boolean {
   return enabled && entries.length >= 2;
 }
 
 export function compareTableActionCells(entries: Entry[]): CompareTableActionCell[] {
-  return entries.map((entry) => ({
-    entryKey: `${entry.category}:${entry.slug}`,
-    actions: resolveCompareEntryActions(entry),
-  }));
+  return compareSurfaceActionCells(entries);
 }
 
 export function compareTableActionsDiverge(entries: Entry[]): boolean {
-  return compareActionsDiverge(entries);
+  return compareSurfaceActionsDiverge(entries);
 }
 
 export function compareTableSharedActionIds(entries: Entry[]): string[] {
-  if (entries.length === 0) return [];
-  const actionSets = entries.map(
-    (entry) => new Set(resolveCompareEntryActions(entry).map((action) => action.id)),
-  );
-  const [first, ...rest] = actionSets;
-  return [...first].filter((id) => rest.every((set) => set.has(id)));
+  return compareSurfaceSharedActionIds(entries);
 }
 
-export function compareTableActionSummary(entries: Entry[]): {
-  comparedCount: number;
-  diverges: boolean;
-  sharedActionIds: string[];
-  uniqueSignatures: number;
-} {
-  const signatures = entries.map(compareActionSignature);
-  return {
-    comparedCount: entries.length,
-    diverges: compareActionsDiverge(entries),
-    sharedActionIds: compareTableSharedActionIds(entries),
-    uniqueSignatures: new Set(signatures).size,
-  };
+export function compareTableActionSummary(entries: Entry[]) {
+  return compareSurfaceActionSummary(entries);
 }

--- a/tests/compare-surface-actions-lib.test.ts
+++ b/tests/compare-surface-actions-lib.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
-  COMPARE_DRAWER_SURFACE,
-  compareDrawerActionCells,
-  compareDrawerActionSummary,
-  compareDrawerActionsDiverge,
-  compareDrawerSharedActionIds,
-} from "@/lib/compare-drawer-actions";
-import { compareSurfaceActionSummary } from "@/lib/compare-surface-actions-lib";
+  compareSurfaceActionCells,
+  compareSurfaceActionSummary,
+  compareSurfaceActionsDiverge,
+  compareSurfaceSharedActionIds,
+} from "@/lib/compare-surface-actions-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -26,13 +24,9 @@ function entry(overrides: Partial<Entry> = {}): Entry {
   } as Entry;
 }
 
-describe("compare drawer actions", () => {
-  it("exposes the compare drawer analytics surface id", () => {
-    expect(COMPARE_DRAWER_SURFACE).toBe("compare-drawer");
-  });
-
+describe("compare surface actions lib", () => {
   it("maps compared entries to per-column next-action cells", () => {
-    expect(compareDrawerActionCells([entry()])).toEqual([
+    expect(compareSurfaceActionCells([entry()])).toEqual([
       {
         entryKey: "mcp:fixture",
         actions: expect.arrayContaining([
@@ -42,71 +36,63 @@ describe("compare drawer actions", () => {
       },
     ]);
     expect(
-      compareDrawerActionCells([
+      compareSurfaceActionCells([
         entry({ category: "skills", slug: "alpha" }),
-        entry({
-          category: "hooks",
-          slug: "beta",
-          claimed: true,
-          sourceUrl: "https://x.dev",
-        }),
+        entry({ category: "hooks", slug: "beta", sourceUrl: "https://x.dev" }),
       ]).map((cell) => cell.entryKey),
     ).toEqual(["skills:alpha", "hooks:beta"]);
   });
 
-  it("detects when drawer columns expose different next-action sets", () => {
+  it("detects when columns expose different next-action sets", () => {
     expect(
-      compareDrawerActionsDiverge([
+      compareSurfaceActionsDiverge([
         entry({ installCommand: "npm i fixture" }),
         entry(),
       ]),
     ).toBe(true);
     expect(
-      compareDrawerActionsDiverge([
+      compareSurfaceActionsDiverge([
         entry({ installCommand: "npm i fixture" }),
         entry({ installCommand: "pnpm add fixture" }),
       ]),
     ).toBe(false);
-    expect(compareDrawerActionsDiverge([])).toBe(false);
+    expect(compareSurfaceActionsDiverge([])).toBe(false);
   });
 
   it("finds action ids shared across every compared entry", () => {
-    expect(compareDrawerSharedActionIds([])).toEqual([]);
-    expect(compareDrawerSharedActionIds([entry()])).toEqual([
+    expect(compareSurfaceSharedActionIds([])).toEqual([]);
+    expect(compareSurfaceSharedActionIds([entry()])).toEqual([
       "dossier",
       "claim",
     ]);
     expect(
-      compareDrawerSharedActionIds([
+      compareSurfaceSharedActionIds([
         entry({ installCommand: "npm i fixture" }),
         entry({ installCommand: "pnpm add fixture" }),
       ]),
     ).toEqual(["dossier", "install", "claim"]);
     expect(
-      compareDrawerSharedActionIds([
+      compareSurfaceSharedActionIds([
         entry({ installCommand: "npm i fixture" }),
         entry(),
       ]),
     ).toEqual(["dossier", "claim"]);
   });
 
-  it("summarizes drawer action divergence for header hints", () => {
+  it("summarizes action divergence for compare surface headers", () => {
     const baseline = entry();
     const withInstall = entry({ installCommand: "npm i fixture" });
-    expect(compareDrawerActionSummary([baseline])).toEqual({
+    expect(compareSurfaceActionSummary([baseline])).toEqual({
       comparedCount: 1,
       diverges: false,
       sharedActionIds: ["dossier", "claim"],
       uniqueSignatures: 1,
     });
-    expect(compareDrawerActionSummary([baseline, withInstall])).toEqual({
+    expect(compareSurfaceActionSummary([baseline, withInstall])).toEqual({
       comparedCount: 2,
       diverges: true,
       sharedActionIds: ["dossier", "claim"],
       uniqueSignatures: 2,
     });
-    expect(compareDrawerActionSummary([baseline, withInstall])).toEqual(
-      compareSurfaceActionSummary([baseline, withInstall]),
-    );
   });
 });

--- a/tests/compare-table-actions.test.ts
+++ b/tests/compare-table-actions.test.ts
@@ -8,6 +8,7 @@ import {
   compareTableSharedActionIds,
   shouldRenderCompareTableActions,
 } from "@/lib/compare-table-actions";
+import { compareSurfaceActionSummary } from "@/lib/compare-surface-actions-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -99,5 +100,8 @@ describe("compare table actions", () => {
       sharedActionIds: ["dossier", "claim"],
       uniqueSignatures: 2,
     });
+    expect(compareTableActionSummary([baseline, withInstall])).toEqual(
+      compareSurfaceActionSummary([baseline, withInstall]),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Add `compare-surface-actions-lib` with shared per-column next-action cells and divergence summaries.
- Slim `compare-drawer-actions` and `compare-table-actions` to surface-specific wrappers.

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-surface-actions-lib.test.ts tests/compare-drawer-actions.test.ts tests/compare-table-actions.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)