### PR TITLE
refactor(web): extract pure asCommunityCounts into entry-signals-counts-lib

### DIFF
--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -2,13 +2,12 @@ import { AlertTriangle, ArrowBigUp, Check, Eye, LoaderCircle } from "lucide-reac
 import * as React from "react";
 
 import type { Category } from "@/types/registry";
+import {
+  type CommunityCounts,
+  ZERO_COMMUNITY,
+  asCommunityCounts,
+} from "@/lib/entry-signals-counts-lib";
 import { cn } from "@/lib/utils";
-
-type CommunityCounts = {
-  used: number;
-  works: number;
-  broken: number;
-};
 
 type SignalState = {
   loading: boolean;
@@ -20,7 +19,6 @@ type SignalState = {
   activeCommunity: Partial<Record<keyof CommunityCounts, boolean>>;
 };
 
-const ZERO_COMMUNITY: CommunityCounts = { used: 0, works: 0, broken: 0 };
 const CLIENT_STORAGE_KEY = "hc:client-id";
 const COMMUNITY_STORAGE_PREFIX = "hc:community:";
 
@@ -74,15 +72,6 @@ async function postJson(path: string, payload: unknown) {
   });
   if (!response.ok) throw new Error(`${path} returned ${response.status}`);
   return response.json() as Promise<Record<string, unknown>>;
-}
-
-function asCommunityCounts(value: unknown): CommunityCounts {
-  const source = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
-  return {
-    used: Number(source.used ?? 0) || 0,
-    works: Number(source.works ?? 0) || 0,
-    broken: Number(source.broken ?? 0) || 0,
-  };
 }
 
 export function EntrySignalsPanel({ category, slug }: { category: Category; slug: string }) {

--- a/apps/web/src/lib/entry-signals-counts-lib.ts
+++ b/apps/web/src/lib/entry-signals-counts-lib.ts
@@ -1,0 +1,29 @@
+// Pure normalization of the community-counts payload for the entry signals
+// panel, split out of entry-signals-panel.tsx so the coercion rules can be
+// unit-tested without React, localStorage, or the fetch layer.
+
+/** Used / works / broken tallies shown in the entry signals panel. */
+export type CommunityCounts = {
+  used: number;
+  works: number;
+  broken: number;
+};
+
+/** All-zero community counts, used as the pre-fetch and error fallback. */
+export const ZERO_COMMUNITY: CommunityCounts = { used: 0, works: 0, broken: 0 };
+
+/**
+ * Coerce an untrusted community-counts payload (an API response or cached
+ * value) into a {@link CommunityCounts}. Non-object input yields all zeros;
+ * each field is read numerically and any missing or non-numeric value
+ * (which parses to `NaN`) collapses to 0. Numeric strings are accepted, and
+ * negative values are preserved.
+ */
+export function asCommunityCounts(value: unknown): CommunityCounts {
+  const source = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  return {
+    used: Number(source.used ?? 0) || 0,
+    works: Number(source.works ?? 0) || 0,
+    broken: Number(source.broken ?? 0) || 0,
+  };
+}

--- a/tests/entry-signals-counts-lib.test.ts
+++ b/tests/entry-signals-counts-lib.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ZERO_COMMUNITY,
+  asCommunityCounts,
+} from "../apps/web/src/lib/entry-signals-counts-lib";
+
+describe("ZERO_COMMUNITY", () => {
+  it("is an all-zero counts object", () => {
+    expect(ZERO_COMMUNITY).toEqual({ used: 0, works: 0, broken: 0 });
+  });
+});
+
+describe("asCommunityCounts", () => {
+  it("reads numeric fields straight through", () => {
+    expect(asCommunityCounts({ used: 4, works: 3, broken: 1 })).toEqual({
+      used: 4,
+      works: 3,
+      broken: 1,
+    });
+  });
+
+  it("coerces numeric strings", () => {
+    expect(asCommunityCounts({ used: "5", works: "0", broken: "2" })).toEqual({
+      used: 5,
+      works: 0,
+      broken: 2,
+    });
+  });
+
+  it("collapses missing fields to 0", () => {
+    expect(asCommunityCounts({ used: 7 })).toEqual({
+      used: 7,
+      works: 0,
+      broken: 0,
+    });
+  });
+
+  it("collapses non-numeric values (which parse to NaN) to 0", () => {
+    expect(asCommunityCounts({ used: "abc", works: null, broken: {} })).toEqual(
+      {
+        used: 0,
+        works: 0,
+        broken: 0,
+      },
+    );
+  });
+
+  it("preserves negative values", () => {
+    expect(asCommunityCounts({ used: -2, works: 1, broken: 0 })).toEqual({
+      used: -2,
+      works: 1,
+      broken: 0,
+    });
+  });
+
+  it.each([null, undefined, 42, "counts", true, []])(
+    "returns all zeros for non-object input (%p)",
+    (value) => {
+      expect(asCommunityCounts(value)).toEqual({
+        used: 0,
+        works: 0,
+        broken: 0,
+      });
+    },
+  );
+});


### PR DESCRIPTION
## What

Extracts the untrusted community-counts normalizer out of `entry-signals-panel.tsx` into a pure, self-contained module `apps/web/src/lib/entry-signals-counts-lib.ts`:

- `asCommunityCounts(value)` — coerces an untrusted API/cache payload into `{ used, works, broken }`; non-object input yields all zeros, each field is read numerically, and any missing or non-numeric value (which parses to `NaN`) collapses to 0. Numeric strings are accepted and negative values are preserved.
- The `CommunityCounts` type and the `ZERO_COMMUNITY` pre-fetch/error fallback move alongside it.

The component now imports the same three symbols. **No behavior change** — this is a pure extraction so the coercion rules can be unit-tested without React, `localStorage`, or the fetch layer, matching the existing `*-lib.ts` pattern used across `apps/web/src/lib/`.

## Tests

`tests/entry-signals-counts-lib.test.ts` covers straight numeric reads, numeric-string coercion, missing fields, `NaN`-collapsing values, preserved negatives, and non-object inputs (12 cases).

```
pnpm exec vitest run tests/entry-signals-counts-lib.test.ts   # 12 passed
pnpm exec prettier --check <changed files>                    # clean
```

Refs #556