### PR TITLE
feat(compare): centralize entry dossier featured comparison links

### DIFF
--- a/apps/web/src/lib/compare-entry-featured-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-ui-lib.ts
@@ -1,0 +1,48 @@
+import type { BestListPickRef } from "@/lib/compare-best-summary";
+import {
+  compareBestListInteractiveLinkLabel,
+  compareBestListInteractiveSearch,
+} from "@/lib/compare-best-summary";
+import {
+  compareFeaturedInteractiveLinkLabel,
+  compareFeaturedInteractiveSearch,
+  resolveComparisonRefs,
+} from "@/lib/compare-featured-link";
+import type { EntryIdentity } from "@/lib/entry-identity";
+
+export type CompareEntryFeaturedComparisonLink = {
+  slug: string;
+  search: { ids: string } | null;
+  label: string;
+};
+
+export type CompareEntryFeaturedBestListLink = {
+  slug: string;
+  search: { ids: string } | null;
+  label: string;
+};
+
+export function compareEntryFeaturedComparisonLinks(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryFeaturedComparisonLink[] {
+  return comparisons.map((comparison) => {
+    const resolved = resolveComparisonRefs(comparison.refs, catalog);
+    return {
+      slug: comparison.slug,
+      search: compareFeaturedInteractiveSearch(comparison.refs, catalog),
+      label: compareFeaturedInteractiveLinkLabel(resolved.length),
+    };
+  });
+}
+
+export function compareEntryFeaturedBestListLinks(
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryFeaturedBestListLink[] {
+  return lists.map((list) => ({
+    slug: list.slug,
+    search: compareBestListInteractiveSearch(list.picks, catalog),
+    label: compareBestListInteractiveLinkLabel(list.picks, catalog),
+  }));
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -40,19 +40,14 @@ import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
 import {
-  compareBestListInteractiveLinkLabel,
-  compareBestListInteractiveSearch,
-} from "@/lib/compare-best-summary";
+  compareEntryFeaturedBestListLinks,
+  compareEntryFeaturedComparisonLinks,
+} from "@/lib/compare-entry-featured-ui-lib";
 import {
   compareDossierHeaderBannerTexts,
   compareDossierInteractiveCompareSearch,
   compareDossierInteractiveLinkLabel,
 } from "@/lib/compare-dossier-ui-lib";
-import {
-  compareFeaturedInteractiveLinkLabel,
-  compareFeaturedInteractiveSearch,
-  resolveComparisonRefs,
-} from "@/lib/compare-featured-link";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -257,24 +252,11 @@ function Dossier() {
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
   const featuredCompareLinks = useMemo(
-    () =>
-      comparedIn.map((comparison) => {
-        const resolved = resolveComparisonRefs(comparison.refs, ENTRIES);
-        return {
-          slug: comparison.slug,
-          search: compareFeaturedInteractiveSearch(comparison.refs, ENTRIES),
-          label: compareFeaturedInteractiveLinkLabel(resolved.length),
-        };
-      }),
+    () => compareEntryFeaturedComparisonLinks(comparedIn, ENTRIES),
     [comparedIn],
   );
   const featuredBestListLinks = useMemo(
-    () =>
-      featuredIn.map((list) => ({
-        slug: list.slug,
-        search: compareBestListInteractiveSearch(list.picks, ENTRIES),
-        label: compareBestListInteractiveLinkLabel(list.picks, ENTRIES),
-      })),
+    () => compareEntryFeaturedBestListLinks(featuredIn, ENTRIES),
     [featuredIn],
   );
   const recents = useRecents();

--- a/tests/compare-entry-featured-ui-lib.test.ts
+++ b/tests/compare-entry-featured-ui-lib.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareEntryFeaturedBestListLinks,
+  compareEntryFeaturedComparisonLinks,
+} from "@/lib/compare-entry-featured-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare entry featured ui lib", () => {
+  it("builds featured comparison links for dossier surfaces", () => {
+    expect(
+      compareEntryFeaturedComparisonLinks(
+        [{ slug: "solo", refs: ["skills/alpha"] }],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "solo",
+        search: null,
+        label: "Open interactively",
+      },
+    ]);
+
+    expect(
+      compareEntryFeaturedComparisonLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "pair",
+        search: { ids: "skills/alpha,hooks/beta" },
+        label: "Open interactively",
+      },
+    ]);
+  });
+
+  it("skips missing refs when building featured comparison links", () => {
+    expect(
+      compareEntryFeaturedComparisonLinks(
+        [{ slug: "partial", refs: ["skills/alpha", "missing/slug"] }],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "partial",
+        search: null,
+        label: "Open interactively",
+      },
+    ]);
+  });
+
+  it("builds featured best-list links for dossier surfaces", () => {
+    expect(
+      compareEntryFeaturedBestListLinks(
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "top-picks",
+        search: { ids: "skills/alpha,hooks/beta" },
+        label: "Open interactively",
+      },
+    ]);
+  });
+
+  it("formats overflow labels for featured best-list links", () => {
+    expect(
+      compareEntryFeaturedBestListLinks(
+        [
+          {
+            slug: "wide-list",
+            picks: [
+              { ref: "skills/alpha" },
+              { ref: "hooks/beta" },
+              { ref: "mcp/gamma" },
+            ],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "wide-list",
+        search: { ids: "skills/alpha,hooks/beta,mcp/gamma" },
+        label: "Open 3 picks in the interactive comparison tool",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-entry-featured-ui-lib` to build featured comparison and best-list interactive links for entry dossier pages.
- Wire the entry dossier route through the new lib instead of assembling featured links inline.
- Add regression tests for partial ref resolution and best-list overflow labels.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-featured-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4373, #4251, #4259)


Made with [Cursor](https://cursor.com)