### PR TITLE
refactor(web): extract parseBriefNumber into brief-number-parse-lib

### DIFF
--- a/apps/web/src/lib/brief-number-parse-lib.ts
+++ b/apps/web/src/lib/brief-number-parse-lib.ts
@@ -1,0 +1,10 @@
+// Pure parser for the brief route's numeric `:number` param, split out of the
+// route so the strict digits-only check can be unit-tested.
+
+/**
+ * Parse a strictly-numeric string to a number, or `NaN` for anything that is
+ * not all ASCII digits (empty, signs, decimals, or trailing characters).
+ */
+export function parseBriefNumber(value: string): number {
+  return /^\d+$/.test(value) ? Number(value) : NaN;
+}

--- a/apps/web/src/routes/brief.$number.tsx
+++ b/apps/web/src/routes/brief.$number.tsx
@@ -3,6 +3,7 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { BriefSections, type BriefSectionsData } from "@/components/brief-sections";
+import { parseBriefNumber } from "@/lib/brief-number-parse-lib";
 import { absoluteUrl } from "@/lib/seo";
 
 const loadBriefIssue = createServerFn({ method: "GET" })
@@ -28,13 +29,9 @@ const loadBriefIssue = createServerFn({ method: "GET" })
     };
   });
 
-function parseNumber(value: string): number {
-  return /^\d+$/.test(value) ? Number(value) : NaN;
-}
-
 export const Route = createFileRoute("/brief/$number")({
   loader: async ({ params }) => {
-    const number = parseNumber(params.number);
+    const number = parseBriefNumber(params.number);
     if (!Number.isInteger(number)) throw notFound();
     const issue = await loadBriefIssue({ data: { number } });
     if (!issue.found) throw notFound();

--- a/tests/brief-number-parse-lib.test.ts
+++ b/tests/brief-number-parse-lib.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { parseBriefNumber } from "../apps/web/src/lib/brief-number-parse-lib";
+
+describe("parseBriefNumber", () => {
+  it("parses an all-digit string to a number", () => {
+    expect(parseBriefNumber("123")).toBe(123);
+    expect(parseBriefNumber("007")).toBe(7);
+  });
+
+  it("returns NaN for non-digit, empty, signed, or decimal input", () => {
+    expect(parseBriefNumber("12a")).toBeNaN();
+    expect(parseBriefNumber("")).toBeNaN();
+    expect(parseBriefNumber("-5")).toBeNaN();
+    expect(parseBriefNumber("1.5")).toBeNaN();
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The brief route parsed its numeric `:number` param inline with a strict digits-only `parseNumber`, so the check had no direct test. This moves it into a new `apps/web/src/lib/brief-number-parse-lib.ts` as `parseBriefNumber` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the brief route resolves `params.number` via `parseBriefNumber`.
- Expected behavior: an all-ASCII-digit string parses to a number; anything else (empty, signs, decimals, trailing chars) returns `NaN`. Identical to the removed inline version.
- Important edge cases or invariants: the strict `^\d+$` check rejects `-5`, `1.5`, and `12a`.
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — param parsing only.
- Focused tests: added `tests/brief-number-parse-lib.test.ts` (2 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/brief-number-parse-lib.test.ts --coverage` → 2/2 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
