### PR TITLE
fix: resolve source evidence allowlist false-pass

### DIFF
--- a/apps/submission-gate/src/source-evidence.ts
+++ b/apps/submission-gate/src/source-evidence.ts
@@ -340,9 +340,8 @@ async function checkOneSourceUrl(
 ): Promise<SourceEvidenceItem> {
   const validation = validateFetchableSourceUrl(item.url);
   if (!validation.ok) {
-    const invalidProtocol = validation.outcome === "invalid_url";
     return withSourceDefaults(item, {
-      status: invalidProtocol ? "hard_failure" : "passed",
+      status: "hard_failure",
       outcome: validation.outcome,
       error: validation.error,
     });

--- a/tests/source-evidence.test.ts
+++ b/tests/source-evidence.test.ts
@@ -38,7 +38,6 @@ describe("submission source evidence", () => {
       "repoUrl: https://github.com/example/repo",
       "documentationUrl: https://docs.github.com/example/repo",
       "downloadUrl: https://registry.npmjs.org/example",
-      "websiteUrl: https://example.com/outside-allowlist",
       "---",
       "",
       "Body.",

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -869,7 +869,7 @@ packageUrl: "https://www.npmjs.com/package/rate-limited"
       `---
 title: Docker Hub Warning Fixture
 repoUrl: "https://github.com/example/project"
-documentationUrl: "https://example.com/docs"
+documentationUrl: "https://docs.github.com/en"
 packageUrl: "https://hub.docker.com/r/example/project"
 ---
 `,
@@ -1056,16 +1056,16 @@ websiteUrl: "https://attacker.example/redirect"
     );
 
     expect(fetchImpl).not.toHaveBeenCalled();
-    expect(report.status).toBe("passed");
+    expect(report.status).toBe("failed");
     expect(report.urls).toEqual([
       expect.objectContaining({
         field: "documentationUrl",
-        status: "passed",
+        status: "hard_failure",
         outcome: "source_host_not_checked",
       }),
       expect.objectContaining({
         field: "websiteUrl",
-        status: "passed",
+        status: "hard_failure",
         outcome: "source_host_not_checked",
       }),
     ]);


### PR DESCRIPTION
## Summary
- Root cause: `checkOneSourceUrl` marked `source_host_not_checked` as `passed`, so non-allowlisted source URLs were treated as successful evidence despite never being verified.
- Fix: treat all failed deterministic URL validation outcomes as `hard_failure`, so uncheckable source URLs now fail source evidence decisively.
- Updated tests to assert failed status for untrusted-host URLs and preserved warning behavior for retryable distribution sources with valid canonical evidence.

## Test plan
- [x] `pnpm vitest run tests/source-evidence.test.ts tests/submission-gate-worker.test.ts -t 'does not fetch source URLs outside the trusted evidence hosts|treats isolated package registry rate limits as warnings when canonical sources pass|downgrades inconclusive distribution URLs when canonical sources verify'`
- [x] `pnpm build`

## Risks / tradeoffs
- Entries using only non-allowlisted source hosts will now be blocked until maintainers provide authoritative sources on trusted hosts.
- This is intentional to prevent unverified source URLs from passing deterministic gate checks.
