### PR TITLE
feat(web): add compare table UI interactive lib

### DIFF
--- a/apps/web/src/lib/compare-table-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-interactive-ui-lib.ts
@@ -1,8 +1,8 @@
 import type { Entry } from "@/types/registry";
 import {
-  compareTablePresentationState,
+  compareTableUiInteractiveUiState,
   type CompareTablePresentationState,
-} from "@/lib/compare-table-ui-lib";
+} from "@/lib/compare-table-ui-interactive-ui-lib";
 
 export type CompareTableInteractiveUiState = CompareTablePresentationState;
 
@@ -10,5 +10,5 @@ export function compareTableInteractiveUiState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableInteractiveUiState {
-  return compareTablePresentationState(entries, showNextActions);
+  return compareTableUiInteractiveUiState(entries, showNextActions);
 }

--- a/apps/web/src/lib/compare-table-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-ui-interactive-ui-lib.ts
@@ -1,0 +1,15 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareTablePresentationState,
+  type CompareTablePresentationState,
+} from "@/lib/compare-table-ui-lib";
+
+export type { CompareTablePresentationState };
+export type CompareTableUiInteractiveUiState = CompareTablePresentationState;
+
+export function compareTableUiInteractiveUiState(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTableUiInteractiveUiState {
+  return compareTablePresentationState(entries, showNextActions);
+}

--- a/tests/compare-table-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-table-ui-interactive-ui-lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareTableUiInteractiveUiState } from "@/lib/compare-table-ui-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare table ui interactive ui lib", () => {
+  it("hides next-action rows for single-entry tables", () => {
+    expect(compareTableUiInteractiveUiState([entry()], true)).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("respects the showNextActions toggle for multi-entry tables", () => {
+    const entries = [entry(), entry({ slug: "other" })];
+    expect(compareTableUiInteractiveUiState(entries, false)).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: false,
+      actionRowDiverges: false,
+    });
+    expect(compareTableUiInteractiveUiState(entries, true)).toEqual({
+      divergingDecisionLabels: new Set(),
+      renderNextActions: true,
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareTableUiInteractiveUiState(
+      [
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ],
+      true,
+    );
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.renderNextActions).toBe(true);
+    expect(state.actionRowDiverges).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-table-ui-interactive-ui-lib` with `compareTableUiInteractiveUiState` for comparison table presentation state
- Wire `compare-table-interactive-ui-lib` through the new lib
- Add regression tests with full patch coverage on the new lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-ui-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4460


Made with [Cursor](https://cursor.com)