### PR TITLE
fix(web): bound npm public proxy cache growth

### DIFF
--- a/apps/web/src/routes/api/public/npm/$.ts
+++ b/apps/web/src/routes/api/public/npm/$.ts
@@ -22,6 +22,16 @@ interface NpmMeta {
 // In-memory cache (per isolate). Avoids hammering registry.npmjs.org.
 const cache = new Map<string, { at: number; data: NpmMeta }>();
 const TTL_MS = 10 * 60 * 1000; // 10 minutes
+const MAX_CACHE_ENTRIES = 256;
+
+function enforceCacheBound() {
+  if (cache.size <= MAX_CACHE_ENTRIES) return;
+  const oldest = cache.entries().next().value as
+    | [string, { at: number; data: NpmMeta }]
+    | undefined;
+  if (!oldest) return;
+  cache.delete(oldest[0]);
+}
 
 async function fetchMeta(pkg: string): Promise<NpmMeta> {
   const cached = cache.get(pkg);
@@ -83,37 +93,44 @@ async function fetchMeta(pkg: string): Promise<NpmMeta> {
     fetchedAt: new Date().toISOString(),
   };
   cache.set(pkg, { at: Date.now(), data });
+  enforceCacheBound();
   return data;
+}
+
+export function __resetNpmMetaCacheForTest() {
+  cache.clear();
 }
 
 export const Route = createApiFileRoute("/api/public/npm/$")({
   server: {
     handlers: {
-      GET: async ({ params }) => {
-        const pkg = params._splat ?? "";
-        if (!pkg || !/^@?[a-z0-9][\w./@-]{0,213}$/i.test(pkg)) {
-          return new Response(JSON.stringify({ error: "Invalid package name" }), {
-            status: 400,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-        try {
-          const data = await fetchMeta(pkg);
-          return new Response(JSON.stringify(data), {
-            status: 200,
-            headers: {
-              "Content-Type": "application/json",
-              "Cache-Control": "public, s-maxage=600, stale-while-revalidate=3600",
-            },
-          });
-        } catch (err) {
-          console.error("npm proxy error", err);
-          return new Response(JSON.stringify({ error: "Upstream metadata unavailable" }), {
-            status: 502,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-      },
+      GET,
     },
   },
 });
+
+export async function GET({ params }: { params: Record<string, string> }) {
+  const pkg = params._splat ?? "";
+  if (!pkg || !/^@?[a-z0-9][\w./@-]{0,213}$/i.test(pkg)) {
+    return new Response(JSON.stringify({ error: "Invalid package name" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+  try {
+    const data = await fetchMeta(pkg);
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "public, s-maxage=600, stale-while-revalidate=3600",
+      },
+    });
+  } catch (err) {
+    console.error("npm proxy error", err);
+    return new Response(JSON.stringify({ error: "Upstream metadata unavailable" }), {
+      status: 502,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}

--- a/tests/npm-public-api.test.ts
+++ b/tests/npm-public-api.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  GET,
+  __resetNpmMetaCacheForTest,
+} from "../apps/web/src/routes/api/public/npm/$";
+
+function pkgFromUrl(input: string) {
+  const url = new URL(input);
+  if (url.hostname === "registry.npmjs.org") {
+    const raw = decodeURIComponent(url.pathname.slice(1));
+    return raw.endsWith("/latest") ? raw.slice(0, -"/latest".length) : raw;
+  }
+  if (url.hostname === "api.npmjs.org") {
+    return decodeURIComponent(url.pathname.split("/").slice(4).join("/"));
+  }
+  return "unknown";
+}
+
+function okJson(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("public npm metadata API cache", () => {
+  beforeEach(() => {
+    __resetNpmMetaCacheForTest();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("serves repeat requests from isolate cache", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const pkg = pkgFromUrl(url);
+      if (url.includes("/latest"))
+        return okJson({ name: pkg, version: "1.0.0" });
+      if (url.includes("/downloads/point/last-week/"))
+        return okJson({ downloads: 123 });
+      return okJson({ time: { "1.0.0": "2026-01-01T00:00:00.000Z" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await GET({ params: { _splat: "cacheable-package" } });
+    const firstCallCount = fetchMock.mock.calls.length;
+    await GET({ params: { _splat: "cacheable-package" } });
+    expect(fetchMock.mock.calls.length).toBe(firstCallCount);
+  });
+
+  it("evicts oldest keys when cache exceeds max entries", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const pkg = pkgFromUrl(url);
+      if (url.includes("/latest"))
+        return okJson({ name: pkg, version: "1.0.0" });
+      if (url.includes("/downloads/point/last-week/"))
+        return okJson({ downloads: 42 });
+      return okJson({ time: { "1.0.0": "2026-01-01T00:00:00.000Z" } });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    for (let i = 0; i < 257; i += 1) {
+      await GET({ params: { _splat: `pkg-${i}` } });
+    }
+    const beforeRefetch = fetchMock.mock.calls.length;
+    await GET({ params: { _splat: "pkg-0" } });
+
+    // 3 upstream calls per miss: latest + downloads + packument.
+    expect(fetchMock.mock.calls.length - beforeRefetch).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Cap the in-memory cache in `api/public/npm` to a fixed maximum and evict oldest entries once the limit is exceeded.
- Keep existing TTL behavior while preventing unbounded isolate memory growth from high-cardinality package lookups.
- Add route-level tests for cache hit behavior and eviction/refetch behavior.

## Test plan
- [x] `pnpm exec vitest run tests/npm-public-api.test.ts`