### PR TITLE
feat(web): add browse results trust decision panel and detail readiness rail

### DIFF
--- a/apps/web/src/components/browse-results-trust-panel.tsx
+++ b/apps/web/src/components/browse-results-trust-panel.tsx
@@ -1,0 +1,122 @@
+import { Link } from "@tanstack/react-router";
+import { GitCompare, Shield, Lock, BadgeCheck, GitBranch, UserCheck } from "lucide-react";
+import type { BrowseResultsTrustDecisionUiState } from "@/lib/browse-results-trust-decision";
+import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+
+const COVERAGE_ICONS = {
+  safety: Shield,
+  privacy: Lock,
+  reviewed: BadgeCheck,
+  "source-backed": GitBranch,
+  claimed: UserCheck,
+} as const;
+
+type CompareLink = {
+  search: { ids: string };
+  selectedCount: number;
+};
+
+export function BrowseResultsTrustPanel({
+  state,
+  compareLink,
+  className,
+}: {
+  state: Extract<BrowseResultsTrustDecisionUiState, { showPanel: true }>;
+  compareLink?: CompareLink | null;
+  className?: string;
+}) {
+  const hint = state.decisionHint ?? state.compareNudge;
+
+  return (
+    <section
+      aria-label="Browse results trust summary"
+      className={cn("rounded-xl border border-border bg-surface/80 px-4 py-4 sm:px-5", className)}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="eyebrow">Trust snapshot</div>
+          <p className="mt-1 text-sm text-ink">
+            {state.resultCount === state.sampleCount
+              ? `${state.resultCount} results in this view`
+              : `Trust signals across ${state.sampleCount} of ${state.resultCount} results`}
+          </p>
+          {state.hasMixedTrust ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {state.trustLevels.map((item) => (
+                <span
+                  key={item.level}
+                  className="inline-flex items-center rounded-full border border-border bg-background px-2 py-0.5 text-[11px] font-medium capitalize text-ink"
+                >
+                  {item.count} {item.level}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {compareLink && compareLink.selectedCount >= 2 ? (
+          <Link
+            to="/compare"
+            search={compareLink.search}
+            onClick={() => {
+              trackEvent("browse_compare_open", {
+                ...browseCompareOpenAnalyticsData(compareLink.selectedCount),
+                surface: "browse-trust-panel",
+              });
+            }}
+            className="inline-flex shrink-0 items-center gap-1.5 self-start rounded-full border border-accent bg-accent/10 px-3 py-1.5 text-xs font-medium text-ink hover:bg-accent/15"
+          >
+            <GitCompare className="h-3.5 w-3.5" aria-hidden />
+            Compare {compareLink.selectedCount} selected
+          </Link>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        {state.coverage.map((chip) => {
+          const Icon = COVERAGE_ICONS[chip.id as keyof typeof COVERAGE_ICONS] ?? Shield;
+          return (
+            <div
+              key={chip.id}
+              className={cn(
+                "rounded-lg border px-3 py-2",
+                chip.emphasis === "high"
+                  ? "border-trust-trusted/30 bg-trust-trusted/5"
+                  : chip.emphasis === "low"
+                    ? "border-trust-review/30 bg-trust-review/5"
+                    : "border-border bg-background",
+              )}
+            >
+              <div className="flex items-center gap-1.5 text-[11px] font-medium text-ink">
+                <Icon className="h-3.5 w-3.5 text-ink-muted" aria-hidden />
+                {chip.label}
+              </div>
+              <div className="mt-1 font-mono text-sm text-ink">
+                {chip.percent}%
+                <span className="ml-1 text-[11px] font-normal text-ink-muted">
+                  ({chip.count}/{chip.total})
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {state.divergingCount > 0 ? (
+        <p className="mt-3 text-xs text-amber-800">
+          {state.divergingCount} trust{" "}
+          {state.divergingCount === 1 ? "signal differs" : "signals differ"} in this sample
+          {state.divergingLabels.length > 0 ? `: ${state.divergingLabels.join(", ")}` : "."}
+        </p>
+      ) : null}
+
+      {hint ? (
+        <p className="mt-2 text-xs text-ink-muted" role="status">
+          {hint}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/entry-detail-rail.tsx
+++ b/apps/web/src/components/entry-detail-rail.tsx
@@ -2,25 +2,37 @@ import type { ReactNode } from "react";
 import { DossierTOC } from "@/components/dossier-toc";
 import { ProvenanceBlock } from "@/components/provenance-block";
 import type { Entry } from "@/types/registry";
-import type { EntryQuickLink, EntryTocItem } from "@/lib/entry-detail-sidebar-lib";
+import type {
+  EntryQuickLink,
+  EntryReadinessRow,
+  EntryTocItem,
+} from "@/lib/entry-detail-sidebar-lib";
 import { EntryDetailQuickLinks } from "@/components/entry-detail-quick-links";
+import { EntryDetailReadinessPanel } from "@/components/entry-detail-readiness";
 
 export function EntryDetailRail({
   entry,
   tocItems,
   quickLinks,
+  readinessRows,
   className,
   children,
 }: {
   entry: Entry;
   tocItems: EntryTocItem[];
   quickLinks?: EntryQuickLink[];
+  readinessRows?: EntryReadinessRow[];
   className?: string;
   children?: ReactNode;
 }) {
   return (
     <aside className={className ?? "space-y-6"}>
       {children}
+      {readinessRows && readinessRows.length > 0 ? (
+        <div className="overflow-hidden rounded-xl border border-border bg-surface">
+          <EntryDetailReadinessPanel rows={readinessRows} className="border-t-0" />
+        </div>
+      ) : null}
       {quickLinks && quickLinks.length > 0 ? (
         <div className="rounded-xl border border-border bg-surface p-4">
           <div className="eyebrow mb-2">Resource links</div>

--- a/apps/web/src/lib/browse-results-trust-decision-lib.ts
+++ b/apps/web/src/lib/browse-results-trust-decision-lib.ts
@@ -1,0 +1,165 @@
+/**
+ * Pure browse results trust decision helpers.
+ *
+ * Summarizes trust coverage and divergence across the current browse result
+ * set so users can decide whether to compare before opening every dossier.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import {
+  compareDecisionSummary,
+  divergingDecisionRowLabels,
+} from "@/lib/compare-table-decision-rows-lib";
+
+export const BROWSE_TRUST_PANEL_MIN_RESULTS = 3;
+export const BROWSE_TRUST_PANEL_SAMPLE_MAX = 40;
+
+const TRUST_LEVEL_ORDER: TrustLevel[] = ["trusted", "review", "limited", "blocked"];
+
+export type BrowseTrustLevelCount = {
+  level: TrustLevel;
+  count: number;
+};
+
+export type BrowseTrustCoverageChip = {
+  id: string;
+  label: string;
+  count: number;
+  total: number;
+  percent: number;
+  emphasis: "high" | "low" | "neutral";
+};
+
+export type BrowseResultsTrustDecisionUiState =
+  | { showPanel: false }
+  | {
+      showPanel: true;
+      resultCount: number;
+      sampleCount: number;
+      trustLevels: BrowseTrustLevelCount[];
+      coverage: BrowseTrustCoverageChip[];
+      divergingCount: number;
+      divergingLabels: string[];
+      decisionHint: string | null;
+      compareNudge: string | null;
+      hasMixedTrust: boolean;
+    };
+
+export function browseTrustLevelBreakdown(entries: Entry[]): BrowseTrustLevelCount[] {
+  const counts: Partial<Record<TrustLevel, number>> = {};
+  for (const entry of entries) {
+    counts[entry.trust] = (counts[entry.trust] ?? 0) + 1;
+  }
+  return TRUST_LEVEL_ORDER.filter((level) => (counts[level] ?? 0) > 0).map((level) => ({
+    level,
+    count: counts[level] ?? 0,
+  }));
+}
+
+function coverageChip(
+  id: string,
+  label: string,
+  count: number,
+  total: number,
+): BrowseTrustCoverageChip {
+  const percent = total > 0 ? Math.round((count / total) * 100) : 0;
+  const emphasis = percent >= 80 ? "high" : percent <= 20 ? "low" : "neutral";
+  return { id, label, count, total, percent, emphasis };
+}
+
+export function browseTrustCoverageChips(entries: Entry[]): BrowseTrustCoverageChip[] {
+  const total = entries.length;
+  if (total === 0) return [];
+
+  const countWhere = (predicate: (entry: Entry) => boolean) => entries.filter(predicate).length;
+
+  return [
+    coverageChip(
+      "safety",
+      "Safety notes",
+      countWhere((entry) => Boolean(entry.safetyNotes || entry.safetyNotesList?.length)),
+      total,
+    ),
+    coverageChip(
+      "privacy",
+      "Privacy notes",
+      countWhere((entry) => Boolean(entry.privacyNotes || entry.privacyNotesList?.length)),
+      total,
+    ),
+    coverageChip(
+      "reviewed",
+      "Reviewed",
+      countWhere((entry) => Boolean(entry.reviewed || entry.reviewedBy)),
+      total,
+    ),
+    coverageChip(
+      "source-backed",
+      "Source-backed",
+      countWhere((entry) => entry.source !== "unverified"),
+      total,
+    ),
+    coverageChip(
+      "claimed",
+      "Claimed",
+      countWhere((entry) => Boolean(entry.claimed)),
+      total,
+    ),
+  ];
+}
+
+export function browseTrustPanelDecisionHint(
+  entries: Entry[],
+  compareCount: number,
+  divergingLabels: string[],
+): string | null {
+  if (divergingLabels.length > 0) {
+    const labels = divergingLabels.slice(0, 3).join(", ");
+    return compareCount >= 2
+      ? `Trust signals differ on ${labels} — open compare to review side by side.`
+      : `Signals differ on ${labels} — add entries to compare before you install.`;
+  }
+
+  const trustLevels = browseTrustLevelBreakdown(entries);
+  if (trustLevels.length >= 2 && compareCount < 2) {
+    return "Mixed trust levels in this set — compare candidates before installing.";
+  }
+
+  const coverage = browseTrustCoverageChips(entries);
+  const weakCoverage = coverage.filter((chip) => chip.emphasis === "low");
+  if (weakCoverage.length >= 2 && compareCount < 2) {
+    return `Only ${weakCoverage[0]?.percent ?? 0}%–${weakCoverage[weakCoverage.length - 1]?.percent ?? 0}% of results have key trust signals — compare before you commit.`;
+  }
+
+  return null;
+}
+
+export function browseResultsTrustDecisionUiState(
+  results: Entry[],
+  compareCount = 0,
+): BrowseResultsTrustDecisionUiState {
+  if (results.length < BROWSE_TRUST_PANEL_MIN_RESULTS) {
+    return { showPanel: false };
+  }
+
+  const sample = results.slice(0, BROWSE_TRUST_PANEL_SAMPLE_MAX);
+  const divergingLabels = divergingDecisionRowLabels(sample);
+  const decision = compareDecisionSummary(sample);
+  const trustLevels = browseTrustLevelBreakdown(sample);
+  const coverage = browseTrustCoverageChips(sample);
+
+  return {
+    showPanel: true,
+    resultCount: results.length,
+    sampleCount: sample.length,
+    trustLevels,
+    coverage,
+    divergingCount: decision.divergingCount,
+    divergingLabels,
+    decisionHint: browseTrustPanelDecisionHint(sample, compareCount, divergingLabels),
+    compareNudge:
+      compareCount >= 2
+        ? `You have ${compareCount} entries selected — open compare to inspect trust gaps.`
+        : null,
+    hasMixedTrust: trustLevels.length >= 2,
+  };
+}

--- a/apps/web/src/lib/browse-results-trust-decision.ts
+++ b/apps/web/src/lib/browse-results-trust-decision.ts
@@ -1,0 +1,16 @@
+/**
+ * Browse results trust decision surface.
+ */
+export type {
+  BrowseResultsTrustDecisionUiState,
+  BrowseTrustCoverageChip,
+  BrowseTrustLevelCount,
+} from "@/lib/browse-results-trust-decision-lib";
+export {
+  BROWSE_TRUST_PANEL_MIN_RESULTS,
+  BROWSE_TRUST_PANEL_SAMPLE_MAX,
+  browseResultsTrustDecisionUiState,
+  browseTrustCoverageChips,
+  browseTrustLevelBreakdown,
+  browseTrustPanelDecisionHint,
+} from "@/lib/browse-results-trust-decision-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -22,6 +22,8 @@ import {
   toggleBrowseTrustSignal,
 } from "@/lib/browse-trust-filters";
 import { browseFilterDecisionUiState } from "@/lib/browse-filter-decision-hints";
+import { browseResultsTrustDecisionUiState } from "@/lib/browse-results-trust-decision";
+import { BrowseResultsTrustPanel } from "@/components/browse-results-trust-panel";
 import {
   CATEGORIES,
   type Category,
@@ -322,6 +324,11 @@ function Browse() {
         compare.items.length,
       ),
     [sp, results, compare.items.length],
+  );
+
+  const browseResultsTrust = useMemo(
+    () => browseResultsTrustDecisionUiState(results, compare.items.length),
+    [results, compare.items.length],
   );
 
   const activeCount =
@@ -780,6 +787,21 @@ function Browse() {
             <p className="mt-2 text-xs text-ink-muted" role="status">
               {browseFilterDecision.hint}
             </p>
+          ) : null}
+
+          {browseResultsTrust.showPanel ? (
+            <BrowseResultsTrustPanel
+              state={browseResultsTrust}
+              compareLink={
+                browseCompareUi?.showHint
+                  ? {
+                      search: browseCompareUi.search,
+                      selectedCount: browseCompareUi.selectedCount,
+                    }
+                  : null
+              }
+              className="mt-3"
+            />
           ) : null}
 
           {sp.category &&

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -57,7 +57,11 @@ import { EntryDetailMobileActionBar } from "@/components/entry-detail-mobile-act
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
-import { buildEntryTocItems, entryQuickLinks } from "@/lib/entry-detail-sidebar-lib";
+import {
+  buildEntryTocItems,
+  entryQuickLinks,
+  entryReadinessRows,
+} from "@/lib/entry-detail-sidebar-lib";
 import { installRiskLevel, INSTALL_RISK_LABEL, INSTALL_RISK_DETAIL } from "@/lib/trust";
 import { useEffect, useMemo, useState, useCallback } from "react";
 import { toast } from "sonner";
@@ -328,6 +332,7 @@ function Dossier() {
     ],
   );
   const quickLinks = useMemo(() => entryQuickLinks(entry), [entry]);
+  const readinessRows = useMemo(() => entryReadinessRows(entry), [entry]);
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
   return (
@@ -741,7 +746,12 @@ function Dossier() {
           />
         </div>
 
-        <EntryDetailRail entry={entry} tocItems={tocItems} quickLinks={quickLinks} />
+        <EntryDetailRail
+          entry={entry}
+          tocItems={tocItems}
+          quickLinks={quickLinks}
+          readinessRows={readinessRows}
+        />
       </div>
       <EntryDetailMobileActionBar entry={entry} copyPayload={tabPayload} />
       <div className="h-14 lg:hidden" aria-hidden />

--- a/tests/browse-results-trust-decision-lib.test.ts
+++ b/tests/browse-results-trust-decision-lib.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseResultsTrustDecisionUiState,
+  browseTrustCoverageChips,
+  browseTrustLevelBreakdown,
+  browseTrustPanelDecisionHint,
+} from "@/lib/browse-results-trust-decision-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("browse results trust decision lib", () => {
+  it("hides the panel until enough results are present", () => {
+    expect(
+      browseResultsTrustDecisionUiState([entry(), entry({ slug: "two" })]),
+    ).toEqual({
+      showPanel: false,
+    });
+  });
+
+  it("summarizes trust level mix and coverage chips", () => {
+    const results = [
+      entry({
+        trust: "trusted",
+        safetyNotes: "Careful",
+        reviewed: true,
+        source: "source-backed",
+      }),
+      entry({ slug: "two", trust: "review", claimed: true }),
+      entry({ slug: "three", trust: "limited", privacyNotes: "Local only" }),
+    ];
+
+    expect(browseTrustLevelBreakdown(results)).toEqual([
+      { level: "trusted", count: 1 },
+      { level: "review", count: 1 },
+      { level: "limited", count: 1 },
+    ]);
+
+    const coverage = browseTrustCoverageChips(results);
+    expect(coverage.find((chip) => chip.id === "safety")).toMatchObject({
+      count: 1,
+      total: 3,
+      percent: 33,
+    });
+    expect(coverage.find((chip) => chip.id === "claimed")?.count).toBe(1);
+  });
+
+  it("builds divergence and compare guidance for mixed trust sets", () => {
+    const results = [
+      entry({ trust: "trusted", reviewed: true, source: "source-backed" }),
+      entry({ slug: "two", trust: "review", source: "unverified" }),
+      entry({ slug: "three", trust: "limited", source: "unverified" }),
+    ];
+
+    const state = browseResultsTrustDecisionUiState(results, 0);
+    expect(state.showPanel).toBe(true);
+    if (!state.showPanel) return;
+
+    expect(state.hasMixedTrust).toBe(true);
+    expect(state.divergingCount).toBeGreaterThan(0);
+    expect(state.decisionHint).toContain("Signals differ");
+  });
+
+  it("prioritizes compare nudge when entries are already selected", () => {
+    const results = [
+      entry({ trust: "trusted", reviewed: true }),
+      entry({ slug: "two", trust: "trusted", reviewed: true }),
+      entry({ slug: "three", trust: "trusted", reviewed: true }),
+    ];
+
+    const state = browseResultsTrustDecisionUiState(results, 2);
+    expect(state.showPanel).toBe(true);
+    if (!state.showPanel) return;
+
+    expect(state.compareNudge).toContain("2 entries selected");
+  });
+
+  it("builds divergence hints from decision row labels", () => {
+    expect(
+      browseTrustPanelDecisionHint(
+        [
+          entry({ trust: "trusted", reviewed: true }),
+          entry({ slug: "two", trust: "review", reviewed: false }),
+        ],
+        2,
+        ["Review status", "Source provenance"],
+      ),
+    ).toContain("Review status");
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add `browse-results-trust-decision-lib` to summarize trust level mix, signal coverage, and divergence across browse results.
- Render a browse trust snapshot panel with coverage chips, divergence callouts, and compare CTA when entries are selected.
- Wire `EntryDetailReadinessPanel` into the entry detail rail for persistent trust readiness on detail pages.

## Test plan
- [x] `pnpm test tests/browse-results-trust-decision-lib.test.ts`
- [x] `pnpm type-check`
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)