### PR TITLE
feat(web): extract security-headers helpers into security-headers-lib

### DIFF
--- a/apps/web/src/lib/security-headers-lib.ts
+++ b/apps/web/src/lib/security-headers-lib.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure security-header helpers.
+ *
+ * The origin parser, the non-production host check, and the edge-cache header
+ * policy — none of which depend on the site config or environment. Given the
+ * same inputs the output is deterministic (the header helpers mutate the passed
+ * `Headers` object in place and return it).
+ *
+ * The public surface (`security-headers.ts` / `@/lib/security-headers`) keeps
+ * the CSP/site-config-bound header set and re-exports the helpers below.
+ */
+
+export function urlOrigin(value: string) {
+  if (!value) return "";
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+// Non-production hosts (preview/staging) must not be indexed — otherwise Google treats
+// e.g. dev.heyclau.de as duplicate content competing with the canonical production site.
+export function isNonProdHost(hostname: string) {
+  return (
+    hostname.startsWith("dev.") ||
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.includes("staging") ||
+    hostname.endsWith(".workers.dev")
+  );
+}
+
+// SSR HTML that no route opted out of is safe to cache at the edge so repeat hits
+// skip re-rendering. Personalized/dynamic routes already set their own `Cache-Control`
+// (typically `no-store`), which is preserved; a `Set-Cookie` (session/personalization)
+// also disables caching as a backstop. CDN-only (`s-maxage`) — no browser `max-age`, so
+// a deploy invalidates immediately for users.
+export const HTML_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=86400";
+
+export function applyEdgeCacheHeaders(headers: Headers, status: number, method: string) {
+  if (method !== "GET" || status !== 200) return headers;
+  if (headers.has("cache-control") || headers.has("set-cookie")) return headers;
+  if (!(headers.get("content-type") ?? "").includes("text/html")) return headers;
+  headers.set("cache-control", HTML_CACHE_CONTROL);
+  return headers;
+}

--- a/apps/web/src/lib/security-headers.ts
+++ b/apps/web/src/lib/security-headers.ts
@@ -1,13 +1,15 @@
+/**
+ * Security-header surface.
+ *
+ * The pure helpers (origin parsing, non-prod host check, edge-cache policy) live
+ * in `security-headers-lib.ts`. This module keeps the site-config / env-bound CSP
+ * header set and re-exports the pure helpers so existing `@/lib/security-headers`
+ * imports stay unchanged.
+ */
+import { isNonProdHost, urlOrigin } from "@/lib/security-headers-lib";
 import { siteConfig } from "./site";
 
-export function urlOrigin(value: string) {
-  if (!value) return "";
-  try {
-    return new URL(value).origin;
-  } catch {
-    return "";
-  }
-}
+export { applyEdgeCacheHeaders, urlOrigin } from "@/lib/security-headers-lib";
 
 const scriptSrc = [
   // Keep scripts constrained to same-origin application bundles. The legacy
@@ -59,18 +61,6 @@ const SECURITY_HEADERS = {
   "x-frame-options": "DENY",
 } as const;
 
-// Non-production hosts (preview/staging) must not be indexed — otherwise Google treats
-// e.g. dev.heyclau.de as duplicate content competing with the canonical production site.
-function isNonProdHost(hostname: string) {
-  return (
-    hostname.startsWith("dev.") ||
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname.includes("staging") ||
-    hostname.endsWith(".workers.dev")
-  );
-}
-
 // RFC 8288 Link header advertising agent-discovery resources from every HTML page.
 const AGENT_LINK_HEADER = [
   `<${siteConfig.url}/.well-known/api-catalog>; rel="api-catalog"`,
@@ -97,21 +87,6 @@ export function applySecurityHeaders(headers: Headers, request?: Request) {
       // Malformed request URL — leave indexing headers untouched.
     }
   }
-  return headers;
-}
-
-// SSR HTML that no route opted out of is safe to cache at the edge so repeat hits
-// skip re-rendering. Personalized/dynamic routes already set their own `Cache-Control`
-// (typically `no-store`), which is preserved; a `Set-Cookie` (session/personalization)
-// also disables caching as a backstop. CDN-only (`s-maxage`) — no browser `max-age`, so
-// a deploy invalidates immediately for users.
-const HTML_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=86400";
-
-export function applyEdgeCacheHeaders(headers: Headers, status: number, method: string) {
-  if (method !== "GET" || status !== 200) return headers;
-  if (headers.has("cache-control") || headers.has("set-cookie")) return headers;
-  if (!(headers.get("content-type") ?? "").includes("text/html")) return headers;
-  headers.set("cache-control", HTML_CACHE_CONTROL);
   return headers;
 }
 

--- a/tests/security-headers-lib.test.ts
+++ b/tests/security-headers-lib.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyEdgeCacheHeaders,
+  HTML_CACHE_CONTROL,
+  isNonProdHost,
+  urlOrigin,
+} from "../apps/web/src/lib/security-headers-lib";
+
+describe("urlOrigin", () => {
+  it("returns the origin of a valid URL", () => {
+    expect(urlOrigin("https://api.github.com/repos/x")).toBe("https://api.github.com");
+    expect(urlOrigin("http://localhost:3000/a?b=c")).toBe("http://localhost:3000");
+  });
+
+  it("returns an empty string for empty or malformed input", () => {
+    expect(urlOrigin("")).toBe("");
+    expect(urlOrigin("not a url")).toBe("");
+  });
+});
+
+describe("isNonProdHost", () => {
+  it("flags preview/staging/local hosts", () => {
+    for (const h of ["dev.heyclau.de", "localhost", "app.localhost", "web-staging.example.com", "web.workers.dev"]) {
+      expect(isNonProdHost(h)).toBe(true);
+    }
+  });
+
+  it("does not flag the production host", () => {
+    for (const h of ["heyclau.de", "www.heyclau.de", "developer.example.com"]) {
+      expect(isNonProdHost(h)).toBe(false);
+    }
+  });
+});
+
+describe("applyEdgeCacheHeaders", () => {
+  const htmlHeaders = () => new Headers({ "content-type": "text/html; charset=utf-8" });
+
+  it("caches a plain GET 200 HTML response", () => {
+    const headers = applyEdgeCacheHeaders(htmlHeaders(), 200, "GET");
+    expect(headers.get("cache-control")).toBe(HTML_CACHE_CONTROL);
+  });
+
+  it("does not cache non-GET, non-200, or non-HTML responses", () => {
+    expect(applyEdgeCacheHeaders(htmlHeaders(), 200, "POST").has("cache-control")).toBe(false);
+    expect(applyEdgeCacheHeaders(htmlHeaders(), 500, "GET").has("cache-control")).toBe(false);
+    expect(
+      applyEdgeCacheHeaders(new Headers({ "content-type": "application/json" }), 200, "GET").has("cache-control"),
+    ).toBe(false);
+  });
+
+  it("preserves an explicit cache-control and never caches a personalized (Set-Cookie) response", () => {
+    const explicit = new Headers({ "content-type": "text/html", "cache-control": "no-store" });
+    expect(applyEdgeCacheHeaders(explicit, 200, "GET").get("cache-control")).toBe("no-store");
+
+    const cookied = new Headers({ "content-type": "text/html", "set-cookie": "sid=1" });
+    expect(applyEdgeCacheHeaders(cookied, 200, "GET").has("cache-control")).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -80,6 +80,7 @@ export default defineConfig({
         "apps/web/src/lib/job-admin.ts",
         "apps/web/src/lib/og-render.server.ts",
         "apps/web/src/lib/peek-hotkey.ts",
+        "apps/web/src/lib/security-headers.ts",
         "apps/web/src/lib/site.ts",
         "apps/web/src/lib/tools.ts",
         "apps/web/src/lib/utils.ts",


### PR DESCRIPTION
Moves the pure/self-contained helpers (`urlOrigin`, `isNonProdHost`, and the edge-cache policy `applyEdgeCacheHeaders` + `HTML_CACHE_CONTROL`) into `security-headers-lib.ts`. The original `security-headers.ts` keeps the `siteConfig`/env-bound CSP header set plus `applySecurityHeaders` and `getSecurityHeaders`, and re-exports the pure helpers, so `@/lib/security-headers` imports are unchanged; it joins the coverage exclude list like the other config-bound shims.

Adds `tests/security-headers-lib.test.ts` (7 cases) covering origin parsing (valid/empty/malformed), the non-prod host matrix (dev./localhost/.localhost/staging/.workers.dev vs production), and the edge-cache policy (GET+200+HTML caches; non-GET/non-200/non-HTML skip; explicit `cache-control` and `Set-Cookie` responses are never overridden) — previously untested. `vitest run` passes; no new type-check errors.