### PR TITLE
feat(web): add compare scenario ranking presets

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -29,6 +29,11 @@ import { brandIdentityLabel } from "@/lib/brand-icons";
 import { compareDecisionBriefState } from "@/lib/compare-decision-brief";
 import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
 import {
+  compareScenarioRankingState,
+  type CompareScenarioId,
+} from "@/lib/compare-scenario-ranking";
+import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
+import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
@@ -318,9 +323,11 @@ function SnippetCell({ entry }: { entry: Entry }) {
 
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
+  const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
+  const scenarioRanking = compareScenarioRankingState(items, scenario);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -421,6 +428,13 @@ export function CompareDrawer() {
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">
             <CompareDecisionBriefPanel state={decisionBrief} compact className="m-3" />
+            <CompareScenarioRankingPanel
+              state={scenarioRanking}
+              selectedScenario={scenario}
+              onSelectScenario={setScenario}
+              compact
+              className="mx-3"
+            />
             <div className="min-w-full">
               <table className="w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-10 bg-surface">

--- a/apps/web/src/components/compare-scenario-ranking-panel.tsx
+++ b/apps/web/src/components/compare-scenario-ranking-panel.tsx
@@ -1,0 +1,105 @@
+import type {
+  CompareScenarioId,
+  CompareScenarioRankingState,
+} from "@/lib/compare-scenario-ranking";
+import { COMPARE_SCENARIO_PRESETS } from "@/lib/compare-scenario-ranking";
+import { cn } from "@/lib/utils";
+
+function scoreDeltaText(delta: number): string {
+  if (delta === 0) return "Top score";
+  if (delta > 0) return `+${delta}`;
+  return `${delta}`;
+}
+
+export function CompareScenarioRankingPanel({
+  state,
+  selectedScenario,
+  onSelectScenario,
+  compact = false,
+  className,
+}: {
+  state: CompareScenarioRankingState;
+  selectedScenario: CompareScenarioId;
+  onSelectScenario: (scenario: CompareScenarioId) => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.ranked.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Scenario ranking"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Scenario ranking</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">
+            Compare by decision preset
+          </h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {COMPARE_SCENARIO_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectScenario(preset.id)}
+            aria-pressed={selectedScenario === preset.id}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedScenario === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+            title={preset.description}
+          >
+            {preset.shortLabel}
+          </button>
+        ))}
+      </div>
+
+      <div
+        className={cn("mt-3 grid gap-2", compact ? "grid-cols-1" : "grid-cols-1 xl:grid-cols-2")}
+      >
+        {state.ranked.map((item) => (
+          <article
+            key={item.entryRef}
+            className={cn(
+              "rounded-lg border border-border bg-background p-3",
+              item.rank === 1 && "ring-1 ring-accent/40",
+            )}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
+                    #{item.rank}
+                  </span>
+                  <h4 className="truncate text-sm font-semibold text-ink">{item.title}</h4>
+                </div>
+                <p className="mt-1 text-[11px] text-ink-muted">{item.rationale[0]}</p>
+              </div>
+              <div className="text-right">
+                <p className="font-mono text-xs text-ink">Score {item.score}</p>
+                <p className="text-[10px] text-ink-subtle">{scoreDeltaText(item.deltaFromTop)}</p>
+              </div>
+            </div>
+            <ul className="mt-2 flex flex-wrap gap-1.5">
+              {item.rationale.slice(1).map((reason) => (
+                <li
+                  key={reason}
+                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                >
+                  {reason}
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-scenario-ranking-lib.ts
+++ b/apps/web/src/lib/compare-scenario-ranking-lib.ts
@@ -1,0 +1,228 @@
+/**
+ * Pure compare scenario ranking helpers.
+ *
+ * Computes per-entry ranking under different decision presets so users can
+ * choose the best candidate for their current risk appetite or speed target.
+ */
+
+import type { Entry } from "@/types/registry";
+import { compareBriefEntryScore } from "@/lib/compare-decision-brief";
+
+export type CompareScenarioId = "balanced" | "safety-first" | "speed-first" | "minimal-risk";
+
+export type CompareScenarioPreset = {
+  id: CompareScenarioId;
+  label: string;
+  shortLabel: string;
+  description: string;
+};
+
+export type CompareScenarioRankedEntry = {
+  entryRef: string;
+  title: string;
+  rank: number;
+  score: number;
+  deltaFromTop: number;
+  rationale: string[];
+};
+
+export type CompareScenarioRankingState = {
+  scenario: CompareScenarioPreset;
+  summary: string;
+  ranked: CompareScenarioRankedEntry[];
+};
+
+export const COMPARE_SCENARIO_PRESETS: CompareScenarioPreset[] = [
+  {
+    id: "balanced",
+    label: "Balanced",
+    shortLabel: "Balanced",
+    description: "Mix trust, safety, and practical adoption signals.",
+  },
+  {
+    id: "safety-first",
+    label: "Safety first",
+    shortLabel: "Safety",
+    description: "Prioritize strong trust, source, and disclosure signals.",
+  },
+  {
+    id: "speed-first",
+    label: "Speed first",
+    shortLabel: "Speed",
+    description: "Prioritize install-ready entries for fast adoption.",
+  },
+  {
+    id: "minimal-risk",
+    label: "Minimal risk",
+    shortLabel: "Low risk",
+    description: "Deprioritize entries with missing trust metadata.",
+  },
+];
+
+function hasSafety(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function isSourceBacked(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function isPackageReady(entry: Pick<Entry, "packageVerified" | "downloadSha256">): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function scenarioBonus(entry: Entry, scenario: CompareScenarioId): number {
+  if (scenario === "balanced") {
+    let score = 0;
+    if (hasSafety(entry)) score += 4;
+    if (hasPrivacy(entry)) score += 4;
+    if (hasInstallPayload(entry)) score += 3;
+    if (isSourceBacked(entry)) score += 3;
+    return score;
+  }
+
+  if (scenario === "safety-first") {
+    let score = 0;
+    if (entry.trust === "trusted") score += 16;
+    if (entry.trust === "blocked") score -= 25;
+    if (isSourceBacked(entry)) score += 10;
+    if (hasSafety(entry)) score += 9;
+    if (hasPrivacy(entry)) score += 9;
+    if (entry.reviewed || entry.reviewedBy) score += 8;
+    if (!isPackageReady(entry)) score -= 4;
+    return score;
+  }
+
+  if (scenario === "speed-first") {
+    let score = 0;
+    if (hasInstallPayload(entry)) score += 18;
+    if (entry.installCommand) score += 6;
+    if (entry.configSnippet) score += 4;
+    if (entry.fullCopy || entry.copySnippet) score += 3;
+    if (entry.claimed) score += 3;
+    if (entry.trust === "blocked") score -= 30;
+    return score;
+  }
+
+  // minimal-risk
+  let score = 0;
+  if (entry.trust === "trusted") score += 14;
+  if (entry.trust === "review") score += 5;
+  if (entry.trust === "limited") score -= 6;
+  if (entry.trust === "blocked") score -= 35;
+  if (isSourceBacked(entry)) score += 8;
+  if (hasSafety(entry)) score += 7;
+  if (hasPrivacy(entry)) score += 7;
+  if (isPackageReady(entry)) score += 6;
+  if (!(entry.reviewed || entry.reviewedBy)) score -= 6;
+  if (entry.source === "unverified") score -= 8;
+  return score;
+}
+
+function scenarioPenalty(entry: Entry, scenario: CompareScenarioId): number {
+  if (scenario === "speed-first") {
+    let penalty = 0;
+    if (!hasInstallPayload(entry)) penalty -= 15;
+    if (entry.source === "unverified") penalty -= 4;
+    return penalty;
+  }
+  if (scenario === "balanced") {
+    let penalty = 0;
+    if (!hasSafety(entry)) penalty -= 3;
+    if (!hasPrivacy(entry)) penalty -= 3;
+    if (entry.trust === "blocked") penalty -= 10;
+    return penalty;
+  }
+  if (scenario === "safety-first") {
+    let penalty = 0;
+    if (!hasSafety(entry)) penalty -= 8;
+    if (!hasPrivacy(entry)) penalty -= 8;
+    if (!isSourceBacked(entry)) penalty -= 9;
+    return penalty;
+  }
+  // minimal-risk
+  let penalty = 0;
+  if (!hasSafety(entry)) penalty -= 10;
+  if (!hasPrivacy(entry)) penalty -= 10;
+  if (!isSourceBacked(entry)) penalty -= 10;
+  if (!isPackageReady(entry)) penalty -= 6;
+  return penalty;
+}
+
+function scenarioScore(entry: Entry, scenario: CompareScenarioId): number {
+  const base = compareBriefEntryScore(entry);
+  return base + scenarioBonus(entry, scenario) + scenarioPenalty(entry, scenario);
+}
+
+function scenarioRationale(entry: Entry, scenario: CompareScenarioId, score: number): string[] {
+  const reasons: string[] = [];
+  if (entry.trust === "trusted") reasons.push("Trusted trust level");
+  if (entry.trust === "blocked") reasons.push("Blocked trust level");
+  if (hasSafety(entry)) reasons.push("Safety notes present");
+  if (hasPrivacy(entry)) reasons.push("Privacy notes present");
+  if (isSourceBacked(entry)) reasons.push("Source provenance available");
+  if (isPackageReady(entry)) reasons.push("Package integrity metadata available");
+  if (hasInstallPayload(entry)) reasons.push("Install payload available");
+  if (scenario === "speed-first" && !hasInstallPayload(entry))
+    reasons.push("Missing install payload");
+  if (scenario === "minimal-risk" && entry.source === "unverified")
+    reasons.push("Unverified source");
+  if (reasons.length === 0) reasons.push(`Scenario score ${score}`);
+  return reasons.slice(0, 4);
+}
+
+function summaryText(scenario: CompareScenarioId, topTitle: string | null): string {
+  if (!topTitle) return "Add entries to see scenario-based ranking.";
+  if (scenario === "balanced") return `${topTitle} leads under balanced weighting.`;
+  if (scenario === "safety-first")
+    return `${topTitle} leads when safety and provenance are prioritized.`;
+  if (scenario === "speed-first")
+    return `${topTitle} leads when fast adoption signals are prioritized.`;
+  return `${topTitle} leads under strict risk-minimization weighting.`;
+}
+
+function resolvePreset(scenario: CompareScenarioId): CompareScenarioPreset {
+  return (
+    COMPARE_SCENARIO_PRESETS.find((preset) => preset.id === scenario) ?? COMPARE_SCENARIO_PRESETS[0]
+  );
+}
+
+export function compareScenarioRankingState(
+  entries: Entry[],
+  scenario: CompareScenarioId,
+): CompareScenarioRankingState {
+  const ranked = entries
+    .map((entry) => ({
+      entry,
+      score: scenarioScore(entry, scenario),
+    }))
+    .sort((left, right) => right.score - left.score);
+
+  const topScore = ranked[0]?.score ?? 0;
+  const rankedEntries: CompareScenarioRankedEntry[] = ranked.map((row, index) => ({
+    entryRef: `${row.entry.category}/${row.entry.slug}`,
+    title: row.entry.title,
+    rank: index + 1,
+    score: row.score,
+    deltaFromTop: row.score - topScore,
+    rationale: scenarioRationale(row.entry, scenario, row.score),
+  }));
+
+  return {
+    scenario: resolvePreset(scenario),
+    summary: summaryText(scenario, ranked[0]?.entry.title ?? null),
+    ranked: rankedEntries,
+  };
+}

--- a/apps/web/src/lib/compare-scenario-ranking.ts
+++ b/apps/web/src/lib/compare-scenario-ranking.ts
@@ -1,0 +1,14 @@
+/**
+ * Compare scenario ranking exports.
+ */
+
+export type {
+  CompareScenarioId,
+  CompareScenarioPreset,
+  CompareScenarioRankedEntry,
+  CompareScenarioRankingState,
+} from "@/lib/compare-scenario-ranking-lib";
+export {
+  COMPARE_SCENARIO_PRESETS,
+  compareScenarioRankingState,
+} from "@/lib/compare-scenario-ranking-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -16,12 +16,17 @@ import { COMPARE_PAGE_SURFACE, type CompareAction } from "@/lib/compare-page-act
 import { comparePageActionsForEntry } from "@/lib/compare-page-actions-interactive-ui-lib";
 import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
 import { compareDecisionBriefState } from "@/lib/compare-decision-brief";
+import {
+  compareScenarioRankingState,
+  type CompareScenarioId,
+} from "@/lib/compare-scenario-ranking";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
+import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -72,6 +77,11 @@ function ComparePage() {
     [items, sp.ids],
   );
   const decisionBrief = React.useMemo(() => compareDecisionBriefState(items), [items]);
+  const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
+  const scenarioRanking = React.useMemo(
+    () => compareScenarioRankingState(items, scenario),
+    [items, scenario],
+  );
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -189,6 +199,12 @@ function ComparePage() {
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">
         <CompareDecisionBriefPanel state={decisionBrief} className="m-3 mb-0" />
+        <CompareScenarioRankingPanel
+          state={scenarioRanking}
+          selectedScenario={scenario}
+          onSelectScenario={setScenario}
+          className="m-3"
+        />
       </div>
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">

--- a/tests/compare-scenario-ranking-lib.test.ts
+++ b/tests/compare-scenario-ranking-lib.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  COMPARE_SCENARIO_PRESETS,
+  compareScenarioRankingState,
+} from "@/lib/compare-scenario-ranking-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare scenario ranking lib", () => {
+  it("exposes all scenario presets", () => {
+    expect(COMPARE_SCENARIO_PRESETS.map((preset) => preset.id)).toEqual([
+      "balanced",
+      "safety-first",
+      "speed-first",
+      "minimal-risk",
+    ]);
+  });
+
+  it("returns empty ranking with no entries", () => {
+    const state = compareScenarioRankingState([], "balanced");
+    expect(state.ranked).toEqual([]);
+    expect(state.summary).toContain("Add entries");
+  });
+
+  it("ranks entries for balanced scenario", () => {
+    const strong = entry({
+      slug: "strong",
+      title: "Strong",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/strong",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const weak = entry({ slug: "weak", title: "Weak", trust: "limited" });
+    const state = compareScenarioRankingState([weak, strong], "balanced");
+    expect(state.ranked[0].title).toBe("Strong");
+    expect(state.ranked[0].rank).toBe(1);
+  });
+
+  it("prioritizes source and notes for safety-first scenario", () => {
+    const safe = entry({
+      slug: "safe",
+      title: "Safe",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/safe",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const fast = entry({
+      slug: "fast",
+      title: "Fast",
+      trust: "review",
+      installCommand: "npm i fast",
+      source: "unverified",
+    });
+    const state = compareScenarioRankingState([fast, safe], "safety-first");
+    expect(state.ranked[0].title).toBe("Safe");
+    expect(state.summary).toContain("safety");
+  });
+
+  it("prioritizes installability for speed-first scenario", () => {
+    const installable = entry({
+      slug: "installable",
+      title: "Installable",
+      trust: "review",
+      installCommand: "npm i installable",
+      configSnippet: "config",
+      fullCopy: "full",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/installable",
+    });
+    const slow = entry({
+      slug: "slow",
+      title: "Slow",
+      trust: "trusted",
+      installCommand: undefined,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/slow",
+    });
+    const state = compareScenarioRankingState(
+      [slow, installable],
+      "speed-first",
+    );
+    expect(state.ranked[0].title).toBe("Installable");
+    expect(state.summary).toContain("fast adoption");
+  });
+
+  it("deprioritizes blocked entries in minimal-risk scenario", () => {
+    const blocked = entry({
+      slug: "blocked",
+      title: "Blocked",
+      trust: "blocked",
+      source: "unverified",
+    });
+    const trusted = entry({
+      slug: "trusted",
+      title: "Trusted",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/trusted",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const state = compareScenarioRankingState(
+      [blocked, trusted],
+      "minimal-risk",
+    );
+    expect(state.ranked.at(-1)?.title).toBe("Blocked");
+    expect(state.ranked.at(-1)?.score).toBeLessThan(state.ranked[0].score);
+  });
+
+  it("includes rank deltas from top", () => {
+    const top = entry({
+      slug: "top",
+      title: "Top",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const low = entry({ slug: "low", title: "Low", trust: "limited" });
+    const state = compareScenarioRankingState([top, low], "balanced");
+    expect(state.ranked[0].deltaFromTop).toBe(0);
+    expect(state.ranked[1].deltaFromTop).toBeLessThan(0);
+  });
+
+  it("includes rationale labels for scored entries", () => {
+    const candidate = entry({
+      title: "Candidate",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/candidate",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      installCommand: "npm i candidate",
+    });
+    const state = compareScenarioRankingState([candidate], "balanced");
+    expect(state.ranked[0].rationale.length).toBeGreaterThan(0);
+  });
+
+  it("adds missing install payload rationale in speed-first mode", () => {
+    const docsOnly = entry({
+      title: "Docs only",
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/docs",
+    });
+    const state = compareScenarioRankingState([docsOnly], "speed-first");
+    expect(state.ranked[0].rationale).toContain("Missing install payload");
+  });
+
+  it("adds unverified-source rationale in minimal-risk mode", () => {
+    const unverified = entry({
+      title: "Unverified",
+      source: "unverified",
+      sourceUrl: undefined,
+    });
+    const state = compareScenarioRankingState([unverified], "minimal-risk");
+    expect(state.ranked[0].rationale).toContain("Unverified source");
+  });
+
+  it("uses balanced summary text", () => {
+    const top = entry({
+      title: "Top",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = compareScenarioRankingState([top], "balanced");
+    expect(state.summary).toContain("balanced weighting");
+  });
+
+  it("uses minimal-risk summary text", () => {
+    const top = entry({
+      title: "Top",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = compareScenarioRankingState([top], "minimal-risk");
+    expect(state.summary).toContain("risk-minimization");
+  });
+
+  it("returns preset metadata in state", () => {
+    const top = entry({
+      title: "Top",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/top",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = compareScenarioRankingState([top], "safety-first");
+    expect(state.scenario.id).toBe("safety-first");
+    expect(state.scenario.label).toBe("Safety first");
+  });
+
+  it("handles tie scores deterministically with stable ordering", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/a",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/b",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = compareScenarioRankingState([a, b], "balanced");
+    expect(state.ranked).toHaveLength(2);
+    expect(state.ranked[0].score).toBe(state.ranked[1].score);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-scenario-ranking-lib` with deterministic scenario scoring presets (`balanced`, `safety-first`, `speed-first`, `minimal-risk`) for compared entries.
- Add `CompareScenarioRankingPanel` and render it on both `/compare` and the compare drawer so users can switch decision posture and see ranked candidates.
- Add focused tests for preset behavior, ranking order, rationale output, summary text, and deltas.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/compare-scenario-ranking-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)