### PR TITLE
feat(web): add compare table interactive UI lib for table state

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -22,7 +22,7 @@ import {
   compareTableEntryActions,
   type CompareAction,
 } from "@/lib/compare-table-actions-ui-lib";
-import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
+import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -293,7 +293,7 @@ export function ComparisonTable({
   showNextActions?: boolean;
 }) {
   const { divergingDecisionLabels, renderNextActions, actionRowDiverges } =
-    compareTablePresentationState(entries, showNextActions);
+    compareTableInteractiveUiState(entries, showNextActions);
 
   return (
     <div className="overflow-auto rounded-xl border border-border">

--- a/apps/web/src/lib/compare-table-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareTablePresentationState,
+  type CompareTablePresentationState,
+} from "@/lib/compare-table-ui-lib";
+
+export type CompareTableInteractiveUiState = CompareTablePresentationState;
+
+export function compareTableInteractiveUiState(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTableInteractiveUiState {
+  return compareTablePresentationState(entries, showNextActions);
+}

--- a/tests/compare-table-interactive-ui-lib.test.ts
+++ b/tests/compare-table-interactive-ui-lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table interactive ui lib", () => {
+  it("hides next-action rows for single-entry tables", () => {
+    expect(compareTableInteractiveUiState([entry()], true)).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("surfaces next-action rows for multi-entry tables when enabled", () => {
+    expect(
+      compareTableInteractiveUiState([entry(), entry({ slug: "other" })], true),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: true,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("respects the showNextActions toggle for multi-entry tables", () => {
+    expect(
+      compareTableInteractiveUiState(
+        [entry(), entry({ slug: "other" })],
+        false,
+      ),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareTableInteractiveUiState(
+      [
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ],
+      true,
+    );
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.renderNextActions).toBe(true);
+    expect(state.actionRowDiverges).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-interactive-ui-lib` with `compareTableInteractiveUiState` for table presentation state
- Wire `comparison-table.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405 / #4409


Made with [Cursor](https://cursor.com)