### PR TITLE
feat(web): strengthen comparison tray trust decision surface

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -1,62 +1,113 @@
 import * as React from "react";
-import { GitCompare, X, ArrowRight } from "lucide-react";
+import { GitCompare, X, ArrowRight, Shield, Lock, Package } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useCompare } from "@/lib/compare";
+import { comparisonTrayChipSignals, comparisonTrayUiState } from "@/lib/comparison-tray-ui";
 import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
+import { cn } from "@/lib/utils";
+import type { Entry } from "@/types/registry";
+
+function TrayChip({ entry, onRemove }: { entry: Entry; onRemove: () => void }) {
+  const signals = comparisonTrayChipSignals(entry);
+
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs">
+      <ReadinessDot entry={entry} />
+      <span className="max-w-[9rem] truncate font-medium text-ink sm:max-w-[12rem]">
+        {entry.title}
+      </span>
+      <TrustBadge level={entry.trust} />
+      <SourceBadge status={entry.source} className="hidden sm:inline-flex" />
+      <span className="inline-flex items-center gap-0.5 text-ink-subtle" aria-hidden>
+        <Shield
+          className={cn("h-3 w-3", signals.hasSafetyNotes ? "text-trust-trusted" : "opacity-40")}
+        />
+        <Lock
+          className={cn("h-3 w-3", signals.hasPrivacyNotes ? "text-trust-trusted" : "opacity-40")}
+        />
+        {signals.installable ? <Package className="h-3 w-3 text-ink-muted" /> : null}
+      </span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="text-ink-subtle hover:text-ink"
+        aria-label={`Remove ${entry.title} from compare`}
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </span>
+  );
+}
 
 export function ComparisonTray() {
   const { items, toggle, clear, open, setOpen } = useCompare();
+  const tray = React.useMemo(() => comparisonTrayUiState(items), [items]);
+
   if (items.length === 0) return null;
 
   return (
     <div className="fixed inset-x-0 bottom-0 z-40 border-t border-border bg-surface/95 backdrop-blur">
-      <div className="mx-auto flex max-w-page items-center gap-3 px-4 py-3 sm:px-6">
-        <div className="flex items-center gap-2 text-sm font-medium text-ink">
-          <GitCompare className="h-4 w-4" />
-          Compare
-          <span className="rounded bg-ink px-1.5 py-0.5 font-mono text-[10px] text-background">
-            {items.length}/4
+      <div className="mx-auto max-w-page px-4 py-3 sm:px-6">
+        {tray.primaryHint ? (
+          <p className="mb-2 line-clamp-2 text-[11px] text-amber-800 sm:line-clamp-1">
+            {tray.primaryHint}
+          </p>
+        ) : null}
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 text-sm font-medium text-ink">
+            <GitCompare className="h-4 w-4" />
+            Compare
+            <span className="rounded bg-ink px-1.5 py-0.5 font-mono text-[10px] text-background">
+              {tray.count}/{tray.maxCount}
+            </span>
+          </div>
+          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+            {items.map((entry) => (
+              <TrayChip
+                key={`${entry.category}/${entry.slug}`}
+                entry={entry}
+                onRemove={() => toggle(entry)}
+              />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={clear}
+            className="hidden text-xs text-ink-muted hover:text-ink sm:inline"
+          >
+            Clear
+          </button>
+          {tray.canQuickCompare ? (
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-background px-3 text-xs font-medium text-ink hover:bg-surface-2"
+            >
+              Quick compare
+            </button>
+          ) : null}
+          {tray.canOpenFullCompare ? (
+            <Link
+              to="/compare"
+              search={{ ids: tray.compareIds }}
+              onClick={() => setOpen(false)}
+              className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-semibold text-accent-ink hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/40"
+            >
+              Full compare <ArrowRight className="h-3 w-3" />
+            </Link>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-semibold text-accent-ink hover:opacity-90"
+            >
+              View selection
+            </button>
+          )}
+          <span className="sr-only" aria-hidden>
+            {open ? "open" : "closed"}
           </span>
         </div>
-        <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
-          {items.map((e) => (
-            <span
-              key={`${e.category}/${e.slug}`}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs"
-            >
-              <ReadinessDot entry={e} />
-              <span className="font-medium text-ink">{e.title}</span>
-              <TrustBadge level={e.trust} />
-              <SourceBadge status={e.source} className="hidden sm:inline-flex" />
-              <button
-                type="button"
-                onClick={() => toggle(e)}
-                className="text-ink-subtle hover:text-ink"
-                aria-label={`Remove ${e.title} from compare`}
-              >
-                <X className="h-3 w-3" />
-              </button>
-            </span>
-          ))}
-        </div>
-        <button
-          type="button"
-          onClick={clear}
-          className="hidden text-xs text-ink-muted hover:text-ink sm:inline"
-        >
-          Clear
-        </button>
-        <Link
-          to="/compare"
-          search={{ ids: items.map((e) => `${e.category}/${e.slug}`).join(",") }}
-          onClick={() => setOpen(false)}
-          className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-semibold text-accent-ink hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/40"
-        >
-          Compare {items.length} <ArrowRight className="h-3 w-3" />
-        </Link>
-        <span className="sr-only" aria-hidden>
-          {open ? "open" : "closed"}
-        </span>
       </div>
     </div>
   );

--- a/apps/web/src/lib/comparison-tray-ui-lib.ts
+++ b/apps/web/src/lib/comparison-tray-ui-lib.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure comparison tray UI helpers.
+ *
+ * Builds compact trust summaries and chip metadata for the fixed compare
+ * tray shown on browse/detail surfaces. Given the same entry metadata the
+ * output is deterministic.
+ */
+
+import type { Entry } from "@/types/registry";
+import {
+  compareCuratedActionBannerText,
+  compareCuratedDecisionBannerText,
+} from "@/lib/compare-curated-summary";
+import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
+
+export type ComparisonTrayChipSignals = {
+  hasSafetyNotes: boolean;
+  hasPrivacyNotes: boolean;
+  reviewed: boolean;
+  claimed: boolean;
+  installable: boolean;
+};
+
+export type ComparisonTrayUiState = {
+  count: number;
+  maxCount: number;
+  canQuickCompare: boolean;
+  canOpenFullCompare: boolean;
+  compareIds: string;
+  primaryHint: string | null;
+  hints: string[];
+  hasTrustDivergence: boolean;
+};
+
+export const COMPARISON_TRAY_MAX_ITEMS = 4;
+
+function hasSafetyNotes(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">) {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacyNotes(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">) {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function isInstallable(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+) {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+export function comparisonTrayChipSignals(
+  entry: Pick<
+    Entry,
+    | "safetyNotes"
+    | "safetyNotesList"
+    | "privacyNotes"
+    | "privacyNotesList"
+    | "reviewed"
+    | "reviewedBy"
+    | "claimed"
+    | "installCommand"
+    | "configSnippet"
+    | "fullCopy"
+    | "copySnippet"
+  >,
+): ComparisonTrayChipSignals {
+  return {
+    hasSafetyNotes: hasSafetyNotes(entry),
+    hasPrivacyNotes: hasPrivacyNotes(entry),
+    reviewed: Boolean(entry.reviewed || entry.reviewedBy),
+    claimed: Boolean(entry.claimed),
+    installable: isInstallable(entry),
+  };
+}
+
+export function comparisonTrayHintMessages(entries: Entry[]): string[] {
+  const summary = compareSurfaceSummary(entries);
+  const hints: string[] = [];
+  const decisionHint = compareCuratedDecisionBannerText(summary.decision);
+  const actionHint = compareCuratedActionBannerText(summary.actionsDiverge);
+  if (decisionHint) hints.push(decisionHint);
+  if (actionHint) hints.push(actionHint);
+  return hints;
+}
+
+export function comparisonTrayUiState(entries: Entry[]): ComparisonTrayUiState {
+  const summary = compareSurfaceSummary(entries);
+  const hints = comparisonTrayHintMessages(entries);
+
+  return {
+    count: entries.length,
+    maxCount: COMPARISON_TRAY_MAX_ITEMS,
+    canQuickCompare: entries.length >= 2,
+    canOpenFullCompare: entries.length >= 2,
+    compareIds: entries.map((entry) => `${entry.category}/${entry.slug}`).join(","),
+    primaryHint: hints[0] ?? null,
+    hints,
+    hasTrustDivergence: summary.hasAnyDivergence,
+  };
+}

--- a/apps/web/src/lib/comparison-tray-ui.ts
+++ b/apps/web/src/lib/comparison-tray-ui.ts
@@ -1,0 +1,16 @@
+/**
+ * Comparison tray UI surface.
+ *
+ * Pure helpers live in `comparison-tray-ui-lib.ts`. This module re-exports
+ * that surface so existing `@/lib/comparison-tray-ui` imports stay stable.
+ */
+export type {
+  ComparisonTrayChipSignals,
+  ComparisonTrayUiState,
+} from "@/lib/comparison-tray-ui-lib";
+export {
+  COMPARISON_TRAY_MAX_ITEMS,
+  comparisonTrayChipSignals,
+  comparisonTrayHintMessages,
+  comparisonTrayUiState,
+} from "@/lib/comparison-tray-ui-lib";

--- a/tests/comparison-tray-ui-lib.test.ts
+++ b/tests/comparison-tray-ui-lib.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  comparisonTrayChipSignals,
+  comparisonTrayHintMessages,
+  comparisonTrayUiState,
+} from "@/lib/comparison-tray-ui-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("comparison tray ui lib", () => {
+  it("derives compact chip trust signals from entry metadata", () => {
+    expect(
+      comparisonTrayChipSignals(
+        entry({
+          safetyNotes: "Read carefully",
+          privacyNotes: "No telemetry",
+          reviewedBy: "maintainer",
+          claimed: true,
+          installCommand: "npm i fixture",
+        }),
+      ),
+    ).toEqual({
+      hasSafetyNotes: true,
+      hasPrivacyNotes: true,
+      reviewed: true,
+      claimed: true,
+      installable: true,
+    });
+  });
+
+  it("requires at least two entries before enabling quick compare actions", () => {
+    expect(comparisonTrayUiState([entry()])).toMatchObject({
+      count: 1,
+      canQuickCompare: false,
+      canOpenFullCompare: false,
+      hasTrustDivergence: false,
+      primaryHint: null,
+    });
+    expect(
+      comparisonTrayUiState([entry(), entry({ slug: "other" })]),
+    ).toMatchObject({
+      count: 2,
+      canQuickCompare: true,
+      canOpenFullCompare: true,
+      compareIds: "mcp/fixture,mcp/other",
+    });
+  });
+
+  it("surfaces trust divergence hints without opening the drawer", () => {
+    const hints = comparisonTrayHintMessages([
+      entry(),
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+    ]);
+    expect(hints).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(
+      comparisonTrayUiState([
+        entry(),
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      ]),
+    ).toMatchObject({
+      hasTrustDivergence: true,
+      primaryHint: hints[0],
+      hints,
+    });
+  });
+
+  it("combines trust and action divergence hints for the tray", () => {
+    expect(
+      comparisonTrayHintMessages([
+        entry(),
+        entry({
+          reviewedBy: "maintainer",
+          reviewedAt: "2026-01-02",
+          installCommand: "npm i fixture",
+        }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract comparison tray helpers into comparison-tray-ui-lib.ts with focused vitest coverage.
- Show trust divergence hints directly in the fixed comparison tray so users can spot differences before opening every dossier.
- Add compact safety/privacy/install indicators on tray chips and split CTAs into Quick compare (drawer) and Full compare (interactive page).

Refs #556
Refs #393

## Test plan
- [x] pnpm exec vitest run tests/comparison-tray-ui-lib.test.ts
- [x] pnpm --filter web type-check
- [ ] Select 2+ entries on /browse and verify tray hint + Quick compare opens the drawer
- [ ] Verify Full compare links to /compare?ids=... with 2+ selections

Made with [Cursor](https://cursor.com)