### PR TITLE
refactor(web): extract peek-hint dismissed-state into peek-hint-lib

### DIFF
--- a/apps/web/src/components/peek-hint.tsx
+++ b/apps/web/src/components/peek-hint.tsx
@@ -1,27 +1,9 @@
 import * as React from "react";
 import { X } from "lucide-react";
 import { Kbd } from "@/components/badges";
+import { defaultLocalStorage } from "@/lib/dossier-prefs-lib";
+import { dismissPeekHint, peekHintDismissed } from "@/lib/peek-hint-lib";
 import { cn } from "@/lib/utils";
-
-const HINT_KEY = "hc.hint.peek.v1";
-
-function alreadyDismissed(): boolean {
-  if (typeof window === "undefined") return true;
-  try {
-    return window.localStorage.getItem(HINT_KEY) === "1";
-  } catch {
-    return true;
-  }
-}
-
-function dismiss() {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(HINT_KEY, "1");
-  } catch {
-    /* noop */
-  }
-}
 
 /**
  * One-time coach mark teaching the global `P` shortcut. Renders inside the
@@ -34,7 +16,7 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
 
   // Defer the eligibility check to the client (avoid SSR/hydration mismatch).
   React.useEffect(() => {
-    setEligible(!alreadyDismissed());
+    setEligible(!peekHintDismissed(defaultLocalStorage()));
   }, []);
 
   React.useEffect(() => {
@@ -48,13 +30,13 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
     const hideT = window.setTimeout(() => {
       setVisible(false);
       setEligible(false);
-      dismiss();
+      dismissPeekHint(defaultLocalStorage());
     }, 8000);
     const onKey = (e: KeyboardEvent) => {
       if (e.key.toLowerCase() === "p" && !e.metaKey && !e.ctrlKey && !e.altKey) {
         setVisible(false);
         setEligible(false);
-        dismiss();
+        dismissPeekHint(defaultLocalStorage());
       }
     };
     window.addEventListener("keydown", onKey);
@@ -85,7 +67,7 @@ export function PeekHint({ hovered, className }: { hovered: boolean; className?:
           e.stopPropagation();
           setVisible(false);
           setEligible(false);
-          dismiss();
+          dismissPeekHint(defaultLocalStorage());
         }}
         aria-label="Dismiss peek shortcut hint"
         className="inline-flex h-4 w-4 items-center justify-center rounded text-ink-subtle hover:text-ink"

--- a/apps/web/src/lib/peek-hint-lib.ts
+++ b/apps/web/src/lib/peek-hint-lib.ts
@@ -1,0 +1,31 @@
+// Pure persistence helpers for the peek-hint coach mark, split out of
+// peek-hint.tsx so the dismissed-state logic can be unit-tested with a fake
+// storage instead of the real `window.localStorage`.
+
+export const PEEK_HINT_KEY = "hc.hint.peek.v1";
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Whether the peek hint has already been dismissed. Missing storage, or storage
+ * that throws (e.g. blocked in private mode), is treated as dismissed so the
+ * one-time hint stays hidden rather than reappearing.
+ */
+export function peekHintDismissed(storage: StorageLike | null | undefined): boolean {
+  if (!storage) return true;
+  try {
+    return storage.getItem(PEEK_HINT_KEY) === "1";
+  } catch {
+    return true;
+  }
+}
+
+/** Record that the peek hint was dismissed. No-op on missing/throwing storage. */
+export function dismissPeekHint(storage: StorageLike | null | undefined): void {
+  if (!storage) return;
+  try {
+    storage.setItem(PEEK_HINT_KEY, "1");
+  } catch {
+    /* noop */
+  }
+}

--- a/tests/peek-hint-lib.test.ts
+++ b/tests/peek-hint-lib.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PEEK_HINT_KEY,
+  dismissPeekHint,
+  peekHintDismissed,
+} from "../apps/web/src/lib/peek-hint-lib";
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+describe("peekHintDismissed", () => {
+  it("is dismissed when there is no storage", () => {
+    expect(peekHintDismissed(null)).toBe(true);
+    expect(peekHintDismissed(undefined)).toBe(true);
+  });
+
+  it("reflects the stored flag", () => {
+    expect(peekHintDismissed(fakeStorage({ [PEEK_HINT_KEY]: "1" }))).toBe(true);
+    expect(peekHintDismissed(fakeStorage())).toBe(false);
+    expect(peekHintDismissed(fakeStorage({ [PEEK_HINT_KEY]: "0" }))).toBe(
+      false,
+    );
+  });
+
+  it("treats a throwing storage as dismissed", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {},
+    };
+    expect(peekHintDismissed(throwing)).toBe(true);
+  });
+});
+
+describe("dismissPeekHint", () => {
+  it("persists the dismissed flag", () => {
+    const storage = fakeStorage();
+    dismissPeekHint(storage);
+    expect(storage._map.get(PEEK_HINT_KEY)).toBe("1");
+    expect(peekHintDismissed(storage)).toBe(true);
+  });
+
+  it("is a no-op on missing storage", () => {
+    expect(() => dismissPeekHint(null)).not.toThrow();
+  });
+
+  it("swallows a throwing storage", () => {
+    const throwing = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("blocked");
+      },
+    };
+    expect(() => dismissPeekHint(throwing)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Re-does #4622 (auto-closed) with the review feedback resolved. Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The peek-hint coach mark read/wrote `window.localStorage` inline, so its dismissed-state logic could not be unit-tested. This extracts it to a new `apps/web/src/lib/peek-hint-lib.ts` as `peekHintDismissed(storage)` / `dismissPeekHint(storage)` with the storage injected.

**Review fix vs #4622:** the component now obtains storage via the existing `defaultLocalStorage()` safe getter (`dossier-prefs-lib`) rather than passing a bare `window.localStorage` argument. Reading `window.localStorage` can throw a `SecurityError` in sandboxed/storage-blocked contexts; evaluating it as a call argument would let that escape the effect/handler uncaught (the defect the AI reviewer flagged on #4622). `defaultLocalStorage` wraps the property access in try/catch and returns `null`, and the lib treats `null` as dismissed / no-op — preserving the original swallow-and-continue behavior end to end.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `PeekHint` reads/persists dismissal via the new lib, using `defaultLocalStorage()`.
- Expected behavior: dismissed when storage is missing, blocked (getter throws), or throwing on access; reflects the `"1"` flag otherwise; writes best-effort. Identical to the previous inline logic, including the SecurityError-tolerant path.
- Important edge cases or invariants: the `window.localStorage` getter access is wrapped by `defaultLocalStorage()` (returns null on throw), so no exception escapes the effect/handler; the lib additionally guards `getItem`/`setItem`.
- Backward compatibility notes: fully backward compatible — the storage key (`hc.hint.peek.v1`) is unchanged.
- Screenshots for frontend/page/UI changes: `No visual impact`.
- Focused tests: added `tests/peek-hint-lib.test.ts` (6 tests) with a fake storage.

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/peek-hint-lib.test.ts` → 6/6 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

Supersedes #4622, which was auto-closed for passing `window.localStorage` as a bare argument (getter-throw could escape uncaught). This version routes storage access through the repo's existing `defaultLocalStorage()` safe getter, so the SecurityError path is handled exactly as before the extraction.
