### PR TITLE
feat(web): compose drawer actionRowDiverges through delegate

### DIFF
--- a/apps/web/src/lib/compare-drawer-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-lib.ts
@@ -13,10 +13,14 @@ export type CompareDrawerUiState = {
 
 export function compareDrawerUiState(items: Entry[]): CompareDrawerUiState {
   return {
-    actionRowDiverges: compareDrawerActionsDiverge(items),
+    actionRowDiverges: compareDrawerUiActionsDiverge(items),
     bannerTexts: compareDrawerHeaderBannerTexts(items),
     fullViewSearch: compareDrawerFullViewSearch(items),
   };
+}
+
+export function compareDrawerUiActionsDiverge(items: Entry[]): boolean {
+  return compareDrawerActionsDiverge(items);
 }
 
 export function compareDrawerShareUrl(items: Entry[]): string {

--- a/tests/compare-drawer-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-lib.test.ts
@@ -5,6 +5,7 @@ import {
   compareDrawerFullViewSearch,
   compareDrawerHeaderBannerTexts,
   compareDrawerShareUrl,
+  compareDrawerUiActionsDiverge,
   compareDrawerUiState,
 } from "@/lib/compare-drawer-ui-lib";
 
@@ -105,6 +106,9 @@ describe("compare drawer ui lib", () => {
       fullViewSearch: { ids: "mcp/fixture,mcp/other" },
     });
     const bundled = compareDrawerUiState(entries);
+    expect(bundled.actionRowDiverges).toBe(
+      compareDrawerUiActionsDiverge(entries),
+    );
     expect(bundled.fullViewSearch).toEqual(
       compareDrawerFullViewSearch(entries),
     );


### PR DESCRIPTION
## Summary
- Add `compareDrawerUiActionsDiverge` delegate and compose `actionRowDiverges` in `compareDrawerUiState` through it
- Assert bundled `actionRowDiverges` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-drawer-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4516, #4517, #4519, and #4533 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-drawer-ui-lib.test.ts`
- [x] 100% coverage on `compare-drawer-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)