### PR TITLE
refactor(web): extract categorySpread into category-spread-lib

### DIFF
--- a/apps/web/src/lib/category-spread-lib.ts
+++ b/apps/web/src/lib/category-spread-lib.ts
@@ -1,0 +1,19 @@
+// Pure top-categories summary for a set of entries, split out of the tag detail
+// route so the count/sort/label resolution can be unit-tested.
+
+import { categoryLabels } from "@/lib/site";
+import { CATEGORIES, type Entry } from "@/types/registry";
+
+/**
+ * The `limit` most-common category labels among `entries`, most-frequent first.
+ * A category id resolves to its `categoryLabels` label, else the `CATEGORIES`
+ * label, else the raw id.
+ */
+export function categorySpread(entries: Entry[], limit = 3): string[] {
+  const counts = new Map<string, number>();
+  for (const e of entries) counts.set(e.category, (counts.get(e.category) ?? 0) + 1);
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => categoryLabels[id] ?? CATEGORIES.find((c) => c.id === id)?.label ?? id);
+}

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -6,8 +6,7 @@ import { PageHeader } from "@/components/page-header";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
-import { categoryLabels } from "@/lib/site";
-import { CATEGORIES, type Entry } from "@/types/registry";
+import { categorySpread } from "@/lib/category-spread-lib";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -15,14 +14,6 @@ import { getTagGroup, relatedTags } from "@/lib/tags";
 
 // The categories a tag's entries actually span — used to vary intro copy per tag so no
 // two indexable tag pages emit the same boilerplate sentence.
-function categorySpread(entries: Entry[], limit = 3): string[] {
-  const counts = new Map<string, number>();
-  for (const e of entries) counts.set(e.category, (counts.get(e.category) ?? 0) + 1);
-  return [...counts.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, limit)
-    .map(([id]) => categoryLabels[id] ?? CATEGORIES.find((c) => c.id === id)?.label ?? id);
-}
 
 function joinList(items: string[]): string {
   if (items.length <= 1) return items[0] ?? "";

--- a/tests/category-spread-lib.test.ts
+++ b/tests/category-spread-lib.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { CATEGORIES } from "../apps/web/src/types/registry";
+import { categoryLabels } from "../apps/web/src/lib/site";
+import { categorySpread } from "../apps/web/src/lib/category-spread-lib";
+
+const entry = (category: string) => ({ category }) as Entry;
+const labelFor = (id: string) =>
+  categoryLabels[id] ?? CATEGORIES.find((c) => c.id === id)?.label ?? id;
+
+describe("categorySpread", () => {
+  it("returns [] for no entries", () => {
+    expect(categorySpread([])).toEqual([]);
+  });
+
+  it("lists the most common category labels first", () => {
+    const result = categorySpread([entry("mcp"), entry("mcp"), entry("hooks")]);
+    expect(result).toEqual([labelFor("mcp"), labelFor("hooks")]);
+  });
+
+  it("honors the limit", () => {
+    const result = categorySpread(
+      [entry("mcp"), entry("hooks"), entry("skills")],
+      1,
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("falls back to the raw id for an unknown category", () => {
+    expect(categorySpread([entry("totally-unknown-cat")])).toEqual([
+      "totally-unknown-cat",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The tag detail route summarized a tag's top categories inline with `categorySpread`, so the count/sort/label resolution had no direct test. This moves it into a new `apps/web/src/lib/category-spread-lib.ts` and imports it (dropping the now-unused `categoryLabels`/`CATEGORIES`/`Entry` imports from the route).

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the `/tags/$tag` route computes its category spread via `categorySpread`.
- Expected behavior: the `limit` most-common category labels among the entries, most-frequent first; a category id resolves to its `categoryLabels` label, else the `CATEGORIES` label, else the raw id. Identical to the removed inline version.
- Important edge cases or invariants: empty input → `[]`; an unknown id falls back to itself; the default limit is 3.
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same category labels.
- Focused tests: added `tests/category-spread-lib.test.ts` (4 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/category-spread-lib.test.ts --coverage` → 4/4 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
