### PR TITLE
refactor(web): move missingNoteWarnings into submission-preflight-lib

### DIFF
--- a/apps/web/src/lib/submission-preflight-lib.ts
+++ b/apps/web/src/lib/submission-preflight-lib.ts
@@ -1,8 +1,27 @@
 import { parseGitHubRepoUrl } from "@heyclaude/registry/source-repo";
 import { canonicalizeSourceUrl } from "@heyclaude/registry/source-url";
+import type { analyzeSubmissionDraftRisk } from "@heyclaude/registry/submission-risk";
 
 import type { DirectoryEntry } from "@/lib/content.server";
 import { siteConfig } from "@/lib/site";
+
+type SubmissionRisk = ReturnType<typeof analyzeSubmissionDraftRisk>;
+type ClassificationWarning = NonNullable<SubmissionRisk["classificationWarnings"]>[number];
+
+/**
+ * Pick out the "missing safety notes" and "missing privacy notes" classification
+ * warnings (if present) from a submission draft's risk analysis. Each is
+ * `undefined` when the corresponding warning was not raised.
+ */
+export function missingNoteWarnings(risk: SubmissionRisk): {
+  safety: ClassificationWarning | undefined;
+  privacy: ClassificationWarning | undefined;
+} {
+  const warnings = risk.classificationWarnings ?? [];
+  const safety = warnings.find((item) => item.id === "missing_safety_notes");
+  const privacy = warnings.find((item) => item.id === "missing_privacy_notes");
+  return { safety, privacy };
+}
 
 export const TOOL_LISTING_FORM_URL = "https://heyclau.de/tools/submit";
 

--- a/apps/web/src/lib/submission-preflight.ts
+++ b/apps/web/src/lib/submission-preflight.ts
@@ -6,18 +6,12 @@ import {
   buildPreflightIssues,
   buildSubmissionPrPreview,
   findDuplicateCandidates,
+  missingNoteWarnings,
   normalizePreflightError,
   normalizePreflightText,
   resolvePreflightRouteSuggestion,
   TOOL_LISTING_FORM_URL,
 } from "@/lib/submission-preflight-lib";
-
-function missingNoteWarnings(risk: ReturnType<typeof analyzeSubmissionDraftRisk>) {
-  const warnings = risk.classificationWarnings ?? [];
-  const safety = warnings.find((item) => item.id === "missing_safety_notes");
-  const privacy = warnings.find((item) => item.id === "missing_privacy_notes");
-  return { safety, privacy };
-}
 
 export async function buildSubmissionPreflight(fields: Record<string, unknown>) {
   const draft = buildSubmissionPrDraft({

--- a/tests/submission-preflight-lib.test.ts
+++ b/tests/submission-preflight-lib.test.ts
@@ -9,6 +9,7 @@ import {
   isSimilarSubmissionTitle,
   isToolsRouteError,
   looksLikeCommercialListing,
+  missingNoteWarnings,
   normalizePreflightError,
   normalizePreflightText,
   preflightBlocker,
@@ -448,6 +449,34 @@ describe("submission preflight routing helpers", () => {
     ).toMatchObject({
       targetPath: "",
       branchHint: "",
+    });
+  });
+});
+
+describe("missingNoteWarnings", () => {
+  const risk = (ids: string[]) =>
+    ({
+      classificationWarnings: ids.map((id) => ({ id })),
+    }) as unknown as Parameters<typeof missingNoteWarnings>[0];
+
+  it("surfaces both note warnings when present", () => {
+    const result = missingNoteWarnings(
+      risk(["missing_safety_notes", "missing_privacy_notes"]),
+    );
+    expect(result.safety?.id).toBe("missing_safety_notes");
+    expect(result.privacy?.id).toBe("missing_privacy_notes");
+  });
+
+  it("returns undefined for a note type that was not flagged", () => {
+    const result = missingNoteWarnings(risk(["missing_safety_notes"]));
+    expect(result.safety?.id).toBe("missing_safety_notes");
+    expect(result.privacy).toBeUndefined();
+  });
+
+  it("returns both undefined when there are no classification warnings", () => {
+    expect(missingNoteWarnings(risk([]))).toEqual({
+      safety: undefined,
+      privacy: undefined,
     });
   });
 });


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

`missingNoteWarnings` — which picks the missing-safety / missing-privacy classification warnings out of a submission draft's risk analysis — lived inline in the request-side `submission-preflight.ts` with no direct test. This moves it into the pure `submission-preflight-lib.ts` (its idiomatic home, next to the other preflight helpers) and imports it back.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `buildSubmissionPreflight` imports `missingNoteWarnings` from the lib instead of defining it locally.
- Expected behavior: returns `{ safety, privacy }`, each the matching `missing_safety_notes` / `missing_privacy_notes` classification warning or `undefined`. Identical to the previous inline implementation.
- Important edge cases or invariants: absent `classificationWarnings` yields `{ safety: undefined, privacy: undefined }`; the risk type is imported via `import type` so no runtime dependency is added.
- Backward compatibility notes: fully backward compatible — pure relocation of a module-private helper.
- Screenshots for frontend/page/UI changes: `No visual impact` — preflight logic only.
- Focused tests: extended `tests/submission-preflight-lib.test.ts` with a `missingNoteWarnings` block (3 tests): both warnings present, one flagged, and none.

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/submission-preflight-lib.test.ts` → 15/15 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor with no behavior change, matching merged extraction PRs #4551 and #4555 (no linked issue). It gives an inline preflight helper a home in the pure `submission-preflight-lib` and direct unit coverage.
