### PR TITLE
feat(web): add entry detail adoption plan panel

### DIFF
--- a/apps/web/src/components/entry-adoption-plan-panel.tsx
+++ b/apps/web/src/components/entry-adoption-plan-panel.tsx
@@ -1,0 +1,166 @@
+import { AlertTriangle, CheckCircle2, Circle, ShieldAlert } from "lucide-react";
+import type { AdoptionPlanPresetId, EntryAdoptionPlanState } from "@/lib/entry-adoption-plan";
+import { ENTRY_ADOPTION_PLAN_PRESETS } from "@/lib/entry-adoption-plan";
+import { cn } from "@/lib/utils";
+
+function RiskBadge({ score }: { score: number }) {
+  const tone =
+    score >= 60
+      ? "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked"
+      : score >= 30
+        ? "border-amber-500/40 bg-amber-500/10 text-amber-900"
+        : "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
+  return (
+    <span
+      className={cn(
+        "inline-flex rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide",
+        tone,
+      )}
+    >
+      Risk {score}
+    </span>
+  );
+}
+
+function StepRow({
+  title,
+  detail,
+  required,
+  done,
+  severity,
+}: {
+  title: string;
+  detail: string;
+  required: boolean;
+  done: boolean;
+  severity: "ok" | "warn" | "critical";
+}) {
+  return (
+    <li
+      className={cn(
+        "rounded-md border px-2.5 py-2",
+        severity === "critical"
+          ? "border-trust-blocked/30 bg-trust-blocked/5"
+          : severity === "warn"
+            ? "border-amber-500/30 bg-amber-500/5"
+            : "border-border bg-background",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-xs font-medium text-ink">
+            {title}
+            {required ? (
+              <span className="ml-1 rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                Required
+              </span>
+            ) : null}
+          </p>
+          <p className="mt-0.5 text-[11px] text-ink-muted">{detail}</p>
+        </div>
+        <span
+          className={cn(
+            "mt-0.5 inline-flex shrink-0 items-center gap-1 text-[10px] uppercase tracking-wide",
+            done ? "text-trust-trusted" : "text-ink-subtle",
+          )}
+        >
+          {done ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Circle className="h-3.5 w-3.5" />}
+          {done ? "Done" : "Pending"}
+        </span>
+      </div>
+    </li>
+  );
+}
+
+export function EntryAdoptionPlanPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: EntryAdoptionPlanState;
+  selectedPreset: AdoptionPlanPresetId;
+  onSelectPreset: (preset: AdoptionPlanPresetId) => void;
+  className?: string;
+}) {
+  return (
+    <section
+      id="adoption-plan"
+      aria-label="Adoption plan"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Adoption plan</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <RiskBadge score={state.riskScore} />
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {ENTRY_ADOPTION_PLAN_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={selectedPreset === preset.id}
+            onClick={() => onSelectPreset(preset.id)}
+            title={preset.description}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      {state.compareSummary ? (
+        <p className="mt-3 rounded-md border border-border bg-background px-3 py-2 text-xs text-ink-muted">
+          {state.compareSummary}
+        </p>
+      ) : null}
+
+      {state.blockers.length > 0 ? (
+        <div className="mt-3 rounded-lg border border-trust-blocked/40 bg-trust-blocked/5 px-3 py-2.5 text-xs">
+          <div className="mb-1 inline-flex items-center gap-1.5 font-medium text-trust-blocked">
+            <ShieldAlert className="h-3.5 w-3.5" aria-hidden />
+            Adoption blockers
+          </div>
+          <ul className="space-y-1 text-ink-muted">
+            {state.blockers.map((blocker) => (
+              <li key={blocker} className="inline-flex items-start gap-1.5">
+                <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0 text-trust-blocked" />
+                <span>{blocker}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-3">
+        {state.stages.map((stage) => (
+          <article key={stage.id} className="rounded-lg border border-border bg-background p-3">
+            <h4 className="text-sm font-semibold text-ink">{stage.title}</h4>
+            <p className="mt-1 text-xs text-ink-muted">{stage.summary}</p>
+            <ul className="mt-2 space-y-1.5">
+              {stage.steps.map((step) => (
+                <StepRow
+                  key={step.id}
+                  title={step.title}
+                  detail={step.detail}
+                  required={step.required}
+                  done={step.done}
+                  severity={step.severity}
+                />
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-adoption-plan-lib.ts
+++ b/apps/web/src/lib/entry-adoption-plan-lib.ts
@@ -1,0 +1,338 @@
+/**
+ * Pure entry adoption-plan helpers.
+ *
+ * Builds scenario-specific adoption steps for the detail page so users can
+ * decide how aggressively to adopt an entry based on trust and compare context.
+ */
+
+import type { Entry } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+
+export type AdoptionPlanPresetId =
+  | "pilot-fast"
+  | "balanced-rollout"
+  | "strict-security"
+  | "reference-only";
+
+export type AdoptionPlanPreset = {
+  id: AdoptionPlanPresetId;
+  label: string;
+  description: string;
+};
+
+export type AdoptionPlanStep = {
+  id: string;
+  title: string;
+  detail: string;
+  required: boolean;
+  done: boolean;
+  severity: "ok" | "warn" | "critical";
+};
+
+export type AdoptionPlanStage = {
+  id: string;
+  title: string;
+  summary: string;
+  steps: AdoptionPlanStep[];
+};
+
+export type EntryAdoptionPlanState = {
+  preset: AdoptionPlanPreset;
+  heading: string;
+  summary: string;
+  compareSummary: string | null;
+  riskScore: number;
+  stages: AdoptionPlanStage[];
+  blockers: string[];
+};
+
+export const ENTRY_ADOPTION_PLAN_PRESETS: AdoptionPlanPreset[] = [
+  {
+    id: "pilot-fast",
+    label: "Pilot fast",
+    description: "Validate quickly in a sandbox and ship with guardrails.",
+  },
+  {
+    id: "balanced-rollout",
+    label: "Balanced rollout",
+    description: "Use staged verification before team-wide adoption.",
+  },
+  {
+    id: "strict-security",
+    label: "Strict security",
+    description: "Require full trust and provenance checks before usage.",
+  },
+  {
+    id: "reference-only",
+    label: "Reference only",
+    description: "Keep for research; avoid operational integration.",
+  },
+];
+
+function hasSafety(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function sourceBacked(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function packageReady(entry: Pick<Entry, "packageVerified" | "downloadSha256">): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function reviewed(entry: Pick<Entry, "reviewed" | "reviewedBy">): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function trustRiskPenalty(entry: Pick<Entry, "trust">): number {
+  if (entry.trust === "blocked") return 40;
+  if (entry.trust === "limited") return 22;
+  if (entry.trust === "review") return 10;
+  return 0;
+}
+
+export function entryAdoptionRiskScore(entry: Entry): number {
+  let score = trustRiskPenalty(entry);
+  if (!sourceBacked(entry)) score += 16;
+  if (!hasSafety(entry)) score += 14;
+  if (!hasPrivacy(entry)) score += 14;
+  if (!reviewed(entry)) score += 8;
+  if (!packageReady(entry)) score += 6;
+  if (!hasInstallPayload(entry)) score += 4;
+  return Math.min(100, score);
+}
+
+function stepSeverity(required: boolean, done: boolean): "ok" | "warn" | "critical" {
+  if (done) return "ok";
+  return required ? "critical" : "warn";
+}
+
+function stage(
+  title: string,
+  summary: string,
+  steps: AdoptionPlanStep[],
+  id: string,
+): AdoptionPlanStage {
+  return { id, title, summary, steps };
+}
+
+function prerequisiteSteps(entry: Entry, strict: boolean): AdoptionPlanStep[] {
+  const sourceDone = sourceBacked(entry);
+  const reviewedDone = reviewed(entry);
+  const installDone = hasInstallPayload(entry);
+  return [
+    {
+      id: "source",
+      title: "Confirm source provenance",
+      detail: sourceDone
+        ? "Source URL/provenance metadata is present."
+        : "Source is unverified. Confirm repository ownership manually.",
+      required: true,
+      done: sourceDone,
+      severity: stepSeverity(true, sourceDone),
+    },
+    {
+      id: "reviewed",
+      title: "Confirm metadata review state",
+      detail: reviewedDone
+        ? "Listing has review metadata."
+        : "No review metadata found; increase manual validation.",
+      required: strict,
+      done: reviewedDone,
+      severity: stepSeverity(strict, reviewedDone),
+    },
+    {
+      id: "payload",
+      title: "Verify install payload",
+      detail: installDone
+        ? "Install/config payload exists and can be inspected."
+        : "No install payload available; treat as reference guidance only.",
+      required: false,
+      done: installDone,
+      severity: stepSeverity(false, installDone),
+    },
+  ];
+}
+
+function safetySteps(entry: Entry, strict: boolean): AdoptionPlanStep[] {
+  const safetyDone = hasSafety(entry);
+  const privacyDone = hasPrivacy(entry);
+  const packageDone = packageReady(entry);
+  return [
+    {
+      id: "safety",
+      title: "Review safety notes",
+      detail: safetyDone
+        ? "Safety notes are present."
+        : "Safety notes missing; review source code paths before execution.",
+      required: true,
+      done: safetyDone,
+      severity: stepSeverity(true, safetyDone),
+    },
+    {
+      id: "privacy",
+      title: "Review privacy notes",
+      detail: privacyDone
+        ? "Privacy notes are present."
+        : "Privacy notes missing; inspect network/data behavior manually.",
+      required: true,
+      done: privacyDone,
+      severity: stepSeverity(true, privacyDone),
+    },
+    {
+      id: "package",
+      title: "Verify package integrity metadata",
+      detail: packageDone
+        ? "Package verification/checksum metadata is available."
+        : "No package verification/checksum metadata.",
+      required: strict,
+      done: packageDone,
+      severity: stepSeverity(strict, packageDone),
+    },
+  ];
+}
+
+function rolloutSteps(entry: Entry, preset: AdoptionPlanPresetId): AdoptionPlanStep[] {
+  if (preset === "reference-only") {
+    return [
+      {
+        id: "reference",
+        title: "Use as reference only",
+        detail:
+          "Keep this entry for comparison and research. Avoid install/integration in production.",
+        required: true,
+        done: true,
+        severity: "ok",
+      },
+    ];
+  }
+
+  const strict = preset === "strict-security";
+  const fast = preset === "pilot-fast";
+  return [
+    {
+      id: "sandbox",
+      title: "Run in isolated sandbox first",
+      detail: fast
+        ? "Run one pilot task in a disposable environment."
+        : "Use a constrained sandbox and observe behavior across multiple tasks.",
+      required: true,
+      done: false,
+      severity: "critical",
+    },
+    {
+      id: "team-rollout",
+      title: "Roll out gradually",
+      detail: strict
+        ? "Require sign-off before team rollout."
+        : "Roll out to a small cohort before wider usage.",
+      required: true,
+      done: false,
+      severity: "critical",
+    },
+    {
+      id: "monitoring",
+      title: "Set monitoring and fallback",
+      detail: "Define rollback path and monitor errors after adoption.",
+      required: false,
+      done: false,
+      severity: "warn",
+    },
+  ];
+}
+
+function presetHeading(preset: AdoptionPlanPresetId): string {
+  if (preset === "pilot-fast") return "Fast pilot adoption plan";
+  if (preset === "balanced-rollout") return "Balanced adoption plan";
+  if (preset === "strict-security") return "Strict security adoption plan";
+  return "Reference-only usage plan";
+}
+
+function presetSummary(preset: AdoptionPlanPresetId, riskScore: number): string {
+  if (preset === "reference-only") {
+    return "Avoid operational use and keep this entry as a reference baseline for compare decisions.";
+  }
+  if (preset === "strict-security") {
+    return `Current risk score ${riskScore}/100. Require all critical checks before any rollout.`;
+  }
+  if (preset === "pilot-fast") {
+    return `Current risk score ${riskScore}/100. Move quickly, but keep sandbox and rollback controls in place.`;
+  }
+  return `Current risk score ${riskScore}/100. Use staged verification before broader rollout.`;
+}
+
+function compareSummary(entry: Entry, compareEntries: Entry[]): string | null {
+  if (compareEntries.length < 2) return null;
+  const peers = compareEntries.filter((candidate) => !sameEntry(candidate, entry));
+  if (peers.length === 0) return null;
+  const bestPeer = peers
+    .slice()
+    .sort((left, right) => entryAdoptionRiskScore(left) - entryAdoptionRiskScore(right))[0];
+  const delta = entryAdoptionRiskScore(entry) - entryAdoptionRiskScore(bestPeer);
+  if (delta <= 0) {
+    return `Lower or equal risk than ${bestPeer.title} in current compare selection (${delta}).`;
+  }
+  return `Higher risk than ${bestPeer.title} by ${delta} points; complete additional checks before adoption.`;
+}
+
+export function entryAdoptionPlanState(
+  entry: Entry,
+  preset: AdoptionPlanPresetId,
+  compareEntries: Entry[],
+): EntryAdoptionPlanState {
+  const riskScore = entryAdoptionRiskScore(entry);
+  const strict = preset === "strict-security";
+  const blockers: string[] = [];
+  if (entry.trust === "blocked") blockers.push("Trust level is blocked.");
+  if (!sourceBacked(entry)) blockers.push("Source provenance is unverified.");
+  if (!hasSafety(entry)) blockers.push("Safety notes are missing.");
+  if (!hasPrivacy(entry)) blockers.push("Privacy notes are missing.");
+
+  const stages: AdoptionPlanStage[] = [
+    stage(
+      "Pre-adoption checks",
+      "Validate source and review signals before any execution.",
+      prerequisiteSteps(entry, strict),
+      "prereq",
+    ),
+    stage(
+      "Security checks",
+      "Confirm safety, privacy, and package integrity signals.",
+      safetySteps(entry, strict),
+      "security",
+    ),
+    stage(
+      "Rollout",
+      "Adopt in controlled steps based on the selected plan.",
+      rolloutSteps(entry, preset),
+      "rollout",
+    ),
+  ];
+
+  const selectedPreset =
+    ENTRY_ADOPTION_PLAN_PRESETS.find((item) => item.id === preset) ??
+    ENTRY_ADOPTION_PLAN_PRESETS[0];
+
+  return {
+    preset: selectedPreset,
+    heading: presetHeading(selectedPreset.id),
+    summary: presetSummary(selectedPreset.id, riskScore),
+    compareSummary: compareSummary(entry, compareEntries),
+    riskScore,
+    stages,
+    blockers,
+  };
+}

--- a/apps/web/src/lib/entry-adoption-plan.ts
+++ b/apps/web/src/lib/entry-adoption-plan.ts
@@ -1,0 +1,16 @@
+/**
+ * Entry adoption plan exports.
+ */
+
+export type {
+  AdoptionPlanPreset,
+  AdoptionPlanPresetId,
+  AdoptionPlanStage,
+  AdoptionPlanStep,
+  EntryAdoptionPlanState,
+} from "@/lib/entry-adoption-plan-lib";
+export {
+  ENTRY_ADOPTION_PLAN_PRESETS,
+  entryAdoptionPlanState,
+  entryAdoptionRiskScore,
+} from "@/lib/entry-adoption-plan-lib";

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -84,6 +84,7 @@ export function buildEntryTocItems(input: {
   const items: EntryTocItem[] = [];
   if (input.risk !== "low") items.push({ id: "risk-callout", label: "Install risk" });
   items.push({ id: "citation-facts", label: "Citation facts" });
+  items.push({ id: "adoption-plan", label: "Adoption plan" });
   if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
   if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
   if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -56,6 +56,7 @@ import { EntryDetailCommandCenter } from "@/components/entry-detail-command-cent
 import { EntryDetailMobileActionBar } from "@/components/entry-detail-mobile-action-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
+import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
   buildEntryTocItems,
@@ -77,6 +78,7 @@ import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-pre
 import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
+import { entryAdoptionPlanState, type AdoptionPlanPresetId } from "@/lib/entry-adoption-plan";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -274,6 +276,7 @@ function Dossier() {
   const tabPayload = liveVariants.find((v) => v.id === tab)?.value;
 
   const compare = useCompare();
+  const [adoptionPreset, setAdoptionPreset] = useState<AdoptionPlanPresetId>("balanced-rollout");
   const inCompare = useIsCompared(entry);
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
@@ -333,6 +336,10 @@ function Dossier() {
   );
   const quickLinks = useMemo(() => entryQuickLinks(entry), [entry]);
   const readinessRows = useMemo(() => entryReadinessRows(entry), [entry]);
+  const adoptionPlan = useMemo(
+    () => entryAdoptionPlanState(entry, adoptionPreset, compare.items),
+    [entry, adoptionPreset, compare.items],
+  );
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
   return (
@@ -483,6 +490,11 @@ function Dossier() {
             </p>
             <CitationFacts entry={entry} />
           </DossierSection>
+          <EntryAdoptionPlanPanel
+            state={adoptionPlan}
+            selectedPreset={adoptionPreset}
+            onSelectPreset={setAdoptionPreset}
+          />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">
               <NoteList value={entry.safetyNotesList ?? [entry.safetyNotes]} />

--- a/tests/entry-adoption-plan-lib.test.ts
+++ b/tests/entry-adoption-plan-lib.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  ENTRY_ADOPTION_PLAN_PRESETS,
+  entryAdoptionPlanState,
+  entryAdoptionRiskScore,
+} from "@/lib/entry-adoption-plan-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry adoption plan lib", () => {
+  it("exposes expected preset ids", () => {
+    expect(ENTRY_ADOPTION_PLAN_PRESETS.map((preset) => preset.id)).toEqual([
+      "pilot-fast",
+      "balanced-rollout",
+      "strict-security",
+      "reference-only",
+    ]);
+  });
+
+  it("computes lower risk scores for strong trust metadata", () => {
+    const strong = entry({
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/strong",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      reviewed: true,
+      packageVerified: true,
+      downloadSha256: "abc",
+      installCommand: "npm i strong",
+    });
+    const weak = entry({
+      slug: "weak",
+      trust: "blocked",
+      source: "unverified",
+    });
+    expect(entryAdoptionRiskScore(strong)).toBeLessThan(
+      entryAdoptionRiskScore(weak),
+    );
+  });
+
+  it("builds baseline plan state with stages", () => {
+    const state = entryAdoptionPlanState(entry(), "balanced-rollout", []);
+    expect(state.stages.map((stage) => stage.id)).toEqual([
+      "prereq",
+      "security",
+      "rollout",
+    ]);
+  });
+
+  it("uses strict-security heading and summary", () => {
+    const state = entryAdoptionPlanState(entry(), "strict-security", []);
+    expect(state.heading).toContain("Strict security");
+    expect(state.summary).toContain("Require all critical checks");
+  });
+
+  it("uses pilot-fast heading and summary", () => {
+    const state = entryAdoptionPlanState(entry(), "pilot-fast", []);
+    expect(state.heading).toContain("Fast pilot");
+    expect(state.summary).toContain("Move quickly");
+  });
+
+  it("uses reference-only heading and summary", () => {
+    const state = entryAdoptionPlanState(entry(), "reference-only", []);
+    expect(state.heading).toContain("Reference-only");
+    expect(state.summary).toContain("reference baseline");
+  });
+
+  it("adds blockers for blocked trust and missing notes", () => {
+    const state = entryAdoptionPlanState(
+      entry({
+        trust: "blocked",
+        source: "unverified",
+        sourceUrl: undefined,
+        safetyNotes: undefined,
+        privacyNotes: undefined,
+      }),
+      "strict-security",
+      [],
+    );
+    expect(state.blockers.length).toBeGreaterThanOrEqual(3);
+    expect(state.blockers.some((blocker) => blocker.includes("blocked"))).toBe(
+      true,
+    );
+  });
+
+  it("produces no blockers when critical signals are present", () => {
+    const state = entryAdoptionPlanState(
+      entry({
+        trust: "trusted",
+        source: "source-backed",
+        sourceUrl: "https://github.com/acme/entry",
+        safetyNotes: "yes",
+        privacyNotes: "yes",
+      }),
+      "balanced-rollout",
+      [],
+    );
+    expect(state.blockers).toEqual([]);
+  });
+
+  it("marks strict-security review and package steps as required", () => {
+    const state = entryAdoptionPlanState(entry(), "strict-security", []);
+    const prereq = state.stages.find((stage) => stage.id === "prereq");
+    const security = state.stages.find((stage) => stage.id === "security");
+    expect(prereq?.steps.find((step) => step.id === "reviewed")?.required).toBe(
+      true,
+    );
+    expect(
+      security?.steps.find((step) => step.id === "package")?.required,
+    ).toBe(true);
+  });
+
+  it("marks balanced review and package steps as optional", () => {
+    const state = entryAdoptionPlanState(entry(), "balanced-rollout", []);
+    const prereq = state.stages.find((stage) => stage.id === "prereq");
+    const security = state.stages.find((stage) => stage.id === "security");
+    expect(prereq?.steps.find((step) => step.id === "reviewed")?.required).toBe(
+      false,
+    );
+    expect(
+      security?.steps.find((step) => step.id === "package")?.required,
+    ).toBe(false);
+  });
+
+  it("returns reference-only rollout stage with single completed step", () => {
+    const state = entryAdoptionPlanState(entry(), "reference-only", []);
+    const rollout = state.stages.find((stage) => stage.id === "rollout");
+    expect(rollout?.steps).toHaveLength(1);
+    expect(rollout?.steps[0].done).toBe(true);
+  });
+
+  it("returns compare summary when compare peers exist and current is riskier", () => {
+    const current = entry({
+      title: "Current",
+      trust: "review",
+      source: "unverified",
+    });
+    const peer = entry({
+      slug: "peer",
+      title: "Peer",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/peer",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const state = entryAdoptionPlanState(current, "balanced-rollout", [
+      current,
+      peer,
+    ]);
+    expect(state.compareSummary).toContain("Higher risk");
+  });
+
+  it("returns compare summary when current has lower or equal risk", () => {
+    const current = entry({
+      title: "Current",
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/current",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+    });
+    const peer = entry({
+      slug: "peer",
+      title: "Peer",
+      trust: "review",
+      source: "unverified",
+    });
+    const state = entryAdoptionPlanState(current, "balanced-rollout", [
+      current,
+      peer,
+    ]);
+    expect(state.compareSummary).toContain("Lower or equal risk");
+  });
+
+  it("returns null compare summary when no peers are selected", () => {
+    const current = entry();
+    const state = entryAdoptionPlanState(current, "balanced-rollout", [
+      current,
+    ]);
+    expect(state.compareSummary).toBeNull();
+  });
+
+  it("keeps risk score bounded to 100", () => {
+    const risky = entry({
+      trust: "blocked",
+      source: "unverified",
+      safetyNotes: undefined,
+      privacyNotes: undefined,
+      reviewed: false,
+      reviewedBy: undefined,
+      packageVerified: undefined,
+      downloadSha256: undefined,
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+    });
+    expect(entryAdoptionRiskScore(risky)).toBeLessThanOrEqual(100);
+  });
+
+  it("marks source step done when source metadata is present", () => {
+    const state = entryAdoptionPlanState(
+      entry({
+        source: "source-backed",
+        sourceUrl: "https://github.com/acme/source",
+      }),
+      "balanced-rollout",
+      [],
+    );
+    const sourceStep = state.stages
+      .find((stage) => stage.id === "prereq")
+      ?.steps.find((step) => step.id === "source");
+    expect(sourceStep?.done).toBe(true);
+  });
+
+  it("marks privacy step pending when privacy notes are missing", () => {
+    const state = entryAdoptionPlanState(
+      entry({ privacyNotes: undefined, privacyNotesList: undefined }),
+      "balanced-rollout",
+      [],
+    );
+    const privacyStep = state.stages
+      .find((stage) => stage.id === "security")
+      ?.steps.find((step) => step.id === "privacy");
+    expect(privacyStep?.done).toBe(false);
+    expect(privacyStep?.severity).toBe("critical");
+  });
+
+  it("marks rollout steps as pending in non-reference presets", () => {
+    const state = entryAdoptionPlanState(entry(), "pilot-fast", []);
+    const rollout = state.stages.find((stage) => stage.id === "rollout");
+    expect(rollout?.steps.every((step) => step.done === false)).toBe(true);
+  });
+});

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -114,6 +114,7 @@ describe("entry-detail-sidebar-lib", () => {
     });
     expect(items.map((item) => item.id)).toEqual([
       "citation-facts",
+      "adoption-plan",
       "privacy",
       "prerequisites",
       "about",


### PR DESCRIPTION
## Summary
- Add `entry-adoption-plan-lib` to compute scenario-based adoption plans (`pilot-fast`, `balanced-rollout`, `strict-security`, `reference-only`) from trust and compare context.
- Add `EntryAdoptionPlanPanel` and render it on entry detail pages with preset switching, risk score, blockers, and staged rollout steps.
- Add deterministic tests for risk scoring, blockers, compare summary behavior, stage semantics, and TOC integration.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/entry-adoption-plan-lib.test.ts tests/entry-detail-sidebar-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)