### PR TITLE
fix(review): enable linked-issue label propagation for bug/feature/priority

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -58,6 +58,28 @@ gate:
 settings:
   reviewEvasionProtection: close
 
+  # Linked-issue label propagation (#4000): a PR closing an issue inherits that issue's point-bearing
+  # gittensor:* label, instead of the PR's own label being decided purely by commit-title regex. Mirrors
+  # the block already live on JSONbored/gittensory (#3903). bug/feature trust a maintainer-authored linked
+  # issue (routine categorization, no reward at stake); priority omits that flag -- it is the scarce,
+  # maintainer-hand-picked reward label and must still require the PR author to be the issue's actual
+  # author/assignee.
+  linkedIssueLabelPropagation:
+    enabled: true
+    mode: exclusive_type_label
+    mappings:
+      - issueLabel: "gittensor:bug"
+        prLabel: "gittensor:bug"
+        removeOtherTypeLabels: true
+        trustMaintainerAuthoredIssue: true
+      - issueLabel: "gittensor:feature"
+        prLabel: "gittensor:feature"
+        removeOtherTypeLabels: true
+        trustMaintainerAuthoredIssue: true
+      - issueLabel: "gittensor:priority"
+        prLabel: "gittensor:priority"
+        removeOtherTypeLabels: true
+
 publicNotes:
   - Content is PR-first — submit one source-backed entry per PR under content/<category>/.
   - Prefer free, source-backed, practical resources. Paid tools, commercial listings, jobs, and


### PR DESCRIPTION
## Summary
Adds the same `settings.linkedIssueLabelPropagation` block already live on `JSONbored/gittensory` (per #3903) to this repo's `.gittensory.yml`. Without it, a PR closing an issue gets its `gittensor:bug`/`gittensor:feature`/`gittensor:priority` label decided purely by commit-title regex, independent of the label already carried by the issue it closes.

Verified `gittensor:bug`/`gittensor:feature`/`gittensor:priority` labels already exist and are in active use on this repo, so this block is a safe, direct copy — same taxonomy as gittensory/metagraphed despite this repo's content-first focus.

Relates to JSONbored/gittensory#4000.

## Scope
- [x] Config-only, no source code change