### PR TITLE
feat(web): bundle curated compare page renderable state into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
@@ -5,18 +5,23 @@ import {
   type CompareCuratedUiState,
 } from "@/lib/compare-curated-ui-lib";
 
-export type CompareCuratedInteractiveUiState = CompareCuratedUiState;
+export type CompareCuratedInteractiveUiState = CompareCuratedUiState & {
+  renderable: boolean;
+};
 
 export function compareCuratedInteractiveUiState(
   refs: string[],
   catalog: EntryIdentity[],
 ): CompareCuratedInteractiveUiState {
-  return compareCuratedUiState(refs, catalog);
+  return {
+    ...compareCuratedUiState(refs, catalog),
+    renderable: compareCuratedHasRenderableEntries(refs, catalog),
+  };
 }
 
 export function compareCuratedInteractivePageRenderable(
   refs: string[],
   catalog: EntryIdentity[],
 ): boolean {
-  return compareCuratedHasRenderableEntries(refs, catalog);
+  return compareCuratedInteractiveUiState(refs, catalog).renderable;
 }

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -8,16 +8,13 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
-import {
-  compareCuratedInteractivePageRenderable,
-  compareCuratedInteractiveUiState,
-} from "@/lib/compare-curated-interactive-ui-lib";
+import { compareCuratedInteractiveUiState } from "@/lib/compare-curated-interactive-ui-lib";
 import { compareCuratedResolvedEntries } from "@/lib/compare-curated-ui-lib";
 
 export const Route = createFileRoute("/compare/$slug")({
   loader: ({ params }) => {
     const comparison = getComparison(params.slug);
-    if (!comparison || !compareCuratedInteractivePageRenderable(comparison.refs, ENTRIES)) {
+    if (!comparison || !compareCuratedInteractiveUiState(comparison.refs, ENTRIES).renderable) {
       throw notFound();
     }
     return {};

--- a/tests/compare-curated-interactive-ui-lib.test.ts
+++ b/tests/compare-curated-interactive-ui-lib.test.ts
@@ -30,10 +30,16 @@ const catalog = [
 
 describe("compare curated interactive ui lib", () => {
   it("requires at least two resolved entries for curated pages", () => {
-    expect(compareCuratedInteractivePageRenderable([], catalog)).toBe(false);
+    expect(compareCuratedInteractiveUiState([], catalog).renderable).toBe(
+      false,
+    );
     expect(
-      compareCuratedInteractivePageRenderable(["skills/alpha"], catalog),
+      compareCuratedInteractiveUiState(["skills/alpha"], catalog).renderable,
     ).toBe(false);
+    expect(
+      compareCuratedInteractiveUiState(["skills/alpha", "hooks/beta"], catalog)
+        .renderable,
+    ).toBe(true);
     expect(
       compareCuratedInteractivePageRenderable(
         ["skills/alpha", "hooks/beta"],
@@ -50,6 +56,7 @@ describe("compare curated interactive ui lib", () => {
       bannerTexts: [],
       interactiveSearch: { ids: "skills/alpha,hooks/beta" },
       interactiveLinkLabel: "Open in the interactive comparison tool",
+      renderable: true,
     });
   });
 
@@ -64,6 +71,7 @@ describe("compare curated interactive ui lib", () => {
       bannerTexts: [],
       interactiveSearch: null,
       interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
+      renderable: false,
     });
   });
 


### PR DESCRIPTION
## Summary
- Compose `compareCuratedHasRenderableEntries` into `compareCuratedInteractiveUiState` as a `renderable` flag.
- Wire the curated compare route loader through the bundled state; keep `compareCuratedInteractivePageRenderable` as a thin delegate.

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-curated-interactive-ui-lib.ts'`
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`

Relates to #556


Made with [Cursor](https://cursor.com)