### PR TITLE
feat(web): bundle compare entry interactive UI state for entry dossier

### DIFF
--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -1,0 +1,29 @@
+import type { Entry } from "@/types/registry";
+import type { BestListPickRef } from "@/lib/compare-best-summary";
+import type { EntryIdentity } from "@/lib/entry-identity";
+import {
+  compareDossierInteractiveUiState,
+  type CompareDossierInteractiveUiState,
+} from "@/lib/compare-dossier-interactive-ui-lib";
+import {
+  compareEntryFeaturedInteractiveUiState,
+  type CompareEntryFeaturedInteractiveUiState,
+} from "@/lib/compare-entry-featured-interactive-ui-lib";
+
+export type CompareEntryInteractiveUiState = {
+  dossierUi: CompareDossierInteractiveUiState;
+  featuredUi: CompareEntryFeaturedInteractiveUiState;
+};
+
+export function compareEntryInteractiveUiState(
+  entry: Entry,
+  alternatives: Entry[],
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryInteractiveUiState {
+  return {
+    dossierUi: compareDossierInteractiveUiState(entry, alternatives),
+    featuredUi: compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog),
+  };
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -39,8 +39,7 @@ import { WatchButton } from "@/components/watch-button";
 import { CopyButton } from "@/components/copy-button";
 import { ResourceCard } from "@/components/resource-card";
 import { ComparisonTable } from "@/components/comparison-table";
-import { compareEntryFeaturedInteractiveUiState } from "@/lib/compare-entry-featured-interactive-ui-lib";
-import { compareDossierInteractiveUiState } from "@/lib/compare-dossier-interactive-ui-lib";
+import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -223,9 +222,12 @@ function Dossier() {
     const pool = altGroup && altGroup.entries.length > 0 ? altGroup.entries : rel;
     return pool.slice(0, 3);
   }, [relGroups, rel]);
-  const dossierCompareUi = useMemo(
-    () => compareDossierInteractiveUiState(entry, alternatives),
-    [entry, alternatives],
+  const entryRef = `${entry.category}/${entry.slug}`;
+  const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
+  const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
+  const { dossierUi: dossierCompareUi, featuredUi } = useMemo(
+    () => compareEntryInteractiveUiState(entry, alternatives, comparedIn, featuredIn, ENTRIES),
+    [entry, alternatives, comparedIn, featuredIn],
   );
   // Deterministic "how do I use this" next-step links — guides sharing a tag,
   // minus any guide already shown in the related grid (no duplicate links).
@@ -237,13 +239,6 @@ function Dossier() {
     );
     return relatedGuides(entry).filter((g) => !shown.has(`${g.category}/${g.slug}`));
   }, [entry, relGroups, rel]);
-  const entryRef = `${entry.category}/${entry.slug}`;
-  const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
-  const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
-  const featuredUi = useMemo(
-    () => compareEntryFeaturedInteractiveUiState(comparedIn, featuredIn, ENTRIES),
-    [comparedIn, featuredIn],
-  );
   const recents = useRecents();
   useEffect(() => {
     recents.pushEntry({ category: entry.category, slug: entry.slug, title: entry.title });

--- a/tests/compare-entry-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-interactive-ui-lib.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const catalog = [
+  entry({ category: "skills", slug: "alpha" }),
+  entry({ category: "hooks", slug: "beta" }),
+  entry({ category: "mcp", slug: "gamma" }),
+];
+
+describe("compare entry interactive ui lib", () => {
+  it("bundles dossier and featured compare state for entry detail surfaces", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(
+      compareEntryInteractiveUiState(
+        primary,
+        [entry({ category: "hooks", slug: "alt" })],
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toEqual({
+      dossierUi: {
+        showCompareSection: true,
+        bannerTexts: [],
+        interactiveSearch: { ids: "skills/primary,hooks/alt" },
+        interactiveLinkLabel: "Open in the interactive comparison tool",
+      },
+      featuredUi: {
+        comparisonLinks: [
+          {
+            slug: "pair",
+            search: { ids: "skills/alpha,hooks/beta" },
+            label: "Open interactively",
+          },
+        ],
+        bestListLinks: [
+          {
+            slug: "top-picks",
+            search: { ids: "skills/alpha,hooks/beta" },
+            label: "Open interactively",
+          },
+        ],
+        hasFeaturedLinks: true,
+      },
+    });
+  });
+
+  it("hides dossier compare and featured links when nothing references the entry", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    expect(
+      compareEntryInteractiveUiState(primary, [], [], [], catalog),
+    ).toEqual({
+      dossierUi: {
+        showCompareSection: false,
+        bannerTexts: [],
+        interactiveSearch: null,
+        interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
+      },
+      featuredUi: {
+        comparisonLinks: [],
+        bestListLinks: [],
+        hasFeaturedLinks: false,
+      },
+    });
+  });
+
+  it("surfaces dossier divergence banners alongside featured links", () => {
+    const primary = entry({ category: "skills", slug: "primary" });
+    const state = compareEntryInteractiveUiState(
+      primary,
+      [
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ],
+      [],
+      [
+        {
+          slug: "wide-list",
+          picks: [
+            { ref: "skills/alpha" },
+            { ref: "hooks/beta" },
+            { ref: "mcp/gamma" },
+          ],
+        },
+      ],
+      catalog,
+    );
+    expect(state.dossierUi.bannerTexts).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — use the actions in the table below to copy install commands and source links per resource.",
+    ]);
+    expect(state.featuredUi.bestListLinks[0]?.label).toBe(
+      "Open 3 picks in the interactive comparison tool",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-entry-interactive-ui-lib` composing dossier compare and featured compare interactive state.
- Wire `entry.$category.$slug.tsx` to a single memoized `compareEntryInteractiveUiState` call.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-entry-interactive-ui-lib.ts'`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)