### PR TITLE
feat(mcp): extract platform helpers into platforms-lib

### DIFF
--- a/packages/mcp/src/platforms-lib.js
+++ b/packages/mcp/src/platforms-lib.js
@@ -1,0 +1,95 @@
+/**
+ * Pure MCP platform helper functions.
+ *
+ * Site URL constants, platform feed slug normalization, and default skill
+ * platform compatibility metadata live here.
+ *
+ * The public surface (`platforms.js` / `@heyclaude/mcp/platforms`) re-exports
+ * everything below so existing imports stay unchanged.
+ */
+export const SITE_URL = "https://heyclau.de";
+
+function slugPart(value, options = {}) {
+  const text = String(value || "")
+    .trim()
+    .toLowerCase();
+  let output = "";
+  let lastWasSeparator = false;
+
+  for (const char of text) {
+    const isAlphaNumeric =
+      (char >= "a" && char <= "z") || (char >= "0" && char <= "9");
+    if (isAlphaNumeric) {
+      output += char;
+      lastWasSeparator = false;
+      continue;
+    }
+    if (char === "&" && options.expandAmpersand) {
+      if (output && !lastWasSeparator) output += "-";
+      output += "and";
+      lastWasSeparator = false;
+      continue;
+    }
+    if (output && !lastWasSeparator) {
+      output += "-";
+      lastWasSeparator = true;
+    }
+  }
+
+  return lastWasSeparator ? output.slice(0, -1) : output;
+}
+
+export function platformFeedSlug(platform) {
+  return slugPart(platform, { expandAmpersand: true });
+}
+
+export function buildSkillPlatformCompatibility(entry) {
+  if (entry?.category !== "skills") return [];
+  if (Array.isArray(entry.platformCompatibility)) {
+    return entry.platformCompatibility;
+  }
+
+  const slug = String(entry?.slug || "").trim();
+  return [
+    {
+      platform: "Claude",
+      support: "native-skill",
+      artifact: "SKILL.md package",
+      installHint: "Install the skill package into your Claude skills folder.",
+    },
+    {
+      platform: "Codex",
+      support: "native-skill",
+      artifact: "SKILL.md package",
+      installHint: "Install the skill package into your Codex skills folder.",
+    },
+    {
+      platform: "Windsurf",
+      support: "native-skill",
+      artifact: "SKILL.md package",
+      installHint: "Install the skill under .windsurf/skills/<skill-name>/.",
+    },
+    {
+      platform: "Gemini",
+      support: "native-skill",
+      artifact: "SKILL.md package",
+      installHint:
+        "Use the skill package with Gemini CLI extension skill support.",
+    },
+    {
+      platform: "Cursor",
+      support: "adapter",
+      artifact: `.cursor/rules/${slug}.mdc`,
+      adapterUrl: `/data/skill-adapters/cursor/${slug}.mdc`,
+      installHint:
+        "Use the generated Cursor rule adapter because Cursor rules are the supported reusable instruction surface.",
+    },
+    {
+      platform: "Generic AGENTS",
+      support: "manual-context",
+      artifact: "SKILL.md package",
+      installHint:
+        "Use SKILL.md as reusable agent context or convert it into the target tool's instruction file.",
+    },
+  ];
+}

--- a/packages/mcp/src/platforms.js
+++ b/packages/mcp/src/platforms.js
@@ -1,86 +1,12 @@
-export const SITE_URL = "https://heyclau.de";
-
-function slugPart(value, options = {}) {
-  const text = String(value || "")
-    .trim()
-    .toLowerCase();
-  let output = "";
-  let lastWasSeparator = false;
-
-  for (const char of text) {
-    const isAlphaNumeric =
-      (char >= "a" && char <= "z") || (char >= "0" && char <= "9");
-    if (isAlphaNumeric) {
-      output += char;
-      lastWasSeparator = false;
-      continue;
-    }
-    if (char === "&" && options.expandAmpersand) {
-      if (output && !lastWasSeparator) output += "-";
-      output += "and";
-      lastWasSeparator = false;
-      continue;
-    }
-    if (output && !lastWasSeparator) {
-      output += "-";
-      lastWasSeparator = true;
-    }
-  }
-
-  return lastWasSeparator ? output.slice(0, -1) : output;
-}
-
-export function platformFeedSlug(platform) {
-  return slugPart(platform, { expandAmpersand: true });
-}
-
-export function buildSkillPlatformCompatibility(entry) {
-  if (entry?.category !== "skills") return [];
-  if (Array.isArray(entry.platformCompatibility)) {
-    return entry.platformCompatibility;
-  }
-
-  const slug = String(entry?.slug || "").trim();
-  return [
-    {
-      platform: "Claude",
-      support: "native-skill",
-      artifact: "SKILL.md package",
-      installHint: "Install the skill package into your Claude skills folder.",
-    },
-    {
-      platform: "Codex",
-      support: "native-skill",
-      artifact: "SKILL.md package",
-      installHint: "Install the skill package into your Codex skills folder.",
-    },
-    {
-      platform: "Windsurf",
-      support: "native-skill",
-      artifact: "SKILL.md package",
-      installHint: "Install the skill under .windsurf/skills/<skill-name>/.",
-    },
-    {
-      platform: "Gemini",
-      support: "native-skill",
-      artifact: "SKILL.md package",
-      installHint:
-        "Use the skill package with Gemini CLI extension skill support.",
-    },
-    {
-      platform: "Cursor",
-      support: "adapter",
-      artifact: `.cursor/rules/${slug}.mdc`,
-      adapterUrl: `/data/skill-adapters/cursor/${slug}.mdc`,
-      installHint:
-        "Use the generated Cursor rule adapter because Cursor rules are the supported reusable instruction surface.",
-    },
-    {
-      platform: "Generic AGENTS",
-      support: "manual-context",
-      artifact: "SKILL.md package",
-      installHint:
-        "Use SKILL.md as reusable agent context or convert it into the target tool's instruction file.",
-    },
-  ];
-}
+/**
+ * MCP platform helpers surface.
+ *
+ * Pure platform slug and compatibility helpers live in `platforms-lib.js`.
+ * This module re-exports that surface so existing `@heyclaude/mcp/platforms`
+ * imports stay unchanged.
+ */
+export {
+  SITE_URL,
+  buildSkillPlatformCompatibility,
+  platformFeedSlug,
+} from "./platforms-lib.js";

--- a/tests/mcp-platforms-lib.test.ts
+++ b/tests/mcp-platforms-lib.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SITE_URL,
+  buildSkillPlatformCompatibility,
+  platformFeedSlug,
+} from "../packages/mcp/src/platforms-lib.js";
+import {
+  SITE_URL as siteUrlFromWrapper,
+  buildSkillPlatformCompatibility as buildCompatibilityFromWrapper,
+  platformFeedSlug as platformFeedSlugFromWrapper,
+} from "../packages/mcp/src/platforms.js";
+
+describe("platforms-lib feed slugs", () => {
+  it("normalizes platform feed slugs with ampersand expansion and separators", () => {
+    expect(platformFeedSlug("Claude & Cursor")).toBe("claude-and-cursor");
+    expect(platformFeedSlug(" Claude---Code!! ")).toBe("claude-code");
+    expect(platformFeedSlug("")).toBe("");
+  });
+});
+
+describe("platforms-lib skill compatibility", () => {
+  it("builds default skill compatibility while preserving explicit metadata", () => {
+    expect(buildSkillPlatformCompatibility({ category: "mcp" })).toEqual([]);
+
+    const explicit = [
+      {
+        platform: "Custom",
+        support: "native-skill",
+        artifact: "custom",
+        installHint: "Use the custom installer.",
+      },
+    ];
+    expect(
+      buildSkillPlatformCompatibility({
+        category: "skills",
+        platformCompatibility: explicit,
+      }),
+    ).toBe(explicit);
+
+    const compatibility = buildSkillPlatformCompatibility({
+      category: "skills",
+      slug: "branch-matrix",
+    });
+    expect(compatibility.map((item) => item.platform)).toEqual([
+      "Claude",
+      "Codex",
+      "Windsurf",
+      "Gemini",
+      "Cursor",
+      "Generic AGENTS",
+    ]);
+    expect(
+      compatibility.find((item) => item.platform === "Cursor"),
+    ).toMatchObject({
+      support: "adapter",
+      artifact: ".cursor/rules/branch-matrix.mdc",
+      adapterUrl: "/data/skill-adapters/cursor/branch-matrix.mdc",
+    });
+  });
+});
+
+describe("platforms re-export compatibility", () => {
+  it("keeps the public wrapper wired to the extracted lib", () => {
+    expect(siteUrlFromWrapper).toBe(SITE_URL);
+    expect(platformFeedSlugFromWrapper).toBe(platformFeedSlug);
+    expect(buildCompatibilityFromWrapper).toBe(buildSkillPlatformCompatibility);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP platform feed slug and skill compatibility helpers into `packages/mcp/src/platforms-lib.js`.
- Keep `packages/mcp/src/platforms.js` as a thin re-export wrapper so existing `@heyclaude/mcp/platforms` imports stay unchanged.
- Add focused lib tests for feed slug normalization, skill compatibility defaults, and re-export compatibility.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/platforms-lib.js` (new extracted platform helpers)
  - `packages/mcp/src/platforms.js` (thin re-export wrapper)
  - `tests/mcp-platforms-lib.test.ts` (new focused tests)
- Expected behavior:
  - Platform feed slug normalization and default skill platform compatibility metadata are unchanged.
- Important edge cases or invariants:
  - Non-skill entries still return an empty compatibility list.
  - Explicit `platformCompatibility` arrays on skill entries are preserved by reference.
  - Cursor adapter paths still derive from the entry slug.
- Backward compatibility notes:
  - Public exports from `platforms.js` are unchanged.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-platforms-lib.test.ts`; existing `tests/mcp-platforms.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-platforms-lib.test.ts tests/mcp-platforms.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate MCP platform helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recent MCP lib splits (`cli-options-lib`, `registry-prompts-lib`, `remote-proxy-lib`).


Made with [Cursor](https://cursor.com)