### PR TITLE
feat(web): add compare context interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-context-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-context-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import { compareContextSelectionParam, compareContextShareUrl } from "@/lib/compare-context-ui-lib";
+
+export type CompareContextInteractiveUiState = {
+  selectionParam: string;
+  shareUrl: string;
+};
+
+export function compareContextInteractiveUiState(items: Entry[]): CompareContextInteractiveUiState {
+  return {
+    selectionParam: compareContextSelectionParam(items),
+    shareUrl: compareContextShareUrl(items),
+  };
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { compareContextSelectionParam, compareContextShareUrl } from "@/lib/compare-context-ui-lib";
+import { compareContextInteractiveUiState } from "@/lib/compare-context-interactive-ui-lib";
 import { hasCompareItem, resolveCompareParam, toggleCompareItem } from "@/lib/compare-selection";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import type { Entry } from "@/types/registry";
@@ -73,13 +73,13 @@ function createCompareStore(): CompareStore {
       // URL, keeping the registry dataset out of the universal client bundle.
       void import("@/data/entries").then(({ ENTRIES }) => {
         const next = resolveCompareParam(ENTRIES, param);
-        const sig = compareContextSelectionParam(next);
-        const curSig = compareContextSelectionParam(state.items);
+        const sig = compareContextInteractiveUiState(next).selectionParam;
+        const curSig = compareContextInteractiveUiState(state.items).selectionParam;
         if (sig !== curSig) setState({ ...state, items: next });
       });
     },
-    serialize: () => compareContextSelectionParam(state.items),
-    getShareUrl: () => compareContextShareUrl(state.items),
+    serialize: () => compareContextInteractiveUiState(state.items).selectionParam,
+    getShareUrl: () => compareContextInteractiveUiState(state.items).shareUrl,
   };
 
   return {

--- a/tests/compare-context-interactive-ui-lib.test.ts
+++ b/tests/compare-context-interactive-ui-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareContextInteractiveUiState } from "@/lib/compare-context-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare context interactive ui lib", () => {
+  it("bundles empty compare context share and selection state", () => {
+    expect(compareContextInteractiveUiState([])).toEqual({
+      selectionParam: "",
+      shareUrl: "/browse",
+    });
+  });
+
+  it("bundles compare context selection params for URL hydration", () => {
+    expect(
+      compareContextInteractiveUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      selectionParam: "skills/alpha,hooks/beta",
+      shareUrl: "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
+    });
+  });
+
+  it("preserves single-entry compare context state", () => {
+    expect(compareContextInteractiveUiState([entry()])).toEqual({
+      selectionParam: "mcp/fixture",
+      shareUrl: "/browse?compare=mcp%2Ffixture",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-context-interactive-ui-lib` with `compareContextInteractiveUiState` for compare provider selection and share URL state
- Wire `compare.tsx` through the new lib for serialize/hydrate/share actions
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-context-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426 / #4437 / #4438


Made with [Cursor](https://cursor.com)