### PR TITLE
feat(web): browse resource card trust hints vs compare tray

### DIFF
--- a/apps/web/src/components/browse-compare-selection-banner.tsx
+++ b/apps/web/src/components/browse-compare-selection-banner.tsx
@@ -1,0 +1,54 @@
+import { Link } from "@tanstack/react-router";
+import { GitCompare } from "lucide-react";
+import type { BrowseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
+import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+
+export function BrowseCompareSelectionBanner({
+  state,
+  compareSearch,
+  className,
+}: {
+  state: BrowseCompareSelectionContextState;
+  compareSearch: { ids: string };
+  className?: string;
+}) {
+  if (!state.showBanner) return null;
+
+  return (
+    <section
+      aria-label="Compare selection context"
+      className={cn("rounded-xl border border-accent/30 bg-accent/5 px-4 py-3 sm:px-5", className)}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-medium text-ink">
+            <GitCompare className="h-4 w-4" aria-hidden />
+            {state.selectedCount} selected for compare
+          </div>
+          {state.headline ? <p className="mt-1 text-sm text-ink">{state.headline}</p> : null}
+          {state.hint ? <p className="mt-1 text-xs text-ink-muted">{state.hint}</p> : null}
+          {state.divergingLabels.length > 0 ? (
+            <p className="mt-1 text-xs text-amber-800">
+              Differs on: {state.divergingLabels.join(", ")}
+            </p>
+          ) : null}
+        </div>
+        <Link
+          to="/compare"
+          search={compareSearch}
+          onClick={() => {
+            trackEvent("browse_compare_open", {
+              ...browseCompareOpenAnalyticsData(state.selectedCount),
+              surface: "browse-compare-selection-banner",
+            });
+          }}
+          className="inline-flex shrink-0 items-center gap-1.5 self-start rounded-full border border-accent bg-background px-3 py-1.5 text-xs font-medium text-ink hover:bg-surface"
+        >
+          Open compare
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/browse-compare-selection-banner.tsx
+++ b/apps/web/src/components/browse-compare-selection-banner.tsx
@@ -1,6 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { GitCompare } from "lucide-react";
 import type { BrowseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
+import { browseCompareSelectionDivergingLine } from "@/lib/resource-card-trust-decision";
 import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
@@ -16,6 +17,8 @@ export function BrowseCompareSelectionBanner({
 }) {
   if (!state.showBanner) return null;
 
+  const divergingLine = browseCompareSelectionDivergingLine(state.divergingLabels);
+
   return (
     <section
       aria-label="Compare selection context"
@@ -29,11 +32,7 @@ export function BrowseCompareSelectionBanner({
           </div>
           {state.headline ? <p className="mt-1 text-sm text-ink">{state.headline}</p> : null}
           {state.hint ? <p className="mt-1 text-xs text-ink-muted">{state.hint}</p> : null}
-          {state.divergingLabels.length > 0 ? (
-            <p className="mt-1 text-xs text-amber-800">
-              Differs on: {state.divergingLabels.join(", ")}
-            </p>
-          ) : null}
+          {divergingLine ? <p className="mt-1 text-xs text-amber-800">{divergingLine}</p> : null}
         </div>
         <Link
           to="/compare"

--- a/apps/web/src/components/resource-card-trust-hint.tsx
+++ b/apps/web/src/components/resource-card-trust-hint.tsx
@@ -1,14 +1,7 @@
 import { GitCompare } from "lucide-react";
 import type { ResourceCardTrustDecisionState } from "@/lib/resource-card-trust-decision";
+import { resourceCardTrustHintToneClass } from "@/lib/resource-card-trust-decision";
 import { cn } from "@/lib/utils";
-
-const KIND_STYLES: Record<ResourceCardTrustDecisionState["kind"], string> = {
-  aligns: "border-border bg-surface text-ink-muted",
-  stronger: "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
-  weaker: "border-trust-review/30 bg-trust-review/5 text-amber-900",
-  diverges: "border-amber-500/30 bg-amber-500/5 text-amber-900",
-  "mixed-trust": "border-accent/30 bg-accent/5 text-ink",
-};
 
 export function ResourceCardTrustHint({
   state,
@@ -23,7 +16,7 @@ export function ResourceCardTrustHint({
     <p
       className={cn(
         "inline-flex items-start gap-1.5 rounded-md border px-2 py-1 text-[11px] leading-snug",
-        KIND_STYLES[state.kind],
+        resourceCardTrustHintToneClass(state.kind),
         className,
       )}
       role="status"

--- a/apps/web/src/components/resource-card-trust-hint.tsx
+++ b/apps/web/src/components/resource-card-trust-hint.tsx
@@ -1,0 +1,35 @@
+import { GitCompare } from "lucide-react";
+import type { ResourceCardTrustDecisionState } from "@/lib/resource-card-trust-decision";
+import { cn } from "@/lib/utils";
+
+const KIND_STYLES: Record<ResourceCardTrustDecisionState["kind"], string> = {
+  aligns: "border-border bg-surface text-ink-muted",
+  stronger: "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
+  weaker: "border-trust-review/30 bg-trust-review/5 text-amber-900",
+  diverges: "border-amber-500/30 bg-amber-500/5 text-amber-900",
+  "mixed-trust": "border-accent/30 bg-accent/5 text-ink",
+};
+
+export function ResourceCardTrustHint({
+  state,
+  className,
+}: {
+  state: ResourceCardTrustDecisionState;
+  className?: string;
+}) {
+  if (!state.showHint) return null;
+
+  return (
+    <p
+      className={cn(
+        "inline-flex items-start gap-1.5 rounded-md border px-2 py-1 text-[11px] leading-snug",
+        KIND_STYLES[state.kind],
+        className,
+      )}
+      role="status"
+    >
+      <GitCompare className="mt-0.5 h-3 w-3 shrink-0 opacity-70" aria-hidden />
+      <span>{state.hint}</span>
+    </p>
+  );
+}

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -27,6 +27,8 @@ import {
   resourceCardInstallIntentType,
 } from "@/lib/resource-card-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
+import { resourceCardTrustDecisionState } from "@/lib/resource-card-trust-decision";
+import { ResourceCardTrustHint } from "@/components/resource-card-trust-hint";
 import { cn } from "@/lib/utils";
 import { trackEvent, outboundHost } from "@/lib/analytics";
 
@@ -50,13 +52,19 @@ function ResourceCardInner({
   entry,
   variant = "row",
   rank,
+  compareItems = [],
 }: {
   entry: Entry;
   variant?: "row" | "grid" | "compact";
   rank?: number;
+  compareItems?: Entry[];
 }) {
   const { toggle, setOpen } = useCompareActions();
   const inCompare = useIsCompared(entry);
+  const trustDecision = React.useMemo(
+    () => resourceCardTrustDecisionState(entry, compareItems),
+    [entry, compareItems],
+  );
   const peekRef = React.useRef<PeekHandle>(null);
   const handle = React.useMemo(() => ({ open: () => peekRef.current?.open() }), []);
   const [hovered, setHovered] = React.useState(false);
@@ -179,6 +187,9 @@ function ResourceCardInner({
               <p className="mt-1.5 line-clamp-2 text-sm text-ink-muted">
                 {entry.cardDescription ?? entry.description}
               </p>
+              {trustDecision ? (
+                <ResourceCardTrustHint state={trustDecision} className="mt-2" />
+              ) : null}
             </div>
             <EntryFacets entry={entry} density="card" />
             <div className="mt-auto flex flex-wrap items-center gap-1.5">
@@ -270,6 +281,7 @@ function ResourceCardInner({
             <LazyEntryAuthorAttribution entry={entry} />
           </div>
           <p className="line-clamp-2 max-w-3xl text-sm text-ink-muted">{entry.description}</p>
+          {trustDecision ? <ResourceCardTrustHint state={trustDecision} className="mt-1" /> : null}
           <div className="flex flex-wrap items-center gap-2 pt-0.5">
             <EntryFacets entry={entry} density="card" />
             <NotesPresenceChips entry={entry} />

--- a/apps/web/src/lib/resource-card-trust-decision-lib.ts
+++ b/apps/web/src/lib/resource-card-trust-decision-lib.ts
@@ -1,0 +1,181 @@
+/**
+ * Pure resource card trust decision helpers.
+ *
+ * Builds browse-card hints that explain how an entry compares to the current
+ * compare tray selection without opening dossiers.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+import {
+  divergingDecisionRowLabels,
+  compareDecisionSummary,
+} from "@/lib/compare-table-decision-rows-lib";
+
+export const RESOURCE_CARD_TRUST_HINT_MIN_COMPARE = 1;
+
+const TRUST_RANK: Record<TrustLevel, number> = {
+  trusted: 4,
+  review: 3,
+  limited: 2,
+  blocked: 1,
+};
+
+export function resourceCardTrustScore(entry: Entry): number {
+  let score = TRUST_RANK[entry.trust] * 10;
+  if (entry.safetyNotes || entry.safetyNotesList?.length) score += 15;
+  if (entry.privacyNotes || entry.privacyNotesList?.length) score += 10;
+  if (entry.reviewed || entry.reviewedBy) score += 15;
+  if (entry.source !== "unverified") score += 10;
+  if (entry.installCommand) score += 5;
+  if (entry.claimed) score += 5;
+  return score;
+}
+
+export type ResourceCardTrustHintKind =
+  | "aligns"
+  | "stronger"
+  | "weaker"
+  | "diverges"
+  | "mixed-trust";
+
+export type ResourceCardTrustDecisionState = {
+  showHint: boolean;
+  kind: ResourceCardTrustHintKind;
+  hint: string;
+  divergingLabels: string[];
+  trustScore: number;
+  compareAverageScore: number;
+  inCompareTray: boolean;
+};
+
+function compareTrayAverageScore(entries: Entry[]): number {
+  if (entries.length === 0) return 0;
+  const total = entries.reduce((sum, entry) => sum + resourceCardTrustScore(entry), 0);
+  return Math.round(total / entries.length);
+}
+
+function resourceCardTrustHintKind(
+  entry: Entry,
+  compareEntries: Entry[],
+  divergingLabels: string[],
+  trustScore: number,
+  averageScore: number,
+): ResourceCardTrustHintKind {
+  if (divergingLabels.length > 0) return "diverges";
+
+  const trustLevels = new Set([entry.trust, ...compareEntries.map((item) => item.trust)]);
+  if (trustLevels.size > 1) return "mixed-trust";
+
+  if (trustScore > averageScore + 5) return "stronger";
+  if (trustScore < averageScore - 5) return "weaker";
+  return "aligns";
+}
+
+function resourceCardTrustHintText(
+  entry: Entry,
+  compareEntries: Entry[],
+  kind: ResourceCardTrustHintKind,
+  divergingLabels: string[],
+): string {
+  const compareTitles = compareEntries.map((item) => item.title);
+  const versus =
+    compareEntries.length === 1 ? compareTitles[0] : `${compareEntries.length} selected entries`;
+
+  switch (kind) {
+    case "diverges": {
+      const labels = divergingLabels.slice(0, 2).join(", ");
+      return `Differs from ${versus} on ${labels} — open compare before installing.`;
+    }
+    case "mixed-trust":
+      return `Mixed trust levels versus ${versus} — compare trust signals side by side.`;
+    case "stronger":
+      return `Stronger trust signals than ${versus} in this selection.`;
+    case "weaker":
+      return `Weaker trust signals than ${versus} — review safety and source first.`;
+    case "aligns":
+    default:
+      return `Trust signals align with ${versus}.`;
+  }
+}
+
+export function resourceCardVersusCompareEntries(entry: Entry, compareEntries: Entry[]): Entry[] {
+  return compareEntries.filter((item) => !sameEntry(item, entry));
+}
+
+export function resourceCardTrustDecisionState(
+  entry: Entry,
+  compareEntries: Entry[],
+): ResourceCardTrustDecisionState | null {
+  const peers = resourceCardVersusCompareEntries(entry, compareEntries);
+  if (peers.length < RESOURCE_CARD_TRUST_HINT_MIN_COMPARE) {
+    return null;
+  }
+
+  const combined = [...peers, entry];
+  const divergingLabels = divergingDecisionRowLabels(combined);
+  const trustScore = resourceCardTrustScore(entry);
+  const compareAverageScore = compareTrayAverageScore(peers);
+  const kind = resourceCardTrustHintKind(
+    entry,
+    peers,
+    divergingLabels,
+    trustScore,
+    compareAverageScore,
+  );
+
+  return {
+    showHint: true,
+    kind,
+    hint: resourceCardTrustHintText(entry, peers, kind, divergingLabels),
+    divergingLabels,
+    trustScore,
+    compareAverageScore,
+    inCompareTray: compareEntries.some((item) => sameEntry(item, entry)),
+  };
+}
+
+export type BrowseCompareSelectionContextState = {
+  showBanner: boolean;
+  selectedCount: number;
+  divergingCount: number;
+  divergingLabels: string[];
+  headline: string | null;
+  hint: string | null;
+};
+
+export function browseCompareSelectionContextState(
+  compareEntries: Entry[],
+): BrowseCompareSelectionContextState {
+  if (compareEntries.length < 2) {
+    return {
+      showBanner: false,
+      selectedCount: compareEntries.length,
+      divergingCount: 0,
+      divergingLabels: [],
+      headline: null,
+      hint: null,
+    };
+  }
+
+  const decision = compareDecisionSummary(compareEntries);
+  const divergingLabels = decision.divergingLabels;
+  const headline =
+    divergingLabels.length > 0
+      ? `${decision.divergingCount} trust ${decision.divergingCount === 1 ? "signal differs" : "signals differ"} across your selection.`
+      : "Selected entries share the same trust signals so far.";
+
+  const hint =
+    divergingLabels.length > 0
+      ? `Browse cards below show how each result compares to ${compareEntries.length} selected entries.`
+      : "Add one more entry with different trust metadata to spot gaps faster.";
+
+  return {
+    showBanner: true,
+    selectedCount: compareEntries.length,
+    divergingCount: decision.divergingCount,
+    divergingLabels,
+    headline,
+    hint,
+  };
+}

--- a/apps/web/src/lib/resource-card-trust-decision-lib.ts
+++ b/apps/web/src/lib/resource-card-trust-decision-lib.ts
@@ -39,6 +39,18 @@ export type ResourceCardTrustHintKind =
   | "diverges"
   | "mixed-trust";
 
+const TRUST_HINT_TONE_CLASS: Record<ResourceCardTrustHintKind, string> = {
+  aligns: "border-border bg-surface text-ink-muted",
+  stronger: "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
+  weaker: "border-trust-review/30 bg-trust-review/5 text-amber-900",
+  diverges: "border-amber-500/30 bg-amber-500/5 text-amber-900",
+  "mixed-trust": "border-accent/30 bg-accent/5 text-ink",
+};
+
+export function resourceCardTrustHintToneClass(kind: ResourceCardTrustHintKind): string {
+  return TRUST_HINT_TONE_CLASS[kind];
+}
+
 export type ResourceCardTrustDecisionState = {
   showHint: boolean;
   kind: ResourceCardTrustHintKind;
@@ -178,4 +190,9 @@ export function browseCompareSelectionContextState(
     headline,
     hint,
   };
+}
+
+export function browseCompareSelectionDivergingLine(labels: string[]): string | null {
+  if (labels.length === 0) return null;
+  return `Differs on: ${labels.join(", ")}`;
 }

--- a/apps/web/src/lib/resource-card-trust-decision.ts
+++ b/apps/web/src/lib/resource-card-trust-decision.ts
@@ -1,0 +1,15 @@
+/**
+ * Resource card trust decision surface.
+ */
+export type {
+  BrowseCompareSelectionContextState,
+  ResourceCardTrustDecisionState,
+  ResourceCardTrustHintKind,
+} from "@/lib/resource-card-trust-decision-lib";
+export {
+  RESOURCE_CARD_TRUST_HINT_MIN_COMPARE,
+  browseCompareSelectionContextState,
+  resourceCardTrustDecisionState,
+  resourceCardTrustScore,
+  resourceCardVersusCompareEntries,
+} from "@/lib/resource-card-trust-decision-lib";

--- a/apps/web/src/lib/resource-card-trust-decision.ts
+++ b/apps/web/src/lib/resource-card-trust-decision.ts
@@ -9,7 +9,9 @@ export type {
 export {
   RESOURCE_CARD_TRUST_HINT_MIN_COMPARE,
   browseCompareSelectionContextState,
+  browseCompareSelectionDivergingLine,
   resourceCardTrustDecisionState,
+  resourceCardTrustHintToneClass,
   resourceCardTrustScore,
   resourceCardVersusCompareEntries,
 } from "@/lib/resource-card-trust-decision-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -24,6 +24,8 @@ import {
 import { browseFilterDecisionUiState } from "@/lib/browse-filter-decision-hints";
 import { browseResultsTrustDecisionUiState } from "@/lib/browse-results-trust-decision";
 import { BrowseResultsTrustPanel } from "@/components/browse-results-trust-panel";
+import { BrowseCompareSelectionBanner } from "@/components/browse-compare-selection-banner";
+import { browseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
 import {
   CATEGORIES,
   type Category,
@@ -329,6 +331,11 @@ function Browse() {
   const browseResultsTrust = useMemo(
     () => browseResultsTrustDecisionUiState(results, compare.items.length),
     [results, compare.items.length],
+  );
+
+  const browseCompareSelection = useMemo(
+    () => browseCompareSelectionContextState(compare.items),
+    [compare.items],
   );
 
   const activeCount =
@@ -1011,10 +1018,22 @@ function Browse() {
             </div>
           ) : (
             <>
+              {browseCompareSelection.showBanner && browseCompareUi ? (
+                <BrowseCompareSelectionBanner
+                  state={browseCompareSelection}
+                  compareSearch={browseCompareUi.search}
+                  className="mt-4"
+                />
+              ) : null}
               {sp.view === "grid" ? (
                 <div className="mt-4 grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
                   {results.slice(0, shown).map((e) => (
-                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} variant="grid" />
+                    <ResourceCard
+                      key={`${e.category}/${e.slug}`}
+                      entry={e}
+                      variant="grid"
+                      compareItems={compare.items}
+                    />
                   ))}
                 </div>
               ) : sp.view === "compact" ? (
@@ -1025,13 +1044,18 @@ function Browse() {
                       entry={e}
                       variant="compact"
                       rank={i + 1}
+                      compareItems={compare.items}
                     />
                   ))}
                 </div>
               ) : (
                 <div className="mt-2 overflow-hidden rounded-lg border border-border bg-surface">
                   {results.slice(0, shown).map((e) => (
-                    <ResourceCard key={`${e.category}/${e.slug}`} entry={e} />
+                    <ResourceCard
+                      key={`${e.category}/${e.slug}`}
+                      entry={e}
+                      compareItems={compare.items}
+                    />
                   ))}
                 </div>
               )}

--- a/tests/resource-card-trust-decision-lib.test.ts
+++ b/tests/resource-card-trust-decision-lib.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
   browseCompareSelectionContextState,
+  browseCompareSelectionDivergingLine,
   resourceCardTrustDecisionState,
+  resourceCardTrustHintToneClass,
   resourceCardTrustScore,
+  resourceCardVersusCompareEntries,
 } from "@/lib/resource-card-trust-decision-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
@@ -42,6 +45,39 @@ describe("resource card trust decision lib", () => {
     );
   });
 
+  it("includes optional trust metadata in the score", () => {
+    const rich = entry({
+      safetyNotesList: ["Careful"],
+      privacyNotes: "Local only",
+      privacyNotesList: ["No network"],
+      reviewedBy: "maintainer",
+      installCommand: "npm i fixture",
+      claimed: true,
+    });
+
+    expect(resourceCardTrustScore(rich)).toBeGreaterThan(
+      resourceCardTrustScore(entry()),
+    );
+  });
+
+  it("maps hint kinds to tone classes", () => {
+    expect(resourceCardTrustHintToneClass("aligns")).toContain("border-border");
+    expect(resourceCardTrustHintToneClass("stronger")).toContain(
+      "trust-trusted",
+    );
+    expect(resourceCardTrustHintToneClass("weaker")).toContain("trust-review");
+    expect(resourceCardTrustHintToneClass("diverges")).toContain("amber-500");
+    expect(resourceCardTrustHintToneClass("mixed-trust")).toContain("accent");
+  });
+
+  it("filters the active card out of compare peers", () => {
+    const left = entry();
+    const right = entry({ slug: "right" });
+    expect(resourceCardVersusCompareEntries(left, [left, right])).toEqual([
+      right,
+    ]);
+  });
+
   it("builds browse-card hints against the compare tray", () => {
     const selected = entry({
       title: "Selected",
@@ -65,6 +101,105 @@ describe("resource card trust decision lib", () => {
     expect(resourceCardTrustDecisionState(entry(), [])).toBeNull();
   });
 
+  it("marks weaker trust signals versus a stronger compare selection", () => {
+    const strong = entry({
+      title: "Strong",
+      trust: "review",
+      reviewed: false,
+      source: "unverified",
+      safetyNotes: "Audited",
+      privacyNotes: "Local only",
+      installCommand: "npm i strong",
+    });
+    const weak = entry({
+      slug: "weak",
+      title: "Weak",
+      trust: "review",
+      reviewed: false,
+      source: "unverified",
+    });
+
+    const state = resourceCardTrustDecisionState(weak, [strong]);
+    expect(state?.kind).toBe("weaker");
+    expect(state?.hint).toContain("Weaker trust signals");
+  });
+
+  it("marks stronger trust signals versus a weaker compare selection", () => {
+    const strong = entry({
+      title: "Strong",
+      trust: "review",
+      reviewed: false,
+      source: "unverified",
+      safetyNotes: "Audited",
+      privacyNotes: "Local only",
+      installCommand: "npm i strong",
+    });
+    const weak = entry({
+      slug: "weak",
+      title: "Weak",
+      trust: "review",
+      reviewed: false,
+      source: "unverified",
+    });
+
+    const state = resourceCardTrustDecisionState(strong, [weak]);
+    expect(state?.kind).toBe("stronger");
+    expect(state?.hint).toContain("Stronger trust signals");
+  });
+
+  it("marks aligned trust signals when scores are close", () => {
+    const left = entry({ trust: "review", source: "unverified" });
+    const right = entry({
+      slug: "right",
+      trust: "review",
+      source: "unverified",
+    });
+
+    const state = resourceCardTrustDecisionState(left, [right]);
+    expect(state?.kind).toBe("aligns");
+    expect(state?.hint).toContain("align with");
+  });
+
+  it("marks mixed trust levels when package signals align", () => {
+    const left = entry({ trust: "trusted" });
+    const right = entry({ slug: "right", trust: "review" });
+
+    const state = resourceCardTrustDecisionState(left, [right]);
+    expect(state?.kind).toBe("mixed-trust");
+    expect(state?.hint).toContain("Mixed trust levels");
+  });
+
+  it("marks diverging decision rows before weaker or stronger hints", () => {
+    const reviewed = entry({ reviewed: true, source: "source-backed" });
+    const unreviewed = entry({
+      slug: "unreviewed",
+      reviewed: false,
+      source: "unverified",
+    });
+
+    const state = resourceCardTrustDecisionState(unreviewed, [reviewed]);
+    expect(state?.kind).toBe("diverges");
+    expect(state?.divergingLabels.length).toBeGreaterThan(0);
+    expect(state?.hint).toContain("open compare");
+  });
+
+  it("uses plural compare copy for multi-select trays", () => {
+    const candidate = entry();
+    const second = entry({ slug: "second" });
+    const third = entry({ slug: "third" });
+
+    const state = resourceCardTrustDecisionState(candidate, [second, third]);
+    expect(state?.hint).toContain("2 selected entries");
+  });
+
+  it("flags when the card is already in the compare tray", () => {
+    const left = entry();
+    const right = entry({ slug: "right" });
+
+    const state = resourceCardTrustDecisionState(left, [left, right]);
+    expect(state?.inCompareTray).toBe(true);
+  });
+
   it("builds browse compare selection banner context for multi-select", () => {
     const left = entry({
       trust: "trusted",
@@ -81,5 +216,63 @@ describe("resource card trust decision lib", () => {
     expect(context.showBanner).toBe(true);
     expect(context.headline).toContain("trust");
     expect(context.hint).toContain("Browse cards below");
+  });
+
+  it("hides the compare selection banner until two entries are selected", () => {
+    expect(browseCompareSelectionContextState([]).showBanner).toBe(false);
+    expect(browseCompareSelectionContextState([entry()]).showBanner).toBe(
+      false,
+    );
+  });
+
+  it("uses aligned headline copy when compare signals match", () => {
+    const left = entry({ reviewed: true, source: "source-backed" });
+    const right = entry({
+      slug: "right",
+      reviewed: true,
+      source: "source-backed",
+    });
+
+    const context = browseCompareSelectionContextState([left, right]);
+    expect(context.headline).toContain("same trust signals");
+    expect(context.hint).toContain("Add one more entry");
+  });
+
+  it("uses singular diverging headline copy for one differing signal", () => {
+    const left = entry({ reviewed: true });
+    const right = entry({ slug: "right", reviewed: false });
+
+    const context = browseCompareSelectionContextState([left, right]);
+    expect(context.headline).toBe(
+      "1 trust signal differs across your selection.",
+    );
+  });
+
+  it("uses plural diverging headline copy for multiple differing signals", () => {
+    const left = entry({
+      reviewed: true,
+      source: "source-backed",
+      claimed: true,
+    });
+    const right = entry({
+      slug: "right",
+      reviewed: false,
+      source: "unverified",
+      claimed: false,
+    });
+
+    const context = browseCompareSelectionContextState([left, right]);
+    expect(context.headline).toContain("trust signals differ");
+    expect(context.divergingCount).toBeGreaterThan(1);
+  });
+
+  it("formats diverging labels for the selection banner", () => {
+    expect(browseCompareSelectionDivergingLine([])).toBeNull();
+    expect(browseCompareSelectionDivergingLine(["Review status"])).toBe(
+      "Differs on: Review status",
+    );
+    expect(
+      browseCompareSelectionDivergingLine(["Review status", "Submitter"]),
+    ).toBe("Differs on: Review status, Submitter");
   });
 });

--- a/tests/resource-card-trust-decision-lib.test.ts
+++ b/tests/resource-card-trust-decision-lib.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseCompareSelectionContextState,
+  resourceCardTrustDecisionState,
+  resourceCardTrustScore,
+} from "@/lib/resource-card-trust-decision-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "skills",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("resource card trust decision lib", () => {
+  it("scores trusted reviewed entries above unverified ones", () => {
+    const trusted = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      safetyNotes: "Careful",
+    });
+    const risky = entry({
+      slug: "risky",
+      trust: "limited",
+      source: "unverified",
+    });
+
+    expect(resourceCardTrustScore(trusted)).toBeGreaterThan(
+      resourceCardTrustScore(risky),
+    );
+  });
+
+  it("builds browse-card hints against the compare tray", () => {
+    const selected = entry({
+      title: "Selected",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+    });
+    const candidate = entry({
+      slug: "candidate",
+      title: "Candidate",
+      trust: "review",
+      source: "unverified",
+    });
+
+    const state = resourceCardTrustDecisionState(candidate, [selected]);
+    expect(state?.showHint).toBe(true);
+    expect(state?.hint).toContain("Selected");
+  });
+
+  it("returns null when the compare tray is empty", () => {
+    expect(resourceCardTrustDecisionState(entry(), [])).toBeNull();
+  });
+
+  it("builds browse compare selection banner context for multi-select", () => {
+    const left = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+    });
+    const right = entry({
+      slug: "right",
+      trust: "review",
+      source: "unverified",
+    });
+
+    const context = browseCompareSelectionContextState([left, right]);
+    expect(context.showBanner).toBe(true);
+    expect(context.headline).toContain("trust");
+    expect(context.hint).toContain("Browse cards below");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `resource-card-trust-decision-lib` with pure trust scoring and hint copy when browse cards are viewed alongside an active compare tray selection.
- Render per-card `ResourceCardTrustHint` on grid and row browse layouts, and a `BrowseCompareSelectionBanner` when two or more entries are selected for compare.
- Wire `compareItems` through browse `ResourceCard` instances so hints stay in sync with tray membership.
- Expand lib regression tests for all hint kinds and banner copy helpers (codecov/patch gate).

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/resource-card-trust-decision-lib.test.ts` (19 tests)
- [x] `pnpm type-check`
- [x] Local lib line coverage 100% (`resource-card-trust-decision-lib.ts`)
- [ ] CI green (`validate-web`, `codecov/patch` >=70%, `required-pr-gate`)