### PR TITLE
feat(compare): centralize best-list comparison page UI helpers

### DIFF
--- a/apps/web/src/lib/compare-best-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-ui-lib.ts
@@ -1,0 +1,22 @@
+import type { Entry } from "@/types/registry";
+import { compareBestBannerTexts, shouldShowBestCompareSection } from "@/lib/compare-best-summary";
+import {
+  compareInteractiveLinkLabel,
+  compareInteractiveSearch,
+} from "@/lib/compare-interactive-link";
+
+export function compareBestHeaderBannerTexts(entries: Entry[]): string[] {
+  return compareBestBannerTexts(entries);
+}
+
+export function compareBestInteractiveSearch(entries: Entry[]): { ids: string } | null {
+  return compareInteractiveSearch(entries);
+}
+
+export function compareBestInteractiveLinkLabel(entryCount: number): string {
+  return compareInteractiveLinkLabel(entryCount);
+}
+
+export function compareBestShowCompareSection(entries: Entry[]): boolean {
+  return shouldShowBestCompareSection(entries);
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -5,11 +5,11 @@ import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entrie
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import { compareBestBannerTexts } from "@/lib/compare-best-summary";
 import {
-  compareInteractiveLinkLabel,
-  compareInteractiveSearch,
-} from "@/lib/compare-interactive-link";
+  compareBestHeaderBannerTexts,
+  compareBestInteractiveLinkLabel,
+  compareBestInteractiveSearch,
+} from "@/lib/compare-best-ui-lib";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
@@ -98,11 +98,11 @@ function BestDetail() {
 
   const compareEntries = useMemo(() => resolved.slice(0, 5).map((p) => p.entry), [resolved]);
   const compareBannerTexts = useMemo(
-    () => compareBestBannerTexts(compareEntries),
+    () => compareBestHeaderBannerTexts(compareEntries),
     [compareEntries],
   );
   const interactiveCompareSearch = useMemo(
-    () => compareInteractiveSearch(compareEntries),
+    () => compareBestInteractiveSearch(compareEntries),
     [compareEntries],
   );
 
@@ -178,7 +178,7 @@ function BestDetail() {
               className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
             >
               <ArrowLeft className="h-4 w-4" />
-              {compareInteractiveLinkLabel(compareEntries.length)}
+              {compareBestInteractiveLinkLabel(compareEntries.length)}
             </Link>
           ) : null}
         </section>

--- a/tests/compare-best-ui-lib.test.ts
+++ b/tests/compare-best-ui-lib.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareBestHeaderBannerTexts,
+  compareBestInteractiveLinkLabel,
+  compareBestInteractiveSearch,
+  compareBestShowCompareSection,
+} from "@/lib/compare-best-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare best ui lib", () => {
+  it("only surfaces best-list compare UI for multi-entry tables", () => {
+    expect(compareBestShowCompareSection([])).toBe(false);
+    expect(compareBestShowCompareSection([entry()])).toBe(false);
+    expect(
+      compareBestShowCompareSection([entry(), entry({ slug: "other" })]),
+    ).toBe(true);
+    expect(compareBestHeaderBannerTexts([entry()])).toEqual([]);
+  });
+
+  it("returns best-list header banner messages", () => {
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareBestHeaderBannerTexts([entry(), reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+  });
+
+  it("builds interactive compare search params for best-list pages", () => {
+    expect(compareBestInteractiveSearch([entry()])).toBeNull();
+    expect(
+      compareBestInteractiveSearch([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({ ids: "skills/alpha,hooks/beta" });
+  });
+
+  it("formats best-list interactive link labels from entry count", () => {
+    expect(compareBestInteractiveLinkLabel(2)).toBe(
+      "Open in the interactive comparison tool",
+    );
+    expect(compareBestInteractiveLinkLabel(4)).toBe(
+      "Open 4 picks in the interactive comparison tool",
+    );
+  });
+
+  it("returns combined trust and action banner messages for best-list headers", () => {
+    expect(
+      compareBestHeaderBannerTexts([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-best-ui-lib` for best-list header banners and interactive compare links.
- Wire `/best/$slug` through the shared UI helpers (parallel to curated/page/drawer UI libs).

Ref #556.

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-ui-lib.test.ts tests/compare-best-summary.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)