### PR TITLE
feat(mcp): extract registry filter helpers into registry-filter-lib

### DIFF
--- a/packages/mcp/src/registry-filter-lib.js
+++ b/packages/mcp/src/registry-filter-lib.js
@@ -1,0 +1,59 @@
+/**
+ * Pure MCP registry entry filter helpers.
+ *
+ * Tag matching, boolean filter normalization, and trust-filter gating live here.
+ * Runtime registry handlers stay in `registry.js`.
+ */
+import { normalizeText } from "./registry-normalize-lib.js";
+import {
+  entryClaimStatusValue,
+  entryHasPrivacyNotes,
+  entryHasSafetyNotes,
+  entryPackageTrustValue,
+  entrySourceStatusValue,
+} from "./search-ranking.js";
+
+export function booleanFilterMatches(value, filter = "all") {
+  if (!filter || filter === "all") return true;
+  return filter === "true" ? Boolean(value) : !value;
+}
+
+export function entryMatchesTag(entry, tag) {
+  if (!tag) return true;
+  return (entry.tags || []).some(
+    (candidate) => normalizeText(candidate) === tag,
+  );
+}
+
+export function entryMatchesTrustFilters(entry, args = {}) {
+  if (!booleanFilterMatches(entryHasSafetyNotes(entry), args.hasSafetyNotes)) {
+    return false;
+  }
+  if (
+    !booleanFilterMatches(entryHasPrivacyNotes(entry), args.hasPrivacyNotes)
+  ) {
+    return false;
+  }
+  if (
+    args.downloadTrust &&
+    args.downloadTrust !== "all" &&
+    entryPackageTrustValue(entry) !== args.downloadTrust
+  ) {
+    return false;
+  }
+  if (
+    args.claimStatus &&
+    args.claimStatus !== "all" &&
+    entryClaimStatusValue(entry) !== args.claimStatus
+  ) {
+    return false;
+  }
+  if (
+    args.sourceStatus &&
+    args.sourceStatus !== "all" &&
+    entrySourceStatusValue(entry) !== args.sourceStatus
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -31,8 +31,6 @@ import {
 } from "./submissions.js";
 import {
   entryClaimStatusValue,
-  entryHasPrivacyNotes,
-  entryHasSafetyNotes,
   entryPackageTrustValue,
   entrySourceStatusValue,
   matchesRegistryPlatform,
@@ -93,6 +91,10 @@ import {
   parsedTrustArgs,
   unique,
 } from "./registry-collection-lib.js";
+import {
+  entryMatchesTag,
+  entryMatchesTrustFilters,
+} from "./registry-filter-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -206,18 +208,6 @@ function entryMatchesPlatform(entry, platform) {
   return matchesRegistryPlatform(entry, platform);
 }
 
-function entryMatchesTag(entry, tag) {
-  if (!tag) return true;
-  return (entry.tags || []).some(
-    (candidate) => normalizeText(candidate) === tag,
-  );
-}
-
-function booleanFilterMatches(value, filter = "all") {
-  if (!filter || filter === "all") return true;
-  return filter === "true" ? Boolean(value) : !value;
-}
-
 function entryPackageTrust(entry) {
   return entryPackageTrustValue(entry);
 }
@@ -228,39 +218,6 @@ function entryClaimStatus(entry) {
 
 function entrySourceStatus(entry) {
   return entrySourceStatusValue(entry);
-}
-
-function entryMatchesTrustFilters(entry, args = {}) {
-  if (!booleanFilterMatches(entryHasSafetyNotes(entry), args.hasSafetyNotes)) {
-    return false;
-  }
-  if (
-    !booleanFilterMatches(entryHasPrivacyNotes(entry), args.hasPrivacyNotes)
-  ) {
-    return false;
-  }
-  if (
-    args.downloadTrust &&
-    args.downloadTrust !== "all" &&
-    entryPackageTrust(entry) !== args.downloadTrust
-  ) {
-    return false;
-  }
-  if (
-    args.claimStatus &&
-    args.claimStatus !== "all" &&
-    entryClaimStatus(entry) !== args.claimStatus
-  ) {
-    return false;
-  }
-  if (
-    args.sourceStatus &&
-    args.sourceStatus !== "all" &&
-    entrySourceStatus(entry) !== args.sourceStatus
-  ) {
-    return false;
-  }
-  return true;
 }
 
 function toSearchResult(entry, ranking = null) {

--- a/tests/mcp-registry-filter-lib.test.ts
+++ b/tests/mcp-registry-filter-lib.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  booleanFilterMatches,
+  entryMatchesTag,
+  entryMatchesTrustFilters,
+} from "../packages/mcp/src/registry-filter-lib.js";
+
+describe("registry-filter-lib boolean filters", () => {
+  it("passes through when filter is all or empty", () => {
+    expect(booleanFilterMatches(true, "all")).toBe(true);
+    expect(booleanFilterMatches(false, "all")).toBe(true);
+    expect(booleanFilterMatches(true)).toBe(true);
+  });
+
+  it("matches explicit true and false filters", () => {
+    expect(booleanFilterMatches(true, "true")).toBe(true);
+    expect(booleanFilterMatches(false, "true")).toBe(false);
+    expect(booleanFilterMatches(false, "false")).toBe(true);
+    expect(booleanFilterMatches(true, "false")).toBe(false);
+  });
+});
+
+describe("registry-filter-lib tag matching", () => {
+  it("accepts entries with normalized tag matches", () => {
+    const entry = { tags: ["MCP", "browser-bridge"] };
+    expect(entryMatchesTag(entry, "")).toBe(true);
+    expect(entryMatchesTag(entry, "mcp")).toBe(true);
+    expect(entryMatchesTag(entry, "missing")).toBe(false);
+  });
+});
+
+describe("registry-filter-lib trust filters", () => {
+  const entry = {
+    safetyNotes: [{ text: "Runs shell commands" }],
+    privacyNotes: [],
+    downloadTrust: "first-party",
+    claimStatus: "verified",
+    sourceStatus: "available",
+  };
+
+  it("accepts entries when trust filters are all", () => {
+    expect(
+      entryMatchesTrustFilters(entry, {
+        hasSafetyNotes: "all",
+        hasPrivacyNotes: "all",
+        downloadTrust: "all",
+        claimStatus: "all",
+        sourceStatus: "all",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects entries that fail boolean or enum trust filters", () => {
+    expect(entryMatchesTrustFilters(entry, { hasSafetyNotes: "false" })).toBe(
+      false,
+    );
+    expect(entryMatchesTrustFilters(entry, { downloadTrust: "external" })).toBe(
+      false,
+    );
+    expect(entryMatchesTrustFilters(entry, { claimStatus: "unclaimed" })).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Extract tag matching, boolean filter normalization, and trust-filter gating into `packages/mcp/src/registry-filter-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so registry search and list behavior stays unchanged.
- Add focused lib tests for boolean filters, tag matching, and trust gating.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-filter-lib.js` (new extracted filter helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-filter-lib.test.ts` (new focused tests)
- Expected behavior:
  - Registry tag filtering and trust gating are unchanged.
- Important edge cases or invariants:
  - Boolean filters still default to `"all"`.
  - Tag matching still normalizes candidate tags before comparing.
  - Trust enum filters still reject entries when values do not match.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-filter-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-filter-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry filter helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-collection-lib`, `registry-normalize-lib`, `registry-response-lib`).
  - Does not touch artifact path helpers, `schemas.js`, endpoint URL helpers, or submission-risk analysis code.

Made with [Cursor](https://cursor.com)