### PR TITLE
feat(compare): bundle best-list compare page UI state in best UI lib

### DIFF
--- a/apps/web/src/lib/compare-best-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-ui-lib.ts
@@ -20,3 +20,19 @@ export function compareBestInteractiveLinkLabel(entryCount: number): string {
 export function compareBestShowCompareSection(entries: Entry[]): boolean {
   return shouldShowBestCompareSection(entries);
 }
+
+export type CompareBestUiState = {
+  showCompareSection: boolean;
+  bannerTexts: string[];
+  interactiveSearch: { ids: string } | null;
+  interactiveLinkLabel: string;
+};
+
+export function compareBestUiState(entries: Entry[]): CompareBestUiState {
+  return {
+    showCompareSection: shouldShowBestCompareSection(entries),
+    bannerTexts: compareBestBannerTexts(entries),
+    interactiveSearch: compareInteractiveSearch(entries),
+    interactiveLinkLabel: compareInteractiveLinkLabel(entries.length),
+  };
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -5,11 +5,7 @@ import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entrie
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import {
-  compareBestHeaderBannerTexts,
-  compareBestInteractiveLinkLabel,
-  compareBestInteractiveSearch,
-} from "@/lib/compare-best-ui-lib";
+import { compareBestUiState } from "@/lib/compare-best-ui-lib";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
@@ -97,14 +93,7 @@ function BestDetail() {
     .filter((p): p is Resolved => p !== null);
 
   const compareEntries = useMemo(() => resolved.slice(0, 5).map((p) => p.entry), [resolved]);
-  const compareBannerTexts = useMemo(
-    () => compareBestHeaderBannerTexts(compareEntries),
-    [compareEntries],
-  );
-  const interactiveCompareSearch = useMemo(
-    () => compareBestInteractiveSearch(compareEntries),
-    [compareEntries],
-  );
+  const compareUi = useMemo(() => compareBestUiState(compareEntries), [compareEntries]);
 
   return (
     <PageContainer className="py-12">
@@ -152,16 +141,16 @@ function BestDetail() {
         </>
       )}
 
-      {resolved.length >= 2 && (
+      {compareUi.showCompareSection && (
         <section className="mt-10">
           <h2 className="h-display-2 text-ink">Compared at a glance</h2>
           <p className="mt-2 max-w-3xl text-sm text-ink-muted">
             The top {Math.min(resolved.length, 5)} picks side by side on trust, install, platform
             support, and disclosed notes — full rationale for each below.
           </p>
-          {compareBannerTexts.length > 0 ? (
+          {compareUi.bannerTexts.length > 0 ? (
             <div className="mt-4 space-y-1.5">
-              {compareBannerTexts.map((text) => (
+              {compareUi.bannerTexts.map((text) => (
                 <p key={text} className="text-sm text-ink-muted">
                   {text}
                 </p>
@@ -171,14 +160,14 @@ function BestDetail() {
           <div className="mt-5">
             <ComparisonTable entries={compareEntries} showNextActions />
           </div>
-          {interactiveCompareSearch ? (
+          {compareUi.interactiveSearch ? (
             <Link
               to="/compare"
-              search={interactiveCompareSearch}
+              search={compareUi.interactiveSearch}
               className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
             >
               <ArrowLeft className="h-4 w-4" />
-              {compareBestInteractiveLinkLabel(compareEntries.length)}
+              {compareUi.interactiveLinkLabel}
             </Link>
           ) : null}
         </section>

--- a/tests/compare-best-ui-lib.test.ts
+++ b/tests/compare-best-ui-lib.test.ts
@@ -5,6 +5,7 @@ import {
   compareBestInteractiveLinkLabel,
   compareBestInteractiveSearch,
   compareBestShowCompareSection,
+  compareBestUiState,
 } from "@/lib/compare-best-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -79,5 +80,38 @@ describe("compare best ui lib", () => {
       "1 trust signal differ across this comparison (Review status).",
       "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+  });
+
+  it("bundles best-list page presentation state for headers and interactive links", () => {
+    expect(
+      compareBestUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+    expect(
+      compareBestUiState([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+      ],
+      interactiveSearch: { ids: "mcp/fixture,mcp/mixed" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareBestUiState` to bundle best-list comparison section visibility, header banners, interactive search, and link labels.
- Wire the best-list detail route through the new helper instead of assembling state inline.
- Add regression tests for combined trust/action banner and interactive link state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)