### PR TITLE
fix(registry): wire remaining URL userinfo guards to source-url helpers

### DIFF
--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -1,5 +1,6 @@
 import { LABELS } from "./constants";
 import { parseSimpleFrontmatter } from "./duplicates";
+import { hasEmbeddedUrlUserinfo } from "../../../packages/registry/src/source-url-lib.js";
 import type { GateDecision, GateDecisionEvidence } from "./review";
 
 export type SubmittedSourceUrl = {
@@ -232,7 +233,7 @@ function validateFetchableSourceUrl(url: string) {
       error: "Source URL must use http or https.",
     };
   }
-  if (parsed.username || parsed.password) {
+  if (hasEmbeddedUrlUserinfo(parsed.href)) {
     return {
       ok: false as const,
       outcome: "invalid_url",

--- a/apps/web/src/data/contributors.ts
+++ b/apps/web/src/data/contributors.ts
@@ -1,15 +1,14 @@
 import { ENTRIES } from "@/data/entries";
 import { authorMatchesSubmitter, contributorSlug } from "@/lib/contributor-identity";
+import { isPublicGitHubProfileUrl } from "@heyclaude/registry/source-url";
 import type { Category, Contributor, Entry } from "@/types/registry";
 
 export { authorMatchesSubmitter, contributorSlug };
 
 export function githubHandle(profileUrl?: string) {
-  if (!profileUrl) return undefined;
+  if (!profileUrl || !isPublicGitHubProfileUrl(profileUrl)) return undefined;
   try {
     const url = new URL(profileUrl);
-    if (url.username || url.password) return undefined;
-    if (url.hostname !== "github.com") return undefined;
     return url.pathname.split("/").filter(Boolean)[0];
   } catch {
     return undefined;

--- a/packages/registry/src/mcp-install-config-lib.js
+++ b/packages/registry/src/mcp-install-config-lib.js
@@ -10,6 +10,8 @@
  * existing imports stay unchanged.
  */
 
+import { hasEmbeddedUrlUserinfo, isPublicHttpsUrl } from "./source-url-lib.js";
+
 export const MCP_INSTALL_TARGET_IDS = [
   "claude-code",
   "codex",
@@ -64,8 +66,8 @@ function isLoopbackHostname(hostname) {
 function isSafeRemoteMcpUrl(value) {
   try {
     const url = new URL(String(value).trim());
-    if (url.username || url.password) return false;
-    if (url.protocol === "https:") return true;
+    if (hasEmbeddedUrlUserinfo(value)) return false;
+    if (isPublicHttpsUrl(value)) return true;
     return url.protocol === "http:" && isLoopbackHostname(url.hostname);
   } catch {
     return false;

--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -9,6 +9,8 @@
  * re-exports everything below so existing imports stay unchanged.
  */
 
+import { hasEmbeddedUrlUserinfo } from "./source-url-lib.js";
+
 const GITHUB_HOST = "github.com";
 
 // GitHub usernames/orgs: alphanumeric with single internal hyphens.
@@ -90,7 +92,7 @@ export function parseGitHubRepoUrl(value) {
     if (!ownerRepo) return null;
     if (
       (url.protocol === "http:" || url.protocol === "https:") &&
-      (url.username || url.password)
+      hasEmbeddedUrlUserinfo(raw)
     ) {
       return null;
     }

--- a/packages/registry/src/submission-risk.js
+++ b/packages/registry/src/submission-risk.js
@@ -5,7 +5,12 @@ import {
   TOOLS_LISTING_FLOW_URL,
 } from "./submission-classification.js";
 import { parseSafeFrontmatter } from "./frontmatter.js";
-import { isPublicHttpsUrl, publicUrlHostname } from "./source-url-lib.js";
+import {
+  isPublicGitHubProfileUrl,
+  isPublicHttpUrl,
+  isPublicHttpsUrl,
+  publicUrlHostname,
+} from "./source-url-lib.js";
 
 export const SUBMISSION_RISK_SCHEMA_VERSION = 1;
 export const SUBMISSION_RISK_COMMENT_MARKER = "<!-- submission-risk-report -->";
@@ -94,8 +99,7 @@ function isLoopbackHttpUrl(value) {
     const url = new URL(value.trim());
     return (
       url.protocol === "http:" &&
-      url.username === "" &&
-      url.password === "" &&
+      isPublicHttpUrl(value) &&
       LOOPBACK_HTTP_HOSTNAMES.has(url.hostname)
     );
   } catch {
@@ -288,12 +292,7 @@ function hostname(value) {
 function githubRepoFromUrl(value) {
   try {
     const url = new URL(normalizeText(value));
-    if (
-      url.protocol !== "https:" ||
-      url.hostname !== "github.com" ||
-      url.username ||
-      url.password
-    ) {
+    if (!isPublicHttpsUrl(value) || url.hostname !== "github.com") {
       return "";
     }
     const [owner, repo] = url.pathname.split("/").filter(Boolean);
@@ -304,16 +303,11 @@ function githubRepoFromUrl(value) {
 }
 
 function githubLoginFromUrl(value) {
+  if (!isPublicGitHubProfileUrl(value)) {
+    return "";
+  }
   try {
     const url = new URL(normalizeText(value));
-    if (
-      url.protocol !== "https:" ||
-      url.hostname !== "github.com" ||
-      url.username ||
-      url.password
-    ) {
-      return "";
-    }
     const [login] = url.pathname.split("/").filter(Boolean);
     return login || "";
   } catch {


### PR DESCRIPTION
## Summary
- Route submission-risk GitHub repo/profile URL parsing through `isPublicHttpsUrl`, `isPublicGitHubProfileUrl`, and `isPublicHttpUrl`
- Reject credential-bearing repo URLs in `source-repo-lib` via `hasEmbeddedUrlUserinfo`
- Align MCP install remote URL checks, web contributor profile handles, and submission-gate source evidence with the shared guards from #4438

## Test plan
- [x] `pnpm exec vitest run tests/source-repo-lib.test.ts tests/mcp-install-config-lib.test.ts tests/contributor-profiles.test.ts tests/submission-risk-invariants.test.ts tests/source-url-lib.test.ts`
- [x] `pnpm type-check` and `pnpm test:mcp`
- [ ] CI `validate-web`, `validate-registry`, `validate-submission-gate`, and `required-pr-gate` green