### PR TITLE
fix(web): require canonical repo on signed webhooks

### DIFF
--- a/apps/web/src/routes/api/public/github/webhook.ts
+++ b/apps/web/src/routes/api/public/github/webhook.ts
@@ -156,7 +156,7 @@ export async function handleGithubWebhookPost(request: Request) {
   }
 
   const repo = (payload.repository as { full_name?: string } | undefined)?.full_name;
-  if (repo && repo !== ALLOWED_REPO) {
+  if (repo !== ALLOWED_REPO) {
     return new Response("Unknown repo", { status: 403 });
   }
 

--- a/tests/github-webhook-route.test.ts
+++ b/tests/github-webhook-route.test.ts
@@ -115,6 +115,7 @@ describe("public GitHub webhook route", () => {
 
   it("accepts signed push events within the body limit", async () => {
     const body = JSON.stringify({
+      repository: { full_name: "jsonbored/awesome-claude" },
       ref: "refs/heads/main",
       commits: [
         {
@@ -131,5 +132,46 @@ describe("public GitHub webhook route", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true, count: 1 });
+  });
+
+  it("rejects signed events missing the canonical repository name", async () => {
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      commits: [
+        {
+          id: "abc123",
+          timestamp: "2026-06-18T23:00:00.000Z",
+          added: ["content/mcp/example.mdx"],
+        },
+      ],
+    });
+
+    const response = await handleGithubWebhookPost(
+      await signedWebhookRequest("push", body),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe("Unknown repo");
+  });
+
+  it("rejects signed events for non-canonical repositories", async () => {
+    const body = JSON.stringify({
+      repository: { full_name: "attacker/awesome-claude" },
+      ref: "refs/heads/main",
+      commits: [
+        {
+          id: "abc123",
+          timestamp: "2026-06-18T23:00:00.000Z",
+          added: ["content/mcp/example.mdx"],
+        },
+      ],
+    });
+
+    const response = await handleGithubWebhookPost(
+      await signedWebhookRequest("push", body),
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.text()).resolves.toBe("Unknown repo");
   });
 });


### PR DESCRIPTION
## Summary
- Enforce that signed webhook payloads include `repository.full_name` and that it exactly matches `jsonbored/awesome-claude`.
- Reject malformed signed payloads that omit repo identity instead of implicitly accepting them.
- Add regression tests for missing-repo and wrong-repo signed push payloads.

## Test plan
- [x] `pnpm exec vitest run tests/github-webhook-route.test.ts`