### PR TITLE
feat(web): extract robots-policy helpers into robots-policy-lib

### DIFF
--- a/apps/web/src/lib/robots-policy-lib.ts
+++ b/apps/web/src/lib/robots-policy-lib.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure robots policy helpers.
+ *
+ * Given `siteConfig`, `getRobotsPolicy` returns the crawl rules (the catch-all
+ * `*` group plus the AI-bots group), disallow paths, content signal, and the
+ * derived sitemap + host. `renderRobotsTxt` turns that policy into robots.txt
+ * text. Both are deterministic given `siteConfig` — nothing here touches the
+ * request or the runtime.
+ *
+ * The public surface (`robots-policy.ts` / `@/lib/robots-policy`) re-exports
+ * `getRobotsPolicy` and `renderRobotsTxt` so existing imports stay unchanged.
+ */
+import { siteConfig } from "@/lib/site";
+
+// Machine endpoints and generated artifacts should not be crawled: they waste crawl budget
+// and surface as "crawled - not indexed" / 404 noise in Search Console.
+// /_next/ was a Next.js artifact; this app is TanStack Start on Workers and never serves it.
+// Hashed build assets live under /assets/* and stay crawlable (Google needs JS/CSS to render).
+const DISALLOW_PATHS = ["/api/", "/data/", "/downloads/"];
+
+// AI content-usage preferences (contentsignals.org / draft-romm-aipref-contentsignals).
+// Fully open: appear in search + AI answers and allow training.
+const CONTENT_SIGNAL = "ai-train=yes, search=yes, ai-input=yes";
+
+export function getRobotsPolicy() {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: DISALLOW_PATHS,
+      },
+      {
+        userAgent: [
+          "GPTBot",
+          "OAI-SearchBot",
+          "ChatGPT-User",
+          "ClaudeBot",
+          "Claude-SearchBot",
+          "Google-Extended",
+        ],
+        allow: "/",
+        disallow: DISALLOW_PATHS,
+      },
+    ],
+    contentSignal: CONTENT_SIGNAL,
+    sitemap: `${siteConfig.url}/sitemap.xml`,
+    host: new URL(siteConfig.url).host,
+  };
+}
+
+export function renderRobotsTxt() {
+  const policy = getRobotsPolicy();
+  const lines: string[] = [];
+  for (const rule of policy.rules) {
+    const userAgents = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
+    for (const userAgent of userAgents) {
+      lines.push(`User-agent: ${userAgent}`);
+    }
+    lines.push(`Allow: ${rule.allow}`);
+    for (const path of rule.disallow ?? []) {
+      lines.push(`Disallow: ${path}`);
+    }
+    // Content-Signal applies to all crawlers — emit it once, under the catch-all group.
+    if (policy.contentSignal && rule.userAgent === "*") {
+      lines.push(`Content-Signal: ${policy.contentSignal}`);
+    }
+    lines.push("");
+  }
+  lines.push(`Sitemap: ${policy.sitemap}`);
+  lines.push(`Host: ${policy.host}`);
+  return lines.join("\n");
+}

--- a/apps/web/src/lib/robots-policy.ts
+++ b/apps/web/src/lib/robots-policy.ts
@@ -1,61 +1,7 @@
-import { siteConfig } from "@/lib/site";
-
-// Machine endpoints and generated artifacts should not be crawled: they waste crawl budget
-// and surface as "crawled - not indexed" / 404 noise in Search Console.
-// /_next/ was a Next.js artifact; this app is TanStack Start on Workers and never serves it.
-// Hashed build assets live under /assets/* and stay crawlable (Google needs JS/CSS to render).
-const DISALLOW_PATHS = ["/api/", "/data/", "/downloads/"];
-
-// AI content-usage preferences (contentsignals.org / draft-romm-aipref-contentsignals).
-// Fully open: appear in search + AI answers and allow training.
-const CONTENT_SIGNAL = "ai-train=yes, search=yes, ai-input=yes";
-
-export function getRobotsPolicy() {
-  return {
-    rules: [
-      {
-        userAgent: "*",
-        allow: "/",
-        disallow: DISALLOW_PATHS,
-      },
-      {
-        userAgent: [
-          "GPTBot",
-          "OAI-SearchBot",
-          "ChatGPT-User",
-          "ClaudeBot",
-          "Claude-SearchBot",
-          "Google-Extended",
-        ],
-        allow: "/",
-        disallow: DISALLOW_PATHS,
-      },
-    ],
-    contentSignal: CONTENT_SIGNAL,
-    sitemap: `${siteConfig.url}/sitemap.xml`,
-    host: new URL(siteConfig.url).host,
-  };
-}
-
-export function renderRobotsTxt() {
-  const policy = getRobotsPolicy();
-  const lines: string[] = [];
-  for (const rule of policy.rules) {
-    const userAgents = Array.isArray(rule.userAgent) ? rule.userAgent : [rule.userAgent];
-    for (const userAgent of userAgents) {
-      lines.push(`User-agent: ${userAgent}`);
-    }
-    lines.push(`Allow: ${rule.allow}`);
-    for (const path of rule.disallow ?? []) {
-      lines.push(`Disallow: ${path}`);
-    }
-    // Content-Signal applies to all crawlers — emit it once, under the catch-all group.
-    if (policy.contentSignal && rule.userAgent === "*") {
-      lines.push(`Content-Signal: ${policy.contentSignal}`);
-    }
-    lines.push("");
-  }
-  lines.push(`Sitemap: ${policy.sitemap}`);
-  lines.push(`Host: ${policy.host}`);
-  return lines.join("\n");
-}
+/**
+ * Robots policy surface.
+ *
+ * Pure helpers live in `robots-policy-lib.ts`. This module re-exports that
+ * surface so existing `@/lib/robots-policy` imports stay unchanged.
+ */
+export { getRobotsPolicy, renderRobotsTxt } from "@/lib/robots-policy-lib";

--- a/tests/robots-policy-lib.test.ts
+++ b/tests/robots-policy-lib.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import { siteConfig } from "../apps/web/src/lib/site";
+import {
+  getRobotsPolicy,
+  renderRobotsTxt,
+} from "../apps/web/src/lib/robots-policy-lib";
+
+const AI_BOTS = [
+  "GPTBot",
+  "OAI-SearchBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-SearchBot",
+  "Google-Extended",
+];
+const DISALLOW_PATHS = ["/api/", "/data/", "/downloads/"];
+const CONTENT_SIGNAL = "ai-train=yes, search=yes, ai-input=yes";
+
+describe("getRobotsPolicy", () => {
+  it("returns exactly two rule groups: the catch-all and the AI-bots group", () => {
+    const policy = getRobotsPolicy();
+    expect(policy.rules).toHaveLength(2);
+  });
+
+  it("first rule is the catch-all `*` group with allow `/` and the disallow paths", () => {
+    const [catchAll] = getRobotsPolicy().rules;
+    expect(catchAll.userAgent).toBe("*");
+    expect(catchAll.allow).toBe("/");
+    expect(catchAll.disallow).toEqual(DISALLOW_PATHS);
+  });
+
+  it("second rule targets every AI bot with allow `/` and the disallow paths", () => {
+    const [, aiRule] = getRobotsPolicy().rules;
+    expect(aiRule.userAgent).toEqual(AI_BOTS);
+    expect(aiRule.allow).toBe("/");
+    expect(aiRule.disallow).toEqual(DISALLOW_PATHS);
+  });
+
+  it("exposes the content signal", () => {
+    expect(getRobotsPolicy().contentSignal).toBe(CONTENT_SIGNAL);
+  });
+
+  it("derives sitemap and host from siteConfig", () => {
+    const policy = getRobotsPolicy();
+    expect(policy.sitemap).toBe(`${siteConfig.url}/sitemap.xml`);
+    expect(policy.host).toBe(new URL(siteConfig.url).host);
+  });
+});
+
+describe("renderRobotsTxt", () => {
+  const output = renderRobotsTxt();
+  const lines = output.split("\n");
+
+  it("emits a User-agent line for the catch-all group", () => {
+    expect(lines).toContain("User-agent: *");
+  });
+
+  it("emits a User-agent line for every AI bot", () => {
+    for (const bot of AI_BOTS) {
+      expect(lines).toContain(`User-agent: ${bot}`);
+    }
+  });
+
+  it("emits an Allow line for each group", () => {
+    const allowLines = lines.filter((line) => line === "Allow: /");
+    expect(allowLines).toHaveLength(2);
+  });
+
+  it("emits each Disallow path once per group (two groups)", () => {
+    for (const path of DISALLOW_PATHS) {
+      const disallowLines = lines.filter(
+        (line) => line === `Disallow: ${path}`,
+      );
+      expect(disallowLines).toHaveLength(2);
+    }
+  });
+
+  it("emits the Content-Signal exactly once, under the catch-all group", () => {
+    const signalLines = lines.filter(
+      (line) => line === `Content-Signal: ${CONTENT_SIGNAL}`,
+    );
+    expect(signalLines).toHaveLength(1);
+    // It must appear within the first group, before the AI-bot User-agent lines.
+    const signalIndex = lines.indexOf(`Content-Signal: ${CONTENT_SIGNAL}`);
+    const firstAiIndex = lines.indexOf(`User-agent: ${AI_BOTS[0]}`);
+    expect(signalIndex).toBeGreaterThan(-1);
+    expect(signalIndex).toBeLessThan(firstAiIndex);
+  });
+
+  it("emits the trailing Sitemap and Host lines derived from siteConfig", () => {
+    const policy = getRobotsPolicy();
+    expect(lines).toContain(`Sitemap: ${policy.sitemap}`);
+    expect(lines).toContain(`Host: ${policy.host}`);
+  });
+
+  it("renders the full deterministic robots.txt document", () => {
+    const policy = getRobotsPolicy();
+    const expected = [
+      "User-agent: *",
+      "Allow: /",
+      "Disallow: /api/",
+      "Disallow: /data/",
+      "Disallow: /downloads/",
+      `Content-Signal: ${CONTENT_SIGNAL}`,
+      "",
+      "User-agent: GPTBot",
+      "User-agent: OAI-SearchBot",
+      "User-agent: ChatGPT-User",
+      "User-agent: ClaudeBot",
+      "User-agent: Claude-SearchBot",
+      "User-agent: Google-Extended",
+      "Allow: /",
+      "Disallow: /api/",
+      "Disallow: /data/",
+      "Disallow: /downloads/",
+      "",
+      `Sitemap: ${policy.sitemap}`,
+      `Host: ${policy.host}`,
+    ].join("\n");
+    expect(output).toBe(expected);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/robots-policy.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Moves the `getRobotsPolicy` / `renderRobotsTxt` logic into a new `robots-policy-lib.ts` module and reduces `robots-policy.ts` to a thin re-export shim (public API unchanged). Adds exhaustive unit tests and excludes the shim from coverage.