### PR TITLE
refactor(web): extract peek-hint dismissed-state into peek-hint-lib

### DIFF
--- a/apps/web/src/components/peek-hint.tsx
+++ b/apps/web/src/components/peek-hint.tsx
@@ -1,27 +1,8 @@
 import * as React from "react";
 import { X } from "lucide-react";
 import { Kbd } from "@/components/badges";
+import { dismissPeekHint, peekHintDismissed } from "@/lib/peek-hint-lib";
 import { cn } from "@/lib/utils";
-
-const HINT_KEY = "hc.hint.peek.v1";
-
-function alreadyDismissed(): boolean {
-  if (typeof window === "undefined") return true;
-  try {
-    return window.localStorage.getItem(HINT_KEY) === "1";
-  } catch {
-    return true;
-  }
-}
-
-function dismiss() {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(HINT_KEY, "1");
-  } catch {
-    /* noop */
-  }
-}
 
 /**
  * One-time coach mark teaching the global `P` shortcut. Renders inside the
@@ -34,7 +15,7 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
 
   // Defer the eligibility check to the client (avoid SSR/hydration mismatch).
   React.useEffect(() => {
-    setEligible(!alreadyDismissed());
+    setEligible(!peekHintDismissed(window.localStorage));
   }, []);
 
   React.useEffect(() => {
@@ -48,13 +29,13 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
     const hideT = window.setTimeout(() => {
       setVisible(false);
       setEligible(false);
-      dismiss();
+      dismissPeekHint(window.localStorage);
     }, 8000);
     const onKey = (e: KeyboardEvent) => {
       if (e.key.toLowerCase() === "p" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         setVisible(false);
         setEligible(false);
-        dismiss();
+        dismissPeekHint(window.localStorage);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -85,7 +66,7 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
           e.stopPropagation();
           setVisible(false);
           setEligible(false);
-          dismiss();
+          dismissPeekHint(window.localStorage);
         }}
         aria-label="Dismiss peek shortcut hint"
         className="inline-flex h-4 w-4 items-center justify-center rounded text-ink-subtle hover:text-ink"

--- a/apps/web/src/lib/peek-hint-lib.ts
+++ b/apps/web/src/lib/peek-hint-lib.ts
@@ -1,0 +1,31 @@
+// Pure persistence helpers for the peek-hint coach mark, split out of
+// peek-hint.tsx so the dismissed-state logic can be unit-tested with a fake
+// storage instead of the real `window.localStorage`.
+
+export const PEEK_HINT_KEY = "hc.hint.peek.v1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Whether the peek hint has already been dismissed. Missing storage, or storage
+ * that throws (e.g. blocked in private mode), is treated as dismissed so the
+ * one-time hint stays hidden rather than reappearing.
+ */
+export function peekHintDismissed(storage: StorageLike | null | undefined): boolean {
+  if (!storage) return true;
+  try {
+    return storage.getItem(PEEK_HINT_KEY) === "1";
+  } catch {
+    return true;
+  }
+}
+
+/** Record that the peek hint was dismissed. No-op on missing/throwing storage. */
+export function dismissPeekHint(storage: StorageLike | null | undefined): void {
+  if (!storage) return;
+  try {
+    storage.setItem(PEEK_HINT_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}

--- a/tests/peek-hint-lib.test.ts
+++ b/tests/peek-hint-lib.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PEEK_HINT_KEY,
+  dismissPeekHint,
+  peekHintDismissed,
+} from "../apps/web/src/lib/peek-hint-lib";
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+describe("peekHintDismissed", () => {
+  it("is dismissed when there is no storage", () => {
+    expect(peekHintDismissed(null)).toBe(true);
+    expect(peekHintDismissed(undefined)).toBe(true);
+  });
+
+  it("reflects the stored flag", () => {
+    expect(peekHintDismissed(fakeStorage({ [PEEK_HINT_KEY]: "1" }))).toBe(true);
+    expect(peekHintDismissed(fakeStorage())).toBe(false);
+    expect(peekHintDismissed(fakeStorage({ [PEEK_HINT_KEY]: "0" }))).toBe(
+      false,
+    );
+  });
+
+  it("treats a throwing storage as dismissed", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {},
+    };
+    expect(peekHintDismissed(throwing)).toBe(true);
+  });
+});
+
+describe("dismissPeekHint", () => {
+  it("persists the dismissed flag", () => {
+    const storage = fakeStorage();
+    dismissPeekHint(storage);
+    expect(storage._map.get(PEEK_HINT_KEY)).toBe("1");
+    expect(peekHintDismissed(storage)).toBe(true);
+  });
+
+  it("is a no-op on missing storage", () => {
+    expect(() => dismissPeekHint(null)).not.toThrow();
+  });
+
+  it("swallows a throwing storage", () => {
+    const throwing = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(() => dismissPeekHint(throwing)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The peek-hint coach mark read/wrote `window.localStorage` inline, so its dismissed-state logic could not be unit-tested. This extracts it to a new `apps/web/src/lib/peek-hint-lib.ts` as `peekHintDismissed(storage)` / `dismissPeekHint(storage)` with the storage injected; the component passes `window.localStorage` at its (client-only) effect/handler call sites.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `PeekHint` reads dismissed state and persists dismissal via the new lib.
- Expected behavior: dismissed when storage is missing or throws (hint stays hidden); reflects the `"1"` flag otherwise; writes are best-effort. Identical to the previous inline logic.
- Important edge cases or invariants: all four call sites run in client-only effects/handlers, so `window.localStorage` is always defined there; the lib still tolerates null/throwing storage defensively.
- Backward compatibility notes: fully backward compatible — the storage key (`hc.hint.peek.v1`) is unchanged, so existing dismissals persist.
- Screenshots for frontend/page/UI changes: `No visual impact` — same one-time-hint behavior.
- Focused tests: added `tests/peek-hint-lib.test.ts` (6 tests) with a fake storage.

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/peek-hint-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that isolates the localStorage side effect behind an injected storage and adds unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue).
