### PR TITLE
fix(submissions): reject embedded URL credentials in source evidence

### DIFF
--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -178,7 +178,10 @@ function sourceRole(item: SubmittedSourceUrl): SourceEvidenceRole {
 
 function withSourceDefaults(
   item: SubmittedSourceUrl,
-  values: Omit<SourceEvidenceItem, keyof SubmittedSourceUrl | "role" | "blocking">,
+  values: Omit<
+    SourceEvidenceItem,
+    keyof SubmittedSourceUrl | "role" | "blocking"
+  >,
 ): SourceEvidenceItem {
   return {
     ...item,
@@ -227,6 +230,13 @@ function validateFetchableSourceUrl(url: string) {
       ok: false as const,
       outcome: "invalid_url",
       error: "Source URL must use http or https.",
+    };
+  }
+  if (parsed.username || parsed.password) {
+    return {
+      ok: false as const,
+      outcome: "invalid_url",
+      error: "Source URL must not embed credentials in userinfo.",
     };
   }
   if (!sourceHostIsTrusted(parsed.hostname)) {
@@ -421,11 +431,13 @@ export async function checkSubmittedSourceEvidence(
     checkedUrls.push(await checkOneSourceUrl(item, fetchImpl));
   }
   for (const item of extracted.slice(MAX_SOURCE_EVIDENCE_URLS)) {
-    checkedUrls.push(withSourceDefaults(item, {
-      status: "hard_failure",
-      outcome: "too_many_source_urls",
-      error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
-    }));
+    checkedUrls.push(
+      withSourceDefaults(item, {
+        status: "hard_failure",
+        outcome: "too_many_source_urls",
+        error: `Only ${MAX_SOURCE_EVIDENCE_URLS} source URLs can be checked automatically.`,
+      }),
+    );
   }
   const urls = downgradeInconclusiveSourceWarnings(checkedUrls);
   const blockingUrls = urls.filter((item) => item.blocking);
@@ -437,9 +449,7 @@ export async function checkSubmittedSourceEvidence(
   return {
     status,
     urls,
-    warnings: urls.filter(
-      (item) => !item.blocking && item.status !== "passed",
-    ),
+    warnings: urls.filter((item) => !item.blocking && item.status !== "passed"),
     hash: await sha256Hex(sourceEvidenceHashInput(urls)),
   };
 }

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -1071,6 +1071,27 @@ websiteUrl: "https://attacker.example/redirect"
     ]);
   });
 
+  it("rejects source URLs with embedded userinfo before fetching", async () => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Userinfo Source Fixture
+repoUrl: "https://token@github.com/example/project"
+---
+`,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(report.status).toBe("failed");
+    expect(report.urls[0]).toMatchObject({
+      field: "repoUrl",
+      status: "hard_failure",
+      outcome: "invalid_url",
+      error: "Source URL must not embed credentials in userinfo.",
+    });
+  });
+
   it("validates redirect targets before following source evidence URLs", async () => {
     const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
       new Response(null, {
@@ -1105,6 +1126,33 @@ documentationUrl: "https://github.com/example/redirect"
       status: "hard_failure",
       outcome: "source_host_not_checked",
       finalUrl: "http://127.0.0.1/internal-secret",
+    });
+  });
+
+  it("rejects redirect targets that embed userinfo credentials", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://user:pass@github.com/example/project" },
+      }),
+    );
+
+    const report = await checkSubmittedSourceEvidence(
+      `---
+title: Redirect Userinfo Fixture
+documentationUrl: "https://github.com/example/redirect"
+---
+`,
+      fetchImpl,
+    );
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(report.status).toBe("failed");
+    expect(report.urls[0]).toMatchObject({
+      field: "documentationUrl",
+      status: "hard_failure",
+      outcome: "invalid_url",
+      finalUrl: "https://user:pass@github.com/example/project",
     });
   });
 


### PR DESCRIPTION
## Summary

The submission gate source-evidence fetcher validated host allowlists and redirect targets but still accepted http(s) URLs with embedded userinfo. Those URLs could be fetched during direct content review, leaking credentials into outbound requests and worker logs.

## Root cause

`validateFetchableSourceUrl` only checked protocol and hostname trust, not `url.username` / `url.password`.

## Fix approach

- Fail closed with `invalid_url` when userinfo is present on initial URLs and redirect targets
- Add coverage for direct and redirect userinfo cases

## Impact

- Prevents credential-bearing source URLs from being fetched by the gate worker
- Aligns runtime fetch guards with registry URL validation from #4409

## Risks / tradeoffs

- None for legitimate public source links

## Test plan

- [x] Vitest for direct and redirect userinfo rejection
- [ ] CI green on PR checks