### PR TITLE
feat(web): add entry detail compare CTA in command center

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   OctagonX,
   FileText,
+  GitCompare,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry, Harness } from "@/types/registry";
@@ -23,6 +24,10 @@ import {
   resolveDetailReadinessItems,
   shouldElevateDetailSafetyGate,
 } from "@/lib/entry-detail-command-center";
+import {
+  entryDetailCompareCtaState,
+  ENTRY_DETAIL_COMPARE_MAX,
+} from "@/lib/entry-detail-compare-ui";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
 import { siteConfig } from "@/lib/site";
@@ -41,6 +46,12 @@ type EntryDetailCommandCenterProps = {
   tabPayload?: string;
   relatedCount: number;
   guideCount: number;
+  compareCta: {
+    inCompare: boolean;
+    compareCount: number;
+    onToggle: () => void;
+    onOpenCompare: () => void;
+  };
 };
 
 function ReadinessRow({ label, value, ok }: { label: string; value: string; ok: boolean }) {
@@ -68,10 +79,12 @@ export function EntryDetailCommandCenter({
   tabPayload,
   relatedCount,
   guideCount,
+  compareCta,
 }: EntryDetailCommandCenterProps) {
   const readiness = resolveDetailReadinessItems(entry);
   const quickLinks = resolveDetailQuickLinks(entry);
   const communityAnchors = resolveDetailCommunityAnchors(relatedCount, guideCount, true);
+  const compareState = entryDetailCompareCtaState(compareCta.inCompare, compareCta.compareCount);
   const safetyGate = detailSafetyGateMessage(risk, entry);
   const elevateSafety = shouldElevateDetailSafetyGate(risk, entry);
   const suggestUrl = entryDetailSuggestChangeUrl(
@@ -231,6 +244,43 @@ export function EntryDetailCommandCenter({
             </ul>
           </div>
         )}
+
+        <div className="border-b border-border px-4 py-3">
+          <div className="eyebrow mb-2">Compare</div>
+          <div className="flex flex-col gap-1.5 text-xs">
+            <button
+              type="button"
+              onClick={compareCta.onToggle}
+              disabled={compareState.disabled}
+              className={cn(
+                "inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 font-medium",
+                compareState.disabled
+                  ? "cursor-not-allowed border-border bg-surface text-ink-subtle"
+                  : compareCta.inCompare
+                    ? "border-accent bg-accent/10 text-ink hover:bg-accent/15"
+                    : "border-border bg-background text-ink hover:bg-surface-2",
+              )}
+            >
+              <GitCompare className="h-3.5 w-3.5" />
+              {compareState.label}
+              <span className="font-mono text-[10px] text-ink-subtle">
+                {compareCta.compareCount}/{ENTRY_DETAIL_COMPARE_MAX}
+              </span>
+            </button>
+            {compareState.hint ? (
+              <p className="text-[11px] text-ink-muted">{compareState.hint}</p>
+            ) : null}
+            {compareState.showOpenCompare ? (
+              <button
+                type="button"
+                onClick={compareCta.onOpenCompare}
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                Open compare tray
+              </button>
+            ) : null}
+          </div>
+        </div>
 
         <div className="px-4 py-3">
           <div className="eyebrow mb-2">Contribute</div>

--- a/apps/web/src/lib/entry-detail-compare-ui-lib.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui-lib.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure entry detail compare CTA helpers.
+ *
+ * Builds compare tray labels and disabled states for the entry command
+ * center without touching compare context or network calls.
+ */
+
+export const ENTRY_DETAIL_COMPARE_MAX = 4;
+
+export type EntryDetailCompareCtaState = {
+  label: string;
+  disabled: boolean;
+  hint: string | null;
+  showOpenCompare: boolean;
+};
+
+export function entryDetailCompareToggleLabel(inCompare: boolean): string {
+  return inCompare ? "Remove from compare" : "Add to compare";
+}
+
+export function entryDetailCompareDisabledReason(
+  inCompare: boolean,
+  compareCount: number,
+  maxCount = ENTRY_DETAIL_COMPARE_MAX,
+): string | null {
+  if (inCompare || compareCount < maxCount) return null;
+  return `Compare is full (${maxCount}/${maxCount}). Remove an entry to add this one.`;
+}
+
+export function entryDetailCompareDrawerEnabled(compareCount: number): boolean {
+  return compareCount >= 2;
+}
+
+export function entryDetailCompareCtaState(
+  inCompare: boolean,
+  compareCount: number,
+  maxCount = ENTRY_DETAIL_COMPARE_MAX,
+): EntryDetailCompareCtaState {
+  const disabledReason = entryDetailCompareDisabledReason(inCompare, compareCount, maxCount);
+
+  return {
+    label: entryDetailCompareToggleLabel(inCompare),
+    disabled: Boolean(disabledReason),
+    hint: disabledReason,
+    showOpenCompare: entryDetailCompareDrawerEnabled(compareCount),
+  };
+}

--- a/apps/web/src/lib/entry-detail-compare-ui.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui.ts
@@ -1,0 +1,11 @@
+/**
+ * Entry detail compare CTA surface.
+ */
+export type { EntryDetailCompareCtaState } from "@/lib/entry-detail-compare-ui-lib";
+export {
+  ENTRY_DETAIL_COMPARE_MAX,
+  entryDetailCompareCtaState,
+  entryDetailCompareDisabledReason,
+  entryDetailCompareDrawerEnabled,
+  entryDetailCompareToggleLabel,
+} from "@/lib/entry-detail-compare-ui-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -58,8 +58,10 @@ import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import { installRiskLevel, INSTALL_RISK_LABEL, INSTALL_RISK_DETAIL } from "@/lib/trust";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { toast } from "sonner";
 import { useRecents } from "@/lib/recents";
+import { useCompare, useIsCompared } from "@/lib/compare";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
@@ -260,6 +262,24 @@ function Dossier() {
 
   const tabPayload = liveVariants.find((v) => v.id === tab)?.value;
 
+  const compare = useCompare();
+  const inCompare = useIsCompared(entry);
+  const onToggleCompare = useCallback(() => {
+    const wasIn = inCompare;
+    compare.toggle(entry);
+    if (wasIn) {
+      toast(`Removed “${entry.title}” from compare`);
+    } else {
+      toast.success("Added to compare", {
+        action: {
+          label: "View",
+          onClick: () => compare.setOpen(true),
+        },
+      });
+    }
+  }, [compare, entry, inCompare]);
+  const onOpenCompare = useCallback(() => compare.setOpen(true), [compare]);
+
   const risk = installRiskLevel(entry);
   const hasSchema = hasSchemaDetails(entry);
 
@@ -390,6 +410,12 @@ function Dossier() {
           tabPayload={tabPayload}
           relatedCount={rel.length}
           guideCount={guides.length}
+          compareCta={{
+            inCompare,
+            compareCount: compare.items.length,
+            onToggle: onToggleCompare,
+            onOpenCompare,
+          }}
         />
       </header>
       <div id="dossier-header-sentinel" aria-hidden className="h-px w-full" />

--- a/tests/entry-detail-compare-ui-lib.test.ts
+++ b/tests/entry-detail-compare-ui-lib.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_COMPARE_MAX,
+  entryDetailCompareCtaState,
+  entryDetailCompareDisabledReason,
+  entryDetailCompareDrawerEnabled,
+  entryDetailCompareToggleLabel,
+} from "@/lib/entry-detail-compare-ui-lib";
+
+describe("entry detail compare ui lib", () => {
+  it("labels compare toggle actions", () => {
+    expect(entryDetailCompareToggleLabel(false)).toBe("Add to compare");
+    expect(entryDetailCompareToggleLabel(true)).toBe("Remove from compare");
+  });
+
+  it("blocks add-to-compare when the tray is full", () => {
+    expect(
+      entryDetailCompareDisabledReason(false, ENTRY_DETAIL_COMPARE_MAX),
+    ).toBe(
+      `Compare is full (${ENTRY_DETAIL_COMPARE_MAX}/${ENTRY_DETAIL_COMPARE_MAX}). Remove an entry to add this one.`,
+    );
+    expect(
+      entryDetailCompareDisabledReason(true, ENTRY_DETAIL_COMPARE_MAX),
+    ).toBeNull();
+    expect(entryDetailCompareDisabledReason(false, 2)).toBeNull();
+  });
+
+  it("enables open-compare affordances once two entries are selected", () => {
+    expect(entryDetailCompareDrawerEnabled(1)).toBe(false);
+    expect(entryDetailCompareDrawerEnabled(2)).toBe(true);
+  });
+
+  it("builds command center compare CTA state", () => {
+    expect(entryDetailCompareCtaState(false, 1)).toEqual({
+      label: "Add to compare",
+      disabled: false,
+      hint: null,
+      showOpenCompare: false,
+    });
+    expect(entryDetailCompareCtaState(true, 3)).toEqual({
+      label: "Remove from compare",
+      disabled: false,
+      hint: null,
+      showOpenCompare: true,
+    });
+    expect(entryDetailCompareCtaState(false, 4)).toMatchObject({
+      label: "Add to compare",
+      disabled: true,
+      showOpenCompare: true,
+    });
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add pure compare CTA helpers for entry detail (`entry-detail-compare-ui-lib.ts`) covering toggle labels, tray-full disabled states, and open-compare affordances.
- Wire compare toggle + open tray actions into the entry detail command center with count badge and full-tray hint.
- Connect entry detail route to compare context with toast feedback on add/remove.

## Test plan
- [x] `pnpm exec vitest run tests/entry-detail-compare-ui-lib.test.ts`
- [x] `pnpm --filter web type-check`
- [ ] CI green on PR