### PR TITLE
feat(web): bundle best-list compare show-section signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-best-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-interactive-ui-lib.ts
@@ -1,8 +1,17 @@
 import type { Entry } from "@/types/registry";
+import { shouldShowBestCompareSection } from "@/lib/compare-best-summary";
 import { compareBestUiState, type CompareBestUiState } from "@/lib/compare-best-ui-lib";
 
 export type CompareBestInteractiveUiState = CompareBestUiState;
 
 export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInteractiveUiState {
-  return compareBestUiState(entries);
+  const ui = compareBestUiState(entries);
+  return {
+    ...ui,
+    showCompareSection: shouldShowBestCompareSection(entries),
+  };
+}
+
+export function compareBestInteractiveShowCompareSection(entries: Entry[]): boolean {
+  return compareBestInteractiveUiState(entries).showCompareSection;
 }

--- a/tests/compare-best-interactive-ui-lib.test.ts
+++ b/tests/compare-best-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareBestInteractiveUiState } from "@/lib/compare-best-interactive-ui-lib";
+import {
+  compareBestInteractiveShowCompareSection,
+  compareBestInteractiveUiState,
+} from "@/lib/compare-best-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -27,6 +30,7 @@ describe("compare best interactive ui lib", () => {
       interactiveSearch: null,
       interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
     });
+    expect(compareBestInteractiveShowCompareSection([entry()])).toBe(false);
   });
 
   it("bundles best-list page presentation state for headers and interactive links", () => {
@@ -41,6 +45,12 @@ describe("compare best interactive ui lib", () => {
       interactiveSearch: { ids: "skills/alpha,hooks/beta" },
       interactiveLinkLabel: "Open in the interactive comparison tool",
     });
+    expect(
+      compareBestInteractiveShowCompareSection([
+        entry({ category: "skills", slug: "alpha" }),
+        entry({ category: "hooks", slug: "beta" }),
+      ]),
+    ).toBe(true);
   });
 
   it("surfaces divergence banners for multi-entry best lists", () => {


### PR DESCRIPTION
## Summary
- Bundle `showCompareSection` explicitly in `compareBestInteractiveUiState` via `shouldShowBestCompareSection`.
- Add `compareBestInteractiveShowCompareSection` delegate mirroring browse/curated compare bundle patterns.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-best-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)