### PR TITLE
feat(web): add compare context UI lib for share URLs

### DIFF
--- a/apps/web/src/lib/compare-context-ui-lib.ts
+++ b/apps/web/src/lib/compare-context-ui-lib.ts
@@ -1,0 +1,11 @@
+import type { Entry } from "@/types/registry";
+import { compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
+import { serializeCompareItems } from "@/lib/compare-selection";
+
+export function compareContextShareUrl(items: Entry[]): string {
+  return compareDrawerShareUrl(items);
+}
+
+export function compareContextSelectionParam(items: Entry[]): string {
+  return serializeCompareItems(items);
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,11 +1,6 @@
 import * as React from "react";
-import { compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
-import {
-  hasCompareItem,
-  resolveCompareParam,
-  serializeCompareItems,
-  toggleCompareItem,
-} from "@/lib/compare-selection";
+import { compareContextSelectionParam, compareContextShareUrl } from "@/lib/compare-context-ui-lib";
+import { hasCompareItem, resolveCompareParam, toggleCompareItem } from "@/lib/compare-selection";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import type { Entry } from "@/types/registry";
 
@@ -78,13 +73,13 @@ function createCompareStore(): CompareStore {
       // URL, keeping the registry dataset out of the universal client bundle.
       void import("@/data/entries").then(({ ENTRIES }) => {
         const next = resolveCompareParam(ENTRIES, param);
-        const sig = serializeCompareItems(next);
-        const curSig = serializeCompareItems(state.items);
+        const sig = compareContextSelectionParam(next);
+        const curSig = compareContextSelectionParam(state.items);
         if (sig !== curSig) setState({ ...state, items: next });
       });
     },
-    serialize: () => serializeCompareItems(state.items),
-    getShareUrl: () => compareDrawerShareUrl(state.items),
+    serialize: () => compareContextSelectionParam(state.items),
+    getShareUrl: () => compareContextShareUrl(state.items),
   };
 
   return {

--- a/tests/compare-context-ui-lib.test.ts
+++ b/tests/compare-context-ui-lib.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareContextSelectionParam,
+  compareContextShareUrl,
+} from "@/lib/compare-context-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare context ui lib", () => {
+  it("builds browse share URLs for compare context actions", () => {
+    expect(compareContextShareUrl([])).toBe("/browse");
+    expect(
+      compareContextShareUrl([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toBe("/browse?compare=skills%2Falpha%2Chooks%2Fbeta");
+  });
+
+  it("serializes compare context selections for URL hydration", () => {
+    expect(compareContextSelectionParam([])).toBe("");
+    expect(
+      compareContextSelectionParam([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toBe("skills/alpha,hooks/beta");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-context-ui-lib` with `compareContextShareUrl` and `compareContextSelectionParam`
- Wire `compare.tsx` provider through the new lib instead of calling drawer/selection helpers directly
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-context-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400


Made with [Cursor](https://cursor.com)