### PR TITLE
refactor(web): extract entry-signals localStorage layer into a lib

### DIFF
--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -7,6 +7,7 @@ import {
   ZERO_COMMUNITY,
   asCommunityCounts,
 } from "@/lib/entry-signals-counts-lib";
+import { defaultLocalStorage } from "@/lib/dossier-prefs-lib";
 import { communityTargetKey, entryKey } from "@/lib/entry-signals-keys-lib";
 import {
   getClientId,
@@ -50,11 +51,11 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
 
   React.useEffect(() => {
     let cancelled = false;
-    const clientId = getClientId(window.localStorage);
+    const clientId = getClientId(defaultLocalStorage());
     setState((current) => ({
       ...current,
       loading: true,
-      activeCommunity: readActiveCommunity(window.localStorage, targetKey),
+      activeCommunity: readActiveCommunity(defaultLocalStorage(), targetKey),
     }));
 
     Promise.allSettled([
@@ -97,7 +98,7 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   }, [key, targetKey]);
 
   const toggleVote = async () => {
-    const clientId = getClientId(window.localStorage);
+    const clientId = getClientId(defaultLocalStorage());
     const nextVote = !state.voted;
     setState((current) => ({
       ...current,
@@ -127,10 +128,10 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   };
 
   const toggleCommunity = async (signalType: keyof CommunityCounts) => {
-    const clientId = getClientId(window.localStorage);
+    const clientId = getClientId(defaultLocalStorage());
     const active = !state.activeCommunity[signalType];
     const nextActive = { ...state.activeCommunity, [signalType]: active };
-    writeActiveCommunity(window.localStorage, targetKey, nextActive);
+    writeActiveCommunity(defaultLocalStorage(), targetKey, nextActive);
     setState((current) => ({
       ...current,
       activeCommunity: nextActive,
@@ -155,7 +156,7 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
       }));
     } catch {
       const rolledBack = { ...state.activeCommunity };
-      writeActiveCommunity(window.localStorage, targetKey, rolledBack);
+      writeActiveCommunity(defaultLocalStorage(), targetKey, rolledBack);
       setState((current) => ({
         ...current,
         communityAvailable: false,

--- a/apps/web/src/components/entry-signals-panel.tsx
+++ b/apps/web/src/components/entry-signals-panel.tsx
@@ -8,6 +8,11 @@ import {
   asCommunityCounts,
 } from "@/lib/entry-signals-counts-lib";
 import { communityTargetKey, entryKey } from "@/lib/entry-signals-keys-lib";
+import {
+  getClientId,
+  readActiveCommunity,
+  writeActiveCommunity,
+} from "@/lib/entry-signals-storage-lib";
 import { cn } from "@/lib/utils";
 
 type SignalState = {
@@ -19,43 +24,6 @@ type SignalState = {
   community: CommunityCounts;
   activeCommunity: Partial<Record<keyof CommunityCounts, boolean>>;
 };
-
-const CLIENT_STORAGE_KEY = "hc:client-id";
-const COMMUNITY_STORAGE_PREFIX = "hc:community:";
-
-function getClientId() {
-  if (typeof window === "undefined") return "";
-  const existing = window.localStorage.getItem(CLIENT_STORAGE_KEY);
-  if (existing && /^[a-zA-Z0-9_-]{16,96}$/.test(existing)) return existing;
-
-  const generated =
-    typeof crypto !== "undefined" && "randomUUID" in crypto
-      ? `hc-${crypto.randomUUID()}`
-      : `hc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 18)}`;
-  window.localStorage.setItem(CLIENT_STORAGE_KEY, generated);
-  return generated;
-}
-
-function readActiveCommunity(targetKey: string): SignalState["activeCommunity"] {
-  if (typeof window === "undefined") return {};
-  try {
-    const raw = window.localStorage.getItem(`${COMMUNITY_STORAGE_PREFIX}${targetKey}`);
-    if (!raw) return {};
-    const parsed = JSON.parse(raw) as Record<string, unknown>;
-    return {
-      used: parsed.used === true,
-      works: parsed.works === true,
-      broken: parsed.broken === true,
-    };
-  } catch {
-    return {};
-  }
-}
-
-function writeActiveCommunity(targetKey: string, active: SignalState["activeCommunity"]) {
-  if (typeof window === "undefined") return;
-  window.localStorage.setItem(`${COMMUNITY_STORAGE_PREFIX}${targetKey}`, JSON.stringify(active));
-}
 
 async function postJson(path: string, payload: unknown) {
   const response = await fetch(path, {
@@ -82,11 +50,11 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
 
   React.useEffect(() => {
     let cancelled = false;
-    const clientId = getClientId();
+    const clientId = getClientId(window.localStorage);
     setState((current) => ({
       ...current,
       loading: true,
-      activeCommunity: readActiveCommunity(targetKey),
+      activeCommunity: readActiveCommunity(window.localStorage, targetKey),
     }));
 
     Promise.allSettled([
@@ -129,7 +97,7 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   }, [key, targetKey]);
 
   const toggleVote = async () => {
-    const clientId = getClientId();
+    const clientId = getClientId(window.localStorage);
     const nextVote = !state.voted;
     setState((current) => ({
       ...current,
@@ -159,10 +127,10 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
   };
 
   const toggleCommunity = async (signalType: keyof CommunityCounts) => {
-    const clientId = getClientId();
+    const clientId = getClientId(window.localStorage);
     const active = !state.activeCommunity[signalType];
     const nextActive = { ...state.activeCommunity, [signalType]: active };
-    writeActiveCommunity(targetKey, nextActive);
+    writeActiveCommunity(window.localStorage, targetKey, nextActive);
     setState((current) => ({
       ...current,
       activeCommunity: nextActive,
@@ -187,7 +155,7 @@ export function EntrySignalsPanel({ category, slug }: { category: Category; slug
       }));
     } catch {
       const rolledBack = { ...state.activeCommunity };
-      writeActiveCommunity(targetKey, rolledBack);
+      writeActiveCommunity(window.localStorage, targetKey, rolledBack);
       setState((current) => ({
         ...current,
         communityAvailable: false,

--- a/apps/web/src/lib/entry-signals-storage-lib.ts
+++ b/apps/web/src/lib/entry-signals-storage-lib.ts
@@ -1,0 +1,68 @@
+// Pure localStorage layer for the entry-signals panel, split out of
+// entry-signals-panel.tsx so the client-id and active-community persistence can
+// be unit-tested with a fake storage and an injected id generator.
+
+import type { CommunityCounts } from "@/lib/entry-signals-counts-lib";
+
+const CLIENT_STORAGE_KEY = "hc:client-id";
+const COMMUNITY_STORAGE_PREFIX = "hc:community:";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+/** The per-signal-kind flags a user has toggled locally. */
+export type ActiveCommunity = Partial<Record<keyof CommunityCounts, boolean>>;
+
+/** Default client-id generator: `crypto.randomUUID` when available, else a
+ *  time+random fallback. Both are prefixed `hc-`. */
+export function defaultClientId(): string {
+  return typeof crypto !== "undefined" && "randomUUID" in crypto
+    ? `hc-${crypto.randomUUID()}`
+    : `hc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 18)}`;
+}
+
+/**
+ * Read the stable per-client id from storage, or generate + persist a new one.
+ * A stored value is reused only when it matches the expected id shape. Returns
+ * "" when there is no storage.
+ */
+export function getClientId(
+  storage: StorageLike | null | undefined,
+  generateId: () => string = defaultClientId,
+): string {
+  if (!storage) return "";
+  const existing = storage.getItem(CLIENT_STORAGE_KEY);
+  if (existing && /^[a-zA-Z0-9_-]{16,96}$/.test(existing)) return existing;
+  const generated = generateId();
+  storage.setItem(CLIENT_STORAGE_KEY, generated);
+  return generated;
+}
+
+/** Read the locally-remembered active community flags for a target. */
+export function readActiveCommunity(
+  storage: StorageLike | null | undefined,
+  targetKey: string,
+): ActiveCommunity {
+  if (!storage) return {};
+  try {
+    const raw = storage.getItem(`${COMMUNITY_STORAGE_PREFIX}${targetKey}`);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return {
+      used: parsed.used === true,
+      works: parsed.works === true,
+      broken: parsed.broken === true,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the active community flags for a target. No-op without storage. */
+export function writeActiveCommunity(
+  storage: StorageLike | null | undefined,
+  targetKey: string,
+  active: ActiveCommunity,
+): void {
+  if (!storage) return;
+  storage.setItem(`${COMMUNITY_STORAGE_PREFIX}${targetKey}`, JSON.stringify(active));
+}

--- a/tests/entry-signals-storage-lib.test.ts
+++ b/tests/entry-signals-storage-lib.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultClientId,
+  getClientId,
+  readActiveCommunity,
+  writeActiveCommunity,
+} from "../apps/web/src/lib/entry-signals-storage-lib";
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+const CLIENT_KEY = "hc:client-id";
+const VALID_ID = "hc-0123456789abcdef";
+
+describe("getClientId", () => {
+  it("returns '' without storage", () => {
+    expect(getClientId(null, () => VALID_ID)).toBe("");
+  });
+
+  it("generates and persists a new id when none is stored", () => {
+    const storage = fakeStorage();
+    expect(getClientId(storage, () => VALID_ID)).toBe(VALID_ID);
+    expect(storage._map.get(CLIENT_KEY)).toBe(VALID_ID);
+  });
+
+  it("reuses a stored id that matches the expected shape", () => {
+    const storage = fakeStorage({ [CLIENT_KEY]: VALID_ID });
+    expect(getClientId(storage, () => "hc-REGENERATED-000000")).toBe(VALID_ID);
+  });
+
+  it("regenerates when the stored id is malformed", () => {
+    const storage = fakeStorage({ [CLIENT_KEY]: "short" });
+    expect(getClientId(storage, () => VALID_ID)).toBe(VALID_ID);
+    expect(storage._map.get(CLIENT_KEY)).toBe(VALID_ID);
+  });
+});
+
+describe("defaultClientId", () => {
+  it("produces an id of the expected shape", () => {
+    expect(defaultClientId()).toMatch(/^hc-[a-zA-Z0-9_-]{13,}$/);
+  });
+});
+
+describe("readActiveCommunity / writeActiveCommunity", () => {
+  it("returns {} without storage or when nothing is stored", () => {
+    expect(readActiveCommunity(null, "entry:mcp/foo")).toEqual({});
+    expect(readActiveCommunity(fakeStorage(), "entry:mcp/foo")).toEqual({});
+  });
+
+  it("normalizes the stored flags to booleans", () => {
+    const storage = fakeStorage({
+      "hc:community:entry:mcp/foo": JSON.stringify({ used: true, works: 1 }),
+    });
+    expect(readActiveCommunity(storage, "entry:mcp/foo")).toEqual({
+      used: true,
+      works: false,
+      broken: false,
+    });
+  });
+
+  it("returns {} for malformed stored JSON", () => {
+    const storage = fakeStorage({ "hc:community:entry:mcp/foo": "{not json" });
+    expect(readActiveCommunity(storage, "entry:mcp/foo")).toEqual({});
+  });
+
+  it("round-trips through writeActiveCommunity", () => {
+    const storage = fakeStorage();
+    writeActiveCommunity(storage, "entry:mcp/foo", {
+      used: true,
+      broken: true,
+    });
+    expect(readActiveCommunity(storage, "entry:mcp/foo")).toEqual({
+      used: true,
+      works: false,
+      broken: true,
+    });
+  });
+
+  it("is a no-op on write without storage", () => {
+    expect(() =>
+      writeActiveCommunity(null, "entry:mcp/foo", { used: true }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The entry-signals panel read/wrote `window.localStorage` (and generated a client id via `crypto`) inline, so none of it could be unit-tested. This extracts the client-id and active-community persistence into a new `apps/web/src/lib/entry-signals-storage-lib.ts` (`getClientId`, `defaultClientId`, `readActiveCommunity`, `writeActiveCommunity`) with the storage and id generator injected; the component passes `window.localStorage` at its client-only effect/handler call sites.

**No behavior change** — storage keys, the id-shape validation, and the boolean-normalizing parse are all preserved.

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `EntrySignalsPanel` reads its client id and active-community flags, and persists toggles, via the new lib.
- Expected behavior: `getClientId` reuses a stored id matching `^[a-zA-Z0-9_-]{16,96}$`, else generates + persists one; `readActiveCommunity` normalizes stored flags to booleans (and returns `{}` on missing/malformed/absent storage); `writeActiveCommunity` persists JSON. Identical to the previous inline logic.
- Important edge cases or invariants: all call sites run in client-only effects/handlers, so `window.localStorage` is defined; the lib still tolerates null/malformed input defensively; the `crypto.randomUUID` → time+random fallback is preserved in `defaultClientId`.
- Backward compatibility notes: fully backward compatible — storage keys (`hc:client-id`, `hc:community:*`) are unchanged, so existing client ids and toggles persist.
- Screenshots for frontend/page/UI changes: `No visual impact` — persistence layer only.
- Focused tests: added `tests/entry-signals-storage-lib.test.ts` (10 tests) with a fake storage and injected id generator.

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/entry-signals-storage-lib.test.ts` → 10/10 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that isolates the localStorage/crypto side effects behind injected dependencies and adds unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue). Complements the already-extracted `entry-signals-keys-lib` / `entry-signals-counts-lib`.
