### PR TITLE
feat(web): add compare decision brief panel and scoring

### DIFF
--- a/apps/web/src/components/compare-decision-brief-panel.tsx
+++ b/apps/web/src/components/compare-decision-brief-panel.tsx
@@ -1,0 +1,162 @@
+import { AlertTriangle, CheckCircle2, Circle, Scale, ShieldAlert } from "lucide-react";
+import type { CompareDecisionBriefState, CompareBriefTone } from "@/lib/compare-decision-brief";
+import { cn } from "@/lib/utils";
+
+const TONE_BADGE: Record<CompareBriefTone, string> = {
+  ready: "border-trust-trusted/30 bg-trust-trusted/10 text-trust-trusted",
+  review: "border-accent/30 bg-accent/10 text-ink",
+  caution: "border-amber-500/30 bg-amber-500/10 text-amber-900",
+  blocked: "border-trust-blocked/30 bg-trust-blocked/10 text-trust-blocked",
+};
+
+const TONE_LABEL: Record<CompareBriefTone, string> = {
+  ready: "Ready",
+  review: "Review",
+  caution: "Caution",
+  blocked: "Blocked",
+};
+
+function ChecklistMark({ done }: { done: boolean }) {
+  return done ? (
+    <CheckCircle2 className="h-3.5 w-3.5 text-trust-trusted" aria-hidden />
+  ) : (
+    <Circle className="h-3.5 w-3.5 text-ink-subtle" aria-hidden />
+  );
+}
+
+export function CompareDecisionBriefPanel({
+  state,
+  className,
+  compact = false,
+}: {
+  state: CompareDecisionBriefState;
+  className?: string;
+  compact?: boolean;
+}) {
+  if (state.comparedCount === 0) return null;
+
+  return (
+    <section
+      aria-label="Decision brief"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Decision brief</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">
+            Ranked next-step guidance
+          </h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2.5 py-1 text-xs text-ink-muted">
+          <Scale className="h-3.5 w-3.5" aria-hidden />
+          {state.comparedCount} compared
+        </div>
+      </div>
+
+      {(state.hasDecisionDivergence || state.hasActionDivergence) && (
+        <div className="mt-3 rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs">
+          <div className="flex items-start gap-2">
+            <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-700" aria-hidden />
+            <div className="min-w-0">
+              <p className="text-amber-900">
+                Divergence detected
+                {state.divergingLabels.length > 0
+                  ? ` on ${state.divergingLabels.slice(0, 4).join(", ")}`
+                  : ""}
+                .
+              </p>
+              {state.hasActionDivergence ? (
+                <p className="mt-0.5 text-amber-800">
+                  Next-step actions differ between compared entries.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div
+        className={cn("mt-4 grid gap-3", compact ? "grid-cols-1" : "grid-cols-1 xl:grid-cols-2")}
+      >
+        {state.entryBriefs.map((brief) => (
+          <article
+            key={brief.entryRef}
+            className={cn(
+              "rounded-lg border border-border bg-background p-3",
+              brief.rank === 1 && "ring-1 ring-trust-trusted/30",
+            )}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
+                    #{brief.rank}
+                  </span>
+                  <h4 className="truncate text-sm font-semibold text-ink">{brief.title}</h4>
+                </div>
+                <p className="mt-1 text-xs text-ink-muted">{brief.headline}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                    TONE_BADGE[brief.tone],
+                  )}
+                >
+                  {TONE_LABEL[brief.tone]}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">Score {brief.score}</p>
+              </div>
+            </div>
+
+            <p className="mt-2 text-xs text-ink">{brief.recommendation}</p>
+            <p className="mt-1 text-[11px] text-ink-subtle">{brief.compareDeltaSummary}</p>
+
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {brief.reasons.map((reason) => (
+                <li
+                  key={reason}
+                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                >
+                  {reason}
+                </li>
+              ))}
+            </ul>
+
+            {!compact && (
+              <ul className="mt-3 space-y-1.5">
+                {brief.checklist.map((item) => (
+                  <li
+                    key={item.id}
+                    className="flex items-start justify-between gap-2 rounded-md border border-border/70 px-2 py-1.5"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-[11px] font-medium text-ink">
+                        {item.label}
+                        {item.required ? (
+                          <span className="ml-1 rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                            Required
+                          </span>
+                        ) : null}
+                      </p>
+                      <p className="mt-0.5 text-[10px] text-ink-subtle">{item.detail}</p>
+                    </div>
+                    <ChecklistMark done={item.done} />
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {compact && brief.checklist.some((item) => item.required && !item.done) ? (
+              <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-900">
+                <AlertTriangle className="h-3 w-3" aria-hidden />
+                Required checks still pending
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -26,6 +26,8 @@ import { trackEvent, entryEventKey } from "@/lib/analytics";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
+import { compareDecisionBriefState } from "@/lib/compare-decision-brief";
+import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
 import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
@@ -318,6 +320,7 @@ export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
+  const decisionBrief = compareDecisionBriefState(items);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -417,6 +420,7 @@ export function CompareDrawer() {
           </div>
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">
+            <CompareDecisionBriefPanel state={decisionBrief} compact className="m-3" />
             <div className="min-w-full">
               <table className="w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-10 bg-surface">

--- a/apps/web/src/lib/compare-decision-brief-lib.ts
+++ b/apps/web/src/lib/compare-decision-brief-lib.ts
@@ -1,0 +1,253 @@
+/**
+ * Pure compare decision-brief helpers.
+ *
+ * Produces per-entry "what to do next" guidance from compare selection
+ * metadata, so users can choose quickly without reading every compare row.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+import { compareDecisionSummary } from "@/lib/compare-table-decision-rows";
+import { compareActionsDiverge } from "@/lib/compare-entry-actions";
+
+const TRUST_SCORE: Record<TrustLevel, number> = {
+  trusted: 4,
+  review: 3,
+  limited: 2,
+  blocked: 1,
+};
+
+export type CompareBriefTone = "ready" | "review" | "caution" | "blocked";
+
+export type CompareBriefChecklistItem = {
+  id: string;
+  label: string;
+  detail: string;
+  done: boolean;
+  required: boolean;
+};
+
+export type CompareEntryBrief = {
+  entryRef: string;
+  title: string;
+  tone: CompareBriefTone;
+  score: number;
+  rank: number;
+  scoreDeltaFromTop: number;
+  headline: string;
+  recommendation: string;
+  reasons: string[];
+  checklist: CompareBriefChecklistItem[];
+  compareDeltaSummary: string;
+};
+
+export type CompareDecisionBriefState = {
+  comparedCount: number;
+  hasDecisionDivergence: boolean;
+  hasActionDivergence: boolean;
+  divergingLabels: string[];
+  topEntryRef: string | null;
+  summary: string;
+  entryBriefs: CompareEntryBrief[];
+};
+
+function hasSafety(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function sourceReady(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function packageReady(entry: Pick<Entry, "packageVerified" | "downloadSha256">): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+export function compareBriefEntryScore(entry: Entry): number {
+  let score = TRUST_SCORE[entry.trust] * 10;
+  if (entry.reviewed || entry.reviewedBy) score += 15;
+  if (sourceReady(entry)) score += 12;
+  if (hasSafety(entry)) score += 10;
+  if (hasPrivacy(entry)) score += 10;
+  if (packageReady(entry)) score += 8;
+  if (entry.claimed) score += 4;
+  if (hasInstallPayload(entry)) score += 3;
+  return score;
+}
+
+function entryTone(entry: Entry, score: number): CompareBriefTone {
+  if (entry.trust === "blocked") return "blocked";
+  if (entry.trust === "limited") return "caution";
+  if (score >= 75 && entry.trust === "trusted") return "ready";
+  return "review";
+}
+
+function toneHeadline(tone: CompareBriefTone): string {
+  if (tone === "ready") return "Strong candidate";
+  if (tone === "review") return "Needs targeted review";
+  if (tone === "caution") return "Use with caution";
+  return "Blocked for install";
+}
+
+function entryReasons(entry: Entry, score: number): string[] {
+  const reasons: string[] = [];
+  if (entry.trust === "trusted") reasons.push("Trusted trust level");
+  if (entry.trust === "blocked") reasons.push("Blocked trust level");
+  if (sourceReady(entry)) reasons.push("Source provenance is present");
+  if (entry.reviewed || entry.reviewedBy) reasons.push("Metadata review signal present");
+  if (hasSafety(entry)) reasons.push("Safety notes available");
+  if (hasPrivacy(entry)) reasons.push("Privacy notes available");
+  if (packageReady(entry)) reasons.push("Package integrity metadata available");
+  if (!hasInstallPayload(entry)) reasons.push("No install payload listed");
+  if (reasons.length === 0) reasons.push(`Decision score ${score}`);
+  return reasons.slice(0, 4);
+}
+
+function entryChecklist(entry: Entry): CompareBriefChecklistItem[] {
+  return [
+    {
+      id: "source",
+      label: "Source & provenance",
+      detail: sourceReady(entry)
+        ? "Source appears linked and provenance is not unverified."
+        : "Source is unverified. Validate ownership manually.",
+      done: sourceReady(entry),
+      required: true,
+    },
+    {
+      id: "safety",
+      label: "Safety notes",
+      detail: hasSafety(entry) ? "Safety notes are present." : "No safety notes listed.",
+      done: hasSafety(entry),
+      required: true,
+    },
+    {
+      id: "privacy",
+      label: "Privacy notes",
+      detail: hasPrivacy(entry) ? "Privacy notes are present." : "No privacy notes listed.",
+      done: hasPrivacy(entry),
+      required: true,
+    },
+    {
+      id: "package",
+      label: "Package integrity",
+      detail: packageReady(entry)
+        ? "Package verification/checksum metadata exists."
+        : "No package verification or checksum metadata.",
+      done: packageReady(entry),
+      required: false,
+    },
+    {
+      id: "installable",
+      label: "Install payload",
+      detail: hasInstallPayload(entry)
+        ? "Install/config payload available for review."
+        : "No install payload to validate.",
+      done: hasInstallPayload(entry),
+      required: false,
+    },
+  ];
+}
+
+function compareDeltaSummary(entry: Entry, top: Entry, topScore: number): string {
+  if (sameEntry(entry, top)) return "Top-ranked in this comparison.";
+  const delta = compareBriefEntryScore(entry) - topScore;
+  if (delta === 0) return "Score parity with top-ranked entry.";
+  if (delta > 0) return `Scores ${delta} points above current top candidate.`;
+  return `${Math.abs(delta)} points below top-ranked candidate.`;
+}
+
+function recommendation(
+  entry: Entry,
+  tone: CompareBriefTone,
+  checklist: CompareBriefChecklistItem[],
+): string {
+  const requiredMissing = checklist.filter((item) => item.required && !item.done).length;
+  if (tone === "blocked") {
+    return "Do not install. Keep this as reference only until trust status changes.";
+  }
+  if (requiredMissing >= 2) {
+    return "Complete source, safety, and privacy checks before adopting this option.";
+  }
+  if (tone === "caution") {
+    return "Use only after validating source ownership and runtime impact in a sandbox.";
+  }
+  if (tone === "ready") {
+    return "Best candidate for trial; still run through your normal security and compatibility checks.";
+  }
+  if (entry.trust === "review") {
+    return "Reasonable candidate, but compare remaining trust differences before deciding.";
+  }
+  return "Use compare details to confirm fit for your workflow.";
+}
+
+function summaryLine(
+  comparedCount: number,
+  divergingLabels: string[],
+  hasActionDivergence: boolean,
+): string {
+  if (comparedCount < 2) return "Add one more resource to see a decision brief comparison.";
+  if (divergingLabels.length === 0 && !hasActionDivergence) {
+    return "Compared entries are closely aligned on trust and next-step actions.";
+  }
+  const labels = divergingLabels.slice(0, 3).join(", ");
+  if (divergingLabels.length > 0 && hasActionDivergence) {
+    return `Signals diverge on ${labels}; next-step actions also differ across entries.`;
+  }
+  if (divergingLabels.length > 0) {
+    return `Signals diverge on ${labels}; use briefs below to select your strongest option.`;
+  }
+  return "Trust signals are similar, but next-step actions differ by entry.";
+}
+
+export function compareDecisionBriefState(entries: Entry[]): CompareDecisionBriefState {
+  const decision = compareDecisionSummary(entries);
+  const hasActionDivergence = compareActionsDiverge(entries);
+  const ranked = entries
+    .map((entry) => ({ entry, score: compareBriefEntryScore(entry) }))
+    .sort((left, right) => right.score - left.score);
+  const top = ranked[0]?.entry ?? null;
+  const topScore = ranked[0]?.score ?? 0;
+
+  const entryBriefs = ranked.map((row, index) => {
+    const checklist = entryChecklist(row.entry);
+    const tone = entryTone(row.entry, row.score);
+    return {
+      entryRef: `${row.entry.category}/${row.entry.slug}`,
+      title: row.entry.title,
+      tone,
+      score: row.score,
+      rank: index + 1,
+      scoreDeltaFromTop: row.score - topScore,
+      headline: toneHeadline(tone),
+      recommendation: recommendation(row.entry, tone, checklist),
+      reasons: entryReasons(row.entry, row.score),
+      checklist,
+      compareDeltaSummary: top
+        ? compareDeltaSummary(row.entry, top, topScore)
+        : "No baseline available.",
+    };
+  });
+
+  return {
+    comparedCount: entries.length,
+    hasDecisionDivergence: decision.divergingCount > 0,
+    hasActionDivergence,
+    divergingLabels: decision.divergingLabels,
+    topEntryRef: top ? `${top.category}/${top.slug}` : null,
+    summary: summaryLine(entries.length, decision.divergingLabels, hasActionDivergence),
+    entryBriefs,
+  };
+}

--- a/apps/web/src/lib/compare-decision-brief.ts
+++ b/apps/web/src/lib/compare-decision-brief.ts
@@ -1,0 +1,14 @@
+/**
+ * Compare decision brief surface exports.
+ */
+
+export type {
+  CompareBriefChecklistItem,
+  CompareBriefTone,
+  CompareDecisionBriefState,
+  CompareEntryBrief,
+} from "@/lib/compare-decision-brief-lib";
+export {
+  compareBriefEntryScore,
+  compareDecisionBriefState,
+} from "@/lib/compare-decision-brief-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -15,11 +15,13 @@ import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { COMPARE_PAGE_SURFACE, type CompareAction } from "@/lib/compare-page-actions-ui-lib";
 import { comparePageActionsForEntry } from "@/lib/compare-page-actions-interactive-ui-lib";
 import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
+import { compareDecisionBriefState } from "@/lib/compare-decision-brief";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
+import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -69,6 +71,7 @@ function ComparePage() {
     () => comparePageInteractiveUiState(items, sp.ids, COMPARISONS, ENTRIES),
     [items, sp.ids],
   );
+  const decisionBrief = React.useMemo(() => compareDecisionBriefState(items), [items]);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -182,6 +185,10 @@ function ComparePage() {
             Clear all
           </button>
         </div>
+      </div>
+
+      <div className="mt-4 overflow-auto rounded-xl border border-border">
+        <CompareDecisionBriefPanel state={decisionBrief} className="m-3 mb-0" />
       </div>
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">

--- a/tests/compare-decision-brief-lib.test.ts
+++ b/tests/compare-decision-brief-lib.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareBriefEntryScore,
+  compareDecisionBriefState,
+} from "@/lib/compare-decision-brief-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare decision brief lib", () => {
+  it("scores trusted reviewed entries above sparse entries", () => {
+    const strong = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/strong",
+      safetyNotes: "Use env var",
+      privacyNotes: "No telemetry",
+      packageVerified: true,
+      downloadSha256: "abc",
+      claimed: true,
+      installCommand: "npm i strong",
+    });
+    const weak = entry({ slug: "weak", trust: "limited" });
+    expect(compareBriefEntryScore(strong)).toBeGreaterThan(
+      compareBriefEntryScore(weak),
+    );
+  });
+
+  it("returns empty-like summary for no entries", () => {
+    const state = compareDecisionBriefState([]);
+    expect(state.comparedCount).toBe(0);
+    expect(state.entryBriefs).toEqual([]);
+    expect(state.topEntryRef).toBeNull();
+  });
+
+  it("builds single-entry brief with rank one", () => {
+    const single = entry({ title: "Only" });
+    const state = compareDecisionBriefState([single]);
+    expect(state.entryBriefs).toHaveLength(1);
+    expect(state.entryBriefs[0].rank).toBe(1);
+    expect(state.entryBriefs[0].entryRef).toBe("tools/fixture");
+  });
+
+  it("ranks entries by score and marks top ref", () => {
+    const top = entry({
+      slug: "top",
+      title: "Top",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const mid = entry({
+      slug: "mid",
+      title: "Mid",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/mid",
+    });
+    const low = entry({ slug: "low", title: "Low", trust: "limited" });
+    const state = compareDecisionBriefState([low, mid, top]);
+    expect(state.topEntryRef).toBe("tools/top");
+    expect(state.entryBriefs.map((brief) => brief.title)).toEqual([
+      "Top",
+      "Mid",
+      "Low",
+    ]);
+  });
+
+  it("marks blocked tone and blocked recommendation", () => {
+    const blocked = entry({ trust: "blocked", title: "Blocked" });
+    const state = compareDecisionBriefState([blocked]);
+    expect(state.entryBriefs[0].tone).toBe("blocked");
+    expect(state.entryBriefs[0].recommendation).toContain("Do not install");
+  });
+
+  it("marks ready tone for high-score trusted entries", () => {
+    const ready = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/ready",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      downloadSha256: "abc",
+      claimed: true,
+      installCommand: "npm i ready",
+    });
+    const state = compareDecisionBriefState([ready]);
+    expect(state.entryBriefs[0].tone).toBe("ready");
+    expect(state.entryBriefs[0].headline).toContain("Strong candidate");
+  });
+
+  it("marks caution tone for limited trust entries", () => {
+    const caution = entry({
+      trust: "limited",
+      title: "Caution",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/caution",
+    });
+    const state = compareDecisionBriefState([caution]);
+    expect(state.entryBriefs[0].tone).toBe("caution");
+  });
+
+  it("marks review tone for mixed-check review entries", () => {
+    const review = entry({
+      trust: "review",
+      title: "Review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/review",
+    });
+    const state = compareDecisionBriefState([review]);
+    expect(state.entryBriefs[0].tone).toBe("review");
+  });
+
+  it("includes required checklist items", () => {
+    const sample = entry({ title: "Checklist" });
+    const state = compareDecisionBriefState([sample]);
+    const required = state.entryBriefs[0].checklist.filter(
+      (item) => item.required,
+    );
+    expect(required.map((item) => item.id)).toEqual([
+      "source",
+      "safety",
+      "privacy",
+    ]);
+  });
+
+  it("sets score delta from top to zero for top entry", () => {
+    const top = entry({
+      slug: "top",
+      title: "Top",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const low = entry({ slug: "low", title: "Low", trust: "limited" });
+    const state = compareDecisionBriefState([top, low]);
+    expect(state.entryBriefs[0].scoreDeltaFromTop).toBe(0);
+    expect(state.entryBriefs[1].scoreDeltaFromTop).toBeLessThan(0);
+  });
+
+  it("provides top-ranked compare delta summary for top entry", () => {
+    const top = entry({
+      slug: "top",
+      title: "Top",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const low = entry({ slug: "low", title: "Low", trust: "limited" });
+    const state = compareDecisionBriefState([top, low]);
+    expect(state.entryBriefs[0].compareDeltaSummary).toContain("Top-ranked");
+    expect(state.entryBriefs[1].compareDeltaSummary).toContain(
+      "below top-ranked",
+    );
+  });
+
+  it("surfaces decision divergence labels when entries differ", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      reviewed: true,
+      source: "source-backed",
+      claimed: true,
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      reviewed: false,
+      source: "unverified",
+      claimed: false,
+    });
+    const state = compareDecisionBriefState([a, b]);
+    expect(state.hasDecisionDivergence).toBe(true);
+    expect(state.divergingLabels.length).toBeGreaterThan(0);
+  });
+
+  it("reports action divergence when installability differs", () => {
+    const installable = entry({
+      slug: "installable",
+      title: "Installable",
+      installCommand: "npm i installable",
+      sourceUrl: "https://github.com/acme/installable",
+      source: "source-backed",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const docsOnly = entry({
+      slug: "docs",
+      title: "Docs",
+      installCommand: undefined,
+      sourceUrl: "https://github.com/acme/docs",
+      source: "source-backed",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = compareDecisionBriefState([installable, docsOnly]);
+    expect(state.hasActionDivergence).toBe(true);
+  });
+
+  it("uses aligned summary when no divergence exists", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/a",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i a",
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/b",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i b",
+    });
+    const state = compareDecisionBriefState([a, b]);
+    expect(state.summary).toContain("closely aligned");
+  });
+
+  it("uses divergence summary when decision labels differ", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/a",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      reviewed: false,
+      source: "unverified",
+      sourceUrl: undefined,
+    });
+    const state = compareDecisionBriefState([a, b]);
+    expect(state.summary).toContain("Signals diverge");
+  });
+
+  it("includes sparse-entry reasons when trust metadata is limited", () => {
+    const sparse = entry({
+      trust: "review",
+      source: "unverified",
+      sourceUrl: undefined,
+      reviewed: false,
+      reviewedBy: undefined,
+      safetyNotes: undefined,
+      privacyNotes: undefined,
+      packageVerified: undefined,
+      downloadSha256: undefined,
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+      claimed: false,
+    });
+    const state = compareDecisionBriefState([sparse]);
+    expect(state.entryBriefs[0].reasons).toContain("No install payload listed");
+  });
+
+  it("promotes complete-source recommendation for ready entries", () => {
+    const ready = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/ready",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      downloadSha256: "abc",
+      installCommand: "npm i ready",
+    });
+    const state = compareDecisionBriefState([ready]);
+    expect(state.entryBriefs[0].recommendation).toContain("Best candidate");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-decision-brief-lib` to rank compared entries with deterministic trust scoring and checklist-based recommendations.
- Add a `CompareDecisionBriefPanel` component and render it on both `/compare` and the compare drawer for quick decision guidance.
- Add regression coverage for ranking, tone mapping, divergence summaries, and checklist/recommendation behavior.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/compare-decision-brief-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)