### PR TITLE
feat(web): compose entry compare bundle signals through interactive delegates

### DIFF
--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -31,8 +31,12 @@ export function compareEntryInteractiveUiState(
   return {
     dossierUi,
     featuredUi,
-    hasFeaturedLinks: featuredUi.hasFeaturedLinks,
-    showDossierCompareSection: dossierUi.showCompareSection,
+    hasFeaturedLinks: compareEntryFeaturedInteractiveShowsFeaturedLinks(
+      comparisons,
+      lists,
+      catalog,
+    ),
+    showDossierCompareSection: compareDossierInteractiveShowCompareSection(entry, alternatives),
   };
 }
 

--- a/tests/compare-entry-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-interactive-ui-lib.test.ts
@@ -89,6 +89,35 @@ describe("compare entry interactive ui lib", () => {
         entry({ category: "hooks", slug: "alt" }),
       ]),
     ).toBe(true);
+    const bundled = compareEntryInteractiveUiState(
+      primary,
+      [entry({ category: "hooks", slug: "alt" })],
+      [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+      [
+        {
+          slug: "top-picks",
+          picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+        },
+      ],
+      catalog,
+    );
+    expect(bundled.hasFeaturedLinks).toBe(
+      compareEntryInteractiveShowsFeaturedLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    );
+    expect(bundled.showDossierCompareSection).toBe(
+      compareEntryInteractiveShowsDossierCompareSection(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    );
   });
 
   it("hides dossier compare and featured links when nothing references the entry", () => {


### PR DESCRIPTION
## Summary
- Compose `hasFeaturedLinks` and `showDossierCompareSection` in `compareEntryInteractiveUiState` through the featured and dossier interactive delegates.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-entry-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)