### PR TITLE
feat(web): compose compare page presentation UI into page interactive bundle

### DIFF
--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -6,6 +6,7 @@ import {
   comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
 } from "@/lib/compare-page-empty-interactive-ui-lib";
+import { comparePagePresentationUiInteractiveUiState } from "@/lib/compare-page-presentation-ui-interactive-ui-lib";
 import {
   comparePageUiInteractiveUiState,
   type ComparePageUiState,
@@ -24,11 +25,12 @@ export function comparePageInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageInteractiveUiState {
+  const presentation = comparePagePresentationUiInteractiveUiState(items);
   const actions = comparePageActionsInteractiveUiState(items);
   return {
     pageUi: comparePageUiInteractiveUiState(items),
     emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
-    actionRowDiverges: actions.actionRowDiverges,
+    actionRowDiverges: presentation.actionRowDiverges,
     actionCells: actions.actionCells,
   };
 }

--- a/apps/web/src/lib/compare-page-presentation-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-presentation-ui-interactive-ui-lib.ts
@@ -1,0 +1,14 @@
+import type { Entry } from "@/types/registry";
+import {
+  comparePagePresentationState,
+  type ComparePagePresentationState,
+} from "@/lib/compare-page-presentation-ui-lib";
+
+export type { ComparePagePresentationState };
+export type ComparePagePresentationUiInteractiveUiState = ComparePagePresentationState;
+
+export function comparePagePresentationUiInteractiveUiState(
+  items: Entry[],
+): ComparePagePresentationUiInteractiveUiState {
+  return comparePagePresentationState(items);
+}

--- a/apps/web/src/lib/compare-page-presentation-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-presentation-ui-lib.ts
@@ -1,0 +1,12 @@
+import type { Entry } from "@/types/registry";
+import { comparePageActionsDiverge } from "@/lib/compare-page-actions-ui-lib";
+
+export type ComparePagePresentationState = {
+  actionRowDiverges: boolean;
+};
+
+export function comparePagePresentationState(items: Entry[]): ComparePagePresentationState {
+  return {
+    actionRowDiverges: comparePageActionsDiverge(items),
+  };
+}

--- a/tests/compare-page-presentation-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-page-presentation-ui-interactive-ui-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePagePresentationUiInteractiveUiState } from "@/lib/compare-page-presentation-ui-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page presentation ui interactive ui lib", () => {
+  it("keeps action rows unhighlighted for uniform compared entries", () => {
+    expect(comparePagePresentationUiInteractiveUiState([entry()])).toEqual({
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging next-action rows for mixed compare columns", () => {
+    expect(
+      comparePagePresentationUiInteractiveUiState([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]).actionRowDiverges,
+    ).toBe(true);
+  });
+});

--- a/tests/compare-page-presentation-ui-lib.test.ts
+++ b/tests/compare-page-presentation-ui-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { comparePagePresentationState } from "@/lib/compare-page-presentation-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page presentation ui lib", () => {
+  it("keeps action rows unhighlighted for a single compared entry", () => {
+    expect(comparePagePresentationState([entry()])).toEqual({
+      actionRowDiverges: false,
+    });
+  });
+
+  it("keeps action rows unhighlighted when columns share the same next-action sets", () => {
+    expect(
+      comparePagePresentationState([
+        entry({ slug: "alpha", installCommand: "npm i fixture" }),
+        entry({ slug: "beta", installCommand: "pnpm add fixture" }),
+      ]),
+    ).toEqual({
+      actionRowDiverges: false,
+    });
+  });
+
+  it("highlights diverging next-action rows for mixed compare columns", () => {
+    expect(
+      comparePagePresentationState([
+        entry({ installCommand: "npm i fixture" }),
+        entry(),
+      ]).actionRowDiverges,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-page-presentation-ui-lib` for action-row presentation signals (mirrors drawer/table presentation libs).
- Add `compare-page-presentation-ui-interactive-ui-lib` interactive wrapper.
- Compose presentation state into `comparePageInteractiveUiState`; keep `actionCells` from the actions sub-lib.

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-presentation-ui-lib.test.ts tests/compare-page-presentation-ui-interactive-ui-lib.test.ts tests/compare-page-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)