### PR TITLE
feat(web): add compare page UI interactive lib

### DIFF
--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -4,7 +4,10 @@ import {
   comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
 } from "@/lib/compare-page-empty-interactive-ui-lib";
-import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
+import {
+  comparePageUiInteractiveUiState,
+  type ComparePageUiState,
+} from "@/lib/compare-page-ui-interactive-ui-lib";
 
 export type ComparePageInteractiveUiState = {
   pageUi: ComparePageUiState;
@@ -18,7 +21,7 @@ export function comparePageInteractiveUiState(
   catalog: EntryIdentity[],
 ): ComparePageInteractiveUiState {
   return {
-    pageUi: comparePageUiState(items),
+    pageUi: comparePageUiInteractiveUiState(items),
     emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
   };
 }

--- a/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
@@ -1,0 +1,9 @@
+import type { Entry } from "@/types/registry";
+import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
+
+export type { ComparePageUiState };
+export type ComparePageUiInteractiveUiState = ComparePageUiState;
+
+export function comparePageUiInteractiveUiState(items: Entry[]): ComparePageUiInteractiveUiState {
+  return comparePageUiState(items);
+}

--- a/tests/compare-page-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-page-ui-interactive-ui-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePageUiInteractiveUiState } from "@/lib/compare-page-ui-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page ui interactive ui lib", () => {
+  it("bundles compare page header banners, share URL, and selection hints", () => {
+    expect(
+      comparePageUiInteractiveUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      singleItemHint: null,
+      shareUrl: "/compare?ids=skills%2Falpha%2Chooks%2Fbeta",
+    });
+  });
+
+  it("surfaces single-item selection hints for one-entry comparisons", () => {
+    expect(comparePageUiInteractiveUiState([entry()]).singleItemHint).toContain(
+      "Add one more resource",
+    );
+  });
+
+  it("highlights diverging next actions in bundled page presentation state", () => {
+    expect(
+      comparePageUiInteractiveUiState([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ slug: "other" }),
+      ]).actionRowDiverges,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-ui-interactive-ui-lib` with `comparePageUiInteractiveUiState` for compare page header/banner/share presentation
- Wire `compare-page-interactive-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4426 / #4443


Made with [Cursor](https://cursor.com)