### PR TITLE
fix(hooks): repair dead Trivy documentationUrl (#3859)

### DIFF
--- a/content/hooks/docker-image-security-scanner.mdx
+++ b/content/hooks/docker-image-security-scanner.mdx
@@ -19,7 +19,7 @@ seoDescription: >-
 author: JSONbored
 authorProfileUrl: "https://github.com/JSONbored"
 dateAdded: "2025-10-19"
-documentationUrl: "https://aquasecurity.github.io/trivy/latest/"
+documentationUrl: "https://trivy.dev/docs/"
 retrievalSources:
   - "https://github.com/aquasecurity/trivy"
   - "https://code.claude.com/docs/en/hooks"


### PR DESCRIPTION
## Summary

Fixes a dead source URL flagged by the link-health sweep in #3859.

`content/hooks/docker-image-security-scanner.mdx` had:

```
documentationUrl: "https://aquasecurity.github.io/trivy/latest/"   # 404
```

Trivy's documentation moved off GitHub Pages to the `trivy.dev` domain, so the old URL now returns **404**. This points `documentationUrl` at the live canonical docs root:

```
documentationUrl: "https://trivy.dev/docs/"   # 200
```

Verified live: old URL → `404`, new URL → `200`. One-line frontmatter change, no other fields touched.

## Submission Source

For direct content PRs:

- [x] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [x] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author. — N/A: this is a link-health repair of an existing maintainer-authored entry (`author: JSONbored`), not a new submission; authorship is unchanged.
- [x] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [x] This PR links the issue it resolves — `Refs #3859` (one checklist item of several).

## Schema and Quality Checks

- [x] Content PR: `pnpm validate:content:strict -- --category hooks` passed locally (87 files, no failures).
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).
- [x] Install/use/copy paths are practical and complete (unchanged).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — single content frontmatter field.
- Expected behavior: the entry's "Documentation" link now resolves (200) instead of 404.
- Important edge cases or invariants: `documentationUrl` remains a canonical, non-tracking HTTPS docs URL on the project's own domain.
- Backward compatibility notes: none; metadata-only.
- Screenshots for frontend/page/UI changes: `No visual impact` — content metadata only.

## Validation

- [x] Direct content PR: I did not run generation or commit generated output.
- [x] I ran the focused checks listed above.

## Notes

Addresses the first checklist item in #3859 ("Link health: dead source URLs"). Kept to a single file per the one-file-one-PR content policy; the other flagged files (`librechat.mdx`, `designlang-mcp-server.mdx`) are separate.
