### PR TITLE
feat(web): bundle entry compare dossier-section signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -14,6 +14,7 @@ export type CompareEntryInteractiveUiState = {
   dossierUi: CompareDossierInteractiveUiState;
   featuredUi: CompareEntryFeaturedInteractiveUiState;
   hasFeaturedLinks: boolean;
+  showDossierCompareSection: boolean;
 };
 
 export function compareEntryInteractiveUiState(
@@ -23,11 +24,13 @@ export function compareEntryInteractiveUiState(
   lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
   catalog: EntryIdentity[],
 ): CompareEntryInteractiveUiState {
+  const dossierUi = compareDossierInteractiveUiState(entry, alternatives);
   const featuredUi = compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog);
   return {
-    dossierUi: compareDossierInteractiveUiState(entry, alternatives),
+    dossierUi,
     featuredUi,
     hasFeaturedLinks: featuredUi.hasFeaturedLinks,
+    showDossierCompareSection: dossierUi.showCompareSection,
   };
 }
 
@@ -37,4 +40,11 @@ export function compareEntryInteractiveShowsFeaturedLinks(
   catalog: EntryIdentity[],
 ): boolean {
   return compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog).hasFeaturedLinks;
+}
+
+export function compareEntryInteractiveShowsDossierCompareSection(
+  entry: Entry,
+  alternatives: Entry[],
+): boolean {
+  return compareDossierInteractiveUiState(entry, alternatives).showCompareSection;
 }

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -229,6 +229,7 @@ function Dossier() {
     dossierUi: dossierCompareUi,
     featuredUi,
     hasFeaturedLinks,
+    showDossierCompareSection,
   } = useMemo(
     () => compareEntryInteractiveUiState(entry, alternatives, comparedIn, featuredIn, ENTRIES),
     [entry, alternatives, comparedIn, featuredIn],
@@ -655,7 +656,7 @@ function Dossier() {
 
           <BadgeSection category={entry.category} slug={entry.slug} title={entry.title} />
 
-          {dossierCompareUi.showCompareSection && (
+          {showDossierCompareSection && (
             <DossierSection id="compare" title="How it compares">
               <p className="mb-4 text-sm text-ink-muted">
                 {entry.title} side by side with{" "}

--- a/tests/compare-entry-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-interactive-ui-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareEntryInteractiveShowsDossierCompareSection,
   compareEntryInteractiveShowsFeaturedLinks,
   compareEntryInteractiveUiState,
 } from "@/lib/compare-entry-interactive-ui-lib";
@@ -69,6 +70,7 @@ describe("compare entry interactive ui lib", () => {
         hasFeaturedLinks: true,
       },
       hasFeaturedLinks: true,
+      showDossierCompareSection: true,
     });
     expect(
       compareEntryInteractiveShowsFeaturedLinks(
@@ -81,6 +83,11 @@ describe("compare entry interactive ui lib", () => {
         ],
         catalog,
       ),
+    ).toBe(true);
+    expect(
+      compareEntryInteractiveShowsDossierCompareSection(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
     ).toBe(true);
   });
 
@@ -101,8 +108,12 @@ describe("compare entry interactive ui lib", () => {
         hasFeaturedLinks: false,
       },
       hasFeaturedLinks: false,
+      showDossierCompareSection: false,
     });
     expect(compareEntryInteractiveShowsFeaturedLinks([], [], catalog)).toBe(
+      false,
+    );
+    expect(compareEntryInteractiveShowsDossierCompareSection(primary, [])).toBe(
       false,
     );
   });
@@ -140,5 +151,6 @@ describe("compare entry interactive ui lib", () => {
       "Open 3 picks in the interactive comparison tool",
     );
     expect(state.hasFeaturedLinks).toBe(true);
+    expect(state.showDossierCompareSection).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Add `showDossierCompareSection` to `compareEntryInteractiveUiState` and a `compareEntryInteractiveShowsDossierCompareSection` delegate.
- Wire the entry dossier compare section to gate on bundled `showDossierCompareSection`.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-entry-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)