### PR TITLE
fix(registry): reject credential-bearing brand asset URLs

### DIFF
--- a/packages/registry/src/brand-assets-lib.js
+++ b/packages/registry/src/brand-assets-lib.js
@@ -286,6 +286,7 @@ export function isAllowedBrandAssetUrl(value) {
   try {
     const parsed = new URL(raw);
     if (parsed.protocol !== "https:") return false;
+    if (parsed.username || parsed.password) return false;
     const host = parsed.hostname.toLowerCase();
     return (
       host === "cdn.brandfetch.io" ||

--- a/tests/brand-assets-lib.test.ts
+++ b/tests/brand-assets-lib.test.ts
@@ -169,6 +169,11 @@ describe("colors and asset urls", () => {
     ).toBe(true);
     expect(isAllowedBrandAssetUrl("https://heyclau.de/logo.png")).toBe(true);
     expect(isAllowedBrandAssetUrl("https://evil.example/icon.png")).toBe(false);
+    expect(
+      isAllowedBrandAssetUrl(
+        "https://token@cdn.brandfetch.io/domain/x/icon.png",
+      ),
+    ).toBe(false);
     expect(isAllowedBrandAssetUrl("not a url")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Reject embedded URL userinfo in `isAllowedBrandAssetUrl` so brand icon and logo fields cannot pass validation with credential-bearing HTTPS URLs on otherwise allowed hosts.

## Test plan
- [x] `vitest run tests/brand-assets-lib.test.ts`