### PR TITLE
refactor(web): extract pure analytics grouping-key helpers into analytics-lib

### DIFF
--- a/apps/web/src/lib/analytics-lib.ts
+++ b/apps/web/src/lib/analytics-lib.ts
@@ -1,0 +1,18 @@
+// Pure, SSR-safe helpers for the analytics layer. These are deterministic
+// string derivations with no `window`/tracker side effects, split out from
+// `analytics.ts` so they can be unit-tested directly (the tracker call in
+// `analytics.ts` stays behind the browser guard). Event data never carries PII,
+// so these helpers only derive stable grouping keys and coarse hostnames.
+
+import { publicUrlHostname } from "@heyclaude/registry/source-url";
+
+/** An entry's stable `category/slug` key, for grouping events by resource. */
+export function entryEventKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+/** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
+export function outboundHost(url: string): string {
+  const hostname = publicUrlHostname(url);
+  return hostname || "unknown";
+}

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -6,8 +6,14 @@
 // by the tracker, so we never re-emit those, and event data never carries PII
 // (no emails, no raw form fields, queries truncated). This keeps the umami
 // dashboard accurate and quiet rather than noisy.
+//
+// The pure grouping-key helpers (`entryEventKey`, `outboundHost`) live in
+// `analytics-lib.ts` so they can be unit-tested without a DOM; they are
+// re-exported here so existing `@/lib/analytics` importers stay unchanged.
 
-import { publicUrlHostname } from "@heyclaude/registry/source-url";
+import { entryEventKey, outboundHost } from "@/lib/analytics-lib";
+
+export { entryEventKey, outboundHost };
 
 type UmamiTracker = {
   track?: (event: string, data?: Record<string, unknown>) => void;
@@ -18,15 +24,4 @@ export function trackEvent(name: string, data?: Record<string, unknown>): void {
   if (typeof window === "undefined") return;
   const umami = (window as unknown as { umami?: UmamiTracker }).umami;
   umami?.track?.(name, data);
-}
-
-/** An entry's stable `category/slug` key, for grouping events by resource. */
-export function entryEventKey(category: string, slug: string): string {
-  return `${category}/${slug}`;
-}
-
-/** Hostname of an outbound URL, for grouping source clicks (no full URL / PII). */
-export function outboundHost(url: string): string {
-  const hostname = publicUrlHostname(url);
-  return hostname || "unknown";
 }

--- a/tests/analytics-lib.test.ts
+++ b/tests/analytics-lib.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { entryEventKey, outboundHost } from "../apps/web/src/lib/analytics-lib";
+
+describe("entryEventKey", () => {
+  it("joins category and slug with a slash", () => {
+    expect(entryEventKey("mcp", "github-mcp-server")).toBe(
+      "mcp/github-mcp-server",
+    );
+  });
+
+  it("preserves the exact category and slug values (no normalization)", () => {
+    expect(entryEventKey("Hooks", "My_Slug")).toBe("Hooks/My_Slug");
+  });
+
+  it("keeps empty segments so the key shape stays stable", () => {
+    expect(entryEventKey("", "")).toBe("/");
+    expect(entryEventKey("tools", "")).toBe("tools/");
+  });
+});
+
+describe("outboundHost", () => {
+  it("returns the hostname for a plain https URL", () => {
+    expect(outboundHost("https://example.com/path?q=1")).toBe("example.com");
+  });
+
+  it("strips a leading www. prefix", () => {
+    expect(outboundHost("https://www.example.com")).toBe("example.com");
+  });
+
+  it("lowercases the hostname", () => {
+    expect(outboundHost("https://GitHub.com/owner/repo")).toBe("github.com");
+  });
+
+  it("keeps non-www subdomains intact", () => {
+    expect(outboundHost("http://api.sub.example.io/v1")).toBe(
+      "api.sub.example.io",
+    );
+  });
+
+  it("returns 'unknown' for a URL that embeds credentials", () => {
+    expect(outboundHost("https://user:pass@example.com/x")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for a non-URL string", () => {
+    expect(outboundHost("not a url")).toBe("unknown");
+  });
+
+  it("returns 'unknown' for an empty string", () => {
+    expect(outboundHost("")).toBe("unknown");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
         "packages/mcp/src/cli-options.js",
         "apps/web/src/data/comparisons.ts",
         "apps/web/src/data/tools.ts",
+        "apps/web/src/lib/analytics.ts",
         "apps/web/src/lib/api/example.functions.ts",
         "apps/web/src/lib/brief-schedule.ts",
         "apps/web/src/lib/csv.ts",


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from recently merged PRs #4551 (client-logs) and #4555 (d1-batch).

The pure, SSR-safe grouping-key helpers `entryEventKey` and `outboundHost` move out of `apps/web/src/lib/analytics.ts` into a new `apps/web/src/lib/analytics-lib.ts`. `analytics.ts` keeps the browser-only `trackEvent` side effect (guarded by `typeof window === "undefined"`) and **re-exports** the two helpers, so every existing `@/lib/analytics` importer (10 components/routes) stays byte-for-byte unchanged.

This isolates the deterministic logic so it can be unit-tested without a DOM, and closes a small coverage gap (`analytics.ts` currently has no direct test).

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — internal lib refactor only. `analytics.ts` re-exports `entryEventKey`/`outboundHost` from the new `analytics-lib.ts`; the public `@/lib/analytics` surface is identical.
- Expected behavior: `entryEventKey(category, slug)` → `"category/slug"`; `outboundHost(url)` → www-stripped, lowercased hostname, or `"unknown"` for credentialed / invalid / empty URLs. Identical to the previous inline implementations.
- Important edge cases or invariants: `trackEvent` remains a no-op on the server and before the tracker loads; event data still carries no PII.
- Backward compatibility notes: fully backward compatible — pure re-export, no import churn.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split, no UI or route change.
- Focused tests: added `tests/analytics-lib.test.ts` (10 tests) — `entryEventKey` key shape (incl. empty segments) and `outboundHost` www-stripping, lowercasing, subdomain retention, and credentialed/invalid/empty → `"unknown"` fallbacks.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/analytics-lib.test.ts` → 10/10 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output (generated `apps/web/public/data/**` + `apps/web/src/generated/**` from the type-check prebuild are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** this is a self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 which also carried no linked issue. It advances the repo's ongoing "extract pure logic into `*-lib` for testability" direction and improves coverage on the analytics helpers.

`analytics.ts` is added to the vitest coverage `exclude` list alongside the other post-extraction shells (`client-logs.ts`, `d1-batch.ts`), since its only remaining logic is the DOM-guarded tracker call that cannot be exercised under the node test environment.
