### PR TITLE
feat(web): add entry detail API and platform integration CTAs

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   OctagonX,
   FileText,
+  Terminal,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry, Harness } from "@/types/registry";
@@ -23,6 +24,7 @@ import {
   resolveDetailReadinessItems,
   shouldElevateDetailSafetyGate,
 } from "@/lib/entry-detail-command-center";
+import { resolveDetailIntegrationLinks } from "@/lib/entry-detail-integration-links";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
 import { siteConfig } from "@/lib/site";
@@ -71,6 +73,7 @@ export function EntryDetailCommandCenter({
 }: EntryDetailCommandCenterProps) {
   const readiness = resolveDetailReadinessItems(entry);
   const quickLinks = resolveDetailQuickLinks(entry);
+  const integrationLinks = resolveDetailIntegrationLinks(entry);
   const communityAnchors = resolveDetailCommunityAnchors(relatedCount, guideCount, true);
   const safetyGate = detailSafetyGateMessage(risk, entry);
   const elevateSafety = shouldElevateDetailSafetyGate(risk, entry);
@@ -232,6 +235,26 @@ export function EntryDetailCommandCenter({
           </div>
         )}
 
+        <div className="border-b border-border px-4 py-3">
+          <div className="eyebrow mb-2">Integrations & API</div>
+          <ul className="space-y-1.5 text-xs">
+            {integrationLinks.map((link) => (
+              <li key={link.id}>
+                <a
+                  href={link.href}
+                  target={link.external ? "_blank" : undefined}
+                  rel={link.external ? "noreferrer" : undefined}
+                  className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+                >
+                  <Terminal className="h-3.5 w-3.5" />
+                  {link.label}
+                  {link.external ? <ExternalLink className="h-3 w-3" /> : null}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
         <div className="px-4 py-3">
           <div className="eyebrow mb-2">Contribute</div>
           <div className="flex flex-col gap-1.5 text-xs">
@@ -286,26 +309,19 @@ export function EntryDetailCommandCenter({
               </a>
             );
           }
-          if (link.id === "registry") {
+          if (link.id === "browse") {
             return (
               <Link
                 key={link.id}
                 to={link.href}
+                search={{ category: entry.category }}
                 className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
               >
                 <Code2 className="h-3.5 w-3.5" /> {link.label}
               </Link>
             );
           }
-          return (
-            <a
-              key={link.id}
-              href={link.href}
-              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-            >
-              <FileText className="h-3.5 w-3.5" /> {link.label}
-            </a>
-          );
+          return null;
         })}
       </div>
     </aside>

--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
-import { Copy, ExternalLink, Package, FileText } from "lucide-react";
+import { Copy, ExternalLink, Package, FileText, Terminal } from "lucide-react";
 import type { Entry } from "@/types/registry";
 import {
   ENTRY_COMMAND_CENTER_ID,
@@ -68,6 +68,8 @@ export function EntryDetailMobileActionBar({
               <Package className="h-3.5 w-3.5" />
             ) : action.id === "copy" ? (
               <Copy className="h-3.5 w-3.5" />
+            ) : action.id === "llm" ? (
+              <Terminal className="h-3.5 w-3.5" />
             ) : action.id === "source" || action.id === "suggest" ? (
               <ExternalLink className="h-3.5 w-3.5" />
             ) : (

--- a/apps/web/src/lib/entry-detail-command-center-lib.ts
+++ b/apps/web/src/lib/entry-detail-command-center-lib.ts
@@ -117,16 +117,9 @@ export function resolveDetailQuickLinks(
   }
 
   links.push({
-    id: "registry",
-    label: "Registry JSON · LLM text",
+    id: "browse",
+    label: "Browse directory",
     href: "/browse",
-    external: false,
-  });
-
-  links.push({
-    id: "llms",
-    label: "LLM plain text",
-    href: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
     external: false,
   });
 
@@ -187,6 +180,14 @@ export function resolveDetailMobileActions(
       copyValue: copyPayload,
     });
   }
+
+  actions.push({
+    id: "llm",
+    label: "LLM",
+    kind: "link",
+    href: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
+    external: false,
+  });
 
   if (entry.sourceUrl) {
     actions.push({

--- a/apps/web/src/lib/entry-detail-integration-links-lib.ts
+++ b/apps/web/src/lib/entry-detail-integration-links-lib.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure entry detail integration link helpers.
+ *
+ * Builds API, assistant, and platform handoff links for the entry command
+ * center. Given the same entry metadata the output is deterministic.
+ */
+
+import type { Entry, Platform } from "@/types/registry";
+import type { DetailQuickLink } from "@/lib/entry-detail-command-center-lib";
+
+export const RAYCAST_EXTENSION_URL = "https://www.raycast.com/jsonbored/heyclaude";
+export const RAYCAST_EXTENSION_DEEPLINK = "raycast://extensions/jsonbored/heyclaude";
+
+export function entryRegistryApiPath(category: string, slug: string): string {
+  return `/api/registry/entries/${category}/${slug}`;
+}
+
+export function entryLlmsApiPath(category: string, slug: string): string {
+  return `${entryRegistryApiPath(category, slug)}/llms`;
+}
+
+export function entrySupportsRaycast(platforms: Platform[]): boolean {
+  return platforms.includes("raycast");
+}
+
+export function entryIsMcpCategory(category: string): boolean {
+  return category === "mcp";
+}
+
+export function resolveDetailIntegrationLinks(
+  entry: Pick<Entry, "category" | "slug" | "platforms">,
+): DetailQuickLink[] {
+  const links: DetailQuickLink[] = [
+    {
+      id: "api-json",
+      label: "Registry API JSON",
+      href: entryRegistryApiPath(entry.category, entry.slug),
+      external: false,
+    },
+    {
+      id: "llms",
+      label: "LLM plain text",
+      href: entryLlmsApiPath(entry.category, entry.slug),
+      external: false,
+    },
+    {
+      id: "manifest",
+      label: "Registry manifest",
+      href: "/api/registry/manifest",
+      external: false,
+    },
+  ];
+
+  if (entryIsMcpCategory(entry.category)) {
+    links.push({
+      id: "mcp-feed",
+      label: "MCP registry feed",
+      href: "/data/mcp-registry-feed.json",
+      external: false,
+    });
+    links.push({
+      id: "ecosystem",
+      label: "MCP ecosystem guide",
+      href: "/ecosystem",
+      external: false,
+    });
+  }
+
+  if (entrySupportsRaycast(entry.platforms)) {
+    links.push({
+      id: "raycast",
+      label: "Open in Raycast",
+      href: RAYCAST_EXTENSION_DEEPLINK,
+      external: true,
+    });
+  }
+
+  return links;
+}
+
+export function detailIntegrationLinkIds(links: DetailQuickLink[]): string[] {
+  return links.map((link) => link.id);
+}

--- a/apps/web/src/lib/entry-detail-integration-links.ts
+++ b/apps/web/src/lib/entry-detail-integration-links.ts
@@ -1,0 +1,13 @@
+/**
+ * Entry detail integration links surface.
+ */
+export {
+  RAYCAST_EXTENSION_DEEPLINK,
+  RAYCAST_EXTENSION_URL,
+  detailIntegrationLinkIds,
+  entryIsMcpCategory,
+  entryLlmsApiPath,
+  entryRegistryApiPath,
+  entrySupportsRaycast,
+  resolveDetailIntegrationLinks,
+} from "@/lib/entry-detail-integration-links-lib";

--- a/tests/entry-detail-command-center-lib.test.ts
+++ b/tests/entry-detail-command-center-lib.test.ts
@@ -47,12 +47,7 @@ describe("entry detail command center lib", () => {
         sourceUrl: "https://github.com/example/repo",
       }),
     );
-    expect(links.map((link) => link.id)).toEqual([
-      "docs",
-      "source",
-      "registry",
-      "llms",
-    ]);
+    expect(links.map((link) => link.id)).toEqual(["docs", "source", "browse"]);
     expect(links[0]).toMatchObject({ external: true });
     expect(links[2]).toMatchObject({ href: "/browse", external: false });
   });
@@ -81,6 +76,7 @@ describe("entry detail command center lib", () => {
     expect(detailMobileActionIds(actions)).toEqual([
       "install",
       "copy",
+      "llm",
       "source",
       "suggest",
       "claim",
@@ -99,7 +95,11 @@ describe("entry detail command center lib", () => {
       "https://heyclau.de/entry/skills/fixture",
       "https://github.com/JSONbored/awesome-claude",
     );
-    expect(detailMobileActionIds(actions)).toEqual(["install", "suggest"]);
+    expect(detailMobileActionIds(actions)).toEqual([
+      "install",
+      "llm",
+      "suggest",
+    ]);
   });
 
   it("elevates the safety gate for risky or note-missing installable entries", () => {

--- a/tests/entry-detail-integration-links-lib.test.ts
+++ b/tests/entry-detail-integration-links-lib.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  detailIntegrationLinkIds,
+  entryLlmsApiPath,
+  entryRegistryApiPath,
+  resolveDetailIntegrationLinks,
+} from "@/lib/entry-detail-integration-links-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry detail integration links lib", () => {
+  it("builds registry API paths for an entry", () => {
+    expect(entryRegistryApiPath("mcp", "browser")).toBe(
+      "/api/registry/entries/mcp/browser",
+    );
+    expect(entryLlmsApiPath("mcp", "browser")).toBe(
+      "/api/registry/entries/mcp/browser/llms",
+    );
+  });
+
+  it("always includes API, LLM, and manifest links", () => {
+    expect(
+      detailIntegrationLinkIds(resolveDetailIntegrationLinks(entry())),
+    ).toEqual(["api-json", "llms", "manifest"]);
+  });
+
+  it("adds MCP ecosystem links for MCP entries", () => {
+    expect(
+      detailIntegrationLinkIds(
+        resolveDetailIntegrationLinks(entry({ category: "mcp" })),
+      ),
+    ).toEqual(["api-json", "llms", "manifest", "mcp-feed", "ecosystem"]);
+  });
+
+  it("adds Raycast handoff when the entry supports Raycast", () => {
+    expect(
+      detailIntegrationLinkIds(
+        resolveDetailIntegrationLinks(
+          entry({
+            platforms: ["claude-code", "raycast"],
+            category: "commands",
+          }),
+        ),
+      ),
+    ).toEqual(["api-json", "llms", "manifest", "raycast"]);
+    expect(
+      resolveDetailIntegrationLinks(
+        entry({ platforms: ["claude-code", "raycast"], category: "commands" }),
+      ).find((link) => link.id === "raycast"),
+    ).toMatchObject({
+      href: "raycast://extensions/jsonbored/heyclaude",
+      external: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract entry detail integration link helpers for API JSON, LLM text, registry manifest, MCP feed, and Raycast handoff.
- Add an Integrations & API section to the entry command center with category/platform-aware links.
- Add an LLM shortcut to the mobile action bar and fix the browse quick link label.

Refs #556
Refs #393

## Test plan
- [x] pnpm exec vitest run tests/entry-detail-integration-links-lib.test.ts tests/entry-detail-command-center-lib.test.ts
- [x] pnpm --filter web type-check
- [ ] Verify MCP entries show MCP feed + ecosystem links
- [ ] Verify Raycast-platform entries show Raycast deeplink
- [ ] Verify mobile LLM button opens plain-text endpoint

Made with [Cursor](https://cursor.com)