### PR TITLE
refactor(web): extract compareScoreLabel into compare-score-label-lib

### DIFF
--- a/apps/web/src/components/entry-detail-decision-playbook.tsx
+++ b/apps/web/src/components/entry-detail-decision-playbook.tsx
@@ -4,6 +4,7 @@ import type {
   DecisionChecklistTone,
   EntryDetailDecisionPlaybookState,
 } from "@/lib/entry-detail-decision-playbook";
+import { compareScoreLabel } from "@/lib/compare-score-label-lib";
 import { cn } from "@/lib/utils";
 
 const TONE_STYLES: Record<DecisionChecklistTone, string> = {
@@ -80,13 +81,6 @@ function SectionCard({
       </ul>
     </section>
   );
-}
-
-function compareScoreLabel(scoreDelta: number | null) {
-  if (scoreDelta === null) return "No baseline selected";
-  if (scoreDelta > 0) return `+${scoreDelta} vs baseline`;
-  if (scoreDelta < 0) return `${scoreDelta} vs baseline`;
-  return "Score parity with baseline";
 }
 
 export function EntryDetailDecisionPlaybook({

--- a/apps/web/src/lib/compare-score-label-lib.ts
+++ b/apps/web/src/lib/compare-score-label-lib.ts
@@ -1,0 +1,14 @@
+// Pure label for a compared entry's score delta vs the baseline, split out of
+// the entry-detail decision playbook so it can be unit-tested without React.
+
+/**
+ * Human label for a score delta against the selected baseline: null when no
+ * baseline is chosen, `+N vs baseline` / `-N vs baseline` for a difference, and
+ * a parity message when the delta is exactly 0.
+ */
+export function compareScoreLabel(scoreDelta: number | null): string {
+  if (scoreDelta === null) return "No baseline selected";
+  if (scoreDelta > 0) return `+${scoreDelta} vs baseline`;
+  if (scoreDelta < 0) return `${scoreDelta} vs baseline`;
+  return "Score parity with baseline";
+}

--- a/tests/compare-score-label-lib.test.ts
+++ b/tests/compare-score-label-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { compareScoreLabel } from "../apps/web/src/lib/compare-score-label-lib";
+
+describe("compareScoreLabel", () => {
+  it("reports when no baseline is selected", () => {
+    expect(compareScoreLabel(null)).toBe("No baseline selected");
+  });
+
+  it("prefixes a positive delta and keeps a negative delta", () => {
+    expect(compareScoreLabel(5)).toBe("+5 vs baseline");
+    expect(compareScoreLabel(-3)).toBe("-3 vs baseline");
+  });
+
+  it("reports parity at exactly zero", () => {
+    expect(compareScoreLabel(0)).toBe("Score parity with baseline");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The entry-detail decision playbook labeled a compared entry's score delta vs the baseline inline with `compareScoreLabel`, so the label logic had no direct test. This moves it into a new `apps/web/src/lib/compare-score-label-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the entry-detail decision playbook renders `compareScoreLabel(scoreDelta)` from the lib.
- Expected behavior: `null` → "No baseline selected"; positive → `+N vs baseline`; negative → `-N vs baseline`; `0` → "Score parity with baseline". Identical to the removed inline version.
- Important edge cases or invariants: the `+` prefix is only added for strictly positive deltas; parity is the exact-zero case.
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same label text.
- Focused tests: added `tests/compare-score-label-lib.test.ts` (3 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/compare-score-label-lib.test.ts --coverage` → 3/3 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
