### PR TITLE
feat(compare): bundle interactive compare page UI state in page UI lib

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -31,3 +31,19 @@ export function comparePageEmptyStateDescription(): string {
 export function comparePageInvalidUrlHint(ids: string, resolvedCount: number): string | null {
   return compareInvalidUrlHint(ids, resolvedCount);
 }
+
+export type ComparePageUiState = {
+  actionRowDiverges: boolean;
+  bannerTexts: string[];
+  singleItemHint: string | null;
+  shareUrl: string;
+};
+
+export function comparePageUiState(items: Entry[]): ComparePageUiState {
+  return {
+    actionRowDiverges: compareActionsDiverge(items),
+    bannerTexts: comparePageBannerTexts(items),
+    singleItemHint: compareSingleItemHintText(items.length),
+    shareUrl: comparePageShareUrlForWindow(items),
+  };
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -17,12 +17,9 @@ import {
   type CompareAction,
 } from "@/lib/compare-entry-actions";
 import {
-  comparePageActionsDiverge,
   comparePageEmptyStateDescription,
-  comparePageHeaderBannerTexts,
   comparePageInvalidUrlHint,
-  comparePageSelectionHint,
-  comparePageShareUrl,
+  comparePageUiState,
 } from "@/lib/compare-page-ui-lib";
 import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
@@ -75,9 +72,7 @@ function ComparePage() {
   const items = compare.items;
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
-  const actionRowDiverges = comparePageActionsDiverge(items);
-  const bannerTexts = comparePageHeaderBannerTexts(items);
-  const singleItemHint = comparePageSelectionHint(items.length);
+  const pageUi = comparePageUiState(items);
   const popularComparisonLinks = React.useMemo(
     () => comparePagePopularComparisonLinks(COMPARISONS, ENTRIES),
     [],
@@ -102,7 +97,7 @@ function ComparePage() {
     setPickerOpen(false);
   };
 
-  const copyShare = () => comparePageShareUrl(items);
+  const copyShare = () => pageUi.shareUrl;
 
   if (items.length === 0) {
     const resolvedFromUrl = resolveIds(sp.ids);
@@ -168,16 +163,18 @@ function ComparePage() {
           <h1 className="mt-1 h-display-2 text-ink text-balance">
             {items.length} {items.length === 1 ? "resource" : "resources"} side by side
           </h1>
-          {bannerTexts.length > 0 ? (
+          {pageUi.bannerTexts.length > 0 ? (
             <div className="mt-2 space-y-1.5">
-              {bannerTexts.map((text) => (
+              {pageUi.bannerTexts.map((text) => (
                 <p key={text} className="text-sm text-ink-muted">
                   {text}
                 </p>
               ))}
             </div>
           ) : null}
-          {singleItemHint ? <p className="mt-2 text-sm text-ink-muted">{singleItemHint}</p> : null}
+          {pageUi.singleItemHint ? (
+            <p className="mt-2 text-sm text-ink-muted">{pageUi.singleItemHint}</p>
+          ) : null}
         </div>
         <div className="flex items-center gap-2">
           <CopyButton value={copyShare()} label="Copy share link" />
@@ -256,18 +253,18 @@ function ComparePage() {
             <tr
               className={cn(
                 "transition-colors duration-200 ease-out",
-                actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+                pageUi.actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
               )}
             >
               <th
                 scope="row"
                 className={cn(
                   "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
-                  actionRowDiverges && "text-amber-800",
+                  pageUi.actionRowDiverges && "text-amber-800",
                 )}
               >
                 Next steps
-                {actionRowDiverges ? (
+                {pageUi.actionRowDiverges ? (
                   <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
                     Differs
                   </span>
@@ -278,7 +275,7 @@ function ComparePage() {
                   key={`actions-${e.category}/${e.slug}`}
                   className={cn(
                     "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
-                    actionRowDiverges && "bg-amber-500/5",
+                    pageUi.actionRowDiverges && "bg-amber-500/5",
                   )}
                 >
                   <CompareNextActions entry={e} />

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -7,6 +7,7 @@ import {
   comparePageInvalidUrlHint,
   comparePageSelectionHint,
   comparePageShareUrl,
+  comparePageUiState,
 } from "@/lib/compare-page-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -78,5 +79,45 @@ describe("compare page ui lib", () => {
     expect(comparePageInvalidUrlHint("skills/missing", 0)).toContain(
       "could not be resolved",
     );
+  });
+
+  it("bundles interactive compare page presentation state", () => {
+    expect(
+      comparePageUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      singleItemHint: null,
+      shareUrl: "/compare?ids=skills%2Falpha%2Chooks%2Fbeta",
+    });
+    expect(
+      comparePageUiState([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across this comparison — review install, source, and claim actions in the table below.",
+      ],
+      singleItemHint: null,
+      shareUrl: "/compare?ids=mcp%2Ffixture%2Cmcp%2Fmixed",
+    });
+    expect(comparePageUiState([entry()])).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      singleItemHint:
+        "Add one more resource to unlock trust and next-step comparisons across the full table.",
+      shareUrl: "/compare?ids=mcp%2Ffixture",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `comparePageUiState` to bundle banner texts, action divergence, selection hints, and share URLs for the interactive compare page.
- Wire the compare index route through the new helper instead of assembling state inline.
- Add regression tests for combined trust/action banner and single-item hint state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)