### PR TITLE
feat(web): expose compare drawer decision rows in signals UI lib

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -35,10 +35,10 @@ import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
 import {
   compareDrawerDecisionRowDiverges,
+  compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
 } from "@/lib/compare-drawer-signals-ui-lib";
-import { COMPARE_DECISION_ROWS } from "@/lib/compare-entry-signals";
 
 interface RowDef {
   label: string;
@@ -51,7 +51,7 @@ const ROWS: RowDef[] = [
     label: "Trust",
     render: (e) => <TrustDrilldown entry={e} />,
   },
-  ...COMPARE_DECISION_ROWS.map((row) => ({
+  ...compareDrawerDecisionRows().map((row) => ({
     label: row.label,
     render: (e: Entry) => {
       const value = row.resolve(e);

--- a/apps/web/src/lib/compare-drawer-signals-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-signals-ui-lib.ts
@@ -9,6 +9,15 @@ import {
 export type { CompareSignalValue };
 export { compareSignalToneClass };
 
+export type CompareDrawerDecisionRow = {
+  label: string;
+  resolve: (entry: Entry) => CompareSignalValue | undefined;
+};
+
+export function compareDrawerDecisionRows(): readonly CompareDrawerDecisionRow[] {
+  return COMPARE_DECISION_ROWS;
+}
+
 export function compareDrawerDecisionRowDiverges(
   resolve: (entry: Entry) => CompareSignalValue | undefined,
   items: Entry[],

--- a/tests/compare-drawer-signals-ui-lib.test.ts
+++ b/tests/compare-drawer-signals-ui-lib.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import { reviewCompareSignal } from "@/lib/compare-entry-signals";
 import {
   compareDrawerDecisionRowDiverges,
+  compareDrawerDecisionRows,
   compareDrawerDivergingDecisionLabels,
   compareSignalToneClass,
 } from "@/lib/compare-drawer-signals-ui-lib";
@@ -48,6 +49,12 @@ describe("compare drawer signals ui lib", () => {
         entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
       ]),
     ).toEqual(["Review status"]);
+  });
+
+  it("exposes drawer decision row definitions for signal cells", () => {
+    const rows = compareDrawerDecisionRows();
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.map((row) => row.label)).toContain("Review status");
   });
 
   it("re-exports compare signal tone classes for drawer cells", () => {


### PR DESCRIPTION
## Summary
- Add `compareDrawerDecisionRows` to `compare-drawer-signals-ui-lib`
- Wire `compare-drawer.tsx` through the lib instead of importing decision rows directly
- Extend regression tests with full patch coverage on changed lib code

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-signals-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400


Made with [Cursor](https://cursor.com)