### PR TITLE
feat(web): bundle entry compare featured-links signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -13,6 +13,7 @@ import {
 export type CompareEntryInteractiveUiState = {
   dossierUi: CompareDossierInteractiveUiState;
   featuredUi: CompareEntryFeaturedInteractiveUiState;
+  hasFeaturedLinks: boolean;
 };
 
 export function compareEntryInteractiveUiState(
@@ -22,8 +23,18 @@ export function compareEntryInteractiveUiState(
   lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
   catalog: EntryIdentity[],
 ): CompareEntryInteractiveUiState {
+  const featuredUi = compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog);
   return {
     dossierUi: compareDossierInteractiveUiState(entry, alternatives),
-    featuredUi: compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog),
+    featuredUi,
+    hasFeaturedLinks: featuredUi.hasFeaturedLinks,
   };
+}
+
+export function compareEntryInteractiveShowsFeaturedLinks(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): boolean {
+  return compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog).hasFeaturedLinks;
 }

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -225,7 +225,11 @@ function Dossier() {
   const entryRef = `${entry.category}/${entry.slug}`;
   const comparedIn = COMPARISONS.filter((c) => c.refs.includes(entryRef));
   const featuredIn = BEST_LISTS.filter((l) => l.picks.some((p) => p.ref === entryRef));
-  const { dossierUi: dossierCompareUi, featuredUi } = useMemo(
+  const {
+    dossierUi: dossierCompareUi,
+    featuredUi,
+    hasFeaturedLinks,
+  } = useMemo(
     () => compareEntryInteractiveUiState(entry, alternatives, comparedIn, featuredIn, ENTRIES),
     [entry, alternatives, comparedIn, featuredIn],
   );
@@ -731,7 +735,7 @@ function Dossier() {
             </DossierSection>
           )}
 
-          {featuredUi.hasFeaturedLinks && (
+          {hasFeaturedLinks && (
             <DossierSection id="featured-in" title="Featured in">
               <ul className="flex flex-col gap-2 text-sm">
                 {featuredIn.map((l) => {

--- a/tests/compare-entry-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
+import {
+  compareEntryInteractiveShowsFeaturedLinks,
+  compareEntryInteractiveUiState,
+} from "@/lib/compare-entry-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -65,7 +68,20 @@ describe("compare entry interactive ui lib", () => {
         ],
         hasFeaturedLinks: true,
       },
+      hasFeaturedLinks: true,
     });
+    expect(
+      compareEntryInteractiveShowsFeaturedLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toBe(true);
   });
 
   it("hides dossier compare and featured links when nothing references the entry", () => {
@@ -84,7 +100,11 @@ describe("compare entry interactive ui lib", () => {
         bestListLinks: [],
         hasFeaturedLinks: false,
       },
+      hasFeaturedLinks: false,
     });
+    expect(compareEntryInteractiveShowsFeaturedLinks([], [], catalog)).toBe(
+      false,
+    );
   });
 
   it("surfaces dossier divergence banners alongside featured links", () => {
@@ -119,5 +139,6 @@ describe("compare entry interactive ui lib", () => {
     expect(state.featuredUi.bestListLinks[0]?.label).toBe(
       "Open 3 picks in the interactive comparison tool",
     );
+    expect(state.hasFeaturedLinks).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `hasFeaturedLinks` to `compareEntryInteractiveUiState` and a `compareEntryInteractiveShowsFeaturedLinks` delegate.
- Wire the entry dossier featured-in section to gate on bundled `hasFeaturedLinks`.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-entry-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)