### PR TITLE
feat(web): extract ecosystem-pulse window filter into ecosystem-pulse-window-lib

### DIFF
--- a/apps/web/src/lib/ecosystem-pulse-window-lib.ts
+++ b/apps/web/src/lib/ecosystem-pulse-window-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure "ecosystem pulse" recency window helper.
+ *
+ * Filters entries to the trailing 14-day window (by UTC day), independent of
+ * time-of-day. It has no module state and no side effects — the reference
+ * "now" is injectable — so it is unit-testable in isolation. The
+ * `ecosystem-pulse-window.ts` module (`@/lib/ecosystem-pulse-window`)
+ * re-exports this surface so existing importers stay unchanged.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PULSE_WINDOW_DAYS = 14;
+
+function utcDayTimestamp(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) return undefined;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+export function filterRecentPulseEntries<T extends { date: string }>(
+  entries: readonly T[],
+  now: Date = new Date(),
+) {
+  const today = utcDayTimestamp(now);
+  if (today === undefined) return [];
+
+  const cutoff = today - (PULSE_WINDOW_DAYS - 1) * DAY_MS;
+  return entries.filter((entry) => {
+    const entryDay = utcDayTimestamp(entry.date);
+    return entryDay !== undefined && entryDay >= cutoff && entryDay <= today;
+  });
+}

--- a/apps/web/src/lib/ecosystem-pulse-window.ts
+++ b/apps/web/src/lib/ecosystem-pulse-window.ts
@@ -1,23 +1,8 @@
-const DAY_MS = 24 * 60 * 60 * 1000;
-const PULSE_WINDOW_DAYS = 14;
-
-function utcDayTimestamp(value: Date | string) {
-  const date = value instanceof Date ? value : new Date(value);
-  const time = date.getTime();
-  if (!Number.isFinite(time)) return undefined;
-  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
-}
-
-export function filterRecentPulseEntries<T extends { date: string }>(
-  entries: readonly T[],
-  now: Date = new Date(),
-) {
-  const today = utcDayTimestamp(now);
-  if (today === undefined) return [];
-
-  const cutoff = today - (PULSE_WINDOW_DAYS - 1) * DAY_MS;
-  return entries.filter((entry) => {
-    const entryDay = utcDayTimestamp(entry.date);
-    return entryDay !== undefined && entryDay >= cutoff && entryDay <= today;
-  });
-}
+/**
+ * Ecosystem-pulse recency window surface.
+ *
+ * The pure filter lives in `ecosystem-pulse-window-lib.ts`
+ * (`@/lib/ecosystem-pulse-window-lib`). This module re-exports it so existing
+ * `@/lib/ecosystem-pulse-window` importers stay unchanged.
+ */
+export { filterRecentPulseEntries } from "@/lib/ecosystem-pulse-window-lib";

--- a/tests/ecosystem-pulse-window-lib.test.ts
+++ b/tests/ecosystem-pulse-window-lib.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { filterRecentPulseEntries } from "../apps/web/src/lib/ecosystem-pulse-window-lib";
+
+// Fixed reference "now": 2026-07-15 12:00 UTC → today's UTC day is 2026-07-15.
+// The trailing window is 14 UTC days inclusive: 2026-07-02 .. 2026-07-15.
+const NOW = new Date("2026-07-15T12:00:00Z");
+
+function entries(...dates: string[]) {
+  return dates.map((date) => ({ date }));
+}
+
+describe("filterRecentPulseEntries", () => {
+  it("keeps an entry dated today", () => {
+    expect(filterRecentPulseEntries(entries("2026-07-15"), NOW)).toEqual([
+      { date: "2026-07-15" },
+    ]);
+  });
+
+  it("ignores the time-of-day and compares by UTC day", () => {
+    expect(
+      filterRecentPulseEntries(entries("2026-07-15T23:59:59Z"), NOW),
+    ).toHaveLength(1);
+  });
+
+  it("keeps the oldest day still inside the 14-day window", () => {
+    expect(filterRecentPulseEntries(entries("2026-07-02"), NOW)).toHaveLength(
+      1,
+    );
+  });
+
+  it("drops the day just outside the window", () => {
+    expect(filterRecentPulseEntries(entries("2026-07-01"), NOW)).toEqual([]);
+  });
+
+  it("drops entries dated in the future", () => {
+    expect(filterRecentPulseEntries(entries("2026-07-16"), NOW)).toEqual([]);
+  });
+
+  it("drops entries with an unparseable date", () => {
+    expect(filterRecentPulseEntries(entries("not-a-date"), NOW)).toEqual([]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(filterRecentPulseEntries([], NOW)).toEqual([]);
+  });
+
+  it("returns an empty array when now is invalid", () => {
+    expect(
+      filterRecentPulseEntries(entries("2026-07-15"), new Date("invalid")),
+    ).toEqual([]);
+  });
+
+  it("keeps only the in-window entries from a mixed set and preserves order", () => {
+    const result = filterRecentPulseEntries(
+      entries("2026-07-14", "2026-06-01", "2026-07-10", "2026-08-01", "bad"),
+      NOW,
+    );
+    expect(result).toEqual([{ date: "2026-07-14" }, { date: "2026-07-10" }]);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -67,6 +67,7 @@ export default defineConfig({
         "apps/web/src/lib/contributor-identity.ts",
         "apps/web/src/lib/contributors.ts",
         "apps/web/src/lib/data-reports.ts",
+        "apps/web/src/lib/ecosystem-pulse-window.ts",
         "apps/web/src/lib/ecosystem-stats.ts",
         "apps/web/src/lib/platform-pages.ts",
         "apps/web/src/lib/api-security.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs), #4555 (d1-batch), and #4556 (contributor-identity).

The pure recency filter moves to a new `apps/web/src/lib/ecosystem-pulse-window-lib.ts` — `filterRecentPulseEntries` (and its internal UTC-day helper / window constants) — and `ecosystem-pulse-window.ts` becomes a thin re-export so the existing importer (`routes/index.tsx`) stays unchanged.

Adds `tests/ecosystem-pulse-window-lib.test.ts` with 9 tests using an injected reference date (`now`): keeps today, compares by UTC day (ignores time-of-day), keeps the inclusive 14-day-window boundary, drops the day just outside it, drops future-dated entries, drops unparseable dates, handles empty input, returns `[]` when `now` is invalid, and preserves order across a mixed set.

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/ecosystem-pulse-window-lib.test.ts` (9 passed), `prettier --check` clean, `git diff --check` clean.