### PR TITLE
feat(web): extract search-query-tokenization helpers into search-query-tokenization-lib

### DIFF
--- a/apps/web/src/lib/search-query-tokenization-lib.ts
+++ b/apps/web/src/lib/search-query-tokenization-lib.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure search query tokenization helpers.
+ *
+ * Query normalization (length cap, trim, lowercase) and bounded
+ * character-by-character tokenization. Given the same input string the output
+ * is fully deterministic — nothing here touches the DOM, network, or clock.
+ *
+ * The public surface (`search-query-tokenization.ts` /
+ * `@/lib/search-query-tokenization`) re-exports everything below so existing
+ * imports stay unchanged.
+ */
+
+export const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+export const MAX_QUERY_LENGTH = 256;
+export const MAX_QUERY_TOKENS = 12;
+
+/** Trim, lowercase, and cap query length before tokenization. */
+export function normalizeSearchQuery(query: string) {
+  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
+}
+
+/** Walk the query character-by-character so pathological inputs cannot force a huge split. */
+export function tokenizeSearchQuery(query: string) {
+  const tokens: string[] = [];
+  let token = "";
+
+  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
+    const char = query[index]!;
+    if (/[a-z0-9+#.-]/i.test(char)) {
+      token += char.toLowerCase();
+      continue;
+    }
+
+    if (token.length >= 2) tokens.push(token);
+    token = "";
+  }
+
+  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
+  return tokens;
+}

--- a/apps/web/src/lib/search-query-tokenization.ts
+++ b/apps/web/src/lib/search-query-tokenization.ts
@@ -1,28 +1,14 @@
-export const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
-export const MAX_QUERY_LENGTH = 256;
-export const MAX_QUERY_TOKENS = 12;
-
-/** Trim, lowercase, and cap query length before tokenization. */
-export function normalizeSearchQuery(query: string) {
-  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
-}
-
-/** Walk the query character-by-character so pathological inputs cannot force a huge split. */
-export function tokenizeSearchQuery(query: string) {
-  const tokens: string[] = [];
-  let token = "";
-
-  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
-    const char = query[index]!;
-    if (/[a-z0-9+#.-]/i.test(char)) {
-      token += char.toLowerCase();
-      continue;
-    }
-
-    if (token.length >= 2) tokens.push(token);
-    token = "";
-  }
-
-  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
-  return tokens;
-}
+/**
+ * Search query tokenization surface.
+ *
+ * Pure helpers live in `search-query-tokenization-lib.ts`. This module
+ * re-exports that surface so existing `@/lib/search-query-tokenization` imports
+ * stay unchanged.
+ */
+export {
+  TOKEN_SPLIT_PATTERN,
+  MAX_QUERY_LENGTH,
+  MAX_QUERY_TOKENS,
+  normalizeSearchQuery,
+  tokenizeSearchQuery,
+} from "@/lib/search-query-tokenization-lib";

--- a/tests/search-query-tokenization-lib.test.ts
+++ b/tests/search-query-tokenization-lib.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_QUERY_LENGTH,
+  MAX_QUERY_TOKENS,
+  TOKEN_SPLIT_PATTERN,
+  normalizeSearchQuery,
+  tokenizeSearchQuery,
+} from "../apps/web/src/lib/search-query-tokenization-lib";
+
+describe("constants", () => {
+  it("exposes the token split pattern", () => {
+    expect(TOKEN_SPLIT_PATTERN).toBeInstanceOf(RegExp);
+    expect(TOKEN_SPLIT_PATTERN.source).toBe("[^a-z0-9+#.-]+");
+    expect(TOKEN_SPLIT_PATTERN.flags).toBe("i");
+  });
+
+  it("caps query length at 256", () => {
+    expect(MAX_QUERY_LENGTH).toBe(256);
+  });
+
+  it("caps token count at 12", () => {
+    expect(MAX_QUERY_TOKENS).toBe(12);
+  });
+});
+
+describe("normalizeSearchQuery", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeSearchQuery("  hello  ")).toBe("hello");
+  });
+
+  it("lowercases the query", () => {
+    expect(normalizeSearchQuery("Hello WORLD")).toBe("hello world");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeSearchQuery("   ")).toBe("");
+  });
+
+  it("caps the query at MAX_QUERY_LENGTH characters", () => {
+    const result = normalizeSearchQuery("a".repeat(300));
+    expect(result).toHaveLength(256);
+    expect(result).toBe("a".repeat(256));
+  });
+
+  it("slices before trimming so leading whitespace counts toward the cap", () => {
+    // First 256 chars are 2 spaces + 254 'a's; trailing 'z's are sliced off,
+    // then the leading spaces are trimmed away.
+    const input = "  " + "a".repeat(254) + "z".repeat(10);
+    expect(normalizeSearchQuery(input)).toBe("a".repeat(254));
+  });
+
+  it("handles an already-normalized query unchanged", () => {
+    expect(normalizeSearchQuery("node.js")).toBe("node.js");
+  });
+});
+
+describe("tokenizeSearchQuery", () => {
+  it("returns no tokens for an empty string", () => {
+    expect(tokenizeSearchQuery("")).toEqual([]);
+  });
+
+  it("returns no tokens for whitespace only", () => {
+    expect(tokenizeSearchQuery("     ")).toEqual([]);
+  });
+
+  it("splits on whitespace", () => {
+    expect(tokenizeSearchQuery("hello world")).toEqual(["hello", "world"]);
+  });
+
+  it("drops tokens shorter than two characters", () => {
+    expect(tokenizeSearchQuery("a b cd")).toEqual(["cd"]);
+  });
+
+  it("drops a trailing single-character token", () => {
+    expect(tokenizeSearchQuery("ab c")).toEqual(["ab"]);
+  });
+
+  it("keeps a two-character token", () => {
+    expect(tokenizeSearchQuery("ab")).toEqual(["ab"]);
+  });
+
+  it("lowercases token characters", () => {
+    expect(tokenizeSearchQuery("Hello World")).toEqual(["hello", "world"]);
+  });
+
+  it("keeps + inside a token", () => {
+    expect(tokenizeSearchQuery("c++")).toEqual(["c++"]);
+  });
+
+  it("keeps # inside a token", () => {
+    expect(tokenizeSearchQuery("c#")).toEqual(["c#"]);
+  });
+
+  it("keeps . inside a token", () => {
+    expect(tokenizeSearchQuery("node.js")).toEqual(["node.js"]);
+  });
+
+  it("keeps - inside a token", () => {
+    expect(tokenizeSearchQuery("code-review")).toEqual(["code-review"]);
+  });
+
+  it("keeps all special characters together and lowercases them", () => {
+    expect(tokenizeSearchQuery("C++ node.JS a-B")).toEqual([
+      "c++",
+      "node.js",
+      "a-b",
+    ]);
+  });
+
+  it("splits on symbols that are not token characters", () => {
+    expect(tokenizeSearchQuery("hello@world")).toEqual(["hello", "world"]);
+  });
+
+  it("collapses runs of delimiters", () => {
+    expect(tokenizeSearchQuery("ab   cd")).toEqual(["ab", "cd"]);
+  });
+
+  it("flushes the final token when it is not followed by a delimiter", () => {
+    expect(tokenizeSearchQuery("ab cd ef")).toEqual(["ab", "cd", "ef"]);
+  });
+
+  it("caps the number of tokens at MAX_QUERY_TOKENS", () => {
+    const words = Array.from({ length: 15 }, (_, i) => `w${i}z`);
+    const result = tokenizeSearchQuery(words.join(" "));
+    expect(result).toHaveLength(12);
+    expect(result).toEqual([
+      "w0z",
+      "w1z",
+      "w2z",
+      "w3z",
+      "w4z",
+      "w5z",
+      "w6z",
+      "w7z",
+      "w8z",
+      "w9z",
+      "w10z",
+      "w11z",
+    ]);
+  });
+
+  it("does not flush a trailing token once the cap is reached", () => {
+    // Exactly 12 delimited tokens, then a 13th trailing token with no
+    // delimiter after it — the trailing flush is skipped because the cap is hit.
+    const twelve = Array.from({ length: 12 }, () => "ab").join(" ");
+    const result = tokenizeSearchQuery(`${twelve} zz`);
+    expect(result).toHaveLength(12);
+    expect(result.every((token) => token === "ab")).toBe(true);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/search-query-tokenization.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Move the pure query normalization and bounded tokenization logic into `search-query-tokenization-lib.ts` and reduce `search-query-tokenization.ts` to a thin re-export shim so existing `@/lib/search-query-tokenization` imports stay unchanged.

Adds exhaustive deterministic unit tests (26) covering `normalizeSearchQuery` (256 slice cap, trim, lowercase), `tokenizeSearchQuery` (short-token drop, delimiter split, special-char retention, 12-token cap, trailing flush), and the exported constants. The shim is excluded from coverage since it only re-exports.