### PR TITLE
refactor(web): extract watch event helpers into watch-events-lib

### DIFF
--- a/apps/web/src/lib/watch-events-lib.ts
+++ b/apps/web/src/lib/watch-events-lib.ts
@@ -1,0 +1,28 @@
+// Pure helpers for turning raw registry feed events into watch identifiers and
+// detail links, split out of the watch hook module so the entry-event guards
+// and encoding can be unit-tested without the React context.
+
+export interface RegistryEvent {
+  id?: string;
+  kind?: string;
+  category?: string;
+  slug?: string;
+  action?: string;
+  date?: string;
+  title?: string;
+  commit?: string;
+}
+
+/** Stable watch-target id for an entry event, or null for non-entry events. */
+export function eventTargetId(event: RegistryEvent): string | null {
+  if (event.kind === "entry" && event.category && event.slug) {
+    return `entry:${event.category}/${event.slug}`;
+  }
+  return null;
+}
+
+/** Data URL for an entry event's detail JSON, or null for non-entry events. */
+export function entryDetailUrl(event: RegistryEvent): string | null {
+  if (event.kind !== "entry" || !event.category || !event.slug) return null;
+  return `/data/entries/${encodeURIComponent(event.category)}/${encodeURIComponent(event.slug)}.json`;
+}

--- a/apps/web/src/lib/watch.tsx
+++ b/apps/web/src/lib/watch.tsx
@@ -6,6 +6,7 @@ import {
   savedSearchAlertTargetId,
   type SavedSearchAlertSearch,
 } from "@/lib/saved-search-alerts";
+import { entryDetailUrl, eventTargetId, type RegistryEvent } from "@/lib/watch-events-lib";
 import type { RegistryEntry } from "@/data/entry-normalize";
 import type { Entry } from "@/types/registry";
 
@@ -75,24 +76,6 @@ function saveState(state: StoredState) {
   }
 }
 
-interface RegistryEvent {
-  id?: string;
-  kind?: string;
-  category?: string;
-  slug?: string;
-  action?: string;
-  date?: string;
-  title?: string;
-  commit?: string;
-}
-
-function eventTargetId(event: RegistryEvent): string | null {
-  if (event.kind === "entry" && event.category && event.slug) {
-    return `entry:${event.category}/${event.slug}`;
-  }
-  return null;
-}
-
 function eventToAlert(event: RegistryEvent, target: WatchTarget): Alert | null {
   const targetId = eventTargetId(event);
   if (!targetId || targetId !== target.id || !event.date) return null;
@@ -130,11 +113,6 @@ function savedSearchSignature(searches: SavedSearchAlertSearch[]) {
       ].join("\t"),
     )
     .join("\n");
-}
-
-function entryDetailUrl(event: RegistryEvent) {
-  if (event.kind !== "entry" || !event.category || !event.slug) return null;
-  return `/data/entries/${encodeURIComponent(event.category)}/${encodeURIComponent(event.slug)}.json`;
 }
 
 async function loadEventEntries(events: RegistryEvent[]) {

--- a/tests/watch-events-lib.test.ts
+++ b/tests/watch-events-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  entryDetailUrl,
+  eventTargetId,
+  type RegistryEvent,
+} from "../apps/web/src/lib/watch-events-lib";
+
+const entryEvent = (over: Partial<RegistryEvent> = {}): RegistryEvent => ({
+  kind: "entry",
+  category: "agents",
+  slug: "my-agent",
+  ...over,
+});
+
+describe("eventTargetId", () => {
+  it("builds a stable id for a complete entry event", () => {
+    expect(eventTargetId(entryEvent())).toBe("entry:agents/my-agent");
+  });
+
+  it("returns null for non-entry kinds or missing category/slug", () => {
+    expect(eventTargetId(entryEvent({ kind: "changelog-stream" }))).toBeNull();
+    expect(eventTargetId(entryEvent({ category: undefined }))).toBeNull();
+    expect(eventTargetId(entryEvent({ slug: undefined }))).toBeNull();
+  });
+});
+
+describe("entryDetailUrl", () => {
+  it("builds an encoded detail JSON url for an entry event", () => {
+    expect(entryDetailUrl(entryEvent({ slug: "a b" }))).toBe(
+      "/data/entries/agents/a%20b.json",
+    );
+  });
+
+  it("returns null for non-entry kinds or missing category/slug", () => {
+    expect(entryDetailUrl(entryEvent({ kind: "integration" }))).toBeNull();
+    expect(entryDetailUrl(entryEvent({ category: undefined }))).toBeNull();
+    expect(entryDetailUrl(entryEvent({ slug: undefined }))).toBeNull();
+  });
+});


### PR DESCRIPTION
### What & why

The watch hook module (`lib/watch.tsx`) defined `eventTargetId()` and `entryDetailUrl()`, plus the `RegistryEvent` shape, inline — so the entry-event guards and detail-URL encoding could not be unit-tested without standing up the React watch context. This moves them into `apps/web/src/lib/watch-events-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/watch-events-lib.ts` — `RegistryEvent`, `eventTargetId(event)`, `entryDetailUrl(event)`.
- `apps/web/src/lib/watch.tsx` — import the helpers/type; drop the local copies. `eventToAlert` and `loadEventEntries` now use the imported versions.
- Add `tests/watch-events-lib.test.ts` — covers entry vs non-entry kinds, missing category/slug, and URL encoding. Branch coverage 100% (10/10).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/watch-events-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; identifiers and URLs are unchanged.
