### PR TITLE
refactor(web): extract pure hashSearch into saved-search-hash-lib

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -30,6 +30,7 @@ import {
   type AlertSchedule,
 } from "@/lib/recents";
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
+import { hashSearch } from "@/lib/saved-search-hash-lib";
 import { CopyButton } from "@/components/copy-button";
 import { cn } from "@/lib/utils";
 
@@ -44,13 +45,6 @@ function applyToBrowseSearch(s: SavedSearch) {
     view: "row" as const,
     compare: "",
   };
-}
-
-function hashSearch(s: SavedSearch): string {
-  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}`;
-  let h = 0;
-  for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
-  return Math.abs(h).toString(36);
 }
 
 export function savedFeedUrl(s: SavedSearch): string {

--- a/apps/web/src/lib/saved-search-hash-lib.ts
+++ b/apps/web/src/lib/saved-search-hash-lib.ts
@@ -1,0 +1,17 @@
+// Pure, deterministic hash for a saved search, split out of
+// saved-search-manager.tsx so it can be unit-tested without React.
+
+import type { SavedSearch } from "@/lib/recents";
+
+/**
+ * Stable base36 hash of a saved search's identifying fields (query plus the
+ * category / trust / source / platform filters). Used to key saved-search alert
+ * segments: equal searches hash equally; different searches (almost) always
+ * differ. Deterministic — no ordering or clock dependence.
+ */
+export function hashSearch(s: SavedSearch): string {
+  const raw = `${s.q}|${s.category ?? ""}|${s.trust ?? ""}|${s.source ?? ""}|${s.platform ?? ""}`;
+  let h = 0;
+  for (let i = 0; i < raw.length; i++) h = (h * 31 + raw.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36);
+}

--- a/tests/saved-search-hash-lib.test.ts
+++ b/tests/saved-search-hash-lib.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { SavedSearch } from "../apps/web/src/lib/recents";
+import { hashSearch } from "../apps/web/src/lib/saved-search-hash-lib";
+
+const search = (over: Partial<SavedSearch> = {}) =>
+  ({ q: "", ...over }) as SavedSearch;
+
+describe("hashSearch", () => {
+  it("is deterministic for the same search", () => {
+    const s = search({ q: "mcp", category: "mcp", trust: "trusted" });
+    expect(hashSearch(s)).toBe(hashSearch(s));
+  });
+
+  it("produces a base36 string", () => {
+    expect(hashSearch(search({ q: "hello world" }))).toMatch(/^[0-9a-z]+$/);
+  });
+
+  it("differs when the query differs", () => {
+    expect(hashSearch(search({ q: "a" }))).not.toBe(
+      hashSearch(search({ q: "b" })),
+    );
+  });
+
+  it("differs when a filter is added", () => {
+    expect(hashSearch(search({ q: "x" }))).not.toBe(
+      hashSearch(search({ q: "x", category: "hooks" })),
+    );
+  });
+
+  it("treats an undefined filter the same as an empty string", () => {
+    expect(hashSearch(search({ q: "x", category: undefined }))).toBe(
+      hashSearch(search({ q: "x", category: "" as SavedSearch["category"] })),
+    );
+  });
+
+  it("distinguishes which filter field a value sits in", () => {
+    expect(hashSearch(search({ q: "x", trust: "trusted" }))).not.toBe(
+      hashSearch(
+        search({ q: "x", source: "trusted" as SavedSearch["source"] }),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The deterministic saved-search hash — used to key saved-search alert segments (`saved-search:${hash}`) — moves out of `apps/web/src/components/saved-search-manager.tsx` into a new `apps/web/src/lib/saved-search-hash-lib.ts`. The component imports it; behavior is unchanged. It previously lived inside a React component and had no direct test.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `SavedSearchManager` now imports `hashSearch` from the new lib.
- Expected behavior: `hashSearch(s)` returns a stable base36 hash of the query plus the category/trust/source/platform filters. Identical to the previous inline implementation.
- Important edge cases or invariants: deterministic; an undefined filter hashes the same as an empty string; the same value in different filter fields hashes differently (field position is preserved).
- Backward compatibility notes: fully backward compatible — `hashSearch` was module-private, and the produced hash string is byte-identical to before, so existing alert segment keys are stable.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split.
- Focused tests: added `tests/saved-search-hash-lib.test.ts` (6 tests) covering determinism, base36 output, query/filter sensitivity, field-position distinction, and undefined-vs-empty equivalence.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/saved-search-hash-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the saved-search hash that previously lived only inside a React component; the produced hash is unchanged so alert segment keys stay stable.
