### PR TITLE
feat(web): bundle dossier compare show-section signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
@@ -1,5 +1,9 @@
 import type { Entry } from "@/types/registry";
-import { compareDossierUiState, type CompareDossierUiState } from "@/lib/compare-dossier-ui-lib";
+import {
+  compareDossierShowCompareSection,
+  compareDossierUiState,
+  type CompareDossierUiState,
+} from "@/lib/compare-dossier-ui-lib";
 
 export type CompareDossierInteractiveUiState = CompareDossierUiState;
 
@@ -7,5 +11,16 @@ export function compareDossierInteractiveUiState(
   entry: Entry,
   alternatives: Entry[],
 ): CompareDossierInteractiveUiState {
-  return compareDossierUiState(entry, alternatives);
+  const ui = compareDossierUiState(entry, alternatives);
+  return {
+    ...ui,
+    showCompareSection: compareDossierShowCompareSection(alternatives),
+  };
+}
+
+export function compareDossierInteractiveShowCompareSection(
+  _entry: Entry,
+  alternatives: Entry[],
+): boolean {
+  return compareDossierShowCompareSection(alternatives);
 }

--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -2,6 +2,7 @@ import type { Entry } from "@/types/registry";
 import type { BestListPickRef } from "@/lib/compare-best-summary";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import {
+  compareDossierInteractiveShowCompareSection,
   compareDossierInteractiveUiState,
   type CompareDossierInteractiveUiState,
 } from "@/lib/compare-dossier-interactive-ui-lib";
@@ -46,5 +47,5 @@ export function compareEntryInteractiveShowsDossierCompareSection(
   entry: Entry,
   alternatives: Entry[],
 ): boolean {
-  return compareDossierInteractiveUiState(entry, alternatives).showCompareSection;
+  return compareDossierInteractiveShowCompareSection(entry, alternatives);
 }

--- a/tests/compare-dossier-interactive-ui-lib.test.ts
+++ b/tests/compare-dossier-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDossierInteractiveUiState } from "@/lib/compare-dossier-interactive-ui-lib";
+import {
+  compareDossierInteractiveShowCompareSection,
+  compareDossierInteractiveUiState,
+} from "@/lib/compare-dossier-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -28,20 +31,23 @@ describe("compare dossier interactive ui lib", () => {
       interactiveSearch: null,
       interactiveLinkLabel: "Open 1 picks in the interactive comparison tool",
     });
+    expect(compareDossierInteractiveShowCompareSection(primary, [])).toBe(
+      false,
+    );
   });
 
   it("bundles dossier compare presentation state for headers and interactive links", () => {
     const primary = entry({ category: "skills", slug: "primary" });
-    expect(
-      compareDossierInteractiveUiState(primary, [
-        entry({ category: "hooks", slug: "alt" }),
-      ]),
-    ).toEqual({
+    const alternatives = [entry({ category: "hooks", slug: "alt" })];
+    expect(compareDossierInteractiveUiState(primary, alternatives)).toEqual({
       showCompareSection: true,
       bannerTexts: [],
       interactiveSearch: { ids: "skills/primary,hooks/alt" },
       interactiveLinkLabel: "Open in the interactive comparison tool",
     });
+    expect(
+      compareDossierInteractiveShowCompareSection(primary, alternatives),
+    ).toBe(true);
   });
 
   it("surfaces divergence banners for dossier alternatives", () => {


### PR DESCRIPTION
## Summary
- Bundle `showCompareSection` in `compareDossierInteractiveUiState` and add `compareDossierInteractiveShowCompareSection`.
- Route `compareEntryInteractiveShowsDossierCompareSection` through the dossier delegate.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-dossier-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)