### PR TITLE
refactor(web): extract variantsForEntry into copy-segmented-lib

### DIFF
--- a/apps/web/src/components/copy-segmented.tsx
+++ b/apps/web/src/components/copy-segmented.tsx
@@ -2,13 +2,10 @@ import * as React from "react";
 import { toast } from "sonner";
 import { Check, Copy } from "lucide-react";
 import { useCopyPref, type CopyVariant } from "@/lib/dossier-prefs";
+import { variantsForEntry, type VariantOption } from "@/lib/copy-segmented-lib";
 import { cn } from "@/lib/utils";
 
-export interface VariantOption {
-  id: CopyVariant;
-  label: string;
-  value?: string;
-}
+export { variantsForEntry, type VariantOption };
 
 interface Props {
   variants: VariantOption[];
@@ -160,28 +157,4 @@ export function CopySegmented({
       <span ref={liveRef} aria-live="polite" className="sr-only" />
     </div>
   );
-}
-
-/**
- * Resolve the variants array for an entry, honoring an optional harness
- * variant override and falling back to the entry's top-level fields.
- */
-export function variantsForEntry(
-  entry: {
-    installCommand?: string;
-    configSnippet?: string;
-    fullCopy?: string;
-    harnessVariants?: Record<
-      string,
-      { installCommand?: string; configSnippet?: string; fullCopy?: string } | undefined
-    >;
-  },
-  harnessId?: string | null,
-): VariantOption[] {
-  const hv = harnessId ? entry.harnessVariants?.[harnessId] : undefined;
-  return [
-    { id: "install", label: "Install", value: hv?.installCommand ?? entry.installCommand },
-    { id: "config", label: "Config", value: hv?.configSnippet ?? entry.configSnippet },
-    { id: "full", label: "Full", value: hv?.fullCopy ?? entry.fullCopy },
-  ];
 }

--- a/apps/web/src/lib/copy-segmented-lib.ts
+++ b/apps/web/src/lib/copy-segmented-lib.ts
@@ -1,0 +1,35 @@
+// Pure resolution of an entry's copy variants (install/config/full), split out
+// of the copy-segmented component so the harness-override precedence and the
+// top-level fallbacks can be unit-tested without rendering the component.
+
+import type { CopyVariant } from "@/lib/dossier-prefs";
+
+export interface VariantOption {
+  id: CopyVariant;
+  label: string;
+  value?: string;
+}
+
+/**
+ * Resolve the variants array for an entry, honoring an optional harness variant
+ * override and falling back to the entry's top-level fields.
+ */
+export function variantsForEntry(
+  entry: {
+    installCommand?: string;
+    configSnippet?: string;
+    fullCopy?: string;
+    harnessVariants?: Record<
+      string,
+      { installCommand?: string; configSnippet?: string; fullCopy?: string } | undefined
+    >;
+  },
+  harnessId?: string | null,
+): VariantOption[] {
+  const hv = harnessId ? entry.harnessVariants?.[harnessId] : undefined;
+  return [
+    { id: "install", label: "Install", value: hv?.installCommand ?? entry.installCommand },
+    { id: "config", label: "Config", value: hv?.configSnippet ?? entry.configSnippet },
+    { id: "full", label: "Full", value: hv?.fullCopy ?? entry.fullCopy },
+  ];
+}

--- a/tests/copy-segmented-lib.test.ts
+++ b/tests/copy-segmented-lib.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { variantsForEntry } from "@/lib/copy-segmented-lib";
+
+describe("variantsForEntry", () => {
+  it("uses the entry's top-level fields when no harness is given", () => {
+    const variants = variantsForEntry({
+      installCommand: "npm i x",
+      configSnippet: "cfg",
+      fullCopy: "full",
+    });
+    expect(variants.map((v) => v.id)).toEqual(["install", "config", "full"]);
+    expect(variants.map((v) => v.value)).toEqual(["npm i x", "cfg", "full"]);
+  });
+
+  it("prefers a matching harness variant override", () => {
+    const variants = variantsForEntry(
+      {
+        installCommand: "base-install",
+        configSnippet: "base-config",
+        fullCopy: "base-full",
+        harnessVariants: {
+          cursor: { installCommand: "cursor-install", fullCopy: "cursor-full" },
+        },
+      },
+      "cursor",
+    );
+    // overridden fields come from the harness; unspecified ones fall back
+    expect(variants[0].value).toBe("cursor-install");
+    expect(variants[1].value).toBe("base-config");
+    expect(variants[2].value).toBe("cursor-full");
+  });
+
+  it("falls back to top-level fields when the harness has no override", () => {
+    const variants = variantsForEntry(
+      { installCommand: "base-install", harnessVariants: {} },
+      "unknown-harness",
+    );
+    expect(variants[0].value).toBe("base-install");
+    expect(variants[1].value).toBeUndefined();
+  });
+
+  it("leaves values undefined when nothing is provided", () => {
+    const variants = variantsForEntry({});
+    expect(variants.every((v) => v.value === undefined)).toBe(true);
+  });
+});


### PR DESCRIPTION
### What & why

`variantsForEntry` — used by the compare drawer, peek button, sticky meta bar, and the entry detail route — lived inside the `copy-segmented` component, so its harness-override precedence and top-level fallbacks were untested. This moves it plus the `VariantOption` type into `apps/web/src/lib/copy-segmented-lib.ts`; the component re-exports both so every importer keeps working unchanged.

### Changes

- Add `apps/web/src/lib/copy-segmented-lib.ts` — `VariantOption` and `variantsForEntry(entry, harnessId)`.
- `apps/web/src/components/copy-segmented.tsx` — import and re-export them; drop the local definitions.
- Add `tests/copy-segmented-lib.test.ts` — covers top-level fields, harness-override precedence, missing-override fallback, and all-undefined. Branch coverage 100% (8/8).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/copy-segmented-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; callers resolve identical variants. Re-export keeps the four existing import sites stable.
