### PR TITLE
feat(web): add compare table signals UI lib for decision rows

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -16,7 +16,7 @@ import {
   comparisonDecisionRows,
   displayCompareSignal,
   signalToneClassForDisplay,
-} from "@/lib/compare-table-decision-rows";
+} from "@/lib/compare-table-signals-ui-lib";
 import { COMPARE_TABLE_SURFACE } from "@/lib/compare-table-actions";
 import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
 import {

--- a/apps/web/src/lib/compare-table-signals-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-signals-ui-lib.ts
@@ -1,0 +1,24 @@
+import type { Entry } from "@/types/registry";
+import { decisionRowDiverges, type CompareSignalValue } from "@/lib/compare-entry-signals";
+import {
+  comparisonDecisionRows,
+  displayCompareSignal,
+  signalToneClassForDisplay,
+  type ComparisonDecisionRow,
+} from "@/lib/compare-table-decision-rows";
+
+export type { CompareSignalValue, ComparisonDecisionRow };
+export { comparisonDecisionRows, displayCompareSignal, signalToneClassForDisplay };
+
+export function compareTableDecisionRowDiverges(
+  resolve: (entry: Entry) => CompareSignalValue | undefined,
+  entries: Entry[],
+): boolean {
+  return decisionRowDiverges(resolve, entries);
+}
+
+export function compareTableDivergingDecisionLabels(entries: Entry[]): string[] {
+  return comparisonDecisionRows()
+    .filter((row) => row.diverges(entries))
+    .map((row) => row.label);
+}

--- a/tests/compare-table-signals-ui-lib.test.ts
+++ b/tests/compare-table-signals-ui-lib.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { reviewCompareSignal } from "@/lib/compare-entry-signals";
+import {
+  compareTableDecisionRowDiverges,
+  compareTableDivergingDecisionLabels,
+  displayCompareSignal,
+  signalToneClassForDisplay,
+} from "@/lib/compare-table-signals-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table signals ui lib", () => {
+  it("detects when table decision rows diverge across compared entries", () => {
+    expect(
+      compareTableDecisionRowDiverges(reviewCompareSignal, [
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toBe(true);
+    expect(
+      compareTableDecisionRowDiverges(reviewCompareSignal, [
+        entry(),
+        entry({ slug: "other" }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("returns diverging table decision row labels", () => {
+    expect(compareTableDivergingDecisionLabels([entry()])).toEqual([]);
+    expect(
+      compareTableDivergingDecisionLabels([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toEqual(["Review status"]);
+  });
+
+  it("re-exports compare signal display helpers for table cells", () => {
+    const signal = reviewCompareSignal(entry());
+    expect(displayCompareSignal(signal).label).toBe("Not reviewed");
+    expect(signalToneClassForDisplay(signal)).toBe("text-ink-subtle");
+    expect(signalToneClassForDisplay(undefined)).toBe("text-ink-subtle");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-signals-ui-lib` with table decision-row divergence helpers and signal display re-exports
- Wire `comparison-table.tsx` through the new lib instead of importing decision-row helpers directly
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-signals-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)