### PR TITLE
feat(web): bundle compare drawer interactive UI state for compare drawer

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -19,10 +19,7 @@ import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
 import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, type CompareAction } from "@/lib/compare-drawer-actions-ui-lib";
-import {
-  compareDrawerActionsForEntry,
-  compareDrawerActionsInteractiveUiState,
-} from "@/lib/compare-drawer-actions-interactive-ui-lib";
+import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
@@ -34,7 +31,6 @@ import {
   compareSignalToneClass,
   type CompareSignalValue,
 } from "@/lib/compare-drawer-signals-ui-lib";
-import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
 
 interface RowDef {
   label: string;
@@ -179,7 +175,7 @@ function DrawerCompareActions({
   actionCells,
 }: {
   entry: Entry;
-  actionCells: ReturnType<typeof compareDrawerActionsInteractiveUiState>["actionCells"];
+  actionCells: ReturnType<typeof compareDrawerInteractiveUiState>["actionCells"];
 }) {
   const actions = compareDrawerActionsForEntry(entry, actionCells);
 
@@ -320,10 +316,8 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
-  const drawerActionsUi = compareDrawerActionsInteractiveUiState(items);
-  const drawerSignalsUi = compareDrawerSignalsInteractiveUiState(items);
-  const { drawerUi, emptyHint, shareUrl } = compareDrawerInteractiveUiState(items);
-  const { actionRowDiverges } = drawerActionsUi;
+  const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
+    compareDrawerInteractiveUiState(items);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -499,12 +493,12 @@ export function CompareDrawer() {
                           actionRowDiverges && "bg-amber-500/5",
                         )}
                       >
-                        <DrawerCompareActions entry={e} actionCells={drawerActionsUi.actionCells} />
+                        <DrawerCompareActions entry={e} actionCells={actionCells} />
                       </td>
                     ))}
                   </tr>
                   {ROWS.map((row, i) => {
-                    const rowDiverges = drawerSignalsUi.divergingDecisionLabels.has(row.label);
+                    const rowDiverges = divergingDecisionLabels.has(row.label);
                     return (
                       <tr
                         key={row.label}

--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -1,5 +1,8 @@
 import type { Entry } from "@/types/registry";
+import type { CompareDrawerActionCell } from "@/lib/compare-drawer-actions-ui-lib";
+import { compareDrawerActionsInteractiveUiState } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
+import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
 import {
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
@@ -9,13 +12,21 @@ export type CompareDrawerInteractiveUiState = {
   drawerUi: CompareDrawerUiState;
   emptyHint: string;
   shareUrl: string;
+  divergingDecisionLabels: Set<string>;
+  actionRowDiverges: boolean;
+  actionCells: CompareDrawerActionCell[];
 };
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
   const emptyUi = compareDrawerEmptyInteractiveUiState(items);
+  const signals = compareDrawerSignalsInteractiveUiState(items);
+  const actions = compareDrawerActionsInteractiveUiState(items);
   return {
     drawerUi: compareDrawerUiInteractiveUiState(items),
     emptyHint: emptyUi.emptyHint,
     shareUrl: emptyUi.shareUrl,
+    divergingDecisionLabels: signals.divergingDecisionLabels,
+    actionRowDiverges: actions.actionRowDiverges,
+    actionCells: actions.actionCells,
   };
 }

--- a/tests/compare-drawer-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-interactive-ui-lib.test.ts
@@ -29,6 +29,9 @@ describe("compare drawer interactive ui lib", () => {
       },
       emptyHint: expect.stringContaining("Compare"),
       shareUrl: "/browse",
+      divergingDecisionLabels: new Set(),
+      actionRowDiverges: false,
+      actionCells: [],
     });
   });
 
@@ -43,14 +46,19 @@ describe("compare drawer interactive ui lib", () => {
     expect(state.shareUrl).toBe(
       "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
     );
+    expect(state.actionCells).toHaveLength(2);
+    expect(state.actionCells[0]).toEqual(
+      expect.objectContaining({ entryKey: "skills:alpha" }),
+    );
   });
 
-  it("highlights diverging next actions in bundled drawer state", () => {
-    expect(
-      compareDrawerInteractiveUiState([
-        entry({ installCommand: "npm i fixture" }),
-        entry({ slug: "other" }),
-      ]).drawerUi.actionRowDiverges,
-    ).toBe(true);
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareDrawerInteractiveUiState([
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ]);
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionCells).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- Compose `compareDrawerUiInteractiveUiState`, `compareDrawerEmptyInteractiveUiState`, `compareDrawerSignalsInteractiveUiState`, and `compareDrawerActionsInteractiveUiState` into flat `compareDrawerInteractiveUiState` (mirrors table #4465 and page #4466).
- Wire `compare-drawer.tsx` to a single call with top-level `divergingDecisionLabels`, `actionRowDiverges`, and `actionCells`.
- Extend tests for bundled signal and action state with 100% lib coverage.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-drawer-interactive-ui-lib.ts'`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)