### PR TITLE
feat(web): add compare mitigation priority queue panel

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -51,6 +51,11 @@ import {
 } from "@/lib/compare-deployment-risk-map";
 import { CompareDeploymentRiskMapPanel } from "@/components/compare-deployment-risk-map-panel";
 import {
+  compareMitigationPriorityState,
+  type MitigationPriorityPresetId,
+} from "@/lib/compare-mitigation-priority";
+import { CompareMitigationPriorityPanel } from "@/components/compare-mitigation-priority-panel";
+import {
   compareDrawerDecisionRows,
   compareSignalToneClass,
   type CompareSignalValue,
@@ -344,6 +349,8 @@ export function CompareDrawer() {
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
   const [riskPreset, setRiskPreset] = React.useState<DeploymentRiskPresetId>("balanced");
+  const [mitigationPreset, setMitigationPreset] =
+    React.useState<MitigationPriorityPresetId>("balanced");
   const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
     compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
@@ -352,6 +359,7 @@ export function CompareDrawer() {
   const rolloutReadiness = compareRolloutReadinessState(items, rolloutPreset);
   const operationalFitHeatmap = compareOperationalFitHeatmapState(items, fitPreset);
   const deploymentRiskMap = compareDeploymentRiskMapState(items, riskPreset);
+  const mitigationPriority = compareMitigationPriorityState(items, mitigationPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
   const onClear = () => {
@@ -478,6 +486,13 @@ export function CompareDrawer() {
               state={deploymentRiskMap}
               selectedPreset={riskPreset}
               onSelectPreset={setRiskPreset}
+              compact
+              className="m-3 mt-0"
+            />
+            <CompareMitigationPriorityPanel
+              state={mitigationPriority}
+              selectedPreset={mitigationPreset}
+              onSelectPreset={setMitigationPreset}
               compact
               className="m-3 mt-0"
             />

--- a/apps/web/src/components/compare-mitigation-priority-panel.tsx
+++ b/apps/web/src/components/compare-mitigation-priority-panel.tsx
@@ -1,0 +1,116 @@
+import type {
+  CompareMitigationPriorityState,
+  MitigationPriorityPresetId,
+} from "@/lib/compare-mitigation-priority";
+import { mitigationPriorityTierClass } from "@/lib/compare-mitigation-priority";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: MitigationPriorityPresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "security-first", label: "Security-first" },
+  { id: "rollout-first", label: "Rollout-first" },
+];
+
+export function CompareMitigationPriorityPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  compact = false,
+  className,
+}: {
+  state: CompareMitigationPriorityState;
+  selectedPreset: MitigationPriorityPresetId;
+  onSelectPreset: (preset: MitigationPriorityPresetId) => void;
+  compact?: boolean;
+  className?: string;
+}) {
+  if (state.entries.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Mitigation priority queue"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Mitigation priority queue</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            urgent {state.urgentCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            watch {state.watchCount}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.entries.map((entry) => (
+          <article
+            key={entry.entryRef}
+            className="rounded-lg border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.rationale}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    mitigationPriorityTierClass(entry.tier),
+                  )}
+                >
+                  {entry.tier}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{entry.priorityScore}/100</p>
+              </div>
+            </div>
+
+            {!compact && entry.actions.length > 0 ? (
+              <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+                {entry.actions.map((action) => (
+                  <div
+                    key={`${entry.entryRef}-${action.signalId}`}
+                    className="rounded border border-border px-2 py-1"
+                  >
+                    <p className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                      {action.label}
+                    </p>
+                    <p className="text-[11px] text-ink-muted">{action.detail}</p>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            <p className="mt-2 text-[11px] text-ink-subtle">
+              Trust {entry.trust} · {entry.actions.length} mitigation items
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/compare-mitigation-priority-lib.ts
+++ b/apps/web/src/lib/compare-mitigation-priority-lib.ts
@@ -1,0 +1,226 @@
+import type { Entry } from "@/types/registry";
+
+export type MitigationPriorityPresetId = "balanced" | "security-first" | "rollout-first";
+export type MitigationPriorityTier = "urgent" | "watch" | "optional";
+export type MitigationSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type MitigationPriorityAction = {
+  signalId: MitigationSignalId;
+  label: string;
+  detail: string;
+  weight: number;
+};
+
+export type MitigationPriorityEntry = {
+  entryRef: string;
+  title: string;
+  priorityScore: number;
+  tier: MitigationPriorityTier;
+  trust: string;
+  actions: MitigationPriorityAction[];
+  rationale: string;
+};
+
+export type CompareMitigationPriorityState = {
+  preset: MitigationPriorityPresetId;
+  heading: string;
+  summary: string;
+  entries: MitigationPriorityEntry[];
+  urgentCount: number;
+  watchCount: number;
+  topEntryRef: string | null;
+};
+
+const SIGNAL_LABELS: Record<MitigationSignalId, string> = {
+  source: "Source provenance",
+  reviewed: "Metadata review",
+  safety: "Safety notes",
+  privacy: "Privacy notes",
+  package: "Package integrity",
+  install: "Install payload",
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function headingForPreset(preset: MitigationPriorityPresetId): string {
+  if (preset === "security-first") return "Mitigation priority queue · security-first";
+  if (preset === "rollout-first") return "Mitigation priority queue · rollout-first";
+  return "Mitigation priority queue · balanced";
+}
+
+function weightsForPreset(preset: MitigationPriorityPresetId): Record<MitigationSignalId, number> {
+  if (preset === "security-first") {
+    return {
+      source: 24,
+      reviewed: 18,
+      safety: 20,
+      privacy: 18,
+      package: 14,
+      install: 6,
+    };
+  }
+  if (preset === "rollout-first") {
+    return {
+      source: 12,
+      reviewed: 10,
+      safety: 12,
+      privacy: 10,
+      package: 8,
+      install: 28,
+    };
+  }
+  return {
+    source: 18,
+    reviewed: 14,
+    safety: 16,
+    privacy: 14,
+    package: 12,
+    install: 16,
+  };
+}
+
+function trustPenalty(entry: Entry): number {
+  if (entry.trust === "blocked") return 28;
+  if (entry.trust === "limited") return 18;
+  if (entry.trust === "review") return 8;
+  return 0;
+}
+
+function tierFromScore(score: number): MitigationPriorityTier {
+  if (score >= 70) return "urgent";
+  if (score >= 40) return "watch";
+  return "optional";
+}
+
+function actionDetail(signalId: MitigationSignalId): string {
+  if (signalId === "source") return "Confirm repository or source URL before adoption.";
+  if (signalId === "reviewed") return "Request maintainer review or internal metadata audit.";
+  if (signalId === "safety") return "Collect safety notes and required guardrails.";
+  if (signalId === "privacy") return "Document privacy posture and data handling.";
+  if (signalId === "package") return "Verify package checksum or signed artifact metadata.";
+  return "Capture install/config payload for reproducible rollout.";
+}
+
+function missingSignals(entry: Entry): MitigationSignalId[] {
+  const missing: MitigationSignalId[] = [];
+  if (!hasSource(entry)) missing.push("source");
+  if (!hasReviewed(entry)) missing.push("reviewed");
+  if (!hasSafety(entry)) missing.push("safety");
+  if (!hasPrivacy(entry)) missing.push("privacy");
+  if (!hasPackage(entry)) missing.push("package");
+  if (!hasInstall(entry)) missing.push("install");
+  return missing;
+}
+
+function rationaleForEntry(
+  entry: Entry,
+  actions: MitigationPriorityAction[],
+  tier: MitigationPriorityTier,
+): string {
+  if (actions.length === 0) return "No blocking mitigation items detected.";
+  if (tier === "urgent") {
+    return `${actions.length} high-priority gaps require action before rollout.`;
+  }
+  if (tier === "watch") {
+    return `${actions.length} mitigation items should be addressed in pilot phase.`;
+  }
+  return `${actions.length} optional improvements remain for ${entry.title}.`;
+}
+
+function summary(entries: MitigationPriorityEntry[]): string {
+  if (entries.length === 0) return "Add entries to build a mitigation priority queue.";
+  const urgent = entries.filter((entry) => entry.tier === "urgent").length;
+  const watch = entries.filter((entry) => entry.tier === "watch").length;
+  if (urgent === 0 && watch === 0) {
+    return "All compared entries are in optional mitigation territory.";
+  }
+  if (urgent > 0) {
+    return `${urgent} entries need urgent mitigation before deployment.`;
+  }
+  return `${watch} entries need watch-level mitigation during pilot rollout.`;
+}
+
+export function mitigationPriorityTierClass(tier: MitigationPriorityTier): string {
+  if (tier === "urgent") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+  if (tier === "watch") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+}
+
+export function compareMitigationPriorityState(
+  entries: Entry[],
+  preset: MitigationPriorityPresetId,
+): CompareMitigationPriorityState {
+  const weights = weightsForPreset(preset);
+  const mapped: MitigationPriorityEntry[] = entries
+    .map((entry) => {
+      const gaps = missingSignals(entry);
+      const actions: MitigationPriorityAction[] = gaps.map((signalId) => ({
+        signalId,
+        label: SIGNAL_LABELS[signalId],
+        detail: actionDetail(signalId),
+        weight: weights[signalId],
+      }));
+      const actionWeight = actions.reduce((sum, action) => sum + action.weight, 0);
+      const priorityScore = Math.min(100, actionWeight + trustPenalty(entry));
+      const tier = tierFromScore(priorityScore);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        priorityScore,
+        tier,
+        trust: entry.trust,
+        actions,
+        rationale: rationaleForEntry(entry, actions, tier),
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.priorityScore - a.priorityScore ||
+        a.title.localeCompare(b.title) ||
+        a.entryRef.localeCompare(b.entryRef),
+    );
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(mapped),
+    entries: mapped,
+    urgentCount: mapped.filter((entry) => entry.tier === "urgent").length,
+    watchCount: mapped.filter((entry) => entry.tier === "watch").length,
+    topEntryRef: mapped[0]?.entryRef ?? null,
+  };
+}

--- a/apps/web/src/lib/compare-mitigation-priority.ts
+++ b/apps/web/src/lib/compare-mitigation-priority.ts
@@ -1,0 +1,12 @@
+export type {
+  CompareMitigationPriorityState,
+  MitigationPriorityAction,
+  MitigationPriorityEntry,
+  MitigationPriorityPresetId,
+  MitigationPriorityTier,
+  MitigationSignalId,
+} from "@/lib/compare-mitigation-priority-lib";
+export {
+  compareMitigationPriorityState,
+  mitigationPriorityTierClass,
+} from "@/lib/compare-mitigation-priority-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -33,6 +33,10 @@ import {
   compareDeploymentRiskMapState,
   type DeploymentRiskPresetId,
 } from "@/lib/compare-deployment-risk-map";
+import {
+  compareMitigationPriorityState,
+  type MitigationPriorityPresetId,
+} from "@/lib/compare-mitigation-priority";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -44,6 +48,7 @@ import { CompareEvidenceGapsPanel } from "@/components/compare-evidence-gaps-pan
 import { CompareRolloutReadinessPanel } from "@/components/compare-rollout-readiness-panel";
 import { CompareOperationalFitHeatmapPanel } from "@/components/compare-operational-fit-heatmap-panel";
 import { CompareDeploymentRiskMapPanel } from "@/components/compare-deployment-risk-map-panel";
+import { CompareMitigationPriorityPanel } from "@/components/compare-mitigation-priority-panel";
 
 const defaultSearch = { ids: "" };
 
@@ -98,6 +103,8 @@ function ComparePage() {
   const [rolloutPreset, setRolloutPreset] = React.useState<RolloutPresetId>("team");
   const [fitPreset, setFitPreset] = React.useState<OperationalFitPresetId>("team-default");
   const [riskPreset, setRiskPreset] = React.useState<DeploymentRiskPresetId>("balanced");
+  const [mitigationPreset, setMitigationPreset] =
+    React.useState<MitigationPriorityPresetId>("balanced");
   const scenarioRanking = React.useMemo(
     () => compareScenarioRankingState(items, scenario),
     [items, scenario],
@@ -114,6 +121,10 @@ function ComparePage() {
   const deploymentRiskMap = React.useMemo(
     () => compareDeploymentRiskMapState(items, riskPreset),
     [items, riskPreset],
+  );
+  const mitigationPriority = React.useMemo(
+    () => compareMitigationPriorityState(items, mitigationPreset),
+    [items, mitigationPreset],
   );
 
   const pushIds = (next: Entry[]) => {
@@ -255,6 +266,12 @@ function ComparePage() {
           state={deploymentRiskMap}
           selectedPreset={riskPreset}
           onSelectPreset={setRiskPreset}
+          className="m-3 mt-0"
+        />
+        <CompareMitigationPriorityPanel
+          state={mitigationPriority}
+          selectedPreset={mitigationPreset}
+          onSelectPreset={setMitigationPreset}
           className="m-3 mt-0"
         />
       </div>

--- a/tests/compare-mitigation-priority-lib.test.ts
+++ b/tests/compare-mitigation-priority-lib.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareMitigationPriorityState,
+  mitigationPriorityTierClass,
+} from "@/lib/compare-mitigation-priority-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("compare mitigation priority lib", () => {
+  it("returns empty summary when no entries", () => {
+    const state = compareMitigationPriorityState([], "balanced");
+    expect(state.entries).toEqual([]);
+    expect(state.topEntryRef).toBeNull();
+    expect(state.summary).toContain("Add entries");
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      compareMitigationPriorityState([strong], "balanced").heading,
+    ).toContain("balanced");
+    expect(
+      compareMitigationPriorityState([strong], "security-first").heading,
+    ).toContain("security");
+    expect(
+      compareMitigationPriorityState([strong], "rollout-first").heading,
+    ).toContain("rollout");
+  });
+
+  it("ranks weak entry above strong entry", () => {
+    const state = compareMitigationPriorityState([strong, weak], "balanced");
+    expect(state.entries[0].entryRef).toBe("tools/weak");
+    expect(state.entries[1].entryRef).toBe("tools/strong");
+  });
+
+  it("assigns urgent tier to weak limited-trust entry", () => {
+    const state = compareMitigationPriorityState([weak], "security-first");
+    expect(state.entries[0].tier).toBe("urgent");
+    expect(state.urgentCount).toBe(1);
+  });
+
+  it("assigns optional tier to complete trusted entry", () => {
+    const state = compareMitigationPriorityState([strong], "balanced");
+    expect(state.entries[0].tier).toBe("optional");
+    expect(state.entries[0].actions).toHaveLength(0);
+  });
+
+  it("tracks top entry ref", () => {
+    const state = compareMitigationPriorityState([strong, weak], "balanced");
+    expect(state.topEntryRef).toBe("tools/weak");
+  });
+
+  it("creates actions for each missing signal", () => {
+    const state = compareMitigationPriorityState([weak], "balanced");
+    expect(state.entries[0].actions.length).toBe(6);
+    expect(state.entries[0].actions.map((action) => action.signalId)).toContain(
+      "source",
+    );
+    expect(state.entries[0].actions.map((action) => action.signalId)).toContain(
+      "install",
+    );
+  });
+
+  it("includes action detail copy", () => {
+    const state = compareMitigationPriorityState([weak], "balanced");
+    const source = state.entries[0].actions.find(
+      (action) => action.signalId === "source",
+    );
+    expect(source?.detail).toContain("source URL");
+  });
+
+  it("changes score profile between security and rollout presets", () => {
+    const installOnly = entry({
+      slug: "install-only",
+      title: "Install only",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/install-only",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: true,
+      downloadSha256: "abc",
+      installCommand: undefined,
+      configSnippet: undefined,
+      copySnippet: undefined,
+      fullCopy: undefined,
+    });
+    const security = compareMitigationPriorityState([installOnly], "security-first");
+    const rollout = compareMitigationPriorityState([installOnly], "rollout-first");
+    expect(security.entries[0].priorityScore).not.toBe(rollout.entries[0].priorityScore);
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = compareMitigationPriorityState([reviewedBy], "balanced");
+    expect(
+      state.entries[0].actions.some((action) => action.signalId === "reviewed"),
+    ).toBe(false);
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = compareMitigationPriorityState([hashed], "balanced");
+    expect(
+      state.entries[0].actions.some((action) => action.signalId === "package"),
+    ).toBe(false);
+  });
+
+  it("returns deterministic title ordering on ties", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = compareMitigationPriorityState([b, a], "balanced");
+    expect(state.entries[0].title).toBe("A");
+  });
+
+  it("generates urgent summary when urgent entries exist", () => {
+    const state = compareMitigationPriorityState([weak], "security-first");
+    expect(state.summary).toContain("urgent mitigation");
+  });
+
+  it("generates optional summary when all entries are low priority", () => {
+    const state = compareMitigationPriorityState([strong], "balanced");
+    expect(state.summary).toContain("optional mitigation");
+  });
+
+  it("maps tier classes for presentation", () => {
+    expect(mitigationPriorityTierClass("urgent")).toContain("trust-blocked");
+    expect(mitigationPriorityTierClass("watch")).toContain("amber");
+    expect(mitigationPriorityTierClass("optional")).toContain("trust-trusted");
+  });
+
+  it("includes rationale for watch tier entries", () => {
+    const watchEntry = entry({
+      slug: "watch",
+      title: "Watch",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/watch",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: undefined,
+      packageVerified: undefined,
+      installCommand: undefined,
+    });
+    const state = compareMitigationPriorityState([watchEntry], "balanced");
+    expect(state.entries[0].rationale).toContain("pilot");
+  });
+});

--- a/tests/compare-mitigation-priority-lib.test.ts
+++ b/tests/compare-mitigation-priority-lib.test.ts
@@ -131,9 +131,17 @@ describe("compare mitigation priority lib", () => {
       copySnippet: undefined,
       fullCopy: undefined,
     });
-    const security = compareMitigationPriorityState([installOnly], "security-first");
-    const rollout = compareMitigationPriorityState([installOnly], "rollout-first");
-    expect(security.entries[0].priorityScore).not.toBe(rollout.entries[0].priorityScore);
+    const security = compareMitigationPriorityState(
+      [installOnly],
+      "security-first",
+    );
+    const rollout = compareMitigationPriorityState(
+      [installOnly],
+      "rollout-first",
+    );
+    expect(security.entries[0].priorityScore).not.toBe(
+      rollout.entries[0].priorityScore,
+    );
   });
 
   it("uses reviewedBy as reviewed signal", () => {


### PR DESCRIPTION
## Summary
- add a preset-driven compare mitigation priority queue lib and panel
- wire the panel into compare page and compare drawer surfaces
- include focused unit coverage for tiers, ranking, presets, and action details

## Validation
- pnpm test tests/compare-mitigation-priority-lib.test.ts
- pnpm type-check
- pnpm build

Closes #556