### PR TITLE
feat(web): add entry detail decision playbook surface

### DIFF
--- a/apps/web/src/components/entry-detail-decision-playbook.tsx
+++ b/apps/web/src/components/entry-detail-decision-playbook.tsx
@@ -1,0 +1,168 @@
+import { AlertTriangle, CheckCircle2, Circle, GitCompare, ShieldAlert } from "lucide-react";
+import type {
+  DecisionChecklistItem,
+  DecisionChecklistTone,
+  EntryDetailDecisionPlaybookState,
+} from "@/lib/entry-detail-decision-playbook";
+import { cn } from "@/lib/utils";
+
+const TONE_STYLES: Record<DecisionChecklistTone, string> = {
+  complete: "border-trust-trusted/30 bg-trust-trusted/5",
+  warning: "border-amber-500/30 bg-amber-500/5",
+  critical: "border-trust-blocked/30 bg-trust-blocked/5",
+};
+
+const TONE_LABELS: Record<DecisionChecklistTone, string> = {
+  complete: "Complete",
+  warning: "Needs review",
+  critical: "Required checks missing",
+};
+
+function ChecklistRow({ item }: { item: DecisionChecklistItem }) {
+  return (
+    <li className="flex items-start justify-between gap-3 rounded-md border border-border/70 bg-background/70 px-2.5 py-2">
+      <div className="min-w-0">
+        <p className="text-xs font-medium text-ink">
+          {item.label}
+          {item.required ? (
+            <span className="ml-1 rounded bg-ink/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-ink-muted">
+              Required
+            </span>
+          ) : null}
+        </p>
+        <p className="mt-0.5 text-[11px] text-ink-muted">{item.detail}</p>
+      </div>
+      <span
+        className={cn(
+          "mt-0.5 inline-flex shrink-0 items-center gap-1 text-[11px] font-medium",
+          item.done
+            ? "text-trust-trusted"
+            : item.required
+              ? "text-trust-blocked"
+              : "text-ink-muted",
+        )}
+      >
+        {item.done ? (
+          <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Circle className="h-3.5 w-3.5" aria-hidden />
+        )}
+        {item.done ? "Done" : "Pending"}
+      </span>
+    </li>
+  );
+}
+
+function SectionCard({
+  title,
+  summary,
+  tone,
+  items,
+}: {
+  title: string;
+  summary: string;
+  tone: DecisionChecklistTone;
+  items: DecisionChecklistItem[];
+}) {
+  return (
+    <section className={cn("rounded-lg border p-3", TONE_STYLES[tone])}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h4 className="text-sm font-semibold text-ink">{title}</h4>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] uppercase tracking-wide text-ink-muted">
+          {TONE_LABELS[tone]}
+        </span>
+      </div>
+      <p className="mb-2.5 text-xs text-ink-muted">{summary}</p>
+      <ul className="space-y-1.5">
+        {items.map((item) => (
+          <ChecklistRow key={item.id} item={item} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function compareScoreLabel(scoreDelta: number | null) {
+  if (scoreDelta === null) return "No baseline selected";
+  if (scoreDelta > 0) return `+${scoreDelta} vs baseline`;
+  if (scoreDelta < 0) return `${scoreDelta} vs baseline`;
+  return "Score parity with baseline";
+}
+
+export function EntryDetailDecisionPlaybook({
+  state,
+  className,
+}: {
+  state: EntryDetailDecisionPlaybookState;
+  className?: string;
+}) {
+  return (
+    <section
+      id="decision-playbook"
+      aria-label="Decision playbook"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Decision playbook</p>
+          <h3 className="mt-1 text-lg font-semibold text-ink">{state.heading}</h3>
+          <p className="mt-2 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <ShieldAlert className="mt-1 hidden h-5 w-5 shrink-0 text-ink-muted sm:block" aria-hidden />
+      </div>
+
+      {state.showEscalationCallout && state.escalationText ? (
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-trust-blocked/40 bg-trust-blocked/5 px-3 py-2.5 text-xs">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-trust-blocked" aria-hidden />
+          <p className="text-ink-muted">{state.escalationText}</p>
+        </div>
+      ) : null}
+
+      <div className="mt-4 rounded-lg border border-border bg-background px-3 py-2.5">
+        <div className="flex items-center gap-2 text-xs font-medium text-ink">
+          <GitCompare className="h-3.5 w-3.5" aria-hidden />
+          Compare context
+        </div>
+        <div className="mt-2 grid gap-2 text-xs text-ink-muted sm:grid-cols-2 lg:grid-cols-4">
+          <div>
+            <span className="text-ink-subtle">Selected</span>
+            <p className="font-mono text-ink">{state.compare.selectedCount}</p>
+          </div>
+          <div>
+            <span className="text-ink-subtle">Current score</span>
+            <p className="font-mono text-ink">{state.compare.currentScore}</p>
+          </div>
+          <div>
+            <span className="text-ink-subtle">Baseline</span>
+            <p className="truncate text-ink">{state.compare.baselineTitle ?? "—"}</p>
+          </div>
+          <div>
+            <span className="text-ink-subtle">Delta</span>
+            <p className="font-mono text-ink">{compareScoreLabel(state.compare.scoreDelta)}</p>
+          </div>
+        </div>
+        {state.compare.divergingSignals.length > 0 ? (
+          <p className="mt-2 text-[11px] text-amber-800">
+            Diverges on: {state.compare.divergingSignals.join(", ")}
+          </p>
+        ) : (
+          <p className="mt-2 text-[11px] text-ink-subtle">
+            No major trust-signal divergence detected in the current selection.
+          </p>
+        )}
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        {state.sections.map((section) => (
+          <SectionCard
+            key={section.id}
+            title={section.title}
+            summary={section.summary}
+            tone={section.tone}
+            items={section.items}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-detail-decision-playbook-lib.ts
+++ b/apps/web/src/lib/entry-detail-decision-playbook-lib.ts
@@ -1,0 +1,364 @@
+/**
+ * Pure decision-playbook helpers for entry detail pages.
+ *
+ * Converts trust metadata + compare-tray context into concrete "next step"
+ * guidance so users can decide quickly without scanning every section.
+ */
+
+import type { Entry, TrustLevel } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+
+export type DecisionChecklistTone = "complete" | "warning" | "critical";
+
+export type DecisionChecklistItem = {
+  id: string;
+  label: string;
+  detail: string;
+  done: boolean;
+  required: boolean;
+};
+
+export type DecisionPlaybookSection = {
+  id: string;
+  title: string;
+  tone: DecisionChecklistTone;
+  summary: string;
+  items: DecisionChecklistItem[];
+};
+
+export type DecisionCompareContext = {
+  selectedCount: number;
+  inCompareTray: boolean;
+  baselineTitle: string | null;
+  baselineScore: number | null;
+  currentScore: number;
+  scoreDelta: number | null;
+  divergingSignals: string[];
+};
+
+export type EntryDetailDecisionPlaybookState = {
+  heading: string;
+  summary: string;
+  compare: DecisionCompareContext;
+  sections: DecisionPlaybookSection[];
+  showEscalationCallout: boolean;
+  escalationText: string | null;
+};
+
+const TRUST_RANK: Record<TrustLevel, number> = {
+  trusted: 4,
+  review: 3,
+  limited: 2,
+  blocked: 1,
+};
+
+function hasSafetyNotes(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacyNotes(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function hasPackageSignals(
+  entry: Pick<Entry, "packageVerified" | "downloadSha256" | "downloadUrl">,
+) {
+  return Boolean(entry.packageVerified !== undefined || entry.downloadSha256 || entry.downloadUrl);
+}
+
+function isSourceBacked(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+export function entryDecisionTrustScore(entry: Entry): number {
+  let score = TRUST_RANK[entry.trust] * 10;
+  if (entry.reviewed || entry.reviewedBy) score += 15;
+  if (hasSafetyNotes(entry)) score += 10;
+  if (hasPrivacyNotes(entry)) score += 10;
+  if (isSourceBacked(entry)) score += 10;
+  if (hasPackageSignals(entry)) score += 8;
+  if (entry.claimed) score += 4;
+  if (hasInstallPayload(entry)) score += 3;
+  return score;
+}
+
+function decisionHeading(entry: Entry): string {
+  if (entry.trust === "blocked") return "Do not install before manual review";
+  if (entry.trust === "limited") return "Evaluate carefully before using";
+  if (entry.trust === "review") return "Review trust signals before you adopt";
+  return "Ready to evaluate for your workflow";
+}
+
+function decisionSummary(entry: Entry): string {
+  if (entry.trust === "blocked") {
+    return "This listing is marked blocked. Treat all install/copy actions as high risk until source and behavior are manually verified.";
+  }
+  if (entry.trust === "limited") {
+    return "Trust metadata is partial. Compare provenance, package details, and safety notes before moving forward.";
+  }
+  if (entry.trust === "review") {
+    return "Signals are present but mixed. Use the checklist below to confirm the source and operational safety for your environment.";
+  }
+  return "Signals are comparatively strong, but you should still validate source, privacy posture, and package provenance for your environment.";
+}
+
+function divergenceLabels(current: Entry, baseline: Entry): string[] {
+  const labels: string[] = [];
+  if (
+    Boolean(current.reviewed || current.reviewedBy) !==
+    Boolean(baseline.reviewed || baseline.reviewedBy)
+  ) {
+    labels.push("review status");
+  }
+  if (current.source !== baseline.source) labels.push("source provenance");
+  if (Boolean(current.packageVerified) !== Boolean(baseline.packageVerified))
+    labels.push("package verification");
+  if (Boolean(current.claimed) !== Boolean(baseline.claimed)) labels.push("submitter claim");
+  if (hasSafetyNotes(current) !== hasSafetyNotes(baseline)) labels.push("safety notes");
+  if (hasPrivacyNotes(current) !== hasPrivacyNotes(baseline)) labels.push("privacy notes");
+  return labels;
+}
+
+function selectBaselinePeer(entry: Entry, compareEntries: Entry[]): Entry | null {
+  const peers = compareEntries.filter((candidate) => !sameEntry(candidate, entry));
+  if (peers.length === 0) return null;
+  return peers
+    .slice()
+    .sort((left, right) => entryDecisionTrustScore(right) - entryDecisionTrustScore(left))[0];
+}
+
+export function entryDecisionCompareContext(
+  entry: Entry,
+  compareEntries: Entry[],
+): DecisionCompareContext {
+  const baseline = selectBaselinePeer(entry, compareEntries);
+  const currentScore = entryDecisionTrustScore(entry);
+  const scoreDelta = baseline ? currentScore - entryDecisionTrustScore(baseline) : null;
+  return {
+    selectedCount: compareEntries.length,
+    inCompareTray: compareEntries.some((candidate) => sameEntry(candidate, entry)),
+    baselineTitle: baseline?.title ?? null,
+    baselineScore: baseline ? entryDecisionTrustScore(baseline) : null,
+    currentScore,
+    scoreDelta,
+    divergingSignals: baseline ? divergenceLabels(entry, baseline) : [],
+  };
+}
+
+function checklistTone(items: DecisionChecklistItem[]): DecisionChecklistTone {
+  const requiredRemaining = items.some((item) => item.required && !item.done);
+  if (requiredRemaining) return "critical";
+  const optionalRemaining = items.some((item) => !item.done);
+  if (optionalRemaining) return "warning";
+  return "complete";
+}
+
+function sourceChecklist(entry: Entry): DecisionPlaybookSection {
+  const items: DecisionChecklistItem[] = [
+    {
+      id: "source-linked",
+      label: "Source link available",
+      detail: entry.sourceUrl
+        ? "Open the canonical repository and verify ownership."
+        : "No source URL is listed on this entry.",
+      done: Boolean(entry.sourceUrl),
+      required: true,
+    },
+    {
+      id: "source-backed",
+      label: "Source provenance status",
+      detail:
+        entry.source !== "unverified"
+          ? `Marked as ${entry.source}.`
+          : "Still marked unverified; treat claims as unconfirmed.",
+      done: entry.source !== "unverified",
+      required: true,
+    },
+    {
+      id: "reviewed",
+      label: "Metadata reviewed",
+      detail:
+        entry.reviewed || entry.reviewedBy
+          ? "Registry metadata indicates a reviewed listing."
+          : "No reviewed flag detected in metadata.",
+      done: Boolean(entry.reviewed || entry.reviewedBy),
+      required: false,
+    },
+  ];
+  return {
+    id: "source",
+    title: "Source and provenance checks",
+    tone: checklistTone(items),
+    summary: "Confirm ownership and provenance before trusting install instructions.",
+    items,
+  };
+}
+
+function safetyChecklist(entry: Entry): DecisionPlaybookSection {
+  const items: DecisionChecklistItem[] = [
+    {
+      id: "safety",
+      label: "Safety notes present",
+      detail: hasSafetyNotes(entry)
+        ? "Review the listed safety guidance before running commands."
+        : "No safety notes listed.",
+      done: hasSafetyNotes(entry),
+      required: true,
+    },
+    {
+      id: "privacy",
+      label: "Privacy notes present",
+      detail: hasPrivacyNotes(entry)
+        ? "Review data handling notes before connecting accounts or secrets."
+        : "No privacy notes listed.",
+      done: hasPrivacyNotes(entry),
+      required: true,
+    },
+    {
+      id: "risk",
+      label: "Trust level risk gate",
+      detail:
+        entry.trust === "blocked"
+          ? "Blocked trust level requires manual validation before any usage."
+          : entry.trust === "limited"
+            ? "Limited trust level requires additional due diligence."
+            : "Trust level does not block evaluation.",
+      done: entry.trust !== "blocked",
+      required: true,
+    },
+  ];
+  return {
+    id: "safety",
+    title: "Safety and privacy checks",
+    tone: checklistTone(items),
+    summary: "Validate risk disclosures before installation or API wiring.",
+    items,
+  };
+}
+
+function packageChecklist(entry: Entry): DecisionPlaybookSection {
+  const items: DecisionChecklistItem[] = [
+    {
+      id: "installable",
+      label: "Install payload available",
+      detail: hasInstallPayload(entry)
+        ? "Install or copy payload is available for review."
+        : "No install payload is present in this listing.",
+      done: hasInstallPayload(entry),
+      required: false,
+    },
+    {
+      id: "package-verified",
+      label: "Package verification flag",
+      detail:
+        entry.packageVerified === true
+          ? "Package marked verified."
+          : entry.packageVerified === false
+            ? "Package explicitly marked unverified."
+            : "No package verification flag provided.",
+      done: entry.packageVerified === true,
+      required: false,
+    },
+    {
+      id: "sha256",
+      label: "Checksum metadata",
+      detail: entry.downloadSha256
+        ? "SHA-256 hash is present."
+        : "No checksum provided for downloaded artifact.",
+      done: Boolean(entry.downloadSha256),
+      required: false,
+    },
+  ];
+  return {
+    id: "package",
+    title: "Package and install checks",
+    tone: checklistTone(items),
+    summary: "Check package metadata and artifact integrity signals.",
+    items,
+  };
+}
+
+function compareChecklist(compare: DecisionCompareContext): DecisionPlaybookSection {
+  const hasCompare = compare.selectedCount >= 2;
+  const hasBaseline = Boolean(compare.baselineTitle);
+  const hasDivergence = compare.divergingSignals.length > 0;
+  const items: DecisionChecklistItem[] = [
+    {
+      id: "compare-active",
+      label: "Compare tray has multiple entries",
+      detail: hasCompare
+        ? `${compare.selectedCount} entries selected.`
+        : "Add at least one more entry to compare trust differences.",
+      done: hasCompare,
+      required: false,
+    },
+    {
+      id: "baseline",
+      label: "Baseline comparison available",
+      detail: hasBaseline
+        ? `Compared against ${compare.baselineTitle}.`
+        : "No baseline peer selected yet.",
+      done: hasBaseline,
+      required: false,
+    },
+    {
+      id: "divergence",
+      label: "Diverging trust signals identified",
+      detail: hasDivergence
+        ? `Signals differ on ${compare.divergingSignals.join(", ")}.`
+        : "No major trust-signal divergence found.",
+      done: hasDivergence,
+      required: false,
+    },
+  ];
+  return {
+    id: "compare",
+    title: "Compare-driven decision checks",
+    tone: checklistTone(items),
+    summary: "Use compare context to validate trade-offs before adoption.",
+    items,
+  };
+}
+
+function escalationText(entry: Entry, sections: DecisionPlaybookSection[]): string | null {
+  if (entry.trust === "blocked") {
+    return "Blocked trust listing: do not run install or config commands until manual source review is complete.";
+  }
+  const criticalOutstanding = sections.some((section) =>
+    section.items.some((item) => item.required && !item.done),
+  );
+  if (criticalOutstanding) {
+    return "Required checks are still incomplete. Finish source and safety verification before adopting this resource.";
+  }
+  return null;
+}
+
+export function entryDetailDecisionPlaybookState(
+  entry: Entry,
+  compareEntries: Entry[],
+): EntryDetailDecisionPlaybookState {
+  const compare = entryDecisionCompareContext(entry, compareEntries);
+  const sections = [
+    sourceChecklist(entry),
+    safetyChecklist(entry),
+    packageChecklist(entry),
+    compareChecklist(compare),
+  ];
+  const escalation = escalationText(entry, sections);
+  return {
+    heading: decisionHeading(entry),
+    summary: decisionSummary(entry),
+    compare,
+    sections,
+    showEscalationCallout: Boolean(escalation),
+    escalationText: escalation,
+  };
+}

--- a/apps/web/src/lib/entry-detail-decision-playbook.ts
+++ b/apps/web/src/lib/entry-detail-decision-playbook.ts
@@ -1,0 +1,16 @@
+/**
+ * Entry detail decision playbook surface exports.
+ */
+
+export type {
+  DecisionChecklistItem,
+  DecisionChecklistTone,
+  DecisionCompareContext,
+  DecisionPlaybookSection,
+  EntryDetailDecisionPlaybookState,
+} from "@/lib/entry-detail-decision-playbook-lib";
+export {
+  entryDecisionCompareContext,
+  entryDecisionTrustScore,
+  entryDetailDecisionPlaybookState,
+} from "@/lib/entry-detail-decision-playbook-lib";

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -85,6 +85,7 @@ export function buildEntryTocItems(input: {
   if (input.risk !== "low") items.push({ id: "risk-callout", label: "Install risk" });
   items.push({ id: "citation-facts", label: "Citation facts" });
   items.push({ id: "adoption-plan", label: "Adoption plan" });
+  items.push({ id: "decision-playbook", label: "Decision playbook" });
   if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
   if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
   if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -341,6 +341,7 @@ function Dossier() {
   const adoptionPlan = useMemo(
     () => entryAdoptionPlanState(entry, adoptionPreset, compare.items),
     [entry, adoptionPreset, compare.items],
+  );
   const decisionPlaybook = useMemo(
     () => entryDetailDecisionPlaybookState(entry, compare.items),
     [entry, compare.items],

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -55,6 +55,7 @@ import { StickyMetaBar } from "@/components/sticky-meta-bar";
 import { EntryDetailCommandCenter } from "@/components/entry-detail-command-center";
 import { EntryDetailMobileActionBar } from "@/components/entry-detail-mobile-action-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
+import { EntryDetailDecisionPlaybook } from "@/components/entry-detail-decision-playbook";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
@@ -79,6 +80,7 @@ import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { entryAdoptionPlanState, type AdoptionPlanPresetId } from "@/lib/entry-adoption-plan";
+import { entryDetailDecisionPlaybookState } from "@/lib/entry-detail-decision-playbook";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -339,6 +341,9 @@ function Dossier() {
   const adoptionPlan = useMemo(
     () => entryAdoptionPlanState(entry, adoptionPreset, compare.items),
     [entry, adoptionPreset, compare.items],
+  const decisionPlaybook = useMemo(
+    () => entryDetailDecisionPlaybookState(entry, compare.items),
+    [entry, compare.items],
   );
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
@@ -490,6 +495,7 @@ function Dossier() {
             </p>
             <CitationFacts entry={entry} />
           </DossierSection>
+          <EntryDetailDecisionPlaybook state={decisionPlaybook} />
           <EntryAdoptionPlanPanel
             state={adoptionPlan}
             selectedPreset={adoptionPreset}

--- a/tests/entry-detail-decision-playbook-lib.test.ts
+++ b/tests/entry-detail-decision-playbook-lib.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  entryDecisionCompareContext,
+  entryDecisionTrustScore,
+  entryDetailDecisionPlaybookState,
+} from "@/lib/entry-detail-decision-playbook-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("entry detail decision playbook lib", () => {
+  it("scores richer trust metadata above sparse entries", () => {
+    const rich = entry({
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      safetyNotes: "Safety",
+      privacyNotes: "Privacy",
+      packageVerified: true,
+      downloadSha256: "abc123",
+      claimed: true,
+    });
+    const sparse = entry({ slug: "sparse", trust: "limited" });
+    expect(entryDecisionTrustScore(rich)).toBeGreaterThan(
+      entryDecisionTrustScore(sparse),
+    );
+  });
+
+  it("builds compare context without baseline when tray has only current entry", () => {
+    const current = entry();
+    const context = entryDecisionCompareContext(current, [current]);
+    expect(context.inCompareTray).toBe(true);
+    expect(context.baselineTitle).toBeNull();
+    expect(context.scoreDelta).toBeNull();
+  });
+
+  it("selects strongest peer as baseline and computes diverging labels", () => {
+    const current = entry({
+      trust: "review",
+      reviewed: false,
+      source: "unverified",
+    });
+    const strong = entry({
+      slug: "strong",
+      title: "Strong",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      claimed: true,
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+    });
+    const weak = entry({ slug: "weak", title: "Weak", trust: "limited" });
+    const context = entryDecisionCompareContext(current, [
+      current,
+      weak,
+      strong,
+    ]);
+    expect(context.baselineTitle).toBe("Strong");
+    expect(context.divergingSignals.length).toBeGreaterThan(0);
+  });
+
+  it("creates escalation callout for blocked entries", () => {
+    const blocked = entry({ trust: "blocked", source: "unverified" });
+    const state = entryDetailDecisionPlaybookState(blocked, []);
+    expect(state.showEscalationCallout).toBe(true);
+    expect(state.escalationText).toContain("Blocked trust");
+  });
+
+  it("creates escalation callout when required checks are missing", () => {
+    const candidate = entry({
+      trust: "review",
+      source: "unverified",
+      safetyNotes: undefined,
+      privacyNotes: undefined,
+    });
+    const state = entryDetailDecisionPlaybookState(candidate, []);
+    expect(state.showEscalationCallout).toBe(true);
+    expect(state.escalationText).toContain("Required checks");
+  });
+
+  it("clears escalation for trusted entries with required checks complete", () => {
+    const trusted = entry({
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://example.com/repo",
+      safetyNotes: "Do this",
+      privacyNotes: "No telemetry",
+    });
+    const state = entryDetailDecisionPlaybookState(trusted, []);
+    expect(state.showEscalationCallout).toBe(false);
+    expect(state.escalationText).toBeNull();
+  });
+
+  it("builds all checklist sections", () => {
+    const state = entryDetailDecisionPlaybookState(entry(), []);
+    expect(state.sections.map((section) => section.id)).toEqual([
+      "source",
+      "safety",
+      "package",
+      "compare",
+    ]);
+  });
+
+  it("marks source checklist critical when source link and provenance are missing", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({ source: "unverified" }),
+      [],
+    );
+    const source = state.sections.find((section) => section.id === "source");
+    expect(source?.tone).toBe("critical");
+  });
+
+  it("marks safety checklist complete when required checks pass", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({
+        trust: "limited",
+        source: "source-backed",
+        sourceUrl: "https://example.com/repo",
+        safetyNotes: "ok",
+        privacyNotes: "ok",
+      }),
+      [],
+    );
+    const safety = state.sections.find((section) => section.id === "safety");
+    expect(safety?.tone).toBe("complete");
+  });
+
+  it("marks compare checklist complete when baseline and divergence are available", () => {
+    const current = entry({
+      source: "source-backed",
+      sourceUrl: "https://example.com/cur",
+    });
+    const baseline = entry({
+      slug: "peer",
+      title: "Peer",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      sourceUrl: "https://example.com/peer",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      claimed: true,
+    });
+    const state = entryDetailDecisionPlaybookState(current, [
+      current,
+      baseline,
+    ]);
+    const compare = state.sections.find((section) => section.id === "compare");
+    expect(compare?.tone).toBe("complete");
+  });
+
+  it("produces compare summary with selected count and score", () => {
+    const current = entry();
+    const peer = entry({
+      slug: "peer",
+      title: "Peer",
+      trust: "trusted",
+      source: "source-backed",
+    });
+    const state = entryDetailDecisionPlaybookState(current, [current, peer]);
+    expect(state.compare.selectedCount).toBe(2);
+    expect(typeof state.compare.currentScore).toBe("number");
+  });
+
+  it("uses blocked heading for blocked trust", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({ trust: "blocked" }),
+      [],
+    );
+    expect(state.heading).toContain("Do not install");
+  });
+
+  it("uses limited heading for limited trust", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({ trust: "limited" }),
+      [],
+    );
+    expect(state.heading).toContain("Evaluate carefully");
+  });
+
+  it("uses review heading for review trust", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({ trust: "review" }),
+      [],
+    );
+    expect(state.heading).toContain("Review trust signals");
+  });
+
+  it("uses trusted heading for trusted trust", () => {
+    const state = entryDetailDecisionPlaybookState(
+      entry({ trust: "trusted" }),
+      [],
+    );
+    expect(state.heading).toContain("Ready to evaluate");
+  });
+});

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -115,6 +115,7 @@ describe("entry-detail-sidebar-lib", () => {
     expect(items.map((item) => item.id)).toEqual([
       "citation-facts",
       "adoption-plan",
+      "decision-playbook",
       "privacy",
       "prerequisites",
       "about",


### PR DESCRIPTION
## Summary
- Add `entry-detail-decision-playbook-lib` to convert trust metadata and compare context into deterministic checklist guidance on detail pages.
- Render `EntryDetailDecisionPlaybook` on entry detail pages and include a dedicated TOC anchor.
- Rebase on latest main and keep compatibility with the new adoption-plan section.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/entry-detail-decision-playbook-lib.test.ts tests/entry-adoption-plan-lib.test.ts tests/entry-detail-sidebar-lib.test.ts`
- [x] `pnpm type-check`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)