### PR TITLE
feat(web): add compare table actions interactive UI lib

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -17,11 +17,11 @@ import {
   displayCompareSignal,
   signalToneClassForDisplay,
 } from "@/lib/compare-table-signals-ui-lib";
+import { COMPARE_TABLE_SURFACE, type CompareAction } from "@/lib/compare-table-actions-ui-lib";
 import {
-  COMPARE_TABLE_SURFACE,
-  compareTableEntryActions,
-  type CompareAction,
-} from "@/lib/compare-table-actions-ui-lib";
+  compareTableActionsForEntry,
+  compareTableActionsInteractiveUiState,
+} from "@/lib/compare-table-actions-interactive-ui-lib";
 import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
@@ -53,8 +53,14 @@ function CompareSignalCell({
   );
 }
 
-function TableCompareActions({ entry }: { entry: Entry }) {
-  const actions = compareTableEntryActions(entry);
+function TableCompareActions({
+  entry,
+  actionCells,
+}: {
+  entry: Entry;
+  actionCells: ReturnType<typeof compareTableActionsInteractiveUiState>["actionCells"];
+}) {
+  const actions = compareTableActionsForEntry(entry, actionCells);
 
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -292,8 +298,9 @@ export function ComparisonTable({
   entries: Entry[];
   showNextActions?: boolean;
 }) {
-  const { divergingDecisionLabels, renderNextActions, actionRowDiverges } =
-    compareTableInteractiveUiState(entries, showNextActions);
+  const { divergingDecisionLabels } = compareTableInteractiveUiState(entries, showNextActions);
+  const tableActionsUi = compareTableActionsInteractiveUiState(entries, showNextActions);
+  const { renderNextActions, actionRowDiverges } = tableActionsUi;
 
   return (
     <div className="overflow-auto rounded-xl border border-border">
@@ -364,7 +371,7 @@ export function ComparisonTable({
                     actionRowDiverges && "bg-amber-500/5",
                   )}
                 >
-                  <TableCompareActions entry={e} />
+                  <TableCompareActions entry={e} actionCells={tableActionsUi.actionCells} />
                 </td>
               ))}
             </tr>

--- a/apps/web/src/lib/compare-table-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-actions-interactive-ui-lib.ts
@@ -1,0 +1,30 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareTableActionCells,
+  compareTableActionsDiverge,
+  shouldRenderCompareTableActions,
+  type CompareTableActionCell,
+} from "@/lib/compare-table-actions-ui-lib";
+
+export type CompareTableActionsInteractiveUiState = {
+  renderNextActions: boolean;
+  actionRowDiverges: boolean;
+  actionCells: CompareTableActionCell[];
+};
+
+export function compareTableActionsInteractiveUiState(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTableActionsInteractiveUiState {
+  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
+  return {
+    renderNextActions,
+    actionRowDiverges: renderNextActions && compareTableActionsDiverge(entries),
+    actionCells: compareTableActionCells(entries),
+  };
+}
+
+export function compareTableActionsForEntry(entry: Entry, actionCells: CompareTableActionCell[]) {
+  const entryKey = `${entry.category}:${entry.slug}`;
+  return actionCells.find((cell) => cell.entryKey === entryKey)?.actions ?? [];
+}

--- a/tests/compare-table-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-table-actions-interactive-ui-lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareTableActionsForEntry,
+  compareTableActionsInteractiveUiState,
+} from "@/lib/compare-table-actions-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table actions interactive ui lib", () => {
+  it("hides next-action rows for single-entry tables", () => {
+    const state = compareTableActionsInteractiveUiState([entry()], true);
+    expect(state).toEqual({
+      renderNextActions: false,
+      actionRowDiverges: false,
+      actionCells: [expect.objectContaining({ entryKey: "mcp:fixture" })],
+    });
+    expect(
+      compareTableActionsForEntry(entry(), state.actionCells).map((a) => a.id),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("respects the showNextActions toggle for multi-entry tables", () => {
+    const entries = [entry(), entry({ slug: "other" })];
+    expect(compareTableActionsInteractiveUiState(entries, false)).toEqual({
+      renderNextActions: false,
+      actionRowDiverges: false,
+      actionCells: expect.any(Array),
+    });
+    expect(compareTableActionsInteractiveUiState(entries, true)).toEqual({
+      renderNextActions: true,
+      actionRowDiverges: false,
+      actionCells: [
+        expect.objectContaining({ entryKey: "mcp:fixture" }),
+        expect.objectContaining({ entryKey: "mcp:other" }),
+      ],
+    });
+  });
+
+  it("returns an empty action list when no bundled cell matches the entry", () => {
+    expect(compareTableActionsForEntry(entry({ slug: "missing" }), [])).toEqual(
+      [],
+    );
+  });
+
+  it("highlights diverging next-action rows when enabled for mixed columns", () => {
+    const state = compareTableActionsInteractiveUiState(
+      [entry({ installCommand: "npm i fixture" }), entry({ slug: "other" })],
+      true,
+    );
+    expect(state.renderNextActions).toBe(true);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-actions-interactive-ui-lib` with `compareTableActionsInteractiveUiState` for comparison table next-action row state
- Wire `comparison-table.tsx` through the new lib for action divergence highlighting and per-column actions
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-actions-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4400 / #4426 / #4433


Made with [Cursor](https://cursor.com)