### PR TITLE
feat(web): compose compare page singleItemHint through delegate

### DIFF
--- a/apps/web/src/lib/compare-page-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-lib.ts
@@ -43,7 +43,7 @@ export function comparePageUiState(items: Entry[]): ComparePageUiState {
   return {
     actionRowDiverges: comparePageActionsDiverge(items),
     bannerTexts: comparePageHeaderBannerTexts(items),
-    singleItemHint: compareSingleItemHintText(items.length),
+    singleItemHint: comparePageSelectionHint(items.length),
     shareUrl: comparePageShareUrl(items),
   };
 }

--- a/tests/compare-page-ui-lib.test.ts
+++ b/tests/compare-page-ui-lib.test.ts
@@ -96,6 +96,9 @@ describe("compare page ui lib", () => {
     expect(bundled.actionRowDiverges).toBe(comparePageActionsDiverge(entries));
     expect(bundled.shareUrl).toBe(comparePageShareUrl(entries));
     expect(bundled.bannerTexts).toEqual(comparePageHeaderBannerTexts(entries));
+    expect(bundled.singleItemHint).toBe(
+      comparePageSelectionHint(entries.length),
+    );
     expect(
       comparePageUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `singleItemHint` in `comparePageUiState` via `comparePageSelectionHint` instead of calling `compareSingleItemHintText` directly
- Assert bundled `singleItemHint` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-page-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-page-ui-lib.test.ts`
- [x] 100% coverage on `compare-page-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)