### PR TITLE
feat(web): extract contributor-identity helpers into contributor-identity-lib

### DIFF
--- a/apps/web/src/lib/contributor-identity-lib.ts
+++ b/apps/web/src/lib/contributor-identity-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure contributor-identity helpers.
+ *
+ * These have no module state and no side effects: given the same input the
+ * output is deterministic, so they are unit-testable in isolation. The
+ * `contributor-identity.ts` module (`@/lib/contributor-identity`) re-exports
+ * this surface so existing importers stay unchanged.
+ */
+
+/**
+ * Normalize a handle/name into a URL-safe slug: trimmed, lowercased, a leading
+ * `@` removed, runs of non-alphanumerics collapsed to single dashes, and
+ * leading/trailing dashes stripped.
+ */
+export function contributorSlug(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Whether an author and a submitter refer to the same contributor. Both must be
+ * present and must normalize to the same non-empty slug.
+ */
+export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
+  if (!author || !submittedBy) return false;
+  const authorSlug = contributorSlug(author);
+  const submittedBySlug = contributorSlug(submittedBy);
+  return Boolean(authorSlug && authorSlug === submittedBySlug);
+}

--- a/apps/web/src/lib/contributor-identity.ts
+++ b/apps/web/src/lib/contributor-identity.ts
@@ -1,15 +1,8 @@
-export function contributorSlug(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^@/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-export function authorMatchesSubmitter(author?: string, submittedBy?: string) {
-  if (!author || !submittedBy) return false;
-  const authorSlug = contributorSlug(author);
-  const submittedBySlug = contributorSlug(submittedBy);
-  return Boolean(authorSlug && authorSlug === submittedBySlug);
-}
+/**
+ * Contributor-identity surface.
+ *
+ * The pure helpers live in `contributor-identity-lib.ts`
+ * (`@/lib/contributor-identity-lib`). This module re-exports that surface so
+ * existing `@/lib/contributor-identity` importers stay unchanged.
+ */
+export { authorMatchesSubmitter, contributorSlug } from "@/lib/contributor-identity-lib";

--- a/tests/contributor-identity-lib.test.ts
+++ b/tests/contributor-identity-lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  authorMatchesSubmitter,
+  contributorSlug,
+} from "../apps/web/src/lib/contributor-identity-lib";
+
+describe("contributorSlug", () => {
+  it("lowercases the value", () => {
+    expect(contributorSlug("Alice")).toBe("alice");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(contributorSlug("  alice  ")).toBe("alice");
+  });
+
+  it("strips a single leading @", () => {
+    expect(contributorSlug("@alice")).toBe("alice");
+  });
+
+  it("collapses runs of non-alphanumerics into single dashes", () => {
+    expect(contributorSlug("Foo   Bar")).toBe("foo-bar");
+    expect(contributorSlug("a@#$b")).toBe("a-b");
+  });
+
+  it("strips leading and trailing dashes", () => {
+    expect(contributorSlug("---lead-trail---")).toBe("lead-trail");
+  });
+
+  it("replaces separators like dots and underscores", () => {
+    expect(contributorSlug("a.b_c")).toBe("a-b-c");
+  });
+
+  it("returns an empty string when nothing alphanumeric remains", () => {
+    expect(contributorSlug("@@@")).toBe("");
+    expect(contributorSlug("   ")).toBe("");
+  });
+
+  it("keeps digits", () => {
+    expect(contributorSlug("User123")).toBe("user123");
+  });
+});
+
+describe("authorMatchesSubmitter", () => {
+  it("returns false when the author is missing", () => {
+    expect(authorMatchesSubmitter(undefined, "alice")).toBe(false);
+  });
+
+  it("returns false when the submitter is missing", () => {
+    expect(authorMatchesSubmitter("alice", undefined)).toBe(false);
+  });
+
+  it("returns false when both are missing", () => {
+    expect(authorMatchesSubmitter()).toBe(false);
+  });
+
+  it("returns false for an empty-string author", () => {
+    expect(authorMatchesSubmitter("", "alice")).toBe(false);
+  });
+
+  it("matches when the two normalize to the same slug", () => {
+    expect(authorMatchesSubmitter("@Alice", "alice")).toBe(true);
+    expect(authorMatchesSubmitter("Foo Bar", "foo-bar")).toBe(true);
+  });
+
+  it("does not match different contributors", () => {
+    expect(authorMatchesSubmitter("alice", "bob")).toBe(false);
+  });
+
+  it("returns false when both normalize to an empty slug", () => {
+    // Both present but slug to "" — an empty slug must never count as a match.
+    expect(authorMatchesSubmitter("@@@", "###")).toBe(false);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -64,6 +64,7 @@ export default defineConfig({
         "apps/web/src/lib/content-section-parsing.ts",
         "apps/web/src/lib/content-section-variant.ts",
         "apps/web/src/lib/content.server.ts",
+        "apps/web/src/lib/contributor-identity.ts",
         "apps/web/src/lib/contributors.ts",
         "apps/web/src/lib/data-reports.ts",
         "apps/web/src/lib/ecosystem-stats.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs), #4552 (search-query-tokenization), and #4555 (d1-batch).

The pure helpers move to a new `apps/web/src/lib/contributor-identity-lib.ts` — `contributorSlug` and `authorMatchesSubmitter` — and `contributor-identity.ts` becomes a thin re-export so existing importers (`data/entry-normalize.ts`, `data/contributors.ts`) stay unchanged.

Adds `tests/contributor-identity-lib.test.ts` with 15 tests: `contributorSlug` (lowercase, trim, leading-`@` strip, separator collapse for spaces/`.`/`_`/symbols, leading/trailing dash strip, all-symbols → empty, digits kept) and `authorMatchesSubmitter` (missing/empty args → false, slug-equal → true, different → false, and two values that both normalize to an empty slug never match).

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/contributor-identity-lib.test.ts` (15 passed), `prettier --check` clean, `git diff --check` clean.