### PR TITLE
refactor(web): extract pure buildRequestUrl into openapi-request-lib

### DIFF
--- a/apps/web/src/components/openapi.tsx
+++ b/apps/web/src/components/openapi.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Send, Loader2, ChevronDown } from "lucide-react";
 import { CopyButton } from "@/components/copy-button";
 import type { OpenApiEndpoint, OpenApiParam } from "@/data/openapi";
+import { buildRequestUrl } from "@/lib/openapi-request-lib";
 import { cn } from "@/lib/utils";
 
 const METHOD_STYLES: Record<OpenApiEndpoint["method"], string> = {
@@ -249,24 +250,6 @@ export function OpenApiPlayground({ endpoint }: { endpoint: OpenApiEndpoint }) {
       )}
     </div>
   );
-}
-
-function buildRequestUrl(endpoint: OpenApiEndpoint, values: Record<string, string>) {
-  let path = endpoint.path.replace(/\{(\w+)\}/g, (_match, name) => {
-    const value = values[name] || endpoint.parameters?.find((p) => p.name === name)?.example;
-    return encodeURIComponent(value || "");
-  });
-
-  const params = new URLSearchParams();
-  endpoint.parameters
-    ?.filter((param) => param.in === "query")
-    .forEach((param) => {
-      const value = values[param.name] || param.example || "";
-      if (value) params.set(param.name, value);
-    });
-  const query = params.toString();
-  if (query) path = `${path}?${query}`;
-  return path;
 }
 
 function ParamInput({

--- a/apps/web/src/lib/openapi-request-lib.ts
+++ b/apps/web/src/lib/openapi-request-lib.ts
@@ -1,0 +1,30 @@
+// Pure request-path builder for the OpenAPI "try it" panel, split out of
+// openapi.tsx so the path-parameter substitution and query-string assembly can
+// be unit-tested without React or a live fetch.
+
+import type { OpenApiEndpoint } from "@/data/openapi";
+
+/**
+ * Build the request path for an endpoint from user-entered parameter values.
+ * Substitutes `{name}` path params (falling back to each param's documented
+ * `example`), URL-encodes the substituted segments, and appends non-empty
+ * `query` params as a query string. Returns the path unchanged when there is
+ * nothing to substitute or append.
+ */
+export function buildRequestUrl(endpoint: OpenApiEndpoint, values: Record<string, string>): string {
+  let path = endpoint.path.replace(/\{(\w+)\}/g, (_match, name) => {
+    const value = values[name] || endpoint.parameters?.find((p) => p.name === name)?.example;
+    return encodeURIComponent(value || "");
+  });
+
+  const params = new URLSearchParams();
+  endpoint.parameters
+    ?.filter((param) => param.in === "query")
+    .forEach((param) => {
+      const value = values[param.name] || param.example || "";
+      if (value) params.set(param.name, value);
+    });
+  const query = params.toString();
+  if (query) path = `${path}?${query}`;
+  return path;
+}

--- a/tests/openapi-request-lib.test.ts
+++ b/tests/openapi-request-lib.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  OpenApiEndpoint,
+  OpenApiParam,
+} from "../apps/web/src/data/openapi";
+import { buildRequestUrl } from "../apps/web/src/lib/openapi-request-lib";
+
+const param = (
+  over: Partial<OpenApiParam> & Pick<OpenApiParam, "name" | "in">,
+) => ({ ...over }) as OpenApiParam;
+
+const endpoint = (over: Partial<OpenApiEndpoint>): OpenApiEndpoint =>
+  ({ path: "/", ...over }) as OpenApiEndpoint;
+
+describe("buildRequestUrl", () => {
+  it("returns a plain path unchanged when there is nothing to substitute", () => {
+    expect(buildRequestUrl(endpoint({ path: "/api/v1/health" }), {})).toBe(
+      "/api/v1/health",
+    );
+  });
+
+  it("substitutes a path param from the provided values", () => {
+    const ep = endpoint({
+      path: "/api/v1/subnets/{netuid}",
+      parameters: [param({ name: "netuid", in: "path" })],
+    });
+    expect(buildRequestUrl(ep, { netuid: "64" })).toBe("/api/v1/subnets/64");
+  });
+
+  it("falls back to the parameter example when no value is provided", () => {
+    const ep = endpoint({
+      path: "/api/v1/subnets/{netuid}",
+      parameters: [param({ name: "netuid", in: "path", example: "1" })],
+    });
+    expect(buildRequestUrl(ep, {})).toBe("/api/v1/subnets/1");
+  });
+
+  it("url-encodes substituted path segments", () => {
+    const ep = endpoint({
+      path: "/api/v1/search/{q}",
+      parameters: [param({ name: "q", in: "path" })],
+    });
+    expect(buildRequestUrl(ep, { q: "a b/c" })).toBe(
+      "/api/v1/search/a%20b%2Fc",
+    );
+  });
+
+  it("substitutes an unknown path param with an empty segment", () => {
+    expect(buildRequestUrl(endpoint({ path: "/x/{missing}" }), {})).toBe("/x/");
+  });
+
+  it("appends non-empty query params and skips empty ones", () => {
+    const ep = endpoint({
+      path: "/api/v1/entries",
+      parameters: [
+        param({ name: "category", in: "query" }),
+        param({ name: "limit", in: "query", example: "10" }),
+        param({ name: "cursor", in: "query" }),
+      ],
+    });
+    expect(buildRequestUrl(ep, { category: "mcp" })).toBe(
+      "/api/v1/entries?category=mcp&limit=10",
+    );
+  });
+
+  it("ignores non-query params when building the query string", () => {
+    const ep = endpoint({
+      path: "/api/v1/subnets/{netuid}",
+      parameters: [
+        param({ name: "netuid", in: "path", example: "7" }),
+        param({ name: "x-key", in: "header", example: "secret" }),
+      ],
+    });
+    expect(buildRequestUrl(ep, {})).toBe("/api/v1/subnets/7");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The pure request-path builder for the OpenAPI "try it" panel moves out of `apps/web/src/components/openapi.tsx` into a new `apps/web/src/lib/openapi-request-lib.ts`. The component imports it; behavior is unchanged. Previously the path-parameter substitution and query-string assembly lived inside a React component and had no direct test.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — `OpenApiPlayground` now imports `buildRequestUrl` from the new lib; the type-only import surface is unchanged.
- Expected behavior: substitutes `{name}` path params (falling back to each param's `example`), URL-encodes substituted segments, appends non-empty `query` params, and returns the path unchanged when there is nothing to add. Identical to the previous inline implementation.
- Important edge cases or invariants: unknown path params resolve to an empty segment; `header`/`path` params are excluded from the query string; `import type` keeps the lib free of a runtime dependency on `@/data/openapi`.
- Backward compatibility notes: fully backward compatible — `buildRequestUrl` was previously module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split.
- Focused tests: added `tests/openapi-request-lib.test.ts` (7 tests) covering pass-through, substitution, example fallback, encoding, unknown-param, query assembly (skipping empties), and non-query exclusion.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/openapi-request-lib.test.ts` → 7/7 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the request-URL logic that previously lived only inside a React component.
