### PR TITLE
feat(web): extract tag-grouping helpers into tags-lib

### DIFF
--- a/apps/web/src/lib/tags-lib.ts
+++ b/apps/web/src/lib/tags-lib.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure tag-grouping helpers.
+ *
+ * Normalizes raw entry tags into slugged groups and derives related-topic
+ * interlinks. Every function is parameterized on the entry list (or a
+ * pre-built group list) it operates on — nothing here reads the global dataset
+ * or memoizes, so given the same inputs the output is deterministic.
+ *
+ * The public surface (`tags.ts` / `@/lib/tags`) binds these to the `ENTRIES`
+ * dataset and keeps the memoized `getAllTagGroups()` cache in the wrapper.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export function tagSlug(tag: string) {
+  return tag
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export type TagGroup = { slug: string; name: string; entries: Entry[] };
+
+/** Build slugged tag groups from a set of entries, sorted by group size (desc). */
+export function buildTagGroups(entries: Entry[]): TagGroup[] {
+  const map = new Map<string, { entries: Entry[]; names: Map<string, number> }>();
+  for (const entry of entries) {
+    // An entry can carry multiple raw tags that normalize to the same slug
+    // (e.g. "AI" and "ai"); count it once per slug so group sizes stay accurate.
+    const seenSlugs = new Set<string>();
+    for (const tag of entry.tags ?? []) {
+      const slug = tagSlug(tag);
+      if (!slug) continue;
+      let group = map.get(slug);
+      if (!group) {
+        group = { entries: [], names: new Map() };
+        map.set(slug, group);
+      }
+      if (!seenSlugs.has(slug)) {
+        group.entries.push(entry);
+        seenSlugs.add(slug);
+      }
+      group.names.set(tag, (group.names.get(tag) ?? 0) + 1);
+    }
+  }
+  return [...map.entries()]
+    .map(([slug, group]) => ({
+      slug,
+      // Canonical display name: most frequent raw casing (ties broken alphabetically).
+      name: [...group.names.entries()].sort(
+        (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+      )[0][0],
+      entries: group.entries,
+    }))
+    .sort((a, b) => b.entries.length - a.entries.length);
+}
+
+export function findTagGroup(groups: TagGroup[], slug: string): TagGroup | undefined {
+  return groups.find((group) => group.slug === slug);
+}
+
+// Tags with enough entries to be a non-thin, indexable hub.
+export function filterIndexableTagGroups(groups: TagGroup[]): TagGroup[] {
+  return groups.filter((group) => group.entries.length >= 2);
+}
+
+// Tags that most co-occur with this one across its entries — for "related topics" interlinking.
+// Only returns indexable (>=2 entry) groups so we never link to thin/noindex tag pages.
+export function computeRelatedTags(groups: TagGroup[], slug: string, limit = 8): TagGroup[] {
+  const group = findTagGroup(groups, slug);
+  if (!group) return [];
+  const counts = new Map<string, number>();
+  for (const entry of group.entries) {
+    for (const tag of entry.tags ?? []) {
+      const s = tagSlug(tag);
+      if (s === group.slug) continue;
+      counts.set(s, (counts.get(s) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([s]) => findTagGroup(groups, s))
+    .filter((g): g is TagGroup => Boolean(g) && (g as TagGroup).entries.length >= 2)
+    .slice(0, limit);
+}

--- a/apps/web/src/lib/tags.ts
+++ b/apps/web/src/lib/tags.ts
@@ -1,76 +1,39 @@
+/**
+ * Tag-grouping surface.
+ *
+ * The pure grouping helpers live in `tags-lib.ts`. This module binds them to the
+ * global `ENTRIES` dataset and keeps the memoized `getAllTagGroups()` cache, so
+ * existing `@/lib/tags` imports stay unchanged.
+ */
 import { ENTRIES } from "@/data/entries";
-import type { Entry } from "@/types/registry";
+import {
+  buildTagGroups,
+  computeRelatedTags,
+  filterIndexableTagGroups,
+  findTagGroup,
+  type TagGroup,
+} from "@/lib/tags-lib";
 
-export function tagSlug(tag: string) {
-  return tag
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-export type TagGroup = { slug: string; name: string; entries: Entry[] };
+export { tagSlug } from "@/lib/tags-lib";
+export type { TagGroup } from "@/lib/tags-lib";
 
 let cache: TagGroup[] | null = null;
 
 export function getAllTagGroups(): TagGroup[] {
-  if (cache) return cache;
-  const map = new Map<string, { entries: Entry[]; names: Map<string, number> }>();
-  for (const entry of ENTRIES) {
-    // An entry can carry multiple raw tags that normalize to the same slug
-    // (e.g. "AI" and "ai"); count it once per slug so group sizes stay accurate.
-    const seenSlugs = new Set<string>();
-    for (const tag of entry.tags ?? []) {
-      const slug = tagSlug(tag);
-      if (!slug) continue;
-      let group = map.get(slug);
-      if (!group) {
-        group = { entries: [], names: new Map() };
-        map.set(slug, group);
-      }
-      if (!seenSlugs.has(slug)) {
-        group.entries.push(entry);
-        seenSlugs.add(slug);
-      }
-      group.names.set(tag, (group.names.get(tag) ?? 0) + 1);
-    }
-  }
-  cache = [...map.entries()]
-    .map(([slug, group]) => ({
-      slug,
-      // Canonical display name: most frequent raw casing (ties broken alphabetically).
-      name: [...group.names.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))[0][0],
-      entries: group.entries,
-    }))
-    .sort((a, b) => b.entries.length - a.entries.length);
+  if (!cache) cache = buildTagGroups(ENTRIES);
   return cache;
 }
 
 export function getTagGroup(slug: string): TagGroup | undefined {
-  return getAllTagGroups().find((group) => group.slug === slug);
+  return findTagGroup(getAllTagGroups(), slug);
 }
 
 // Tags with enough entries to be a non-thin, indexable hub.
 export function getIndexableTagGroups(): TagGroup[] {
-  return getAllTagGroups().filter((group) => group.entries.length >= 2);
+  return filterIndexableTagGroups(getAllTagGroups());
 }
 
 // Tags that most co-occur with this one across its entries — for "related topics" interlinking.
-// Only returns indexable (>=2 entry) groups so we never link to thin/noindex tag pages.
 export function relatedTags(slug: string, limit = 8): TagGroup[] {
-  const group = getTagGroup(slug);
-  if (!group) return [];
-  const counts = new Map<string, number>();
-  for (const entry of group.entries) {
-    for (const tag of entry.tags ?? []) {
-      const s = tagSlug(tag);
-      if (s === group.slug) continue;
-      counts.set(s, (counts.get(s) ?? 0) + 1);
-    }
-  }
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .map(([s]) => getTagGroup(s))
-    .filter((g): g is TagGroup => Boolean(g) && (g as TagGroup).entries.length >= 2)
-    .slice(0, limit);
+  return computeRelatedTags(getAllTagGroups(), slug, limit);
 }

--- a/tests/tags-lib.test.ts
+++ b/tests/tags-lib.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "@/types/registry";
+import {
+  buildTagGroups,
+  computeRelatedTags,
+  filterIndexableTagGroups,
+  findTagGroup,
+  tagSlug,
+} from "../apps/web/src/lib/tags-lib";
+
+function entry(slug: string, tags: string[]): Entry {
+  return {
+    category: "mcp",
+    slug,
+    title: slug,
+    description: "d",
+    author: "a",
+    tags,
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+  } as Entry;
+}
+
+describe("tagSlug", () => {
+  it("lowercases, trims, and slugs non-alphanumeric runs", () => {
+    expect(tagSlug("AI Tools")).toBe("ai-tools");
+    expect(tagSlug("  Foo  ")).toBe("foo");
+    expect(tagSlug("C++ / Rust")).toBe("c-rust");
+  });
+
+  it("strips leading/trailing separators and is empty for symbol-only input", () => {
+    expect(tagSlug("--Hello--")).toBe("hello");
+    expect(tagSlug("!!!")).toBe("");
+  });
+});
+
+describe("buildTagGroups", () => {
+  it("groups entries by slug and sorts by group size descending", () => {
+    const groups = buildTagGroups([
+      entry("a", ["AI", "cli"]),
+      entry("b", ["AI"]),
+      entry("c", ["cli", "AI"]),
+    ]);
+    // "ai" has 3 entries, "cli" has 2 → ai first.
+    expect(groups.map((g) => [g.slug, g.entries.length])).toEqual([
+      ["ai", 3],
+      ["cli", 2],
+    ]);
+  });
+
+  it("counts an entry once per slug even when it carries same-slug raw tags", () => {
+    const groups = buildTagGroups([entry("a", ["AI", "ai", "A.I."])]);
+    const ai = findTagGroup(groups, "ai");
+    expect(ai?.entries).toHaveLength(1);
+  });
+
+  it("picks the most frequent raw casing as the canonical group name", () => {
+    const groups = buildTagGroups([
+      entry("a", ["AI"]),
+      entry("b", ["AI"]),
+      entry("c", ["ai"]),
+    ]);
+    expect(findTagGroup(groups, "ai")?.name).toBe("AI");
+  });
+
+  it("ignores empty/symbol-only tags", () => {
+    const groups = buildTagGroups([entry("a", ["", "!!!", "Valid"])]);
+    expect(groups.map((g) => g.slug)).toEqual(["valid"]);
+  });
+});
+
+describe("filterIndexableTagGroups", () => {
+  it("keeps only groups with at least two entries", () => {
+    const groups = buildTagGroups([
+      entry("a", ["shared", "solo"]),
+      entry("b", ["shared"]),
+    ]);
+    expect(filterIndexableTagGroups(groups).map((g) => g.slug)).toEqual(["shared"]);
+  });
+});
+
+describe("computeRelatedTags", () => {
+  const groups = buildTagGroups([
+    entry("a", ["ai", "cli", "web"]),
+    entry("b", ["ai", "cli"]),
+    entry("c", ["ai", "web"]),
+    entry("d", ["web"]),
+  ]);
+
+  it("returns [] for an unknown slug", () => {
+    expect(computeRelatedTags(groups, "missing")).toEqual([]);
+  });
+
+  it("ranks co-occurring indexable tags by count and excludes the tag itself", () => {
+    // Within the "ai" group (a,b,c): cli co-occurs 2x, web 2x — both indexable (>=2 entries).
+    const related = computeRelatedTags(groups, "ai").map((g) => g.slug);
+    expect(related).toContain("cli");
+    expect(related).toContain("web");
+    expect(related).not.toContain("ai");
+  });
+
+  it("honors the limit", () => {
+    expect(computeRelatedTags(groups, "ai", 1)).toHaveLength(1);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
         "apps/web/src/lib/og-render.server.ts",
         "apps/web/src/lib/peek-hotkey.ts",
         "apps/web/src/lib/site.ts",
+        "apps/web/src/lib/tags.ts",
         "apps/web/src/lib/tools.ts",
         "apps/web/src/lib/utils.ts",
         "apps/submission-gate/src/index.ts",


### PR DESCRIPTION
Moves the pure tag-grouping logic (`tagSlug`, `buildTagGroups`, `findTagGroup`, `filterIndexableTagGroups`, `computeRelatedTags`) into `tags-lib.ts`, parameterized on the entry/group list rather than reading the global `ENTRIES` dataset — so the logic becomes unit-testable with injected fixtures. The original `tags.ts` keeps the `ENTRIES` binding and the memoized `getAllTagGroups()` cache and re-exports the same public API (`getAllTagGroups`, `getTagGroup`, `getIndexableTagGroups`, `relatedTags`, `tagSlug`, `TagGroup`), so `@/lib/tags` imports are unchanged; it joins the coverage exclude list like the other data-bound shims.

Adds `tests/tags-lib.test.ts` (10 cases) covering slug normalization, grouping + size-sort, same-slug de-duplication, canonical-name selection, empty-tag skipping, indexable filtering, and related-tag ranking/limit — logic that previously could only run against the full dataset and had no unit coverage. `vitest run` passes; no new type-check errors.