### PR TITLE
fix(registry): strip URL userinfo during source canonicalization

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -185,6 +185,8 @@ function normalizeUrl(value: unknown) {
   try {
     const parsed = new URL(raw);
     if (!["http:", "https:"].includes(parsed.protocol)) return "";
+    parsed.username = "";
+    parsed.password = "";
     parsed.protocol = "https:";
     parsed.hostname = normalizeHostname(parsed.hostname);
     parsed.hash = "";

--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -805,6 +805,8 @@ function normalizeSubmissionUrlForMatch(value) {
     return "";
   }
   url.protocol = url.protocol.toLowerCase();
+  url.username = "";
+  url.password = "";
   url.hostname = url.hostname.toLowerCase().replace(/^www\./, "");
   url.hash = "";
   const droppedKeys = [];

--- a/packages/registry/src/relationships-lib.js
+++ b/packages/registry/src/relationships-lib.js
@@ -88,6 +88,8 @@ export function normalizeUrl(value) {
 
   try {
     const url = new URL(text);
+    url.username = "";
+    url.password = "";
     url.hash = "";
     for (const key of [...url.searchParams.keys()]) {
       if (

--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -88,6 +88,12 @@ export function parseGitHubRepoUrl(value) {
     }
     const ownerRepo = ownerRepoFromPath(url.pathname);
     if (!ownerRepo) return null;
+    if (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (url.username || url.password)
+    ) {
+      return null;
+    }
     parsed = { host: normalizeHost(url.hostname), ...ownerRepo };
   }
 

--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -122,6 +122,8 @@ export function canonicalizeSourceUrl(value) {
   if (!stripped) return "";
   try {
     const url = new URL(stripped);
+    url.username = "";
+    url.password = "";
     url.hash = "";
     url.protocol = url.protocol.toLowerCase();
     url.hostname = url.hostname.replace(/^www\./i, "").toLowerCase();

--- a/tests/relationships-lib.test.ts
+++ b/tests/relationships-lib.test.ts
@@ -101,6 +101,9 @@ describe("normalizeUrl", () => {
     expect(normalizeUrl("https://github.com/Acme/Widget.git")).toBe(
       "https://github.com/acme/widget",
     );
+    expect(normalizeUrl("https://token@github.com/acme/widget")).toBe(
+      "https://github.com/acme/widget",
+    );
   });
 
   it("sorts remaining query params for stability", () => {

--- a/tests/source-repo-lib.test.ts
+++ b/tests/source-repo-lib.test.ts
@@ -424,6 +424,13 @@ describe("parseGitHubRepoUrl duplicate equivalence classes", () => {
 
 describe("parseGitHubRepoUrl enterprise and typo rejection", () => {
   it.each([
+    "https://token@github.com/OpenAI/whisper",
+    "https://user:pass@github.com/OpenAI/whisper",
+  ])("rejects https URLs with embedded userinfo: %s", (input) => {
+    expect(parseGitHubRepoUrl(input)).toBeNull();
+  });
+
+  it.each([
     "github.com/OpenAI/whisper",
     "www.github.com/OpenAI/whisper",
     "https://github.com",

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -183,6 +183,19 @@ describe("canonicalizeSourceUrl", () => {
     ).toBe("https://example.com/docs?a=1&b=2");
   });
 
+  it("strips embedded userinfo so duplicate keys ignore credential noise", () => {
+    const canonical = "https://github.com/example/demo";
+    expect(canonicalizeSourceUrl("https://token@github.com/example/demo")).toBe(
+      canonical,
+    );
+    expect(
+      canonicalizeSourceUrl("https://user:pass@github.com/example/demo"),
+    ).toBe(canonical);
+    expect(
+      canonicalizeSourceUrl("https://github.com@evil.example.com/example/demo"),
+    ).not.toBe(canonical);
+  });
+
   it("sorts query params lexicographically", () => {
     expect(canonicalizeSourceUrl("https://example.com/docs?z=9&m=1&a=2")).toBe(
       "https://example.com/docs?a=2&m=1&z=9",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2653,6 +2653,38 @@ sourceUrls:
     });
   });
 
+  it("detects duplicate submissions when source URLs differ only by embedded userinfo", () => {
+    const existing = extractContentDuplicateSignals({
+      filePath: "content/mcp/userinfo-dedupe.mdx",
+      content: `---
+title: Userinfo Dedupe MCP
+slug: userinfo-dedupe
+category: mcp
+description: MCP server for duplicate canonicalization tests.
+repoUrl: https://github.com/acme/userinfo-dedupe
+---
+`,
+    });
+    const candidate = extractContentDuplicateSignals({
+      filePath: "content/mcp/userinfo-dedupe-copy.mdx",
+      content: `---
+title: Userinfo Dedupe Copy
+slug: userinfo-dedupe-copy
+category: mcp
+description: MCP server for duplicate canonicalization tests.
+repoUrl: https://token@github.com/acme/userinfo-dedupe
+---
+`,
+    });
+
+    expect(candidate.urls).toContain("https://github.com/acme/userinfo-dedupe");
+    expect(findContentDuplicateMatch(candidate, [existing])).toMatchObject({
+      reasons: expect.arrayContaining([
+        expect.stringContaining("same canonical source URL"),
+      ]),
+    });
+  });
+
   it("detects neutral duplicate submissions from canonical source URLs", () => {
     const existing = extractContentDuplicateSignals({
       filePath: "content/tools/ccusage.mdx",

--- a/tests/submission-preflight-lib.test.ts
+++ b/tests/submission-preflight-lib.test.ts
@@ -152,6 +152,11 @@ describe("submission preflight duplicate detection", () => {
       }),
     ).toEqual(["https://github.com/example/demo"]);
     expect(
+      submittedSourceUrls({
+        github_url: "https://token@github.com/example/demo",
+      }),
+    ).toEqual(["https://github.com/example/demo"]);
+    expect(
       submittedSourceValues({ website_url: "https://example.com" }),
     ).toEqual([
       undefined,


### PR DESCRIPTION
## Summary

Duplicate detection keyed source URLs through canonicalization helpers that preserved embedded userinfo. Submitters could bypass preflight duplicate blockers by reusing the same repo with different `https://token@github.com/...` variants.

## Root cause

`canonicalizeSourceUrl`, MCP duplicate matchers, submission-gate duplicate normalization, and relation graph URL normalization all serialized URLs without clearing `username` / `password`, so logically identical sources produced different comparison keys.

## Fix approach

- Strip userinfo while canonicalizing http(s) source URLs
- Reject https repo URLs with embedded credentials in `parseGitHubRepoUrl` (ssh/scp transport variants unchanged)
- Align submission-gate, MCP duplicate search, and relationships normalization

## Impact

- Closes a duplicate-detection bypass in preflight, direct content gate review, and relation inference
- Complements validation hardening in #4409 without overlapping that PR

## Risks / tradeoffs

- None for legitimate URLs; userinfo should never appear in public registry source links

## Test plan

- [x] Vitest for source-url, source-repo, preflight, relationships, submission-gate userinfo duplicate case
- [ ] CI green on PR checks