### PR TITLE
feat(compare): extend compare page UI lib with actions and empty state

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -1,5 +1,10 @@
 import type { Entry } from "@/types/registry";
-import { compareSingleItemHintText } from "@/lib/compare-empty-guidance";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+import {
+  compareEmptyStateDescription,
+  compareInvalidUrlHint,
+  compareSingleItemHintText,
+} from "@/lib/compare-empty-guidance";
 import { comparePageBannerTexts } from "@/lib/compare-page-summary";
 import { comparePageShareUrlForWindow } from "@/lib/compare-share-link";
 
@@ -13,4 +18,16 @@ export function comparePageHeaderBannerTexts(items: Entry[]): string[] {
 
 export function comparePageSelectionHint(itemCount: number): string | null {
   return compareSingleItemHintText(itemCount);
+}
+
+export function comparePageActionsDiverge(items: Entry[]): boolean {
+  return compareActionsDiverge(items);
+}
+
+export function comparePageEmptyStateDescription(): string {
+  return compareEmptyStateDescription();
+}
+
+export function comparePageInvalidUrlHint(ids: string, resolvedCount: number): string | null {
+  return compareInvalidUrlHint(ids, resolvedCount);
 }

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -12,18 +12,19 @@ import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
 import {
-  compareActionsDiverge,
   recordCompareIntentEvent,
   resolveCompareEntryActions,
   type CompareAction,
 } from "@/lib/compare-entry-actions";
 import {
+  comparePageActionsDiverge,
+  comparePageEmptyStateDescription,
   comparePageHeaderBannerTexts,
+  comparePageInvalidUrlHint,
   comparePageSelectionHint,
   comparePageShareUrl,
 } from "@/lib/compare-page-ui-lib";
 import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
-import { compareEmptyStateDescription, compareInvalidUrlHint } from "@/lib/compare-empty-guidance";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -74,7 +75,7 @@ function ComparePage() {
   const items = compare.items;
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
-  const actionRowDiverges = compareActionsDiverge(items);
+  const actionRowDiverges = comparePageActionsDiverge(items);
   const bannerTexts = comparePageHeaderBannerTexts(items);
   const singleItemHint = comparePageSelectionHint(items.length);
   const popularComparisonLinks = React.useMemo(
@@ -109,13 +110,13 @@ function ComparePage() {
       // Render directly from URL while context hydrates.
       return <Skeleton ids={sp.ids} />;
     }
-    const invalidUrlHint = compareInvalidUrlHint(sp.ids, 0);
+    const invalidUrlHint = comparePageInvalidUrlHint(sp.ids, 0);
     return (
       <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
         <div className="rounded-xl border border-dashed border-border bg-surface p-10 text-center">
           <div className="eyebrow">Comparison</div>
           <h1 className="mt-2 h-display-2 text-ink text-balance">Nothing to compare yet</h1>
-          <p className="mt-2 text-sm text-ink-muted">{compareEmptyStateDescription()}</p>
+          <p className="mt-2 text-sm text-ink-muted">{comparePageEmptyStateDescription()}</p>
           {invalidUrlHint ? <p className="mt-2 text-sm text-amber-800">{invalidUrlHint}</p> : null}
           <div className="mt-5 flex justify-center gap-2">
             <Link

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  comparePageActionsDiverge,
+  comparePageEmptyStateDescription,
   comparePageHeaderBannerTexts,
+  comparePageInvalidUrlHint,
   comparePageSelectionHint,
   comparePageShareUrl,
 } from "@/lib/compare-page-ui-lib";
@@ -51,5 +54,29 @@ describe("compare page ui lib", () => {
       "Add one more resource to unlock trust and next-step comparisons across the full table.",
     );
     expect(comparePageSelectionHint(2)).toBeNull();
+  });
+
+  it("detects when interactive compare columns expose different next actions", () => {
+    expect(comparePageActionsDiverge([])).toBe(false);
+    expect(
+      comparePageActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ slug: "other" }),
+      ]),
+    ).toBe(true);
+    expect(
+      comparePageActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ slug: "other", installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns empty-state copy and invalid URL hints for the compare page", () => {
+    expect(comparePageEmptyStateDescription()).toContain("directory");
+    expect(comparePageInvalidUrlHint("", 0)).toBeNull();
+    expect(comparePageInvalidUrlHint("skills/missing", 0)).toContain(
+      "could not be resolved",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Extend `compare-page-ui-lib` with action divergence and empty-state hint helpers for the interactive compare page.
- Wire the compare index route through the lib instead of importing guidance and action helpers directly.
- Add regression tests for next-action divergence and invalid URL hints.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4381, #4251, #4259)


Made with [Cursor](https://cursor.com)