### PR TITLE
refactor(web): extract pctOf into pct-of-lib

### DIFF
--- a/apps/web/src/lib/pct-of-lib.ts
+++ b/apps/web/src/lib/pct-of-lib.ts
@@ -1,0 +1,7 @@
+// Pure percentage helper, split out of the state-of-claude-tooling route so the
+// divide-by-zero guard can be unit-tested.
+
+/** `n` as a whole-number percentage of `total`, or 0 when `total` is 0. */
+export function pctOf(n: number, total: number): number {
+  return total ? Math.round((n / total) * 100) : 0;
+}

--- a/apps/web/src/routes/state-of-claude-tooling.tsx
+++ b/apps/web/src/routes/state-of-claude-tooling.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/types/registry";
 import { ENTRIES, QUALITY_STATS, REGISTRY_GENERATED_AT } from "@/data/entries";
 import { installMethodDistribution, notesCoverage } from "@/lib/ecosystem-stats";
+import { pctOf } from "@/lib/pct-of-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, OG_WIDTH, OG_HEIGHT } from "@/lib/og-image";
 import { stringifyJsonLd } from "@/lib/json-ld";
@@ -36,10 +37,6 @@ interface DistRow {
   label: string;
   count: number;
   pct: number;
-}
-
-function pctOf(n: number, total: number) {
-  return total ? Math.round((n / total) * 100) : 0;
 }
 
 const TOTAL = ENTRIES.length;

--- a/tests/pct-of-lib.test.ts
+++ b/tests/pct-of-lib.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { pctOf } from "../apps/web/src/lib/pct-of-lib";
+
+describe("pctOf", () => {
+  it("computes a rounded percentage", () => {
+    expect(pctOf(1, 3)).toBe(33);
+    expect(pctOf(2, 3)).toBe(67);
+    expect(pctOf(5, 5)).toBe(100);
+  });
+
+  it("returns 0 when the total is 0", () => {
+    expect(pctOf(4, 0)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The state-of-claude-tooling route computed rounded percentages inline with `pctOf` (10 call sites), so the divide-by-zero guard had no direct test. This moves it into a new `apps/web/src/lib/pct-of-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the `/state-of-claude-tooling` distribution tables compute percentages via `pctOf`.
- Expected behavior: `Math.round((n / total) * 100)`, or `0` when `total` is `0`. Identical to the removed inline version.
- Important edge cases or invariants: the `total === 0` guard prevents a divide-by-zero `NaN`.
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same percentages.
- Focused tests: added `tests/pct-of-lib.test.ts` (2 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/pct-of-lib.test.ts --coverage` → 2/2 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
