### PR TITLE
feat(web): add compare best interactive UI lib for best lists

### DIFF
--- a/apps/web/src/lib/compare-best-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-interactive-ui-lib.ts
@@ -1,0 +1,8 @@
+import type { Entry } from "@/types/registry";
+import { compareBestUiState, type CompareBestUiState } from "@/lib/compare-best-ui-lib";
+
+export type CompareBestInteractiveUiState = CompareBestUiState;
+
+export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInteractiveUiState {
+  return compareBestUiState(entries);
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -5,7 +5,7 @@ import { BEST_LISTS, ENTRIES, type BestList, type BestPick } from "@/data/entrie
 import type { Entry } from "@/types/registry";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import { compareBestUiState } from "@/lib/compare-best-ui-lib";
+import { compareBestInteractiveUiState } from "@/lib/compare-best-interactive-ui-lib";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
@@ -93,7 +93,7 @@ function BestDetail() {
     .filter((p): p is Resolved => p !== null);
 
   const compareEntries = useMemo(() => resolved.slice(0, 5).map((p) => p.entry), [resolved]);
-  const compareUi = useMemo(() => compareBestUiState(compareEntries), [compareEntries]);
+  const compareUi = useMemo(() => compareBestInteractiveUiState(compareEntries), [compareEntries]);
 
   return (
     <PageContainer className="py-12">

--- a/tests/compare-best-interactive-ui-lib.test.ts
+++ b/tests/compare-best-interactive-ui-lib.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareBestInteractiveUiState } from "@/lib/compare-best-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare best interactive ui lib", () => {
+  it("hides compare UI for single-entry best lists", () => {
+    expect(compareBestInteractiveUiState([entry()])).toEqual({
+      showCompareSection: false,
+      bannerTexts: [],
+      interactiveSearch: null,
+      interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
+    });
+  });
+
+  it("bundles best-list page presentation state for headers and interactive links", () => {
+    expect(
+      compareBestInteractiveUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+  });
+
+  it("surfaces divergence banners for multi-entry best lists", () => {
+    expect(
+      compareBestInteractiveUiState([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across picks — use the actions in the table below to copy install commands and source links per resource.",
+      ],
+      interactiveSearch: { ids: "mcp/fixture,mcp/mixed" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-best-interactive-ui-lib` with `compareBestInteractiveUiState` for best-list compare section state
- Wire `best.$slug.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405 / #4417 / #4418


Made with [Cursor](https://cursor.com)