### PR TITLE
feat(web): compose dossier compare showCompareSection through delegate

### DIFF
--- a/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
@@ -14,7 +14,7 @@ export function compareDossierInteractiveUiState(
   const ui = compareDossierUiState(entry, alternatives);
   return {
     ...ui,
-    showCompareSection: compareDossierShowCompareSection(alternatives),
+    showCompareSection: compareDossierInteractiveShowCompareSection(entry, alternatives),
   };
 }
 

--- a/tests/compare-dossier-interactive-ui-lib.test.ts
+++ b/tests/compare-dossier-interactive-ui-lib.test.ts
@@ -48,6 +48,10 @@ describe("compare dossier interactive ui lib", () => {
     expect(
       compareDossierInteractiveShowCompareSection(primary, alternatives),
     ).toBe(true);
+    const bundled = compareDossierInteractiveUiState(primary, alternatives);
+    expect(bundled.showCompareSection).toBe(
+      compareDossierInteractiveShowCompareSection(primary, alternatives),
+    );
   });
 
   it("surfaces divergence banners for dossier alternatives", () => {


### PR DESCRIPTION
## Summary
- Compose `showCompareSection` in `compareDossierInteractiveUiState` via `compareDossierInteractiveShowCompareSection` instead of calling `compareDossierShowCompareSection` directly
- Assert bundled `showCompareSection` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-dossier-interactive-ui-lib.ts` and its test file — no overlap with open PR #4514 (`feat/mcp-artifact-loader-and-web-signals-content-libs`), so this should merge cleanly before or after that PR without rebase.

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-interactive-ui-lib.test.ts`
- [x] 100% coverage on `compare-dossier-interactive-ui-lib.ts`
- [x] `pnpm --filter web run type-check`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)