### PR TITLE
refactor(web): extract faqFor into category-faq-lib

### DIFF
--- a/apps/web/src/lib/category-faq-lib.ts
+++ b/apps/web/src/lib/category-faq-lib.ts
@@ -1,0 +1,25 @@
+// Pure FAQ builder for a category landing page, split out of the $category route
+// so the question set and description/usage fallbacks can be unit-tested.
+
+import { categoryDescriptions, categoryUsageHints } from "@/lib/site";
+
+export function faqFor(id: string, label: string): Array<{ q: string; a: string }> {
+  return [
+    {
+      q: `What are Claude ${label}?`,
+      a:
+        categoryDescriptions[id] ??
+        `Claude ${label} are community-submitted resources curated in the HeyClaude directory.`,
+    },
+    {
+      q: `How do I use ${label} from HeyClaude?`,
+      a:
+        categoryUsageHints[id] ??
+        `Open any entry to see install or usage details, copy the snippet or config, and review the linked source before adding it to your Claude setup.`,
+    },
+    {
+      q: `Are HeyClaude ${label} reviewed before they are listed?`,
+      a: "Each entry is metadata-reviewed for source, trust, and safety/privacy signals before it appears. HeyClaude does not scan for malware, so always review the linked source before installing anything that touches your filesystem, network, or credentials.",
+    },
+  ];
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -7,9 +7,9 @@ import {
   categoryLabels,
   categoryDescriptions,
   categorySeoDescriptions,
-  categoryUsageHints,
   categoryQuickstarts,
 } from "@/lib/site";
+import { faqFor } from "@/lib/category-faq-lib";
 import { ResourceCard } from "@/components/resource-card";
 import { PageContainer } from "@/components/page-container";
 import { PageHeader } from "@/components/page-header";
@@ -26,27 +26,6 @@ const categoryIds = new Set(CATEGORIES.map((c) => c.id));
 // Reuse the canonical registry ranking (recommendedScore) so hub order matches /browse.
 // Cached per render pass so head() and the component don't each re-run the search.
 const topEntriesFor = cache((id: string) => search({ categories: [id as Category] }));
-
-function faqFor(id: string, label: string) {
-  return [
-    {
-      q: `What are Claude ${label}?`,
-      a:
-        categoryDescriptions[id] ??
-        `Claude ${label} are community-submitted resources curated in the HeyClaude directory.`,
-    },
-    {
-      q: `How do I use ${label} from HeyClaude?`,
-      a:
-        categoryUsageHints[id] ??
-        `Open any entry to see install or usage details, copy the snippet or config, and review the linked source before adding it to your Claude setup.`,
-    },
-    {
-      q: `Are HeyClaude ${label} reviewed before they are listed?`,
-      a: "Each entry is metadata-reviewed for source, trust, and safety/privacy signals before it appears. HeyClaude does not scan for malware, so always review the linked source before installing anything that touches your filesystem, network, or credentials.",
-    },
-  ];
-}
 
 export const Route = createFileRoute("/$category")({
   loader: ({ params }) => {

--- a/tests/category-faq-lib.test.ts
+++ b/tests/category-faq-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  categoryDescriptions,
+  categoryUsageHints,
+} from "../apps/web/src/lib/site";
+import { faqFor } from "../apps/web/src/lib/category-faq-lib";
+
+describe("faqFor", () => {
+  it("builds three questions that embed the label", () => {
+    const faqs = faqFor("mcp", "MCP servers");
+    expect(faqs).toHaveLength(3);
+    expect(faqs[0].q).toBe("What are Claude MCP servers?");
+    expect(faqs[1].q).toBe("How do I use MCP servers from HeyClaude?");
+    expect(faqs[2].q).toContain("reviewed before they are listed");
+  });
+
+  it("uses the category description and usage hint when available", () => {
+    const faqs = faqFor("mcp", "MCP servers");
+    expect(faqs[0].a).toBe(categoryDescriptions.mcp);
+    expect(faqs[1].a).toBe(categoryUsageHints.mcp);
+  });
+
+  it("falls back to generic answers for an unknown category id", () => {
+    const faqs = faqFor("totally-unknown", "Widgets");
+    expect(faqs[0].a).toContain("community-submitted resources");
+    expect(faqs[1].a).toContain("Open any entry");
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The `$category` landing route built its FAQ list inline with `faqFor`, so the question set and description/usage fallbacks had no direct test. This moves it into a new `apps/web/src/lib/category-faq-lib.ts` and imports it (dropping the now-unused `categoryUsageHints` import from the route).

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the `/$category` route renders `faqFor(id, label)` from the lib.
- Expected behavior: three label-embedded FAQ entries; the first two answers use `categoryDescriptions[id]` / `categoryUsageHints[id]` when present, else a generic fallback; the third is a fixed review-policy answer. Identical to the removed inline version.
- Important edge cases or invariants: an unknown category id yields the generic description/usage fallbacks.
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same FAQ content.
- Focused tests: added `tests/category-faq-lib.test.ts` (3 tests, branch coverage 100%).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/category-faq-lib.test.ts --coverage` → 3/3 passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
