### PR TITLE
fix(tools): repair dead LibreChat packageUrl (#3859)

### DIFF
--- a/content/tools/librechat.mdx
+++ b/content/tools/librechat.mdx
@@ -21,7 +21,7 @@ dateAdded: "2026-06-18"
 websiteUrl: "https://librechat.ai/"
 documentationUrl: "https://docs.librechat.ai/"
 repoUrl: "https://github.com/danny-avila/LibreChat"
-packageUrl: "https://registry.librechat.ai/"
+packageUrl: "https://github.com/danny-avila/LibreChat/pkgs/container/librechat"
 pricingModel: free
 disclosure: editorial
 applicationCategory: DeveloperApplication


### PR DESCRIPTION
## Summary

Fixes a dead source URL flagged by the link-health sweep in #3859.

`content/tools/librechat.mdx` had:

```
packageUrl: "https://registry.librechat.ai/"   # 404
```

The LibreChat package-registry subdomain is gone (**404**). LibreChat ships as an official GHCR container image — the entry already installs it via `docker compose up -d` — so this points `packageUrl` at the live canonical container package page:

```
packageUrl: "https://github.com/danny-avila/LibreChat/pkgs/container/librechat"   # 200
```

I intentionally did **not** duplicate `repoUrl` (which already points at the same repository); the container package page is the accurate "package" target for a self-hosted Docker app. Verified live: old URL → `404`, new URL → `200`. One-line frontmatter change, no other fields touched.

## Submission Source

For direct content PRs:

- [x] This PR changes exactly one `content/<category>/<slug>.mdx` file.
- [x] The entry includes source/provenance URLs and practical install/use details.
- [ ] `submittedBy` and `submittedByUrl` match the PR author. — N/A: link-health repair of an existing maintainer-authored entry (`author: LibreChat`), not a new submission; authorship is unchanged.
- [x] I did not modify `README.md`, generated registry outputs, downloads, workflows, packages, scripts, or multiple content entries.
- [x] I did not request HeyClaude-hosted `/downloads/...` package hosting for community-submitted ZIP/MCPB artifacts.
- [x] This PR links the issue it resolves — `Refs #3859` (one checklist item of several).

## Schema and Quality Checks

- [x] Content PR: `pnpm validate:content:strict -- --category tools` passed locally (183 files, no failures).
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).
- [x] Install/use/copy paths are practical and complete (unchanged; `docker compose up -d`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — single content frontmatter field.
- Expected behavior: the entry's "Package" link now resolves (200) to the official container image page instead of 404.
- Important edge cases or invariants: `packageUrl` is a canonical, non-tracking HTTPS URL and is distinct from `repoUrl`.
- Backward compatibility notes: none; metadata-only.
- Screenshots for frontend/page/UI changes: `No visual impact` — content metadata only.

## Validation

- [x] Direct content PR: I did not run generation or commit generated output.
- [x] I ran the focused checks listed above.

## Notes

Addresses the `librechat.mdx` checklist item in #3859 ("Link health: dead source URLs"). Kept to a single file per the one-file-one-PR content policy; the `docker-image-security-scanner.mdx` item is handled in a separate PR.
