### PR TITLE
feat(web): add compare table signals interactive UI lib

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -22,7 +22,7 @@ import {
   compareTableActionsForEntry,
   compareTableActionsInteractiveUiState,
 } from "@/lib/compare-table-actions-interactive-ui-lib";
-import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
+import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -298,7 +298,7 @@ export function ComparisonTable({
   entries: Entry[];
   showNextActions?: boolean;
 }) {
-  const { divergingDecisionLabels } = compareTableInteractiveUiState(entries, showNextActions);
+  const { divergingDecisionLabels } = compareTableSignalsInteractiveUiState(entries);
   const tableActionsUi = compareTableActionsInteractiveUiState(entries, showNextActions);
   const { renderNextActions, actionRowDiverges } = tableActionsUi;
 

--- a/apps/web/src/lib/compare-table-signals-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-signals-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import { compareTableDivergingDecisionLabels } from "@/lib/compare-table-signals-ui-lib";
+
+export type CompareTableSignalsInteractiveUiState = {
+  divergingDecisionLabels: Set<string>;
+};
+
+export function compareTableSignalsInteractiveUiState(
+  entries: Entry[],
+): CompareTableSignalsInteractiveUiState {
+  return {
+    divergingDecisionLabels: new Set(compareTableDivergingDecisionLabels(entries)),
+  };
+}

--- a/tests/compare-table-signals-interactive-ui-lib.test.ts
+++ b/tests/compare-table-signals-interactive-ui-lib.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table signals interactive ui lib", () => {
+  it("returns no diverging decision labels for uniform compared entries", () => {
+    expect(compareTableSignalsInteractiveUiState([entry()])).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+    expect(
+      compareTableSignalsInteractiveUiState([
+        entry(),
+        entry({ slug: "other" }),
+      ]),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+  });
+
+  it("highlights diverging review status decision rows", () => {
+    expect(
+      compareTableSignalsInteractiveUiState([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toEqual({
+      divergingDecisionLabels: new Set(["Review status"]),
+    });
+  });
+
+  it("returns an empty label set when no entries are compared", () => {
+    expect(compareTableSignalsInteractiveUiState([])).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-signals-interactive-ui-lib` with `compareTableSignalsInteractiveUiState` for comparison table decision-row divergence state
- Wire `comparison-table.tsx` through the new lib for diverging decision row highlighting
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-signals-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426


Made with [Cursor](https://cursor.com)