### PR TITLE
refactor(web): dedupe contributorSlug to reuse contributor-identity-lib

### DIFF
--- a/apps/web/src/lib/contributors.ts
+++ b/apps/web/src/lib/contributors.ts
@@ -1,6 +1,12 @@
 import { cache } from "react";
 
 import { getDirectoryEntries, type DirectoryEntry } from "@/lib/content.server";
+import { contributorSlug } from "@/lib/contributor-identity-lib";
+
+// `contributorSlug` is the canonical handle->slug normalizer and already lives
+// (unit-tested) in contributor-identity-lib. Re-export it here so existing
+// `@/lib/contributors` consumers keep working without a second, drifting copy.
+export { contributorSlug };
 
 export type ContributorSummary = {
   slug: string;
@@ -9,15 +15,6 @@ export type ContributorSummary = {
   entryCount: number;
   entries: DirectoryEntry[];
 };
-
-export function contributorSlug(value: string) {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/^@/, "")
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
 
 export const getContributors = cache(async () => {
   const entries = await getDirectoryEntries();


### PR DESCRIPTION
## Summary

Removes a duplicated helper. `apps/web/src/lib/contributors.ts` carried a **byte-for-byte copy** of `contributorSlug` that already exists — and is unit-tested — as the canonical normalizer in `apps/web/src/lib/contributor-identity-lib.ts`.

Two identical copies can silently drift, and only this file's copy was uncovered. This imports the canonical helper, re-exports it so existing `@/lib/contributors` consumers keep working, and drops the local duplicate. `getContributors` now uses the shared implementation.

**No behavior change** — the two implementations were identical (same trim → lowercase → strip leading `@` → collapse non-alphanumerics to `-` → strip edge dashes).

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — one internal lib module (`contributors.ts`).
- Expected behavior: identical. `contributorSlug` now resolves to `contributor-identity-lib`'s implementation (which is covered by `tests/contributor-identity-lib.test.ts`); `getContributors`/`getContributor` are unchanged.
- Important edge cases or invariants: no external module imports `contributorSlug` from `@/lib/contributors` (verified), and the re-export preserves the public surface regardless. `contributor-identity-lib` is an import-free leaf module, so there is no import cycle.
- Backward compatibility notes: fully backward compatible.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal dedup, no UI or route change.
- Focused tests: no new test needed — the canonical `contributorSlug` is already unit-tested in `tests/contributor-identity-lib.test.ts`; this PR simply routes the second call site to it.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec prettier --check apps/web/src/lib/contributors.ts` clean.
- [x] I did not run generation or commit generated output (the type-check prebuild's generated files are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** self-contained reuse/simplification cleanup with no behavior change, matching the small merged refactors in this repo. It removes a real duplicate so the handle→slug normalizer has a single source of truth. `contributors.ts` is already on the vitest coverage `exclude` list, so no coverage-config change is needed and the diff touches no measured lines.
