### PR TITLE
feat(web): redesign entry detail command center

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -1,0 +1,313 @@
+import {
+  ArrowUpRight,
+  BookOpen,
+  ExternalLink,
+  GitBranch,
+  Code2,
+  AlertTriangle,
+  OctagonX,
+  FileText,
+} from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import type { Entry, Harness } from "@/types/registry";
+import { CopyButton } from "@/components/copy-button";
+import { HarnessVariantPicker } from "@/components/harness-variant-picker";
+import type { VariantOption } from "@/components/copy-segmented";
+import type { CopyVariant } from "@/lib/dossier-prefs";
+import {
+  ENTRY_COMMAND_CENTER_ID,
+  detailSafetyGateMessage,
+  entryDetailSuggestChangeUrl,
+  resolveDetailCommunityAnchors,
+  resolveDetailQuickLinks,
+  resolveDetailReadinessItems,
+  shouldElevateDetailSafetyGate,
+} from "@/lib/entry-detail-command-center";
+import { INSTALL_RISK_LABEL } from "@/lib/trust";
+import type { InstallRisk } from "@/lib/trust-lib";
+import { siteConfig } from "@/lib/site";
+import { absoluteUrl } from "@/lib/seo";
+import { cn } from "@/lib/utils";
+
+type EntryDetailCommandCenterProps = {
+  entry: Entry;
+  risk: InstallRisk;
+  harnessAvailable: Harness[];
+  harness: Harness | null;
+  onHarnessChange: (value: Harness | null) => void;
+  liveVariants: VariantOption[];
+  tab: CopyVariant;
+  onTabChange: (value: CopyVariant) => void;
+  tabPayload?: string;
+  relatedCount: number;
+  guideCount: number;
+};
+
+function ReadinessRow({ label, value, ok }: { label: string; value: string; ok: boolean }) {
+  return (
+    <li className="flex items-center justify-between">
+      <span className="text-ink-muted">{label}</span>
+      <span
+        className={cn("font-medium capitalize", ok ? "text-trust-trusted" : "text-trust-review")}
+      >
+        {value}
+      </span>
+    </li>
+  );
+}
+
+export function EntryDetailCommandCenter({
+  entry,
+  risk,
+  harnessAvailable,
+  harness,
+  onHarnessChange,
+  liveVariants,
+  tab,
+  onTabChange,
+  tabPayload,
+  relatedCount,
+  guideCount,
+}: EntryDetailCommandCenterProps) {
+  const readiness = resolveDetailReadinessItems(entry);
+  const quickLinks = resolveDetailQuickLinks(entry);
+  const communityAnchors = resolveDetailCommunityAnchors(relatedCount, guideCount, true);
+  const safetyGate = detailSafetyGateMessage(risk, entry);
+  const elevateSafety = shouldElevateDetailSafetyGate(risk, entry);
+  const suggestUrl = entryDetailSuggestChangeUrl(
+    entry,
+    absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    siteConfig.githubUrl,
+  );
+
+  return (
+    <aside
+      id={ENTRY_COMMAND_CENTER_ID}
+      className="min-w-0 scroll-mt-24 lg:sticky lg:top-20 lg:self-start"
+    >
+      <div className="overflow-hidden rounded-xl border border-border bg-surface">
+        <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
+          <div className="eyebrow">Command center</div>
+          {entry.sourceUrl && (
+            <a
+              href={entry.sourceUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
+            >
+              Source <ArrowUpRight className="h-3 w-3" />
+            </a>
+          )}
+        </div>
+
+        {elevateSafety && safetyGate && (
+          <div
+            className={cn(
+              "flex items-start gap-2 border-b border-border px-4 py-3 text-xs",
+              risk === "high"
+                ? "bg-trust-blocked/5 text-trust-blocked"
+                : "bg-trust-review/5 text-trust-review",
+            )}
+          >
+            {risk === "high" ? (
+              <OctagonX className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            ) : (
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+            )}
+            <div className="min-w-0">
+              <div className="font-semibold text-ink">
+                {risk !== "low" ? INSTALL_RISK_LABEL[risk] : "Review before installing"}
+              </div>
+              <p className="mt-0.5 text-ink-muted">{safetyGate}</p>
+              {(entry.safetyNotes || entry.privacyNotes) && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {entry.safetyNotes && (
+                    <a
+                      href="#safety"
+                      className="font-medium text-ink underline-offset-2 hover:underline"
+                    >
+                      Safety notes
+                    </a>
+                  )}
+                  {entry.privacyNotes && (
+                    <a
+                      href="#privacy"
+                      className="font-medium text-ink underline-offset-2 hover:underline"
+                    >
+                      Privacy notes
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="border-b border-border px-4 py-3">
+          <div className="eyebrow mb-2">Install & copy</div>
+          {harnessAvailable.length >= 2 && (
+            <div className="mb-3">
+              <div className="mb-1.5 text-[10px] uppercase tracking-wider text-ink-subtle">
+                Harness variant
+              </div>
+              <HarnessVariantPicker
+                available={harnessAvailable}
+                value={harness}
+                onChange={onHarnessChange}
+              />
+            </div>
+          )}
+          <div className="flex gap-1">
+            {(["install", "config", "full"] as const).map((t) => {
+              const payload = liveVariants.find((v) => v.id === t)?.value;
+              if (!payload) return null;
+              return (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => onTabChange(t)}
+                  aria-pressed={tab === t}
+                  className={cn(
+                    "rounded-t-md px-2.5 py-1.5 text-xs font-medium capitalize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
+                    tab === t ? "bg-background text-ink" : "text-ink-muted hover:text-ink",
+                  )}
+                >
+                  {t}
+                </button>
+              );
+            })}
+          </div>
+          <div className="rounded-b-md bg-background p-3">
+            {tabPayload ? (
+              <>
+                <pre className="max-h-64 overflow-auto rounded-md bg-surface-2 p-3 font-mono text-[12px] leading-relaxed text-ink">
+                  <code>{tabPayload}</code>
+                </pre>
+                <div className="mt-3 flex items-center gap-2">
+                  <CopyButton
+                    value={tabPayload}
+                    label={`Copy ${tab}`}
+                    size="md"
+                    className="flex-1 justify-center"
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="rounded-md bg-surface-2 p-4 text-xs text-ink-muted">
+                No installable payload for this tab.
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="border-b border-border px-4 py-3">
+          <div className="eyebrow mb-2">Trust & readiness</div>
+          <ul className="space-y-1.5 text-xs">
+            {readiness.map((item) => (
+              <ReadinessRow key={item.id} label={item.label} value={item.value} ok={item.ok} />
+            ))}
+          </ul>
+        </div>
+
+        {communityAnchors.length > 0 && (
+          <div className="border-b border-border px-4 py-3">
+            <div className="eyebrow mb-2">Community context</div>
+            <ul className="space-y-1.5 text-xs">
+              {communityAnchors.map((anchor) => (
+                <li key={anchor.id}>
+                  <a
+                    href={`#${anchor.targetId}`}
+                    className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+                  >
+                    {anchor.label}
+                    {typeof anchor.count === "number" && (
+                      <span className="font-mono text-[10px] text-ink-subtle">
+                        ({anchor.count})
+                      </span>
+                    )}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <div className="px-4 py-3">
+          <div className="eyebrow mb-2">Contribute</div>
+          <div className="flex flex-col gap-1.5 text-xs">
+            <a
+              href={suggestUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+            >
+              <FileText className="h-3.5 w-3.5" /> Suggest a metadata change{" "}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+            {!entry.claimed && (
+              <Link
+                to="/claim"
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                Claim this listing
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-1.5 text-xs">
+        {quickLinks.map((link) => {
+          if (link.id === "docs") {
+            return (
+              <a
+                key={link.id}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                <BookOpen className="h-3.5 w-3.5" /> {link.label}{" "}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            );
+          }
+          if (link.id === "source") {
+            return (
+              <a
+                key={link.id}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                <GitBranch className="h-3.5 w-3.5" /> {link.label}{" "}
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            );
+          }
+          if (link.id === "registry") {
+            return (
+              <Link
+                key={link.id}
+                to={link.href}
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                <Code2 className="h-3.5 w-3.5" /> {link.label}
+              </Link>
+            );
+          }
+          return (
+            <a
+              key={link.id}
+              href={link.href}
+              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+            >
+              <FileText className="h-3.5 w-3.5" /> {link.label}
+            </a>
+          );
+        })}
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -1,0 +1,97 @@
+import { useCallback } from "react";
+import { toast } from "sonner";
+import { Copy, ExternalLink, Package, FileText } from "lucide-react";
+import type { Entry } from "@/types/registry";
+import {
+  ENTRY_COMMAND_CENTER_ID,
+  resolveDetailMobileActions,
+} from "@/lib/entry-detail-command-center";
+import { siteConfig } from "@/lib/site";
+import { absoluteUrl } from "@/lib/seo";
+import { cn } from "@/lib/utils";
+
+type EntryDetailMobileActionBarProps = {
+  entry: Entry;
+  copyPayload?: string;
+};
+
+export function EntryDetailMobileActionBar({
+  entry,
+  copyPayload,
+}: EntryDetailMobileActionBarProps) {
+  const entryPageUrl = absoluteUrl(`/entry/${entry.category}/${entry.slug}`);
+  const actions = resolveDetailMobileActions(
+    entry,
+    copyPayload,
+    entryPageUrl,
+    siteConfig.githubUrl,
+  );
+
+  const onAction = useCallback(
+    async (actionId: string) => {
+      const action = actions.find((item) => item.id === actionId);
+      if (!action) return;
+
+      if (action.kind === "scroll" && action.scrollTargetId) {
+        const target = document.getElementById(action.scrollTargetId ?? ENTRY_COMMAND_CENTER_ID);
+        target?.scrollIntoView({ behavior: "smooth", block: "start" });
+        return;
+      }
+
+      if (action.kind === "copy" && action.copyValue) {
+        try {
+          await navigator.clipboard.writeText(action.copyValue);
+          toast.success("Copied install command");
+        } catch {
+          toast.error("Copy failed");
+        }
+        return;
+      }
+
+      if (action.kind === "link" && action.href) {
+        if (action.external) {
+          window.open(action.href, "_blank", "noopener,noreferrer");
+        } else {
+          window.location.assign(action.href);
+        }
+      }
+    },
+    [actions],
+  );
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 px-3 py-2 backdrop-blur lg:hidden">
+      <div className="pointer-events-auto mx-auto flex max-w-[1200px] gap-2">
+        {actions.map((action) => {
+          const icon =
+            action.id === "install" ? (
+              <Package className="h-3.5 w-3.5" />
+            ) : action.id === "copy" ? (
+              <Copy className="h-3.5 w-3.5" />
+            ) : action.id === "source" || action.id === "suggest" ? (
+              <ExternalLink className="h-3.5 w-3.5" />
+            ) : (
+              <FileText className="h-3.5 w-3.5" />
+            );
+
+          return (
+            <button
+              key={action.id}
+              type="button"
+              onClick={() => onAction(action.id)}
+              className={cn(
+                "inline-flex h-10 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md px-2 text-xs font-medium",
+                action.primary
+                  ? "bg-ink text-background hover:bg-ink/90"
+                  : "border border-border bg-surface text-ink hover:bg-surface-2",
+              )}
+            >
+              {icon}
+              <span className="truncate">{action.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/entry-detail-command-center-lib.ts
+++ b/apps/web/src/lib/entry-detail-command-center-lib.ts
@@ -1,0 +1,311 @@
+/**
+ * Pure entry detail command center helpers.
+ *
+ * Organizes install/copy actions, trust readiness, quick links, and mobile
+ * action bar items from entry metadata. Given the same entry fields the
+ * output is deterministic — no network or DOM access.
+ */
+
+import type { InstallRisk } from "@/lib/trust-lib";
+import type { Entry } from "@/types/registry";
+import { TRUST_LABEL } from "@/types/registry";
+
+export const ENTRY_COMMAND_CENTER_ID = "entry-command-center";
+
+export type DetailReadinessItem = {
+  id: string;
+  label: string;
+  value: string;
+  ok: boolean;
+};
+
+export type DetailQuickLink = {
+  id: string;
+  label: string;
+  href: string;
+  external?: boolean;
+};
+
+export type DetailMobileActionKind = "scroll" | "copy" | "link";
+
+export type DetailMobileAction = {
+  id: string;
+  label: string;
+  kind: DetailMobileActionKind;
+  href?: string;
+  copyValue?: string;
+  scrollTargetId?: string;
+  primary?: boolean;
+  external?: boolean;
+};
+
+export type DetailCommunityAnchor = {
+  id: string;
+  label: string;
+  targetId: string;
+  count?: number;
+};
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+) {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function hasSafetyNotes(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">) {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacyNotes(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">) {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+export function resolveDetailReadinessItems(
+  entry: Pick<Entry, "trust" | "source" | "safetyNotes" | "reviewed">,
+): DetailReadinessItem[] {
+  return [
+    {
+      id: "trust",
+      label: "Trust",
+      value: TRUST_LABEL[entry.trust],
+      ok: entry.trust === "trusted",
+    },
+    {
+      id: "source",
+      label: "Source",
+      value: entry.source,
+      ok: entry.source !== "unverified",
+    },
+    {
+      id: "safety",
+      label: "Safety notes",
+      value: entry.safetyNotes ? "Present" : "Missing",
+      ok: Boolean(entry.safetyNotes),
+    },
+    {
+      id: "reviewed",
+      label: "Reviewed",
+      value: entry.reviewed ? "Yes" : "No",
+      ok: Boolean(entry.reviewed),
+    },
+  ];
+}
+
+export function resolveDetailQuickLinks(
+  entry: Pick<Entry, "docsUrl" | "sourceUrl" | "category" | "slug">,
+): DetailQuickLink[] {
+  const links: DetailQuickLink[] = [];
+
+  if (entry.docsUrl) {
+    links.push({
+      id: "docs",
+      label: "Documentation",
+      href: entry.docsUrl,
+      external: true,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    links.push({
+      id: "source",
+      label: "Source repository",
+      href: entry.sourceUrl,
+      external: true,
+    });
+  }
+
+  links.push({
+    id: "registry",
+    label: "Registry JSON · LLM text",
+    href: "/browse",
+    external: false,
+  });
+
+  links.push({
+    id: "llms",
+    label: "LLM plain text",
+    href: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
+    external: false,
+  });
+
+  return links;
+}
+
+export function entryDetailSuggestChangeUrl(
+  entry: Pick<Entry, "category" | "slug" | "title">,
+  entryPageUrl: string,
+  githubUrl: string,
+): string {
+  const title = encodeURIComponent(`Suggest change: ${entry.title}`);
+  const body = encodeURIComponent(
+    [
+      `Entry: ${entryPageUrl}`,
+      `Registry ref: \`${entry.category}/${entry.slug}\``,
+      "",
+      "Describe the metadata or safety improvement:",
+      "",
+      "- ",
+    ].join("\n"),
+  );
+  return `${githubUrl}/issues/new?title=${title}&body=${body}`;
+}
+
+export function resolveDetailMobileActions(
+  entry: Pick<
+    Entry,
+    | "sourceUrl"
+    | "installCommand"
+    | "configSnippet"
+    | "fullCopy"
+    | "copySnippet"
+    | "category"
+    | "slug"
+    | "title"
+    | "claimed"
+  >,
+  copyPayload: string | undefined,
+  entryPageUrl: string,
+  githubUrl: string,
+): DetailMobileAction[] {
+  const actions: DetailMobileAction[] = [
+    {
+      id: "install",
+      label: "Install",
+      kind: "scroll",
+      scrollTargetId: ENTRY_COMMAND_CENTER_ID,
+      primary: true,
+    },
+  ];
+
+  if (copyPayload) {
+    actions.push({
+      id: "copy",
+      label: "Copy",
+      kind: "copy",
+      copyValue: copyPayload,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
+      id: "source",
+      label: "Source",
+      kind: "link",
+      href: entry.sourceUrl,
+      external: true,
+    });
+  }
+
+  actions.push({
+    id: "suggest",
+    label: "Suggest change",
+    kind: "link",
+    href: entryDetailSuggestChangeUrl(entry, entryPageUrl, githubUrl),
+    external: true,
+  });
+
+  if (!entry.claimed) {
+    actions.push({
+      id: "claim",
+      label: "Claim",
+      kind: "link",
+      href: "/claim",
+      external: false,
+    });
+  }
+
+  return actions;
+}
+
+export function shouldElevateDetailSafetyGate(
+  risk: InstallRisk,
+  entry: Pick<
+    Entry,
+    | "safetyNotes"
+    | "privacyNotes"
+    | "safetyNotesList"
+    | "privacyNotesList"
+    | "installCommand"
+    | "configSnippet"
+    | "fullCopy"
+    | "copySnippet"
+  >,
+): boolean {
+  if (risk !== "low") return true;
+  if (!hasInstallPayload(entry)) return false;
+  return !hasSafetyNotes(entry) || !hasPrivacyNotes(entry);
+}
+
+export function detailSafetyGateMessage(
+  risk: InstallRisk,
+  entry: Pick<
+    Entry,
+    | "safetyNotes"
+    | "privacyNotes"
+    | "safetyNotesList"
+    | "privacyNotesList"
+    | "installCommand"
+    | "configSnippet"
+    | "fullCopy"
+    | "copySnippet"
+  >,
+): string | null {
+  if (!shouldElevateDetailSafetyGate(risk, entry)) return null;
+
+  if (risk === "high") {
+    return "High install risk — read safety and privacy notes before copying or installing.";
+  }
+  if (risk === "medium") {
+    return "Review safety and privacy notes before installing or copying commands.";
+  }
+
+  const missing: string[] = [];
+  if (!hasSafetyNotes(entry)) missing.push("safety");
+  if (!hasPrivacyNotes(entry)) missing.push("privacy");
+  if (missing.length === 0) {
+    return "Review trust signals before installing or copying commands.";
+  }
+  return `Missing ${missing.join(" and ")} notes — review the source before installing.`;
+}
+
+export function resolveDetailCommunityAnchors(
+  relatedCount: number,
+  guideCount: number,
+  signalSectionAvailable: boolean,
+): DetailCommunityAnchor[] {
+  const anchors: DetailCommunityAnchor[] = [];
+
+  if (relatedCount > 0) {
+    anchors.push({
+      id: "related",
+      label: "Related entries",
+      targetId: "related",
+      count: relatedCount,
+    });
+  }
+
+  if (guideCount > 0) {
+    anchors.push({
+      id: "guides",
+      label: "Related guides",
+      targetId: "guides",
+      count: guideCount,
+    });
+  }
+
+  if (signalSectionAvailable) {
+    anchors.push({
+      id: "signals",
+      label: "Community signals",
+      targetId: "signals",
+    });
+  }
+
+  return anchors;
+}
+
+export function detailMobileActionIds(actions: DetailMobileAction[]): string[] {
+  return actions.map((action) => action.id);
+}

--- a/apps/web/src/lib/entry-detail-command-center.ts
+++ b/apps/web/src/lib/entry-detail-command-center.ts
@@ -1,0 +1,25 @@
+/**
+ * Entry detail command center surface.
+ *
+ * Pure helpers live in `entry-detail-command-center-lib.ts`. This module
+ * re-exports that surface so existing `@/lib/entry-detail-command-center`
+ * imports stay stable.
+ */
+export type {
+  DetailCommunityAnchor,
+  DetailMobileAction,
+  DetailMobileActionKind,
+  DetailQuickLink,
+  DetailReadinessItem,
+} from "@/lib/entry-detail-command-center-lib";
+export {
+  ENTRY_COMMAND_CENTER_ID,
+  detailMobileActionIds,
+  detailSafetyGateMessage,
+  entryDetailSuggestChangeUrl,
+  resolveDetailCommunityAnchors,
+  resolveDetailMobileActions,
+  resolveDetailQuickLinks,
+  resolveDetailReadinessItems,
+  shouldElevateDetailSafetyGate,
+} from "@/lib/entry-detail-command-center-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -2,14 +2,10 @@ import { createFileRoute, Link, notFound, redirect } from "@tanstack/react-route
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import {
-  ArrowUpRight,
-  BookOpen,
   ExternalLink,
-  GitBranch,
   ShieldCheck,
   AlertTriangle,
   ListChecks,
-  Code2,
   Sparkles,
   Star,
   FileText,
@@ -56,15 +52,16 @@ import { SourceCitations } from "@/components/source-citations";
 import { CitationFacts } from "@/components/citation-facts";
 import { ProvenanceBlock } from "@/components/provenance-block";
 import { StickyMetaBar } from "@/components/sticky-meta-bar";
+import { EntryDetailCommandCenter } from "@/components/entry-detail-command-center";
+import { EntryDetailMobileActionBar } from "@/components/entry-detail-mobile-action-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
-import { TRUST_LABEL, PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
+import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import { installRiskLevel, INSTALL_RISK_LABEL, INSTALL_RISK_DETAIL } from "@/lib/trust";
 import { useEffect, useMemo, useState } from "react";
 import { useRecents } from "@/lib/recents";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
-import { HarnessVariantPicker } from "@/components/harness-variant-picker";
 import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 
@@ -381,129 +378,19 @@ function Dossier() {
           <EntryFacets entry={entry} density="card" className="mt-3" />
         </div>
 
-        {/* Sticky install panel */}
-        <aside className="min-w-0 lg:sticky lg:top-20 lg:self-start">
-          <div className="overflow-hidden rounded-xl border border-border bg-surface">
-            <div className="flex items-center justify-between border-b border-border px-4 py-2.5">
-              <div className="eyebrow">Install</div>
-              {entry.sourceUrl && (
-                <a
-                  href={entry.sourceUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
-                >
-                  Source <ArrowUpRight className="h-3 w-3" />
-                </a>
-              )}
-            </div>
-            {harnessAvailable.length >= 2 && (
-              <div className="border-b border-border px-3 py-2">
-                <div className="mb-1.5 text-[10px] uppercase tracking-wider text-ink-subtle">
-                  Harness variant
-                </div>
-                <HarnessVariantPicker
-                  available={harnessAvailable}
-                  value={harness as Harness | null}
-                  onChange={setHarness}
-                />
-              </div>
-            )}
-            <div className="flex gap-1 border-b border-border px-3 pt-2">
-              {(["install", "config", "full"] as const).map((t) => {
-                const payload = liveVariants.find((v) => v.id === t)?.value;
-                if (!payload) return null;
-                return (
-                  <button
-                    key={t}
-                    onClick={() => setTab(t)}
-                    aria-pressed={tab === t}
-                    className={cn(
-                      "rounded-t-md px-2.5 py-1.5 text-xs font-medium capitalize focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
-                      tab === t ? "bg-background text-ink" : "text-ink-muted hover:text-ink",
-                    )}
-                  >
-                    {t}
-                  </button>
-                );
-              })}
-            </div>
-            <div className="bg-background p-3">
-              {tabPayload ? (
-                <>
-                  <pre className="max-h-64 overflow-auto rounded-md bg-surface-2 p-3 font-mono text-[12px] leading-relaxed text-ink">
-                    <code>{tabPayload}</code>
-                  </pre>
-                  <div className="mt-3 flex items-center gap-2">
-                    <CopyButton
-                      value={tabPayload}
-                      label={`Copy ${tab}`}
-                      size="md"
-                      className="flex-1 justify-center"
-                    />
-                  </div>
-                </>
-              ) : (
-                <div className="rounded-md bg-surface-2 p-4 text-xs text-ink-muted">
-                  No installable payload for this tab.
-                </div>
-              )}
-            </div>
-
-            <div className="border-t border-border px-4 py-3">
-              <div className="eyebrow mb-2">Readiness</div>
-              <ul className="space-y-1.5 text-xs">
-                <Readiness
-                  label="Trust"
-                  value={TRUST_LABEL[entry.trust]}
-                  ok={entry.trust === "trusted"}
-                />
-                <Readiness label="Source" value={entry.source} ok={entry.source !== "unverified"} />
-                <Readiness
-                  label="Safety notes"
-                  value={entry.safetyNotes ? "Present" : "Missing"}
-                  ok={!!entry.safetyNotes}
-                />
-                <Readiness
-                  label="Reviewed"
-                  value={entry.reviewed ? "Yes" : "No"}
-                  ok={!!entry.reviewed}
-                />
-              </ul>
-            </div>
-          </div>
-
-          <div className="mt-3 flex flex-col gap-1.5 text-xs">
-            {entry.docsUrl && (
-              <a
-                href={entry.docsUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-              >
-                <BookOpen className="h-3.5 w-3.5" /> Documentation{" "}
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-            {entry.sourceUrl && (
-              <a
-                href={entry.sourceUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-              >
-                <GitBranch className="h-3.5 w-3.5" /> Source repository{" "}
-                <ExternalLink className="h-3 w-3" />
-              </a>
-            )}
-            <Link
-              to="/browse"
-              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-            >
-              <Code2 className="h-3.5 w-3.5" /> Registry JSON · LLM text
-            </Link>
-          </div>
-        </aside>
+        <EntryDetailCommandCenter
+          entry={entry}
+          risk={risk}
+          harnessAvailable={harnessAvailable}
+          harness={harness as Harness | null}
+          onHarnessChange={setHarness}
+          liveVariants={liveVariants}
+          tab={tab}
+          onTabChange={setTab}
+          tabPayload={tabPayload}
+          relatedCount={rel.length}
+          guideCount={guides.length}
+        />
       </header>
       <div id="dossier-header-sentinel" aria-hidden className="h-px w-full" />
 
@@ -823,6 +710,8 @@ function Dossier() {
           </div>
         </aside>
       </div>
+      <EntryDetailMobileActionBar entry={entry} copyPayload={tabPayload} />
+      <div className="h-14 lg:hidden" aria-hidden />
     </div>
   );
 }
@@ -1220,18 +1109,5 @@ function DossierSection({
       </div>
       <div className="prose-editorial text-sm">{children}</div>
     </section>
-  );
-}
-
-function Readiness({ label, value, ok }: { label: string; value: string; ok: boolean }) {
-  return (
-    <li className="flex items-center justify-between">
-      <span className="text-ink-muted">{label}</span>
-      <span
-        className={cn("font-medium capitalize", ok ? "text-trust-trusted" : "text-trust-review")}
-      >
-        {value}
-      </span>
-    </li>
   );
 }

--- a/tests/entry-detail-command-center-lib.test.ts
+++ b/tests/entry-detail-command-center-lib.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  detailMobileActionIds,
+  detailSafetyGateMessage,
+  entryDetailSuggestChangeUrl,
+  resolveDetailCommunityAnchors,
+  resolveDetailMobileActions,
+  resolveDetailQuickLinks,
+  resolveDetailReadinessItems,
+  shouldElevateDetailSafetyGate,
+} from "@/lib/entry-detail-command-center-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture Skill",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry detail command center lib", () => {
+  it("builds readiness rows from trust metadata", () => {
+    expect(
+      resolveDetailReadinessItems(entry({ trust: "trusted", reviewed: true })),
+    ).toEqual([
+      { id: "trust", label: "Trust", value: "Trusted", ok: true },
+      { id: "source", label: "Source", value: "unverified", ok: false },
+      { id: "safety", label: "Safety notes", value: "Missing", ok: false },
+      { id: "reviewed", label: "Reviewed", value: "Yes", ok: true },
+    ]);
+  });
+
+  it("orders quick links with docs and source before registry helpers", () => {
+    const links = resolveDetailQuickLinks(
+      entry({
+        docsUrl: "https://example.com/docs",
+        sourceUrl: "https://github.com/example/repo",
+      }),
+    );
+    expect(links.map((link) => link.id)).toEqual([
+      "docs",
+      "source",
+      "registry",
+      "llms",
+    ]);
+    expect(links[0]).toMatchObject({ external: true });
+    expect(links[2]).toMatchObject({ href: "/browse", external: false });
+  });
+
+  it("builds a GitHub issue URL for suggest-change actions", () => {
+    const url = entryDetailSuggestChangeUrl(
+      entry({ title: "Fixture Skill" }),
+      "https://heyclau.de/entry/skills/fixture",
+      "https://github.com/JSONbored/awesome-claude",
+    );
+    expect(url).toContain("/issues/new?");
+    expect(url).toContain(encodeURIComponent("Suggest change: Fixture Skill"));
+    expect(url).toContain(encodeURIComponent("skills/fixture"));
+  });
+
+  it("surfaces install, copy, source, and suggest actions on mobile", () => {
+    const actions = resolveDetailMobileActions(
+      entry({
+        installCommand: "npm i fixture",
+        sourceUrl: "https://github.com/example/repo",
+      }),
+      "npm i fixture",
+      "https://heyclau.de/entry/skills/fixture",
+      "https://github.com/JSONbored/awesome-claude",
+    );
+    expect(detailMobileActionIds(actions)).toEqual([
+      "install",
+      "copy",
+      "source",
+      "suggest",
+      "claim",
+    ]);
+    expect(actions[0]).toMatchObject({ kind: "scroll", primary: true });
+    expect(actions[1]).toMatchObject({
+      kind: "copy",
+      copyValue: "npm i fixture",
+    });
+  });
+
+  it("omits copy and claim actions when payload or claim state is absent", () => {
+    const actions = resolveDetailMobileActions(
+      entry({ claimed: true }),
+      undefined,
+      "https://heyclau.de/entry/skills/fixture",
+      "https://github.com/JSONbored/awesome-claude",
+    );
+    expect(detailMobileActionIds(actions)).toEqual(["install", "suggest"]);
+  });
+
+  it("elevates the safety gate for risky or note-missing installable entries", () => {
+    expect(shouldElevateDetailSafetyGate("high", entry())).toBe(true);
+    expect(
+      shouldElevateDetailSafetyGate(
+        "low",
+        entry({ installCommand: "npm i fixture" }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldElevateDetailSafetyGate(
+        "low",
+        entry({
+          installCommand: "npm i fixture",
+          safetyNotes: "Read carefully",
+          privacyNotes: "No telemetry",
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns contextual safety gate copy", () => {
+    expect(detailSafetyGateMessage("high", entry())).toContain(
+      "High install risk",
+    );
+    expect(
+      detailSafetyGateMessage(
+        "low",
+        entry({ installCommand: "npm i fixture" }),
+      ),
+    ).toContain("Missing safety and privacy notes");
+    expect(
+      detailSafetyGateMessage(
+        "medium",
+        entry({
+          safetyNotes: "ok",
+          privacyNotes: "ok",
+          installCommand: "npm i fixture",
+        }),
+      ),
+    ).toContain("Review safety and privacy notes");
+  });
+
+  it("builds community anchor links without overwhelming empty pages", () => {
+    expect(resolveDetailCommunityAnchors(0, 0, false)).toEqual([]);
+    expect(resolveDetailCommunityAnchors(3, 2, true)).toEqual([
+      {
+        id: "related",
+        label: "Related entries",
+        targetId: "related",
+        count: 3,
+      },
+      { id: "guides", label: "Related guides", targetId: "guides", count: 2 },
+      { id: "signals", label: "Community signals", targetId: "signals" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract entry detail command center into entry-detail-command-center-lib.ts with focused vitest coverage.
- Replace the header install sidebar with a structured command center: safety gate, install/copy tabs, trust readiness, community anchors, and contribution links.
- Add a mobile bottom action bar for install, copy, source, and suggest-change actions.

Closes #440
Refs #393

## Test plan
- [x] pnpm exec vitest run tests/entry-detail-command-center-lib.test.ts
- [x] pnpm build
- [ ] Verify entry detail page on desktop: command center shows safety gate, install tabs, trust readiness, and community anchors.
- [ ] Verify mobile action bar appears below lg breakpoint and scroll/copy/source/suggest actions work.

Made with [Cursor](https://cursor.com)