### PR TITLE
feat(web): extract compare-selection helpers into compare-selection-lib

### DIFF
--- a/apps/web/src/lib/compare-selection-lib.ts
+++ b/apps/web/src/lib/compare-selection-lib.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure compare-selection helpers.
+ *
+ * Maintains the "entries queued for comparison" list from URL params and toggle
+ * actions. Nothing here touches the network or the DOM — given the same inputs
+ * the output is deterministic.
+ *
+ * The public surface (`compare-selection.ts` / `@/lib/compare-selection`)
+ * re-exports everything below so existing imports stay unchanged.
+ */
+
+import { entryRef, parseEntryRef, sameEntry, type EntryIdentity } from "@/lib/entry-identity";
+
+export const DEFAULT_COMPARE_LIMIT = 4;
+
+export function hasCompareItem(items: EntryIdentity[], entry: EntryIdentity) {
+  return items.some((item) => sameEntry(item, entry));
+}
+
+export function toggleCompareItem<T extends EntryIdentity>(
+  items: T[],
+  entry: T,
+  limit = DEFAULT_COMPARE_LIMIT,
+): T[] {
+  if (hasCompareItem(items, entry)) {
+    return items.filter((item) => !sameEntry(item, entry));
+  }
+  if (items.length >= limit) return items;
+  return [...items, entry];
+}
+
+export function serializeCompareItems(items: EntryIdentity[]) {
+  return items.map(entryRef).join(",");
+}
+
+export function resolveCompareParam<T extends EntryIdentity>(
+  entries: T[],
+  param: string,
+  limit = DEFAULT_COMPARE_LIMIT,
+): T[] {
+  if (!param) return [];
+
+  const refs = param
+    .split(",")
+    .map((value) => parseEntryRef(value.trim()))
+    .filter((ref): ref is EntryIdentity => Boolean(ref));
+
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const ref of refs) {
+    if (out.length >= limit) break;
+    const key = entryRef(ref);
+    if (seen.has(key)) continue;
+    const entry = entries.find((candidate) => sameEntry(candidate, ref));
+    if (entry) {
+      out.push(entry);
+      seen.add(key);
+    }
+  }
+  return out;
+}

--- a/apps/web/src/lib/compare-selection.ts
+++ b/apps/web/src/lib/compare-selection.ts
@@ -1,50 +1,13 @@
-import { entryRef, parseEntryRef, sameEntry, type EntryIdentity } from "@/lib/entry-identity";
-
-const DEFAULT_COMPARE_LIMIT = 4;
-
-export function hasCompareItem(items: EntryIdentity[], entry: EntryIdentity) {
-  return items.some((item) => sameEntry(item, entry));
-}
-
-export function toggleCompareItem<T extends EntryIdentity>(
-  items: T[],
-  entry: T,
-  limit = DEFAULT_COMPARE_LIMIT,
-): T[] {
-  if (hasCompareItem(items, entry)) {
-    return items.filter((item) => !sameEntry(item, entry));
-  }
-  if (items.length >= limit) return items;
-  return [...items, entry];
-}
-
-export function serializeCompareItems(items: EntryIdentity[]) {
-  return items.map(entryRef).join(",");
-}
-
-export function resolveCompareParam<T extends EntryIdentity>(
-  entries: T[],
-  param: string,
-  limit = DEFAULT_COMPARE_LIMIT,
-): T[] {
-  if (!param) return [];
-
-  const refs = param
-    .split(",")
-    .map((value) => parseEntryRef(value.trim()))
-    .filter((ref): ref is EntryIdentity => Boolean(ref));
-
-  const seen = new Set<string>();
-  const out: T[] = [];
-  for (const ref of refs) {
-    if (out.length >= limit) break;
-    const key = entryRef(ref);
-    if (seen.has(key)) continue;
-    const entry = entries.find((candidate) => sameEntry(candidate, ref));
-    if (entry) {
-      out.push(entry);
-      seen.add(key);
-    }
-  }
-  return out;
-}
+/**
+ * Compare-selection surface.
+ *
+ * The pure selection helpers live in `compare-selection-lib.ts`. This module
+ * re-exports that surface so existing `@/lib/compare-selection` imports stay
+ * unchanged.
+ */
+export {
+  hasCompareItem,
+  toggleCompareItem,
+  serializeCompareItems,
+  resolveCompareParam,
+} from "@/lib/compare-selection-lib";

--- a/tests/compare-selection-lib.test.ts
+++ b/tests/compare-selection-lib.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_COMPARE_LIMIT,
+  hasCompareItem,
+  resolveCompareParam,
+  serializeCompareItems,
+  toggleCompareItem,
+} from "../apps/web/src/lib/compare-selection-lib";
+
+type Item = { category: string; slug: string };
+
+const A: Item = { category: "skills", slug: "alpha" };
+const B: Item = { category: "agents", slug: "beta" };
+const C: Item = { category: "commands", slug: "gamma" };
+const D: Item = { category: "hooks", slug: "delta" };
+const E: Item = { category: "mcp", slug: "epsilon" };
+
+describe("hasCompareItem", () => {
+  it("matches by category + slug, not identity", () => {
+    expect(hasCompareItem([A, B], { category: "agents", slug: "beta" })).toBe(true);
+    expect(hasCompareItem([A, B], C)).toBe(false);
+    // Same slug, different category must not match.
+    expect(hasCompareItem([A], { category: "agents", slug: "alpha" })).toBe(false);
+  });
+
+  it("is false for an empty list", () => {
+    expect(hasCompareItem([], A)).toBe(false);
+  });
+});
+
+describe("toggleCompareItem", () => {
+  it("adds an absent entry", () => {
+    expect(toggleCompareItem([A], B)).toEqual([A, B]);
+  });
+
+  it("removes a present entry (by identity, keeping the rest)", () => {
+    expect(toggleCompareItem([A, B, C], B)).toEqual([A, C]);
+  });
+
+  it("does not add past the limit, but still allows a removal at the limit", () => {
+    const full = [A, B, C, D];
+    expect(full).toHaveLength(DEFAULT_COMPARE_LIMIT);
+    // Adding a new one at the cap is a no-op (returns the same list).
+    expect(toggleCompareItem(full, E)).toEqual(full);
+    // Removing one already present still works even at the cap.
+    expect(toggleCompareItem(full, C)).toEqual([A, B, D]);
+  });
+
+  it("honors a custom limit", () => {
+    expect(toggleCompareItem([A, B], C, 2)).toEqual([A, B]);
+    expect(toggleCompareItem([A], C, 2)).toEqual([A, C]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [A, B];
+    toggleCompareItem(input, C);
+    expect(input).toEqual([A, B]);
+  });
+});
+
+describe("serializeCompareItems", () => {
+  it("joins entry refs (category/slug) with commas in order", () => {
+    expect(serializeCompareItems([A, C])).toBe("skills/alpha,commands/gamma");
+  });
+
+  it("is empty for no items", () => {
+    expect(serializeCompareItems([])).toBe("");
+  });
+});
+
+describe("resolveCompareParam", () => {
+  const entries = [A, B, C, D, E];
+
+  it("returns [] for an empty param", () => {
+    expect(resolveCompareParam(entries, "")).toEqual([]);
+  });
+
+  it("resolves refs to entries preserving param order", () => {
+    expect(resolveCompareParam(entries, "commands/gamma,skills/alpha")).toEqual([C, A]);
+  });
+
+  it("trims whitespace and drops malformed / unmatched refs", () => {
+    expect(
+      resolveCompareParam(entries, " skills/alpha , not-a-ref , mcp/missing , agents/beta "),
+    ).toEqual([A, B]);
+  });
+
+  it("de-duplicates repeated refs", () => {
+    expect(resolveCompareParam(entries, "skills/alpha,skills/alpha")).toEqual([A]);
+  });
+
+  it("caps the result at the limit", () => {
+    expect(
+      resolveCompareParam(entries, "skills/alpha,agents/beta,commands/gamma,hooks/delta,mcp/epsilon"),
+    ).toHaveLength(DEFAULT_COMPARE_LIMIT);
+    expect(resolveCompareParam(entries, "skills/alpha,agents/beta,commands/gamma", 2)).toEqual([A, B]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -56,6 +56,7 @@ export default defineConfig({
         "apps/web/src/lib/community-signals.ts",
         "apps/web/src/lib/compare-entry-actions.ts",
         "apps/web/src/lib/compare-entry-signals.ts",
+        "apps/web/src/lib/compare-selection.ts",
         "apps/web/src/lib/content-section-parsing.ts",
         "apps/web/src/lib/content-section-variant.ts",
         "apps/web/src/lib/content.server.ts",


### PR DESCRIPTION
Moves the pure compare-selection helpers (`hasCompareItem`, `toggleCompareItem`, `serializeCompareItems`, `resolveCompareParam`) into `compare-selection-lib.ts`, matching the `lib/` module convention already used across the compare surface (compare-entry-actions, compare-entry-signals, …). The original `compare-selection.ts` becomes a thin re-export so existing `@/lib/compare-selection` imports are unchanged, and it joins the coverage exclude list like the other extracted shims.

Adds `tests/compare-selection-lib.test.ts` (14 cases) covering identity matching, toggle add/remove + limit behaviour and input immutability, serialization, and param resolution (ordering, whitespace/malformed-ref dropping, de-duplication, and the limit cap) — this helper family previously had no unit coverage. `vitest run` passes; no new type-check errors.