### PR TITLE
feat(compare): centralize comparison table presentation state

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -15,14 +15,10 @@ import { brandIdentityLabel } from "@/lib/brand-icons";
 import {
   comparisonDecisionRows,
   displayCompareSignal,
-  divergingDecisionRowLabels,
   signalToneClassForDisplay,
 } from "@/lib/compare-table-decision-rows";
-import {
-  COMPARE_TABLE_SURFACE,
-  compareTableActionsDiverge,
-  shouldRenderCompareTableActions,
-} from "@/lib/compare-table-actions";
+import { COMPARE_TABLE_SURFACE } from "@/lib/compare-table-actions";
+import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
 import {
   recordCompareIntentEvent,
   resolveCompareEntryActions,
@@ -296,9 +292,8 @@ export function ComparisonTable({
   entries: Entry[];
   showNextActions?: boolean;
 }) {
-  const divergingLabels = new Set(divergingDecisionRowLabels(entries));
-  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
-  const actionRowDiverges = renderNextActions && compareTableActionsDiverge(entries);
+  const { divergingDecisionLabels, renderNextActions, actionRowDiverges } =
+    compareTablePresentationState(entries, showNextActions);
 
   return (
     <div className="overflow-auto rounded-xl border border-border">
@@ -375,7 +370,7 @@ export function ComparisonTable({
             </tr>
           ) : null}
           {COMPARISON_ROWS.map((row, i) => {
-            const rowDiverges = divergingLabels.has(row.label);
+            const rowDiverges = divergingDecisionLabels.has(row.label);
             return (
               <tr
                 key={row.label}

--- a/apps/web/src/lib/compare-table-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-ui-lib.ts
@@ -1,0 +1,24 @@
+import type { Entry } from "@/types/registry";
+import { divergingDecisionRowLabels } from "@/lib/compare-table-decision-rows";
+import {
+  compareTableActionsDiverge,
+  shouldRenderCompareTableActions,
+} from "@/lib/compare-table-actions";
+
+export type CompareTablePresentationState = {
+  divergingDecisionLabels: Set<string>;
+  renderNextActions: boolean;
+  actionRowDiverges: boolean;
+};
+
+export function compareTablePresentationState(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTablePresentationState {
+  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
+  return {
+    divergingDecisionLabels: new Set(divergingDecisionRowLabels(entries)),
+    renderNextActions,
+    actionRowDiverges: renderNextActions && compareTableActionsDiverge(entries),
+  };
+}

--- a/tests/compare-table-ui-lib.test.ts
+++ b/tests/compare-table-ui-lib.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table ui lib", () => {
+  it("hides next-action rows for single-entry tables", () => {
+    expect(compareTablePresentationState([entry()], true)).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("surfaces next-action rows for multi-entry tables when enabled", () => {
+    expect(
+      compareTablePresentationState([entry(), entry({ slug: "other" })], true),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: true,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("respects the showNextActions toggle for multi-entry tables", () => {
+    expect(
+      compareTablePresentationState([entry(), entry({ slug: "other" })], false),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareTablePresentationState(
+      [
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ],
+      true,
+    );
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.renderNextActions).toBe(true);
+    expect(state.actionRowDiverges).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-ui-lib` with helpers for diverging decision rows and next-action row visibility.
- Wire `ComparisonTable` through the new lib instead of assembling presentation state inline.
- Add regression tests for toggles and combined diverging trust/action highlighting.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4377, #4251, #4259)


Made with [Cursor](https://cursor.com)