### PR TITLE
feat(compare): centralize curated comparison page UI helpers

### DIFF
--- a/apps/web/src/lib/compare-curated-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-ui-lib.ts
@@ -1,0 +1,18 @@
+import type { Entry } from "@/types/registry";
+import { compareCuratedBannerTexts } from "@/lib/compare-curated-summary";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
+
+export function compareCuratedHeaderBannerTexts(entries: Entry[]): string[] {
+  return compareCuratedBannerTexts(entries);
+}
+
+export function compareCuratedInteractiveSearch(entries: Entry[]): { ids: string } | null {
+  return compareInteractiveSearch(entries);
+}
+
+export function compareCuratedInteractiveLinkLabel(entryCount: number): string {
+  return compareInteractiveLinkLabel(entryCount);
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -9,11 +9,11 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
-import { compareCuratedBannerTexts } from "@/lib/compare-curated-summary";
 import {
-  compareInteractiveLinkLabel,
-  compareInteractiveSearch,
-} from "@/lib/compare-interactive-link";
+  compareCuratedHeaderBannerTexts,
+  compareCuratedInteractiveLinkLabel,
+  compareCuratedInteractiveSearch,
+} from "@/lib/compare-curated-ui-lib";
 
 function resolveRefs(refs: string[]): Entry[] {
   const out: Entry[] = [];
@@ -101,8 +101,8 @@ function ComparisonPage() {
   const comparison = getComparison(slug);
   if (!comparison) return null;
   const entries = resolveRefs(comparison.refs);
-  const bannerTexts = compareCuratedBannerTexts(entries);
-  const interactiveSearch = compareInteractiveSearch(entries);
+  const bannerTexts = compareCuratedHeaderBannerTexts(entries);
+  const interactiveSearch = compareCuratedInteractiveSearch(entries);
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">
@@ -133,7 +133,7 @@ function ComparisonPage() {
             search={interactiveSearch}
             className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
           >
-            <ArrowLeft className="h-4 w-4" /> {compareInteractiveLinkLabel(entries.length)}
+            <ArrowLeft className="h-4 w-4" /> {compareCuratedInteractiveLinkLabel(entries.length)}
           </Link>
         ) : null}
       </header>

--- a/tests/compare-curated-ui-lib.test.ts
+++ b/tests/compare-curated-ui-lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareCuratedHeaderBannerTexts,
+  compareCuratedInteractiveLinkLabel,
+  compareCuratedInteractiveSearch,
+} from "@/lib/compare-curated-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare curated ui lib", () => {
+  it("returns curated comparison header banner messages", () => {
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareCuratedHeaderBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(compareCuratedHeaderBannerTexts([entry()])).toEqual([]);
+  });
+
+  it("builds interactive compare search params for curated pages", () => {
+    expect(compareCuratedInteractiveSearch([entry()])).toBeNull();
+    expect(
+      compareCuratedInteractiveSearch([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+  });
+
+  it("formats curated interactive link labels from entry count", () => {
+    expect(compareCuratedInteractiveLinkLabel(2)).toBe(
+      "Open in the interactive comparison tool",
+    );
+    expect(compareCuratedInteractiveLinkLabel(3)).toBe(
+      "Open 3 picks in the interactive comparison tool",
+    );
+  });
+
+  it("returns combined trust and action banner messages for curated headers", () => {
+    expect(
+      compareCuratedHeaderBannerTexts([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-curated-ui-lib` for curated comparison header banners and interactive compare links.
- Wire `/compare/$slug` through the shared UI helpers (parallel to page/drawer/browse UI libs).

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-ui-lib.test.ts tests/compare-curated-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)