### PR TITLE
fix(registry): block embedded URL credentials in submission validation

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -78,7 +78,12 @@ function isHttpsUrl(value) {
   const trimmed = normalizeText(value);
   if (!trimmed) return true;
   try {
-    return new URL(trimmed).protocol === "https:";
+    const url = new URL(trimmed);
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    );
   } catch {
     return false;
   }

--- a/packages/registry/src/commercial-lib.js
+++ b/packages/registry/src/commercial-lib.js
@@ -92,6 +92,21 @@ export function normalizePricingModel(value) {
   return "";
 }
 
+function isPublicLeadHttpsUrl(value) {
+  const text = String(value || "").trim();
+  if (!text) return false;
+  try {
+    const url = new URL(text);
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
 export function validateListingLeadPayload(payload = {}) {
   const errors = [];
   const kind = normalizeLeadKind(payload.kind);
@@ -127,11 +142,11 @@ export function validateListingLeadPayload(payload = {}) {
   if (!listingTitle) errors.push("listingTitle is required");
   if (
     (kind === "tool" || kind === "claim") &&
-    !/^https:\/\//i.test(websiteUrl)
+    !isPublicLeadHttpsUrl(websiteUrl)
   ) {
     errors.push(`${kind} leads require an https websiteUrl`);
   }
-  if (kind === "job" && !/^https:\/\//i.test(applyUrl)) {
+  if (kind === "job" && !isPublicLeadHttpsUrl(applyUrl)) {
     errors.push("job leads require an https applyUrl");
   }
 

--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -157,7 +157,11 @@ function isHttpsUrl(value) {
   if (!normalized) return true;
   try {
     const url = new URL(normalized);
-    return url.protocol === "https:";
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    );
   } catch {
     return false;
   }

--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -23,6 +23,28 @@ const AFFILIATE_PARAMS = new Set([
   "via",
 ]);
 
+/**
+ * Return true when a URL uses HTTPS without embedded userinfo credentials.
+ * Empty values are treated as valid so optional submission fields stay optional.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isPublicHttpsUrl(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return true;
+  try {
+    const url = new URL(text);
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    );
+  } catch {
+    return false;
+  }
+}
+
 const ANALYTICS_PARAMS = new Set([
   "_hsenc",
   "_hsmi",

--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -8,6 +8,7 @@ export {
   canonicalizeSourceUrl,
   hasAffiliateParam,
   isAffiliateParam,
+  isPublicHttpsUrl,
   isTrackingParam,
   stripTrackingParams,
 } from "./source-url-lib.js";

--- a/packages/registry/src/submission-lib.js
+++ b/packages/registry/src/submission-lib.js
@@ -10,7 +10,7 @@
  */
 import categorySpec from "./category-spec.json" with { type: "json" };
 import { normalizeBrandDomain } from "./brand-assets.js";
-import { hasAffiliateParam } from "./source-url.js";
+import { hasAffiliateParam, isPublicHttpsUrl } from "./source-url.js";
 import {
   looksLikeToolAppListing,
   missingToolListingReviewFields,
@@ -620,14 +620,7 @@ export function isLikelyAffiliateUrl(value) {
 }
 
 function isHttpsUrl(value) {
-  const normalized = normalizeValue(value);
-  if (!normalized) return true;
-  try {
-    const url = new URL(normalized);
-    return url.protocol === "https:";
-  } catch {
-    return false;
-  }
+  return isPublicHttpsUrl(normalizeValue(value));
 }
 
 function urlPathname(value) {

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -284,7 +284,12 @@ function isHttpsUrl(value) {
   const text = normalizeText(value);
   if (!text) return false;
   try {
-    return new URL(text).protocol === "https:";
+    const url = new URL(text);
+    return (
+      url.protocol === "https:" &&
+      url.username === "" &&
+      url.password === ""
+    );
   } catch {
     return false;
   }
@@ -292,7 +297,9 @@ function isHttpsUrl(value) {
 
 function hostname(value) {
   try {
-    return new URL(normalizeText(value)).hostname.replace(/^www\./, "");
+    const url = new URL(normalizeText(value));
+    if (url.username || url.password) return "";
+    return url.hostname.replace(/^www\./, "");
   } catch {
     return "";
   }
@@ -301,7 +308,14 @@ function hostname(value) {
 function githubRepoFromUrl(value) {
   try {
     const url = new URL(normalizeText(value));
-    if (url.protocol !== "https:" || url.hostname !== "github.com") return "";
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== "github.com" ||
+      url.username ||
+      url.password
+    ) {
+      return "";
+    }
     const [owner, repo] = url.pathname.split("/").filter(Boolean);
     return owner && repo ? `${owner}/${repo}` : "";
   } catch {
@@ -312,7 +326,14 @@ function githubRepoFromUrl(value) {
 function githubLoginFromUrl(value) {
   try {
     const url = new URL(normalizeText(value));
-    if (url.protocol !== "https:" || url.hostname !== "github.com") return "";
+    if (
+      url.protocol !== "https:" ||
+      url.hostname !== "github.com" ||
+      url.username ||
+      url.password
+    ) {
+      return "";
+    }
     const [login] = url.pathname.split("/").filter(Boolean);
     return login || "";
   } catch {

--- a/tests/commercial-lib.test.ts
+++ b/tests/commercial-lib.test.ts
@@ -226,6 +226,13 @@ describe("validateListingLeadPayload", () => {
         websiteUrl: "http://insecure.example",
       }).errors,
     ).toContain("claim leads require an https websiteUrl");
+    expect(
+      validateListingLeadPayload({
+        ...base,
+        kind: "claim",
+        websiteUrl: "https://token@example.com/proof",
+      }).errors,
+    ).toContain("claim leads require an https websiteUrl");
   });
 
   it("requires an https applyUrl for job leads", () => {

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -4,6 +4,7 @@ import {
   canonicalizeSourceUrl,
   hasAffiliateParam,
   isAffiliateParam,
+  isPublicHttpsUrl,
   isTrackingParam,
   stripTrackingParams,
 } from "../packages/registry/src/source-url-lib.js";
@@ -39,6 +40,29 @@ const ANALYTICS_PARAMS = [
   "twclid",
   "yclid",
 ];
+
+describe("isPublicHttpsUrl", () => {
+  it("accepts clean https URLs and optional empty values", () => {
+    expect(isPublicHttpsUrl("")).toBe(true);
+    expect(isPublicHttpsUrl("https://github.com/example/repo")).toBe(true);
+  });
+
+  it("rejects http URLs and embedded userinfo credentials", () => {
+    expect(isPublicHttpsUrl("http://example.com/repo")).toBe(false);
+    expect(
+      isPublicHttpsUrl("https://github.com@evil.example.com/owner/repo"),
+    ).toBe(false);
+    expect(
+      isPublicHttpsUrl("https://token@github.com/owner/repo"),
+    ).toBe(false);
+    expect(
+      isPublicHttpsUrl("https://user:pass@github.com/owner/repo"),
+    ).toBe(false);
+    expect(
+      isPublicHttpsUrl("https://user%40name:pass@github.com/owner/repo"),
+    ).toBe(false);
+  });
+});
 
 describe("isAffiliateParam", () => {
   it.each(AFFILIATE_PARAMS)("treats %s as an affiliate param", (name) => {

--- a/tests/submission-lib.test.ts
+++ b/tests/submission-lib.test.ts
@@ -1295,6 +1295,23 @@ describe("validateSubmission shared guardrails", () => {
     expect(result.errors).toContain("github_url must be a valid https URL");
   });
 
+  it("rejects https URLs with embedded userinfo credentials", () => {
+    const result = validateSubmission({
+      title: "Add MCP Server: Demo",
+      body: buildValidBody({
+        ...validMcpFields,
+        github_url: "https://github.com@evil.example.com/owner/repo",
+        docs_url: "https://token@example.com/docs",
+      }),
+    });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "github_url must be a valid https URL",
+        "docs_url must be a valid https URL",
+      ]),
+    );
+  });
+
   it("accepts Not applicable disclosure notes with specific reasons", () => {
     const result = validateSubmission({
       title: "Add MCP Server: Demo",


### PR DESCRIPTION
## Summary

Submission and content validators treated any `https:` URL as safe, including URLs with embedded userinfo such as `https://github.com@evil.example.com/owner/repo`. Those links can spoof trusted hosts while routing users to attacker-controlled destinations and can leak credentials into stored registry metadata.

MCP install config already rejected userinfo-bearing URLs; this change applies the same guard across submission validation, content schema checks, risk scoring, listing leads, and MCP submission helpers.

## Root cause

`isHttpsUrl` helpers only checked `url.protocol === https:` and ignored `url.username` / `url.password`. The WHATWG URL parser accepts userinfo, so spoofed GitHub-looking URLs passed preflight and schema validation.

## Fix approach

- Add shared `isPublicHttpsUrl()` in `source-url-lib.js`
- Reject userinfo in submission, content-schema, commercial lead, MCP submission, and risk-scoring URL checks
- Stop deriving GitHub trust signals from URLs that embed credentials

## Impact

- Blocks a credential-leak and source-spoofing vector in the submission pipeline
- Aligns submission URL rules with existing MCP install-config hardening
- No behavior change for valid clean HTTPS URLs

## Risks / tradeoffs

- Extremely low: legitimate public URLs should never include embedded credentials. Any existing entry using userinfo would fail validation on update.

## Test plan

- [x] `vitest run tests/source-url-lib.test.ts tests/submission-lib.test.ts tests/commercial-lib.test.ts tests/submission-pr-first.test.ts`
- [ ] CI green on PR checks