### PR TITLE
feat(web): add compare page empty UI lib for empty state

### DIFF
--- a/apps/web/src/lib/compare-page-empty-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-ui-lib.ts
@@ -1,0 +1,27 @@
+import {
+  comparePageEmptyStateDescription,
+  comparePageInvalidUrlHint,
+} from "@/lib/compare-page-ui-lib";
+import {
+  comparePagePopularComparisonLinks,
+  type ComparePagePopularComparisonLink,
+} from "@/lib/compare-page-featured-ui-lib";
+import type { EntryIdentity } from "@/lib/entry-identity";
+
+export type ComparePageEmptyUiState = {
+  description: string;
+  invalidUrlHint: string | null;
+  popularComparisonLinks: ComparePagePopularComparisonLink[];
+};
+
+export function comparePageEmptyUiState(
+  ids: string,
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePageEmptyUiState {
+  return {
+    description: comparePageEmptyStateDescription(),
+    invalidUrlHint: comparePageInvalidUrlHint(ids, 0),
+    popularComparisonLinks: comparePagePopularComparisonLinks(comparisons, catalog),
+  };
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -16,12 +16,8 @@ import {
   resolveCompareEntryActions,
   type CompareAction,
 } from "@/lib/compare-entry-actions";
-import {
-  comparePageEmptyStateDescription,
-  comparePageInvalidUrlHint,
-  comparePageUiState,
-} from "@/lib/compare-page-ui-lib";
-import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
+import { comparePageUiState } from "@/lib/compare-page-ui-lib";
+import { comparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -73,9 +69,9 @@ function ComparePage() {
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
   const pageUi = comparePageUiState(items);
-  const popularComparisonLinks = React.useMemo(
-    () => comparePagePopularComparisonLinks(COMPARISONS, ENTRIES),
-    [],
+  const emptyUi = React.useMemo(
+    () => comparePageEmptyUiState(sp.ids, COMPARISONS, ENTRIES),
+    [sp.ids],
   );
 
   const pushIds = (next: Entry[]) => {
@@ -105,14 +101,15 @@ function ComparePage() {
       // Render directly from URL while context hydrates.
       return <Skeleton ids={sp.ids} />;
     }
-    const invalidUrlHint = comparePageInvalidUrlHint(sp.ids, 0);
     return (
       <div className="mx-auto max-w-3xl px-4 py-16 sm:px-6">
         <div className="rounded-xl border border-dashed border-border bg-surface p-10 text-center">
           <div className="eyebrow">Comparison</div>
           <h1 className="mt-2 h-display-2 text-ink text-balance">Nothing to compare yet</h1>
-          <p className="mt-2 text-sm text-ink-muted">{comparePageEmptyStateDescription()}</p>
-          {invalidUrlHint ? <p className="mt-2 text-sm text-amber-800">{invalidUrlHint}</p> : null}
+          <p className="mt-2 text-sm text-ink-muted">{emptyUi.description}</p>
+          {emptyUi.invalidUrlHint ? (
+            <p className="mt-2 text-sm text-amber-800">{emptyUi.invalidUrlHint}</p>
+          ) : null}
           <div className="mt-5 flex justify-center gap-2">
             <Link
               to="/browse"
@@ -124,7 +121,7 @@ function ComparePage() {
           <div className="mt-6">
             <div className="eyebrow mb-2">Popular comparisons</div>
             <div className="flex flex-wrap justify-center gap-2">
-              {popularComparisonLinks.map((comparison) => (
+              {emptyUi.popularComparisonLinks.map((comparison) => (
                 <div
                   key={comparison.slug}
                   className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"

--- a/tests/compare-page-empty-ui-lib.test.ts
+++ b/tests/compare-page-empty-ui-lib.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+];
+
+describe("compare page empty ui lib", () => {
+  it("bundles empty-state copy, invalid URL hints, and popular comparison links", () => {
+    expect(
+      comparePageEmptyUiState(
+        "",
+        [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            refs: ["skills/alpha", "hooks/beta"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      description: expect.stringContaining("directory"),
+      invalidUrlHint: null,
+      popularComparisonLinks: [
+        {
+          slug: "pair",
+          heading: "Alpha vs Beta",
+          interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+          interactiveLabel: "Open interactively",
+        },
+      ],
+    });
+  });
+
+  it("surfaces invalid URL hints when ids cannot be resolved", () => {
+    const state = comparePageEmptyUiState("skills/missing", [], catalog);
+    expect(state.invalidUrlHint).toContain("could not be resolved");
+    expect(state.popularComparisonLinks).toEqual([]);
+  });
+
+  it("omits interactive search when fewer than two refs resolve", () => {
+    expect(
+      comparePageEmptyUiState(
+        "",
+        [{ slug: "solo", heading: "Alpha only", refs: ["skills/alpha"] }],
+        catalog,
+      ).popularComparisonLinks,
+    ).toEqual([
+      {
+        slug: "solo",
+        heading: "Alpha only",
+        interactiveSearch: null,
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `comparePageEmptyUiState` to bundle empty-state copy, invalid URL hints, and popular comparison links for the interactive compare page
- Wire `compare.index.tsx` through the new lib instead of calling helpers individually
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-empty-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)