### PR TITLE
refactor(web): extract resolveClaimWebsiteUrl into claim-website-url-lib

### DIFF
--- a/apps/web/src/lib/claim-website-url-lib.ts
+++ b/apps/web/src/lib/claim-website-url-lib.ts
@@ -1,0 +1,28 @@
+// Pure resolution of the canonical website URL used when claiming an entry,
+// split out of the claim route so the candidate/proof precedence can be
+// unit-tested. Only https URLs are accepted; a `owner/repo` (or GitHub URL)
+// proof is normalized to a canonical github.com URL.
+
+import type { Entry } from "@/types/registry";
+
+export function resolveClaimWebsiteUrl(entry: Entry, proof: Record<string, string>): string {
+  const candidates = [entry.sourceUrl, entry.repoUrl, entry.docsUrl, entry.websiteUrl];
+  for (const url of candidates) {
+    const trimmed = (url ?? "").trim();
+    if (/^https:\/\//i.test(trimmed)) return trimmed;
+  }
+  const repo = (proof.repo ?? "").trim();
+  if (repo) {
+    const normalized = repo
+      .replace(/^https?:\/\/github\.com\//i, "")
+      .replace(/^github\.com\//i, "")
+      .replace(/^\//, "")
+      .replace(/[?#].*$/, "");
+    if (/^[\w.-]+\/[\w.-]+$/.test(normalized)) {
+      return `https://github.com/${normalized}`;
+    }
+  }
+  const link = (proof.link ?? "").trim();
+  if (/^https:\/\//i.test(link)) return link;
+  return "";
+}

--- a/apps/web/src/routes/claim.tsx
+++ b/apps/web/src/routes/claim.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, ShieldCheck, ListChecks } from "lucide-react";
 import { ENTRIES } from "@/data/entries";
+import { resolveClaimWebsiteUrl } from "@/lib/claim-website-url-lib";
 import { cn } from "@/lib/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { absoluteUrl } from "@/lib/seo";
@@ -78,31 +79,6 @@ const PROOF_FIELDS = [
 ] as const;
 
 const TYPE_OPTIONS: ClaimType[] = ["maintain", "transfer", "correct", "remove"];
-
-function resolveClaimWebsiteUrl(
-  entry: (typeof ENTRIES)[number],
-  proof: Record<string, string>,
-): string {
-  const candidates = [entry.sourceUrl, entry.repoUrl, entry.docsUrl, entry.websiteUrl];
-  for (const url of candidates) {
-    const trimmed = (url ?? "").trim();
-    if (/^https:\/\//i.test(trimmed)) return trimmed;
-  }
-  const repo = (proof.repo ?? "").trim();
-  if (repo) {
-    const normalized = repo
-      .replace(/^https?:\/\/github\.com\//i, "")
-      .replace(/^github\.com\//i, "")
-      .replace(/^\//, "")
-      .replace(/[?#].*$/, "");
-    if (/^[\w.-]+\/[\w.-]+$/.test(normalized)) {
-      return `https://github.com/${normalized}`;
-    }
-  }
-  const link = (proof.link ?? "").trim();
-  if (/^https:\/\//i.test(link)) return link;
-  return "";
-}
 
 function ClaimPage() {
   const [done, setDone] = React.useState(false);

--- a/tests/claim-website-url-lib.test.ts
+++ b/tests/claim-website-url-lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { resolveClaimWebsiteUrl } from "../apps/web/src/lib/claim-website-url-lib";
+
+const entry = (over: Partial<Entry> = {}) => ({ ...over }) as Entry;
+
+describe("resolveClaimWebsiteUrl", () => {
+  it("prefers the first https entry URL in source/repo/docs/website order", () => {
+    expect(
+      resolveClaimWebsiteUrl(
+        entry({
+          sourceUrl: "http://insecure.example",
+          repoUrl: "https://github.com/o/r",
+          websiteUrl: "https://site.example",
+        }),
+        {},
+      ),
+    ).toBe("https://github.com/o/r");
+  });
+
+  it("falls back to a later https field when earlier ones are missing/insecure", () => {
+    expect(
+      resolveClaimWebsiteUrl(
+        entry({
+          sourceUrl: "  ",
+          repoUrl: "http://insecure.example",
+          docsUrl: "ftp://docs.example",
+          websiteUrl: "https://site.example",
+        }),
+        {},
+      ),
+    ).toBe("https://site.example");
+  });
+
+  it("normalizes an owner/repo proof to a canonical github URL", () => {
+    expect(resolveClaimWebsiteUrl(entry(), { repo: "owner/name" })).toBe(
+      "https://github.com/owner/name",
+    );
+  });
+
+  it("strips a github URL / trailing query from a repo proof", () => {
+    expect(
+      resolveClaimWebsiteUrl(entry(), {
+        repo: "https://github.com/owner/name?tab=readme",
+      }),
+    ).toBe("https://github.com/owner/name");
+  });
+
+  it("ignores a malformed repo proof and falls back to an https link proof", () => {
+    expect(
+      resolveClaimWebsiteUrl(entry(), {
+        repo: "not-a-repo",
+        link: "https://proof.example/verify",
+      }),
+    ).toBe("https://proof.example/verify");
+  });
+
+  it("returns '' when nothing usable is present", () => {
+    // No proof at all (link undefined), and a non-https link proof.
+    expect(resolveClaimWebsiteUrl(entry({ sourceUrl: "ftp://x" }), {})).toBe(
+      "",
+    );
+    expect(resolveClaimWebsiteUrl(entry(), { link: "http://insecure" })).toBe(
+      "",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The claim route resolved the canonical website URL for a listing claim inline with `resolveClaimWebsiteUrl`, so its candidate/proof precedence had no direct test. This moves it into a new `apps/web/src/lib/claim-website-url-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `/claim` submits `websiteUrl: resolveClaimWebsiteUrl(...)` from the lib.
- Expected behavior: returns the first https URL among the entry's source/repo/docs/website fields; else normalizes an `owner/repo` (or github URL) proof to a canonical `https://github.com/...`; else an https `link` proof; else "". Identical to the removed inline version.
- Important edge cases or invariants: only https is accepted (http/ftp/blank skipped); a repo proof strips a leading github URL and a trailing `?`/`#`, and must match `owner/repo`; empty inputs yield "".
- Backward compatibility notes: fully backward compatible — `resolveClaimWebsiteUrl` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — claim payload only.
- Focused tests: added `tests/claim-website-url-lib.test.ts` (6 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/claim-website-url-lib.test.ts --coverage` → 6/6 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that adds unit coverage for the claim URL resolution, matching merged extraction PRs #4551 and #4555 (no linked issue).
