### PR TITLE
feat(web): improve shell navigation, footer, and detail sidebar patterns

### DIFF
--- a/apps/web/src/components/app-shell.tsx
+++ b/apps/web/src/components/app-shell.tsx
@@ -16,17 +16,12 @@ import {
   SheetDescription,
 } from "@/components/ui/sheet";
 import { CATEGORIES } from "@/types/registry";
-
-const NAV = [
-  { to: "/browse", label: "Browse" },
-  { to: "/trending", label: "Trending" },
-  { to: "/best", label: "Best" },
-  { to: "/tags", label: "Tags" },
-  { to: "/for", label: "Platforms" },
-  { to: "/ecosystem", label: "Ecosystem" },
-  { to: "/jobs", label: "Jobs" },
-  { to: "/quality", label: "Quality" },
-] as const;
+import {
+  SHELL_MOBILE_NAV_SECTIONS,
+  SHELL_PRIMARY_NAV,
+  shellNavItemActive,
+} from "@/lib/app-shell-nav-lib";
+import { footerColumnSpanClass, SHELL_FOOTER_COLUMNS } from "@/lib/app-shell-footer-lib";
 
 export function TopBar() {
   const { theme, toggle } = useTheme();
@@ -57,6 +52,8 @@ export function TopBar() {
           type="button"
           onClick={() => setMobileNavOpen(true)}
           aria-label="Open menu"
+          aria-expanded={mobileNavOpen}
+          aria-controls="mobile-primary-nav"
           className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-border bg-surface text-ink-muted hover:text-ink md:hidden"
         >
           <Menu className="h-4 w-4" />
@@ -71,9 +68,9 @@ export function TopBar() {
           </span>
         </Link>
 
-        <nav className="hidden items-center gap-1 md:flex">
-          {NAV.map((item) => {
-            const active = pathname.startsWith(item.to);
+        <nav aria-label="Primary" className="hidden items-center gap-1 md:flex">
+          {SHELL_PRIMARY_NAV.map((item) => {
+            const active = shellNavItemActive(pathname, item.to);
             return (
               <Link
                 key={item.to}
@@ -134,28 +131,37 @@ export function TopBar() {
         <SheetContent side="left" className="w-72">
           <SheetHeader>
             <SheetTitle className="font-display text-base font-semibold text-ink">Menu</SheetTitle>
-            <SheetDescription className="sr-only">Primary site navigation links.</SheetDescription>
+            <SheetDescription className="sr-only">
+              Primary site navigation grouped by product area.
+            </SheetDescription>
           </SheetHeader>
-          <nav className="mt-6 flex flex-col gap-1">
-            {NAV.map((item) => {
-              const active = pathname.startsWith(item.to);
-              return (
-                <Link
-                  key={item.to}
-                  to={item.to}
-                  onClick={() => setMobileNavOpen(false)}
-                  aria-current={active ? "page" : undefined}
-                  className={cn(
-                    "rounded-md px-3 py-2 text-sm transition-colors duration-200 ease-out",
-                    active
-                      ? "bg-surface-2 text-ink"
-                      : "text-ink-muted hover:bg-surface-2 hover:text-ink",
-                  )}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
+          <nav id="mobile-primary-nav" aria-label="Primary" className="mt-6 flex flex-col gap-6">
+            {SHELL_MOBILE_NAV_SECTIONS.map((section) => (
+              <div key={section.id}>
+                <div className="eyebrow mb-2">{section.label}</div>
+                <div className="flex flex-col gap-1">
+                  {section.links.map((item) => {
+                    const active = shellNavItemActive(pathname, item.to);
+                    return (
+                      <Link
+                        key={item.to}
+                        to={item.to}
+                        onClick={() => setMobileNavOpen(false)}
+                        aria-current={active ? "page" : undefined}
+                        className={cn(
+                          "rounded-md px-3 py-2 text-sm transition-colors duration-200 ease-out",
+                          active
+                            ? "bg-surface-2 text-ink"
+                            : "text-ink-muted hover:bg-surface-2 hover:text-ink",
+                        )}
+                      >
+                        {item.label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            ))}
           </nav>
         </SheetContent>
       </Sheet>
@@ -190,46 +196,9 @@ export function Footer() {
             <FeedChip href="/llms.txt" label="llms.txt" />
           </div>
         </div>
-        <FooterCol
-          title="Product"
-          links={[
-            { to: "/browse", label: "Browse" },
-            { to: "/trending", label: "Trending" },
-            { to: "/tags", label: "Tags" },
-            { to: "/for", label: "Platforms" },
-            { to: "/best", label: "Best lists" },
-            { to: "/compare", label: "Compare" },
-            { to: "/quality", label: "Quality" },
-            { to: "/state-of-claude-tooling", label: "State of tooling" },
-            { to: "/changelog", label: "Changelog" },
-            { to: "/brief", label: "Weekly Brief" },
-          ]}
-          span={3}
-        />
-        <FooterCol
-          title="Integrations"
-          links={[
-            { to: "/integrations", label: "All integrations" },
-            { to: "/integrations/mcp-server", label: "MCP server" },
-            { to: "/ecosystem", label: "Ecosystem" },
-            { to: "/api-docs", label: "API docs" },
-            { to: "/feeds", label: "Feeds" },
-            { to: "/subscriptions", label: "Subscriptions" },
-          ]}
-          span={3}
-        />
-        <FooterCol
-          title="Resources"
-          links={[
-            { to: "/submit", label: "Submit a resource" },
-            { to: "/claim", label: "Claim a listing" },
-            { to: "/contributors", label: "Contributors" },
-            { to: "/validators", label: "Review coverage" },
-            { to: "/advertise", label: "Advertise" },
-            { to: "/about", label: "About" },
-          ]}
-          span={3}
-        />
+        {SHELL_FOOTER_COLUMNS.map((column) => (
+          <FooterCol key={column.id} title={column.title} links={column.links} span={column.span} />
+        ))}
       </div>
       <div className="border-t border-border">
         <div className="mx-auto max-w-page px-4 py-4 sm:px-6">
@@ -251,7 +220,7 @@ export function Footer() {
       <div className="border-t border-border">
         <div className="mx-auto flex max-w-page flex-col items-start gap-3 px-4 py-5 text-xs text-ink-subtle sm:flex-row sm:items-center sm:justify-between sm:px-6">
           <span>© {new Date().getFullYear()} HeyClaude · heyclau.de</span>
-          <nav className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <nav aria-label="Legal" className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Link to="/legal" className="hover:text-ink">
               Legal
             </Link>
@@ -306,11 +275,10 @@ function FooterCol({
 }: {
   title: string;
   links: { to: string; label: string }[];
-  span?: number;
+  span?: 2 | 3 | 4;
 }) {
-  const spanClass = span === 3 ? "md:col-span-3" : span === 4 ? "md:col-span-4" : "md:col-span-2";
   return (
-    <div className={spanClass}>
+    <div className={footerColumnSpanClass(span)}>
       <div className="eyebrow mb-3">{title}</div>
       <ul className="flex flex-col gap-2">
         {links.map((l) => (

--- a/apps/web/src/components/entry-detail-quick-links.tsx
+++ b/apps/web/src/components/entry-detail-quick-links.tsx
@@ -1,0 +1,48 @@
+import { Link } from "@tanstack/react-router";
+import { BookOpen, Code2, ExternalLink, GitBranch } from "lucide-react";
+import type { EntryQuickLink } from "@/lib/entry-detail-sidebar-lib";
+
+const QUICK_LINK_ICONS = {
+  docs: BookOpen,
+  source: GitBranch,
+  "registry-json": Code2,
+} as const;
+
+export function EntryDetailQuickLinks({ links }: { links: EntryQuickLink[] }) {
+  if (!links.length) return null;
+  return (
+    <nav aria-label="Entry resource links" className="mt-3 flex flex-col gap-1.5 text-xs">
+      {links.map((link) => {
+        const Icon = QUICK_LINK_ICONS[link.id as keyof typeof QUICK_LINK_ICONS] ?? Code2;
+        if (link.href) {
+          return (
+            <a
+              key={link.id}
+              href={link.href}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+            >
+              <Icon className="h-3.5 w-3.5" aria-hidden />
+              {link.label}
+              <ExternalLink className="h-3 w-3" aria-hidden />
+            </a>
+          );
+        }
+        if (link.to) {
+          return (
+            <Link
+              key={link.id}
+              to={link.to}
+              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+            >
+              <Icon className="h-3.5 w-3.5" aria-hidden />
+              {link.label}
+            </Link>
+          );
+        }
+        return null;
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/entry-detail-rail.tsx
+++ b/apps/web/src/components/entry-detail-rail.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+import { DossierTOC } from "@/components/dossier-toc";
+import { ProvenanceBlock } from "@/components/provenance-block";
+import type { Entry } from "@/types/registry";
+import type { EntryTocItem } from "@/lib/entry-detail-sidebar-lib";
+
+export function EntryDetailRail({
+  entry,
+  tocItems,
+  className,
+  children,
+}: {
+  entry: Entry;
+  tocItems: EntryTocItem[];
+  className?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <aside className={className ?? "space-y-6"}>
+      {children}
+      <div className="hidden lg:block lg:sticky lg:top-20">
+        <DossierTOC items={tocItems} />
+      </div>
+      <ProvenanceBlock entry={entry} />
+      <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">
+        HeyClaude reviews metadata, provenance, and surface-level safety. We don't scan for malware.
+        Always read the source before installing tools that touch your filesystem, network, or
+        credentials.
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/entry-detail-readiness.tsx
+++ b/apps/web/src/components/entry-detail-readiness.tsx
@@ -1,0 +1,37 @@
+import { CheckCircle2, Circle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { EntryReadinessRow } from "@/lib/entry-detail-sidebar-lib";
+
+export function EntryDetailReadinessPanel({
+  rows,
+  className,
+}: {
+  rows: EntryReadinessRow[];
+  className?: string;
+}) {
+  return (
+    <div className={cn("border-t border-border px-4 py-3", className)}>
+      <div className="eyebrow mb-2">Readiness</div>
+      <ul className="space-y-1.5 text-xs">
+        {rows.map((row) => (
+          <li key={row.label} className="flex items-center justify-between gap-2">
+            <span className="text-ink-muted">{row.label}</span>
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 font-medium",
+                row.ok ? "text-trust-trusted" : "text-ink-muted",
+              )}
+            >
+              {row.ok ? (
+                <CheckCircle2 className="h-3 w-3" aria-hidden />
+              ) : (
+                <Circle className="h-3 w-3" aria-hidden />
+              )}
+              {row.value}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/lib/app-shell-footer-lib.ts
+++ b/apps/web/src/lib/app-shell-footer-lib.ts
@@ -1,0 +1,68 @@
+import type { ShellNavLink } from "@/lib/app-shell-nav-lib";
+
+export type FooterColumn = {
+  id: string;
+  title: string;
+  links: ShellNavLink[];
+  span?: 2 | 3 | 4;
+};
+
+export const SHELL_FOOTER_COLUMNS: FooterColumn[] = [
+  {
+    id: "product",
+    title: "Product",
+    span: 3,
+    links: [
+      { to: "/browse", label: "Browse" },
+      { to: "/trending", label: "Trending" },
+      { to: "/tags", label: "Tags" },
+      { to: "/for", label: "Platforms" },
+      { to: "/best", label: "Best lists" },
+      { to: "/compare", label: "Compare" },
+      { to: "/quality", label: "Quality" },
+      { to: "/changelog", label: "Changelog" },
+      { to: "/brief", label: "Weekly Brief" },
+    ],
+  },
+  {
+    id: "contribution",
+    title: "Contribution",
+    span: 3,
+    links: [
+      { to: "/submit", label: "Submit a resource" },
+      { to: "/claim", label: "Claim a listing" },
+      { to: "/contributors", label: "Contributors" },
+      { to: "/validators", label: "Review coverage" },
+      { to: "/advertise", label: "Advertise" },
+    ],
+  },
+  {
+    id: "api-mcp",
+    title: "API & MCP",
+    span: 3,
+    links: [
+      { to: "/integrations", label: "All integrations" },
+      { to: "/integrations/mcp-server", label: "MCP server" },
+      { to: "/ecosystem", label: "Ecosystem" },
+      { to: "/api-docs", label: "API docs" },
+      { to: "/feeds", label: "Feeds" },
+      { to: "/subscriptions", label: "Subscriptions" },
+    ],
+  },
+  {
+    id: "community",
+    title: "Community",
+    span: 3,
+    links: [
+      { to: "/about", label: "About" },
+      { to: "/jobs", label: "Jobs" },
+      { to: "/state-of-claude-tooling", label: "State of tooling" },
+    ],
+  },
+];
+
+export function footerColumnSpanClass(span: FooterColumn["span"] = 2): string {
+  if (span === 4) return "md:col-span-4";
+  if (span === 3) return "md:col-span-3";
+  return "md:col-span-2";
+}

--- a/apps/web/src/lib/app-shell-nav-lib.ts
+++ b/apps/web/src/lib/app-shell-nav-lib.ts
@@ -1,0 +1,75 @@
+export type ShellNavLink = {
+  to: string;
+  label: string;
+  external?: boolean;
+};
+
+export type ShellNavSection = {
+  id: string;
+  label: string;
+  links: ShellNavLink[];
+};
+
+/** Primary desktop navigation — high-traffic discovery paths. */
+export const SHELL_PRIMARY_NAV: ShellNavLink[] = [
+  { to: "/browse", label: "Browse" },
+  { to: "/trending", label: "Trending" },
+  { to: "/best", label: "Best" },
+  { to: "/quality", label: "Quality" },
+  { to: "/ecosystem", label: "Ecosystem" },
+  { to: "/jobs", label: "Jobs" },
+];
+
+/** Grouped mobile navigation aligned with Technical Atlas shell paths. */
+export const SHELL_MOBILE_NAV_SECTIONS: ShellNavSection[] = [
+  {
+    id: "explore",
+    label: "Explore",
+    links: [
+      { to: "/browse", label: "Browse directory" },
+      { to: "/trending", label: "Trending" },
+      { to: "/best", label: "Best lists" },
+      { to: "/tags", label: "Tags" },
+      { to: "/for", label: "Platforms" },
+      { to: "/compare", label: "Compare" },
+    ],
+  },
+  {
+    id: "trust",
+    label: "Trust & quality",
+    links: [
+      { to: "/quality", label: "Quality signals" },
+      { to: "/validators", label: "Review coverage" },
+      { to: "/state-of-claude-tooling", label: "State of tooling" },
+    ],
+  },
+  {
+    id: "api-mcp",
+    label: "API & MCP",
+    links: [
+      { to: "/integrations", label: "Integrations" },
+      { to: "/integrations/mcp-server", label: "MCP server" },
+      { to: "/api-docs", label: "API docs" },
+      { to: "/feeds", label: "Feeds" },
+    ],
+  },
+  {
+    id: "community",
+    label: "Community",
+    links: [
+      { to: "/submit", label: "Submit a resource" },
+      { to: "/claim", label: "Claim a listing" },
+      { to: "/contributors", label: "Contributors" },
+      { to: "/about", label: "About HeyClaude" },
+    ],
+  },
+];
+
+export function shellNavItemActive(pathname: string, to: string): boolean {
+  if (to === "/") return pathname === "/";
+  return pathname === to || pathname.startsWith(`${to}/`);
+}
+
+export function flattenShellMobileNav(): ShellNavLink[] {
+  return SHELL_MOBILE_NAV_SECTIONS.flatMap((section) => section.links);
+}

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -1,0 +1,99 @@
+import { TRUST_LABEL, type Entry } from "@/types/registry";
+import type { InstallRisk } from "@/lib/trust";
+
+export type EntryReadinessRow = {
+  label: string;
+  value: string;
+  ok: boolean;
+};
+
+export type EntryQuickLink = {
+  id: string;
+  label: string;
+  href?: string;
+  to?: string;
+  external?: boolean;
+};
+
+export function entryReadinessRows(entry: Entry): EntryReadinessRow[] {
+  return [
+    {
+      label: "Trust",
+      value: TRUST_LABEL[entry.trust],
+      ok: entry.trust === "trusted",
+    },
+    {
+      label: "Source",
+      value: entry.source,
+      ok: entry.source !== "unverified",
+    },
+    {
+      label: "Safety notes",
+      value: entry.safetyNotes ? "Present" : "Missing",
+      ok: Boolean(entry.safetyNotes),
+    },
+    {
+      label: "Reviewed",
+      value: entry.reviewed ? "Yes" : "No",
+      ok: Boolean(entry.reviewed),
+    },
+  ];
+}
+
+export function entryQuickLinks(entry: Entry): EntryQuickLink[] {
+  const links: EntryQuickLink[] = [];
+  if (entry.docsUrl) {
+    links.push({
+      id: "docs",
+      label: "Documentation",
+      href: entry.docsUrl,
+      external: true,
+    });
+  }
+  if (entry.sourceUrl) {
+    links.push({
+      id: "source",
+      label: "Source repository",
+      href: entry.sourceUrl,
+      external: true,
+    });
+  }
+  links.push({
+    id: "registry-json",
+    label: "Registry JSON · LLM text",
+    to: "/browse",
+  });
+  return links;
+}
+
+export type EntryTocItem = {
+  id: string;
+  label: string;
+};
+
+export function buildEntryTocItems(input: {
+  risk: InstallRisk;
+  hasSafetyNotes: boolean;
+  hasPrivacyNotes: boolean;
+  hasPrerequisites: boolean;
+  hasSchema: boolean;
+  hasAlternatives: boolean;
+  hasRelated: boolean;
+  hasGuides: boolean;
+}): EntryTocItem[] {
+  const items: EntryTocItem[] = [];
+  if (input.risk !== "low") items.push({ id: "risk-callout", label: "Install risk" });
+  items.push({ id: "citation-facts", label: "Citation facts" });
+  if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
+  if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
+  if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });
+  if (input.hasSchema) items.push({ id: "schema", label: "Schema details" });
+  items.push({ id: "about", label: "About this resource" });
+  items.push({ id: "citations", label: "Source citations" });
+  items.push({ id: "badge", label: "Add a badge" });
+  if (input.hasAlternatives) items.push({ id: "compare", label: "How it compares" });
+  if (input.hasRelated) items.push({ id: "related", label: "Related" });
+  if (input.hasGuides) items.push({ id: "guides", label: "Related guides" });
+  items.push({ id: "signals", label: "Signals" });
+  return items;
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -3,13 +3,9 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import {
   ArrowUpRight,
-  BookOpen,
-  ExternalLink,
-  GitBranch,
   ShieldCheck,
   AlertTriangle,
   ListChecks,
-  Code2,
   Sparkles,
   Star,
   FileText,
@@ -48,18 +44,25 @@ import { categoryLabels, categoryUsageHints, siteConfig } from "@/lib/site";
 import { tagSlug } from "@/lib/tags";
 // (HoverChevrons removed — related uses static grid)
 import { ShareMenu } from "@/components/share-menu";
-import { DossierTOC, type TocItem } from "@/components/dossier-toc";
+import type { TocItem } from "@/components/dossier-toc";
+import { EntryDetailQuickLinks } from "@/components/entry-detail-quick-links";
+import { EntryDetailRail } from "@/components/entry-detail-rail";
+import { EntryDetailReadinessPanel } from "@/components/entry-detail-readiness";
 import { EntryFacets } from "@/components/entry-facets";
 import { HarnessBadge } from "@/components/harness-badge";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { SourceCitations } from "@/components/source-citations";
 import { CitationFacts } from "@/components/citation-facts";
-import { ProvenanceBlock } from "@/components/provenance-block";
 import { StickyMetaBar } from "@/components/sticky-meta-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
-import { TRUST_LABEL, PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
+import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
+import {
+  buildEntryTocItems,
+  entryQuickLinks,
+  entryReadinessRows,
+} from "@/lib/entry-detail-sidebar-lib";
 import { installRiskLevel, INSTALL_RISK_LABEL, INSTALL_RISK_DETAIL } from "@/lib/trust";
 import { useEffect, useMemo, useState } from "react";
 import { useRecents } from "@/lib/recents";
@@ -266,33 +269,31 @@ function Dossier() {
   const risk = installRiskLevel(entry);
   const hasSchema = hasSchemaDetails(entry);
 
-  const tocItems = useMemo<TocItem[]>(() => {
-    const items: TocItem[] = [];
-    if (risk !== "low") items.push({ id: "risk-callout", label: "Install risk" });
-    items.push({ id: "citation-facts", label: "Citation facts" });
-    if (entry.safetyNotes) items.push({ id: "safety", label: "Safety notes" });
-    if (entry.privacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
-    if (entry.prerequisites && entry.prerequisites.length > 0)
-      items.push({ id: "prerequisites", label: "Prerequisites" });
-    if (hasSchema) items.push({ id: "schema", label: "Schema details" });
-    items.push({ id: "about", label: "About this resource" });
-    items.push({ id: "citations", label: "Source citations" });
-    items.push({ id: "badge", label: "Add a badge" });
-    if (alternatives.length > 0) items.push({ id: "compare", label: "How it compares" });
-    if (rel.length > 0) items.push({ id: "related", label: "Related" });
-    if (guides.length > 0) items.push({ id: "guides", label: "Related guides" });
-    items.push({ id: "signals", label: "Signals" });
-    return items;
-  }, [
-    risk,
-    entry.safetyNotes,
-    entry.privacyNotes,
-    entry.prerequisites,
-    hasSchema,
-    alternatives.length,
-    rel.length,
-    guides.length,
-  ]);
+  const tocItems = useMemo<TocItem[]>(
+    () =>
+      buildEntryTocItems({
+        risk,
+        hasSafetyNotes: Boolean(entry.safetyNotes),
+        hasPrivacyNotes: Boolean(entry.privacyNotes),
+        hasPrerequisites: Boolean(entry.prerequisites?.length),
+        hasSchema,
+        hasAlternatives: alternatives.length > 0,
+        hasRelated: rel.length > 0,
+        hasGuides: guides.length > 0,
+      }),
+    [
+      risk,
+      entry.safetyNotes,
+      entry.privacyNotes,
+      entry.prerequisites,
+      hasSchema,
+      alternatives.length,
+      rel.length,
+      guides.length,
+    ],
+  );
+  const readinessRows = useMemo(() => entryReadinessRows(entry), [entry]);
+  const quickLinks = useMemo(() => entryQuickLinks(entry), [entry]);
 
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
@@ -450,59 +451,10 @@ function Dossier() {
               )}
             </div>
 
-            <div className="border-t border-border px-4 py-3">
-              <div className="eyebrow mb-2">Readiness</div>
-              <ul className="space-y-1.5 text-xs">
-                <Readiness
-                  label="Trust"
-                  value={TRUST_LABEL[entry.trust]}
-                  ok={entry.trust === "trusted"}
-                />
-                <Readiness label="Source" value={entry.source} ok={entry.source !== "unverified"} />
-                <Readiness
-                  label="Safety notes"
-                  value={entry.safetyNotes ? "Present" : "Missing"}
-                  ok={!!entry.safetyNotes}
-                />
-                <Readiness
-                  label="Reviewed"
-                  value={entry.reviewed ? "Yes" : "No"}
-                  ok={!!entry.reviewed}
-                />
-              </ul>
-            </div>
+            <EntryDetailReadinessPanel rows={readinessRows} />
           </div>
 
-          <div className="mt-3 flex flex-col gap-1.5 text-xs">
-            {entry.docsUrl && (
-              <a
-                href={entry.docsUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-              >
-                <BookOpen className="h-3.5 w-3.5" /> Documentation{" "}
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-            {entry.sourceUrl && (
-              <a
-                href={entry.sourceUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-              >
-                <GitBranch className="h-3.5 w-3.5" /> Source repository{" "}
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-            <Link
-              to="/browse"
-              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-            >
-              <Code2 className="h-3.5 w-3.5" /> Registry JSON · LLM text
-            </Link>
-          </div>
+          <EntryDetailQuickLinks links={quickLinks} />
         </aside>
       </header>
       <div id="dossier-header-sentinel" aria-hidden className="h-px w-full" />
@@ -811,17 +763,7 @@ function Dossier() {
           />
         </div>
 
-        <aside className="space-y-6">
-          <div className="hidden lg:block lg:sticky lg:top-20">
-            <DossierTOC items={tocItems} />
-          </div>
-          <ProvenanceBlock entry={entry} />
-          <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">
-            HeyClaude reviews metadata, provenance, and surface-level safety. We don't scan for
-            malware. Always read the source before installing tools that touch your filesystem,
-            network, or credentials.
-          </div>
-        </aside>
+        <EntryDetailRail entry={entry} tocItems={tocItems} />
       </div>
     </div>
   );
@@ -1220,18 +1162,5 @@ function DossierSection({
       </div>
       <div className="prose-editorial text-sm">{children}</div>
     </section>
-  );
-}
-
-function Readiness({ label, value, ok }: { label: string; value: string; ok: boolean }) {
-  return (
-    <li className="flex items-center justify-between">
-      <span className="text-ink-muted">{label}</span>
-      <span
-        className={cn("font-medium capitalize", ok ? "text-trust-trusted" : "text-trust-review")}
-      >
-        {value}
-      </span>
-    </li>
   );
 }

--- a/tests/app-shell-footer-lib.test.ts
+++ b/tests/app-shell-footer-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SHELL_FOOTER_COLUMNS,
+  footerColumnSpanClass,
+} from "../apps/web/src/lib/app-shell-footer-lib";
+
+describe("app-shell-footer-lib", () => {
+  it("organizes footer links into product, contribution, API, and community columns", () => {
+    expect(SHELL_FOOTER_COLUMNS.map((column) => column.id)).toEqual([
+      "product",
+      "contribution",
+      "api-mcp",
+      "community",
+    ]);
+    const contribution = SHELL_FOOTER_COLUMNS.find((column) => column.id === "contribution");
+    expect(contribution?.links.map((link) => link.to)).toEqual([
+      "/submit",
+      "/claim",
+      "/contributors",
+      "/validators",
+      "/advertise",
+    ]);
+  });
+
+  it("maps footer column spans to grid classes", () => {
+    expect(footerColumnSpanClass(3)).toBe("md:col-span-3");
+    expect(footerColumnSpanClass()).toBe("md:col-span-2");
+  });
+});

--- a/tests/app-shell-footer-lib.test.ts
+++ b/tests/app-shell-footer-lib.test.ts
@@ -13,7 +13,9 @@ describe("app-shell-footer-lib", () => {
       "api-mcp",
       "community",
     ]);
-    const contribution = SHELL_FOOTER_COLUMNS.find((column) => column.id === "contribution");
+    const contribution = SHELL_FOOTER_COLUMNS.find(
+      (column) => column.id === "contribution",
+    );
     expect(contribution?.links.map((link) => link.to)).toEqual([
       "/submit",
       "/claim",

--- a/tests/app-shell-nav-lib.test.ts
+++ b/tests/app-shell-nav-lib.test.ts
@@ -22,8 +22,10 @@ describe("app-shell-nav-lib", () => {
       "api-mcp",
       "community",
     ]);
-    expect(flattenShellMobileNav().some((link) => link.to === "/integrations/mcp-server")).toBe(
-      true,
-    );
+    expect(
+      flattenShellMobileNav().some(
+        (link) => link.to === "/integrations/mcp-server",
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/app-shell-nav-lib.test.ts
+++ b/tests/app-shell-nav-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SHELL_MOBILE_NAV_SECTIONS,
+  SHELL_PRIMARY_NAV,
+  flattenShellMobileNav,
+  shellNavItemActive,
+} from "../apps/web/src/lib/app-shell-nav-lib";
+
+describe("app-shell-nav-lib", () => {
+  it("marks browse and nested paths active", () => {
+    expect(shellNavItemActive("/browse", "/browse")).toBe(true);
+    expect(shellNavItemActive("/browse/tools", "/browse")).toBe(true);
+    expect(shellNavItemActive("/trending", "/browse")).toBe(false);
+  });
+
+  it("groups mobile navigation into product areas", () => {
+    expect(SHELL_PRIMARY_NAV.map((item) => item.to)).toContain("/quality");
+    expect(SHELL_MOBILE_NAV_SECTIONS.map((section) => section.id)).toEqual([
+      "explore",
+      "trust",
+      "api-mcp",
+      "community",
+    ]);
+    expect(flattenShellMobileNav().some((link) => link.to === "/integrations/mcp-server")).toBe(
+      true,
+    );
+  });
+});

--- a/tests/citation-facts.test.ts
+++ b/tests/citation-facts.test.ts
@@ -124,11 +124,16 @@ describe("entry page wiring", () => {
     path.join(repoRoot, "apps/web/src/routes/entry.$category.$slug.tsx"),
     "utf8",
   );
+  const sidebarLib = fs.readFileSync(
+    path.join(repoRoot, "apps/web/src/lib/entry-detail-sidebar-lib.ts"),
+    "utf8",
+  );
 
   it("renders the consolidated CitationFacts block in its own section", () => {
     expect(src).toContain("CitationFacts");
     expect(src).toContain('id="citation-facts"');
-    expect(src).toContain('label: "Citation facts"');
+    expect(src).toContain("buildEntryTocItems");
+    expect(sidebarLib).toContain('label: "Citation facts"');
   });
 
   it("exposes the per-entry LLMS endpoint both as a visible link and a head alternate", () => {

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -26,10 +26,16 @@ function sampleEntry(overrides: Partial<Entry> = {}): Entry {
 describe("entry-detail-sidebar-lib", () => {
   it("builds readiness rows from entry trust signals", () => {
     const rows = entryReadinessRows(
-      sampleEntry({ trust: "trusted", safetyNotes: "Keep secrets local.", reviewed: true }),
+      sampleEntry({
+        trust: "trusted",
+        safetyNotes: "Keep secrets local.",
+        reviewed: true,
+      }),
     );
     expect(rows.find((row) => row.label === "Trust")?.ok).toBe(true);
-    expect(rows.find((row) => row.label === "Safety notes")?.value).toBe("Present");
+    expect(rows.find((row) => row.label === "Safety notes")?.value).toBe(
+      "Present",
+    );
     expect(rows.find((row) => row.label === "Reviewed")?.ok).toBe(true);
   });
 
@@ -40,7 +46,11 @@ describe("entry-detail-sidebar-lib", () => {
         sourceUrl: "https://github.com/org/repo",
       }),
     );
-    expect(links.map((link) => link.id)).toEqual(["docs", "source", "registry-json"]);
+    expect(links.map((link) => link.id)).toEqual([
+      "docs",
+      "source",
+      "registry-json",
+    ]);
   });
 
   it("orders dossier TOC items with optional risk and schema sections", () => {

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildEntryTocItems,
+  entryQuickLinks,
+  entryReadinessRows,
+} from "../apps/web/src/lib/entry-detail-sidebar-lib";
+import type { Entry } from "../apps/web/src/types/registry";
+
+function sampleEntry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "sample",
+    title: "Sample",
+    description: "Sample entry",
+    author: "Author",
+    tags: [],
+    platforms: [],
+    trust: "review",
+    source: "source-backed",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry-detail-sidebar-lib", () => {
+  it("builds readiness rows from entry trust signals", () => {
+    const rows = entryReadinessRows(
+      sampleEntry({ trust: "trusted", safetyNotes: "Keep secrets local.", reviewed: true }),
+    );
+    expect(rows.find((row) => row.label === "Trust")?.ok).toBe(true);
+    expect(rows.find((row) => row.label === "Safety notes")?.value).toBe("Present");
+    expect(rows.find((row) => row.label === "Reviewed")?.ok).toBe(true);
+  });
+
+  it("builds quick links for docs and source URLs", () => {
+    const links = entryQuickLinks(
+      sampleEntry({
+        docsUrl: "https://example.com/docs",
+        sourceUrl: "https://github.com/org/repo",
+      }),
+    );
+    expect(links.map((link) => link.id)).toEqual(["docs", "source", "registry-json"]);
+  });
+
+  it("orders dossier TOC items with optional risk and schema sections", () => {
+    const items = buildEntryTocItems({
+      risk: "high",
+      hasSafetyNotes: true,
+      hasPrivacyNotes: false,
+      hasPrerequisites: false,
+      hasSchema: true,
+      hasAlternatives: false,
+      hasRelated: true,
+      hasGuides: false,
+    });
+    expect(items[0]).toEqual({ id: "risk-callout", label: "Install risk" });
+    expect(items.some((item) => item.id === "schema")).toBe(true);
+    expect(items.at(-1)).toEqual({ id: "signals", label: "Signals" });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `app-shell-nav-lib` and `app-shell-footer-lib` with grouped Explore / Trust / API-MCP / Community paths
- Reorganize desktop nav (adds Quality) and mobile sheet navigation with labeled sections
- Reorganize footer into Product, Contribution, API & MCP, and Community columns
- Extract reusable entry detail sidebar helpers and components (readiness panel, quick links, dossier rail)

Closes #439
Refs #393

## Test plan
- [x] `pnpm exec vitest run tests/app-shell-nav-lib.test.ts tests/app-shell-footer-lib.test.ts tests/entry-detail-sidebar-lib.test.ts tests/citation-facts.test.ts`
- [x] `pnpm type-check` and `pnpm build`
- [ ] CI `validate-web`, `validate-ci`, `coverage`, and `required-pr-gate` green