### PR TITLE
fix(raycast): reject credential-bearing MCP server URLs

### DIFF
--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -359,6 +359,7 @@ function isLoopbackHostname(hostname: string) {
 function isSafeRemoteMcpUrl(value: string) {
   try {
     const url = new URL(value.trim());
+    if (url.username || url.password) return false;
     if (url.protocol === "https:") return true;
     return url.protocol === "http:" && isLoopbackHostname(url.hostname);
   } catch {

--- a/tests/mcp-installer-url-credentials.test.ts
+++ b/tests/mcp-installer-url-credentials.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  mcpConfigSupportsTarget,
+  mcpInstallTargetsForConfig,
+} from "../integrations/raycast/src/mcp-installer.js";
+
+describe("Raycast MCP installer URL credential hardening", () => {
+  it("rejects http/sse URLs that embed a user and password", () => {
+    for (const type of ["http", "sse"] as const) {
+      const config = {
+        type,
+        url: "https://user:pass@remote.example.com/mcp",
+      };
+      expect(mcpConfigSupportsTarget(config, "claude-code")).toBe(false);
+      expect(mcpInstallTargetsForConfig(config)).toEqual([]);
+    }
+  });
+
+  it("rejects a bare userinfo token with no password", () => {
+    const config = {
+      type: "http",
+      url: "https://supersecrettoken@remote.example.com/mcp",
+    };
+    expect(mcpConfigSupportsTarget(config, "claude-code")).toBe(false);
+    expect(mcpInstallTargetsForConfig(config)).toEqual([]);
+  });
+
+  it("rejects embedded credentials even on a loopback http URL", () => {
+    const config = {
+      type: "http",
+      url: "http://user:pass@127.0.0.1:8080/mcp",
+    };
+    expect(mcpConfigSupportsTarget(config, "claude-code")).toBe(false);
+    expect(mcpInstallTargetsForConfig(config)).toEqual([]);
+  });
+
+  it("accepts a clean remote https URL", () => {
+    const config = {
+      type: "http",
+      url: "https://remote.example.com/mcp",
+    };
+    expect(mcpConfigSupportsTarget(config, "claude-code")).toBe(true);
+    expect(mcpInstallTargetsForConfig(config)).toContain("claude-code");
+  });
+
+  it("accepts a clean loopback http URL", () => {
+    const config = {
+      type: "http",
+      url: "http://127.0.0.1:8080/mcp",
+    };
+    expect(mcpConfigSupportsTarget(config, "claude-code")).toBe(true);
+    expect(mcpInstallTargetsForConfig(config)).toContain("claude-code");
+  });
+});


### PR DESCRIPTION
## Summary
- Align Raycast `isSafeRemoteMcpUrl` with registry `mcp-install-config-lib` by rejecting http/sse server URLs that embed credentials in userinfo.
- Prevents one-click MCP install plans from accepting configs that would persist secrets in saved client configs and logs.

## Test plan
- [x] `vitest run tests/mcp-installer-url-credentials.test.ts`