### PR TITLE
refactor(web): extract scoreEntry into quality-score-lib

### DIFF
--- a/apps/web/src/lib/quality-score-lib.ts
+++ b/apps/web/src/lib/quality-score-lib.ts
@@ -1,0 +1,54 @@
+// Pure quality-scoring for a registry entry, split out of the quality route so
+// the scoring rules can be unit-tested without the route or the full dataset.
+
+import type { Entry } from "@/types/registry";
+
+export interface QualityRow {
+  entry: Entry;
+  score: number;
+  recommendations: string[];
+}
+
+/**
+ * Score an entry out of 100, deducting for missing provenance/safety/privacy/
+ * review/install/tag signals (some only for the risk-bearing categories), and
+ * collect the matching recommendations. The score is clamped to a 0 floor.
+ */
+export function scoreEntry(e: Entry): QualityRow {
+  const recs: string[] = [];
+  let score = 100;
+  if (e.source === "unverified") {
+    score -= 30;
+    recs.push("Add a verifiable source URL.");
+  }
+  if (
+    !e.safetyNotes &&
+    (e.category === "mcp" ||
+      e.category === "hooks" ||
+      e.category === "skills" ||
+      e.category === "commands")
+  ) {
+    score -= 20;
+    recs.push("Add safety notes for this risk-bearing category.");
+  }
+  if (!e.privacyNotes && (e.category === "mcp" || e.category === "skills")) {
+    score -= 10;
+    recs.push("Add privacy notes covering data flow.");
+  }
+  if (!e.reviewed) {
+    score -= 10;
+    recs.push("Awaiting maintainer review.");
+  }
+  if (
+    !e.installCommand &&
+    (e.category === "mcp" || e.category === "skills" || e.category === "commands")
+  ) {
+    score -= 10;
+    recs.push("Add an install command.");
+  }
+  if (!e.tags || e.tags.length < 2) {
+    score -= 5;
+    recs.push("Add more tags for discoverability.");
+  }
+  return { entry: e, score: Math.max(0, score), recommendations: recs };
+}

--- a/apps/web/src/routes/quality.tsx
+++ b/apps/web/src/routes/quality.tsx
@@ -13,6 +13,7 @@ import {
 import { useState } from "react";
 import { CATEGORIES } from "@/types/registry";
 import { ENTRIES, QUALITY_STATS } from "@/data/entries";
+import { scoreEntry, type QualityRow } from "@/lib/quality-score-lib";
 import { ARTIFACT_CONTRACTS, CHANGELOG } from "@/data/changelog";
 import { FeedHealthPanel } from "@/components/feed-health-panel";
 import { CountUp } from "@/components/count-up";
@@ -47,51 +48,6 @@ export const Route = createFileRoute("/quality")({
   }),
   component: QualityPage,
 });
-
-interface QualityRow {
-  entry: (typeof ENTRIES)[number];
-  score: number;
-  recommendations: string[];
-}
-
-function scoreEntry(e: (typeof ENTRIES)[number]): QualityRow {
-  const recs: string[] = [];
-  let score = 100;
-  if (e.source === "unverified") {
-    score -= 30;
-    recs.push("Add a verifiable source URL.");
-  }
-  if (
-    !e.safetyNotes &&
-    (e.category === "mcp" ||
-      e.category === "hooks" ||
-      e.category === "skills" ||
-      e.category === "commands")
-  ) {
-    score -= 20;
-    recs.push("Add safety notes for this risk-bearing category.");
-  }
-  if (!e.privacyNotes && (e.category === "mcp" || e.category === "skills")) {
-    score -= 10;
-    recs.push("Add privacy notes covering data flow.");
-  }
-  if (!e.reviewed) {
-    score -= 10;
-    recs.push("Awaiting maintainer review.");
-  }
-  if (
-    !e.installCommand &&
-    (e.category === "mcp" || e.category === "skills" || e.category === "commands")
-  ) {
-    score -= 10;
-    recs.push("Add an install command.");
-  }
-  if (!e.tags || e.tags.length < 2) {
-    score -= 5;
-    recs.push("Add more tags for discoverability.");
-  }
-  return { entry: e, score: Math.max(0, score), recommendations: recs };
-}
 
 // Precomputed once at module load — the registry is static, so these no longer
 // re-run (927× scoreEntry + sort + per-category scans, ~28K iterations) on every

--- a/tests/quality-score-lib.test.ts
+++ b/tests/quality-score-lib.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { scoreEntry } from "../apps/web/src/lib/quality-score-lib";
+
+const entry = (over: Partial<Entry>) =>
+  ({
+    category: "agents",
+    tags: ["a", "b"],
+    reviewed: true,
+    ...over,
+  }) as Entry;
+
+describe("scoreEntry", () => {
+  it("gives a fully-populated entry a perfect score with no recommendations", () => {
+    const row = scoreEntry(
+      entry({
+        category: "mcp",
+        source: "verified",
+        safetyNotes: ["be careful"],
+        privacyNotes: ["local only"],
+        installCommand: "npx x",
+        reviewed: true,
+        tags: ["a", "b"],
+      }),
+    );
+    expect(row.score).toBe(100);
+    expect(row.recommendations).toEqual([]);
+  });
+
+  it("deducts 30 for an unverified source", () => {
+    const row = scoreEntry(entry({ source: "unverified" }));
+    expect(row.score).toBe(70);
+    expect(row.recommendations).toContain("Add a verifiable source URL.");
+  });
+
+  it("deducts safety/privacy/install only for risk-bearing categories", () => {
+    const mcp = scoreEntry(entry({ category: "mcp" }));
+    // -20 safety, -10 privacy, -10 install (reviewed:true, tags ok, source ok)
+    expect(mcp.score).toBe(60);
+    expect(mcp.recommendations).toEqual([
+      "Add safety notes for this risk-bearing category.",
+      "Add privacy notes covering data flow.",
+      "Add an install command.",
+    ]);
+
+    // A non-risk category with the same gaps loses none of those points.
+    expect(scoreEntry(entry({ category: "rules" })).score).toBe(100);
+  });
+
+  it("covers hooks (safety only) and commands (safety + install) categories", () => {
+    expect(scoreEntry(entry({ category: "hooks" })).score).toBe(80); // -20 safety
+    expect(scoreEntry(entry({ category: "commands" })).score).toBe(70); // -20 safety -10 install
+  });
+
+  it("deducts 10 for an unreviewed entry", () => {
+    const row = scoreEntry(entry({ reviewed: false }));
+    expect(row.score).toBe(90);
+    expect(row.recommendations).toContain("Awaiting maintainer review.");
+  });
+
+  it("deducts 5 when there are fewer than two tags", () => {
+    expect(scoreEntry(entry({ tags: ["only"] })).score).toBe(95);
+    expect(scoreEntry(entry({ tags: undefined })).score).toBe(95);
+  });
+
+  it("sums every applicable deduction for a worst-case entry", () => {
+    const row = scoreEntry(
+      entry({
+        category: "mcp",
+        source: "unverified",
+        reviewed: false,
+        tags: [],
+      }),
+    );
+    // 100 -30 -20 -10 -10 -10 -5 = 15 (never negative for these rules).
+    expect(row.score).toBe(15);
+    expect(row.recommendations).toHaveLength(6);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The registry quality route scored entries inline with `scoreEntry` (and the `QualityRow` type), so the scoring rules had no direct test. This moves both into a new `apps/web/src/lib/quality-score-lib.ts` and imports them.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the `/quality` route builds `QUALITY_ROWS` via `scoreEntry` from the lib.
- Expected behavior: scores an entry out of 100, deducting for an unverified source (−30), missing safety notes on risk-bearing categories (−20), missing privacy notes on mcp/skills (−10), missing maintainer review (−10), missing install command on mcp/skills/commands (−10), and fewer than two tags (−5); collects the matching recommendations; clamps to a 0 floor. Identical to the removed inline version.
- Important edge cases or invariants: the safety/privacy/install deductions apply only to their risk-bearing categories; a non-risk category with the same gaps keeps full marks.
- Backward compatibility notes: fully backward compatible — `scoreEntry`/`QualityRow` were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — scoring only.
- Focused tests: added `tests/quality-score-lib.test.ts` (7 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/quality-score-lib.test.ts --coverage` → 7/7 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that adds unit coverage for the quality scoring rules, matching merged extraction PRs #4551 and #4555 (no linked issue).
