### PR TITLE
refactor(web): extract defaultAlerts into saved-search-default-alerts-lib

### DIFF
--- a/apps/web/src/components/saved-search-manager.tsx
+++ b/apps/web/src/components/saved-search-manager.tsx
@@ -32,6 +32,7 @@ import {
 import { subscribeToNewsletter } from "@/lib/api/newsletter";
 import { hashSearch } from "@/lib/saved-search-hash-lib";
 import { applyToBrowseSearch } from "@/lib/saved-search-nav-lib";
+import { defaultAlerts } from "@/lib/saved-search-default-alerts-lib";
 import { savedFeedUrl } from "@/lib/saved-search-feed-url-lib";
 import { CopyButton } from "@/components/copy-button";
 import { cn } from "@/lib/utils";
@@ -53,10 +54,6 @@ const CHANNEL_META: {
 ];
 
 const CADENCES: AlertCadence[] = ["instant", "daily", "weekly"];
-
-function defaultAlerts(): AlertSchedule {
-  return { enabled: true, channels: ["inapp"], cadence: "instant" };
-}
 
 function AlertEditor({
   search,

--- a/apps/web/src/lib/saved-search-default-alerts-lib.ts
+++ b/apps/web/src/lib/saved-search-default-alerts-lib.ts
@@ -1,0 +1,9 @@
+// Pure default alert schedule for a saved search, split out of the saved-search
+// manager so the default can be unit-tested (and reused) without React.
+
+import type { AlertSchedule } from "@/lib/recents";
+
+/** The schedule applied to a saved search that has no alerts yet: enabled, in-app, instant. */
+export function defaultAlerts(): AlertSchedule {
+  return { enabled: true, channels: ["inapp"], cadence: "instant" };
+}

--- a/tests/saved-search-default-alerts-lib.test.ts
+++ b/tests/saved-search-default-alerts-lib.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultAlerts } from "../apps/web/src/lib/saved-search-default-alerts-lib";
+
+describe("defaultAlerts", () => {
+  it("returns an enabled, in-app, instant schedule", () => {
+    expect(defaultAlerts()).toEqual({
+      enabled: true,
+      channels: ["inapp"],
+      cadence: "instant",
+    });
+  });
+
+  it("returns a fresh object each call (safe to mutate)", () => {
+    const a = defaultAlerts();
+    const b = defaultAlerts();
+    expect(a).not.toBe(b);
+    expect(a.channels).not.toBe(b.channels);
+  });
+});


### PR DESCRIPTION
## Summary

Mirrors the `*-lib` extraction-for-testability pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch).

The saved-search manager built the default alert schedule inline with `defaultAlerts`, so the default had no direct test. This moves it into a new `apps/web/src/lib/saved-search-default-alerts-lib.ts` and imports it.

**No behavior change.**

## Submission Source

For platform/code/docs PRs:

- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks

- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence

- Changed routes/components/endpoints/tools: the saved-search alert editor seeds a search's alerts with `defaultAlerts()` from the lib.
- Expected behavior: returns `{ enabled: true, channels: ["inapp"], cadence: "instant" }`. Identical to the removed inline version.
- Important edge cases or invariants: each call returns a fresh object (safe to mutate without leaking into other saved searches).
- Backward compatibility notes: fully backward compatible — the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` — same default schedule.
- Focused tests: added `tests/saved-search-default-alerts-lib.test.ts` (2 tests).

## Validation

- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run tests/saved-search-default-alerts-lib.test.ts --coverage` → 2/2 passing.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes

**No linked issue (maintainer-lane rationale):** self-contained testability refactor that gives the default alert schedule a reusable, tested home, matching merged extraction PRs #4551 and #4555 (no linked issue).
