### PR TITLE
fix(mcp): reject userinfo in endpoint URLs and align Raycast guards

### DIFF
--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -7,6 +7,8 @@
 // (no emails, no raw form fields, queries truncated). This keeps the umami
 // dashboard accurate and quiet rather than noisy.
 
+import { publicUrlHostname } from "@heyclaude/registry/source-url";
+
 type UmamiTracker = {
   track?: (event: string, data?: Record<string, unknown>) => void;
 };
@@ -25,11 +27,6 @@ export function entryEventKey(category: string, slug: string): string {
 
 /** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
 export function outboundHost(url: string): string {
-  try {
-    const parsed = new URL(url);
-    if (parsed.username || parsed.password) return "unknown";
-    return parsed.hostname.replace(/^www\./, "");
-  } catch {
-    return "unknown";
-  }
+  const hostname = publicUrlHostname(url);
+  return hostname || "unknown";
 }

--- a/integrations/raycast/src/mcp-installer.ts
+++ b/integrations/raycast/src/mcp-installer.ts
@@ -11,6 +11,7 @@ import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { isRecord } from "./utils";
+import { hasEmbeddedUrlUserinfo, isPublicHttpsUrl } from "./public-url-lib";
 import type { RaycastDetail, RaycastEntry } from "./feed";
 
 const execFileAsync = promisify(execFile);
@@ -359,8 +360,8 @@ function isLoopbackHostname(hostname: string) {
 function isSafeRemoteMcpUrl(value: string) {
   try {
     const url = new URL(value.trim());
-    if (url.username || url.password) return false;
-    if (url.protocol === "https:") return true;
+    if (hasEmbeddedUrlUserinfo(value)) return false;
+    if (isPublicHttpsUrl(value)) return true;
     return url.protocol === "http:" && isLoopbackHostname(url.hostname);
   } catch {
     return false;

--- a/integrations/raycast/src/public-url-lib.ts
+++ b/integrations/raycast/src/public-url-lib.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure public URL helpers for the publishable Raycast extension.
+ *
+ * Mirrors registry source-url userinfo guards without importing
+ * @heyclaude/registry so the extension bundle stays self-contained.
+ */
+
+function parseUrl(value: unknown) {
+  const text = String(value ?? "").trim();
+  if (!text) return null;
+  try {
+    return new URL(text);
+  } catch {
+    return null;
+  }
+}
+
+export function hasEmbeddedUrlUserinfo(value: unknown) {
+  const url = parseUrl(value);
+  if (!url) return false;
+  return Boolean(url.username || url.password);
+}
+
+export function isPublicHttpsUrl(value: unknown) {
+  const text = String(value ?? "").trim();
+  if (!text) return false;
+  const url = parseUrl(value);
+  if (!url) return false;
+  return (
+    url.protocol === "https:" && url.username === "" && url.password === ""
+  );
+}
+
+export function publicUrlHostname(value: unknown) {
+  const url = parseUrl(value);
+  if (!url || url.username || url.password) return "";
+  return url.hostname.replace(/^www\./i, "").toLowerCase();
+}

--- a/integrations/raycast/src/submission.ts
+++ b/integrations/raycast/src/submission.ts
@@ -1,4 +1,9 @@
 import { type SubmissionDraft } from "./feed";
+import {
+  hasEmbeddedUrlUserinfo,
+  isPublicHttpsUrl,
+  publicUrlHostname,
+} from "./public-url-lib";
 
 export type SubmissionFormValues = {
   category: string;
@@ -44,24 +49,15 @@ export function normalizeDomain(value?: string) {
     const url = new URL(
       trimmed.includes("://") ? trimmed : `https://${trimmed}`,
     );
-    if (url.username || url.password) return "";
-    return url.hostname.replace(/^www\./i, "").toLowerCase();
+    if (hasEmbeddedUrlUserinfo(url.href)) return "";
+    return publicUrlHostname(url.href);
   } catch {
     return trimmed.toLowerCase();
   }
 }
 
 export function isValidHttpsUrl(value?: string) {
-  const trimmed = String(value || "").trim();
-  if (!trimmed) return false;
-  try {
-    const url = new URL(trimmed);
-    return (
-      url.protocol === "https:" && url.username === "" && url.password === ""
-    );
-  } catch {
-    return false;
-  }
+  return isPublicHttpsUrl(value);
 }
 
 export function isValidDomain(value?: string) {

--- a/packages/mcp/src/endpoint-url-lib.js
+++ b/packages/mcp/src/endpoint-url-lib.js
@@ -6,6 +6,8 @@
  * The public surface (`endpoint-url.js`) re-exports everything below so
  * existing imports stay unchanged.
  */
+import { hasEmbeddedUrlUserinfo } from "./public-url-lib.js";
+
 export const DEFAULT_REMOTE_MCP_URL = "https://heyclau.de/api/mcp";
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30000;
 
@@ -20,6 +22,11 @@ const localHosts = new Set([
 export function normalizeEndpointUrl(value = DEFAULT_REMOTE_MCP_URL) {
   const raw = String(value || "").trim();
   if (!raw) throw new Error("MCP endpoint URL is required.");
+  if (hasEmbeddedUrlUserinfo(raw)) {
+    throw new Error(
+      "MCP endpoint URL must not embed credentials in userinfo.",
+    );
+  }
 
   const url = new URL(raw);
   if (url.protocol !== "https:" && !localHosts.has(url.hostname)) {

--- a/packages/mcp/src/public-url-lib.js
+++ b/packages/mcp/src/public-url-lib.js
@@ -15,6 +15,12 @@ function parseUrl(value) {
   }
 }
 
+export function hasEmbeddedUrlUserinfo(value) {
+  const url = parseUrl(value);
+  if (!url) return false;
+  return Boolean(url.username || url.password);
+}
+
 export function isPublicHttpsUrl(value) {
   const text = String(value ?? "").trim();
   if (!text) return true;

--- a/tests/mcp-endpoint-url-lib.test.ts
+++ b/tests/mcp-endpoint-url-lib.test.ts
@@ -42,6 +42,9 @@ describe("endpoint-url-lib endpoint normalization", () => {
     expect(() => normalizeEndpointUrl("http://example.com")).toThrow(
       /HTTPS outside localhost/i,
     );
+    expect(() =>
+      normalizeEndpointUrl("https://token@example.com/api/mcp"),
+    ).toThrow(/must not embed credentials/i);
   });
 });
 

--- a/tests/raycast-public-url-lib.test.ts
+++ b/tests/raycast-public-url-lib.test.ts
@@ -2,32 +2,20 @@ import { describe, expect, it } from "vitest";
 
 import {
   hasEmbeddedUrlUserinfo,
-  isPublicGitHubProfileUrl,
   isPublicHttpsUrl,
   publicUrlHostname,
-} from "../packages/mcp/src/public-url-lib.js";
+} from "../integrations/raycast/src/public-url-lib";
 
-describe("MCP public URL helpers", () => {
+describe("Raycast public URL helpers", () => {
   it("detects embedded userinfo credentials", () => {
     expect(hasEmbeddedUrlUserinfo("https://token@example.com/docs")).toBe(true);
     expect(hasEmbeddedUrlUserinfo("https://example.com/docs")).toBe(false);
   });
 
   it("validates public https URLs without userinfo", () => {
-    expect(isPublicHttpsUrl("")).toBe(true);
     expect(isPublicHttpsUrl("https://example.com/docs")).toBe(true);
     expect(isPublicHttpsUrl("http://example.com/docs")).toBe(false);
     expect(isPublicHttpsUrl("https://token@example.com/docs")).toBe(false);
-  });
-
-  it("validates GitHub profile URLs without userinfo", () => {
-    expect(isPublicGitHubProfileUrl("https://github.com/octocat")).toBe(true);
-    expect(isPublicGitHubProfileUrl("https://token@github.com/octocat")).toBe(
-      false,
-    );
-    expect(isPublicGitHubProfileUrl("https://github.com/octocat/repo")).toBe(
-      false,
-    );
   });
 
   it("extracts hostnames only from credential-free URLs", () => {


### PR DESCRIPTION
## Summary
- Reject credential-bearing MCP endpoint URLs in `endpoint-url-lib` via shared `hasEmbeddedUrlUserinfo`
- Route web analytics `outboundHost` through registry `publicUrlHostname`
- Extract self-contained `integrations/raycast/src/public-url-lib.ts` for submission and MCP installer URL validation

## Test plan
- [x] `pnpm exec vitest run tests/mcp-endpoint-url-lib.test.ts tests/mcp-public-url-lib.test.ts tests/raycast-public-url-lib.test.ts tests/raycast-submission-validation.test.ts tests/web-non-ui-utilities.test.ts`
- [x] `pnpm type-check` and `pnpm test:mcp`
- [ ] CI `validate-web`, `validate-mcp`, `validate-raycast`, and `required-pr-gate` green