### PR TITLE
feat(web): add browse active-filter trust decision hints

### DIFF
--- a/apps/web/src/lib/browse-filter-decision-hints-lib.ts
+++ b/apps/web/src/lib/browse-filter-decision-hints-lib.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure browse active-filter decision hint helpers.
+ *
+ * Builds trust-oriented guidance when browse filters narrow the registry
+ * without touching the network. Given the same slice and result metadata the
+ * output is deterministic.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import {
+  browseTrustSignalLabel,
+  isBrowseTrustSignalFilter,
+  type BrowseTrustSearchSlice,
+} from "@/lib/browse-trust-filters-lib";
+
+const TRUST_LEVEL_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+
+export type BrowseFilterDecisionKind =
+  | "trust-mix"
+  | "signal-filter"
+  | "trust-filter"
+  | "narrow-set"
+  | "compare";
+
+export type BrowseFilterDecisionUiState = {
+  hint: string | null;
+  kind: BrowseFilterDecisionKind | null;
+};
+
+export function browseActiveFilterCount(slice: BrowseTrustSearchSlice): number {
+  return (
+    Number(!!slice.q) +
+    Number(!!slice.category) +
+    Number(!!slice.trust) +
+    Number(!!slice.source) +
+    Number(!!slice.signal) +
+    Number(!!slice.platform)
+  );
+}
+
+export function browseFilteredTrustMixHint(entries: Entry[]): string | null {
+  if (entries.length < 2) return null;
+
+  const counts: Partial<Record<TrustLevel, number>> = {};
+  for (const entry of entries) {
+    counts[entry.trust] = (counts[entry.trust] ?? 0) + 1;
+  }
+
+  const levels = TRUST_LEVEL_ORDER.filter((level) => (counts[level] ?? 0) > 0);
+  if (levels.length < 2) return null;
+
+  const parts = levels.map((level) => `${counts[level]} ${level}`);
+  return `${parts.join(" · ")} in this set — compare to see which signals differ.`;
+}
+
+export function browseFilterDecisionUiState(
+  slice: BrowseTrustSearchSlice,
+  results: Entry[],
+  compareCount = 0,
+): BrowseFilterDecisionUiState {
+  const activeCount = browseActiveFilterCount(slice);
+  if (activeCount === 0 || results.length === 0) {
+    return { hint: null, kind: null };
+  }
+
+  const trustMixHint = browseFilteredTrustMixHint(results);
+  if (trustMixHint) {
+    return { hint: trustMixHint, kind: "trust-mix" };
+  }
+
+  if (isBrowseTrustSignalFilter(slice.signal)) {
+    const label = browseTrustSignalLabel(slice.signal);
+    const hint =
+      compareCount >= 2
+        ? `${label} filter — open compare to see trust gaps in your selection.`
+        : `${label} filter active — add entries to compare trust side by side.`;
+    return { hint, kind: "signal-filter" };
+  }
+
+  if (slice.trust) {
+    return {
+      hint: `All ${results.length} results are ${slice.trust} trust — check install risk per entry.`,
+      kind: "trust-filter",
+    };
+  }
+
+  if (activeCount >= 2) {
+    const hint =
+      compareCount >= 2
+        ? "Narrow filter set — open compare to review trust differences."
+        : "Narrow filter set — select entries to compare trust side by side.";
+    return { hint, kind: "narrow-set" };
+  }
+
+  if (compareCount >= 2) {
+    return {
+      hint: "Open compare to review trust and next steps across your selection.",
+      kind: "compare",
+    };
+  }
+
+  if (
+    (slice.q || slice.category || slice.source || slice.platform) &&
+    results.length >= 3 &&
+    compareCount < 2
+  ) {
+    return {
+      hint: "Select entries to compare install and trust signals side by side.",
+      kind: "compare",
+    };
+  }
+
+  return { hint: null, kind: null };
+}

--- a/apps/web/src/lib/browse-filter-decision-hints.ts
+++ b/apps/web/src/lib/browse-filter-decision-hints.ts
@@ -1,0 +1,12 @@
+/**
+ * Browse active-filter decision hint surface.
+ */
+export type {
+  BrowseFilterDecisionKind,
+  BrowseFilterDecisionUiState,
+} from "@/lib/browse-filter-decision-hints-lib";
+export {
+  browseActiveFilterCount,
+  browseFilteredTrustMixHint,
+  browseFilterDecisionUiState,
+} from "@/lib/browse-filter-decision-hints-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -21,6 +21,7 @@ import {
   isBrowseTrustSignalFilter,
   toggleBrowseTrustSignal,
 } from "@/lib/browse-trust-filters";
+import { browseFilterDecisionUiState } from "@/lib/browse-filter-decision-hints";
 import {
   CATEGORIES,
   type Category,
@@ -303,6 +304,24 @@ function Browse() {
   const browseCompareUi = useMemo(
     () => browseCompareInteractiveUiState(compare.items),
     [compare.items],
+  );
+
+  const browseFilterDecision = useMemo(
+    () =>
+      browseFilterDecisionUiState(
+        {
+          q: sp.q,
+          category: sp.category,
+          trust: sp.trust,
+          source: sp.source,
+          signal: sp.signal,
+          platform: sp.platform,
+          sort: sp.sort,
+        },
+        results,
+        compare.items.length,
+      ),
+    [sp, results, compare.items.length],
   );
 
   const activeCount =
@@ -756,6 +775,12 @@ function Browse() {
           {activeFilters.length > 0 && (
             <FilterSummaryBar filters={activeFilters} onClearAll={clearAll} className="mt-3" />
           )}
+
+          {browseFilterDecision.hint ? (
+            <p className="mt-2 text-xs text-ink-muted" role="status">
+              {browseFilterDecision.hint}
+            </p>
+          ) : null}
 
           {sp.category &&
             (() => {

--- a/tests/browse-filter-decision-hints-lib.test.ts
+++ b/tests/browse-filter-decision-hints-lib.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseActiveFilterCount,
+  browseFilteredTrustMixHint,
+  browseFilterDecisionUiState,
+} from "@/lib/browse-filter-decision-hints-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const emptySlice = {
+  q: "",
+  category: "",
+  trust: "",
+  source: "",
+  signal: "",
+  platform: "",
+  sort: "popular" as const,
+};
+
+describe("browse filter decision hints lib", () => {
+  it("counts active browse filters from URL slice", () => {
+    expect(browseActiveFilterCount(emptySlice)).toBe(0);
+    expect(
+      browseActiveFilterCount({
+        ...emptySlice,
+        trust: "trusted",
+        signal: "reviewed",
+      }),
+    ).toBe(2);
+  });
+
+  it("summarizes mixed trust levels in filtered results", () => {
+    expect(
+      browseFilteredTrustMixHint([
+        entry({ trust: "trusted" }),
+        entry({ trust: "review", slug: "two" }),
+      ]),
+    ).toBe(
+      "1 trusted · 1 review in this set — compare to see which signals differ.",
+    );
+    expect(
+      browseFilteredTrustMixHint([entry({ trust: "trusted" })]),
+    ).toBeNull();
+  });
+
+  it("prioritizes trust-mix hints over signal-filter guidance", () => {
+    expect(
+      browseFilterDecisionUiState({ ...emptySlice, signal: "safety-notes" }, [
+        entry({ trust: "trusted" }),
+        entry({ trust: "review", slug: "two" }),
+      ]),
+    ).toEqual({
+      hint: "1 trusted · 1 review in this set — compare to see which signals differ.",
+      kind: "trust-mix",
+    });
+  });
+
+  it("builds trust-signal and narrow-set decision hints", () => {
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, signal: "privacy-notes" },
+        [entry(), entry({ slug: "two" })],
+        0,
+      ),
+    ).toEqual({
+      hint: "Privacy notes filter active — add entries to compare trust side by side.",
+      kind: "signal-filter",
+    });
+
+    expect(
+      browseFilterDecisionUiState(
+        { ...emptySlice, category: "skills", platform: "claude-code" },
+        [entry(), entry({ slug: "two" })],
+        2,
+      ),
+    ).toEqual({
+      hint: "Narrow filter set — open compare to review trust differences.",
+      kind: "narrow-set",
+    });
+  });
+
+  it("returns null when filters are inactive or results are empty", () => {
+    expect(browseFilterDecisionUiState(emptySlice, [entry()])).toEqual({
+      hint: null,
+      kind: null,
+    });
+    expect(
+      browseFilterDecisionUiState({ ...emptySlice, trust: "review" }, []),
+    ).toEqual({
+      hint: null,
+      kind: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add rowse-filter-decision-hints-lib for trust-mix summaries and filter-context decision guidance on browse.
- Show a status hint below the active filter bar when filters narrow results (mixed trust levels, signal filters, narrow sets, compare nudges).
- Keep logic pure and unit-tested without new network calls.

Refs #556

## Test plan
- [x] pnpm test tests/browse-filter-decision-hints-lib.test.ts
- [x] pnpm type-check
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)