### PR TITLE
feat(web): extract D1 batching primitives into d1-batch-lib

### DIFF
--- a/apps/web/src/lib/d1-batch-lib.ts
+++ b/apps/web/src/lib/d1-batch-lib.ts
@@ -1,0 +1,48 @@
+/**
+ * Pure D1 batching primitives for dynamic-state count queries.
+ *
+ * Votes, intent events, and community signals all read counts in small D1
+ * batches to stay under the bound-variable limit and keep dynamic-state queries
+ * reliable. The chunking loop and placeholder construction were duplicated in
+ * each helper, which risked drift when one was updated and the others were not.
+ * These helpers centralize the shared parts without changing query semantics or
+ * response shapes.
+ *
+ * They have no module state and no side effects, so they are unit-testable in
+ * isolation. `d1-batch.ts` (`@/lib/d1-batch`) re-exports this surface so
+ * existing importers stay unchanged.
+ */
+
+/** Conservative batch size that keeps each prepared query well under D1's
+ * bound-variable ceiling, even for the two-variable target-pair queries. */
+export const D1_SAFE_VARIABLE_BATCH_SIZE = 25;
+
+/**
+ * Split `items` into contiguous chunks of at most `size` entries. An empty
+ * input yields an empty array; callers should still guard the no-work case
+ * before touching the database.
+ */
+export function chunk<T>(items: readonly T[], size: number = D1_SAFE_VARIABLE_BATCH_SIZE): T[][] {
+  if (size <= 0) throw new RangeError("chunk size must be positive");
+  const batches: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
+/** Build a `?, ?, ...` placeholder list for a single-column `IN (...)` clause. */
+export function inPlaceholders(count: number): string {
+  return Array.from({ length: count }, () => "?").join(", ");
+}
+
+/**
+ * Build the `WHERE` fragment for matching a batch of (kind, key) pairs, e.g.
+ * `(target_kind = ? AND target_key = ?) OR (...)`. Returns an empty string for
+ * an empty batch so callers can guard before binding values.
+ */
+export function targetPairConditions(count: number, kindColumn: string, keyColumn: string): string {
+  return Array.from({ length: count }, () => `(${kindColumn} = ? AND ${keyColumn} = ?)`).join(
+    " OR ",
+  );
+}

--- a/apps/web/src/lib/d1-batch.ts
+++ b/apps/web/src/lib/d1-batch.ts
@@ -1,52 +1,12 @@
 /**
  * Shared D1 batching primitives for dynamic-state count queries.
  *
- * Votes, intent events, and community signals all read counts in small D1
- * batches to stay under the bound-variable limit and keep dynamic-state queries
- * reliable. The chunking loop and placeholder construction were duplicated in
- * each helper, which risked drift when one was updated and the others were not.
- * These helpers centralize the shared parts without changing query semantics or
- * response shapes.
+ * The pure helpers live in `d1-batch-lib.ts` (`@/lib/d1-batch-lib`). This module
+ * re-exports that surface so existing `@/lib/d1-batch` importers stay unchanged.
  */
-
-/** Conservative batch size that keeps each prepared query well under D1's
- * bound-variable ceiling, even for the two-variable target-pair queries. */
-export const D1_SAFE_VARIABLE_BATCH_SIZE = 25;
-
-/**
- * Split `items` into contiguous chunks of at most `size` entries. An empty
- * input yields an empty array; callers should still guard the no-work case
- * before touching the database.
- */
-export function chunk<T>(
-  items: readonly T[],
-  size: number = D1_SAFE_VARIABLE_BATCH_SIZE,
-): T[][] {
-  if (size <= 0) throw new RangeError("chunk size must be positive");
-  const batches: T[][] = [];
-  for (let index = 0; index < items.length; index += size) {
-    batches.push(items.slice(index, index + size));
-  }
-  return batches;
-}
-
-/** Build a `?, ?, ...` placeholder list for a single-column `IN (...)` clause. */
-export function inPlaceholders(count: number): string {
-  return Array.from({ length: count }, () => "?").join(", ");
-}
-
-/**
- * Build the `WHERE` fragment for matching a batch of (kind, key) pairs, e.g.
- * `(target_kind = ? AND target_key = ?) OR (...)`. Returns an empty string for
- * an empty batch so callers can guard before binding values.
- */
-export function targetPairConditions(
-  count: number,
-  kindColumn: string,
-  keyColumn: string,
-): string {
-  return Array.from(
-    { length: count },
-    () => `(${kindColumn} = ? AND ${keyColumn} = ?)`,
-  ).join(" OR ");
-}
+export {
+  D1_SAFE_VARIABLE_BATCH_SIZE,
+  chunk,
+  inPlaceholders,
+  targetPairConditions,
+} from "@/lib/d1-batch-lib";

--- a/tests/d1-batch-lib.test.ts
+++ b/tests/d1-batch-lib.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  D1_SAFE_VARIABLE_BATCH_SIZE,
+  chunk,
+  inPlaceholders,
+  targetPairConditions,
+} from "../apps/web/src/lib/d1-batch-lib";
+
+describe("D1_SAFE_VARIABLE_BATCH_SIZE", () => {
+  it("is a conservative positive batch size", () => {
+    expect(D1_SAFE_VARIABLE_BATCH_SIZE).toBe(25);
+  });
+});
+
+describe("chunk", () => {
+  it("returns an empty array for empty input", () => {
+    expect(chunk([])).toEqual([]);
+  });
+
+  it("keeps a single batch when input fits the size", () => {
+    expect(chunk([1, 2, 3], 5)).toEqual([[1, 2, 3]]);
+  });
+
+  it("splits input larger than the size into contiguous batches", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("produces evenly sized batches for an exact multiple", () => {
+    expect(chunk([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ]);
+  });
+
+  it("uses the default batch size when size is omitted", () => {
+    const items = Array.from(
+      { length: D1_SAFE_VARIABLE_BATCH_SIZE + 3 },
+      (_, i) => i,
+    );
+    const batches = chunk(items);
+    expect(batches).toHaveLength(2);
+    expect(batches[0]).toHaveLength(D1_SAFE_VARIABLE_BATCH_SIZE);
+    expect(batches[1]).toHaveLength(3);
+  });
+
+  it("throws a RangeError for a zero size", () => {
+    expect(() => chunk([1, 2], 0)).toThrow(RangeError);
+  });
+
+  it("throws a RangeError for a negative size", () => {
+    expect(() => chunk([1, 2], -1)).toThrow(RangeError);
+  });
+
+  it("does not mutate the input array", () => {
+    const items = [1, 2, 3];
+    chunk(items, 2);
+    expect(items).toEqual([1, 2, 3]);
+  });
+});
+
+describe("inPlaceholders", () => {
+  it("returns an empty string for a zero count", () => {
+    expect(inPlaceholders(0)).toBe("");
+  });
+
+  it("returns a single placeholder for count 1", () => {
+    expect(inPlaceholders(1)).toBe("?");
+  });
+
+  it("joins multiple placeholders with a comma and space", () => {
+    expect(inPlaceholders(3)).toBe("?, ?, ?");
+  });
+});
+
+describe("targetPairConditions", () => {
+  it("returns an empty string for a zero count", () => {
+    expect(targetPairConditions(0, "target_kind", "target_key")).toBe("");
+  });
+
+  it("builds a single pair condition", () => {
+    expect(targetPairConditions(1, "target_kind", "target_key")).toBe(
+      "(target_kind = ? AND target_key = ?)",
+    );
+  });
+
+  it("joins multiple pair conditions with OR and uses the given columns", () => {
+    expect(targetPairConditions(2, "k", "v")).toBe(
+      "(k = ? AND v = ?) OR (k = ? AND v = ?)",
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
         "apps/web/src/lib/csv.ts",
+        "apps/web/src/lib/d1-batch.ts",
         "apps/web/src/lib/format.ts",
         "apps/web/src/lib/api-logs.ts",
         "apps/web/src/lib/client-logs.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs #4488 (peek-hotkey), #4551 (client-logs), and #4552 (search-query-tokenization).

The pure batching primitives move to a new `apps/web/src/lib/d1-batch-lib.ts` — `chunk`, `inPlaceholders`, `targetPairConditions`, and the `D1_SAFE_VARIABLE_BATCH_SIZE` constant — and `d1-batch.ts` becomes a thin re-export so existing importers (`votes.ts`, `intent-events.ts`, `community-signals.ts`, `source-repo-signals.server.ts`) stay unchanged.

Adds `tests/d1-batch-lib.test.ts` with 15 tests: `chunk` (empty input, fits-in-one, splits with remainder, exact multiple, default size, `RangeError` on zero/negative size, no input mutation), `inPlaceholders` (0/1/n), and `targetPairConditions` (0/1/n with custom columns).

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/d1-batch-lib.test.ts` (15 passed), `prettier --check` clean, `git diff --check` clean.