### PR TITLE
feat(web): expand compare next-step CTA coverage

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -275,12 +275,12 @@ function DrawerActionButton({ entry, action }: { entry: Entry; action: CompareAc
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, {

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -126,12 +126,12 @@ function TableActionButton({ entry, action }: { entry: Entry; action: CompareAct
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, {

--- a/apps/web/src/lib/compare-entry-actions-lib.ts
+++ b/apps/web/src/lib/compare-entry-actions-lib.ts
@@ -25,10 +25,18 @@ export type CompareAction = {
   external?: boolean;
 };
 
+function entryRegistryApiPath(category: string, slug: string): string {
+  return `/api/registry/entries/${category}/${slug}`;
+}
+
+function entryLlmsApiPath(category: string, slug: string): string {
+  return `${entryRegistryApiPath(category, slug)}/llms`;
+}
+
 export function resolveCompareEntryActions(
   entry: Pick<
     Entry,
-    "category" | "slug" | "installCommand" | "sourceUrl" | "claimed" | "configSnippet"
+    "category" | "slug" | "installCommand" | "sourceUrl" | "claimed" | "configSnippet" | "platforms"
   >,
 ): CompareAction[] {
   const actions: CompareAction[] = [
@@ -65,6 +73,47 @@ export function resolveCompareEntryActions(
 
   if (entry.sourceUrl) {
     actions.push({
+      id: "api-json",
+      label: "API JSON",
+      kind: "link",
+      href: entryRegistryApiPath(entry.category, entry.slug),
+      intentType: "open",
+      analyticsEvent: "compare_open_api_json",
+    });
+    actions.push({
+      id: "llms",
+      label: "Open LLM",
+      kind: "link",
+      href: entryLlmsApiPath(entry.category, entry.slug),
+      intentType: "open",
+      analyticsEvent: "compare_open_llms",
+    });
+    if (entry.category === "mcp") {
+      actions.push({
+        id: "mcp-feed",
+        label: "MCP feed",
+        kind: "link",
+        href: "/data/mcp-registry-feed.json",
+        intentType: "open",
+        analyticsEvent: "compare_open_mcp_feed",
+      });
+    }
+  }
+
+  if (entry.sourceUrl && (entry.platforms ?? []).includes("raycast")) {
+    actions.push({
+      id: "raycast",
+      label: "Open Raycast",
+      kind: "link",
+      href: "https://www.raycast.com/jsonbored/heyclaude",
+      intentType: "open",
+      analyticsEvent: "compare_open_raycast",
+      external: true,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
       id: "source",
       label: "Open source",
       kind: "link",
@@ -72,6 +121,16 @@ export function resolveCompareEntryActions(
       intentType: "open",
       analyticsEvent: "compare_open_source",
       external: true,
+    });
+  }
+
+  if (entry.sourceUrl) {
+    actions.push({
+      id: "newsletter",
+      label: "Newsletter",
+      kind: "link",
+      href: "/subscriptions",
+      analyticsEvent: "compare_open_newsletter",
     });
   }
 

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -504,12 +504,12 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
       );
     }
 
-    if (action.href && action.external) {
+    if (action.href) {
       return (
         <a
           href={action.href}
-          target="_blank"
-          rel="noreferrer"
+          target={action.external ? "_blank" : undefined}
+          rel={action.external ? "noreferrer" : undefined}
           onClick={() => {
             if (action.analyticsEvent) {
               trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });

--- a/tests/compare-entry-actions-lib.test.ts
+++ b/tests/compare-entry-actions-lib.test.ts
@@ -84,8 +84,15 @@ describe("resolveCompareEntryActions", () => {
         claimed: true,
       }),
     );
-    expect(actions.map((action) => action.id)).toEqual(["dossier", "source"]);
-    expect(actions[1]).toMatchObject({
+    expect(actions.map((action) => action.id)).toEqual([
+      "dossier",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
+    expect(actions.find((action) => action.id === "source")).toMatchObject({
       kind: "link",
       href: "https://github.com/org/repo",
       intentType: "open",
@@ -104,7 +111,16 @@ describe("resolveCompareEntryActions", () => {
           claimed: true,
         }),
       ).map((action) => action.id),
-    ).toEqual(["dossier", "install", "config", "source"]);
+    ).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
   });
 
   it("preserves dossier → install → config → source → claim ordering", () => {
@@ -116,7 +132,17 @@ describe("resolveCompareEntryActions", () => {
         claimed: false,
       }),
     ).map((action) => action.id);
-    expect(ids).toEqual(["dossier", "install", "config", "source", "claim"]);
+    expect(ids).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+      "claim",
+    ]);
   });
 });
 
@@ -195,7 +221,11 @@ describe("action metadata", () => {
     const linkActions = actions.filter((action) => action.kind === "link");
     expect(linkActions.map((action) => action.id)).toEqual([
       "dossier",
+      "api-json",
+      "llms",
+      "mcp-feed",
       "source",
+      "newsletter",
       "claim",
     ]);
   });
@@ -241,7 +271,7 @@ describe("compareActionSignature", () => {
           claimed: true,
         }),
       ),
-    ).toBe("dossier|install|config|source");
+    ).toBe("dossier|install|config|api-json|llms|mcp-feed|source|newsletter");
   });
 
   it("changes when optional actions appear or disappear", () => {
@@ -267,7 +297,7 @@ describe("compareActionSignature", () => {
     [
       "source only",
       entry({ sourceUrl: "https://x", claimed: true }),
-      "dossier|source",
+      "dossier|api-json|llms|mcp-feed|source|newsletter",
     ],
     ["claimed sparse", entry({ claimed: true }), "dossier"],
   ] as const)("signature for %s is %s", (_label, e, signature) => {
@@ -448,7 +478,7 @@ describe("integration snapshots", () => {
         claimed: false,
       }),
     );
-    expect(actions).toHaveLength(5);
+    expect(actions).toHaveLength(9);
     expect(
       compareActionSignature(
         entry({
@@ -460,7 +490,9 @@ describe("integration snapshots", () => {
           claimed: false,
         }),
       ),
-    ).toBe("dossier|install|config|source|claim");
+    ).toBe(
+      "dossier|install|config|api-json|llms|mcp-feed|source|newsletter|claim",
+    );
   });
 
   it("builds a minimal skill entry action bundle", () => {

--- a/tests/compare-entry-actions.test.ts
+++ b/tests/compare-entry-actions.test.ts
@@ -42,7 +42,16 @@ describe("compare entry actions", () => {
           claimed: true,
         }),
       ).map((action) => action.id),
-    ).toEqual(["dossier", "install", "config", "source"]);
+    ).toEqual([
+      "dossier",
+      "install",
+      "config",
+      "api-json",
+      "llms",
+      "mcp-feed",
+      "source",
+      "newsletter",
+    ]);
   });
 
   it("detects when compared entries expose different next-action sets", () => {


### PR DESCRIPTION
## Summary
- Expands compare Next steps CTAs with API JSON, LLM, MCP feed, and newsletter actions when source links are present.
- Keeps intent-event payloads privacy-light (`type` + `entryKey`) while adding open-intent coverage for new compare links.
- Renders both internal and external link CTAs consistently across compare drawer, compare table, and interactive compare page.
- Recovery PR for closed #4684 with scoped compare-only changes (no browse decision confidence files).

Closes #556

## Validation
- `pnpm test tests/compare-entry-actions.test.ts tests/web-compare-entry-actions.test.ts tests/compare-entry-actions-lib.test.ts`
- `pnpm type-check`
- `pnpm build`
- `npx prettier --write` on touched files

## Test plan
- [ ] Compare two entries with source links and verify API JSON/LLM/MCP feed/newsletter CTAs appear in Next steps.
- [ ] Compare entries without source links and verify legacy CTA set remains (dossier/install/config/claim as applicable).
- [ ] Verify internal links open correctly (no blank tab) and external links still open in new tabs.