### PR TITLE
feat(web): extract jobs-utils helpers into jobs-utils-lib

### DIFF
--- a/apps/web/src/lib/jobs-utils-lib.ts
+++ b/apps/web/src/lib/jobs-utils-lib.ts
@@ -1,0 +1,100 @@
+/**
+ * Pure jobs-board helpers.
+ *
+ * Presentation and ranking math for the jobs surface — company monograms and
+ * tints, relative "posted" labels, tier sorting, and the deterministic daily
+ * spotlight rotation. Nothing here touches the network or the clock beyond an
+ * injectable `now`, so given the same inputs the output is deterministic.
+ *
+ * The public surface (`jobs-utils.ts` / `@/lib/jobs-utils`) re-exports
+ * everything below so existing imports stay unchanged.
+ */
+
+import type { JobListing } from "@/types/registry";
+
+export function monogram(company: string): string {
+  return company
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? "")
+    .join("");
+}
+
+// Deterministic soft tint per company (hash → hue)
+export function companyTint(company: string): { bg: string; fg: string } {
+  let h = 0;
+  for (let i = 0; i < company.length; i++) h = (h * 31 + company.charCodeAt(i)) | 0;
+  const hue = Math.abs(h) % 360;
+  return {
+    bg: `oklch(0.94 0.04 ${hue})`,
+    fg: `oklch(0.32 0.08 ${hue})`,
+  };
+}
+
+const DAY = 86_400_000;
+export function daysSince(iso: string, now = Date.now()): number {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return Infinity;
+  return Math.floor((now - t) / DAY);
+}
+
+export function relativePosted(iso: string, now = Date.now()): string {
+  const d = daysSince(iso, now);
+  if (!Number.isFinite(d)) return "—";
+  if (d <= 0) return "today";
+  if (d === 1) return "1d ago";
+  if (d < 7) return `${d}d ago`;
+  if (d < 30) return `${Math.floor(d / 7)}w ago`;
+  if (d < 365) return `${Math.floor(d / 30)}mo ago`;
+  return `${Math.floor(d / 365)}y ago`;
+}
+
+export function isFresh(iso: string, now = Date.now()): boolean {
+  return daysSince(iso, now) <= 7;
+}
+
+export function sortJobs(jobs: JobListing[]): JobListing[] {
+  const order: Record<JobListing["tier"], number> = {
+    sponsored: 0,
+    featured: 1,
+    standard: 2,
+    free: 3,
+  };
+  return [...jobs].sort((a, b) => {
+    if (order[a.tier] !== order[b.tier]) return order[a.tier] - order[b.tier];
+    return b.postedAt.localeCompare(a.postedAt);
+  });
+}
+
+// Score for "in the spotlight" rotation. Rewards verified employer,
+// disclosed compensation, remote-friendly, and freshness.
+function spotlightScore(job: JobListing, now = Date.now()): number {
+  let s = 0;
+  if (job.lastVerifiedAt) s += 3;
+  if (job.compensation) s += 2;
+  if (job.isRemote) s += 1;
+  if (isFresh(job.postedAt, now)) s += 2;
+  if (job.tier === "sponsored") s += 1;
+  return s;
+}
+
+// Deterministic per-day rotation through a high-signal pool.
+// Same day → same pick; next day → next role. No randomness, no flicker.
+export function pickDailySpotlight(
+  jobs: JobListing[],
+  now = Date.now(),
+): { current: JobListing | null; next: JobListing | null } {
+  const pool = jobs
+    .filter((j) => spotlightScore(j, now) >= 4)
+    .sort((a, b) => {
+      const diff = spotlightScore(b, now) - spotlightScore(a, now);
+      if (diff !== 0) return diff;
+      return a.slug.localeCompare(b.slug);
+    });
+  if (pool.length === 0) return { current: null, next: null };
+  const dayIndex = Math.floor(now / DAY);
+  const i = ((dayIndex % pool.length) + pool.length) % pool.length;
+  const j = (i + 1) % pool.length;
+  return { current: pool[i] ?? null, next: pool[j] ?? null };
+}

--- a/apps/web/src/lib/jobs-utils.ts
+++ b/apps/web/src/lib/jobs-utils.ts
@@ -1,88 +1,16 @@
-import type { JobListing } from "@/types/registry";
-
-export function monogram(company: string): string {
-  return company
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((w) => w[0]?.toUpperCase() ?? "")
-    .join("");
-}
-
-// Deterministic soft tint per company (hash → hue)
-export function companyTint(company: string): { bg: string; fg: string } {
-  let h = 0;
-  for (let i = 0; i < company.length; i++) h = (h * 31 + company.charCodeAt(i)) | 0;
-  const hue = Math.abs(h) % 360;
-  return {
-    bg: `oklch(0.94 0.04 ${hue})`,
-    fg: `oklch(0.32 0.08 ${hue})`,
-  };
-}
-
-const DAY = 86_400_000;
-export function daysSince(iso: string, now = Date.now()): number {
-  const t = Date.parse(iso);
-  if (Number.isNaN(t)) return Infinity;
-  return Math.floor((now - t) / DAY);
-}
-
-export function relativePosted(iso: string, now = Date.now()): string {
-  const d = daysSince(iso, now);
-  if (!Number.isFinite(d)) return "—";
-  if (d <= 0) return "today";
-  if (d === 1) return "1d ago";
-  if (d < 7) return `${d}d ago`;
-  if (d < 30) return `${Math.floor(d / 7)}w ago`;
-  if (d < 365) return `${Math.floor(d / 30)}mo ago`;
-  return `${Math.floor(d / 365)}y ago`;
-}
-
-export function isFresh(iso: string, now = Date.now()): boolean {
-  return daysSince(iso, now) <= 7;
-}
-
-export function sortJobs(jobs: JobListing[]): JobListing[] {
-  const order: Record<JobListing["tier"], number> = {
-    sponsored: 0,
-    featured: 1,
-    standard: 2,
-    free: 3,
-  };
-  return [...jobs].sort((a, b) => {
-    if (order[a.tier] !== order[b.tier]) return order[a.tier] - order[b.tier];
-    return b.postedAt.localeCompare(a.postedAt);
-  });
-}
-
-// Score for "in the spotlight" rotation. Rewards verified employer,
-// disclosed compensation, remote-friendly, and freshness.
-function spotlightScore(job: JobListing, now = Date.now()): number {
-  let s = 0;
-  if (job.lastVerifiedAt) s += 3;
-  if (job.compensation) s += 2;
-  if (job.isRemote) s += 1;
-  if (isFresh(job.postedAt, now)) s += 2;
-  if (job.tier === "sponsored") s += 1;
-  return s;
-}
-
-// Deterministic per-day rotation through a high-signal pool.
-// Same day → same pick; next day → next role. No randomness, no flicker.
-export function pickDailySpotlight(
-  jobs: JobListing[],
-  now = Date.now(),
-): { current: JobListing | null; next: JobListing | null } {
-  const pool = jobs
-    .filter((j) => spotlightScore(j, now) >= 4)
-    .sort((a, b) => {
-      const diff = spotlightScore(b, now) - spotlightScore(a, now);
-      if (diff !== 0) return diff;
-      return a.slug.localeCompare(b.slug);
-    });
-  if (pool.length === 0) return { current: null, next: null };
-  const dayIndex = Math.floor(now / DAY);
-  const i = ((dayIndex % pool.length) + pool.length) % pool.length;
-  const j = (i + 1) % pool.length;
-  return { current: pool[i] ?? null, next: pool[j] ?? null };
-}
+/**
+ * Jobs-board utility surface.
+ *
+ * The pure presentation/ranking helpers live in `jobs-utils-lib.ts`. This
+ * module re-exports that surface so existing `@/lib/jobs-utils` imports stay
+ * unchanged.
+ */
+export {
+  monogram,
+  companyTint,
+  daysSince,
+  relativePosted,
+  isFresh,
+  sortJobs,
+  pickDailySpotlight,
+} from "@/lib/jobs-utils-lib";

--- a/tests/jobs-utils-lib.test.ts
+++ b/tests/jobs-utils-lib.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import type { JobListing } from "@/types/registry";
+import {
+  companyTint,
+  daysSince,
+  isFresh,
+  monogram,
+  pickDailySpotlight,
+  relativePosted,
+  sortJobs,
+} from "../apps/web/src/lib/jobs-utils-lib";
+
+const DAY = 86_400_000;
+const NOW = Date.parse("2026-07-01T00:00:00Z");
+const iso = (daysAgo: number) => new Date(NOW - daysAgo * DAY).toISOString();
+
+function job(overrides: Partial<JobListing> = {}): JobListing {
+  return {
+    slug: "role",
+    title: "Engineer",
+    company: "Acme",
+    location: "Remote",
+    type: "full-time",
+    postedAt: iso(1),
+    description: "A role.",
+    tier: "standard",
+    ...overrides,
+  };
+}
+
+describe("monogram", () => {
+  it("takes up to two leading initials, uppercased", () => {
+    expect(monogram("Anthropic")).toBe("A");
+    expect(monogram("Open AI")).toBe("OA");
+    expect(monogram("a b c d")).toBe("AB");
+  });
+
+  it("collapses extra whitespace and is empty for a blank name", () => {
+    expect(monogram("  Foo   Bar  ")).toBe("FB");
+    expect(monogram("   ")).toBe("");
+  });
+});
+
+describe("companyTint", () => {
+  it("is deterministic per company and returns oklch bg/fg", () => {
+    const a = companyTint("Anthropic");
+    expect(a).toEqual(companyTint("Anthropic"));
+    expect(a.bg).toMatch(/^oklch\(0\.94 0\.04 \d+\)$/);
+    expect(a.fg).toMatch(/^oklch\(0\.32 0\.08 \d+\)$/);
+  });
+
+  it("varies the hue between different companies", () => {
+    expect(companyTint("Anthropic").bg).not.toBe(companyTint("OpenAI").bg);
+  });
+});
+
+describe("daysSince", () => {
+  it("computes whole days elapsed against an injected now", () => {
+    expect(daysSince(iso(0), NOW)).toBe(0);
+    expect(daysSince(iso(5), NOW)).toBe(5);
+  });
+
+  it("returns Infinity for an unparseable date", () => {
+    expect(daysSince("not-a-date", NOW)).toBe(Infinity);
+  });
+});
+
+describe("relativePosted", () => {
+  it("labels each bucket", () => {
+    expect(relativePosted(iso(0), NOW)).toBe("today");
+    expect(relativePosted(iso(1), NOW)).toBe("1d ago");
+    expect(relativePosted(iso(3), NOW)).toBe("3d ago");
+    expect(relativePosted(iso(14), NOW)).toBe("2w ago");
+    expect(relativePosted(iso(60), NOW)).toBe("2mo ago");
+    expect(relativePosted(iso(400), NOW)).toBe("1y ago");
+  });
+
+  it("renders an em dash for an invalid date", () => {
+    expect(relativePosted("nope", NOW)).toBe("—");
+  });
+});
+
+describe("isFresh", () => {
+  it("is fresh within 7 days, stale after", () => {
+    expect(isFresh(iso(7), NOW)).toBe(true);
+    expect(isFresh(iso(8), NOW)).toBe(false);
+  });
+});
+
+describe("sortJobs", () => {
+  it("orders by tier then by postedAt descending, without mutating input", () => {
+    const input = [
+      job({ slug: "free-new", tier: "free", postedAt: iso(0) }),
+      job({ slug: "sponsored-old", tier: "sponsored", postedAt: iso(10) }),
+      job({ slug: "standard", tier: "standard", postedAt: iso(1) }),
+      job({ slug: "featured", tier: "featured", postedAt: iso(2) }),
+    ];
+    const snapshot = [...input];
+    const sorted = sortJobs(input);
+    expect(sorted.map((j) => j.slug)).toEqual([
+      "sponsored-old",
+      "featured",
+      "standard",
+      "free-new",
+    ]);
+    expect(input).toEqual(snapshot);
+  });
+
+  it("breaks a tier tie by newest postedAt first", () => {
+    const sorted = sortJobs([
+      job({ slug: "older", tier: "standard", postedAt: iso(5) }),
+      job({ slug: "newer", tier: "standard", postedAt: iso(1) }),
+    ]);
+    expect(sorted.map((j) => j.slug)).toEqual(["newer", "older"]);
+  });
+});
+
+describe("pickDailySpotlight", () => {
+  // Two high-signal jobs (score >= 4): verified(3)+fresh(2) = 5.
+  const pool = [
+    job({ slug: "a", lastVerifiedAt: iso(0), postedAt: iso(1) }),
+    job({ slug: "b", lastVerifiedAt: iso(0), postedAt: iso(1) }),
+  ];
+
+  it("returns null current/next when no job clears the score threshold", () => {
+    const weak = [job({ slug: "weak", postedAt: iso(40) })]; // stale, unverified → score 0
+    expect(pickDailySpotlight(weak, NOW)).toEqual({
+      current: null,
+      next: null,
+    });
+  });
+
+  it("rotates deterministically by day: same day → same pick, next day → next", () => {
+    const today = pickDailySpotlight(pool, NOW);
+    expect(pickDailySpotlight(pool, NOW + DAY - 1)).toEqual(today); // same UTC day slot
+    const tomorrow = pickDailySpotlight(pool, NOW + DAY);
+    expect(tomorrow.current?.slug).toBe(today.next?.slug); // advanced by one
+    expect(tomorrow.current?.slug).not.toBe(today.current?.slug);
+  });
+
+  it("scores compensation/remote/sponsored and orders higher-signal jobs first", () => {
+    // strong: compensation(2) + isRemote(1) + fresh(2) + sponsored(1) = 6.
+    const strong = job({
+      slug: "strong",
+      compensation: "$1",
+      isRemote: true,
+      tier: "sponsored",
+      postedAt: iso(1),
+    });
+    // weak-but-eligible: verified(3) + fresh(2) = 5.
+    const weak = job({
+      slug: "weak",
+      lastVerifiedAt: iso(0),
+      postedAt: iso(1),
+    });
+    // Both clear the threshold, so the pool holds exactly these two (the
+    // score-diff sort branch runs because their scores differ); which one is
+    // "current" vs "next" depends on the day-index rotation.
+    const { current, next } = pickDailySpotlight([weak, strong], NOW);
+    expect([current?.slug, next?.slug].sort()).toEqual(["strong", "weak"]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
         "apps/web/src/lib/og-fonts.ts",
         "apps/web/src/lib/og-image.ts",
         "apps/web/src/lib/job-admin.ts",
+        "apps/web/src/lib/jobs-utils.ts",
         "apps/web/src/lib/og-render.server.ts",
         "apps/web/src/lib/peek-hotkey.ts",
         "apps/web/src/lib/site.ts",


### PR DESCRIPTION
Moves the pure jobs-board helpers (`monogram`, `companyTint`, `daysSince`, `relativePosted`, `isFresh`, `sortJobs`, `pickDailySpotlight`) into `jobs-utils-lib.ts`, matching the `lib/` module convention. The original `jobs-utils.ts` becomes a thin re-export so existing imports are unchanged, and it joins the coverage exclude list. Adds `tests/jobs-utils-lib.test.ts` (14 cases) fully covering the helpers — monogram, tint determinism, day math + invalid dates, every relative-posted bucket, freshness boundary, tier/recency sort + immutability, the spotlight score (compensation/remote/sponsored), and the deterministic daily rotation. `vitest run` passes, prettier + type-check clean.

(Replaces #4446, closed on a formatting nit now fixed.)