### PR TITLE
fix(web): harden compatibility-matrix CSV export against formula injection

### DIFF
--- a/apps/web/src/components/compatibility-matrix.tsx
+++ b/apps/web/src/components/compatibility-matrix.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Download, Search, X } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CopyButton } from "@/components/copy-button";
+import { csvEscape } from "@/lib/csv";
 import { cn } from "@/lib/utils";
 
 export type Support = "native" | "adapter" | "manual" | "none";
@@ -68,8 +69,8 @@ export function CompatibilityMatrix({
     const body = rows
       .map((r) =>
         [
-          csv(r.capability),
-          csv(r.blurb),
+          csvEscape(r.capability),
+          csvEscape(r.blurb),
           ...clients.map((c) => SUPPORT_META[r.cells[c.id]].label),
         ].join(","),
       )
@@ -303,9 +304,4 @@ function CellPopover({
       )}
     </div>
   );
-}
-
-function csv(v: string) {
-  if (/[",\n]/.test(v)) return `"${v.replace(/"/g, '""')}"`;
-  return v;
 }


### PR DESCRIPTION
## Summary

Fixes a CSV formula-injection gap and removes a duplicated escaper. The compatibility-matrix CSV download built cells with a local `csv()` helper that only quoted values containing `"`, `,`, or newline — it did **not** neutralize spreadsheet formula-injection payloads. A `capability`/`blurb` cell beginning with `=`, `+`, `-`, or `@` would execute as a formula when the exported file is opened in Excel / Google Sheets.

This replaces the local helper with the canonical, unit-tested `csvEscape` from `@/lib/csv` (already used for the app's server-side CSV), which prefixes those cells with a safe leading quote and applies the same quoting. It both closes the injection gap on the user-facing capability/detail columns and removes a duplicated CSV escaper.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `CompatibilityMatrix` CSV download (`apps/web/src/components/compatibility-matrix.tsx`).
- Expected behavior: for ordinary text the exported cells are unchanged; cells whose value starts with `=`/`+`/`-`/`@` are now prefixed with a `'` guard (via `csvEscape`) so they are not interpreted as formulas. Quote/comma/newline quoting is preserved.
- Important edge cases or invariants: `csvEscape(value: unknown)` coerces via `String(value ?? "")`, a superset of the old `csv(v: string)`, so both call sites (`capability`, `blurb`) type-check unchanged. The support-status column uses a fixed safe enum label set and is left as-is.
- Backward compatibility notes: export format is unchanged for non-payload text; this is a security hardening, not a schema change.
- Screenshots for frontend/page/UI changes: `No visual impact` — affects only the generated CSV file contents, not the rendered UI.
- Focused tests: none added — `csvEscape` is already covered by `tests/csv-lib.test.ts` and `tests/api-router-security.test.ts`.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec prettier --check apps/web/src/components/compatibility-matrix.tsx` clean.
- [x] I did not run generation or commit generated output (type-check prebuild artifacts are gitignored and untracked).

## Notes

**No linked issue (maintainer-lane rationale):** small, self-contained security hardening + dedup that routes a client-side CSV export through the same injection-safe `csvEscape` the server already uses. The touched file is a `.tsx` component (outside the coverage scope), so no coverage-config change is needed and the fix relies on `csvEscape`'s existing tests.
