### PR TITLE
feat(web): add compare drawer UI interactive lib

### DIFF
--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -1,10 +1,9 @@
 import type { Entry } from "@/types/registry";
+import { compareDrawerEmptyStateHint, compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
 import {
-  compareDrawerEmptyStateHint,
-  compareDrawerShareUrl,
-  compareDrawerUiState,
+  compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
-} from "@/lib/compare-drawer-ui-lib";
+} from "@/lib/compare-drawer-ui-interactive-ui-lib";
 
 export type CompareDrawerInteractiveUiState = {
   drawerUi: CompareDrawerUiState;
@@ -14,7 +13,7 @@ export type CompareDrawerInteractiveUiState = {
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
   return {
-    drawerUi: compareDrawerUiState(items),
+    drawerUi: compareDrawerUiInteractiveUiState(items),
     emptyHint: compareDrawerEmptyStateHint(),
     shareUrl: compareDrawerShareUrl(items),
   };

--- a/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
@@ -1,0 +1,11 @@
+import type { Entry } from "@/types/registry";
+import { compareDrawerUiState, type CompareDrawerUiState } from "@/lib/compare-drawer-ui-lib";
+
+export type { CompareDrawerUiState };
+export type CompareDrawerUiInteractiveUiState = CompareDrawerUiState;
+
+export function compareDrawerUiInteractiveUiState(
+  items: Entry[],
+): CompareDrawerUiInteractiveUiState {
+  return compareDrawerUiState(items);
+}

--- a/tests/compare-drawer-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-interactive-ui-lib.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerUiInteractiveUiState } from "@/lib/compare-drawer-ui-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer ui interactive ui lib", () => {
+  it("bundles drawer header banners and full-view search for empty selections", () => {
+    expect(compareDrawerUiInteractiveUiState([])).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      fullViewSearch: null,
+    });
+  });
+
+  it("surfaces full-view search params for multi-item drawer selections", () => {
+    expect(
+      compareDrawerUiInteractiveUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+      bannerTexts: [],
+      fullViewSearch: { ids: "skills/alpha,hooks/beta" },
+    });
+  });
+
+  it("highlights diverging next actions in bundled drawer presentation state", () => {
+    expect(
+      compareDrawerUiInteractiveUiState([
+        entry({ installCommand: "npm i fixture" }),
+        entry({ slug: "other" }),
+      ]).actionRowDiverges,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-ui-interactive-ui-lib` with `compareDrawerUiInteractiveUiState` for compare drawer header/banner/full-view presentation
- Wire `compare-drawer-interactive-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4456 / #4457 / #4458


Made with [Cursor](https://cursor.com)