### PR TITLE
refactor(web): extract joinList into join-list-lib

### DIFF
--- a/apps/web/src/lib/join-list-lib.ts
+++ b/apps/web/src/lib/join-list-lib.ts
@@ -1,0 +1,9 @@
+// Pure grammatical list join (Oxford comma), split out of the tag detail route
+// so it can be unit-tested and reused.
+
+/** Join a list into readable prose: "a", "a and b", or "a, b, and c". */
+export function joinList(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? "";
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
+}

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -7,6 +7,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { categorySpread } from "@/lib/category-spread-lib";
+import { joinList } from "@/lib/join-list-lib";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -14,12 +15,6 @@ import { getTagGroup, relatedTags } from "@/lib/tags";
 
 // The categories a tag's entries actually span — used to vary intro copy per tag so no
 // two indexable tag pages emit the same boilerplate sentence.
-
-function joinList(items: string[]): string {
-  if (items.length <= 1) return items[0] ?? "";
-  if (items.length === 2) return `${items[0]} and ${items[1]}`;
-  return `${items.slice(0, -1).join(", ")}, and ${items[items.length - 1]}`;
-}
 
 export const Route = createFileRoute("/tags/$tag")({
   loader: ({ params }) => {

--- a/tests/join-list-lib.test.ts
+++ b/tests/join-list-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { joinList } from "../apps/web/src/lib/join-list-lib";
+
+describe("joinList", () => {
+  it("returns '' for an empty list and the sole item for one", () => {
+    expect(joinList([])).toBe("");
+    expect(joinList(["mcp"])).toBe("mcp");
+  });
+
+  it("joins two items with 'and'", () => {
+    expect(joinList(["mcp", "hooks"])).toBe("mcp and hooks");
+  });
+
+  it("uses an Oxford comma for three or more", () => {
+    expect(joinList(["mcp", "hooks", "skills"])).toBe("mcp, hooks, and skills");
+  });
+});


### PR DESCRIPTION
### What & why

The tag detail route (`tags.$tag.tsx`) built a human-readable list ("a, b, and c") inline. This extracts that pure grammatical join into `apps/web/src/lib/join-list-lib.ts` as `joinList(items)` so it can be unit-tested and reused.

### Changes

- Add `apps/web/src/lib/join-list-lib.ts` — `joinList` returns `""`/single item, `"a and b"` for two, and an Oxford-comma join for three or more.
- `apps/web/src/routes/tags.$tag.tsx` uses `joinList` instead of the inline expression.
- Add `tests/join-list-lib.test.ts` — covers empty, single, two, and 3+ inputs. Branch coverage 100% (6/6).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/join-list-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean (git-stored LF)

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests), no user-facing or behavior change; the route renders identically.
