### PR TITLE
feat(web): compose curated compare renderable through page delegate and route gate

### DIFF
--- a/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
@@ -15,7 +15,7 @@ export function compareCuratedInteractiveUiState(
 ): CompareCuratedInteractiveUiState {
   return {
     ...compareCuratedUiState(refs, catalog),
-    renderable: compareCuratedHasRenderableEntries(refs, catalog),
+    renderable: compareCuratedInteractivePageRenderable(refs, catalog),
   };
 }
 

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -91,8 +91,9 @@ function ComparisonPage() {
   const { slug } = Route.useParams();
   const comparison = getComparison(slug);
   if (!comparison) return null;
-  const { entries, bannerTexts, interactiveSearch, interactiveLinkLabel } =
-    compareCuratedInteractiveUiState(comparison.refs, ENTRIES);
+  const curatedUi = compareCuratedInteractiveUiState(comparison.refs, ENTRIES);
+  if (!curatedUi.renderable) return null;
+  const { entries, bannerTexts, interactiveSearch, interactiveLinkLabel } = curatedUi;
 
   return (
     <div className="mx-auto max-w-page px-4 py-10 sm:px-6">

--- a/tests/compare-curated-interactive-ui-lib.test.ts
+++ b/tests/compare-curated-interactive-ui-lib.test.ts
@@ -46,6 +46,16 @@ describe("compare curated interactive ui lib", () => {
         catalog,
       ),
     ).toBe(true);
+    const bundled = compareCuratedInteractiveUiState(
+      ["skills/alpha", "hooks/beta"],
+      catalog,
+    );
+    expect(bundled.renderable).toBe(
+      compareCuratedInteractivePageRenderable(
+        ["skills/alpha", "hooks/beta"],
+        catalog,
+      ),
+    );
   });
 
   it("bundles curated compare page presentation state", () => {


### PR DESCRIPTION
## Summary
- Compose `renderable` in `compareCuratedInteractiveUiState` through `compareCuratedInteractivePageRenderable`.
- Gate the curated compare page component on bundled `renderable` state.

Part of #556 compare/decision surface bundling.

## Test plan
- [x] `pnpm exec vitest run tests/compare-curated-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-curated-interactive-ui-lib.ts'` (100% patch coverage)
- [x] `pnpm --filter web run type-check`
- [x] `trunk check --ci` on touched files


Made with [Cursor](https://cursor.com)