### PR TITLE
feat(web): add compare drawer actions UI lib for next steps

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -18,17 +18,17 @@ import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
-import { COMPARE_DRAWER_SURFACE } from "@/lib/compare-drawer-actions";
+import {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerEntryActions,
+  type CompareAction,
+} from "@/lib/compare-drawer-actions-ui-lib";
 import {
   compareDrawerEmptyStateHint,
   compareDrawerShareUrl,
   compareDrawerUiState,
 } from "@/lib/compare-drawer-ui-lib";
-import {
-  recordCompareIntentEvent,
-  resolveCompareEntryActions,
-  type CompareAction,
-} from "@/lib/compare-entry-actions";
+import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -181,7 +181,7 @@ function CompareSignalCell({ value }: { value: CompareSignalValue }) {
 }
 
 function DrawerCompareActions({ entry }: { entry: Entry }) {
-  const actions = resolveCompareEntryActions(entry);
+  const actions = compareDrawerEntryActions(entry);
 
   return (
     <div className="flex flex-wrap gap-1.5">

--- a/apps/web/src/lib/compare-drawer-actions-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-actions-ui-lib.ts
@@ -1,0 +1,23 @@
+import type { Entry } from "@/types/registry";
+import { resolveCompareEntryActions, type CompareAction } from "@/lib/compare-entry-actions";
+import {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerActionCells,
+  compareDrawerActionSummary,
+  compareDrawerActionsDiverge,
+  compareDrawerSharedActionIds,
+  type CompareDrawerActionCell,
+} from "@/lib/compare-drawer-actions";
+
+export {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerActionCells,
+  compareDrawerActionSummary,
+  compareDrawerActionsDiverge,
+  compareDrawerSharedActionIds,
+};
+export type { CompareAction, CompareDrawerActionCell };
+
+export function compareDrawerEntryActions(entry: Entry): CompareAction[] {
+  return resolveCompareEntryActions(entry);
+}

--- a/tests/compare-drawer-actions-ui-lib.test.ts
+++ b/tests/compare-drawer-actions-ui-lib.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerActionCells,
+  compareDrawerActionSummary,
+  compareDrawerActionsDiverge,
+  compareDrawerEntryActions,
+  compareDrawerSharedActionIds,
+} from "@/lib/compare-drawer-actions-ui-lib";
+import { compareSurfaceActionSummary } from "@/lib/compare-surface-actions-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer actions ui lib", () => {
+  it("exposes the compare drawer analytics surface id", () => {
+    expect(COMPARE_DRAWER_SURFACE).toBe("compare-drawer");
+  });
+
+  it("resolves next actions for a single compared entry", () => {
+    expect(
+      compareDrawerEntryActions(entry()).map((action) => action.id),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("maps compared entries to per-column next-action cells", () => {
+    expect(compareDrawerActionCells([entry()])).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+    expect(
+      compareDrawerActionCells([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({
+          category: "hooks",
+          slug: "beta",
+          claimed: true,
+          sourceUrl: "https://x.dev",
+        }),
+      ]).map((cell) => cell.entryKey),
+    ).toEqual(["skills:alpha", "hooks:beta"]);
+  });
+
+  it("detects when drawer columns expose different next-action sets", () => {
+    expect(
+      compareDrawerActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toBe(true);
+    expect(
+      compareDrawerActionsDiverge([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ installCommand: "pnpm add fixture" }),
+      ]),
+    ).toBe(false);
+    expect(compareDrawerActionsDiverge([])).toBe(false);
+  });
+
+  it("finds action ids shared across every compared entry", () => {
+    expect(compareDrawerSharedActionIds([])).toEqual([]);
+    expect(compareDrawerSharedActionIds([entry()])).toEqual([
+      "dossier",
+      "claim",
+    ]);
+    expect(
+      compareDrawerSharedActionIds([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("summarizes drawer action divergence for header hints", () => {
+    const baseline = entry();
+    const withInstall = entry({ installCommand: "npm i fixture" });
+    expect(compareDrawerActionSummary([baseline])).toEqual({
+      comparedCount: 1,
+      diverges: false,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 1,
+    });
+    expect(compareDrawerActionSummary([baseline, withInstall])).toEqual({
+      comparedCount: 2,
+      diverges: true,
+      sharedActionIds: ["dossier", "claim"],
+      uniqueSignatures: 2,
+    });
+    expect(compareDrawerActionSummary([baseline, withInstall])).toEqual(
+      compareSurfaceActionSummary([baseline, withInstall]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-actions-ui-lib` with drawer action cells, divergence helpers, and analytics surface id
- Wire `compare-drawer.tsx` through `compareDrawerEntryActions` and `COMPARE_DRAWER_SURFACE`
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-actions-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400


Made with [Cursor](https://cursor.com)