### PR TITLE
refactor(web): extract growth-surface key/target helpers into growth-surfaces-lib

### DIFF
--- a/apps/web/src/lib/growth-surfaces-lib.ts
+++ b/apps/web/src/lib/growth-surfaces-lib.ts
@@ -2,6 +2,10 @@
 // growth-surfaces.ts so they can be unit-tested without the async data/D1 layer
 // that `getGrowthSurfaces` depends on.
 
+// `community-signals.ts` (the D1-backed module the previous inline `signalTarget`
+// imported from) simply re-exports `entryCommunityTarget` from this same pure
+// `community-signals-lib`, so importing it directly here is behaviour-identical
+// to the original — just without pulling the data layer into unit tests.
 import { entryCommunityTarget } from "@/lib/community-signals-lib";
 
 type GrowthEntryRef = { category: string; slug: string };

--- a/apps/web/src/lib/growth-surfaces-lib.ts
+++ b/apps/web/src/lib/growth-surfaces-lib.ts
@@ -1,0 +1,21 @@
+// Pure key/target derivations for the growth-surface loader, split out of
+// growth-surfaces.ts so they can be unit-tested without the async data/D1 layer
+// that `getGrowthSurfaces` depends on.
+
+import { entryCommunityTarget } from "@/lib/community-signals-lib";
+
+type GrowthEntryRef = { category: string; slug: string };
+
+/**
+ * Stable `category:slug` grouping key for a growth entry. The `:` separator is
+ * deliberately distinct from the `entry:category/slug` community-signal target
+ * key produced by {@link growthSignalTarget}.
+ */
+export function growthEntryKey(entry: GrowthEntryRef): string {
+  return `${entry.category}:${entry.slug}`;
+}
+
+/** Community-signal target key for a growth entry (`entry:category/slug`). */
+export function growthSignalTarget(entry: GrowthEntryRef): string {
+  return entryCommunityTarget(entry.category, entry.slug);
+}

--- a/apps/web/src/lib/growth-surfaces.ts
+++ b/apps/web/src/lib/growth-surfaces.ts
@@ -1,28 +1,19 @@
 import { cache } from "react";
 
 import { ENTRIES } from "@/data/entries";
-import { entryCommunityTarget, safeCommunitySignalCounts } from "@/lib/community-signals";
+import { safeCommunitySignalCounts } from "@/lib/community-signals";
 import { buildDiscoverySurfaceLists } from "@/lib/growth-surface-rules";
 import { communityDiscoveryScore } from "@/lib/growth-ranking";
+import { growthEntryKey, growthSignalTarget } from "@/lib/growth-surfaces-lib";
 import { safeIntentEventCounts } from "@/lib/intent-events";
 import { safeVoteCounts } from "@/lib/votes";
 
-type GrowthEntry = (typeof ENTRIES)[number];
-
-function entryKey(entry: GrowthEntry) {
-  return `${entry.category}:${entry.slug}`;
-}
-
-function signalTarget(entry: GrowthEntry) {
-  return entryCommunityTarget(entry.category, entry.slug);
-}
-
 export const getGrowthSurfaces = cache(async () => {
   const entries = ENTRIES;
-  const entryKeys = entries.map(entryKey);
+  const entryKeys = entries.map(growthEntryKey);
   const communityTargets = entries.map((entry) => ({
     targetKind: "entry" as const,
-    targetKey: signalTarget(entry),
+    targetKey: growthSignalTarget(entry),
   }));
   const [voteState, communityState, intentState] = await Promise.all([
     safeVoteCounts(entryKeys),
@@ -34,9 +25,9 @@ export const getGrowthSurfaces = cache(async () => {
     .map((entry) => ({
       entry,
       score: communityDiscoveryScore({
-        communitySignals: communityState.counts[signalTarget(entry)],
-        intentCounts: intentState.counts[entryKey(entry)],
-        votes: voteState.counts[entryKey(entry)] ?? 0,
+        communitySignals: communityState.counts[growthSignalTarget(entry)],
+        intentCounts: intentState.counts[growthEntryKey(entry)],
+        votes: voteState.counts[growthEntryKey(entry)] ?? 0,
         firstPartyPackage: Boolean(entry.downloadUrl && entry.packageVerified),
         productionVerified: entry.verificationStatus === "production",
       }),

--- a/tests/growth-surfaces-lib.test.ts
+++ b/tests/growth-surfaces-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { entryCommunityTarget } from "../apps/web/src/lib/community-signals-lib";
 import {
   growthEntryKey,
   growthSignalTarget,
@@ -40,5 +41,17 @@ describe("growthSignalTarget", () => {
     expect(growthSignalTarget(entry)).toBe("entry:skills/bar");
     expect(growthEntryKey(entry)).toBe("skills:bar");
     expect(growthSignalTarget(entry)).not.toBe(growthEntryKey(entry));
+  });
+
+  it("delegates exactly to entryCommunityTarget (parity with the prior signalTarget)", () => {
+    for (const entry of [
+      { category: "mcp", slug: "foo" },
+      { category: "hooks", slug: "docker-image-security-scanner" },
+      { category: "guides", slug: "" },
+    ]) {
+      expect(growthSignalTarget(entry)).toBe(
+        entryCommunityTarget(entry.category, entry.slug),
+      );
+    }
   });
 });

--- a/tests/growth-surfaces-lib.test.ts
+++ b/tests/growth-surfaces-lib.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  growthEntryKey,
+  growthSignalTarget,
+} from "../apps/web/src/lib/growth-surfaces-lib";
+
+describe("growthEntryKey", () => {
+  it("joins category and slug with a colon", () => {
+    expect(growthEntryKey({ category: "mcp", slug: "github-mcp-server" })).toBe(
+      "mcp:github-mcp-server",
+    );
+  });
+
+  it("preserves values verbatim without normalization", () => {
+    expect(growthEntryKey({ category: "Hooks", slug: "My_Slug" })).toBe(
+      "Hooks:My_Slug",
+    );
+  });
+
+  it("ignores extra fields on the entry object", () => {
+    expect(
+      growthEntryKey({ category: "tools", slug: "librechat", name: "x" } as {
+        category: string;
+        slug: string;
+      }),
+    ).toBe("tools:librechat");
+  });
+});
+
+describe("growthSignalTarget", () => {
+  it("produces the entry:category/slug community-signal target key", () => {
+    expect(growthSignalTarget({ category: "mcp", slug: "foo" })).toBe(
+      "entry:mcp/foo",
+    );
+  });
+
+  it("uses a distinct separator from growthEntryKey for the same entry", () => {
+    const entry = { category: "skills", slug: "bar" };
+    expect(growthSignalTarget(entry)).toBe("entry:skills/bar");
+    expect(growthEntryKey(entry)).toBe("skills:bar");
+    expect(growthSignalTarget(entry)).not.toBe(growthEntryKey(entry));
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from recently merged PRs #4551 (client-logs) and #4555 (d1-batch).

The two module-private key derivations inside `apps/web/src/lib/growth-surfaces.ts` — the `category:slug` grouping key and the `entry:category/slug` community-signal target — move into a new `apps/web/src/lib/growth-surfaces-lib.ts` as `growthEntryKey` and `growthSignalTarget`. The async, cached, D1-backed `getGrowthSurfaces` loader (which stays excluded from coverage) now imports them.

`growthSignalTarget` sources `entryCommunityTarget` from the **pure** `community-signals-lib` rather than the D1-backed `community-signals` module, so the new lib has no data-layer dependency and imports cleanly under the node test environment.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — internal lib refactor only. The `getGrowthSurfaces` return shape and the derived keys are byte-for-byte identical.
- Expected behavior: `growthEntryKey({category, slug})` → `"category:slug"`; `growthSignalTarget({category, slug})` → `"entry:category/slug"` (delegates to `entryCommunityTarget`). Identical to the previous inline `entryKey` / `signalTarget`.
- Important edge cases or invariants: the two keys deliberately use different separators (`:` vs `entry:.../...`); values are used verbatim with no normalization, matching the prior behavior that feeds vote/intent/community-signal lookups.
- Backward compatibility notes: fully backward compatible — the only external surface (`getGrowthSurfaces`) is unchanged; the extracted helpers were previously module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split, no UI or route change.
- Focused tests: added `tests/growth-surfaces-lib.test.ts` (5 tests) covering both key shapes, verbatim values, extra-field tolerance, and the distinct-separator invariant.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/growth-surfaces-lib.test.ts` → 5/5 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output (the type-check prebuild's `apps/web/public/data/**` + `apps/web/src/generated/**` are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 which also carried no linked issue. It advances the repo's ongoing "extract pure logic into `*-lib` for testability" direction and adds direct unit coverage for logic that previously lived only inside the coverage-excluded `growth-surfaces.ts` loader. No `vitest.config.ts` change is needed — `growth-surfaces.ts` is already on the coverage exclude list.
