### PR TITLE
feat(web): extract brief send-slot computation into brief-schedule-lib

### DIFF
--- a/apps/web/src/lib/brief-schedule-lib.ts
+++ b/apps/web/src/lib/brief-schedule-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure weekly-brief scheduling helper.
+ *
+ * Computes the next send slot with no module state and no side effects — the
+ * reference date is passed in — so it is unit-testable in isolation. The
+ * `brief-schedule.ts` module (`@/lib/brief-schedule`) re-exports this surface so
+ * existing importers stay unchanged.
+ */
+
+// The weekly send slot: Sunday 16:00 UTC — the cadence subscribers signed up
+// for ("Weekly · Sundays"). Generation runs Friday, leaving the weekend for
+// review before the Sunday send.
+const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
+const SEND_HOUR_UTC = 16;
+
+/**
+ * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
+ * before 16:00, otherwise the following Sunday). Returned as an ISO string for
+ * the scheduled_send_at column.
+ */
+export function nextSendSlot(from: Date): string {
+  const slot = new Date(
+    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), SEND_HOUR_UTC, 0, 0, 0),
+  );
+  let add = (SEND_DOW - slot.getUTCDay() + 7) % 7;
+  if (add === 0 && from.getTime() >= slot.getTime()) add = 7;
+  slot.setUTCDate(slot.getUTCDate() + add);
+  return slot.toISOString();
+}

--- a/apps/web/src/lib/brief-schedule.ts
+++ b/apps/web/src/lib/brief-schedule.ts
@@ -1,20 +1,8 @@
-// The weekly send slot: Sunday 16:00 UTC — the cadence subscribers signed up
-// for ("Weekly · Sundays"). Generation runs Friday, leaving the weekend for
-// review before the Sunday send.
-const SEND_DOW = 0; // 0=Sun..6=Sat; Sunday
-const SEND_HOUR_UTC = 16;
-
 /**
- * The next Sunday 16:00 UTC strictly at or after `from` (today if it's Sunday
- * before 16:00, otherwise the following Sunday). Returned as an ISO string for
- * the scheduled_send_at column.
+ * Weekly-brief scheduling surface.
+ *
+ * The pure slot computation lives in `brief-schedule-lib.ts`
+ * (`@/lib/brief-schedule-lib`). This module re-exports it so existing
+ * `@/lib/brief-schedule` importers stay unchanged.
  */
-export function nextSendSlot(from: Date): string {
-  const slot = new Date(
-    Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate(), SEND_HOUR_UTC, 0, 0, 0),
-  );
-  let add = (SEND_DOW - slot.getUTCDay() + 7) % 7;
-  if (add === 0 && from.getTime() >= slot.getTime()) add = 7;
-  slot.setUTCDate(slot.getUTCDate() + add);
-  return slot.toISOString();
-}
+export { nextSendSlot } from "@/lib/brief-schedule-lib";

--- a/tests/brief-schedule-lib.test.ts
+++ b/tests/brief-schedule-lib.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { nextSendSlot } from "../apps/web/src/lib/brief-schedule-lib";
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+// Derive a known Sunday 16:00 UTC from the function itself, so the assertions
+// below never depend on hard-coding the weekday of an arbitrary calendar date.
+const knownSunday = new Date(nextSendSlot(new Date("2026-06-01T00:00:00Z")));
+
+function sameDayAt(base: Date, hour: number): Date {
+  return new Date(
+    Date.UTC(
+      base.getUTCFullYear(),
+      base.getUTCMonth(),
+      base.getUTCDate(),
+      hour,
+      0,
+      0,
+      0,
+    ),
+  );
+}
+
+describe("nextSendSlot", () => {
+  it("always returns a Sunday at exactly 16:00:00.000 UTC", () => {
+    for (const iso of [
+      "2026-06-01T00:00:00Z",
+      "2026-06-03T09:30:00Z",
+      "2026-06-06T23:59:59Z",
+      "2026-12-25T12:00:00Z",
+    ]) {
+      const slot = new Date(nextSendSlot(new Date(iso)));
+      expect(slot.getUTCDay()).toBe(0);
+      expect(slot.getUTCHours()).toBe(16);
+      expect(slot.getUTCMinutes()).toBe(0);
+      expect(slot.getUTCSeconds()).toBe(0);
+      expect(slot.getUTCMilliseconds()).toBe(0);
+    }
+  });
+
+  it("returns a slot strictly after `from`, within one week", () => {
+    for (const iso of ["2026-06-01T00:00:00Z", "2026-06-04T18:00:00Z"]) {
+      const from = new Date(iso);
+      const slot = new Date(nextSendSlot(from));
+      expect(slot.getTime()).toBeGreaterThan(from.getTime());
+      expect(slot.getTime() - from.getTime()).toBeLessThanOrEqual(WEEK_MS);
+    }
+  });
+
+  it("uses the same Sunday when `from` is that Sunday before 16:00", () => {
+    const before = sameDayAt(knownSunday, 10);
+    expect(nextSendSlot(before)).toBe(knownSunday.toISOString());
+  });
+
+  it("rolls to the following Sunday when `from` is exactly the 16:00 slot", () => {
+    const next = new Date(nextSendSlot(knownSunday));
+    expect(next.getTime() - knownSunday.getTime()).toBe(WEEK_MS);
+  });
+
+  it("rolls to the following Sunday when `from` is that Sunday after 16:00", () => {
+    const after = sameDayAt(knownSunday, 18);
+    const next = new Date(nextSendSlot(after));
+    expect(next.getUTCDay()).toBe(0);
+    expect(next.getTime()).toBeGreaterThan(knownSunday.getTime());
+    expect(next.getTime() - knownSunday.getTime()).toBe(WEEK_MS);
+  });
+
+  it("returns an ISO 8601 UTC string", () => {
+    expect(nextSendSlot(new Date("2026-06-01T00:00:00Z"))).toMatch(
+      /^\d{4}-\d{2}-\d{2}T16:00:00\.000Z$/,
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -52,6 +52,7 @@ export default defineConfig({
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
         "apps/web/src/lib/api/example.functions.ts",
+        "apps/web/src/lib/brief-schedule.ts",
         "apps/web/src/lib/csv.ts",
         "apps/web/src/lib/d1-batch.ts",
         "apps/web/src/lib/format.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs #4555 (d1-batch), #4556 (contributor-identity), and #4557 (ecosystem-pulse-window).

The pure send-slot computation moves to a new `apps/web/src/lib/brief-schedule-lib.ts` — `nextSendSlot` (the next Sunday 16:00 UTC) — and `brief-schedule.ts` becomes a thin re-export so the existing dynamic importer (`routes/brief.approve.tsx`) stays unchanged.

Adds `tests/brief-schedule-lib.test.ts` with 6 tests: the result is always a Sunday at exactly 16:00:00.000 UTC, always strictly after `from` and within one week, a Sunday before 16:00 keeps the same day, a Sunday exactly at / after 16:00 rolls to the following week, and the output matches the ISO-8601 UTC shape. The known-Sunday fixture is derived from the function itself so the assertions never hard-code a calendar weekday.

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/brief-schedule-lib.test.ts` (6 passed), `prettier --check` clean, `git diff --check` clean.