### PR TITLE
feat(web): compose best compare showCompareSection through delegate

### DIFF
--- a/apps/web/src/lib/compare-best-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-interactive-ui-lib.ts
@@ -8,7 +8,7 @@ export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInte
   const ui = compareBestUiState(entries);
   return {
     ...ui,
-    showCompareSection: shouldShowBestCompareSection(entries),
+    showCompareSection: compareBestInteractiveShowCompareSection(entries),
   };
 }
 

--- a/tests/compare-best-interactive-ui-lib.test.ts
+++ b/tests/compare-best-interactive-ui-lib.test.ts
@@ -51,6 +51,14 @@ describe("compare best interactive ui lib", () => {
         entry({ category: "hooks", slug: "beta" }),
       ]),
     ).toBe(true);
+    const entries = [
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ];
+    const bundled = compareBestInteractiveUiState(entries);
+    expect(bundled.showCompareSection).toBe(
+      compareBestInteractiveShowCompareSection(entries),
+    );
   });
 
   it("surfaces divergence banners for multi-entry best lists", () => {


### PR DESCRIPTION
## Summary
- Compose `showCompareSection` in `compareBestInteractiveUiState` via `compareBestInteractiveShowCompareSection` instead of calling `shouldShowBestCompareSection` directly
- Assert bundled `showCompareSection` matches the delegate in tests (100% lib coverage)

## Test plan
- [x] `trunk check --ci` on changed files
- [x] `pnpm --filter web run type-check`
- [x] `vitest` with 100% coverage on `compare-best-interactive-ui-lib.ts`

Part of #556 compare surface bundling.


Made with [Cursor](https://cursor.com)