### PR TITLE
fix(web): fail newsletter unsubscribe on upstream network errors

### DIFF
--- a/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
+++ b/apps/web/src/routes/api/public/newsletter/unsubscribe.ts
@@ -61,7 +61,7 @@ async function parsePayload(request: Request): Promise<UnsubscribePayload> {
   return Schema.parse(JSON.parse(rawBody)) as UnsubscribePayload;
 }
 
-async function POST(request: Request): Promise<Response> {
+export async function POST(request: Request): Promise<Response> {
   const requestId = getRequestId(request);
 
   if (!isAllowedOrigin(request)) {
@@ -132,7 +132,7 @@ async function POST(request: Request): Promise<Response> {
     }
   }
 
-  if (lastError && lastError !== "network") {
+  if (lastError) {
     logApiError(request, "newsletter.unsubscribe.provider_error", {
       email: redactEmail(payload.email),
       error: lastError,

--- a/tests/newsletter-unsubscribe-route.test.ts
+++ b/tests/newsletter-unsubscribe-route.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { POST } from "../apps/web/src/routes/api/public/newsletter/unsubscribe";
+
+const WEBHOOK_URL = "https://heyclau.de/api/public/newsletter/unsubscribe";
+
+const globalWithEnv = globalThis as typeof globalThis & { __env__?: unknown };
+
+function unsubscribeRequest(body: unknown) {
+  return new Request(WEBHOOK_URL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://heyclau.de",
+      "cf-connecting-ip": "203.0.113.10",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("newsletter unsubscribe route", () => {
+  beforeEach(() => {
+    globalWithEnv.__env__ = {
+      RESEND_API_KEY: "resend-key",
+      RESEND_SEGMENT_ID: "seg-general",
+    };
+  });
+
+  afterEach(() => {
+    delete globalWithEnv.__env__;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns provider_error when upstream calls fail with network errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new Error("network down"))),
+    );
+
+    const response = await POST(
+      unsubscribeRequest({ email: "user@example.com" }),
+    );
+    const body = (await response.json()) as { error?: { code?: string } };
+
+    expect(response.status).toBe(502);
+    expect(body.error?.code).toBe("provider_error");
+  });
+
+  it("treats 404 provider responses as a successful unsubscribe", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not found", { status: 404 })),
+    );
+
+    const response = await POST(
+      unsubscribeRequest({ email: "user@example.com" }),
+    );
+    const body = (await response.json()) as { ok?: boolean };
+
+    expect(response.status).toBe(200);
+    expect(body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Return `provider_error` when Resend unsubscribe calls fail due to network errors, instead of incorrectly returning success.
- Keep 404 responses as successful idempotent unsubscribes to avoid membership disclosure.
- Add route tests for both network-failure and 404-success behavior.

## Test plan
- [x] `pnpm exec vitest run tests/newsletter-unsubscribe-route.test.ts`