### PR TITLE
feat(web): add safe intent-event recording for detail and compare CTAs

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -3,6 +3,11 @@ import { GitCompare, X, ArrowRight, Shield, Lock, Package } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useCompare } from "@/lib/compare";
 import { comparisonTrayChipSignals, comparisonTrayUiState } from "@/lib/comparison-tray-ui";
+import {
+  comparisonTrayFullCompareAnalyticsData,
+  comparisonTrayQuickCompareAnalyticsData,
+} from "@/lib/entry-detail-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
@@ -80,7 +85,12 @@ export function ComparisonTray() {
           {tray.canQuickCompare ? (
             <button
               type="button"
-              onClick={() => setOpen(true)}
+              onClick={() => {
+                trackEvent("compare_tray_quick_compare", {
+                  ...comparisonTrayQuickCompareAnalyticsData(tray.count),
+                });
+                setOpen(true);
+              }}
               className="inline-flex h-8 items-center gap-1 rounded-md border border-border bg-background px-3 text-xs font-medium text-ink hover:bg-surface-2"
             >
               Quick compare
@@ -90,7 +100,12 @@ export function ComparisonTray() {
             <Link
               to="/compare"
               search={{ ids: tray.compareIds }}
-              onClick={() => setOpen(false)}
+              onClick={() => {
+                trackEvent("compare_tray_full_compare", {
+                  ...comparisonTrayFullCompareAnalyticsData(tray.count),
+                });
+                setOpen(false);
+              }}
               className="inline-flex h-8 items-center gap-1 rounded-md bg-accent px-3 text-xs font-semibold text-accent-ink hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/40"
             >
               Full compare <ArrowRight className="h-3 w-3" />

--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -28,6 +28,12 @@ import {
   entryDetailCompareCtaState,
   ENTRY_DETAIL_COMPARE_MAX,
 } from "@/lib/entry-detail-compare-ui";
+import {
+  entryDetailCopyAnalyticsData,
+  entryDetailCopyAnalyticsEvent,
+  entryDetailCopyIntentType,
+} from "@/lib/entry-detail-cta-events";
+import { recordIntentEvent } from "@/lib/intent-event-client";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
 import { siteConfig } from "@/lib/site";
@@ -202,6 +208,11 @@ export function EntryDetailCommandCenter({
                     label={`Copy ${tab}`}
                     size="md"
                     className="flex-1 justify-center"
+                    event={entryDetailCopyAnalyticsEvent(tab)}
+                    eventData={entryDetailCopyAnalyticsData(entry.category, entry.slug)}
+                    onCopied={() => {
+                      void recordIntentEvent(entryDetailCopyIntentType(tab), entry);
+                    }}
                   />
                 </div>
               </>

--- a/apps/web/src/lib/compare-entry-actions.ts
+++ b/apps/web/src/lib/compare-entry-actions.ts
@@ -13,24 +13,11 @@ export {
 } from "@/lib/compare-entry-actions-lib";
 
 import type { Entry } from "@/types/registry";
+import { recordIntentEvent } from "@/lib/intent-event-client";
 
 export async function recordCompareIntentEvent(
   type: "copy" | "open" | "install",
   entry: Pick<Entry, "category" | "slug">,
 ): Promise<boolean> {
-  try {
-    const response = await fetch("/api/intent-events", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        type,
-        entryKey: `${entry.category}:${entry.slug}`,
-      }),
-    });
-    if (!response.ok) return false;
-    const payload = (await response.json()) as { stored?: boolean };
-    return payload.stored === true;
-  } catch {
-    return false;
-  }
+  return recordIntentEvent(type, entry);
 }

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure entry detail CTA analytics and intent-event helpers.
+ *
+ * Maps detail-page actions to privacy-light event names and intent types
+ * without embedding copy payloads or other sensitive data.
+ */
+
+import type { CopyVariant } from "@/lib/dossier-prefs";
+import type { IntentEventClientType } from "@/lib/intent-event-client-lib";
+
+export const ENTRY_DETAIL_COMMAND_CENTER_SURFACE = "detail-command-center";
+export const ENTRY_DETAIL_COMPARE_SURFACE = "detail-compare";
+export const BROWSE_COMPARE_SURFACE = "browse-compare";
+export const COMPARE_TRAY_SURFACE = "compare-tray";
+
+export function entryDetailEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailCopyIntentType(tab: CopyVariant): IntentEventClientType {
+  return tab === "install" ? "install" : "copy";
+}
+
+export function entryDetailCopyAnalyticsEvent(tab: CopyVariant): string {
+  return `detail_copy_${tab}`;
+}
+
+export function entryDetailCopyAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+  };
+}
+
+export function entryDetailCompareAnalyticsEvent(adding: boolean): string {
+  return adding ? "detail_compare_add" : "detail_compare_remove";
+}
+
+export function entryDetailCompareAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+  };
+}
+
+export function browseCompareOpenAnalyticsData(selectedCount: number) {
+  return {
+    count: selectedCount,
+    surface: BROWSE_COMPARE_SURFACE,
+  };
+}
+
+export function comparisonTrayQuickCompareAnalyticsData(count: number) {
+  return { count, surface: COMPARE_TRAY_SURFACE };
+}
+
+export function comparisonTrayFullCompareAnalyticsData(count: number) {
+  return { count, surface: COMPARE_TRAY_SURFACE };
+}

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -1,0 +1,18 @@
+/**
+ * Entry detail CTA event surface.
+ */
+export {
+  BROWSE_COMPARE_SURFACE,
+  COMPARE_TRAY_SURFACE,
+  ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+  ENTRY_DETAIL_COMPARE_SURFACE,
+  browseCompareOpenAnalyticsData,
+  comparisonTrayFullCompareAnalyticsData,
+  comparisonTrayQuickCompareAnalyticsData,
+  entryDetailCompareAnalyticsData,
+  entryDetailCompareAnalyticsEvent,
+  entryDetailCopyAnalyticsData,
+  entryDetailCopyAnalyticsEvent,
+  entryDetailCopyIntentType,
+  entryDetailEntryKey,
+} from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/lib/intent-event-client-lib.ts
+++ b/apps/web/src/lib/intent-event-client-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure client intent-event helpers.
+ *
+ * Builds privacy-light POST bodies and interprets API responses without
+ * touching fetch or browser globals.
+ */
+
+export const INTENT_EVENTS_API_PATH = "/api/intent-events";
+
+export const INTENT_EVENT_CLIENT_TYPES = ["copy", "open", "install"] as const;
+
+export type IntentEventClientType = (typeof INTENT_EVENT_CLIENT_TYPES)[number];
+
+export function buildIntentEventEntryKey(category: string, slug: string): string {
+  return `${category}:${slug}`;
+}
+
+export function buildIntentEventRequestBody(type: IntentEventClientType, entryKey: string): string {
+  return JSON.stringify({ type, entryKey });
+}
+
+export function intentEventWasStored(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object") return false;
+  return (payload as { stored?: boolean }).stored === true;
+}

--- a/apps/web/src/lib/intent-event-client.ts
+++ b/apps/web/src/lib/intent-event-client.ts
@@ -1,0 +1,45 @@
+/**
+ * Client intent-event recording surface.
+ *
+ * Fire-and-forget POSTs to `/api/intent-events` that degrade safely when D1
+ * or the network is unavailable. Payloads never include copy text or other
+ * sensitive fields — only event type and entry key.
+ */
+export type { IntentEventClientType } from "@/lib/intent-event-client-lib";
+export {
+  INTENT_EVENT_CLIENT_TYPES,
+  INTENT_EVENTS_API_PATH,
+  buildIntentEventEntryKey,
+  buildIntentEventRequestBody,
+  intentEventWasStored,
+} from "@/lib/intent-event-client-lib";
+
+import {
+  buildIntentEventEntryKey,
+  buildIntentEventRequestBody,
+  INTENT_EVENTS_API_PATH,
+  intentEventWasStored,
+  type IntentEventClientType,
+} from "@/lib/intent-event-client-lib";
+import { normalizeIntentEntryKey } from "@/lib/intent-events-lib";
+import type { Entry } from "@/types/registry";
+
+export async function recordIntentEvent(
+  type: IntentEventClientType,
+  entry: Pick<Entry, "category" | "slug">,
+): Promise<boolean> {
+  const entryKey = normalizeIntentEntryKey(buildIntentEventEntryKey(entry.category, entry.slug));
+  if (!entryKey) return false;
+
+  try {
+    const response = await fetch(INTENT_EVENTS_API_PATH, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: buildIntentEventRequestBody(type, entryKey),
+    });
+    if (!response.ok) return false;
+    return intentEventWasStored(await response.json());
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -41,6 +41,8 @@ import {
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
 import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
+import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
 import { SavedSearchManager } from "@/components/saved-search-manager";
@@ -649,6 +651,11 @@ function Browse() {
                     <Link
                       to="/compare"
                       search={browseCompareUi.search}
+                      onClick={() => {
+                        trackEvent("browse_compare_open", {
+                          ...browseCompareOpenAnalyticsData(browseCompareUi.selectedCount),
+                        });
+                      }}
                       className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
                     >
                       <span className="font-mono">{browseCompareUi.selectedCount}</span> selected ·

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -62,6 +62,11 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 import { toast } from "sonner";
 import { useRecents } from "@/lib/recents";
 import { useCompare, useIsCompared } from "@/lib/compare";
+import { trackEvent } from "@/lib/analytics";
+import {
+  entryDetailCompareAnalyticsData,
+  entryDetailCompareAnalyticsEvent,
+} from "@/lib/entry-detail-cta-events";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
@@ -267,6 +272,10 @@ function Dossier() {
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
     compare.toggle(entry);
+    trackEvent(entryDetailCompareAnalyticsEvent(!wasIn), {
+      ...entryDetailCompareAnalyticsData(entry.category, entry.slug),
+      compareCount: wasIn ? Math.max(0, compare.items.length - 1) : compare.items.length + 1,
+    });
     if (wasIn) {
       toast(`Removed “${entry.title}” from compare`);
     } else {
@@ -278,7 +287,13 @@ function Dossier() {
       });
     }
   }, [compare, entry, inCompare]);
-  const onOpenCompare = useCallback(() => compare.setOpen(true), [compare]);
+  const onOpenCompare = useCallback(() => {
+    compare.setOpen(true);
+    trackEvent("detail_compare_open_tray", {
+      ...entryDetailCompareAnalyticsData(entry.category, entry.slug),
+      compareCount: compare.items.length,
+    });
+  }, [compare, entry.category, entry.slug]);
 
   const risk = installRiskLevel(entry);
   const hasSchema = hasSchemaDetails(entry);

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  browseCompareOpenAnalyticsData,
+  comparisonTrayFullCompareAnalyticsData,
+  comparisonTrayQuickCompareAnalyticsData,
+  entryDetailCompareAnalyticsData,
+  entryDetailCompareAnalyticsEvent,
+  entryDetailCopyAnalyticsData,
+  entryDetailCopyAnalyticsEvent,
+  entryDetailCopyIntentType,
+} from "@/lib/entry-detail-cta-events-lib";
+
+describe("entry detail cta events lib", () => {
+  it("maps copy tabs to intent types without sensitive payloads", () => {
+    expect(entryDetailCopyIntentType("install")).toBe("install");
+    expect(entryDetailCopyIntentType("config")).toBe("copy");
+    expect(entryDetailCopyIntentType("full")).toBe("copy");
+  });
+
+  it("builds analytics event names and data for detail CTAs", () => {
+    expect(entryDetailCopyAnalyticsEvent("install")).toBe(
+      "detail_copy_install",
+    );
+    expect(entryDetailCopyAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-command-center",
+    });
+    expect(entryDetailCompareAnalyticsEvent(true)).toBe("detail_compare_add");
+    expect(entryDetailCompareAnalyticsEvent(false)).toBe(
+      "detail_compare_remove",
+    );
+    expect(entryDetailCompareAnalyticsData("skills", "demo")).toEqual({
+      entry: "skills/demo",
+      surface: "detail-compare",
+    });
+  });
+
+  it("builds browse and compare tray analytics data without entry payloads", () => {
+    expect(browseCompareOpenAnalyticsData(3)).toEqual({
+      count: 3,
+      surface: "browse-compare",
+    });
+    expect(comparisonTrayQuickCompareAnalyticsData(2)).toEqual({
+      count: 2,
+      surface: "compare-tray",
+    });
+    expect(comparisonTrayFullCompareAnalyticsData(4)).toEqual({
+      count: 4,
+      surface: "compare-tray",
+    });
+  });
+});

--- a/tests/intent-event-client-lib.test.ts
+++ b/tests/intent-event-client-lib.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIntentEventEntryKey,
+  buildIntentEventRequestBody,
+  intentEventWasStored,
+} from "@/lib/intent-event-client-lib";
+
+describe("intent event client lib", () => {
+  it("builds privacy-light intent event request bodies", () => {
+    expect(buildIntentEventEntryKey("skills", "demo")).toBe("skills:demo");
+    expect(buildIntentEventRequestBody("install", "skills:demo")).toBe(
+      JSON.stringify({ type: "install", entryKey: "skills:demo" }),
+    );
+  });
+
+  it("interprets stored intent-event API responses", () => {
+    expect(intentEventWasStored({ stored: true })).toBe(true);
+    expect(
+      intentEventWasStored({ stored: false, reason: "insert_failed" }),
+    ).toBe(false);
+    expect(intentEventWasStored(null)).toBe(false);
+  });
+});

--- a/tests/intent-event-client.test.ts
+++ b/tests/intent-event-client.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { recordIntentEvent } from "@/lib/intent-event-client";
+
+describe("intent event client", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("records intent events with normalized entry keys and degrades safely", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ stored: true }),
+      })
+      .mockRejectedValueOnce(new Error("offline"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      recordIntentEvent("install", { category: "skills", slug: "demo" }),
+    ).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith("/api/intent-events", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ type: "install", entryKey: "skills:demo" }),
+    });
+
+    await expect(
+      recordIntentEvent("open", { category: "skills", slug: "demo" }),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects invalid entry keys before calling the network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      recordIntentEvent("copy", { category: "Skills", slug: "Bad Slug!" }),
+    ).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add shared `intent-event-client` helpers that POST only event type + entry key and degrade safely when D1 or the network is unavailable.
- Wire entry detail command-center copy actions to umami analytics + D1 intent events (no copy payloads).
- Emit conversion analytics for detail compare toggles, browse compare open, and compare-tray quick/full compare actions.
- Refactor `recordCompareIntentEvent` to use the shared client.

## Test plan
- [x] `pnpm exec vitest run tests/intent-event-client-lib.test.ts tests/intent-event-client.test.ts tests/entry-detail-cta-events-lib.test.ts tests/compare-entry-actions.test.ts`
- [x] `pnpm --filter web type-check`
- [ ] CI green on PR