### PR TITLE
feat(web): add compare evidence gaps panel

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -33,6 +33,8 @@ import {
   type CompareScenarioId,
 } from "@/lib/compare-scenario-ranking";
 import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
+import { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
+import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
 import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
@@ -328,6 +330,7 @@ export function CompareDrawer() {
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
   const scenarioRanking = compareScenarioRankingState(items, scenario);
+  const evidenceGaps = compareEvidenceGapsState(items);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -435,6 +438,7 @@ export function CompareDrawer() {
               compact
               className="mx-3"
             />
+            <CompareEvidenceGapsPanel state={evidenceGaps} compact className="m-3 mt-0" />
             <div className="min-w-full">
               <table className="w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-10 bg-surface">

--- a/apps/web/src/components/compare-evidence-gaps-panel.tsx
+++ b/apps/web/src/components/compare-evidence-gaps-panel.tsx
@@ -1,0 +1,77 @@
+import type { CompareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
+import { cn } from "@/lib/utils";
+
+function severityClass(severity: "low" | "medium" | "high"): string {
+  if (severity === "high") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+  if (severity === "medium") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+}
+
+export function CompareEvidenceGapsPanel({
+  state,
+  compact = false,
+  className,
+}: {
+  state: CompareEvidenceGapsState;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.comparedCount === 0) return null;
+
+  return (
+    <section
+      aria-label="Evidence gaps"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Evidence gaps</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.headline}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          {state.comparedCount} compared
+        </span>
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.rows.map((row) => (
+          <article key={row.id} className="rounded-lg border border-border bg-background p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{row.label}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{row.hint}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    severityClass(row.severity),
+                  )}
+                >
+                  {row.severity}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{row.coveragePercent}% covered</p>
+              </div>
+            </div>
+
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
+                Present: {row.presentCount}
+              </span>
+              <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
+                Missing: {row.missingCount}
+              </span>
+            </div>
+
+            {!compact && row.missingRefs.length > 0 ? (
+              <p className="mt-2 text-[11px] text-ink-subtle">
+                Missing in: {row.missingRefs.join(", ")}
+              </p>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-evidence-gaps-lib.ts
+++ b/apps/web/src/lib/compare-evidence-gaps-lib.ts
@@ -1,0 +1,189 @@
+/**
+ * Pure compare evidence-gap helpers.
+ *
+ * Highlights missing trust evidence across compared entries so users can spot
+ * what to verify before choosing a candidate.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export type CompareEvidenceGapId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type CompareEvidenceGapRow = {
+  id: CompareEvidenceGapId;
+  label: string;
+  missingCount: number;
+  presentCount: number;
+  coveragePercent: number;
+  severity: "low" | "medium" | "high";
+  missingRefs: string[];
+  hint: string;
+};
+
+export type CompareEntryEvidenceCell = {
+  entryRef: string;
+  title: string;
+  signals: Record<CompareEvidenceGapId, boolean>;
+  missingLabels: string[];
+};
+
+export type CompareEvidenceGapsState = {
+  comparedCount: number;
+  headline: string;
+  summary: string;
+  rows: CompareEvidenceGapRow[];
+  entries: CompareEntryEvidenceCell[];
+  highSeverityCount: number;
+};
+
+function hasSafety(entry: Pick<Entry, "safetyNotes" | "safetyNotesList">): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Pick<Entry, "privacyNotes" | "privacyNotesList">): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasInstallPayload(
+  entry: Pick<Entry, "installCommand" | "configSnippet" | "fullCopy" | "copySnippet">,
+): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.fullCopy || entry.copySnippet,
+  );
+}
+
+function hasSource(entry: Pick<Entry, "source" | "sourceUrl">): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Pick<Entry, "reviewed" | "reviewedBy">): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasPackage(entry: Pick<Entry, "packageVerified" | "downloadSha256">): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+const GAP_LABELS: Record<CompareEvidenceGapId, string> = {
+  source: "Source provenance",
+  reviewed: "Metadata review",
+  safety: "Safety notes",
+  privacy: "Privacy notes",
+  package: "Package integrity",
+  install: "Install payload",
+};
+
+function gapHint(id: CompareEvidenceGapId, missingCount: number): string {
+  if (missingCount === 0) return "No gap detected in current selection.";
+  if (id === "source") return "Verify ownership/source before adopting missing entries.";
+  if (id === "reviewed") return "Prioritize reviewed entries for production rollout.";
+  if (id === "safety") return "Missing safety notes require manual code and behavior review.";
+  if (id === "privacy") return "Missing privacy notes require data-flow validation.";
+  if (id === "package") return "Missing package metadata increases integrity risk.";
+  return "Missing install payload may slow adoption and verification.";
+}
+
+function severityForCoverage(coveragePercent: number): "low" | "medium" | "high" {
+  if (coveragePercent >= 80) return "low";
+  if (coveragePercent >= 50) return "medium";
+  return "high";
+}
+
+function signalMap(entry: Entry): Record<CompareEvidenceGapId, boolean> {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstallPayload(entry),
+  };
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function summarize(
+  rows: CompareEvidenceGapRow[],
+  comparedCount: number,
+): {
+  headline: string;
+  summary: string;
+  highSeverityCount: number;
+} {
+  if (comparedCount < 2) {
+    return {
+      headline: "Add more entries to compare evidence gaps",
+      summary: "Select at least two entries to inspect trust-evidence coverage differences.",
+      highSeverityCount: 0,
+    };
+  }
+  const highSeverity = rows.filter((row) => row.severity === "high");
+  if (highSeverity.length === 0) {
+    return {
+      headline: "Evidence coverage is strong across compared entries",
+      summary: "Most trust signals are present for each candidate in this selection.",
+      highSeverityCount: 0,
+    };
+  }
+  const labels = highSeverity.slice(0, 3).map((row) => row.label.toLowerCase());
+  return {
+    headline: `${highSeverity.length} high-severity evidence gap${highSeverity.length === 1 ? "" : "s"}`,
+    summary: `Largest gaps: ${labels.join(", ")}.`,
+    highSeverityCount: highSeverity.length,
+  };
+}
+
+export function compareEvidenceGapsState(entries: Entry[]): CompareEvidenceGapsState {
+  const entryCells: CompareEntryEvidenceCell[] = entries.map((entry) => {
+    const signals = signalMap(entry);
+    const missingLabels = (Object.keys(signals) as CompareEvidenceGapId[])
+      .filter((id) => !signals[id])
+      .map((id) => GAP_LABELS[id]);
+    return {
+      entryRef: entryRef(entry),
+      title: entry.title,
+      signals,
+      missingLabels,
+    };
+  });
+
+  const rows: CompareEvidenceGapRow[] = (Object.keys(GAP_LABELS) as CompareEvidenceGapId[]).map(
+    (id) => {
+      const missingRefs = entryCells
+        .filter((cell) => !cell.signals[id])
+        .map((cell) => cell.entryRef);
+      const missingCount = missingRefs.length;
+      const presentCount = entries.length - missingCount;
+      const coveragePercent =
+        entries.length === 0 ? 100 : Math.round((presentCount / entries.length) * 100);
+      return {
+        id,
+        label: GAP_LABELS[id],
+        missingCount,
+        presentCount,
+        coveragePercent,
+        severity: severityForCoverage(coveragePercent),
+        missingRefs,
+        hint: gapHint(id, missingCount),
+      };
+    },
+  );
+
+  const summary = summarize(rows, entries.length);
+  return {
+    comparedCount: entries.length,
+    headline: summary.headline,
+    summary: summary.summary,
+    rows,
+    entries: entryCells,
+    highSeverityCount: summary.highSeverityCount,
+  };
+}

--- a/apps/web/src/lib/compare-evidence-gaps.ts
+++ b/apps/web/src/lib/compare-evidence-gaps.ts
@@ -1,0 +1,11 @@
+/**
+ * Compare evidence-gaps exports.
+ */
+
+export type {
+  CompareEntryEvidenceCell,
+  CompareEvidenceGapId,
+  CompareEvidenceGapRow,
+  CompareEvidenceGapsState,
+} from "@/lib/compare-evidence-gaps-lib";
+export { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -20,6 +20,7 @@ import {
   compareScenarioRankingState,
   type CompareScenarioId,
 } from "@/lib/compare-scenario-ranking";
+import { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -27,6 +28,7 @@ import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
 import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
+import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -82,6 +84,7 @@ function ComparePage() {
     () => compareScenarioRankingState(items, scenario),
     [items, scenario],
   );
+  const evidenceGaps = React.useMemo(() => compareEvidenceGapsState(items), [items]);
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -205,6 +208,7 @@ function ComparePage() {
           onSelectScenario={setScenario}
           className="m-3"
         />
+        <CompareEvidenceGapsPanel state={evidenceGaps} className="m-3 mt-0" />
       </div>
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">

--- a/tests/compare-evidence-gaps-lib.test.ts
+++ b/tests/compare-evidence-gaps-lib.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("compare evidence gaps lib", () => {
+  it("returns default summary for empty compare set", () => {
+    const state = compareEvidenceGapsState([]);
+    expect(state.comparedCount).toBe(0);
+    expect(state.rows).toHaveLength(6);
+    expect(state.headline).toContain("Add more entries");
+  });
+
+  it("builds per-entry signal cells and missing labels", () => {
+    const state = compareEvidenceGapsState([entry()]);
+    expect(state.entries).toHaveLength(1);
+    expect(state.entries[0].missingLabels.length).toBeGreaterThan(0);
+  });
+
+  it("reports full coverage as low severity", () => {
+    const strong = entry({
+      trust: "trusted",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/strong",
+      reviewed: true,
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      downloadSha256: "abc",
+      installCommand: "npm i strong",
+    });
+    const state = compareEvidenceGapsState([strong]);
+    expect(state.rows.every((row) => row.severity === "low")).toBe(true);
+  });
+
+  it("reports high severity when coverage drops below 50%", () => {
+    const strong = entry({
+      slug: "strong",
+      title: "Strong",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/strong",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      reviewed: true,
+      packageVerified: true,
+      installCommand: "npm i strong",
+    });
+    const weak = entry({
+      slug: "weak",
+      title: "Weak",
+      source: "unverified",
+      sourceUrl: undefined,
+      safetyNotes: undefined,
+      privacyNotes: undefined,
+      reviewed: false,
+      packageVerified: undefined,
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+    });
+    const state = compareEvidenceGapsState([strong, weak, weak]);
+    expect(state.rows.some((row) => row.severity === "high")).toBe(true);
+    expect(state.highSeverityCount).toBeGreaterThan(0);
+  });
+
+  it("tracks missing refs for each gap row", () => {
+    const a = entry({
+      slug: "a",
+      title: "A",
+      source: "unverified",
+      sourceUrl: undefined,
+    });
+    const b = entry({
+      slug: "b",
+      title: "B",
+      source: "source-backed",
+      sourceUrl: "https://x.com",
+    });
+    const state = compareEvidenceGapsState([a, b]);
+    const sourceRow = state.rows.find((row) => row.id === "source");
+    expect(sourceRow?.missingRefs).toContain("tools/a");
+    expect(sourceRow?.missingRefs).not.toContain("tools/b");
+  });
+
+  it("computes coverage percentage from present and missing counts", () => {
+    const withSafety = entry({ slug: "a", safetyNotes: "yes" });
+    const withoutSafety = entry({ slug: "b", safetyNotes: undefined });
+    const state = compareEvidenceGapsState([withSafety, withoutSafety]);
+    const safetyRow = state.rows.find((row) => row.id === "safety");
+    expect(safetyRow?.presentCount).toBe(1);
+    expect(safetyRow?.missingCount).toBe(1);
+    expect(safetyRow?.coveragePercent).toBe(50);
+  });
+
+  it("marks medium severity at 50-79 coverage", () => {
+    const a = entry({ slug: "a", reviewed: true });
+    const b = entry({ slug: "b", reviewed: true });
+    const c = entry({ slug: "c", reviewed: false });
+    const state = compareEvidenceGapsState([a, b, c]);
+    const reviewedRow = state.rows.find((row) => row.id === "reviewed");
+    expect(reviewedRow?.severity).toBe("medium");
+  });
+
+  it("produces strong headline when no high-severity rows exist", () => {
+    const a = entry({
+      slug: "a",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/a",
+      reviewed: true,
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      installCommand: "npm i a",
+    });
+    const b = entry({
+      slug: "b",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/b",
+      reviewed: true,
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      installCommand: "npm i b",
+    });
+    const state = compareEvidenceGapsState([a, b]);
+    expect(state.highSeverityCount).toBe(0);
+    expect(state.headline).toContain("strong");
+  });
+
+  it("summarizes high severity labels when present", () => {
+    const a = entry({ slug: "a", source: "unverified", sourceUrl: undefined });
+    const b = entry({ slug: "b", source: "unverified", sourceUrl: undefined });
+    const state = compareEvidenceGapsState([a, b]);
+    expect(state.highSeverityCount).toBeGreaterThan(0);
+    expect(state.summary).toContain("Largest gaps");
+  });
+
+  it("includes gap-specific hints", () => {
+    const state = compareEvidenceGapsState([entry()]);
+    expect(state.rows.find((row) => row.id === "source")?.hint).toContain(
+      "ownership",
+    );
+    expect(state.rows.find((row) => row.id === "privacy")?.hint).toContain(
+      "data-flow",
+    );
+  });
+
+  it("includes install gap hints when payload is missing", () => {
+    const noInstall = entry({
+      installCommand: undefined,
+      configSnippet: undefined,
+      fullCopy: undefined,
+      copySnippet: undefined,
+    });
+    const state = compareEvidenceGapsState([noInstall]);
+    const installRow = state.rows.find((row) => row.id === "install");
+    expect(installRow?.hint).toContain("adoption");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-evidence-gaps-lib` to compute per-signal trust-evidence coverage and missing-entry refs across compared entries.
- Add `CompareEvidenceGapsPanel` and render it on both `/compare` and the compare drawer so users can spot missing source/review/safety/privacy/package/install evidence quickly.
- Add focused tests for severity mapping, coverage percentages, summaries, and gap hints.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/compare-evidence-gaps-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)