### PR TITLE
feat(web): bundle compare context selection-changed signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-context-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-context-interactive-ui-lib.ts
@@ -12,3 +12,11 @@ export function compareContextInteractiveUiState(items: Entry[]): CompareContext
     shareUrl: compareContextShareUrl(items),
   };
 }
+
+/** True when hydrated selection differs from the live compare tray selection. */
+export function compareContextSelectionChanged(next: Entry[], current: Entry[]): boolean {
+  return (
+    compareContextInteractiveUiState(next).selectionParam !==
+    compareContextInteractiveUiState(current).selectionParam
+  );
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
-import { compareContextInteractiveUiState } from "@/lib/compare-context-interactive-ui-lib";
+import {
+  compareContextInteractiveUiState,
+  compareContextSelectionChanged,
+} from "@/lib/compare-context-interactive-ui-lib";
 import { hasCompareItem, resolveCompareParam, toggleCompareItem } from "@/lib/compare-selection";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import type { Entry } from "@/types/registry";
@@ -73,9 +76,9 @@ function createCompareStore(): CompareStore {
       // URL, keeping the registry dataset out of the universal client bundle.
       void import("@/data/entries").then(({ ENTRIES }) => {
         const next = resolveCompareParam(ENTRIES, param);
-        const sig = compareContextInteractiveUiState(next).selectionParam;
-        const curSig = compareContextInteractiveUiState(state.items).selectionParam;
-        if (sig !== curSig) setState({ ...state, items: next });
+        if (compareContextSelectionChanged(next, state.items)) {
+          setState({ ...state, items: next });
+        }
       });
     },
     serialize: () => compareContextInteractiveUiState(state.items).selectionParam,

--- a/tests/compare-context-interactive-ui-lib.test.ts
+++ b/tests/compare-context-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareContextInteractiveUiState } from "@/lib/compare-context-interactive-ui-lib";
+import {
+  compareContextInteractiveUiState,
+  compareContextSelectionChanged,
+} from "@/lib/compare-context-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -44,5 +47,14 @@ describe("compare context interactive ui lib", () => {
       selectionParam: "mcp/fixture",
       shareUrl: "/browse?compare=mcp%2Ffixture",
     });
+  });
+
+  it("detects when hydrated selection differs from live tray selection", () => {
+    const alpha = entry({ category: "skills", slug: "alpha" });
+    const beta = entry({ category: "hooks", slug: "beta" });
+    expect(compareContextSelectionChanged([alpha], [])).toBe(true);
+    expect(compareContextSelectionChanged([alpha], [alpha])).toBe(false);
+    expect(compareContextSelectionChanged([alpha, beta], [alpha])).toBe(true);
+    expect(compareContextSelectionChanged([], [])).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareContextSelectionChanged` to the compare-context interactive UI lib so hydration can detect tray selection drift through the bundled state.
- Wire `compare.tsx` URL hydration to use the new helper instead of inline selection-param comparisons.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-context-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-context-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)