### PR TITLE
feat(web): compose compare page presentation UI into page UI interactive state

### DIFF
--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -6,7 +6,6 @@ import {
   comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
 } from "@/lib/compare-page-empty-interactive-ui-lib";
-import { comparePagePresentationUiInteractiveUiState } from "@/lib/compare-page-presentation-ui-interactive-ui-lib";
 import {
   comparePageUiInteractiveUiState,
   type ComparePageUiState,
@@ -25,12 +24,12 @@ export function comparePageInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageInteractiveUiState {
-  const presentation = comparePagePresentationUiInteractiveUiState(items);
+  const pageUi = comparePageUiInteractiveUiState(items);
   const actions = comparePageActionsInteractiveUiState(items);
   return {
-    pageUi: comparePageUiInteractiveUiState(items),
+    pageUi,
     emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
-    actionRowDiverges: presentation.actionRowDiverges,
+    actionRowDiverges: pageUi.actionRowDiverges,
     actionCells: actions.actionCells,
   };
 }

--- a/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
@@ -1,9 +1,15 @@
 import type { Entry } from "@/types/registry";
+import { comparePagePresentationState } from "@/lib/compare-page-presentation-ui-lib";
 import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
 
 export type { ComparePageUiState };
 export type ComparePageUiInteractiveUiState = ComparePageUiState;
 
 export function comparePageUiInteractiveUiState(items: Entry[]): ComparePageUiInteractiveUiState {
-  return comparePageUiState(items);
+  const pageUi = comparePageUiState(items);
+  const presentation = comparePagePresentationState(items);
+  return {
+    ...pageUi,
+    actionRowDiverges: presentation.actionRowDiverges,
+  };
 }


### PR DESCRIPTION
## Summary
- Compose `comparePagePresentationState` into `comparePageUiInteractiveUiState` for action-row signals (mirrors table #4468).
- Source `comparePageInteractiveUiState` top-level `actionRowDiverges` from `pageUi` instead of a separate presentation call.

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-interactive-ui-lib.test.ts tests/compare-page-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)