### PR TITLE
feat(web): add compare page actions interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-page-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-actions-interactive-ui-lib.ts
@@ -1,0 +1,25 @@
+import type { Entry } from "@/types/registry";
+import {
+  comparePageActionCells,
+  comparePageActionsDiverge,
+  type ComparePageActionCell,
+} from "@/lib/compare-page-actions-ui-lib";
+
+export type ComparePageActionsInteractiveUiState = {
+  actionRowDiverges: boolean;
+  actionCells: ComparePageActionCell[];
+};
+
+export function comparePageActionsInteractiveUiState(
+  entries: Entry[],
+): ComparePageActionsInteractiveUiState {
+  return {
+    actionRowDiverges: comparePageActionsDiverge(entries),
+    actionCells: comparePageActionCells(entries),
+  };
+}
+
+export function comparePageActionsForEntry(entry: Entry, actionCells: ComparePageActionCell[]) {
+  const entryKey = `${entry.category}:${entry.slug}`;
+  return actionCells.find((cell) => cell.entryKey === entryKey)?.actions ?? [];
+}

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -12,11 +12,11 @@ import { COMPARISON_ROWS as ROWS } from "@/components/comparison-table";
 import { useCompare } from "@/lib/compare";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
+import { COMPARE_PAGE_SURFACE, type CompareAction } from "@/lib/compare-page-actions-ui-lib";
 import {
-  COMPARE_PAGE_SURFACE,
-  comparePageEntryActions,
-  type CompareAction,
-} from "@/lib/compare-page-actions-ui-lib";
+  comparePageActionsForEntry,
+  comparePageActionsInteractiveUiState,
+} from "@/lib/compare-page-actions-interactive-ui-lib";
 import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
@@ -72,6 +72,7 @@ function ComparePage() {
     () => comparePageInteractiveUiState(items, sp.ids, COMPARISONS, ENTRIES),
     [items, sp.ids],
   );
+  const pageActionsUi = React.useMemo(() => comparePageActionsInteractiveUiState(items), [items]);
   const pageUi = interactiveUi.pageUi;
   const emptyUi = interactiveUi.emptyUi;
 
@@ -251,18 +252,18 @@ function ComparePage() {
             <tr
               className={cn(
                 "transition-colors duration-200 ease-out",
-                pageUi.actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+                pageActionsUi.actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
               )}
             >
               <th
                 scope="row"
                 className={cn(
                   "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
-                  pageUi.actionRowDiverges && "text-amber-800",
+                  pageActionsUi.actionRowDiverges && "text-amber-800",
                 )}
               >
                 Next steps
-                {pageUi.actionRowDiverges ? (
+                {pageActionsUi.actionRowDiverges ? (
                   <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
                     Differs
                   </span>
@@ -273,10 +274,10 @@ function ComparePage() {
                   key={`actions-${e.category}/${e.slug}`}
                   className={cn(
                     "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
-                    pageUi.actionRowDiverges && "bg-amber-500/5",
+                    pageActionsUi.actionRowDiverges && "bg-amber-500/5",
                   )}
                 >
-                  <CompareNextActions entry={e} />
+                  <CompareNextActions entry={e} actionCells={pageActionsUi.actionCells} />
                 </td>
               ))}
               {items.length < 4 && (
@@ -347,8 +348,14 @@ function ComparePage() {
   );
 }
 
-function CompareNextActions({ entry }: { entry: Entry }) {
-  const actions = comparePageEntryActions(entry);
+function CompareNextActions({
+  entry,
+  actionCells,
+}: {
+  entry: Entry;
+  actionCells: ReturnType<typeof comparePageActionsInteractiveUiState>["actionCells"];
+}) {
+  const actions = comparePageActionsForEntry(entry, actionCells);
 
   return (
     <div className="flex flex-wrap gap-1.5">

--- a/tests/compare-page-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-page-actions-interactive-ui-lib.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  comparePageActionsForEntry,
+  comparePageActionsInteractiveUiState,
+} from "@/lib/compare-page-actions-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page actions interactive ui lib", () => {
+  it("bundles per-column action cells for a single compared entry", () => {
+    const state = comparePageActionsInteractiveUiState([entry()]);
+    expect(state.actionRowDiverges).toBe(false);
+    expect(state.actionCells).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+    expect(
+      comparePageActionsForEntry(entry(), state.actionCells).map((a) => a.id),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("keeps action rows unhighlighted when columns share the same next-action sets", () => {
+    expect(
+      comparePageActionsInteractiveUiState([
+        entry({ slug: "alpha", installCommand: "npm i fixture" }),
+        entry({ slug: "beta", installCommand: "pnpm add fixture" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+      actionCells: [
+        expect.objectContaining({ entryKey: "mcp:alpha" }),
+        expect.objectContaining({ entryKey: "mcp:beta" }),
+      ],
+    });
+  });
+
+  it("returns an empty action list when no bundled cell matches the entry", () => {
+    expect(comparePageActionsForEntry(entry({ slug: "missing" }), [])).toEqual(
+      [],
+    );
+  });
+
+  it("highlights diverging next-action rows for mixed compare columns", () => {
+    const state = comparePageActionsInteractiveUiState([
+      entry({ installCommand: "npm i fixture" }),
+      entry(),
+    ]);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
+    expect(comparePageActionsForEntry(entry(), state.actionCells)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "dossier" })]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-actions-interactive-ui-lib` with `comparePageActionsInteractiveUiState` for compare page next-action row state
- Wire `compare.index.tsx` through the new lib for action divergence highlighting and per-column actions
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-actions-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4426


Made with [Cursor](https://cursor.com)