### PR TITLE
refactor(web): extract hasLiveSignals into trending-live-signals-lib

### DIFF
--- a/apps/web/src/lib/trending-live-signals-lib.ts
+++ b/apps/web/src/lib/trending-live-signals-lib.ts
@@ -1,0 +1,13 @@
+// Pure "are any live signals present" check for the trending route, split out so
+// it can be unit-tested without React.
+
+export type SignalState = {
+  votes?: boolean;
+  community?: boolean;
+  intent?: boolean;
+};
+
+/** True when any of the vote / community / intent live signals are available. */
+export function hasLiveSignals(signals?: SignalState): boolean {
+  return Boolean(signals?.votes || signals?.community || signals?.intent);
+}

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { hasLiveSignals, type SignalState } from "@/lib/trending-live-signals-lib";
 import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router";
 import { z } from "zod";
 import { ArrowRight, Clock, Flame, Info, Rss, Star, TrendingUp } from "lucide-react";
@@ -25,12 +26,6 @@ const trendingSchema = z.object({
   window: z.enum(["7d", "30d", "all"]).catch(defaultSearch.window).default(defaultSearch.window),
   category: z.string().catch(defaultSearch.category).default(defaultSearch.category),
 });
-
-type SignalState = {
-  votes?: boolean;
-  community?: boolean;
-  intent?: boolean;
-};
 
 type TrendingEntry = Entry & {
   trendingScore?: number;
@@ -95,10 +90,6 @@ export const Route = createFileRoute("/trending")({
   }),
   component: TrendingPage,
 });
-
-function hasLiveSignals(signals?: SignalState) {
-  return Boolean(signals?.votes || signals?.community || signals?.intent);
-}
 
 function fallbackRows(): TrendingEntry[] {
   return search({ sort: "popular" })

--- a/tests/trending-live-signals-lib.test.ts
+++ b/tests/trending-live-signals-lib.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { hasLiveSignals } from "../apps/web/src/lib/trending-live-signals-lib";
+
+describe("hasLiveSignals", () => {
+  it("is false with no signals or all-off signals", () => {
+    expect(hasLiveSignals(undefined)).toBe(false);
+    expect(hasLiveSignals({})).toBe(false);
+    expect(
+      hasLiveSignals({ votes: false, community: false, intent: false }),
+    ).toBe(false);
+  });
+
+  it("is true when any single signal is available", () => {
+    expect(hasLiveSignals({ votes: true })).toBe(true);
+    expect(hasLiveSignals({ community: true })).toBe(true);
+    expect(hasLiveSignals({ intent: true })).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
Mirrors the `*-lib` extraction pattern from merged PRs #4551 (client-logs) and #4555 (d1-batch). The trending route decided whether live signals were present inline with `hasLiveSignals` (and the `SignalState` type), so it had no direct test. This moves both into `apps/web/src/lib/trending-live-signals-lib.ts`. **No behavior change.**

## Submission Source
For platform/code/docs PRs:
- [x] This is not a direct content submission.
- [x] Changed routes/components/endpoints/tools are listed below.
- [x] Screenshots or `No visual impact` are included when relevant.
- [x] This PR links the issue it resolves, or the no-issue maintainer-lane rationale is written in **Notes**.

## Schema and Quality Checks
- [x] Platform/code PR: focused validation is listed below.
- [x] No forbidden fields were added (`viewCount`, `copyCount`, `popularityScore`).

## Quality Evidence
- Changed routes/components/endpoints/tools: the trending route gates its live-vs-fallback rows on `hasLiveSignals`.
- Expected behavior: true when any of `votes`/`community`/`intent` is set, else false. Identical to the removed inline version.
- Important edge cases or invariants: undefined and all-off both return false.
- Backward compatibility notes: fully backward compatible - the helper/type were module-private.
- Screenshots for frontend/page/UI changes: `No visual impact` - same gating.
- Focused tests: `tests/trending-live-signals-lib.test.ts` (2 tests, branch coverage 100%).

## Validation
- [x] `tsc --noEmit` passed (exit 0).
- [x] `pnpm exec vitest run` -> passing, branches 100%.
- [x] `pnpm exec prettier --check` clean.
- [x] I did not run generation or commit generated output.

## Notes
**No linked issue (maintainer-lane rationale):** self-contained testability refactor, matching merged extraction PRs #4551 and #4555 (no linked issue).
