### PR TITLE
feat(mcp): extract registry body excerpt helpers into registry-excerpt-lib

### DIFF
--- a/packages/mcp/src/registry-excerpt-lib.js
+++ b/packages/mcp/src/registry-excerpt-lib.js
@@ -1,0 +1,114 @@
+/**
+ * Pure MCP registry entry body excerpt helpers.
+ *
+ * Token-efficient body projection, excerpt trimming, and asset-field omission
+ * live here. Runtime registry handlers stay in `registry.js`.
+ */
+export const ENTRY_BODY_EXCERPT_CHARS = 1200;
+
+// Large copyable-content fields that largely duplicate the body or the install
+// asset. In non-full modes they are omitted (and surfaced via omittedFields)
+// because the caller should pull them from entry.asset when needed,
+// rather than paying for tens of kilobytes on every detail lookup.
+export const ENTRY_ASSET_FIELDS = [
+  "scriptBody",
+  "fullCopyableContent",
+  "copySnippet",
+];
+
+export function excerptText(text, limit) {
+  if (text.length <= limit) {
+    return text;
+  }
+  const slice = text.slice(0, limit);
+  // Back off to the last paragraph/sentence/word boundary so the excerpt does
+  // not end mid-word; fall back to the hard cut if no decent boundary exists.
+  const boundary = Math.max(
+    slice.lastIndexOf("\n\n"),
+    slice.lastIndexOf("\n"),
+    slice.lastIndexOf(". "),
+    slice.lastIndexOf(" "),
+  );
+  const cut = boundary > limit * 0.6 ? slice.slice(0, boundary) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
+export function withAssetHint(bodyMeta) {
+  if (bodyMeta.omittedFields.length > 0) {
+    bodyMeta.assetHint =
+      "Large copyable fields were omitted to save context; call entry.asset for the full script or snippet.";
+  }
+  return bodyMeta;
+}
+
+// Projects an entry's heavy content to the requested verbosity so the default
+// entry.detail response stays token-efficient. Returns the (possibly
+// trimmed) entry plus body metadata describing exactly what was returned.
+export function projectEntryBody(entry, requestedMode) {
+  const mode =
+    requestedMode === "none" || requestedMode === "full"
+      ? requestedMode
+      : "excerpt";
+  const body = typeof entry.body === "string" ? entry.body : "";
+  const bodyChars = body.length;
+
+  if (mode === "full") {
+    return {
+      entry,
+      bodyMeta: {
+        bodyMode: "full",
+        bodyChars,
+        bodyTruncated: false,
+        omittedFields: [],
+      },
+    };
+  }
+
+  // Lean modes: drop large copyable asset fields, keep small useful ones.
+  const projected = { ...entry };
+  const omittedFields = [];
+  for (const field of ENTRY_ASSET_FIELDS) {
+    const value = projected[field];
+    const size = typeof value === "string" ? value.length : 0;
+    if (size > ENTRY_BODY_EXCERPT_CHARS) {
+      delete projected[field];
+      omittedFields.push({ field, chars: size });
+    }
+  }
+
+  if (mode === "none") {
+    delete projected.body;
+    return {
+      entry: projected,
+      bodyMeta: withAssetHint({
+        bodyMode: "none",
+        bodyChars,
+        bodyTruncated: bodyChars > 0,
+        omittedFields,
+      }),
+    };
+  }
+
+  if (bodyChars > ENTRY_BODY_EXCERPT_CHARS) {
+    projected.body = excerptText(body, ENTRY_BODY_EXCERPT_CHARS);
+    return {
+      entry: projected,
+      bodyMeta: withAssetHint({
+        bodyMode: "excerpt",
+        bodyChars,
+        bodyTruncated: true,
+        omittedFields,
+      }),
+    };
+  }
+
+  return {
+    entry: projected,
+    bodyMeta: withAssetHint({
+      bodyMode: "excerpt",
+      bodyChars,
+      bodyTruncated: false,
+      omittedFields,
+    }),
+  };
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -95,6 +95,7 @@ import {
   entryMatchesTag,
   entryMatchesTrustFilters,
 } from "./registry-filter-lib.js";
+import { projectEntryBody } from "./registry-excerpt-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -1088,111 +1089,6 @@ export async function getRelatedEntries(args = {}, options = {}) {
     count: entries.length,
     entries,
   };
-}
-
-const ENTRY_BODY_EXCERPT_CHARS = 1200;
-
-// Large copyable-content fields that largely duplicate the body or the install
-// asset. In non-full modes they are omitted (and surfaced via omittedFields)
-// because the caller should pull them from entry.asset when needed,
-// rather than paying for tens of kilobytes on every detail lookup.
-const ENTRY_ASSET_FIELDS = ["scriptBody", "fullCopyableContent", "copySnippet"];
-
-function excerptText(text, limit) {
-  if (text.length <= limit) {
-    return text;
-  }
-  const slice = text.slice(0, limit);
-  // Back off to the last paragraph/sentence/word boundary so the excerpt does
-  // not end mid-word; fall back to the hard cut if no decent boundary exists.
-  const boundary = Math.max(
-    slice.lastIndexOf("\n\n"),
-    slice.lastIndexOf("\n"),
-    slice.lastIndexOf(". "),
-    slice.lastIndexOf(" "),
-  );
-  const cut = boundary > limit * 0.6 ? slice.slice(0, boundary) : slice;
-  return `${cut.trimEnd()}…`;
-}
-
-// Projects an entry's heavy content to the requested verbosity so the default
-// entry.detail response stays token-efficient. Returns the (possibly
-// trimmed) entry plus body metadata describing exactly what was returned.
-function projectEntryBody(entry, requestedMode) {
-  const mode =
-    requestedMode === "none" || requestedMode === "full"
-      ? requestedMode
-      : "excerpt";
-  const body = typeof entry.body === "string" ? entry.body : "";
-  const bodyChars = body.length;
-
-  if (mode === "full") {
-    return {
-      entry,
-      bodyMeta: {
-        bodyMode: "full",
-        bodyChars,
-        bodyTruncated: false,
-        omittedFields: [],
-      },
-    };
-  }
-
-  // Lean modes: drop large copyable asset fields, keep small useful ones.
-  const projected = { ...entry };
-  const omittedFields = [];
-  for (const field of ENTRY_ASSET_FIELDS) {
-    const value = projected[field];
-    const size = typeof value === "string" ? value.length : 0;
-    if (size > ENTRY_BODY_EXCERPT_CHARS) {
-      delete projected[field];
-      omittedFields.push({ field, chars: size });
-    }
-  }
-
-  if (mode === "none") {
-    delete projected.body;
-    return {
-      entry: projected,
-      bodyMeta: withAssetHint({
-        bodyMode: "none",
-        bodyChars,
-        bodyTruncated: bodyChars > 0,
-        omittedFields,
-      }),
-    };
-  }
-
-  if (bodyChars > ENTRY_BODY_EXCERPT_CHARS) {
-    projected.body = excerptText(body, ENTRY_BODY_EXCERPT_CHARS);
-    return {
-      entry: projected,
-      bodyMeta: withAssetHint({
-        bodyMode: "excerpt",
-        bodyChars,
-        bodyTruncated: true,
-        omittedFields,
-      }),
-    };
-  }
-
-  return {
-    entry: projected,
-    bodyMeta: withAssetHint({
-      bodyMode: "excerpt",
-      bodyChars,
-      bodyTruncated: false,
-      omittedFields,
-    }),
-  };
-}
-
-function withAssetHint(bodyMeta) {
-  if (bodyMeta.omittedFields.length > 0) {
-    bodyMeta.assetHint =
-      "Large copyable fields were omitted to save context; call entry.asset for the full script or snippet.";
-  }
-  return bodyMeta;
 }
 
 export async function getEntryDetail(args = {}, options = {}) {

--- a/tests/mcp-registry-excerpt-lib.test.ts
+++ b/tests/mcp-registry-excerpt-lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ENTRY_ASSET_FIELDS,
+  ENTRY_BODY_EXCERPT_CHARS,
+  excerptText,
+  projectEntryBody,
+} from "../packages/mcp/src/registry-excerpt-lib.js";
+
+describe("registry-excerpt-lib excerpt trimming", () => {
+  it("returns short text unchanged and trims long text at boundaries", () => {
+    expect(excerptText("hello", 10)).toBe("hello");
+    const long = "First paragraph.\n\nSecond paragraph with more detail.";
+    const excerpt = excerptText(long, 20);
+    expect(excerpt.endsWith("…")).toBe(true);
+    expect(excerpt.length).toBeLessThanOrEqual(21);
+  });
+});
+
+describe("registry-excerpt-lib body projection", () => {
+  const entry = {
+    body: "x".repeat(ENTRY_BODY_EXCERPT_CHARS + 50),
+    scriptBody: "y".repeat(ENTRY_BODY_EXCERPT_CHARS + 10),
+    fullCopyableContent: "small",
+    title: "Example",
+  };
+
+  it("exports excerpt constants and asset field names", () => {
+    expect(ENTRY_BODY_EXCERPT_CHARS).toBe(1200);
+    expect(ENTRY_ASSET_FIELDS).toEqual([
+      "scriptBody",
+      "fullCopyableContent",
+      "copySnippet",
+    ]);
+  });
+
+  it("returns full entries without truncation in full mode", () => {
+    const { entry: projected, bodyMeta } = projectEntryBody(entry, "full");
+    expect(projected.body).toBe(entry.body);
+    expect(bodyMeta).toEqual({
+      bodyMode: "full",
+      bodyChars: entry.body.length,
+      bodyTruncated: false,
+      omittedFields: [],
+    });
+  });
+
+  it("omits body and large asset fields in none mode", () => {
+    const { entry: projected, bodyMeta } = projectEntryBody(entry, "none");
+    expect(projected.body).toBeUndefined();
+    expect(projected.scriptBody).toBeUndefined();
+    expect(projected.fullCopyableContent).toBe("small");
+    expect(bodyMeta.bodyMode).toBe("none");
+    expect(bodyMeta.omittedFields).toEqual([
+      { field: "scriptBody", chars: entry.scriptBody.length },
+    ]);
+    expect(bodyMeta.assetHint).toMatch(/entry\.asset/i);
+  });
+
+  it("excerpts long bodies and marks truncation in excerpt mode", () => {
+    const { entry: projected, bodyMeta } = projectEntryBody(entry, "excerpt");
+    expect(projected.body.endsWith("…")).toBe(true);
+    expect(bodyMeta.bodyMode).toBe("excerpt");
+    expect(bodyMeta.bodyTruncated).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract entry body projection, excerpt trimming, and asset-field omission into `packages/mcp/src/registry-excerpt-lib.js`.
- Keep `packages/mcp/src/registry.js` importing `projectEntryBody` so entry.detail behavior stays unchanged.
- Add focused lib tests for excerpt trimming and body projection modes.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-excerpt-lib.js` (new extracted body excerpt helpers)
  - `packages/mcp/src/registry.js` (imports extracted helper; runtime handlers unchanged)
  - `tests/mcp-registry-excerpt-lib.test.ts` (new focused tests)
- Expected behavior:
  - Entry detail body modes (`full`, `excerpt`, `none`) and asset omission are unchanged.
- Important edge cases or invariants:
  - Long bodies still excerpt at paragraph/sentence/word boundaries when possible.
  - Large copyable asset fields still omit in lean modes with asset hints.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-excerpt-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-excerpt-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry body excerpt helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-filter-lib`, `registry-collection-lib`, `registry-response-lib`).
  - Does not touch artifact path helpers, `schemas.js`, endpoint URL helpers, or submission-risk analysis code.

Made with [Cursor](https://cursor.com)