### PR TITLE
feat(mcp): extract registry collection helpers into registry-collection-lib

### DIFF
--- a/packages/mcp/src/registry-collection-lib.js
+++ b/packages/mcp/src/registry-collection-lib.js
@@ -1,0 +1,39 @@
+/**
+ * Pure MCP registry collection and date helpers.
+ *
+ * Trust-filter argument normalization, array utilities, and date floor parsing
+ * live here. Runtime registry handlers stay in `registry.js`.
+ */
+import { normalizeText } from "./registry-normalize-lib.js";
+
+export function parsedTrustArgs(args = {}) {
+  return {
+    hasSafetyNotes: args.hasSafetyNotes || "all",
+    hasPrivacyNotes: args.hasPrivacyNotes || "all",
+    downloadTrust: args.downloadTrust || "all",
+    claimStatus: args.claimStatus || "all",
+    sourceStatus: args.sourceStatus || "all",
+  };
+}
+
+export function intersection(left = [], right = [], normalize = normalizeText) {
+  const rightValues = new Set((right || []).map(normalize).filter(Boolean));
+  return (left || [])
+    .map(normalize)
+    .filter((value, index, values) => value && values.indexOf(value) === index)
+    .filter((value) => rightValues.has(value));
+}
+
+export function unique(values = []) {
+  return values.filter(
+    (value, index, list) => value && list.indexOf(value) === index,
+  );
+}
+
+export function normalizeDateFloor(value) {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  const timestamp = Date.parse(text);
+  if (!Number.isFinite(timestamp)) return "";
+  return new Date(timestamp).toISOString().slice(0, 10);
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -87,6 +87,12 @@ import {
   RESOURCE_TEMPLATES,
   listRegistryResourceTemplates,
 } from "./registry-resource-metadata-lib.js";
+import {
+  intersection,
+  normalizeDateFloor,
+  parsedTrustArgs,
+  unique,
+} from "./registry-collection-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -257,16 +263,6 @@ function entryMatchesTrustFilters(entry, args = {}) {
   return true;
 }
 
-function parsedTrustArgs(args = {}) {
-  return {
-    hasSafetyNotes: args.hasSafetyNotes || "all",
-    hasPrivacyNotes: args.hasPrivacyNotes || "all",
-    downloadTrust: args.downloadTrust || "all",
-    claimStatus: args.claimStatus || "all",
-    sourceStatus: args.sourceStatus || "all",
-  };
-}
-
 function toSearchResult(entry, ranking = null) {
   return {
     key: `${entry.category}:${entry.slug}`,
@@ -325,28 +321,6 @@ function entrySourceHosts(entry) {
   ]
     .map(sourceHost)
     .filter(Boolean);
-}
-
-function intersection(left = [], right = [], normalize = normalizeText) {
-  const rightValues = new Set((right || []).map(normalize).filter(Boolean));
-  return (left || [])
-    .map(normalize)
-    .filter((value, index, values) => value && values.indexOf(value) === index)
-    .filter((value) => rightValues.has(value));
-}
-
-function unique(values = []) {
-  return values.filter(
-    (value, index, list) => value && list.indexOf(value) === index,
-  );
-}
-
-function normalizeDateFloor(value) {
-  const text = String(value || "").trim();
-  if (!text) return "";
-  const timestamp = Date.parse(text);
-  if (!Number.isFinite(timestamp)) return "";
-  return new Date(timestamp).toISOString().slice(0, 10);
 }
 
 function sourceSummary(entry) {

--- a/tests/mcp-registry-collection-lib.test.ts
+++ b/tests/mcp-registry-collection-lib.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  intersection,
+  normalizeDateFloor,
+  parsedTrustArgs,
+  unique,
+} from "../packages/mcp/src/registry-collection-lib.js";
+
+describe("registry-collection-lib trust args", () => {
+  it("defaults trust filter args to all", () => {
+    expect(parsedTrustArgs({})).toEqual({
+      hasSafetyNotes: "all",
+      hasPrivacyNotes: "all",
+      downloadTrust: "all",
+      claimStatus: "all",
+      sourceStatus: "all",
+    });
+    expect(
+      parsedTrustArgs({
+        hasSafetyNotes: "yes",
+        claimStatus: "claimed",
+      }),
+    ).toEqual({
+      hasSafetyNotes: "yes",
+      hasPrivacyNotes: "all",
+      downloadTrust: "all",
+      claimStatus: "claimed",
+      sourceStatus: "all",
+    });
+  });
+});
+
+describe("registry-collection-lib array helpers", () => {
+  it("deduplicates and intersects normalized values", () => {
+    expect(unique(["mcp", "mcp", "", "skills"])).toEqual(["mcp", "skills"]);
+    expect(
+      intersection(["Codex", "codex", "Cursor"], ["cursor", "vscode"]),
+    ).toEqual(["cursor"]);
+  });
+});
+
+describe("registry-collection-lib date floors", () => {
+  it("normalizes valid dates to YYYY-MM-DD and rejects invalid input", () => {
+    expect(normalizeDateFloor("2026-03-15T12:00:00.000Z")).toBe("2026-03-15");
+    expect(normalizeDateFloor("")).toBe("");
+    expect(normalizeDateFloor("not-a-date")).toBe("");
+  });
+});


### PR DESCRIPTION
# Pull Request

## Summary

- Extract trust-filter argument normalization, array utilities, and date floor parsing into `packages/mcp/src/registry-collection-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so registry search/list behavior stays unchanged.
- Add focused lib tests for trust args, array helpers, and date floor parsing.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-collection-lib.js` (new extracted collection helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-collection-lib.test.ts` (new focused tests)
- Expected behavior:
  - Registry trust filtering, deduplication/intersection helpers, and date floor parsing are unchanged.
- Important edge cases or invariants:
  - Trust filter args still default to `"all"`.
  - `intersection` still normalizes values before comparing.
  - Invalid date floors still return an empty string.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-collection-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-collection-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry collection helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-resource-metadata-lib`, `registry-response-lib`, `registry-normalize-lib`).
  - Does not touch `schemas.js`, endpoint URL helpers, or submission-risk analysis code.


Made with [Cursor](https://cursor.com)