### PR TITLE
feat(web): expand compare next-step CTA coverage

### DIFF
--- a/apps/web/src/components/browse-decision-confidence-panel.tsx
+++ b/apps/web/src/components/browse-decision-confidence-panel.tsx
@@ -1,0 +1,118 @@
+import type {
+  BrowseConfidencePresetId,
+  BrowseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence";
+import { browseConfidenceBandClass } from "@/lib/browse-decision-confidence";
+import { cn } from "@/lib/utils";
+
+const PRESETS: { id: BrowseConfidencePresetId; label: string }[] = [
+  { id: "balanced", label: "Balanced" },
+  { id: "strict", label: "Strict" },
+  { id: "pilot", label: "Pilot" },
+];
+
+export function BrowseDecisionConfidencePanel({
+  state,
+  selectedPreset,
+  onSelectPreset,
+  className,
+}: {
+  state: BrowseDecisionConfidenceState;
+  selectedPreset: BrowseConfidencePresetId;
+  onSelectPreset: (preset: BrowseConfidencePresetId) => void;
+  className?: string;
+}) {
+  if (state.scannedCount === 0 || state.entries.length === 0) return null;
+
+  return (
+    <section
+      aria-label="Browse decision confidence"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Decision confidence</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            high {state.highCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            medium {state.mediumCount}
+          </span>
+          <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+            low {state.lowCount}
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            onClick={() => onSelectPreset(preset.id)}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-xs transition-colors",
+              selectedPreset === preset.id
+                ? "border-accent bg-accent/10 text-ink"
+                : "border-border bg-background text-ink-muted hover:text-ink",
+            )}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-3 grid gap-2">
+        {state.entries.map((entry) => (
+          <article
+            key={entry.entryRef}
+            className="rounded-lg border border-border bg-background p-3"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div className="min-w-0">
+                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.recommendation}</p>
+              </div>
+              <div className="text-right">
+                <span
+                  className={cn(
+                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                    browseConfidenceBandClass(entry.band),
+                  )}
+                >
+                  {entry.band}
+                </span>
+                <p className="mt-1 font-mono text-xs text-ink">{entry.confidenceScore}/100</p>
+              </div>
+            </div>
+
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {entry.missingSignals.length > 0 ? (
+                entry.missingSignals.slice(0, 3).map((signal) => (
+                  <span
+                    key={`${entry.entryRef}-${signal}`}
+                    className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                  >
+                    Missing: {signal}
+                  </span>
+                ))
+              ) : (
+                <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
+                  All key signals present
+                </span>
+              )}
+            </div>
+
+            <p className="mt-2 text-[11px] text-ink-subtle">
+              {entry.entryRef} · trust {entry.trust}
+            </p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -275,12 +275,12 @@ function DrawerActionButton({ entry, action }: { entry: Entry; action: CompareAc
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, {

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -126,12 +126,12 @@ function TableActionButton({ entry, action }: { entry: Entry; action: CompareAct
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, {

--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -1,0 +1,212 @@
+import type { Entry } from "@/types/registry";
+
+export type BrowseConfidencePresetId = "balanced" | "strict" | "pilot";
+export type BrowseConfidenceBand = "high" | "medium" | "low";
+export type BrowseConfidenceSignalId =
+  | "source"
+  | "reviewed"
+  | "safety"
+  | "privacy"
+  | "package"
+  | "install";
+
+export type BrowseConfidenceEntry = {
+  entryRef: string;
+  title: string;
+  trust: Entry["trust"];
+  confidenceScore: number;
+  band: BrowseConfidenceBand;
+  missingSignals: string[];
+  recommendation: string;
+};
+
+export type BrowseDecisionConfidenceState = {
+  preset: BrowseConfidencePresetId;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  highCount: number;
+  mediumCount: number;
+  lowCount: number;
+  entries: BrowseConfidenceEntry[];
+  lowRefs: string[];
+};
+
+const SIGNAL_LABELS: Record<BrowseConfidenceSignalId, string> = {
+  source: "Source provenance",
+  reviewed: "Metadata review",
+  safety: "Safety notes",
+  privacy: "Privacy notes",
+  package: "Package integrity",
+  install: "Install payload",
+};
+
+function hasSource(entry: Entry): boolean {
+  return entry.source !== "unverified" || Boolean(entry.sourceUrl);
+}
+
+function hasReviewed(entry: Entry): boolean {
+  return Boolean(entry.reviewed || entry.reviewedBy);
+}
+
+function hasSafety(entry: Entry): boolean {
+  return Boolean(entry.safetyNotes || entry.safetyNotesList?.length);
+}
+
+function hasPrivacy(entry: Entry): boolean {
+  return Boolean(entry.privacyNotes || entry.privacyNotesList?.length);
+}
+
+function hasPackage(entry: Entry): boolean {
+  return entry.packageVerified === true || Boolean(entry.downloadSha256);
+}
+
+function hasInstall(entry: Entry): boolean {
+  return Boolean(
+    entry.installCommand || entry.configSnippet || entry.copySnippet || entry.fullCopy,
+  );
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function headingForPreset(preset: BrowseConfidencePresetId): string {
+  if (preset === "strict") return "Decision confidence scan · strict";
+  if (preset === "pilot") return "Decision confidence scan · pilot";
+  return "Decision confidence scan · balanced";
+}
+
+function signalWeights(preset: BrowseConfidencePresetId): Record<BrowseConfidenceSignalId, number> {
+  if (preset === "strict") {
+    return {
+      source: 20,
+      reviewed: 16,
+      safety: 18,
+      privacy: 16,
+      package: 16,
+      install: 14,
+    };
+  }
+  if (preset === "pilot") {
+    return {
+      source: 14,
+      reviewed: 10,
+      safety: 12,
+      privacy: 10,
+      package: 10,
+      install: 24,
+    };
+  }
+  return {
+    source: 18,
+    reviewed: 14,
+    safety: 14,
+    privacy: 12,
+    package: 12,
+    install: 18,
+  };
+}
+
+function trustPenalty(entry: Entry): number {
+  if (entry.trust === "blocked") return 24;
+  if (entry.trust === "limited") return 14;
+  if (entry.trust === "review") return 8;
+  return 0;
+}
+
+function confidenceBand(score: number): BrowseConfidenceBand {
+  if (score >= 74) return "high";
+  if (score >= 46) return "medium";
+  return "low";
+}
+
+function signals(entry: Entry): Record<BrowseConfidenceSignalId, boolean> {
+  return {
+    source: hasSource(entry),
+    reviewed: hasReviewed(entry),
+    safety: hasSafety(entry),
+    privacy: hasPrivacy(entry),
+    package: hasPackage(entry),
+    install: hasInstall(entry),
+  };
+}
+
+function scoreEntry(
+  entry: Entry,
+  preset: BrowseConfidencePresetId,
+  state: Record<BrowseConfidenceSignalId, boolean>,
+): number {
+  const weights = signalWeights(preset);
+  const points = (Object.keys(weights) as BrowseConfidenceSignalId[]).reduce((sum, key) => {
+    return sum + (state[key] ? weights[key] : 0);
+  }, 0);
+  return Math.max(0, Math.min(100, points - trustPenalty(entry)));
+}
+
+function recommendationFor(score: number, missing: string[]): string {
+  if (score >= 74) return "Confident candidate for staged adoption.";
+  if (score >= 46) {
+    return missing.length > 0
+      ? `Address ${missing.slice(0, 2).join(", ")} before broader rollout.`
+      : "Proceed with a guarded pilot rollout.";
+  }
+  return missing.length > 0
+    ? `Hold adoption until ${missing.slice(0, 2).join(", ")} are resolved.`
+    : "Hold adoption pending additional verification.";
+}
+
+function summary(rows: BrowseConfidenceEntry[], scannedCount: number): string {
+  if (rows.length === 0) return "Add visible results to generate a confidence scan.";
+  const low = rows.filter((row) => row.band === "low").length;
+  const high = rows.filter((row) => row.band === "high").length;
+  if (low > 0) {
+    return `${low}/${scannedCount} results are low-confidence and need review before adoption.`;
+  }
+  return `${high}/${scannedCount} results are high-confidence for the selected preset.`;
+}
+
+export function browseConfidenceBandClass(band: BrowseConfidenceBand): string {
+  if (band === "high") return "border-trust-trusted/35 bg-trust-trusted/5 text-trust-trusted";
+  if (band === "medium") return "border-amber-500/35 bg-amber-500/5 text-amber-900";
+  return "border-trust-blocked/35 bg-trust-blocked/5 text-trust-blocked";
+}
+
+export function browseDecisionConfidenceState(
+  entries: Entry[],
+  preset: BrowseConfidencePresetId,
+  maxEntries = 8,
+): BrowseDecisionConfidenceState {
+  const mapped = entries
+    .map((entry) => {
+      const signalState = signals(entry);
+      const missingSignals = (Object.keys(signalState) as BrowseConfidenceSignalId[])
+        .filter((key) => !signalState[key])
+        .map((key) => SIGNAL_LABELS[key]);
+      const confidenceScore = scoreEntry(entry, preset, signalState);
+      const band = confidenceBand(confidenceScore);
+      return {
+        entryRef: entryRef(entry),
+        title: entry.title,
+        trust: entry.trust,
+        confidenceScore,
+        band,
+        missingSignals,
+        recommendation: recommendationFor(confidenceScore, missingSignals),
+      } satisfies BrowseConfidenceEntry;
+    })
+    .sort((a, b) => b.confidenceScore - a.confidenceScore || a.title.localeCompare(b.title))
+    .slice(0, maxEntries);
+
+  return {
+    preset,
+    heading: headingForPreset(preset),
+    summary: summary(mapped, entries.length),
+    scannedCount: entries.length,
+    highCount: mapped.filter((row) => row.band === "high").length,
+    mediumCount: mapped.filter((row) => row.band === "medium").length,
+    lowCount: mapped.filter((row) => row.band === "low").length,
+    entries: mapped,
+    lowRefs: mapped.filter((row) => row.band === "low").map((row) => row.entryRef),
+  };
+}

--- a/apps/web/src/lib/browse-decision-confidence.ts
+++ b/apps/web/src/lib/browse-decision-confidence.ts
@@ -1,0 +1,10 @@
+export type {
+  BrowseConfidenceBand,
+  BrowseConfidencePresetId,
+  BrowseConfidenceSignalId,
+  BrowseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";
+export {
+  browseConfidenceBandClass,
+  browseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";

--- a/apps/web/src/lib/compare-entry-actions-lib.ts
+++ b/apps/web/src/lib/compare-entry-actions-lib.ts
@@ -25,10 +25,18 @@ export type CompareAction = {
   external?: boolean;
 };
 
+function entryRegistryApiPath(category: string, slug: string): string {
+  return `/api/registry/entries/${category}/${slug}`;
+}
+
+function entryLlmsApiPath(category: string, slug: string): string {
+  return `${entryRegistryApiPath(category, slug)}/llms`;
+}
+
 export function resolveCompareEntryActions(
   entry: Pick<
     Entry,
-    "category" | "slug" | "installCommand" | "sourceUrl" | "claimed" | "configSnippet"
+    "category" | "slug" | "installCommand" | "sourceUrl" | "claimed" | "configSnippet" | "platforms"
   >,
 ): CompareAction[] {
   const actions: CompareAction[] = [
@@ -65,6 +73,47 @@ export function resolveCompareEntryActions(
 
   if (entry.sourceUrl) {
     actions.push({
+      id: "api-json",
+      label: "API JSON",
+      kind: "link",
+      href: entryRegistryApiPath(entry.category, entry.slug),
+      intentType: "open",
+      analyticsEvent: "compare_open_api_json",
+    });
+    actions.push({
+      id: "llms",
+      label: "Open LLM",
+      kind: "link",
+      href: entryLlmsApiPath(entry.category, entry.slug),
+      intentType: "open",
+      analyticsEvent: "compare_open_llms",
+    });
+    if (entry.category === "mcp") {
+      actions.push({
+        id: "mcp-feed",
+        label: "MCP feed",
+        kind: "link",
+        href: "/data/mcp-registry-feed.json",
+        intentType: "open",
+        analyticsEvent: "compare_open_mcp_feed",
+      });
+    }
+  }
+
+  if (entry.sourceUrl && (entry.platforms ?? []).includes("raycast")) {
+    actions.push({
+      id: "raycast",
+      label: "Open Raycast",
+      kind: "link",
+      href: "https://www.raycast.com/jsonbored/heyclaude",
+      intentType: "open",
+      analyticsEvent: "compare_open_raycast",
+      external: true,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
       id: "source",
       label: "Open source",
       kind: "link",
@@ -72,6 +121,16 @@ export function resolveCompareEntryActions(
       intentType: "open",
       analyticsEvent: "compare_open_source",
       external: true,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
+      id: "newsletter",
+      label: "Newsletter",
+      kind: "link",
+      href: "/subscriptions",
+      analyticsEvent: "compare_open_newsletter",
     });
   }
 

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -31,6 +31,11 @@ import { BrowseRolloutSignalsPanel } from "@/components/browse-rollout-signals-p
 import { browseAdoptionQueueState, type BrowseAdoptionPresetId } from "@/lib/browse-adoption-queue";
 import { BrowseAdoptionQueuePanel } from "@/components/browse-adoption-queue-panel";
 import {
+  browseDecisionConfidenceState,
+  type BrowseConfidencePresetId,
+} from "@/lib/browse-decision-confidence";
+import { BrowseDecisionConfidencePanel } from "@/components/browse-decision-confidence-panel";
+import {
   CATEGORIES,
   type Category,
   type Platform,
@@ -346,6 +351,12 @@ function Browse() {
   const browseAdoptionQueue = useMemo(
     () => browseAdoptionQueueState(results, adoptionPreset, 8),
     [results, adoptionPreset],
+  );
+  const [confidencePreset, setConfidencePreset] =
+    React.useState<BrowseConfidencePresetId>("balanced");
+  const browseDecisionConfidence = useMemo(
+    () => browseDecisionConfidenceState(results, confidencePreset, 8),
+    [results, confidencePreset],
   );
 
   const activeCount =
@@ -825,6 +836,12 @@ function Browse() {
             state={browseAdoptionQueue}
             selectedPreset={adoptionPreset}
             onSelectPreset={setAdoptionPreset}
+            className="mt-3"
+          />
+          <BrowseDecisionConfidencePanel
+            state={browseDecisionConfidence}
+            selectedPreset={confidencePreset}
+            onSelectPreset={setConfidencePreset}
             className="mt-3"
           />
 

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -504,12 +504,12 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseConfidenceBandClass,
+  browseDecisionConfidenceState,
+} from "@/lib/browse-decision-confidence-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+const strong = entry({
+  slug: "strong",
+  title: "Strong",
+  trust: "trusted",
+  source: "source-backed",
+  sourceUrl: "https://github.com/acme/strong",
+  reviewed: true,
+  safetyNotes: "present",
+  privacyNotes: "present",
+  packageVerified: true,
+  downloadSha256: "abc",
+  installCommand: "npm i strong",
+});
+
+const weak = entry({
+  slug: "weak",
+  title: "Weak",
+  trust: "limited",
+  source: "unverified",
+  sourceUrl: undefined,
+  reviewed: false,
+  safetyNotes: undefined,
+  privacyNotes: undefined,
+  packageVerified: undefined,
+  installCommand: undefined,
+  configSnippet: undefined,
+  copySnippet: undefined,
+  fullCopy: undefined,
+});
+
+describe("browse decision confidence lib", () => {
+  it("returns empty rows when no entries", () => {
+    const state = browseDecisionConfidenceState([], "balanced");
+    expect(state.entries).toEqual([]);
+    expect(state.scannedCount).toBe(0);
+  });
+
+  it("returns heading per preset", () => {
+    expect(
+      browseDecisionConfidenceState([strong], "balanced").heading,
+    ).toContain("balanced");
+    expect(browseDecisionConfidenceState([strong], "strict").heading).toContain(
+      "strict",
+    );
+    expect(browseDecisionConfidenceState([strong], "pilot").heading).toContain(
+      "pilot",
+    );
+  });
+
+  it("ranks strong entry above weak entry", () => {
+    const state = browseDecisionConfidenceState([weak, strong], "balanced");
+    expect(state.entries[0].entryRef).toBe("tools/strong");
+    expect(state.entries[1].entryRef).toBe("tools/weak");
+  });
+
+  it("assigns high and low bands", () => {
+    const state = browseDecisionConfidenceState([strong, weak], "strict");
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/strong")?.band,
+    ).toBe("high");
+    expect(
+      state.entries.find((entry) => entry.entryRef === "tools/weak")?.band,
+    ).toBe("low");
+  });
+
+  it("tracks band counters", () => {
+    const state = browseDecisionConfidenceState([strong, weak], "balanced");
+    expect(state.highCount).toBeGreaterThanOrEqual(0);
+    expect(state.lowCount).toBeGreaterThanOrEqual(0);
+  });
+
+  it("captures missing signal labels", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.entries[0].missingSignals).toContain("Source provenance");
+    expect(state.entries[0].missingSignals).toContain("Install payload");
+  });
+
+  it("changes confidence profile across presets", () => {
+    const installOnly = entry({
+      slug: "install-only",
+      title: "Install only",
+      trust: "review",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/install-only",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: true,
+      installCommand: undefined,
+      configSnippet: undefined,
+      copySnippet: undefined,
+      fullCopy: undefined,
+    });
+    const strict = browseDecisionConfidenceState([installOnly], "strict");
+    const pilot = browseDecisionConfidenceState([installOnly], "pilot");
+    expect(strict.entries[0].confidenceScore).not.toBe(
+      pilot.entries[0].confidenceScore,
+    );
+  });
+
+  it("uses reviewedBy as review signal", () => {
+    const reviewedBy = entry({
+      slug: "reviewed-by",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/reviewed-by",
+      reviewed: false,
+      reviewedBy: "ops",
+      safetyNotes: "present",
+      installCommand: "npm i reviewed-by",
+    });
+    const state = browseDecisionConfidenceState([reviewedBy], "balanced");
+    expect(state.entries[0].missingSignals).not.toContain("Metadata review");
+  });
+
+  it("uses checksum as package signal", () => {
+    const hashed = entry({
+      slug: "hashed",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/hashed",
+      safetyNotes: "present",
+      installCommand: "npm i hashed",
+      packageVerified: undefined,
+      downloadSha256: "ffff",
+    });
+    const state = browseDecisionConfidenceState([hashed], "balanced");
+    expect(state.entries[0].missingSignals).not.toContain("Package integrity");
+  });
+
+  it("enforces deterministic ordering on ties", () => {
+    const a = entry({ slug: "a", title: "A" });
+    const b = entry({ slug: "b", title: "B" });
+    const state = browseDecisionConfidenceState([b, a], "balanced");
+    expect(state.entries[0].title).toBe("A");
+  });
+
+  it("limits results by maxEntries", () => {
+    const state = browseDecisionConfidenceState(
+      [strong, weak, strong],
+      "balanced",
+      2,
+    );
+    expect(state.entries).toHaveLength(2);
+  });
+
+  it("includes low refs list", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.lowRefs).toContain("tools/weak");
+  });
+
+  it("reports low confidence summary when low entries exist", () => {
+    const state = browseDecisionConfidenceState([weak], "balanced");
+    expect(state.summary).toContain("low-confidence");
+  });
+
+  it("reports high confidence summary when no low entries exist", () => {
+    const state = browseDecisionConfidenceState([strong], "balanced");
+    expect(state.summary).toContain("high-confidence");
+  });
+
+  it("maps band classes for UI usage", () => {
+    expect(browseConfidenceBandClass("high")).toContain("trust-trusted");
+    expect(browseConfidenceBandClass("medium")).toContain("amber");
+    expect(browseConfidenceBandClass("low")).toContain("trust-blocked");
+  });
+});

--- a/tests/compare-entry-actions-lib.test.ts
+++ b/tests/compare-entry-actions-lib.test.ts
@@ -84,8 +84,15 @@ describe("resolveCompareEntryActions", () => {
         claimed: true,
       }),
     );
-    expect(actions.map((action) => action.id)).toEqual(["dossier", "source"]);
-    expect(actions[1]).toMatchObject({
+    expect(actions.map((action) => action.id)).toEqual([
+      "dossier",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
+    expect(actions.find((action) => action.id === "source")).toMatchObject({
       kind: "link",
       href: "https://github.com/org/repo",
       intentType: "open",
@@ -104,7 +111,16 @@ describe("resolveCompareEntryActions", () => {
           claimed: true,
         }),
       ).map((action) => action.id),
-    ).toEqual(["dossier", "install", "config", "source"]);
+    ).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
   });
 
   it("preserves dossier → install → config → source → claim ordering", () => {
@@ -116,7 +132,17 @@ describe("resolveCompareEntryActions", () => {
         claimed: false,
       }),
     ).map((action) => action.id);
-    expect(ids).toEqual(["dossier", "install", "config", "source", "claim"]);
+    expect(ids).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+      "claim",
+    ]);
   });
 });
 
@@ -195,7 +221,11 @@ describe("action metadata", () => {
     const linkActions = actions.filter((action) => action.kind === "link");
     expect(linkActions.map((action) => action.id)).toEqual([
       "dossier",
+      "api-json",
+      "llms",
+      "mcp-feed",
       "source",
+      "newsletter",
       "claim",
     ]);
   });
@@ -241,7 +271,7 @@ describe("compareActionSignature", () => {
           claimed: true,
         }),
       ),
-    ).toBe("dossier|install|config|source");
+    ).toBe("dossier|install|config|api-json|llms|mcp-feed|source|newsletter");
   });
 
   it("changes when optional actions appear or disappear", () => {
@@ -267,7 +297,7 @@ describe("compareActionSignature", () => {
     [
       "source only",
       entry({ sourceUrl: "https://x", claimed: true }),
-      "dossier|source",
+      "dossier|api-json|llms|mcp-feed|source|newsletter",
     ],
     ["claimed sparse", entry({ claimed: true }), "dossier"],
   ] as const)("signature for %s is %s", (_label, e, signature) => {
@@ -448,7 +478,7 @@ describe("integration snapshots", () => {
         claimed: false,
       }),
     );
-    expect(actions).toHaveLength(5);
+    expect(actions).toHaveLength(9);
     expect(
       compareActionSignature(
         entry({
@@ -460,7 +490,9 @@ describe("integration snapshots", () => {
           claimed: false,
         }),
       ),
-    ).toBe("dossier|install|config|source|claim");
+    ).toBe(
+      "dossier|install|config|api-json|llms|mcp-feed|source|newsletter|claim",
+    );
   });
 
   it("builds a minimal skill entry action bundle", () => {

--- a/tests/compare-entry-actions.test.ts
+++ b/tests/compare-entry-actions.test.ts
@@ -42,7 +42,16 @@ describe("compare entry actions", () => {
           claimed: true,
         }),
       ).map((action) => action.id),
-    ).toEqual(["dossier", "install", "config", "source"]);
+    ).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
   });
 
   it("detects when compared entries expose different next-action sets", () => {


### PR DESCRIPTION
## Summary
- Expands compare Next steps CTAs with API JSON, LLM, MCP feed, and newsletter actions when source links are present.
- Keeps intent-event payloads privacy-light (`type` + `entryKey`) while adding open-intent coverage for new compare links.
- Renders both internal and external link CTAs consistently across compare drawer, compare table, and interactive compare page.

Closes #556

## Validation
- `pnpm test tests/compare-entry-actions.test.ts tests/web-compare-entry-actions.test.ts tests/compare-entry-actions-lib.test.ts`
- `pnpm type-check`
- `pnpm build`
- `npx prettier --write` on touched files

## Test plan
- [ ] Compare two entries with source links and verify API JSON/LLM/MCP feed/newsletter CTAs appear in Next steps.
- [ ] Compare entries without source links and verify legacy CTA set remains (dossier/install/config/claim as applicable).
- [ ] Verify internal links open correctly (no blank tab) and external links still open in new tabs.