### PR TITLE
feat(web): extract csv helpers into csv-lib

### DIFF
--- a/apps/web/src/lib/csv-lib.ts
+++ b/apps/web/src/lib/csv-lib.ts
@@ -1,0 +1,22 @@
+/**
+ * Pure CSV-cell escaping helper.
+ *
+ * `csvEscape` normalizes a single cell value for safe CSV output: it neutralizes
+ * spreadsheet formula-injection prefixes (`=`, `+`, `-`, `@`) by prepending a
+ * single quote, and quotes/escapes values that contain commas, quotes, or line
+ * breaks. Everything here is deterministic given its input; the public surface
+ * (`csv.ts` / `@/lib/csv`) re-exports the helper below.
+ */
+
+export function csvEscape(value: unknown) {
+  const raw = String(value ?? "");
+  const trimmedStart = raw.trimStart();
+  const normalized =
+    trimmedStart.startsWith("=") ||
+    trimmedStart.startsWith("+") ||
+    trimmedStart.startsWith("-") ||
+    trimmedStart.startsWith("@")
+      ? `'${raw}`
+      : raw;
+  return /[",\n\r]/.test(normalized) ? `"${normalized.replaceAll('"', '""')}"` : normalized;
+}

--- a/apps/web/src/lib/csv.ts
+++ b/apps/web/src/lib/csv.ts
@@ -1,14 +1,7 @@
-export function csvEscape(value: unknown) {
-  const raw = String(value ?? "");
-  const trimmedStart = raw.trimStart();
-  const normalized =
-    trimmedStart.startsWith("=") ||
-    trimmedStart.startsWith("+") ||
-    trimmedStart.startsWith("-") ||
-    trimmedStart.startsWith("@")
-      ? `'${raw}`
-      : raw;
-  return /[",\n\r]/.test(normalized)
-    ? `"${normalized.replaceAll('"', '""')}"`
-    : normalized;
-}
+/**
+ * CSV-cell escaping surface.
+ *
+ * The pure escaping logic lives in `csv-lib.ts`. This module re-exports the
+ * helper so existing `@/lib/csv` imports stay unchanged.
+ */
+export { csvEscape } from "@/lib/csv-lib";

--- a/tests/csv-lib.test.ts
+++ b/tests/csv-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { csvEscape } from "../apps/web/src/lib/csv-lib";
+
+describe("csvEscape", () => {
+  it("passes plain values through unchanged", () => {
+    expect(csvEscape("hello")).toBe("hello");
+    expect(csvEscape("simple value")).toBe("simple value");
+    expect(csvEscape("123")).toBe("123");
+    expect(csvEscape(42)).toBe("42");
+    expect(csvEscape(true)).toBe("true");
+  });
+
+  it("neutralizes formula-injection prefixes with a leading quote", () => {
+    expect(csvEscape("=SUM(A1:A2)")).toBe("'=SUM(A1:A2)");
+    expect(csvEscape("+1")).toBe("'+1");
+    expect(csvEscape("-1")).toBe("'-1");
+    expect(csvEscape("@cmd")).toBe("'@cmd");
+  });
+
+  it("detects formula prefixes after leading whitespace but preserves the raw value", () => {
+    expect(csvEscape("  =SUM(A1)")).toBe("'  =SUM(A1)");
+    expect(csvEscape("\t+danger")).toBe("'\t+danger");
+  });
+
+  it("wraps values containing a comma in quotes", () => {
+    expect(csvEscape("a,b")).toBe('"a,b"');
+  });
+
+  it("wraps and doubles embedded quotes", () => {
+    expect(csvEscape('say "hi"')).toBe('"say ""hi"""');
+    expect(csvEscape('"')).toBe('""""');
+  });
+
+  it("wraps values containing newlines and carriage returns", () => {
+    expect(csvEscape("line1\nline2")).toBe('"line1\nline2"');
+    expect(csvEscape("line1\rline2")).toBe('"line1\rline2"');
+    expect(csvEscape("line1\r\nline2")).toBe('"line1\r\nline2"');
+  });
+
+  it("maps null and undefined to an empty string", () => {
+    expect(csvEscape(null)).toBe("");
+    expect(csvEscape(undefined)).toBe("");
+  });
+
+  it("handles a formula-prefixed value that also needs quoting", () => {
+    expect(csvEscape("=1,2")).toBe(`"'=1,2"`);
+    expect(csvEscape('=say "hi"')).toBe(`"'=say ""hi"""`);
+    expect(csvEscape("=a\nb")).toBe(`"'=a\nb"`);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/csv.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Extract `csvEscape` into a pure `csv-lib.ts` module and turn `csv.ts` into a thin re-export shim that preserves the exact public API.

- Adds exhaustive deterministic tests (`tests/csv-lib.test.ts`) covering plain passthrough, formula-injection prefixes (`=`, `+`, `-`, `@`), quote/comma/newline/CR escaping, `null`/`undefined`, and combined formula+quoting cases.
- Excludes the shim `csv.ts` from coverage (logic now lives in `-lib`).