### PR TITLE
refactor(web): extract deploymentRiskBandClass into risk-map lib

### DIFF
--- a/apps/web/src/components/compare-deployment-risk-map-panel.tsx
+++ b/apps/web/src/components/compare-deployment-risk-map-panel.tsx
@@ -1,8 +1,8 @@
 import type {
   CompareDeploymentRiskMapState,
-  DeploymentRiskBand,
   DeploymentRiskPresetId,
 } from "@/lib/compare-deployment-risk-map";
+import { deploymentRiskBandClass } from "@/lib/compare-deployment-risk-map-lib";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: DeploymentRiskPresetId; label: string }[] = [
@@ -10,12 +10,6 @@ const PRESETS: { id: DeploymentRiskPresetId; label: string }[] = [
   { id: "security", label: "Security" },
   { id: "speed", label: "Speed" },
 ];
-
-function bandClass(band: DeploymentRiskBand): string {
-  if (band === "high") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
-  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
-  return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
-}
 
 export function CompareDeploymentRiskMapPanel({
   state,
@@ -78,7 +72,7 @@ export function CompareDeploymentRiskMapPanel({
                 <span
                   className={cn(
                     "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                    bandClass(entry.riskBand),
+                    deploymentRiskBandClass(entry.riskBand),
                   )}
                 >
                   {entry.riskBand}

--- a/apps/web/src/lib/compare-deployment-risk-map-lib.ts
+++ b/apps/web/src/lib/compare-deployment-risk-map-lib.ts
@@ -3,6 +3,13 @@ import type { Entry } from "@/types/registry";
 export type DeploymentRiskPresetId = "balanced" | "security" | "speed";
 export type DeploymentRiskBand = "low" | "medium" | "high";
 
+/** Tailwind border/background/text classes for a deployment risk band chip. */
+export function deploymentRiskBandClass(band: DeploymentRiskBand): string {
+  if (band === "high") return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+}
+
 export type DeploymentRiskRow = {
   id: string;
   label: string;

--- a/tests/compare-deployment-risk-map-lib.test.ts
+++ b/tests/compare-deployment-risk-map-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDeploymentRiskMapState } from "@/lib/compare-deployment-risk-map-lib";
+import {
+  compareDeploymentRiskMapState,
+  deploymentRiskBandClass,
+} from "@/lib/compare-deployment-risk-map-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -199,5 +202,13 @@ describe("compare deployment risk map lib", () => {
     const b = entry({ slug: "b", title: "B" });
     const state = compareDeploymentRiskMapState([b, a], "balanced");
     expect(state.entries[0].title).toBe("A");
+  });
+});
+
+describe("deploymentRiskBandClass", () => {
+  it("maps each band to its chip classes", () => {
+    expect(deploymentRiskBandClass("high")).toContain("text-trust-blocked");
+    expect(deploymentRiskBandClass("medium")).toContain("text-amber-900");
+    expect(deploymentRiskBandClass("low")).toContain("text-trust-trusted");
   });
 });


### PR DESCRIPTION
### What & why

`compare-deployment-risk-map-panel.tsx` defined a local `bandClass()` mapping a `DeploymentRiskBand` to its chip border/background/text classes. This moves it next to the band type in `compare-deployment-risk-map-lib.ts` as the exported `deploymentRiskBandClass`, so the class mapping is unit-testable and colocated with `DeploymentRiskBand` (the same lib that already derives the bands).

### Changes

- `apps/web/src/lib/compare-deployment-risk-map-lib.ts` — add `deploymentRiskBandClass(band)`.
- `apps/web/src/components/compare-deployment-risk-map-panel.tsx` — import and use it; remove the local copy and the now-unused `DeploymentRiskBand` type import.
- `tests/compare-deployment-risk-map-lib.test.ts` — add a case covering all three bands (high / medium / low).

### Validation

- `pnpm --filter web type-check` — clean
- `pnpm exec vitest run tests/compare-deployment-risk-map-lib.test.ts` — 17 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the panel renders identical classes.
