### PR TITLE
feat(web): compose best compare showCompareSection through page delegate

### DIFF
--- a/apps/web/src/lib/compare-best-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-ui-lib.ts
@@ -30,7 +30,7 @@ export type CompareBestUiState = {
 
 export function compareBestUiState(entries: Entry[]): CompareBestUiState {
   return {
-    showCompareSection: shouldShowBestCompareSection(entries),
+    showCompareSection: compareBestShowCompareSection(entries),
     bannerTexts: compareBestBannerTexts(entries),
     interactiveSearch: compareInteractiveSearch(entries),
     interactiveLinkLabel: compareInteractiveLinkLabel(entries.length),

--- a/tests/compare-best-ui-lib.test.ts
+++ b/tests/compare-best-ui-lib.test.ts
@@ -94,6 +94,14 @@ describe("compare best ui lib", () => {
       interactiveSearch: { ids: "skills/alpha,hooks/beta" },
       interactiveLinkLabel: "Open in the interactive comparison tool",
     });
+    const entries = [
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ];
+    const bundled = compareBestUiState(entries);
+    expect(bundled.showCompareSection).toBe(
+      compareBestShowCompareSection(entries),
+    );
     expect(
       compareBestUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `showCompareSection` in `compareBestUiState` via `compareBestShowCompareSection` instead of calling `shouldShowBestCompareSection` directly
- Assert bundled `showCompareSection` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-best-ui-lib.ts` and its test file — no overlap with open PR #4514 (`feat/mcp-artifact-loader-and-web-signals-content-libs`), so this should merge cleanly before or after that PR without rebase.

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-ui-lib.test.ts`
- [x] 100% coverage on `compare-best-ui-lib.ts`
- [x] Verified clean merge with PR #4514 via `git merge-tree`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)