### PR TITLE
refactor(web): extract pure toToolListing mapping into tools-lib

### DIFF
--- a/apps/web/src/lib/tools-lib.ts
+++ b/apps/web/src/lib/tools-lib.ts
@@ -1,0 +1,37 @@
+// Pure mapping from a directory entry (+ optional commercial placement row) to a
+// `ToolListing`. Split out of tools.ts so it can be unit-tested without the D1
+// placement query and content loader that `getTools` depends on.
+
+import type { DirectoryEntry, ToolListing } from "@heyclaude/registry";
+
+export type PlacementRow = {
+  target_key: string;
+  tier: string;
+  disclosure: string;
+  starts_at: string | null;
+  expires_at: string | null;
+};
+
+export function toToolListing(entry: DirectoryEntry, placement?: PlacementRow): ToolListing {
+  const sponsored = placement?.tier === "sponsored";
+  const featured = sponsored || placement?.tier === "featured";
+
+  return {
+    ...entry,
+    featured,
+    sponsored,
+    disclosure: (placement?.disclosure ||
+      entry.disclosure ||
+      "editorial") as ToolListing["disclosure"],
+    placement: placement
+      ? {
+          targetKind: "tool",
+          targetKey: placement.target_key,
+          tier: placement.tier as "standard" | "featured" | "sponsored",
+          disclosure: placement.disclosure as "editorial" | "affiliate" | "sponsored",
+          startsAt: placement.starts_at || undefined,
+          expiresAt: placement.expires_at || undefined,
+        }
+      : undefined,
+  };
+}

--- a/apps/web/src/lib/tools.ts
+++ b/apps/web/src/lib/tools.ts
@@ -1,40 +1,9 @@
-import type { DirectoryEntry, ToolListing } from "@heyclaude/registry";
+import type { ToolListing } from "@heyclaude/registry";
 import { compareToolListings } from "@heyclaude/registry/commercial";
 
 import { getDirectoryEntriesByCategory } from "@/lib/content.server";
 import { getSiteDb } from "@/lib/db";
-
-type PlacementRow = {
-  target_key: string;
-  tier: string;
-  disclosure: string;
-  starts_at: string | null;
-  expires_at: string | null;
-};
-
-function toToolListing(entry: DirectoryEntry, placement?: PlacementRow): ToolListing {
-  const sponsored = placement?.tier === "sponsored";
-  const featured = sponsored || placement?.tier === "featured";
-
-  return {
-    ...entry,
-    featured,
-    sponsored,
-    disclosure: (placement?.disclosure ||
-      entry.disclosure ||
-      "editorial") as ToolListing["disclosure"],
-    placement: placement
-      ? {
-          targetKind: "tool",
-          targetKey: placement.target_key,
-          tier: placement.tier as "standard" | "featured" | "sponsored",
-          disclosure: placement.disclosure as "editorial" | "affiliate" | "sponsored",
-          startsAt: placement.starts_at || undefined,
-          expiresAt: placement.expires_at || undefined,
-        }
-      : undefined,
-  };
-}
+import { toToolListing, type PlacementRow } from "@/lib/tools-lib";
 
 async function getActivePlacements() {
   const db = getSiteDb();

--- a/tests/tools-lib.test.ts
+++ b/tests/tools-lib.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { DirectoryEntry } from "@heyclaude/registry";
+
+import {
+  toToolListing,
+  type PlacementRow,
+} from "../apps/web/src/lib/tools-lib";
+
+const entry = (overrides: Partial<DirectoryEntry> = {}) =>
+  ({ slug: "librechat", title: "LibreChat", ...overrides }) as DirectoryEntry;
+
+const placement = (overrides: Partial<PlacementRow> = {}): PlacementRow => ({
+  target_key: "tools:librechat",
+  tier: "standard",
+  disclosure: "editorial",
+  starts_at: null,
+  expires_at: null,
+  ...overrides,
+});
+
+describe("toToolListing", () => {
+  it("defaults to non-featured, non-sponsored, editorial disclosure with no placement", () => {
+    const listing = toToolListing(entry());
+    expect(listing.featured).toBe(false);
+    expect(listing.sponsored).toBe(false);
+    expect(listing.disclosure).toBe("editorial");
+    expect(listing.placement).toBeUndefined();
+  });
+
+  it("spreads the original entry fields through", () => {
+    const listing = toToolListing(entry({ slug: "x", title: "X Tool" }));
+    expect(listing.slug).toBe("x");
+    expect(listing.title).toBe("X Tool");
+  });
+
+  it("marks a sponsored placement as both sponsored and featured", () => {
+    const listing = toToolListing(entry(), placement({ tier: "sponsored" }));
+    expect(listing.sponsored).toBe(true);
+    expect(listing.featured).toBe(true);
+  });
+
+  it("marks a featured placement as featured but not sponsored", () => {
+    const listing = toToolListing(entry(), placement({ tier: "featured" }));
+    expect(listing.sponsored).toBe(false);
+    expect(listing.featured).toBe(true);
+  });
+
+  it("leaves a standard placement neither featured nor sponsored", () => {
+    const listing = toToolListing(entry(), placement({ tier: "standard" }));
+    expect(listing.sponsored).toBe(false);
+    expect(listing.featured).toBe(false);
+  });
+
+  it("prefers the placement disclosure, then the entry disclosure, then editorial", () => {
+    expect(
+      toToolListing(entry(), placement({ disclosure: "sponsored" })).disclosure,
+    ).toBe("sponsored");
+    expect(
+      toToolListing(
+        entry({ disclosure: "affiliate" }),
+        placement({ disclosure: "" }),
+      ).disclosure,
+    ).toBe("affiliate");
+    expect(toToolListing(entry({ disclosure: undefined })).disclosure).toBe(
+      "editorial",
+    );
+  });
+
+  it("maps placement window fields and coerces empty dates to undefined", () => {
+    const listing = toToolListing(
+      entry(),
+      placement({
+        tier: "featured",
+        disclosure: "affiliate",
+        starts_at: "2026-01-01",
+        expires_at: null,
+      }),
+    );
+    expect(listing.placement).toEqual({
+      targetKind: "tool",
+      targetKey: "tools:librechat",
+      tier: "featured",
+      disclosure: "affiliate",
+      startsAt: "2026-01-01",
+      expiresAt: undefined,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The pure `toToolListing(entry, placement)` transform and its `PlacementRow` type move out of `apps/web/src/lib/tools.ts` into a new `apps/web/src/lib/tools-lib.ts`. `tools.ts` keeps the D1-backed `getActivePlacements` / `getTools` / `getToolBySlug` loaders and imports the helper, so behavior and the public surface are unchanged. This closes a coverage gap — the mapping logic previously lived only inside the coverage-excluded `tools.ts`.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — internal lib refactor. `getTools`/`getToolBySlug` return identical `ToolListing[]`.
- Expected behavior: `toToolListing` maps a directory entry (+ optional placement) to a `ToolListing` — `tier === "sponsored"` ⇒ sponsored+featured; `tier === "featured"` ⇒ featured; disclosure resolves placement → entry → `"editorial"`; the placement window maps through with empty dates coerced to `undefined`. Identical to the previous inline implementation.
- Important edge cases or invariants: no placement ⇒ `placement: undefined`, `featured/sponsored` false; original entry fields are spread through unchanged.
- Backward compatibility notes: fully backward compatible — the extracted symbols were previously module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split.
- Focused tests: added `tests/tools-lib.test.ts` (7 tests) covering the tier→featured/sponsored mapping, the disclosure fallback chain, entry pass-through, and the placement-window mapping.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/tools-lib.test.ts` → 7/7 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output (type-check prebuild artifacts are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 which carried no linked issue. It advances the repo's "extract pure logic into `*-lib`" direction and adds direct unit coverage for the tool-listing mapping. `tools.ts` is already on the vitest coverage `exclude` list, so no `vitest.config.ts` change is needed.
