### PR TITLE
refactor(web): extract submit URL-origin guards into submit-url-safety-lib

### DIFF
--- a/apps/web/src/lib/submit-url-safety-lib.ts
+++ b/apps/web/src/lib/submit-url-safety-lib.ts
@@ -1,0 +1,43 @@
+// Pure same-origin URL guards for the submit flow, split out of the route so the
+// origin allowlisting can be unit-tested. Both never throw and collapse unsafe
+// or cross-origin input to "".
+
+import { siteConfig } from "@/lib/site";
+
+/** The origin of a URL, or "" when it cannot be parsed. */
+export function originFor(value: string): string {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Return `value` only when it resolves (against `baseUrl`) to an http(s) URL
+ * whose origin is in `allowedOrigins`; a same-origin, root-relative input is
+ * returned as a path. Anything else (missing, cross-origin, non-http, or
+ * unparseable) becomes "".
+ */
+export function safeUrlForOrigins(
+  value: string | undefined,
+  allowedOrigins: Set<string>,
+  baseUrl = siteConfig.url,
+): string {
+  if (!value) return "";
+  try {
+    const url = new URL(value, baseUrl);
+    if (
+      (url.protocol !== "https:" && url.protocol !== "http:") ||
+      !allowedOrigins.has(url.origin)
+    ) {
+      return "";
+    }
+    if (value.startsWith("/") && url.origin === originFor(baseUrl)) {
+      return `${url.pathname}${url.search}${url.hash}`;
+    }
+    return url.toString();
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -20,6 +20,7 @@ import {
 import { logClientError } from "@/lib/client-logs";
 import { safeGitHubAuthUrl } from "@/lib/github-auth-url-lib";
 import { siteConfig } from "@/lib/site";
+import { originFor, safeUrlForOrigins } from "@/lib/submit-url-safety-lib";
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
@@ -75,37 +76,6 @@ type PreflightResponse = {
     url?: string;
   };
 };
-
-function originFor(value: string) {
-  try {
-    return new URL(value).origin;
-  } catch {
-    return "";
-  }
-}
-
-function safeUrlForOrigins(
-  value: string | undefined,
-  allowedOrigins: Set<string>,
-  baseUrl = siteConfig.url,
-) {
-  if (!value) return "";
-  try {
-    const url = new URL(value, baseUrl);
-    if (
-      (url.protocol !== "https:" && url.protocol !== "http:") ||
-      !allowedOrigins.has(url.origin)
-    ) {
-      return "";
-    }
-    if (value.startsWith("/") && url.origin === originFor(baseUrl)) {
-      return `${url.pathname}${url.search}${url.hash}`;
-    }
-    return url.toString();
-  } catch {
-    return "";
-  }
-}
 
 function safeGateStatusUrl(value: string | undefined) {
   const gateOrigin = originFor(siteConfig.submissionGateUrl);

--- a/tests/submit-url-safety-lib.test.ts
+++ b/tests/submit-url-safety-lib.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  originFor,
+  safeUrlForOrigins,
+} from "../apps/web/src/lib/submit-url-safety-lib";
+
+const BASE = "https://base.example";
+
+describe("originFor", () => {
+  it("returns the origin of a valid URL", () => {
+    expect(originFor("https://a.example/x?y=1")).toBe("https://a.example");
+  });
+
+  it("returns '' for an unparseable URL", () => {
+    expect(originFor("not a url")).toBe("");
+  });
+});
+
+describe("safeUrlForOrigins", () => {
+  it("returns '' for a missing value", () => {
+    expect(safeUrlForOrigins(undefined, new Set([BASE]), BASE)).toBe("");
+  });
+
+  it("returns an allowed absolute https URL unchanged", () => {
+    expect(
+      safeUrlForOrigins(
+        "https://ok.example/p?q=1",
+        new Set(["https://ok.example"]),
+        BASE,
+      ),
+    ).toBe("https://ok.example/p?q=1");
+  });
+
+  it("rejects a cross-origin URL", () => {
+    expect(
+      safeUrlForOrigins(
+        "https://evil.example/p",
+        new Set(["https://ok.example"]),
+        BASE,
+      ),
+    ).toBe("");
+  });
+
+  it("rejects a non-http(s) protocol even on an allowed origin", () => {
+    expect(
+      safeUrlForOrigins(
+        "ftp://ok.example/p",
+        new Set(["ftp://ok.example"]),
+        BASE,
+      ),
+    ).toBe("");
+  });
+
+  it("returns a same-origin root-relative input as a path", () => {
+    expect(safeUrlForOrigins("/dash?x=1#h", new Set([BASE]), BASE)).toBe(
+      "/dash?x=1#h",
+    );
+  });
+
+  it("returns '' when the URL cannot be parsed (invalid base)", () => {
+    expect(safeUrlForOrigins("x", new Set([BASE]), "")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The submit route sanitized redirect/status URLs inline with `originFor` and `safeUrlForOrigins` (same-origin allowlisting), so these security checks had no direct test. This moves both into a new `apps/web/src/lib/submit-url-safety-lib.ts` and imports them; the route keeps `safeGateStatusUrl` / `sanitizePreflightResponse`, which now call the shared helpers.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: `/submit` sanitizes the gate status URL and preflight next-action URL via the shared helpers.
- Expected behavior: `originFor` returns a URL's origin or ""; `safeUrlForOrigins` returns the value only when it resolves (against `baseUrl`) to an http(s) URL whose origin is allow-listed, returns a same-origin root-relative input as a path, and collapses everything else (missing, cross-origin, non-http, unparseable) to "". Identical to the removed inline versions.
- Important edge cases or invariants: cross-origin and non-http(s) inputs are rejected; an unparseable value (e.g. invalid base) is caught and returns "".
- Backward compatibility notes: fully backward compatible — both helpers were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — URL sanitization only.
- Focused tests: added `tests/submit-url-safety-lib.test.ts` (8 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/submit-url-safety-lib.test.ts --coverage` -> 8/8 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that adds unit coverage for the submit-flow same-origin URL guards, matching merged extraction PRs #4551 and #4555 (no linked issue).
