### PR TITLE
feat(web): extract api-logs helpers into api-logs-lib

### DIFF
--- a/apps/web/src/lib/api-logs-lib.ts
+++ b/apps/web/src/lib/api-logs-lib.ts
@@ -1,0 +1,56 @@
+/**
+ * Pure API-logging helpers.
+ *
+ * Builds the structured request metadata, the JSON log payload, and the
+ * email-redaction / sampling utilities used by the API logger. Everything here
+ * is deterministic given its inputs (the log payload takes an injectable
+ * timestamp); the actual `console` dispatch lives in the `api-logs.ts` wrapper.
+ *
+ * The public surface (`api-logs.ts` / `@/lib/api-logs`) re-exports the public
+ * helpers below.
+ */
+
+export type LogLevel = "info" | "warn" | "error";
+
+export type LogMeta = Record<string, unknown>;
+
+/** Non-identifying request metadata for a structured log line. */
+export function pickRequestMeta(request: Request) {
+  const url = new URL(request.url);
+  return {
+    method: request.method,
+    path: url.pathname,
+    query: url.search ? "present" : "none",
+    cfRay: request.headers.get("cf-ray") ?? undefined,
+    userAgent: request.headers.get("user-agent") ?? undefined,
+  };
+}
+
+/** The structured log payload; timestamp is injectable so it is deterministic. */
+export function buildLogPayload(
+  level: LogLevel,
+  event: string,
+  meta: LogMeta,
+  now: Date = new Date(),
+) {
+  return {
+    ts: now.toISOString(),
+    level,
+    event,
+    ...meta,
+  };
+}
+
+export function sample(rate: number) {
+  return Math.random() < rate;
+}
+
+export function redactEmail(value: string) {
+  const email = String(value || "")
+    .trim()
+    .toLowerCase();
+  const [local, domain] = email.split("@");
+  if (!local || !domain) return "invalid";
+  const visible = local.slice(0, 2);
+  return `${visible}***@${domain}`;
+}

--- a/apps/web/src/lib/api-logs.ts
+++ b/apps/web/src/lib/api-logs.ts
@@ -1,26 +1,17 @@
-type LogLevel = "info" | "warn" | "error";
+/**
+ * API-logging surface.
+ *
+ * The pure metadata/payload/redaction helpers live in `api-logs-lib.ts`. This
+ * module keeps the `console` dispatch and the request-bound `logApi*` wrappers,
+ * and re-exports the pure helpers so existing `@/lib/api-logs` imports stay
+ * unchanged.
+ */
+import { buildLogPayload, type LogLevel, type LogMeta, pickRequestMeta } from "@/lib/api-logs-lib";
 
-type LogMeta = Record<string, unknown>;
-
-function pickRequestMeta(request: Request) {
-  const url = new URL(request.url);
-  return {
-    method: request.method,
-    path: url.pathname,
-    query: url.search ? "present" : "none",
-    cfRay: request.headers.get("cf-ray") ?? undefined,
-    userAgent: request.headers.get("user-agent") ?? undefined,
-  };
-}
+export { redactEmail, sample } from "@/lib/api-logs-lib";
 
 function writeLog(level: LogLevel, event: string, meta: LogMeta) {
-  const payload = {
-    ts: new Date().toISOString(),
-    level,
-    event,
-    ...meta,
-  };
-  const line = JSON.stringify(payload);
+  const line = JSON.stringify(buildLogPayload(level, event, meta));
   if (level === "error") {
     console.error(line);
     return;
@@ -32,40 +23,14 @@ function writeLog(level: LogLevel, event: string, meta: LogMeta) {
   console.info(line);
 }
 
-export function logApiInfo(
-  request: Request,
-  event: string,
-  meta: LogMeta = {},
-) {
+export function logApiInfo(request: Request, event: string, meta: LogMeta = {}) {
   writeLog("info", event, { ...pickRequestMeta(request), ...meta });
 }
 
-export function logApiWarn(
-  request: Request,
-  event: string,
-  meta: LogMeta = {},
-) {
+export function logApiWarn(request: Request, event: string, meta: LogMeta = {}) {
   writeLog("warn", event, { ...pickRequestMeta(request), ...meta });
 }
 
-export function logApiError(
-  request: Request,
-  event: string,
-  meta: LogMeta = {},
-) {
+export function logApiError(request: Request, event: string, meta: LogMeta = {}) {
   writeLog("error", event, { ...pickRequestMeta(request), ...meta });
-}
-
-export function sample(rate: number) {
-  return Math.random() < rate;
-}
-
-export function redactEmail(value: string) {
-  const email = String(value || "")
-    .trim()
-    .toLowerCase();
-  const [local, domain] = email.split("@");
-  if (!local || !domain) return "invalid";
-  const visible = local.slice(0, 2);
-  return `${visible}***@${domain}`;
 }

--- a/tests/api-logs-lib.test.ts
+++ b/tests/api-logs-lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLogPayload,
+  pickRequestMeta,
+  redactEmail,
+  sample,
+} from "../apps/web/src/lib/api-logs-lib";
+
+describe("pickRequestMeta", () => {
+  it("extracts method, path, query presence, and forwarded headers", () => {
+    const request = new Request("https://x.dev/api/entries?q=ai", {
+      method: "POST",
+      headers: { "cf-ray": "abc123", "user-agent": "vitest" },
+    });
+    expect(pickRequestMeta(request)).toEqual({
+      method: "POST",
+      path: "/api/entries",
+      query: "present",
+      cfRay: "abc123",
+      userAgent: "vitest",
+    });
+  });
+
+  it("reports query as 'none' and omits absent headers as undefined", () => {
+    const meta = pickRequestMeta(new Request("https://x.dev/api/health"));
+    expect(meta.query).toBe("none");
+    expect(meta.cfRay).toBeUndefined();
+    expect(meta.userAgent).toBeUndefined();
+  });
+});
+
+describe("buildLogPayload", () => {
+  it("stamps an injected timestamp and spreads level/event/meta", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z");
+    expect(buildLogPayload("warn", "rate_limited", { path: "/api", count: 3 }, now)).toEqual({
+      ts: "2026-07-01T12:00:00.000Z",
+      level: "warn",
+      event: "rate_limited",
+      path: "/api",
+      count: 3,
+    });
+  });
+});
+
+describe("sample", () => {
+  it("never samples at rate 0 and always samples at rate 1", () => {
+    // Math.random() is in [0, 1): always < 1, never < 0 — deterministic bounds.
+    for (let i = 0; i < 50; i++) {
+      expect(sample(0)).toBe(false);
+      expect(sample(1)).toBe(true);
+    }
+  });
+});
+
+describe("redactEmail", () => {
+  it("keeps the first two local chars and the domain, masking the rest", () => {
+    expect(redactEmail("alice@example.com")).toBe("al***@example.com");
+  });
+
+  it("normalizes case and whitespace before redacting", () => {
+    expect(redactEmail("  Bob@Example.COM ")).toBe("bo***@example.com");
+  });
+
+  it("returns 'invalid' for non-email input", () => {
+    expect(redactEmail("not-an-email")).toBe("invalid");
+    expect(redactEmail("")).toBe("invalid");
+    expect(redactEmail("@no-local.com")).toBe("invalid");
+  });
+
+  it("handles a one-character local part", () => {
+    expect(redactEmail("x@d.io")).toBe("x***@d.io");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",
         "apps/web/src/lib/compare-entry-actions.ts",


### PR DESCRIPTION
Moves the pure logging helpers (`pickRequestMeta`, `buildLogPayload`, `sample`, `redactEmail`) into `api-logs-lib.ts`, with the log payload taking an injectable timestamp so it is deterministic and unit-testable. The original `api-logs.ts` keeps the `console` dispatch (`writeLog`) and the request-bound `logApiInfo/Warn/Error` wrappers and re-exports the pure helpers, so `@/lib/api-logs` imports are unchanged; it joins the coverage exclude list like the other side-effecting shims.

Adds `tests/api-logs-lib.test.ts` (8 cases) covering request-meta extraction (method/path/query-presence/forwarded headers + absent-header handling), the timestamped payload shape, the `sample()` 0/1 bounds, and email redaction (masking, case/whitespace normalization, invalid input, one-char local) — previously untested. `vitest run` passes; no new type-check errors.