### PR TITLE
feat(web): compose entry featured has-links through page delegate

### DIFF
--- a/apps/web/src/lib/compare-entry-featured-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-ui-lib.ts
@@ -47,6 +47,17 @@ export function compareEntryFeaturedBestListLinks(
   }));
 }
 
+export function compareEntryFeaturedShowsFeaturedLinks(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): boolean {
+  return (
+    compareEntryFeaturedComparisonLinks(comparisons, catalog).length > 0 ||
+    compareEntryFeaturedBestListLinks(lists, catalog).length > 0
+  );
+}
+
 export type CompareEntryFeaturedUiState = {
   comparisonLinks: CompareEntryFeaturedComparisonLink[];
   bestListLinks: CompareEntryFeaturedBestListLink[];
@@ -63,6 +74,6 @@ export function compareEntryFeaturedUiState(
   return {
     comparisonLinks,
     bestListLinks,
-    hasFeaturedLinks: comparisonLinks.length > 0 || bestListLinks.length > 0,
+    hasFeaturedLinks: compareEntryFeaturedShowsFeaturedLinks(comparisons, lists, catalog),
   };
 }

--- a/tests/compare-entry-featured-ui-lib.test.ts
+++ b/tests/compare-entry-featured-ui-lib.test.ts
@@ -3,6 +3,7 @@ import type { Entry } from "@/types/registry";
 import {
   compareEntryFeaturedBestListLinks,
   compareEntryFeaturedComparisonLinks,
+  compareEntryFeaturedShowsFeaturedLinks,
   compareEntryFeaturedUiState,
 } from "@/lib/compare-entry-featured-ui-lib";
 
@@ -118,18 +119,16 @@ describe("compare entry featured ui lib", () => {
   });
 
   it("bundles entry dossier featured comparison and best-list links", () => {
-    expect(
-      compareEntryFeaturedUiState(
-        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
-        [
-          {
-            slug: "top-picks",
-            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
-          },
-        ],
-        catalog,
-      ),
-    ).toEqual({
+    const comparisons = [
+      { slug: "pair", refs: ["skills/alpha", "hooks/beta"] },
+    ];
+    const lists = [
+      {
+        slug: "top-picks",
+        picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+      },
+    ];
+    expect(compareEntryFeaturedUiState(comparisons, lists, catalog)).toEqual({
       comparisonLinks: [
         {
           slug: "pair",
@@ -146,6 +145,10 @@ describe("compare entry featured ui lib", () => {
       ],
       hasFeaturedLinks: true,
     });
+    const bundled = compareEntryFeaturedUiState(comparisons, lists, catalog);
+    expect(bundled.hasFeaturedLinks).toBe(
+      compareEntryFeaturedShowsFeaturedLinks(comparisons, lists, catalog),
+    );
     expect(compareEntryFeaturedUiState([], [], catalog)).toEqual({
       comparisonLinks: [],
       bestListLinks: [],


### PR DESCRIPTION
## Summary
- Compose `hasFeaturedLinks` in `compareEntryFeaturedUiState` via `compareEntryFeaturedShowsFeaturedLinks` instead of inlining link-length checks
- Assert bundled `hasFeaturedLinks` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-entry-featured-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, #4519, and #4522 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-entry-featured-ui-lib.test.ts`
- [x] 100% coverage on `compare-entry-featured-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)