### PR TITLE
feat(web): add compare page trust decision panel and drawer surface

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -21,6 +21,8 @@ import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, type CompareAction } from "@/lib/compare-drawer-actions-ui-lib";
 import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
+import { comparePageTrustDecisionUiState } from "@/lib/compare-page-trust-decision";
+import { ComparePageTrustDecisionPanel } from "@/components/compare-page-trust-decision-panel";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import type { Entry, Harness } from "@/types/registry";
@@ -319,6 +321,7 @@ export function CompareDrawer() {
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const { bannerTexts, fullViewSearch } = drawerUi;
+  const trustDecision = React.useMemo(() => comparePageTrustDecisionUiState(items), [items]);
 
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
@@ -410,6 +413,16 @@ export function CompareDrawer() {
             </div>
           </div>
         </SheetHeader>
+
+        {trustDecision.showPanel ? (
+          <ComparePageTrustDecisionPanel
+            state={trustDecision}
+            entries={items}
+            actionCells={actionCells}
+            variant="compact"
+            className="mx-4 mt-3 sm:mx-6"
+          />
+        ) : null}
 
         {items.length === 0 ? (
           <div className="flex h-[60vh] items-center justify-center px-6 text-sm text-ink-muted">

--- a/apps/web/src/components/compare-page-trust-decision-panel.tsx
+++ b/apps/web/src/components/compare-page-trust-decision-panel.tsx
@@ -1,0 +1,274 @@
+import { Link } from "@tanstack/react-router";
+import { Shield, Lock, BadgeCheck, Package, AlertTriangle } from "lucide-react";
+import type { ComparePageTrustDecisionUiState } from "@/lib/compare-page-trust-decision";
+import type { ComparePageActionCell } from "@/lib/compare-page-actions-ui-lib";
+import { comparePageActionsForEntry } from "@/lib/compare-page-actions-interactive-ui-lib";
+import { COMPARE_PAGE_SURFACE } from "@/lib/compare-page-summary";
+import type { CompareAction } from "@/lib/compare-entry-actions";
+import { CopyButton } from "@/components/copy-button";
+import { TrustBadge, SourceBadge } from "@/components/badges";
+import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
+import { trackEvent, entryEventKey } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+import type { Entry } from "@/types/registry";
+
+function ComparePanelActionButton({ entry, action }: { entry: Entry; action: CompareAction }) {
+  const eventKey = entryEventKey(entry.category, entry.slug);
+
+  if (action.kind === "copy" && action.copyValue) {
+    return (
+      <CopyButton
+        value={action.copyValue}
+        label={action.label}
+        event={action.analyticsEvent}
+        eventData={{ entry: eventKey, surface: COMPARE_PAGE_SURFACE }}
+        onCopied={() => {
+          if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+        }}
+      />
+    );
+  }
+
+  if (action.kind === "link") {
+    if (action.id === "dossier") {
+      return (
+        <Link
+          to="/entry/$category/$slug"
+          params={{ category: entry.category, slug: entry.slug }}
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.id === "claim") {
+      return (
+        <Link
+          to="/claim"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
+            }
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </Link>
+      );
+    }
+
+    if (action.href && action.external) {
+      return (
+        <a
+          href={action.href}
+          target="_blank"
+          rel="noreferrer"
+          onClick={() => {
+            if (action.analyticsEvent) {
+              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
+            }
+            if (action.intentType) void recordCompareIntentEvent(action.intentType, entry);
+          }}
+          className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
+        >
+          {action.label}
+        </a>
+      );
+    }
+  }
+
+  return null;
+}
+
+export function ComparePageTrustDecisionPanel({
+  state,
+  entries,
+  actionCells,
+  variant = "page",
+  className,
+}: {
+  state: Extract<ComparePageTrustDecisionUiState, { showPanel: true }>;
+  entries: Entry[];
+  actionCells: ComparePageActionCell[];
+  variant?: "page" | "compact";
+  className?: string;
+}) {
+  const compact = variant === "compact";
+  const entryByKey = new Map(entries.map((entry) => [`${entry.category}/${entry.slug}`, entry]));
+
+  return (
+    <section
+      aria-label="Compare trust decision summary"
+      className={cn(
+        "rounded-xl border border-border bg-surface/80",
+        compact ? "px-3 py-3" : "px-4 py-4 sm:px-5",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="eyebrow">Trust decision</div>
+          {state.headline ? (
+            <p className={cn("mt-1 text-ink", compact ? "text-sm" : "text-base")}>
+              {state.headline}
+            </p>
+          ) : (
+            <p className="mt-1 text-sm text-ink-muted">
+              Review trust signals side by side before you install or copy anything.
+            </p>
+          )}
+          {state.primaryHint ? (
+            <p className="mt-1 text-xs text-ink-muted">{state.primaryHint}</p>
+          ) : null}
+        </div>
+        {state.sharedActionIds.length > 0 ? (
+          <div className="text-xs text-ink-muted">
+            Shared actions:{" "}
+            <span className="font-medium text-ink">{state.sharedActionIds.join(", ")}</span>
+          </div>
+        ) : null}
+      </div>
+
+      <div
+        className={cn(
+          "mt-4 grid gap-3",
+          compact ? "sm:grid-cols-2" : "md:grid-cols-2 xl:grid-cols-4",
+        )}
+      >
+        {state.entrySnapshots.map((snapshot) => {
+          const entry = entryByKey.get(snapshot.entryKey);
+          if (!entry) return null;
+          const actions = comparePageActionsForEntry(entry, actionCells).slice(0, 2);
+          const isSafest = snapshot.entryKey === state.safestEntryKey;
+
+          return (
+            <article
+              key={snapshot.entryKey}
+              className={cn(
+                "rounded-lg border bg-background p-3",
+                isSafest ? "border-accent/50 ring-1 ring-accent/20" : "border-border",
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <Link
+                    to="/entry/$category/$slug"
+                    params={{ category: snapshot.category, slug: snapshot.slug }}
+                    className="line-clamp-2 font-display text-sm font-semibold text-ink hover:underline"
+                  >
+                    {snapshot.title}
+                  </Link>
+                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                    <TrustBadge level={snapshot.trust} />
+                    <SourceBadge status={snapshot.sourceBacked ? "source-backed" : "unverified"} />
+                  </div>
+                </div>
+                {isSafest ? (
+                  <span className="shrink-0 rounded-full bg-accent/10 px-2 py-0.5 text-[10px] font-medium text-ink">
+                    Strongest
+                  </span>
+                ) : null}
+              </div>
+
+              <ul className="mt-3 space-y-1 text-[11px] text-ink-muted">
+                <li className="inline-flex items-center gap-1.5">
+                  <Shield
+                    className={cn(
+                      "h-3 w-3",
+                      snapshot.hasSafetyNotes ? "text-trust-trusted" : "opacity-40",
+                    )}
+                    aria-hidden
+                  />
+                  {snapshot.hasSafetyNotes ? "Safety notes" : "No safety notes"}
+                </li>
+                <li className="inline-flex items-center gap-1.5">
+                  <Lock
+                    className={cn(
+                      "h-3 w-3",
+                      snapshot.hasPrivacyNotes ? "text-trust-trusted" : "opacity-40",
+                    )}
+                    aria-hidden
+                  />
+                  {snapshot.hasPrivacyNotes ? "Privacy notes" : "No privacy notes"}
+                </li>
+                <li className="inline-flex items-center gap-1.5">
+                  <BadgeCheck
+                    className={cn(
+                      "h-3 w-3",
+                      snapshot.reviewed ? "text-trust-trusted" : "opacity-40",
+                    )}
+                    aria-hidden
+                  />
+                  {snapshot.reviewed ? "Reviewed" : "Not reviewed"}
+                </li>
+                <li className="inline-flex items-center gap-1.5">
+                  <Package
+                    className={cn(
+                      "h-3 w-3",
+                      snapshot.installable ? "text-ink-muted" : "opacity-40",
+                    )}
+                    aria-hidden
+                  />
+                  {snapshot.installable ? "Install command" : "Manual setup"}
+                </li>
+              </ul>
+
+              {snapshot.caution ? (
+                <p className="mt-2 inline-flex items-start gap-1 text-[11px] text-amber-800">
+                  <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+                  {snapshot.caution}
+                </p>
+              ) : null}
+
+              <p className="mt-2 text-[11px] text-ink-muted">{snapshot.recommendedAction}</p>
+
+              <div className="mt-3 flex flex-wrap gap-1.5">
+                {actions.map((action) => (
+                  <ComparePanelActionButton key={action.id} entry={entry} action={action} />
+                ))}
+              </div>
+            </article>
+          );
+        })}
+      </div>
+
+      {state.divergingRows.length > 0 ? (
+        <div className="mt-4 overflow-auto rounded-lg border border-border">
+          <table className="min-w-full text-left text-xs">
+            <thead className="bg-surface-2/60 text-ink-subtle">
+              <tr>
+                <th className="px-3 py-2 font-medium">Signal</th>
+                {state.entrySnapshots.map((snapshot) => (
+                  <th key={snapshot.entryKey} className="px-3 py-2 font-medium">
+                    {snapshot.title}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {state.divergingRows.map((row) => (
+                <tr key={row.label} className="border-t border-border">
+                  <th scope="row" className="px-3 py-2 font-medium text-ink-muted">
+                    {row.label}
+                  </th>
+                  {row.cells.map((cell) => (
+                    <td key={cell.entryKey} className={cn("px-3 py-2", cell.toneClass)}>
+                      {cell.label}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-page-trust-decision-lib.ts
+++ b/apps/web/src/lib/compare-page-trust-decision-lib.ts
@@ -1,0 +1,235 @@
+/**
+ * Pure compare page trust decision helpers.
+ *
+ * Builds entry trust snapshots, diverging decision rows, and guidance for the
+ * full compare page without touching the network.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import {
+  COMPARE_DECISION_ROWS,
+  compareSignalToneClass,
+  resolveCompareSignal,
+  type CompareSignalTone,
+} from "@/lib/compare-entry-signals-lib";
+import {
+  compareDecisionSummary,
+  divergingDecisionRowLabels,
+} from "@/lib/compare-table-decision-rows-lib";
+import { comparePageActionSummary } from "@/lib/compare-page-actions-ui-lib";
+
+export const COMPARE_PAGE_TRUST_PANEL_MIN_ITEMS = 2;
+
+const TRUST_RANK: Record<TrustLevel, number> = {
+  trusted: 4,
+  review: 3,
+  limited: 2,
+  blocked: 1,
+};
+
+export type CompareEntryTrustSnapshot = {
+  entryKey: string;
+  category: string;
+  slug: string;
+  title: string;
+  trust: TrustLevel;
+  hasSafetyNotes: boolean;
+  hasPrivacyNotes: boolean;
+  reviewed: boolean;
+  sourceBacked: boolean;
+  installable: boolean;
+  claimed: boolean;
+  trustScore: number;
+  recommendedAction: string;
+  caution: string | null;
+};
+
+export type CompareDivergingDecisionRow = {
+  label: string;
+  cells: {
+    entryKey: string;
+    title: string;
+    label: string;
+    tone: CompareSignalTone;
+    toneClass: string;
+  }[];
+};
+
+export type ComparePageTrustDecisionUiState =
+  | { showPanel: false }
+  | {
+      showPanel: true;
+      headline: string | null;
+      primaryHint: string | null;
+      entrySnapshots: CompareEntryTrustSnapshot[];
+      divergingRows: CompareDivergingDecisionRow[];
+      divergingLabels: string[];
+      divergingCount: number;
+      safestEntryKey: string | null;
+      actionsDiverge: boolean;
+      sharedActionIds: string[];
+    };
+
+export function compareEntryKey(entry: Pick<Entry, "category" | "slug">): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+export function compareEntryTrustScore(entry: Entry): number {
+  let score = TRUST_RANK[entry.trust] * 10;
+  if (entry.safetyNotes || entry.safetyNotesList?.length) score += 15;
+  if (entry.privacyNotes || entry.privacyNotesList?.length) score += 10;
+  if (entry.reviewed || entry.reviewedBy) score += 15;
+  if (entry.source !== "unverified") score += 10;
+  if (entry.installCommand) score += 5;
+  if (entry.claimed) score += 5;
+  return score;
+}
+
+export function compareEntryTrustCaution(entry: Entry): string | null {
+  if (entry.trust === "blocked") {
+    return "Blocked trust level — do not install without maintainer review.";
+  }
+  if (!entry.safetyNotes && !entry.safetyNotesList?.length) {
+    return "No safety notes on file.";
+  }
+  if (entry.source === "unverified") {
+    return "Source is unverified.";
+  }
+  if (!entry.reviewed && !entry.reviewedBy) {
+    return "Not maintainer-reviewed yet.";
+  }
+  return null;
+}
+
+export function compareEntryRecommendedAction(entry: Entry): string {
+  if (entry.trust === "blocked" || entry.trust === "limited") {
+    return "Review safety notes and source before any install.";
+  }
+  if (!entry.reviewed && !entry.reviewedBy) {
+    return "Open the dossier and source repo before installing.";
+  }
+  if (entry.installCommand) {
+    return "Copy install after confirming trust signals match your risk tolerance.";
+  }
+  return "Open the dossier for setup guidance and prerequisites.";
+}
+
+export function compareEntryTrustSnapshot(entry: Entry): CompareEntryTrustSnapshot {
+  return {
+    entryKey: compareEntryKey(entry),
+    category: entry.category,
+    slug: entry.slug,
+    title: entry.title,
+    trust: entry.trust,
+    hasSafetyNotes: Boolean(entry.safetyNotes || entry.safetyNotesList?.length),
+    hasPrivacyNotes: Boolean(entry.privacyNotes || entry.privacyNotesList?.length),
+    reviewed: Boolean(entry.reviewed || entry.reviewedBy),
+    sourceBacked: entry.source !== "unverified",
+    installable: Boolean(entry.installCommand),
+    claimed: Boolean(entry.claimed),
+    trustScore: compareEntryTrustScore(entry),
+    recommendedAction: compareEntryRecommendedAction(entry),
+    caution: compareEntryTrustCaution(entry),
+  };
+}
+
+export function comparePageDivergingDecisionRows(entries: Entry[]): CompareDivergingDecisionRow[] {
+  return COMPARE_DECISION_ROWS.map((row) => ({
+    label: row.label,
+    cells: entries.map((entry) => {
+      const signal = resolveCompareSignal(row.resolve(entry));
+      return {
+        entryKey: compareEntryKey(entry),
+        title: entry.title,
+        label: signal.label,
+        tone: signal.tone,
+        toneClass: compareSignalToneClass(signal.tone),
+      };
+    }),
+  })).filter((row) => {
+    const signatures = row.cells.map((cell) => `${cell.tone}:${cell.label}`);
+    return new Set(signatures).size > 1;
+  });
+}
+
+export function comparePageSafestEntryKey(snapshots: CompareEntryTrustSnapshot[]): string | null {
+  if (snapshots.length === 0) return null;
+  const sorted = [...snapshots].sort((left, right) => right.trustScore - left.trustScore);
+  const top = sorted[0];
+  const tied = sorted.filter((snapshot) => snapshot.trustScore === top.trustScore);
+  return tied.length === 1 ? top.entryKey : null;
+}
+
+export function comparePageTrustDecisionHeadline(
+  entries: Entry[],
+  divergingLabels: string[],
+  safestEntryKey: string | null,
+): string | null {
+  if (divergingLabels.length > 0) {
+    const labels = divergingLabels.slice(0, 3).join(", ");
+    return `${labels} differ across this comparison.`;
+  }
+
+  const trustLevels = new Set(entries.map((entry) => entry.trust));
+  if (trustLevels.size > 1) {
+    return "Trust levels differ — confirm install risk before you choose.";
+  }
+
+  if (safestEntryKey) {
+    const safest = entries.find((entry) => compareEntryKey(entry) === safestEntryKey);
+    if (safest) {
+      return `${safest.title} has the strongest trust signals in this set.`;
+    }
+  }
+
+  return null;
+}
+
+export function comparePageTrustPrimaryHint(
+  entries: Entry[],
+  actionsDiverge: boolean,
+  safestEntryKey: string | null,
+): string | null {
+  if (actionsDiverge) {
+    return "Next steps differ per entry — use the action row below or open each dossier.";
+  }
+
+  const missingSafety = entries.filter(
+    (entry) => !entry.safetyNotes && !entry.safetyNotesList?.length,
+  ).length;
+  if (missingSafety > 0 && entries.length > 1) {
+    return `${missingSafety} of ${entries.length} entries are missing safety notes — compare before installing.`;
+  }
+
+  if (safestEntryKey && entries.length > 2) {
+    return "Start with the highlighted entry, then spot-check the others for gaps.";
+  }
+
+  return null;
+}
+
+export function comparePageTrustDecisionUiState(entries: Entry[]): ComparePageTrustDecisionUiState {
+  if (entries.length < COMPARE_PAGE_TRUST_PANEL_MIN_ITEMS) {
+    return { showPanel: false };
+  }
+
+  const entrySnapshots = entries.map(compareEntryTrustSnapshot);
+  const divergingRows = comparePageDivergingDecisionRows(entries);
+  const divergingLabels = divergingDecisionRowLabels(entries);
+  const decision = compareDecisionSummary(entries);
+  const actionSummary = comparePageActionSummary(entries);
+  const safestEntryKey = comparePageSafestEntryKey(entrySnapshots);
+
+  return {
+    showPanel: true,
+    headline: comparePageTrustDecisionHeadline(entries, divergingLabels, safestEntryKey),
+    primaryHint: comparePageTrustPrimaryHint(entries, actionSummary.diverges, safestEntryKey),
+    entrySnapshots,
+    divergingRows,
+    divergingLabels,
+    divergingCount: decision.divergingCount,
+    safestEntryKey,
+    actionsDiverge: actionSummary.diverges,
+    sharedActionIds: actionSummary.sharedActionIds,
+  };
+}

--- a/apps/web/src/lib/compare-page-trust-decision.ts
+++ b/apps/web/src/lib/compare-page-trust-decision.ts
@@ -1,0 +1,21 @@
+/**
+ * Compare page trust decision surface.
+ */
+export type {
+  CompareDivergingDecisionRow,
+  CompareEntryTrustSnapshot,
+  ComparePageTrustDecisionUiState,
+} from "@/lib/compare-page-trust-decision-lib";
+export {
+  COMPARE_PAGE_TRUST_PANEL_MIN_ITEMS,
+  compareEntryKey,
+  compareEntryRecommendedAction,
+  compareEntryTrustCaution,
+  compareEntryTrustScore,
+  compareEntryTrustSnapshot,
+  comparePageDivergingDecisionRows,
+  comparePageSafestEntryKey,
+  comparePageTrustDecisionHeadline,
+  comparePageTrustDecisionUiState,
+  comparePageTrustPrimaryHint,
+} from "@/lib/compare-page-trust-decision-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -15,6 +15,8 @@ import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { COMPARE_PAGE_SURFACE, type CompareAction } from "@/lib/compare-page-actions-ui-lib";
 import { comparePageActionsForEntry } from "@/lib/compare-page-actions-interactive-ui-lib";
 import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
+import { comparePageTrustDecisionUiState } from "@/lib/compare-page-trust-decision";
+import { ComparePageTrustDecisionPanel } from "@/components/compare-page-trust-decision-panel";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -69,6 +71,7 @@ function ComparePage() {
     () => comparePageInteractiveUiState(items, sp.ids, COMPARISONS, ENTRIES),
     [items, sp.ids],
   );
+  const trustDecision = React.useMemo(() => comparePageTrustDecisionUiState(items), [items]);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -183,6 +186,15 @@ function ComparePage() {
           </button>
         </div>
       </div>
+
+      {trustDecision.showPanel ? (
+        <ComparePageTrustDecisionPanel
+          state={trustDecision}
+          entries={items}
+          actionCells={actionCells}
+          className="mt-4"
+        />
+      ) : null}
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">
         <table className="w-full border-collapse text-sm">

--- a/tests/compare-page-trust-decision-lib.test.ts
+++ b/tests/compare-page-trust-decision-lib.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareEntryTrustScore,
+  compareEntryTrustSnapshot,
+  comparePageDivergingDecisionRows,
+  comparePageSafestEntryKey,
+  comparePageTrustDecisionUiState,
+} from "@/lib/compare-page-trust-decision-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare page trust decision lib", () => {
+  it("requires at least two entries before showing the panel", () => {
+    expect(comparePageTrustDecisionUiState([entry()])).toEqual({
+      showPanel: false,
+    });
+  });
+
+  it("scores trusted reviewed entries above unverified ones", () => {
+    const trusted = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      safetyNotes: "Careful",
+      installCommand: "npm i demo",
+    });
+    const risky = entry({
+      slug: "risky",
+      trust: "limited",
+      source: "unverified",
+    });
+
+    expect(compareEntryTrustScore(trusted)).toBeGreaterThan(
+      compareEntryTrustScore(risky),
+    );
+    expect(
+      comparePageSafestEntryKey([
+        compareEntryTrustSnapshot(risky),
+        compareEntryTrustSnapshot(trusted),
+      ]),
+    ).toBe("skills/fixture");
+  });
+
+  it("builds diverging decision rows and guidance for mixed comparisons", () => {
+    const left = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      installCommand: "npm i left",
+    });
+    const right = entry({
+      slug: "right",
+      trust: "review",
+      source: "unverified",
+    });
+
+    const rows = comparePageDivergingDecisionRows([left, right]);
+    expect(rows.length).toBeGreaterThan(0);
+
+    const state = comparePageTrustDecisionUiState([left, right]);
+    expect(state.showPanel).toBe(true);
+    if (!state.showPanel) return;
+
+    expect(state.entrySnapshots).toHaveLength(2);
+    expect(state.headline).toBeTruthy();
+    expect(state.divergingCount).toBeGreaterThan(0);
+  });
+
+  it("flags missing safety notes in the primary hint for larger sets", () => {
+    const state = comparePageTrustDecisionUiState([
+      entry({ slug: "one" }),
+      entry({ slug: "two", safetyNotes: "Careful" }),
+      entry({ slug: "three" }),
+    ]);
+
+    expect(state.showPanel).toBe(true);
+    if (!state.showPanel) return;
+    expect(state.primaryHint).toContain("missing safety notes");
+  });
+});


### PR DESCRIPTION
Refs #556
Refs #393

## Summary
- Add `compare-page-trust-decision-lib` for entry trust snapshots, safest-pick scoring, diverging decision rows, and guidance hints.
- Render a trust decision panel on `/compare` with per-entry trust chips, cautions, quick actions, and a diverging-signals table.
- Reuse the compact panel variant in the quick compare drawer for the same decision surface before opening every dossier.

## Test plan
- [x] `pnpm test tests/compare-page-trust-decision-lib.test.ts`
- [x] `pnpm type-check`
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)