### PR TITLE
feat(web): compose compare table UI state into table interactive bundle

### DIFF
--- a/apps/web/src/lib/compare-table-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-interactive-ui-lib.ts
@@ -1,7 +1,7 @@
 import type { Entry } from "@/types/registry";
 import type { CompareTableActionCell } from "@/lib/compare-table-actions-ui-lib";
 import { compareTableActionsInteractiveUiState } from "@/lib/compare-table-actions-interactive-ui-lib";
-import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
+import { compareTableUiInteractiveUiState } from "@/lib/compare-table-ui-interactive-ui-lib";
 
 export type CompareTableInteractiveUiState = {
   divergingDecisionLabels: Set<string>;
@@ -14,12 +14,10 @@ export function compareTableInteractiveUiState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableInteractiveUiState {
-  const signals = compareTableSignalsInteractiveUiState(entries);
+  const tableUi = compareTableUiInteractiveUiState(entries, showNextActions);
   const actions = compareTableActionsInteractiveUiState(entries, showNextActions);
   return {
-    divergingDecisionLabels: signals.divergingDecisionLabels,
-    renderNextActions: actions.renderNextActions,
-    actionRowDiverges: actions.actionRowDiverges,
+    ...tableUi,
     actionCells: actions.actionCells,
   };
 }


### PR DESCRIPTION
## Summary
- Compose `compareTableUiInteractiveUiState` into `compareTableInteractiveUiState` for presentation fields (`divergingDecisionLabels`, `renderNextActions`, `actionRowDiverges`).
- Keep `actionCells` from `compareTableActionsInteractiveUiState` (mirrors how page/drawer bundles compose UI sub-libs).

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-table-interactive-ui-lib.ts'`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)