### PR TITLE
refactor(web): extract pure facetsFor into entry-facets-lib

### DIFF
--- a/apps/web/src/components/entry-facets.tsx
+++ b/apps/web/src/components/entry-facets.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
-import { Layers, ShieldCheck, Sparkles, Terminal, Zap } from "lucide-react";
 import { type Entry } from "@/types/registry";
+import { facetsFor, type Facet } from "@/lib/entry-facets-lib";
 import { cn } from "@/lib/utils";
 
 /**
@@ -51,15 +50,6 @@ export function EntryFacets({
   );
 }
 
-interface Facet {
-  label: string;
-  value: string;
-  detail?: string;
-  icon?: React.ElementType;
-  tone?: "default" | "accent" | "trust";
-  mono?: boolean;
-}
-
 function FacetChip({ facet }: { facet: Facet }) {
   const Icon = facet.icon;
   return (
@@ -78,66 +68,4 @@ function FacetChip({ facet }: { facet: Facet }) {
       <span className="text-ink">{facet.value}</span>
     </span>
   );
-}
-
-function facetsFor(e: Entry): Facet[] {
-  switch (e.category) {
-    case "hooks":
-      return e.trigger
-        ? [
-            {
-              label: "Trigger",
-              value: e.trigger,
-              icon: Zap,
-              tone: "accent",
-              detail: "Runs at this lifecycle event. Keep idempotent.",
-            },
-          ]
-        : [];
-    case "commands":
-      return e.commandSyntax
-        ? [
-            {
-              label: "Invocation",
-              value: e.commandSyntax,
-              icon: Terminal,
-              mono: true,
-            },
-          ]
-        : [];
-    case "statuslines":
-      return e.scriptLanguage
-        ? [
-            {
-              label: "Language",
-              value: e.scriptLanguage,
-              icon: Terminal,
-              detail: "Runs on every prompt render — keep fast and side-effect free.",
-            },
-          ]
-        : [];
-    case "skills": {
-      const out: Facet[] = [];
-      if (e.skillLevel) out.push({ label: "Level", value: e.skillLevel, icon: Sparkles });
-      if (e.skillType) out.push({ label: "Type", value: e.skillType });
-      if (e.verificationStatus)
-        out.push({ label: "Verified", value: e.verificationStatus, icon: ShieldCheck });
-      return out;
-    }
-    case "collections":
-      return e.items && e.items.length > 0
-        ? [
-            {
-              label: "Bundle",
-              value: `${e.items.length} item${e.items.length === 1 ? "" : "s"}`,
-              icon: Layers,
-              detail: e.installationOrder
-                ? `Install order: ${e.installationOrder.slice(0, 3).join(" → ")}`
-                : undefined,
-            },
-          ]
-        : [];
-    default:
-      return [];
-  }
 }

--- a/apps/web/src/lib/entry-facets-lib.ts
+++ b/apps/web/src/lib/entry-facets-lib.ts
@@ -1,0 +1,89 @@
+// Pure per-category facet derivation for the entry-facets panel, split out of
+// entry-facets.tsx so the category → facet mapping can be unit-tested without
+// rendering React.
+
+import type { ElementType } from "react";
+import { Layers, ShieldCheck, Sparkles, Terminal, Zap } from "lucide-react";
+
+import { type Entry } from "@/types/registry";
+
+export interface Facet {
+  label: string;
+  value: string;
+  detail?: string;
+  icon?: ElementType;
+  tone?: "default" | "accent" | "trust";
+  mono?: boolean;
+}
+
+/**
+ * Category-specific metadata rows the generic card otherwise hides: hook
+ * trigger, command syntax, statusline language, skill level/type/verification,
+ * and collection bundle size. Returns `[]` when the category has no facet or the
+ * relevant field is absent.
+ */
+export function facetsFor(e: Entry): Facet[] {
+  switch (e.category) {
+    case "hooks":
+      return e.trigger
+        ? [
+            {
+              label: "Trigger",
+              value: e.trigger,
+              icon: Zap,
+              tone: "accent",
+              detail: "Runs at this lifecycle event. Keep idempotent.",
+            },
+          ]
+        : [];
+    case "commands":
+      return e.commandSyntax
+        ? [
+            {
+              label: "Invocation",
+              value: e.commandSyntax,
+              icon: Terminal,
+              mono: true,
+            },
+          ]
+        : [];
+    case "statuslines":
+      return e.scriptLanguage
+        ? [
+            {
+              label: "Language",
+              value: e.scriptLanguage,
+              icon: Terminal,
+              detail: "Runs on every prompt render — keep fast and side-effect free.",
+            },
+          ]
+        : [];
+    case "skills": {
+      const out: Facet[] = [];
+      if (e.skillLevel) out.push({ label: "Level", value: e.skillLevel, icon: Sparkles });
+      if (e.skillType) out.push({ label: "Type", value: e.skillType });
+      if (e.verificationStatus)
+        out.push({
+          label: "Verified",
+          value: e.verificationStatus,
+          icon: ShieldCheck,
+        });
+      return out;
+    }
+    case "collections":
+      return e.items && e.items.length > 0
+        ? [
+            {
+              label: "Bundle",
+              value: `${e.items.length} item${e.items.length === 1 ? "" : "s"}`,
+              icon: Layers,
+              detail: e.installationOrder
+                ? `Install order: ${e.installationOrder.slice(0, 3).join(" → ")}`
+                : undefined,
+            },
+          ]
+        : [];
+    default:
+      return [];
+  }
+}

--- a/tests/entry-facets-lib.test.ts
+++ b/tests/entry-facets-lib.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { facetsFor } from "../apps/web/src/lib/entry-facets-lib";
+
+const entry = (over: Partial<Entry>) => ({ category: "mcp", ...over }) as Entry;
+
+describe("facetsFor", () => {
+  it("returns [] for a category with no facet mapping", () => {
+    expect(facetsFor(entry({ category: "mcp" }))).toEqual([]);
+  });
+
+  it("maps a hook trigger to an accent Trigger facet, or [] when absent", () => {
+    const [facet] = facetsFor(
+      entry({ category: "hooks", trigger: "PostToolUse" }),
+    );
+    expect(facet).toMatchObject({
+      label: "Trigger",
+      value: "PostToolUse",
+      tone: "accent",
+    });
+    expect(facet.icon).toBeDefined();
+    expect(facetsFor(entry({ category: "hooks" }))).toEqual([]);
+  });
+
+  it("maps command syntax to a monospace Invocation facet", () => {
+    const [facet] = facetsFor(
+      entry({ category: "commands", commandSyntax: "/review" }),
+    );
+    expect(facet).toMatchObject({
+      label: "Invocation",
+      value: "/review",
+      mono: true,
+    });
+  });
+
+  it("maps a statusline script language to a Language facet", () => {
+    const [facet] = facetsFor(
+      entry({ category: "statuslines", scriptLanguage: "bash" }),
+    );
+    expect(facet.label).toBe("Language");
+    expect(facet.value).toBe("bash");
+  });
+
+  it("collects the present skill fields, skipping absent ones", () => {
+    const facets = facetsFor(
+      entry({
+        category: "skills",
+        skillLevel: "advanced",
+        verificationStatus: "production",
+      }),
+    );
+    expect(facets.map((f) => f.label)).toEqual(["Level", "Verified"]);
+    expect(facetsFor(entry({ category: "skills" }))).toEqual([]);
+  });
+
+  it("pluralizes the collection bundle count and includes the install order", () => {
+    const many = facetsFor(
+      entry({
+        category: "collections",
+        items: ["a", "b"],
+        installationOrder: ["a", "b"],
+      }) as Entry,
+    );
+    expect(many[0]).toMatchObject({ label: "Bundle", value: "2 items" });
+    expect(many[0].detail).toContain("Install order: a → b");
+
+    const one = facetsFor(
+      entry({ category: "collections", items: ["only"] }) as Entry,
+    );
+    expect(one[0].value).toBe("1 item");
+    expect(one[0].detail).toBeUndefined();
+
+    expect(
+      facetsFor(entry({ category: "collections", items: [] }) as Entry),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The per-category facet derivation (`facetsFor` plus the `Facet` type) moves out of `apps/web/src/components/entry-facets.tsx` into a new `apps/web/src/lib/entry-facets-lib.ts`. The component now only renders and imports both. Behavior is unchanged.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `EntryFacets` / `FacetChip` now import `facetsFor` + `Facet` from the new lib.
- Expected behavior: `facetsFor(entry)` returns the category-specific facet rows — hook trigger, command syntax (mono), statusline language, skill level/type/verification, and collection bundle size — or `[]` when the category has no facet or the field is absent. Identical to the previous inline implementation.
- Important edge cases or invariants: absent fields yield `[]`; skills collect only the present fields; collection count pluralizes ("1 item" vs "N items") and includes the install-order detail only when present.
- Backward compatibility notes: fully backward compatible — `facetsFor`/`Facet` were module-private. The lucide-icon imports and the `React` import that existed solely for the moved logic are removed from the component.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split, same rendered facets.
- Focused tests: added `tests/entry-facets-lib.test.ts` (6 tests) covering every category branch and its empty-field fallbacks.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/entry-facets-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the per-category facet logic that previously lived only inside a React component.
