### PR TITLE
fix(registry): reject embedded URL credentials in content schema

### DIFF
--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -8,6 +8,7 @@ export function githubHandle(profileUrl?: string) {
   if (!profileUrl) return undefined;
   try {
     const url = new URL(profileUrl);
+    if (url.username || url.password) return undefined;
     if (url.hostname !== "github.com") return undefined;
     return url.pathname.split("/").filter(Boolean)[0];
   } catch {

--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -170,7 +170,11 @@ function isHttpUrl(value) {
   if (!normalized) return true;
   try {
     const url = new URL(normalized);
-    return url.protocol === "https:" || url.protocol === "http:";
+    return (
+      (url.protocol === "https:" || url.protocol === "http:") &&
+      url.username === "" &&
+      url.password === ""
+    );
   } catch {
     return false;
   }

--- a/tests/content-schema.test.ts
+++ b/tests/content-schema.test.ts
@@ -300,6 +300,25 @@ describe("inferStructuredFields", () => {
     expect(result.missingRecommended).not.toContain("downloadUrl");
   });
 
+  it("rejects http and https URLs with embedded userinfo", () => {
+    const result = validateEntry("mcp", {
+      slug: "userinfo-urls",
+      title: "Userinfo URLs",
+      description: "Reject credential-bearing profile and repo URLs.",
+      author: "JSONbored",
+      dateAdded: "2026-01-01",
+      authorProfileUrl: "https://token@github.com/victim",
+      repoUrl: "http://user:pass@example.com/repo",
+    });
+
+    expect(result.semanticErrors).toEqual(
+      expect.arrayContaining([
+        "authorProfileUrl must use http or https",
+        "repoUrl must use http or https",
+      ]),
+    );
+  });
+
   it("orders frontmatter while dropping empty values and appending unknown keys", () => {
     expect(
       orderFrontmatter({

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -925,6 +925,7 @@ describe("web non-UI utility coverage", () => {
     ).toBe(true);
     expect(contributorSlug(" @Example User! ")).toBe("example-user");
     expect(githubHandle("https://github.com/JSONbored")).toBe("JSONbored");
+    expect(githubHandle("https://token@github.com/victim")).toBeUndefined();
     expect(githubHandle("https://example.com/JSONbored")).toBeUndefined();
     expect(githubHandle("not a url")).toBeUndefined();
 


### PR DESCRIPTION
## Summary
- Reject embedded URL userinfo in content-schema `isHttpUrl` validation for fields like `authorProfileUrl` and `repoUrl`, closing a gap left after submission-layer hardening (#4409).
- Reject credential-bearing GitHub profile URLs in `githubHandle()` so contributor identity parsing cannot treat spoofed links as verified handles.

## Test plan
- [x] `vitest run tests/content-schema.test.ts`
- [x] `vitest run tests/web-non-ui-utilities.test.ts` (after web prebuild)