### PR TITLE
feat(mcp): extract registry normalization into registry-normalize-lib

### DIFF
--- a/packages/mcp/src/registry-normalize-lib.js
+++ b/packages/mcp/src/registry-normalize-lib.js
@@ -1,0 +1,55 @@
+/**
+ * Pure MCP registry normalization helpers.
+ *
+ * Platform alias resolution and bounded pagination/filter normalization live
+ * here. Runtime registry handlers stay in `registry.js`.
+ */
+
+// Maps a slugified platform filter input to a canonical platform ID, matching
+// the canonical IDs in generated artifacts (see packages/registry platforms.js).
+const platformAliases = new Map([
+  ["claude", "claude-code"],
+  ["claude-code", "claude-code"],
+  ["claude-desktop", "claude-desktop"],
+  ["codex", "codex"],
+  ["openai", "codex"],
+  ["windsurf", "windsurf"],
+  ["gemini", "gemini"],
+  ["cursor", "cursor"],
+  ["cursor-rules", "cursor"],
+  ["vscode", "vscode"],
+  ["vs-code", "vscode"],
+  ["raycast", "raycast"],
+  ["aider", "aider"],
+  ["zed", "zed"],
+  ["continue", "continue"],
+  ["cli", "cli"],
+  ["generic-agents", "cli"],
+  ["agents", "cli"],
+  ["agents-context", "cli"],
+  ["agents-md", "cli"],
+]);
+
+export function normalizeText(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase();
+}
+
+export function normalizeLimit(value, fallback = 10) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return fallback;
+  return Math.max(1, Math.min(25, Math.trunc(numeric)));
+}
+
+export function normalizeOffset(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  return Math.max(0, Math.min(5000, Math.trunc(numeric)));
+}
+
+export function normalizePlatform(value) {
+  const normalized = normalizeText(value).replace(/[^a-z0-9]+/g, "-");
+  if (!normalized) return "";
+  return platformAliases.get(normalized) || String(value || "").trim();
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -67,6 +67,12 @@ import {
   getRegistryPrompt,
   listRegistryPrompts,
 } from "./registry-prompts-lib.js";
+import {
+  normalizeLimit,
+  normalizeOffset,
+  normalizePlatform,
+  normalizeText,
+} from "./registry-normalize-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -76,31 +82,6 @@ export {
 };
 
 export { PROMPT_DEFINITIONS, getRegistryPrompt, listRegistryPrompts };
-
-// Maps a slugified platform filter input to a canonical platform ID, matching
-// the canonical IDs in generated artifacts (see packages/registry platforms.js).
-const platformAliases = new Map([
-  ["claude", "claude-code"],
-  ["claude-code", "claude-code"],
-  ["claude-desktop", "claude-desktop"],
-  ["codex", "codex"],
-  ["openai", "codex"],
-  ["windsurf", "windsurf"],
-  ["gemini", "gemini"],
-  ["cursor", "cursor"],
-  ["cursor-rules", "cursor"],
-  ["vscode", "vscode"],
-  ["vs-code", "vscode"],
-  ["raycast", "raycast"],
-  ["aider", "aider"],
-  ["zed", "zed"],
-  ["continue", "continue"],
-  ["cli", "cli"],
-  ["generic-agents", "cli"],
-  ["agents", "cli"],
-  ["agents-context", "cli"],
-  ["agents-md", "cli"],
-]);
 
 function dataDirFromOptions(options = {}) {
   const envDataDir =
@@ -181,30 +162,6 @@ function unwrapEntries(payload) {
     throw new Error("Expected registry artifact envelope with entries array.");
   }
   return payload.entries;
-}
-
-function normalizeText(value) {
-  return String(value || "")
-    .trim()
-    .toLowerCase();
-}
-
-function normalizeLimit(value, fallback = 10) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return fallback;
-  return Math.max(1, Math.min(25, Math.trunc(numeric)));
-}
-
-function normalizeOffset(value) {
-  const numeric = Number(value);
-  if (!Number.isFinite(numeric)) return 0;
-  return Math.max(0, Math.min(5000, Math.trunc(numeric)));
-}
-
-function normalizePlatform(value) {
-  const normalized = normalizeText(value).replace(/[^a-z0-9]+/g, "-");
-  if (!normalized) return "";
-  return platformAliases.get(normalized) || String(value || "").trim();
 }
 
 function entryMatchesQuery(entry, query) {

--- a/tests/mcp-registry-normalize-lib.test.ts
+++ b/tests/mcp-registry-normalize-lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeLimit,
+  normalizeOffset,
+  normalizePlatform,
+  normalizeText,
+} from "../packages/mcp/src/registry-normalize-lib.js";
+
+describe("registry-normalize-lib text and pagination", () => {
+  it("normalizes text to trimmed lowercase", () => {
+    expect(normalizeText("  Skills  ")).toBe("skills");
+    expect(normalizeText("")).toBe("");
+  });
+
+  it("clamps registry list limits and offsets", () => {
+    expect(normalizeLimit(3)).toBe(3);
+    expect(normalizeLimit(100)).toBe(25);
+    expect(normalizeLimit("not-a-number")).toBe(10);
+    expect(normalizeOffset(10)).toBe(10);
+    expect(normalizeOffset(9000)).toBe(5000);
+    expect(normalizeOffset(-5)).toBe(0);
+  });
+});
+
+describe("registry-normalize-lib platform aliases", () => {
+  it("resolves common platform aliases to canonical registry IDs", () => {
+    expect(normalizePlatform("Claude")).toBe("claude-code");
+    expect(normalizePlatform("openai")).toBe("codex");
+    expect(normalizePlatform("VS Code")).toBe("vscode");
+    expect(normalizePlatform("generic-agents")).toBe("cli");
+  });
+
+  it("returns empty string for blank platform filters", () => {
+    expect(normalizePlatform("   ")).toBe("");
+  });
+
+  it("preserves unknown platform labels without alias mapping", () => {
+    expect(normalizePlatform("Antigravity")).toBe("Antigravity");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP platform alias resolution and pagination normalization helpers into `packages/mcp/src/registry-normalize-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so registry search/list behavior stays unchanged.
- Add focused lib tests for text normalization, limit/offset clamping, and platform alias resolution.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-normalize-lib.js` (new extracted normalization helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-normalize-lib.test.ts` (new focused tests)
- Expected behavior:
  - Registry search/list platform filtering and pagination bounds are unchanged.
- Important edge cases or invariants:
  - Platform aliases (`claude` → `claude-code`, `openai` → `codex`, etc.) remain the same.
  - Limits still clamp to 1–25 and offsets to 0–5000.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-normalize-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-normalize-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry normalization helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`server-lib`, `platforms-lib`, `registry-tools-lib`).
  - Does not touch `schemas.js`, endpoint URL helpers, or submission-risk analysis code.


Made with [Cursor](https://cursor.com)