### PR TITLE
feat(web): clarify compare tray action guidance copy

### DIFF
--- a/apps/web/src/lib/compare-curated-summary-lib.ts
+++ b/apps/web/src/lib/compare-curated-summary-lib.ts
@@ -26,7 +26,7 @@ export function compareCuratedDecisionBannerText(decision: CompareDecisionSummar
 
 export function compareCuratedActionBannerText(actionsDiverge: boolean): string | null {
   if (!actionsDiverge) return null;
-  return "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.";
+  return "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.";
 }
 
 export function compareCuratedBannerTexts(entries: Entry[]): string[] {

--- a/tests/compare-curated-summary.test.ts
+++ b/tests/compare-curated-summary.test.ts
@@ -89,7 +89,7 @@ describe("compare curated summary", () => {
   it("formats action divergence banner copy for curated headers", () => {
     expect(compareCuratedActionBannerText(false)).toBeNull();
     expect(compareCuratedActionBannerText(true)).toBe(
-      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
     );
   });
 
@@ -107,7 +107,7 @@ describe("compare curated summary", () => {
         entry({ installCommand: "npm i fixture" }),
       ]),
     ).toEqual([
-      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
     ]);
     expect(compareCuratedBannerTexts([entry()])).toEqual([]);
     expect(
@@ -122,7 +122,7 @@ describe("compare curated summary", () => {
       ]),
     ).toEqual([
       "1 trust signal differ across this comparison (Review status).",
-      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
     ]);
   });
 

--- a/tests/compare-curated-ui-lib.test.ts
+++ b/tests/compare-curated-ui-lib.test.ts
@@ -106,7 +106,7 @@ describe("compare curated ui lib", () => {
       ]),
     ).toEqual([
       "1 trust signal differ across this comparison (Review status).",
-      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
     ]);
   });
 
@@ -146,7 +146,7 @@ describe("compare curated ui lib", () => {
       ],
       bannerTexts: [
         "1 trust signal differ across this comparison (Review status).",
-        "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+        "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
       ],
       interactiveSearch: { ids: "skills/alpha,hooks/beta" },
       interactiveLinkLabel: "Open in the interactive comparison tool",

--- a/tests/comparison-tray-ui-lib.test.ts
+++ b/tests/comparison-tray-ui-lib.test.ts
@@ -94,7 +94,7 @@ describe("comparison tray ui lib", () => {
       ]),
     ).toEqual([
       "1 trust signal differ across this comparison (Review status).",
-      "Next steps differ across entries — open the interactive comparison to copy install commands and source links per resource.",
+      "Next steps differ across entries — open the interactive comparison to compare install/config copy, source links, API JSON, and LLM/MCP handoff links per resource.",
     ]);
   });
 });


### PR DESCRIPTION
## Summary
- Refines compare-tray/curated header action-difference messaging to explicitly call out install/config copy, source links, API JSON, and LLM/MCP handoff links.
- Keeps trust-difference messaging unchanged while improving CTA clarity to match current compare surfaces.
- Updates focused tests to lock banner copy and tray hint behavior.

Closes #556

## Validation
- `pnpm test tests/comparison-tray-ui-lib.test.ts tests/compare-curated-summary.test.ts tests/compare-curated-ui-lib.test.ts`
- `pnpm type-check`
- `pnpm build`
- `npx prettier --write` on touched files

## Test plan
- [ ] Compare entries with diverging next-step actions and verify new hint copy appears in tray/header.
- [ ] Compare entries with trust-only divergence and verify trust hint remains first.
- [ ] Verify no copy regression on curated compare pages.