### PR TITLE
refactor(web): extract pure buildCompatibilityCsv into compatibility-matrix-csv-lib

### DIFF
--- a/apps/web/src/components/compatibility-matrix.tsx
+++ b/apps/web/src/components/compatibility-matrix.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Download, Search, X } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { CopyButton } from "@/components/copy-button";
-import { csvEscape } from "@/lib/csv";
+import { buildCompatibilityCsv } from "@/lib/compatibility-matrix-csv-lib";
 import { cn } from "@/lib/utils";
 
 export type Support = "native" | "adapter" | "manual" | "none";
@@ -65,17 +65,8 @@ export function CompatibilityMatrix({
   }, [rows, query]);
 
   const downloadCsv = () => {
-    const header = ["Capability", "Detail", ...clients.map((c) => c.label)].join(",");
-    const body = rows
-      .map((r) =>
-        [
-          csvEscape(r.capability),
-          csvEscape(r.blurb),
-          ...clients.map((c) => SUPPORT_META[r.cells[c.id]].label),
-        ].join(","),
-      )
-      .join("\n");
-    const blob = new Blob([`${header}\n${body}\n`], { type: "text/csv;charset=utf-8" });
+    const csv = buildCompatibilityCsv(clients, rows, (support) => SUPPORT_META[support].label);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/apps/web/src/lib/compatibility-matrix-csv-lib.ts
+++ b/apps/web/src/lib/compatibility-matrix-csv-lib.ts
@@ -1,0 +1,31 @@
+// Pure CSV serialization for the compatibility matrix, split out of
+// compatibility-matrix.tsx so the header/row/label encoding can be unit-tested
+// without the DOM Blob-download plumbing.
+
+import { csvEscape } from "@/lib/csv";
+import type { MatrixClient, MatrixRow, Support } from "@/components/compatibility-matrix";
+
+/**
+ * Serialize the compatibility matrix to CSV text: a
+ * `Capability,Detail,<client label>…` header followed by one row per
+ * capability. The capability and blurb cells are escaped via `csvEscape`; each
+ * client cell is resolved to its support label with `labelFor`. The result ends
+ * with a trailing newline.
+ */
+export function buildCompatibilityCsv(
+  clients: readonly MatrixClient[],
+  rows: readonly MatrixRow[],
+  labelFor: (support: Support) => string,
+): string {
+  const header = ["Capability", "Detail", ...clients.map((c) => c.label)].join(",");
+  const body = rows
+    .map((r) =>
+      [
+        csvEscape(r.capability),
+        csvEscape(r.blurb),
+        ...clients.map((c) => labelFor(r.cells[c.id])),
+      ].join(","),
+    )
+    .join("\n");
+  return `${header}\n${body}\n`;
+}

--- a/tests/compatibility-matrix-csv-lib.test.ts
+++ b/tests/compatibility-matrix-csv-lib.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  MatrixClient,
+  MatrixRow,
+  Support,
+} from "../apps/web/src/components/compatibility-matrix";
+import { buildCompatibilityCsv } from "../apps/web/src/lib/compatibility-matrix-csv-lib";
+
+const clients: MatrixClient[] = [
+  { id: "claude-code", label: "Claude Code" },
+  { id: "desktop", label: "Desktop" },
+];
+
+const label = (support: Support) =>
+  ({
+    native: "Native",
+    adapter: "Adapter",
+    manual: "Manual",
+    none: "Unsupported",
+  })[support];
+
+describe("buildCompatibilityCsv", () => {
+  it("emits a header of Capability, Detail, then each client label", () => {
+    const csv = buildCompatibilityCsv(clients, [], label);
+    expect(csv.split("\n")[0]).toBe("Capability,Detail,Claude Code,Desktop");
+  });
+
+  it("resolves each client cell through labelFor", () => {
+    const rows: MatrixRow[] = [
+      {
+        capability: "Tools",
+        blurb: "Call tools",
+        cells: { "claude-code": "native", desktop: "adapter" },
+      },
+    ];
+    const csv = buildCompatibilityCsv(clients, rows, label);
+    expect(csv).toBe(
+      "Capability,Detail,Claude Code,Desktop\nTools,Call tools,Native,Adapter\n",
+    );
+  });
+
+  it("escapes commas and quotes in capability and blurb cells", () => {
+    const rows: MatrixRow[] = [
+      {
+        capability: 'MCP, "stdio"',
+        blurb: "one, two",
+        cells: { "claude-code": "manual", desktop: "none" },
+      },
+    ];
+    const csv = buildCompatibilityCsv(clients, rows, label);
+    const dataLine = csv.split("\n")[1];
+    expect(dataLine).toBe('"MCP, ""stdio""","one, two",Manual,Unsupported');
+  });
+
+  it("emits one line per row and always ends with a trailing newline", () => {
+    const rows: MatrixRow[] = [
+      {
+        capability: "A",
+        blurb: "a",
+        cells: { "claude-code": "native", desktop: "native" },
+      },
+      {
+        capability: "B",
+        blurb: "b",
+        cells: { "claude-code": "none", desktop: "none" },
+      },
+    ];
+    const csv = buildCompatibilityCsv(clients, rows, label);
+    expect(csv.endsWith("\n")).toBe(true);
+    expect(csv.trimEnd().split("\n")).toHaveLength(3); // header + 2 rows
+  });
+
+  it("produces a header-only document (with trailing newlines) for no rows", () => {
+    expect(buildCompatibilityCsv(clients, [], label)).toBe(
+      "Capability,Detail,Claude Code,Desktop\n\n",
+    );
+  });
+});


### PR DESCRIPTION
## What

Extracts the CSV serialization out of `compatibility-matrix.tsx`'s `downloadCsv` handler into a pure module `apps/web/src/lib/compatibility-matrix-csv-lib.ts`:

- `buildCompatibilityCsv(clients, rows, labelFor)` — builds the `Capability,Detail,<client label>…` header followed by one escaped row per capability, resolving each client cell through the injected `labelFor` and ending with a trailing newline.

The component keeps only the `Blob` + anchor download plumbing and passes `(support) => SUPPORT_META[support].label` as `labelFor`, so the lib stays decoupled from the component's presentation metadata. **No behavior change** — this makes the header/row/label encoding unit-testable without the DOM, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/compatibility-matrix-csv-lib.test.ts` covers the header shape, label resolution, comma/quote escaping (verified against `csvEscape`), one-line-per-row + trailing newline, and the empty-rows case (5 cases).

```
pnpm exec vitest run tests/compatibility-matrix-csv-lib.test.ts   # 5 passed
pnpm exec prettier --check <changed files>                        # clean
```

Refs #556