### PR TITLE
refactor(web): extract pure sponsorKindLabel into sponsor-kind-lib

### DIFF
--- a/apps/web/src/components/sponsors-section.tsx
+++ b/apps/web/src/components/sponsors-section.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { IntegrationMark } from "@/components/integration-marks";
 import { PARTNER_ROLE_LABEL, PARTNERS, SPONSORS, type Partner } from "@/data/sponsors";
+import { sponsorKindLabel } from "@/lib/sponsor-kind-lib";
 import { cn } from "@/lib/utils";
 
 export function SponsorsSection() {
@@ -56,7 +57,7 @@ export function SponsorsSection() {
                   />
                 ) : (
                   <span className="text-[10px] uppercase tracking-wider text-ink-subtle">
-                    {kindBadge(s.kind)}
+                    {sponsorKindLabel(s.kind)}
                   </span>
                 )}
                 <span className="text-xs font-medium text-ink">{s.name}</span>
@@ -348,16 +349,6 @@ function Field({
       />
     </div>
   );
-}
-
-function kindBadge(kind: string) {
-  return kind === "ai"
-    ? "AI"
-    : kind === "infra"
-      ? "INFRA"
-      : kind === "credits"
-        ? "CREDITS"
-        : "SERVICE";
 }
 
 // Silence unused warning for cn until used elsewhere in this file.

--- a/apps/web/src/lib/sponsor-kind-lib.ts
+++ b/apps/web/src/lib/sponsor-kind-lib.ts
@@ -1,0 +1,19 @@
+// Pure sponsor-kind → badge label mapping, split out of sponsors-section.tsx so
+// it can be unit-tested without React.
+
+/**
+ * Short uppercase badge label for a sponsor kind. Known kinds map to their own
+ * label; any unknown kind falls back to "SERVICE".
+ */
+export function sponsorKindLabel(kind: string): string {
+  switch (kind) {
+    case "ai":
+      return "AI";
+    case "infra":
+      return "INFRA";
+    case "credits":
+      return "CREDITS";
+    default:
+      return "SERVICE";
+  }
+}

--- a/tests/sponsor-kind-lib.test.ts
+++ b/tests/sponsor-kind-lib.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { sponsorKindLabel } from "../apps/web/src/lib/sponsor-kind-lib";
+
+describe("sponsorKindLabel", () => {
+  it("maps each known sponsor kind to its badge label", () => {
+    expect(sponsorKindLabel("ai")).toBe("AI");
+    expect(sponsorKindLabel("infra")).toBe("INFRA");
+    expect(sponsorKindLabel("credits")).toBe("CREDITS");
+  });
+
+  it("falls back to SERVICE for an unknown kind", () => {
+    expect(sponsorKindLabel("partner")).toBe("SERVICE");
+    expect(sponsorKindLabel("")).toBe("SERVICE");
+  });
+
+  it("is case-sensitive (only the exact lowercase keys match)", () => {
+    expect(sponsorKindLabel("AI")).toBe("SERVICE");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The sponsor-kind → badge-label mapping (`kindBadge`) moves out of `apps/web/src/components/sponsors-section.tsx` into a new `apps/web/src/lib/sponsor-kind-lib.ts` as `sponsorKindLabel`, rewritten as an equivalent `switch`. The component imports it; behavior is unchanged.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the "Powered by" sponsor strip in `SponsorsSection` now renders `sponsorKindLabel(s.kind)`.
- Expected behavior: `"ai"→"AI"`, `"infra"→"INFRA"`, `"credits"→"CREDITS"`, and any other/empty kind → `"SERVICE"`. Identical to the previous nested-ternary `kindBadge`.
- Important edge cases or invariants: matching is exact and case-sensitive; unknown kinds fall back to `"SERVICE"`.
- Backward compatibility notes: fully backward compatible — `kindBadge` was module-private; the `switch` is behavior-equivalent to the ternary chain.
- Screenshots for frontend/page/UI changes: `No visual impact` — same badge text.
- Focused tests: added `tests/sponsor-kind-lib.test.ts` (3 tests) covering the known labels, the unknown/empty fallback, and case-sensitivity.

## Validation

- [x] Platform/code PR: `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/sponsor-kind-lib.test.ts` → 3/3 passing.
- [x] `pnpm exec prettier --check` clean on all changed files.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It adds direct unit coverage for the sponsor-kind badge mapping that previously lived only inside a React component.
