### PR TITLE
feat(web): add claim, newsletter, and peek-open conversion CTA analytics

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/lib/entry-detail-integration-links";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 import { trackEvent } from "@/lib/analytics";
+import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
 import { siteConfig } from "@/lib/site";
@@ -368,6 +369,12 @@ export function EntryDetailCommandCenter({
               <Link
                 to="/claim"
                 className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+                onClick={() =>
+                  trackEvent(
+                    claimCtaAnalyticsEvent(),
+                    claimCtaAnalyticsData("detail-command-center", entry.category, entry.slug),
+                  )
+                }
               >
                 Claim this listing
               </Link>

--- a/apps/web/src/components/newsletter-inline.tsx
+++ b/apps/web/src/components/newsletter-inline.tsx
@@ -1,6 +1,11 @@
 import { useState, type FormEvent } from "react";
 import { Mail, Check, ArrowRight } from "lucide-react";
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
+import { trackEvent } from "@/lib/analytics";
+import {
+  newsletterSubscribeAnalyticsData,
+  newsletterSubscribeAnalyticsEvent,
+} from "@/lib/conversion-cta-events";
 import { cn } from "@/lib/utils";
 
 type Variant = "quiet" | "card" | "footer-strip";
@@ -47,10 +52,10 @@ export function NewsletterInline({
     if (result.ok) {
       setDone(true);
       setPending(result.pending);
-      // First-party site analytics (umami) — not an email tracking pixel.
-      (
-        window as unknown as { umami?: { track?: (e: string, d?: Record<string, unknown>) => void } }
-      ).umami?.track?.("newsletter-subscribe", { source });
+      trackEvent(
+        newsletterSubscribeAnalyticsEvent(),
+        newsletterSubscribeAnalyticsData(source, result.pending),
+      );
       return;
     }
     setError(result.error);

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -35,6 +35,8 @@ import {
   peekCopyIntentType,
   peekPanelActionAnalyticsData,
   peekPanelActionAnalyticsEvent,
+  peekPanelOpenAnalyticsData,
+  peekPanelOpenAnalyticsEvent,
 } from "@/lib/peek-panel-cta-events";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 
@@ -58,12 +60,30 @@ export const PeekButton = React.forwardRef<PeekHandle, Props>(function PeekButto
 ) {
   const peekId = entryDomId(entry);
   const [open, setOpen] = React.useState(false);
-  React.useImperativeHandle(ref, () => ({ open: () => setOpen(true) }), []);
+  const openRef = React.useRef(open);
+  openRef.current = open;
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (next && !openRef.current) {
+        trackEvent(
+          peekPanelOpenAnalyticsEvent(),
+          peekPanelOpenAnalyticsData(entry.category, entry.slug),
+        );
+      }
+      setOpen(next);
+    },
+    [entry.category, entry.slug],
+  );
+
+  React.useImperativeHandle(ref, () => ({ open: () => handleOpenChange(true) }), [
+    handleOpenChange,
+  ]);
   React.useEffect(() => {
     installPeekShortcut();
   }, []);
   return (
-    <Sheet open={open} onOpenChange={setOpen}>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
       <TooltipProvider delayDuration={300}>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/apps/web/src/lib/conversion-cta-events-lib.ts
+++ b/apps/web/src/lib/conversion-cta-events-lib.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure claim and newsletter conversion CTA analytics helpers.
+ *
+ * Builds privacy-light event names and data without emails or other PII.
+ */
+
+export const NEWSLETTER_CTA_SURFACE = "newsletter";
+
+export type ClaimCtaSurface =
+  | "detail-command-center"
+  | "detail-mobile"
+  | "compare-table"
+  | "compare-drawer";
+
+export function claimCtaAnalyticsEvent(): string {
+  return "claim_cta_click";
+}
+
+export function claimCtaAnalyticsData(surface: ClaimCtaSurface, category?: string, slug?: string) {
+  return {
+    surface,
+    ...(category && slug ? { entry: `${category}/${slug}` } : {}),
+  };
+}
+
+export function newsletterSubscribeAnalyticsEvent(): string {
+  return "newsletter-subscribe";
+}
+
+export function newsletterSubscribeAnalyticsData(source: string, pending: boolean) {
+  return {
+    source: sanitizeNewsletterSource(source),
+    pending,
+    surface: NEWSLETTER_CTA_SURFACE,
+  };
+}
+
+export function sanitizeNewsletterSource(source: string): string {
+  return source.trim().slice(0, 64) || "inline";
+}

--- a/apps/web/src/lib/conversion-cta-events.ts
+++ b/apps/web/src/lib/conversion-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Claim and newsletter conversion CTA surface.
+ */
+export type { ClaimCtaSurface } from "@/lib/conversion-cta-events-lib";
+export {
+  NEWSLETTER_CTA_SURFACE,
+  claimCtaAnalyticsData,
+  claimCtaAnalyticsEvent,
+  newsletterSubscribeAnalyticsData,
+  newsletterSubscribeAnalyticsEvent,
+  sanitizeNewsletterSource,
+} from "@/lib/conversion-cta-events-lib";

--- a/apps/web/src/lib/peek-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/peek-panel-cta-events-lib.ts
@@ -44,3 +44,14 @@ export function peekPanelActionAnalyticsData(
     surface: PEEK_PANEL_SURFACE,
   };
 }
+
+export function peekPanelOpenAnalyticsEvent(): string {
+  return "peek_open";
+}
+
+export function peekPanelOpenAnalyticsData(category: string, slug: string) {
+  return {
+    entry: peekPanelEntryKey(category, slug),
+    surface: PEEK_PANEL_SURFACE,
+  };
+}

--- a/apps/web/src/lib/peek-panel-cta-events.ts
+++ b/apps/web/src/lib/peek-panel-cta-events.ts
@@ -10,4 +10,6 @@ export {
   peekPanelActionAnalyticsData,
   peekPanelActionAnalyticsEvent,
   peekPanelEntryKey,
+  peekPanelOpenAnalyticsData,
+  peekPanelOpenAnalyticsEvent,
 } from "@/lib/peek-panel-cta-events-lib";

--- a/tests/conversion-cta-events-lib.test.ts
+++ b/tests/conversion-cta-events-lib.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  claimCtaAnalyticsData,
+  claimCtaAnalyticsEvent,
+  newsletterSubscribeAnalyticsData,
+  newsletterSubscribeAnalyticsEvent,
+  sanitizeNewsletterSource,
+} from "@/lib/conversion-cta-events-lib";
+
+describe("conversion cta events lib", () => {
+  it("builds claim CTA analytics without requiring an entry key", () => {
+    expect(claimCtaAnalyticsEvent()).toBe("claim_cta_click");
+    expect(
+      claimCtaAnalyticsData("detail-command-center", "mcp", "browser"),
+    ).toEqual({
+      surface: "detail-command-center",
+      entry: "mcp/browser",
+    });
+    expect(claimCtaAnalyticsData("compare-table")).toEqual({
+      surface: "compare-table",
+    });
+  });
+
+  it("builds newsletter subscribe analytics without email or PII", () => {
+    expect(newsletterSubscribeAnalyticsEvent()).toBe("newsletter-subscribe");
+    expect(newsletterSubscribeAnalyticsData("entry:mcp/browser", true)).toEqual(
+      {
+        source: "entry:mcp/browser",
+        pending: true,
+        surface: "newsletter",
+      },
+    );
+    expect(sanitizeNewsletterSource("  ")).toBe("inline");
+    expect(sanitizeNewsletterSource("x".repeat(80))).toHaveLength(64);
+  });
+});

--- a/tests/peek-panel-cta-events-lib.test.ts
+++ b/tests/peek-panel-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   peekCopyIntentType,
   peekPanelActionAnalyticsData,
   peekPanelActionAnalyticsEvent,
+  peekPanelOpenAnalyticsData,
+  peekPanelOpenAnalyticsEvent,
 } from "@/lib/peek-panel-cta-events-lib";
 
 describe("peek panel cta events lib", () => {
@@ -24,6 +26,11 @@ describe("peek panel cta events lib", () => {
     expect(peekPanelActionAnalyticsData("skills", "demo", "dossier")).toEqual({
       entry: "skills/demo",
       action: "dossier",
+      surface: "peek-panel",
+    });
+    expect(peekPanelOpenAnalyticsEvent()).toBe("peek_open");
+    expect(peekPanelOpenAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
       surface: "peek-panel",
     });
   });


### PR DESCRIPTION
## Summary

- Add `conversion-cta-events-lib` for privacy-light claim and newsletter subscribe analytics (no email/PII in event payloads).
- Route newsletter subscribe success through shared `trackEvent` instead of direct `window.umami` calls; include `pending` double-opt-in flag and truncated `source`.
- Track entry detail command center claim CTA clicks with entry-scoped surface metadata.
- Emit `peek_open` when the peek sheet opens (button, keyboard shortcut, or imperative open) without duplicate events on close/reopen cycles.

Refs #556

## Test plan

- [x] `pnpm test tests/conversion-cta-events-lib.test.ts tests/peek-panel-cta-events-lib.test.ts`
- [x] `pnpm type-check`
- [ ] CI green on PR
