### PR TITLE
refactor(web): extract pure distBarWidths into data-report-bars-lib

### DIFF
--- a/apps/web/src/components/data-report.tsx
+++ b/apps/web/src/components/data-report.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { BadgeCheck } from "lucide-react";
 
 import { CountUp } from "@/components/count-up";
+import { distBarWidths } from "@/lib/data-report-bars-lib";
 
 /** A single labelled distribution row: a count and its share of the relevant total. */
 export interface DistRow {
@@ -65,20 +66,17 @@ export function DataSection({
 
 /** Horizontal-bar distribution table; bars are scaled to the largest row. */
 export function DistTable({ rows }: { rows: DistRow[] }) {
-  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  const widths = distBarWidths(rows);
   return (
     <div className="overflow-hidden rounded-xl border border-border bg-surface">
-      {rows.map((row) => (
+      {rows.map((row, i) => (
         <div
           key={row.label}
           className="grid grid-cols-[160px_1fr_56px_56px] items-center gap-4 border-b border-border px-5 py-3 last:border-0"
         >
           <div className="font-display text-sm font-semibold text-ink">{row.label}</div>
           <div className="h-2 overflow-hidden rounded-full bg-surface-2">
-            <div
-              className="h-full bg-ink"
-              style={{ width: `${max ? Math.round((row.count / max) * 100) : 0}%` }}
-            />
+            <div className="h-full bg-ink" style={{ width: `${widths[i]}%` }} />
           </div>
           <div className="text-right font-mono text-xs tabular-nums text-ink">{row.count}</div>
           <div className="text-right font-mono text-xs tabular-nums text-ink-subtle">

--- a/apps/web/src/lib/data-report-bars-lib.ts
+++ b/apps/web/src/lib/data-report-bars-lib.ts
@@ -1,0 +1,15 @@
+// Pure bar-width computation for a data report's distribution table, split out
+// of data-report.tsx so the max-scaling can be unit-tested without rendering.
+
+import type { DistRow } from "@/components/data-report";
+
+/**
+ * Percentage widths (0–100) for a distribution table's bars, one per row, each
+ * scaled to the largest row's `count`. Every row resolves to 0 when the maximum
+ * count is 0 (including an empty list), and each width is rounded to a whole
+ * number.
+ */
+export function distBarWidths(rows: readonly DistRow[]): number[] {
+  const max = rows.reduce((m, r) => Math.max(m, r.count), 0);
+  return rows.map((r) => (max ? Math.round((r.count / max) * 100) : 0));
+}

--- a/tests/data-report-bars-lib.test.ts
+++ b/tests/data-report-bars-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import type { DistRow } from "../apps/web/src/components/data-report";
+import { distBarWidths } from "../apps/web/src/lib/data-report-bars-lib";
+
+const row = (label: string, count: number): DistRow => ({
+  label,
+  count,
+  pct: 0,
+});
+
+describe("distBarWidths", () => {
+  it("returns an empty array for no rows", () => {
+    expect(distBarWidths([])).toEqual([]);
+  });
+
+  it("scales every row to the largest count", () => {
+    expect(distBarWidths([row("a", 10), row("b", 5), row("c", 1)])).toEqual([
+      100, 50, 10,
+    ]);
+  });
+
+  it("gives the max row 100%", () => {
+    expect(distBarWidths([row("a", 3), row("b", 9)])).toEqual([33, 100]);
+  });
+
+  it("returns 0 for every row when all counts are 0", () => {
+    expect(distBarWidths([row("a", 0), row("b", 0)])).toEqual([0, 0]);
+  });
+
+  it("rounds each width to a whole number", () => {
+    // 1/3 => 33.33.. rounds to 33, 2/3 => 66.66.. rounds to 67
+    expect(distBarWidths([row("a", 1), row("b", 2), row("c", 3)])).toEqual([
+      33, 67, 100,
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Moves the `DistTable` bar-width computation out of `data-report.tsx` into a pure module `apps/web/src/lib/data-report-bars-lib.ts`:

- `distBarWidths(rows)` — returns the percentage width (0–100) for each distribution row, scaled to the largest row's `count`. Every row resolves to 0 when the max count is 0 (including an empty list), each width rounded to a whole number.

`DistTable` maps the returned widths by index. **No behavior change** — this makes the max-scaling unit-testable without rendering, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/data-report-bars-lib.test.ts`: empty list, scaling to the largest count, max→100%, all-zero→all-0, and whole-number rounding (5 cases).

```
pnpm exec vitest run tests/data-report-bars-lib.test.ts   # 5 passed
pnpm exec prettier --check <changed files>                # clean
```

Refs #556