### PR TITLE
refactor(web): dedupe statHint into report-stat-hint-lib

### DIFF
--- a/apps/web/src/lib/report-stat-hint-lib.ts
+++ b/apps/web/src/lib/report-stat-hint-lib.ts
@@ -1,0 +1,13 @@
+// Pure display helper for report "stat" tiles, shared by the state-of-* report
+// routes (previously an identical copy in each). Split out so it can be
+// unit-tested without rendering the route.
+
+import type { ReportStat } from "@/lib/data-reports";
+
+/**
+ * Display string for a stat's hint: when the hint is the literal "%" token it
+ * renders as "<value>%", otherwise the hint text is returned verbatim.
+ */
+export function statHint(stat: ReportStat): string {
+  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
+}

--- a/apps/web/src/routes/state-of-agent-skills.tsx
+++ b/apps/web/src/routes/state-of-agent-skills.tsx
@@ -4,7 +4,8 @@ import { Sparkles, BadgeCheck, Boxes, ShieldCheck, CalendarClock } from "lucide-
 
 import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { buildSkillsReport } from "@/lib/skills-stats";
-import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { buildReportDataset } from "@/lib/data-reports";
+import { statHint } from "@/lib/report-stat-hint-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -31,10 +32,6 @@ const OG_IMAGE = ogImageUrl({
   title: MODEL.title,
   description: `${MODEL.total} agent skills by use case, type & verification`,
 });
-
-function statHint(stat: ReportStat): string {
-  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
-}
 
 export const Route = createFileRoute("/state-of-agent-skills")({
   head: () => {

--- a/apps/web/src/routes/state-of-ai-agents.tsx
+++ b/apps/web/src/routes/state-of-ai-agents.tsx
@@ -4,7 +4,8 @@ import { Bot, ShieldCheck, GitBranch, Zap, CalendarClock } from "lucide-react";
 
 import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { buildAgentsReport } from "@/lib/agents-stats";
-import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { buildReportDataset } from "@/lib/data-reports";
+import { statHint } from "@/lib/report-stat-hint-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -31,10 +32,6 @@ const OG_IMAGE = ogImageUrl({
   title: MODEL.title,
   description: `${MODEL.total} AI agents by use case, disclosure & setup`,
 });
-
-function statHint(stat: ReportStat): string {
-  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
-}
 
 export const Route = createFileRoute("/state-of-ai-agents")({
   head: () => {

--- a/apps/web/src/routes/state-of-claude-code-hooks.tsx
+++ b/apps/web/src/routes/state-of-claude-code-hooks.tsx
@@ -4,7 +4,8 @@ import { Webhook, Zap, ShieldCheck, Gauge, CalendarClock } from "lucide-react";
 
 import { ENTRIES, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { buildHooksReport } from "@/lib/hooks-stats";
-import { buildReportDataset, type ReportStat } from "@/lib/data-reports";
+import { buildReportDataset } from "@/lib/data-reports";
+import { statHint } from "@/lib/report-stat-hint-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -31,10 +32,6 @@ const OG_IMAGE = ogImageUrl({
   title: MODEL.title,
   description: `${MODEL.total} Claude Code hooks by event, use case & safety`,
 });
-
-function statHint(stat: ReportStat): string {
-  return stat.hint === "%" ? `${stat.value}%` : stat.hint;
-}
 
 export const Route = createFileRoute("/state-of-claude-code-hooks")({
   head: () => {

--- a/tests/report-stat-hint-lib.test.ts
+++ b/tests/report-stat-hint-lib.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { statHint } from "../apps/web/src/lib/report-stat-hint-lib";
+
+const stat = (over: { hint: string; value?: string | number }) =>
+  ({ value: "42", ...over }) as Parameters<typeof statHint>[0];
+
+describe("statHint", () => {
+  it("renders '<value>%' when the hint is the '%' token", () => {
+    expect(statHint(stat({ hint: "%", value: "63" }))).toBe("63%");
+  });
+
+  it("returns the hint verbatim when it is not the '%' token", () => {
+    expect(statHint(stat({ hint: "of teams surveyed" }))).toBe(
+      "of teams surveyed",
+    );
+  });
+
+  it("does not treat a hint that merely contains '%' as the token", () => {
+    expect(statHint(stat({ hint: "up 5% YoY", value: "5" }))).toBe("up 5% YoY");
+  });
+});


### PR DESCRIPTION
## Summary

The three state-of-* report routes (`state-of-agent-skills`, `state-of-ai-agents`, `state-of-claude-code-hooks`) each carried an **identical** local `statHint`. This extracts the single implementation to a new `apps/web/src/lib/report-stat-hint-lib.ts` and imports it into all three.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the three `state-of-*` routes render `statHint(stat)` from the shared lib.
- Expected behavior: `"<value>%"` when the hint is the literal `"%"` token, else the hint verbatim. Identical to the three removed copies.
- Important edge cases or invariants: a hint that merely contains `%` (e.g. `"up 5% YoY"`) is returned verbatim; only the exact `"%"` token triggers the value substitution. Each route drops its now-unused `type ReportStat` import (kept `buildReportDataset`).
- Backward compatibility notes: fully backward compatible — pure relocation/dedup of a module-private helper.
- Screenshots for frontend/page/UI changes: `No visual impact` — same stat-tile hints.
- Focused tests: added `tests/report-stat-hint-lib.test.ts` (3 tests), branch coverage 100%.

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/report-stat-hint-lib.test.ts --coverage` → 3/3 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** reuse/simplification cleanup that removes a triplicated helper across three routes and adds unit coverage, matching the merged small refactors in this repo (no linked issue).
