### PR TITLE
feat(web): extract search query tokenization into search-query-tokenization-lib

### DIFF
--- a/apps/web/src/lib/search-query-tokenization-lib.ts
+++ b/apps/web/src/lib/search-query-tokenization-lib.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure search-query tokenization helpers.
+ *
+ * These have no module state and no side effects: given the same query string
+ * the output is deterministic, so they are unit-testable in isolation. The
+ * `search-query-tokenization.ts` module (`@/lib/search-query-tokenization`)
+ * re-exports this surface so existing importers stay unchanged.
+ */
+
+export const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
+export const MAX_QUERY_LENGTH = 256;
+export const MAX_QUERY_TOKENS = 12;
+
+/** Trim, lowercase, and cap query length before tokenization. */
+export function normalizeSearchQuery(query: string) {
+  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
+}
+
+/** Walk the query character-by-character so pathological inputs cannot force a huge split. */
+export function tokenizeSearchQuery(query: string) {
+  const tokens: string[] = [];
+  let token = "";
+
+  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
+    const char = query[index]!;
+    if (/[a-z0-9+#.-]/i.test(char)) {
+      token += char.toLowerCase();
+      continue;
+    }
+
+    if (token.length >= 2) tokens.push(token);
+    token = "";
+  }
+
+  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
+  return tokens;
+}

--- a/apps/web/src/lib/search-query-tokenization.ts
+++ b/apps/web/src/lib/search-query-tokenization.ts
@@ -1,28 +1,14 @@
-export const TOKEN_SPLIT_PATTERN = /[^a-z0-9+#.-]+/i;
-export const MAX_QUERY_LENGTH = 256;
-export const MAX_QUERY_TOKENS = 12;
-
-/** Trim, lowercase, and cap query length before tokenization. */
-export function normalizeSearchQuery(query: string) {
-  return query.slice(0, MAX_QUERY_LENGTH).trim().toLowerCase();
-}
-
-/** Walk the query character-by-character so pathological inputs cannot force a huge split. */
-export function tokenizeSearchQuery(query: string) {
-  const tokens: string[] = [];
-  let token = "";
-
-  for (let index = 0; index < query.length && tokens.length < MAX_QUERY_TOKENS; index += 1) {
-    const char = query[index]!;
-    if (/[a-z0-9+#.-]/i.test(char)) {
-      token += char.toLowerCase();
-      continue;
-    }
-
-    if (token.length >= 2) tokens.push(token);
-    token = "";
-  }
-
-  if (tokens.length < MAX_QUERY_TOKENS && token.length >= 2) tokens.push(token);
-  return tokens;
-}
+/**
+ * Search-query tokenization surface.
+ *
+ * The pure tokenization helpers live in `search-query-tokenization-lib.ts`
+ * (`@/lib/search-query-tokenization-lib`). This module re-exports that surface
+ * so existing `@/lib/search-query-tokenization` importers stay unchanged.
+ */
+export {
+  MAX_QUERY_LENGTH,
+  MAX_QUERY_TOKENS,
+  TOKEN_SPLIT_PATTERN,
+  normalizeSearchQuery,
+  tokenizeSearchQuery,
+} from "@/lib/search-query-tokenization-lib";

--- a/tests/search-query-tokenization-lib.test.ts
+++ b/tests/search-query-tokenization-lib.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_QUERY_LENGTH,
+  MAX_QUERY_TOKENS,
+  TOKEN_SPLIT_PATTERN,
+  normalizeSearchQuery,
+  tokenizeSearchQuery,
+} from "../apps/web/src/lib/search-query-tokenization-lib";
+
+describe("constants", () => {
+  it("exposes the expected caps and split pattern", () => {
+    expect(MAX_QUERY_LENGTH).toBe(256);
+    expect(MAX_QUERY_TOKENS).toBe(12);
+    expect("a b".split(TOKEN_SPLIT_PATTERN)).toEqual(["a", "b"]);
+  });
+});
+
+describe("normalizeSearchQuery", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeSearchQuery("  hello  ")).toBe("hello");
+  });
+
+  it("lowercases the query", () => {
+    expect(normalizeSearchQuery("HeLLo World")).toBe("hello world");
+  });
+
+  it("caps length at MAX_QUERY_LENGTH before trimming", () => {
+    const long = "a".repeat(MAX_QUERY_LENGTH + 50);
+    expect(normalizeSearchQuery(long)).toBe("a".repeat(MAX_QUERY_LENGTH));
+  });
+
+  it("trims whitespace that remains after the length cap", () => {
+    // slice(0, 256) lands inside a run of spaces, which trim() then removes.
+    const q = "x".repeat(250) + " ".repeat(20) + "tail";
+    expect(normalizeSearchQuery(q)).toBe("x".repeat(250));
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeSearchQuery("    ")).toBe("");
+  });
+});
+
+describe("tokenizeSearchQuery", () => {
+  it("splits on non-token characters", () => {
+    expect(tokenizeSearchQuery("hello world")).toEqual(["hello", "world"]);
+  });
+
+  it("lowercases tokens", () => {
+    expect(tokenizeSearchQuery("Hello WORLD")).toEqual(["hello", "world"]);
+  });
+
+  it("drops tokens shorter than two characters", () => {
+    expect(tokenizeSearchQuery("a bc d ef")).toEqual(["bc", "ef"]);
+  });
+
+  it("keeps the allowed special characters + # . -", () => {
+    expect(tokenizeSearchQuery("c++ c# node.js co-op")).toEqual([
+      "c++",
+      "c#",
+      "node.js",
+      "co-op",
+    ]);
+  });
+
+  it("collapses runs of separators", () => {
+    expect(tokenizeSearchQuery("foo,,,bar   baz")).toEqual([
+      "foo",
+      "bar",
+      "baz",
+    ]);
+  });
+
+  it("flushes a trailing token when it is long enough", () => {
+    expect(tokenizeSearchQuery("alpha beta")).toEqual(["alpha", "beta"]);
+  });
+
+  it("drops a trailing token shorter than two characters", () => {
+    expect(tokenizeSearchQuery("alpha b")).toEqual(["alpha"]);
+  });
+
+  it("caps the number of tokens at MAX_QUERY_TOKENS", () => {
+    const many = Array.from({ length: 20 }, (_, i) => `tok${i}`).join(" ");
+    const result = tokenizeSearchQuery(many);
+    expect(result).toHaveLength(MAX_QUERY_TOKENS);
+    expect(result[0]).toBe("tok0");
+    expect(result[MAX_QUERY_TOKENS - 1]).toBe(`tok${MAX_QUERY_TOKENS - 1}`);
+  });
+
+  it("does not flush a trailing token once the cap is reached", () => {
+    // 12 two-char tokens fill the cap; the 13th (also valid) must be ignored.
+    const q = Array.from({ length: 13 }, () => "ab").join(" ");
+    expect(tokenizeSearchQuery(q)).toHaveLength(MAX_QUERY_TOKENS);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(tokenizeSearchQuery("")).toEqual([]);
+  });
+
+  it("returns an empty array when nothing meets the minimum length", () => {
+    expect(tokenizeSearchQuery("a b c !")).toEqual([]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         "apps/web/src/lib/jobs-utils.ts",
         "apps/web/src/lib/og-render.server.ts",
         "apps/web/src/lib/peek-hotkey.ts",
+        "apps/web/src/lib/search-query-tokenization.ts",
         "apps/web/src/lib/security-headers.ts",
         "apps/web/src/lib/site.ts",
         "apps/web/src/lib/tags.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs like #4488 (peek-hotkey) and #4551 (client-logs).

The pure query helpers move to a new `apps/web/src/lib/search-query-tokenization-lib.ts` — `normalizeSearchQuery`, `tokenizeSearchQuery`, and the `TOKEN_SPLIT_PATTERN` / `MAX_QUERY_LENGTH` / `MAX_QUERY_TOKENS` constants — and `search-query-tokenization.ts` becomes a thin re-export so existing importers (`data/search.ts`, `saved-search-alerts-lib.ts`) stay unchanged.

Adds `tests/search-query-tokenization-lib.test.ts` with 17 tests covering: trim/lowercase/length-cap in `normalizeSearchQuery`; and in `tokenizeSearchQuery` the separator split, lowercasing, two-character minimum (leading and trailing), the allowed `+ # . -` characters, separator-run collapsing, the `MAX_QUERY_TOKENS` cap (including no trailing flush once the cap is hit), and empty/all-too-short inputs.

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/search-query-tokenization-lib.test.ts` (17 passed), `prettier --check` clean, `git diff --check` clean.