### PR TITLE
feat(mcp): extract registry response helpers into registry-response-lib

### DIFF
--- a/packages/mcp/src/registry-response-lib.js
+++ b/packages/mcp/src/registry-response-lib.js
@@ -1,0 +1,54 @@
+/**
+ * Pure MCP registry response envelope helpers.
+ *
+ * Shared success/error payload shapes and policy attachment live here.
+ * Runtime registry handlers stay in `registry.js`.
+ */
+import { MCP_PUBLIC_POLICY } from "./registry-tools-lib.js";
+
+export function notes(values) {
+  return Array.isArray(values)
+    ? values.map((value) => String(value || "").trim()).filter(Boolean)
+    : [];
+}
+
+export function withPublicPolicy(result) {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return result;
+  }
+  if (result.policy) return result;
+  return { ...result, policy: MCP_PUBLIC_POLICY };
+}
+
+export function notFound(message) {
+  return { ok: false, error: { code: "not_found", message } };
+}
+
+export function invalid(message) {
+  return { ok: false, error: { code: "invalid_request", message } };
+}
+
+export function invalidWithDetails(message, details) {
+  return { ok: false, error: { code: "invalid_request", message, details } };
+}
+
+/**
+ * Build the standard "unavailable" error envelope used when a dynamic
+ * resource cannot be loaded. Distinct from `notFound` / `invalid` so MCP
+ * clients can tell apart "endpoint failed" from "no such resource" and
+ * keep the surface read-only.
+ *
+ * @param {string} message Human-readable explanation.
+ * @param {string} [details] Optional underlying error message.
+ * @returns {{ ok: false, error: { code: "unavailable", message: string, details?: string } }}
+ */
+export function unavailable(message, details) {
+  return {
+    ok: false,
+    error: {
+      code: "unavailable",
+      message,
+      ...(details ? { details } : {}),
+    },
+  };
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -74,6 +74,14 @@ import {
   normalizePlatform,
   normalizeText,
 } from "./registry-normalize-lib.js";
+import {
+  invalid,
+  invalidWithDetails,
+  notFound,
+  notes,
+  unavailable,
+  withPublicPolicy,
+} from "./registry-response-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -326,26 +334,12 @@ function unique(values = []) {
   );
 }
 
-function notes(values) {
-  return Array.isArray(values)
-    ? values.map((value) => String(value || "").trim()).filter(Boolean)
-    : [];
-}
-
 function normalizeDateFloor(value) {
   const text = String(value || "").trim();
   if (!text) return "";
   const timestamp = Date.parse(text);
   if (!Number.isFinite(timestamp)) return "";
   return new Date(timestamp).toISOString().slice(0, 10);
-}
-
-function withPublicPolicy(result) {
-  if (!result || typeof result !== "object" || Array.isArray(result)) {
-    return result;
-  }
-  if (result.policy) return result;
-  return { ...result, policy: MCP_PUBLIC_POLICY };
 }
 
 function sourceSummary(entry) {
@@ -579,18 +573,6 @@ async function readEntry(category, slug, options = {}) {
   } catch {
     return null;
   }
-}
-
-function notFound(message) {
-  return { ok: false, error: { code: "not_found", message } };
-}
-
-function invalid(message) {
-  return { ok: false, error: { code: "invalid_request", message } };
-}
-
-function invalidWithDetails(message, details) {
-  return { ok: false, error: { code: "invalid_request", message, details } };
 }
 
 export async function searchRegistry(args = {}, options = {}) {
@@ -1710,27 +1692,6 @@ async function fetchPublicApiJson(apiPath, options = {}) {
   } finally {
     clearTimeout(timeout);
   }
-}
-
-/**
- * Build the standard "unavailable" error envelope used when a dynamic
- * resource cannot be loaded. Distinct from `notFound` / `invalid` so MCP
- * clients can tell apart "endpoint failed" from "no such resource" and
- * keep the surface read-only.
- *
- * @param {string} message Human-readable explanation.
- * @param {string} [details] Optional underlying error message.
- * @returns {{ ok: false, error: { code: "unavailable", message: string, details?: string } }}
- */
-function unavailable(message, details) {
-  return {
-    ok: false,
-    error: {
-      code: "unavailable",
-      message,
-      ...(details ? { details } : {}),
-    },
-  };
 }
 
 /**

--- a/tests/mcp-registry-response-lib.test.ts
+++ b/tests/mcp-registry-response-lib.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { MCP_PUBLIC_POLICY } from "../packages/mcp/src/registry-tools-lib.js";
+import {
+  invalid,
+  invalidWithDetails,
+  notFound,
+  notes,
+  unavailable,
+  withPublicPolicy,
+} from "../packages/mcp/src/registry-response-lib.js";
+
+describe("registry-response-lib note normalization", () => {
+  it("trims and drops empty note values", () => {
+    expect(notes(["  safety first  ", "", "  privacy  "])).toEqual([
+      "safety first",
+      "privacy",
+    ]);
+    expect(notes("not-an-array")).toEqual([]);
+  });
+});
+
+describe("registry-response-lib error envelopes", () => {
+  it("builds not_found and invalid_request envelopes", () => {
+    expect(notFound("missing entry")).toEqual({
+      ok: false,
+      error: { code: "not_found", message: "missing entry" },
+    });
+    expect(invalid("bad args")).toEqual({
+      ok: false,
+      error: { code: "invalid_request", message: "bad args" },
+    });
+    expect(invalidWithDetails("bad args", { field: "slug" })).toEqual({
+      ok: false,
+      error: {
+        code: "invalid_request",
+        message: "bad args",
+        details: { field: "slug" },
+      },
+    });
+  });
+
+  it("builds unavailable envelopes with optional details", () => {
+    expect(unavailable("upstream failed")).toEqual({
+      ok: false,
+      error: { code: "unavailable", message: "upstream failed" },
+    });
+    expect(unavailable("upstream failed", "timeout")).toEqual({
+      ok: false,
+      error: {
+        code: "unavailable",
+        message: "upstream failed",
+        details: "timeout",
+      },
+    });
+  });
+});
+
+describe("registry-response-lib policy attachment", () => {
+  it("adds the public MCP policy to object payloads once", () => {
+    expect(withPublicPolicy({ ok: true, kind: "registry.search" })).toEqual({
+      ok: true,
+      kind: "registry.search",
+      policy: MCP_PUBLIC_POLICY,
+    });
+    expect(
+      withPublicPolicy({
+        ok: true,
+        policy: { readOnly: true },
+      }),
+    ).toEqual({
+      ok: true,
+      policy: { readOnly: true },
+    });
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2535,17 +2535,21 @@ describe("HeyClaude read-only MCP helpers", () => {
         path.join(repoRoot, "packages/mcp/src/registry.js"),
         "utf8",
       );
+      const responseLibSource = fs.readFileSync(
+        path.join(repoRoot, "packages/mcp/src/registry-response-lib.js"),
+        "utf8",
+      );
 
-      const requireDocstringBefore = (declaration: string) => {
-        const index = registrySource.indexOf(declaration);
+      const requireDocstringBefore = (
+        declaration: string,
+        source = registrySource,
+      ) => {
+        const index = source.indexOf(declaration);
         expect(
           index,
           `Expected to find declaration: ${declaration}`,
         ).toBeGreaterThan(-1);
-        const preceding = registrySource.slice(
-          Math.max(0, index - 4000),
-          index,
-        );
+        const preceding = source.slice(Math.max(0, index - 4000), index);
         const trimmed = preceding.trimEnd();
         expect(
           trimmed.endsWith("*/"),
@@ -2565,7 +2569,7 @@ describe("HeyClaude read-only MCP helpers", () => {
       requireDocstringBefore("export async function listJobsActive(");
       requireDocstringBefore("async function fetchPublicApiJson(");
       requireDocstringBefore("function publicApiBaseUrl(");
-      requireDocstringBefore("function unavailable(");
+      requireDocstringBefore("export function unavailable(", responseLibSource);
       requireDocstringBefore("function toTrendingEntry(");
       requireDocstringBefore("function toJobEntry(");
       requireDocstringBefore("const DISCOVERY_RESOURCES = [");


### PR DESCRIPTION
# Pull Request

## Summary

- Extract shared MCP error envelopes and policy attachment helpers into `packages/mcp/src/registry-response-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so registry tool/resource behavior stays unchanged.
- Add focused lib tests for note normalization, error envelopes, and policy attachment.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-response-lib.js` (new extracted response helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-response-lib.test.ts` (new focused tests)
  - `tests/mcp-server.test.ts` (docstring gate now checks extracted `unavailable` helper)
- Expected behavior:
  - Registry tool/resource success and error envelopes are unchanged.
- Important edge cases or invariants:
  - `not_found`, `invalid_request`, and `unavailable` codes remain stable.
  - `withPublicPolicy` still attaches `MCP_PUBLIC_POLICY` once per payload.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-response-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-response-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry response helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-normalize-lib`, `server-lib`, `registry-tools-lib`).
  - Does not touch `schemas.js`, endpoint URL helpers, or submission-risk analysis code.


Made with [Cursor](https://cursor.com)