### PR TITLE
fix(ci): skip malformed impact PR dates

### DIFF
--- a/scripts/gittensor-impact-card.mjs
+++ b/scripts/gittensor-impact-card.mjs
@@ -62,7 +62,7 @@ function bucketWeekly(prs, now) {
 
   for (const pr of prs) {
     const t = new Date(pr.mergedAt);
-    if (t < bucketStart || t > now) continue;
+    if (Number.isNaN(t.getTime()) || t < bucketStart || t > now) continue;
     const idx = Math.min(WEEKS - 1, Math.floor((t - bucketStart) / weekMs));
     prBuckets[idx] += 1;
     locBuckets[idx] += (pr.additions || 0) + (pr.deletions || 0);


### PR DESCRIPTION
### Motivation
- Prevent the scheduled Gittensor impact-card renderer from crashing when external PR records contain missing or invalid `mergedAt` values that produce an invalid `Date` and a `NaN` bucket index.

### Description
- Add a validity check to `bucketWeekly()` that skips PRs where `new Date(pr.mergedAt)` is invalid by testing `Number.isNaN(t.getTime())` before computing the weekly bucket index.

### Testing
- Ran the renderer with a mocked API that includes invalid and missing `mergedAt` values using `node --input-type=module - "$tmpdir/invalid.svg" <<'NODE' ... NODE` and verified an SVG is written, ran `pnpm exec prettier --check scripts/gittensor-impact-card.mjs`, and ran `git diff --check`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dfad588b8832c84c0ab410785bdf6)