### PR TITLE
feat(web): add entry compare benchmark panel

### DIFF
--- a/apps/web/src/components/entry-compare-benchmark-panel.tsx
+++ b/apps/web/src/components/entry-compare-benchmark-panel.tsx
@@ -1,0 +1,111 @@
+import type {
+  CompareBenchmarkPresetId,
+  EntryCompareBenchmarkState,
+} from "@/lib/entry-compare-benchmark";
+import { compareBenchmarkVerdictClass } from "@/lib/entry-compare-benchmark";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: CompareBenchmarkPresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "security", label: "Security" },
+  { id: "rollout", label: "Rollout" },
+];
+
+export function EntryCompareBenchmarkPanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: EntryCompareBenchmarkState;
+  selectedPreset: CompareBenchmarkPresetId;
+  onSelectPreset: (preset: CompareBenchmarkPresetId) => void;
+  className?: string;
+}) {
+  if (!state.showPanel) return null;
+
+  return (
+    <section
+      id="compare-benchmark"
+      aria-label="Compare benchmark"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Compare benchmark</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="text-right">
+          <p className="font-mono text-xs text-ink-subtle">{state.targetRef}</p>
+          <p className="mt-1 font-mono text-sm text-ink">{state.targetScore}/100</p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      {state.benchmarkSummary ? (
+        <p className="mt-3 text-sm text-ink-muted">{state.benchmarkSummary}</p>
+      ) : null}
+
+      <div className="mt-3 grid gap-2">
+        {state.rows.map((row) => (
+          <article key={row.entryRef} className="rounded-lg border border-border bg-background p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{row.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{row.summary}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    compareBenchmarkVerdictClass(row.verdict),
+                  )}
+                >
+                  {row.verdict}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">
+                  {row.totalScore}/100 ({row.delta >= 0 ? "+" : ""}
+                  {row.delta})
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+              {row.dimensions.map((dimension) => (
+                <div
+                  key={`${row.entryRef}-${dimension.id}`}
+                  className="rounded border border-border px-2 py-1"
+                >
+                  <p className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                    {dimension.label}
+                  </p>
+                  <p className="text-[11px] text-ink-muted">
+                    {dimension.score}/100 · {dimension.detail}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-compare-benchmark-lib.ts
+++ b/apps/web/src/lib/entry-compare-benchmark-lib.ts
@@ -1,0 +1,272 @@
+import type { Entry } from "@/types/registry";
+import { sameEntry } from "@/lib/entry-identity";
+
+export type CompareBenchmarkPresetId = "balanced" | "security" | "rollout";
+export type CompareBenchmarkVerdict = "stronger" | "weaker" | "aligned";
+export type CompareBenchmarkDimensionId = "trust" | "evidence" | "operability" | "risk";
+
+export type CompareBenchmarkDimensionScore = {
+  id: CompareBenchmarkDimensionId;
+  label: string;
+  score: number;
+  detail: string;
+};
+
+export type CompareBenchmarkRow = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  totalScore: number;
+  delta: number;
+  verdict: CompareBenchmarkVerdict;
+  dimensions: CompareBenchmarkDimensionScore[];
+  summary: string;
+};
+
+export type EntryCompareBenchmarkState = {
+  preset: CompareBenchmarkPresetId;
+  heading: string;
+  summary: string;
+  targetRef: string;
+  targetTitle: string;
+  targetScore: number;
+  rows: CompareBenchmarkRow[];
+  strongerCount: number;
+  weakerCount: number;
+  benchmarkSummary: string | null;
+  showPanel: boolean;
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function headingForPreset(preset: CompareBenchmarkPresetId): string {
+  if (preset === "security") return "Compare benchmark · security posture";
+  if (preset === "rollout") return "Compare benchmark · rollout readiness";
+  return "Compare benchmark · balanced";
+}
+
+function weightsForPreset(
+  preset: CompareBenchmarkPresetId,
+): Record<CompareBenchmarkDimensionId, number> {
+  if (preset === "security") {
+    return { trust: 30, evidence: 35, operability: 10, risk: 25 };
+  }
+  if (preset === "rollout") {
+    return { trust: 15, evidence: 20, operability: 40, risk: 25 };
+  }
+  return { trust: 25, evidence: 30, operability: 25, risk: 20 };
+}
+
+function trustScore(entry: Entry): number {
+  if (entry.trust === "trusted") return 100;
+  if (entry.trust === "review") return 60;
+  if (entry.trust === "limited") return 32;
+  return 0;
+}
+
+function evidenceScore(entry: Entry): number {
+  const signals = [
+    hasSource(entry),
+    hasReviewed(entry),
+    hasSafety(entry),
+    hasPrivacy(entry),
+    hasPackage(entry),
+    hasInstall(entry),
+  ];
+  return Math.round((signals.filter(Boolean).length / signals.length) * 100);
+}
+
+function operabilityScore(entry: Entry): number {
+  if (hasInstall(entry) && hasPackage(entry)) return 100;
+  if (hasInstall(entry) || hasPackage(entry)) return 55;
+  return 0;
+}
+
+function riskScore(entry: Entry): number {
+  const penalties = [
+    !hasSource(entry) ? 22 : 0,
+    !hasReviewed(entry) ? 16 : 0,
+    !hasSafety(entry) ? 14 : 0,
+    !hasPrivacy(entry) ? 12 : 0,
+    !hasPackage(entry) ? 10 : 0,
+    !hasInstall(entry) ? 8 : 0,
+    entry.trust === "blocked" ? 18 : entry.trust === "limited" ? 10 : 0,
+  ];
+  return Math.max(0, 100 - penalties.reduce((sum, value) => sum + value, 0));
+}
+
+function dimensionScores(entry: Entry): CompareBenchmarkDimensionScore[] {
+  const trust = trustScore(entry);
+  const evidence = evidenceScore(entry);
+  const operability = operabilityScore(entry);
+  const risk = riskScore(entry);
+  return [
+    {
+      id: "trust",
+      label: "Trust tier",
+      score: trust,
+      detail:
+        trust >= 90
+          ? "Trusted posture."
+          : trust >= 50
+            ? "Review-first posture."
+            : trust >= 20
+              ? "Limited posture."
+              : "Blocked posture.",
+    },
+    {
+      id: "evidence",
+      label: "Evidence coverage",
+      score: evidence,
+      detail:
+        evidence >= 90
+          ? "Evidence signals are complete."
+          : evidence >= 50
+            ? "Partial evidence coverage."
+            : "Sparse evidence coverage.",
+    },
+    {
+      id: "operability",
+      label: "Operability",
+      score: operability,
+      detail:
+        operability >= 90
+          ? "Install and package metadata present."
+          : "Rollout payload gaps remain.",
+    },
+    {
+      id: "risk",
+      label: "Risk posture",
+      score: risk,
+      detail:
+        risk >= 75
+          ? "Low residual deployment risk."
+          : risk >= 45
+            ? "Moderate deployment risk."
+            : "High deployment risk.",
+    },
+  ];
+}
+
+function totalScore(entry: Entry, preset: CompareBenchmarkPresetId): number {
+  const weights = weightsForPreset(preset);
+  const dimensions = dimensionScores(entry);
+  const weighted = dimensions.reduce((sum, dimension) => {
+    return sum + (dimension.score / 100) * weights[dimension.id];
+  }, 0);
+  return Math.round(weighted);
+}
+
+function verdictForDelta(delta: number): CompareBenchmarkVerdict {
+  if (delta >= 8) return "stronger";
+  if (delta <= -8) return "weaker";
+  return "aligned";
+}
+
+function rowSummary(verdict: CompareBenchmarkVerdict, delta: number): string {
+  if (verdict === "stronger") return `Scores ${Math.abs(delta)} points higher than this entry.`;
+  if (verdict === "weaker") return `Scores ${Math.abs(delta)} points lower than this entry.`;
+  return "Scores within alignment range for this preset.";
+}
+
+function benchmarkSummary(rows: CompareBenchmarkRow[]): string | null {
+  if (rows.length === 0) return null;
+  const stronger = rows.filter((row) => row.verdict === "stronger").length;
+  const weaker = rows.filter((row) => row.verdict === "weaker").length;
+  if (stronger === 0 && weaker === 0) {
+    return "Compared entries are aligned with this entry on benchmark score.";
+  }
+  if (stronger > weaker) {
+    return `${stronger} compared entries currently benchmark stronger than this entry.`;
+  }
+  if (weaker > stronger) {
+    return `${weaker} compared entries currently benchmark weaker than this entry.`;
+  }
+  return "Compared entries show mixed benchmark deltas against this entry.";
+}
+
+function summary(targetScore: number, rows: CompareBenchmarkRow[]): string {
+  if (rows.length === 0) {
+    return "Add other entries to compare tray to benchmark this dossier.";
+  }
+  const stronger = rows.filter((row) => row.verdict === "stronger").length;
+  if (stronger > 0) {
+    return `This entry scores ${targetScore}/100 with ${stronger} stronger compare candidates.`;
+  }
+  return `This entry leads the compare tray at ${targetScore}/100 for the selected preset.`;
+}
+
+export function compareBenchmarkVerdictClass(verdict: CompareBenchmarkVerdict): string {
+  if (verdict === "stronger")
+    return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (verdict === "weaker") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+  return "border-border bg-background text-ink-muted";
+}
+
+export function entryCompareBenchmarkState(
+  entry: Entry,
+  preset: CompareBenchmarkPresetId,
+  compareItems: Entry[],
+): EntryCompareBenchmarkState {
+  const targetScore = totalScore(entry, preset);
+  const peers = compareItems.filter((candidate) => !sameEntry(candidate, entry));
+  const rows: CompareBenchmarkRow[] = peers
+    .map((candidate) => {
+      const score = totalScore(candidate, preset);
+      const delta = score - targetScore;
+      const verdict = verdictForDelta(delta);
+      return {
+        entryRef: entryRef(candidate),
+        title: candidate.title,
+        trust: candidate.trust,
+        totalScore: score,
+        delta,
+        verdict,
+        dimensions: dimensionScores(candidate),
+        summary: rowSummary(verdict, delta),
+      };
+    })
+    .sort((a, b) => b.totalScore - a.totalScore || a.title.localeCompare(b.title));
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(targetScore, rows),
+    targetRef: entryRef(entry),
+    targetTitle: entry.title,
+    targetScore,
+    rows,
+    strongerCount: rows.filter((row) => row.verdict === "stronger").length,
+    weakerCount: rows.filter((row) => row.verdict === "weaker").length,
+    benchmarkSummary: benchmarkSummary(rows),
+    showPanel: peers.length > 0,
+  };
+}

--- a/apps/web/src/lib/entry-compare-benchmark.ts
+++ b/apps/web/src/lib/entry-compare-benchmark.ts
@@ -1,0 +1,12 @@
+export type {
+  CompareBenchmarkDimensionId,
+  CompareBenchmarkDimensionScore,
+  CompareBenchmarkPresetId,
+  CompareBenchmarkRow,
+  CompareBenchmarkVerdict,
+  EntryCompareBenchmarkState,
+} from "@/lib/entry-compare-benchmark-lib";
+export {
+  compareBenchmarkVerdictClass,
+  entryCompareBenchmarkState,
+} from "@/lib/entry-compare-benchmark-lib";

--- a/apps/web/src/lib/entry-detail-sidebar-lib.ts
+++ b/apps/web/src/lib/entry-detail-sidebar-lib.ts
@@ -88,6 +88,7 @@ export function buildEntryTocItems(input: {
   items.push({ id: "decision-playbook", label: "Decision playbook" });
   items.push({ id: "evidence-matrix", label: "Evidence matrix" });
   items.push({ id: "decision-timeline", label: "Decision timeline" });
+  items.push({ id: "compare-benchmark", label: "Compare benchmark" });
   if (input.hasSafetyNotes) items.push({ id: "safety", label: "Safety notes" });
   if (input.hasPrivacyNotes) items.push({ id: "privacy", label: "Privacy notes" });
   if (input.hasPrerequisites) items.push({ id: "prerequisites", label: "Prerequisites" });

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -62,6 +62,7 @@ import { EntryDecisionTimelinePanel } from "@/components/entry-decision-timeline
 import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
+import { EntryCompareBenchmarkPanel } from "@/components/entry-compare-benchmark-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
   buildEntryTocItems,
@@ -93,6 +94,10 @@ import {
   entryDecisionTimelineState,
   type DecisionTimelinePresetId,
 } from "@/lib/entry-decision-timeline";
+import {
+  entryCompareBenchmarkState,
+  type CompareBenchmarkPresetId,
+} from "@/lib/entry-compare-benchmark";
 
 const loadFullEntry = createServerFn({ method: "GET" })
   .inputValidator(z.object({ category: z.string().min(1), slug: z.string().min(1) }))
@@ -293,6 +298,7 @@ function Dossier() {
   const [adoptionPreset, setAdoptionPreset] = useState<AdoptionPlanPresetId>("balanced-rollout");
   const [evidencePreset, setEvidencePreset] = useState<EvidenceMatrixPresetId>("balanced");
   const [timelinePreset, setTimelinePreset] = useState<DecisionTimelinePresetId>("balanced");
+  const [benchmarkPreset, setBenchmarkPreset] = useState<CompareBenchmarkPresetId>("balanced");
   const inCompare = useIsCompared(entry);
   const onToggleCompare = useCallback(() => {
     const wasIn = inCompare;
@@ -367,6 +373,10 @@ function Dossier() {
   const decisionTimeline = useMemo(
     () => entryDecisionTimelineState(entry, timelinePreset, compare.items),
     [entry, timelinePreset, compare.items],
+  );
+  const compareBenchmark = useMemo(
+    () => entryCompareBenchmarkState(entry, benchmarkPreset, compare.items),
+    [entry, benchmarkPreset, compare.items],
   );
   const entryUrl = `/entry/${entry.category}/${entry.slug}`;
 
@@ -533,6 +543,11 @@ function Dossier() {
             state={decisionTimeline}
             selectedPreset={timelinePreset}
             onSelectPreset={setTimelinePreset}
+          />
+          <EntryCompareBenchmarkPanel
+            state={compareBenchmark}
+            selectedPreset={benchmarkPreset}
+            onSelectPreset={setBenchmarkPreset}
           />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">

--- a/tests/entry-compare-benchmark-lib.test.ts
+++ b/tests/entry-compare-benchmark-lib.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  compareBenchmarkVerdictClass,
+  entryCompareBenchmarkState,
+} from "@/lib/entry-compare-benchmark-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const target = entry({
+  slug: "target",
+  title: "Target",
+  trust: "review",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/target",
+  reviewed: true,
+  safetyNotes: "present",
+  installCommand: "npm i target",
+});
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+});
+
+describe("entry compare benchmark lib", () => {
+  it("hides panel when no compare peers exist", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [target]);
+    expect(state.showPanel).toBe(false);
+    expect(state.rows).toEqual([]);
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      entryCompareBenchmarkState(target, "balanced", [strong]).heading,
+    ).toContain("balanced");
+    expect(
+      entryCompareBenchmarkState(target, "security", [strong]).heading,
+    ).toContain("security");
+    expect(
+      entryCompareBenchmarkState(target, "rollout", [strong]).heading,
+    ).toContain("rollout");
+  });
+
+  it("builds benchmark rows excluding target entry", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [
+      target,
+      strong,
+      weak,
+    ]);
+    expect(state.rows).toHaveLength(2);
+    expect(state.rows.some((row) => row.entryRef === "tools/target")).toBe(
+      false,
+    );
+  });
+
+  it("ranks stronger entry above weaker entry", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [
+      weak,
+      strong,
+    ]);
+    expect(state.rows[0].entryRef).toBe("tools/strong");
+    expect(state.rows[1].entryRef).toBe("tools/weak");
+  });
+
+  it("marks stronger and weaker verdicts", () => {
+    const state = entryCompareBenchmarkState(weak, "balanced", [strong, weak]);
+    expect(
+      state.rows.find((row) => row.entryRef === "tools/strong")?.verdict,
+    ).toBe("stronger");
+    const reverse = entryCompareBenchmarkState(strong, "balanced", [weak]);
+    expect(
+      reverse.rows.find((row) => row.entryRef === "tools/weak")?.verdict,
+    ).toBe("weaker");
+  });
+
+  it("tracks stronger and weaker counts", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [
+      strong,
+      weak,
+    ]);
+    expect(state.strongerCount).toBeGreaterThanOrEqual(0);
+    expect(state.weakerCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("includes four dimension scores per row", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [strong]);
+    expect(state.rows[0].dimensions).toHaveLength(4);
+  });
+
+  it("changes score profile between security and rollout presets", () => {
+    const installOnly = entry({
+      slug: "install-only",
+      title: "Install only",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/install-only",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: undefined,
+      installCommand: "npm i install-only",
+    });
+    const security = entryCompareBenchmarkState(installOnly, "security", [
+      strong,
+    ]);
+    const rollout = entryCompareBenchmarkState(installOnly, "rollout", [
+      strong,
+    ]);
+    expect(security.targetScore).not.toBe(rollout.targetScore);
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = entryCompareBenchmarkState(reviewedBy, "balanced", [weak]);
+    expect(state.targetScore).toBeGreaterThan(
+      entryCompareBenchmarkState(weak, "balanced", []).targetScore,
+    );
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = entryCompareBenchmarkState(hashed, "balanced", []);
+    expect(state.targetScore).toBeGreaterThan(0);
+  });
+
+  it("returns deterministic title ordering on ties", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = entryCompareBenchmarkState(target, "balanced", [b, a]);
+    expect(state.rows[0].title).toBe("A");
+  });
+
+  it("generates benchmark summary when peers exist", () => {
+    const state = entryCompareBenchmarkState(target, "balanced", [
+      strong,
+      weak,
+    ]);
+    expect(state.benchmarkSummary).toBeTruthy();
+  });
+
+  it("generates lead summary when no stronger peers", () => {
+    const state = entryCompareBenchmarkState(strong, "balanced", [
+      weak,
+      target,
+    ]);
+    expect(state.summary).toContain("leads the compare tray");
+  });
+
+  it("maps verdict classes for presentation", () => {
+    expect(compareBenchmarkVerdictClass("stronger")).toContain("trust-trusted");
+    expect(compareBenchmarkVerdictClass("weaker")).toContain("trust-blocked");
+    expect(compareBenchmarkVerdictClass("aligned")).toContain("border-border");
+  });
+
+  it("includes row summary with delta magnitude", () => {
+    const state = entryCompareBenchmarkState(weak, "balanced", [strong]);
+    const row = state.rows[0];
+    expect(row.summary).toContain("points");
+  });
+});

--- a/tests/entry-detail-sidebar-lib.test.ts
+++ b/tests/entry-detail-sidebar-lib.test.ts
@@ -118,6 +118,7 @@ describe("entry-detail-sidebar-lib", () => {
       "decision-playbook",
       "evidence-matrix",
       "decision-timeline",
+      "compare-benchmark",
       "privacy",
       "prerequisites",
       "about",


### PR DESCRIPTION
## Summary
- add a preset-driven entry compare benchmark lib for dossier vs compare tray scoring
- render compare benchmark panel on entry detail pages with dimension breakdowns
- include focused unit coverage for verdicts, presets, ranking, and sidebar TOC wiring

## Validation
- pnpm test tests/entry-compare-benchmark-lib.test.ts tests/entry-detail-sidebar-lib.test.ts
- pnpm type-check
- pnpm build

Closes #556