### PR TITLE
feat(web): extract error-capture pure helper into error-capture-lib

### DIFF
--- a/apps/web/src/lib/error-capture-lib.ts
+++ b/apps/web/src/lib/error-capture-lib.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure freshness helper for the out-of-band error capture buffer.
+ *
+ * The stateful buffer, global `error`/`unhandledrejection` listeners, and the
+ * `consumeLastCapturedError` reader live in `error-capture.ts`
+ * (`@/lib/error-capture`), which re-exports these helpers. Nothing here touches
+ * global state — the freshness check is a deterministic function of timestamps.
+ */
+
+export const CAPTURE_TTL_MS = 5_000;
+
+/** True if a value captured at `at` is still within `ttlMs` of `now`. */
+export function isCaptureFresh(at: number, now: number, ttlMs: number = CAPTURE_TTL_MS): boolean {
+  return now - at <= ttlMs;
+}

--- a/apps/web/src/lib/error-capture.ts
+++ b/apps/web/src/lib/error-capture.ts
@@ -1,8 +1,14 @@
 // Captures the original Error out-of-band so server.ts can recover the stack
 // when h3 has already swallowed the throw into a generic 500 Response.
+//
+// The pure freshness check lives in `error-capture-lib.ts`
+// (`@/lib/error-capture-lib`); this module keeps the capture buffer and the
+// global `error`/`unhandledrejection` listeners.
+import { CAPTURE_TTL_MS, isCaptureFresh } from "@/lib/error-capture-lib";
+
+export { isCaptureFresh, CAPTURE_TTL_MS } from "@/lib/error-capture-lib";
 
 let lastCapturedError: { error: unknown; at: number } | undefined;
-const TTL_MS = 5_000;
 
 function record(error: unknown) {
   lastCapturedError = { error, at: Date.now() };
@@ -17,7 +23,7 @@ if (typeof globalThis.addEventListener === "function") {
 
 export function consumeLastCapturedError(): unknown {
   if (!lastCapturedError) return undefined;
-  if (Date.now() - lastCapturedError.at > TTL_MS) {
+  if (!isCaptureFresh(lastCapturedError.at, Date.now(), CAPTURE_TTL_MS)) {
     lastCapturedError = undefined;
     return undefined;
   }

--- a/tests/error-capture-lib.test.ts
+++ b/tests/error-capture-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CAPTURE_TTL_MS,
+  isCaptureFresh,
+} from "../apps/web/src/lib/error-capture-lib";
+
+describe("isCaptureFresh", () => {
+  it("is fresh while within the ttl window", () => {
+    expect(isCaptureFresh(1_000, 1_000 + (CAPTURE_TTL_MS - 1))).toBe(true);
+  });
+
+  it("is fresh exactly at the ttl boundary", () => {
+    expect(isCaptureFresh(1_000, 1_000 + CAPTURE_TTL_MS)).toBe(true);
+  });
+
+  it("is stale beyond the ttl window", () => {
+    expect(isCaptureFresh(1_000, 1_000 + CAPTURE_TTL_MS + 1)).toBe(false);
+  });
+
+  it("honours a custom ttl argument", () => {
+    expect(isCaptureFresh(0, 100, 100)).toBe(true);
+    expect(isCaptureFresh(0, 101, 100)).toBe(false);
+  });
+
+  it("exposes a 5000ms default ttl", () => {
+    expect(CAPTURE_TTL_MS).toBe(5000);
+  });
+});


### PR DESCRIPTION
Mirrors the compare-entry-actions -lib split: the TTL freshness check moves to a new `error-capture-lib.ts` (`isCaptureFresh` + `CAPTURE_TTL_MS`), while `error-capture.ts` keeps the capture buffer + global error listeners and re-exports the helper. Behaviour is identical; adds unit coverage (5 tests).