### PR TITLE
feat(compare): centralize curated comparison ref resolution

### DIFF
--- a/apps/web/src/lib/compare-curated-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-ui-lib.ts
@@ -1,9 +1,22 @@
 import type { Entry } from "@/types/registry";
 import { compareCuratedBannerTexts } from "@/lib/compare-curated-summary";
+import { resolveComparisonRefs } from "@/lib/compare-featured-link";
 import {
   compareInteractiveLinkLabel,
   compareInteractiveSearch,
 } from "@/lib/compare-interactive-link";
+import type { EntryIdentity } from "@/lib/entry-identity";
+
+export function compareCuratedResolvedEntries(refs: string[], catalog: EntryIdentity[]): Entry[] {
+  return resolveComparisonRefs(refs, catalog) as Entry[];
+}
+
+export function compareCuratedHasRenderableEntries(
+  refs: string[],
+  catalog: EntryIdentity[],
+): boolean {
+  return compareCuratedResolvedEntries(refs, catalog).length >= 2;
+}
 
 export function compareCuratedHeaderBannerTexts(entries: Entry[]): string[] {
   return compareCuratedBannerTexts(entries);

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { ArrowLeft } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
-import type { Entry } from "@/types/registry";
 import { ComparisonTable } from "@/components/comparison-table";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
@@ -10,31 +9,25 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
 import {
+  compareCuratedHasRenderableEntries,
   compareCuratedHeaderBannerTexts,
   compareCuratedInteractiveLinkLabel,
   compareCuratedInteractiveSearch,
+  compareCuratedResolvedEntries,
 } from "@/lib/compare-curated-ui-lib";
-
-function resolveRefs(refs: string[]): Entry[] {
-  const out: Entry[] = [];
-  for (const ref of refs) {
-    const [category, slug] = ref.split("/");
-    const entry = ENTRIES.find((e) => e.category === category && e.slug === slug);
-    if (entry) out.push(entry);
-  }
-  return out;
-}
 
 export const Route = createFileRoute("/compare/$slug")({
   loader: ({ params }) => {
     const comparison = getComparison(params.slug);
-    if (!comparison || resolveRefs(comparison.refs).length < 2) throw notFound();
+    if (!comparison || !compareCuratedHasRenderableEntries(comparison.refs, ENTRIES)) {
+      throw notFound();
+    }
     return {};
   },
   head: ({ params }) => {
     const comparison = getComparison(params.slug);
     if (!comparison) return { meta: [] };
-    const entries = resolveRefs(comparison.refs);
+    const entries = compareCuratedResolvedEntries(comparison.refs, ENTRIES);
     const url = absoluteUrl(`/compare/${comparison.slug}`);
     const ogImage = ogImageUrl({
       title: comparison.heading,
@@ -100,7 +93,7 @@ function ComparisonPage() {
   const { slug } = Route.useParams();
   const comparison = getComparison(slug);
   if (!comparison) return null;
-  const entries = resolveRefs(comparison.refs);
+  const entries = compareCuratedResolvedEntries(comparison.refs, ENTRIES);
   const bannerTexts = compareCuratedHeaderBannerTexts(entries);
   const interactiveSearch = compareCuratedInteractiveSearch(entries);
 

--- a/tests/compare-curated-ui-lib.test.ts
+++ b/tests/compare-curated-ui-lib.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareCuratedHasRenderableEntries,
   compareCuratedHeaderBannerTexts,
   compareCuratedInteractiveLinkLabel,
   compareCuratedInteractiveSearch,
+  compareCuratedResolvedEntries,
 } from "@/lib/compare-curated-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -23,7 +25,42 @@ function entry(overrides: Partial<Entry> = {}): Entry {
   } as Entry;
 }
 
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
 describe("compare curated ui lib", () => {
+  it("resolves curated comparison refs against the entry catalog", () => {
+    expect(compareCuratedResolvedEntries([], catalog)).toEqual([]);
+    expect(
+      compareCuratedResolvedEntries(["skills/alpha", "hooks/beta"], catalog),
+    ).toEqual([catalog[0], catalog[1]]);
+    expect(
+      compareCuratedResolvedEntries(["skills/alpha", "missing/slug"], catalog),
+    ).toEqual([catalog[0]]);
+  });
+
+  it("requires at least two resolved entries for curated pages", () => {
+    expect(compareCuratedHasRenderableEntries([], catalog)).toBe(false);
+    expect(compareCuratedHasRenderableEntries(["skills/alpha"], catalog)).toBe(
+      false,
+    );
+    expect(
+      compareCuratedHasRenderableEntries(
+        ["skills/alpha", "hooks/beta"],
+        catalog,
+      ),
+    ).toBe(true);
+    expect(
+      compareCuratedHasRenderableEntries(
+        ["skills/alpha", "missing/slug"],
+        catalog,
+      ),
+    ).toBe(false);
+  });
+
   it("returns curated comparison header banner messages", () => {
     const reviewed = entry({
       slug: "reviewed",


### PR DESCRIPTION
## Summary
- Extend `compare-curated-ui-lib` with shared ref resolution and renderability helpers for curated comparison pages.
- Wire the curated compare route through the lib instead of duplicating catalog lookup logic.
- Add regression tests for partial ref resolution and minimum entry thresholds.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)