### PR TITLE
fix(submission-gate): require status token for draft reads

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -710,10 +710,7 @@ async function getDraftRoute(request: Request, env: Env, id: string) {
   if (rateLimitResponse) return rateLimitResponse;
 
   const token = new URL(request.url).searchParams.get("token") || "";
-  if (
-    !token ||
-    !(await verifyDraftState(env.SUBMISSION_GATE_DB, id, token))
-  ) {
+  if (!token || !(await verifyDraftState(env.SUBMISSION_GATE_DB, id, token))) {
     return json({ ok: false, error: "not_found" }, { status: 404 });
   }
 

--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -510,9 +510,11 @@ function callbackUrl(request: Request) {
   return `${url.origin}/auth/github/callback`;
 }
 
-function draftStatusUrl(request: Request, id: string) {
+function draftStatusUrl(request: Request, id: string, token: string) {
   const url = new URL(request.url);
-  return `${url.origin}/drafts/${id}`;
+  const status = new URL(`/drafts/${id}`, url.origin);
+  status.searchParams.set("token", token);
+  return status.toString();
 }
 
 function requestBodyTooLarge(limitBytes: number) {
@@ -689,7 +691,7 @@ async function createDraftRoute(request: Request, env: Env) {
     ok: true,
     configured,
     draftId: id,
-    statusUrl: draftStatusUrl(request, id),
+    statusUrl: draftStatusUrl(request, id, state),
     authUrl: authUrl || undefined,
     target,
     manualPr: configured
@@ -703,7 +705,18 @@ async function createDraftRoute(request: Request, env: Env) {
   });
 }
 
-async function getDraftRoute(env: Env, id: string) {
+async function getDraftRoute(request: Request, env: Env, id: string) {
+  const rateLimitResponse = await enforceDraftRateLimit(request, env);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  const token = new URL(request.url).searchParams.get("token") || "";
+  if (
+    !token ||
+    !(await verifyDraftState(env.SUBMISSION_GATE_DB, id, token))
+  ) {
+    return json({ ok: false, error: "not_found" }, { status: 404 });
+  }
+
   const draft = await getDraft(env.SUBMISSION_GATE_DB, id);
   if (!draft) return json({ ok: false, error: "not_found" }, { status: 404 });
   const fields = redactPublicDraftFields(
@@ -770,7 +783,7 @@ async function githubCallbackRoute(request: Request, env: Env) {
   });
 
   return textResponse(
-    `<meta http-equiv="refresh" content="0; url=${draftStatusUrl(request, draftId)}">Submission queued.`,
+    `<meta http-equiv="refresh" content="0; url=${draftStatusUrl(request, draftId, stateToken)}">Submission queued.`,
   );
 }
 
@@ -4510,7 +4523,7 @@ async function route(request: Request, env: Env, ctx: ExecutionContext) {
     if (!/^draft_[0-9a-f-]{36}$/i.test(id)) {
       return json({ ok: false, error: "invalid_id" }, { status: 400 });
     }
-    return getDraftRoute(env, id);
+    return getDraftRoute(request, env, id);
   }
   if (request.method === "GET" && url.pathname === "/auth/github/start") {
     const draftId = url.searchParams.get("draftId") || "";

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2576,6 +2576,28 @@ ${urls}
     expect(source).toContain("const MAX_DRAFT_BODY_BYTES = 64 * 1024");
   });
 
+  it("requires a draft status token before returning draft metadata", () => {
+    const source = readWorkerSource();
+    const routeSource =
+      source.match(
+        /async function getDraftRoute[\s\S]*?\nasync function githubCallbackRoute/,
+      )?.[0] || "";
+    const rateLimitIndex = routeSource.indexOf(
+      "enforceDraftRateLimit(request, env)",
+    );
+    const tokenIndex = routeSource.indexOf('searchParams.get("token")');
+    const verifyIndex = routeSource.indexOf(
+      "verifyDraftState(env.SUBMISSION_GATE_DB, id, token)",
+    );
+    const notFoundIndex = routeSource.indexOf('error: "not_found"');
+
+    expect(rateLimitIndex).toBeGreaterThan(0);
+    expect(tokenIndex).toBeGreaterThan(rateLimitIndex);
+    expect(verifyIndex).toBeGreaterThan(tokenIndex);
+    expect(notFoundIndex).toBeGreaterThan(verifyIndex);
+    expect(source).toContain('status.searchParams.set("token", token)');
+  });
+
   it("configures a durable Cloudflare rate limit for draft creation", () => {
     const wranglerConfig = fs.readFileSync(
       path.join(repoRoot, "apps/submission-gate/wrangler.jsonc"),


### PR DESCRIPTION
## Summary
- Root cause: `GET /drafts/{id}` returned submission draft metadata with only the UUID, while `POST /drafts` was origin-gated and rate-limited. Anyone who learned a draft ID could poll category, slug, branch, and field metadata without authorization.
- Fix: issue the per-draft auth state as a `token` query parameter in `statusUrl`, require `verifyDraftState()` on draft reads, and apply the existing draft rate limiter to GET requests.
- Impact: draft status reads are now capability-based; unauthenticated UUID enumeration no longer exposes submission metadata.

## Test plan
- [x] `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "requires a draft status token|guards public draft creation"`
- [x] `pnpm build`

## Risks / tradeoffs
- `statusUrl` now includes a secret token; clients must treat it like a capability URL (do not log or share broadly).
- Invalid or missing tokens return `404` to avoid leaking draft existence.
