### PR TITLE
fix(review): enable skip-drafts and linked-issue label propagation

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -51,11 +51,41 @@ gate:
     mode: advisory           # block | advisory | off — readiness-score floor, advisory only
     minScore: 60
 
+# AI-review eligibility filters: a draft PR previously re-triggered a full AI review on every push,
+# letting a contributor iterate for free while tokens kept burning — skip_drafts stops that.
+# skip_docs_only is deliberately NOT set here: this repo's primary contribution type (a content/
+# entry) is itself markdown and must not be misclassified as skippable documentation.
+review:
+  auto_review:
+    skip_drafts: true
+
+# Linked-issue label propagation: on the (optional, less common) PRs here that do link an issue, the
+# PR inherits that issue's point-bearing gittensor:* label instead of the PR's own label being
+# decided purely by its commit-title prefix. bug/feature trust a maintainer-authored linked issue
+# (routine categorization, no reward at stake); priority intentionally omits that flag and still
+# requires the PR author to be the issue's actual author/assignee, since it is the scarce,
+# maintainer-hand-picked reward label.
+#
 # Review-evasion protection (config-as-code override; layered OVER the dashboard's own default of
 # "off"): closing or converting-to-draft your OWN PR while gittensory has an active review pass
 # running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is treated
 # as dodging the one-shot review rather than an ordinary action.
 settings:
+  linkedIssueLabelPropagation:
+    enabled: true
+    mode: exclusive_type_label
+    mappings:
+      - issueLabel: "gittensor:bug"
+        prLabel: "gittensor:bug"
+        removeOtherTypeLabels: true
+        trustMaintainerAuthoredIssue: true
+      - issueLabel: "gittensor:feature"
+        prLabel: "gittensor:feature"
+        removeOtherTypeLabels: true
+        trustMaintainerAuthoredIssue: true
+      - issueLabel: "gittensor:priority"
+        prLabel: "gittensor:priority"
+        removeOtherTypeLabels: true
   reviewEvasionProtection: close
 
 publicNotes:


### PR DESCRIPTION
## Summary

Part of JSONbored/gittensory#3999 and JSONbored/gittensory#4000 (both tracked upstream in JSONbored/gittensory — not closing them directly from here since they cover all three gated repos; the upstream tracking issues will be closed once every repo's config PR is confirmed merged).

- `review.auto_review.skip_drafts: true` — a push to a draft PR was re-triggering a full AI review on every commit; this stops that. `skip_docs_only` is deliberately NOT set here, since this repo's primary contribution type (a `content/` entry) is itself markdown and must not be misclassified as skippable documentation.
- `settings.linkedIssueLabelPropagation` — on the (optional, less common) PRs here that do link an issue, the PR now inherits that issue's `gittensor:bug`/`feature`/`priority` label instead of the label being decided purely by commit-title regex. Mirrors the config already live on JSONbored/gittensory's own `.gittensory.yml`.

## Validation

- Parsed and validated locally with the `yaml` package against the exact schema `gittensory`'s engine expects (`packages/gittensory-engine/src/focus-manifest.ts`).
- Confirmed this repo's labels (`gittensor:bug`/`gittensor:feature`/`gittensor:priority`) match the mapping used.

## Notes

Config-only change to `.gittensory.yml` — no source code touched.