### PR TITLE
refactor(web): extract public jobs filters into public-jobs-filter-lib

### DIFF
--- a/apps/web/src/lib/public-jobs-filter-lib.ts
+++ b/apps/web/src/lib/public-jobs-filter-lib.ts
@@ -1,0 +1,46 @@
+// Pure filter/sort helpers for the public jobs API route, split out so the
+// free-text match, tri-state boolean filter, and posted-at parsing can be
+// unit-tested without invoking the handler.
+
+import type { PublicJobListing } from "@/lib/jobs";
+
+/** Case-insensitive free-text match across a job's searchable fields. */
+export function matchesQuery(job: PublicJobListing, query: string): boolean {
+  if (!query) return true;
+  const haystack = [
+    job.title,
+    job.company,
+    job.location,
+    job.description,
+    job.type,
+    job.compensation,
+    job.equity,
+    job.bonus,
+    job.sourceLabel,
+    ...(job.labels ?? []),
+    ...(job.benefits ?? []),
+    ...(job.responsibilities ?? []),
+    ...(job.requirements ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(query);
+}
+
+/** Tri-state boolean filter: "" / "all" pass everything, else match the flag. */
+export function matchesBoolFilter(filter: "all" | "true" | "false" | "", value: boolean): boolean {
+  if (!filter || filter === "all") return true;
+  return filter === "true" ? value : !value;
+}
+
+/** Parse a job's posted time (postedAt, then firstSeenAt) to epoch ms, or null. */
+export function jobPostedAtMs(job: PublicJobListing): number | null {
+  const candidates = [job.postedAt, job.firstSeenAt];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const parsed = Date.parse(candidate);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}

--- a/apps/web/src/routes/api/jobs.ts
+++ b/apps/web/src/routes/api/jobs.ts
@@ -3,47 +3,10 @@ import { createApiFileRoute } from "@/lib/api/file-route";
 import { publicJobsQuerySchema } from "@/lib/api/contracts";
 import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { cachedJsonResponse } from "@/lib/http-cache";
-import { buildPublicJobsIndex, getJobs, type PublicJobListing } from "@/lib/jobs";
+import { buildPublicJobsIndex, getJobs } from "@/lib/jobs";
+import { jobPostedAtMs, matchesBoolFilter, matchesQuery } from "@/lib/public-jobs-filter-lib";
 
 const MAX_OFFSET = 10_000;
-
-function matchesQuery(job: PublicJobListing, query: string) {
-  if (!query) return true;
-  const haystack = [
-    job.title,
-    job.company,
-    job.location,
-    job.description,
-    job.type,
-    job.compensation,
-    job.equity,
-    job.bonus,
-    job.sourceLabel,
-    ...(job.labels ?? []),
-    ...(job.benefits ?? []),
-    ...(job.responsibilities ?? []),
-    ...(job.requirements ?? []),
-  ]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-  return haystack.includes(query);
-}
-
-function matchesBoolFilter(filter: "all" | "true" | "false" | "", value: boolean) {
-  if (!filter || filter === "all") return true;
-  return filter === "true" ? value : !value;
-}
-
-function jobPostedAtMs(job: PublicJobListing): number | null {
-  const candidates = [job.postedAt, job.firstSeenAt];
-  for (const candidate of candidates) {
-    if (!candidate) continue;
-    const parsed = Date.parse(candidate);
-    if (Number.isFinite(parsed)) return parsed;
-  }
-  return null;
-}
 
 export const GET = createApiHandler("jobs.list", async ({ request, query: parsedQuery }) => {
   const {

--- a/tests/public-jobs-filter-lib.test.ts
+++ b/tests/public-jobs-filter-lib.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import type { PublicJobListing } from "@/lib/jobs";
+import {
+  jobPostedAtMs,
+  matchesBoolFilter,
+  matchesQuery,
+} from "@/lib/public-jobs-filter-lib";
+
+const job = (over: Partial<PublicJobListing> = {}): PublicJobListing =>
+  ({
+    title: "Staff Engineer",
+    company: "Acme",
+    labels: [],
+    ...over,
+  }) as PublicJobListing;
+
+describe("matchesQuery", () => {
+  it("passes everything for an empty query", () => {
+    expect(matchesQuery(job(), "")).toBe(true);
+  });
+
+  it("matches case-insensitively across searchable fields", () => {
+    expect(matchesQuery(job({ location: "Remote" }), "remote")).toBe(true);
+    expect(matchesQuery(job({ requirements: ["Rust", "Go"] }), "rust")).toBe(
+      true,
+    );
+  });
+
+  it("returns false when nothing matches", () => {
+    expect(matchesQuery(job(), "kubernetes")).toBe(false);
+  });
+
+  it("tolerates missing optional array fields", () => {
+    expect(
+      matchesQuery(
+        job({
+          labels: undefined,
+          benefits: undefined,
+          responsibilities: undefined,
+          requirements: undefined,
+        }),
+        "acme",
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("matchesBoolFilter", () => {
+  it("passes everything for '' or 'all'", () => {
+    expect(matchesBoolFilter("", true)).toBe(true);
+    expect(matchesBoolFilter("all", false)).toBe(true);
+  });
+
+  it("matches the flag for 'true'/'false'", () => {
+    expect(matchesBoolFilter("true", true)).toBe(true);
+    expect(matchesBoolFilter("true", false)).toBe(false);
+    expect(matchesBoolFilter("false", false)).toBe(true);
+    expect(matchesBoolFilter("false", true)).toBe(false);
+  });
+});
+
+describe("jobPostedAtMs", () => {
+  it("prefers postedAt, then firstSeenAt", () => {
+    expect(jobPostedAtMs(job({ postedAt: "2026-01-02T00:00:00Z" }))).toBe(
+      Date.parse("2026-01-02T00:00:00Z"),
+    );
+    expect(
+      jobPostedAtMs(
+        job({ postedAt: undefined, firstSeenAt: "2026-01-01T00:00:00Z" }),
+      ),
+    ).toBe(Date.parse("2026-01-01T00:00:00Z"));
+  });
+
+  it("returns null when there is no parseable date", () => {
+    expect(jobPostedAtMs(job())).toBeNull();
+    expect(jobPostedAtMs(job({ postedAt: "not-a-date" }))).toBeNull();
+  });
+});


### PR DESCRIPTION
### What & why

The public jobs API route defined `matchesQuery()`, `matchesBoolFilter()`, and `jobPostedAtMs()` inline, so the free-text match, tri-state boolean filter, and posted-at parsing could not be unit-tested without invoking the handler. This moves them into `apps/web/src/lib/public-jobs-filter-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/public-jobs-filter-lib.ts` — `matchesQuery`, `matchesBoolFilter`, `jobPostedAtMs`.
- `apps/web/src/routes/api/jobs.ts` — import the helpers; drop the local copies and the now-unused `PublicJobListing` import.
- Add `tests/public-jobs-filter-lib.test.ts` — covers empty/hit/miss queries and missing optional arrays, the tri-state filter, and postedAt/firstSeenAt precedence with the null fallback. Branch coverage 100% (20/20).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/public-jobs-filter-lib.test.ts` — 8 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the route filters and sorts identically.
