### PR TITLE
feat(web): compose drawer fullViewSearch through delegate

### DIFF
--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -15,7 +15,7 @@ export function compareDrawerUiState(items: Entry[]): CompareDrawerUiState {
   return {
     actionRowDiverges: compareDrawerActionsDiverge(items),
     bannerTexts: compareDrawerBannerTexts(items),
-    fullViewSearch: compareFullViewSearch(items),
+    fullViewSearch: compareDrawerFullViewSearch(items),
   };
 }
 

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -87,17 +87,16 @@ describe("compare drawer ui lib", () => {
   });
 
   it("bundles drawer presentation state for banners, actions, and full-view links", () => {
+    const entries = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
     expect(compareDrawerUiState([])).toEqual({
       actionRowDiverges: false,
       bannerTexts: [],
       fullViewSearch: null,
     });
-    expect(
-      compareDrawerUiState([
-        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
-        entry({ slug: "other", installCommand: "npm i fixture" }),
-      ]),
-    ).toEqual({
+    expect(compareDrawerUiState(entries)).toEqual({
       actionRowDiverges: true,
       bannerTexts: [
         "1 trust signal differ across this comparison (Review status).",
@@ -105,5 +104,9 @@ describe("compare drawer ui lib", () => {
       ],
       fullViewSearch: { ids: "mcp/fixture,mcp/other" },
     });
+    const bundled = compareDrawerUiState(entries);
+    expect(bundled.fullViewSearch).toEqual(
+      compareDrawerFullViewSearch(entries),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Compose `fullViewSearch` in `compareDrawerUiState` via `compareDrawerFullViewSearch` instead of calling `compareFullViewSearch` directly
- Assert bundled `fullViewSearch` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-drawer-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, and #4519 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts`
- [x] 100% coverage on `compare-drawer-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)