### PR TITLE
feat(web): bundle compare table interactive UI state for comparison table

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -18,11 +18,8 @@ import {
   signalToneClassForDisplay,
 } from "@/lib/compare-table-signals-ui-lib";
 import { COMPARE_TABLE_SURFACE, type CompareAction } from "@/lib/compare-table-actions-ui-lib";
-import {
-  compareTableActionsForEntry,
-  compareTableActionsInteractiveUiState,
-} from "@/lib/compare-table-actions-interactive-ui-lib";
-import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
+import { compareTableActionsForEntry } from "@/lib/compare-table-actions-interactive-ui-lib";
+import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -58,7 +55,7 @@ function TableCompareActions({
   actionCells,
 }: {
   entry: Entry;
-  actionCells: ReturnType<typeof compareTableActionsInteractiveUiState>["actionCells"];
+  actionCells: ReturnType<typeof compareTableInteractiveUiState>["actionCells"];
 }) {
   const actions = compareTableActionsForEntry(entry, actionCells);
 
@@ -298,9 +295,8 @@ export function ComparisonTable({
   entries: Entry[];
   showNextActions?: boolean;
 }) {
-  const { divergingDecisionLabels } = compareTableSignalsInteractiveUiState(entries);
-  const tableActionsUi = compareTableActionsInteractiveUiState(entries, showNextActions);
-  const { renderNextActions, actionRowDiverges } = tableActionsUi;
+  const { divergingDecisionLabels, renderNextActions, actionRowDiverges, actionCells } =
+    compareTableInteractiveUiState(entries, showNextActions);
 
   return (
     <div className="overflow-auto rounded-xl border border-border">
@@ -371,7 +367,7 @@ export function ComparisonTable({
                     actionRowDiverges && "bg-amber-500/5",
                   )}
                 >
-                  <TableCompareActions entry={e} actionCells={tableActionsUi.actionCells} />
+                  <TableCompareActions entry={e} actionCells={actionCells} />
                 </td>
               ))}
             </tr>

--- a/apps/web/src/lib/compare-table-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-interactive-ui-lib.ts
@@ -1,14 +1,25 @@
 import type { Entry } from "@/types/registry";
-import {
-  compareTableUiInteractiveUiState,
-  type CompareTablePresentationState,
-} from "@/lib/compare-table-ui-interactive-ui-lib";
+import type { CompareTableActionCell } from "@/lib/compare-table-actions-ui-lib";
+import { compareTableActionsInteractiveUiState } from "@/lib/compare-table-actions-interactive-ui-lib";
+import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
 
-export type CompareTableInteractiveUiState = CompareTablePresentationState;
+export type CompareTableInteractiveUiState = {
+  divergingDecisionLabels: Set<string>;
+  renderNextActions: boolean;
+  actionRowDiverges: boolean;
+  actionCells: CompareTableActionCell[];
+};
 
 export function compareTableInteractiveUiState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableInteractiveUiState {
-  return compareTableUiInteractiveUiState(entries, showNextActions);
+  const signals = compareTableSignalsInteractiveUiState(entries);
+  const actions = compareTableActionsInteractiveUiState(entries, showNextActions);
+  return {
+    divergingDecisionLabels: signals.divergingDecisionLabels,
+    renderNextActions: actions.renderNextActions,
+    actionRowDiverges: actions.actionRowDiverges,
+    actionCells: actions.actionCells,
+  };
 }

--- a/tests/compare-table-interactive-ui-lib.test.ts
+++ b/tests/compare-table-interactive-ui-lib.test.ts
@@ -25,17 +25,20 @@ describe("compare table interactive ui lib", () => {
       divergingDecisionLabels: new Set(),
       renderNextActions: false,
       actionRowDiverges: false,
+      actionCells: [expect.objectContaining({ entryKey: "mcp:fixture" })],
     });
   });
 
-  it("surfaces next-action rows for multi-entry tables when enabled", () => {
-    expect(
-      compareTableInteractiveUiState([entry(), entry({ slug: "other" })], true),
-    ).toEqual({
-      divergingDecisionLabels: new Set(),
-      renderNextActions: true,
-      actionRowDiverges: false,
-    });
+  it("bundles per-column action cells for multi-entry tables", () => {
+    const state = compareTableInteractiveUiState(
+      [entry(), entry({ slug: "other" })],
+      true,
+    );
+    expect(state.renderNextActions).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
+    expect(state.actionCells[0]).toEqual(
+      expect.objectContaining({ entryKey: "mcp:fixture" }),
+    );
   });
 
   it("respects the showNextActions toggle for multi-entry tables", () => {
@@ -48,6 +51,7 @@ describe("compare table interactive ui lib", () => {
       divergingDecisionLabels: new Set(),
       renderNextActions: false,
       actionRowDiverges: false,
+      actionCells: expect.any(Array),
     });
   });
 
@@ -62,5 +66,6 @@ describe("compare table interactive ui lib", () => {
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.renderNextActions).toBe(true);
     expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- Compose `compare-table-interactive-ui-lib` from signals and actions interactive sub-libs
- Wire `comparison-table.tsx` through the bundled `compareTableInteractiveUiState`
- Extend regression tests with full patch coverage on the updated lib module

Ref #556

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on changed files
- [x] No file overlap with open PRs #4251 / #4259 / #4398 / #4460


Made with [Cursor](https://cursor.com)