### PR TITLE
feat(registry): centralize public URL userinfo validation helpers

### DIFF
--- a/apps/submission-gate/src/duplicates.ts
+++ b/apps/submission-gate/src/duplicates.ts
@@ -1,4 +1,5 @@
 import { parseSafeFrontmatter } from "../../../packages/registry/src/frontmatter.js";
+import { publicUrlHostname } from "../../../packages/registry/src/source-url-lib.js";
 
 export type ContentDuplicateSignals = {
   filePath: string;
@@ -232,11 +233,8 @@ function normalizeUrl(value: unknown) {
 }
 
 function domainFromUrl(value: string) {
-  try {
-    return normalizeHostname(new URL(value).hostname);
-  } catch {
-    return "";
-  }
+  const hostname = publicUrlHostname(value);
+  return hostname ? normalizeHostname(hostname) : "";
 }
 
 function pathParts(filePath: string) {

--- a/apps/web/src/data/tools.ts
+++ b/apps/web/src/data/tools.ts
@@ -1,19 +1,10 @@
 import { ENTRIES } from "@/data/entries";
+import { isPublicGitHubHostUrl } from "@heyclaude/registry/source-url";
 import type { CommercialTool, Disclosure, PricingModel } from "@/types/registry";
 
 function pricingModelFor(entry: (typeof ENTRIES)[number]): PricingModel {
-  if (entry.repoUrl || isGithubUrl(entry.sourceUrl)) return "open-source";
+  if (entry.repoUrl || isPublicGitHubHostUrl(entry.sourceUrl)) return "open-source";
   return "freemium";
-}
-
-function isGithubUrl(value: string | undefined) {
-  if (!value) return false;
-  try {
-    const hostname = new URL(value).hostname.toLowerCase();
-    return hostname === "github.com" || hostname.endsWith(".github.com");
-  } catch {
-    return false;
-  }
 }
 
 function disclosureFor(entry: (typeof ENTRIES)[number]): Disclosure {

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -26,7 +26,9 @@ export function entryEventKey(category: string, slug: string): string {
 /** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
 export function outboundHost(url: string): string {
   try {
-    return new URL(url).hostname.replace(/^www\./, "");
+    const parsed = new URL(url);
+    if (parsed.username || parsed.password) return "unknown";
+    return parsed.hostname.replace(/^www\./, "");
   } catch {
     return "unknown";
   }

--- a/integrations/raycast/src/submission.ts
+++ b/integrations/raycast/src/submission.ts
@@ -44,6 +44,7 @@ export function normalizeDomain(value?: string) {
     const url = new URL(
       trimmed.includes("://") ? trimmed : `https://${trimmed}`,
     );
+    if (url.username || url.password) return "";
     return url.hostname.replace(/^www\./i, "").toLowerCase();
   } catch {
     return trimmed.toLowerCase();

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -341,7 +341,9 @@ function sourceHost(value) {
   const text = String(value || "").trim();
   if (!text) return "";
   try {
-    return new URL(text).hostname.toLowerCase().replace(/^www\./, "");
+    const url = new URL(text);
+    if (url.username || url.password) return "";
+    return url.hostname.toLowerCase().replace(/^www\./, "");
   } catch {
     return "";
   }

--- a/packages/mcp/src/submissions-lib.js
+++ b/packages/mcp/src/submissions-lib.js
@@ -8,6 +8,11 @@
  * The public surface (`submissions.js`) re-exports everything below so
  * existing MCP imports stay unchanged.
  */
+import {
+  isPublicGitHubProfileUrl,
+  isPublicHttpsUrl,
+} from "../../registry/src/source-url-lib.js";
+
 export const SUBMISSION_SITE_URL = "https://heyclau.de/submit";
 
 function normalizeText(value) {
@@ -75,16 +80,7 @@ function isCanonicalDomain(value) {
 }
 
 function isHttpsUrl(value) {
-  const trimmed = normalizeText(value);
-  if (!trimmed) return true;
-  try {
-    const url = new URL(trimmed);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
+  return isPublicHttpsUrl(normalizeText(value));
 }
 
 const TRACKING_QUERY_KEYS = new Set([
@@ -123,18 +119,7 @@ function isPublicContact(value) {
   const contact = normalizeText(value);
   if (!contact) return true;
   if (/^https?:\/\//i.test(contact)) {
-    try {
-      const url = new URL(contact);
-      return (
-        url.protocol === "https:" &&
-        url.username === "" &&
-        url.password === "" &&
-        url.hostname === "github.com" &&
-        url.pathname.split("/").filter(Boolean).length === 1
-      );
-    } catch {
-      return false;
-    }
+    return isPublicGitHubProfileUrl(contact);
   }
   if (isEmailLike(contact)) return true;
   if (isGitHubHandle(contact)) return true;

--- a/packages/registry/src/brand-assets-lib.js
+++ b/packages/registry/src/brand-assets-lib.js
@@ -10,6 +10,8 @@
  * `@heyclaude/registry/brand-assets`) re-exports everything below so existing
  * imports stay unchanged.
  */
+import { isPublicHttpsUrl } from "./source-url-lib.js";
+
 export const BRAND_ASSET_SOURCES = [
   "brandfetch",
   "manual",
@@ -285,7 +287,7 @@ export function isAllowedBrandAssetUrl(value) {
 
   try {
     const parsed = new URL(raw);
-    if (parsed.protocol !== "https:") return false;
+    if (!isPublicHttpsUrl(raw)) return false;
     const host = parsed.hostname.toLowerCase();
     return (
       host === "cdn.brandfetch.io" ||

--- a/packages/registry/src/commercial-lib.js
+++ b/packages/registry/src/commercial-lib.js
@@ -10,6 +10,8 @@
  * The public package surface (`commercial.js` / `@heyclaude/registry/commercial`)
  * re-exports everything below so existing imports stay unchanged.
  */
+import { isPublicHttpsUrl } from "./source-url-lib.js";
+
 export const LISTING_LEAD_KINDS = ["job", "tool", "claim"];
 export const COMMERCIAL_TIERS = ["free", "standard", "featured", "sponsored"];
 export const PAID_JOB_TIERS = ["standard", "featured", "sponsored"];
@@ -95,14 +97,7 @@ export function normalizePricingModel(value) {
 function isPublicLeadHttpsUrl(value) {
   const text = String(value || "").trim();
   if (!text) return false;
-  try {
-    const url = new URL(text);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
+  return isPublicHttpsUrl(text);
 }
 
 export function validateListingLeadPayload(payload = {}) {

--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -9,6 +9,7 @@
  * re-exports everything below so existing imports stay unchanged.
  */
 import categorySpec from "./category-spec.json" with { type: "json" };
+import { isPublicHttpUrl, isPublicHttpsUrl } from "./source-url-lib.js";
 import {
   BRAND_ASSET_SOURCES,
   isAllowedBrandAssetUrl,
@@ -150,34 +151,6 @@ function keywordKey(value) {
     .replace(/[^a-z0-9+#.]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .replace(/-{2,}/g, "-");
-}
-
-function isHttpsUrl(value) {
-  const normalized = String(value || "").trim();
-  if (!normalized) return true;
-  try {
-    const url = new URL(normalized);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
-}
-
-function isHttpUrl(value) {
-  const normalized = String(value || "").trim();
-  if (!normalized) return true;
-  try {
-    const url = new URL(normalized);
-    return (
-      (url.protocol === "https:" || url.protocol === "http:") &&
-      url.username === "" &&
-      url.password === ""
-    );
-  } catch {
-    return false;
-  }
 }
 
 function isIsoDateOrDateTime(value) {
@@ -833,14 +806,14 @@ export function validateEntry(category, data, inferred = {}) {
     "repositoryUrl",
     "websiteUrl",
   ]) {
-    if (!isHttpUrl(merged[field])) {
+    if (!isPublicHttpUrl(merged[field])) {
       semanticErrors.push(`${field} must use http or https`);
     }
   }
 
   if (Array.isArray(merged.sourceUrls)) {
     for (const sourceUrl of merged.sourceUrls) {
-      if (!isHttpUrl(sourceUrl)) {
+      if (!isPublicHttpUrl(sourceUrl)) {
         semanticErrors.push("sourceUrls must use http or https");
         break;
       }
@@ -849,7 +822,7 @@ export function validateEntry(category, data, inferred = {}) {
 
   if (Array.isArray(merged.retrievalSources)) {
     for (const retrievalSource of merged.retrievalSources) {
-      if (!isHttpsUrl(retrievalSource)) {
+      if (!isPublicHttpsUrl(retrievalSource)) {
         semanticErrors.push("retrievalSources must use https URLs");
         break;
       }
@@ -862,7 +835,7 @@ export function validateEntry(category, data, inferred = {}) {
     "importPrUrl",
     "claimedByUrl",
   ]) {
-    if (!isHttpsUrl(merged[field])) {
+    if (!isPublicHttpsUrl(merged[field])) {
       semanticErrors.push(`${field} must use https`);
     }
   }
@@ -936,10 +909,10 @@ export function validateEntry(category, data, inferred = {}) {
       .trim()
       .toLowerCase();
 
-    if (websiteUrl && !isHttpsUrl(websiteUrl)) {
+    if (websiteUrl && !isPublicHttpsUrl(websiteUrl)) {
       semanticErrors.push("websiteUrl must use https");
     }
-    if (affiliateUrl && !isHttpsUrl(affiliateUrl)) {
+    if (affiliateUrl && !isPublicHttpsUrl(affiliateUrl)) {
       semanticErrors.push("affiliateUrl must use https");
     }
     if (

--- a/packages/registry/src/source-url-lib.js
+++ b/packages/registry/src/source-url-lib.js
@@ -23,26 +23,6 @@ const AFFILIATE_PARAMS = new Set([
   "via",
 ]);
 
-/**
- * Return true when a URL uses HTTPS without embedded userinfo credentials.
- * Empty values are treated as valid so optional submission fields stay optional.
- *
- * @param {unknown} value
- * @returns {boolean}
- */
-export function isPublicHttpsUrl(value) {
-  const text = String(value ?? "").trim();
-  if (!text) return true;
-  try {
-    const url = new URL(text);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
-}
-
 const ANALYTICS_PARAMS = new Set([
   "_hsenc",
   "_hsmi",
@@ -60,6 +40,121 @@ const ANALYTICS_PARAMS = new Set([
   "twclid",
   "yclid",
 ]);
+
+function parseUrl(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  try {
+    return new URL(text);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Return true when a URL embeds credentials in the userinfo component.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function hasEmbeddedUrlUserinfo(value) {
+  const url = parseUrl(value);
+  if (!url) return false;
+  return Boolean(url.username || url.password);
+}
+
+/**
+ * Return true when a URL uses HTTPS without embedded userinfo credentials.
+ * Empty values are treated as valid so optional submission fields stay optional.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isPublicHttpsUrl(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return true;
+  const url = parseUrl(value);
+  if (!url) return false;
+  return (
+    url.protocol === "https:" && url.username === "" && url.password === ""
+  );
+}
+
+/**
+ * Return true when a URL uses HTTP or HTTPS without embedded userinfo.
+ * Empty values are treated as valid so optional fields stay optional.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isPublicHttpUrl(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return true;
+  const url = parseUrl(value);
+  if (!url) return false;
+  return (
+    (url.protocol === "https:" || url.protocol === "http:") &&
+    url.username === "" &&
+    url.password === ""
+  );
+}
+
+/**
+ * Return the normalized hostname for a URL, or "" when invalid or credential-bearing.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function publicUrlHostname(value) {
+  const url = parseUrl(value);
+  if (!url || url.username || url.password) return "";
+  return url.hostname.replace(/^www\./i, "").toLowerCase();
+}
+
+/**
+ * Return the canonical href for a public HTTP(S) URL, or "" when invalid.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function publicHttpUrlHref(value) {
+  const text = String(value ?? "").trim();
+  if (!text) return "";
+  const url = parseUrl(value);
+  if (!url || url.username || url.password) return "";
+  if (url.protocol !== "https:" && url.protocol !== "http:") return "";
+  return url.href;
+}
+
+/**
+ * Return true for a single-segment GitHub profile URL without embedded userinfo.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isPublicGitHubProfileUrl(value) {
+  const url = parseUrl(value);
+  if (!url) return false;
+  return (
+    url.protocol === "https:" &&
+    url.username === "" &&
+    url.password === "" &&
+    url.hostname === "github.com" &&
+    url.pathname.split("/").filter(Boolean).length === 1
+  );
+}
+
+/**
+ * Return true when a URL resolves to github.com or a *.github.com host.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isPublicGitHubHostUrl(value) {
+  const hostname = publicUrlHostname(value);
+  if (!hostname) return false;
+  return hostname === "github.com" || hostname.endsWith(".github.com");
+}
 
 function normalizeParamName(name) {
   return String(name ?? "")

--- a/packages/registry/src/source-url.js
+++ b/packages/registry/src/source-url.js
@@ -7,8 +7,14 @@
 export {
   canonicalizeSourceUrl,
   hasAffiliateParam,
+  hasEmbeddedUrlUserinfo,
   isAffiliateParam,
+  isPublicGitHubHostUrl,
+  isPublicGitHubProfileUrl,
+  isPublicHttpUrl,
   isPublicHttpsUrl,
   isTrackingParam,
+  publicHttpUrlHref,
+  publicUrlHostname,
   stripTrackingParams,
 } from "./source-url-lib.js";

--- a/packages/registry/src/submission-lib.js
+++ b/packages/registry/src/submission-lib.js
@@ -10,7 +10,12 @@
  */
 import categorySpec from "./category-spec.json" with { type: "json" };
 import { normalizeBrandDomain } from "./brand-assets.js";
-import { hasAffiliateParam, isPublicHttpsUrl } from "./source-url.js";
+import {
+  hasAffiliateParam,
+  isPublicGitHubProfileUrl,
+  isPublicHttpsUrl,
+  publicUrlHostname,
+} from "./source-url.js";
 import {
   looksLikeToolAppListing,
   missingToolListingReviewFields,
@@ -634,21 +639,15 @@ function urlPathname(value) {
 }
 
 function urlHostname(value) {
-  const normalized = normalizeValue(value);
-  if (!normalized) return "";
-  try {
-    return new URL(normalized).hostname.replace(/^www\./, "").toLowerCase();
-  } catch {
-    return "";
-  }
+  return publicUrlHostname(normalizeValue(value));
 }
 
 function isGitHubSourcePath(value) {
   const normalized = normalizeValue(value);
-  if (!normalized) return false;
+  if (!normalized || !isPublicHttpsUrl(normalized)) return false;
   try {
     const url = new URL(normalized);
-    if (url.protocol !== "https:" || url.hostname !== "github.com") {
+    if (url.hostname !== "github.com") {
       return false;
     }
     const [, , pathType] = url.pathname.split("/").filter(Boolean);
@@ -700,18 +699,7 @@ function isValidPublicContact(value) {
   const normalized = normalizeValue(value);
   if (!normalized) return true;
   if (/^https?:\/\//i.test(normalized)) {
-    try {
-      const url = new URL(normalized);
-      return (
-        url.protocol === "https:" &&
-        url.username === "" &&
-        url.password === "" &&
-        url.hostname === "github.com" &&
-        url.pathname.split("/").filter(Boolean).length === 1
-      );
-    } catch {
-      return false;
-    }
+    return isPublicGitHubProfileUrl(normalized);
   }
   if (normalized.includes("@")) {
     const parts = normalized.split("@");

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,6 +5,7 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
+import { isPublicHttpsUrl, publicUrlHostname } from "./source-url-lib.js";
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
@@ -280,27 +281,8 @@ function draftUrl(draft = {}) {
   return normalizeText(draft.html_url || draft.url);
 }
 
-function isHttpsUrl(value) {
-  const text = normalizeText(value);
-  if (!text) return false;
-  try {
-    const url = new URL(text);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
-}
-
 function hostname(value) {
-  try {
-    const url = new URL(normalizeText(value));
-    if (url.username || url.password) return "";
-    return url.hostname.replace(/^www\./, "");
-  } catch {
-    return "";
-  }
+  return publicUrlHostname(normalizeText(value));
 }
 
 function githubRepoFromUrl(value) {
@@ -869,7 +851,7 @@ function addSourceSignals(report, fields, text) {
   }
 
   for (const url of sourceFields) {
-    if (!isHttpsUrl(url)) {
+    if (!isPublicHttpsUrl(url)) {
       addFlag(
         report,
         "medium",

--- a/packages/registry/src/weekly-brief-lib.js
+++ b/packages/registry/src/weekly-brief-lib.js
@@ -10,6 +10,7 @@
  * re-exports everything below so existing imports stay unchanged.
  */
 import { generatedAtForEntries, SITE_URL, truncateText } from "./artifacts.js";
+import { publicHttpUrlHref } from "./source-url-lib.js";
 
 export const WEEKLY_BRIEF_SCHEMA_VERSION = 1;
 
@@ -37,17 +38,7 @@ export function keyFor(entry) {
 }
 
 export function httpUrl(value) {
-  const normalized = text(value);
-  if (!normalized) return "";
-  try {
-    const url = new URL(normalized);
-    if (url.username || url.password) return "";
-    return url.protocol === "https:" || url.protocol === "http:"
-      ? url.href
-      : "";
-  } catch {
-    return "";
-  }
+  return publicHttpUrlHref(value);
 }
 
 export function siteUrlBase(siteUrl) {

--- a/tests/brand-assets-lib.test.ts
+++ b/tests/brand-assets-lib.test.ts
@@ -169,6 +169,11 @@ describe("colors and asset urls", () => {
     ).toBe(true);
     expect(isAllowedBrandAssetUrl("https://heyclau.de/logo.png")).toBe(true);
     expect(isAllowedBrandAssetUrl("https://evil.example/icon.png")).toBe(false);
+    expect(
+      isAllowedBrandAssetUrl(
+        "https://token@cdn.brandfetch.io/domain/x/icon.png",
+      ),
+    ).toBe(false);
     expect(isAllowedBrandAssetUrl("not a url")).toBe(false);
   });
 });

--- a/tests/raycast-submission-validation.test.ts
+++ b/tests/raycast-submission-validation.test.ts
@@ -18,6 +18,11 @@ describe("normalizeDomain", () => {
     expect(normalizeDomain("Example.COM")).toBe("example.com");
   });
 
+  it("rejects URL-form brand domains with embedded userinfo", () => {
+    expect(normalizeDomain("https://token@asana.com")).toBe("");
+    expect(isValidDomain("https://token@asana.com")).toBe(false);
+  });
+
   it("returns an empty string for empty or missing input", () => {
     // The parameter is declared `value?: string`, so a missing/blank value is
     // a supported call shape that normalizes to "".

--- a/tests/source-url-lib.test.ts
+++ b/tests/source-url-lib.test.ts
@@ -3,9 +3,15 @@ import { describe, expect, it } from "vitest";
 import {
   canonicalizeSourceUrl,
   hasAffiliateParam,
+  hasEmbeddedUrlUserinfo,
   isAffiliateParam,
+  isPublicGitHubHostUrl,
+  isPublicGitHubProfileUrl,
+  isPublicHttpUrl,
   isPublicHttpsUrl,
   isTrackingParam,
+  publicHttpUrlHref,
+  publicUrlHostname,
   stripTrackingParams,
 } from "../packages/registry/src/source-url-lib.js";
 
@@ -59,6 +65,54 @@ describe("isPublicHttpsUrl", () => {
     expect(
       isPublicHttpsUrl("https://user%40name:pass@github.com/owner/repo"),
     ).toBe(false);
+  });
+});
+
+describe("public URL userinfo helpers", () => {
+  it("detects embedded userinfo across common credential shapes", () => {
+    expect(hasEmbeddedUrlUserinfo("https://token@github.com/owner/repo")).toBe(
+      true,
+    );
+    expect(hasEmbeddedUrlUserinfo("https://user:pass@example.com/docs")).toBe(
+      true,
+    );
+    expect(hasEmbeddedUrlUserinfo("https://github.com/owner/repo")).toBe(false);
+    expect(hasEmbeddedUrlUserinfo("not a url")).toBe(false);
+  });
+
+  it("validates public http and https URLs without userinfo", () => {
+    expect(isPublicHttpUrl("http://example.com/docs")).toBe(true);
+    expect(isPublicHttpUrl("https://example.com/docs")).toBe(true);
+    expect(isPublicHttpUrl("https://token@example.com/docs")).toBe(false);
+    expect(isPublicHttpUrl("ftp://example.com/docs")).toBe(false);
+    expect(isPublicHttpUrl("")).toBe(true);
+  });
+
+  it("extracts hostnames and hrefs only from credential-free URLs", () => {
+    expect(publicUrlHostname("https://www.Example.com/path")).toBe(
+      "example.com",
+    );
+    expect(publicUrlHostname("https://token@example.com/path")).toBe("");
+    expect(publicHttpUrlHref("https://example.com/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(publicHttpUrlHref("https://token@example.com/path")).toBe("");
+    expect(publicHttpUrlHref("ftp://example.com/path")).toBe("");
+  });
+
+  it("validates GitHub profile and host URLs without userinfo", () => {
+    expect(isPublicGitHubProfileUrl("https://github.com/octocat")).toBe(true);
+    expect(isPublicGitHubProfileUrl("https://token@github.com/octocat")).toBe(
+      false,
+    );
+    expect(isPublicGitHubProfileUrl("https://github.com/octocat/repo")).toBe(
+      false,
+    );
+    expect(isPublicGitHubHostUrl("https://github.com/octocat/repo")).toBe(true);
+    expect(isPublicGitHubHostUrl("https://token@github.com/octocat/repo")).toBe(
+      false,
+    );
+    expect(isPublicGitHubHostUrl("https://gist.github.com/octocat")).toBe(true);
   });
 });
 

--- a/tests/web-non-ui-utilities.test.ts
+++ b/tests/web-non-ui-utilities.test.ts
@@ -804,6 +804,9 @@ describe("web non-UI utility coverage", () => {
     expect(outboundHost("https://www.example.com/path?q=secret")).toBe(
       "example.com",
     );
+    expect(outboundHost("https://token@example.com/path?q=secret")).toBe(
+      "unknown",
+    );
     expect(outboundHost("not a url")).toBe("unknown");
     vi.stubGlobal("window", {
       location: {


### PR DESCRIPTION
## Summary
Consolidates credential-bearing URL hardening into shared `@heyclaude/registry/source-url` helpers and wires them across the registry, MCP, web, Raycast, and submission-gate surfaces.

### New helpers (`source-url-lib.js`)
- `hasEmbeddedUrlUserinfo`
- `isPublicHttpUrl` / `isPublicHttpsUrl` (refactored)
- `publicUrlHostname`, `publicHttpUrlHref`
- `isPublicGitHubProfileUrl`, `isPublicGitHubHostUrl`

### Consumers updated
- Content schema, brand assets, commercial leads, submission + risk validators
- Weekly brief link emission, MCP registry source hosts, MCP submission contacts
- Web tools pricing + analytics outbound host grouping
- Raycast brand-domain normalization, submission-gate duplicate domain extraction

Supersedes the narrower brand-asset-only fix in #4427.

## Test plan
- [x] `vitest run tests/source-url-lib.test.ts tests/brand-assets-lib.test.ts tests/content-schema-lib.test.ts`
- [x] `vitest run tests/submission-lib.test.ts tests/mcp-submissions-lib.test.ts tests/weekly-brief-lib.test.ts`
- [x] `vitest run tests/raycast-submission-validation.test.ts`