### PR TITLE
refactor(web): dedupe normalizeJobListing into job-listing-lib

### DIFF
--- a/apps/web/src/lib/job-listing-lib.ts
+++ b/apps/web/src/lib/job-listing-lib.ts
@@ -1,0 +1,40 @@
+// Pure normalizer for raw job-listing data, shared by the jobs index and job
+// detail routes (previously a byte-for-byte copy in each). Fills defaults and
+// coerces field types so the UI always receives a well-formed `JobListing`.
+
+import type { JobListing, JobTier } from "@/types/registry";
+
+export function normalizeJobListing(
+  value: Partial<JobListing> & Record<string, unknown>,
+): JobListing {
+  const postedAt = String(value.postedAt || value.lastVerifiedAt || new Date(0).toISOString());
+  return {
+    slug: String(value.slug || ""),
+    title: String(value.title || "Untitled role"),
+    company: String(value.company || "Unknown company"),
+    companyUrl: typeof value.companyUrl === "string" ? value.companyUrl : undefined,
+    location: String(value.location || "Remote"),
+    isRemote: Boolean(value.isRemote),
+    isWorldwide: Boolean(value.isWorldwide),
+    type: String(value.type || "Role"),
+    postedAt,
+    lastVerifiedAt: typeof value.lastVerifiedAt === "string" ? value.lastVerifiedAt : undefined,
+    compensation: typeof value.compensation === "string" ? value.compensation : undefined,
+    equity: typeof value.equity === "string" ? value.equity : undefined,
+    bonus: typeof value.bonus === "string" ? value.bonus : undefined,
+    description: String(value.description || ""),
+    benefits: Array.isArray(value.benefits) ? value.benefits.map(String) : undefined,
+    responsibilities: Array.isArray(value.responsibilities)
+      ? value.responsibilities.map(String)
+      : undefined,
+    requirements: Array.isArray(value.requirements) ? value.requirements.map(String) : undefined,
+    labels: Array.isArray(value.labels) ? value.labels.map(String) : undefined,
+    applyUrl: typeof value.applyUrl === "string" ? value.applyUrl : undefined,
+    tier: (value.tier as JobTier) || "free",
+    sourceKind: value.sourceKind as JobListing["sourceKind"],
+    sourceUrl: typeof value.sourceUrl === "string" ? value.sourceUrl : undefined,
+    curationNote: typeof value.curationNote === "string" ? value.curationNote : undefined,
+    featured: Boolean(value.featured),
+    sponsored: Boolean(value.sponsored),
+  };
+}

--- a/apps/web/src/routes/jobs.$slug.tsx
+++ b/apps/web/src/routes/jobs.$slug.tsx
@@ -10,7 +10,8 @@ import { companyTint, monogram, relativePosted, sortJobs } from "@/lib/jobs-util
 import { CopyButton } from "@/components/copy-button";
 import type { ReactNode } from "react";
 import type { ErrorComponentProps } from "@tanstack/react-router";
-import type { JobListing, JobTier } from "@/types/registry";
+import type { JobListing } from "@/types/registry";
+import { normalizeJobListing } from "@/lib/job-listing-lib";
 
 const loadJobDetailData = createServerFn({ method: "GET" })
   .inputValidator(z.object({ slug: z.string().min(1) }))
@@ -112,39 +113,6 @@ export const Route = createFileRoute("/jobs/$slug")({
   },
   component: JobDetail,
 });
-
-function normalizeJobListing(value: Partial<JobListing> & Record<string, unknown>): JobListing {
-  const postedAt = String(value.postedAt || value.lastVerifiedAt || new Date(0).toISOString());
-  return {
-    slug: String(value.slug || ""),
-    title: String(value.title || "Untitled role"),
-    company: String(value.company || "Unknown company"),
-    companyUrl: typeof value.companyUrl === "string" ? value.companyUrl : undefined,
-    location: String(value.location || "Remote"),
-    isRemote: Boolean(value.isRemote),
-    isWorldwide: Boolean(value.isWorldwide),
-    type: String(value.type || "Role"),
-    postedAt,
-    lastVerifiedAt: typeof value.lastVerifiedAt === "string" ? value.lastVerifiedAt : undefined,
-    compensation: typeof value.compensation === "string" ? value.compensation : undefined,
-    equity: typeof value.equity === "string" ? value.equity : undefined,
-    bonus: typeof value.bonus === "string" ? value.bonus : undefined,
-    description: String(value.description || ""),
-    benefits: Array.isArray(value.benefits) ? value.benefits.map(String) : undefined,
-    responsibilities: Array.isArray(value.responsibilities)
-      ? value.responsibilities.map(String)
-      : undefined,
-    requirements: Array.isArray(value.requirements) ? value.requirements.map(String) : undefined,
-    labels: Array.isArray(value.labels) ? value.labels.map(String) : undefined,
-    applyUrl: typeof value.applyUrl === "string" ? value.applyUrl : undefined,
-    tier: (value.tier as JobTier) || "free",
-    sourceKind: value.sourceKind as JobListing["sourceKind"],
-    sourceUrl: typeof value.sourceUrl === "string" ? value.sourceUrl : undefined,
-    curationNote: typeof value.curationNote === "string" ? value.curationNote : undefined,
-    featured: Boolean(value.featured),
-    sponsored: Boolean(value.sponsored),
-  };
-}
 
 function JobDetail() {
   const { slug, job: initialJob, related } = Route.useLoaderData();

--- a/apps/web/src/routes/jobs.index.tsx
+++ b/apps/web/src/routes/jobs.index.tsx
@@ -5,6 +5,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { useEffect, useMemo, useState } from "react";
 import { ArrowUpRight, Search, Sparkles, X } from "lucide-react";
 import type { JobListing, JobTier } from "@/types/registry";
+import { normalizeJobListing } from "@/lib/job-listing-lib";
 import { cn } from "@/lib/utils";
 import { JobCard } from "@/components/job-card";
 import { isFresh, pickDailySpotlight, relativePosted, sortJobs } from "@/lib/jobs-utils";
@@ -52,39 +53,6 @@ export const Route = createFileRoute("/jobs/")({
 
 type RemoteFilter = "all" | "remote" | "onsite";
 type SortMode = "default" | "newest" | "salary";
-
-function normalizeJobListing(value: Partial<JobListing> & Record<string, unknown>): JobListing {
-  const postedAt = String(value.postedAt || value.lastVerifiedAt || new Date(0).toISOString());
-  return {
-    slug: String(value.slug || ""),
-    title: String(value.title || "Untitled role"),
-    company: String(value.company || "Unknown company"),
-    companyUrl: typeof value.companyUrl === "string" ? value.companyUrl : undefined,
-    location: String(value.location || "Remote"),
-    isRemote: Boolean(value.isRemote),
-    isWorldwide: Boolean(value.isWorldwide),
-    type: String(value.type || "Role"),
-    postedAt,
-    lastVerifiedAt: typeof value.lastVerifiedAt === "string" ? value.lastVerifiedAt : undefined,
-    compensation: typeof value.compensation === "string" ? value.compensation : undefined,
-    equity: typeof value.equity === "string" ? value.equity : undefined,
-    bonus: typeof value.bonus === "string" ? value.bonus : undefined,
-    description: String(value.description || ""),
-    benefits: Array.isArray(value.benefits) ? value.benefits.map(String) : undefined,
-    responsibilities: Array.isArray(value.responsibilities)
-      ? value.responsibilities.map(String)
-      : undefined,
-    requirements: Array.isArray(value.requirements) ? value.requirements.map(String) : undefined,
-    labels: Array.isArray(value.labels) ? value.labels.map(String) : undefined,
-    applyUrl: typeof value.applyUrl === "string" ? value.applyUrl : undefined,
-    tier: (value.tier as JobTier) || "free",
-    sourceKind: value.sourceKind as JobListing["sourceKind"],
-    sourceUrl: typeof value.sourceUrl === "string" ? value.sourceUrl : undefined,
-    curationNote: typeof value.curationNote === "string" ? value.curationNote : undefined,
-    featured: Boolean(value.featured),
-    sponsored: Boolean(value.sponsored),
-  };
-}
 
 function JobsPage() {
   const loaderData = Route.useLoaderData();

--- a/tests/job-listing-lib.test.ts
+++ b/tests/job-listing-lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeJobListing } from "../apps/web/src/lib/job-listing-lib";
+
+describe("normalizeJobListing", () => {
+  it("fills sensible defaults for an empty input", () => {
+    const job = normalizeJobListing({});
+    expect(job).toMatchObject({
+      slug: "",
+      title: "Untitled role",
+      company: "Unknown company",
+      location: "Remote",
+      type: "Role",
+      tier: "free",
+      isRemote: false,
+      isWorldwide: false,
+      featured: false,
+      sponsored: false,
+      postedAt: new Date(0).toISOString(),
+    });
+    expect(job.applyUrl).toBeUndefined();
+    expect(job.benefits).toBeUndefined();
+  });
+
+  it("falls back postedAt to lastVerifiedAt when postedAt is absent", () => {
+    expect(
+      normalizeJobListing({ lastVerifiedAt: "2026-05-01T00:00:00.000Z" })
+        .postedAt,
+    ).toBe("2026-05-01T00:00:00.000Z");
+  });
+
+  it("coerces optional string fields, dropping non-strings", () => {
+    expect(
+      normalizeJobListing({ companyUrl: "https://x.example" }).companyUrl,
+    ).toBe("https://x.example");
+    expect(
+      normalizeJobListing({ companyUrl: 42 as unknown as string }).companyUrl,
+    ).toBeUndefined();
+  });
+
+  it("maps array fields to string arrays and leaves non-arrays undefined", () => {
+    expect(
+      normalizeJobListing({ benefits: ["Remote", 3 as unknown as string] })
+        .benefits,
+    ).toEqual(["Remote", "3"]);
+    expect(
+      normalizeJobListing({ requirements: "nope" as unknown as string[] })
+        .requirements,
+    ).toBeUndefined();
+  });
+
+  it("preserves provided identity and flag fields", () => {
+    const job = normalizeJobListing({
+      slug: "staff-eng",
+      title: "Staff Engineer",
+      company: "Acme",
+      isRemote: true,
+      featured: true,
+      tier: "featured",
+    });
+    expect(job).toMatchObject({
+      slug: "staff-eng",
+      title: "Staff Engineer",
+      company: "Acme",
+      isRemote: true,
+      featured: true,
+      tier: "featured",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The jobs index (`jobs.index.tsx`) and job detail (`jobs.$slug.tsx`) routes each carried a **byte-for-byte copy** of `normalizeJobListing`. Two copies can silently drift, and neither was unit-tested. This extracts the single implementation to a new `apps/web/src/lib/job-listing-lib.ts` and imports it into both routes.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `jobs.index` and `jobs.$slug` loaders/handlers now import `normalizeJobListing` from the shared lib.
- Expected behavior: identical — fills defaults (`Untitled role`, `Unknown company`, `Remote`, `Role`, `tier: free`, epoch `postedAt`), falls back `postedAt`→`lastVerifiedAt`, coerces optional strings and maps array fields to string arrays. Byte-identical to the two removed copies.
- Important edge cases or invariants: non-string optional fields and non-array list fields become `undefined`; `new Date(0)` is a constant (deterministic), not `Date.now()`.
- Backward compatibility notes: fully backward compatible — pure relocation/dedup of a module-private helper. `jobs.$slug.tsx` drops its now-unused `JobTier` import; `jobs.index.tsx` keeps it (used by its tier filter).
- Screenshots for frontend/page/UI changes: `No visual impact` — same normalized data.
- Focused tests: added `tests/job-listing-lib.test.ts` (5 tests).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/job-listing-lib.test.ts` → 5/5 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** reuse/simplification cleanup that removes a real duplicate across two routes and adds unit coverage, matching the merged small refactors in this repo (no linked issue).
