### PR TITLE
feat(web): add browse trust utility dropdown and mobile chips

### DIFF
--- a/apps/web/src/lib/browse-trust-filters-lib.ts
+++ b/apps/web/src/lib/browse-trust-filters-lib.ts
@@ -1,0 +1,124 @@
+/**
+ * Pure browse trust-signal filter helpers.
+ *
+ * Centralizes trust quick-filter options, facet counting, and utility
+ * dropdown labels for the browse directory. Given the same registry slice
+ * and URL state the output is deterministic.
+ */
+
+import { countSearchResults, TRUST_SIGNAL_FILTERS, type TrustSignalFilter } from "@/data/search";
+import type { Category, Platform, SourceStatus, TrustLevel } from "@/types/registry";
+
+export const BROWSE_TRUST_SIGNAL_OPTIONS: { id: TrustSignalFilter; label: string }[] = [
+  { id: "safety-notes", label: "Safety notes" },
+  { id: "privacy-notes", label: "Privacy notes" },
+  { id: "source-backed", label: "Source-backed" },
+  { id: "trusted-package", label: "Trusted package" },
+  { id: "reviewed", label: "Reviewed" },
+  { id: "checksums", label: "Checksums" },
+];
+
+const BROWSE_TRUST_SIGNAL_LABEL = Object.fromEntries(
+  BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => [option.id, option.label]),
+) as Record<TrustSignalFilter, string>;
+
+export type BrowseTrustSearchSlice = {
+  q: string;
+  category: string;
+  trust: string;
+  source: string;
+  signal: string;
+  platform: string;
+  sort: "popular" | "newest" | "title";
+};
+
+export type BrowseTrustUtilityOption = {
+  id: "" | TrustSignalFilter;
+  label: string;
+  count: number;
+};
+
+export function isBrowseTrustSignalFilter(value: string): value is TrustSignalFilter {
+  return TRUST_SIGNAL_FILTERS.includes(value as TrustSignalFilter);
+}
+
+export function browseTrustSignalLabel(value: string): string {
+  return isBrowseTrustSignalFilter(value) ? BROWSE_TRUST_SIGNAL_LABEL[value] : "";
+}
+
+export function toggleBrowseTrustSignal(
+  current: string,
+  next: TrustSignalFilter,
+): "" | TrustSignalFilter {
+  return current === next ? "" : next;
+}
+
+function toSearchFilters(slice: BrowseTrustSearchSlice, signalOverride?: string) {
+  const signal = signalOverride ?? slice.signal;
+  return {
+    q: slice.q,
+    categories: slice.category ? [slice.category as Category] : undefined,
+    trust: slice.trust ? [slice.trust as TrustLevel] : undefined,
+    source: slice.source ? [slice.source as SourceStatus] : undefined,
+    signal: isBrowseTrustSignalFilter(signal) ? signal : ("" as const),
+    platforms: slice.platform ? [slice.platform as Platform] : undefined,
+    sort: slice.sort,
+  };
+}
+
+export function buildBrowseTrustSignalCounts(
+  slice: BrowseTrustSearchSlice,
+  countFn: typeof countSearchResults = countSearchResults,
+): Record<TrustSignalFilter, number> {
+  return Object.fromEntries(
+    BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => [
+      option.id,
+      countFn(toSearchFilters(slice, option.id)),
+    ]),
+  ) as Record<TrustSignalFilter, number>;
+}
+
+export function formatBrowseTrustUtilityOptionLabel(label: string, count: number): string {
+  return `${label} (${count})`;
+}
+
+export function buildBrowseTrustUtilityOptions(
+  counts: Record<TrustSignalFilter, number>,
+): BrowseTrustUtilityOption[] {
+  return [
+    { id: "", label: "All trust signals", count: 0 },
+    ...BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => ({
+      id: option.id,
+      label: formatBrowseTrustUtilityOptionLabel(option.label, counts[option.id] ?? 0),
+      count: counts[option.id] ?? 0,
+    })),
+  ];
+}
+
+export function browseTrustRelaxationTrials(
+  slice: BrowseTrustSearchSlice,
+): { label: string; patch: Partial<BrowseTrustSearchSlice> }[] {
+  const trials: { label: string; patch: Partial<BrowseTrustSearchSlice> }[] = [];
+  if (slice.platform) {
+    trials.push({ label: `Remove platform "${slice.platform}"`, patch: { platform: "" } });
+  }
+  if (isBrowseTrustSignalFilter(slice.signal)) {
+    trials.push({
+      label: `Remove signal "${browseTrustSignalLabel(slice.signal)}"`,
+      patch: { signal: "" },
+    });
+  }
+  if (slice.source) {
+    trials.push({ label: `Remove source "${slice.source}"`, patch: { source: "" } });
+  }
+  if (slice.trust) {
+    trials.push({ label: `Remove trust "${slice.trust}"`, patch: { trust: "" } });
+  }
+  if (slice.category) {
+    trials.push({ label: `Remove category "${slice.category}"`, patch: { category: "" } });
+  }
+  if (slice.q) {
+    trials.push({ label: `Clear search "${slice.q}"`, patch: { q: "" } });
+  }
+  return trials;
+}

--- a/apps/web/src/lib/browse-trust-filters.ts
+++ b/apps/web/src/lib/browse-trust-filters.ts
@@ -1,0 +1,20 @@
+/**
+ * Browse trust filter surface.
+ *
+ * Pure helpers live in `browse-trust-filters-lib.ts`. This module re-exports
+ * that surface so existing `@/lib/browse-trust-filters` imports stay stable.
+ */
+export type {
+  BrowseTrustSearchSlice,
+  BrowseTrustUtilityOption,
+} from "@/lib/browse-trust-filters-lib";
+export {
+  BROWSE_TRUST_SIGNAL_OPTIONS,
+  browseTrustRelaxationTrials,
+  browseTrustSignalLabel,
+  buildBrowseTrustSignalCounts,
+  buildBrowseTrustUtilityOptions,
+  formatBrowseTrustUtilityOptionLabel,
+  isBrowseTrustSignalFilter,
+  toggleBrowseTrustSignal,
+} from "@/lib/browse-trust-filters-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -11,13 +11,16 @@ import { useMemo } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
+import { countSearchResults, normalizeSearchQuery, search } from "@/data/search";
 import {
-  countSearchResults,
-  normalizeSearchQuery,
-  search,
-  TRUST_SIGNAL_FILTERS,
-  type TrustSignalFilter,
-} from "@/data/search";
+  BROWSE_TRUST_SIGNAL_OPTIONS,
+  browseTrustRelaxationTrials,
+  browseTrustSignalLabel,
+  buildBrowseTrustSignalCounts,
+  buildBrowseTrustUtilityOptions,
+  isBrowseTrustSignalFilter,
+  toggleBrowseTrustSignal,
+} from "@/lib/browse-trust-filters";
 import {
   CATEGORIES,
   type Category,
@@ -155,7 +158,7 @@ export const Route = createFileRoute("/browse")({
     // Stale/external links with unknown category values (e.g. ?category=plugins) render an
     // empty result set that Google flags as a soft 404. Redirect them to clean /browse.
     const invalidCategory = search.category && !CATEGORIES.some((c) => c.id === search.category);
-    const invalidSignal = search.signal && !isTrustSignalFilter(search.signal);
+    const invalidSignal = search.signal && !isBrowseTrustSignalFilter(search.signal);
     if (invalidCategory || invalidSignal) {
       throw redirect({
         to: "/browse",
@@ -199,25 +202,6 @@ const PLATFORM_IDS: Platform[] = [
   "cli",
   "raycast",
 ];
-const TRUST_SIGNAL_OPTIONS: { id: TrustSignalFilter; label: string }[] = [
-  { id: "safety-notes", label: "Safety notes" },
-  { id: "privacy-notes", label: "Privacy notes" },
-  { id: "source-backed", label: "Source-backed" },
-  { id: "trusted-package", label: "Trusted package" },
-  { id: "reviewed", label: "Reviewed" },
-  { id: "checksums", label: "Checksums" },
-];
-const TRUST_SIGNAL_LABEL = Object.fromEntries(
-  TRUST_SIGNAL_OPTIONS.map((option) => [option.id, option.label]),
-) as Record<TrustSignalFilter, string>;
-
-function isTrustSignalFilter(value: string): value is TrustSignalFilter {
-  return TRUST_SIGNAL_FILTERS.includes(value as TrustSignalFilter);
-}
-
-function signalLabel(value: string) {
-  return isTrustSignalFilter(value) ? TRUST_SIGNAL_LABEL[value] : "";
-}
 
 function Browse() {
   const sp = Route.useSearch();
@@ -275,7 +259,7 @@ function Browse() {
       categories: sp.category ? [sp.category as Category] : undefined,
       trust: sp.trust ? [sp.trust as TrustLevel] : undefined,
       source: sp.source ? [sp.source as SourceStatus] : undefined,
-      signal: isTrustSignalFilter(sp.signal) ? sp.signal : "",
+      signal: isBrowseTrustSignalFilter(sp.signal) ? sp.signal : "",
       platforms: sp.platform ? [sp.platform as Platform] : undefined,
       sort: sp.sort,
     }),
@@ -346,7 +330,7 @@ function Browse() {
     if (activeCount === 0) return;
     const label = sp.q
       ? `“${sp.q}”${sp.category ? ` · ${sp.category}` : ""}`
-      : `${sp.category || sp.trust || sp.source || signalLabel(sp.signal) || sp.platform || "Filter"}`;
+      : `${sp.category || sp.trust || sp.source || browseTrustSignalLabel(sp.signal) || sp.platform || "Filter"}`;
     recents.saveSearch({
       label,
       q: sp.q,
@@ -381,7 +365,7 @@ function Browse() {
         categories: merged.category ? [merged.category as Category] : undefined,
         trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
         source: merged.source ? [merged.source as SourceStatus] : undefined,
-        signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
+        signal: isBrowseTrustSignalFilter(merged.signal) ? merged.signal : "",
         platforms: merged.platform ? [merged.platform as Platform] : undefined,
         sort: merged.sort,
       });
@@ -390,9 +374,15 @@ function Browse() {
       category: Object.fromEntries(CATEGORIES.map((c) => [c.id, countFor("category", c.id)])),
       trust: Object.fromEntries(TRUST_LEVELS.map((t) => [t, countFor("trust", t)])),
       source: Object.fromEntries(SOURCE_STATUSES.map((s) => [s, countFor("source", s)])),
-      signal: Object.fromEntries(
-        TRUST_SIGNAL_OPTIONS.map((option) => [option.id, countFor("signal", option.id)]),
-      ),
+      signal: buildBrowseTrustSignalCounts({
+        q: sp.q,
+        category: sp.category,
+        trust: sp.trust,
+        source: sp.source,
+        signal: sp.signal,
+        platform: sp.platform,
+        sort: sp.sort,
+      }),
       platform: Object.fromEntries(PLATFORM_IDS.map((p) => [p, countFor("platform", p)])),
     } as Record<string, Record<string, number>>;
   }, [sp]);
@@ -440,11 +430,11 @@ function Browse() {
       value: sp.source,
       onClear: () => set({ source: "" }),
     });
-  if (isTrustSignalFilter(sp.signal))
+  if (isBrowseTrustSignalFilter(sp.signal))
     activeFilters.push({
       key: "signal",
       label: "Signal",
-      value: signalLabel(sp.signal),
+      value: browseTrustSignalLabel(sp.signal),
       onClear: () => set({ signal: "" }),
     });
   if (sp.platform)
@@ -459,15 +449,15 @@ function Browse() {
   const suggestions = useMemo(() => {
     if (results.length > 0 || activeFilters.length === 0)
       return [] as { label: string; apply: () => void; count: number }[];
-    const trials: { label: string; patch: Partial<typeof sp> }[] = [];
-    if (sp.platform)
-      trials.push({ label: `Remove platform "${sp.platform}"`, patch: { platform: "" } });
-    if (sp.signal)
-      trials.push({ label: `Remove signal "${signalLabel(sp.signal)}"`, patch: { signal: "" } });
-    if (sp.source) trials.push({ label: `Remove source "${sp.source}"`, patch: { source: "" } });
-    if (sp.trust) trials.push({ label: `Remove trust "${sp.trust}"`, patch: { trust: "" } });
-    if (sp.category) trials.push({ label: `Search all categories`, patch: { category: "" } });
-    if (sp.q) trials.push({ label: `Drop search "${sp.q}"`, patch: { q: "" } });
+    const trials = browseTrustRelaxationTrials({
+      q: sp.q,
+      category: sp.category,
+      trust: sp.trust,
+      source: sp.source,
+      signal: sp.signal,
+      platform: sp.platform,
+      sort: sp.sort,
+    });
     return trials
       .map((t) => {
         const merged = { ...sp, ...t.patch };
@@ -476,7 +466,7 @@ function Browse() {
           categories: merged.category ? [merged.category as Category] : undefined,
           trust: merged.trust ? [merged.trust as TrustLevel] : undefined,
           source: merged.source ? [merged.source as SourceStatus] : undefined,
-          signal: isTrustSignalFilter(merged.signal) ? merged.signal : "",
+          signal: isBrowseTrustSignalFilter(merged.signal) ? merged.signal : "",
           platforms: merged.platform ? [merged.platform as Platform] : undefined,
           sort: merged.sort,
         });
@@ -486,6 +476,11 @@ function Browse() {
       .slice(0, 3);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sp, results.length]);
+
+  const trustUtilityOptions = useMemo(
+    () => buildBrowseTrustUtilityOptions(facetCounts.signal),
+    [facetCounts.signal],
+  );
 
   return (
     <div className="mx-auto max-w-page px-4 py-6 sm:px-6">
@@ -662,7 +657,23 @@ function Browse() {
                   </div>
                 ) : null}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="inline-flex items-center gap-1.5 text-xs text-ink-muted">
+                  <SlidersHorizontal className="h-3.5 w-3.5" />
+                  Utility
+                  <select
+                    value={sp.signal}
+                    onChange={(e) => set({ signal: e.target.value })}
+                    aria-label="Trust signal utility filter"
+                    className="h-7 max-w-[11rem] rounded-md border border-border bg-surface px-2 text-xs text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                  >
+                    {trustUtilityOptions.map((option) => (
+                      <option key={option.id || "all"} value={option.id}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
                 <label className="inline-flex items-center gap-1.5 text-xs text-ink-muted">
                   <ArrowDownNarrowWide className="h-3.5 w-3.5" />
                   Sort
@@ -706,7 +717,7 @@ function Browse() {
                   : sp.category ||
                     sp.trust ||
                     sp.source ||
-                    signalLabel(sp.signal) ||
+                    browseTrustSignalLabel(sp.signal) ||
                     sp.platform ||
                     ""
               }
@@ -714,12 +725,12 @@ function Browse() {
               onSave={saveCurrent}
             />
             <FilterChipGroup label="Trust signal quick filters" multi={false}>
-              {TRUST_SIGNAL_OPTIONS.map((option) => (
+              {BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => (
                 <FilterChip
                   key={option.id}
                   role="radio"
                   active={sp.signal === option.id}
-                  onClick={() => set({ signal: sp.signal === option.id ? "" : option.id })}
+                  onClick={() => set({ signal: toggleBrowseTrustSignal(sp.signal, option.id) })}
                   count={axisCount("signal", option.id)}
                 >
                   {option.label}
@@ -770,6 +781,31 @@ function Browse() {
                     {c.label}
                   </FilterChip>
                 </Link>
+              ))}
+            </div>
+            <span
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent"
+            />
+          </div>
+
+          <div className="relative mt-2 lg:hidden">
+            <div
+              className="flex gap-2 overflow-x-auto pb-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              role="radiogroup"
+              aria-label="Trust signal quick filters"
+            >
+              {BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => (
+                <span key={option.id} className="shrink-0">
+                  <FilterChip
+                    role="radio"
+                    active={sp.signal === option.id}
+                    onClick={() => set({ signal: toggleBrowseTrustSignal(sp.signal, option.id) })}
+                    count={axisCount("signal", option.id)}
+                  >
+                    {option.label}
+                  </FilterChip>
+                </span>
               ))}
             </div>
             <span

--- a/tests/browse-trust-filters-lib.test.ts
+++ b/tests/browse-trust-filters-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
+import { countSearchResults } from "@/data/search";
 import {
   BROWSE_TRUST_SIGNAL_OPTIONS,
   browseTrustRelaxationTrials,
@@ -49,6 +50,9 @@ describe("browse trust filters lib", () => {
   it("toggles trust signal selection for quick chips", () => {
     expect(toggleBrowseTrustSignal("", "reviewed")).toBe("reviewed");
     expect(toggleBrowseTrustSignal("reviewed", "reviewed")).toBe("");
+    expect(toggleBrowseTrustSignal("safety-notes", "reviewed")).toBe(
+      "reviewed",
+    );
   });
 
   it("counts trust signals from the currently loaded entries", () => {
@@ -73,6 +77,58 @@ describe("browse trust filters lib", () => {
     expect(counts["safety-notes"]).toBe(1);
     expect(counts["privacy-notes"]).toBe(1);
     expect(counts["reviewed"]).toBe(1);
+    expect(counts["source-backed"]).toBe(0);
+  });
+
+  it("builds facet counts through countSearchResults with active browse filters", () => {
+    const entries = [
+      entry({
+        category: "mcp",
+        slug: "safe-mcp",
+        safetyNotes: "Sandboxed",
+        platforms: ["claude-code"],
+        source: "source-backed",
+      }),
+      entry({
+        category: "mcp",
+        slug: "other-mcp",
+        platforms: ["claude-code"],
+        reviewed: true,
+      }),
+      entry({
+        category: "skills",
+        slug: "skill",
+        safetyNotes: "Read docs",
+        platforms: ["cursor"],
+      }),
+    ];
+
+    const counts = buildBrowseTrustSignalCounts(
+      {
+        ...slice,
+        category: "mcp",
+        platform: "claude-code",
+      },
+      (filters) => countSearchResults(filters, entries),
+    );
+
+    expect(counts["safety-notes"]).toBe(1);
+    expect(counts["reviewed"]).toBe(1);
+    expect(counts["source-backed"]).toBe(1);
+    expect(counts["privacy-notes"]).toBe(0);
+  });
+
+  it("ignores invalid signal values when building facet counts", () => {
+    const entries = [entry({ safetyNotes: "Present" })];
+    const counts = buildBrowseTrustSignalCounts(
+      { ...slice, signal: "not-a-signal" },
+      (filters) => countSearchResults(filters, entries),
+    );
+
+    expect(counts["safety-notes"]).toBe(1);
+    expect(Object.keys(counts)).toHaveLength(
+      BROWSE_TRUST_SIGNAL_OPTIONS.length,
+    );
   });
 
   it("formats utility dropdown labels with facet counts", () => {
@@ -115,5 +171,19 @@ describe("browse trust filters lib", () => {
       { category: "" },
       { q: "" },
     ]);
+  });
+
+  it("skips signal relaxation when the active signal is invalid", () => {
+    expect(
+      browseTrustRelaxationTrials({
+        ...slice,
+        signal: "not-real",
+        platform: "claude-code",
+      }).map((trial) => trial.label),
+    ).toEqual(['Remove platform "claude-code"']);
+  });
+
+  it("returns no relaxation trials when browse filters are empty", () => {
+    expect(browseTrustRelaxationTrials(slice)).toEqual([]);
   });
 });

--- a/tests/browse-trust-filters-lib.test.ts
+++ b/tests/browse-trust-filters-lib.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  BROWSE_TRUST_SIGNAL_OPTIONS,
+  browseTrustRelaxationTrials,
+  browseTrustSignalLabel,
+  buildBrowseTrustSignalCounts,
+  buildBrowseTrustUtilityOptions,
+  formatBrowseTrustUtilityOptionLabel,
+  isBrowseTrustSignalFilter,
+  toggleBrowseTrustSignal,
+} from "@/lib/browse-trust-filters-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const slice = {
+  q: "",
+  category: "",
+  trust: "",
+  source: "",
+  signal: "",
+  platform: "",
+  sort: "popular" as const,
+};
+
+describe("browse trust filters lib", () => {
+  it("recognizes trust signal filter ids", () => {
+    expect(isBrowseTrustSignalFilter("safety-notes")).toBe(true);
+    expect(isBrowseTrustSignalFilter("unknown")).toBe(false);
+    expect(browseTrustSignalLabel("reviewed")).toBe("Reviewed");
+    expect(browseTrustSignalLabel("bogus")).toBe("");
+  });
+
+  it("toggles trust signal selection for quick chips", () => {
+    expect(toggleBrowseTrustSignal("", "reviewed")).toBe("reviewed");
+    expect(toggleBrowseTrustSignal("reviewed", "reviewed")).toBe("");
+  });
+
+  it("counts trust signals from the currently loaded entries", () => {
+    const entries = [
+      entry({ safetyNotes: "Read carefully" }),
+      entry({ slug: "other", privacyNotes: "No telemetry" }),
+      entry({ slug: "third", reviewed: true }),
+    ];
+    const counts = buildBrowseTrustSignalCounts(
+      slice,
+      (filters) =>
+        entries.filter((row) => {
+          if (filters.signal === "safety-notes")
+            return Boolean(row.safetyNotes);
+          if (filters.signal === "privacy-notes")
+            return Boolean(row.privacyNotes);
+          if (filters.signal === "reviewed") return Boolean(row.reviewed);
+          return false;
+        }).length,
+    );
+
+    expect(counts["safety-notes"]).toBe(1);
+    expect(counts["privacy-notes"]).toBe(1);
+    expect(counts["reviewed"]).toBe(1);
+  });
+
+  it("formats utility dropdown labels with facet counts", () => {
+    expect(formatBrowseTrustUtilityOptionLabel("Safety notes", 12)).toBe(
+      "Safety notes (12)",
+    );
+    const options = buildBrowseTrustUtilityOptions({
+      "safety-notes": 3,
+      "privacy-notes": 2,
+      "source-backed": 1,
+      "trusted-package": 0,
+      reviewed: 4,
+      checksums: 0,
+    });
+    expect(options[0]).toEqual({
+      id: "",
+      label: "All trust signals",
+      count: 0,
+    });
+    expect(options[1]?.label).toBe("Safety notes (3)");
+    expect(options).toHaveLength(BROWSE_TRUST_SIGNAL_OPTIONS.length + 1);
+  });
+
+  it("orders empty-state relaxation trials from least specific filters first", () => {
+    expect(
+      browseTrustRelaxationTrials({
+        ...slice,
+        q: "mcp",
+        category: "mcp",
+        trust: "trusted",
+        source: "source-backed",
+        signal: "reviewed",
+        platform: "claude-code",
+      }).map((trial) => trial.patch),
+    ).toEqual([
+      { platform: "" },
+      { signal: "" },
+      { source: "" },
+      { trust: "" },
+      { category: "" },
+      { q: "" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract browse trust filter helpers into rowse-trust-filters-lib.ts with focused vitest coverage.
- Restore the utility trust-signal dropdown (with facet counts) alongside existing quick chips.
- Add a mobile horizontal trust chip strip below category filters.

Closes #427

## Test plan
- [x] pnpm exec vitest run tests/browse-trust-filters-lib.test.ts tests/discovery-surfaces.test.ts
- [x] pnpm --filter web type-check
- [ ] Verify utility dropdown and quick chips stay in sync on /browse
- [ ] Verify mobile trust chip strip scrolls horizontally and updates URL signal param

Made with [Cursor](https://cursor.com)