### PR TITLE
feat(web): add compare drawer actions interactive UI lib

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -18,11 +18,11 @@ import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
+import { COMPARE_DRAWER_SURFACE, type CompareAction } from "@/lib/compare-drawer-actions-ui-lib";
 import {
-  COMPARE_DRAWER_SURFACE,
-  compareDrawerEntryActions,
-  type CompareAction,
-} from "@/lib/compare-drawer-actions-ui-lib";
+  compareDrawerActionsForEntry,
+  compareDrawerActionsInteractiveUiState,
+} from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
@@ -176,8 +176,14 @@ function CompareSignalCell({ value }: { value: CompareSignalValue }) {
   );
 }
 
-function DrawerCompareActions({ entry }: { entry: Entry }) {
-  const actions = compareDrawerEntryActions(entry);
+function DrawerCompareActions({
+  entry,
+  actionCells,
+}: {
+  entry: Entry;
+  actionCells: ReturnType<typeof compareDrawerActionsInteractiveUiState>["actionCells"];
+}) {
+  const actions = compareDrawerActionsForEntry(entry, actionCells);
 
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -316,8 +322,10 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
+  const drawerActionsUi = compareDrawerActionsInteractiveUiState(items);
   const { drawerUi, emptyHint, shareUrl } = compareDrawerInteractiveUiState(items);
-  const { actionRowDiverges, bannerTexts, fullViewSearch } = drawerUi;
+  const { actionRowDiverges } = drawerActionsUi;
+  const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -492,7 +500,7 @@ export function CompareDrawer() {
                           actionRowDiverges && "bg-amber-500/5",
                         )}
                       >
-                        <DrawerCompareActions entry={e} />
+                        <DrawerCompareActions entry={e} actionCells={drawerActionsUi.actionCells} />
                       </td>
                     ))}
                   </tr>

--- a/apps/web/src/lib/compare-drawer-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-actions-interactive-ui-lib.ts
@@ -1,0 +1,25 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerActionCells,
+  compareDrawerActionsDiverge,
+  type CompareDrawerActionCell,
+} from "@/lib/compare-drawer-actions-ui-lib";
+
+export type CompareDrawerActionsInteractiveUiState = {
+  actionRowDiverges: boolean;
+  actionCells: CompareDrawerActionCell[];
+};
+
+export function compareDrawerActionsInteractiveUiState(
+  entries: Entry[],
+): CompareDrawerActionsInteractiveUiState {
+  return {
+    actionRowDiverges: compareDrawerActionsDiverge(entries),
+    actionCells: compareDrawerActionCells(entries),
+  };
+}
+
+export function compareDrawerActionsForEntry(entry: Entry, actionCells: CompareDrawerActionCell[]) {
+  const entryKey = `${entry.category}:${entry.slug}`;
+  return actionCells.find((cell) => cell.entryKey === entryKey)?.actions ?? [];
+}

--- a/tests/compare-drawer-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-actions-interactive-ui-lib.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerActionsForEntry,
+  compareDrawerActionsInteractiveUiState,
+} from "@/lib/compare-drawer-actions-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer actions interactive ui lib", () => {
+  it("bundles per-column action cells for a single compared entry", () => {
+    const state = compareDrawerActionsInteractiveUiState([entry()]);
+    expect(state.actionRowDiverges).toBe(false);
+    expect(state.actionCells).toEqual([
+      {
+        entryKey: "mcp:fixture",
+        actions: expect.arrayContaining([
+          expect.objectContaining({ id: "dossier" }),
+          expect.objectContaining({ id: "claim" }),
+        ]),
+      },
+    ]);
+    expect(
+      compareDrawerActionsForEntry(entry(), state.actionCells).map((a) => a.id),
+    ).toEqual(["dossier", "claim"]);
+  });
+
+  it("keeps action rows unhighlighted when columns share the same next-action sets", () => {
+    expect(
+      compareDrawerActionsInteractiveUiState([
+        entry({ slug: "alpha", installCommand: "npm i fixture" }),
+        entry({ slug: "beta", installCommand: "pnpm add fixture" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+      actionCells: [
+        expect.objectContaining({ entryKey: "mcp:alpha" }),
+        expect.objectContaining({ entryKey: "mcp:beta" }),
+      ],
+    });
+  });
+
+  it("returns an empty action list when no bundled cell matches the entry", () => {
+    expect(
+      compareDrawerActionsForEntry(entry({ slug: "missing" }), []),
+    ).toEqual([]);
+  });
+
+  it("highlights diverging next-action rows for mixed compare columns", () => {
+    const state = compareDrawerActionsInteractiveUiState([
+      entry({ installCommand: "npm i fixture" }),
+      entry(),
+    ]);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
+    expect(compareDrawerActionsForEntry(entry(), state.actionCells)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "dossier" })]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-actions-interactive-ui-lib` with `compareDrawerActionsInteractiveUiState` for compare drawer next-action row state
- Wire `compare-drawer.tsx` through the new lib for action divergence highlighting and per-column actions
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-actions-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426 / #4435


Made with [Cursor](https://cursor.com)