### PR TITLE
feat(web): add compare dossier interactive UI lib for entry pages

### DIFF
--- a/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
@@ -1,0 +1,11 @@
+import type { Entry } from "@/types/registry";
+import { compareDossierUiState, type CompareDossierUiState } from "@/lib/compare-dossier-ui-lib";
+
+export type CompareDossierInteractiveUiState = CompareDossierUiState;
+
+export function compareDossierInteractiveUiState(
+  entry: Entry,
+  alternatives: Entry[],
+): CompareDossierInteractiveUiState {
+  return compareDossierUiState(entry, alternatives);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -40,7 +40,7 @@ import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
 import { compareEntryFeaturedUiState } from "@/lib/compare-entry-featured-ui-lib";
-import { compareDossierUiState } from "@/lib/compare-dossier-ui-lib";
+import { compareDossierInteractiveUiState } from "@/lib/compare-dossier-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -224,7 +224,7 @@ function Dossier() {
     return pool.slice(0, 3);
   }, [relGroups, rel]);
   const dossierCompareUi = useMemo(
-    () => compareDossierUiState(entry, alternatives),
+    () => compareDossierInteractiveUiState(entry, alternatives),
     [entry, alternatives],
   );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,

--- a/tests/compare-dossier-interactive-ui-lib.test.ts
+++ b/tests/compare-dossier-interactive-ui-lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDossierInteractiveUiState } from "@/lib/compare-dossier-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare dossier interactive ui lib", () => {
+  it("hides dossier compare UI when no alternatives exist", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(compareDossierInteractiveUiState(primary, [])).toEqual({
+      showCompareSection: false,
+      bannerTexts: [],
+      interactiveSearch: null,
+      interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
+    });
+  });
+
+  it("bundles dossier compare presentation state for headers and interactive links", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(
+      compareDossierInteractiveUiState(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [],
+      interactiveSearch: { ids: "skills/primary,hooks/alt" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+  });
+
+  it("surfaces divergence banners for dossier alternatives", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(
+      compareDossierInteractiveUiState(primary, [
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual({
+      showCompareSection: true,
+      bannerTexts: [
+        "1 trust signal differ across this comparison (Review status).",
+        "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+      ],
+      interactiveSearch: { ids: "skills/primary,mcp/mixed" },
+      interactiveLinkLabel: "Open in the interactive comparison tool",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-dossier-interactive-ui-lib` with `compareDossierInteractiveUiState` for entry dossier compare section state
- Wire `entry.$category.$slug.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4405 / #4418


Made with [Cursor](https://cursor.com)