### PR TITLE
feat(web): add compare drawer interactive UI lib for drawer state

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -23,11 +23,7 @@ import {
   compareDrawerEntryActions,
   type CompareAction,
 } from "@/lib/compare-drawer-actions-ui-lib";
-import {
-  compareDrawerEmptyStateHint,
-  compareDrawerShareUrl,
-  compareDrawerUiState,
-} from "@/lib/compare-drawer-ui-lib";
+import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import type { Entry, Harness } from "@/types/registry";
@@ -320,7 +316,8 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
-  const { actionRowDiverges, bannerTexts, fullViewSearch } = compareDrawerUiState(items);
+  const { drawerUi, emptyHint, shareUrl } = compareDrawerInteractiveUiState(items);
+  const { actionRowDiverges, bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -398,7 +395,7 @@ export function CompareDrawer() {
                 </Link>
               ) : null}
               <CopyButton
-                value={compareDrawerShareUrl(items)}
+                value={shareUrl}
                 label="Copy compare link"
                 disabled={items.length === 0}
               />
@@ -415,7 +412,7 @@ export function CompareDrawer() {
 
         {items.length === 0 ? (
           <div className="flex h-[60vh] items-center justify-center px-6 text-sm text-ink-muted">
-            {compareDrawerEmptyStateHint()}
+            {emptyHint}
           </div>
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">

--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -1,0 +1,21 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerEmptyStateHint,
+  compareDrawerShareUrl,
+  compareDrawerUiState,
+  type CompareDrawerUiState,
+} from "@/lib/compare-drawer-ui-lib";
+
+export type CompareDrawerInteractiveUiState = {
+  drawerUi: CompareDrawerUiState;
+  emptyHint: string;
+  shareUrl: string;
+};
+
+export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
+  return {
+    drawerUi: compareDrawerUiState(items),
+    emptyHint: compareDrawerEmptyStateHint(),
+    shareUrl: compareDrawerShareUrl(items),
+  };
+}

--- a/tests/compare-drawer-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-interactive-ui-lib.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer interactive ui lib", () => {
+  it("bundles drawer presentation, empty hint, and share URL state", () => {
+    expect(compareDrawerInteractiveUiState([])).toEqual({
+      drawerUi: {
+        actionRowDiverges: false,
+        bannerTexts: [],
+        fullViewSearch: null,
+      },
+      emptyHint: expect.stringContaining("Compare"),
+      shareUrl: "/browse",
+    });
+  });
+
+  it("surfaces full-view search and share URLs for multi-item selections", () => {
+    const state = compareDrawerInteractiveUiState([
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ]);
+    expect(state.drawerUi.fullViewSearch).toEqual({
+      ids: "skills/alpha,hooks/beta",
+    });
+    expect(state.shareUrl).toBe(
+      "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
+    );
+  });
+
+  it("highlights diverging next actions in bundled drawer state", () => {
+    expect(
+      compareDrawerInteractiveUiState([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ slug: "other" }),
+      ]).drawerUi.actionRowDiverges,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-interactive-ui-lib` with `compareDrawerInteractiveUiState` bundling drawer UI, empty hint, and share URL
- Wire `compare-drawer.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405


Made with [Cursor](https://cursor.com)