### PR TITLE
feat(web): add browse adoption queue panel

### DIFF
--- a/apps/web/src/components/browse-adoption-queue-panel.tsx
+++ b/apps/web/src/components/browse-adoption-queue-panel.tsx
@@ -1,0 +1,110 @@
+import type { BrowseAdoptionPresetId, BrowseAdoptionQueueState } from "@/lib/browse-adoption-queue";
+import { browseAdoptionTierClass } from "@/lib/browse-adoption-queue";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: BrowseAdoptionPresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "security-first", label: "Security-first" },
+  { id: "fast-pilot", label: "Fast pilot" },
+];
+
+export function BrowseAdoptionQueuePanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: BrowseAdoptionQueueState;
+  selectedPreset: BrowseAdoptionPresetId;
+  onSelectPreset: (preset: BrowseAdoptionPresetId) => void;
+  className?: string;
+}) {
+  if (state.scannedCount === 0 || state.rows.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Browse adoption queue"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Adoption queue</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            ready {state.readyCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            caution {state.cautionCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            hold {state.holdCount}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.rows.map((row) => (
+          <article key={row.entryRef} className="rounded-lg border border-border bg-background p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{row.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">
+                  {row.blockers.length > 0
+                    ? `${row.blockers.length} blockers: ${row.blockers.slice(0, 2).join(", ")}`
+                    : "No required blockers for this preset."}
+                </p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    browseAdoptionTierClass(row.tier),
+                  )}
+                >
+                  {row.tier}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{row.readinessScore}/100</p>
+              </div>
+            </div>
+
+            <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+              {row.nextSteps.map((step) => (
+                <p
+                  key={`${row.entryRef}-${step}`}
+                  className="rounded border border-border px-2 py-1 text-[11px] text-ink-muted"
+                >
+                  {step}
+                </p>
+              ))}
+            </div>
+
+            <p className="mt-2 text-[11px] text-ink-subtle">
+              {row.entryRef} · trust {row.trust} · confidence {row.confidence}%
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-adoption-queue-lib.ts
+++ b/apps/web/src/lib/browse-adoption-queue-lib.ts
@@ -1,0 +1,239 @@
+import type { Entry } from "@/types/registry";
+
+export type BrowseAdoptionPresetId = "balanced" | "security-first" | "fast-pilot";
+export type BrowseAdoptionTier = "ready" | "caution" | "hold";
+export type BrowseAdoptionSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type BrowseAdoptionQueueRow = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  readinessScore: number;
+  tier: BrowseAdoptionTier;
+  blockers: string[];
+  nextSteps: string[];
+  confidence: number;
+};
+
+export type BrowseAdoptionQueueState = {
+  preset: BrowseAdoptionPresetId;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  rows: BrowseAdoptionQueueRow[];
+  readyCount: number;
+  cautionCount: number;
+  holdCount: number;
+};
+
+const SIGNAL_LABELS: Record<BrowseAdoptionSignalId, string> = {
+  source: "Source provenance",
+  reviewed: "Metadata review",
+  safety: "Safety notes",
+  privacy: "Privacy notes",
+  package: "Package integrity",
+  install: "Install payload",
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function headingForPreset(preset: BrowseAdoptionPresetId): string {
+  if (preset === "security-first") return "Browse adoption queue · security-first";
+  if (preset === "fast-pilot") return "Browse adoption queue · fast pilot";
+  return "Browse adoption queue · balanced";
+}
+
+function weightMap(preset: BrowseAdoptionPresetId): Record<BrowseAdoptionSignalId, number> {
+  if (preset === "security-first") {
+    return {
+      source: 22,
+      reviewed: 16,
+      safety: 18,
+      privacy: 16,
+      package: 14,
+      install: 8,
+    };
+  }
+  if (preset === "fast-pilot") {
+    return {
+      source: 12,
+      reviewed: 10,
+      safety: 10,
+      privacy: 8,
+      package: 8,
+      install: 22,
+    };
+  }
+  return {
+    source: 18,
+    reviewed: 14,
+    safety: 14,
+    privacy: 12,
+    package: 12,
+    install: 14,
+  };
+}
+
+function trustPenalty(entry: Entry): number {
+  if (entry.trust === "blocked") return 26;
+  if (entry.trust === "limited") return 16;
+  if (entry.trust === "review") return 8;
+  return 0;
+}
+
+function tierFromScore(score: number): BrowseAdoptionTier {
+  if (score >= 75) return "ready";
+  if (score >= 45) return "caution";
+  return "hold";
+}
+
+function signalMap(entry: Entry): Record<BrowseAdoptionSignalId, boolean> {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstall(entry),
+  };
+}
+
+function blockersFromSignals(
+  signals: Record<BrowseAdoptionSignalId, boolean>,
+  preset: BrowseAdoptionPresetId,
+): string[] {
+  const required: BrowseAdoptionSignalId[] =
+    preset === "security-first"
+      ? ["source", "reviewed", "safety", "privacy", "package"]
+      : preset === "fast-pilot"
+        ? ["source", "install"]
+        : ["source", "reviewed", "safety", "install"];
+  return required.filter((id) => !signals[id]).map((id) => SIGNAL_LABELS[id]);
+}
+
+function stepForSignal(id: BrowseAdoptionSignalId): string {
+  if (id === "source") return "Confirm repository/source URL and maintainer ownership.";
+  if (id === "reviewed") return "Request metadata review from maintainers or internal owners.";
+  if (id === "safety") return "Capture safety notes with misuse/guardrail guidance.";
+  if (id === "privacy") return "Document privacy posture and data handling expectations.";
+  if (id === "package") return "Collect package checksum or signed artifact information.";
+  return "Add install/config payload for reproducible team rollout.";
+}
+
+function nextSteps(signals: Record<BrowseAdoptionSignalId, boolean>, blockers: string[]): string[] {
+  const missing = (Object.keys(signals) as BrowseAdoptionSignalId[]).filter((id) => !signals[id]);
+  const ordered = missing
+    .sort((a, b) => {
+      const blockerA = blockers.includes(SIGNAL_LABELS[a]) ? 0 : 1;
+      const blockerB = blockers.includes(SIGNAL_LABELS[b]) ? 0 : 1;
+      return blockerA - blockerB;
+    })
+    .slice(0, 3)
+    .map((id) => stepForSignal(id));
+  return ordered;
+}
+
+function confidenceScore(signals: Record<BrowseAdoptionSignalId, boolean>): number {
+  const present = (Object.values(signals).filter(Boolean).length / 6) * 100;
+  return Math.round(present);
+}
+
+function rowScore(
+  entry: Entry,
+  signals: Record<BrowseAdoptionSignalId, boolean>,
+  preset: BrowseAdoptionPresetId,
+): number {
+  const weights = weightMap(preset);
+  const achieved = (Object.keys(weights) as BrowseAdoptionSignalId[]).reduce((sum, id) => {
+    return sum + (signals[id] ? weights[id] : 0);
+  }, 0);
+  const raw = achieved - trustPenalty(entry);
+  return Math.max(0, Math.min(100, raw));
+}
+
+function summary(rows: BrowseAdoptionQueueRow[], scannedCount: number): string {
+  if (rows.length === 0) return "Add visible results to generate an adoption queue.";
+  const ready = rows.filter((row) => row.tier === "ready").length;
+  const hold = rows.filter((row) => row.tier === "hold").length;
+  if (hold > 0) {
+    return `${hold}/${scannedCount} visible results are in hold tier and need mitigation before adoption.`;
+  }
+  return `${ready}/${scannedCount} visible results are ready for staged adoption under this preset.`;
+}
+
+export function browseAdoptionTierClass(tier: BrowseAdoptionTier): string {
+  if (tier === "ready") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (tier === "caution") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+}
+
+export function browseAdoptionQueueState(
+  entries: Entry[],
+  preset: BrowseAdoptionPresetId,
+  maxRows = 8,
+): BrowseAdoptionQueueState {
+  const rows = entries
+    .map((entry) => {
+      const signals = signalMap(entry);
+      const blockers = blockersFromSignals(signals, preset);
+      const readinessScore = rowScore(entry, signals, preset);
+      const tier = tierFromScore(readinessScore);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        trust: entry.trust,
+        readinessScore,
+        tier,
+        blockers,
+        nextSteps: nextSteps(signals, blockers),
+        confidence: confidenceScore(signals),
+      } satisfies BrowseAdoptionQueueRow;
+    })
+    .sort((a, b) => b.readinessScore - a.readinessScore || a.title.localeCompare(b.title))
+    .slice(0, maxRows);
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(rows, entries.length),
+    scannedCount: entries.length,
+    rows,
+    readyCount: rows.filter((row) => row.tier === "ready").length,
+    cautionCount: rows.filter((row) => row.tier === "caution").length,
+    holdCount: rows.filter((row) => row.tier === "hold").length,
+  };
+}

--- a/apps/web/src/lib/browse-adoption-queue.ts
+++ b/apps/web/src/lib/browse-adoption-queue.ts
@@ -1,0 +1,8 @@
+export type {
+  BrowseAdoptionPresetId,
+  BrowseAdoptionQueueRow,
+  BrowseAdoptionQueueState,
+  BrowseAdoptionSignalId,
+  BrowseAdoptionTier,
+} from "@/lib/browse-adoption-queue-lib";
+export { browseAdoptionQueueState, browseAdoptionTierClass } from "@/lib/browse-adoption-queue-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -28,6 +28,8 @@ import { BrowseCompareSelectionBanner } from "@/components/browse-compare-select
 import { browseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
 import { browseRolloutSignalsState } from "@/lib/browse-rollout-signals";
 import { BrowseRolloutSignalsPanel } from "@/components/browse-rollout-signals-panel";
+import { browseAdoptionQueueState, type BrowseAdoptionPresetId } from "@/lib/browse-adoption-queue";
+import { BrowseAdoptionQueuePanel } from "@/components/browse-adoption-queue-panel";
 import {
   CATEGORIES,
   type Category,
@@ -340,6 +342,11 @@ function Browse() {
     [compare.items],
   );
   const browseRolloutSignals = useMemo(() => browseRolloutSignalsState(results, 12), [results]);
+  const [adoptionPreset, setAdoptionPreset] = React.useState<BrowseAdoptionPresetId>("balanced");
+  const browseAdoptionQueue = useMemo(
+    () => browseAdoptionQueueState(results, adoptionPreset, 8),
+    [results, adoptionPreset],
+  );
 
   const activeCount =
     Number(!!sp.q) +
@@ -622,7 +629,7 @@ function Browse() {
 
         {/* Results */}
         <div>
-          <div className="sticky top-16 z-20 -mx-4 flex flex-col gap-3 border-b border-border bg-background/95 px-4 pb-4 pt-2 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:-mx-6 sm:px-6">
+          <div className="sticky top-16 z-20 -mx-4 flex flex-col gap-3 border-b border-border bg-background/95 px-4 pb-4 pt-2 backdrop-blur supports-backdrop-filter:bg-background/80 sm:-mx-6 sm:px-6">
             <div className="flex items-center gap-2 rounded-lg border border-border bg-surface px-3 focus-within:border-accent/50 focus-within:ring-2 focus-within:ring-accent/40">
               <SearchIcon className="h-4 w-4 text-ink-muted" />
               <input
@@ -708,7 +715,7 @@ function Browse() {
                     value={sp.signal}
                     onChange={(e) => set({ signal: e.target.value })}
                     aria-label="Trust signal utility filter"
-                    className="h-7 max-w-[11rem] rounded-md border border-border bg-surface px-2 text-xs text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
+                    className="h-7 max-w-44 rounded-md border border-border bg-surface px-2 text-xs text-ink focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40"
                   >
                     {trustUtilityOptions.map((option) => (
                       <option key={option.id || "all"} value={option.id}>
@@ -814,6 +821,12 @@ function Browse() {
             />
           ) : null}
           <BrowseRolloutSignalsPanel state={browseRolloutSignals} className="mt-3" />
+          <BrowseAdoptionQueuePanel
+            state={browseAdoptionQueue}
+            selectedPreset={adoptionPreset}
+            onSelectPreset={setAdoptionPreset}
+            className="mt-3"
+          />
 
           {sp.category &&
             (() => {
@@ -828,7 +841,7 @@ function Browse() {
           {/* Mobile filter chips */}
           <div className="relative mt-4 lg:hidden">
             <div
-              className="flex gap-2 overflow-x-auto pb-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              className="scrollbar-none flex gap-2 overflow-x-auto pb-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
               role="radiogroup"
               aria-label="Filter by category"
             >
@@ -850,13 +863,13 @@ function Browse() {
             </div>
             <span
               aria-hidden
-              className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent"
+              className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-background to-transparent"
             />
           </div>
 
           <div className="relative mt-2 lg:hidden">
             <div
-              className="flex gap-2 overflow-x-auto pb-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
+              className="scrollbar-none flex gap-2 overflow-x-auto pb-2 [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden"
               role="radiogroup"
               aria-label="Trust signal quick filters"
             >
@@ -875,7 +888,7 @@ function Browse() {
             </div>
             <span
               aria-hidden
-              className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-background to-transparent"
+              className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-linear-to-l from-background to-transparent"
             />
           </div>
 

--- a/tests/browse-adoption-queue-lib.test.ts
+++ b/tests/browse-adoption-queue-lib.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseAdoptionQueueState,
+  browseAdoptionTierClass,
+} from "@/lib/browse-adoption-queue-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("browse adoption queue lib", () => {
+  it("returns empty rows for no entries", () => {
+    const state = browseAdoptionQueueState([], "balanced");
+    expect(state.rows).toEqual([]);
+    expect(state.scannedCount).toBe(0);
+  });
+
+  it("returns heading per preset", () => {
+    expect(browseAdoptionQueueState([strong], "balanced").heading).toContain(
+      "balanced",
+    );
+    expect(
+      browseAdoptionQueueState([strong], "security-first").heading,
+    ).toContain("security");
+    expect(browseAdoptionQueueState([strong], "fast-pilot").heading).toContain(
+      "pilot",
+    );
+  });
+
+  it("ranks strong entry above weak entry", () => {
+    const state = browseAdoptionQueueState([weak, strong], "balanced");
+    expect(state.rows[0].entryRef).toBe("tools/strong");
+    expect(state.rows[1].entryRef).toBe("tools/weak");
+  });
+
+  it("assigns ready and hold tiers", () => {
+    const state = browseAdoptionQueueState([strong, weak], "security-first");
+    expect(
+      state.rows.find((row) => row.entryRef === "tools/strong")?.tier,
+    ).toBe("ready");
+    expect(state.rows.find((row) => row.entryRef === "tools/weak")?.tier).toBe(
+      "hold",
+    );
+  });
+
+  it("tracks tier counters", () => {
+    const state = browseAdoptionQueueState([strong, weak], "balanced");
+    expect(state.readyCount).toBeGreaterThanOrEqual(0);
+    expect(state.holdCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("creates blockers based on preset requirements", () => {
+    const state = browseAdoptionQueueState([weak], "security-first");
+    expect(state.rows[0].blockers).toContain("Source provenance");
+    expect(state.rows[0].blockers).toContain("Package integrity");
+  });
+
+  it("creates next steps for missing signals", () => {
+    const state = browseAdoptionQueueState([weak], "balanced");
+    expect(state.rows[0].nextSteps.length).toBeGreaterThan(0);
+  });
+
+  it("limits rows by maxRows argument", () => {
+    const state = browseAdoptionQueueState(
+      [strong, weak, strong],
+      "balanced",
+      2,
+    );
+    expect(state.rows).toHaveLength(2);
+  });
+
+  it("changes scoring profile across presets", () => {
+    const installOnly = entry({
+      slug: "install-only",
+      title: "Install only",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/install-only",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: true,
+      installCommand: undefined,
+      configSnippet: undefined,
+      copySnippet: undefined,
+      fullCopy: undefined,
+    });
+    const security = browseAdoptionQueueState([installOnly], "security-first");
+    const pilot = browseAdoptionQueueState([installOnly], "fast-pilot");
+    expect(security.rows[0].readinessScore).not.toBe(
+      pilot.rows[0].readinessScore,
+    );
+  });
+
+  it("uses reviewedBy as reviewed signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = browseAdoptionQueueState([reviewedBy], "balanced");
+    expect(state.rows[0].blockers).not.toContain("Metadata review");
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = browseAdoptionQueueState([hashed], "balanced");
+    expect(state.rows[0].blockers).not.toContain("Package integrity");
+  });
+
+  it("keeps deterministic ordering on equal scores", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = browseAdoptionQueueState([b, a], "balanced");
+    expect(state.rows[0].title).toBe("A");
+  });
+
+  it("reports hold-heavy summary when hold tiers exist", () => {
+    const state = browseAdoptionQueueState([weak], "balanced");
+    expect(state.summary).toContain("hold tier");
+  });
+
+  it("reports ready summary when no hold tiers exist", () => {
+    const state = browseAdoptionQueueState([strong], "balanced");
+    expect(state.summary).toContain("ready for staged adoption");
+  });
+
+  it("maps tier classes for presentation", () => {
+    expect(browseAdoptionTierClass("ready")).toContain("trust-trusted");
+    expect(browseAdoptionTierClass("caution")).toContain("amber");
+    expect(browseAdoptionTierClass("hold")).toContain("trust-blocked");
+  });
+});


### PR DESCRIPTION
## Summary
- add a preset-driven browse adoption queue lib and panel
- wire the panel into browse route with readiness tiers and blockers
- add focused tests for scoring, tiers, preset deltas, and helpers

## Validation
- pnpm test tests/browse-adoption-queue-lib.test.ts
- pnpm type-check
- pnpm build

Closes #556