### PR TITLE
feat(web): add browse decision confidence panel

### DIFF
--- a/apps/web/src/components/browse-decision-confidence-panel.tsx
+++ b/apps/web/src/components/browse-decision-confidence-panel.tsx
@@ -1,0 +1,118 @@
+import type {
+  BrowseConfidencePresetId,
+  BrowseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence";
+import { browseConfidenceBandClass } from "@/lib/browse-decision-confidence";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: BrowseConfidencePresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "strict", label: "Strict" },
+  { id: "pilot", label: "Pilot" },
+];
+
+export function BrowseDecisionConfidencePanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: BrowseDecisionConfidenceState;
+  selectedPreset: BrowseConfidencePresetId;
+  onSelectPreset: (preset: BrowseConfidencePresetId) => void;
+  className?: string;
+}) {
+  if (state.scannedCount === 0 || state.entries.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Browse decision confidence"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Decision confidence</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            high {state.highCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            medium {state.mediumCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            low {state.lowCount}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.entries.map((entry) => (
+          <article
+            key={entry.entryRef}
+            className="rounded-lg border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.recommendation}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    browseConfidenceBandClass(entry.band),
+                  )}
+                >
+                  {entry.band}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{entry.confidenceScore}/100</p>
+              </div>
+            </div>
+
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {entry.missingSignals.length > 0 ? (
+                entry.missingSignals.slice(0, 3).map((signal) => (
+                  <span
+                    key={`${entry.entryRef}-${signal}`}
+                    className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                  >
+                    Missing: {signal}
+                  </span>
+                ))
+              ) : (
+                <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
+                  All key signals present
+                </span>
+              )}
+            </div>
+
+            <p className="mt-2 text-[11px] text-ink-subtle">
+              {entry.entryRef} · trust {entry.trust}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -1,0 +1,212 @@
+import type { Entry } from "@/types/registry";
+
+export type BrowseConfidencePresetId = "balanced" | "strict" | "pilot";
+export type BrowseConfidenceBand = "high" | "medium" | "low";
+export type BrowseConfidenceSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type BrowseConfidenceEntry = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  confidenceScore: number;
+  band: BrowseConfidenceBand;
+  missingSignals: string[];
+  recommendation: string;
+};
+
+export type BrowseDecisionConfidenceState = {
+  preset: BrowseConfidencePresetId;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  entries: BrowseConfidenceEntry[];
+  lowRefs: string[];
+};
+
+const SIGNAL_LABELS: Record<BrowseConfidenceSignalId, string> = {
+  source: "Source provenance",
+  reviewed: "Metadata review",
+  safety: "Safety notes",
+  privacy: "Privacy notes",
+  package: "Package integrity",
+  install: "Install payload",
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function headingForPreset(preset: BrowseConfidencePresetId): string {
+  if (preset === "strict") return "Decision confidence scan · strict";
+  if (preset === "pilot") return "Decision confidence scan · pilot";
+  return "Decision confidence scan · balanced";
+}
+
+function signalWeights(preset: BrowseConfidencePresetId): Record<BrowseConfidenceSignalId, number> {
+  if (preset === "strict") {
+    return {
+      source: 20,
+      reviewed: 16,
+      safety: 18,
+      privacy: 16,
+      package: 16,
+      install: 14,
+    };
+  }
+  if (preset === "pilot") {
+    return {
+      source: 14,
+      reviewed: 10,
+      safety: 12,
+      privacy: 10,
+      package: 10,
+      install: 24,
+    };
+  }
+  return {
+    source: 18,
+    reviewed: 14,
+    safety: 14,
+    privacy: 12,
+    package: 12,
+    install: 18,
+  };
+}
+
+function trustPenalty(entry: Entry): number {
+  if (entry.trust === "blocked") return 24;
+  if (entry.trust === "limited") return 14;
+  if (entry.trust === "review") return 8;
+  return 0;
+}
+
+function confidenceBand(score: number): BrowseConfidenceBand {
+  if (score >= 74) return "high";
+  if (score >= 46) return "medium";
+  return "low";
+}
+
+function signals(entry: Entry): Record<BrowseConfidenceSignalId, boolean> {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstall(entry),
+  };
+}
+
+function scoreEntry(
+  entry: Entry,
+  preset: BrowseConfidencePresetId,
+  state: Record<BrowseConfidenceSignalId, boolean>,
+): number {
+  const weights = signalWeights(preset);
+  const points = (Object.keys(weights) as BrowseConfidenceSignalId[]).reduce((sum, key) => {
+    return sum + (state[key] ? weights[key] : 0);
+  }, 0);
+  return Math.max(0, Math.min(100, points - trustPenalty(entry)));
+}
+
+function recommendationFor(score: number, missing: string[]): string {
+  if (score >= 74) return "Confident candidate for staged adoption.";
+  if (score >= 46) {
+    return missing.length > 0
+      ? `Address ${missing.slice(0, 2).join(", ")} before broader rollout.`
+      : "Proceed with a guarded pilot rollout.";
+  }
+  return missing.length > 0
+    ? `Hold adoption until ${missing.slice(0, 2).join(", ")} are resolved.`
+    : "Hold adoption pending additional verification.";
+}
+
+function summary(rows: BrowseConfidenceEntry[], scannedCount: number): string {
+  if (rows.length === 0) return "Add visible results to generate a confidence scan.";
+  const low = rows.filter((row) => row.band === "low").length;
+  const high = rows.filter((row) => row.band === "high").length;
+  if (low > 0) {
+    return `${low}/${scannedCount} results are low-confidence and need review before adoption.`;
+  }
+  return `${high}/${scannedCount} results are high-confidence for the selected preset.`;
+}
+
+export function browseConfidenceBandClass(band: BrowseConfidenceBand): string {
+  if (band === "high") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+}
+
+export function browseDecisionConfidenceState(
+  entries: Entry[],
+  preset: BrowseConfidencePresetId,
+  maxEntries = 8,
+): BrowseDecisionConfidenceState {
+  const mapped = entries
+    .map((entry) => {
+      const signalState = signals(entry);
+      const missingSignals = (Object.keys(signalState) as BrowseConfidenceSignalId[])
+        .filter((key) => !signalState[key])
+        .map((key) => SIGNAL_LABELS[key]);
+      const confidenceScore = scoreEntry(entry, preset, signalState);
+      const band = confidenceBand(confidenceScore);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        trust: entry.trust,
+        confidenceScore,
+        band,
+        missingSignals,
+        recommendation: recommendationFor(confidenceScore, missingSignals),
+      } satisfies BrowseConfidenceEntry;
+    })
+    .sort((a, b) => b.confidenceScore - a.confidenceScore || a.title.localeCompare(b.title))
+    .slice(0, maxEntries);
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(mapped, entries.length),
+    scannedCount: entries.length,
+    highCount: mapped.filter((row) => row.band === "high").length,
+    mediumCount: mapped.filter((row) => row.band === "medium").length,
+    lowCount: mapped.filter((row) => row.band === "low").length,
+    entries: mapped,
+    lowRefs: mapped.filter((row) => row.band === "low").map((row) => row.entryRef),
+  };
+}

--- a/apps/web/src/lib/browse-decision-confidence.ts
+++ b/apps/web/src/lib/browse-decision-confidence.ts
@@ -1,0 +1,10 @@
+export type {
+  BrowseConfidenceBand,
+  BrowseConfidencePresetId,
+  BrowseConfidenceSignalId,
+  BrowseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";
+export {
+  browseConfidenceBandClass,
+  browseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -31,6 +31,11 @@ import { BrowseRolloutSignalsPanel } from "@/components/browse-rollout-signals-p
 import { browseAdoptionQueueState, type BrowseAdoptionPresetId } from "@/lib/browse-adoption-queue";
 import { BrowseAdoptionQueuePanel } from "@/components/browse-adoption-queue-panel";
 import {
+  browseDecisionConfidenceState,
+  type BrowseConfidencePresetId,
+} from "@/lib/browse-decision-confidence";
+import { BrowseDecisionConfidencePanel } from "@/components/browse-decision-confidence-panel";
+import {
   CATEGORIES,
   type Category,
   type Platform,
@@ -346,6 +351,12 @@ function Browse() {
   const browseAdoptionQueue = useMemo(
     () => browseAdoptionQueueState(results, adoptionPreset, 8),
     [results, adoptionPreset],
+  );
+  const [confidencePreset, setConfidencePreset] =
+    React.useState<BrowseConfidencePresetId>("balanced");
+  const browseDecisionConfidence = useMemo(
+    () => browseDecisionConfidenceState(results, confidencePreset, 8),
+    [results, confidencePreset],
   );
 
   const activeCount =
@@ -825,6 +836,12 @@ function Browse() {
             state={browseAdoptionQueue}
             selectedPreset={adoptionPreset}
             onSelectPreset={setAdoptionPreset}
+            className="mt-3"
+          />
+          <BrowseDecisionConfidencePanel
+            state={browseDecisionConfidence}
+            selectedPreset={confidencePreset}
+            onSelectPreset={setConfidencePreset}
             className="mt-3"
           />
 

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseConfidenceBandClass,
+  browseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("browse decision confidence lib", () => {
+  it("returns empty rows when no entries", () => {
+    const state = browseDecisionConfidenceState([], "balanced");
+    expect(state.entries).toEqual([]);
+    expect(state.scannedCount).toBe(0);
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      browseDecisionConfidenceState([strong], "balanced").heading,
+    ).toContain("balanced");
+    expect(browseDecisionConfidenceState([strong], "strict").heading).toContain(
+      "strict",
+    );
+    expect(browseDecisionConfidenceState([strong], "pilot").heading).toContain(
+      "pilot",
+    );
+  });
+
+  it("ranks strong entry above weak entry", () => {
+    const state = browseDecisionConfidenceState([weak, strong], "balanced");
+    expect(state.entries[0].entryRef).toBe("tools/strong");
+    expect(state.entries[1].entryRef).toBe("tools/weak");
+  });
+
+  it("assigns high and low bands", () => {
+    const state = browseDecisionConfidenceState([strong, weak], "strict");
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/strong")?.band,
+    ).toBe("high");
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/weak")?.band,
+    ).toBe("low");
+  });
+
+  it("tracks band counters", () => {
+    const state = browseDecisionConfidenceState([strong, weak], "balanced");
+    expect(state.highCount).toBeGreaterThanOrEqual(0);
+    expect(state.lowCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captures missing signal labels", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.entries[0].missingSignals).toContain("Source provenance");
+    expect(state.entries[0].missingSignals).toContain("Install payload");
+  });
+
+  it("changes confidence profile across presets", () => {
+    const installOnly = entry({
+      slug: "install-only",
+      title: "Install only",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/install-only",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: true,
+      installCommand: undefined,
+      configSnippet: undefined,
+      copySnippet: undefined,
+      fullCopy: undefined,
+    });
+    const strict = browseDecisionConfidenceState([installOnly], "strict");
+    const pilot = browseDecisionConfidenceState([installOnly], "pilot");
+    expect(strict.entries[0].confidenceScore).not.toBe(
+      pilot.entries[0].confidenceScore,
+    );
+  });
+
+  it("uses reviewedBy as review signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = browseDecisionConfidenceState([reviewedBy], "balanced");
+    expect(state.entries[0].missingSignals).not.toContain("Metadata review");
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = browseDecisionConfidenceState([hashed], "balanced");
+    expect(state.entries[0].missingSignals).not.toContain("Package integrity");
+  });
+
+  it("enforces deterministic ordering on ties", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = browseDecisionConfidenceState([b, a], "balanced");
+    expect(state.entries[0].title).toBe("A");
+  });
+
+  it("limits results by maxEntries", () => {
+    const state = browseDecisionConfidenceState(
+      [strong, weak, strong],
+      "balanced",
+      2,
+    );
+    expect(state.entries).toHaveLength(2);
+  });
+
+  it("includes low refs list", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.lowRefs).toContain("tools/weak");
+  });
+
+  it("reports low confidence summary when low entries exist", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.summary).toContain("low-confidence");
+  });
+
+  it("reports high confidence summary when no low entries exist", () => {
+    const state = browseDecisionConfidenceState([strong], "balanced");
+    expect(state.summary).toContain("high-confidence");
+  });
+
+  it("maps band classes for UI usage", () => {
+    expect(browseConfidenceBandClass("high")).toContain("trust-trusted");
+    expect(browseConfidenceBandClass("medium")).toContain("amber");
+    expect(browseConfidenceBandClass("low")).toContain("trust-blocked");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds browse decision confidence scoring lib, panel, and route wiring on latest main (includes merged #4675 adoption queue).
- Surfaces preset-weighted trust/safety/privacy/package/review signal gaps with high/medium/low bands and recommendations.
- Recovery PR for closed #4677 after Gittensory duplicate overlap with #4675 (now merged).

Closes #556

## Validation
- `pnpm test tests/browse-decision-confidence-lib.test.ts` — 15 passed
- `pnpm type-check` — pass
- `pnpm build` — pass
- `npx prettier --write` on touched test/route files

## Test plan
- [ ] Open browse with filtered results; verify confidence panel renders below adoption queue
- [ ] Switch balanced/strict/pilot presets and confirm banding + recommendations update
- [ ] Confirm no regressions to adoption queue or rollout signals panels