### PR TITLE
feat(web): add compare drawer signals interactive UI lib

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -30,16 +30,15 @@ import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
 import {
-  compareDrawerDecisionRowDiverges,
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
 } from "@/lib/compare-drawer-signals-ui-lib";
+import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
 
 interface RowDef {
   label: string;
   render: (e: Entry) => React.ReactNode;
-  diverges?: (items: Entry[]) => boolean;
 }
 
 const ROWS: RowDef[] = [
@@ -54,7 +53,6 @@ const ROWS: RowDef[] = [
       if (!value) return <span className="text-xs text-ink-subtle">—</span>;
       return <CompareSignalCell value={value} />;
     },
-    diverges: (items: Entry[]) => compareDrawerDecisionRowDiverges(row.resolve, items),
   })),
   {
     label: "Safety",
@@ -323,6 +321,7 @@ function SnippetCell({ entry }: { entry: Entry }) {
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const drawerActionsUi = compareDrawerActionsInteractiveUiState(items);
+  const drawerSignalsUi = compareDrawerSignalsInteractiveUiState(items);
   const { drawerUi, emptyHint, shareUrl } = compareDrawerInteractiveUiState(items);
   const { actionRowDiverges } = drawerActionsUi;
   const { bannerTexts, fullViewSearch } = drawerUi;
@@ -505,7 +504,7 @@ export function CompareDrawer() {
                     ))}
                   </tr>
                   {ROWS.map((row, i) => {
-                    const rowDiverges = row.diverges?.(items) ?? false;
+                    const rowDiverges = drawerSignalsUi.divergingDecisionLabels.has(row.label);
                     return (
                       <tr
                         key={row.label}

--- a/apps/web/src/lib/compare-drawer-signals-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-signals-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import { compareDrawerDivergingDecisionLabels } from "@/lib/compare-drawer-signals-ui-lib";
+
+export type CompareDrawerSignalsInteractiveUiState = {
+  divergingDecisionLabels: Set<string>;
+};
+
+export function compareDrawerSignalsInteractiveUiState(
+  entries: Entry[],
+): CompareDrawerSignalsInteractiveUiState {
+  return {
+    divergingDecisionLabels: new Set(compareDrawerDivergingDecisionLabels(entries)),
+  };
+}

--- a/tests/compare-drawer-signals-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-signals-interactive-ui-lib.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer signals interactive ui lib", () => {
+  it("returns no diverging decision labels for uniform compared entries", () => {
+    expect(compareDrawerSignalsInteractiveUiState([entry()])).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+    expect(
+      compareDrawerSignalsInteractiveUiState([
+        entry(),
+        entry({ slug: "other" }),
+      ]),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+  });
+
+  it("highlights diverging review status decision rows", () => {
+    expect(
+      compareDrawerSignalsInteractiveUiState([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toEqual({
+      divergingDecisionLabels: new Set(["Review status"]),
+    });
+  });
+
+  it("returns an empty label set when no entries are compared", () => {
+    expect(compareDrawerSignalsInteractiveUiState([])).toEqual({
+      divergingDecisionLabels: new Set(),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-signals-interactive-ui-lib` with `compareDrawerSignalsInteractiveUiState` for compare drawer decision-row divergence state
- Wire `compare-drawer.tsx` through the new lib for diverging decision row highlighting
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-signals-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426 / #4443


Made with [Cursor](https://cursor.com)