### PR TITLE
feat(web): compose compare decision divergence count through delegate

### DIFF
--- a/apps/web/src/lib/compare-table-decision-rows.ts
+++ b/apps/web/src/lib/compare-table-decision-rows.ts
@@ -28,8 +28,12 @@ export function divergingDecisionRowLabels(entries: Entry[]): string[] {
     .map((row) => row.label);
 }
 
+export function compareDecisionDivergingCount(entries: Entry[]): number {
+  return divergingDecisionRowLabels(entries).length;
+}
+
 export function hasCompareDecisionDivergence(entries: Entry[]): boolean {
-  return divergingDecisionRowLabels(entries).length > 0;
+  return compareDecisionDivergingCount(entries) > 0;
 }
 
 export function compareDecisionSummary(entries: Entry[]): {
@@ -40,7 +44,7 @@ export function compareDecisionSummary(entries: Entry[]): {
   const divergingLabels = divergingDecisionRowLabels(entries);
   return {
     comparedCount: entries.length,
-    divergingCount: divergingLabels.length,
+    divergingCount: compareDecisionDivergingCount(entries),
     divergingLabels,
   };
 }

--- a/tests/compare-table-decision-rows.test.ts
+++ b/tests/compare-table-decision-rows.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareDecisionDivergingCount,
   compareDecisionSummary,
   comparisonDecisionRows,
   displayCompareSignal,
@@ -61,11 +62,17 @@ describe("compare table decision rows", () => {
       "Package trust",
     ]);
     expect(hasCompareDecisionDivergence([reviewed, baseline])).toBe(true);
-    expect(compareDecisionSummary([reviewed, baseline])).toEqual({
+    const entries = [reviewed, baseline];
+    const summary = compareDecisionSummary(entries);
+    expect(summary).toEqual({
       comparedCount: 2,
       divergingCount: 1,
       divergingLabels: ["Review status"],
     });
+    expect(summary.divergingCount).toBe(compareDecisionDivergingCount(entries));
+    expect(hasCompareDecisionDivergence(entries)).toBe(
+      compareDecisionDivergingCount(entries) > 0,
+    );
   });
 
   it("detects submitter present-versus-missing divergence", () => {


### PR DESCRIPTION
## Summary
- Add `compareDecisionDivergingCount` delegate and compose `hasCompareDecisionDivergence` and `compareDecisionSummary.divergingCount` through it
- Assert bundled `divergingCount` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-table-decision-rows.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-table-decision-rows.test.ts`
- [x] 100% coverage on `compare-table-decision-rows.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)