### PR TITLE
refactor(web): extract tierClass into compare-rollout-tier-lib

### DIFF
--- a/apps/web/src/components/compare-rollout-readiness-panel.tsx
+++ b/apps/web/src/components/compare-rollout-readiness-panel.tsx
@@ -1,14 +1,9 @@
+import { tierClass } from "@/lib/compare-rollout-tier-lib";
 import type {
   CompareRolloutReadinessState,
   RolloutPresetId,
 } from "@/lib/compare-rollout-readiness";
 import { cn } from "@/lib/utils";
-
-function tierClass(tier: "ready" | "review" | "hold"): string {
-  if (tier === "ready") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
-  if (tier === "hold") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
-  return "border-amber-500/30 bg-amber-500/5 text-amber-900";
-}
 
 const PRESETS: { id: RolloutPresetId; label: string }[] = [
   { id: "prototype", label: "Prototype" },

--- a/apps/web/src/lib/compare-rollout-tier-lib.ts
+++ b/apps/web/src/lib/compare-rollout-tier-lib.ts
@@ -1,0 +1,9 @@
+// Pure readiness-tier -> CSS class mapping for the compare rollout readiness
+// panel, split out so the mapping can be unit-tested without React.
+
+/** Border/background/text classes for a rollout-readiness tier. */
+export function tierClass(tier: "ready" | "review" | "hold"): string {
+  if (tier === "ready") return "border-trust-trusted/30 bg-trust-trusted/5 text-trust-trusted";
+  if (tier === "hold") return "border-trust-blocked/30 bg-trust-blocked/5 text-trust-blocked";
+  return "border-amber-500/30 bg-amber-500/5 text-amber-900";
+}

--- a/tests/compare-rollout-tier-lib.test.ts
+++ b/tests/compare-rollout-tier-lib.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+
+import { tierClass } from "../apps/web/src/lib/compare-rollout-tier-lib";
+
+describe("tierClass", () => {
+  it("maps ready/hold/review to trusted/blocked/amber classes", () => {
+    expect(tierClass("ready")).toContain("text-trust-trusted");
+    expect(tierClass("hold")).toContain("text-trust-blocked");
+    expect(tierClass("review")).toContain("text-amber-900");
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The compare rollout readiness panel mapped a readiness tier to CSS classes inline with `tierClass`, so the mapping had no direct test. This moves it into `apps/web/src/lib/compare-rollout-tier-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: `CompareRolloutReadinessPanel` styles tier chips via `tierClass`.
- Expected behavior: `ready` -> trusted, `hold` -> blocked, `review` -> amber. Identical to the removed inline version.
- Important edge cases or invariants: the three tiers map to distinct class strings.
- Backward compatibility notes: fully backward compatible - the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same classes.
- Focused tests: `tests/compare-rollout-tier-lib.test.ts` (1 test, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
