### PR TITLE
feat(web): compose browse compare showHint through delegate

### DIFF
--- a/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
@@ -14,7 +14,7 @@ export function browseCompareInteractiveUiState(
   if (!shouldShowBrowseCompareHint(items)) return null;
   return {
     ...browseCompareUiState(items)!,
-    showHint: true,
+    showHint: browseCompareInteractiveUiShowsHint(items),
   };
 }
 

--- a/tests/compare-browse-interactive-ui-lib.test.ts
+++ b/tests/compare-browse-interactive-ui-lib.test.ts
@@ -50,6 +50,8 @@ describe("compare browse interactive ui lib", () => {
       showHint: true,
     });
     expect(browseCompareInteractiveUiShowsHint(five)).toBe(true);
+    const bundled = browseCompareInteractiveUiState(five);
+    expect(bundled?.showHint).toBe(browseCompareInteractiveUiShowsHint(five));
   });
 
   it("surfaces divergence hints in browse compare CTA state", () => {


### PR DESCRIPTION
## Summary
- Compose `showHint` in `browseCompareInteractiveUiState` via `browseCompareInteractiveUiShowsHint` instead of hardcoded `true`
- Assert bundled `showHint` matches the delegate in tests (100% lib coverage)

## Test plan
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`
- [x] `vitest` with 100% coverage on `compare-browse-interactive-ui-lib.ts`

Part of #556 compare surface bundling.


Made with [Cursor](https://cursor.com)