### PR TITLE
feat(web): compose compare page action-row divergence through delegate

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -41,7 +41,7 @@ export type ComparePageUiState = {
 
 export function comparePageUiState(items: Entry[]): ComparePageUiState {
   return {
-    actionRowDiverges: compareActionsDiverge(items),
+    actionRowDiverges: comparePageActionsDiverge(items),
     bannerTexts: comparePageBannerTexts(items),
     singleItemHint: compareSingleItemHintText(items.length),
     shareUrl: comparePageShareUrlForWindow(items),

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -82,17 +82,18 @@ describe("compare page ui lib", () => {
   });
 
   it("bundles interactive compare page presentation state", () => {
-    expect(
-      comparePageUiState([
-        entry({ category: "skills", slug: "alpha" }),
-        entry({ category: "hooks", slug: "beta" }),
-      ]),
-    ).toEqual({
+    const entries = [
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ];
+    expect(comparePageUiState(entries)).toEqual({
       actionRowDiverges: false,
       bannerTexts: [],
       singleItemHint: null,
       shareUrl: "/compare?ids=skills%2Falpha%2Chooks%2Fbeta",
     });
+    const bundled = comparePageUiState(entries);
+    expect(bundled.actionRowDiverges).toBe(comparePageActionsDiverge(entries));
     expect(
       comparePageUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `actionRowDiverges` in `comparePageUiState` via `comparePageActionsDiverge` (delegate) instead of calling `compareActionsDiverge` directly
- Assert bundled `actionRowDiverges` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `apps/web/src/lib/compare-page-ui-lib.ts` and `tests/compare-page-ui-lib.test.ts`
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] 100% coverage on `compare-page-ui-lib.ts`


Made with [Cursor](https://cursor.com)