### PR TITLE
feat(mcp): extract registry asset helpers into registry-asset-lib

### DIFF
--- a/packages/mcp/src/registry-asset-lib.js
+++ b/packages/mcp/src/registry-asset-lib.js
@@ -1,0 +1,84 @@
+/**
+ * Pure MCP registry entry asset helpers.
+ *
+ * Copyable asset shaping, category-primary asset selection, and install
+ * complexity scoring live here. Runtime registry handlers stay in `registry.js`.
+ */
+export function contentAsset(type, label, content, format = "markdown") {
+  const text =
+    content && typeof content === "object"
+      ? JSON.stringify(content, null, 2)
+      : String(content || "").trim();
+  if (!text) return null;
+  return {
+    type,
+    label,
+    format,
+    content: text,
+    length: text.length,
+  };
+}
+
+export function categoryPrimaryAsset(entry) {
+  const assets = [
+    contentAsset(
+      "full_content",
+      "Full usable entry content",
+      entry.fullCopyableContent || entry.copySnippet || entry.body,
+    ),
+    contentAsset(
+      "install_command",
+      "Install command",
+      entry.installCommand,
+      "shell",
+    ),
+    contentAsset(
+      "config_snippet",
+      "Configuration snippet",
+      entry.configSnippet,
+      "text",
+    ),
+    contentAsset("script", "Script body", entry.scriptBody, "text"),
+    contentAsset(
+      "command_syntax",
+      "Command syntax",
+      entry.commandSyntax,
+      "text",
+    ),
+    contentAsset("usage", "Usage snippet", entry.usageSnippet, "markdown"),
+    contentAsset("items", "Collection items", entry.items, "json"),
+  ].filter(Boolean);
+
+  const preferredByCategory = {
+    agents: ["full_content", "usage"],
+    rules: ["full_content", "script", "usage"],
+    hooks: ["config_snippet", "script", "install_command", "usage"],
+    mcp: ["config_snippet", "install_command", "usage"],
+    skills: ["install_command", "full_content", "usage"],
+    statuslines: ["config_snippet", "script", "full_content", "usage"],
+    commands: ["command_syntax", "install_command", "full_content", "usage"],
+    collections: ["items", "full_content", "usage"],
+    guides: ["full_content", "usage"],
+  };
+  const preferred = preferredByCategory[entry.category] || ["full_content"];
+  return (
+    preferred
+      .map((type) => assets.find((asset) => asset.type === type))
+      .find(Boolean) ||
+    assets[0] ||
+    null
+  );
+}
+
+export function entryInstallComplexity(entry) {
+  const pieces = [
+    entry.installCommand,
+    entry.configSnippet,
+    entry.downloadUrl,
+    entry.prerequisites,
+  ].filter((value) => String(value || "").trim());
+  if (pieces.length >= 3) return "higher";
+  if (pieces.length === 2) return "medium";
+  if (pieces.length === 1) return "low";
+  return "unknown";
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -96,6 +96,11 @@ import {
   entryMatchesTrustFilters,
 } from "./registry-filter-lib.js";
 import { projectEntryBody } from "./registry-excerpt-lib.js";
+import {
+  categoryPrimaryAsset,
+  contentAsset,
+  entryInstallComplexity,
+} from "./registry-asset-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -418,85 +423,6 @@ function entryTrustSignalCoverage(entry) {
     present: presentOrdered,
     missing,
   };
-}
-
-function contentAsset(type, label, content, format = "markdown") {
-  const text =
-    content && typeof content === "object"
-      ? JSON.stringify(content, null, 2)
-      : String(content || "").trim();
-  if (!text) return null;
-  return {
-    type,
-    label,
-    format,
-    content: text,
-    length: text.length,
-  };
-}
-
-function categoryPrimaryAsset(entry) {
-  const assets = [
-    contentAsset(
-      "full_content",
-      "Full usable entry content",
-      entry.fullCopyableContent || entry.copySnippet || entry.body,
-    ),
-    contentAsset(
-      "install_command",
-      "Install command",
-      entry.installCommand,
-      "shell",
-    ),
-    contentAsset(
-      "config_snippet",
-      "Configuration snippet",
-      entry.configSnippet,
-      "text",
-    ),
-    contentAsset("script", "Script body", entry.scriptBody, "text"),
-    contentAsset(
-      "command_syntax",
-      "Command syntax",
-      entry.commandSyntax,
-      "text",
-    ),
-    contentAsset("usage", "Usage snippet", entry.usageSnippet, "markdown"),
-    contentAsset("items", "Collection items", entry.items, "json"),
-  ].filter(Boolean);
-
-  const preferredByCategory = {
-    agents: ["full_content", "usage"],
-    rules: ["full_content", "script", "usage"],
-    hooks: ["config_snippet", "script", "install_command", "usage"],
-    mcp: ["config_snippet", "install_command", "usage"],
-    skills: ["install_command", "full_content", "usage"],
-    statuslines: ["config_snippet", "script", "full_content", "usage"],
-    commands: ["command_syntax", "install_command", "full_content", "usage"],
-    collections: ["items", "full_content", "usage"],
-    guides: ["full_content", "usage"],
-  };
-  const preferred = preferredByCategory[entry.category] || ["full_content"];
-  return (
-    preferred
-      .map((type) => assets.find((asset) => asset.type === type))
-      .find(Boolean) ||
-    assets[0] ||
-    null
-  );
-}
-
-function entryInstallComplexity(entry) {
-  const pieces = [
-    entry.installCommand,
-    entry.configSnippet,
-    entry.downloadUrl,
-    entry.prerequisites,
-  ].filter((value) => String(value || "").trim());
-  if (pieces.length >= 3) return "higher";
-  if (pieces.length === 2) return "medium";
-  if (pieces.length === 1) return "low";
-  return "unknown";
 }
 
 async function readEntry(category, slug, options = {}) {

--- a/tests/mcp-registry-asset-lib.test.ts
+++ b/tests/mcp-registry-asset-lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  categoryPrimaryAsset,
+  contentAsset,
+  entryInstallComplexity,
+} from "../packages/mcp/src/registry-asset-lib.js";
+
+describe("registry-asset-lib content assets", () => {
+  it("builds typed assets and skips empty content", () => {
+    expect(contentAsset("usage", "Usage snippet", "Run `npm test`")).toEqual({
+      type: "usage",
+      label: "Usage snippet",
+      format: "markdown",
+      content: "Run `npm test`",
+      length: 14,
+    });
+    expect(contentAsset("items", "Collection items", null)).toBeNull();
+    expect(contentAsset("usage", "Usage snippet", "   ")).toBeNull();
+  });
+});
+
+describe("registry-asset-lib category primary asset", () => {
+  it("prefers category-specific asset types", () => {
+    const entry = {
+      category: "skills",
+      installCommand: "npm install -g skill",
+      body: "Skill body",
+    };
+    expect(categoryPrimaryAsset(entry)).toMatchObject({
+      type: "install_command",
+      content: "npm install -g skill",
+    });
+  });
+
+  it("falls back to full content when preferred types are missing", () => {
+    const entry = {
+      category: "guides",
+      body: "Guide content",
+    };
+    expect(categoryPrimaryAsset(entry)).toMatchObject({
+      type: "full_content",
+      content: "Guide content",
+    });
+  });
+});
+
+describe("registry-asset-lib install complexity", () => {
+  it("scores install complexity from available setup fields", () => {
+    expect(entryInstallComplexity({})).toBe("unknown");
+    expect(
+      entryInstallComplexity({ installCommand: "npm install -g tool" }),
+    ).toBe("low");
+    expect(
+      entryInstallComplexity({
+        installCommand: "npm install -g tool",
+        configSnippet: "export KEY=1",
+      }),
+    ).toBe("medium");
+    expect(
+      entryInstallComplexity({
+        installCommand: "npm install -g tool",
+        configSnippet: "export KEY=1",
+        downloadUrl: "https://example.com/pkg.tgz",
+      }),
+    ).toBe("higher");
+  });
+});


### PR DESCRIPTION
## Summary

- Extract copyable asset shaping, category-primary asset selection, and install complexity scoring into `packages/mcp/src/registry-asset-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so entry.asset and toolbox behavior stays unchanged.
- Add focused lib tests for asset building, category preferences, and install complexity.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-asset-lib.js` (new extracted asset helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-asset-lib.test.ts` (new focused tests)
- Expected behavior:
  - Copyable asset selection and install complexity scoring are unchanged.
- Important edge cases or invariants:
  - Category-specific primary asset preferences still apply.
  - Empty asset content still returns null.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-asset-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-asset-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry asset helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-excerpt-lib`, `registry-filter-lib`, `registry-collection-lib`).
  - Does not touch artifact path helpers, `schemas.js`, endpoint URL helpers, or submission-risk analysis code.

Made with [Cursor](https://cursor.com)