### PR TITLE
feat(compare): add compare drawer signals UI lib for decision rows

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -34,11 +34,11 @@ import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
 import {
-  COMPARE_DECISION_ROWS,
+  compareDrawerDecisionRowDiverges,
   compareSignalToneClass,
-  decisionRowDiverges,
   type CompareSignalValue,
-} from "@/lib/compare-entry-signals";
+} from "@/lib/compare-drawer-signals-ui-lib";
+import { COMPARE_DECISION_ROWS } from "@/lib/compare-entry-signals";
 
 interface RowDef {
   label: string;
@@ -58,7 +58,7 @@ const ROWS: RowDef[] = [
       if (!value) return <span className="text-xs text-ink-subtle">—</span>;
       return <CompareSignalCell value={value} />;
     },
-    diverges: (items: Entry[]) => decisionRowDiverges(row.resolve, items),
+    diverges: (items: Entry[]) => compareDrawerDecisionRowDiverges(row.resolve, items),
   })),
   {
     label: "Safety",

--- a/apps/web/src/lib/compare-drawer-signals-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-signals-ui-lib.ts
@@ -1,0 +1,23 @@
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_DECISION_ROWS,
+  compareSignalToneClass,
+  decisionRowDiverges,
+  type CompareSignalValue,
+} from "@/lib/compare-entry-signals";
+
+export type { CompareSignalValue };
+export { compareSignalToneClass };
+
+export function compareDrawerDecisionRowDiverges(
+  resolve: (entry: Entry) => CompareSignalValue | undefined,
+  items: Entry[],
+): boolean {
+  return decisionRowDiverges(resolve, items);
+}
+
+export function compareDrawerDivergingDecisionLabels(items: Entry[]): string[] {
+  return COMPARE_DECISION_ROWS.filter((row) => decisionRowDiverges(row.resolve, items)).map(
+    (row) => row.label,
+  );
+}

--- a/tests/compare-drawer-signals-ui-lib.test.ts
+++ b/tests/compare-drawer-signals-ui-lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { reviewCompareSignal } from "@/lib/compare-entry-signals";
+import {
+  compareDrawerDecisionRowDiverges,
+  compareDrawerDivergingDecisionLabels,
+  compareSignalToneClass,
+} from "@/lib/compare-drawer-signals-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer signals ui lib", () => {
+  it("detects when drawer decision rows diverge across compared entries", () => {
+    expect(
+      compareDrawerDecisionRowDiverges(reviewCompareSignal, [
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toBe(true);
+    expect(
+      compareDrawerDecisionRowDiverges(reviewCompareSignal, [
+        entry(),
+        entry({ slug: "other" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns diverging drawer decision row labels", () => {
+    expect(compareDrawerDivergingDecisionLabels([entry()])).toEqual([]);
+    expect(
+      compareDrawerDivergingDecisionLabels([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toEqual(["Review status"]);
+  });
+
+  it("re-exports compare signal tone classes for drawer cells", () => {
+    expect(compareSignalToneClass("verified")).toBe("text-trust-trusted");
+    expect(compareSignalToneClass("missing")).toBe("text-ink-subtle");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-signals-ui-lib` with drawer decision-row divergence helpers and signal tone re-exports.
- Wire the compare drawer component through the new lib instead of importing signal helpers directly.
- Add regression tests for diverging decision row labels and tone classes.

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-signals-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs (#4251, #4259)


Made with [Cursor](https://cursor.com)