### PR TITLE
refactor(web): extract hasSchemaDetails into entry-schema-details-lib

### DIFF
--- a/apps/web/src/lib/entry-schema-details-lib.ts
+++ b/apps/web/src/lib/entry-schema-details-lib.ts
@@ -1,0 +1,38 @@
+// Pure predicate for whether an entry carries any of the optional, category-
+// specific schema fields worth rendering a "details" section for. Split out of
+// the entry route so the check can be unit-tested without the page.
+
+import type { Entry } from "@/types/registry";
+
+export function hasSchemaDetails(entry: Entry): boolean {
+  return Boolean(
+    entry.skillType ||
+    entry.skillLevel ||
+    entry.verificationStatus ||
+    entry.verifiedAt ||
+    entry.retrievalSources?.length ||
+    entry.testedPlatforms?.length ||
+    entry.platformCompatibility?.length ||
+    entry.trigger ||
+    entry.commandSyntax ||
+    entry.argumentHint ||
+    entry.allowedTools?.length ||
+    entry.scriptLanguage ||
+    entry.scriptBody ||
+    entry.items?.length ||
+    entry.installationOrder?.length ||
+    entry.estimatedSetupTime ||
+    entry.difficulty ||
+    entry.websiteUrl ||
+    entry.pricingModel ||
+    entry.disclosure ||
+    entry.applicationCategory ||
+    entry.operatingSystem ||
+    entry.repoStats ||
+    entry.downloadUrl ||
+    entry.packageVerified !== undefined ||
+    entry.downloadSha256 ||
+    entry.copySnippet ||
+    entry.fullCopy,
+  );
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -38,6 +38,7 @@ import { ComparisonTable } from "@/components/comparison-table";
 import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { hasSchemaDetails } from "@/lib/entry-schema-details-lib";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
 import { categoryLabels, categoryUsageHints, siteConfig } from "@/lib/site";
 import { tagSlug } from "@/lib/tags";
@@ -814,39 +815,6 @@ function BadgeSection({
         />
       </div>
     </DossierSection>
-  );
-}
-
-function hasSchemaDetails(entry: Entry) {
-  return Boolean(
-    entry.skillType ||
-    entry.skillLevel ||
-    entry.verificationStatus ||
-    entry.verifiedAt ||
-    entry.retrievalSources?.length ||
-    entry.testedPlatforms?.length ||
-    entry.platformCompatibility?.length ||
-    entry.trigger ||
-    entry.commandSyntax ||
-    entry.argumentHint ||
-    entry.allowedTools?.length ||
-    entry.scriptLanguage ||
-    entry.scriptBody ||
-    entry.items?.length ||
-    entry.installationOrder?.length ||
-    entry.estimatedSetupTime ||
-    entry.difficulty ||
-    entry.websiteUrl ||
-    entry.pricingModel ||
-    entry.disclosure ||
-    entry.applicationCategory ||
-    entry.operatingSystem ||
-    entry.repoStats ||
-    entry.downloadUrl ||
-    entry.packageVerified !== undefined ||
-    entry.downloadSha256 ||
-    entry.copySnippet ||
-    entry.fullCopy,
   );
 }
 

--- a/tests/entry-schema-details-lib.test.ts
+++ b/tests/entry-schema-details-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { hasSchemaDetails } from "../apps/web/src/lib/entry-schema-details-lib";
+
+const entry = (over: Partial<Entry> = {}) => ({ ...over }) as Entry;
+
+describe("hasSchemaDetails", () => {
+  it("is false when none of the optional schema fields are present", () => {
+    expect(hasSchemaDetails(entry())).toBe(false);
+  });
+
+  it("is true when a scalar schema field is set", () => {
+    expect(hasSchemaDetails(entry({ skillType: "capability" }))).toBe(true);
+    expect(hasSchemaDetails(entry({ difficulty: "intermediate" }))).toBe(true);
+  });
+
+  it("is true for a non-empty array field but false for an empty one", () => {
+    expect(hasSchemaDetails(entry({ testedPlatforms: ["claude-code"] }))).toBe(
+      true,
+    );
+    expect(hasSchemaDetails(entry({ testedPlatforms: [] }))).toBe(false);
+  });
+
+  it("treats an explicit packageVerified: false as details present", () => {
+    expect(hasSchemaDetails(entry({ packageVerified: false }))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The entry detail route decided whether to render a schema-details section with a long inline `hasSchemaDetails` predicate (a big OR over ~27 optional fields), so this check had no direct test. This moves it into a new `apps/web/src/lib/entry-schema-details-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the entry detail route gates its schema-details section on `hasSchemaDetails(entry)` from the lib.
- Expected behavior: returns true when the entry carries any of the optional category-specific fields (skill/verification/trigger/command/collection/tool/download/etc.), else false. Identical to the removed inline predicate.
- Important edge cases or invariants: empty arrays stay false (`?.length`), and an explicit `packageVerified: false` counts as details present (`!== undefined`).
- Backward compatibility notes: fully backward compatible — the predicate was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — section gating only.
- Focused tests: added `tests/entry-schema-details-lib.test.ts` (4 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/entry-schema-details-lib.test.ts --coverage` → 4/4 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
