### PR TITLE
fix(registry): reject credential-bearing URLs in weekly brief output

### DIFF
--- a/packages/registry/src/weekly-brief-lib.js
+++ b/packages/registry/src/weekly-brief-lib.js
@@ -41,6 +41,7 @@ export function httpUrl(value) {
   if (!normalized) return "";
   try {
     const url = new URL(normalized);
+    if (url.username || url.password) return "";
     return url.protocol === "https:" || url.protocol === "http:"
       ? url.href
       : "";

--- a/tests/weekly-brief-lib.test.ts
+++ b/tests/weekly-brief-lib.test.ts
@@ -98,6 +98,11 @@ describe("url and date helpers", () => {
     expect(httpUrl("")).toBe("");
   });
 
+  it("rejects http(s) urls with embedded userinfo credentials", () => {
+    expect(httpUrl("https://token@github.com/owner/repo")).toBe("");
+    expect(httpUrl("http://user:pass@127.0.0.1/docs")).toBe("");
+  });
+
   it("normalizes site bases and entry urls", () => {
     expect(siteUrlBase("https://example.com/")).toBe("https://example.com");
     expect(siteUrlBase("bad")).toBe(SITE_URL);


### PR DESCRIPTION
## Summary
- Reject embedded URL userinfo in weekly-brief `httpUrl()` so newsletter markdown never emits credential-bearing canonical or source links.
- Falls back to generated entry URLs when a stored canonical URL carries userinfo.

## Test plan
- [x] `vitest run tests/weekly-brief-lib.test.ts`