### PR TITLE
feat(mcp): extract registry toolbox helpers into registry-toolbox-lib

### DIFF
--- a/packages/mcp/src/registry-toolbox-lib.js
+++ b/packages/mcp/src/registry-toolbox-lib.js
@@ -1,0 +1,195 @@
+/**
+ * Pure MCP registry toolbox planner helpers.
+ *
+ * Diverse ranked-entry selection, fit reasons, caveats, install distillation,
+ * and trust rollups live here. Runtime registry handlers stay in `registry.js`.
+ */
+import { categoryPrimaryAsset } from "./registry-asset-lib.js";
+import { unique } from "./registry-collection-lib.js";
+import { notes } from "./registry-response-lib.js";
+import {
+  entryPackageTrustValue,
+  entrySourceStatusValue,
+} from "./search-ranking.js";
+
+export const TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT = 600;
+
+export function selectDiverseRankedEntries(ranked, limit) {
+  const selected = [];
+  const byCategory = new Map();
+
+  for (const item of ranked) {
+    const category = item.entry.category || "";
+    const current = byCategory.get(category) || 0;
+    if (current >= 2) continue;
+    selected.push(item);
+    byCategory.set(category, current + 1);
+    if (selected.length >= limit) return selected;
+  }
+
+  for (const item of ranked) {
+    if (selected.includes(item)) continue;
+    selected.push(item);
+    if (selected.length >= limit) return selected;
+  }
+
+  return selected;
+}
+
+export function toolboxFitReasons(entry, ranking) {
+  const reasons = [...(ranking.reasons || []).slice(0, 4)];
+  if (entry.category) {
+    reasons.push(`${entry.category} workflow surface`);
+  }
+  if (entrySourceStatusValue(entry) === "available") {
+    reasons.push("source-backed metadata");
+  }
+  if (
+    entryPackageTrustValue(entry) === "first-party" ||
+    entry.packageVerified ||
+    entry.trustSignals?.packageVerified
+  ) {
+    reasons.push("first-party or verified package signal");
+  }
+  if (notes(entry.safetyNotes).length && notes(entry.privacyNotes).length) {
+    reasons.push("safety and privacy notes present");
+  } else if (notes(entry.safetyNotes).length) {
+    reasons.push("safety notes present");
+  } else if (notes(entry.privacyNotes).length) {
+    reasons.push("privacy notes present");
+  }
+  if (entry.installCommand || entry.downloadUrl || entry.configSnippet) {
+    reasons.push("actionable setup surface");
+  }
+  if ((entry.platforms || []).length) {
+    reasons.push(
+      `platform compatibility: ${(entry.platforms || []).slice(0, 3).join(", ")}`,
+    );
+  }
+  if ((entry.supportLevels || []).length) {
+    reasons.push("support levels documented");
+  }
+  if (entry.claimStatus === "verified" || entry.reviewedBy) {
+    reasons.push("review/provenance metadata");
+  }
+  return unique(reasons).slice(0, 8);
+}
+
+export function toolboxCaveats(entry) {
+  const caveats = [];
+  const packageTrust = entryPackageTrustValue(entry);
+  const safetyNotes = notes(entry.safetyNotes);
+  const privacyNotes = notes(entry.privacyNotes);
+  const checksum =
+    entry.checksum ||
+    entry.packageChecksum ||
+    entry.downloadSha256 ||
+    entry.skillPackage?.sha256 ||
+    "";
+  if (entrySourceStatusValue(entry) !== "available") {
+    caveats.push("Source metadata is missing or incomplete.");
+  }
+  if (packageTrust === "external") {
+    caveats.push("Package/download is external; verify upstream before use.");
+  }
+  if (entry.downloadUrl && !checksum) {
+    caveats.push("Download checksum metadata is not present.");
+  }
+  if (!safetyNotes.length) {
+    caveats.push("No structured safety notes are present.");
+  }
+  if (!privacyNotes.length) {
+    caveats.push("No structured privacy notes are present.");
+  }
+  if (
+    ["mcp", "hooks", "commands", "skills", "statuslines"].includes(
+      entry.category,
+    )
+  ) {
+    caveats.push(
+      "Risk-bearing workflow surface; inspect commands, permissions, and data access before use.",
+    );
+  }
+  return unique(caveats).slice(0, 5);
+}
+
+export function toolboxNextActions(entry) {
+  return [
+    `Inspect entry.detail with category=${entry.category} and slug=${entry.slug}.`,
+    `Run entry.trust with category=${entry.category} and slug=${entry.slug}; this is still metadata review only.`,
+    "Use entry.compare with nearby candidates before recommending a final stack.",
+    `Use entry.asset with category=${entry.category} and slug=${entry.slug} only after trust review.`,
+  ];
+}
+
+// Distills the ready-to-run install surface for a toolbox entry from its full
+// payload so the planner returns copy-pasteable commands instead of pointing at
+// more tool calls. Large config snippets are summarized rather than inlined to
+// preserve the lean response contract (callers use entry.asset for them).
+export function toolboxInstall(entry) {
+  if (!entry) return null;
+  const installCommand = String(
+    entry.installCommand || entry.commandSyntax || "",
+  ).trim();
+  const configSnippet = String(entry.configSnippet || "").trim();
+  const downloadUrl = String(entry.downloadUrl || "").trim();
+  const usageSnippet = String(entry.usageSnippet || "").trim();
+
+  const install = {
+    installable: Boolean(entry.installable),
+    primaryAssetType: categoryPrimaryAsset(entry)?.type || "",
+  };
+  if (installCommand) install.installCommand = installCommand;
+  if (downloadUrl) install.downloadUrl = downloadUrl;
+  if (usageSnippet) install.usageSnippet = usageSnippet;
+  if (configSnippet) {
+    if (configSnippet.length <= TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT) {
+      install.configSnippet = configSnippet;
+    } else {
+      install.configSnippetChars = configSnippet.length;
+      install.configHint =
+        "Config snippet is large; call entry.asset for the full snippet.";
+    }
+  }
+  if (!installCommand && !downloadUrl && !configSnippet && !usageSnippet) {
+    install.note =
+      "No install command published; use the source or canonical URL.";
+  }
+  return install;
+}
+
+export function toolboxCategoryMix(entries) {
+  const counts = new Map();
+  for (const entry of entries) {
+    const category = entry.category || "unknown";
+    counts.set(category, (counts.get(category) || 0) + 1);
+  }
+  return [...counts]
+    .map(([category, count]) => ({ category, count }))
+    .sort((left, right) => left.category.localeCompare(right.category));
+}
+
+export function toolboxTrustSummary(entries) {
+  return {
+    sourceBacked: entries.filter(
+      (entry) => entry.trust?.source?.status === "available",
+    ).length,
+    firstPartyOrVerifiedPackages: entries.filter(
+      (entry) =>
+        entry.trust?.package?.downloadTrust === "first-party" ||
+        entry.trust?.package?.packageVerified,
+    ).length,
+    entriesWithSafetyNotes: entries.filter(
+      (entry) => entry.trust?.disclosures?.hasSafetyNotes,
+    ).length,
+    entriesWithPrivacyNotes: entries.filter(
+      (entry) => entry.trust?.disclosures?.hasPrivacyNotes,
+    ).length,
+    externalPackages: entries.filter(
+      (entry) => entry.trust?.package?.downloadTrust === "external",
+    ).length,
+    missingSource: entries.filter(
+      (entry) => entry.trust?.source?.status !== "available",
+    ).length,
+  };
+}

--- a/packages/mcp/src/registry.js
+++ b/packages/mcp/src/registry.js
@@ -101,6 +101,15 @@ import {
   contentAsset,
   entryInstallComplexity,
 } from "./registry-asset-lib.js";
+import {
+  selectDiverseRankedEntries,
+  toolboxCaveats,
+  toolboxCategoryMix,
+  toolboxFitReasons,
+  toolboxInstall,
+  toolboxNextActions,
+  toolboxTrustSummary,
+} from "./registry-toolbox-lib.js";
 
 export {
   LOCAL_DRAFT_TOOL_NAMES,
@@ -470,182 +479,6 @@ export async function searchRegistry(args = {}, options = {}) {
     tag: tag || "",
     filters: trustFilters,
     entries,
-  };
-}
-
-function selectDiverseRankedEntries(ranked, limit) {
-  const selected = [];
-  const byCategory = new Map();
-
-  for (const item of ranked) {
-    const category = item.entry.category || "";
-    const current = byCategory.get(category) || 0;
-    if (current >= 2) continue;
-    selected.push(item);
-    byCategory.set(category, current + 1);
-    if (selected.length >= limit) return selected;
-  }
-
-  for (const item of ranked) {
-    if (selected.includes(item)) continue;
-    selected.push(item);
-    if (selected.length >= limit) return selected;
-  }
-
-  return selected;
-}
-
-function toolboxFitReasons(entry, ranking) {
-  const reasons = [...(ranking.reasons || []).slice(0, 4)];
-  if (entry.category) {
-    reasons.push(`${entry.category} workflow surface`);
-  }
-  if (entrySourceStatus(entry) === "available") {
-    reasons.push("source-backed metadata");
-  }
-  if (
-    entryPackageTrust(entry) === "first-party" ||
-    entry.packageVerified ||
-    entry.trustSignals?.packageVerified
-  ) {
-    reasons.push("first-party or verified package signal");
-  }
-  if (notes(entry.safetyNotes).length && notes(entry.privacyNotes).length) {
-    reasons.push("safety and privacy notes present");
-  } else if (notes(entry.safetyNotes).length) {
-    reasons.push("safety notes present");
-  } else if (notes(entry.privacyNotes).length) {
-    reasons.push("privacy notes present");
-  }
-  if (entry.installCommand || entry.downloadUrl || entry.configSnippet) {
-    reasons.push("actionable setup surface");
-  }
-  if ((entry.platforms || []).length) {
-    reasons.push(
-      `platform compatibility: ${(entry.platforms || []).slice(0, 3).join(", ")}`,
-    );
-  }
-  if ((entry.supportLevels || []).length) {
-    reasons.push("support levels documented");
-  }
-  if (entry.claimStatus === "verified" || entry.reviewedBy) {
-    reasons.push("review/provenance metadata");
-  }
-  return unique(reasons).slice(0, 8);
-}
-
-function toolboxCaveats(entry) {
-  const caveats = [];
-  const packageTrust = entryPackageTrust(entry);
-  const safetyNotes = notes(entry.safetyNotes);
-  const privacyNotes = notes(entry.privacyNotes);
-  if (entrySourceStatus(entry) !== "available") {
-    caveats.push("Source metadata is missing or incomplete.");
-  }
-  if (packageTrust === "external") {
-    caveats.push("Package/download is external; verify upstream before use.");
-  }
-  if (entry.downloadUrl && !entryTrustSummary(entry).package.checksum) {
-    caveats.push("Download checksum metadata is not present.");
-  }
-  if (!safetyNotes.length) {
-    caveats.push("No structured safety notes are present.");
-  }
-  if (!privacyNotes.length) {
-    caveats.push("No structured privacy notes are present.");
-  }
-  if (
-    ["mcp", "hooks", "commands", "skills", "statuslines"].includes(
-      entry.category,
-    )
-  ) {
-    caveats.push(
-      "Risk-bearing workflow surface; inspect commands, permissions, and data access before use.",
-    );
-  }
-  return unique(caveats).slice(0, 5);
-}
-
-function toolboxNextActions(entry) {
-  return [
-    `Inspect entry.detail with category=${entry.category} and slug=${entry.slug}.`,
-    `Run entry.trust with category=${entry.category} and slug=${entry.slug}; this is still metadata review only.`,
-    "Use entry.compare with nearby candidates before recommending a final stack.",
-    `Use entry.asset with category=${entry.category} and slug=${entry.slug} only after trust review.`,
-  ];
-}
-
-const TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT = 600;
-
-// Distills the ready-to-run install surface for a toolbox entry from its full
-// payload so the planner returns copy-pasteable commands instead of pointing at
-// more tool calls. Large config snippets are summarized rather than inlined to
-// preserve the lean response contract (callers use entry.asset for them).
-function toolboxInstall(entry) {
-  if (!entry) return null;
-  const installCommand = String(
-    entry.installCommand || entry.commandSyntax || "",
-  ).trim();
-  const configSnippet = String(entry.configSnippet || "").trim();
-  const downloadUrl = String(entry.downloadUrl || "").trim();
-  const usageSnippet = String(entry.usageSnippet || "").trim();
-
-  const install = {
-    installable: Boolean(entry.installable),
-    primaryAssetType: categoryPrimaryAsset(entry)?.type || "",
-  };
-  if (installCommand) install.installCommand = installCommand;
-  if (downloadUrl) install.downloadUrl = downloadUrl;
-  if (usageSnippet) install.usageSnippet = usageSnippet;
-  if (configSnippet) {
-    if (configSnippet.length <= TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT) {
-      install.configSnippet = configSnippet;
-    } else {
-      install.configSnippetChars = configSnippet.length;
-      install.configHint =
-        "Config snippet is large; call entry.asset for the full snippet.";
-    }
-  }
-  if (!installCommand && !downloadUrl && !configSnippet && !usageSnippet) {
-    install.note =
-      "No install command published; use the source or canonical URL.";
-  }
-  return install;
-}
-
-function toolboxCategoryMix(entries) {
-  const counts = new Map();
-  for (const entry of entries) {
-    const category = entry.category || "unknown";
-    counts.set(category, (counts.get(category) || 0) + 1);
-  }
-  return [...counts]
-    .map(([category, count]) => ({ category, count }))
-    .sort((left, right) => left.category.localeCompare(right.category));
-}
-
-function toolboxTrustSummary(entries) {
-  return {
-    sourceBacked: entries.filter(
-      (entry) => entry.trust?.source?.status === "available",
-    ).length,
-    firstPartyOrVerifiedPackages: entries.filter(
-      (entry) =>
-        entry.trust?.package?.downloadTrust === "first-party" ||
-        entry.trust?.package?.packageVerified,
-    ).length,
-    entriesWithSafetyNotes: entries.filter(
-      (entry) => entry.trust?.disclosures?.hasSafetyNotes,
-    ).length,
-    entriesWithPrivacyNotes: entries.filter(
-      (entry) => entry.trust?.disclosures?.hasPrivacyNotes,
-    ).length,
-    externalPackages: entries.filter(
-      (entry) => entry.trust?.package?.downloadTrust === "external",
-    ).length,
-    missingSource: entries.filter(
-      (entry) => entry.trust?.source?.status !== "available",
-    ).length,
   };
 }
 

--- a/tests/mcp-registry-toolbox-lib.test.ts
+++ b/tests/mcp-registry-toolbox-lib.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  selectDiverseRankedEntries,
+  toolboxCaveats,
+  toolboxCategoryMix,
+  toolboxFitReasons,
+  toolboxInstall,
+  toolboxNextActions,
+  toolboxTrustSummary,
+  TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT,
+} from "../packages/mcp/src/registry-toolbox-lib.js";
+
+describe("registry-toolbox-lib diverse selection", () => {
+  it("limits category repetition before filling remaining slots", () => {
+    const ranked = [
+      { entry: { category: "mcp", slug: "a" }, score: 10, reasons: [] },
+      { entry: { category: "mcp", slug: "b" }, score: 9, reasons: [] },
+      { entry: { category: "mcp", slug: "c" }, score: 8, reasons: [] },
+      { entry: { category: "skills", slug: "d" }, score: 7, reasons: [] },
+    ];
+    const selected = selectDiverseRankedEntries(ranked, 3);
+    expect(selected.map((item) => item.entry.slug)).toEqual(["a", "b", "d"]);
+  });
+});
+
+describe("registry-toolbox-lib fit and caveats", () => {
+  const entry = {
+    category: "skills",
+    slug: "example",
+    platforms: ["Codex"],
+    installCommand: "npm install -g skill",
+    safetyNotes: [{ text: "Runs shell commands" }],
+    privacyNotes: [],
+    claimStatus: "verified",
+  };
+
+  it("builds fit reasons from ranking and entry metadata", () => {
+    const reasons = toolboxFitReasons(entry, {
+      score: 12,
+      reasons: ["tag:automation"],
+    });
+    expect(reasons).toEqual(
+      expect.arrayContaining([
+        "tag:automation",
+        "skills workflow surface",
+        "actionable setup surface",
+      ]),
+    );
+  });
+
+  it("lists caveats for risk-bearing categories and missing disclosures", () => {
+    const caveats = toolboxCaveats({
+      category: "mcp",
+      slug: "server",
+      downloadUrl: "https://example.com/pkg.tgz",
+    });
+    expect(caveats).toEqual(
+      expect.arrayContaining([
+        "Source metadata is missing or incomplete.",
+        "Download checksum metadata is not present.",
+        "No structured safety notes are present.",
+      ]),
+    );
+  });
+});
+
+describe("registry-toolbox-lib install and rollups", () => {
+  it("inlines small config snippets and summarizes large ones", () => {
+    const small = toolboxInstall({
+      installable: true,
+      installCommand: "npm install -g tool",
+      configSnippet: "export KEY=1",
+    });
+    expect(small).toMatchObject({
+      installCommand: "npm install -g tool",
+      configSnippet: "export KEY=1",
+    });
+
+    const largeSnippet = "x".repeat(TOOLBOX_CONFIG_SNIPPET_INLINE_LIMIT + 1);
+    const large = toolboxInstall({ configSnippet: largeSnippet });
+    expect(large?.configSnippetChars).toBe(largeSnippet.length);
+    expect(large?.configHint).toMatch(/entry\.asset/i);
+  });
+
+  it("builds next actions and category/trust rollups", () => {
+    expect(toolboxNextActions({ category: "mcp", slug: "server" })).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("entry.detail"),
+        expect.stringContaining("entry.trust"),
+      ]),
+    );
+    expect(
+      toolboxCategoryMix([
+        { category: "skills" },
+        { category: "mcp" },
+        { category: "skills" },
+      ]),
+    ).toEqual([
+      { category: "mcp", count: 1 },
+      { category: "skills", count: 2 },
+    ]);
+    expect(
+      toolboxTrustSummary([
+        {
+          trust: {
+            source: { status: "available" },
+            package: { downloadTrust: "first-party", packageVerified: true },
+            disclosures: { hasSafetyNotes: true, hasPrivacyNotes: false },
+          },
+        },
+      ]),
+    ).toMatchObject({
+      sourceBacked: 1,
+      firstPartyOrVerifiedPackages: 1,
+      entriesWithSafetyNotes: 1,
+      entriesWithPrivacyNotes: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Extract diverse ranked-entry selection and toolbox planner helpers into `packages/mcp/src/registry-toolbox-lib.js`.
- Keep `packages/mcp/src/registry.js` importing the extracted helpers so planner and recommend behavior stays unchanged.
- Add focused lib tests for selection, fit reasons, caveats, install distillation, and trust rollups.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`)

## Quality Evidence

- Changed routes/components/endpoints/tools:
  - `packages/mcp/src/registry-toolbox-lib.js` (new extracted toolbox helpers)
  - `packages/mcp/src/registry.js` (imports extracted helpers; runtime handlers unchanged)
  - `tests/mcp-registry-toolbox-lib.test.ts` (new focused tests)
- Expected behavior:
  - Workflow planner and best-match recommend responses are unchanged.
- Important edge cases or invariants:
  - Category diversity cap still limits repeated categories before backfilling.
  - Large config snippets still summarize with entry.asset hints.
- Backward compatibility notes:
  - No public export surface changed; helpers remain internal to registry handlers.
- Screenshots for frontend/page/UI changes:
  - No visual impact — MCP server-side refactor only.
- Accessibility notes for UI changes:
  - N/A
- Focused tests or reason tests are not practical:
  - Added `tests/mcp-registry-toolbox-lib.test.ts`; existing `tests/mcp-server.test.ts` still passes.

## Validation

- [x] Platform/code PR: `pnpm build` passed, or the reason it was not run is listed below.
- [x] I ran the focused checks listed above.
- [x] I spot-checked the affected detail page(s), route(s), or integration surface(s), if applicable.

Focused checks run locally:
- `pnpm validate:clean`
- `pnpm validate:tasks`
- `git diff --check`
- `pnpm exec prettier --check` on changed files
- `pnpm test:mcp`
- `pnpm exec vitest run tests/mcp-registry-toolbox-lib.test.ts tests/mcp-server.test.ts`
- `pnpm validate:mcp-package`

## Notes

- Linked issue or no-issue rationale:
  - No linked issue. Maintainer-lane refactor to isolate registry toolbox helpers for easier testing and reuse without changing public MCP behavior.
- Any caveats, follow-ups, or reviewer context:
  - Follows the same extraction pattern as recently merged MCP lib splits (`registry-asset-lib`, `registry-excerpt-lib`, `registry-filter-lib`).
  - Does not touch artifact path helpers, `schemas.js`, endpoint URL helpers, or submission-risk analysis code.

Made with [Cursor](https://cursor.com)