### PR TITLE
feat(web): add compare curated interactive UI lib for curated pages

### DIFF
--- a/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
@@ -1,0 +1,22 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  compareCuratedHasRenderableEntries,
+  compareCuratedUiState,
+  type CompareCuratedUiState,
+} from "@/lib/compare-curated-ui-lib";
+
+export type CompareCuratedInteractiveUiState = CompareCuratedUiState;
+
+export function compareCuratedInteractiveUiState(
+  refs: string[],
+  catalog: EntryIdentity[],
+): CompareCuratedInteractiveUiState {
+  return compareCuratedUiState(refs, catalog);
+}
+
+export function compareCuratedInteractivePageRenderable(
+  refs: string[],
+  catalog: EntryIdentity[],
+): boolean {
+  return compareCuratedHasRenderableEntries(refs, catalog);
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -9,15 +9,15 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
 import {
-  compareCuratedHasRenderableEntries,
-  compareCuratedResolvedEntries,
-  compareCuratedUiState,
-} from "@/lib/compare-curated-ui-lib";
+  compareCuratedInteractivePageRenderable,
+  compareCuratedInteractiveUiState,
+} from "@/lib/compare-curated-interactive-ui-lib";
+import { compareCuratedResolvedEntries } from "@/lib/compare-curated-ui-lib";
 
 export const Route = createFileRoute("/compare/$slug")({
   loader: ({ params }) => {
     const comparison = getComparison(params.slug);
-    if (!comparison || !compareCuratedHasRenderableEntries(comparison.refs, ENTRIES)) {
+    if (!comparison || !compareCuratedInteractivePageRenderable(comparison.refs, ENTRIES)) {
       throw notFound();
     }
     return {};
@@ -91,10 +91,8 @@ function ComparisonPage() {
   const { slug } = Route.useParams();
   const comparison = getComparison(slug);
   if (!comparison) return null;
-  const { entries, bannerTexts, interactiveSearch, interactiveLinkLabel } = compareCuratedUiState(
-    comparison.refs,
-    ENTRIES,
-  );
+  const { entries, bannerTexts, interactiveSearch, interactiveLinkLabel } =
+    compareCuratedInteractiveUiState(comparison.refs, ENTRIES);
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">

--- a/tests/compare-curated-interactive-ui-lib.test.ts
+++ b/tests/compare-curated-interactive-ui-lib.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareCuratedInteractivePageRenderable,
+  compareCuratedInteractiveUiState,
+} from "@/lib/compare-curated-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare curated interactive ui lib", () => {
+  it("requires at least two resolved entries for curated pages", () => {
+    expect(compareCuratedInteractivePageRenderable([], catalog)).toBe(false);
+    expect(
+      compareCuratedInteractivePageRenderable(["skills/alpha"], catalog),
+    ).toBe(false);
+    expect(
+      compareCuratedInteractivePageRenderable(
+        ["skills/alpha", "hooks/beta"],
+        catalog,
+      ),
+    ).toBe(true);
+  });
+
+  it("bundles curated compare page presentation state", () => {
+    expect(
+      compareCuratedInteractiveUiState(["skills/alpha", "hooks/beta"], catalog),
+    ).toEqual({
+      entries: [catalog[0], catalog[1]],
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+  });
+
+  it("omits interactive search when fewer than two refs resolve", () => {
+    expect(
+      compareCuratedInteractiveUiState(
+        ["skills/alpha", "missing/slug"],
+        catalog,
+      ),
+    ).toEqual({
+      entries: [catalog[0]],
+      bannerTexts: [],
+      interactiveSearch: null,
+      interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
+    });
+  });
+
+  it("surfaces banner text when trust signals diverge", () => {
+    const reviewed = entry({
+      category: "skills",
+      slug: "reviewed",
+      reviewedBy: "maintainer",
+      reviewedAt: "2026-01-02",
+    });
+    const refs = ["skills/alpha", "skills/reviewed"];
+    const extendedCatalog = [...catalog, reviewed];
+    expect(
+      compareCuratedInteractiveUiState(refs, extendedCatalog).bannerTexts,
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-curated-interactive-ui-lib` with `compareCuratedInteractiveUiState` and page renderability helper
- Wire `compare.$slug.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405 / #4409 / #4412


Made with [Cursor](https://cursor.com)