### PR TITLE
docs(readme): embed the live Gittensor contributor-impact card

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@
   </tr>
 </table>
 
+## Gittensor Contributor Impact
+
+<p align="center">
+  <a href="https://gittensor.io/miners/repository?name=JSONbored/awesome-claude">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-light.svg">
+      <img src="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-light.svg" alt="Gittensor contributor impact" width="600">
+    </picture>
+  </a>
+</p>
+
+Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows/gittensor-impact.yml). Unofficial community project — contribution eligibility and rewards follow Gittensor's current rules.
+
 ## Explore The Directory
 
 <table>

--- a/scripts/generate-readme.mjs
+++ b/scripts/generate-readme.mjs
@@ -190,6 +190,20 @@ const readme = `<table>
   </tr>
 </table>
 
+## Gittensor Contributor Impact
+
+<p align="center">
+  <a href="https://gittensor.io/miners/repository?name=JSONbored/awesome-claude">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-light.svg">
+      <img src="https://raw.githubusercontent.com/JSONbored/awesome-claude/gittensor-impact-assets/gittensor-impact-light.svg" alt="Gittensor contributor impact" width="600">
+    </picture>
+  </a>
+</p>
+
+Refreshed weekly by [\`.github/workflows/gittensor-impact.yml\`](.github/workflows/gittensor-impact.yml). Unofficial community project — contribution eligibility and rewards follow Gittensor's current rules.
+
 ## Explore The Directory
 
 <table>


### PR DESCRIPTION
## Summary

Fast-follow to #4612 — the `gittensor-impact` workflow has now run successfully (after switching to branch-mode publishing to work around GitHub's new immutable-release restriction) and published `gittensor-impact-{dark,light}.svg` to the `gittensor-impact-assets` branch. Wires the actual rendered comparison card into `scripts/generate-readme.mjs` (regenerating `README.md`), alongside the small text badge already merged in #4612.

## Validation

- `npm run generate:readme` / `npm run validate:readme` — in sync
- `npx vitest run tests/readme-generation.test.ts` — 3 passed
- `git diff --check` clean