### PR TITLE
refactor(web): extract booleanLabel into boolean-label-lib

### DIFF
--- a/apps/web/src/lib/boolean-label-lib.ts
+++ b/apps/web/src/lib/boolean-label-lib.ts
@@ -1,0 +1,8 @@
+// Pure yes/no label for an optional boolean field, split out of the entry detail
+// route so it can be unit-tested. Returns undefined when the value is absent so
+// callers can omit the row entirely.
+
+export function booleanLabel(value?: boolean): string | undefined {
+  if (value === undefined) return undefined;
+  return value ? "Yes" : "No";
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -39,6 +39,7 @@ import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { hasSchemaDetails } from "@/lib/entry-schema-details-lib";
+import { booleanLabel } from "@/lib/boolean-label-lib";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
 import { categoryLabels, categoryUsageHints, siteConfig } from "@/lib/site";
 import { tagSlug } from "@/lib/tags";
@@ -984,11 +985,6 @@ function SchemaDetails({ entry }: { entry: Entry }) {
       </div>
     </DossierSection>
   );
-}
-
-function booleanLabel(value?: boolean) {
-  if (value === undefined) return undefined;
-  return value ? "Yes" : "No";
 }
 
 function MetadataGroup({

--- a/tests/boolean-label-lib.test.ts
+++ b/tests/boolean-label-lib.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { booleanLabel } from "../apps/web/src/lib/boolean-label-lib";
+
+describe("booleanLabel", () => {
+  it("returns undefined for an absent value", () => {
+    expect(booleanLabel(undefined)).toBeUndefined();
+  });
+
+  it("maps true to Yes and false to No", () => {
+    expect(booleanLabel(true)).toBe("Yes");
+    expect(booleanLabel(false)).toBe("No");
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The entry detail route rendered optional boolean fields with an inline `booleanLabel` (undefined -> omit, else Yes/No), so it had no direct test. This moves it into `apps/web/src/lib/boolean-label-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: entry detail `FieldRow`s use `booleanLabel(...)`.
- Expected behavior: `undefined` -> `undefined` (row omitted), `true` -> "Yes", `false` -> "No". Identical to the removed inline version.
- Important edge cases or invariants: the absent case returns undefined so callers can drop the row.
- Backward compatibility notes: fully backward compatible - the helper was module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same labels.
- Focused tests: `tests/boolean-label-lib.test.ts` (2 tests, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
