### PR TITLE
feat(web): add entry detail API and platform integration CTAs

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -8,6 +8,10 @@ import {
   OctagonX,
   FileText,
   GitCompare,
+  Terminal,
+  Database,
+  Globe,
+  ScrollText,
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry, Harness } from "@/types/registry";
@@ -32,8 +36,16 @@ import {
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailIntegrationAnalyticsData,
+  entryDetailIntegrationAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  detailIntegrationLinkIcon,
+  resolveDetailIntegrationLinks,
+  type DetailIntegrationLinkIcon,
+} from "@/lib/entry-detail-integration-links";
 import { recordIntentEvent } from "@/lib/intent-event-client";
+import { trackEvent } from "@/lib/analytics";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
 import { siteConfig } from "@/lib/site";
@@ -73,6 +85,25 @@ function ReadinessRow({ label, value, ok }: { label: string; value: string; ok: 
   );
 }
 
+function IntegrationLinkIcon({ icon }: { icon: DetailIntegrationLinkIcon }) {
+  const className = "h-3.5 w-3.5";
+  switch (icon) {
+    case "code":
+      return <Code2 className={className} />;
+    case "manifest":
+      return <ScrollText className={className} />;
+    case "feed":
+      return <Database className={className} />;
+    case "ecosystem":
+      return <Globe className={className} />;
+    case "raycast":
+      return <ExternalLink className={className} />;
+    case "terminal":
+    default:
+      return <Terminal className={className} />;
+  }
+}
+
 export function EntryDetailCommandCenter({
   entry,
   risk,
@@ -89,6 +120,7 @@ export function EntryDetailCommandCenter({
 }: EntryDetailCommandCenterProps) {
   const readiness = resolveDetailReadinessItems(entry);
   const quickLinks = resolveDetailQuickLinks(entry);
+  const integrationLinks = resolveDetailIntegrationLinks(entry);
   const communityAnchors = resolveDetailCommunityAnchors(relatedCount, guideCount, true);
   const compareState = entryDetailCompareCtaState(compareCta.inCompare, compareCta.compareCount);
   const safetyGate = detailSafetyGateMessage(risk, entry);
@@ -293,6 +325,37 @@ export function EntryDetailCommandCenter({
           </div>
         </div>
 
+        <div className="border-b border-border px-4 py-3">
+          <div className="eyebrow mb-2">Integrations & API</div>
+          <ul className="space-y-1.5 text-xs">
+            {integrationLinks.map((link) => (
+              <li key={link.id}>
+                <a
+                  href={link.href}
+                  target={link.external ? "_blank" : undefined}
+                  rel={link.external ? "noreferrer" : undefined}
+                  onClick={() => {
+                    trackEvent(
+                      entryDetailIntegrationAnalyticsEvent(link.id),
+                      entryDetailIntegrationAnalyticsData(
+                        entry.category,
+                        entry.slug,
+                        link.id,
+                      ),
+                    );
+                    void recordIntentEvent("open", entry);
+                  }}
+                  className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+                >
+                  <IntegrationLinkIcon icon={detailIntegrationLinkIcon(link.id)} />
+                  {link.label}
+                  {link.external ? <ExternalLink className="h-3 w-3" /> : null}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+
         <div className="px-4 py-3">
           <div className="eyebrow mb-2">Contribute</div>
           <div className="flex flex-col gap-1.5 text-xs">
@@ -347,26 +410,19 @@ export function EntryDetailCommandCenter({
               </a>
             );
           }
-          if (link.id === "registry") {
+          if (link.id === "browse") {
             return (
               <Link
                 key={link.id}
                 to={link.href}
+                search={{ category: entry.category }}
                 className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
               >
                 <Code2 className="h-3.5 w-3.5" /> {link.label}
               </Link>
             );
           }
-          return (
-            <a
-              key={link.id}
-              href={link.href}
-              className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
-            >
-              <FileText className="h-3.5 w-3.5" /> {link.label}
-            </a>
-          );
+          return null;
         })}
       </div>
     </aside>

--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -337,11 +337,7 @@ export function EntryDetailCommandCenter({
                   onClick={() => {
                     trackEvent(
                       entryDetailIntegrationAnalyticsEvent(link.id),
-                      entryDetailIntegrationAnalyticsData(
-                        entry.category,
-                        entry.slug,
-                        link.id,
-                      ),
+                      entryDetailIntegrationAnalyticsData(entry.category, entry.slug, link.id),
                     );
                     void recordIntentEvent("open", entry);
                   }}

--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
-import { Copy, ExternalLink, Package, FileText } from "lucide-react";
+import { Copy, ExternalLink, Package, FileText, Terminal } from "lucide-react";
 import type { Entry } from "@/types/registry";
 import {
   ENTRY_COMMAND_CENTER_ID,
@@ -88,6 +88,8 @@ export function EntryDetailMobileActionBar({
               <Package className="h-3.5 w-3.5" />
             ) : action.id === "copy" ? (
               <Copy className="h-3.5 w-3.5" />
+            ) : action.id === "llms" ? (
+              <Terminal className="h-3.5 w-3.5" />
             ) : action.id === "source" || action.id === "suggest" ? (
               <ExternalLink className="h-3.5 w-3.5" />
             ) : (

--- a/apps/web/src/lib/entry-detail-command-center-lib.ts
+++ b/apps/web/src/lib/entry-detail-command-center-lib.ts
@@ -7,6 +7,7 @@
  */
 
 import type { InstallRisk } from "@/lib/trust-lib";
+import { entryLlmsApiPath } from "@/lib/entry-detail-integration-links-lib";
 import type { Entry } from "@/types/registry";
 import { TRUST_LABEL } from "@/types/registry";
 
@@ -117,16 +118,9 @@ export function resolveDetailQuickLinks(
   }
 
   links.push({
-    id: "registry",
-    label: "Registry JSON · LLM text",
+    id: "browse",
+    label: "Browse directory",
     href: "/browse",
-    external: false,
-  });
-
-  links.push({
-    id: "llms",
-    label: "LLM plain text",
-    href: `/api/registry/entries/${entry.category}/${entry.slug}/llms`,
     external: false,
   });
 
@@ -187,6 +181,14 @@ export function resolveDetailMobileActions(
       copyValue: copyPayload,
     });
   }
+
+  actions.push({
+    id: "llms",
+    label: "LLM",
+    kind: "link",
+    href: entryLlmsApiPath(entry.category, entry.slug),
+    external: false,
+  });
 
   if (entry.sourceUrl) {
     actions.push({

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -83,5 +83,30 @@ export function entryDetailMobileCopyIntentType(
 }
 
 export function entryDetailMobileLinkIntentType(actionId: string): IntentEventClientType | null {
-  return actionId === "source" ? "open" : null;
+  if (actionId === "source" || actionId === "llms") return "open";
+  return null;
+}
+
+export function entryDetailIntegrationAnalyticsEvent(linkId: string): string {
+  return `detail_integration_${linkId.replace(/-/g, "_")}`;
+}
+
+export function entryDetailIntegrationAnalyticsData(
+  category: string,
+  slug: string,
+  linkId: string,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    link: linkId,
+    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+  };
+}
+
+export function entryDetailMobileLlmsAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    link: "llms",
+    surface: ENTRY_DETAIL_MOBILE_SURFACE,
+  };
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -16,8 +16,11 @@ export {
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
   entryDetailEntryKey,
+  entryDetailIntegrationAnalyticsData,
+  entryDetailIntegrationAnalyticsEvent,
   entryDetailMobileActionAnalyticsData,
   entryDetailMobileActionAnalyticsEvent,
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
+  entryDetailMobileLlmsAnalyticsData,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-integration-links-lib.ts
+++ b/apps/web/src/lib/entry-detail-integration-links-lib.ts
@@ -1,0 +1,109 @@
+/**
+ * Pure entry detail integration link helpers.
+ *
+ * Builds API, assistant, and platform handoff links for the entry command
+ * center. Given the same entry metadata the output is deterministic.
+ */
+
+import type { Entry, Platform } from "@/types/registry";
+import type { DetailQuickLink } from "@/lib/entry-detail-command-center-lib";
+
+export const RAYCAST_EXTENSION_URL = "https://www.raycast.com/jsonbored/heyclaude";
+
+export type DetailIntegrationLinkIcon =
+  | "code"
+  | "terminal"
+  | "manifest"
+  | "feed"
+  | "ecosystem"
+  | "raycast";
+
+export function detailIntegrationLinkIcon(linkId: string): DetailIntegrationLinkIcon {
+  switch (linkId) {
+    case "api-json":
+      return "code";
+    case "llms":
+      return "terminal";
+    case "manifest":
+      return "manifest";
+    case "mcp-feed":
+      return "feed";
+    case "ecosystem":
+      return "ecosystem";
+    case "raycast":
+      return "raycast";
+    default:
+      return "terminal";
+  }
+}
+
+export function entryRegistryApiPath(category: string, slug: string): string {
+  return `/api/registry/entries/${category}/${slug}`;
+}
+
+export function entryLlmsApiPath(category: string, slug: string): string {
+  return `${entryRegistryApiPath(category, slug)}/llms`;
+}
+
+export function entrySupportsRaycast(platforms: Platform[]): boolean {
+  return platforms.includes("raycast");
+}
+
+export function entryIsMcpCategory(category: string): boolean {
+  return category === "mcp";
+}
+
+export function resolveDetailIntegrationLinks(
+  entry: Pick<Entry, "category" | "slug" | "platforms">,
+): DetailQuickLink[] {
+  const links: DetailQuickLink[] = [
+    {
+      id: "api-json",
+      label: "Registry API JSON",
+      href: entryRegistryApiPath(entry.category, entry.slug),
+      external: false,
+    },
+    {
+      id: "llms",
+      label: "LLM plain text",
+      href: entryLlmsApiPath(entry.category, entry.slug),
+      external: false,
+    },
+    {
+      id: "manifest",
+      label: "Registry manifest",
+      href: "/api/registry/manifest",
+      external: false,
+    },
+  ];
+
+  if (entryIsMcpCategory(entry.category)) {
+    links.push({
+      id: "mcp-feed",
+      label: "MCP registry feed",
+      href: "/data/mcp-registry-feed.json",
+      external: false,
+    });
+    links.push({
+      id: "ecosystem",
+      label: "MCP ecosystem guide",
+      href: "/ecosystem",
+      external: false,
+    });
+  }
+
+  if (entrySupportsRaycast(entry.platforms)) {
+    links.push({
+      id: "raycast",
+      label: "Open in Raycast",
+      href: RAYCAST_EXTENSION_URL,
+      external: true,
+    });
+  }
+
+  return links;
+}
+
+export function detailIntegrationLinkIds(links: DetailQuickLink[]): string[] {
+  return links.map((link) => link.id);
+}

--- a/apps/web/src/lib/entry-detail-integration-links.ts
+++ b/apps/web/src/lib/entry-detail-integration-links.ts
@@ -1,0 +1,14 @@
+/**
+ * Entry detail integration links surface.
+ */
+export type { DetailIntegrationLinkIcon } from "@/lib/entry-detail-integration-links-lib";
+export {
+  RAYCAST_EXTENSION_URL,
+  detailIntegrationLinkIcon,
+  detailIntegrationLinkIds,
+  entryIsMcpCategory,
+  entryLlmsApiPath,
+  entryRegistryApiPath,
+  entrySupportsRaycast,
+  resolveDetailIntegrationLinks,
+} from "@/lib/entry-detail-integration-links-lib";

--- a/tests/entry-detail-command-center-lib.test.ts
+++ b/tests/entry-detail-command-center-lib.test.ts
@@ -47,12 +47,7 @@ describe("entry detail command center lib", () => {
         sourceUrl: "https://github.com/example/repo",
       }),
     );
-    expect(links.map((link) => link.id)).toEqual([
-      "docs",
-      "source",
-      "registry",
-      "llms",
-    ]);
+    expect(links.map((link) => link.id)).toEqual(["docs", "source", "browse"]);
     expect(links[0]).toMatchObject({ external: true });
     expect(links[2]).toMatchObject({ href: "/browse", external: false });
   });
@@ -81,6 +76,7 @@ describe("entry detail command center lib", () => {
     expect(detailMobileActionIds(actions)).toEqual([
       "install",
       "copy",
+      "llms",
       "source",
       "suggest",
       "claim",
@@ -99,7 +95,11 @@ describe("entry detail command center lib", () => {
       "https://heyclau.de/entry/skills/fixture",
       "https://github.com/JSONbored/awesome-claude",
     );
-    expect(detailMobileActionIds(actions)).toEqual(["install", "suggest"]);
+    expect(detailMobileActionIds(actions)).toEqual([
+      "install",
+      "llms",
+      "suggest",
+    ]);
   });
 
   it("elevates the safety gate for risky or note-missing installable entries", () => {

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -8,10 +8,13 @@ import {
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailIntegrationAnalyticsData,
+  entryDetailIntegrationAnalyticsEvent,
   entryDetailMobileActionAnalyticsData,
   entryDetailMobileActionAnalyticsEvent,
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
+  entryDetailMobileLlmsAnalyticsData,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -70,6 +73,25 @@ describe("entry detail cta events lib", () => {
     );
     expect(entryDetailMobileCopyIntentType({})).toBe("copy");
     expect(entryDetailMobileLinkIntentType("source")).toBe("open");
+    expect(entryDetailMobileLinkIntentType("llms")).toBe("open");
     expect(entryDetailMobileLinkIntentType("claim")).toBeNull();
+  });
+
+  it("builds integration CTA analytics without sensitive payloads", () => {
+    expect(entryDetailIntegrationAnalyticsEvent("api-json")).toBe(
+      "detail_integration_api_json",
+    );
+    expect(
+      entryDetailIntegrationAnalyticsData("mcp", "browser", "llms"),
+    ).toEqual({
+      entry: "mcp/browser",
+      link: "llms",
+      surface: "detail-command-center",
+    });
+    expect(entryDetailMobileLlmsAnalyticsData("skills", "demo")).toEqual({
+      entry: "skills/demo",
+      link: "llms",
+      surface: "detail-mobile",
+    });
   });
 });

--- a/tests/entry-detail-integration-links-lib.test.ts
+++ b/tests/entry-detail-integration-links-lib.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  detailIntegrationLinkIcon,
+  detailIntegrationLinkIds,
+  entryLlmsApiPath,
+  entryRegistryApiPath,
+  resolveDetailIntegrationLinks,
+} from "@/lib/entry-detail-integration-links-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry detail integration links lib", () => {
+  it("builds registry API paths for an entry", () => {
+    expect(entryRegistryApiPath("mcp", "browser")).toBe(
+      "/api/registry/entries/mcp/browser",
+    );
+    expect(entryLlmsApiPath("mcp", "browser")).toBe(
+      "/api/registry/entries/mcp/browser/llms",
+    );
+  });
+
+  it("always includes API, LLM, and manifest links", () => {
+    expect(
+      detailIntegrationLinkIds(resolveDetailIntegrationLinks(entry())),
+    ).toEqual(["api-json", "llms", "manifest"]);
+  });
+
+  it("adds MCP ecosystem links for MCP entries", () => {
+    expect(
+      detailIntegrationLinkIds(
+        resolveDetailIntegrationLinks(entry({ category: "mcp" })),
+      ),
+    ).toEqual(["api-json", "llms", "manifest", "mcp-feed", "ecosystem"]);
+  });
+
+  it("maps integration link ids to icon tokens", () => {
+    expect(detailIntegrationLinkIcon("api-json")).toBe("code");
+    expect(detailIntegrationLinkIcon("llms")).toBe("terminal");
+    expect(detailIntegrationLinkIcon("manifest")).toBe("manifest");
+    expect(detailIntegrationLinkIcon("mcp-feed")).toBe("feed");
+    expect(detailIntegrationLinkIcon("ecosystem")).toBe("ecosystem");
+    expect(detailIntegrationLinkIcon("raycast")).toBe("raycast");
+    expect(detailIntegrationLinkIcon("unknown")).toBe("terminal");
+  });
+
+  it("adds Raycast handoff when the entry supports Raycast", () => {
+    expect(
+      detailIntegrationLinkIds(
+        resolveDetailIntegrationLinks(
+          entry({
+            platforms: ["claude-code", "raycast"],
+            category: "commands",
+          }),
+        ),
+      ),
+    ).toEqual(["api-json", "llms", "manifest", "raycast"]);
+    expect(
+      resolveDetailIntegrationLinks(
+        entry({ platforms: ["claude-code", "raycast"], category: "commands" }),
+      ).find((link) => link.id === "raycast"),
+    ).toMatchObject({
+      href: "https://www.raycast.com/jsonbored/heyclaude",
+      external: true,
+    });
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Extract integration/API link helpers (`entry-detail-integration-links-lib.ts`) for registry JSON, LLM plain text, manifest, MCP feed/ecosystem, and Raycast marketplace.
- Add **Integrations & API** section to the entry detail command center (alongside compare + copy CTAs).
- Replace separate registry/LLM quick links with a single **Browse directory** link filtered by category; add mobile **LLM** action with per-link icons and privacy-light CTA events.
- Rebased onto main after #4583; merges mobile + integration CTA event helpers without payload leakage.

## Test plan
- [x] `pnpm exec vitest run tests/entry-detail-integration-links-lib.test.ts tests/entry-detail-command-center-lib.test.ts tests/entry-detail-cta-events-lib.test.ts`
- [x] `pnpm --filter web type-check`
- [x] CI green on branch (prior run on force-push)