### PR TITLE
feat(web): add entry decision timeline panel

### DIFF
--- a/apps/web/src/components/entry-decision-timeline-panel.tsx
+++ b/apps/web/src/components/entry-decision-timeline-panel.tsx
@@ -1,0 +1,138 @@
+import type {
+  DecisionTimelinePresetId,
+  EntryDecisionTimelineState,
+} from "@/lib/entry-decision-timeline";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: DecisionTimelinePresetId; label: string }[] = [
+  { id: "fast-track", label: "Fast track" },
+  { id: "balanced", label: "Balanced" },
+  { id: "security-first", label: "Security first" },
+];
+
+function toneClass(tone: "complete" | "warning" | "critical"): string {
+  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
+  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
+  return "border-border bg-background";
+}
+
+function riskClass(score: number): string {
+  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
+}
+
+export function EntryDecisionTimelinePanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: EntryDecisionTimelineState;
+  selectedPreset: DecisionTimelinePresetId;
+  onSelectPreset: (preset: DecisionTimelinePresetId) => void;
+  className?: string;
+}) {
+  return (
+    <section
+      id="decision-timeline"
+      aria-label="Decision timeline"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Decision timeline</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span
+          className={cn(
+            "inline-flex rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide",
+            riskClass(state.riskScore),
+          )}
+        >
+          Risk {state.riskScore}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={selectedPreset === preset.id}
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-4 grid gap-2">
+        {state.steps.map((step) => (
+          <article
+            key={step.id}
+            className={cn("rounded-md border px-3 py-2.5", toneClass(step.tone))}
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="text-[10px] uppercase tracking-wide text-ink-subtle">{step.phase}</p>
+                <h4 className="text-xs font-semibold text-ink">
+                  {step.title}
+                  {step.required ? (
+                    <span className="ml-1 rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                      Required
+                    </span>
+                  ) : null}
+                </h4>
+                <p className="mt-1 text-[11px] text-ink-muted">{step.detail}</p>
+              </div>
+              <span className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                {step.done ? "Done" : "Pending"}
+              </span>
+            </div>
+          </article>
+        ))}
+      </div>
+
+      {state.blockers.length > 0 ? (
+        <p className="mt-3 rounded-md border border-trust-blocked/35 bg-trust-blocked/5 px-3 py-2 text-xs text-trust-blocked">
+          Blockers: {state.blockers.join(", ")}
+        </p>
+      ) : (
+        <p className="mt-3 rounded-md border border-trust-trusted/35 bg-trust-trusted/5 px-3 py-2 text-xs text-trust-trusted">
+          No required blockers for this timeline preset.
+        </p>
+      )}
+
+      {state.benchmarkSummary ? (
+        <p className="mt-3 text-xs text-ink-muted">{state.benchmarkSummary}</p>
+      ) : null}
+      {state.benchmarks.length > 0 ? (
+        <div className="mt-2 rounded-md border border-border bg-background px-3 py-2">
+          <p className="text-[11px] font-medium text-ink">Compare benchmark deltas</p>
+          <ul className="mt-1.5 space-y-1">
+            {state.benchmarks.map((benchmark) => (
+              <li
+                key={benchmark.entryRef}
+                className="flex items-center justify-between gap-2 text-[11px]"
+              >
+                <span className="truncate text-ink">{benchmark.title}</span>
+                <span className="font-mono text-ink-muted">
+                  {benchmark.score} ({benchmark.delta >= 0 ? "+" : ""}
+                  {benchmark.delta})
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-decision-timeline-lib.ts
+++ b/apps/web/src/lib/entry-decision-timeline-lib.ts
@@ -1,0 +1,261 @@
+import type { Entry } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+
+export type DecisionTimelinePresetId = "fast-track" | "balanced" | "security-first";
+
+export type DecisionTimelineStepTone = "complete" | "warning" | "critical";
+
+export type DecisionTimelineStep = {
+  id: string;
+  phase: "triage" | "verify" | "rollout";
+  title: string;
+  detail: string;
+  required: boolean;
+  done: boolean;
+  tone: DecisionTimelineStepTone;
+};
+
+export type DecisionTimelineBenchmark = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  score: number;
+  delta: number;
+};
+
+export type EntryDecisionTimelineState = {
+  preset: DecisionTimelinePresetId;
+  heading: string;
+  summary: string;
+  riskScore: number;
+  steps: DecisionTimelineStep[];
+  blockers: string[];
+  benchmarkSummary: string | null;
+  benchmarks: DecisionTimelineBenchmark[];
+};
+
+const STEP_DEFS: Array<{
+  id: string;
+  phase: "triage" | "verify" | "rollout";
+  title: string;
+  signal: "source" | "reviewed" | "safety" | "privacy" | "package" | "install";
+}> = [
+  { id: "source", phase: "triage", title: "Confirm source provenance", signal: "source" },
+  { id: "reviewed", phase: "triage", title: "Check metadata review status", signal: "reviewed" },
+  { id: "safety", phase: "verify", title: "Review safety notes", signal: "safety" },
+  { id: "privacy", phase: "verify", title: "Review privacy notes", signal: "privacy" },
+  {
+    id: "package",
+    phase: "verify",
+    title: "Validate package integrity metadata",
+    signal: "package",
+  },
+  {
+    id: "install",
+    phase: "rollout",
+    title: "Verify install payload and commands",
+    signal: "install",
+  },
+];
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function signalPresent(
+  entry: Entry,
+  signal: "source" | "reviewed" | "safety" | "privacy" | "package" | "install",
+): boolean {
+  if (signal === "source") return hasSource(entry);
+  if (signal === "reviewed") return hasReviewed(entry);
+  if (signal === "safety") return hasSafety(entry);
+  if (signal === "privacy") return hasPrivacy(entry);
+  if (signal === "package") return hasPackage(entry);
+  return hasInstall(entry);
+}
+
+function requiredMap(
+  preset: DecisionTimelinePresetId,
+): Record<"source" | "reviewed" | "safety" | "privacy" | "package" | "install", boolean> {
+  if (preset === "fast-track") {
+    return {
+      source: true,
+      reviewed: false,
+      safety: true,
+      privacy: false,
+      package: false,
+      install: true,
+    };
+  }
+  if (preset === "security-first") {
+    return {
+      source: true,
+      reviewed: true,
+      safety: true,
+      privacy: true,
+      package: true,
+      install: true,
+    };
+  }
+  return {
+    source: true,
+    reviewed: true,
+    safety: true,
+    privacy: false,
+    package: false,
+    install: true,
+  };
+}
+
+function detail(signal: DecisionTimelineStep["id"], done: boolean): string {
+  if (done) {
+    if (signal === "source") return "Source/provenance metadata is available.";
+    if (signal === "reviewed") return "Review metadata is available.";
+    if (signal === "safety") return "Safety notes are available.";
+    if (signal === "privacy") return "Privacy notes are available.";
+    if (signal === "package") return "Package integrity metadata is available.";
+    return "Install payload is available.";
+  }
+  if (signal === "source") return "Source/provenance metadata is missing.";
+  if (signal === "reviewed") return "Review metadata is missing.";
+  if (signal === "safety") return "Safety notes are missing.";
+  if (signal === "privacy") return "Privacy notes are missing.";
+  if (signal === "package") return "Package integrity metadata is missing.";
+  return "Install payload is missing.";
+}
+
+function stepTone(required: boolean, done: boolean): DecisionTimelineStepTone {
+  if (done) return "complete";
+  return required ? "critical" : "warning";
+}
+
+function trustPenalty(trust: Entry["trust"]): number {
+  if (trust === "blocked") return 42;
+  if (trust === "limited") return 24;
+  if (trust === "review") return 10;
+  return 0;
+}
+
+function scoreEntry(entry: Entry): number {
+  let score = 0;
+  if (hasSource(entry)) score += 24;
+  if (hasReviewed(entry)) score += 16;
+  if (hasSafety(entry)) score += 20;
+  if (hasPrivacy(entry)) score += 12;
+  if (hasPackage(entry)) score += 10;
+  if (hasInstall(entry)) score += 18;
+  return score;
+}
+
+function headingForPreset(preset: DecisionTimelinePresetId): string {
+  if (preset === "fast-track") return "Decision timeline · fast track";
+  if (preset === "security-first") return "Decision timeline · security first";
+  return "Decision timeline · balanced";
+}
+
+function summarize(input: {
+  preset: DecisionTimelinePresetId;
+  riskScore: number;
+  blockers: string[];
+  completeCount: number;
+}): string {
+  if (input.blockers.length === 0) {
+    return `${input.completeCount}/6 steps complete with no blocking gaps for this preset.`;
+  }
+  if (input.preset === "security-first") {
+    return `Security-first blockers: ${input.blockers.slice(0, 2).join(", ")}.`;
+  }
+  return `Blocking gaps: ${input.blockers.slice(0, 2).join(", ")}. Risk ${input.riskScore}.`;
+}
+
+function benchmarkSummary(benchmarks: DecisionTimelineBenchmark[]): string | null {
+  if (benchmarks.length === 0) return null;
+  const stronger = benchmarks.filter((item) => item.delta > 0).length;
+  const weaker = benchmarks.filter((item) => item.delta < 0).length;
+  if (stronger === 0 && weaker === 0)
+    return "Compared entries are tied on timeline evidence score.";
+  if (stronger > weaker)
+    return `${stronger} compared entries currently score higher on timeline evidence.`;
+  if (weaker > stronger)
+    return `${weaker} compared entries currently score lower on timeline evidence.`;
+  return "Compared entries show mixed timeline evidence scores.";
+}
+
+export function entryDecisionTimelineState(
+  entry: Entry,
+  preset: DecisionTimelinePresetId,
+  compareItems: Entry[],
+): EntryDecisionTimelineState {
+  const required = requiredMap(preset);
+  const steps: DecisionTimelineStep[] = STEP_DEFS.map((def) => {
+    const done = signalPresent(entry, def.signal);
+    const needed = required[def.signal];
+    return {
+      id: def.id,
+      phase: def.phase,
+      title: def.title,
+      required: needed,
+      done,
+      tone: stepTone(needed, done),
+      detail: detail(def.id, done),
+    };
+  });
+
+  const blockers = steps.filter((step) => step.required && !step.done).map((step) => step.title);
+  const completeCount = steps.filter((step) => step.done).length;
+  const riskScore = Math.min(
+    100,
+    trustPenalty(entry.trust) +
+      blockers.length * 14 +
+      steps.filter((step) => !step.required && !step.done).length * 4,
+  );
+
+  const targetScore = scoreEntry(entry);
+  const benchmarks: DecisionTimelineBenchmark[] = compareItems
+    .filter((candidate) => !sameEntry(candidate, entry))
+    .map((candidate) => {
+      const score = scoreEntry(candidate);
+      return {
+        entryRef: `${candidate.category}/${candidate.slug}`,
+        title: candidate.title,
+        trust: candidate.trust,
+        score,
+        delta: score - targetScore,
+      };
+    })
+    .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
+    .slice(0, 4);
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summarize({ preset, riskScore, blockers, completeCount }),
+    riskScore,
+    steps,
+    blockers,
+    benchmarkSummary: benchmarkSummary(benchmarks),
+    benchmarks,
+  };
+}

--- a/apps/web/src/lib/entry-decision-timeline.ts
+++ b/apps/web/src/lib/entry-decision-timeline.ts
@@ -1,0 +1,8 @@
+export type {
+  DecisionTimelineBenchmark,
+  DecisionTimelinePresetId,
+  DecisionTimelineStep,
+  DecisionTimelineStepTone,
+  EntryDecisionTimelineState,
+} from "@/lib/entry-decision-timeline-lib";
+export { entryDecisionTimelineState } from "@/lib/entry-decision-timeline-lib";

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -87,6 +87,7 @@ export function buildEntryTocItems(input: {
   items.push({ id: "adoption-plan", label: "Adoption plan" });
   items.push({ id: "decision-playbook", label: "Decision playbook" });
   items.push({ id: "evidence-matrix", label: "Evidence matrix" });
+  items.push({ id: "decision-timeline", label: "Decision timeline" });
   if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
   if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
   if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -88,7 +88,10 @@ import {
   entryEvidenceReadinessMatrixState,
   type EvidenceMatrixPresetId,
 } from "@/lib/entry-evidence-readiness-matrix";
-import { entryDecisionTimelineState, type DecisionTimelinePresetId } from "@/lib/entry-decision-timeline";
+import {
+  entryDecisionTimelineState,
+  type DecisionTimelinePresetId,
+} from "@/lib/entry-decision-timeline";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -359,6 +362,7 @@ function Dossier() {
   const evidenceMatrix = useMemo(
     () => entryEvidenceReadinessMatrixState(entry, evidencePreset, compare.items),
     [entry, evidencePreset, compare.items],
+  );
   const decisionTimeline = useMemo(
     () => entryDecisionTimelineState(entry, timelinePreset, compare.items),
     [entry, timelinePreset, compare.items],

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -57,6 +57,7 @@ import { EntryDetailCommandCenter } from "@/components/entry-detail-command-cent
 import { EntryDetailMobileActionBar } from "@/components/entry-detail-mobile-action-bar";
 import { EntrySignalsPanel } from "@/components/entry-signals-panel";
 import { EntryDetailDecisionPlaybook } from "@/components/entry-detail-decision-playbook";
+import { EntryDecisionTimelinePanel } from "@/components/entry-decision-timeline-panel";
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
@@ -87,6 +88,7 @@ import {
   entryEvidenceReadinessMatrixState,
   type EvidenceMatrixPresetId,
 } from "@/lib/entry-evidence-readiness-matrix";
+import { entryDecisionTimelineState, type DecisionTimelinePresetId } from "@/lib/entry-decision-timeline";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -286,6 +288,7 @@ function Dossier() {
   const compare = useCompare();
   const [adoptionPreset, setAdoptionPreset] = useState<AdoptionPlanPresetId>("balanced-rollout");
   const [evidencePreset, setEvidencePreset] = useState<EvidenceMatrixPresetId>("balanced");
+  const [timelinePreset, setTimelinePreset] = useState<DecisionTimelinePresetId>("balanced");
   const inCompare = useIsCompared(entry);
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
@@ -356,6 +359,9 @@ function Dossier() {
   const evidenceMatrix = useMemo(
     () => entryEvidenceReadinessMatrixState(entry, evidencePreset, compare.items),
     [entry, evidencePreset, compare.items],
+  const decisionTimeline = useMemo(
+    () => entryDecisionTimelineState(entry, timelinePreset, compare.items),
+    [entry, timelinePreset, compare.items],
   );
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
@@ -517,6 +523,11 @@ function Dossier() {
             state={evidenceMatrix}
             selectedPreset={evidencePreset}
             onSelectPreset={setEvidencePreset}
+          />
+          <EntryDecisionTimelinePanel
+            state={decisionTimeline}
+            selectedPreset={timelinePreset}
+            onSelectPreset={setTimelinePreset}
           />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">

--- a/tests/entry-decision-timeline-lib.test.ts
+++ b/tests/entry-decision-timeline-lib.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { entryDecisionTimelineState } from "@/lib/entry-decision-timeline-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const mid = entry({
+  slug: "mid",
+  title: "Mid",
+  trust: "review",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/mid",
+  reviewed: false,
+  safetyNotes: "present",
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: "npm i mid",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("entry decision timeline lib", () => {
+  it("returns heading per preset", () => {
+    expect(
+      entryDecisionTimelineState(strong, "fast-track", []).heading,
+    ).toContain("fast track");
+    expect(
+      entryDecisionTimelineState(strong, "balanced", []).heading,
+    ).toContain("balanced");
+    expect(
+      entryDecisionTimelineState(strong, "security-first", []).heading,
+    ).toContain("security first");
+  });
+
+  it("creates six timeline steps", () => {
+    expect(
+      entryDecisionTimelineState(strong, "balanced", []).steps,
+    ).toHaveLength(6);
+  });
+
+  it("marks missing required steps as critical", () => {
+    const state = entryDecisionTimelineState(weak, "security-first", []);
+    expect(
+      state.steps.some((step) => step.required && step.tone === "critical"),
+    ).toBe(true);
+  });
+
+  it("marks missing optional steps as warning", () => {
+    const state = entryDecisionTimelineState(mid, "balanced", []);
+    const privacy = state.steps.find((step) => step.id === "privacy");
+    expect(privacy?.required).toBe(false);
+    expect(privacy?.tone).toBe("warning");
+  });
+
+  it("marks complete steps as complete tone", () => {
+    const state = entryDecisionTimelineState(strong, "security-first", []);
+    expect(state.steps.every((step) => step.tone === "complete")).toBe(true);
+  });
+
+  it("sets blockers from required missing steps", () => {
+    const state = entryDecisionTimelineState(weak, "security-first", []);
+    expect(state.blockers.length).toBeGreaterThan(0);
+    expect(state.blockers[0]).toContain("Confirm");
+  });
+
+  it("produces no blockers when required signals are present", () => {
+    const state = entryDecisionTimelineState(strong, "security-first", []);
+    expect(state.blockers).toEqual([]);
+  });
+
+  it("computes low risk score for strong entry", () => {
+    const state = entryDecisionTimelineState(strong, "security-first", []);
+    expect(state.riskScore).toBeLessThan(20);
+  });
+
+  it("computes high risk score for weak entry", () => {
+    const state = entryDecisionTimelineState(weak, "security-first", []);
+    expect(state.riskScore).toBeGreaterThanOrEqual(60);
+  });
+
+  it("uses blocker-based summary when gaps exist", () => {
+    const state = entryDecisionTimelineState(weak, "balanced", []);
+    expect(state.summary).toContain("Blocking gaps");
+  });
+
+  it("uses complete summary when no blockers exist", () => {
+    const state = entryDecisionTimelineState(strong, "balanced", []);
+    expect(state.summary).toContain("steps complete");
+  });
+
+  it("keeps privacy optional in fast-track preset", () => {
+    const state = entryDecisionTimelineState(weak, "fast-track", []);
+    const privacy = state.steps.find((step) => step.id === "privacy");
+    expect(privacy?.required).toBe(false);
+  });
+
+  it("keeps package required in security-first preset", () => {
+    const state = entryDecisionTimelineState(weak, "security-first", []);
+    const packageStep = state.steps.find((step) => step.id === "package");
+    expect(packageStep?.required).toBe(true);
+  });
+
+  it("excludes target entry from benchmarks", () => {
+    const state = entryDecisionTimelineState(strong, "balanced", [strong, mid]);
+    expect(
+      state.benchmarks.some((row) => row.entryRef === "tools/strong"),
+    ).toBe(false);
+  });
+
+  it("sorts benchmarks by score descending", () => {
+    const state = entryDecisionTimelineState(mid, "balanced", [strong, weak]);
+    expect(state.benchmarks[0].entryRef).toBe("tools/strong");
+  });
+
+  it("limits benchmarks to top four rows", () => {
+    const compare = [strong, mid, weak].concat(
+      Array.from({ length: 4 }).map((_, idx) =>
+        entry({
+          slug: `extra-${idx}`,
+          title: `Extra ${idx}`,
+          source: "source-backed",
+          sourceUrl: `https://example.com/${idx}`,
+          installCommand: "npm i extra",
+        }),
+      ),
+    );
+    const state = entryDecisionTimelineState(mid, "balanced", compare);
+    expect(state.benchmarks.length).toBeLessThanOrEqual(4);
+  });
+
+  it("creates benchmark summary when compare entries exist", () => {
+    const state = entryDecisionTimelineState(mid, "balanced", [strong, weak]);
+    expect(state.benchmarkSummary).toBeTruthy();
+  });
+
+  it("returns null benchmark summary for no compare entries", () => {
+    const state = entryDecisionTimelineState(mid, "balanced", []);
+    expect(state.benchmarkSummary).toBeNull();
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://example.com/reviewed-by",
+      reviewed: false,
+      reviewedBy: "team",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = entryDecisionTimelineState(reviewedBy, "balanced", []);
+    expect(state.steps.find((step) => step.id === "reviewed")?.done).toBe(true);
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://example.com/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = entryDecisionTimelineState(hashed, "balanced", []);
+    expect(state.steps.find((step) => step.id === "package")?.done).toBe(true);
+  });
+});

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -117,6 +117,7 @@ describe("entry-detail-sidebar-lib", () => {
       "adoption-plan",
       "decision-playbook",
       "evidence-matrix",
+      "decision-timeline",
       "privacy",
       "prerequisites",
       "about",


### PR DESCRIPTION
## Summary
- Add `entry-decision-timeline-lib` to generate preset-based decision phases, required blockers, risk score, and compare benchmark deltas on entry detail pages.
- Add `EntryDecisionTimelinePanel` with preset switching and integrate it into the entry detail route.
- Add the timeline section to the detail TOC and extend tests for timeline logic and sidebar ordering.

Refs #556
Refs #393

## Test plan
- [x] `pnpm test tests/entry-decision-timeline-lib.test.ts tests/entry-detail-sidebar-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] CI green (`validate-web`, `codecov/patch`, `required-pr-gate`)