### PR TITLE
feat(web): wire entry detail mobile bar CTAs to intent events

### DIFF
--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -8,6 +8,14 @@ import {
 } from "@/lib/entry-detail-command-center";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
+import { trackEvent } from "@/lib/analytics";
+import {
+  entryDetailMobileActionAnalyticsData,
+  entryDetailMobileActionAnalyticsEvent,
+  entryDetailMobileCopyIntentType,
+  entryDetailMobileLinkIntentType,
+} from "@/lib/entry-detail-cta-events";
+import { recordIntentEvent } from "@/lib/intent-event-client";
 import { cn } from "@/lib/utils";
 
 type EntryDetailMobileActionBarProps = {
@@ -32,7 +40,14 @@ export function EntryDetailMobileActionBar({
       const action = actions.find((item) => item.id === actionId);
       if (!action) return;
 
+      const analyticsData = entryDetailMobileActionAnalyticsData(
+        entry.category,
+        entry.slug,
+        actionId,
+      );
+
       if (action.kind === "scroll" && action.scrollTargetId) {
+        trackEvent(entryDetailMobileActionAnalyticsEvent(actionId), analyticsData);
         const target = document.getElementById(action.scrollTargetId ?? ENTRY_COMMAND_CENTER_ID);
         target?.scrollIntoView({ behavior: "smooth", block: "start" });
         return;
@@ -41,6 +56,8 @@ export function EntryDetailMobileActionBar({
       if (action.kind === "copy" && action.copyValue) {
         try {
           await navigator.clipboard.writeText(action.copyValue);
+          trackEvent(entryDetailMobileActionAnalyticsEvent(actionId), analyticsData);
+          void recordIntentEvent(entryDetailMobileCopyIntentType(entry), entry);
           toast.success("Copied install command");
         } catch {
           toast.error("Copy failed");
@@ -49,6 +66,9 @@ export function EntryDetailMobileActionBar({
       }
 
       if (action.kind === "link" && action.href) {
+        trackEvent(entryDetailMobileActionAnalyticsEvent(actionId), analyticsData);
+        const intentType = entryDetailMobileLinkIntentType(actionId);
+        if (intentType) void recordIntentEvent(intentType, entry);
         if (action.external) {
           window.open(action.href, "_blank", "noopener,noreferrer");
         } else {
@@ -56,7 +76,7 @@ export function EntryDetailMobileActionBar({
         }
       }
     },
-    [actions],
+    [actions, entry],
   );
 
   return (

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -7,9 +7,11 @@
 
 import type { CopyVariant } from "@/lib/dossier-prefs";
 import type { IntentEventClientType } from "@/lib/intent-event-client-lib";
+import type { Entry } from "@/types/registry";
 
 export const ENTRY_DETAIL_COMMAND_CENTER_SURFACE = "detail-command-center";
 export const ENTRY_DETAIL_COMPARE_SURFACE = "detail-compare";
+export const ENTRY_DETAIL_MOBILE_SURFACE = "detail-mobile";
 export const BROWSE_COMPARE_SURFACE = "browse-compare";
 export const COMPARE_TRAY_SURFACE = "compare-tray";
 
@@ -56,4 +58,30 @@ export function comparisonTrayQuickCompareAnalyticsData(count: number) {
 
 export function comparisonTrayFullCompareAnalyticsData(count: number) {
   return { count, surface: COMPARE_TRAY_SURFACE };
+}
+
+export function entryDetailMobileActionAnalyticsEvent(actionId: string): string {
+  return `detail_mobile_${actionId.replace(/-/g, "_")}`;
+}
+
+export function entryDetailMobileActionAnalyticsData(
+  category: string,
+  slug: string,
+  actionId: string,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    action: actionId,
+    surface: ENTRY_DETAIL_MOBILE_SURFACE,
+  };
+}
+
+export function entryDetailMobileCopyIntentType(
+  entry: Pick<Entry, "installCommand">,
+): IntentEventClientType {
+  return entry.installCommand ? "install" : "copy";
+}
+
+export function entryDetailMobileLinkIntentType(actionId: string): IntentEventClientType | null {
+  return actionId === "source" ? "open" : null;
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -6,6 +6,7 @@ export {
   COMPARE_TRAY_SURFACE,
   ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
   ENTRY_DETAIL_COMPARE_SURFACE,
+  ENTRY_DETAIL_MOBILE_SURFACE,
   browseCompareOpenAnalyticsData,
   comparisonTrayFullCompareAnalyticsData,
   comparisonTrayQuickCompareAnalyticsData,
@@ -15,4 +16,8 @@ export {
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
   entryDetailEntryKey,
+  entryDetailMobileActionAnalyticsData,
+  entryDetailMobileActionAnalyticsEvent,
+  entryDetailMobileCopyIntentType,
+  entryDetailMobileLinkIntentType,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -67,6 +67,7 @@ import {
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
@@ -271,7 +272,11 @@ function Dossier() {
   const inCompare = useIsCompared(entry);
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
-    compare.toggle(entry);
+    const changed = compare.toggle(entry);
+    if (!changed) {
+      toast.error(resourceCardCompareFullMessage());
+      return;
+    }
     trackEvent(entryDetailCompareAnalyticsEvent(!wasIn), {
       ...entryDetailCompareAnalyticsData(entry.category, entry.slug),
       compareCount: wasIn ? Math.max(0, compare.items.length - 1) : compare.items.length + 1,

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -8,6 +8,10 @@ import {
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailMobileActionAnalyticsData,
+  entryDetailMobileActionAnalyticsEvent,
+  entryDetailMobileCopyIntentType,
+  entryDetailMobileLinkIntentType,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -48,5 +52,24 @@ describe("entry detail cta events lib", () => {
       count: 4,
       surface: "compare-tray",
     });
+  });
+
+  it("builds mobile action analytics and intent helpers", () => {
+    expect(entryDetailMobileActionAnalyticsEvent("copy")).toBe(
+      "detail_mobile_copy",
+    );
+    expect(
+      entryDetailMobileActionAnalyticsData("mcp", "browser", "install"),
+    ).toEqual({
+      entry: "mcp/browser",
+      action: "install",
+      surface: "detail-mobile",
+    });
+    expect(entryDetailMobileCopyIntentType({ installCommand: "npm i x" })).toBe(
+      "install",
+    );
+    expect(entryDetailMobileCopyIntentType({})).toBe("copy");
+    expect(entryDetailMobileLinkIntentType("source")).toBe("open");
+    expect(entryDetailMobileLinkIntentType("claim")).toBeNull();
   });
 });


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Extend `entry-detail-cta-events-lib` with mobile action analytics and intent helpers.
- Wire entry detail mobile bar install/copy/source actions to umami + D1 intent events (no payloads).
- Surface compare-tray-full toast on entry detail compare toggle using the shared `compare.toggle` boolean.

## Test plan
- [x] `pnpm exec vitest run tests/entry-detail-cta-events-lib.test.ts tests/intent-event-client.test.ts`
- [x] `pnpm --filter web type-check`
- [ ] CI green on PR