### PR TITLE
feat(web): compose compare page bannerTexts through delegate

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -42,7 +42,7 @@ export type ComparePageUiState = {
 export function comparePageUiState(items: Entry[]): ComparePageUiState {
   return {
     actionRowDiverges: comparePageActionsDiverge(items),
-    bannerTexts: comparePageBannerTexts(items),
+    bannerTexts: comparePageHeaderBannerTexts(items),
     singleItemHint: compareSingleItemHintText(items.length),
     shareUrl: comparePageShareUrl(items),
   };

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -95,6 +95,7 @@ describe("compare page ui lib", () => {
     const bundled = comparePageUiState(entries);
     expect(bundled.actionRowDiverges).toBe(comparePageActionsDiverge(entries));
     expect(bundled.shareUrl).toBe(comparePageShareUrl(entries));
+    expect(bundled.bannerTexts).toEqual(comparePageHeaderBannerTexts(entries));
     expect(
       comparePageUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `bannerTexts` in `comparePageUiState` via `comparePageHeaderBannerTexts` instead of calling `comparePageBannerTexts` directly
- Assert bundled `bannerTexts` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-page-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] 100% coverage on `compare-page-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)