### PR TITLE
feat(web): add compare operational fit heatmap panel

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -41,6 +41,11 @@ import {
 } from "@/lib/compare-rollout-readiness";
 import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
 import {
+  compareOperationalFitHeatmapState,
+  type OperationalFitPresetId,
+} from "@/lib/compare-operational-fit-heatmap";
+import { CompareOperationalFitHeatmapPanel } from "@/components/compare-operational-fit-heatmap-panel";
+import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
@@ -332,12 +337,14 @@ export function CompareDrawer() {
   const { items, open, setOpen, toggle, clear, hydrate } = useCompare();
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
+  const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
   const scenarioRanking = compareScenarioRankingState(items, scenario);
   const evidenceGaps = compareEvidenceGapsState(items);
   const rolloutReadiness = compareRolloutReadinessState(items, rolloutPreset);
+  const operationalFitHeatmap = compareOperationalFitHeatmapState(items, fitPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -450,6 +457,13 @@ export function CompareDrawer() {
               state={rolloutReadiness}
               selectedPreset={rolloutPreset}
               onSelectPreset={setRolloutPreset}
+              compact
+              className="m-3 mt-0"
+            />
+            <CompareOperationalFitHeatmapPanel
+              state={operationalFitHeatmap}
+              selectedPreset={fitPreset}
+              onSelectPreset={setFitPreset}
               compact
               className="m-3 mt-0"
             />

--- a/apps/web/src/components/compare-operational-fit-heatmap-panel.tsx
+++ b/apps/web/src/components/compare-operational-fit-heatmap-panel.tsx
@@ -1,0 +1,112 @@
+import type {
+  CompareOperationalFitHeatmapState,
+  OperationalFitPresetId,
+  OperationalFitTone,
+} from "@/lib/compare-operational-fit-heatmap";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: OperationalFitPresetId; label: string }[] = [
+  { id: "team-default", label: "Team default" },
+  { id: "security-hardening", label: "Security hardening" },
+  { id: "rapid-adoption", label: "Rapid adoption" },
+];
+
+function toneClass(tone: OperationalFitTone): string {
+  if (tone === "strong") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (tone === "mixed") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+}
+
+export function CompareOperationalFitHeatmapPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  compact = false,
+  className,
+}: {
+  state: CompareOperationalFitHeatmapState;
+  selectedPreset: OperationalFitPresetId;
+  onSelectPreset: (preset: OperationalFitPresetId) => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.entries.length === 0) return null;
+
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Operational fit heatmap</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          best {state.bestEntryRef ?? "n/a"}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.entries.map((entry) => (
+          <article
+            key={entry.entryRef}
+            className="rounded-md border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.recommendation}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    toneClass(entry.fitTone),
+                  )}
+                >
+                  {entry.fitTone}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{entry.totalScore}/100</p>
+              </div>
+            </div>
+
+            {!compact ? (
+              <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+                {entry.cells.map((cell) => (
+                  <div
+                    key={`${entry.entryRef}-${cell.axisId}`}
+                    className="rounded border border-border px-2 py-1"
+                  >
+                    <p className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                      {cell.axisId}
+                    </p>
+                    <p className="text-[11px] text-ink-muted">{cell.reason}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            <p className="mt-2 text-[11px] text-ink-subtle">Confidence {entry.confidence}%</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
+++ b/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
@@ -1,0 +1,297 @@
+import type { Entry } from "@/types/registry";
+
+export type OperationalFitPresetId = "team-default" | "security-hardening" | "rapid-adoption";
+export type OperationalFitTone = "strong" | "mixed" | "weak";
+
+export type OperationalFitAxis = {
+  id: string;
+  label: string;
+  weight: number;
+  description: string;
+};
+
+export type OperationalFitEntryCell = {
+  axisId: string;
+  score: number;
+  tone: OperationalFitTone;
+  reason: string;
+};
+
+export type OperationalFitEntry = {
+  entryRef: string;
+  title: string;
+  totalScore: number;
+  fitTone: OperationalFitTone;
+  confidence: number;
+  cells: OperationalFitEntryCell[];
+  recommendation: string;
+};
+
+export type CompareOperationalFitHeatmapState = {
+  preset: OperationalFitPresetId;
+  heading: string;
+  summary: string;
+  axes: OperationalFitAxis[];
+  entries: OperationalFitEntry[];
+  bestEntryRef: string | null;
+  weakEntryRefs: string[];
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function toneFromScore(score: number): OperationalFitTone {
+  if (score >= 75) return "strong";
+  if (score >= 45) return "mixed";
+  return "weak";
+}
+
+function headingForPreset(preset: OperationalFitPresetId): string {
+  if (preset === "security-hardening") return "Operational fit heatmap · security hardening";
+  if (preset === "rapid-adoption") return "Operational fit heatmap · rapid adoption";
+  return "Operational fit heatmap · team default";
+}
+
+function axesForPreset(preset: OperationalFitPresetId): OperationalFitAxis[] {
+  if (preset === "security-hardening") {
+    return [
+      {
+        id: "provenance",
+        label: "Provenance",
+        weight: 20,
+        description: "Source + review confidence.",
+      },
+      {
+        id: "safety",
+        label: "Safety posture",
+        weight: 20,
+        description: "Safety and privacy disclosures.",
+      },
+      {
+        id: "integrity",
+        label: "Integrity",
+        weight: 20,
+        description: "Package verification metadata.",
+      },
+      {
+        id: "operability",
+        label: "Operability",
+        weight: 12,
+        description: "Install and config readiness.",
+      },
+      {
+        id: "trust",
+        label: "Trust tier",
+        weight: 28,
+        description: "Registry trust posture impact.",
+      },
+    ];
+  }
+  if (preset === "rapid-adoption") {
+    return [
+      {
+        id: "provenance",
+        label: "Provenance",
+        weight: 16,
+        description: "Source + review confidence.",
+      },
+      {
+        id: "safety",
+        label: "Safety posture",
+        weight: 14,
+        description: "Safety and privacy disclosures.",
+      },
+      {
+        id: "integrity",
+        label: "Integrity",
+        weight: 10,
+        description: "Package verification metadata.",
+      },
+      {
+        id: "operability",
+        label: "Operability",
+        weight: 40,
+        description: "Install and config readiness.",
+      },
+      {
+        id: "trust",
+        label: "Trust tier",
+        weight: 20,
+        description: "Registry trust posture impact.",
+      },
+    ];
+  }
+  return [
+    {
+      id: "provenance",
+      label: "Provenance",
+      weight: 20,
+      description: "Source + review confidence.",
+    },
+    {
+      id: "safety",
+      label: "Safety posture",
+      weight: 18,
+      description: "Safety and privacy disclosures.",
+    },
+    {
+      id: "integrity",
+      label: "Integrity",
+      weight: 12,
+      description: "Package verification metadata.",
+    },
+    {
+      id: "operability",
+      label: "Operability",
+      weight: 28,
+      description: "Install and config readiness.",
+    },
+    { id: "trust", label: "Trust tier", weight: 22, description: "Registry trust posture impact." },
+  ];
+}
+
+function trustScore(entry: Entry): number {
+  if (entry.trust === "trusted") return 100;
+  if (entry.trust === "review") return 60;
+  if (entry.trust === "limited") return 32;
+  return 0;
+}
+
+function axisScore(entry: Entry, axisId: string): { score: number; reason: string } {
+  if (axisId === "provenance") {
+    const source = hasSource(entry);
+    const reviewed = hasReviewed(entry);
+    if (source && reviewed) return { score: 100, reason: "Source and review signals present." };
+    if (source) return { score: 65, reason: "Source present but review signal missing." };
+    if (reviewed) return { score: 35, reason: "Review present without source provenance." };
+    return { score: 0, reason: "Source and review signals missing." };
+  }
+  if (axisId === "safety") {
+    const safety = hasSafety(entry);
+    const privacy = hasPrivacy(entry);
+    if (safety && privacy) return { score: 100, reason: "Safety and privacy notes present." };
+    if (safety || privacy)
+      return { score: 55, reason: "Only one of safety/privacy notes present." };
+    return { score: 0, reason: "Safety and privacy notes missing." };
+  }
+  if (axisId === "integrity") {
+    if (hasPackage(entry)) return { score: 100, reason: "Package integrity metadata present." };
+    return { score: 0, reason: "Package integrity metadata missing." };
+  }
+  if (axisId === "operability") {
+    if (hasInstall(entry)) return { score: 100, reason: "Install/config payload present." };
+    return { score: 0, reason: "Install/config payload missing." };
+  }
+  const score = trustScore(entry);
+  return {
+    score,
+    reason:
+      score >= 90
+        ? "Trusted posture."
+        : score >= 50
+          ? "Review-first posture."
+          : score >= 20
+            ? "Limited posture."
+            : "Blocked posture.",
+  };
+}
+
+function recommendation(entry: OperationalFitEntry): string {
+  if (entry.fitTone === "strong") return "Good candidate for staged rollout.";
+  if (entry.fitTone === "mixed") return "Adopt with targeted mitigations first.";
+  return "Keep in hold state until key gaps are resolved.";
+}
+
+function summary(entries: OperationalFitEntry[]): string {
+  if (entries.length === 0) return "Add entries to generate an operational fit map.";
+  const strong = entries.filter((entry) => entry.fitTone === "strong").length;
+  const weak = entries.filter((entry) => entry.fitTone === "weak").length;
+  if (weak === 0) return `${strong}/${entries.length} entries show strong operational fit.`;
+  return `${weak} entries have weak operational fit; prioritize mitigation before deployment.`;
+}
+
+export function compareOperationalFitHeatmapState(
+  entries: Entry[],
+  preset: OperationalFitPresetId,
+): CompareOperationalFitHeatmapState {
+  const axes = axesForPreset(preset);
+  const mapped: OperationalFitEntry[] = entries
+    .map((entry) => {
+      const cells: OperationalFitEntryCell[] = axes.map((axis) => {
+        const result = axisScore(entry, axis.id);
+        return {
+          axisId: axis.id,
+          score: result.score,
+          tone: toneFromScore(result.score),
+          reason: result.reason,
+        };
+      });
+
+      const weightedTotal = cells.reduce((sum, cell) => {
+        const axis = axes.find((row) => row.id === cell.axisId)!;
+        return sum + (cell.score / 100) * axis.weight;
+      }, 0);
+      const totalScore = Math.round(weightedTotal);
+      const confidence = Math.round(
+        cells.reduce((sum, cell) => sum + cell.score, 0) / cells.length,
+      );
+      const fitTone = toneFromScore(totalScore);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        totalScore,
+        fitTone,
+        confidence,
+        cells,
+        recommendation: recommendation({
+          entryRef: entryRef(entry),
+          title: entry.title,
+          totalScore,
+          fitTone,
+          confidence,
+          cells,
+          recommendation: "",
+        }),
+      };
+    })
+    .sort((a, b) => b.totalScore - a.totalScore || a.title.localeCompare(b.title));
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(mapped),
+    axes,
+    entries: mapped,
+    bestEntryRef: mapped[0]?.entryRef ?? null,
+    weakEntryRefs: mapped
+      .filter((entry) => entry.fitTone === "weak")
+      .map((entry) => entry.entryRef),
+  };
+}

--- a/apps/web/src/lib/compare-operational-fit-heatmap.ts
+++ b/apps/web/src/lib/compare-operational-fit-heatmap.ts
@@ -1,0 +1,9 @@
+export type {
+  CompareOperationalFitHeatmapState,
+  OperationalFitAxis,
+  OperationalFitEntry,
+  OperationalFitEntryCell,
+  OperationalFitPresetId,
+  OperationalFitTone,
+} from "@/lib/compare-operational-fit-heatmap-lib";
+export { compareOperationalFitHeatmapState } from "@/lib/compare-operational-fit-heatmap-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -25,6 +25,10 @@ import {
   compareRolloutReadinessState,
   type RolloutPresetId,
 } from "@/lib/compare-rollout-readiness";
+import {
+  compareOperationalFitHeatmapState,
+  type OperationalFitPresetId,
+} from "@/lib/compare-operational-fit-heatmap";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -34,6 +38,7 @@ import { CompareDecisionBriefPanel } from "@/components/compare-decision-brief-p
 import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranking-panel";
 import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
 import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
+import { CompareOperationalFitHeatmapPanel } from "@/components/compare-operational-fit-heatmap-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -86,6 +91,7 @@ function ComparePage() {
   const decisionBrief = React.useMemo(() => compareDecisionBriefState(items), [items]);
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
+  const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
   const scenarioRanking = React.useMemo(
     () => compareScenarioRankingState(items, scenario),
     [items, scenario],
@@ -94,6 +100,10 @@ function ComparePage() {
   const rolloutReadiness = React.useMemo(
     () => compareRolloutReadinessState(items, rolloutPreset),
     [items, rolloutPreset],
+  );
+  const operationalFitHeatmap = React.useMemo(
+    () => compareOperationalFitHeatmapState(items, fitPreset),
+    [items, fitPreset],
   );
 
   const pushIds = (next: Entry[]) => {
@@ -223,6 +233,12 @@ function ComparePage() {
           state={rolloutReadiness}
           selectedPreset={rolloutPreset}
           onSelectPreset={setRolloutPreset}
+          className="m-3 mt-0"
+        />
+        <CompareOperationalFitHeatmapPanel
+          state={operationalFitHeatmap}
+          selectedPreset={fitPreset}
+          onSelectPreset={setFitPreset}
           className="m-3 mt-0"
         />
       </div>

--- a/tests/compare-operational-fit-heatmap-lib.test.ts
+++ b/tests/compare-operational-fit-heatmap-lib.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareOperationalFitHeatmapState } from "@/lib/compare-operational-fit-heatmap-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("compare operational fit heatmap lib", () => {
+  it("returns empty state when no entries", () => {
+    const state = compareOperationalFitHeatmapState([], "team-default");
+    expect(state.entries).toEqual([]);
+    expect(state.bestEntryRef).toBeNull();
+  });
+
+  it("builds five axes", () => {
+    const state = compareOperationalFitHeatmapState([strong], "team-default");
+    expect(state.axes).toHaveLength(5);
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      compareOperationalFitHeatmapState([strong], "team-default").heading,
+    ).toContain("team");
+    expect(
+      compareOperationalFitHeatmapState([strong], "security-hardening").heading,
+    ).toContain("security");
+    expect(
+      compareOperationalFitHeatmapState([strong], "rapid-adoption").heading,
+    ).toContain("rapid");
+  });
+
+  it("scores strong entry above weak entry", () => {
+    const state = compareOperationalFitHeatmapState(
+      [weak, strong],
+      "team-default",
+    );
+    expect(state.entries[0].entryRef).toBe("tools/strong");
+    expect(state.entries[1].entryRef).toBe("tools/weak");
+  });
+
+  it("assigns strong and weak tones", () => {
+    const state = compareOperationalFitHeatmapState(
+      [strong, weak],
+      "team-default",
+    );
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/strong")?.fitTone,
+    ).toBe("strong");
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/weak")?.fitTone,
+    ).toBe("weak");
+  });
+
+  it("sets best entry ref and weak refs", () => {
+    const state = compareOperationalFitHeatmapState(
+      [strong, weak],
+      "team-default",
+    );
+    expect(state.bestEntryRef).toBe("tools/strong");
+    expect(state.weakEntryRefs).toContain("tools/weak");
+  });
+
+  it("creates cells for each axis", () => {
+    const state = compareOperationalFitHeatmapState([strong], "team-default");
+    expect(state.entries[0].cells).toHaveLength(5);
+  });
+
+  it("shows provenance reason when source and review present", () => {
+    const state = compareOperationalFitHeatmapState([strong], "team-default");
+    const provenance = state.entries[0].cells.find(
+      (cell) => cell.axisId === "provenance",
+    );
+    expect(provenance?.reason).toContain("Source and review");
+  });
+
+  it("shows safety reason when notes missing", () => {
+    const state = compareOperationalFitHeatmapState([weak], "team-default");
+    const safety = state.entries[0].cells.find(
+      (cell) => cell.axisId === "safety",
+    );
+    expect(safety?.reason).toContain("missing");
+  });
+
+  it("changes score by preset for mixed entry", () => {
+    const mixed = entry({
+      slug: "mixed",
+      title: "Mixed",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/mixed",
+      reviewed: false,
+      safetyNotes: "present",
+      privacyNotes: undefined,
+      packageVerified: undefined,
+      installCommand: undefined,
+    });
+    const security = compareOperationalFitHeatmapState(
+      [mixed],
+      "security-hardening",
+    );
+    const speed = compareOperationalFitHeatmapState([mixed], "rapid-adoption");
+    expect(security.entries[0].totalScore).not.toBe(
+      speed.entries[0].totalScore,
+    );
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = compareOperationalFitHeatmapState(
+      [reviewedBy],
+      "team-default",
+    );
+    const provenance = state.entries[0].cells.find(
+      (cell) => cell.axisId === "provenance",
+    );
+    expect(provenance?.score).toBeGreaterThan(60);
+  });
+
+  it("uses checksum as integrity signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = compareOperationalFitHeatmapState([hashed], "team-default");
+    const integrity = state.entries[0].cells.find(
+      (cell) => cell.axisId === "integrity",
+    );
+    expect(integrity?.score).toBe(100);
+  });
+
+  it("returns deterministic title ordering on ties", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = compareOperationalFitHeatmapState([b, a], "team-default");
+    expect(state.entries[0].title).toBe("A");
+  });
+
+  it("generates summary for weak entries", () => {
+    const state = compareOperationalFitHeatmapState([weak], "team-default");
+    expect(state.summary).toContain("weak operational fit");
+  });
+
+  it("generates summary when weak entries absent", () => {
+    const state = compareOperationalFitHeatmapState([strong], "team-default");
+    expect(state.summary).toContain("strong operational fit");
+  });
+});


### PR DESCRIPTION
## Summary
- add a new preset-driven operational fit heatmap lib for compare entries
- render a new compare panel in both compare page and compare drawer surfaces
- include focused unit coverage for scoring, reasons, ranking, and preset deltas

## Validation
- pnpm test tests/compare-operational-fit-heatmap-lib.test.ts
- pnpm type-check
- pnpm build

Closes #556