### PR TITLE
feat(web): add compare page featured interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-page-empty-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-ui-lib.ts
@@ -2,10 +2,8 @@ import {
   comparePageEmptyStateDescription,
   comparePageInvalidUrlHint,
 } from "@/lib/compare-page-ui-lib";
-import {
-  comparePagePopularComparisonLinks,
-  type ComparePagePopularComparisonLink,
-} from "@/lib/compare-page-featured-ui-lib";
+import type { ComparePagePopularComparisonLink } from "@/lib/compare-page-featured-ui-lib";
+import { comparePageFeaturedInteractiveUiState } from "@/lib/compare-page-featured-interactive-ui-lib";
 import type { EntryIdentity } from "@/lib/entry-identity";
 
 export type ComparePageEmptyUiState = {
@@ -22,6 +20,6 @@ export function comparePageEmptyUiState(
   return {
     description: comparePageEmptyStateDescription(),
     invalidUrlHint: comparePageInvalidUrlHint(ids, 0),
-    popularComparisonLinks: comparePagePopularComparisonLinks(comparisons, catalog),
+    popularComparisonLinks: comparePageFeaturedInteractiveUiState(comparisons, catalog),
   };
 }

--- a/apps/web/src/lib/compare-page-featured-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-featured-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  comparePagePopularComparisonLinks,
+  type ComparePagePopularComparisonLink,
+} from "@/lib/compare-page-featured-ui-lib";
+
+export type ComparePageFeaturedInteractiveUiState = ComparePagePopularComparisonLink[];
+
+export function comparePageFeaturedInteractiveUiState(
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePageFeaturedInteractiveUiState {
+  return comparePagePopularComparisonLinks(comparisons, catalog);
+}

--- a/tests/compare-page-featured-interactive-ui-lib.test.ts
+++ b/tests/compare-page-featured-interactive-ui-lib.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePageFeaturedInteractiveUiState } from "@/lib/compare-page-featured-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare page featured interactive ui lib", () => {
+  it("builds popular comparison links for compare page empty state", () => {
+    expect(
+      comparePageFeaturedInteractiveUiState(
+        [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            refs: ["skills/alpha", "hooks/beta"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "pair",
+        heading: "Alpha vs Beta",
+        interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+
+  it("omits interactive search when fewer than two refs resolve", () => {
+    expect(
+      comparePageFeaturedInteractiveUiState(
+        [{ slug: "solo", heading: "Alpha only", refs: ["skills/alpha"] }],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "solo",
+        heading: "Alpha only",
+        interactiveSearch: null,
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+
+  it("formats overflow labels for wide popular comparison links", () => {
+    expect(
+      comparePageFeaturedInteractiveUiState(
+        [
+          {
+            slug: "triple",
+            heading: "Three-way",
+            refs: ["skills/alpha", "hooks/beta", "mcp/gamma"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual([
+      {
+        slug: "triple",
+        heading: "Three-way",
+        interactiveSearch: { ids: "skills/alpha,hooks/beta,mcp/gamma" },
+        interactiveLabel: "Open 3 picks in the interactive comparison tool",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-featured-interactive-ui-lib` with `comparePageFeaturedInteractiveUiState` for compare page popular comparison links
- Wire `compare-page-empty-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-featured-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426


Made with [Cursor](https://cursor.com)