### PR TITLE
feat(web): add browse rollout signals panel

### DIFF
--- a/apps/web/src/components/browse-rollout-signals-panel.tsx
+++ b/apps/web/src/components/browse-rollout-signals-panel.tsx
@@ -1,0 +1,82 @@
+import type { BrowseRolloutSignalsState } from "@/lib/browse-rollout-signals";
+import { cn } from "@/lib/utils";
+
+function toneClass(tone: "good" | "watch" | "risk"): string {
+  if (tone === "good") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+  if (tone === "watch") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+}
+
+export function BrowseRolloutSignalsPanel({
+  state,
+  className,
+}: {
+  state: BrowseRolloutSignalsState;
+  className?: string;
+}) {
+  if (!state.showPanel) return null;
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="eyebrow">Rollout signal scan</p>
+          <h3 className="mt-1 text-sm font-semibold text-ink">{state.heading}</h3>
+          <p className="mt-1 text-xs text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          {state.scannedCount} scanned
+        </span>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        {state.rows.map((row) => (
+          <article key={row.id} className="rounded-md border border-border bg-background p-2.5">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-ink">{row.label}</p>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{row.message}</p>
+              </div>
+              <span
+                className={cn(
+                  "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                  toneClass(row.tone),
+                )}
+              >
+                {row.tone}
+              </span>
+            </div>
+            <p className="mt-1.5 font-mono text-[11px] text-ink">
+              {row.coveragePercent}% ({row.presentCount}/{row.presentCount + row.missingCount})
+            </p>
+          </article>
+        ))}
+      </div>
+
+      {state.flaggedEntries.length > 0 ? (
+        <div className="mt-3 rounded-md border border-border bg-background p-2.5">
+          <p className="text-[11px] font-medium text-ink">Most at-risk entries in this view</p>
+          <ul className="mt-1.5 space-y-1.5">
+            {state.flaggedEntries.map((entry) => (
+              <li
+                key={entry.entryRef}
+                className="flex items-start justify-between gap-2 text-[11px]"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-ink">{entry.title}</p>
+                  <p className="truncate text-ink-subtle">
+                    {entry.missingRequired.length > 0
+                      ? `Missing required: ${entry.missingRequired.join(", ")}`
+                      : "No required rollout gaps"}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-ink-muted">
+                  {entry.signalCoveragePercent}%
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-rollout-signals-lib.ts
+++ b/apps/web/src/lib/browse-rollout-signals-lib.ts
@@ -1,0 +1,203 @@
+import type { Entry } from "@/types/registry";
+
+export type BrowseRolloutSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type BrowseRolloutSignalTone = "good" | "watch" | "risk";
+
+export type BrowseRolloutSignalRow = {
+  id: BrowseRolloutSignalId;
+  label: string;
+  presentCount: number;
+  missingCount: number;
+  coveragePercent: number;
+  tone: BrowseRolloutSignalTone;
+  message: string;
+};
+
+export type BrowseRolloutEntryFlag = {
+  entryRef: string;
+  title: string;
+  missingRequired: string[];
+  signalCoveragePercent: number;
+};
+
+export type BrowseRolloutSignalsState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  strongCount: number;
+  riskCount: number;
+  rows: BrowseRolloutSignalRow[];
+  flaggedEntries: BrowseRolloutEntryFlag[];
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function signalMap(entry: Entry): Record<BrowseRolloutSignalId, boolean> {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstall(entry),
+  };
+}
+
+function signalLabel(id: BrowseRolloutSignalId): string {
+  if (id === "source") return "Source provenance";
+  if (id === "reviewed") return "Metadata review";
+  if (id === "safety") return "Safety notes";
+  if (id === "privacy") return "Privacy notes";
+  if (id === "package") return "Package integrity";
+  return "Install payload";
+}
+
+function toneFromCoverage(coverage: number): BrowseRolloutSignalTone {
+  if (coverage >= 75) return "good";
+  if (coverage >= 45) return "watch";
+  return "risk";
+}
+
+function rowMessage(id: BrowseRolloutSignalId, tone: BrowseRolloutSignalTone): string {
+  if (tone === "good") return `${signalLabel(id)} is broadly covered in current results.`;
+  if (tone === "watch") return `${signalLabel(id)} is mixed and needs spot-checking.`;
+  return `${signalLabel(id)} is sparse; verify before rollout decisions.`;
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function requiredMissingLabels(signals: Record<BrowseRolloutSignalId, boolean>): string[] {
+  const required: BrowseRolloutSignalId[] = ["source", "safety", "install"];
+  return required.filter((id) => !signals[id]).map((id) => signalLabel(id));
+}
+
+function summarize(
+  rows: BrowseRolloutSignalRow[],
+  entryFlags: BrowseRolloutEntryFlag[],
+): {
+  heading: string;
+  summary: string;
+  strongCount: number;
+  riskCount: number;
+} {
+  const riskRows = rows.filter((row) => row.tone === "risk");
+  const goodRows = rows.filter((row) => row.tone === "good");
+  const strongEntries = entryFlags.filter((flag) => flag.missingRequired.length === 0).length;
+  const riskEntries = entryFlags.filter((flag) => flag.missingRequired.length >= 2).length;
+
+  if (entryFlags.length === 0) {
+    return {
+      heading: "Add filters to inspect rollout signals",
+      summary: "Rollout guidance appears once browse results are available.",
+      strongCount: 0,
+      riskCount: 0,
+    };
+  }
+  if (riskRows.length === 0) {
+    return {
+      heading: "Rollout signals look strong across current browse results",
+      summary: `${goodRows.length} strong signal groups and ${strongEntries} entries with no required gaps.`,
+      strongCount: strongEntries,
+      riskCount: riskEntries,
+    };
+  }
+  const topRisk = riskRows
+    .slice(0, 2)
+    .map((row) => row.label.toLowerCase())
+    .join(", ");
+  return {
+    heading: `${riskRows.length} rollout risk signal${riskRows.length === 1 ? "" : "s"} in current results`,
+    summary: `Biggest gaps: ${topRisk}. ${riskEntries} entries have 2+ required gaps.`,
+    strongCount: strongEntries,
+    riskCount: riskEntries,
+  };
+}
+
+export function browseRolloutSignalsState(
+  entries: Entry[],
+  scannedCount = 12,
+): BrowseRolloutSignalsState {
+  const scoped = entries.slice(0, scannedCount);
+  const entryFlags: BrowseRolloutEntryFlag[] = scoped
+    .map((entry) => {
+      const signals = signalMap(entry);
+      const present = Object.values(signals).filter(Boolean).length;
+      const signalCoveragePercent = Math.round((present / 6) * 100);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        missingRequired: requiredMissingLabels(signals),
+        signalCoveragePercent,
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.missingRequired.length - a.missingRequired.length ||
+        a.signalCoveragePercent - b.signalCoveragePercent,
+    );
+
+  const rows: BrowseRolloutSignalRow[] = (
+    ["source", "reviewed", "safety", "privacy", "package", "install"] as BrowseRolloutSignalId[]
+  ).map((id) => {
+    const presentCount = scoped.filter((entry) => signalMap(entry)[id]).length;
+    const missingCount = scoped.length - presentCount;
+    const coveragePercent =
+      scoped.length === 0 ? 100 : Math.round((presentCount / scoped.length) * 100);
+    const tone = toneFromCoverage(coveragePercent);
+    return {
+      id,
+      label: signalLabel(id),
+      presentCount,
+      missingCount,
+      coveragePercent,
+      tone,
+      message: rowMessage(id, tone),
+    };
+  });
+
+  const summary = summarize(rows, entryFlags);
+  return {
+    showPanel: scoped.length >= 2,
+    heading: summary.heading,
+    summary: summary.summary,
+    scannedCount: scoped.length,
+    strongCount: summary.strongCount,
+    riskCount: summary.riskCount,
+    rows,
+    flaggedEntries: entryFlags.slice(0, 5),
+  };
+}

--- a/apps/web/src/lib/browse-rollout-signals.ts
+++ b/apps/web/src/lib/browse-rollout-signals.ts
@@ -1,0 +1,8 @@
+export type {
+  BrowseRolloutEntryFlag,
+  BrowseRolloutSignalId,
+  BrowseRolloutSignalRow,
+  BrowseRolloutSignalTone,
+  BrowseRolloutSignalsState,
+} from "@/lib/browse-rollout-signals-lib";
+export { browseRolloutSignalsState } from "@/lib/browse-rollout-signals-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -26,6 +26,8 @@ import { browseResultsTrustDecisionUiState } from "@/lib/browse-results-trust-de
 import { BrowseResultsTrustPanel } from "@/components/browse-results-trust-panel";
 import { BrowseCompareSelectionBanner } from "@/components/browse-compare-selection-banner";
 import { browseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
+import { browseRolloutSignalsState } from "@/lib/browse-rollout-signals";
+import { BrowseRolloutSignalsPanel } from "@/components/browse-rollout-signals-panel";
 import {
   CATEGORIES,
   type Category,
@@ -337,6 +339,7 @@ function Browse() {
     () => browseCompareSelectionContextState(compare.items),
     [compare.items],
   );
+  const browseRolloutSignals = useMemo(() => browseRolloutSignalsState(results, 12), [results]);
 
   const activeCount =
     Number(!!sp.q) +
@@ -810,6 +813,7 @@ function Browse() {
               className="mt-3"
             />
           ) : null}
+          <BrowseRolloutSignalsPanel state={browseRolloutSignals} className="mt-3" />
 
           {sp.category &&
             (() => {

--- a/tests/browse-rollout-signals-lib.test.ts
+++ b/tests/browse-rollout-signals-lib.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { browseRolloutSignalsState } from "@/lib/browse-rollout-signals-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const medium = entry({
+  slug: "medium",
+  title: "Medium",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/medium",
+  reviewed: false,
+  safetyNotes: "present",
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: "npm i medium",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("browse rollout signals lib", () => {
+  it("hides panel when fewer than two entries are scanned", () => {
+    expect(browseRolloutSignalsState([], 12).showPanel).toBe(false);
+    expect(browseRolloutSignalsState([strong], 12).showPanel).toBe(false);
+  });
+
+  it("shows panel and scans up to provided count", () => {
+    const state = browseRolloutSignalsState([strong, medium, weak], 2);
+    expect(state.showPanel).toBe(true);
+    expect(state.scannedCount).toBe(2);
+  });
+
+  it("always returns six signal rows", () => {
+    const state = browseRolloutSignalsState([strong, medium], 12);
+    expect(state.rows).toHaveLength(6);
+  });
+
+  it("computes full source coverage as good tone", () => {
+    const state = browseRolloutSignalsState([strong, medium], 12);
+    const sourceRow = state.rows.find((row) => row.id === "source");
+    expect(sourceRow?.coveragePercent).toBe(100);
+    expect(sourceRow?.tone).toBe("good");
+  });
+
+  it("computes low coverage as risk tone", () => {
+    const state = browseRolloutSignalsState([weak, weak, strong], 12);
+    const reviewedRow = state.rows.find((row) => row.id === "reviewed");
+    expect(reviewedRow?.coveragePercent).toBe(33);
+    expect(reviewedRow?.tone).toBe("risk");
+  });
+
+  it("computes medium coverage as watch tone", () => {
+    const state = browseRolloutSignalsState([strong, weak], 12);
+    const reviewedRow = state.rows.find((row) => row.id === "reviewed");
+    expect(reviewedRow?.coveragePercent).toBe(50);
+    expect(reviewedRow?.tone).toBe("watch");
+  });
+
+  it("tracks missing required labels per entry", () => {
+    const state = browseRolloutSignalsState([weak, strong], 12);
+    const weakFlag = state.flaggedEntries.find(
+      (entry) => entry.entryRef === "tools/weak",
+    );
+    expect(weakFlag?.missingRequired).toEqual([
+      "Source provenance",
+      "Safety notes",
+      "Install payload",
+    ]);
+  });
+
+  it("ranks flagged entries by required gaps and low coverage", () => {
+    const state = browseRolloutSignalsState([strong, weak, medium], 12);
+    expect(state.flaggedEntries[0].entryRef).toBe("tools/weak");
+  });
+
+  it("limits flagged entries to top five", () => {
+    const entries = Array.from({ length: 8 }).map((_, index) =>
+      entry({
+        slug: `weak-${index}`,
+        title: `Weak ${index}`,
+        source: "unverified",
+        installCommand: undefined,
+        safetyNotes: undefined,
+      }),
+    );
+    const state = browseRolloutSignalsState(entries, 12);
+    expect(state.flaggedEntries).toHaveLength(5);
+  });
+
+  it("reports entry signal coverage percent", () => {
+    const state = browseRolloutSignalsState([strong], 12);
+    expect(state.flaggedEntries[0].signalCoveragePercent).toBe(100);
+  });
+
+  it("returns strong heading when no risk rows exist", () => {
+    const state = browseRolloutSignalsState([strong, strong], 12);
+    expect(state.heading).toContain("strong");
+    expect(state.riskCount).toBe(0);
+  });
+
+  it("returns risk heading when risk rows exist", () => {
+    const state = browseRolloutSignalsState([strong, weak, weak], 12);
+    expect(state.heading).toContain("risk signal");
+    expect(state.summary).toContain("Biggest gaps");
+  });
+
+  it("sets strong and risk entry counters", () => {
+    const state = browseRolloutSignalsState([strong, medium, weak], 12);
+    expect(state.strongCount).toBeGreaterThanOrEqual(1);
+    expect(state.riskCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses scoped results for row counts", () => {
+    const state = browseRolloutSignalsState([strong, strong, weak], 2);
+    const sourceRow = state.rows.find((row) => row.id === "source");
+    expect(sourceRow?.presentCount).toBe(2);
+    expect(sourceRow?.missingCount).toBe(0);
+  });
+
+  it("adds row messages tied to signal tone", () => {
+    const state = browseRolloutSignalsState([strong, weak], 12);
+    const watchRow = state.rows.find((row) => row.id === "reviewed");
+    expect(watchRow?.message).toContain("mixed");
+  });
+
+  it("keeps row labels stable", () => {
+    const state = browseRolloutSignalsState([strong, weak], 12);
+    expect(state.rows.map((row) => row.label)).toEqual([
+      "Source provenance",
+      "Metadata review",
+      "Safety notes",
+      "Privacy notes",
+      "Package integrity",
+      "Install payload",
+    ]);
+  });
+
+  it("handles reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      title: "Reviewed By",
+      reviewed: false,
+      reviewedBy: "team",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = browseRolloutSignalsState([reviewedBy, weak], 12);
+    const reviewedRow = state.rows.find((row) => row.id === "reviewed");
+    expect(reviewedRow?.presentCount).toBe(1);
+  });
+
+  it("handles package hash as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      title: "Hashed",
+      downloadSha256: "ffff",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+    });
+    const state = browseRolloutSignalsState([hashed, weak], 12);
+    const packageRow = state.rows.find((row) => row.id === "package");
+    expect(packageRow?.presentCount).toBe(1);
+  });
+
+  it("reports default empty-state copy for no results", () => {
+    const state = browseRolloutSignalsState([], 12);
+    expect(state.heading).toContain("Add filters");
+    expect(state.summary).toContain("guidance");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `browse-rollout-signals-lib` to compute rollout-signal coverage from current browse results and flag entries with missing required adoption signals.
- Add `BrowseRolloutSignalsPanel` and render it in browse alongside trust/filter decision surfaces.
- Add focused tests for signal coverage math, tone mapping, required-gap flagging, ranking, and summary copy.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/browse-rollout-signals-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)