### PR TITLE
feat(compare): bundle entry dossier featured links in featured UI lib

### DIFF
--- a/apps/web/src/lib/compare-entry-featured-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-ui-lib.ts
@@ -46,3 +46,23 @@ export function compareEntryFeaturedBestListLinks(
     label: compareBestListInteractiveLinkLabel(list.picks, catalog),
   }));
 }
+
+export type CompareEntryFeaturedUiState = {
+  comparisonLinks: CompareEntryFeaturedComparisonLink[];
+  bestListLinks: CompareEntryFeaturedBestListLink[];
+  hasFeaturedLinks: boolean;
+};
+
+export function compareEntryFeaturedUiState(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryFeaturedUiState {
+  const comparisonLinks = compareEntryFeaturedComparisonLinks(comparisons, catalog);
+  const bestListLinks = compareEntryFeaturedBestListLinks(lists, catalog);
+  return {
+    comparisonLinks,
+    bestListLinks,
+    hasFeaturedLinks: comparisonLinks.length > 0 || bestListLinks.length > 0,
+  };
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -39,10 +39,7 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import {
-  compareEntryFeaturedBestListLinks,
-  compareEntryFeaturedComparisonLinks,
-} from "@/lib/compare-entry-featured-ui-lib";
+import { compareEntryFeaturedUiState } from "@/lib/compare-entry-featured-ui-lib";
 import { compareDossierUiState } from "@/lib/compare-dossier-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -243,13 +240,9 @@ function Dossier() {
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
-  const featuredCompareLinks = useMemo(
-    () => compareEntryFeaturedComparisonLinks(comparedIn, ENTRIES),
-    [comparedIn],
-  );
-  const featuredBestListLinks = useMemo(
-    () => compareEntryFeaturedBestListLinks(featuredIn, ENTRIES),
-    [featuredIn],
+  const featuredUi = useMemo(
+    () => compareEntryFeaturedUiState(comparedIn, featuredIn, ENTRIES),
+    [comparedIn, featuredIn],
   );
   const recents = useRecents();
   useEffect(() => {
@@ -743,11 +736,13 @@ function Dossier() {
             </DossierSection>
           )}
 
-          {(featuredIn.length > 0 || comparedIn.length > 0) && (
+          {featuredUi.hasFeaturedLinks && (
             <DossierSection id="featured-in" title="Featured in">
               <ul className="flex flex-col gap-2 text-sm">
                 {featuredIn.map((l) => {
-                  const bestListLink = featuredBestListLinks.find((link) => link.slug === l.slug);
+                  const bestListLink = featuredUi.bestListLinks.find(
+                    (link) => link.slug === l.slug,
+                  );
                   return (
                     <li
                       key={`best-${l.slug}`}
@@ -773,7 +768,9 @@ function Dossier() {
                   );
                 })}
                 {comparedIn.map((c) => {
-                  const featuredLink = featuredCompareLinks.find((link) => link.slug === c.slug);
+                  const featuredLink = featuredUi.comparisonLinks.find(
+                    (link) => link.slug === c.slug,
+                  );
                   return (
                     <li
                       key={`cmp-${c.slug}`}

--- a/tests/compare-entry-featured-ui-lib.test.ts
+++ b/tests/compare-entry-featured-ui-lib.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   compareEntryFeaturedBestListLinks,
   compareEntryFeaturedComparisonLinks,
+  compareEntryFeaturedUiState,
 } from "@/lib/compare-entry-featured-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -114,5 +115,41 @@ describe("compare entry featured ui lib", () => {
         label: "Open 3 picks in the interactive comparison tool",
       },
     ]);
+  });
+
+  it("bundles entry dossier featured comparison and best-list links", () => {
+    expect(
+      compareEntryFeaturedUiState(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      comparisonLinks: [
+        {
+          slug: "pair",
+          search: { ids: "skills/alpha,hooks/beta" },
+          label: "Open interactively",
+        },
+      ],
+      bestListLinks: [
+        {
+          slug: "top-picks",
+          search: { ids: "skills/alpha,hooks/beta" },
+          label: "Open interactively",
+        },
+      ],
+      hasFeaturedLinks: true,
+    });
+    expect(compareEntryFeaturedUiState([], [], catalog)).toEqual({
+      comparisonLinks: [],
+      bestListLinks: [],
+      hasFeaturedLinks: false,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareEntryFeaturedUiState` to bundle featured comparison and best-list links for entry dossier pages.
- Wire the entry dossier route through the new helper instead of assembling featured links inline.
- Add regression tests for combined featured link state.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-featured-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)