### PR TITLE
feat(web): bundle browse compare show-hint signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
@@ -1,10 +1,23 @@
 import type { Entry } from "@/types/registry";
+import { shouldShowBrowseCompareHint } from "@/lib/compare-browse-summary";
 import { browseCompareUiState } from "@/lib/compare-browse-ui-lib";
 
-export type BrowseCompareInteractiveUiState = NonNullable<ReturnType<typeof browseCompareUiState>>;
+export type BrowseCompareInteractiveUiState = NonNullable<
+  ReturnType<typeof browseCompareUiState>
+> & {
+  showHint: boolean;
+};
 
 export function browseCompareInteractiveUiState(
   items: Entry[],
 ): BrowseCompareInteractiveUiState | null {
-  return browseCompareUiState(items);
+  if (!shouldShowBrowseCompareHint(items)) return null;
+  return {
+    ...browseCompareUiState(items)!,
+    showHint: true,
+  };
+}
+
+export function browseCompareInteractiveUiShowsHint(items: Entry[]): boolean {
+  return browseCompareInteractiveUiState(items)?.showHint ?? false;
 }

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -639,7 +639,7 @@ function Browse() {
                     </>
                   )}
                 </span>
-                {browseCompareUi ? (
+                {browseCompareUi?.showHint ? (
                   <div className="inline-flex flex-col items-end gap-1">
                     {browseCompareUi.overflowHint ? (
                       <span className="max-w-xs text-right text-[11px] text-amber-800">

--- a/tests/compare-browse-interactive-ui-lib.test.ts
+++ b/tests/compare-browse-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
+import {
+  browseCompareInteractiveUiShowsHint,
+  browseCompareInteractiveUiState,
+} from "@/lib/compare-browse-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -23,6 +26,8 @@ describe("compare browse interactive ui lib", () => {
   it("returns null when fewer than two items are selected", () => {
     expect(browseCompareInteractiveUiState([])).toBeNull();
     expect(browseCompareInteractiveUiState([entry()])).toBeNull();
+    expect(browseCompareInteractiveUiShowsHint([])).toBe(false);
+    expect(browseCompareInteractiveUiShowsHint([entry()])).toBe(false);
   });
 
   it("builds capped compare CTA state aligned with hint and overflow copy", () => {
@@ -42,7 +47,9 @@ describe("compare browse interactive ui lib", () => {
       selectedCount: 4,
       hint: "Open compare to review trust and next steps side by side.",
       overflowHint: "Opening 4 of 5 selected in compare.",
+      showHint: true,
     });
+    expect(browseCompareInteractiveUiShowsHint(five)).toBe(true);
   });
 
   it("surfaces divergence hints in browse compare CTA state", () => {
@@ -61,6 +68,18 @@ describe("compare browse interactive ui lib", () => {
       selectedCount: 2,
       hint: "1 trust signal differ · next steps differ — open compare for details.",
       overflowHint: null,
+      showHint: true,
     });
+    expect(
+      browseCompareInteractiveUiShowsHint([
+        entry(),
+        entry({
+          slug: "mixed",
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `showHint` to `browseCompareInteractiveUiState` and a `browseCompareInteractiveUiShowsHint` delegate, mirroring the curated compare `renderable` bundle pattern.
- Wire the browse directory CTA to gate on `browseCompareUi.showHint`.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-browse-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)