### PR TITLE
fix(web): reject unsafe paths in data artifact loaders

### DIFF
--- a/apps/web/src/lib/content-artifact-lib.ts
+++ b/apps/web/src/lib/content-artifact-lib.ts
@@ -31,6 +31,15 @@ export function isSafeContentPathPart(value: string) {
   return /^[a-z0-9-]+$/.test(value);
 }
 
+export function safeDataArtifactPath(fileName: string) {
+  const normalized = String(fileName || "").replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  if (!parts.length || parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`Unsafe data artifact path: ${fileName}`);
+  }
+  return parts.join("/");
+}
+
 export function normalizeRegistryEntries<T>(payload: RegistryEnvelope<T>): T[] {
   if (!Array.isArray(payload?.entries)) {
     throw new Error("Invalid registry artifact: expected entries envelope");

--- a/apps/web/src/lib/content.server.ts
+++ b/apps/web/src/lib/content.server.ts
@@ -18,6 +18,7 @@ import {
   localDataFilePaths,
   normalizeEntryDetailPayload,
   normalizeRegistryEntries,
+  safeDataArtifactPath,
 } from "@/lib/content-artifact-lib";
 import {
   buildCategorySummaries,
@@ -75,37 +76,39 @@ async function readLocalJsonDataFile<T>(fileName: string): Promise<T> {
 }
 
 export async function loadJsonDataFile<T>(fileName: string): Promise<T> {
+  const safePath = safeDataArtifactPath(fileName);
   try {
-    return await readLocalJsonDataFile<T>(fileName);
+    return await readLocalJsonDataFile<T>(safePath);
   } catch {
     // In the Cloudflare Worker runtime, read from the static ASSETS binding.
     const assets = getCloudflareBinding<{
       fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     }>("ASSETS");
     if (!assets) {
-      throw new Error(`Static ASSETS binding is not available for ${fileName}`);
+      throw new Error(`Static ASSETS binding is not available for ${safePath}`);
     }
-    const response = await assets.fetch(new Request(`${DATA_ORIGIN}/data/${fileName}`));
+    const response = await assets.fetch(new Request(`${DATA_ORIGIN}/data/${safePath}`));
     if (!response.ok) {
-      throw new Error(`Failed to load ${fileName} asset (${response.status})`);
+      throw new Error(`Failed to load ${safePath} asset (${response.status})`);
     }
     return (await response.json()) as T;
   }
 }
 
 export async function loadTextDataFile(fileName: string): Promise<string> {
+  const safePath = safeDataArtifactPath(fileName);
   try {
-    return await readLocalDataFile(fileName);
+    return await readLocalDataFile(safePath);
   } catch {
     const assets = getCloudflareBinding<{
       fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
     }>("ASSETS");
     if (!assets) {
-      throw new Error(`Static ASSETS binding is not available for ${fileName}`);
+      throw new Error(`Static ASSETS binding is not available for ${safePath}`);
     }
-    const response = await assets.fetch(new Request(`${DATA_ORIGIN}/data/${fileName}`));
+    const response = await assets.fetch(new Request(`${DATA_ORIGIN}/data/${safePath}`));
     if (!response.ok) {
-      throw new Error(`Failed to load ${fileName} asset (${response.status})`);
+      throw new Error(`Failed to load ${safePath} asset (${response.status})`);
     }
     return response.text();
   }

--- a/tests/content-artifact-lib.test.ts
+++ b/tests/content-artifact-lib.test.ts
@@ -7,6 +7,7 @@ import {
   localDataFilePaths,
   normalizeEntryDetailPayload,
   normalizeRegistryEntries,
+  safeDataArtifactPath,
 } from "../apps/web/src/lib/content-artifact-lib";
 
 describe("content-artifact-lib DATA_ORIGIN", () => {
@@ -3306,6 +3307,25 @@ describe("content-artifact-lib isSafeContentPathPart", () => {
     expect(isSafeContentPathPart("statuslines")).toBe(true);
     expect(isSafeContentPathPart("statuslines-slug-7")).toBe(true);
     expect(isSafeContentPathPart("STATUSLINES")).toBe(false);
+  });
+});
+
+describe("content-artifact-lib safeDataArtifactPath", () => {
+  it("accepts canonical registry artifact paths", () => {
+    expect(safeDataArtifactPath("search-index.json")).toBe("search-index.json");
+    expect(safeDataArtifactPath("entries/mcp/browser-bridge.json")).toBe(
+      "entries/mcp/browser-bridge.json",
+    );
+  });
+
+  it("rejects traversal and empty path segments", () => {
+    expect(() => safeDataArtifactPath("../registry-manifest.json")).toThrow(
+      /Unsafe data artifact path/,
+    );
+    expect(() => safeDataArtifactPath("entries/../secret.json")).toThrow(
+      /Unsafe data artifact path/,
+    );
+    expect(() => safeDataArtifactPath("")).toThrow(/Unsafe data artifact path/);
   });
 });
 


### PR DESCRIPTION
## Summary
- Root cause: `loadJsonDataFile` and `loadTextDataFile` accepted arbitrary `fileName` strings and joined them into local filesystem paths and Worker `ASSETS` URLs without rejecting `..` or empty segments. The MCP web bridge forwards artifact paths through these loaders, creating a latent path-traversal read primitive.
- Fix: add `safeDataArtifactPath()` (matching the MCP registry `safeRelativePath` contract) and validate every loader input before local reads and asset fetches.
- Impact: traversal segments in artifact paths now fail closed instead of reaching filesystem or static asset resolution.

## Test plan
- [x] `pnpm exec vitest run tests/content-artifact-lib.test.ts -t safeDataArtifactPath`
- [x] `pnpm build`

## Risks / tradeoffs
- Any caller passing malformed relative paths will now throw instead of attempting resolution. Current production callers use hardcoded or slug-validated paths only.
