### PR TITLE
fix(submission-gate): require status token for GitHub OAuth start

### DIFF
--- a/apps/submission-gate/src/index.ts
+++ b/apps/submission-gate/src/index.ts
@@ -4523,12 +4523,19 @@ async function route(request: Request, env: Env, ctx: ExecutionContext) {
     return getDraftRoute(request, env, id);
   }
   if (request.method === "GET" && url.pathname === "/auth/github/start") {
+    const rateLimitResponse = await enforceDraftRateLimit(request, env);
+    if (rateLimitResponse) return rateLimitResponse;
+
     const draftId = url.searchParams.get("draftId") || "";
+    const token = url.searchParams.get("token") || "";
+    if (
+      !draftId ||
+      !token ||
+      !(await verifyDraftState(env.SUBMISSION_GATE_DB, draftId, token))
+    ) {
+      return json({ ok: false, error: "not_found" }, { status: 404 });
+    }
     const state = randomToken();
-    const draft = draftId
-      ? await getDraft(env.SUBMISSION_GATE_DB, draftId)
-      : null;
-    if (!draft) return json({ ok: false, error: "not_found" }, { status: 404 });
     await updateDraftAuthState(env.SUBMISSION_GATE_DB, draftId, state);
     return json({
       ok: true,

--- a/tests/submission-gate-worker.test.ts
+++ b/tests/submission-gate-worker.test.ts
@@ -2598,6 +2598,29 @@ ${urls}
     expect(source).toContain('status.searchParams.set("token", token)');
   });
 
+  it("requires a draft status token before starting GitHub OAuth", () => {
+    const source = readWorkerSource();
+    const routeSource =
+      source.match(
+        /if \(request\.method === "GET" && url\.pathname === "\/auth\/github\/start"\)[\s\S]*?\n  if \(request\.method === "GET" && url\.pathname === "\/auth\/github\/callback"\)/,
+      )?.[0] || "";
+    const rateLimitIndex = routeSource.indexOf(
+      "enforceDraftRateLimit(request, env)",
+    );
+    const tokenIndex = routeSource.indexOf('searchParams.get("token")');
+    const verifyIndex = routeSource.indexOf(
+      "verifyDraftState(env.SUBMISSION_GATE_DB, draftId, token)",
+    );
+    const updateIndex = routeSource.indexOf("updateDraftAuthState");
+    const notFoundIndex = routeSource.indexOf('error: "not_found"');
+
+    expect(rateLimitIndex).toBeGreaterThan(0);
+    expect(tokenIndex).toBeGreaterThan(rateLimitIndex);
+    expect(verifyIndex).toBeGreaterThan(tokenIndex);
+    expect(updateIndex).toBeGreaterThan(verifyIndex);
+    expect(notFoundIndex).toBeGreaterThan(0);
+  });
+
   it("configures a durable Cloudflare rate limit for draft creation", () => {
     const wranglerConfig = fs.readFileSync(
       path.join(repoRoot, "apps/submission-gate/wrangler.jsonc"),


### PR DESCRIPTION
## Summary
- Root cause: `GET /auth/github/start?draftId=…` accepted only the draft UUID, rotated OAuth state, and returned a fresh GitHub authorize URL without verifying the draft status token. An attacker who learned a draft ID could invalidate the victim's OAuth flow or complete GitHub auth against their draft.
- Fix: require the same `token` query parameter used by `GET /drafts/{id}` and `verifyDraftState()` before calling `updateDraftAuthState`, plus apply the existing draft rate limiter.
- Impact: OAuth start is now capability-based, closing the remaining IDOR gap from the draft read hardening in #4535.

## Test plan
- [x] `pnpm exec vitest run tests/submission-gate-worker.test.ts -t "requires a draft status token|starting GitHub OAuth"`
- [x] `pnpm build`

## Risks / tradeoffs
- Clients calling `/auth/github/start` must now pass `?token=` alongside `draftId` (same secret returned in `statusUrl` from `POST /drafts`).
