### PR TITLE
feat(compare): bundle curated compare page UI state in curated UI lib

### DIFF
--- a/apps/web/src/lib/compare-curated-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-ui-lib.ts
@@ -29,3 +29,23 @@ export function compareCuratedInteractiveSearch(entries: Entry[]): { ids: string
 export function compareCuratedInteractiveLinkLabel(entryCount: number): string {
   return compareInteractiveLinkLabel(entryCount);
 }
+
+export type CompareCuratedUiState = {
+  entries: Entry[];
+  bannerTexts: string[];
+  interactiveSearch: { ids: string } | null;
+  interactiveLinkLabel: string;
+};
+
+export function compareCuratedUiState(
+  refs: string[],
+  catalog: EntryIdentity[],
+): CompareCuratedUiState {
+  const entries = compareCuratedResolvedEntries(refs, catalog);
+  return {
+    entries,
+    bannerTexts: compareCuratedBannerTexts(entries),
+    interactiveSearch: compareInteractiveSearch(entries),
+    interactiveLinkLabel: compareInteractiveLinkLabel(entries.length),
+  };
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -10,10 +10,8 @@ import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
 import {
   compareCuratedHasRenderableEntries,
-  compareCuratedHeaderBannerTexts,
-  compareCuratedInteractiveLinkLabel,
-  compareCuratedInteractiveSearch,
   compareCuratedResolvedEntries,
+  compareCuratedUiState,
 } from "@/lib/compare-curated-ui-lib";
 
 export const Route = createFileRoute("/compare/$slug")({
@@ -93,9 +91,10 @@ function ComparisonPage() {
   const { slug } = Route.useParams();
   const comparison = getComparison(slug);
   if (!comparison) return null;
-  const entries = compareCuratedResolvedEntries(comparison.refs, ENTRIES);
-  const bannerTexts = compareCuratedHeaderBannerTexts(entries);
-  const interactiveSearch = compareCuratedInteractiveSearch(entries);
+  const { entries, bannerTexts, interactiveSearch, interactiveLinkLabel } = compareCuratedUiState(
+    comparison.refs,
+    ENTRIES,
+  );
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">
@@ -126,7 +125,7 @@ function ComparisonPage() {
             search={interactiveSearch}
             className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
           >
-            <ArrowLeft className="h-4 w-4" /> {compareCuratedInteractiveLinkLabel(entries.length)}
+            <ArrowLeft className="h-4 w-4" /> {interactiveLinkLabel}
           </Link>
         ) : null}
       </header>

--- a/tests/compare-curated-ui-lib.test.ts
+++ b/tests/compare-curated-ui-lib.test.ts
@@ -6,6 +6,7 @@ import {
   compareCuratedInteractiveLinkLabel,
   compareCuratedInteractiveSearch,
   compareCuratedResolvedEntries,
+  compareCuratedUiState,
 } from "@/lib/compare-curated-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -107,5 +108,48 @@ describe("compare curated ui lib", () => {
       "1 trust signal differ across this comparison (Review status).",
       "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
     ]);
+  });
+
+  it("bundles curated page presentation state for headers and interactive links", () => {
+    expect(
+      compareCuratedUiState(["skills/alpha", "hooks/beta"], catalog),
+    ).toEqual({
+      entries: [catalog[0], catalog[1]],
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+    expect(
+      compareCuratedUiState(
+        ["skills/alpha", "hooks/beta"],
+        [
+          catalog[0],
+          entry({
+            category: "hooks",
+            slug: "beta",
+            reviewedBy: "maintainer",
+            reviewedAt: "2026-01-02",
+            installCommand: "npm i fixture",
+          }),
+        ],
+      ),
+    ).toEqual({
+      entries: [
+        catalog[0],
+        entry({
+          category: "hooks",
+          slug: "beta",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ],
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      ],
+      interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareCuratedUiState` to bundle resolved entries, header banners, interactive search, and link labels for curated compare pages.
- Wire the curated compare route through the new helper instead of assembling state inline.
- Add regression tests for combined trust/action banner and interactive link state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4383, #4251, #4259)


Made with [Cursor](https://cursor.com)