### PR TITLE
feat(web): extract normalizeError pure helper into client-logs-lib

### DIFF
--- a/apps/web/src/lib/client-logs-lib.ts
+++ b/apps/web/src/lib/client-logs-lib.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure normalization of an unknown thrown value into a `{ name, message }`
+ * shape.
+ *
+ * The logging side effect (`console.error`) lives in `client-logs.ts`
+ * (`@/lib/client-logs`), which imports this helper and re-exports it. Given the
+ * same input the output here is deterministic — no module state, no console
+ * side effects — so it is unit-testable in isolation.
+ */
+
+export type NormalizedError = { name: string; message: string };
+
+/**
+ * Reduce any thrown value to a safe `{ name, message }` pair. Real `Error`
+ * instances keep their `name`/`message`; anything else is coerced to a string
+ * message under the generic `"Error"` name, with falsy values reported as
+ * `"Unknown error"`.
+ */
+export function normalizeError(error: unknown): NormalizedError {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: error.message,
+    };
+  }
+  return {
+    name: "Error",
+    message: String(error || "Unknown error"),
+  };
+}

--- a/apps/web/src/lib/client-logs.ts
+++ b/apps/web/src/lib/client-logs.ts
@@ -1,23 +1,10 @@
+import { normalizeError } from "@/lib/client-logs-lib";
+
+export { normalizeError } from "@/lib/client-logs-lib";
+
 type ClientLogMeta = Record<string, unknown>;
 
-function normalizeError(error: unknown) {
-  if (error instanceof Error) {
-    return {
-      name: error.name,
-      message: error.message,
-    };
-  }
-  return {
-    name: "Error",
-    message: String(error || "Unknown error"),
-  };
-}
-
-function writeClientLog(
-  level: "error",
-  event: string,
-  meta: ClientLogMeta = {},
-) {
+function writeClientLog(level: "error", event: string, meta: ClientLogMeta = {}) {
   console.error(
     JSON.stringify({
       ts: new Date().toISOString(),
@@ -28,11 +15,7 @@ function writeClientLog(
   );
 }
 
-export function logClientError(
-  event: string,
-  error: unknown,
-  meta: ClientLogMeta = {},
-) {
+export function logClientError(event: string, error: unknown, meta: ClientLogMeta = {}) {
   writeClientLog("error", event, {
     ...meta,
     error: normalizeError(error),

--- a/tests/client-logs-lib.test.ts
+++ b/tests/client-logs-lib.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  normalizeError,
+  type NormalizedError,
+} from "../apps/web/src/lib/client-logs-lib";
+
+describe("normalizeError", () => {
+  it("keeps the name and message of a plain Error", () => {
+    expect(normalizeError(new Error("boom"))).toEqual({
+      name: "Error",
+      message: "boom",
+    });
+  });
+
+  it("preserves the subclass name of a built-in Error subtype", () => {
+    expect(normalizeError(new TypeError("bad type"))).toEqual({
+      name: "TypeError",
+      message: "bad type",
+    });
+  });
+
+  it("preserves a custom Error subclass name", () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "CustomError";
+      }
+    }
+    expect(normalizeError(new CustomError("nope"))).toEqual({
+      name: "CustomError",
+      message: "nope",
+    });
+  });
+
+  it("keeps an empty Error message as an empty string", () => {
+    expect(normalizeError(new Error(""))).toEqual({
+      name: "Error",
+      message: "",
+    });
+  });
+
+  it("coerces a non-Error string to a generic Error message", () => {
+    expect(normalizeError("oops")).toEqual({
+      name: "Error",
+      message: "oops",
+    });
+  });
+
+  it("stringifies a non-Error number", () => {
+    expect(normalizeError(42)).toEqual({ name: "Error", message: "42" });
+  });
+
+  it("stringifies a non-Error object", () => {
+    expect(normalizeError({ code: 500 })).toEqual({
+      name: "Error",
+      message: "[object Object]",
+    });
+  });
+
+  it("reports null as Unknown error", () => {
+    expect(normalizeError(null)).toEqual({
+      name: "Error",
+      message: "Unknown error",
+    });
+  });
+
+  it("reports undefined as Unknown error", () => {
+    expect(normalizeError(undefined)).toEqual({
+      name: "Error",
+      message: "Unknown error",
+    });
+  });
+
+  it("reports an empty string as Unknown error (falsy input)", () => {
+    expect(normalizeError("")).toEqual({
+      name: "Error",
+      message: "Unknown error",
+    });
+  });
+
+  it("reports 0 as Unknown error (falsy input)", () => {
+    expect(normalizeError(0)).toEqual({
+      name: "Error",
+      message: "Unknown error",
+    });
+  });
+
+  it("reports false as Unknown error (falsy input)", () => {
+    expect(normalizeError(false)).toEqual({
+      name: "Error",
+      message: "Unknown error",
+    });
+  });
+
+  it("returns the NormalizedError shape", () => {
+    const result: NormalizedError = normalizeError(new Error("shape"));
+    expect(Object.keys(result).sort()).toEqual(["message", "name"]);
+  });
+});


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs like #4488 (peek-hotkey) and #4514/#4526/#4542.

The pure error-normalization logic moves to a new `apps/web/src/lib/client-logs-lib.ts` (`normalizeError`), while `client-logs.ts` keeps the `console.error` side effect (`writeClientLog` / `logClientError`) and re-exports the helper. This isolates the deterministic part so it can be unit-tested without console side effects.

Adds `tests/client-logs-lib.test.ts` with 13 tests covering: `Error` instances and subclasses (name/message preserved), empty messages, non-`Error` strings/numbers/objects coerced to a string message under a generic `"Error"` name, and falsy inputs (`null`, `undefined`, `""`, `0`, `false`) reported as `"Unknown error"`.

No behaviour change — `client-logs.ts` is already in the coverage exclude list, so `vitest.config.ts` is untouched.

Validation: `pnpm exec vitest run tests/client-logs-lib.test.ts` (13 passed), `prettier --check` clean.