### PR TITLE
feat(web): extend compare tray chip trust signals

### DIFF
--- a/apps/web/src/components/comparison-tray.tsx
+++ b/apps/web/src/components/comparison-tray.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { GitCompare, X, ArrowRight, Shield, Lock, Package } from "lucide-react";
+import { BadgeCheck, GitCompare, X, ArrowRight, Shield, Lock, Link2, Package } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { useCompare } from "@/lib/compare";
 import { comparisonTrayChipSignals, comparisonTrayUiState } from "@/lib/comparison-tray-ui";
@@ -9,6 +9,7 @@ import {
 } from "@/lib/entry-detail-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { TrustBadge, SourceBadge, ReadinessDot } from "./badges";
+import { compareSignalToneClass } from "@/lib/compare-entry-signals";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 
@@ -29,6 +30,22 @@ function TrayChip({ entry, onRemove }: { entry: Entry; onRemove: () => void }) {
         />
         <Lock
           className={cn("h-3 w-3", signals.hasPrivacyNotes ? "text-trust-trusted" : "opacity-40")}
+        />
+        <BadgeCheck
+          className={cn(
+            "h-3 w-3",
+            signals.packageTrustTone === "missing"
+              ? "opacity-40"
+              : compareSignalToneClass(signals.packageTrustTone),
+          )}
+        />
+        <Link2
+          className={cn(
+            "h-3 w-3",
+            signals.sourceProvenanceTone === "missing"
+              ? "opacity-40"
+              : compareSignalToneClass(signals.sourceProvenanceTone),
+          )}
         />
         {signals.installable ? <Package className="h-3 w-3 text-ink-muted" /> : null}
       </span>

--- a/apps/web/src/lib/comparison-tray-ui-lib.ts
+++ b/apps/web/src/lib/comparison-tray-ui-lib.ts
@@ -11,6 +11,12 @@ import {
   compareCuratedActionBannerText,
   compareCuratedDecisionBannerText,
 } from "@/lib/compare-curated-summary";
+import {
+  packageTrustCompareSignal,
+  reviewCompareSignal,
+  sourceProvenanceCompareSignal,
+  type CompareSignalTone,
+} from "@/lib/compare-entry-signals-lib";
 import { compareSurfaceSummary } from "@/lib/compare-surface-summary-lib";
 
 export type ComparisonTrayChipSignals = {
@@ -19,6 +25,8 @@ export type ComparisonTrayChipSignals = {
   reviewed: boolean;
   claimed: boolean;
   installable: boolean;
+  packageTrustTone: CompareSignalTone;
+  sourceProvenanceTone: CompareSignalTone;
 };
 
 export type ComparisonTrayUiState = {
@@ -59,19 +67,32 @@ export function comparisonTrayChipSignals(
     | "privacyNotesList"
     | "reviewed"
     | "reviewedBy"
+    | "reviewedAt"
     | "claimed"
     | "installCommand"
     | "configSnippet"
     | "fullCopy"
     | "copySnippet"
+    | "packageVerified"
+    | "verifiedAt"
+    | "trustSignals"
+    | "downloadSha256"
+    | "source"
+    | "sourceSubmissionUrl"
+    | "importPrUrl"
   >,
 ): ComparisonTrayChipSignals {
+  const packageTrust = packageTrustCompareSignal(entry);
+  const sourceProvenance = sourceProvenanceCompareSignal(entry);
+
   return {
     hasSafetyNotes: hasSafetyNotes(entry),
     hasPrivacyNotes: hasPrivacyNotes(entry),
-    reviewed: Boolean(entry.reviewed || entry.reviewedBy),
+    reviewed: reviewCompareSignal(entry).tone !== "missing",
     claimed: Boolean(entry.claimed),
     installable: isInstallable(entry),
+    packageTrustTone: packageTrust.tone,
+    sourceProvenanceTone: sourceProvenance.tone,
   };
 }
 

--- a/tests/comparison-tray-ui-lib.test.ts
+++ b/tests/comparison-tray-ui-lib.test.ts
@@ -41,7 +41,48 @@ describe("comparison tray ui lib", () => {
       reviewed: true,
       claimed: true,
       installable: true,
+      packageTrustTone: "missing",
+      sourceProvenanceTone: "missing",
     });
+  });
+
+  it("maps package trust and source provenance tones from compare signal helpers", () => {
+    expect(
+      comparisonTrayChipSignals(
+        entry({
+          packageVerified: true,
+          verifiedAt: "2026-01-02",
+          sourceSubmissionUrl: "https://github.com/org/repo/issues/1",
+        }),
+      ),
+    ).toEqual({
+      hasSafetyNotes: false,
+      hasPrivacyNotes: false,
+      reviewed: false,
+      claimed: false,
+      installable: false,
+      packageTrustTone: "verified",
+      sourceProvenanceTone: "present",
+    });
+    expect(
+      comparisonTrayChipSignals(
+        entry({ downloadSha256: "abc", source: "source-backed" }),
+      ),
+    ).toMatchObject({
+      packageTrustTone: "present",
+      sourceProvenanceTone: "present",
+    });
+  });
+
+  it("surfaces package trust divergence hints in the tray", () => {
+    expect(
+      comparisonTrayHintMessages([
+        entry(),
+        entry({ packageVerified: true, verifiedAt: "2026-01-02" }),
+      ]),
+    ).toEqual([
+      "1 trust signal differ across this comparison (Package trust).",
+    ]);
   });
 
   it("requires at least two entries before enabling quick compare actions", () => {


### PR DESCRIPTION
## Summary
- Extends compare tray chip metadata with package-trust and source-provenance tones aligned to compare decision rows.
- Surfaces package trust and submission/source provenance icons on tray chips so users can spot trust gaps before opening full compare.
- Adds focused tests for tone mapping and package-trust divergence hints.

Closes #556

## Validation
- `pnpm test tests/comparison-tray-ui-lib.test.ts`
- `pnpm type-check`
- `pnpm build`
- `npx prettier --write` on touched files

## Test plan
- [ ] Add two entries with different package trust to compare tray; verify BadgeCheck/Link2 icon tones differ.
- [ ] Confirm tray hint still shows package trust divergence text.
- [ ] Verify quick/full compare actions still work with 2+ entries.