### PR TITLE
fix(web): validate GitHub repo keys before source signal fetch

### DIFF
--- a/apps/web/src/lib/source-repo-signals-fetch-lib.ts
+++ b/apps/web/src/lib/source-repo-signals-fetch-lib.ts
@@ -1,15 +1,31 @@
 import { parseAbbreviatedCount } from "@heyclaude/registry/presentation";
 
-import { GITHUB_API_VERSION, REQUEST_TIMEOUT_MS } from "@/lib/source-repo-signals-lib";
+import {
+  GITHUB_API_VERSION,
+  REQUEST_TIMEOUT_MS,
+  parseGitHubRepoUrl,
+} from "@/lib/source-repo-signals-lib";
 
 type Fetcher = typeof fetch;
 
+export function parseGitHubRepoKey(repoKey: string) {
+  const normalized = String(repoKey || "").trim();
+  if (!normalized) return null;
+  const segments = normalized.split("/");
+  if (segments.length !== 2 || segments.some((segment) => !segment)) {
+    return null;
+  }
+  const parsed = parseGitHubRepoUrl(`https://github.com/${normalized}`);
+  if (!parsed) return null;
+  return { owner: parsed.owner, repo: parsed.repo };
+}
+
 export function buildGitHubRepoApiUrl(owner: string, repo: string) {
-  return `https://api.github.com/repos/${owner}/${repo}`;
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
 }
 
 export function buildShieldsStarsUrl(owner: string, repo: string) {
-  return `https://img.shields.io/github/stars/${owner}/${repo}.json`;
+  return `https://img.shields.io/github/stars/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}.json`;
 }
 
 export function parseGitHubRepoApiPayload(data: Record<string, unknown>) {
@@ -42,8 +58,9 @@ async function fetchShieldsStars(repo: { owner: string; repo: string }, fetcher:
 }
 
 export async function fetchGitHubSourceSignal(repoKey: string, fetcher: Fetcher = fetch) {
-  const [owner, repo] = repoKey.split("/");
-  if (!owner || !repo) throw new Error(`invalid_repo:${repoKey}`);
+  const parsed = parseGitHubRepoKey(repoKey);
+  if (!parsed) throw new Error(`invalid_repo:${repoKey}`);
+  const { owner, repo } = parsed;
 
   const headers: HeadersInit = {
     accept: "application/vnd.github+json",

--- a/tests/source-repo-signals-fetch-lib.test.ts
+++ b/tests/source-repo-signals-fetch-lib.test.ts
@@ -1969,9 +1969,9 @@ describe("source-repo-signals-fetch-lib parseGitHubRepoKey", () => {
     expect(parseGitHubRepoKey("only-owner")).toBeNull();
     expect(parseGitHubRepoKey("owner/repo/extra")).toBeNull();
     expect(parseGitHubRepoKey("owner/repo@evil.com")).toBeNull();
-    await expect(fetchGitHubSourceSignal("bad/key/extra", fetch)).rejects.toThrow(
-      "invalid_repo:bad/key/extra",
-    );
+    await expect(
+      fetchGitHubSourceSignal("bad/key/extra", fetch),
+    ).rejects.toThrow("invalid_repo:bad/key/extra");
   });
 });
 

--- a/tests/source-repo-signals-fetch-lib.test.ts
+++ b/tests/source-repo-signals-fetch-lib.test.ts
@@ -5,6 +5,7 @@ import {
   buildShieldsStarsUrl,
   fetchGitHubSourceSignal,
   parseGitHubRepoApiPayload,
+  parseGitHubRepoKey,
   parseShieldsStarsPayload,
 } from "../apps/web/src/lib/source-repo-signals-fetch-lib";
 
@@ -1952,6 +1953,25 @@ describe("source-repo-signals-fetch-lib parseShieldsStarsPayload", () => {
   it("parseShieldsStarsPayload matrix 59", () => {
     const parsed = parseShieldsStarsPayload({ value: "590" });
     expect(parsed?.stars).toBe(590);
+  });
+});
+
+describe("source-repo-signals-fetch-lib parseGitHubRepoKey", () => {
+  it("accepts canonical owner/repo keys", () => {
+    expect(parseGitHubRepoKey("openai/whisper")).toEqual({
+      owner: "openai",
+      repo: "whisper",
+    });
+  });
+
+  it("rejects malformed or untrusted repo keys before outbound fetch", async () => {
+    expect(parseGitHubRepoKey("")).toBeNull();
+    expect(parseGitHubRepoKey("only-owner")).toBeNull();
+    expect(parseGitHubRepoKey("owner/repo/extra")).toBeNull();
+    expect(parseGitHubRepoKey("owner/repo@evil.com")).toBeNull();
+    await expect(fetchGitHubSourceSignal("bad/key/extra", fetch)).rejects.toThrow(
+      "invalid_repo:bad/key/extra",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Root cause: `fetchGitHubSourceSignal` split `repoKey` on `/` and interpolated owner/repo into outbound GitHub and Shields URLs without canonical validation, so malformed keys could reach the fetch layer.
- Fix: add `parseGitHubRepoKey()` using the shared `parseGitHubRepoUrl()` validator and reject invalid keys before any outbound request; URL builders now encode path segments.
- Impact: poisoned or malformed repo keys fail closed at the fetch boundary instead of constructing untrusted outbound URLs.

## Test plan
- [x] `pnpm exec vitest run tests/source-repo-signals-fetch-lib.test.ts`
- [x] `pnpm build`

## Risks / tradeoffs
- Repo keys that previously slipped through naive splitting now throw `invalid_repo:*` early. Production keys already flow through the canonical parser upstream.
