### PR TITLE
feat(web): compose compare drawer presentation UI into drawer interactive bundle

### DIFF
--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -2,7 +2,7 @@ import type { Entry } from "@/types/registry";
 import type { CompareDrawerActionCell } from "@/lib/compare-drawer-actions-ui-lib";
 import { compareDrawerActionsInteractiveUiState } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
-import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
+import { compareDrawerPresentationUiInteractiveUiState } from "@/lib/compare-drawer-presentation-ui-interactive-ui-lib";
 import {
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
@@ -19,14 +19,14 @@ export type CompareDrawerInteractiveUiState = {
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
   const emptyUi = compareDrawerEmptyInteractiveUiState(items);
-  const signals = compareDrawerSignalsInteractiveUiState(items);
+  const presentation = compareDrawerPresentationUiInteractiveUiState(items);
   const actions = compareDrawerActionsInteractiveUiState(items);
   return {
     drawerUi: compareDrawerUiInteractiveUiState(items),
     emptyHint: emptyUi.emptyHint,
     shareUrl: emptyUi.shareUrl,
-    divergingDecisionLabels: signals.divergingDecisionLabels,
-    actionRowDiverges: actions.actionRowDiverges,
+    divergingDecisionLabels: presentation.divergingDecisionLabels,
+    actionRowDiverges: presentation.actionRowDiverges,
     actionCells: actions.actionCells,
   };
 }

--- a/apps/web/src/lib/compare-drawer-presentation-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-presentation-ui-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import {
+  compareDrawerPresentationState,
+  type CompareDrawerPresentationState,
+} from "@/lib/compare-drawer-presentation-ui-lib";
+
+export type { CompareDrawerPresentationState };
+export type CompareDrawerPresentationUiInteractiveUiState = CompareDrawerPresentationState;
+
+export function compareDrawerPresentationUiInteractiveUiState(
+  items: Entry[],
+): CompareDrawerPresentationUiInteractiveUiState {
+  return compareDrawerPresentationState(items);
+}

--- a/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
@@ -1,0 +1,15 @@
+import type { Entry } from "@/types/registry";
+import { compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
+import { compareDrawerDivergingDecisionLabels } from "@/lib/compare-drawer-signals-ui-lib";
+
+export type CompareDrawerPresentationState = {
+  divergingDecisionLabels: Set<string>;
+  actionRowDiverges: boolean;
+};
+
+export function compareDrawerPresentationState(items: Entry[]): CompareDrawerPresentationState {
+  return {
+    divergingDecisionLabels: new Set(compareDrawerDivergingDecisionLabels(items)),
+    actionRowDiverges: compareDrawerActionsDiverge(items),
+  };
+}

--- a/tests/compare-drawer-presentation-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-presentation-ui-interactive-ui-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerPresentationUiInteractiveUiState } from "@/lib/compare-drawer-presentation-ui-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer presentation ui interactive ui lib", () => {
+  it("returns no diverging labels for uniform compared entries", () => {
+    expect(compareDrawerPresentationUiInteractiveUiState([entry()])).toEqual({
+      divergingDecisionLabels: new Set(),
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareDrawerPresentationUiInteractiveUiState([
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ]);
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.actionRowDiverges).toBe(true);
+  });
+});

--- a/tests/compare-drawer-presentation-ui-lib.test.ts
+++ b/tests/compare-drawer-presentation-ui-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDrawerPresentationState } from "@/lib/compare-drawer-presentation-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare drawer presentation ui lib", () => {
+  it("returns no diverging labels for uniform compared entries", () => {
+    expect(compareDrawerPresentationState([entry()])).toEqual({
+      divergingDecisionLabels: new Set(),
+      actionRowDiverges: false,
+    });
+    expect(
+      compareDrawerPresentationState([entry(), entry({ slug: "other" })]),
+    ).toEqual({
+      divergingDecisionLabels: new Set(),
+      actionRowDiverges: false,
+    });
+  });
+
+  it("returns an empty label set when no entries are compared", () => {
+    expect(compareDrawerPresentationState([])).toEqual({
+      divergingDecisionLabels: new Set(),
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareDrawerPresentationState([
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ]);
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.actionRowDiverges).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-drawer-presentation-ui-lib` for decision-row and action-row presentation signals (mirrors `compare-table-ui-lib`).
- Add `compare-drawer-presentation-ui-interactive-ui-lib` interactive wrapper.
- Compose presentation state into `compareDrawerInteractiveUiState`; keep `actionCells` from the actions sub-lib.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-presentation-ui-lib.test.ts tests/compare-drawer-presentation-ui-interactive-ui-lib.test.ts tests/compare-drawer-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)