### PR TITLE
refactor(web): extract pure alertBucket into alerts-bucket-lib

### DIFF
--- a/apps/web/src/components/alerts-dropdown.tsx
+++ b/apps/web/src/components/alerts-dropdown.tsx
@@ -3,6 +3,7 @@ import { Bell, CheckCheck, AlertTriangle, Info, OctagonX } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useWatch, type Alert } from "@/lib/watch";
+import { alertBucket } from "@/lib/alerts-bucket-lib";
 import { cn } from "@/lib/utils";
 
 const SEV_ICON = {
@@ -11,20 +12,13 @@ const SEV_ICON = {
   blocker: { Icon: OctagonX, cls: "text-trust-blocked" },
 };
 
-function bucket(alert: Alert, lastSeenAt: string) {
-  const t = Date.parse(alert.date);
-  const now = Date.now();
-  if (t > now - 86_400_000) return "Today";
-  if (t > now - 7 * 86_400_000) return "This week";
-  return "Earlier";
-}
-
 export function AlertsDropdown() {
   const { alerts, unreadCount, lastSeenAt, markAllRead, targets, savedSearchAlertCount } =
     useWatch();
   const grouped = React.useMemo(() => {
     const out: Record<string, Alert[]> = { Today: [], "This week": [], Earlier: [] };
-    for (const a of alerts) out[bucket(a, lastSeenAt)].push(a);
+    const now = Date.now();
+    for (const a of alerts) out[alertBucket(a.date, now)].push(a);
     return out;
   }, [alerts, lastSeenAt]);
 

--- a/apps/web/src/lib/alerts-bucket-lib.ts
+++ b/apps/web/src/lib/alerts-bucket-lib.ts
@@ -1,0 +1,19 @@
+// Pure recency-bucketing for the alerts dropdown, split out of
+// alerts-dropdown.tsx so the date boundaries can be unit-tested with an
+// injected `now` (no reliance on the real clock).
+
+export type AlertBucket = "Today" | "This week" | "Earlier";
+
+const DAY_MS = 86_400_000;
+
+/**
+ * Group an alert by its ISO `date` into a recency bucket relative to `now`
+ * (epoch ms): within the last day → "Today", within the last 7 days →
+ * "This week", otherwise "Earlier". Unparseable dates fall into "Earlier".
+ */
+export function alertBucket(dateIso: string, now: number): AlertBucket {
+  const t = Date.parse(dateIso);
+  if (t > now - DAY_MS) return "Today";
+  if (t > now - 7 * DAY_MS) return "This week";
+  return "Earlier";
+}

--- a/tests/alerts-bucket-lib.test.ts
+++ b/tests/alerts-bucket-lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { alertBucket } from "../apps/web/src/lib/alerts-bucket-lib";
+
+// Fixed reference point so the boundaries are deterministic.
+const NOW = Date.parse("2026-07-07T12:00:00.000Z");
+const DAY = 86_400_000;
+
+describe("alertBucket", () => {
+  it("buckets an alert from the last 24h as Today", () => {
+    expect(alertBucket(new Date(NOW - 1000).toISOString(), NOW)).toBe("Today");
+    expect(alertBucket(new Date(NOW - (DAY - 1)).toISOString(), NOW)).toBe(
+      "Today",
+    );
+  });
+
+  it("buckets an alert older than a day but within a week as This week", () => {
+    expect(alertBucket(new Date(NOW - 2 * DAY).toISOString(), NOW)).toBe(
+      "This week",
+    );
+    expect(alertBucket(new Date(NOW - (7 * DAY - 1)).toISOString(), NOW)).toBe(
+      "This week",
+    );
+  });
+
+  it("buckets an alert older than a week as Earlier", () => {
+    expect(alertBucket(new Date(NOW - 8 * DAY).toISOString(), NOW)).toBe(
+      "Earlier",
+    );
+  });
+
+  it("treats the exact 1-day boundary as no longer Today", () => {
+    expect(alertBucket(new Date(NOW - DAY).toISOString(), NOW)).toBe(
+      "This week",
+    );
+  });
+
+  it("falls back to Earlier for an unparseable date", () => {
+    expect(alertBucket("not a date", NOW)).toBe("Earlier");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The alerts dropdown grouped alerts with a local `bucket()` that read the wall clock via `Date.now()` internally (so it could not be unit-tested) and took an unused `lastSeenAt` argument. This extracts the recency logic to a new `apps/web/src/lib/alerts-bucket-lib.ts` as `alertBucket(dateIso, now)` — `now` is injected and the dead parameter is dropped. The component computes `now` once per grouping pass and passes it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `AlertsDropdown` grouping only.
- Expected behavior: alerts within the last day → "Today", within 7 days → "This week", otherwise (and for unparseable dates) → "Earlier". Identical to the previous inline logic. Computing `now` once per grouping pass (instead of once per alert) makes the day/week boundary consistent across the batch — same result, no longer clock-racy within a render.
- Important edge cases or invariants: the exact 1-day boundary falls out of "Today" (strict `>` preserved); unparseable dates bucket as "Earlier"; the previously-unused `lastSeenAt` argument is removed.
- Backward compatibility notes: fully backward compatible — `bucket` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same grouping output.
- Focused tests: added `tests/alerts-bucket-lib.test.ts` (5 tests) covering all three buckets, the exact 1-day edge, and the unparseable-date fallback.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/alerts-bucket-lib.test.ts` → 5/5 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that also drops a dead parameter and removes a hidden `Date.now()` dependency, matching the merged small refactors in this repo (no linked issue). The touched component is a `.tsx` outside the coverage scope; the extracted lib is measured and fully covered by the new test.
