### PR TITLE
feat(web): extract contributor profile-summary stats into contributor-profile-summary-lib

### DIFF
--- a/apps/web/src/lib/contributor-profile-summary-lib.ts
+++ b/apps/web/src/lib/contributor-profile-summary-lib.ts
@@ -1,0 +1,26 @@
+/**
+ * Pure contributor profile-summary helpers.
+ *
+ * These derive display stats from a Contributor with no module state and no
+ * side effects, so they are unit-testable in isolation. The
+ * `contributor-profile-summary.ts` module (`@/lib/contributor-profile-summary`)
+ * re-exports them and keeps the data-coupled `submitterAttribution` surface.
+ */
+import type { Contributor } from "@/types/registry";
+
+export function contributorProfileStats(contributor: Contributor) {
+  return {
+    accepted: contributor.acceptedCount,
+    reviewed: contributor.reviewedCount ?? 0,
+    sourceLinked: contributor.sourceSubmissionCount ?? 0,
+    categories: contributor.categories?.length ?? 0,
+  };
+}
+
+export function contributorCardSummary(contributor: Contributor) {
+  const stats = contributorProfileStats(contributor);
+  const parts = [`${stats.accepted} accepted`];
+  if (stats.reviewed > 0) parts.push(`${stats.reviewed} reviewed`);
+  if (stats.sourceLinked > 0) parts.push(`${stats.sourceLinked} source-linked`);
+  return parts.join(" · ");
+}

--- a/apps/web/src/lib/contributor-profile-summary.ts
+++ b/apps/web/src/lib/contributor-profile-summary.ts
@@ -1,22 +1,10 @@
 import { contributorForSubmitter } from "@/data/contributors";
-import type { Contributor, Entry } from "@/types/registry";
+import type { Entry } from "@/types/registry";
 
-export function contributorProfileStats(contributor: Contributor) {
-  return {
-    accepted: contributor.acceptedCount,
-    reviewed: contributor.reviewedCount ?? 0,
-    sourceLinked: contributor.sourceSubmissionCount ?? 0,
-    categories: contributor.categories?.length ?? 0,
-  };
-}
-
-export function contributorCardSummary(contributor: Contributor) {
-  const stats = contributorProfileStats(contributor);
-  const parts = [`${stats.accepted} accepted`];
-  if (stats.reviewed > 0) parts.push(`${stats.reviewed} reviewed`);
-  if (stats.sourceLinked > 0) parts.push(`${stats.sourceLinked} source-linked`);
-  return parts.join(" · ");
-}
+export {
+  contributorCardSummary,
+  contributorProfileStats,
+} from "@/lib/contributor-profile-summary-lib";
 
 export type SubmitterAttribution =
   | { kind: "contributor"; slug: string; label: string }

--- a/tests/contributor-profile-summary-lib.test.ts
+++ b/tests/contributor-profile-summary-lib.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  contributorCardSummary,
+  contributorProfileStats,
+} from "../apps/web/src/lib/contributor-profile-summary-lib";
+import type { Contributor } from "../apps/web/src/types/registry";
+
+function contributor(overrides: Partial<Contributor> = {}): Contributor {
+  return { acceptedCount: 0, ...overrides } as Contributor;
+}
+
+describe("contributorProfileStats", () => {
+  it("passes through acceptedCount and reads all optional fields", () => {
+    expect(
+      contributorProfileStats(
+        contributor({
+          acceptedCount: 5,
+          reviewedCount: 3,
+          sourceSubmissionCount: 2,
+          categories: ["a", "b"] as unknown as Contributor["categories"],
+        }),
+      ),
+    ).toEqual({ accepted: 5, reviewed: 3, sourceLinked: 2, categories: 2 });
+  });
+
+  it("defaults missing optional counts to zero", () => {
+    expect(contributorProfileStats(contributor({ acceptedCount: 4 }))).toEqual({
+      accepted: 4,
+      reviewed: 0,
+      sourceLinked: 0,
+      categories: 0,
+    });
+  });
+
+  it("counts categories by length", () => {
+    expect(
+      contributorProfileStats(
+        contributor({
+          categories: ["x", "y", "z"] as unknown as Contributor["categories"],
+        }),
+      ).categories,
+    ).toBe(3);
+  });
+});
+
+describe("contributorCardSummary", () => {
+  it("always shows the accepted count", () => {
+    expect(contributorCardSummary(contributor({ acceptedCount: 7 }))).toBe(
+      "7 accepted",
+    );
+  });
+
+  it("omits reviewed and source-linked when they are zero", () => {
+    expect(
+      contributorCardSummary(
+        contributor({
+          acceptedCount: 1,
+          reviewedCount: 0,
+          sourceSubmissionCount: 0,
+        }),
+      ),
+    ).toBe("1 accepted");
+  });
+
+  it("appends reviewed and source-linked segments when present", () => {
+    expect(
+      contributorCardSummary(
+        contributor({
+          acceptedCount: 9,
+          reviewedCount: 4,
+          sourceSubmissionCount: 2,
+        }),
+      ),
+    ).toBe("9 accepted · 4 reviewed · 2 source-linked");
+  });
+
+  it("includes reviewed but not source-linked when only reviewed is present", () => {
+    expect(
+      contributorCardSummary(
+        contributor({ acceptedCount: 2, reviewedCount: 5 }),
+      ),
+    ).toBe("2 accepted · 5 reviewed");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
         "apps/web/src/lib/content-section-variant.ts",
         "apps/web/src/lib/content.server.ts",
         "apps/web/src/lib/contributor-identity.ts",
+        "apps/web/src/lib/contributor-profile-summary.ts",
         "apps/web/src/lib/contributors.ts",
         "apps/web/src/lib/data-reports.ts",
         "apps/web/src/lib/ecosystem-pulse-window.ts",


### PR DESCRIPTION
Mirrors the `*-lib` extraction pattern from merged PRs #4556 (contributor-identity), #4557 (ecosystem-pulse-window), and #4560 (brief-schedule).

The pure display helpers move to a new `apps/web/src/lib/contributor-profile-summary-lib.ts` — `contributorProfileStats` and `contributorCardSummary`. `contributor-profile-summary.ts` re-exports them and keeps the data-coupled `submitterAttribution` (which depends on `contributorForSubmitter`) in place, so existing importers (`routes/contributors.index.tsx`, `routes/contributors.$slug.tsx`) stay unchanged.

Adds `tests/contributor-profile-summary-lib.test.ts` with 7 tests: `contributorProfileStats` (pass-through of `acceptedCount`, `?? 0` defaults for missing optional counts, category length) and `contributorCardSummary` (always shows accepted, omits zero reviewed/source-linked, appends both when present, reviewed-only case).

The shim is added to the coverage `exclude` list in `vitest.config.ts` (one line), matching the pattern. No behaviour change.

Validation: `pnpm exec vitest run tests/contributor-profile-summary-lib.test.ts` (7 passed), `prettier --check` clean, `git diff --check` clean.