### PR TITLE
feat(web): extract format helpers into format-lib

### DIFF
--- a/apps/web/src/lib/format-lib.ts
+++ b/apps/web/src/lib/format-lib.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure number/date formatting helpers used across the web app.
+ *
+ * Implementation module for `@/lib/format`, which re-exports the public API.
+ * Kept dependency-free so it is trivially unit-testable in isolation.
+ */
+
+/** Compact number formatter: 1234 → 1.2k, 14300 → 14.3k, 2_000_000 → 2M. */
+export function formatCompact(n: number | undefined | null): string {
+  if (n == null || Number.isNaN(n)) return "—";
+  if (n < 1_000) return String(n);
+  if (n < 1_000_000) return withUnit(n / 1_000, "k", "M");
+  if (n < 1_000_000_000) return withUnit(n / 1_000_000, "M", "B");
+  // Billions: always one decimal (matches the original behavior — 123.5B, not 124B), and there's no
+  // higher unit to promote into, so the boundary-promotion in withUnit doesn't apply here.
+  return `${(n / 1_000_000_000).toFixed(1).replace(/\.0$/, "")}B`;
+}
+
+/** Format a k/M value: integer at ≥100 (so "120k", not "120.0k"), else one decimal. If rounding
+ *  overflows the unit to "1000" (e.g. 999_999/1_000 → 999.999 → "1000"), promote to the next unit
+ *  ("1M"/"1B") instead of the nonsensical "1000k"/"1000M". */
+function withUnit(v: number, suffix: string, promoted: string): string {
+  const text = v >= 100 ? v.toFixed(0) : v.toFixed(1).replace(/\.0$/, "");
+  return text === "1000" ? `1${promoted}` : `${text}${suffix}`;
+}
+
+/** Format an ISO date relative to now: "3d ago", "2h ago", "just now". */
+export function timeAgo(iso: string | undefined | null): string {
+  if (!iso) return "—";
+  const d = new Date(iso).getTime();
+  if (Number.isNaN(d)) return "—";
+  const diff = Date.now() - d;
+  if (diff < 0) return "—";
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `${h}h ago`;
+  const day = Math.round(h / 24);
+  if (day < 30) return `${day}d ago`;
+  const mo = Math.round(day / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.round(mo / 12)}y ago`;
+}

--- a/apps/web/src/lib/format.ts
+++ b/apps/web/src/lib/format.ts
@@ -1,37 +1,7 @@
-/** Compact number formatter: 1234 → 1.2k, 14300 → 14.3k, 2_000_000 → 2M. */
-export function formatCompact(n: number | undefined | null): string {
-  if (n == null || Number.isNaN(n)) return "—";
-  if (n < 1_000) return String(n);
-  if (n < 1_000_000) return withUnit(n / 1_000, "k", "M");
-  if (n < 1_000_000_000) return withUnit(n / 1_000_000, "M", "B");
-  // Billions: always one decimal (matches the original behavior — 123.5B, not 124B), and there's no
-  // higher unit to promote into, so the boundary-promotion in withUnit doesn't apply here.
-  return `${(n / 1_000_000_000).toFixed(1).replace(/\.0$/, "")}B`;
-}
-
-/** Format a k/M value: integer at ≥100 (so "120k", not "120.0k"), else one decimal. If rounding
- *  overflows the unit to "1000" (e.g. 999_999/1_000 → 999.999 → "1000"), promote to the next unit
- *  ("1M"/"1B") instead of the nonsensical "1000k"/"1000M". */
-function withUnit(v: number, suffix: string, promoted: string): string {
-  const text = v >= 100 ? v.toFixed(0) : v.toFixed(1).replace(/\.0$/, "");
-  return text === "1000" ? `1${promoted}` : `${text}${suffix}`;
-}
-
-/** Format an ISO date relative to now: "3d ago", "2h ago", "just now". */
-export function timeAgo(iso: string | undefined | null): string {
-  if (!iso) return "—";
-  const d = new Date(iso).getTime();
-  if (Number.isNaN(d)) return "—";
-  const diff = Date.now() - d;
-  if (diff < 0) return "—";
-  const min = Math.round(diff / 60_000);
-  if (min < 1) return "just now";
-  if (min < 60) return `${min}m ago`;
-  const h = Math.round(min / 60);
-  if (h < 24) return `${h}h ago`;
-  const day = Math.round(h / 24);
-  if (day < 30) return `${day}d ago`;
-  const mo = Math.round(day / 30);
-  if (mo < 12) return `${mo}mo ago`;
-  return `${Math.round(mo / 12)}y ago`;
-}
+/**
+ * Public entrypoint for number/date formatting helpers.
+ *
+ * The implementation lives in `@/lib/format-lib`; this module re-exports the
+ * stable public API so import sites stay unchanged.
+ */
+export { formatCompact, timeAgo } from "@/lib/format-lib";

--- a/tests/format-lib.test.ts
+++ b/tests/format-lib.test.ts
@@ -1,0 +1,106 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { formatCompact, timeAgo } from "../apps/web/src/lib/format-lib";
+
+describe("formatCompact", () => {
+  it("returns the em-dash for nullish and NaN inputs", () => {
+    expect(formatCompact(null)).toBe("—");
+    expect(formatCompact(undefined)).toBe("—");
+    expect(formatCompact(Number.NaN)).toBe("—");
+  });
+
+  it("passes small values (< 1000) through as plain strings", () => {
+    expect(formatCompact(0)).toBe("0");
+    expect(formatCompact(42)).toBe("42");
+    expect(formatCompact(999)).toBe("999");
+    expect(formatCompact(-5)).toBe("-5");
+  });
+
+  it("formats the thousands (k) bucket with one decimal below 100", () => {
+    expect(formatCompact(1000)).toBe("1k");
+    expect(formatCompact(1234)).toBe("1.2k");
+    expect(formatCompact(14_300)).toBe("14.3k");
+    expect(formatCompact(2000)).toBe("2k");
+  });
+
+  it("uses an integer in the k bucket at or above 100", () => {
+    expect(formatCompact(120_000)).toBe("120k");
+    expect(formatCompact(120_400)).toBe("120k");
+  });
+
+  it("promotes 999_999 to 1M instead of 1000k", () => {
+    expect(formatCompact(999_999)).toBe("1M");
+  });
+
+  it("formats the millions (M) bucket", () => {
+    expect(formatCompact(2_000_000)).toBe("2M");
+    expect(formatCompact(1_500_000)).toBe("1.5M");
+    expect(formatCompact(120_000_000)).toBe("120M");
+  });
+
+  it("promotes 999_999_999 to 1B instead of 1000M", () => {
+    expect(formatCompact(999_999_999)).toBe("1B");
+  });
+
+  it("formats the billions (B) bucket with a stripped trailing .0", () => {
+    expect(formatCompact(1_000_000_000)).toBe("1B");
+    expect(formatCompact(2_000_000_000)).toBe("2B");
+    expect(formatCompact(123_500_000_000)).toBe("123.5B");
+  });
+});
+
+describe("timeAgo", () => {
+  const NOW = new Date("2026-06-15T12:00:00.000Z");
+  const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString();
+  const SECOND = 1_000;
+  const MINUTE = 60_000;
+  const HOUR = 60 * MINUTE;
+  const DAY = 24 * HOUR;
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns the em-dash for nullish, invalid, and future dates", () => {
+    expect(timeAgo(null)).toBe("—");
+    expect(timeAgo(undefined)).toBe("—");
+    expect(timeAgo("")).toBe("—");
+    expect(timeAgo("not-a-date")).toBe("—");
+    expect(timeAgo(ago(-MINUTE))).toBe("—");
+  });
+
+  it('returns "just now" under a minute', () => {
+    expect(timeAgo(ago(20 * SECOND))).toBe("just now");
+    expect(timeAgo(NOW.toISOString())).toBe("just now");
+  });
+
+  it("formats the minutes bucket", () => {
+    expect(timeAgo(ago(5 * MINUTE))).toBe("5m ago");
+    expect(timeAgo(ago(59 * MINUTE))).toBe("59m ago");
+  });
+
+  it("formats the hours bucket", () => {
+    expect(timeAgo(ago(2 * HOUR))).toBe("2h ago");
+    expect(timeAgo(ago(23 * HOUR))).toBe("23h ago");
+  });
+
+  it("formats the days bucket", () => {
+    expect(timeAgo(ago(2 * DAY))).toBe("2d ago");
+    expect(timeAgo(ago(29 * DAY))).toBe("29d ago");
+  });
+
+  it("formats the months bucket", () => {
+    expect(timeAgo(ago(60 * DAY))).toBe("2mo ago");
+    expect(timeAgo(ago(330 * DAY))).toBe("11mo ago");
+  });
+
+  it("formats the years bucket", () => {
+    expect(timeAgo(ago(400 * DAY))).toBe("1y ago");
+    expect(timeAgo(ago(800 * DAY))).toBe("2y ago");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/format.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Extracts the pure formatting helpers into a dependency-free `format-lib` module. `formatCompact`/`timeAgo` (and the private `withUnit` helper) now live in `apps/web/src/lib/format-lib.ts`; `apps/web/src/lib/format.ts` becomes a thin shim that re-exports the exact same public API, so no import sites change.

Adds `tests/format-lib.test.ts` with exhaustive, deterministic coverage: `formatCompact` nullish/NaN, small-value passthrough, k/M/B buckets, the ≥100 integer vs 1-decimal rule, and the unit-promotion boundary (999_999→1M, 999_999_999→1B); `timeAgo` nullish/invalid/future plus every relative bucket, with a fixed system clock via `vi.setSystemTime`. 15 tests, all passing.