### PR TITLE
feat(mcp): extract registry artifact path helpers into registry-artifact-lib

### DIFF
--- a/packages/mcp/src/registry-artifact-lib.js
+++ b/packages/mcp/src/registry-artifact-lib.js
@@ -1,0 +1,31 @@
+/**
+ * Pure MCP registry artifact path helpers.
+ *
+ * Slug-safe path validation and artifact envelope parsing live here.
+ * Runtime registry handlers stay in `registry.js`.
+ */
+import path from "node:path";
+
+const safePathPartPattern = /^[a-z0-9-]+$/;
+
+export function isSafePathPart(value) {
+  return safePathPartPattern.test(String(value || ""));
+}
+
+export function safeRelativePath(relativePath) {
+  const parts = String(relativePath || "").split("/");
+  if (
+    !parts.length ||
+    parts.some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error(`Unsafe registry artifact path: ${relativePath}`);
+  }
+  return parts.join(path.sep);
+}
+
+export function unwrapEntries(payload) {
+  if (!payload || !Array.isArray(payload.entries)) {
+    throw new Error("Expected registry artifact envelope with entries array.");
+  }
+  return payload.entries;
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -44,7 +44,6 @@ import {
 
 export * from "./schemas.js";
 
-const safePathPartPattern = /^[a-z0-9-]+$/;
 const jsonMimeType = "application/json";
 const DISCOVERY_RESOURCE_LIMIT = 25;
 const DISCOVERY_FETCH_TIMEOUT_MS = 5000;
@@ -93,6 +92,11 @@ import {
   parsedTrustArgs,
   unique,
 } from "./registry-collection-lib.js";
+import {
+  isSafePathPart,
+  safeRelativePath,
+  unwrapEntries,
+} from "./registry-artifact-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -124,21 +128,6 @@ function dataDirFromOptions(options = {}) {
     "../../..",
   );
   return path.join(repoRoot, "apps", "web", "public", "data");
-}
-
-function isSafePathPart(value) {
-  return safePathPartPattern.test(String(value || ""));
-}
-
-function safeRelativePath(relativePath) {
-  const parts = String(relativePath || "").split("/");
-  if (
-    !parts.length ||
-    parts.some((part) => !part || part === "." || part === "..")
-  ) {
-    throw new Error(`Unsafe registry artifact path: ${relativePath}`);
-  }
-  return parts.join(path.sep);
 }
 
 async function readTextArtifact(relativePath, options = {}) {
@@ -177,13 +166,6 @@ async function readJsonArtifact(relativePath, options = {}) {
   const parsed = JSON.parse(await readTextArtifact(relativePath, options));
   cache.set(cacheKey, parsed);
   return parsed;
-}
-
-function unwrapEntries(payload) {
-  if (!payload || !Array.isArray(payload.entries)) {
-    throw new Error("Expected registry artifact envelope with entries array.");
-  }
-  return payload.entries;
 }
 
 function entryMatchesQuery(entry, query) {

--- a/tests/mcp-registry-artifact-lib.test.ts
+++ b/tests/mcp-registry-artifact-lib.test.ts
@@ -1,0 +1,36 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  isSafePathPart,
+  safeRelativePath,
+  unwrapEntries,
+} from "../packages/mcp/src/registry-artifact-lib.js";
+
+describe("registry-artifact-lib path safety", () => {
+  it("accepts slug-safe category and entry path parts", () => {
+    expect(isSafePathPart("skills")).toBe(true);
+    expect(isSafePathPart("browser-bridge")).toBe(true);
+    expect(isSafePathPart("Bad_Slug")).toBe(false);
+    expect(isSafePathPart("../escape")).toBe(false);
+  });
+
+  it("normalizes safe relative artifact paths and rejects traversal", () => {
+    expect(safeRelativePath("entries/skills/browser-bridge.json")).toBe(
+      path.join("entries", "skills", "browser-bridge.json"),
+    );
+    expect(() => safeRelativePath("entries/../secrets.json")).toThrow(
+      /Unsafe registry artifact path/i,
+    );
+  });
+});
+
+describe("registry-artifact-lib envelope parsing", () => {
+  it("unwraps registry artifact envelopes with entries arrays", () => {
+    const entries = [{ category: "mcp", slug: "example" }];
+    expect(unwrapEntries({ entries })).toBe(entries);
+    expect(() => unwrapEntries({ entries: null })).toThrow(
+      /Expected registry artifact envelope/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract slug-safe path validation and artifact envelope parsing into `packages/mcp/src/registry-artifact-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so registry artifact reads stay unchanged.
- Add focused lib tests for path safety and envelope parsing.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-artifact-lib.js` (new extracted artifact path helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-artifact-lib.test.ts` (new focused tests)
- Expected behavior:
  - Registry artifact path validation and envelope parsing are unchanged.
- Important edge cases or invariants:
  - Unsafe path segments (`..`, empty parts) still throw.
  - Artifact envelopes without an `entries` array still throw.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-artifact-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-artifact-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry artifact path helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-collection-lib`, `registry-resource-metadata-lib`, `registry-response-lib`).
  - Does not touch `schemas.js`, endpoint URL helpers, or submission-risk analysis code.

Made with [Cursor](https://cursor.com)