### PR TITLE
refactor(web): extract pure isFeedCurrent into feed-freshness-lib

### DIFF
--- a/apps/web/src/lib/feed-freshness-lib.ts
+++ b/apps/web/src/lib/feed-freshness-lib.ts
@@ -1,0 +1,19 @@
+// Pure feed-freshness check, split out of feeds.ts so the age threshold can be
+// unit-tested with an injected `now` instead of the wall clock.
+
+const DEFAULT_FRESHNESS_DAYS = 30;
+
+/**
+ * Whether a feed's latest item is still "current": its `latest` timestamp is
+ * within `freshnessDays` of `now` (epoch ms). A missing/empty `latest` is not
+ * current.
+ */
+export function isFeedCurrent(
+  latest: string | null,
+  now: number,
+  freshnessDays = DEFAULT_FRESHNESS_DAYS,
+): boolean {
+  if (!latest) return false;
+  const ageMs = now - new Date(latest).getTime();
+  return ageMs <= freshnessDays * 24 * 60 * 60 * 1000;
+}

--- a/apps/web/src/lib/feeds.ts
+++ b/apps/web/src/lib/feeds.ts
@@ -11,6 +11,7 @@
  * derived from the body bytes is stable across requests. The dispatcher helper
  * `respondFeed` handles `If-None-Match` and emits cache headers.
  */
+import { isFeedCurrent } from "@/lib/feed-freshness-lib";
 import { getGrowthSurfaces } from "@/lib/growth-surfaces";
 import { ifNoneMatchMatches } from "@/lib/http-cache";
 import { CATEGORIES } from "@/types/registry";
@@ -115,14 +116,6 @@ export interface FeedHealth {
   isCurrent: boolean;
 }
 
-const FRESHNESS_DAYS = 30;
-
-function isCurrent(latest: string | null): boolean {
-  if (!latest) return false;
-  const ageMs = Date.now() - new Date(latest).getTime();
-  return ageMs <= FRESHNESS_DAYS * 24 * 60 * 60 * 1000;
-}
-
 async function healthFor(
   id: string,
   title: string,
@@ -139,7 +132,7 @@ async function healthFor(
     latestItemAt: latest,
     lastBuilt: latest ?? new Date(0).toISOString(),
     etag: await etagFor(body),
-    isCurrent: isCurrent(latest),
+    isCurrent: isFeedCurrent(latest, Date.now()),
   };
 }
 

--- a/tests/feed-freshness-lib.test.ts
+++ b/tests/feed-freshness-lib.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { isFeedCurrent } from "../apps/web/src/lib/feed-freshness-lib";
+
+const NOW = Date.parse("2026-07-07T12:00:00.000Z");
+const DAY = 24 * 60 * 60 * 1000;
+
+describe("isFeedCurrent", () => {
+  it("is not current when there is no latest timestamp", () => {
+    expect(isFeedCurrent(null, NOW)).toBe(false);
+    expect(isFeedCurrent("", NOW)).toBe(false);
+  });
+
+  it("is current within the default 30-day window", () => {
+    expect(isFeedCurrent(new Date(NOW - DAY).toISOString(), NOW)).toBe(true);
+    expect(isFeedCurrent(new Date(NOW - 30 * DAY).toISOString(), NOW)).toBe(
+      true,
+    );
+  });
+
+  it("is not current past the 30-day window", () => {
+    expect(isFeedCurrent(new Date(NOW - 31 * DAY).toISOString(), NOW)).toBe(
+      false,
+    );
+  });
+
+  it("honors a custom freshnessDays threshold", () => {
+    const sevenDaysAgo = new Date(NOW - 8 * DAY).toISOString();
+    expect(isFeedCurrent(sevenDaysAgo, NOW, 7)).toBe(false);
+    expect(isFeedCurrent(sevenDaysAgo, NOW, 30)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

`feeds.ts` computed feed freshness with a local `isCurrent` that read `Date.now()` internally, so it could not be unit-tested. This extracts it to a new `apps/web/src/lib/feed-freshness-lib.ts` as `isFeedCurrent(latest, now, freshnessDays = 30)` with `now` injected; the health builder passes `Date.now()`.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `allFeedHealth`/`healthFor` set `isCurrent` via `isFeedCurrent(latest, Date.now())`.
- Expected behavior: not current when `latest` is missing; current when within `freshnessDays` (default 30, inclusive of the boundary) of `now`; not current beyond it. Identical to the previous inline `isCurrent`.
- Important edge cases or invariants: the 30-day boundary is inclusive (`<=`); the threshold is now a parameter (default 30) rather than a module constant.
- Backward compatibility notes: fully backward compatible — `isCurrent`/`FRESHNESS_DAYS` were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — feed-health metadata only.
- Focused tests: added `tests/feed-freshness-lib.test.ts` (4 tests).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/feed-freshness-lib.test.ts` → 4/4 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that removes a hidden `Date.now()` dependency and adds unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue).
