### PR TITLE
refactor(web): extract pure umami nav helpers into umami-nav-lib

### DIFF
--- a/apps/web/src/components/umami-tracker.tsx
+++ b/apps/web/src/components/umami-tracker.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 import { useRouterState } from "@tanstack/react-router";
 
+import { currentUrlPath, externalReferrer } from "@/lib/umami-nav-lib";
+
 type UmamiPayload = {
   website: string;
   screen: string;
@@ -35,19 +37,6 @@ type FirstPartyUmami = {
 const COLLECTOR_URL = "/u/api/send";
 const SENSITIVE_PAGEVIEW_PATHS = new Set(["/brief/approve"]);
 
-function currentUrlPath() {
-  return `${window.location.pathname}${window.location.search}`;
-}
-
-function externalReferrer() {
-  if (!document.referrer) return "";
-  try {
-    return new URL(document.referrer).origin === window.location.origin ? "" : document.referrer;
-  } catch {
-    return "";
-  }
-}
-
 export function isAllowedUmamiHost(hostname: string, allowedHosts: readonly string[]) {
   if (allowedHosts.length === 0) return true;
   const normalized = hostname.toLowerCase();
@@ -66,7 +55,7 @@ export function buildUmamiPayload(
     language: navigator.language,
     title: document.title,
     hostname: window.location.hostname,
-    url: currentUrlPath(),
+    url: currentUrlPath(window.location),
     referrer,
     ...(event ? { name: event } : {}),
     ...(data ? { data } : {}),
@@ -161,9 +150,10 @@ export function UmamiTracker({
       return;
     }
 
-    const current = currentUrlPath();
+    const current = currentUrlPath(window.location);
     if (previousUrlRef.current === current) return;
-    referrerRef.current = previousUrlRef.current || externalReferrer();
+    referrerRef.current =
+      previousUrlRef.current || externalReferrer(document.referrer, window.location.origin);
     previousUrlRef.current = current;
     window.umami?.track();
     referrerRef.current = current;

--- a/apps/web/src/lib/umami-nav-lib.ts
+++ b/apps/web/src/lib/umami-nav-lib.ts
@@ -1,0 +1,22 @@
+// Pure navigation helpers for the umami tracker, split out of umami-tracker.tsx
+// so the URL/referrer derivation can be unit-tested without a browser. The
+// caller supplies the location/referrer values.
+
+/** Path + query string of a location (no scheme/host). */
+export function currentUrlPath(location: { pathname: string; search: string }): string {
+  return `${location.pathname}${location.search}`;
+}
+
+/**
+ * The referrer to report, or "" when there is none, it is same-origin, or it is
+ * malformed. Only external referrers are attributed; `origin` is the current
+ * page origin to compare against.
+ */
+export function externalReferrer(referrer: string, origin: string): string {
+  if (!referrer) return "";
+  try {
+    return new URL(referrer).origin === origin ? "" : referrer;
+  } catch {
+    return "";
+  }
+}

--- a/tests/umami-nav-lib.test.ts
+++ b/tests/umami-nav-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  currentUrlPath,
+  externalReferrer,
+} from "../apps/web/src/lib/umami-nav-lib";
+
+describe("currentUrlPath", () => {
+  it("joins pathname and search", () => {
+    expect(currentUrlPath({ pathname: "/browse", search: "?q=mcp" })).toBe(
+      "/browse?q=mcp",
+    );
+  });
+
+  it("returns just the pathname when there is no query", () => {
+    expect(currentUrlPath({ pathname: "/entry/mcp/foo", search: "" })).toBe(
+      "/entry/mcp/foo",
+    );
+  });
+});
+
+describe("externalReferrer", () => {
+  const ORIGIN = "https://heyclaude.com";
+
+  it("returns '' when there is no referrer", () => {
+    expect(externalReferrer("", ORIGIN)).toBe("");
+  });
+
+  it("returns '' for a same-origin referrer", () => {
+    expect(externalReferrer("https://heyclaude.com/browse", ORIGIN)).toBe("");
+  });
+
+  it("returns the referrer for an external origin", () => {
+    expect(externalReferrer("https://news.ycombinator.com/", ORIGIN)).toBe(
+      "https://news.ycombinator.com/",
+    );
+  });
+
+  it("returns '' for a malformed referrer", () => {
+    expect(externalReferrer("not a url", ORIGIN)).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

`currentUrlPath` and `externalReferrer` read `window`/`document` directly, so they could not be unit-tested. This extracts them to a new `apps/web/src/lib/umami-nav-lib.ts` with the location/referrer/origin injected; the tracker passes `window.location`, `document.referrer`, and `window.location.origin`.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `UmamiTracker` / `buildUmamiPayload` call the helpers with injected browser values.
- Expected behavior: `currentUrlPath` → `pathname + search`; `externalReferrer` returns the referrer only when it is a valid, external origin, else `""`. Identical to the previous inline logic.
- Important edge cases or invariants: same-origin and malformed referrers both yield `""`; the helpers no longer touch globals.
- Backward compatibility notes: fully backward compatible — both were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — analytics payload derivation only.
- Focused tests: added `tests/umami-nav-lib.test.ts` (6 tests).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/umami-nav-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that removes hidden `window`/`document` dependencies and adds unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue).
