### PR TITLE
refactor(web): extract toolListingTierInterest into tool-listing-tier-lib

### DIFF
--- a/apps/web/src/lib/tool-listing-tier-lib.ts
+++ b/apps/web/src/lib/tool-listing-tier-lib.ts
@@ -1,0 +1,13 @@
+// Pure coercion of a submitted tool-listing tier, split out of the tools submit
+// route so the allowlist + default can be unit-tested.
+
+export const TOOL_LISTING_TIERS = ["featured", "sponsored"] as const;
+export type ToolListingTier = (typeof TOOL_LISTING_TIERS)[number];
+
+/** Coerce a raw form value to a valid tool-listing tier, defaulting to "featured". */
+export function toolListingTierInterest(raw: FormDataEntryValue | null): ToolListingTier {
+  const value = String(raw ?? "featured");
+  return TOOL_LISTING_TIERS.includes(value as ToolListingTier)
+    ? (value as ToolListingTier)
+    : "featured";
+}

--- a/apps/web/src/routes/tools.submit.tsx
+++ b/apps/web/src/routes/tools.submit.tsx
@@ -1,3 +1,4 @@
+import { toolListingTierInterest } from "@/lib/tool-listing-tier-lib";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState, type FormEvent } from "react";
 import { ArrowRight } from "lucide-react";
@@ -5,15 +6,6 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { CommercialDisclosure } from "@/components/commercial-disclosure";
 import { absoluteUrl } from "@/lib/seo";
 import { submitListingLead } from "@/lib/listing-lead-client";
-
-const TOOL_LISTING_TIERS = ["featured", "sponsored"] as const;
-
-function toolListingTierInterest(raw: FormDataEntryValue | null) {
-  const value = String(raw ?? "featured");
-  return TOOL_LISTING_TIERS.includes(value as (typeof TOOL_LISTING_TIERS)[number])
-    ? (value as (typeof TOOL_LISTING_TIERS)[number])
-    : "featured";
-}
 
 export const Route = createFileRoute("/tools/submit")({
   head: () => ({

--- a/tests/tool-listing-tier-lib.test.ts
+++ b/tests/tool-listing-tier-lib.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+
+import { toolListingTierInterest } from "../apps/web/src/lib/tool-listing-tier-lib";
+
+describe("toolListingTierInterest", () => {
+  it("defaults to 'featured' for null or unknown values", () => {
+    expect(toolListingTierInterest(null)).toBe("featured");
+    expect(toolListingTierInterest("enterprise")).toBe("featured");
+  });
+
+  it("passes through an allow-listed tier", () => {
+    expect(toolListingTierInterest("featured")).toBe("featured");
+    expect(toolListingTierInterest("sponsored")).toBe("sponsored");
+  });
+});


### PR DESCRIPTION
### What & why

The tools submit route (`tools.submit.tsx`) coerced the submitted `tierInterest` form field inline. This extracts that pure allowlist coercion into `apps/web/src/lib/tool-listing-tier-lib.ts` as `toolListingTierInterest(raw)` (plus the `TOOL_LISTING_TIERS` allowlist and `ToolListingTier` type), so the default/allowlist behavior is unit-testable and reusable.

### Changes

- Add `apps/web/src/lib/tool-listing-tier-lib.ts` — exports `TOOL_LISTING_TIERS`, `ToolListingTier`, and `toolListingTierInterest(raw)` which returns an allow-listed tier or defaults to `"featured"`.
- `apps/web/src/routes/tools.submit.tsx` uses the helper instead of the inline coercion.
- Add `tests/tool-listing-tier-lib.test.ts` — covers null, unknown, and each allow-listed value. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/tool-listing-tier-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the route coerces the field identically.
