### PR TITLE
refactor(web): extract safeGitHubAuthUrl into github-auth-url-lib

### DIFF
--- a/apps/web/src/lib/github-auth-url-lib.ts
+++ b/apps/web/src/lib/github-auth-url-lib.ts
@@ -1,0 +1,22 @@
+// Pure allowlist validator for a GitHub OAuth "authorize" URL, split out of the
+// submit route so it can be unit-tested. Only an https URL on an allowed GitHub
+// host is accepted; anything else collapses to "" so the caller never follows an
+// attacker-controlled redirect target.
+
+const GITHUB_AUTH_HOSTS = new Set(["github.com"]);
+
+/**
+ * Return the normalized URL string only when `value` parses as an `https:` URL
+ * whose hostname is an allowed GitHub host; otherwise return "". Never throws.
+ */
+export function safeGitHubAuthUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" || !GITHUB_AUTH_HOSTS.has(url.hostname)) {
+      return "";
+    }
+    return url.toString();
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -18,6 +18,7 @@ import {
   type SpecField,
 } from "@/lib/submission-spec";
 import { logClientError } from "@/lib/client-logs";
+import { safeGitHubAuthUrl } from "@/lib/github-auth-url-lib";
 import { siteConfig } from "@/lib/site";
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -46,7 +47,6 @@ export const Route = createFileRoute("/submit")({
 });
 
 const STEPS = ["Category", "Details", "Safety & privacy", "Review"] as const;
-const GITHUB_AUTH_HOSTS = new Set(["github.com"]);
 
 type PreflightResponse = {
   ok: true;
@@ -75,18 +75,6 @@ type PreflightResponse = {
     url?: string;
   };
 };
-
-function safeGitHubAuthUrl(value: string) {
-  try {
-    const url = new URL(value);
-    if (url.protocol !== "https:" || !GITHUB_AUTH_HOSTS.has(url.hostname)) {
-      return "";
-    }
-    return url.toString();
-  } catch {
-    return "";
-  }
-}
 
 function originFor(value: string) {
   try {

--- a/tests/github-auth-url-lib.test.ts
+++ b/tests/github-auth-url-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { safeGitHubAuthUrl } from "../apps/web/src/lib/github-auth-url-lib";
+
+describe("safeGitHubAuthUrl", () => {
+  it("accepts an https github.com URL and returns it normalized", () => {
+    expect(
+      safeGitHubAuthUrl("https://github.com/login/oauth/authorize?client_id=x"),
+    ).toBe("https://github.com/login/oauth/authorize?client_id=x");
+  });
+
+  it("rejects a non-https scheme", () => {
+    expect(safeGitHubAuthUrl("http://github.com/login/oauth/authorize")).toBe(
+      "",
+    );
+  });
+
+  it("rejects a host that is not on the allowlist", () => {
+    expect(
+      safeGitHubAuthUrl("https://evil.example/login/oauth/authorize"),
+    ).toBe("");
+    expect(safeGitHubAuthUrl("https://github.com.evil.example/authorize")).toBe(
+      "",
+    );
+  });
+
+  it("returns '' for an unparseable value", () => {
+    expect(safeGitHubAuthUrl("not a url")).toBe("");
+    expect(safeGitHubAuthUrl("")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The submit route validated the GitHub OAuth "authorize" URL inline with `safeGitHubAuthUrl` (plus its `GITHUB_AUTH_HOSTS` allowlist), so this security-relevant check had no direct test. This moves both into a new `apps/web/src/lib/github-auth-url-lib.ts` and imports the helper.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the `/submit` GitHub continuation calls `safeGitHubAuthUrl` from the lib.
- Expected behavior: returns the normalized URL only when it parses as an `https:` URL on an allowed GitHub host (`github.com`); otherwise `""`. Never throws. Identical to the removed inline version.
- Important edge cases or invariants: non-https schemes, look-alike hosts (`github.com.evil.example`), disallowed hosts, and unparseable input all collapse to `""`, so the caller never navigates to an attacker-controlled target.
- Backward compatibility notes: fully backward compatible — `safeGitHubAuthUrl`/`GITHUB_AUTH_HOSTS` were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — URL validation only.
- Focused tests: added `tests/github-auth-url-lib.test.ts` (4 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/github-auth-url-lib.test.ts --coverage` → 4/4 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that gives a security-relevant URL allowlist check a home and direct unit coverage, matching merged extraction PRs #4551 and #4555 (no linked issue).
