### PR TITLE
refactor(web): reuse canonical timeAgo in feed-health-panel

### DIFF
--- a/apps/web/src/components/feed-health-panel.tsx
+++ b/apps/web/src/components/feed-health-panel.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { CheckCircle2, AlertTriangle, ExternalLink, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
+import { timeAgo } from "@/lib/format-lib";
 import { cn } from "@/lib/utils";
 
 interface FeedHealth {
@@ -18,18 +19,6 @@ interface HealthPayload {
   generatedAt: string;
   count: number;
   feeds: FeedHealth[];
-}
-
-function formatAgo(iso: string | null): string {
-  if (!iso) return "—";
-  const ms = Date.now() - new Date(iso).getTime();
-  const m = Math.round(ms / 60000);
-  if (m < 1) return "just now";
-  if (m < 60) return `${m}m ago`;
-  const h = Math.round(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.round(h / 24);
-  return `${d}d ago`;
 }
 
 export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
@@ -76,7 +65,7 @@ export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
         <div>
           <div className="font-display text-sm font-semibold text-ink">Feed health</div>
           <p className="text-xs text-ink-muted">
-            {current}/{total} feeds current · last checked {formatAgo(data.generatedAt)}
+            {current}/{total} feeds current · last checked {timeAgo(data.generatedAt)}
           </p>
         </div>
         <a
@@ -121,8 +110,8 @@ export function FeedHealthPanel({ compact = false }: { compact?: boolean }) {
               </a>
             </div>
             <div className="text-ink-muted">{f.itemCount} items</div>
-            <div className="text-ink-muted">latest {formatAgo(f.latestItemAt)}</div>
-            <div className="text-ink-muted">built {formatAgo(f.lastBuilt)}</div>
+            <div className="text-ink-muted">latest {timeAgo(f.latestItemAt)}</div>
+            <div className="text-ink-muted">built {timeAgo(f.lastBuilt)}</div>
             <div className="truncate font-mono text-ink-subtle" title={f.etag}>
               {f.etag.replace(/"/g, "")}
             </div>


### PR DESCRIPTION
## Summary

Removes a duplicated relative-time formatter. `feed-health-panel.tsx` carried a local `formatAgo` that duplicates the canonical, unit-tested `timeAgo` helper in `apps/web/src/lib/format-lib.ts`. Two formatters can drift, and only this copy was uncovered.

This drops the local copy and uses `timeAgo`. For the recent timestamps this panel renders (< 30 days) the output is **identical**; `timeAgo` additionally guards invalid/negative dates (returns `"—"` instead of `"NaN…"`) and extends to months/years, so the panel now matches how the rest of the app renders relative times.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `FeedHealthPanel` (`apps/web/src/components/feed-health-panel.tsx`) only.
- Expected behavior: relative-time labels ("just now", "Nm ago", "Nh ago", "Nd ago", "—") are unchanged for the sub-30-day timestamps the feed-health endpoint returns. Behavior differs only for out-of-range inputs the panel does not normally show: invalid/negative dates now render `"—"` (previously `"NaN…"`), and ages ≥ 30 days render `"Nmo ago"` / `"Ny ago"` — both matching the canonical `timeAgo` used elsewhere.
- Important edge cases or invariants: `timeAgo` accepts `string | undefined | null`, a superset of the old `formatAgo(string | null)` signature, so all three call sites (`generatedAt`, `latestItemAt`, `lastBuilt`) type-check unchanged.
- Backward compatibility notes: display-only; no data or API change.
- Screenshots for frontend/page/UI changes: `No visual impact` for normal data (identical labels on recent feeds); the only visible difference is a more robust label for invalid/very-old timestamps.
- Focused tests: none added — `timeAgo` is already covered by `tests/format-lib.test.ts`.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec prettier --check apps/web/src/components/feed-health-panel.tsx` clean.
- [x] I did not run generation or commit generated output (type-check prebuild artifacts are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** small reuse/simplification cleanup that removes a duplicate of a canonical, tested helper — matching the merged small refactors in this repo. It gives relative-time rendering a single source of truth. The touched file is a `.tsx` component (already outside the coverage scope), so no coverage-config change is needed.
