### PR TITLE
feat(web): point browse compare show-hint delegate at selection summary signal

### DIFF
--- a/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
@@ -19,5 +19,5 @@ export function browseCompareInteractiveUiState(
 }
 
 export function browseCompareInteractiveUiShowsHint(items: Entry[]): boolean {
-  return browseCompareInteractiveUiState(items)?.showHint ?? false;
+  return shouldShowBrowseCompareHint(items);
 }


### PR DESCRIPTION
## Summary
- Point `browseCompareInteractiveUiShowsHint` at `shouldShowBrowseCompareHint` for lightweight browse compare CTA checks.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-browse-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-browse-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)