### PR TITLE
feat(compare): centralize compare page popular comparison links

### DIFF
--- a/apps/web/src/lib/compare-page-featured-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-featured-ui-lib.ts
@@ -1,0 +1,28 @@
+import {
+  compareFeaturedInteractiveLinkLabel,
+  compareFeaturedInteractiveSearch,
+  resolveComparisonRefs,
+} from "@/lib/compare-featured-link";
+import type { EntryIdentity } from "@/lib/entry-identity";
+
+export type ComparePagePopularComparisonLink = {
+  slug: string;
+  heading: string;
+  interactiveSearch: { ids: string } | null;
+  interactiveLabel: string;
+};
+
+export function comparePagePopularComparisonLinks(
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePagePopularComparisonLink[] {
+  return comparisons.map((comparison) => {
+    const resolvedCount = resolveComparisonRefs(comparison.refs, catalog).length;
+    return {
+      slug: comparison.slug,
+      heading: comparison.heading,
+      interactiveSearch: compareFeaturedInteractiveSearch(comparison.refs, catalog),
+      interactiveLabel: compareFeaturedInteractiveLinkLabel(resolvedCount),
+    };
+  });
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -22,11 +22,7 @@ import {
   comparePageSelectionHint,
   comparePageShareUrl,
 } from "@/lib/compare-page-ui-lib";
-import {
-  compareFeaturedInteractiveLinkLabel,
-  compareFeaturedInteractiveSearch,
-  resolveComparisonRefs,
-} from "@/lib/compare-featured-link";
+import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
 import { compareEmptyStateDescription, compareInvalidUrlHint } from "@/lib/compare-empty-guidance";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
@@ -81,6 +77,10 @@ function ComparePage() {
   const actionRowDiverges = compareActionsDiverge(items);
   const bannerTexts = comparePageHeaderBannerTexts(items);
   const singleItemHint = comparePageSelectionHint(items.length);
+  const popularComparisonLinks = React.useMemo(
+    () => comparePagePopularComparisonLinks(COMPARISONS, ENTRIES),
+    [],
+  );
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -128,33 +128,29 @@ function ComparePage() {
           <div className="mt-6">
             <div className="eyebrow mb-2">Popular comparisons</div>
             <div className="flex flex-wrap justify-center gap-2">
-              {COMPARISONS.map((c) => {
-                const resolvedCount = resolveComparisonRefs(c.refs, ENTRIES).length;
-                const interactiveSearch = compareFeaturedInteractiveSearch(c.refs, ENTRIES);
-                return (
-                  <div
-                    key={c.slug}
-                    className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
+              {popularComparisonLinks.map((comparison) => (
+                <div
+                  key={comparison.slug}
+                  className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
+                >
+                  <Link
+                    to="/compare/$slug"
+                    params={{ slug: comparison.slug }}
+                    className="text-xs text-ink-muted hover:text-ink"
                   >
+                    {comparison.heading}
+                  </Link>
+                  {comparison.interactiveSearch ? (
                     <Link
-                      to="/compare/$slug"
-                      params={{ slug: c.slug }}
-                      className="text-xs text-ink-muted hover:text-ink"
+                      to="/compare"
+                      search={comparison.interactiveSearch}
+                      className="text-[10px] text-ink-subtle hover:text-ink"
                     >
-                      {c.heading}
+                      {comparison.interactiveLabel}
                     </Link>
-                    {interactiveSearch ? (
-                      <Link
-                        to="/compare"
-                        search={interactiveSearch}
-                        className="text-[10px] text-ink-subtle hover:text-ink"
-                      >
-                        {compareFeaturedInteractiveLinkLabel(resolvedCount)}
-                      </Link>
-                    ) : null}
-                  </div>
-                );
-              })}
+                  ) : null}
+                </div>
+              ))}
             </div>
           </div>
         </div>

--- a/tests/compare-page-featured-ui-lib.test.ts
+++ b/tests/compare-page-featured-ui-lib.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare page featured ui lib", () => {
+  it("builds popular comparison links for the compare page empty state", () => {
+    expect(
+      comparePagePopularComparisonLinks(
+        [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            refs: ["skills/alpha", "hooks/beta"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "pair",
+        heading: "Alpha vs Beta",
+        interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+
+  it("omits interactive search when fewer than two refs resolve", () => {
+    expect(
+      comparePagePopularComparisonLinks(
+        [{ slug: "solo", heading: "Alpha only", refs: ["skills/alpha"] }],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "solo",
+        heading: "Alpha only",
+        interactiveSearch: null,
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+
+  it("formats overflow labels for popular comparison links", () => {
+    expect(
+      comparePagePopularComparisonLinks(
+        [
+          {
+            slug: "triple",
+            heading: "Three-way",
+            refs: ["skills/alpha", "hooks/beta", "mcp/gamma"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "triple",
+        heading: "Three-way",
+        interactiveSearch: { ids: "skills/alpha,hooks/beta,mcp/gamma" },
+        interactiveLabel: "Open 3 picks in the interactive comparison tool",
+      },
+    ]);
+  });
+
+  it("ignores missing refs when building popular comparison links", () => {
+    expect(
+      comparePagePopularComparisonLinks(
+        [
+          {
+            slug: "partial",
+            heading: "Partial refs",
+            refs: ["skills/alpha", "missing/slug"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "partial",
+        heading: "Partial refs",
+        interactiveSearch: null,
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-featured-ui-lib` to build popular comparison links for the interactive compare page empty state.
- Wire the compare index route through the new lib instead of assembling featured links inline.
- Add regression tests for partial ref resolution and overflow labels.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-featured-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)