### PR TITLE
refactor(web): extract pure absoluteShareUrl into share-url-lib

### DIFF
--- a/apps/web/src/components/share-menu.tsx
+++ b/apps/web/src/components/share-menu.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { absoluteShareUrl } from "@/lib/share-url-lib";
 
 export interface ShareMenuProps {
   /** Absolute or root-relative URL of the entry page. */
@@ -23,12 +24,6 @@ export interface ShareMenuProps {
   raycastUrl?: string;
 }
 
-function abs(url: string) {
-  if (typeof window === "undefined") return url;
-  if (/^https?:\/\//.test(url)) return url;
-  return `${window.location.origin}${url}`;
-}
-
 async function copy(value: string, label: string) {
   try {
     await navigator.clipboard.writeText(value);
@@ -39,7 +34,10 @@ async function copy(value: string, label: string) {
 }
 
 export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl }: ShareMenuProps) {
-  const absolute = abs(url);
+  const absolute = absoluteShareUrl(
+    url,
+    typeof window === "undefined" ? "" : window.location.origin,
+  );
   const citation = description
     ? `[${title}](${absolute}) — ${description}`
     : `[${title}](${absolute})`;

--- a/apps/web/src/lib/share-url-lib.ts
+++ b/apps/web/src/lib/share-url-lib.ts
@@ -1,0 +1,13 @@
+// Pure share-URL resolution, split out of share-menu.tsx so it can be
+// unit-tested without a browser `window`.
+
+/**
+ * Resolve a possibly-relative share URL to an absolute one. A URL that already
+ * starts with `http(s)://` is returned unchanged; otherwise `origin` is
+ * prepended. Pure — the caller supplies `origin` (e.g. `window.location.origin`,
+ * or `""` on the server, where a relative URL is returned unchanged).
+ */
+export function absoluteShareUrl(url: string, origin: string): string {
+  if (/^https?:\/\//.test(url)) return url;
+  return `${origin}${url}`;
+}

--- a/tests/share-url-lib.test.ts
+++ b/tests/share-url-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { absoluteShareUrl } from "../apps/web/src/lib/share-url-lib";
+
+const ORIGIN = "https://heyclaude.com";
+
+describe("absoluteShareUrl", () => {
+  it("prepends the origin to a root-relative url", () => {
+    expect(absoluteShareUrl("/entry/mcp/foo", ORIGIN)).toBe(
+      "https://heyclaude.com/entry/mcp/foo",
+    );
+  });
+
+  it("returns an already-absolute https url unchanged", () => {
+    expect(absoluteShareUrl("https://example.com/x", ORIGIN)).toBe(
+      "https://example.com/x",
+    );
+  });
+
+  it("returns an already-absolute http url unchanged", () => {
+    expect(absoluteShareUrl("http://example.com/x", ORIGIN)).toBe(
+      "http://example.com/x",
+    );
+  });
+
+  it("leaves a relative url unchanged when origin is empty (server render)", () => {
+    expect(absoluteShareUrl("/x", "")).toBe("/x");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The share menu's `abs()` resolved a relative URL against the browser origin, so it could not be unit-tested (it read `window` internally). This extracts it to a new `apps/web/src/lib/share-url-lib.ts` as `absoluteShareUrl(url, origin)` with the origin injected. The component passes `window.location.origin` (or `""` on the server, where a relative URL is returned unchanged — matching the previous `typeof window === "undefined"` guard).

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `ShareMenu` now computes `absolute` via `absoluteShareUrl(url, origin)`.
- Expected behavior: a URL starting with `http(s)://` is returned unchanged; any other URL has `origin` prepended. On the server the component passes `""`, so a relative URL is returned unchanged — identical to the previous `abs()` behavior in every case (server, absolute, relative).
- Important edge cases or invariants: the origin is supplied by the caller, so the helper has no hidden `window` dependency.
- Backward compatibility notes: fully backward compatible — `abs` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split; the produced share/citation URLs are identical.
- Focused tests: added `tests/share-url-lib.test.ts` (4 tests) covering root-relative prepend, http/https absolute pass-through, and the empty-origin server case.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/share-url-lib.test.ts` → 4/4 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that removes a hidden `window` dependency and adds direct unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue).
