### PR TITLE
fix(registry): reject userinfo in tools affiliate URL validation

### DIFF
--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -936,10 +936,10 @@ export function validateEntry(category, data, inferred = {}) {
       .trim()
       .toLowerCase();
 
-    if (websiteUrl && !/^https:\/\//i.test(websiteUrl)) {
+    if (websiteUrl && !isHttpsUrl(websiteUrl)) {
       semanticErrors.push("websiteUrl must use https");
     }
-    if (affiliateUrl && !/^https:\/\//i.test(affiliateUrl)) {
+    if (affiliateUrl && !isHttpsUrl(affiliateUrl)) {
       semanticErrors.push("affiliateUrl must use https");
     }
     if (

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -969,6 +969,15 @@ describe("validateEntry", () => {
     });
     expect(result.semanticErrors).toContain("affiliateUrl must use https");
   });
+
+  it("rejects affiliateUrl values with embedded userinfo credentials", () => {
+    const result = validateEntry("tools", {
+      ...VALID_TOOL,
+      affiliateUrl: "https://token@example.com/affiliate",
+      disclosure: "affiliate",
+    });
+    expect(result.semanticErrors).toContain("affiliateUrl must use https");
+  });
 });
 
 describe("orderFrontmatter", () => {


### PR DESCRIPTION
## Summary
- Replace tools `affiliateUrl` and `websiteUrl` prefix-regex checks with `isHttpsUrl`, which rejects embedded URL userinfo.
- Closes a gap where `affiliateUrl` was not covered by the shared `isHttpUrl` field loop.

## Test plan
- [x] `vitest run tests/content-schema-lib.test.ts`