### PR TITLE
refactor(web): extract operationalFitToneClass into heatmap lib

### DIFF
--- a/apps/web/src/components/compare-operational-fit-heatmap-panel.tsx
+++ b/apps/web/src/components/compare-operational-fit-heatmap-panel.tsx
@@ -1,8 +1,8 @@
 import type {
   CompareOperationalFitHeatmapState,
   OperationalFitPresetId,
-  OperationalFitTone,
 } from "@/lib/compare-operational-fit-heatmap";
+import { operationalFitToneClass } from "@/lib/compare-operational-fit-heatmap-lib";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: OperationalFitPresetId; label: string }[] = [
@@ -10,12 +10,6 @@ const PRESETS: { id: OperationalFitPresetId; label: string }[] = [
   { id: "security-hardening", label: "Security hardening" },
   { id: "rapid-adoption", label: "Rapid adoption" },
 ];
-
-function toneClass(tone: OperationalFitTone): string {
-  if (tone === "strong") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
-  if (tone === "mixed") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
-  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
-}
 
 export function CompareOperationalFitHeatmapPanel({
   state,
@@ -78,7 +72,7 @@ export function CompareOperationalFitHeatmapPanel({
                 <span
                   className={cn(
                     "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                    toneClass(entry.fitTone),
+                    operationalFitToneClass(entry.fitTone),
                   )}
                 >
                   {entry.fitTone}

--- a/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
+++ b/apps/web/src/lib/compare-operational-fit-heatmap-lib.ts
@@ -3,6 +3,13 @@ import type { Entry } from "@/types/registry";
 export type OperationalFitPresetId = "team-default" | "security-hardening" | "rapid-adoption";
 export type OperationalFitTone = "strong" | "mixed" | "weak";
 
+/** Tailwind border/background/text classes for an operational-fit tone chip. */
+export function operationalFitToneClass(tone: OperationalFitTone): string {
+  if (tone === "strong") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (tone === "mixed") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+}
+
 export type OperationalFitAxis = {
   id: string;
   label: string;

--- a/tests/compare-operational-fit-heatmap-lib.test.ts
+++ b/tests/compare-operational-fit-heatmap-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareOperationalFitHeatmapState } from "@/lib/compare-operational-fit-heatmap-lib";
+import {
+  compareOperationalFitHeatmapState,
+  operationalFitToneClass,
+} from "@/lib/compare-operational-fit-heatmap-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -200,5 +203,13 @@ describe("compare operational fit heatmap lib", () => {
   it("generates summary when weak entries absent", () => {
     const state = compareOperationalFitHeatmapState([strong], "team-default");
     expect(state.summary).toContain("strong operational fit");
+  });
+});
+
+describe("operationalFitToneClass", () => {
+  it("maps each tone to its chip classes", () => {
+    expect(operationalFitToneClass("strong")).toContain("text-trust-trusted");
+    expect(operationalFitToneClass("mixed")).toContain("text-amber-900");
+    expect(operationalFitToneClass("weak")).toContain("text-trust-blocked");
   });
 });


### PR DESCRIPTION
### What & why

`compare-operational-fit-heatmap-panel.tsx` defined a local `toneClass()` mapping an `OperationalFitTone` to its chip border/background/text classes. This moves it next to the tone type in `compare-operational-fit-heatmap-lib.ts` as the exported `operationalFitToneClass`, so the class mapping is unit-testable and colocated with `OperationalFitTone` (the same lib that already derives the tones).

### Changes

- `apps/web/src/lib/compare-operational-fit-heatmap-lib.ts` — add `operationalFitToneClass(tone)`.
- `apps/web/src/components/compare-operational-fit-heatmap-panel.tsx` — import and use it; remove the local copy and the now-unused `OperationalFitTone` type import.
- `tests/compare-operational-fit-heatmap-lib.test.ts` — add a case covering all three tones (strong / mixed / weak).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/compare-operational-fit-heatmap-lib.test.ts` — 16 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the panel renders identical classes.
