### PR TITLE
feat(mcp): extract registry resource metadata into resource-metadata-lib

### DIFF
--- a/packages/mcp/src/registry-resource-metadata-lib.js
+++ b/packages/mcp/src/registry-resource-metadata-lib.js
@@ -1,0 +1,67 @@
+/**
+ * Pure MCP registry resource metadata helpers.
+ *
+ * Static MCP resource template and discovery resource descriptors live here.
+ * Runtime registry handlers stay in `registry.js`.
+ */
+const jsonMimeType = "application/json";
+
+export const RESOURCE_TEMPLATES = [
+  {
+    uriTemplate: "heyclaude://entry/{category}/{slug}",
+    name: "HeyClaude entry detail",
+    title: "HeyClaude entry detail",
+    description:
+      "Read a single generated HeyClaude entry detail artifact as JSON.",
+    mimeType: jsonMimeType,
+  },
+  {
+    uriTemplate: "heyclaude://category/{category}",
+    name: "HeyClaude category entries",
+    title: "HeyClaude category entries",
+    description:
+      "Read generated summary entries for one HeyClaude category as JSON.",
+    mimeType: jsonMimeType,
+  },
+];
+
+/**
+ * Static MCP resource descriptors for the bounded discovery surfaces
+ * exposed alongside the directory and category feeds. Appended to
+ * {@link listRegistryResources} output and routed by
+ * {@link readRegistryResource}.
+ *
+ * @type {Array<{ uri: string, name: string, title: string, description: string, mimeType: string }>}
+ */
+export const DISCOVERY_RESOURCES = [
+  {
+    uri: "heyclaude://registry/recent",
+    name: "HeyClaude recent registry updates",
+    title: "HeyClaude recent registry updates",
+    description:
+      "Bounded list of recently added or upstream-updated HeyClaude entries from the generated search index.",
+    mimeType: jsonMimeType,
+  },
+  {
+    uri: "heyclaude://registry/trending",
+    name: "HeyClaude trending registry entries",
+    title: "HeyClaude trending registry entries",
+    description:
+      "Bounded list of trending HeyClaude entries from the public /api/registry/trending endpoint; degrades gracefully when dynamic state is unavailable.",
+    mimeType: jsonMimeType,
+  },
+  {
+    uri: "heyclaude://jobs/active",
+    name: "HeyClaude active jobs",
+    title: "HeyClaude active jobs",
+    description:
+      "Bounded list of active public job listings from the public /api/jobs endpoint; degrades gracefully when dynamic state is unavailable.",
+    mimeType: jsonMimeType,
+  },
+];
+
+export function listRegistryResourceTemplates() {
+  return {
+    resourceTemplates: RESOURCE_TEMPLATES,
+  };
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -82,6 +82,11 @@ import {
   unavailable,
   withPublicPolicy,
 } from "./registry-response-lib.js";
+import {
+  DISCOVERY_RESOURCES,
+  RESOURCE_TEMPLATES,
+  listRegistryResourceTemplates,
+} from "./registry-resource-metadata-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -91,6 +96,8 @@ export {
 };
 
 export { PROMPT_DEFINITIONS, getRegistryPrompt, listRegistryPrompts };
+
+export { RESOURCE_TEMPLATES, listRegistryResourceTemplates };
 
 function dataDirFromOptions(options = {}) {
   const envDataDir =
@@ -1570,60 +1577,6 @@ export async function getClientSetup(args = {}) {
   };
 }
 
-export const RESOURCE_TEMPLATES = [
-  {
-    uriTemplate: "heyclaude://entry/{category}/{slug}",
-    name: "HeyClaude entry detail",
-    title: "HeyClaude entry detail",
-    description:
-      "Read a single generated HeyClaude entry detail artifact as JSON.",
-    mimeType: jsonMimeType,
-  },
-  {
-    uriTemplate: "heyclaude://category/{category}",
-    name: "HeyClaude category entries",
-    title: "HeyClaude category entries",
-    description:
-      "Read generated summary entries for one HeyClaude category as JSON.",
-    mimeType: jsonMimeType,
-  },
-];
-
-/**
- * Static MCP resource descriptors for the bounded discovery surfaces
- * exposed alongside the directory and category feeds. Appended to
- * {@link listRegistryResources} output and routed by
- * {@link readRegistryResource}.
- *
- * @type {Array<{ uri: string, name: string, title: string, description: string, mimeType: string }>}
- */
-const DISCOVERY_RESOURCES = [
-  {
-    uri: "heyclaude://registry/recent",
-    name: "HeyClaude recent registry updates",
-    title: "HeyClaude recent registry updates",
-    description:
-      "Bounded list of recently added or upstream-updated HeyClaude entries from the generated search index.",
-    mimeType: jsonMimeType,
-  },
-  {
-    uri: "heyclaude://registry/trending",
-    name: "HeyClaude trending registry entries",
-    title: "HeyClaude trending registry entries",
-    description:
-      "Bounded list of trending HeyClaude entries from the public /api/registry/trending endpoint; degrades gracefully when dynamic state is unavailable.",
-    mimeType: jsonMimeType,
-  },
-  {
-    uri: "heyclaude://jobs/active",
-    name: "HeyClaude active jobs",
-    title: "HeyClaude active jobs",
-    description:
-      "Bounded list of active public job listings from the public /api/jobs endpoint; degrades gracefully when dynamic state is unavailable.",
-    mimeType: jsonMimeType,
-  },
-];
-
 /**
  * Resolve the public HeyClaude API base URL. Prefers an explicit override
  * on `options.publicApiBaseUrl`, then the `HEYCLAUDE_PUBLIC_API_URL`
@@ -1913,12 +1866,6 @@ export async function listRegistryResources(args = {}, options = {}) {
       })),
       ...DISCOVERY_RESOURCES,
     ],
-  };
-}
-
-export function listRegistryResourceTemplates() {
-  return {
-    resourceTemplates: RESOURCE_TEMPLATES,
   };
 }
 

--- a/tests/mcp-registry-resource-metadata-lib.test.ts
+++ b/tests/mcp-registry-resource-metadata-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DISCOVERY_RESOURCES,
+  RESOURCE_TEMPLATES,
+  listRegistryResourceTemplates,
+} from "../packages/mcp/src/registry-resource-metadata-lib.js";
+import {
+  RESOURCE_TEMPLATES as templatesFromWrapper,
+  listRegistryResourceTemplates as listTemplatesFromWrapper,
+} from "../packages/mcp/src/registry.js";
+
+describe("registry-resource-metadata-lib templates", () => {
+  it("lists entry and category resource templates", () => {
+    expect(listRegistryResourceTemplates()).toEqual({
+      resourceTemplates: RESOURCE_TEMPLATES,
+    });
+    expect(RESOURCE_TEMPLATES.map((resource) => resource.uriTemplate)).toEqual([
+      "heyclaude://entry/{category}/{slug}",
+      "heyclaude://category/{category}",
+    ]);
+  });
+
+  it("lists bounded discovery resources for recent, trending, and jobs feeds", () => {
+    expect(DISCOVERY_RESOURCES.map((resource) => resource.uri)).toEqual([
+      "heyclaude://registry/recent",
+      "heyclaude://registry/trending",
+      "heyclaude://jobs/active",
+    ]);
+  });
+});
+
+describe("registry re-export compatibility", () => {
+  it("keeps the public registry wrapper wired to the extracted lib", () => {
+    expect(templatesFromWrapper).toBe(RESOURCE_TEMPLATES);
+    expect(listTemplatesFromWrapper).toBe(listRegistryResourceTemplates);
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -2539,6 +2539,13 @@ describe("HeyClaude read-only MCP helpers", () => {
         path.join(repoRoot, "packages/mcp/src/registry-response-lib.js"),
         "utf8",
       );
+      const resourceMetadataLibSource = fs.readFileSync(
+        path.join(
+          repoRoot,
+          "packages/mcp/src/registry-resource-metadata-lib.js",
+        ),
+        "utf8",
+      );
 
       const requireDocstringBefore = (
         declaration: string,
@@ -2572,7 +2579,10 @@ describe("HeyClaude read-only MCP helpers", () => {
       requireDocstringBefore("export function unavailable(", responseLibSource);
       requireDocstringBefore("function toTrendingEntry(");
       requireDocstringBefore("function toJobEntry(");
-      requireDocstringBefore("const DISCOVERY_RESOURCES = [");
+      requireDocstringBefore(
+        "export const DISCOVERY_RESOURCES = [",
+        resourceMetadataLibSource,
+      );
     });
 
     it("lists discovery resources alongside the directory and category feeds", async () => {


### PR DESCRIPTION
# Pull Request

## Summary

- Extract MCP resource template and discovery resource descriptors into `packages/mcp/src/registry-resource-metadata-lib.js`.
- Keep `packages/mcp/src/registry.js` as the public registry surface with imports plus re-exports so existing `@heyclaude/mcp/registry` consumers stay unchanged.
- Add focused lib tests for resource templates, discovery resources, and re-export compatibility.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-resource-metadata-lib.js` (new extracted resource metadata helpers)
  - `packages/mcp/src/registry.js` (imports + re-exports; runtime handlers unchanged)
  - `tests/mcp-registry-resource-metadata-lib.test.ts` (new focused tests)
  - `tests/mcp-server.test.ts` (docstring gate now checks extracted discovery resources)
- Expected behavior:
  - MCP resource template listing and discovery resource descriptors are unchanged.
- Important edge cases or invariants:
  - Entry/category templates and recent/trending/jobs discovery URIs remain the same.
- Backward compatibility notes:
  - Public exports `RESOURCE_TEMPLATES` and `listRegistryResourceTemplates` from `registry.js` are unchanged.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-resource-metadata-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-resource-metadata-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate MCP resource metadata for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-response-lib`, `registry-normalize-lib`, `server-lib`).
  - Does not touch `schemas.js`, endpoint URL helpers, or submission-risk analysis code.


Made with [Cursor](https://cursor.com)