### PR TITLE
fix(registry): reject normalized git url userinfo

### DIFF
--- a/packages/registry/src/source-repo-lib.js
+++ b/packages/registry/src/source-repo-lib.js
@@ -81,10 +81,11 @@ export function parseGitHubRepoUrl(value) {
 
   if (!parsed) {
     let url;
+    const parseableUrl = raw.replace(/^git\+/i, "");
     try {
       // Drop a "git+" prefix so "git+https://..." parses; "git://" and "ssh://"
       // are already valid URL schemes that keep their host and path.
-      url = new URL(raw.replace(/^git\+/i, ""));
+      url = new URL(parseableUrl);
     } catch {
       return null;
     }
@@ -92,7 +93,7 @@ export function parseGitHubRepoUrl(value) {
     if (!ownerRepo) return null;
     if (
       (url.protocol === "http:" || url.protocol === "https:") &&
-      hasEmbeddedUrlUserinfo(raw)
+      hasEmbeddedUrlUserinfo(parseableUrl)
     ) {
       return null;
     }

--- a/tests/source-repo-lib.test.ts
+++ b/tests/source-repo-lib.test.ts
@@ -426,6 +426,8 @@ describe("parseGitHubRepoUrl enterprise and typo rejection", () => {
   it.each([
     "https://token@github.com/OpenAI/whisper",
     "https://user:pass@github.com/OpenAI/whisper",
+    "git+https:user:pass@github.com/OpenAI/whisper",
+    "git+https:/user@github.com/OpenAI/whisper",
   ])("rejects https URLs with embedded userinfo: %s", (input) => {
     expect(parseGitHubRepoUrl(input)).toBeNull();
   });


### PR DESCRIPTION
### Motivation
- A mismatch allowed malformed `git+https` inputs to bypass the embedded-credentials guard because parsing used a `git+`-stripped URL while the userinfo check re-parsed the original raw string. 
- The change prevents credential-bearing but malformed inputs from canonicalizing into trusted GitHub repo URLs.

### Description
- Introduce `parseableUrl = raw.replace(/^git\+/i, "")` and use it for both `new URL(...)` parsing and the `hasEmbeddedUrlUserinfo(...)` check in `parseGitHubRepoUrl` in `packages/registry/src/source-repo-lib.js`.
- This ensures the same normalized string is examined for embedded userinfo that the URL parser actually uses.
- Add regression tests in `tests/source-repo-lib.test.ts` for `git+https:user:pass@github.com/OpenAI/whisper` and `git+https:/user@github.com/OpenAI/whisper` to assert these malformed forms are rejected.

### Testing
- Ran `pnpm exec vitest run tests/source-repo-lib.test.ts` which passed (209 tests passed).
- Ran `pnpm exec vitest run tests/source-repo.test.ts tests/registry-source-repo.test.ts` which passed (6 tests passed).
- Ran `git diff --check` and kept diff/lint checks clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ab9f0173c832ca33dd318c6129942)