### PR TITLE
fix(registry): reject credential-bearing GitHub profile contacts

### DIFF
--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -122,18 +122,23 @@ function isLikelyAffiliateUrl(value) {
 function isPublicContact(value) {
   const contact = normalizeText(value);
   if (!contact) return true;
+  if (/^https?:\/\//i.test(contact)) {
+    try {
+      const url = new URL(contact);
+      return (
+        url.protocol === "https:" &&
+        url.username === "" &&
+        url.password === "" &&
+        url.hostname === "github.com" &&
+        url.pathname.split("/").filter(Boolean).length === 1
+      );
+    } catch {
+      return false;
+    }
+  }
   if (isEmailLike(contact)) return true;
   if (isGitHubHandle(contact)) return true;
-  try {
-    const url = new URL(contact);
-    return (
-      url.protocol === "https:" &&
-      url.hostname === "github.com" &&
-      url.pathname.split("/").filter(Boolean).length === 1
-    );
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 function isEmailLike(value) {

--- a/packages/registry/src/submission-lib.js
+++ b/packages/registry/src/submission-lib.js
@@ -699,6 +699,20 @@ function isUsefulDisclosureNote(value) {
 function isValidPublicContact(value) {
   const normalized = normalizeValue(value);
   if (!normalized) return true;
+  if (/^https?:\/\//i.test(normalized)) {
+    try {
+      const url = new URL(normalized);
+      return (
+        url.protocol === "https:" &&
+        url.username === "" &&
+        url.password === "" &&
+        url.hostname === "github.com" &&
+        url.pathname.split("/").filter(Boolean).length === 1
+      );
+    } catch {
+      return false;
+    }
+  }
   if (normalized.includes("@")) {
     const parts = normalized.split("@");
     const [local, domain] = parts;
@@ -731,16 +745,7 @@ function isValidPublicContact(value) {
     return true;
   }
 
-  try {
-    const url = new URL(normalized);
-    return (
-      url.protocol === "https:" &&
-      url.hostname === "github.com" &&
-      url.pathname.split("/").filter(Boolean).length === 1
-    );
-  } catch {
-    return false;
-  }
+  return false;
 }
 
 const TOOL_PRICING_MODELS = new Set([

--- a/tests/mcp-submissions-lib.test.ts
+++ b/tests/mcp-submissions-lib.test.ts
@@ -153,6 +153,18 @@ describe("submissions-lib spec validation", () => {
     );
   });
 
+  it("rejects GitHub profile contact URLs with embedded userinfo", () => {
+    const result = validateSubmissionDraftFromSpec(submissionSpec, {
+      fields: {
+        ...validMcpFields,
+        contact_email: "https://token@github.com/victim",
+      },
+    });
+    expect(result.errors.join("\n")).toContain(
+      "Invalid public contact: use a GitHub handle, GitHub profile URL, or email.",
+    );
+  });
+
   it("requires collections items and guide content", () => {
     expect(
       validateSubmissionDraftFromSpec(submissionSpec, {

--- a/tests/submission-lib.test.ts
+++ b/tests/submission-lib.test.ts
@@ -1192,6 +1192,21 @@ describe("validateSubmission shared guardrails", () => {
     );
   });
 
+  it("rejects GitHub profile contact URLs with embedded userinfo", () => {
+    const result = validateSubmission({
+      title: "Add MCP Server: Demo",
+      body: buildValidBody({
+        ...validMcpFields,
+        contact_email: "https://token@github.com/victim",
+      }),
+    });
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        "Invalid public contact: use a GitHub handle, GitHub profile URL, or email",
+      ]),
+    );
+  });
+
   it("auto-normalizes slug to kebab-case during parsing", () => {
     const result = validateSubmission({
       title: "Add MCP Server: Demo",


### PR DESCRIPTION
## Summary
- Validate URL-form public contacts before the email heuristic so `https://token@github.com/user` is not accepted as an email address.
- Require empty URL userinfo when accepting GitHub profile links in both registry and MCP submission validators.

## Test plan
- [x] `vitest run tests/submission-lib.test.ts tests/mcp-submissions-lib.test.ts`