### PR TITLE
refactor(web): extract pure applyToBrowseSearch into saved-search-nav-lib

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -31,21 +31,9 @@ import {
 } from "@/lib/recents";
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
 import { hashSearch } from "@/lib/saved-search-hash-lib";
+import { applyToBrowseSearch } from "@/lib/saved-search-nav-lib";
 import { CopyButton } from "@/components/copy-button";
 import { cn } from "@/lib/utils";
-
-function applyToBrowseSearch(s: SavedSearch) {
-  return {
-    q: s.q ?? "",
-    category: s.category ?? "",
-    trust: s.trust ?? "",
-    source: s.source ?? "",
-    platform: s.platform ?? "",
-    sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
-    view: "row" as const,
-    compare: "",
-  };
-}
 
 export function savedFeedUrl(s: SavedSearch): string {
   const p = new URLSearchParams();

--- a/apps/web/src/lib/saved-search-nav-lib.ts
+++ b/apps/web/src/lib/saved-search-nav-lib.ts
@@ -1,0 +1,23 @@
+// Pure mapping from a saved search to the /browse route's search-params shape,
+// split out of saved-search-manager.tsx so it can be unit-tested without React
+// Router.
+
+import type { SavedSearch } from "@/lib/recents";
+
+/**
+ * Build the `/browse` search params for a saved search: each filter defaults to
+ * an empty string when absent, `sort` falls back to "popular", and the results
+ * always open in the row view with no active comparison.
+ */
+export function applyToBrowseSearch(s: SavedSearch) {
+  return {
+    q: s.q ?? "",
+    category: s.category ?? "",
+    trust: s.trust ?? "",
+    source: s.source ?? "",
+    platform: s.platform ?? "",
+    sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
+    view: "row" as const,
+    compare: "",
+  };
+}

--- a/tests/saved-search-nav-lib.test.ts
+++ b/tests/saved-search-nav-lib.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import type { SavedSearch } from "../apps/web/src/lib/recents";
+import { applyToBrowseSearch } from "../apps/web/src/lib/saved-search-nav-lib";
+
+const search = (over: Partial<SavedSearch> = {}) =>
+  ({ q: "", ...over }) as SavedSearch;
+
+describe("applyToBrowseSearch", () => {
+  it("defaults every filter to an empty string and sort to popular", () => {
+    expect(applyToBrowseSearch(search())).toEqual({
+      q: "",
+      category: "",
+      trust: "",
+      source: "",
+      platform: "",
+      sort: "popular",
+      view: "row",
+      compare: "",
+    });
+  });
+
+  it("passes through the provided query and filters", () => {
+    const result = applyToBrowseSearch(
+      search({
+        q: "mcp",
+        category: "mcp",
+        trust: "trusted",
+        source: "official",
+        platform: "claude-code",
+      }),
+    );
+    expect(result).toMatchObject({
+      q: "mcp",
+      category: "mcp",
+      trust: "trusted",
+      source: "official",
+      platform: "claude-code",
+    });
+  });
+
+  it("preserves an explicit sort", () => {
+    expect(applyToBrowseSearch(search({ sort: "newest" })).sort).toBe("newest");
+  });
+
+  it("always opens the row view with no active comparison", () => {
+    const result = applyToBrowseSearch(search({ q: "x" }));
+    expect(result.view).toBe("row");
+    expect(result.compare).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The saved-search → `/browse` search-params mapping moves out of `apps/web/src/components/saved-search-manager.tsx` into a new `apps/web/src/lib/saved-search-nav-lib.ts`. The component imports it; behavior is unchanged. It previously lived inside a React component and had no direct test.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `SavedSearchManager.apply` still navigates to `/browse` with `applyToBrowseSearch(s)`, now imported from the new lib.
- Expected behavior: each filter (`q`/`category`/`trust`/`source`/`platform`) defaults to `""` when absent, `sort` falls back to `"popular"`, and results always open in the `row` view with an empty `compare`. Identical to the previous inline implementation.
- Important edge cases or invariants: an explicit `sort` is preserved; the `view`/`compare` constants are unchanged.
- Backward compatibility notes: fully backward compatible — `applyToBrowseSearch` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — internal module split; the produced /browse navigation is identical.
- Focused tests: added `tests/saved-search-nav-lib.test.ts` (4 tests) covering defaults + sort fallback, filter pass-through, explicit-sort preservation, and the constant view/compare.

## Validation

- [x] Platform/code PR: `pnpm --filter web type-check` passed (tsr generate + `tsc --noEmit`, exit 0).
- [x] `pnpm exec vitest run tests/saved-search-nav-lib.test.ts` → 4/4 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the saved-search → browse mapping that previously lived only inside a React component.
