### PR TITLE
feat(web): bundle compare page interactive UI state for compare route

### DIFF
--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -1,5 +1,7 @@
 import type { Entry } from "@/types/registry";
 import type { EntryIdentity } from "@/lib/entry-identity";
+import type { ComparePageActionCell } from "@/lib/compare-page-actions-ui-lib";
+import { comparePageActionsInteractiveUiState } from "@/lib/compare-page-actions-interactive-ui-lib";
 import {
   comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
@@ -12,6 +14,8 @@ import {
 export type ComparePageInteractiveUiState = {
   pageUi: ComparePageUiState;
   emptyUi: ComparePageEmptyUiState;
+  actionRowDiverges: boolean;
+  actionCells: ComparePageActionCell[];
 };
 
 export function comparePageInteractiveUiState(
@@ -20,8 +24,11 @@ export function comparePageInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageInteractiveUiState {
+  const actions = comparePageActionsInteractiveUiState(items);
   return {
     pageUi: comparePageUiInteractiveUiState(items),
     emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
+    actionRowDiverges: actions.actionRowDiverges,
+    actionCells: actions.actionCells,
   };
 }

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -13,10 +13,7 @@ import { useCompare } from "@/lib/compare";
 import { resolveCompareParam, serializeCompareItems } from "@/lib/compare-selection";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { COMPARE_PAGE_SURFACE, type CompareAction } from "@/lib/compare-page-actions-ui-lib";
-import {
-  comparePageActionsForEntry,
-  comparePageActionsInteractiveUiState,
-} from "@/lib/compare-page-actions-interactive-ui-lib";
+import { comparePageActionsForEntry } from "@/lib/compare-page-actions-interactive-ui-lib";
 import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
@@ -68,13 +65,10 @@ function ComparePage() {
   const items = compare.items;
   const [hoverRow, setHoverRow] = React.useState<number | null>(null);
   const [pickerOpen, setPickerOpen] = React.useState(false);
-  const interactiveUi = React.useMemo(
+  const { pageUi, emptyUi, actionRowDiverges, actionCells } = React.useMemo(
     () => comparePageInteractiveUiState(items, sp.ids, COMPARISONS, ENTRIES),
     [items, sp.ids],
   );
-  const pageActionsUi = React.useMemo(() => comparePageActionsInteractiveUiState(items), [items]);
-  const pageUi = interactiveUi.pageUi;
-  const emptyUi = interactiveUi.emptyUi;
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -252,18 +246,18 @@ function ComparePage() {
             <tr
               className={cn(
                 "transition-colors duration-200 ease-out",
-                pageActionsUi.actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
+                actionRowDiverges ? "bg-amber-500/5" : "bg-surface-2/30",
               )}
             >
               <th
                 scope="row"
                 className={cn(
                   "sticky left-0 z-10 w-[150px] border-b border-r border-border bg-inherit p-3 text-left align-top text-xs font-medium text-ink-muted",
-                  pageActionsUi.actionRowDiverges && "text-amber-800",
+                  actionRowDiverges && "text-amber-800",
                 )}
               >
                 Next steps
-                {pageActionsUi.actionRowDiverges ? (
+                {actionRowDiverges ? (
                   <span className="mt-0.5 block text-[10px] font-normal uppercase tracking-wide text-amber-700">
                     Differs
                   </span>
@@ -274,10 +268,10 @@ function ComparePage() {
                   key={`actions-${e.category}/${e.slug}`}
                   className={cn(
                     "min-w-[260px] max-w-[320px] border-b border-r border-border p-3 align-top",
-                    pageActionsUi.actionRowDiverges && "bg-amber-500/5",
+                    actionRowDiverges && "bg-amber-500/5",
                   )}
                 >
-                  <CompareNextActions entry={e} actionCells={pageActionsUi.actionCells} />
+                  <CompareNextActions entry={e} actionCells={actionCells} />
                 </td>
               ))}
               {items.length < 4 && (
@@ -353,7 +347,7 @@ function CompareNextActions({
   actionCells,
 }: {
   entry: Entry;
-  actionCells: ReturnType<typeof comparePageActionsInteractiveUiState>["actionCells"];
+  actionCells: ReturnType<typeof comparePageInteractiveUiState>["actionCells"];
 }) {
   const actions = comparePageActionsForEntry(entry, actionCells);
 

--- a/tests/compare-page-interactive-ui-lib.test.ts
+++ b/tests/compare-page-interactive-ui-lib.test.ts
@@ -61,6 +61,11 @@ describe("compare page interactive ui lib", () => {
           },
         ],
       },
+      actionRowDiverges: false,
+      actionCells: [
+        expect.objectContaining({ entryKey: "skills:alpha" }),
+        expect.objectContaining({ entryKey: "hooks:beta" }),
+      ],
     });
   });
 
@@ -76,13 +81,16 @@ describe("compare page interactive ui lib", () => {
   });
 
   it("highlights diverging next actions in bundled page state", () => {
-    expect(
-      comparePageInteractiveUiState(
-        [entry({ installCommand: "npm i fixture" }), entry({ slug: "other" })],
-        "",
-        [],
-        catalog,
-      ).pageUi.actionRowDiverges,
-    ).toBe(true);
+    const state = comparePageInteractiveUiState(
+      [entry({ installCommand: "npm i fixture" }), entry({ slug: "other" })],
+      "",
+      [],
+      catalog,
+    );
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
+    expect(state.actionCells[0]).toEqual(
+      expect.objectContaining({ entryKey: "mcp:fixture" }),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Compose `comparePageUiInteractiveUiState`, `comparePageEmptyInteractiveUiState`, and `comparePageActionsInteractiveUiState` into flat `comparePageInteractiveUiState` (mirrors table bundle #4465).
- Wire `compare.index.tsx` to a single memoized call with top-level `actionRowDiverges` and `actionCells`.
- Extend tests for bundled action state with 100% lib coverage.

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-page-interactive-ui-lib.ts'`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)