### PR TITLE
fix(web): sanitize MCP artifact fallback paths

### DIFF
--- a/apps/web/src/lib/mcp-artifact-readers-lib.ts
+++ b/apps/web/src/lib/mcp-artifact-readers-lib.ts
@@ -1,0 +1,42 @@
+import { safeDataArtifactPath } from "@/lib/content-artifact-lib";
+import { loadJsonDataFile, loadTextDataFile } from "@/lib/content.server";
+
+type StaticAssetsBinding = {
+  fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+};
+
+function assetRequest(origin: string, fileName: string) {
+  return new Request(`${origin}/data/${fileName}`);
+}
+
+export function createMcpArtifactReaders(origin: string, assets?: StaticAssetsBinding) {
+  const loadAssetText = async (fileName: string) => {
+    const response = await (assets?.fetch(assetRequest(origin, fileName)) ??
+      fetch(assetRequest(origin, fileName)));
+    if (!response.ok) {
+      throw new Error(`Failed to load ${fileName} asset (${response.status})`);
+    }
+    return response.text();
+  };
+
+  const readTextArtifact = async (fileName: string) => {
+    const safePath = safeDataArtifactPath(fileName);
+    try {
+      return await loadTextDataFile(safePath);
+    } catch {
+      return loadAssetText(safePath);
+    }
+  };
+
+  return {
+    readTextArtifact,
+    readJsonArtifact: async <T>(fileName: string): Promise<T> => {
+      const safePath = safeDataArtifactPath(fileName);
+      try {
+        return await loadJsonDataFile<T>(safePath);
+      } catch {
+        return JSON.parse(await loadAssetText(safePath)) as T;
+      }
+    },
+  };
+}

--- a/apps/web/src/routes/api/mcp.ts
+++ b/apps/web/src/routes/api/mcp.ts
@@ -10,7 +10,7 @@ import {
 } from "@/lib/api-security";
 import { logApiError, logApiWarn } from "@/lib/api-logs";
 import { getCloudflareBinding } from "@/lib/cloudflare-env.server";
-import { loadJsonDataFile, loadTextDataFile } from "@/lib/content.server";
+import { createMcpArtifactReaders } from "@/lib/mcp-artifact-readers-lib";
 import { applySecurityHeaders } from "@/lib/security-headers";
 
 const route = getApiRouteDefinition("mcp.streamable");
@@ -66,40 +66,6 @@ function mcpMethodNotAllowed() {
       },
     ),
   );
-}
-
-function assetRequest(origin: string, fileName: string) {
-  return new Request(`${origin}/data/${fileName}`);
-}
-
-function createMcpArtifactReaders(origin: string, assets?: StaticAssetsBinding) {
-  const loadAssetText = async (fileName: string) => {
-    const response = await (assets?.fetch(assetRequest(origin, fileName)) ??
-      fetch(assetRequest(origin, fileName)));
-    if (!response.ok) {
-      throw new Error(`Failed to load ${fileName} asset (${response.status})`);
-    }
-    return response.text();
-  };
-
-  const readTextArtifact = async (fileName: string) => {
-    try {
-      return await loadTextDataFile(fileName);
-    } catch {
-      return loadAssetText(fileName);
-    }
-  };
-
-  return {
-    readTextArtifact,
-    readJsonArtifact: async <T>(fileName: string): Promise<T> => {
-      try {
-        return await loadJsonDataFile<T>(fileName);
-      } catch {
-        return JSON.parse(await loadAssetText(fileName)) as T;
-      }
-    },
-  };
 }
 
 async function validateMcpRequest(request: Request) {

--- a/tests/mcp-artifact-readers-lib.test.ts
+++ b/tests/mcp-artifact-readers-lib.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/content.server", () => ({
+  loadTextDataFile: vi.fn(),
+  loadJsonDataFile: vi.fn(),
+}));
+
+import { loadJsonDataFile, loadTextDataFile } from "@/lib/content.server";
+import { createMcpArtifactReaders } from "../apps/web/src/lib/mcp-artifact-readers-lib";
+
+const loadTextDataFileMock = vi.mocked(loadTextDataFile);
+const loadJsonDataFileMock = vi.mocked(loadJsonDataFile);
+
+describe("mcp-artifact-readers-lib", () => {
+  beforeEach(() => {
+    loadTextDataFileMock.mockReset();
+    loadJsonDataFileMock.mockReset();
+  });
+
+  it("rejects unsafe artifact paths before loading or falling back to assets", async () => {
+    const assetsFetch = vi.fn();
+    const readers = createMcpArtifactReaders("https://heyclau.de", {
+      fetch: assetsFetch,
+    });
+
+    await expect(
+      readers.readTextArtifact("../registry-manifest.json"),
+    ).rejects.toThrow(/Unsafe data artifact path/);
+    expect(loadTextDataFileMock).not.toHaveBeenCalled();
+    expect(assetsFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to assets using the sanitized path when local data loading fails", async () => {
+    loadTextDataFileMock.mockRejectedValue(new Error("local file missing"));
+    const assetsFetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      expect(url).toBe("https://heyclau.de/data/search-index.json");
+      return new Response("artifact-text", { status: 200 });
+    });
+    const readers = createMcpArtifactReaders("https://heyclau.de", {
+      fetch: assetsFetch,
+    });
+
+    await expect(readers.readTextArtifact("search-index.json")).resolves.toBe(
+      "artifact-text",
+    );
+    expect(loadTextDataFileMock).toHaveBeenCalledWith("search-index.json");
+    expect(assetsFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to assets for JSON artifacts using the sanitized path", async () => {
+    loadJsonDataFileMock.mockRejectedValue(new Error("local file missing"));
+    const assetsFetch = vi.fn(async () => {
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+    const readers = createMcpArtifactReaders("https://heyclau.de", {
+      fetch: assetsFetch,
+    });
+
+    await expect(
+      readers.readJsonArtifact<{ ok: boolean }>("search-index.json"),
+    ).resolves.toEqual({
+      ok: true,
+    });
+    expect(loadJsonDataFileMock).toHaveBeenCalledWith("search-index.json");
+    expect(assetsFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract MCP artifact readers into `mcp-artifact-readers-lib.ts` and apply `safeDataArtifactPath` before both local data loads and ASSETS fallback.
- Close the bypass where rejected traversal paths could retry via unsanitized `loadAssetText(fileName)`.

## Test plan
- [x] `pnpm exec vitest run tests/mcp-artifact-readers-lib.test.ts tests/mcp-http-route.test.ts`
- [x] Unsafe paths (`../registry-manifest.json`) reject before any asset fetch
- [x] Safe-path fallback still loads from `/data/{safePath}` when local files are missing