### PR TITLE
refactor(web): extract pure entry-signals key builders into entry-signals-keys-lib

### DIFF
--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -7,6 +7,7 @@ import {
   ZERO_COMMUNITY,
   asCommunityCounts,
 } from "@/lib/entry-signals-counts-lib";
+import { communityTargetKey, entryKey } from "@/lib/entry-signals-keys-lib";
 import { cn } from "@/lib/utils";
 
 type SignalState = {
@@ -21,14 +22,6 @@ type SignalState = {
 
 const CLIENT_STORAGE_KEY = "hc:client-id";
 const COMMUNITY_STORAGE_PREFIX = "hc:community:";
-
-function entryKey(category: Category, slug: string) {
-  return `${category}:${slug}`;
-}
-
-function communityTargetKey(category: Category, slug: string) {
-  return `entry:${category}/${slug}`;
-}
 
 function getClientId() {
   if (typeof window === "undefined") return "";

--- a/apps/web/src/lib/entry-signals-keys-lib.ts
+++ b/apps/web/src/lib/entry-signals-keys-lib.ts
@@ -1,0 +1,19 @@
+// Pure key builders for the entry signals panel, split out of
+// entry-signals-panel.tsx so the localStorage and community-target key formats
+// can be unit-tested and reused without React.
+
+import type { Category } from "@/types/registry";
+
+/** Local key for an entry's cached signal state: `${category}:${slug}`. */
+export function entryKey(category: Category, slug: string) {
+  return `${category}:${slug}`;
+}
+
+/**
+ * Community-signals API target key for an entry: `entry:${category}/${slug}`.
+ * This is the shape the signals endpoints key their counts by, distinct from
+ * the local {@link entryKey} storage key.
+ */
+export function communityTargetKey(category: Category, slug: string) {
+  return `entry:${category}/${slug}`;
+}

--- a/tests/entry-signals-keys-lib.test.ts
+++ b/tests/entry-signals-keys-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import type { Category } from "../apps/web/src/types/registry";
+import {
+  communityTargetKey,
+  entryKey,
+} from "../apps/web/src/lib/entry-signals-keys-lib";
+
+describe("entryKey", () => {
+  it("joins category and slug with a colon", () => {
+    expect(entryKey("mcp" as Category, "opensearch")).toBe("mcp:opensearch");
+  });
+});
+
+describe("communityTargetKey", () => {
+  it("builds the entry: target namespace with a slash separator", () => {
+    expect(communityTargetKey("mcp" as Category, "opensearch")).toBe(
+      "entry:mcp/opensearch",
+    );
+  });
+
+  it("differs from the local entryKey for the same input", () => {
+    const category = "agents" as Category;
+    const slug = "reviewer";
+    expect(communityTargetKey(category, slug)).not.toBe(
+      entryKey(category, slug),
+    );
+  });
+});


### PR DESCRIPTION
## What

Moves the two pure key builders out of `entry-signals-panel.tsx` into `apps/web/src/lib/entry-signals-keys-lib.ts`:

- `entryKey(category, slug)` → `${category}:${slug}` — local key for an entry's cached signal state.
- `communityTargetKey(category, slug)` → `entry:${category}/${slug}` — the target namespace the community-signals endpoints key their counts by.

The component imports both. **No behavior change** — this makes the two distinct key formats unit-testable and reusable without React, and follows up the earlier `entry-signals-counts-lib` extraction from the same component.

## Tests

`tests/entry-signals-keys-lib.test.ts`: colon-joined local key, `entry:`-namespaced target key, and that the two formats differ for the same input (3 cases).

```
pnpm exec vitest run tests/entry-signals-keys-lib.test.ts   # 3 passed
pnpm exec prettier --check <changed files>                  # clean
```

Refs #556