### PR TITLE
feat(web): add compare entry featured interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
@@ -1,0 +1,16 @@
+import type { BestListPickRef } from "@/lib/compare-best-summary";
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  compareEntryFeaturedUiState,
+  type CompareEntryFeaturedUiState,
+} from "@/lib/compare-entry-featured-ui-lib";
+
+export type CompareEntryFeaturedInteractiveUiState = CompareEntryFeaturedUiState;
+
+export function compareEntryFeaturedInteractiveUiState(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryFeaturedInteractiveUiState {
+  return compareEntryFeaturedUiState(comparisons, lists, catalog);
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -39,7 +39,7 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import { compareEntryFeaturedUiState } from "@/lib/compare-entry-featured-ui-lib";
+import { compareEntryFeaturedInteractiveUiState } from "@/lib/compare-entry-featured-interactive-ui-lib";
 import { compareDossierInteractiveUiState } from "@/lib/compare-dossier-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -241,7 +241,7 @@ function Dossier() {
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
   const featuredUi = useMemo(
-    () => compareEntryFeaturedUiState(comparedIn, featuredIn, ENTRIES),
+    () => compareEntryFeaturedInteractiveUiState(comparedIn, featuredIn, ENTRIES),
     [comparedIn, featuredIn],
   );
   const recents = useRecents();

--- a/tests/compare-entry-featured-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-featured-interactive-ui-lib.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareEntryFeaturedInteractiveUiState } from "@/lib/compare-entry-featured-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare entry featured interactive ui lib", () => {
+  it("hides featured compare links when no comparisons or best lists reference the entry", () => {
+    expect(compareEntryFeaturedInteractiveUiState([], [], catalog)).toEqual({
+      comparisonLinks: [],
+      bestListLinks: [],
+      hasFeaturedLinks: false,
+    });
+  });
+
+  it("bundles featured comparison and best-list links for dossier surfaces", () => {
+    expect(
+      compareEntryFeaturedInteractiveUiState(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      comparisonLinks: [
+        {
+          slug: "pair",
+          search: { ids: "skills/alpha,hooks/beta" },
+          label: "Open interactively",
+        },
+      ],
+      bestListLinks: [
+        {
+          slug: "top-picks",
+          search: { ids: "skills/alpha,hooks/beta" },
+          label: "Open interactively",
+        },
+      ],
+      hasFeaturedLinks: true,
+    });
+  });
+
+  it("formats overflow labels for wide featured best lists", () => {
+    expect(
+      compareEntryFeaturedInteractiveUiState(
+        [],
+        [
+          {
+            slug: "wide-list",
+            picks: [
+              { ref: "skills/alpha" },
+              { ref: "hooks/beta" },
+              { ref: "mcp/gamma" },
+            ],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      comparisonLinks: [],
+      bestListLinks: [
+        {
+          slug: "wide-list",
+          search: { ids: "skills/alpha,hooks/beta,mcp/gamma" },
+          label: "Open 3 picks in the interactive comparison tool",
+        },
+      ],
+      hasFeaturedLinks: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-entry-featured-interactive-ui-lib` with `compareEntryFeaturedInteractiveUiState` for entry dossier featured compare links
- Wire `entry.$category.$slug.tsx` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-featured-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4426 / #4427 / #4429


Made with [Cursor](https://cursor.com)