### PR TITLE
feat(mcp): extract registry prompt helpers into registry-prompts-lib

### DIFF
--- a/packages/mcp/src/registry-prompts-lib.js
+++ b/packages/mcp/src/registry-prompts-lib.js
@@ -1,0 +1,140 @@
+/**
+ * Pure MCP registry prompt helpers.
+ *
+ * Prompt definitions and prompt message builders live here. Runtime registry
+ * handlers stay in `registry.js`.
+ *
+ * The public surface (`registry.js` / `@heyclaude/mcp/registry`) re-exports
+ * everything below so existing imports stay unchanged.
+ */
+
+export const PROMPT_DEFINITIONS = [
+  {
+    name: "asset.find",
+    title: "Find the best Claude asset",
+    description:
+      "Guide a client through searching, comparing, and recommending HeyClaude entries for a use case.",
+    arguments: [
+      {
+        name: "use_case",
+        description: "The task, workflow, or problem the user wants to solve.",
+        required: true,
+      },
+      {
+        name: "category",
+        description: "Optional HeyClaude category to constrain discovery.",
+      },
+      {
+        name: "platform",
+        description:
+          "Optional client/platform such as Claude, Codex, Cursor, or Windsurf.",
+      },
+    ],
+  },
+  {
+    name: "submission.prepare",
+    title: "Prepare a HeyClaude submission",
+    description:
+      "Guide a user through drafting a maintainer-reviewed HeyClaude submission without opening a PR automatically.",
+    arguments: [
+      { name: "category", description: "Submission category.", required: true },
+      { name: "name", description: "Submission name or title." },
+      {
+        name: "source_url",
+        description: "Primary source, docs, package, or repo URL.",
+      },
+    ],
+  },
+  {
+    name: "submission.review",
+    title: "Review submission before opening PR",
+    description:
+      "Check a draft for schema gaps, duplicate risk, source review, and maintainer checklist items.",
+    arguments: [
+      {
+        name: "draft",
+        description: "A concise description or JSON-shaped draft fields.",
+        required: true,
+      },
+    ],
+  },
+  {
+    name: "install.asset",
+    title: "Install a HeyClaude asset safely",
+    description:
+      "Guide installation/use of one entry while keeping source and secret-handling checks explicit.",
+    arguments: [
+      { name: "category", description: "Entry category.", required: true },
+      { name: "slug", description: "Entry slug.", required: true },
+      { name: "platform", description: "Optional target client/platform." },
+    ],
+  },
+];
+
+function promptArgument(args, name) {
+  return String(args?.[name] || "").trim();
+}
+
+export function listRegistryPrompts() {
+  return {
+    prompts: PROMPT_DEFINITIONS,
+  };
+}
+
+export function getRegistryPrompt(args = {}) {
+  const name = String(args.name || "");
+  const prompt = PROMPT_DEFINITIONS.find(
+    (candidate) => candidate.name === name,
+  );
+  if (!prompt) {
+    return {
+      description: "Unknown HeyClaude MCP prompt.",
+      messages: [
+        {
+          role: "user",
+          content: {
+            type: "text",
+            text: `Unknown HeyClaude MCP prompt: ${name}`,
+          },
+        },
+      ],
+    };
+  }
+  const values = args.arguments || {};
+  const useCase = promptArgument(values, "use_case");
+  const category = promptArgument(values, "category");
+  const platform = promptArgument(values, "platform");
+  const slug = promptArgument(values, "slug");
+  const sourceUrl = promptArgument(values, "source_url");
+  const draft = promptArgument(values, "draft");
+
+  const promptTextByName = {
+    "asset.find": `Find the best HeyClaude asset for this use case: ${useCase || "(not provided)"}.
+
+Use the read-only HeyClaude MCP tools. Start with registry.search or registry.list${category ? ` in category ${category}` : ""}${platform ? ` for platform ${platform}` : ""}. Compare credible candidates with entry.compare, inspect details with entry.detail, and cite exact category/slug pairs. Do not invent popularity metrics when source stats are absent.`,
+    "submission.prepare": `Prepare a HeyClaude submission draft${category ? ` for category ${category}` : ""}${promptArgument(values, "name") ? ` named ${promptArgument(values, "name")}` : ""}${sourceUrl ? ` from ${sourceUrl}` : ""}.
+
+Use submission.schema, submission.examples, submission.prepare, submission.review, and submission.duplicates. Return missing fields and the canonical PR-first submit URL/body. Do not create GitHub issues or publish content.`,
+    "submission.review": `Review this HeyClaude submission draft before a PR is opened:
+
+${draft || "(draft not provided)"}
+
+Use submission.review and submission.duplicates where structured fields are available. Treat schema-valid as not publish-valid, call out source-review needs, and keep the result maintainer-reviewed.`,
+    "install.asset": `Help install or use the HeyClaude entry ${category || "(category)"}/${slug || "(slug)"}${platform ? ` for ${platform}` : ""}.
+
+Use install.guidance and entry.asset. Include source links, config/install text exactly as returned, and secret-handling cautions where relevant. Do not write local files or claim the install was completed.`,
+  };
+
+  return {
+    description: prompt.description,
+    messages: [
+      {
+        role: "user",
+        content: {
+          type: "text",
+          text: promptTextByName[name],
+        },
+      },
+    ],
+  };
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -62,6 +62,11 @@ import {
   READ_ONLY_TOOL_NAMES,
   TOOL_DEFINITIONS,
 } from "./registry-tools-lib.js";
+import {
+  PROMPT_DEFINITIONS,
+  getRegistryPrompt,
+  listRegistryPrompts,
+} from "./registry-prompts-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -69,6 +74,8 @@ export {
   READ_ONLY_TOOL_NAMES,
   TOOL_DEFINITIONS,
 };
+
+export { PROMPT_DEFINITIONS, getRegistryPrompt, listRegistryPrompts };
 
 // Maps a slugified platform filter input to a canonical platform ID, matching
 // the canonical IDs in generated artifacts (see packages/registry platforms.js).
@@ -1972,69 +1979,6 @@ export async function listJobsActive(options = {}) {
   };
 }
 
-export const PROMPT_DEFINITIONS = [
-  {
-    name: "asset.find",
-    title: "Find the best Claude asset",
-    description:
-      "Guide a client through searching, comparing, and recommending HeyClaude entries for a use case.",
-    arguments: [
-      {
-        name: "use_case",
-        description: "The task, workflow, or problem the user wants to solve.",
-        required: true,
-      },
-      {
-        name: "category",
-        description: "Optional HeyClaude category to constrain discovery.",
-      },
-      {
-        name: "platform",
-        description:
-          "Optional client/platform such as Claude, Codex, Cursor, or Windsurf.",
-      },
-    ],
-  },
-  {
-    name: "submission.prepare",
-    title: "Prepare a HeyClaude submission",
-    description:
-      "Guide a user through drafting a maintainer-reviewed HeyClaude submission without opening a PR automatically.",
-    arguments: [
-      { name: "category", description: "Submission category.", required: true },
-      { name: "name", description: "Submission name or title." },
-      {
-        name: "source_url",
-        description: "Primary source, docs, package, or repo URL.",
-      },
-    ],
-  },
-  {
-    name: "submission.review",
-    title: "Review submission before opening PR",
-    description:
-      "Check a draft for schema gaps, duplicate risk, source review, and maintainer checklist items.",
-    arguments: [
-      {
-        name: "draft",
-        description: "A concise description or JSON-shaped draft fields.",
-        required: true,
-      },
-    ],
-  },
-  {
-    name: "install.asset",
-    title: "Install a HeyClaude asset safely",
-    description:
-      "Guide installation/use of one entry while keeping source and secret-handling checks explicit.",
-    arguments: [
-      { name: "category", description: "Entry category.", required: true },
-      { name: "slug", description: "Entry slug.", required: true },
-      { name: "platform", description: "Optional target client/platform." },
-    ],
-  },
-];
-
 export async function listRegistryResources(args = {}, options = {}) {
   const manifest = await readJsonArtifact("registry-manifest.json", options);
   const categories = Object.keys(manifest.categories || {}).sort();
@@ -2147,75 +2091,6 @@ export async function readRegistryResource(args = {}, options = {}) {
 
   return resourcePayload(payload);
 }
-
-function promptArgument(args, name) {
-  return String(args?.[name] || "").trim();
-}
-
-export function listRegistryPrompts() {
-  return {
-    prompts: PROMPT_DEFINITIONS,
-  };
-}
-
-export function getRegistryPrompt(args = {}) {
-  const name = String(args.name || "");
-  const prompt = PROMPT_DEFINITIONS.find(
-    (candidate) => candidate.name === name,
-  );
-  if (!prompt) {
-    return {
-      description: "Unknown HeyClaude MCP prompt.",
-      messages: [
-        {
-          role: "user",
-          content: {
-            type: "text",
-            text: `Unknown HeyClaude MCP prompt: ${name}`,
-          },
-        },
-      ],
-    };
-  }
-  const values = args.arguments || {};
-  const useCase = promptArgument(values, "use_case");
-  const category = promptArgument(values, "category");
-  const platform = promptArgument(values, "platform");
-  const slug = promptArgument(values, "slug");
-  const sourceUrl = promptArgument(values, "source_url");
-  const draft = promptArgument(values, "draft");
-
-  const promptTextByName = {
-    "asset.find": `Find the best HeyClaude asset for this use case: ${useCase || "(not provided)"}.
-
-Use the read-only HeyClaude MCP tools. Start with registry.search or registry.list${category ? ` in category ${category}` : ""}${platform ? ` for platform ${platform}` : ""}. Compare credible candidates with entry.compare, inspect details with entry.detail, and cite exact category/slug pairs. Do not invent popularity metrics when source stats are absent.`,
-    "submission.prepare": `Prepare a HeyClaude submission draft${category ? ` for category ${category}` : ""}${promptArgument(values, "name") ? ` named ${promptArgument(values, "name")}` : ""}${sourceUrl ? ` from ${sourceUrl}` : ""}.
-
-Use submission.schema, submission.examples, submission.prepare, submission.review, and submission.duplicates. Return missing fields and the canonical PR-first submit URL/body. Do not create GitHub issues or publish content.`,
-    "submission.review": `Review this HeyClaude submission draft before a PR is opened:
-
-${draft || "(draft not provided)"}
-
-Use submission.review and submission.duplicates where structured fields are available. Treat schema-valid as not publish-valid, call out source-review needs, and keep the result maintainer-reviewed.`,
-    "install.asset": `Help install or use the HeyClaude entry ${category || "(category)"}/${slug || "(slug)"}${platform ? ` for ${platform}` : ""}.
-
-Use install.guidance and entry.asset. Include source links, config/install text exactly as returned, and secret-handling cautions where relevant. Do not write local files or claim the install was completed.`,
-  };
-
-  return {
-    description: prompt.description,
-    messages: [
-      {
-        role: "user",
-        content: {
-          type: "text",
-          text: promptTextByName[name],
-        },
-      },
-    ],
-  };
-}
-
 export async function getCompatibility(args = {}, options = {}) {
   const category = normalizeText(args.category || "skills");
   const slug = normalizeText(args.slug);

--- a/tests/mcp-registry-prompts-lib.test.ts
+++ b/tests/mcp-registry-prompts-lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PROMPT_DEFINITIONS,
+  getRegistryPrompt,
+  listRegistryPrompts,
+} from "../packages/mcp/src/registry-prompts-lib.js";
+import {
+  PROMPT_DEFINITIONS as promptsFromWrapper,
+  getRegistryPrompt as getPromptFromWrapper,
+  listRegistryPrompts as listPromptsFromWrapper,
+} from "../packages/mcp/src/registry.js";
+
+describe("registry-prompts-lib definitions", () => {
+  it("lists the read-only workflow prompts exposed by MCP", () => {
+    expect(listRegistryPrompts()).toEqual({ prompts: PROMPT_DEFINITIONS });
+    expect(PROMPT_DEFINITIONS.map((prompt) => prompt.name)).toEqual([
+      "asset.find",
+      "submission.prepare",
+      "submission.review",
+      "install.asset",
+    ]);
+  });
+
+  it("requires asset.find use_case arguments in generated prompt text", () => {
+    const prompt = getRegistryPrompt({
+      name: "asset.find",
+      arguments: {
+        use_case: "browser automation",
+        category: "mcp",
+        platform: "Cursor",
+      },
+    });
+    expect(prompt.messages[0]?.content).toMatchObject({
+      type: "text",
+      text: expect.stringContaining("browser automation"),
+    });
+    expect(String(prompt.messages[0]?.content?.text)).toContain("category mcp");
+    expect(String(prompt.messages[0]?.content?.text)).toContain(
+      "for platform Cursor",
+    );
+  });
+
+  it("returns an unknown-prompt fallback without throwing", () => {
+    const prompt = getRegistryPrompt({ name: "missing.prompt" });
+    expect(String(prompt.messages[0]?.content?.text)).toContain(
+      "Unknown HeyClaude MCP prompt: missing.prompt",
+    );
+  });
+});
+
+describe("registry re-export compatibility", () => {
+  it("keeps the public registry wrapper wired to the extracted lib", () => {
+    expect(listPromptsFromWrapper()).toEqual(listRegistryPrompts());
+    expect(promptsFromWrapper).toBe(PROMPT_DEFINITIONS);
+    expect(
+      getPromptFromWrapper({
+        name: "install.asset",
+        arguments: { category: "skills", slug: "browser-bridge" },
+      }),
+    ).toEqual(
+      getRegistryPrompt({
+        name: "install.asset",
+        arguments: { category: "skills", slug: "browser-bridge" },
+      }),
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP prompt definitions and prompt message builders into `packages/mcp/src/registry-prompts-lib.js`.
- Keep `packages/mcp/src/registry.js` as the public registry surface with imports plus re-exports so existing `@heyclaude/mcp/registry` consumers stay unchanged.
- Add focused lib tests for prompt listing, argument interpolation, unknown-prompt fallback, and re-export compatibility.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-prompts-lib.js` (new extracted prompt helpers)
  - `packages/mcp/src/registry.js` (imports + re-exports; resource handlers unchanged)
  - `tests/mcp-registry-prompts-lib.test.ts` (new focused tests)
- Expected behavior:
  - MCP prompt listing and prompt message generation are unchanged; only module boundaries moved.
- Important edge cases or invariants:
  - The four workflow prompts (`asset.find`, `submission.prepare`, `submission.review`, `install.asset`) remain read-only guidance templates.
  - Unknown prompt names still return a safe fallback message.
- Backward compatibility notes:
  - Public exports from `registry.js` are unchanged.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-prompts-lib.test.ts`; existing MCP server tests still pass.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-prompts-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate MCP prompt helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recent MCP lib splits (`registry-tools-lib`, `remote-proxy-lib`, `search-ranking-lib`).
  - Registry resource handlers (`listRegistryResources`, `readRegistryResource`, etc.) intentionally remain in `registry.js`.


Made with [Cursor](https://cursor.com)