### PR TITLE
refactor(web): extract pure monogram initials and hue into monogram-lib

### DIFF
--- a/apps/web/src/components/monogram.tsx
+++ b/apps/web/src/components/monogram.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { monogramHue, monogramInitials } from "@/lib/monogram-lib";
 
 /** Deterministic citron-tinted gradient monogram avatar. */
 export function Monogram({
@@ -11,18 +12,10 @@ export function Monogram({
   size?: number;
   className?: string;
 }) {
-  const initials = React.useMemo(() => {
-    const parts = name.trim().split(/\s+/);
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
-  }, [name]);
+  const initials = React.useMemo(() => monogramInitials(name), [name]);
 
-  // Deterministic hue offset from the name
-  const hue = React.useMemo(() => {
-    let h = 0;
-    for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
-    return Math.abs(h % 60) - 30; // -30..+30 around citron (115)
-  }, [name]);
+  // Deterministic hue offset (−30..+30 around citron 115) from the name
+  const hue = React.useMemo(() => monogramHue(name), [name]);
 
   const bg = `linear-gradient(135deg, oklch(0.94 0.18 ${115 + hue}) 0%, oklch(0.88 0.12 ${115 + hue + 20}) 100%)`;
   const fontPx = Math.round(size * 0.38);

--- a/apps/web/src/lib/monogram-lib.ts
+++ b/apps/web/src/lib/monogram-lib.ts
@@ -1,0 +1,25 @@
+// Pure monogram derivations (initials and a deterministic hue), split out of
+// monogram.tsx so the name → initials/hue mapping can be unit-tested without
+// rendering.
+
+/**
+ * Uppercased initials for a monogram: the first two letters of a single-word
+ * name, or the first letters of the first and last words otherwise. Surrounding
+ * and repeated whitespace is collapsed first.
+ */
+export function monogramInitials(name: string): string {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+/**
+ * Deterministic hue offset in the range −30..+30 (applied around the citron
+ * base hue of 115) hashed from a name, so the same name always renders the same
+ * tint.
+ */
+export function monogramHue(name: string): number {
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h * 31 + name.charCodeAt(i)) | 0;
+  return Math.abs(h % 60) - 30;
+}

--- a/tests/monogram-lib.test.ts
+++ b/tests/monogram-lib.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  monogramHue,
+  monogramInitials,
+} from "../apps/web/src/lib/monogram-lib";
+
+describe("monogramInitials", () => {
+  it("uses the first two letters of a single-word name", () => {
+    expect(monogramInitials("Anthropic")).toBe("AN");
+  });
+
+  it("uses first + last word initials for a multi-word name", () => {
+    expect(monogramInitials("Model Context Protocol")).toBe("MP");
+  });
+
+  it("collapses surrounding and repeated whitespace", () => {
+    expect(monogramInitials("  John   Doe  ")).toBe("JD");
+  });
+
+  it("uppercases lowercase input", () => {
+    expect(monogramInitials("git")).toBe("GI");
+  });
+
+  it("handles a single character", () => {
+    expect(monogramInitials("x")).toBe("X");
+  });
+});
+
+describe("monogramHue", () => {
+  it("is deterministic for the same name", () => {
+    expect(monogramHue("Anthropic")).toBe(monogramHue("Anthropic"));
+  });
+
+  it("stays within the -30..30 range for varied inputs", () => {
+    for (const name of [
+      "",
+      "a",
+      "Anthropic",
+      "Model Context Protocol",
+      "🙂 emoji",
+      "12345",
+    ]) {
+      const hue = monogramHue(name);
+      expect(hue).toBeGreaterThanOrEqual(-30);
+      expect(hue).toBeLessThanOrEqual(30);
+    }
+  });
+
+  it("generally differs between unrelated names", () => {
+    expect(monogramHue("Anthropic")).not.toBe(monogramHue("OpenAI"));
+  });
+});


### PR DESCRIPTION
## What

Moves the two pure derivations out of `monogram.tsx` into `apps/web/src/lib/monogram-lib.ts`:

- `monogramInitials(name)` — uppercased initials: the first two letters of a single-word name, or the first letters of the first and last words otherwise (whitespace collapsed first).
- `monogramHue(name)` — deterministic hue offset in `−30..+30` (applied around the citron base hue 115), hashed from the name so the same name always renders the same tint.

The component memoizes calls to both. **No behavior change** — this makes the name → initials/hue mapping unit-testable without rendering, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/monogram-lib.test.ts`: single-word vs multi-word initials, whitespace collapsing, uppercasing, single char; hue determinism, `−30..30` range across varied/emoji/numeric inputs, and divergence between unrelated names (8 cases).

```
pnpm exec vitest run tests/monogram-lib.test.ts   # 8 passed
pnpm exec prettier --check <changed files>        # clean
```

Refs #556