### PR TITLE
feat(compare): centralize entry dossier comparison UI helpers

### DIFF
--- a/apps/web/src/lib/compare-dossier-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-ui-lib.ts
@@ -1,0 +1,25 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareDossierBannerTexts,
+  compareDossierInteractiveSearch,
+} from "@/lib/compare-dossier-summary";
+import { compareInteractiveLinkLabel } from "@/lib/compare-interactive-link";
+
+export function compareDossierHeaderBannerTexts(entry: Entry, alternatives: Entry[]): string[] {
+  return compareDossierBannerTexts(entry, alternatives);
+}
+
+export function compareDossierInteractiveCompareSearch(
+  entry: Entry,
+  alternatives: Entry[],
+): { ids: string } | null {
+  return compareDossierInteractiveSearch(entry, alternatives);
+}
+
+export function compareDossierInteractiveLinkLabel(comparedCount: number): string {
+  return compareInteractiveLinkLabel(comparedCount);
+}
+
+export function compareDossierShowCompareSection(alternatives: Entry[]): boolean {
+  return alternatives.length > 0;
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -44,10 +44,10 @@ import {
   compareBestListInteractiveSearch,
 } from "@/lib/compare-best-summary";
 import {
-  compareDossierBannerTexts,
-  compareDossierInteractiveSearch,
-} from "@/lib/compare-dossier-summary";
-import { compareInteractiveLinkLabel } from "@/lib/compare-interactive-link";
+  compareDossierHeaderBannerTexts,
+  compareDossierInteractiveCompareSearch,
+  compareDossierInteractiveLinkLabel,
+} from "@/lib/compare-dossier-ui-lib";
 import {
   compareFeaturedInteractiveLinkLabel,
   compareFeaturedInteractiveSearch,
@@ -236,11 +236,11 @@ function Dossier() {
     return pool.slice(0, 3);
   }, [relGroups, rel]);
   const compareBannerTexts = useMemo(
-    () => compareDossierBannerTexts(entry, alternatives),
+    () => compareDossierHeaderBannerTexts(entry, alternatives),
     [entry, alternatives],
   );
   const dossierCompareSearch = useMemo(
-    () => compareDossierInteractiveSearch(entry, alternatives),
+    () => compareDossierInteractiveCompareSearch(entry, alternatives),
     [entry, alternatives],
   );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,
@@ -716,7 +716,7 @@ function Dossier() {
                   className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
                 >
                   <ArrowLeft className="h-4 w-4" />
-                  {compareInteractiveLinkLabel(alternatives.length + 1)}
+                  {compareDossierInteractiveLinkLabel(alternatives.length + 1)}
                 </Link>
               ) : null}
             </DossierSection>

--- a/tests/compare-dossier-ui-lib.test.ts
+++ b/tests/compare-dossier-ui-lib.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDossierHeaderBannerTexts,
+  compareDossierInteractiveCompareSearch,
+  compareDossierInteractiveLinkLabel,
+  compareDossierShowCompareSection,
+} from "@/lib/compare-dossier-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare dossier ui lib", () => {
+  it("only surfaces dossier compare UI when alternatives exist", () => {
+    expect(compareDossierShowCompareSection([])).toBe(false);
+    expect(compareDossierShowCompareSection([entry({ slug: "alt" })])).toBe(
+      true,
+    );
+  });
+
+  it("returns dossier header banner messages", () => {
+    const primary = entry({ slug: "primary" });
+    const reviewed = entry({
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    expect(compareDossierHeaderBannerTexts(primary, [reviewed])).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+  });
+
+  it("builds interactive compare search params for dossier alternatives", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(compareDossierInteractiveCompareSearch(primary, [])).toBeNull();
+    expect(
+      compareDossierInteractiveCompareSearch(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    ).toEqual({ ids: "skills/primary,hooks/alt" });
+  });
+
+  it("formats dossier interactive link labels from compared entry count", () => {
+    expect(compareDossierInteractiveLinkLabel(2)).toBe(
+      "Open in the interactive comparison tool",
+    );
+    expect(compareDossierInteractiveLinkLabel(4)).toBe(
+      "Open 4 picks in the interactive comparison tool",
+    );
+  });
+
+  it("returns combined trust and action banner messages for dossier headers", () => {
+    const primary = entry({ slug: "primary" });
+    expect(
+      compareDossierHeaderBannerTexts(primary, [
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-dossier-ui-lib` with dossier compare section helpers (header banners, interactive search params, link labels, visibility gate).
- Wire the entry dossier route through the new lib instead of importing dossier summary and interactive link helpers directly.
- Add regression tests covering trust/action banner combinations and interactive compare routing.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-ui-lib.test.ts --coverage`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)