### PR TITLE
feat(web): extract contributor-identity helpers into contributor-identity-lib

### DIFF
--- a/apps/web/src/lib/contributor-identity-lib.ts
+++ b/apps/web/src/lib/contributor-identity-lib.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure contributor identity helpers.
+ *
+ * Slug derivation and submitter matching used to reconcile author handles
+ * against submission credit. Given the same strings the output is fully
+ * deterministic — nothing here touches the DOM, network, or clock.
+ *
+ * The public surface (`contributor-identity.ts` / `@/lib/contributor-identity`)
+ * re-exports everything below so existing imports stay unchanged.
+ */
+
+export function contributorSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
+  if (!author || !submittedBy) return false;
+  const authorSlug = contributorSlug(author);
+  const submittedBySlug = contributorSlug(submittedBy);
+  return Boolean(authorSlug && authorSlug === submittedBySlug);
+}

--- a/apps/web/src/lib/contributor-identity.ts
+++ b/apps/web/src/lib/contributor-identity.ts
@@ -1,15 +1,7 @@
-export function contributorSlug(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^@/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
-  if (!author || !submittedBy) return false;
-  const authorSlug = contributorSlug(author);
-  const submittedBySlug = contributorSlug(submittedBy);
-  return Boolean(authorSlug && authorSlug === submittedBySlug);
-}
+/**
+ * Contributor identity surface.
+ *
+ * Pure helpers live in `contributor-identity-lib.ts`. This module re-exports
+ * that surface so existing `@/lib/contributor-identity` imports stay unchanged.
+ */
+export { contributorSlug, authorMatchesSubmitter } from "@/lib/contributor-identity-lib";

--- a/tests/contributor-identity-lib.test.ts
+++ b/tests/contributor-identity-lib.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authorMatchesSubmitter,
+  contributorSlug,
+} from "../apps/web/src/lib/contributor-identity-lib";
+
+describe("contributorSlug", () => {
+  it("lowercases the value", () => {
+    expect(contributorSlug("JohnDoe")).toBe("johndoe");
+  });
+
+  it("strips a leading @ handle marker", () => {
+    expect(contributorSlug("@octocat")).toBe("octocat");
+  });
+
+  it("only strips a single leading @", () => {
+    expect(contributorSlug("@@octocat")).toBe("octocat");
+  });
+
+  it("trims surrounding whitespace before slugifying", () => {
+    expect(contributorSlug("  Jane Roe  ")).toBe("jane-roe");
+  });
+
+  it("replaces runs of non-alphanumeric characters with a single dash", () => {
+    expect(contributorSlug("john   doe")).toBe("john-doe");
+    expect(contributorSlug("john__doe")).toBe("john-doe");
+  });
+
+  it("keeps digits", () => {
+    expect(contributorSlug("user123")).toBe("user123");
+  });
+
+  it("strips leading and trailing dashes", () => {
+    expect(contributorSlug("--john--")).toBe("john");
+  });
+
+  it("collapses interior separators while stripping edges", () => {
+    expect(contributorSlug("  .John. .Doe.  ")).toBe("john-doe");
+  });
+
+  it("returns an empty string for symbol-only input", () => {
+    expect(contributorSlug("@#$%")).toBe("");
+  });
+
+  it("returns an empty string for a lone @ marker", () => {
+    expect(contributorSlug("@")).toBe("");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(contributorSlug("")).toBe("");
+  });
+
+  it("leaves an already-normalized slug unchanged", () => {
+    expect(contributorSlug("code-review")).toBe("code-review");
+  });
+});
+
+describe("authorMatchesSubmitter", () => {
+  it("returns true when both slugs are equal", () => {
+    expect(authorMatchesSubmitter("John Doe", "john-doe")).toBe(true);
+  });
+
+  it("returns true when the @ handle normalizes to the same slug", () => {
+    expect(authorMatchesSubmitter("@alice", "alice")).toBe(true);
+  });
+
+  it("returns false when the slugs differ", () => {
+    expect(authorMatchesSubmitter("alice", "bob")).toBe(false);
+  });
+
+  it("returns false when author is missing", () => {
+    expect(authorMatchesSubmitter(undefined, "bob")).toBe(false);
+  });
+
+  it("returns false when submittedBy is missing", () => {
+    expect(authorMatchesSubmitter("alice", undefined)).toBe(false);
+  });
+
+  it("returns false when author is an empty string", () => {
+    expect(authorMatchesSubmitter("", "bob")).toBe(false);
+  });
+
+  it("returns false when submittedBy is an empty string", () => {
+    expect(authorMatchesSubmitter("alice", "")).toBe(false);
+  });
+
+  it("returns false when both inputs are missing", () => {
+    expect(authorMatchesSubmitter()).toBe(false);
+  });
+
+  it("returns false when both inputs slugify to empty strings", () => {
+    expect(authorMatchesSubmitter("@#$%", "!!!")).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/contributor-identity.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Moves the pure `contributorSlug` / `authorMatchesSubmitter` helpers into a new `contributor-identity-lib.ts` module and reduces `contributor-identity.ts` to a thin re-export shim (public API unchanged). Adds exhaustive unit tests and excludes the shim from coverage.