### PR TITLE
fix(ci): gate web API security tests in required validate-web lane

### DIFF
--- a/.github/workflows/content-validation.yml
+++ b/.github/workflows/content-validation.yml
@@ -770,6 +770,10 @@ jobs:
         if: ${{ needs.classify-pr.outputs.web == 'true' }}
         run: pnpm build
 
+      - name: Run web API security tests
+        if: ${{ needs.classify-pr.outputs.web == 'true' }}
+        run: pnpm exec vitest run tests/api-security-lib.test.ts tests/api-security-request-helpers.test.ts tests/api-security-allowed-origin.test.ts tests/api-router-security.test.ts
+
   validate-mcp:
     name: validate-mcp
     needs: [classify-pr, prebuild]


### PR DESCRIPTION
## Summary
- Root cause: the full Vitest suite was deduplicated into the separate `coverage` workflow (not part of `required-pr-gate`), so web API security regressions could pass required PR validation when `coverage` was skipped or delayed.
- Fix: run the focused web API security Vitest subset (`api-security-lib`, `api-security-request-helpers`, `api-security-allowed-origin`, `api-router-security`) inside the required `validate-web` lane.
- Impact: security-sensitive API router and helper regressions now block merges through `required-pr-gate` without re-running the entire test suite.

## Test plan
- [x] `pnpm exec vitest run tests/api-security-lib.test.ts tests/api-security-request-helpers.test.ts tests/api-security-allowed-origin.test.ts tests/api-router-security.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`

## Risks / tradeoffs
- Adds ~3s of targeted Vitest runtime to web-classified PRs in `validate-web`.
- The full suite still runs once in `coverage`; this only restores a required security gate, not full duplication.
