### PR TITLE
feat(web): compose dossier compare showCompareSection through page delegate

### DIFF
--- a/apps/web/src/lib/compare-dossier-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-ui-lib.ts
@@ -34,7 +34,7 @@ export type CompareDossierUiState = {
 export function compareDossierUiState(entry: Entry, alternatives: Entry[]): CompareDossierUiState {
   const comparedCount = alternatives.length + 1;
   return {
-    showCompareSection: alternatives.length > 0,
+    showCompareSection: compareDossierShowCompareSection(alternatives),
     bannerTexts: compareDossierBannerTexts(entry, alternatives),
     interactiveSearch: compareDossierInteractiveSearch(entry, alternatives),
     interactiveLinkLabel: compareInteractiveLinkLabel(comparedCount),

--- a/tests/compare-dossier-ui-lib.test.ts
+++ b/tests/compare-dossier-ui-lib.test.ts
@@ -93,6 +93,11 @@ describe("compare dossier ui lib", () => {
       interactiveSearch: { ids: "skills/primary,hooks/alt" },
       interactiveLinkLabel: "Open in the interactive comparison tool",
     });
+    const alternatives = [entry({ category: "hooks", slug: "alt" })];
+    const bundled = compareDossierUiState(primary, alternatives);
+    expect(bundled.showCompareSection).toBe(
+      compareDossierShowCompareSection(alternatives),
+    );
     expect(
       compareDossierUiState(primary, [
         entry({


### PR DESCRIPTION
## Summary
- Compose `showCompareSection` in `compareDossierUiState` via `compareDossierShowCompareSection` instead of inlining `alternatives.length > 0`
- Assert bundled `showCompareSection` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-dossier-ui-lib.ts` and its test file — no overlap with open PRs #4516, #4517, or #4519
- Verified clean merge with all three via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-dossier-ui-lib.test.ts`
- [x] 100% coverage on `compare-dossier-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)