### PR TITLE
feat(web): compose drawer decision-row signals into drawer UI interactive state

### DIFF
--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -2,7 +2,6 @@ import type { Entry } from "@/types/registry";
 import type { CompareDrawerActionCell } from "@/lib/compare-drawer-actions-ui-lib";
 import { compareDrawerActionsInteractiveUiState } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
-import { compareDrawerPresentationUiInteractiveUiState } from "@/lib/compare-drawer-presentation-ui-interactive-ui-lib";
 import {
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
@@ -19,14 +18,13 @@ export type CompareDrawerInteractiveUiState = {
 
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
   const emptyUi = compareDrawerEmptyInteractiveUiState(items);
-  const drawerUi = compareDrawerUiInteractiveUiState(items);
-  const presentation = compareDrawerPresentationUiInteractiveUiState(items);
+  const { divergingDecisionLabels, ...drawerUi } = compareDrawerUiInteractiveUiState(items);
   const actions = compareDrawerActionsInteractiveUiState(items);
   return {
     drawerUi,
     emptyHint: emptyUi.emptyHint,
     shareUrl: emptyUi.shareUrl,
-    divergingDecisionLabels: presentation.divergingDecisionLabels,
+    divergingDecisionLabels,
     actionRowDiverges: drawerUi.actionRowDiverges,
     actionCells: actions.actionCells,
   };

--- a/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
@@ -3,7 +3,9 @@ import { compareDrawerPresentationState } from "@/lib/compare-drawer-presentatio
 import { compareDrawerUiState, type CompareDrawerUiState } from "@/lib/compare-drawer-ui-lib";
 
 export type { CompareDrawerUiState };
-export type CompareDrawerUiInteractiveUiState = CompareDrawerUiState;
+export type CompareDrawerUiInteractiveUiState = CompareDrawerUiState & {
+  divergingDecisionLabels: Set<string>;
+};
 
 export function compareDrawerUiInteractiveUiState(
   items: Entry[],
@@ -13,5 +15,6 @@ export function compareDrawerUiInteractiveUiState(
   return {
     ...drawerUi,
     actionRowDiverges: presentation.actionRowDiverges,
+    divergingDecisionLabels: presentation.divergingDecisionLabels,
   };
 }

--- a/tests/compare-drawer-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-interactive-ui-lib.test.ts
@@ -25,6 +25,7 @@ describe("compare drawer ui interactive ui lib", () => {
       actionRowDiverges: false,
       bannerTexts: [],
       fullViewSearch: null,
+      divergingDecisionLabels: new Set(),
     });
   });
 
@@ -38,15 +39,16 @@ describe("compare drawer ui interactive ui lib", () => {
       actionRowDiverges: false,
       bannerTexts: [],
       fullViewSearch: { ids: "skills/alpha,hooks/beta" },
+      divergingDecisionLabels: new Set(),
     });
   });
 
-  it("highlights diverging next actions in bundled drawer presentation state", () => {
-    expect(
-      compareDrawerUiInteractiveUiState([
-        entry({ installCommand: "npm i fixture" }),
-        entry({ slug: "other" }),
-      ]).actionRowDiverges,
-    ).toBe(true);
+  it("highlights diverging decision rows and next actions", () => {
+    const state = compareDrawerUiInteractiveUiState([
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ]);
+    expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
+    expect(state.actionRowDiverges).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Extend `compareDrawerUiInteractiveUiState` with `divergingDecisionLabels` from `compareDrawerPresentationState` (mirrors table UI holding full presentation signals).
- Source `compareDrawerInteractiveUiState` decision-row signals from `drawerUi` without a separate presentation sub-lib call.

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-interactive-ui-lib.test.ts tests/compare-drawer-interactive-ui-lib.test.ts --coverage`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)