### PR TITLE
feat(mcp): extract endpoint URL helpers into endpoint-url-lib

### DIFF
--- a/packages/mcp/src/endpoint-url-lib.js
+++ b/packages/mcp/src/endpoint-url-lib.js
@@ -1,0 +1,46 @@
+/**
+ * Pure MCP endpoint URL and timeout helpers.
+ *
+ * Remote MCP endpoint normalization and timeout parsing live here.
+ *
+ * The public surface (`endpoint-url.js`) re-exports everything below so
+ * existing imports stay unchanged.
+ */
+export const DEFAULT_REMOTE_MCP_URL = "https://heyclau.de/api/mcp";
+export const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
+
+const localHosts = new Set([
+  "127.0.0.1",
+  "localhost",
+  "::1",
+  "[::1]",
+  "0.0.0.0",
+]);
+
+export function normalizeEndpointUrl(value = DEFAULT_REMOTE_MCP_URL) {
+  const raw = String(value || "").trim();
+  if (!raw) throw new Error("MCP endpoint URL is required.");
+
+  const url = new URL(raw);
+  if (url.protocol !== "https:" && !localHosts.has(url.hostname)) {
+    throw new Error("MCP endpoint URL must use HTTPS outside localhost.");
+  }
+
+  if (url.pathname === "/" || url.pathname === "") {
+    url.pathname = "/api/mcp";
+  }
+
+  return url;
+}
+
+export function normalizeTimeoutMs(
+  value,
+  fallback = DEFAULT_REQUEST_TIMEOUT_MS,
+) {
+  if (value === undefined || value === null || value === "") return fallback;
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric < 1000 || numeric > 300000) {
+    throw new Error("Timeout must be between 1000 and 300000 milliseconds.");
+  }
+  return Math.trunc(numeric);
+}

--- a/packages/mcp/src/endpoint-url.js
+++ b/packages/mcp/src/endpoint-url.js
@@ -1,38 +1,12 @@
-export const DEFAULT_REMOTE_MCP_URL = "https://heyclau.de/api/mcp";
-export const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
-
-const localHosts = new Set([
-  "127.0.0.1",
-  "localhost",
-  "::1",
-  "[::1]",
-  "0.0.0.0",
-]);
-
-export function normalizeEndpointUrl(value = DEFAULT_REMOTE_MCP_URL) {
-  const raw = String(value || "").trim();
-  if (!raw) throw new Error("MCP endpoint URL is required.");
-
-  const url = new URL(raw);
-  if (url.protocol !== "https:" && !localHosts.has(url.hostname)) {
-    throw new Error("MCP endpoint URL must use HTTPS outside localhost.");
-  }
-
-  if (url.pathname === "/" || url.pathname === "") {
-    url.pathname = "/api/mcp";
-  }
-
-  return url;
-}
-
-export function normalizeTimeoutMs(
-  value,
-  fallback = DEFAULT_REQUEST_TIMEOUT_MS,
-) {
-  if (value === undefined || value === null || value === "") return fallback;
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric) || numeric < 1000 || numeric > 300000) {
-    throw new Error("Timeout must be between 1000 and 300000 milliseconds.");
-  }
-  return Math.trunc(numeric);
-}
+/**
+ * MCP endpoint URL surface.
+ *
+ * Pure endpoint normalization helpers live in `endpoint-url-lib.js`. This
+ * module re-exports that surface so existing imports stay unchanged.
+ */
+export {
+  DEFAULT_REMOTE_MCP_URL,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  normalizeEndpointUrl,
+  normalizeTimeoutMs,
+} from "./endpoint-url-lib.js";

--- a/tests/mcp-endpoint-url-lib.test.ts
+++ b/tests/mcp-endpoint-url-lib.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_REMOTE_MCP_URL,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  normalizeEndpointUrl,
+  normalizeTimeoutMs,
+} from "../packages/mcp/src/endpoint-url-lib.js";
+import {
+  DEFAULT_REMOTE_MCP_URL as defaultUrlFromWrapper,
+  DEFAULT_REQUEST_TIMEOUT_MS as defaultTimeoutFromWrapper,
+  normalizeEndpointUrl as normalizeEndpointUrlFromWrapper,
+  normalizeTimeoutMs as normalizeTimeoutMsFromWrapper,
+} from "../packages/mcp/src/endpoint-url.js";
+
+describe("endpoint-url-lib endpoint normalization", () => {
+  it("defaults to the production MCP endpoint path", () => {
+    expect(DEFAULT_REMOTE_MCP_URL).toBe("https://heyclau.de/api/mcp");
+    expect(normalizeEndpointUrl().toString()).toBe(DEFAULT_REMOTE_MCP_URL);
+  });
+
+  it("appends /api/mcp for bare HTTPS origins", () => {
+    expect(normalizeEndpointUrl("https://example.com").toString()).toBe(
+      "https://example.com/api/mcp",
+    );
+    expect(
+      normalizeEndpointUrl("https://example.com/custom/mcp").toString(),
+    ).toBe("https://example.com/custom/mcp");
+  });
+
+  it("allows localhost and loopback HTTP endpoints", () => {
+    expect(normalizeEndpointUrl("http://localhost:3000").toString()).toBe(
+      "http://localhost:3000/api/mcp",
+    );
+    expect(normalizeEndpointUrl("http://0.0.0.0:3845").toString()).toBe(
+      "http://0.0.0.0:3845/api/mcp",
+    );
+  });
+
+  it("rejects empty and non-HTTPS remote endpoints", () => {
+    expect(() => normalizeEndpointUrl("")).toThrow(/endpoint URL is required/i);
+    expect(() => normalizeEndpointUrl("http://example.com")).toThrow(
+      /HTTPS outside localhost/i,
+    );
+  });
+});
+
+describe("endpoint-url-lib timeout normalization", () => {
+  it("returns fallback values for nullish input", () => {
+    expect(normalizeTimeoutMs(undefined, 5000)).toBe(5000);
+    expect(normalizeTimeoutMs(null, 5000)).toBe(5000);
+    expect(normalizeTimeoutMs("", 5000)).toBe(5000);
+    expect(normalizeTimeoutMs(undefined)).toBe(DEFAULT_REQUEST_TIMEOUT_MS);
+  });
+
+  it("accepts in-range numbers and rejects invalid values", () => {
+    expect(normalizeTimeoutMs(2500)).toBe(2500);
+    expect(normalizeTimeoutMs("3000")).toBe(3000);
+    expect(() => normalizeTimeoutMs(999)).toThrow(
+      /Timeout must be between 1000 and 300000 milliseconds/i,
+    );
+  });
+});
+
+describe("endpoint-url re-export compatibility", () => {
+  it("keeps the public wrapper wired to the extracted lib", () => {
+    expect(defaultUrlFromWrapper).toBe(DEFAULT_REMOTE_MCP_URL);
+    expect(defaultTimeoutFromWrapper).toBe(DEFAULT_REQUEST_TIMEOUT_MS);
+    expect(normalizeEndpointUrlFromWrapper).toBe(normalizeEndpointUrl);
+    expect(normalizeTimeoutMsFromWrapper).toBe(normalizeTimeoutMs);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP endpoint normalization and timeout parsing into `packages/mcp/src/endpoint-url-lib.js`.
- Keep `packages/mcp/src/endpoint-url.js` as a thin re-export wrapper so existing imports stay unchanged.
- Add focused lib tests for endpoint defaults, localhost handling, HTTPS enforcement, timeout bounds, and re-export compatibility.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/endpoint-url-lib.js` (new extracted endpoint helpers)
  - `packages/mcp/src/endpoint-url.js` (thin re-export wrapper)
  - `tests/mcp-endpoint-url-lib.test.ts` (new focused tests)
- Expected behavior:
  - Remote MCP endpoint normalization and timeout parsing are unchanged.
- Important edge cases or invariants:
  - Bare HTTPS origins still default to `/api/mcp`.
  - Localhost and loopback HTTP endpoints remain allowed.
  - Timeout parsing still accepts only 1000–300000 ms.
- Backward compatibility notes:
  - Public exports from `endpoint-url.js` are unchanged.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-endpoint-url-lib.test.ts`; existing `tests/mcp-normalize-timeout.test.ts` and `tests/mcp-cli.test.ts` still pass.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-endpoint-url-lib.test.ts tests/mcp-normalize-timeout.test.ts tests/mcp-cli.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate MCP endpoint helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recent MCP lib splits (`platforms-lib`, `cli-options-lib`, `remote-proxy-lib`).


Made with [Cursor](https://cursor.com)