### PR TITLE
refactor(web): extract decision-timeline tone/risk class helpers

### DIFF
--- a/apps/web/src/components/entry-decision-timeline-panel.tsx
+++ b/apps/web/src/components/entry-decision-timeline-panel.tsx
@@ -2,6 +2,7 @@ import type {
   DecisionTimelinePresetId,
   EntryDecisionTimelineState,
 } from "@/lib/entry-decision-timeline";
+import { decisionRiskClass, decisionStepToneClass } from "@/lib/entry-decision-timeline-lib";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: DecisionTimelinePresetId; label: string }[] = [
@@ -9,18 +10,6 @@ const PRESETS: { id: DecisionTimelinePresetId; label: string }[] = [
   { id: "balanced", label: "Balanced" },
   { id: "security-first", label: "Security first" },
 ];
-
-function toneClass(tone: "complete" | "warning" | "critical"): string {
-  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
-  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
-  return "border-border bg-background";
-}
-
-function riskClass(score: number): string {
-  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
-  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
-  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
-}
 
 export function EntryDecisionTimelinePanel({
   state,
@@ -48,7 +37,7 @@ export function EntryDecisionTimelinePanel({
         <span
           className={cn(
             "inline-flex rounded-full border px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide",
-            riskClass(state.riskScore),
+            decisionRiskClass(state.riskScore),
           )}
         >
           Risk {state.riskScore}
@@ -78,7 +67,7 @@ export function EntryDecisionTimelinePanel({
         {state.steps.map((step) => (
           <article
             key={step.id}
-            className={cn("rounded-md border px-3 py-2.5", toneClass(step.tone))}
+            className={cn("rounded-md border px-3 py-2.5", decisionStepToneClass(step.tone))}
           >
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div className="min-w-0">

--- a/apps/web/src/lib/entry-decision-timeline-lib.ts
+++ b/apps/web/src/lib/entry-decision-timeline-lib.ts
@@ -5,6 +5,20 @@ export type DecisionTimelinePresetId = "fast-track" | "balanced" | "security-fir
 
 export type DecisionTimelineStepTone = "complete" | "warning" | "critical";
 
+/** Tailwind border/background classes for a decision-timeline step card. */
+export function decisionStepToneClass(tone: DecisionTimelineStepTone): string {
+  if (tone === "critical") return "border-trust-blocked/35 bg-trust-blocked/5";
+  if (tone === "warning") return "border-amber-500/35 bg-amber-500/5";
+  return "border-border bg-background";
+}
+
+/** Tailwind chip classes for a decision-timeline risk score (0-100). */
+export function decisionRiskClass(score: number): string {
+  if (score >= 60) return "border-trust-blocked/40 bg-trust-blocked/10 text-trust-blocked";
+  if (score >= 30) return "border-amber-500/40 bg-amber-500/10 text-amber-900";
+  return "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted";
+}
+
 export type DecisionTimelineStep = {
   id: string;
   phase: "triage" | "verify" | "rollout";

--- a/tests/entry-decision-timeline-lib.test.ts
+++ b/tests/entry-decision-timeline-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { entryDecisionTimelineState } from "@/lib/entry-decision-timeline-lib";
+import {
+  decisionRiskClass,
+  decisionStepToneClass,
+  entryDecisionTimelineState,
+} from "@/lib/entry-decision-timeline-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -207,5 +211,21 @@ describe("entry decision timeline lib", () => {
     });
     const state = entryDecisionTimelineState(hashed, "balanced", []);
     expect(state.steps.find((step) => step.id === "package")?.done).toBe(true);
+  });
+});
+
+describe("decisionStepToneClass", () => {
+  it("maps each step tone to its card classes", () => {
+    expect(decisionStepToneClass("critical")).toContain("bg-trust-blocked/5");
+    expect(decisionStepToneClass("warning")).toContain("bg-amber-500/5");
+    expect(decisionStepToneClass("complete")).toContain("bg-background");
+  });
+});
+
+describe("decisionRiskClass", () => {
+  it("bands the risk score into chip classes", () => {
+    expect(decisionRiskClass(60)).toContain("text-trust-blocked");
+    expect(decisionRiskClass(30)).toContain("text-amber-900");
+    expect(decisionRiskClass(29)).toContain("text-trust-trusted");
   });
 });


### PR DESCRIPTION
The entry decision timeline panel defined local `toneClass()`/`riskClass()` helpers mapping a step tone and a risk score to Tailwind classes. This moves them beside the timeline types in `entry-decision-timeline-lib.ts` as the exported `decisionStepToneClass` and `decisionRiskClass`.

- `entry-decision-timeline-lib.ts` — add `decisionStepToneClass(tone)` and `decisionRiskClass(score)`.
- `entry-decision-timeline-panel.tsx` — import and use them; drop the local copies.
- tests — cover each step tone and each risk band boundary.

Validated: `tsc --noEmit` clean, `vitest run` 22 passed, `prettier --check` clean. No matching issue — maintainer-lane internal refactor, no behavior change.