### PR TITLE
refactor(web): extract pure hostOf into source-citations-lib

### DIFF
--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry } from "@/types/registry";
+import { hostOf } from "@/lib/source-citations-lib";
 
 type Citation = {
   label: string;
@@ -19,15 +20,6 @@ type Citation = {
   verifiedAt?: string;
   contributorSlug?: string;
 };
-
-function hostOf(url?: string): string | undefined {
-  if (!url) return undefined;
-  try {
-    return new URL(url).host.replace(/^www\./, "");
-  } catch {
-    return url;
-  }
-}
 
 export function SourceCitations({
   entry,

--- a/apps/web/src/lib/source-citations-lib.ts
+++ b/apps/web/src/lib/source-citations-lib.ts
@@ -1,0 +1,16 @@
+// Pure display helper for the source-citations panel, split out of
+// source-citations.tsx so it can be unit-tested without React.
+
+/**
+ * Display host for a citation URL: the URL host with a leading `www.` stripped.
+ * Returns the original string unchanged when it is not a parseable URL (so a
+ * best-effort hint is still shown), or `undefined` when the input is empty.
+ */
+export function hostOf(url?: string): string | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url).host.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}

--- a/tests/source-citations-lib.test.ts
+++ b/tests/source-citations-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { hostOf } from "../apps/web/src/lib/source-citations-lib";
+
+describe("hostOf", () => {
+  it("returns undefined for an empty or missing url", () => {
+    expect(hostOf(undefined)).toBeUndefined();
+    expect(hostOf("")).toBeUndefined();
+  });
+
+  it("returns the host of a plain https url", () => {
+    expect(hostOf("https://example.com/path?q=1")).toBe("example.com");
+  });
+
+  it("strips a leading www. prefix", () => {
+    expect(hostOf("https://www.example.com")).toBe("example.com");
+  });
+
+  it("keeps non-www subdomains intact", () => {
+    expect(hostOf("https://docs.example.com/x")).toBe("docs.example.com");
+  });
+
+  it("preserves a non-default port in the host", () => {
+    expect(hostOf("http://localhost:3000/x")).toBe("localhost:3000");
+  });
+
+  it("returns the original string when the url cannot be parsed", () => {
+    expect(hostOf("not a url")).toBe("not a url");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The pure `hostOf` display helper moves out of `apps/web/src/components/source-citations.tsx` into a new `apps/web/src/lib/source-citations-lib.ts`. The component imports it; behavior is unchanged. `hostOf` has six call sites and previously had no direct test.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: none — `SourceCitations` now imports `hostOf` from the new lib.
- Expected behavior: `hostOf(url)` returns the URL host with a leading `www.` stripped, the raw string unchanged for unparseable input (best-effort hint), and `undefined` for empty input. Identical to the previous inline implementation.
- Important edge cases or invariants: non-www subdomains and non-default ports are preserved; empty/undefined → `undefined`.
- Backward compatibility notes: fully backward compatible — `hostOf` was previously module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split.
- Focused tests: added `tests/source-citations-lib.test.ts` (6 tests) covering empty/undefined, plain host, www-stripping, subdomain retention, port preservation, and unparseable-input passthrough.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/source-citations-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the citation host-display helper that previously lived only inside a React component.
