### PR TITLE
refactor(web): extract pure trustSummaryLine into trust-summary-line-lib

### DIFF
--- a/apps/web/src/components/trust-drilldown.tsx
+++ b/apps/web/src/components/trust-drilldown.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { TrustBadge } from "@/components/badges";
 import { getTrustReasons, summarizeTrust, type TrustReason } from "@/lib/trust";
+import { trustSummaryLine } from "@/lib/trust-summary-line-lib";
 import type { Entry } from "@/types/registry";
 import {
   CheckCircle2,
@@ -30,13 +31,7 @@ export function TrustDrilldown({
 }) {
   const reasons = React.useMemo(() => getTrustReasons(entry), [entry]);
   const counts = summarizeTrust(reasons);
-  const summary = [
-    counts.blocker && `${counts.blocker} blocker${counts.blocker === 1 ? "" : "s"}`,
-    counts.warning && `${counts.warning} warning${counts.warning === 1 ? "" : "s"}`,
-    counts.info && `${counts.info} info`,
-  ]
-    .filter(Boolean)
-    .join(", ");
+  const summary = trustSummaryLine(counts);
 
   return (
     <Popover>

--- a/apps/web/src/lib/trust-summary-line-lib.ts
+++ b/apps/web/src/lib/trust-summary-line-lib.ts
@@ -1,0 +1,26 @@
+// Pure human-readable trust summary line, split out of trust-drilldown.tsx so
+// the pluralization and non-zero filtering can be unit-tested without React.
+
+/** Severity tallies as produced by `summarizeTrust`. */
+export type TrustSeverityCounts = {
+  ok: number;
+  info: number;
+  warning: number;
+  blocker: number;
+};
+
+/**
+ * One-line trust summary: a comma-joined list of the non-zero blocker/warning/
+ * info tallies, in that order and pluralized, e.g. "2 blockers, 1 warning,
+ * 3 info". Returns an empty string when all three are 0. The `ok` tally is
+ * intentionally omitted from the line.
+ */
+export function trustSummaryLine(counts: TrustSeverityCounts): string {
+  return [
+    counts.blocker && `${counts.blocker} blocker${counts.blocker === 1 ? "" : "s"}`,
+    counts.warning && `${counts.warning} warning${counts.warning === 1 ? "" : "s"}`,
+    counts.info && `${counts.info} info`,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}

--- a/tests/trust-summary-line-lib.test.ts
+++ b/tests/trust-summary-line-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type TrustSeverityCounts,
+  trustSummaryLine,
+} from "../apps/web/src/lib/trust-summary-line-lib";
+
+const counts = (
+  over: Partial<TrustSeverityCounts> = {},
+): TrustSeverityCounts => ({
+  ok: 0,
+  info: 0,
+  warning: 0,
+  blocker: 0,
+  ...over,
+});
+
+describe("trustSummaryLine", () => {
+  it("returns an empty string when there are no blocker/warning/info tallies", () => {
+    expect(trustSummaryLine(counts({ ok: 5 }))).toBe("");
+  });
+
+  it("orders blocker, then warning, then info", () => {
+    expect(trustSummaryLine(counts({ blocker: 2, warning: 3, info: 4 }))).toBe(
+      "2 blockers, 3 warnings, 4 info",
+    );
+  });
+
+  it("pluralizes blocker and warning but not info", () => {
+    expect(trustSummaryLine(counts({ blocker: 1, warning: 1, info: 1 }))).toBe(
+      "1 blocker, 1 warning, 1 info",
+    );
+  });
+
+  it("omits zero tallies", () => {
+    expect(trustSummaryLine(counts({ warning: 2 }))).toBe("2 warnings");
+  });
+
+  it("ignores the ok tally entirely", () => {
+    expect(trustSummaryLine(counts({ ok: 9, info: 1 }))).toBe("1 info");
+  });
+});


### PR DESCRIPTION
## What

Moves the one-line trust summary builder out of `trust-drilldown.tsx` into a pure module `apps/web/src/lib/trust-summary-line-lib.ts`:

- `trustSummaryLine(counts)` — comma-joins the non-zero blocker/warning/info tallies, in that order and pluralized (e.g. `"2 blockers, 1 warning, 3 info"`), and returns `""` when all three are 0. The `ok` tally is intentionally omitted.

The component passes `summarizeTrust`'s counts straight through. **No behavior change** — this makes the pluralization and non-zero filtering unit-testable without React, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/trust-summary-line-lib.test.ts`: empty when no blocker/warning/info, blocker→warning→info ordering, plural rules (info never pluralized), zero-tally omission, and that `ok` is ignored (5 cases).

```
pnpm exec vitest run tests/trust-summary-line-lib.test.ts   # 5 passed
pnpm exec prettier --check <changed files>                  # clean
```

Refs #556