### PR TITLE
feat(web): compose featured links into compare page empty interactive state

### DIFF
--- a/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
@@ -1,8 +1,10 @@
 import type { EntryIdentity } from "@/lib/entry-identity";
+import { comparePageFeaturedInteractiveUiState } from "@/lib/compare-page-featured-interactive-ui-lib";
+import type { ComparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
 import {
-  comparePageEmptyUiState,
-  type ComparePageEmptyUiState,
-} from "@/lib/compare-page-empty-ui-lib";
+  comparePageEmptyStateDescription,
+  comparePageInvalidUrlHint,
+} from "@/lib/compare-page-ui-lib";
 
 export type { ComparePageEmptyUiState };
 export type ComparePageEmptyInteractiveUiState = ComparePageEmptyUiState;
@@ -12,5 +14,9 @@ export function comparePageEmptyInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageEmptyInteractiveUiState {
-  return comparePageEmptyUiState(ids, comparisons, catalog);
+  return {
+    description: comparePageEmptyStateDescription(),
+    invalidUrlHint: comparePageInvalidUrlHint(ids, 0),
+    popularComparisonLinks: comparePageFeaturedInteractiveUiState(comparisons, catalog),
+  };
 }

--- a/apps/web/src/lib/compare-page-empty-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-ui-lib.ts
@@ -3,7 +3,7 @@ import {
   comparePageInvalidUrlHint,
 } from "@/lib/compare-page-ui-lib";
 import type { ComparePagePopularComparisonLink } from "@/lib/compare-page-featured-ui-lib";
-import { comparePageFeaturedInteractiveUiState } from "@/lib/compare-page-featured-interactive-ui-lib";
+import { comparePagePopularComparisonLinks } from "@/lib/compare-page-featured-ui-lib";
 import type { EntryIdentity } from "@/lib/entry-identity";
 
 export type ComparePageEmptyUiState = {
@@ -20,6 +20,6 @@ export function comparePageEmptyUiState(
   return {
     description: comparePageEmptyStateDescription(),
     invalidUrlHint: comparePageInvalidUrlHint(ids, 0),
-    popularComparisonLinks: comparePageFeaturedInteractiveUiState(comparisons, catalog),
+    popularComparisonLinks: comparePagePopularComparisonLinks(comparisons, catalog),
   };
 }


### PR DESCRIPTION
## Summary
- Compose `comparePageFeaturedInteractiveUiState` directly in `comparePageEmptyInteractiveUiState` (mirrors drawer empty interactive pattern).
- Keep `compare-page-empty-ui-lib` on non-interactive `comparePagePopularComparisonLinks` helpers for UI-layer callers.

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-empty-interactive-ui-lib.test.ts tests/compare-page-empty-ui-lib.test.ts tests/compare-page-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)