### PR TITLE
feat(web): bundle compare context serialize and share-url delegates into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-context-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-context-interactive-ui-lib.ts
@@ -20,3 +20,11 @@ export function compareContextSelectionChanged(next: Entry[], current: Entry[]):
     compareContextInteractiveUiState(current).selectionParam
   );
 }
+
+export function compareContextInteractiveSelectionParam(items: Entry[]): string {
+  return compareContextInteractiveUiState(items).selectionParam;
+}
+
+export function compareContextInteractiveShareUrl(items: Entry[]): string {
+  return compareContextInteractiveUiState(items).shareUrl;
+}

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import {
-  compareContextInteractiveUiState,
+  compareContextInteractiveSelectionParam,
+  compareContextInteractiveShareUrl,
   compareContextSelectionChanged,
 } from "@/lib/compare-context-interactive-ui-lib";
 import { hasCompareItem, resolveCompareParam, toggleCompareItem } from "@/lib/compare-selection";
@@ -81,8 +82,8 @@ function createCompareStore(): CompareStore {
         }
       });
     },
-    serialize: () => compareContextInteractiveUiState(state.items).selectionParam,
-    getShareUrl: () => compareContextInteractiveUiState(state.items).shareUrl,
+    serialize: () => compareContextInteractiveSelectionParam(state.items),
+    getShareUrl: () => compareContextInteractiveShareUrl(state.items),
   };
 
   return {

--- a/tests/compare-context-interactive-ui-lib.test.ts
+++ b/tests/compare-context-interactive-ui-lib.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareContextInteractiveSelectionParam,
+  compareContextInteractiveShareUrl,
   compareContextInteractiveUiState,
   compareContextSelectionChanged,
 } from "@/lib/compare-context-interactive-ui-lib";
@@ -56,5 +58,15 @@ describe("compare context interactive ui lib", () => {
     expect(compareContextSelectionChanged([alpha], [alpha])).toBe(false);
     expect(compareContextSelectionChanged([alpha, beta], [alpha])).toBe(true);
     expect(compareContextSelectionChanged([], [])).toBe(false);
+  });
+
+  it("delegates serialize and share URL from bundled compare context state", () => {
+    const items = [entry({ category: "skills", slug: "alpha" })];
+    expect(compareContextInteractiveSelectionParam(items)).toBe("skills/alpha");
+    expect(compareContextInteractiveShareUrl(items)).toBe(
+      "/browse?compare=skills%2Falpha",
+    );
+    expect(compareContextInteractiveSelectionParam([])).toBe("");
+    expect(compareContextInteractiveShareUrl([])).toBe("/browse");
   });
 });


### PR DESCRIPTION
## Summary
- Add `compareContextInteractiveSelectionParam` and `compareContextInteractiveShareUrl` delegates on the compare-context interactive bundle.
- Wire the compare store `serialize` and `getShareUrl` actions to use the bundled delegates.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-context-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-context-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)