### PR TITLE
feat(compare): bundle dossier compare UI state in dossier UI lib

### DIFF
--- a/apps/web/src/lib/compare-dossier-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-ui-lib.ts
@@ -23,3 +23,20 @@ export function compareDossierInteractiveLinkLabel(comparedCount: number): strin
 export function compareDossierShowCompareSection(alternatives: Entry[]): boolean {
   return alternatives.length > 0;
 }
+
+export type CompareDossierUiState = {
+  showCompareSection: boolean;
+  bannerTexts: string[];
+  interactiveSearch: { ids: string } | null;
+  interactiveLinkLabel: string;
+};
+
+export function compareDossierUiState(entry: Entry, alternatives: Entry[]): CompareDossierUiState {
+  const comparedCount = alternatives.length + 1;
+  return {
+    showCompareSection: alternatives.length > 0,
+    bannerTexts: compareDossierBannerTexts(entry, alternatives),
+    interactiveSearch: compareDossierInteractiveSearch(entry, alternatives),
+    interactiveLinkLabel: compareInteractiveLinkLabel(comparedCount),
+  };
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -43,11 +43,7 @@ import {
   compareEntryFeaturedBestListLinks,
   compareEntryFeaturedComparisonLinks,
 } from "@/lib/compare-entry-featured-ui-lib";
-import {
-  compareDossierHeaderBannerTexts,
-  compareDossierInteractiveCompareSearch,
-  compareDossierInteractiveLinkLabel,
-} from "@/lib/compare-dossier-ui-lib";
+import { compareDossierUiState } from "@/lib/compare-dossier-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -230,12 +226,8 @@ function Dossier() {
     const pool = altGroup && altGroup.entries.length > 0 ? altGroup.entries : rel;
     return pool.slice(0, 3);
   }, [relGroups, rel]);
-  const compareBannerTexts = useMemo(
-    () => compareDossierHeaderBannerTexts(entry, alternatives),
-    [entry, alternatives],
-  );
-  const dossierCompareSearch = useMemo(
-    () => compareDossierInteractiveCompareSearch(entry, alternatives),
+  const dossierCompareUi = useMemo(
+    () => compareDossierUiState(entry, alternatives),
     [entry, alternatives],
   );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,
@@ -671,7 +663,7 @@ function Dossier() {
 
           <BadgeSection category={entry.category} slug={entry.slug} title={entry.title} />
 
-          {alternatives.length > 0 && (
+          {dossierCompareUi.showCompareSection && (
             <DossierSection id="compare" title="How it compares">
               <p className="mb-4 text-sm text-ink-muted">
                 {entry.title} side by side with{" "}
@@ -681,9 +673,9 @@ function Dossier() {
                 on trust, install, platform support, and disclosed safety notes — all from reviewed
                 registry metadata.
               </p>
-              {compareBannerTexts.length > 0 ? (
+              {dossierCompareUi.bannerTexts.length > 0 ? (
                 <div className="mb-4 space-y-1.5">
-                  {compareBannerTexts.map((text) => (
+                  {dossierCompareUi.bannerTexts.map((text) => (
                     <p key={text} className="text-sm text-ink-muted">
                       {text}
                     </p>
@@ -691,14 +683,14 @@ function Dossier() {
                 </div>
               ) : null}
               <ComparisonTable entries={[entry, ...alternatives]} showNextActions />
-              {dossierCompareSearch ? (
+              {dossierCompareUi.interactiveSearch ? (
                 <Link
                   to="/compare"
-                  search={dossierCompareSearch}
+                  search={dossierCompareUi.interactiveSearch}
                   className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
                 >
                   <ArrowLeft className="h-4 w-4" />
-                  {compareDossierInteractiveLinkLabel(alternatives.length + 1)}
+                  {dossierCompareUi.interactiveLinkLabel}
                 </Link>
               ) : null}
             </DossierSection>

--- a/tests/compare-dossier-ui-lib.test.ts
+++ b/tests/compare-dossier-ui-lib.test.ts
@@ -5,6 +5,7 @@ import {
   compareDossierInteractiveCompareSearch,
   compareDossierInteractiveLinkLabel,
   compareDossierShowCompareSection,
+  compareDossierUiState,
 } from "@/lib/compare-dossier-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -78,5 +79,37 @@ describe("compare dossier ui lib", () => {
       "1 trust signal differ across this comparison (Review status).",
       "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
     ]);
+  });
+
+  it("bundles dossier compare presentation state for headers and interactive links", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(
+      compareDossierUiState(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/primary,hooks/alt" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+    expect(
+      compareDossierUiState(primary, [
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+      ],
+      interactiveSearch: { ids: "skills/primary,mcp/mixed" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareDossierUiState` to bundle dossier comparison section visibility, header banners, interactive search, and link labels.
- Wire the entry dossier route through the new helper instead of assembling state inline.
- Add regression tests for combined trust/action banner and interactive link state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)