### PR TITLE
feat(web): wire best-list compare section gate through bundled showCompareSection

### DIFF
--- a/apps/web/src/lib/compare-best-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-interactive-ui-lib.ts
@@ -13,5 +13,5 @@ export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInte
 }
 
 export function compareBestInteractiveShowCompareSection(entries: Entry[]): boolean {
-  return compareBestInteractiveUiState(entries).showCompareSection;
+  return shouldShowBestCompareSection(entries);
 }

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -141,7 +141,7 @@ function BestDetail() {
         </>
       )}
 
-      {compareUi.showCompareSection && (
+      {compareUi?.showCompareSection ? (
         <section className="mt-10">
           <h2 className="h-display-2 text-ink">Compared at a glance</h2>
           <p className="mt-2 max-w-3xl text-sm text-ink-muted">
@@ -171,7 +171,7 @@ function BestDetail() {
             </Link>
           ) : null}
         </section>
-      )}
+      ) : null}
 
       <ol className="mt-10 flex flex-col gap-6 stagger-children">
         {resolved.map((p: Resolved, i: number) => (


### PR DESCRIPTION
## Summary
- Point `compareBestInteractiveShowCompareSection` at `shouldShowBestCompareSection` for lightweight section checks.
- Gate the best-list compare table on bundled `compareUi.showCompareSection`.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-best-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)