### PR TITLE
refactor(web): extract riskTone/cellToneClass into entry-evidence-tone-lib

### DIFF
--- a/apps/web/src/components/entry-evidence-readiness-matrix.tsx
+++ b/apps/web/src/components/entry-evidence-readiness-matrix.tsx
@@ -1,3 +1,4 @@
+import { cellToneClass, riskTone } from "@/lib/entry-evidence-tone-lib";
 import {
   type EntryEvidenceReadinessMatrixState,
   type EvidenceMatrixPresetId,
@@ -9,18 +10,6 @@ const PRESETS: { id: EvidenceMatrixPresetId; label: string }[] = [
   { id: "strict", label: "Strict" },
   { id: "pilot", label: "Pilot" },
 ];
-
-function riskTone(score: number): string {
-  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
-  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
-  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
-}
-
-function cellToneClass(tone: "complete" | "warning" | "critical"): string {
-  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
-  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
-  return "border-border bg-background";
-}
 
 export function EntryEvidenceReadinessMatrix({
   state,

--- a/apps/web/src/lib/entry-evidence-tone-lib.ts
+++ b/apps/web/src/lib/entry-evidence-tone-lib.ts
@@ -1,0 +1,16 @@
+// Pure tone/score -> CSS class mappings for the entry evidence-readiness matrix,
+// split out so the mappings can be unit-tested without React.
+
+/** Border/background/text classes for a risk score (higher = worse). */
+export function riskTone(score: number): string {
+  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
+}
+
+/** Border/background classes for a matrix cell's completeness tone. */
+export function cellToneClass(tone: "complete" | "warning" | "critical"): string {
+  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
+  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
+  return "border-border bg-background";
+}

--- a/tests/entry-evidence-tone-lib.test.ts
+++ b/tests/entry-evidence-tone-lib.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cellToneClass,
+  riskTone,
+} from "../apps/web/src/lib/entry-evidence-tone-lib";
+
+describe("riskTone", () => {
+  it("maps score bands to blocked / amber / trusted classes", () => {
+    expect(riskTone(60)).toContain("text-trust-blocked");
+    expect(riskTone(30)).toContain("text-amber-900");
+    expect(riskTone(29)).toContain("text-trust-trusted");
+  });
+});
+
+describe("cellToneClass", () => {
+  it("maps critical/warning/complete to blocked/amber/neutral classes", () => {
+    expect(cellToneClass("critical")).toContain("bg-trust-blocked/5");
+    expect(cellToneClass("warning")).toContain("bg-amber-500/5");
+    expect(cellToneClass("complete")).toBe("border-border bg-background");
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The entry evidence-readiness matrix mapped a risk score and a cell tone to CSS classes inline with `riskTone`/`cellToneClass`, so neither had a direct test. This moves both into `apps/web/src/lib/entry-evidence-tone-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: `EntryEvidenceReadinessMatrix` styles risk badges/cells via `riskTone`/`cellToneClass`.
- Expected behavior: `riskTone` -> blocked at >=60, amber at >=30, else trusted; `cellToneClass` -> blocked/amber/neutral for critical/warning/complete. Identical to the removed inline versions.
- Important edge cases or invariants: the score band boundaries (60, 30) and the three cell tones map to distinct classes.
- Backward compatibility notes: fully backward compatible - both helpers were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same classes.
- Focused tests: `tests/entry-evidence-tone-lib.test.ts` (2 tests, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
