### PR TITLE
feat(web): add compare rollout readiness planner

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -36,6 +36,11 @@ import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranki
 import { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
 import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
 import {
+  compareRolloutReadinessState,
+  type RolloutPresetId,
+} from "@/lib/compare-rollout-readiness";
+import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
+import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
@@ -326,11 +331,13 @@ function SnippetCell({ entry }: { entry: Entry }) {
 export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
+  const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
   const scenarioRanking = compareScenarioRankingState(items, scenario);
   const evidenceGaps = compareEvidenceGapsState(items);
+  const rolloutReadiness = compareRolloutReadinessState(items, rolloutPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -439,6 +446,13 @@ export function CompareDrawer() {
               className="mx-3"
             />
             <CompareEvidenceGapsPanel state={evidenceGaps} compact className="m-3 mt-0" />
+            <CompareRolloutReadinessPanel
+              state={rolloutReadiness}
+              selectedPreset={rolloutPreset}
+              onSelectPreset={setRolloutPreset}
+              compact
+              className="m-3 mt-0"
+            />
             <div className="min-w-full">
               <table className="w-full border-collapse text-sm">
                 <thead className="sticky top-0 z-10 bg-surface">

--- a/apps/web/src/components/compare-rollout-readiness-panel.tsx
+++ b/apps/web/src/components/compare-rollout-readiness-panel.tsx
@@ -1,0 +1,120 @@
+import type {
+  CompareRolloutReadinessState,
+  RolloutPresetId,
+} from "@/lib/compare-rollout-readiness";
+import { cn } from "@/lib/utils";
+
+function tierClass(tier: "ready" | "review" | "hold"): string {
+  if (tier === "ready") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+  if (tier === "hold") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+  return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+}
+
+const PRESETS: { id: RolloutPresetId; label: string }[] = [
+  { id: "prototype", label: "Prototype" },
+  { id: "team", label: "Team" },
+  { id: "production", label: "Production" },
+];
+
+export function CompareRolloutReadinessPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  compact = false,
+  className,
+}: {
+  state: CompareRolloutReadinessState;
+  selectedPreset: RolloutPresetId;
+  onSelectPreset: (preset: RolloutPresetId) => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.comparedCount === 0) return null;
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="eyebrow">Rollout readiness</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          {state.comparedCount} entries
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => {
+          const active = selectedPreset === preset.id;
+          return (
+            <button
+              key={preset.id}
+              type="button"
+              onClick={() => onSelectPreset(preset.id)}
+              className={cn(
+                "inline-flex rounded-md border px-2.5 py-1 text-xs transition",
+                active
+                  ? "border-ink bg-ink text-background"
+                  : "border-border bg-background text-ink-muted hover:text-ink",
+              )}
+            >
+              {preset.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="mt-3 grid gap-2.5">
+        {state.plans.map((plan) => (
+          <article
+            key={plan.entryRef}
+            className="rounded-lg border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <h4 className="text-sm font-semibold text-ink">{plan.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{plan.summary}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    tierClass(plan.tier),
+                  )}
+                >
+                  {plan.tier}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{plan.score}/100</p>
+              </div>
+            </div>
+
+            {!compact && plan.blockers.length > 0 ? (
+              <p className="mt-2 text-[11px] text-trust-blocked">
+                Blockers: {plan.blockers.join(", ")}
+              </p>
+            ) : null}
+
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {plan.checklist.map((item) => (
+                <span
+                  key={`${plan.entryRef}-${item.id}`}
+                  className={cn(
+                    "rounded border px-2 py-0.5 text-[10px]",
+                    item.tone === "complete" &&
+                      "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted",
+                    item.tone === "warning" && "border-amber-500/30 bg-amber-500/5 text-amber-900",
+                    item.tone === "blocked" &&
+                      "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked",
+                  )}
+                >
+                  {item.label}
+                  {item.required ? " (required)" : ""}
+                </span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-rollout-readiness-lib.ts
+++ b/apps/web/src/lib/compare-rollout-readiness-lib.ts
@@ -1,0 +1,256 @@
+import type { Entry } from "@/types/registry";
+
+export type RolloutPresetId = "prototype" | "team" | "production";
+export type RolloutChecklistTone = "complete" | "warning" | "blocked";
+
+export type RolloutChecklistItem = {
+  id: string;
+  label: string;
+  tone: RolloutChecklistTone;
+  detail: string;
+  required: boolean;
+};
+
+export type CompareRolloutEntryPlan = {
+  entryRef: string;
+  title: string;
+  score: number;
+  tier: "ready" | "review" | "hold";
+  summary: string;
+  blockers: string[];
+  checklist: RolloutChecklistItem[];
+};
+
+export type CompareRolloutReadinessState = {
+  preset: RolloutPresetId;
+  heading: string;
+  summary: string;
+  comparedCount: number;
+  plans: CompareRolloutEntryPlan[];
+  trailingEntryRefs: string[];
+  highestRiskRefs: string[];
+};
+
+type SignalMap = {
+  source: boolean;
+  reviewed: boolean;
+  safety: boolean;
+  privacy: boolean;
+  package: boolean;
+  install: boolean;
+};
+
+const PRESET_HEADING: Record<RolloutPresetId, string> = {
+  prototype: "Prototype rollout readiness",
+  team: "Team rollout readiness",
+  production: "Production rollout readiness",
+};
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function signalMap(entry: Entry): SignalMap {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstall(entry),
+  };
+}
+
+function weightsForPreset(preset: RolloutPresetId): Record<keyof SignalMap, number> {
+  if (preset === "prototype") {
+    return { source: 24, reviewed: 12, safety: 18, privacy: 10, package: 8, install: 28 };
+  }
+  if (preset === "production") {
+    return { source: 20, reviewed: 20, safety: 20, privacy: 14, package: 14, install: 12 };
+  }
+  return { source: 22, reviewed: 16, safety: 20, privacy: 12, package: 10, install: 20 };
+}
+
+function requiredByPreset(preset: RolloutPresetId): Record<keyof SignalMap, boolean> {
+  if (preset === "prototype") {
+    return {
+      source: true,
+      reviewed: false,
+      safety: true,
+      privacy: false,
+      package: false,
+      install: true,
+    };
+  }
+  if (preset === "production") {
+    return {
+      source: true,
+      reviewed: true,
+      safety: true,
+      privacy: true,
+      package: true,
+      install: true,
+    };
+  }
+  return {
+    source: true,
+    reviewed: true,
+    safety: true,
+    privacy: false,
+    package: false,
+    install: true,
+  };
+}
+
+function scorePlan(signals: SignalMap, preset: RolloutPresetId): number {
+  const weights = weightsForPreset(preset);
+  let score = 0;
+  (Object.keys(weights) as (keyof SignalMap)[]).forEach((key) => {
+    if (signals[key]) score += weights[key];
+  });
+  return score;
+}
+
+function tierFromScore(score: number): "ready" | "review" | "hold" {
+  if (score >= 80) return "ready";
+  if (score >= 55) return "review";
+  return "hold";
+}
+
+function itemTone(signalPresent: boolean, required: boolean): RolloutChecklistTone {
+  if (signalPresent) return "complete";
+  return required ? "blocked" : "warning";
+}
+
+function detailForSignal(key: keyof SignalMap, present: boolean): string {
+  if (present) {
+    if (key === "source") return "Source provenance is documented.";
+    if (key === "reviewed") return "Metadata review signal is present.";
+    if (key === "safety") return "Safety notes are available.";
+    if (key === "privacy") return "Privacy notes are available.";
+    if (key === "package") return "Package integrity metadata is available.";
+    return "Install payload is documented for execution.";
+  }
+  if (key === "source") return "No reliable source provenance listed.";
+  if (key === "reviewed") return "No metadata review signal listed.";
+  if (key === "safety") return "No safety notes listed.";
+  if (key === "privacy") return "No privacy notes listed.";
+  if (key === "package") return "No package verification/integrity metadata listed.";
+  return "No install payload listed.";
+}
+
+function checklistForEntry(signals: SignalMap, preset: RolloutPresetId): RolloutChecklistItem[] {
+  const required = requiredByPreset(preset);
+  const labels: Record<keyof SignalMap, string> = {
+    source: "Source provenance",
+    reviewed: "Metadata reviewed",
+    safety: "Safety notes",
+    privacy: "Privacy notes",
+    package: "Package integrity",
+    install: "Install payload",
+  };
+  return (Object.keys(labels) as (keyof SignalMap)[]).map((key) => ({
+    id: key,
+    label: labels[key],
+    required: required[key],
+    tone: itemTone(signals[key], required[key]),
+    detail: detailForSignal(key, signals[key]),
+  }));
+}
+
+function blockersFromChecklist(items: RolloutChecklistItem[]): string[] {
+  return items.filter((item) => item.tone === "blocked").map((item) => `${item.label} missing`);
+}
+
+function summaryForPlan(plan: {
+  tier: "ready" | "review" | "hold";
+  blockers: string[];
+  score: number;
+}): string {
+  if (plan.tier === "ready") return `Ready to roll with score ${plan.score}.`;
+  if (plan.tier === "hold") {
+    if (plan.blockers.length > 0) {
+      return `Hold rollout until blockers clear: ${plan.blockers.slice(0, 2).join(", ")}.`;
+    }
+    return `Hold rollout; insufficient trust evidence (score ${plan.score}).`;
+  }
+  if (plan.blockers.length > 0) {
+    return `Review before rollout: ${plan.blockers.slice(0, 2).join(", ")}.`;
+  }
+  return `Needs review before rollout (score ${plan.score}).`;
+}
+
+function compareSummary(preset: RolloutPresetId, plans: CompareRolloutEntryPlan[]): string {
+  if (plans.length === 0) return "Add entries to generate rollout readiness guidance.";
+  const readyCount = plans.filter((plan) => plan.tier === "ready").length;
+  const holdCount = plans.filter((plan) => plan.tier === "hold").length;
+  if (preset === "prototype") {
+    return `${readyCount}/${plans.length} entries are ready for quick prototype rollout.`;
+  }
+  if (preset === "production") {
+    return `${holdCount} entries currently blocked for production rollout.`;
+  }
+  return `${readyCount} ready, ${holdCount} hold, ${plans.length - readyCount - holdCount} review.`;
+}
+
+export function compareRolloutReadinessState(
+  entries: Entry[],
+  preset: RolloutPresetId,
+): CompareRolloutReadinessState {
+  const plans: CompareRolloutEntryPlan[] = entries
+    .map((entry) => {
+      const signals = signalMap(entry);
+      const checklist = checklistForEntry(signals, preset);
+      const blockers = blockersFromChecklist(checklist);
+      const score = scorePlan(signals, preset);
+      const tier = tierFromScore(score);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        score,
+        tier,
+        blockers,
+        checklist,
+        summary: summaryForPlan({ tier, blockers, score }),
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title));
+
+  const trailingEntryRefs = plans.slice(-2).map((plan) => plan.entryRef);
+  const highestRiskRefs = plans.filter((plan) => plan.tier === "hold").map((plan) => plan.entryRef);
+  return {
+    preset,
+    heading: PRESET_HEADING[preset],
+    summary: compareSummary(preset, plans),
+    comparedCount: entries.length,
+    plans,
+    trailingEntryRefs,
+    highestRiskRefs,
+  };
+}

--- a/apps/web/src/lib/compare-rollout-readiness.ts
+++ b/apps/web/src/lib/compare-rollout-readiness.ts
@@ -1,0 +1,8 @@
+export type {
+  RolloutChecklistItem,
+  RolloutChecklistTone,
+  RolloutPresetId,
+  CompareRolloutEntryPlan,
+  CompareRolloutReadinessState,
+} from "@/lib/compare-rollout-readiness-lib";
+export { compareRolloutReadinessState } from "@/lib/compare-rollout-readiness-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -21,6 +21,10 @@ import {
   type CompareScenarioId,
 } from "@/lib/compare-scenario-ranking";
 import { compareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
+import {
+  compareRolloutReadinessState,
+  type RolloutPresetId,
+} from "@/lib/compare-rollout-readiness";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -29,6 +33,7 @@ import type { Entry } from "@/types/registry";
 import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-panel";
 import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
 import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
+import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -80,11 +85,16 @@ function ComparePage() {
   );
   const decisionBrief = React.useMemo(() => compareDecisionBriefState(items), [items]);
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
+  const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const scenarioRanking = React.useMemo(
     () => compareScenarioRankingState(items, scenario),
     [items, scenario],
   );
   const evidenceGaps = React.useMemo(() => compareEvidenceGapsState(items), [items]);
+  const rolloutReadiness = React.useMemo(
+    () => compareRolloutReadinessState(items, rolloutPreset),
+    [items, rolloutPreset],
+  );
 
   const pushIds = (next: Entry[]) => {
     const ids = serializeCompareItems(next);
@@ -209,6 +219,12 @@ function ComparePage() {
           className="m-3"
         />
         <CompareEvidenceGapsPanel state={evidenceGaps} className="m-3 mt-0" />
+        <CompareRolloutReadinessPanel
+          state={rolloutReadiness}
+          selectedPreset={rolloutPreset}
+          onSelectPreset={setRolloutPreset}
+          className="m-3 mt-0"
+        />
       </div>
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">

--- a/tests/compare-rollout-readiness-lib.test.ts
+++ b/tests/compare-rollout-readiness-lib.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareRolloutReadinessState } from "@/lib/compare-rollout-readiness-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "Present",
+  privacyNotes: "Present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const mid = entry({
+  slug: "mid",
+  title: "Mid",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/mid",
+  reviewed: false,
+  safetyNotes: "Present",
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: "npm i mid",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  copySnippet: undefined,
+  configSnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("compare rollout readiness lib", () => {
+  it("returns empty summary when no entries compared", () => {
+    const state = compareRolloutReadinessState([], "team");
+    expect(state.comparedCount).toBe(0);
+    expect(state.plans).toEqual([]);
+    expect(state.summary).toContain("Add entries");
+  });
+
+  it("uses preset heading values", () => {
+    expect(
+      compareRolloutReadinessState([strong], "prototype").heading,
+    ).toContain("Prototype");
+    expect(compareRolloutReadinessState([strong], "team").heading).toContain(
+      "Team",
+    );
+    expect(
+      compareRolloutReadinessState([strong], "production").heading,
+    ).toContain("Production");
+  });
+
+  it("scores stronger entries above weaker entries", () => {
+    const state = compareRolloutReadinessState([weak, strong], "team");
+    expect(state.plans[0].entryRef).toBe("tools/strong");
+    expect(state.plans[1].entryRef).toBe("tools/weak");
+    expect(state.plans[0].score).toBeGreaterThan(state.plans[1].score);
+  });
+
+  it("assigns ready tier for high scores", () => {
+    const state = compareRolloutReadinessState([strong], "production");
+    expect(state.plans[0].tier).toBe("ready");
+  });
+
+  it("assigns hold tier for low scores", () => {
+    const state = compareRolloutReadinessState([weak], "production");
+    expect(state.plans[0].tier).toBe("hold");
+  });
+
+  it("assigns review tier for medium scores", () => {
+    const state = compareRolloutReadinessState([mid], "team");
+    expect(state.plans[0].tier).toBe("review");
+  });
+
+  it("marks missing required signals as blocked", () => {
+    const state = compareRolloutReadinessState([weak], "production");
+    const plan = state.plans[0];
+    expect(
+      plan.checklist.some((item) => item.required && item.tone === "blocked"),
+    ).toBe(true);
+    expect(plan.blockers.length).toBeGreaterThan(0);
+  });
+
+  it("marks missing optional signals as warning", () => {
+    const state = compareRolloutReadinessState([mid], "team");
+    const privacyItem = state.plans[0].checklist.find(
+      (item) => item.id === "privacy",
+    );
+    expect(privacyItem?.required).toBe(false);
+    expect(privacyItem?.tone).toBe("warning");
+  });
+
+  it("marks present signals as complete", () => {
+    const state = compareRolloutReadinessState([strong], "team");
+    expect(
+      state.plans[0].checklist.every((item) => item.tone === "complete"),
+    ).toBe(true);
+  });
+
+  it("includes required marker based on preset", () => {
+    const prototype = compareRolloutReadinessState([mid], "prototype");
+    const production = compareRolloutReadinessState([mid], "production");
+    const privacyPrototype = prototype.plans[0].checklist.find(
+      (item) => item.id === "privacy",
+    );
+    const privacyProduction = production.plans[0].checklist.find(
+      (item) => item.id === "privacy",
+    );
+    expect(privacyPrototype?.required).toBe(false);
+    expect(privacyProduction?.required).toBe(true);
+  });
+
+  it("produces blocker labels from blocked checklist items", () => {
+    const state = compareRolloutReadinessState([weak], "production");
+    expect(
+      state.plans[0].blockers.some((label) => label.includes("missing")),
+    ).toBe(true);
+  });
+
+  it("creates hold summary with blocker detail", () => {
+    const state = compareRolloutReadinessState([weak], "production");
+    expect(state.plans[0].summary).toContain("Hold rollout");
+    expect(state.plans[0].summary).toContain("blockers");
+  });
+
+  it("creates ready summary for high score entries", () => {
+    const state = compareRolloutReadinessState([strong], "team");
+    expect(state.plans[0].summary).toContain("Ready");
+  });
+
+  it("includes trailing refs for lowest scoring plans", () => {
+    const state = compareRolloutReadinessState([strong, mid, weak], "team");
+    expect(state.trailingEntryRefs.length).toBe(2);
+    expect(state.trailingEntryRefs).toContain("tools/weak");
+  });
+
+  it("lists highest risk refs for hold entries", () => {
+    const state = compareRolloutReadinessState([strong, weak], "production");
+    expect(state.highestRiskRefs).toContain("tools/weak");
+    expect(state.highestRiskRefs).not.toContain("tools/strong");
+  });
+
+  it("uses prototype compare summary phrasing", () => {
+    const state = compareRolloutReadinessState([strong, weak], "prototype");
+    expect(state.summary).toContain("prototype rollout");
+  });
+
+  it("uses production compare summary phrasing", () => {
+    const state = compareRolloutReadinessState([strong, weak], "production");
+    expect(state.summary).toContain("production rollout");
+  });
+
+  it("uses team compare summary phrasing", () => {
+    const state = compareRolloutReadinessState([strong, mid, weak], "team");
+    expect(state.summary).toContain("ready");
+    expect(state.summary).toContain("hold");
+  });
+
+  it("emits checklist detail text for missing and present", () => {
+    const missingState = compareRolloutReadinessState([weak], "team");
+    const presentState = compareRolloutReadinessState([strong], "team");
+    const missingSource = missingState.plans[0].checklist.find(
+      (item) => item.id === "source",
+    );
+    const presentSource = presentState.plans[0].checklist.find(
+      (item) => item.id === "source",
+    );
+    expect(missingSource?.detail).toContain("No reliable source");
+    expect(presentSource?.detail).toContain("documented");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `compare-rollout-readiness-lib` with preset-weighted scoring and checklist/blocker generation for compare entries.
- Add `CompareRolloutReadinessPanel` and integrate it on compare page and compare drawer with interactive preset switching.
- Add dedicated tests covering score tiers, required/optional checklist behavior, summaries, trailing refs, and risk refs.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/compare-rollout-readiness-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)