### PR TITLE
feat(web): extract d1-batch helpers into d1-batch-lib

### DIFF
--- a/apps/web/src/lib/d1-batch-lib.ts
+++ b/apps/web/src/lib/d1-batch-lib.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared D1 batching primitives for dynamic-state count queries.
+ *
+ * Votes, intent events, and community signals all read counts in small D1
+ * batches to stay under the bound-variable limit and keep dynamic-state queries
+ * reliable. The chunking loop and placeholder construction were duplicated in
+ * each helper, which risked drift when one was updated and the others were not.
+ * These helpers centralize the shared parts without changing query semantics or
+ * response shapes. The public surface (`d1-batch.ts` / `@/lib/d1-batch`) is a
+ * thin re-export of the pure helpers below.
+ */
+
+/** Conservative batch size that keeps each prepared query well under D1's
+ * bound-variable ceiling, even for the two-variable target-pair queries. */
+export const D1_SAFE_VARIABLE_BATCH_SIZE = 25;
+
+/**
+ * Split `items` into contiguous chunks of at most `size` entries. An empty
+ * input yields an empty array; callers should still guard the no-work case
+ * before touching the database.
+ */
+export function chunk<T>(items: readonly T[], size: number = D1_SAFE_VARIABLE_BATCH_SIZE): T[][] {
+  if (size <= 0) throw new RangeError("chunk size must be positive");
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
+/** Build a `?, ?, ...` placeholder list for a single-column `IN (...)` clause. */
+export function inPlaceholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+/**
+ * Build the `WHERE` fragment for matching a batch of (kind, key) pairs, e.g.
+ * `(target_kind = ? AND target_key = ?) OR (...)`. Returns an empty string for
+ * an empty batch so callers can guard before binding values.
+ */
+export function targetPairConditions(count: number, kindColumn: string, keyColumn: string): string {
+  return Array.from({ length: count }, () => `(${kindColumn} = ? AND ${keyColumn} = ?)`).join(
+    " OR ",
+  );
+}

--- a/apps/web/src/lib/d1-batch.ts
+++ b/apps/web/src/lib/d1-batch.ts
@@ -1,52 +1,12 @@
 /**
  * Shared D1 batching primitives for dynamic-state count queries.
  *
- * Votes, intent events, and community signals all read counts in small D1
- * batches to stay under the bound-variable limit and keep dynamic-state queries
- * reliable. The chunking loop and placeholder construction were duplicated in
- * each helper, which risked drift when one was updated and the others were not.
- * These helpers centralize the shared parts without changing query semantics or
- * response shapes.
+ * The implementation lives in `d1-batch-lib.ts`; this module is a thin
+ * re-export so existing `@/lib/d1-batch` imports stay unchanged.
  */
-
-/** Conservative batch size that keeps each prepared query well under D1's
- * bound-variable ceiling, even for the two-variable target-pair queries. */
-export const D1_SAFE_VARIABLE_BATCH_SIZE = 25;
-
-/**
- * Split `items` into contiguous chunks of at most `size` entries. An empty
- * input yields an empty array; callers should still guard the no-work case
- * before touching the database.
- */
-export function chunk<T>(
-  items: readonly T[],
-  size: number = D1_SAFE_VARIABLE_BATCH_SIZE,
-): T[][] {
-  if (size <= 0) throw new RangeError("chunk size must be positive");
-  const batches: T[][] = [];
-  for (let index = 0; index < items.length; index += size) {
-    batches.push(items.slice(index, index + size));
-  }
-  return batches;
-}
-
-/** Build a `?, ?, ...` placeholder list for a single-column `IN (...)` clause. */
-export function inPlaceholders(count: number): string {
-  return Array.from({ length: count }, () => "?").join(", ");
-}
-
-/**
- * Build the `WHERE` fragment for matching a batch of (kind, key) pairs, e.g.
- * `(target_kind = ? AND target_key = ?) OR (...)`. Returns an empty string for
- * an empty batch so callers can guard before binding values.
- */
-export function targetPairConditions(
-  count: number,
-  kindColumn: string,
-  keyColumn: string,
-): string {
-  return Array.from(
-    { length: count },
-    () => `(${kindColumn} = ? AND ${keyColumn} = ?)`,
-  ).join(" OR ");
-}
+export {
+  chunk,
+  D1_SAFE_VARIABLE_BATCH_SIZE,
+  inPlaceholders,
+  targetPairConditions,
+} from "@/lib/d1-batch-lib";

--- a/tests/d1-batch-lib.test.ts
+++ b/tests/d1-batch-lib.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  chunk,
+  D1_SAFE_VARIABLE_BATCH_SIZE,
+  inPlaceholders,
+  targetPairConditions,
+} from "../apps/web/src/lib/d1-batch-lib";
+
+describe("D1_SAFE_VARIABLE_BATCH_SIZE", () => {
+  it("is the conservative default of 25", () => {
+    expect(D1_SAFE_VARIABLE_BATCH_SIZE).toBe(25);
+  });
+});
+
+describe("chunk", () => {
+  it("returns an empty array for empty input", () => {
+    expect(chunk([])).toEqual([]);
+  });
+
+  it("splits into contiguous batches of at most `size`", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("keeps a single batch when input fits within `size`", () => {
+    expect(chunk([1, 2], 5)).toEqual([[1, 2]]);
+  });
+
+  it("produces even batches for an exact multiple", () => {
+    expect(chunk([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("defaults to the safe batch size", () => {
+    const items = Array.from({ length: 55 }, (_, i) => i);
+    const batches = chunk(items);
+    expect(batches).toHaveLength(3);
+    expect(batches[0]).toHaveLength(25);
+    expect(batches[1]).toHaveLength(25);
+    expect(batches[2]).toHaveLength(5);
+  });
+
+  it("throws a RangeError for a non-positive size", () => {
+    expect(() => chunk([1], 0)).toThrow(RangeError);
+    expect(() => chunk([1], -3)).toThrow(RangeError);
+  });
+});
+
+describe("inPlaceholders", () => {
+  it("builds a comma-separated placeholder list", () => {
+    expect(inPlaceholders(3)).toBe("?, ?, ?");
+    expect(inPlaceholders(1)).toBe("?");
+  });
+
+  it("returns an empty string for a zero count", () => {
+    expect(inPlaceholders(0)).toBe("");
+  });
+});
+
+describe("targetPairConditions", () => {
+  it("joins per-pair conditions with OR", () => {
+    expect(targetPairConditions(2, "target_kind", "target_key")).toBe(
+      "(target_kind = ? AND target_key = ?) OR (target_kind = ? AND target_key = ?)",
+    );
+  });
+
+  it("emits a single group for a count of one", () => {
+    expect(targetPairConditions(1, "k", "v")).toBe("(k = ? AND v = ?)");
+  });
+
+  it("returns an empty string for an empty batch", () => {
+    expect(targetPairConditions(0, "k", "v")).toBe("");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/d1-batch.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",
         "apps/web/src/lib/community-signals.ts",


### PR DESCRIPTION
Moves the D1 chunking + placeholder primitives into a new d1-batch-lib module; d1-batch.ts becomes a thin re-export shim (public API unchanged). Adds exhaustive unit tests and excludes the shim from coverage.