### PR TITLE
feat(web): add compare table actions UI lib for next steps

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -17,13 +17,13 @@ import {
   displayCompareSignal,
   signalToneClassForDisplay,
 } from "@/lib/compare-table-signals-ui-lib";
-import { COMPARE_TABLE_SURFACE } from "@/lib/compare-table-actions";
-import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
 import {
-  recordCompareIntentEvent,
-  resolveCompareEntryActions,
+  COMPARE_TABLE_SURFACE,
+  compareTableEntryActions,
   type CompareAction,
-} from "@/lib/compare-entry-actions";
+} from "@/lib/compare-table-actions-ui-lib";
+import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
+import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -54,7 +54,7 @@ function CompareSignalCell({
 }
 
 function TableCompareActions({ entry }: { entry: Entry }) {
-  const actions = resolveCompareEntryActions(entry);
+  const actions = compareTableEntryActions(entry);
 
   return (
     <div className="flex flex-wrap gap-1.5">

--- a/apps/web/src/lib/compare-table-actions-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-actions-ui-lib.ts
@@ -1,0 +1,25 @@
+import type { Entry } from "@/types/registry";
+import { resolveCompareEntryActions, type CompareAction } from "@/lib/compare-entry-actions";
+import {
+  COMPARE_TABLE_SURFACE,
+  compareTableActionCells,
+  compareTableActionSummary,
+  compareTableActionsDiverge,
+  compareTableSharedActionIds,
+  shouldRenderCompareTableActions,
+  type CompareTableActionCell,
+} from "@/lib/compare-table-actions";
+
+export {
+  COMPARE_TABLE_SURFACE,
+  compareTableActionCells,
+  compareTableActionSummary,
+  compareTableActionsDiverge,
+  compareTableSharedActionIds,
+  shouldRenderCompareTableActions,
+};
+export type { CompareAction, CompareTableActionCell };
+
+export function compareTableEntryActions(entry: Entry): CompareAction[] {
+  return resolveCompareEntryActions(entry);
+}

--- a/tests/compare-table-actions-ui-lib.test.ts
+++ b/tests/compare-table-actions-ui-lib.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_TABLE_SURFACE,
+  compareTableActionCells,
+  compareTableActionSummary,
+  compareTableActionsDiverge,
+  compareTableEntryActions,
+  compareTableSharedActionIds,
+  shouldRenderCompareTableActions,
+} from "@/lib/compare-table-actions-ui-lib";
+import { compareSurfaceActionSummary } from "@/lib/compare-surface-actions-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table actions ui lib", () => {
+  it("exposes the compare table analytics surface id", () => {
+    expect(COMPARE_TABLE_SURFACE).toBe("compare-table");
+  });
+
+  it("resolves next actions for a single compared entry", () => {
+    expect(
+      compareTableEntryActions(entry()).map((action) => action.id),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("only renders next-action rows when enabled for multi-entry tables", () => {
+    expect(shouldRenderCompareTableActions([], true)).toBe(false);
+    expect(shouldRenderCompareTableActions([entry()], true)).toBe(false);
+    expect(
+      shouldRenderCompareTableActions(
+        [entry(), entry({ slug: "other" })],
+        false,
+      ),
+    ).toBe(false);
+    expect(
+      shouldRenderCompareTableActions(
+        [entry(), entry({ slug: "other" })],
+        true,
+      ),
+    ).toBe(true);
+  });
+
+  it("maps compared entries to per-column next-action cells", () => {
+    expect(compareTableActionCells([entry()])).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+  });
+
+  it("detects when table columns expose different next-action sets", () => {
+    expect(
+      compareTableActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      compareTableActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(compareTableActionsDiverge([])).toBe(false);
+  });
+
+  it("finds action ids shared across every compared entry", () => {
+    expect(compareTableSharedActionIds([])).toEqual([]);
+    expect(compareTableSharedActionIds([entry()])).toEqual([
+      "dossier",
+      "claim",
+    ]);
+    expect(
+      compareTableSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("summarizes table action divergence for row highlighting", () => {
+    const baseline = entry();
+    const withInstall = entry({ installCommand: "npm i fixture" });
+    expect(compareTableActionSummary([baseline, withInstall])).toEqual({
+      comparedCount: 2,
+      diverges: true,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 2,
+    });
+    expect(compareTableActionSummary([baseline, withInstall])).toEqual(
+      compareSurfaceActionSummary([baseline, withInstall]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-actions-ui-lib` with table action cells, divergence helpers, and analytics surface id
- Wire `comparison-table.tsx` through `compareTableEntryActions` and `COMPARE_TABLE_SURFACE`
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-actions-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259


Made with [Cursor](https://cursor.com)