### PR TITLE
feat(web): add entry evidence readiness matrix

### DIFF
--- a/apps/web/src/components/entry-evidence-readiness-matrix.tsx
+++ b/apps/web/src/components/entry-evidence-readiness-matrix.tsx
@@ -1,0 +1,129 @@
+import {
+  type EntryEvidenceReadinessMatrixState,
+  type EvidenceMatrixPresetId,
+} from "@/lib/entry-evidence-readiness-matrix";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: EvidenceMatrixPresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "strict", label: "Strict" },
+  { id: "pilot", label: "Pilot" },
+];
+
+function riskTone(score: number): string {
+  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
+}
+
+function cellToneClass(tone: "complete" | "warning" | "critical"): string {
+  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
+  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
+  return "border-border bg-background";
+}
+
+export function EntryEvidenceReadinessMatrix({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: EntryEvidenceReadinessMatrixState;
+  selectedPreset: EvidenceMatrixPresetId;
+  onSelectPreset: (preset: EvidenceMatrixPresetId) => void;
+  className?: string;
+}) {
+  return (
+    <section
+      id="evidence-matrix"
+      aria-label="Evidence readiness matrix"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Evidence readiness</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span
+          className={cn(
+            "inline-flex rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide",
+            riskTone(state.riskScore),
+          )}
+        >
+          Risk {state.riskScore}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={selectedPreset === preset.id}
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 grid gap-2.5 sm:grid-cols-2">
+        {state.cells.map((cell) => (
+          <article
+            key={cell.id}
+            className={cn("rounded-md border px-3 py-2.5", cellToneClass(cell.tone))}
+          >
+            <div className="flex items-start justify-between gap-2">
+              <h4 className="text-xs font-semibold text-ink">{cell.label}</h4>
+              <span className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                {cell.present ? "Present" : "Missing"}
+              </span>
+            </div>
+            <p className="mt-1 text-[11px] text-ink-muted">{cell.detail}</p>
+            <p className="mt-1 text-[10px] text-ink-subtle">
+              {cell.required ? "Required in this preset" : "Optional in this preset"}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      {state.requiredMissing.length > 0 ? (
+        <p className="mt-3 rounded-md border border-trust-blocked/35 bg-trust-blocked/5 px-3 py-2 text-xs text-trust-blocked">
+          Required gaps: {state.requiredMissing.join(", ")}
+        </p>
+      ) : (
+        <p className="mt-3 rounded-md border border-trust-trusted/35 bg-trust-trusted/5 px-3 py-2 text-xs text-trust-trusted">
+          Required evidence gates are covered for this preset.
+        </p>
+      )}
+
+      {state.benchmarkSummary ? (
+        <p className="mt-3 text-xs text-ink-muted">{state.benchmarkSummary}</p>
+      ) : null}
+
+      {state.benchmarks.length > 0 ? (
+        <div className="mt-2 rounded-md border border-border bg-background px-3 py-2">
+          <p className="text-[11px] font-medium text-ink">Compare benchmark snapshot</p>
+          <ul className="mt-1.5 space-y-1">
+            {state.benchmarks.map((benchmark) => (
+              <li
+                key={benchmark.entryRef}
+                className="flex items-center justify-between gap-2 text-[11px]"
+              >
+                <span className="truncate text-ink">{benchmark.title}</span>
+                <span className="font-mono text-ink-muted">{benchmark.score}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -86,6 +86,7 @@ export function buildEntryTocItems(input: {
   items.push({ id: "citation-facts", label: "Citation facts" });
   items.push({ id: "adoption-plan", label: "Adoption plan" });
   items.push({ id: "decision-playbook", label: "Decision playbook" });
+  items.push({ id: "evidence-matrix", label: "Evidence matrix" });
   if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
   if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
   if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });

--- a/apps/web/src/lib/entry-evidence-readiness-matrix-lib.ts
+++ b/apps/web/src/lib/entry-evidence-readiness-matrix-lib.ts
@@ -1,0 +1,277 @@
+import type { Entry } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+
+export type EvidenceMatrixPresetId = "balanced" | "strict" | "pilot";
+
+export type EvidenceMatrixSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type EvidenceMatrixTone = "complete" | "warning" | "critical";
+
+export type EntryEvidenceMatrixCell = {
+  id: EvidenceMatrixSignalId;
+  label: string;
+  required: boolean;
+  present: boolean;
+  tone: EvidenceMatrixTone;
+  detail: string;
+};
+
+export type EntryEvidenceBenchmark = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  score: number;
+  strongerThanTarget: boolean;
+  weakerThanTarget: boolean;
+};
+
+export type EntryEvidenceReadinessMatrixState = {
+  preset: EvidenceMatrixPresetId;
+  heading: string;
+  summary: string;
+  riskScore: number;
+  completeCount: number;
+  requiredMissing: string[];
+  cells: EntryEvidenceMatrixCell[];
+  benchmarkSummary: string | null;
+  benchmarks: EntryEvidenceBenchmark[];
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function signalPresent(entry: Entry, id: EvidenceMatrixSignalId): boolean {
+  if (id === "source") return hasSource(entry);
+  if (id === "reviewed") return hasReviewed(entry);
+  if (id === "safety") return hasSafety(entry);
+  if (id === "privacy") return hasPrivacy(entry);
+  if (id === "package") return hasPackage(entry);
+  return hasInstall(entry);
+}
+
+function signalLabel(id: EvidenceMatrixSignalId): string {
+  if (id === "source") return "Source provenance";
+  if (id === "reviewed") return "Metadata review";
+  if (id === "safety") return "Safety notes";
+  if (id === "privacy") return "Privacy notes";
+  if (id === "package") return "Package integrity";
+  return "Install payload";
+}
+
+function requiredSignals(preset: EvidenceMatrixPresetId): Record<EvidenceMatrixSignalId, boolean> {
+  if (preset === "pilot") {
+    return {
+      source: true,
+      reviewed: false,
+      safety: true,
+      privacy: false,
+      package: false,
+      install: true,
+    };
+  }
+  if (preset === "strict") {
+    return {
+      source: true,
+      reviewed: true,
+      safety: true,
+      privacy: true,
+      package: true,
+      install: true,
+    };
+  }
+  return {
+    source: true,
+    reviewed: true,
+    safety: true,
+    privacy: false,
+    package: false,
+    install: true,
+  };
+}
+
+function signalWeight(id: EvidenceMatrixSignalId): number {
+  if (id === "source") return 24;
+  if (id === "reviewed") return 16;
+  if (id === "safety") return 20;
+  if (id === "privacy") return 12;
+  if (id === "package") return 10;
+  return 18;
+}
+
+function cellDetail(id: EvidenceMatrixSignalId, present: boolean): string {
+  if (present) {
+    if (id === "source") return "Source repository/provenance is listed.";
+    if (id === "reviewed") return "Review metadata is present.";
+    if (id === "safety") return "Safety notes are present.";
+    if (id === "privacy") return "Privacy notes are present.";
+    if (id === "package") return "Package integrity metadata is present.";
+    return "Install payload is available.";
+  }
+  if (id === "source") return "Source provenance is missing.";
+  if (id === "reviewed") return "Review metadata is missing.";
+  if (id === "safety") return "Safety notes are missing.";
+  if (id === "privacy") return "Privacy notes are missing.";
+  if (id === "package") return "Package integrity metadata is missing.";
+  return "Install payload is missing.";
+}
+
+function headingForPreset(preset: EvidenceMatrixPresetId): string {
+  if (preset === "strict") return "Evidence readiness matrix · strict";
+  if (preset === "pilot") return "Evidence readiness matrix · pilot";
+  return "Evidence readiness matrix · balanced";
+}
+
+function trustPenalty(trust: Entry["trust"]): number {
+  if (trust === "blocked") return 34;
+  if (trust === "limited") return 20;
+  if (trust === "review") return 10;
+  return 0;
+}
+
+function riskScore(entry: Entry, cells: EntryEvidenceMatrixCell[]): number {
+  const requiredMissPenalty = cells.filter((cell) => cell.required && !cell.present).length * 16;
+  const optionalMissPenalty = cells.filter((cell) => !cell.required && !cell.present).length * 5;
+  return Math.min(100, trustPenalty(entry.trust) + requiredMissPenalty + optionalMissPenalty);
+}
+
+function evidenceScore(entry: Entry): number {
+  const ids: EvidenceMatrixSignalId[] = [
+    "source",
+    "reviewed",
+    "safety",
+    "privacy",
+    "package",
+    "install",
+  ];
+  return ids.reduce((score, id) => score + (signalPresent(entry, id) ? signalWeight(id) : 0), 0);
+}
+
+function compareSummary(targetScore: number, benchmarks: EntryEvidenceBenchmark[]): string | null {
+  if (benchmarks.length === 0) return null;
+  const stronger = benchmarks.filter((item) => item.strongerThanTarget).length;
+  const weaker = benchmarks.filter((item) => item.weakerThanTarget).length;
+  if (stronger === 0 && weaker === 0) {
+    return "Compared entries are tied on evidence coverage.";
+  }
+  if (stronger > weaker) {
+    return `${stronger} compared entr${stronger === 1 ? "y is" : "ies are"} stronger than this entry on evidence coverage.`;
+  }
+  if (weaker > stronger) {
+    return `${weaker} compared entr${weaker === 1 ? "y is" : "ies are"} weaker than this entry on evidence coverage.`;
+  }
+  return `Evidence coverage is mixed across compared entries (target score ${targetScore}).`;
+}
+
+function summaryForState(input: {
+  riskScore: number;
+  requiredMissing: string[];
+  preset: EvidenceMatrixPresetId;
+  completeCount: number;
+}): string {
+  if (input.requiredMissing.length === 0) {
+    if (input.preset === "strict") {
+      return `All strict evidence gates are covered (${input.completeCount}/6 signals complete).`;
+    }
+    return `Required evidence gates are covered (${input.completeCount}/6 signals complete).`;
+  }
+  const top = input.requiredMissing.slice(0, 2).join(", ");
+  return `Missing required evidence: ${top}. Risk score ${input.riskScore}.`;
+}
+
+export function entryEvidenceReadinessMatrixState(
+  entry: Entry,
+  preset: EvidenceMatrixPresetId,
+  compareItems: Entry[],
+): EntryEvidenceReadinessMatrixState {
+  const required = requiredSignals(preset);
+  const ids: EvidenceMatrixSignalId[] = [
+    "source",
+    "reviewed",
+    "safety",
+    "privacy",
+    "package",
+    "install",
+  ];
+  const cells: EntryEvidenceMatrixCell[] = ids.map((id) => {
+    const present = signalPresent(entry, id);
+    const req = required[id];
+    const tone: EvidenceMatrixTone = present ? "complete" : req ? "critical" : "warning";
+    return {
+      id,
+      label: signalLabel(id),
+      required: req,
+      present,
+      tone,
+      detail: cellDetail(id, present),
+    };
+  });
+
+  const completeCount = cells.filter((cell) => cell.present).length;
+  const requiredMissing = cells
+    .filter((cell) => cell.required && !cell.present)
+    .map((cell) => cell.label);
+  const matrixRiskScore = riskScore(entry, cells);
+  const targetScore = evidenceScore(entry);
+
+  const benchmarks: EntryEvidenceBenchmark[] = compareItems
+    .filter((candidate) => !sameEntry(candidate, entry))
+    .map((candidate) => {
+      const score = evidenceScore(candidate);
+      return {
+        entryRef: `${candidate.category}/${candidate.slug}`,
+        title: candidate.title,
+        trust: candidate.trust,
+        score,
+        strongerThanTarget: score > targetScore,
+        weakerThanTarget: score < targetScore,
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, 4);
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summaryForState({
+      riskScore: matrixRiskScore,
+      requiredMissing,
+      preset,
+      completeCount,
+    }),
+    riskScore: matrixRiskScore,
+    completeCount,
+    requiredMissing,
+    cells,
+    benchmarkSummary: compareSummary(targetScore, benchmarks),
+    benchmarks,
+  };
+}

--- a/apps/web/src/lib/entry-evidence-readiness-matrix.ts
+++ b/apps/web/src/lib/entry-evidence-readiness-matrix.ts
@@ -1,0 +1,9 @@
+export type {
+  EvidenceMatrixPresetId,
+  EvidenceMatrixSignalId,
+  EvidenceMatrixTone,
+  EntryEvidenceBenchmark,
+  EntryEvidenceMatrixCell,
+  EntryEvidenceReadinessMatrixState,
+} from "@/lib/entry-evidence-readiness-matrix-lib";
+export { entryEvidenceReadinessMatrixState } from "@/lib/entry-evidence-readiness-matrix-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -59,6 +59,7 @@ import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryDetailDecisionPlaybook } from "@/components/entry-detail-decision-playbook";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
+import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
   buildEntryTocItems,
@@ -82,6 +83,10 @@ import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { entryAdoptionPlanState, type AdoptionPlanPresetId } from "@/lib/entry-adoption-plan";
 import { entryDetailDecisionPlaybookState } from "@/lib/entry-detail-decision-playbook";
+import {
+  entryEvidenceReadinessMatrixState,
+  type EvidenceMatrixPresetId,
+} from "@/lib/entry-evidence-readiness-matrix";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -280,6 +285,7 @@ function Dossier() {
 
   const compare = useCompare();
   const [adoptionPreset, setAdoptionPreset] = useState<AdoptionPlanPresetId>("balanced-rollout");
+  const [evidencePreset, setEvidencePreset] = useState<EvidenceMatrixPresetId>("balanced");
   const inCompare = useIsCompared(entry);
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
@@ -346,6 +352,10 @@ function Dossier() {
   const decisionPlaybook = useMemo(
     () => entryDetailDecisionPlaybookState(entry, compare.items),
     [entry, compare.items],
+  );
+  const evidenceMatrix = useMemo(
+    () => entryEvidenceReadinessMatrixState(entry, evidencePreset, compare.items),
+    [entry, evidencePreset, compare.items],
   );
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
@@ -502,6 +512,11 @@ function Dossier() {
             state={adoptionPlan}
             selectedPreset={adoptionPreset}
             onSelectPreset={setAdoptionPreset}
+          />
+          <EntryEvidenceReadinessMatrix
+            state={evidenceMatrix}
+            selectedPreset={evidencePreset}
+            onSelectPreset={setEvidencePreset}
           />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -116,6 +116,7 @@ describe("entry-detail-sidebar-lib", () => {
       "citation-facts",
       "adoption-plan",
       "decision-playbook",
+      "evidence-matrix",
       "privacy",
       "prerequisites",
       "about",

--- a/tests/entry-evidence-readiness-matrix-lib.test.ts
+++ b/tests/entry-evidence-readiness-matrix-lib.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { entryEvidenceReadinessMatrixState } from "@/lib/entry-evidence-readiness-matrix-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const medium = entry({
+  slug: "medium",
+  title: "Medium",
+  trust: "review",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/medium",
+  reviewed: false,
+  safetyNotes: "present",
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: "npm i medium",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("entry evidence readiness matrix lib", () => {
+  it("returns heading per preset", () => {
+    expect(
+      entryEvidenceReadinessMatrixState(strong, "balanced", []).heading,
+    ).toContain("balanced");
+    expect(
+      entryEvidenceReadinessMatrixState(strong, "strict", []).heading,
+    ).toContain("strict");
+    expect(
+      entryEvidenceReadinessMatrixState(strong, "pilot", []).heading,
+    ).toContain("pilot");
+  });
+
+  it("creates six signal cells", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "balanced", []);
+    expect(state.cells).toHaveLength(6);
+  });
+
+  it("marks present cells as complete", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "strict", []);
+    expect(state.cells.every((cell) => cell.tone === "complete")).toBe(true);
+  });
+
+  it("marks missing required signals as critical", () => {
+    const state = entryEvidenceReadinessMatrixState(weak, "strict", []);
+    expect(
+      state.cells.some((cell) => cell.required && cell.tone === "critical"),
+    ).toBe(true);
+  });
+
+  it("marks missing optional signals as warning", () => {
+    const state = entryEvidenceReadinessMatrixState(medium, "balanced", []);
+    const privacy = state.cells.find((cell) => cell.id === "privacy");
+    expect(privacy?.required).toBe(false);
+    expect(privacy?.tone).toBe("warning");
+  });
+
+  it("tracks required missing labels", () => {
+    const state = entryEvidenceReadinessMatrixState(weak, "strict", []);
+    expect(state.requiredMissing).toContain("Source provenance");
+    expect(state.requiredMissing.length).toBeGreaterThan(2);
+  });
+
+  it("computes complete count from present cells", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "strict", []);
+    expect(state.completeCount).toBe(6);
+  });
+
+  it("generates low risk score for fully-covered trusted entry", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "strict", []);
+    expect(state.riskScore).toBeLessThan(20);
+  });
+
+  it("generates high risk score for limited entry with gaps", () => {
+    const state = entryEvidenceReadinessMatrixState(weak, "strict", []);
+    expect(state.riskScore).toBeGreaterThanOrEqual(60);
+  });
+
+  it("includes missing summary when required evidence absent", () => {
+    const state = entryEvidenceReadinessMatrixState(weak, "strict", []);
+    expect(state.summary).toContain("Missing required evidence");
+  });
+
+  it("includes all-clear summary when required evidence covered", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "strict", []);
+    expect(state.summary).toContain("All strict evidence gates are covered");
+  });
+
+  it("removes target entry from benchmarks using sameEntry", () => {
+    const state = entryEvidenceReadinessMatrixState(strong, "balanced", [
+      strong,
+      medium,
+    ]);
+    expect(
+      state.benchmarks.some((item) => item.entryRef === "tools/strong"),
+    ).toBe(false);
+    expect(
+      state.benchmarks.some((item) => item.entryRef === "tools/medium"),
+    ).toBe(true);
+  });
+
+  it("sorts benchmarks by score descending", () => {
+    const state = entryEvidenceReadinessMatrixState(medium, "balanced", [
+      weak,
+      strong,
+    ]);
+    expect(state.benchmarks[0].entryRef).toBe("tools/strong");
+  });
+
+  it("flags stronger and weaker benchmark comparisons", () => {
+    const state = entryEvidenceReadinessMatrixState(medium, "balanced", [
+      strong,
+      weak,
+    ]);
+    const stronger = state.benchmarks.find(
+      (item) => item.entryRef === "tools/strong",
+    );
+    const weakerOne = state.benchmarks.find(
+      (item) => item.entryRef === "tools/weak",
+    );
+    expect(stronger?.strongerThanTarget).toBe(true);
+    expect(weakerOne?.weakerThanTarget).toBe(true);
+  });
+
+  it("builds benchmark summary text when compare items exist", () => {
+    const state = entryEvidenceReadinessMatrixState(medium, "balanced", [
+      strong,
+      weak,
+    ]);
+    expect(state.benchmarkSummary).toBeTruthy();
+  });
+
+  it("returns null benchmark summary with no compare items", () => {
+    const state = entryEvidenceReadinessMatrixState(medium, "balanced", []);
+    expect(state.benchmarkSummary).toBeNull();
+  });
+
+  it("limits benchmarks to top four entries", () => {
+    const compare = [strong, medium, weak].concat(
+      Array.from({ length: 4 }).map((_, i) =>
+        entry({
+          slug: `other-${i}`,
+          title: `Other ${i}`,
+          source: "source-backed",
+          sourceUrl: `https://example.com/${i}`,
+          installCommand: "npm i other",
+        }),
+      ),
+    );
+    const state = entryEvidenceReadinessMatrixState(
+      medium,
+      "balanced",
+      compare,
+    );
+    expect(state.benchmarks.length).toBeLessThanOrEqual(4);
+  });
+
+  it("uses reviewedBy as reviewed evidence", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      source: "source-backed",
+      sourceUrl: "https://example.com/reviewed",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed",
+    });
+    const state = entryEvidenceReadinessMatrixState(reviewedBy, "balanced", []);
+    expect(state.cells.find((cell) => cell.id === "reviewed")?.present).toBe(
+      true,
+    );
+  });
+
+  it("uses checksum as package evidence", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://example.com/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = entryEvidenceReadinessMatrixState(hashed, "balanced", []);
+    expect(state.cells.find((cell) => cell.id === "package")?.present).toBe(
+      true,
+    );
+  });
+
+  it("pilot preset keeps privacy optional", () => {
+    const state = entryEvidenceReadinessMatrixState(weak, "pilot", []);
+    const privacy = state.cells.find((cell) => cell.id === "privacy");
+    expect(privacy?.required).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `entry-evidence-readiness-matrix-lib` to compute signal-by-signal readiness cells, required-gap tracking, risk scoring, and compare benchmarks for detail pages.
- Add `EntryEvidenceReadinessMatrix` UI with preset switching (balanced/strict/pilot), required-gap callouts, and benchmark snapshot.
- Integrate matrix into entry detail route and sidebar TOC with updated tests.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/entry-evidence-readiness-matrix-lib.test.ts tests/entry-detail-sidebar-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)