### PR TITLE
feat(web): add compare page interactive UI lib for page state

### DIFF
--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -1,0 +1,24 @@
+import type { Entry } from "@/types/registry";
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  comparePageEmptyUiState,
+  type ComparePageEmptyUiState,
+} from "@/lib/compare-page-empty-ui-lib";
+import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
+
+export type ComparePageInteractiveUiState = {
+  pageUi: ComparePageUiState;
+  emptyUi: ComparePageEmptyUiState;
+};
+
+export function comparePageInteractiveUiState(
+  items: Entry[],
+  ids: string,
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePageInteractiveUiState {
+  return {
+    pageUi: comparePageUiState(items),
+    emptyUi: comparePageEmptyUiState(ids, comparisons, catalog),
+  };
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -17,8 +17,7 @@ import {
   comparePageEntryActions,
   type CompareAction,
 } from "@/lib/compare-page-actions-ui-lib";
-import { comparePageUiState } from "@/lib/compare-page-ui-lib";
-import { comparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
+import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -69,11 +68,12 @@ function ComparePage() {
   const items = compare.items;
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
-  const pageUi = comparePageUiState(items);
-  const emptyUi = React.useMemo(
-    () => comparePageEmptyUiState(sp.ids, COMPARISONS, ENTRIES),
-    [sp.ids],
+  const interactiveUi = React.useMemo(
+    () => comparePageInteractiveUiState(items, sp.ids, COMPARISONS, ENTRIES),
+    [items, sp.ids],
   );
+  const pageUi = interactiveUi.pageUi;
+  const emptyUi = interactiveUi.emptyUi;
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);

--- a/tests/compare-page-interactive-ui-lib.test.ts
+++ b/tests/compare-page-interactive-ui-lib.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+];
+
+describe("compare page interactive ui lib", () => {
+  it("bundles interactive compare page and empty-state presentation", () => {
+    expect(
+      comparePageInteractiveUiState(
+        [
+          entry({ category: "skills", slug: "alpha" }),
+          entry({ category: "hooks", slug: "beta" }),
+        ],
+        "",
+        [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            refs: ["skills/alpha", "hooks/beta"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      pageUi: {
+        actionRowDiverges: false,
+        bannerTexts: [],
+        singleItemHint: null,
+        shareUrl: "/compare?ids=skills%2Falpha%2Chooks%2Fbeta",
+      },
+      emptyUi: {
+        description: expect.stringContaining("directory"),
+        invalidUrlHint: null,
+        popularComparisonLinks: [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+            interactiveLabel: "Open interactively",
+          },
+        ],
+      },
+    });
+  });
+
+  it("surfaces single-item hints and invalid URL hints together", () => {
+    const state = comparePageInteractiveUiState(
+      [entry()],
+      "skills/missing",
+      [],
+      catalog,
+    );
+    expect(state.pageUi.singleItemHint).toContain("Add one more resource");
+    expect(state.emptyUi.invalidUrlHint).toContain("could not be resolved");
+  });
+
+  it("highlights diverging next actions in bundled page state", () => {
+    expect(
+      comparePageInteractiveUiState(
+        [entry({ installCommand: "npm i fixture" }), entry({ slug: "other" })],
+        "",
+        [],
+        catalog,
+      ).pageUi.actionRowDiverges,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-interactive-ui-lib` with `comparePageInteractiveUiState` bundling page and empty UI state
- Wire `compare.index.tsx` through the new lib instead of calling page/empty helpers separately
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405 / #4407


Made with [Cursor](https://cursor.com)