### PR TITLE
refactor(web): extract categoryBreakdown into contributor-category-breakdown-lib

### DIFF
--- a/apps/web/src/lib/contributor-category-breakdown-lib.ts
+++ b/apps/web/src/lib/contributor-category-breakdown-lib.ts
@@ -1,0 +1,19 @@
+// Pure per-category tally for a contributor's entries, split out of the
+// contributor detail route so the counting/sorting can be unit-tested.
+
+import type { Category, Entry } from "@/types/registry";
+
+/**
+ * Count a contributor's entries by category, returned most-frequent first with
+ * ties broken alphabetically by category id.
+ */
+export function categoryBreakdown(entries: Entry[]): Array<{ category: Category; count: number }> {
+  const counts = new Map<Category, number>();
+  for (const entry of entries) {
+    counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([category, count]) => ({ category, count }))
+    .sort((left, right) => right.count - left.count || left.category.localeCompare(right.category));
+}

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -25,6 +25,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { ogImageUrl } from "@/lib/og-image";
 import { submitterAttribution } from "@/lib/contributor-profile-summary";
 import type { Category, Contributor, Entry } from "@/types/registry";
+import { categoryBreakdown } from "@/lib/contributor-category-breakdown-lib";
 
 export const Route = createFileRoute("/contributors/$slug")({
   loader: ({ params }) => {
@@ -209,17 +210,6 @@ function ContributorPage() {
       </div>
     </div>
   );
-}
-
-function categoryBreakdown(entries: Entry[]) {
-  const counts = new Map<Category, number>();
-  for (const entry of entries) {
-    counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1);
-  }
-
-  return [...counts.entries()]
-    .map(([category, count]) => ({ category, count }))
-    .sort((left, right) => right.count - left.count || left.category.localeCompare(right.category));
 }
 
 function ContributorStat({

--- a/tests/contributor-category-breakdown-lib.test.ts
+++ b/tests/contributor-category-breakdown-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import type { Category, Entry } from "../apps/web/src/types/registry";
+import { categoryBreakdown } from "../apps/web/src/lib/contributor-category-breakdown-lib";
+
+const entry = (category: Category) => ({ category }) as Entry;
+
+describe("categoryBreakdown", () => {
+  it("returns [] for no entries", () => {
+    expect(categoryBreakdown([])).toEqual([]);
+  });
+
+  it("counts entries per category, most-frequent first", () => {
+    expect(
+      categoryBreakdown([entry("mcp"), entry("mcp"), entry("hooks")]),
+    ).toEqual([
+      { category: "mcp", count: 2 },
+      { category: "hooks", count: 1 },
+    ]);
+  });
+
+  it("breaks count ties alphabetically by category id", () => {
+    expect(categoryBreakdown([entry("mcp"), entry("hooks")])).toEqual([
+      { category: "hooks", count: 1 },
+      { category: "mcp", count: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The contributor detail route tallied a contributor's entries per category inline with `categoryBreakdown`, so the count/sort had no direct test. This moves it into a new `apps/web/src/lib/contributor-category-breakdown-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `/contributors/$slug` builds its category credits via `categoryBreakdown` from the lib.
- Expected behavior: counts a contributor's entries per category, returned most-frequent first with count ties broken alphabetically by category id. Identical to the removed inline version.
- Important edge cases or invariants: an empty input returns `[]`; a repeated category increments (the `?? 0` seed), and equal counts fall back to `localeCompare`.
- Backward compatibility notes: fully backward compatible — `categoryBreakdown` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same category-credit tiles.
- Focused tests: added `tests/contributor-category-breakdown-lib.test.ts` (3 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/contributor-category-breakdown-lib.test.ts --coverage` → 3/3 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that adds unit coverage for the contributor category tally, matching merged extraction PRs #4551 and #4555 (no linked issue).
