### PR TITLE
feat(web): extract contributor-profile-summary helpers into contributor-profile-summary-lib

### DIFF
--- a/apps/web/src/lib/contributor-profile-summary-lib.ts
+++ b/apps/web/src/lib/contributor-profile-summary-lib.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure contributor profile-summary helpers.
+ *
+ * The stat rollup, the card summary string, and the submitter-attribution
+ * decision are all deterministic given their inputs. The public surface
+ * (`contributor-profile-summary.ts` / `@/lib/contributor-profile-summary`)
+ * keeps the `contributorForSubmitter` data lookup and re-exports the helpers
+ * below, resolving the contributor before delegating to `submitterAttributionFrom`.
+ */
+import type { Contributor, Entry } from "@/types/registry";
+
+export function contributorProfileStats(contributor: Contributor) {
+  return {
+    accepted: contributor.acceptedCount,
+    reviewed: contributor.reviewedCount ?? 0,
+    sourceLinked: contributor.sourceSubmissionCount ?? 0,
+    categories: contributor.categories?.length ?? 0,
+  };
+}
+
+export function contributorCardSummary(contributor: Contributor) {
+  const stats = contributorProfileStats(contributor);
+  const parts = [`${stats.accepted} accepted`];
+  if (stats.reviewed > 0) parts.push(`${stats.reviewed} reviewed`);
+  if (stats.sourceLinked > 0) parts.push(`${stats.sourceLinked} source-linked`);
+  return parts.join(" · ");
+}
+
+export type SubmitterAttribution =
+  | { kind: "contributor"; slug: string; label: string }
+  | { kind: "external"; href: string; label: string }
+  | { kind: "plain"; label: string };
+
+/**
+ * Decide how to attribute an entry's submitter, given the already-resolved
+ * contributor (or `null`/`undefined` when the submitter is not a known
+ * contributor). Returns `undefined` when the entry has no submitter.
+ */
+export function submitterAttributionFrom(
+  entry: Pick<Entry, "submittedBy" | "submittedByUrl">,
+  contributor: Pick<Contributor, "slug"> | null | undefined,
+): SubmitterAttribution | undefined {
+  if (!entry.submittedBy) return undefined;
+
+  if (contributor) {
+    return {
+      kind: "contributor",
+      slug: contributor.slug,
+      label: entry.submittedBy,
+    };
+  }
+  if (entry.submittedByUrl) {
+    return {
+      kind: "external",
+      href: entry.submittedByUrl,
+      label: entry.submittedBy,
+    };
+  }
+  return { kind: "plain", label: entry.submittedBy };
+}

--- a/apps/web/src/lib/contributor-profile-summary.ts
+++ b/apps/web/src/lib/contributor-profile-summary.ts
@@ -1,39 +1,21 @@
+/**
+ * Contributor profile-summary surface.
+ *
+ * The pure helpers live in `contributor-profile-summary-lib.ts`. This module
+ * keeps the `contributorForSubmitter` data lookup and re-exports the helpers so
+ * existing `@/lib/contributor-profile-summary` imports stay unchanged.
+ */
 import { contributorForSubmitter } from "@/data/contributors";
-import type { Contributor, Entry } from "@/types/registry";
+import { submitterAttributionFrom } from "@/lib/contributor-profile-summary-lib";
+import type { Entry } from "@/types/registry";
 
-export function contributorProfileStats(contributor: Contributor) {
-  return {
-    accepted: contributor.acceptedCount,
-    reviewed: contributor.reviewedCount ?? 0,
-    sourceLinked: contributor.sourceSubmissionCount ?? 0,
-    categories: contributor.categories?.length ?? 0,
-  };
-}
+export {
+  contributorCardSummary,
+  contributorProfileStats,
+  submitterAttributionFrom,
+  type SubmitterAttribution,
+} from "@/lib/contributor-profile-summary-lib";
 
-export function contributorCardSummary(contributor: Contributor) {
-  const stats = contributorProfileStats(contributor);
-  const parts = [`${stats.accepted} accepted`];
-  if (stats.reviewed > 0) parts.push(`${stats.reviewed} reviewed`);
-  if (stats.sourceLinked > 0) parts.push(`${stats.sourceLinked} source-linked`);
-  return parts.join(" · ");
-}
-
-export type SubmitterAttribution =
-  | { kind: "contributor"; slug: string; label: string }
-  | { kind: "external"; href: string; label: string }
-  | { kind: "plain"; label: string };
-
-export function submitterAttribution(
-  entry: Pick<Entry, "submittedBy" | "submittedByUrl">,
-): SubmitterAttribution | undefined {
-  if (!entry.submittedBy) return undefined;
-
-  const contributor = contributorForSubmitter(entry);
-  if (contributor) {
-    return { kind: "contributor", slug: contributor.slug, label: entry.submittedBy };
-  }
-  if (entry.submittedByUrl) {
-    return { kind: "external", href: entry.submittedByUrl, label: entry.submittedBy };
-  }
-  return { kind: "plain", label: entry.submittedBy };
+export function submitterAttribution(entry: Pick<Entry, "submittedBy" | "submittedByUrl">) {
+  return submitterAttributionFrom(entry, contributorForSubmitter(entry));
 }

--- a/tests/contributor-profile-summary-lib.test.ts
+++ b/tests/contributor-profile-summary-lib.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contributorCardSummary,
+  contributorProfileStats,
+  submitterAttributionFrom,
+} from "../apps/web/src/lib/contributor-profile-summary-lib";
+import type { Contributor, Entry } from "../apps/web/src/types/registry";
+
+const contributor = (over: Partial<Contributor> = {}): Contributor =>
+  ({
+    slug: "ada",
+    acceptedCount: 0,
+    ...over,
+  }) as Contributor;
+
+describe("contributorProfileStats", () => {
+  it("reads all counts when present", () => {
+    expect(
+      contributorProfileStats(
+        contributor({
+          acceptedCount: 7,
+          reviewedCount: 4,
+          sourceSubmissionCount: 2,
+          categories: ["a", "b", "c"] as unknown as Contributor["categories"],
+        }),
+      ),
+    ).toEqual({ accepted: 7, reviewed: 4, sourceLinked: 2, categories: 3 });
+  });
+
+  it("defaults nullish optional counts to 0", () => {
+    expect(contributorProfileStats(contributor({ acceptedCount: 3 }))).toEqual({
+      accepted: 3,
+      reviewed: 0,
+      sourceLinked: 0,
+      categories: 0,
+    });
+  });
+});
+
+describe("contributorCardSummary", () => {
+  it("shows only accepted when the other counts are zero", () => {
+    expect(contributorCardSummary(contributor({ acceptedCount: 5 }))).toBe(
+      "5 accepted",
+    );
+  });
+
+  it("appends reviewed only when positive", () => {
+    expect(
+      contributorCardSummary(
+        contributor({ acceptedCount: 5, reviewedCount: 2 }),
+      ),
+    ).toBe("5 accepted · 2 reviewed");
+  });
+
+  it("appends source-linked only when positive", () => {
+    expect(
+      contributorCardSummary(
+        contributor({ acceptedCount: 5, sourceSubmissionCount: 3 }),
+      ),
+    ).toBe("5 accepted · 3 source-linked");
+  });
+
+  it("joins every part in order when all are positive", () => {
+    expect(
+      contributorCardSummary(
+        contributor({
+          acceptedCount: 5,
+          reviewedCount: 2,
+          sourceSubmissionCount: 3,
+        }),
+      ),
+    ).toBe("5 accepted · 2 reviewed · 3 source-linked");
+  });
+});
+
+describe("submitterAttributionFrom", () => {
+  const entry = (
+    over: Partial<Entry> = {},
+  ): Pick<Entry, "submittedBy" | "submittedByUrl"> =>
+    ({ submittedBy: "Grace", ...over }) as Entry;
+
+  it("returns undefined when there is no submitter", () => {
+    expect(
+      submitterAttributionFrom(entry({ submittedBy: undefined }), null),
+    ).toBeUndefined();
+    expect(
+      submitterAttributionFrom(entry({ submittedBy: "" }), null),
+    ).toBeUndefined();
+  });
+
+  it("prefers a known contributor", () => {
+    expect(
+      submitterAttributionFrom(entry({ submittedByUrl: "https://x.example" }), {
+        slug: "grace",
+      }),
+    ).toEqual({ kind: "contributor", slug: "grace", label: "Grace" });
+  });
+
+  it("falls back to an external link when a URL is present", () => {
+    expect(
+      submitterAttributionFrom(
+        entry({ submittedByUrl: "https://x.example" }),
+        null,
+      ),
+    ).toEqual({ kind: "external", href: "https://x.example", label: "Grace" });
+  });
+
+  it("falls back to a plain label when there is no contributor or URL", () => {
+    expect(submitterAttributionFrom(entry(), undefined)).toEqual({
+      kind: "plain",
+      label: "Grace",
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/contributor-profile-summary.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Moves the pure profile-stats, card-summary, and submitter-attribution decision into a new contributor-profile-summary-lib module; the original file keeps the contributorForSubmitter lookup and re-exports the helpers. Adds exhaustive unit tests and excludes the shim from coverage.