### PR TITLE
feat(web): add compare deployment risk map panel

### DIFF
--- a/apps/web/src/components/compare-deployment-risk-map-panel.tsx
+++ b/apps/web/src/components/compare-deployment-risk-map-panel.tsx
@@ -1,0 +1,102 @@
+import type {
+  CompareDeploymentRiskMapState,
+  DeploymentRiskBand,
+  DeploymentRiskPresetId,
+} from "@/lib/compare-deployment-risk-map";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: DeploymentRiskPresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "security", label: "Security" },
+  { id: "speed", label: "Speed" },
+];
+
+function bandClass(band: DeploymentRiskBand): string {
+  if (band === "high") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+}
+
+export function CompareDeploymentRiskMapPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  compact = false,
+  className,
+}: {
+  state: CompareDeploymentRiskMapState;
+  selectedPreset: DeploymentRiskPresetId;
+  onSelectPreset: (preset: DeploymentRiskPresetId) => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.entries.length === 0) return null;
+
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Deployment risk map</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          high {state.highRiskCount} · low {state.lowRiskCount}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.entries.map((entry) => (
+          <article
+            key={entry.entryRef}
+            className="rounded-md border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.mitigationSummary}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    bandClass(entry.riskBand),
+                  )}
+                >
+                  {entry.riskBand}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">risk {entry.riskScore}</p>
+              </div>
+            </div>
+
+            {!compact && entry.topRiskReasons.length > 0 ? (
+              <p className="mt-2 text-[11px] text-ink-subtle">
+                Top reasons: {entry.topRiskReasons.join(", ")}
+              </p>
+            ) : null}
+
+            <p className="mt-1 text-[11px] text-ink-muted">Confidence {entry.confidenceScore}%</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -46,6 +46,11 @@ import {
 } from "@/lib/compare-operational-fit-heatmap";
 import { CompareOperationalFitHeatmapPanel } from "@/components/compare-operational-fit-heatmap-panel";
 import {
+  compareDeploymentRiskMapState,
+  type DeploymentRiskPresetId,
+} from "@/lib/compare-deployment-risk-map";
+import { CompareDeploymentRiskMapPanel } from "@/components/compare-deployment-risk-map-panel";
+import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
@@ -338,6 +343,7 @@ export function CompareDrawer() {
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
+  const [riskPreset, setRiskPreset] = React.useState<DeploymentRiskPresetId>("balanced");
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
@@ -345,6 +351,7 @@ export function CompareDrawer() {
   const evidenceGaps = compareEvidenceGapsState(items);
   const rolloutReadiness = compareRolloutReadinessState(items, rolloutPreset);
   const operationalFitHeatmap = compareOperationalFitHeatmapState(items, fitPreset);
+  const deploymentRiskMap = compareDeploymentRiskMapState(items, riskPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -464,6 +471,13 @@ export function CompareDrawer() {
               state={operationalFitHeatmap}
               selectedPreset={fitPreset}
               onSelectPreset={setFitPreset}
+              compact
+              className="m-3 mt-0"
+            />
+            <CompareDeploymentRiskMapPanel
+              state={deploymentRiskMap}
+              selectedPreset={riskPreset}
+              onSelectPreset={setRiskPreset}
               compact
               className="m-3 mt-0"
             />

--- a/apps/web/src/lib/compare-deployment-risk-map-lib.ts
+++ b/apps/web/src/lib/compare-deployment-risk-map-lib.ts
@@ -1,0 +1,203 @@
+import type { Entry } from "@/types/registry";
+
+export type DeploymentRiskPresetId = "balanced" | "security" | "speed";
+export type DeploymentRiskBand = "low" | "medium" | "high";
+
+export type DeploymentRiskRow = {
+  id: string;
+  label: string;
+  weight: number;
+};
+
+export type DeploymentRiskEntry = {
+  entryRef: string;
+  title: string;
+  riskScore: number;
+  riskBand: DeploymentRiskBand;
+  confidenceScore: number;
+  topRiskReasons: string[];
+  mitigationSummary: string;
+};
+
+export type CompareDeploymentRiskMapState = {
+  preset: DeploymentRiskPresetId;
+  heading: string;
+  summary: string;
+  rows: DeploymentRiskRow[];
+  entries: DeploymentRiskEntry[];
+  lowRiskCount: number;
+  highRiskCount: number;
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function riskBand(score: number): DeploymentRiskBand {
+  if (score >= 60) return "high";
+  if (score >= 30) return "medium";
+  return "low";
+}
+
+function headingForPreset(preset: DeploymentRiskPresetId): string {
+  if (preset === "security") return "Deployment risk map · security-first";
+  if (preset === "speed") return "Deployment risk map · speed-first";
+  return "Deployment risk map · balanced";
+}
+
+function rowWeights(preset: DeploymentRiskPresetId): DeploymentRiskRow[] {
+  if (preset === "security") {
+    return [
+      { id: "source", label: "Source provenance", weight: 22 },
+      { id: "reviewed", label: "Review signal", weight: 16 },
+      { id: "safety", label: "Safety notes", weight: 18 },
+      { id: "privacy", label: "Privacy notes", weight: 16 },
+      { id: "package", label: "Package integrity", weight: 16 },
+      { id: "install", label: "Install payload", weight: 12 },
+    ];
+  }
+  if (preset === "speed") {
+    return [
+      { id: "source", label: "Source provenance", weight: 18 },
+      { id: "reviewed", label: "Review signal", weight: 10 },
+      { id: "safety", label: "Safety notes", weight: 14 },
+      { id: "privacy", label: "Privacy notes", weight: 10 },
+      { id: "package", label: "Package integrity", weight: 8 },
+      { id: "install", label: "Install payload", weight: 40 },
+    ];
+  }
+  return [
+    { id: "source", label: "Source provenance", weight: 20 },
+    { id: "reviewed", label: "Review signal", weight: 14 },
+    { id: "safety", label: "Safety notes", weight: 18 },
+    { id: "privacy", label: "Privacy notes", weight: 12 },
+    { id: "package", label: "Package integrity", weight: 12 },
+    { id: "install", label: "Install payload", weight: 24 },
+  ];
+}
+
+function riskScoreFor(
+  entry: Entry,
+  rows: DeploymentRiskRow[],
+): {
+  score: number;
+  reasons: string[];
+  confidence: number;
+} {
+  let score = 0;
+  let covered = 0;
+  const reasons: string[] = [];
+
+  for (const row of rows) {
+    let present = false;
+    if (row.id === "source") present = hasSource(entry);
+    if (row.id === "reviewed") present = hasReviewed(entry);
+    if (row.id === "safety") present = hasSafety(entry);
+    if (row.id === "privacy") present = hasPrivacy(entry);
+    if (row.id === "package") present = hasPackage(entry);
+    if (row.id === "install") present = hasInstall(entry);
+
+    if (!present) {
+      score += row.weight;
+      reasons.push(`${row.label} missing`);
+    } else {
+      covered += row.weight;
+    }
+  }
+
+  if (entry.trust === "blocked") {
+    score += 25;
+    reasons.push("Trust flagged blocked");
+  } else if (entry.trust === "limited") {
+    score += 14;
+    reasons.push("Trust flagged limited");
+  } else if (entry.trust === "review") {
+    score += 6;
+    reasons.push("Trust still review-first");
+  }
+
+  const normalized = Math.min(100, score);
+  const confidence = Math.max(0, Math.min(100, covered));
+  return { score: normalized, reasons, confidence };
+}
+
+function mitigationSummary(entry: DeploymentRiskEntry): string {
+  if (entry.riskBand === "low") return "Suitable for staged rollout with routine checks.";
+  if (entry.riskBand === "medium")
+    return "Run additional source and safety review before broader rollout.";
+  return "Hold deployment until required trust and integrity gaps are resolved.";
+}
+
+function summary(entries: DeploymentRiskEntry[]): string {
+  if (entries.length === 0) return "Add entries to generate a deployment risk map.";
+  const high = entries.filter((entry) => entry.riskBand === "high").length;
+  const low = entries.filter((entry) => entry.riskBand === "low").length;
+  if (high === 0) return `No high-risk entries detected; ${low}/${entries.length} are low risk.`;
+  return `${high}/${entries.length} entries are high risk and need mitigation before rollout.`;
+}
+
+export function compareDeploymentRiskMapState(
+  entries: Entry[],
+  preset: DeploymentRiskPresetId,
+): CompareDeploymentRiskMapState {
+  const rows = rowWeights(preset);
+  const mapped: DeploymentRiskEntry[] = entries
+    .map((entry) => {
+      const risk = riskScoreFor(entry, rows);
+      const band = riskBand(risk.score);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        riskScore: risk.score,
+        riskBand: band,
+        confidenceScore: risk.confidence,
+        topRiskReasons: risk.reasons.slice(0, 3),
+        mitigationSummary: mitigationSummary({
+          entryRef: entryRef(entry),
+          title: entry.title,
+          riskScore: risk.score,
+          riskBand: band,
+          confidenceScore: risk.confidence,
+          topRiskReasons: risk.reasons.slice(0, 3),
+          mitigationSummary: "",
+        }),
+      };
+    })
+    .sort((a, b) => b.riskScore - a.riskScore || a.title.localeCompare(b.title));
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(mapped),
+    rows,
+    entries: mapped,
+    lowRiskCount: mapped.filter((entry) => entry.riskBand === "low").length,
+    highRiskCount: mapped.filter((entry) => entry.riskBand === "high").length,
+  };
+}

--- a/apps/web/src/lib/compare-deployment-risk-map.ts
+++ b/apps/web/src/lib/compare-deployment-risk-map.ts
@@ -1,0 +1,8 @@
+export type {
+  CompareDeploymentRiskMapState,
+  DeploymentRiskBand,
+  DeploymentRiskEntry,
+  DeploymentRiskPresetId,
+  DeploymentRiskRow,
+} from "@/lib/compare-deployment-risk-map-lib";
+export { compareDeploymentRiskMapState } from "@/lib/compare-deployment-risk-map-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -29,6 +29,10 @@ import {
   compareOperationalFitHeatmapState,
   type OperationalFitPresetId,
 } from "@/lib/compare-operational-fit-heatmap";
+import {
+  compareDeploymentRiskMapState,
+  type DeploymentRiskPresetId,
+} from "@/lib/compare-deployment-risk-map";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -39,6 +43,7 @@ import { CompareScenarioRankingPanel } from "@/components/compare-scenario-ranki
 import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-panel";
 import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
 import { CompareOperationalFitHeatmapPanel } from "@/components/compare-operational-fit-heatmap-panel";
+import { CompareDeploymentRiskMapPanel } from "@/components/compare-deployment-risk-map-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -92,6 +97,7 @@ function ComparePage() {
   const [scenario, setScenario] = React.useState<CompareScenarioId>("balanced");
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
+  const [riskPreset, setRiskPreset] = React.useState<DeploymentRiskPresetId>("balanced");
   const scenarioRanking = React.useMemo(
     () => compareScenarioRankingState(items, scenario),
     [items, scenario],
@@ -104,6 +110,10 @@ function ComparePage() {
   const operationalFitHeatmap = React.useMemo(
     () => compareOperationalFitHeatmapState(items, fitPreset),
     [items, fitPreset],
+  );
+  const deploymentRiskMap = React.useMemo(
+    () => compareDeploymentRiskMapState(items, riskPreset),
+    [items, riskPreset],
   );
 
   const pushIds = (next: Entry[]) => {
@@ -239,6 +249,12 @@ function ComparePage() {
           state={operationalFitHeatmap}
           selectedPreset={fitPreset}
           onSelectPreset={setFitPreset}
+          className="m-3 mt-0"
+        />
+        <CompareDeploymentRiskMapPanel
+          state={deploymentRiskMap}
+          selectedPreset={riskPreset}
+          onSelectPreset={setRiskPreset}
           className="m-3 mt-0"
         />
       </div>

--- a/tests/compare-deployment-risk-map-lib.test.ts
+++ b/tests/compare-deployment-risk-map-lib.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { compareDeploymentRiskMapState } from "@/lib/compare-deployment-risk-map-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const lowRisk = entry({
+  slug: "low",
+  title: "Low",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/low",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i low",
+});
+
+const highRisk = entry({
+  slug: "high",
+  title: "High",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("compare deployment risk map lib", () => {
+  it("returns empty summary when no entries", () => {
+    const state = compareDeploymentRiskMapState([], "balanced");
+    expect(state.entries).toEqual([]);
+    expect(state.summary).toContain("Add entries");
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      compareDeploymentRiskMapState([lowRisk], "balanced").heading,
+    ).toContain("balanced");
+    expect(
+      compareDeploymentRiskMapState([lowRisk], "security").heading,
+    ).toContain("security");
+    expect(compareDeploymentRiskMapState([lowRisk], "speed").heading).toContain(
+      "speed",
+    );
+  });
+
+  it("builds six weighted rows", () => {
+    const state = compareDeploymentRiskMapState([lowRisk], "balanced");
+    expect(state.rows).toHaveLength(6);
+  });
+
+  it("scores high-risk entries above low-risk entries", () => {
+    const state = compareDeploymentRiskMapState(
+      [lowRisk, highRisk],
+      "balanced",
+    );
+    expect(state.entries[0].entryRef).toBe("tools/high");
+    expect(state.entries[0].riskScore).toBeGreaterThan(
+      state.entries[1].riskScore,
+    );
+  });
+
+  it("assigns risk bands by score", () => {
+    const state = compareDeploymentRiskMapState(
+      [lowRisk, highRisk],
+      "balanced",
+    );
+    const high = state.entries.find((entry) => entry.entryRef === "tools/high");
+    const low = state.entries.find((entry) => entry.entryRef === "tools/low");
+    expect(high?.riskBand).toBe("high");
+    expect(low?.riskBand).toBe("low");
+  });
+
+  it("tracks high and low risk counters", () => {
+    const state = compareDeploymentRiskMapState(
+      [lowRisk, highRisk],
+      "balanced",
+    );
+    expect(state.highRiskCount).toBe(1);
+    expect(state.lowRiskCount).toBe(1);
+  });
+
+  it("adds top risk reasons for missing signals", () => {
+    const state = compareDeploymentRiskMapState([highRisk], "balanced");
+    expect(state.entries[0].topRiskReasons.length).toBeGreaterThan(0);
+    expect(state.entries[0].topRiskReasons[0]).toContain("missing");
+  });
+
+  it("keeps reasons capped to top three", () => {
+    const state = compareDeploymentRiskMapState([highRisk], "balanced");
+    expect(state.entries[0].topRiskReasons.length).toBeLessThanOrEqual(3);
+  });
+
+  it("changes score profile between security and speed presets", () => {
+    const mixed = entry({
+      slug: "mixed",
+      title: "Mixed",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/mixed",
+      reviewed: false,
+      safetyNotes: "present",
+      privacyNotes: undefined,
+      packageVerified: undefined,
+      installCommand: undefined,
+      configSnippet: undefined,
+      copySnippet: undefined,
+      fullCopy: undefined,
+    });
+    const security = compareDeploymentRiskMapState([mixed], "security");
+    const speed = compareDeploymentRiskMapState([mixed], "speed");
+    expect(security.entries[0].riskScore).not.toBe(speed.entries[0].riskScore);
+  });
+
+  it("reports confidence from covered weights", () => {
+    const low = compareDeploymentRiskMapState([lowRisk], "balanced");
+    const high = compareDeploymentRiskMapState([highRisk], "balanced");
+    expect(low.entries[0].confidenceScore).toBeGreaterThan(
+      high.entries[0].confidenceScore,
+    );
+  });
+
+  it("includes mitigation summary copy", () => {
+    const state = compareDeploymentRiskMapState([highRisk], "balanced");
+    expect(state.entries[0].mitigationSummary.length).toBeGreaterThan(10);
+  });
+
+  it("includes high risk summary when high entries exist", () => {
+    const state = compareDeploymentRiskMapState(
+      [highRisk, lowRisk],
+      "balanced",
+    );
+    expect(state.summary).toContain("high risk");
+  });
+
+  it("includes low risk summary when no high entries", () => {
+    const state = compareDeploymentRiskMapState([lowRisk], "balanced");
+    expect(state.summary).toContain("No high-risk");
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      title: "Reviewed By",
+      reviewed: false,
+      reviewedBy: "ops",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = compareDeploymentRiskMapState([reviewedBy], "balanced");
+    expect(state.entries[0].riskScore).toBeLessThan(90);
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      title: "Hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = compareDeploymentRiskMapState([hashed], "balanced");
+    expect(state.entries[0].topRiskReasons.join(" ")).not.toContain(
+      "Package integrity missing",
+    );
+  });
+
+  it("keeps deterministic ordering on ties by title", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = compareDeploymentRiskMapState([b, a], "balanced");
+    expect(state.entries[0].title).toBe("A");
+  });
+});


### PR DESCRIPTION
## Summary
- add a compare deployment risk map lib with preset-driven risk and confidence scoring
- render deployment risk map panel in compare page and compare drawer surfaces
- include focused unit coverage for presets, sorting, risk bands, and mitigation summaries

## Validation
- pnpm test tests/compare-deployment-risk-map-lib.test.ts
- pnpm type-check
- pnpm build

Closes #556