### PR TITLE
fix(raycast): reject credential-bearing submission source URLs

### DIFF
--- a/integrations/raycast/src/submission.ts
+++ b/integrations/raycast/src/submission.ts
@@ -55,7 +55,9 @@ export function isValidHttpsUrl(value?: string) {
   if (!trimmed) return false;
   try {
     const url = new URL(trimmed);
-    return url.protocol === "https:";
+    return (
+      url.protocol === "https:" && url.username === "" && url.password === ""
+    );
   } catch {
     return false;
   }

--- a/tests/raycast-submission-validation.test.ts
+++ b/tests/raycast-submission-validation.test.ts
@@ -34,6 +34,11 @@ describe("isValidHttpsUrl", () => {
     expect(isValidHttpsUrl("not a url")).toBe(false);
     expect(isValidHttpsUrl("")).toBe(false);
   });
+
+  it("rejects https URLs with embedded userinfo credentials", () => {
+    expect(isValidHttpsUrl("https://token@github.com/owner/repo")).toBe(false);
+    expect(isValidHttpsUrl("https://user:pass@example.com/docs")).toBe(false);
+  });
 });
 
 describe("isValidDomain", () => {


### PR DESCRIPTION
## Summary
- Reject embedded URL userinfo in Raycast `isValidHttpsUrl`, which gates the content submission form before draft text is generated.
- Prevents credential-bearing source URLs from reaching clipboard output and GitHub issues ahead of backend submission validation.

## Test plan
- [x] `vitest run tests/raycast-submission-validation.test.ts`