### PR TITLE
feat(web): add compare browse interactive UI lib for browse CTA

### DIFF
--- a/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
@@ -1,0 +1,10 @@
+import type { Entry } from "@/types/registry";
+import { browseCompareUiState } from "@/lib/compare-browse-ui-lib";
+
+export type BrowseCompareInteractiveUiState = NonNullable<ReturnType<typeof browseCompareUiState>>;
+
+export function browseCompareInteractiveUiState(
+  items: Entry[],
+): BrowseCompareInteractiveUiState | null {
+  return browseCompareUiState(items);
+}

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -37,7 +37,7 @@ import {
   ExternalLink,
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
-import { browseCompareUiState } from "@/lib/compare-browse-ui-lib";
+import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -314,7 +314,10 @@ function Browse() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareSig]);
 
-  const browseCompareUi = useMemo(() => browseCompareUiState(compare.items), [compare.items]);
+  const browseCompareUi = useMemo(
+    () => browseCompareInteractiveUiState(compare.items),
+    [compare.items],
+  );
 
   const activeCount =
     Number(!!sp.q) +

--- a/tests/compare-browse-interactive-ui-lib.test.ts
+++ b/tests/compare-browse-interactive-ui-lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare browse interactive ui lib", () => {
+  it("returns null when fewer than two items are selected", () => {
+    expect(browseCompareInteractiveUiState([])).toBeNull();
+    expect(browseCompareInteractiveUiState([entry()])).toBeNull();
+  });
+
+  it("builds capped compare CTA state aligned with hint and overflow copy", () => {
+    const five = [
+      entry({ slug: "one" }),
+      entry({ slug: "two" }),
+      entry({ slug: "three" }),
+      entry({ slug: "four" }),
+      entry({
+        slug: "five",
+        reviewedBy: "maintainer",
+        reviewedAt: "2026-01-02",
+      }),
+    ];
+    expect(browseCompareInteractiveUiState(five)).toEqual({
+      search: { ids: "mcp/one,mcp/two,mcp/three,mcp/four" },
+      selectedCount: 4,
+      hint: "Open compare to review trust and next steps side by side.",
+      overflowHint: "Opening 4 of 5 selected in compare.",
+    });
+  });
+
+  it("surfaces divergence hints in browse compare CTA state", () => {
+    expect(
+      browseCompareInteractiveUiState([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      search: { ids: "mcp/fixture,mcp/mixed" },
+      selectedCount: 2,
+      hint: "1 trust signal differ · next steps differ — open compare for details.",
+      overflowHint: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-browse-interactive-ui-lib` with `browseCompareInteractiveUiState` for browse compare CTA state
- Wire `browse.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405


Made with [Cursor](https://cursor.com)