### PR TITLE
refactor(web): extract pure savedFeedUrl into saved-search-feed-url-lib

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -32,19 +32,9 @@ import {
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
 import { hashSearch } from "@/lib/saved-search-hash-lib";
 import { applyToBrowseSearch } from "@/lib/saved-search-nav-lib";
+import { savedFeedUrl } from "@/lib/saved-search-feed-url-lib";
 import { CopyButton } from "@/components/copy-button";
 import { cn } from "@/lib/utils";
-
-export function savedFeedUrl(s: SavedSearch): string {
-  const p = new URLSearchParams();
-  if (s.q) p.set("q", s.q);
-  if (s.category) p.set("category", s.category);
-  if (s.trust) p.set("trust", s.trust);
-  if (s.source) p.set("source", s.source);
-  if (s.platform) p.set("platform", s.platform);
-  if (s.label) p.set("label", s.label);
-  return `/feeds/saved.xml?${p.toString()}`;
-}
 
 interface ManagerProps {
   open?: boolean;

--- a/apps/web/src/lib/saved-search-feed-url-lib.ts
+++ b/apps/web/src/lib/saved-search-feed-url-lib.ts
@@ -1,0 +1,22 @@
+// Pure `/feeds/saved.xml` URL builder for a saved search, split out of
+// saved-search-manager.tsx so the query-string assembly can be unit-tested
+// without React Router.
+
+import type { SavedSearch } from "@/lib/recents";
+
+/**
+ * Build the RSS feed URL for a saved search. Each of `q`, `category`, `trust`,
+ * `source`, `platform`, and `label` is appended as a query param only when it
+ * is a non-empty value, so empty filters are omitted. The params are
+ * URL-encoded via `URLSearchParams`.
+ */
+export function savedFeedUrl(s: SavedSearch): string {
+  const p = new URLSearchParams();
+  if (s.q) p.set("q", s.q);
+  if (s.category) p.set("category", s.category);
+  if (s.trust) p.set("trust", s.trust);
+  if (s.source) p.set("source", s.source);
+  if (s.platform) p.set("platform", s.platform);
+  if (s.label) p.set("label", s.label);
+  return `/feeds/saved.xml?${p.toString()}`;
+}

--- a/tests/saved-search-feed-url-lib.test.ts
+++ b/tests/saved-search-feed-url-lib.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import type { SavedSearch } from "../apps/web/src/lib/recents";
+import { savedFeedUrl } from "../apps/web/src/lib/saved-search-feed-url-lib";
+
+const search = (over: Partial<SavedSearch> = {}) =>
+  ({ q: "", ...over }) as SavedSearch;
+
+describe("savedFeedUrl", () => {
+  it("omits every empty filter, yielding a bare feed path", () => {
+    expect(savedFeedUrl(search())).toBe("/feeds/saved.xml?");
+  });
+
+  it("appends each provided filter as a query param", () => {
+    const url = savedFeedUrl(
+      search({
+        q: "mcp",
+        category: "mcp",
+        trust: "trusted",
+        source: "official",
+        platform: "claude-code",
+        label: "my feed",
+      }),
+    );
+    const params = new URL(`https://x.test${url}`).searchParams;
+    expect(params.get("q")).toBe("mcp");
+    expect(params.get("category")).toBe("mcp");
+    expect(params.get("trust")).toBe("trusted");
+    expect(params.get("source")).toBe("official");
+    expect(params.get("platform")).toBe("claude-code");
+    expect(params.get("label")).toBe("my feed");
+  });
+
+  it("includes only the non-empty filters", () => {
+    expect(savedFeedUrl(search({ q: "agents", category: "" }))).toBe(
+      "/feeds/saved.xml?q=agents",
+    );
+  });
+
+  it("URL-encodes values with spaces and reserved characters", () => {
+    const url = savedFeedUrl(search({ q: "a b & c" }));
+    expect(url).toContain("q=a+b+%26+c");
+  });
+});


### PR DESCRIPTION
## What

Moves the `/feeds/saved.xml` URL builder out of `saved-search-manager.tsx` into a pure module `apps/web/src/lib/saved-search-feed-url-lib.ts`:

- `savedFeedUrl(s)` — appends `q`, `category`, `trust`, `source`, `platform`, and `label` as query params only when non-empty (empty filters are omitted), URL-encoding via `URLSearchParams`.

The component imports the same helper. **No behavior change** — this makes the query-string assembly unit-testable without React Router, matching the existing `saved-search-nav-lib` / `saved-search-hash-lib` extractions.

## Tests

`tests/saved-search-feed-url-lib.test.ts`: bare path when all filters empty, all-filters-set, only-non-empty-included, and space/reserved-character encoding (4 cases).

```
pnpm exec vitest run tests/saved-search-feed-url-lib.test.ts   # 4 passed
pnpm exec prettier --check <changed files>                     # clean
```

Refs #556