### PR TITLE
refactor(web): extract scoreDeltaText into scenario-score-delta-lib

### DIFF
--- a/apps/web/src/components/compare-scenario-ranking-panel.tsx
+++ b/apps/web/src/components/compare-scenario-ranking-panel.tsx
@@ -3,13 +3,8 @@ import type {
   CompareScenarioRankingState,
 } from "@/lib/compare-scenario-ranking";
 import { COMPARE_SCENARIO_PRESETS } from "@/lib/compare-scenario-ranking";
+import { scoreDeltaText } from "@/lib/scenario-score-delta-lib";
 import { cn } from "@/lib/utils";
-
-function scoreDeltaText(delta: number): string {
-  if (delta === 0) return "Top score";
-  if (delta > 0) return `+${delta}`;
-  return `${delta}`;
-}
 
 export function CompareScenarioRankingPanel({
   state,

--- a/apps/web/src/lib/scenario-score-delta-lib.ts
+++ b/apps/web/src/lib/scenario-score-delta-lib.ts
@@ -1,0 +1,12 @@
+// Pure label for a scenario's score delta from the top, split out of the
+// compare-scenario ranking panel so it can be unit-tested without React.
+
+/**
+ * Label for how far an item's score sits below the top: "Top score" at 0, a
+ * `+N` string for a positive delta, and the raw (negative) number otherwise.
+ */
+export function scoreDeltaText(delta: number): string {
+  if (delta === 0) return "Top score";
+  if (delta > 0) return `+${delta}`;
+  return `${delta}`;
+}

--- a/tests/scenario-score-delta-lib.test.ts
+++ b/tests/scenario-score-delta-lib.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { scoreDeltaText } from "../apps/web/src/lib/scenario-score-delta-lib";
+
+describe("scoreDeltaText", () => {
+  it("labels a zero delta as the top score", () => {
+    expect(scoreDeltaText(0)).toBe("Top score");
+  });
+
+  it("prefixes a positive delta with '+'", () => {
+    expect(scoreDeltaText(4)).toBe("+4");
+  });
+
+  it("renders a negative delta as the raw number", () => {
+    expect(scoreDeltaText(-3)).toBe("-3");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The compare-scenario ranking panel labeled each item's score delta from the top inline with `scoreDeltaText`, so the label logic had no direct test. This moves it into a new `apps/web/src/lib/scenario-score-delta-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the compare-scenario ranking panel renders `scoreDeltaText(item.deltaFromTop)` from the lib.
- Expected behavior: `0` → "Top score"; a positive delta → `"+N"`; a negative delta → the raw number. Identical to the removed inline version.
- Important edge cases or invariants: the `+` prefix is only added for strictly positive deltas.
- Backward compatibility notes: fully backward compatible — `scoreDeltaText` was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same label text.
- Focused tests: added `tests/scenario-score-delta-lib.test.ts` (3 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/scenario-score-delta-lib.test.ts --coverage` → 3/3 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
