### PR TITLE
feat(web): add compare drawer empty interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-drawer-empty-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-empty-interactive-ui-lib.ts
@@ -1,0 +1,16 @@
+import type { Entry } from "@/types/registry";
+import { compareDrawerEmptyStateHint, compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
+
+export type CompareDrawerEmptyInteractiveUiState = {
+  emptyHint: string;
+  shareUrl: string;
+};
+
+export function compareDrawerEmptyInteractiveUiState(
+  items: Entry[],
+): CompareDrawerEmptyInteractiveUiState {
+  return {
+    emptyHint: compareDrawerEmptyStateHint(),
+    shareUrl: compareDrawerShareUrl(items),
+  };
+}

--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -1,5 +1,5 @@
 import type { Entry } from "@/types/registry";
-import { compareDrawerEmptyStateHint, compareDrawerShareUrl } from "@/lib/compare-drawer-ui-lib";
+import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
 import {
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
@@ -12,9 +12,10 @@ export type CompareDrawerInteractiveUiState = {
 };
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
+  const emptyUi = compareDrawerEmptyInteractiveUiState(items);
   return {
     drawerUi: compareDrawerUiInteractiveUiState(items),
-    emptyHint: compareDrawerEmptyStateHint(),
-    shareUrl: compareDrawerShareUrl(items),
+    emptyHint: emptyUi.emptyHint,
+    shareUrl: emptyUi.shareUrl,
   };
 }

--- a/tests/compare-drawer-empty-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-empty-interactive-ui-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer empty interactive ui lib", () => {
+  it("bundles drawer empty-state hint and browse share URL for no selection", () => {
+    expect(compareDrawerEmptyInteractiveUiState([])).toEqual({
+      emptyHint: expect.stringContaining("Compare"),
+      shareUrl: "/browse",
+    });
+  });
+
+  it("builds browse share URLs for multi-item drawer selections", () => {
+    expect(
+      compareDrawerEmptyInteractiveUiState([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toEqual({
+      emptyHint: expect.stringContaining("Compare"),
+      shareUrl: "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
+    });
+  });
+
+  it("preserves single-entry drawer share URLs", () => {
+    expect(compareDrawerEmptyInteractiveUiState([entry()])).toEqual({
+      emptyHint: expect.stringContaining("Compare"),
+      shareUrl: "/browse?compare=mcp%2Ffixture",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-empty-interactive-ui-lib` with `compareDrawerEmptyInteractiveUiState` for drawer empty hint and share URL state
- Wire `compare-drawer-interactive-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-empty-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4460


Made with [Cursor](https://cursor.com)