### PR TITLE
feat(compare): extend drawer UI lib with header and empty hints

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -19,9 +19,12 @@ import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
-import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
-import { compareDrawerEmptyHint } from "@/lib/compare-empty-guidance";
-import { compareDrawerFullViewSearch, compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
+import {
+  compareDrawerEmptyStateHint,
+  compareDrawerFullViewSearch,
+  compareDrawerHeaderBannerTexts,
+  compareDrawerShareUrl,
+} from "@/lib/compare-drawer-ui-lib";
 import {
   recordCompareIntentEvent,
   resolveCompareEntryActions,
@@ -319,7 +322,7 @@ function SnippetCell({ entry }: { entry: Entry }) {
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const actionRowDiverges = compareDrawerActionsDiverge(items);
-  const bannerTexts = compareDrawerBannerTexts(items);
+  const bannerTexts = compareDrawerHeaderBannerTexts(items);
   const fullViewSearch = compareDrawerFullViewSearch(items);
 
   const onClear = () => {
@@ -415,7 +418,7 @@ export function CompareDrawer() {
 
         {items.length === 0 ? (
           <div className="flex h-[60vh] items-center justify-center px-6 text-sm text-ink-muted">
-            {compareDrawerEmptyHint()}
+            {compareDrawerEmptyStateHint()}
           </div>
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">

--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -1,5 +1,7 @@
 import type { Entry } from "@/types/registry";
 import { compareBrowseShareUrlForWindow } from "@/lib/compare-browse-share-link";
+import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
+import { compareDrawerEmptyHint } from "@/lib/compare-empty-guidance";
 import { compareFullViewSearch } from "@/lib/compare-interactive-link";
 
 export function compareDrawerShareUrl(items: Entry[]): string {
@@ -8,4 +10,12 @@ export function compareDrawerShareUrl(items: Entry[]): string {
 
 export function compareDrawerFullViewSearch(items: Entry[]): { ids: string } | null {
   return compareFullViewSearch(items);
+}
+
+export function compareDrawerHeaderBannerTexts(items: Entry[]): string[] {
+  return compareDrawerBannerTexts(items);
+}
+
+export function compareDrawerEmptyStateHint(): string {
+  return compareDrawerEmptyHint();
 }

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareDrawerEmptyStateHint,
   compareDrawerFullViewSearch,
+  compareDrawerHeaderBannerTexts,
   compareDrawerShareUrl,
 } from "@/lib/compare-drawer-ui-lib";
 
@@ -47,5 +49,39 @@ describe("compare drawer ui lib", () => {
         entry({ slug: "five" }),
       ]),
     ).toEqual({ ids: "mcp/one,mcp/two,mcp/three,mcp/four" });
+  });
+
+  it("returns drawer header banner messages from drawer summaries", () => {
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDrawerHeaderBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+  });
+
+  it("guides empty drawer readers to add resources from cards", () => {
+    expect(compareDrawerEmptyStateHint()).toBe(
+      "Add resources to compare by tapping the Compare button on any card.",
+    );
+  });
+
+  it("returns combined trust and action banner messages for drawer headers", () => {
+    expect(
+      compareDrawerHeaderBannerTexts([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across this comparison — review install, source, and claim actions per entry.",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- Extend `compare-drawer-ui-lib` with header banner and empty-state hint helpers.
- Wire `CompareDrawer` through the shared UI builders (parallel to page/curated UI libs).

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts tests/compare-drawer-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4368


Made with [Cursor](https://cursor.com)