### PR TITLE
feat(web): bundle entry featured compare has-links signal into interactive UI lib

### DIFF
--- a/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
@@ -1,6 +1,8 @@
 import type { BestListPickRef } from "@/lib/compare-best-summary";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import {
+  compareEntryFeaturedBestListLinks,
+  compareEntryFeaturedComparisonLinks,
   compareEntryFeaturedUiState,
   type CompareEntryFeaturedUiState,
 } from "@/lib/compare-entry-featured-ui-lib";
@@ -12,5 +14,24 @@ export function compareEntryFeaturedInteractiveUiState(
   lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
   catalog: EntryIdentity[],
 ): CompareEntryFeaturedInteractiveUiState {
-  return compareEntryFeaturedUiState(comparisons, lists, catalog);
+  const ui = compareEntryFeaturedUiState(comparisons, lists, catalog);
+  return {
+    ...ui,
+    hasFeaturedLinks: compareEntryFeaturedInteractiveShowsFeaturedLinks(
+      comparisons,
+      lists,
+      catalog,
+    ),
+  };
+}
+
+export function compareEntryFeaturedInteractiveShowsFeaturedLinks(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): boolean {
+  return (
+    compareEntryFeaturedComparisonLinks(comparisons, catalog).length > 0 ||
+    compareEntryFeaturedBestListLinks(lists, catalog).length > 0
+  );
 }

--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -7,6 +7,7 @@ import {
   type CompareDossierInteractiveUiState,
 } from "@/lib/compare-dossier-interactive-ui-lib";
 import {
+  compareEntryFeaturedInteractiveShowsFeaturedLinks,
   compareEntryFeaturedInteractiveUiState,
   type CompareEntryFeaturedInteractiveUiState,
 } from "@/lib/compare-entry-featured-interactive-ui-lib";
@@ -40,7 +41,7 @@ export function compareEntryInteractiveShowsFeaturedLinks(
   lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
   catalog: EntryIdentity[],
 ): boolean {
-  return compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog).hasFeaturedLinks;
+  return compareEntryFeaturedInteractiveShowsFeaturedLinks(comparisons, lists, catalog);
 }
 
 export function compareEntryInteractiveShowsDossierCompareSection(

--- a/tests/compare-entry-featured-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-featured-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareEntryFeaturedInteractiveUiState } from "@/lib/compare-entry-featured-interactive-ui-lib";
+import {
+  compareEntryFeaturedInteractiveShowsFeaturedLinks,
+  compareEntryFeaturedInteractiveUiState,
+} from "@/lib/compare-entry-featured-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -32,6 +35,9 @@ describe("compare entry featured interactive ui lib", () => {
       bestListLinks: [],
       hasFeaturedLinks: false,
     });
+    expect(
+      compareEntryFeaturedInteractiveShowsFeaturedLinks([], [], catalog),
+    ).toBe(false);
   });
 
   it("bundles featured comparison and best-list links for dossier surfaces", () => {
@@ -63,6 +69,18 @@ describe("compare entry featured interactive ui lib", () => {
       ],
       hasFeaturedLinks: true,
     });
+    expect(
+      compareEntryFeaturedInteractiveShowsFeaturedLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    ).toBe(true);
   });
 
   it("formats overflow labels for wide featured best lists", () => {
@@ -92,5 +110,21 @@ describe("compare entry featured interactive ui lib", () => {
       ],
       hasFeaturedLinks: true,
     });
+    expect(
+      compareEntryFeaturedInteractiveShowsFeaturedLinks(
+        [],
+        [
+          {
+            slug: "wide-list",
+            picks: [
+              { ref: "skills/alpha" },
+              { ref: "hooks/beta" },
+              { ref: "mcp/gamma" },
+            ],
+          },
+        ],
+        catalog,
+      ),
+    ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- Bundle `hasFeaturedLinks` in `compareEntryFeaturedInteractiveUiState` and add `compareEntryFeaturedInteractiveShowsFeaturedLinks`.
- Route `compareEntryInteractiveShowsFeaturedLinks` through the featured delegate.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-featured-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts`
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)