### PR TITLE
refactor(web): extract severityClass into compare-evidence-severity-lib

### DIFF
--- a/apps/web/src/components/compare-evidence-gaps-panel.tsx
+++ b/apps/web/src/components/compare-evidence-gaps-panel.tsx
@@ -1,11 +1,6 @@
+import { severityClass } from "@/lib/compare-evidence-severity-lib";
 import type { CompareEvidenceGapsState } from "@/lib/compare-evidence-gaps";
 import { cn } from "@/lib/utils";
-
-function severityClass(severity: "low" | "medium" | "high"): string {
-  if (severity === "high") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
-  if (severity === "medium") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
-  return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
-}
 
 export function CompareEvidenceGapsPanel({
   state,

--- a/apps/web/src/lib/compare-evidence-severity-lib.ts
+++ b/apps/web/src/lib/compare-evidence-severity-lib.ts
@@ -1,0 +1,9 @@
+// Pure severity -> CSS class mapping for the compare evidence-gaps panel, split
+// out so the mapping can be unit-tested without React.
+
+/** Border/background/text classes for an evidence-gap severity. */
+export function severityClass(severity: "low" | "medium" | "high"): string {
+  if (severity === "high") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+  if (severity === "medium") return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+  return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+}

--- a/tests/compare-evidence-severity-lib.test.ts
+++ b/tests/compare-evidence-severity-lib.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { severityClass } from "../apps/web/src/lib/compare-evidence-severity-lib";
+
+describe("severityClass", () => {
+  it("maps high/medium/low to blocked/amber/trusted classes", () => {
+    expect(severityClass("high")).toContain("text-trust-blocked");
+    expect(severityClass("medium")).toContain("text-amber-900");
+    expect(severityClass("low")).toContain("text-trust-trusted");
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The compare evidence-gaps panel mapped a severity to CSS classes inline with `severityClass`, so the mapping had no direct test. This moves it into `apps/web/src/lib/compare-evidence-severity-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: `CompareEvidenceGapsPanel` styles severity chips via `severityClass`.
- Expected behavior: `high` -> blocked, `medium` -> amber, `low` -> trusted. Identical to the removed inline version.
- Important edge cases or invariants: the three severities map to distinct class strings.
- Backward compatibility notes: fully backward compatible - the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same classes.
- Focused tests: `tests/compare-evidence-severity-lib.test.ts` (1 test, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
