### PR TITLE
feat(web): add compare page actions UI lib for next steps

### DIFF
--- a/apps/web/src/lib/compare-page-actions-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-actions-ui-lib.ts
@@ -1,0 +1,35 @@
+import type { Entry } from "@/types/registry";
+import { resolveCompareEntryActions, type CompareAction } from "@/lib/compare-entry-actions";
+import { COMPARE_PAGE_SURFACE } from "@/lib/compare-page-summary";
+import {
+  compareSurfaceActionCells,
+  compareSurfaceActionSummary,
+  compareSurfaceActionsDiverge,
+  compareSurfaceSharedActionIds,
+  type CompareSurfaceActionCell,
+} from "@/lib/compare-surface-actions-lib";
+
+export { COMPARE_PAGE_SURFACE };
+export type { CompareAction };
+
+export type ComparePageActionCell = CompareSurfaceActionCell;
+
+export function comparePageEntryActions(entry: Entry): CompareAction[] {
+  return resolveCompareEntryActions(entry);
+}
+
+export function comparePageActionCells(entries: Entry[]): ComparePageActionCell[] {
+  return compareSurfaceActionCells(entries);
+}
+
+export function comparePageActionsDiverge(entries: Entry[]): boolean {
+  return compareSurfaceActionsDiverge(entries);
+}
+
+export function comparePageSharedActionIds(entries: Entry[]): string[] {
+  return compareSurfaceSharedActionIds(entries);
+}
+
+export function comparePageActionSummary(entries: Entry[]) {
+  return compareSurfaceActionSummary(entries);
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -11,11 +11,12 @@ import { CopyButton } from "@/components/copy-button";
 import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
+import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import {
-  recordCompareIntentEvent,
-  resolveCompareEntryActions,
+  COMPARE_PAGE_SURFACE,
+  comparePageEntryActions,
   type CompareAction,
-} from "@/lib/compare-entry-actions";
+} from "@/lib/compare-page-actions-ui-lib";
 import { comparePageUiState } from "@/lib/compare-page-ui-lib";
 import { comparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
@@ -347,7 +348,7 @@ function ComparePage() {
 }
 
 function CompareNextActions({ entry }: { entry: Entry }) {
-  const actions = resolveCompareEntryActions(entry);
+  const actions = comparePageEntryActions(entry);
 
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -367,7 +368,7 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
         value={action.copyValue}
         label={action.label}
         event={action.analyticsEvent}
-        eventData={{ entry: eventKey, surface: "compare-page" }}
+        eventData={{ entry: eventKey, surface: COMPARE_PAGE_SURFACE }}
         onCopied={() => {
           if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
         }}
@@ -383,7 +384,7 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
           params={{ category: entry.category, slug: entry.slug }}
           onClick={() => {
             if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
             }
             if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
           }}
@@ -400,7 +401,7 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
           to="/claim"
           onClick={() => {
             if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
             }
           }}
           className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
@@ -418,7 +419,7 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
           rel="noreferrer"
           onClick={() => {
             if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, { entry: eventKey, surface: "compare-page" });
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
             }
             if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
           }}

--- a/tests/compare-page-actions-ui-lib.test.ts
+++ b/tests/compare-page-actions-ui-lib.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_PAGE_SURFACE,
+  comparePageActionCells,
+  comparePageActionSummary,
+  comparePageActionsDiverge,
+  comparePageEntryActions,
+  comparePageSharedActionIds,
+} from "@/lib/compare-page-actions-ui-lib";
+import { compareSurfaceActionSummary } from "@/lib/compare-surface-actions-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page actions ui lib", () => {
+  it("exposes the compare page analytics surface id", () => {
+    expect(COMPARE_PAGE_SURFACE).toBe("compare-page");
+  });
+
+  it("resolves next actions for a single compared entry", () => {
+    expect(comparePageEntryActions(entry()).map((action) => action.id)).toEqual(
+      ["dossier", "claim"],
+    );
+  });
+
+  it("maps compared entries to per-column next-action cells", () => {
+    expect(comparePageActionCells([entry()])).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+    expect(
+      comparePageActionCells([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({
+          category: "hooks",
+          slug: "beta",
+          claimed: true,
+          sourceUrl: "https://x.dev",
+        }),
+      ]).map((cell) => cell.entryKey),
+    ).toEqual(["skills:alpha", "hooks:beta"]);
+  });
+
+  it("detects when page columns expose different next-action sets", () => {
+    expect(
+      comparePageActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      comparePageActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(comparePageActionsDiverge([])).toBe(false);
+  });
+
+  it("finds action ids shared across every compared entry", () => {
+    expect(comparePageSharedActionIds([])).toEqual([]);
+    expect(comparePageSharedActionIds([entry()])).toEqual(["dossier", "claim"]);
+    expect(
+      comparePageSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toEqual(["dossier", "install", "claim"]);
+    expect(
+      comparePageSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("summarizes page action divergence for header hints", () => {
+    const baseline = entry();
+    const withInstall = entry({ installCommand: "npm i fixture" });
+    expect(comparePageActionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      diverges: false,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 1,
+    });
+    expect(comparePageActionSummary([baseline, withInstall])).toEqual({
+      comparedCount: 2,
+      diverges: true,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 2,
+    });
+    expect(comparePageActionSummary([baseline, withInstall])).toEqual(
+      compareSurfaceActionSummary([baseline, withInstall]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-actions-ui-lib` with page action cells, divergence helpers, and analytics surface id
- Wire `compare.index.tsx` through `comparePageEntryActions` and `COMPARE_PAGE_SURFACE`
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-actions-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)