### PR TITLE
feat(web): compose compare drawer presentation UI into drawer UI interactive state

### DIFF
--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -19,14 +19,15 @@ export type CompareDrawerInteractiveUiState = {
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
   const emptyUi = compareDrawerEmptyInteractiveUiState(items);
+  const drawerUi = compareDrawerUiInteractiveUiState(items);
   const presentation = compareDrawerPresentationUiInteractiveUiState(items);
   const actions = compareDrawerActionsInteractiveUiState(items);
   return {
-    drawerUi: compareDrawerUiInteractiveUiState(items),
+    drawerUi,
     emptyHint: emptyUi.emptyHint,
     shareUrl: emptyUi.shareUrl,
     divergingDecisionLabels: presentation.divergingDecisionLabels,
-    actionRowDiverges: presentation.actionRowDiverges,
+    actionRowDiverges: drawerUi.actionRowDiverges,
     actionCells: actions.actionCells,
   };
 }

--- a/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
@@ -1,4 +1,5 @@
 import type { Entry } from "@/types/registry";
+import { compareDrawerPresentationState } from "@/lib/compare-drawer-presentation-ui-lib";
 import { compareDrawerUiState, type CompareDrawerUiState } from "@/lib/compare-drawer-ui-lib";
 
 export type { CompareDrawerUiState };
@@ -7,5 +8,10 @@ export type CompareDrawerUiInteractiveUiState = CompareDrawerUiState;
 export function compareDrawerUiInteractiveUiState(
   items: Entry[],
 ): CompareDrawerUiInteractiveUiState {
-  return compareDrawerUiState(items);
+  const drawerUi = compareDrawerUiState(items);
+  const presentation = compareDrawerPresentationState(items);
+  return {
+    ...drawerUi,
+    actionRowDiverges: presentation.actionRowDiverges,
+  };
 }


### PR DESCRIPTION
## Summary
- Compose `compareDrawerPresentationState` into `compareDrawerUiInteractiveUiState` for action-row signals (mirrors page #4480).
- Source `compareDrawerInteractiveUiState` top-level `actionRowDiverges` from `drawerUi`; keep `divergingDecisionLabels` from the presentation sub-lib.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-interactive-ui-lib.test.ts tests/compare-drawer-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)