### PR TITLE
feat(web): compose compare page shareUrl through delegate

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -44,6 +44,6 @@ export function comparePageUiState(items: Entry[]): ComparePageUiState {
     actionRowDiverges: comparePageActionsDiverge(items),
     bannerTexts: comparePageBannerTexts(items),
     singleItemHint: compareSingleItemHintText(items.length),
-    shareUrl: comparePageShareUrlForWindow(items),
+    shareUrl: comparePageShareUrl(items),
   };
 }

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -94,6 +94,7 @@ describe("compare page ui lib", () => {
     });
     const bundled = comparePageUiState(entries);
     expect(bundled.actionRowDiverges).toBe(comparePageActionsDiverge(entries));
+    expect(bundled.shareUrl).toBe(comparePageShareUrl(entries));
     expect(
       comparePageUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `shareUrl` in `comparePageUiState` via `comparePageShareUrl` instead of calling `comparePageShareUrlForWindow` directly
- Assert bundled `shareUrl` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-page-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] 100% coverage on `compare-page-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)