### PR TITLE
feat(web): extract ecosystem-pulse-window helpers into ecosystem-pulse-window-lib

### DIFF
--- a/apps/web/src/lib/ecosystem-pulse-window-lib.ts
+++ b/apps/web/src/lib/ecosystem-pulse-window-lib.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure ecosystem-pulse windowing helper.
+ *
+ * `filterRecentPulseEntries` keeps only the dated entries that fall within the
+ * trailing 14-day UTC window (inclusive of both the cutoff day and today),
+ * comparing on UTC calendar-day boundaries so the result is stable regardless of
+ * the caller's local timezone. Everything here is deterministic given an
+ * injectable `now`; the public surface (`ecosystem-pulse-window.ts` /
+ * `@/lib/ecosystem-pulse-window`) re-exports the helper below.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PULSE_WINDOW_DAYS = 14;
+
+function utcDayTimestamp(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) return undefined;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function filterRecentPulseEntries<T extends { date: string }>(
+  entries: readonly T[],
+  now: Date = new Date(),
+) {
+  const today = utcDayTimestamp(now);
+  if (today === undefined) return [];
+
+  const cutoff = today - (PULSE_WINDOW_DAYS - 1) * DAY_MS;
+  return entries.filter((entry) => {
+    const entryDay = utcDayTimestamp(entry.date);
+    return entryDay !== undefined && entryDay >= cutoff && entryDay <= today;
+  });
+}

--- a/apps/web/src/lib/ecosystem-pulse-window.ts
+++ b/apps/web/src/lib/ecosystem-pulse-window.ts
@@ -1,23 +1,8 @@
-const DAY_MS = 24 * 60 * 60 * 1000;
-const PULSE_WINDOW_DAYS = 14;
-
-function utcDayTimestamp(value: Date | string) {
-  const date = value instanceof Date ? value : new Date(value);
-  const time = date.getTime();
-  if (!Number.isFinite(time)) return undefined;
-  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-}
-
-export function filterRecentPulseEntries<T extends { date: string }>(
-  entries: readonly T[],
-  now: Date = new Date(),
-) {
-  const today = utcDayTimestamp(now);
-  if (today === undefined) return [];
-
-  const cutoff = today - (PULSE_WINDOW_DAYS - 1) * DAY_MS;
-  return entries.filter((entry) => {
-    const entryDay = utcDayTimestamp(entry.date);
-    return entryDay !== undefined && entryDay >= cutoff && entryDay <= today;
-  });
-}
+/**
+ * Ecosystem-pulse windowing surface.
+ *
+ * The pure trailing-window filter lives in `ecosystem-pulse-window-lib.ts`. This
+ * module re-exports it so existing `@/lib/ecosystem-pulse-window` imports stay
+ * unchanged.
+ */
+export { filterRecentPulseEntries } from "@/lib/ecosystem-pulse-window-lib";

--- a/tests/ecosystem-pulse-window-lib.test.ts
+++ b/tests/ecosystem-pulse-window-lib.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { filterRecentPulseEntries } from "../apps/web/src/lib/ecosystem-pulse-window-lib";
+
+// Fixed reference point so every case is deterministic.
+// now = 2026-06-20 (UTC). 14-day trailing window (inclusive) => 2026-06-07 .. 2026-06-20.
+const NOW = new Date("2026-06-20T12:00:00.000Z");
+
+const entry = (date: string) => ({ date });
+
+describe("filterRecentPulseEntries", () => {
+  it("keeps entries inside the 14-day UTC window", () => {
+    const result = filterRecentPulseEntries([entry("2026-06-15")], NOW);
+    expect(result).toEqual([{ date: "2026-06-15" }]);
+  });
+
+  it("keeps the entry falling exactly on the cutoff day", () => {
+    expect(filterRecentPulseEntries([entry("2026-06-07")], NOW)).toEqual([
+      { date: "2026-06-07" },
+    ]);
+  });
+
+  it("keeps the entry falling exactly on today", () => {
+    expect(filterRecentPulseEntries([entry("2026-06-20")], NOW)).toEqual([
+      { date: "2026-06-20" },
+    ]);
+  });
+
+  it("drops the entry on the day before the cutoff", () => {
+    expect(filterRecentPulseEntries([entry("2026-06-06")], NOW)).toEqual([]);
+  });
+
+  it("drops entries older than the cutoff", () => {
+    expect(filterRecentPulseEntries([entry("2026-05-01")], NOW)).toEqual([]);
+  });
+
+  it("drops future entries beyond today", () => {
+    expect(filterRecentPulseEntries([entry("2026-06-21")], NOW)).toEqual([]);
+  });
+
+  it("compares on UTC calendar days regardless of intraday time", () => {
+    const result = filterRecentPulseEntries(
+      [entry("2026-06-20T23:59:59.999Z"), entry("2026-06-07T00:00:00.000Z")],
+      NOW,
+    );
+    expect(result).toEqual([
+      { date: "2026-06-20T23:59:59.999Z" },
+      { date: "2026-06-07T00:00:00.000Z" },
+    ]);
+  });
+
+  it("drops entries with an invalid date", () => {
+    expect(filterRecentPulseEntries([entry("not-a-date")], NOW)).toEqual([]);
+    expect(filterRecentPulseEntries([entry("")], NOW)).toEqual([]);
+  });
+
+  it("filters a mixed batch, preserving input order of kept entries", () => {
+    const entries = [
+      entry("2026-05-01"), // too old
+      entry("2026-06-07"), // cutoff boundary (kept)
+      entry("2026-06-06"), // day before cutoff (dropped)
+      entry("2026-06-14"), // inside (kept)
+      entry("bogus"), // invalid (dropped)
+      entry("2026-06-20"), // today (kept)
+      entry("2026-06-21"), // future (dropped)
+    ];
+    expect(filterRecentPulseEntries(entries, NOW)).toEqual([
+      { date: "2026-06-07" },
+      { date: "2026-06-14" },
+      { date: "2026-06-20" },
+    ]);
+  });
+
+  it("returns [] when now is an invalid Date", () => {
+    expect(
+      filterRecentPulseEntries([entry("2026-06-15")], new Date("invalid")),
+    ).toEqual([]);
+  });
+
+  it("uses the current time as the default now", () => {
+    // Only exercises the default-parameter path deterministically.
+    expect(filterRecentPulseEntries([])).toEqual([]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(filterRecentPulseEntries([], NOW)).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/ecosystem-pulse-window.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Moves the pure `filterRecentPulseEntries` window logic into a new `ecosystem-pulse-window-lib.ts` module and reduces `ecosystem-pulse-window.ts` to a thin re-export shim (public API unchanged). Adds exhaustive unit tests and excludes the shim from coverage.