### PR TITLE
feat(web): wire peek panel copy and link CTAs to intent events

### DIFF
--- a/apps/web/src/components/copy-segmented.tsx
+++ b/apps/web/src/components/copy-segmented.tsx
@@ -21,6 +21,8 @@ interface Props {
   hideCopy?: boolean;
   /** Optional id for aria-labelledby on the radiogroup. */
   labelId?: string;
+  /** Optional hook after a successful clipboard write. */
+  onCopied?: (variant: CopyVariant) => void;
 }
 
 /**
@@ -35,6 +37,7 @@ export function CopySegmented({
   className,
   hideCopy = false,
   labelId,
+  onCopied,
 }: Props) {
   const [pref, setPref] = useCopyPref();
   const available = variants.filter((v) => !!v.value);
@@ -55,11 +58,12 @@ export function CopySegmented({
       toast.success(msg);
       if (liveRef.current) liveRef.current.textContent = msg;
       setJustCopied(true);
+      onCopied?.(active);
       window.setTimeout(() => setJustCopied(false), 1200);
     } catch {
       toast.error("Copy failed");
     }
-  }, [payload, active, entryTitle]);
+  }, [payload, active, entryTitle, onCopied]);
 
   const moveBy = (delta: number) => {
     const idx = available.findIndex((v) => v.id === active);

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -28,6 +28,15 @@ import { entryDomId } from "@/lib/entry-identity";
 import { cn } from "@/lib/utils";
 import { setHotPeek, clearHotPeek, installPeekShortcut } from "@/lib/peek-hotkey";
 import { LazyEntryAuthorAttribution, LazyLinkedSourceCitations } from "./lazy-linked-attribution";
+import { trackEvent } from "@/lib/analytics";
+import {
+  peekCopyAnalyticsData,
+  peekCopyAnalyticsEvent,
+  peekCopyIntentType,
+  peekPanelActionAnalyticsData,
+  peekPanelActionAnalyticsEvent,
+} from "@/lib/peek-panel-cta-events";
+import { recordIntentEvent } from "@/lib/intent-event-client";
 
 export interface PeekHandle {
   open: () => void;
@@ -99,6 +108,28 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
   const [harness, setHarness] = useHarnessPref(entry.category, entry.slug, harnessAvailable);
   const variants = React.useMemo(() => variantsForEntry(entry, harness), [entry, harness]);
 
+  const onPeekCopy = React.useCallback(
+    (variant: CopyVariant) => {
+      trackEvent(
+        peekCopyAnalyticsEvent(variant),
+        peekCopyAnalyticsData(entry.category, entry.slug, variant),
+      );
+      void recordIntentEvent(peekCopyIntentType(variant), entry);
+    },
+    [entry],
+  );
+
+  const onPeekAction = React.useCallback(
+    (action: "dossier" | "source" | "docs") => {
+      trackEvent(
+        peekPanelActionAnalyticsEvent(action),
+        peekPanelActionAnalyticsData(entry.category, entry.slug, action),
+      );
+      if (action === "source") void recordIntentEvent("open", entry);
+    },
+    [entry],
+  );
+
   return (
     <>
       <SheetHeader className="space-y-3 text-left">
@@ -166,6 +197,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
             variants={variants}
             entryTitle={entry.title}
             labelId={`peek-snippet-${peekId}`}
+            onCopied={onPeekCopy}
           />
         </div>
         {variants.find((v) => v.id === variants.find((x) => x.value)?.id)?.value && (
@@ -182,6 +214,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
         <Link
           to="/entry/$category/$slug"
           params={{ category: entry.category, slug: entry.slug }}
+          onClick={() => onPeekAction("dossier")}
           className="inline-flex h-8 items-center gap-1.5 rounded-md bg-ink px-3 text-xs font-medium text-background hover:bg-ink/90"
         >
           Open dossier <ArrowUpRight className="h-3 w-3" />
@@ -191,6 +224,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
             href={entry.sourceUrl}
             target="_blank"
             rel="noreferrer"
+            onClick={() => onPeekAction("source")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink hover:bg-surface-2"
           >
             <GitBranch className="h-3.5 w-3.5" /> Source <ExternalLink className="h-3 w-3" />
@@ -201,6 +235,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
             href={entry.docsUrl}
             target="_blank"
             rel="noreferrer"
+            onClick={() => onPeekAction("docs")}
             className="inline-flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface px-3 text-xs font-medium text-ink hover:bg-surface-2"
           >
             <BookOpen className="h-3.5 w-3.5" /> Docs <ExternalLink className="h-3 w-3" />

--- a/apps/web/src/lib/peek-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/peek-panel-cta-events-lib.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure peek panel CTA analytics and intent-event helpers.
+ */
+
+import type { CopyVariant } from "@/lib/dossier-prefs";
+import type { IntentEventClientType } from "@/lib/intent-event-client-lib";
+
+export const PEEK_PANEL_SURFACE = "peek-panel";
+
+export type PeekPanelAction = "dossier" | "source" | "docs";
+
+export function peekPanelEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function peekCopyIntentType(variant: CopyVariant): IntentEventClientType {
+  return variant === "install" ? "install" : "copy";
+}
+
+export function peekCopyAnalyticsEvent(variant: CopyVariant): string {
+  return `peek_copy_${variant}`;
+}
+
+export function peekCopyAnalyticsData(category: string, slug: string, variant: CopyVariant) {
+  return {
+    entry: peekPanelEntryKey(category, slug),
+    variant,
+    surface: PEEK_PANEL_SURFACE,
+  };
+}
+
+export function peekPanelActionAnalyticsEvent(action: PeekPanelAction): string {
+  return `peek_${action}`;
+}
+
+export function peekPanelActionAnalyticsData(
+  category: string,
+  slug: string,
+  action: PeekPanelAction,
+) {
+  return {
+    entry: peekPanelEntryKey(category, slug),
+    action,
+    surface: PEEK_PANEL_SURFACE,
+  };
+}

--- a/apps/web/src/lib/peek-panel-cta-events.ts
+++ b/apps/web/src/lib/peek-panel-cta-events.ts
@@ -1,0 +1,13 @@
+/**
+ * Peek panel CTA event surface.
+ */
+export type { PeekPanelAction } from "@/lib/peek-panel-cta-events-lib";
+export {
+  PEEK_PANEL_SURFACE,
+  peekCopyAnalyticsData,
+  peekCopyAnalyticsEvent,
+  peekCopyIntentType,
+  peekPanelActionAnalyticsData,
+  peekPanelActionAnalyticsEvent,
+  peekPanelEntryKey,
+} from "@/lib/peek-panel-cta-events-lib";

--- a/tests/peek-panel-cta-events-lib.test.ts
+++ b/tests/peek-panel-cta-events-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  peekCopyAnalyticsData,
+  peekCopyAnalyticsEvent,
+  peekCopyIntentType,
+  peekPanelActionAnalyticsData,
+  peekPanelActionAnalyticsEvent,
+} from "@/lib/peek-panel-cta-events-lib";
+
+describe("peek panel cta events lib", () => {
+  it("maps peek copy variants to intent types", () => {
+    expect(peekCopyIntentType("install")).toBe("install");
+    expect(peekCopyIntentType("config")).toBe("copy");
+  });
+
+  it("builds privacy-light peek analytics payloads", () => {
+    expect(peekCopyAnalyticsEvent("install")).toBe("peek_copy_install");
+    expect(peekCopyAnalyticsData("mcp", "browser", "full")).toEqual({
+      entry: "mcp/browser",
+      variant: "full",
+      surface: "peek-panel",
+    });
+    expect(peekPanelActionAnalyticsEvent("source")).toBe("peek_source");
+    expect(peekPanelActionAnalyticsData("skills", "demo", "dossier")).toEqual({
+      entry: "skills/demo",
+      action: "dossier",
+      surface: "peek-panel",
+    });
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add `peek-panel-cta-events-lib` for privacy-light peek analytics and intent types.
- Extend `CopySegmented` with an optional `onCopied` hook for conversion tracking.
- Wire peek panel copy, dossier, source, and docs actions to umami + D1 intent events (no payloads).

## Test plan
- [x] `pnpm exec vitest run tests/peek-panel-cta-events-lib.test.ts`
- [x] `pnpm --filter web type-check`
- [ ] CI green on PR