### PR TITLE
feat(web): wire curated compare loader through page-renderable delegate

### DIFF
--- a/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
@@ -23,5 +23,5 @@ export function compareCuratedInteractivePageRenderable(
   refs: string[],
   catalog: EntryIdentity[],
 ): boolean {
-  return compareCuratedInteractiveUiState(refs, catalog).renderable;
+  return compareCuratedHasRenderableEntries(refs, catalog);
 }

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -8,13 +8,16 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
-import { compareCuratedInteractiveUiState } from "@/lib/compare-curated-interactive-ui-lib";
+import {
+  compareCuratedInteractivePageRenderable,
+  compareCuratedInteractiveUiState,
+} from "@/lib/compare-curated-interactive-ui-lib";
 import { compareCuratedResolvedEntries } from "@/lib/compare-curated-ui-lib";
 
 export const Route = createFileRoute("/compare/$slug")({
   loader: ({ params }) => {
     const comparison = getComparison(params.slug);
-    if (!comparison || !compareCuratedInteractiveUiState(comparison.refs, ENTRIES).renderable) {
+    if (!comparison || !compareCuratedInteractivePageRenderable(comparison.refs, ENTRIES)) {
       throw notFound();
     }
     return {};


### PR DESCRIPTION
## Summary
- Point `compareCuratedInteractivePageRenderable` at `compareCuratedHasRenderableEntries` for lightweight loader checks.
- Wire the curated compare slug route loader to use the page-renderable delegate.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-curated-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)