### PR TITLE
feat(compare): bundle compare drawer UI state in drawer UI lib

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -18,12 +18,11 @@ import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
-import { COMPARE_DRAWER_SURFACE, compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
+import { COMPARE_DRAWER_SURFACE } from "@/lib/compare-drawer-actions";
 import {
   compareDrawerEmptyStateHint,
-  compareDrawerFullViewSearch,
-  compareDrawerHeaderBannerTexts,
   compareDrawerShareUrl,
+  compareDrawerUiState,
 } from "@/lib/compare-drawer-ui-lib";
 import {
   recordCompareIntentEvent,
@@ -321,9 +320,7 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
-  const actionRowDiverges = compareDrawerActionsDiverge(items);
-  const bannerTexts = compareDrawerHeaderBannerTexts(items);
-  const fullViewSearch = compareDrawerFullViewSearch(items);
+  const { actionRowDiverges, bannerTexts, fullViewSearch } = compareDrawerUiState(items);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");

--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -1,8 +1,23 @@
 import type { Entry } from "@/types/registry";
+import { compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
 import { compareBrowseShareUrlForWindow } from "@/lib/compare-browse-share-link";
 import { compareDrawerBannerTexts } from "@/lib/compare-drawer-summary";
 import { compareDrawerEmptyHint } from "@/lib/compare-empty-guidance";
 import { compareFullViewSearch } from "@/lib/compare-interactive-link";
+
+export type CompareDrawerUiState = {
+  actionRowDiverges: boolean;
+  bannerTexts: string[];
+  fullViewSearch: { ids: string } | null;
+};
+
+export function compareDrawerUiState(items: Entry[]): CompareDrawerUiState {
+  return {
+    actionRowDiverges: compareDrawerActionsDiverge(items),
+    bannerTexts: compareDrawerBannerTexts(items),
+    fullViewSearch: compareFullViewSearch(items),
+  };
+}
 
 export function compareDrawerShareUrl(items: Entry[]): string {
   return compareBrowseShareUrlForWindow(items);

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -5,6 +5,7 @@ import {
   compareDrawerFullViewSearch,
   compareDrawerHeaderBannerTexts,
   compareDrawerShareUrl,
+  compareDrawerUiState,
 } from "@/lib/compare-drawer-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -83,5 +84,26 @@ describe("compare drawer ui lib", () => {
       "1 trust signal differ across this comparison (Review status).",
       "Next steps differ across this comparison — review install, source, and claim actions per entry.",
     ]);
+  });
+
+  it("bundles drawer presentation state for banners, actions, and full-view links", () => {
+    expect(compareDrawerUiState([])).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      fullViewSearch: null,
+    });
+    expect(
+      compareDrawerUiState([
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across this comparison — review install, source, and claim actions per entry.",
+      ],
+      fullViewSearch: { ids: "mcp/fixture,mcp/other" },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareDrawerUiState` to bundle drawer banner, action divergence, and full-view search state.
- Wire the compare drawer component through the new helper instead of assembling state inline.
- Add regression tests for combined trust/action banner and full-view link state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)