### PR TITLE
refactor(web): extract toneClass into browse-rollout-tone-lib

### DIFF
--- a/apps/web/src/components/browse-rollout-signals-panel.tsx
+++ b/apps/web/src/components/browse-rollout-signals-panel.tsx
@@ -1,11 +1,6 @@
+import { toneClass } from "@/lib/browse-rollout-tone-lib";
 import type { BrowseRolloutSignalsState } from "@/lib/browse-rollout-signals";
 import { cn } from "@/lib/utils";
-
-function toneClass(tone: "good" | "watch" | "risk"): string {
-  if (tone === "good") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
-  if (tone === "watch") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
-  return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
-}
 
 export function BrowseRolloutSignalsPanel({
   state,

--- a/apps/web/src/lib/browse-rollout-tone-lib.ts
+++ b/apps/web/src/lib/browse-rollout-tone-lib.ts
@@ -1,0 +1,9 @@
+// Pure tone -> CSS class mapping for the browse rollout signals panel, split out
+// so the mapping can be unit-tested without React.
+
+/** Border/background/text classes for a rollout signal tone. */
+export function toneClass(tone: "good" | "watch" | "risk"): string {
+  if (tone === "good") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+  if (tone === "watch") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+}

--- a/tests/browse-rollout-tone-lib.test.ts
+++ b/tests/browse-rollout-tone-lib.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { toneClass } from "../apps/web/src/lib/browse-rollout-tone-lib";
+
+describe("toneClass", () => {
+  it("maps good/watch/risk to distinct trust/amber/blocked classes", () => {
+    expect(toneClass("good")).toContain("text-trust-trusted");
+    expect(toneClass("watch")).toContain("text-amber-900");
+    expect(toneClass("risk")).toContain("text-trust-blocked");
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The browse rollout signals panel mapped a signal tone to CSS classes inline with `toneClass`, so the mapping had no direct test. This moves it into `apps/web/src/lib/browse-rollout-tone-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: `BrowseRolloutSignalsPanel` styles tone chips via `toneClass`.
- Expected behavior: `good` -> trusted classes, `watch` -> amber, `risk` -> blocked. Identical to the removed inline version.
- Important edge cases or invariants: the three tones map to distinct class strings.
- Backward compatibility notes: fully backward compatible - the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same classes.
- Focused tests: `tests/browse-rollout-tone-lib.test.ts` (1 test, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
