### PR TITLE
feat(web): add compare page empty interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
@@ -1,0 +1,16 @@
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  comparePageEmptyUiState,
+  type ComparePageEmptyUiState,
+} from "@/lib/compare-page-empty-ui-lib";
+
+export type { ComparePageEmptyUiState };
+export type ComparePageEmptyInteractiveUiState = ComparePageEmptyUiState;
+
+export function comparePageEmptyInteractiveUiState(
+  ids: string,
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePageEmptyInteractiveUiState {
+  return comparePageEmptyUiState(ids, comparisons, catalog);
+}

--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -1,9 +1,9 @@
 import type { Entry } from "@/types/registry";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import {
-  comparePageEmptyUiState,
+  comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
-} from "@/lib/compare-page-empty-ui-lib";
+} from "@/lib/compare-page-empty-interactive-ui-lib";
 import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
 
 export type ComparePageInteractiveUiState = {
@@ -19,6 +19,6 @@ export function comparePageInteractiveUiState(
 ): ComparePageInteractiveUiState {
   return {
     pageUi: comparePageUiState(items),
-    emptyUi: comparePageEmptyUiState(ids, comparisons, catalog),
+    emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
   };
 }

--- a/tests/compare-page-empty-interactive-ui-lib.test.ts
+++ b/tests/compare-page-empty-interactive-ui-lib.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePageEmptyInteractiveUiState } from "@/lib/compare-page-empty-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+];
+
+describe("compare page empty interactive ui lib", () => {
+  it("bundles empty-state copy, invalid URL hints, and popular comparison links", () => {
+    expect(
+      comparePageEmptyInteractiveUiState(
+        "",
+        [
+          {
+            slug: "pair",
+            heading: "Alpha vs Beta",
+            refs: ["skills/alpha", "hooks/beta"],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      description: expect.stringContaining("directory"),
+      invalidUrlHint: null,
+      popularComparisonLinks: [
+        {
+          slug: "pair",
+          heading: "Alpha vs Beta",
+          interactiveSearch: { ids: "skills/alpha,hooks/beta" },
+          interactiveLabel: "Open interactively",
+        },
+      ],
+    });
+  });
+
+  it("surfaces invalid URL hints when ids cannot be resolved", () => {
+    const state = comparePageEmptyInteractiveUiState(
+      "skills/missing",
+      [],
+      catalog,
+    );
+    expect(state.invalidUrlHint).toContain("could not be resolved");
+    expect(state.popularComparisonLinks).toEqual([]);
+  });
+
+  it("omits interactive search when fewer than two refs resolve", () => {
+    expect(
+      comparePageEmptyInteractiveUiState(
+        "",
+        [{ slug: "solo", heading: "Alpha only", refs: ["skills/alpha"] }],
+        catalog,
+      ).popularComparisonLinks,
+    ).toEqual([
+      {
+        slug: "solo",
+        heading: "Alpha only",
+        interactiveSearch: null,
+        interactiveLabel: "Open interactively",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-empty-interactive-ui-lib` with `comparePageEmptyInteractiveUiState` for compare page empty-state presentation
- Wire `compare-page-interactive-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-empty-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426 / #4443 / #4447


Made with [Cursor](https://cursor.com)