### PR TITLE
refactor(web): extract trendingRowsFromPayload into trending-rows-lib

### DIFF
--- a/apps/web/src/lib/trending-rows-lib.ts
+++ b/apps/web/src/lib/trending-rows-lib.ts
@@ -1,0 +1,39 @@
+// Pure mapping of raw trending payload entries to registry-backed rows, split
+// out of the trending route so the lookup/skip/score-rounding can be unit-tested
+// without the live payload or the registry data module.
+
+import type { Entry } from "@/types/registry";
+
+export type TrendingEntry = Entry & {
+  trendingScore?: number;
+  trendingReasons?: string[];
+};
+
+export type TrendingPayloadEntry = {
+  category: string;
+  slug: string;
+  score?: number;
+  reasons?: string[];
+};
+
+/**
+ * Map raw trending payload entries to registry-backed rows, skipping any whose
+ * (category, slug) no longer resolves to a known entry. Scores are rounded and
+ * missing reasons default to an empty list.
+ */
+export function trendingRowsFromPayload(
+  entries: ReadonlyArray<TrendingPayloadEntry>,
+  getEntry: (category: string, slug: string) => Entry | undefined,
+): TrendingEntry[] {
+  const rows: TrendingEntry[] = [];
+  for (const item of entries) {
+    const entry = getEntry(item.category, item.slug);
+    if (!entry) continue;
+    rows.push({
+      ...entry,
+      trendingScore: Math.round(Number(item.score ?? 0)),
+      trendingReasons: item.reasons ?? [],
+    });
+  }
+  return rows;
+}

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { hasLiveSignals, type SignalState } from "@/lib/trending-live-signals-lib";
+import { trendingRowsFromPayload, type TrendingEntry } from "@/lib/trending-rows-lib";
 import { createFileRoute, Link, stripSearchParams } from "@tanstack/react-router";
 import { z } from "zod";
 import { ArrowRight, Clock, Flame, Info, Rss, Star, TrendingUp } from "lucide-react";
@@ -10,7 +11,7 @@ import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { TrendingPodium } from "@/components/trending-podium";
 import { ShareMenu } from "@/components/share-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { CATEGORIES, type Entry } from "@/types/registry";
+import { CATEGORIES } from "@/types/registry";
 import { formatCompact } from "@/lib/format";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
@@ -26,11 +27,6 @@ const trendingSchema = z.object({
   window: z.enum(["7d", "30d", "all"]).catch(defaultSearch.window).default(defaultSearch.window),
   category: z.string().catch(defaultSearch.category).default(defaultSearch.category),
 });
-
-type TrendingEntry = Entry & {
-  trendingScore?: number;
-  trendingReasons?: string[];
-};
 
 type TrendingPayload = {
   signalsAvailable?: SignalState;
@@ -103,17 +99,7 @@ function fallbackRows(): TrendingEntry[] {
 }
 
 function rowsFromPayload(payload: TrendingPayload): TrendingEntry[] {
-  const rows: TrendingEntry[] = [];
-  for (const item of payload.entries ?? []) {
-    const entry = getEntry(item.category, item.slug);
-    if (!entry) continue;
-    rows.push({
-      ...entry,
-      trendingScore: Math.round(Number(item.score ?? 0)),
-      trendingReasons: item.reasons ?? [],
-    });
-  }
-  return rows;
+  return trendingRowsFromPayload(payload.entries ?? [], getEntry);
 }
 
 function useTrendingRows() {

--- a/tests/trending-rows-lib.test.ts
+++ b/tests/trending-rows-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "@/types/registry";
+import { trendingRowsFromPayload } from "@/lib/trending-rows-lib";
+
+const entry = (category: string, slug: string): Entry =>
+  ({ category, slug, title: `${category}/${slug}` }) as Entry;
+
+const lookup =
+  (known: Record<string, Entry>) => (category: string, slug: string) =>
+    known[`${category}/${slug}`];
+
+describe("trendingRowsFromPayload", () => {
+  it("maps payload entries to registry-backed rows", () => {
+    const rows = trendingRowsFromPayload(
+      [{ category: "agents", slug: "a", score: 12.6, reasons: ["hot"] }],
+      lookup({ "agents/a": entry("agents", "a") }),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].slug).toBe("a");
+    expect(rows[0].trendingScore).toBe(13);
+    expect(rows[0].trendingReasons).toEqual(["hot"]);
+  });
+
+  it("skips entries that no longer resolve", () => {
+    const rows = trendingRowsFromPayload(
+      [
+        { category: "agents", slug: "gone" },
+        { category: "agents", slug: "a" },
+      ],
+      lookup({ "agents/a": entry("agents", "a") }),
+    );
+    expect(rows.map((row) => row.slug)).toEqual(["a"]);
+  });
+
+  it("defaults missing score to 0 and missing reasons to an empty list", () => {
+    const rows = trendingRowsFromPayload(
+      [{ category: "agents", slug: "a" }],
+      lookup({ "agents/a": entry("agents", "a") }),
+    );
+    expect(rows[0].trendingScore).toBe(0);
+    expect(rows[0].trendingReasons).toEqual([]);
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(trendingRowsFromPayload([], lookup({}))).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

The trending route mapped the raw trending payload to registry-backed rows inline. This extracts that pure mapping into `apps/web/src/lib/trending-rows-lib.ts` as `trendingRowsFromPayload(entries, getEntry)`, so the lookup / skip-missing / score-rounding / reason-defaulting logic is unit-testable without the live payload or the registry data module (the entry lookup is injected as a parameter).

### Changes

- Add `apps/web/src/lib/trending-rows-lib.ts` — `trendingRowsFromPayload` plus the `TrendingEntry` / `TrendingPayloadEntry` types.
- `apps/web/src/routes/trending.tsx` — `rowsFromPayload` delegates to the helper; drop the now-unused local `TrendingEntry` type and `Entry` import.
- Add `tests/trending-rows-lib.test.ts` — covers mapping, missing-entry skip, score rounding, reason defaulting, and empty input. Branch coverage 100% (6/6).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/trending-rows-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the route builds identical rows.
