### PR TITLE
feat(web): compose drawer bannerTexts through delegate

### DIFF
--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -14,7 +14,7 @@ export type CompareDrawerUiState = {
 export function compareDrawerUiState(items: Entry[]): CompareDrawerUiState {
   return {
     actionRowDiverges: compareDrawerActionsDiverge(items),
-    bannerTexts: compareDrawerBannerTexts(items),
+    bannerTexts: compareDrawerHeaderBannerTexts(items),
     fullViewSearch: compareDrawerFullViewSearch(items),
   };
 }

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -108,5 +108,8 @@ describe("compare drawer ui lib", () => {
     expect(bundled.fullViewSearch).toEqual(
       compareDrawerFullViewSearch(entries),
     );
+    expect(bundled.bannerTexts).toEqual(
+      compareDrawerHeaderBannerTexts(entries),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Compose `bannerTexts` in `compareDrawerUiState` via `compareDrawerHeaderBannerTexts` instead of calling `compareDrawerBannerTexts` directly
- Assert bundled `bannerTexts` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-drawer-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, #4519, and #4533 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts`
- [x] 100% coverage on `compare-drawer-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)