### PR TITLE
feat(web): wire browse resource card CTAs to intent events

### DIFF
--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -18,8 +18,17 @@ import { PeekButton, setHotPeek, clearHotPeek, type PeekHandle } from "./peek-bu
 import { PeekHint } from "./peek-hint";
 import { LazyEntryAuthorAttribution } from "./lazy-linked-attribution";
 import { useCompareActions, useIsCompared } from "@/lib/compare";
+import { recordIntentEvent } from "@/lib/intent-event-client";
+import {
+  resourceCardCompareAnalyticsData,
+  resourceCardCompareAnalyticsEvent,
+  resourceCardInstallAnalyticsData,
+  resourceCardInstallAnalyticsEvent,
+  resourceCardInstallIntentType,
+} from "@/lib/resource-card-cta-events";
+import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { cn } from "@/lib/utils";
-import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
+import { trackEvent, outboundHost } from "@/lib/analytics";
 
 import { formatCompact, timeAgo } from "@/lib/format";
 const fmtNum = (n?: number) => formatCompact(n);
@@ -74,7 +83,14 @@ function ResourceCardInner({
 
   const onCompareToggle = () => {
     const wasIn = inCompare;
-    toggle(entry);
+    const changed = toggle(entry);
+    if (!changed) {
+      toast.error(resourceCardCompareFullMessage());
+      return;
+    }
+    trackEvent(resourceCardCompareAnalyticsEvent(!wasIn), {
+      ...resourceCardCompareAnalyticsData(entry.category, entry.slug),
+    });
     if (wasIn) {
       toast(`Removed “${entry.title}” from compare`);
     } else {
@@ -84,6 +100,12 @@ function ResourceCardInner({
       });
     }
   };
+
+  const onInstallCopied = () => {
+    void recordIntentEvent(resourceCardInstallIntentType(entry), entry);
+  };
+
+  const installAnalyticsData = resourceCardInstallAnalyticsData(entry.category, entry.slug);
 
   if (variant === "compact") {
     return (
@@ -184,8 +206,9 @@ function ResourceCardInner({
                 value={installPayload}
                 label="Copy install"
                 toastLabel={`Copied install — ${entry.title}`}
-                event="copy-install"
-                eventData={{ entry: entryEventKey(entry.category, entry.slug) }}
+                event={resourceCardInstallAnalyticsEvent()}
+                eventData={installAnalyticsData}
+                onCopied={onInstallCopied}
               />
             </div>
           )}
@@ -276,8 +299,9 @@ function ResourceCardInner({
                 value={installPayload}
                 label="Install"
                 className="w-full justify-center"
-                event="copy-install"
-                eventData={{ entry: entryEventKey(entry.category, entry.slug) }}
+                event={resourceCardInstallAnalyticsEvent()}
+                eventData={installAnalyticsData}
+                onCopied={onInstallCopied}
               />
             ) : (
               <span aria-hidden className="block h-7 w-full" />
@@ -305,8 +329,9 @@ function ResourceCardInner({
                 rel="noreferrer"
                 onClick={() =>
                   trackEvent("source-click", {
-                    entry: entryEventKey(entry.category, entry.slug),
+                    entry: resourceCardInstallAnalyticsData(entry.category, entry.slug).entry,
                     host: outboundHost(entry.sourceUrl!),
+                    surface: installAnalyticsData.surface,
                   })
                 }
                 className="inline-flex h-7 w-full items-center justify-center gap-1 rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"

--- a/apps/web/src/lib/compare.tsx
+++ b/apps/web/src/lib/compare.tsx
@@ -10,7 +10,7 @@ import type { Entry } from "@/types/registry";
 
 interface CompareActions {
   setOpen: (open: boolean) => void;
-  toggle: (e: Entry) => void;
+  toggle: (e: Entry) => boolean;
   clear: () => void;
   has: (entry: EntryIdentity) => boolean;
   /** Hydrate selection from a `cat/slug,cat/slug` URL param string. */
@@ -60,8 +60,9 @@ function createCompareStore(): CompareStore {
     toggle: (e) => {
       const cur = state.items;
       const next = toggleCompareItem(cur, e);
-      if (next === cur) return; // at the 4-item cap — no change
+      if (next === cur) return false;
       setState({ ...state, items: next });
+      return true;
     },
     clear: () => {
       if (state.items.length === 0 && !state.open) return;

--- a/apps/web/src/lib/resource-card-compare-ui-lib.ts
+++ b/apps/web/src/lib/resource-card-compare-ui-lib.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure resource card compare CTA helpers.
+ */
+
+import { DEFAULT_COMPARE_LIMIT } from "@/lib/compare-selection-lib";
+
+export function resourceCardCompareFullMessage(maxCount = DEFAULT_COMPARE_LIMIT): string {
+  return `Compare is full (${maxCount}/${maxCount}). Remove an entry to add this one.`;
+}
+
+export function resourceCardCompareWouldBlock(
+  inCompare: boolean,
+  compareCount: number,
+  maxCount = DEFAULT_COMPARE_LIMIT,
+): boolean {
+  return !inCompare && compareCount >= maxCount;
+}

--- a/apps/web/src/lib/resource-card-compare-ui.ts
+++ b/apps/web/src/lib/resource-card-compare-ui.ts
@@ -1,0 +1,7 @@
+/**
+ * Resource card compare CTA surface.
+ */
+export {
+  resourceCardCompareFullMessage,
+  resourceCardCompareWouldBlock,
+} from "@/lib/resource-card-compare-ui-lib";

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure resource card CTA analytics and intent-event helpers.
+ *
+ * Maps browse card actions to privacy-light event names without embedding
+ * install payloads or other sensitive fields.
+ */
+
+import type { Entry } from "@/types/registry";
+import type { IntentEventClientType } from "@/lib/intent-event-client-lib";
+
+export const RESOURCE_CARD_SURFACE = "browse-card";
+
+export function resourceCardEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function resourceCardInstallIntentType(
+  entry: Pick<Entry, "installCommand">,
+): IntentEventClientType {
+  return entry.installCommand ? "install" : "copy";
+}
+
+export function resourceCardInstallAnalyticsEvent(): string {
+  return "browse_card_copy_install";
+}
+
+export function resourceCardInstallAnalyticsData(category: string, slug: string) {
+  return {
+    entry: resourceCardEntryKey(category, slug),
+    surface: RESOURCE_CARD_SURFACE,
+  };
+}
+
+export function resourceCardCompareAnalyticsEvent(adding: boolean): string {
+  return adding ? "browse_card_compare_add" : "browse_card_compare_remove";
+}
+
+export function resourceCardCompareAnalyticsData(category: string, slug: string) {
+  return {
+    entry: resourceCardEntryKey(category, slug),
+    surface: RESOURCE_CARD_SURFACE,
+  };
+}

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Resource card CTA event surface.
+ */
+export {
+  RESOURCE_CARD_SURFACE,
+  resourceCardCompareAnalyticsData,
+  resourceCardCompareAnalyticsEvent,
+  resourceCardEntryKey,
+  resourceCardInstallAnalyticsData,
+  resourceCardInstallAnalyticsEvent,
+  resourceCardInstallIntentType,
+} from "@/lib/resource-card-cta-events-lib";

--- a/tests/resource-card-compare-ui-lib.test.ts
+++ b/tests/resource-card-compare-ui-lib.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  resourceCardCompareFullMessage,
+  resourceCardCompareWouldBlock,
+} from "@/lib/resource-card-compare-ui-lib";
+
+describe("resource card compare ui lib", () => {
+  it("detects when compare is full for new additions", () => {
+    expect(resourceCardCompareWouldBlock(false, 4)).toBe(true);
+    expect(resourceCardCompareWouldBlock(true, 4)).toBe(false);
+    expect(resourceCardCompareWouldBlock(false, 2)).toBe(false);
+  });
+
+  it("returns a tray-full message for blocked compare adds", () => {
+    expect(resourceCardCompareFullMessage()).toBe(
+      "Compare is full (4/4). Remove an entry to add this one.",
+    );
+  });
+});

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  resourceCardCompareAnalyticsData,
+  resourceCardCompareAnalyticsEvent,
+  resourceCardInstallAnalyticsData,
+  resourceCardInstallAnalyticsEvent,
+  resourceCardInstallIntentType,
+} from "@/lib/resource-card-cta-events-lib";
+
+describe("resource card cta events lib", () => {
+  it("maps install copy actions to intent types", () => {
+    expect(resourceCardInstallIntentType({ installCommand: "npm i x" })).toBe(
+      "install",
+    );
+    expect(resourceCardInstallIntentType({})).toBe("copy");
+  });
+
+  it("builds privacy-light analytics events and data", () => {
+    expect(resourceCardInstallAnalyticsEvent()).toBe(
+      "browse_card_copy_install",
+    );
+    expect(resourceCardInstallAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
+      surface: "browse-card",
+    });
+    expect(resourceCardCompareAnalyticsEvent(true)).toBe(
+      "browse_card_compare_add",
+    );
+    expect(resourceCardCompareAnalyticsEvent(false)).toBe(
+      "browse_card_compare_remove",
+    );
+    expect(resourceCardCompareAnalyticsData("skills", "demo")).toEqual({
+      entry: "skills/demo",
+      surface: "browse-card",
+    });
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add `resource-card-cta-events-lib` for browse-card install/compare analytics and intent types (no payloads).
- Record D1 intent events on resource card install copy; emit umami events for install and compare toggles.
- Return a boolean from `compare.toggle` and toast when the compare tray is full (4/4).

## Test plan
- [x] `pnpm exec vitest run tests/resource-card-cta-events-lib.test.ts tests/resource-card-compare-ui-lib.test.ts tests/compare-selection-lib.test.ts`
- [x] `pnpm --filter web type-check`
- [ ] CI green on PR