### PR TITLE
refactor(web): extract brand-asset URL guard into brand-asset-url-lib

### DIFF
--- a/apps/web/src/lib/brand-asset-url-lib.ts
+++ b/apps/web/src/lib/brand-asset-url-lib.ts
@@ -1,0 +1,22 @@
+// Pure allowlist guard for the brand-asset proxy: only https URLs on trusted
+// brandfetch CDN hosts may be fetched. Split out of the route so the guard can
+// be unit-tested without the handler.
+
+export const TRUSTED_BRAND_ASSET_HOSTS = new Set(["asset.brandfetch.io", "cdn.brandfetch.io"]);
+
+/**
+ * Normalize a brand-asset URL to a trusted https URL, or "" when it is not
+ * https, not on an allow-listed brandfetch CDN host, or not a valid URL.
+ */
+export function normalizeTrustedBrandAssetUrl(value: string): string {
+  try {
+    const parsed = new URL(value);
+    if (parsed.protocol !== "https:") return "";
+    if (!TRUSTED_BRAND_ASSET_HOSTS.has(parsed.hostname.toLowerCase())) {
+      return "";
+    }
+    return parsed.toString();
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
+++ b/apps/web/src/routes/api/brand-assets/$kind/$domain.ts
@@ -1,18 +1,15 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
-import {
-  brandfetchLogoUrl,
-  normalizeBrandDomain,
-} from "@heyclaude/registry/brand-assets";
+import { brandfetchLogoUrl, normalizeBrandDomain } from "@heyclaude/registry/brand-assets";
 
 import { brandAssetParamsSchema } from "@/lib/api/contracts";
 import { apiError, createApiHandler, type InferApiParams } from "@/lib/api/router";
 import { getEnvString } from "@/lib/cloudflare-env.server";
+import { normalizeTrustedBrandAssetUrl } from "@/lib/brand-asset-url-lib";
 import { applySecurityHeaders } from "@/lib/security-headers";
 
 const CACHE_CONTROL = "public, max-age=86400, stale-while-revalidate=604800";
 const MAX_BRAND_ASSET_BYTES = 1024 * 1024;
-const TRUSTED_BRAND_ASSET_HOSTS = new Set(["asset.brandfetch.io", "cdn.brandfetch.io"]);
 const TRUSTED_BRAND_ASSET_CONTENT_TYPES = new Set([
   "image/avif",
   "image/jpeg",
@@ -54,19 +51,6 @@ function resolveBrandLogoUrl(domain: string, clientId: string) {
     type: "logo",
     width: 512,
   });
-}
-
-function normalizeTrustedBrandAssetUrl(value: string) {
-  try {
-    const parsed = new URL(value);
-    if (parsed.protocol !== "https:") return "";
-    if (!TRUSTED_BRAND_ASSET_HOSTS.has(parsed.hostname.toLowerCase())) {
-      return "";
-    }
-    return parsed.toString();
-  } catch {
-    return "";
-  }
 }
 
 async function fetchTrustedBrandAsset(value: string) {

--- a/tests/brand-asset-url-lib.test.ts
+++ b/tests/brand-asset-url-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTrustedBrandAssetUrl } from "@/lib/brand-asset-url-lib";
+
+describe("normalizeTrustedBrandAssetUrl", () => {
+  it("accepts https URLs on trusted brandfetch hosts", () => {
+    expect(
+      normalizeTrustedBrandAssetUrl("https://cdn.brandfetch.io/logo.png"),
+    ).toBe("https://cdn.brandfetch.io/logo.png");
+    expect(
+      normalizeTrustedBrandAssetUrl("https://ASSET.brandfetch.io/x.webp"),
+    ).toBe("https://asset.brandfetch.io/x.webp");
+  });
+
+  it("rejects non-https protocols", () => {
+    expect(
+      normalizeTrustedBrandAssetUrl("http://cdn.brandfetch.io/logo.png"),
+    ).toBe("");
+  });
+
+  it("rejects untrusted hosts", () => {
+    expect(normalizeTrustedBrandAssetUrl("https://evil.example/logo.png")).toBe(
+      "",
+    );
+  });
+
+  it("rejects unparseable values", () => {
+    expect(normalizeTrustedBrandAssetUrl("not a url")).toBe("");
+    expect(normalizeTrustedBrandAssetUrl("")).toBe("");
+  });
+});


### PR DESCRIPTION
### What & why

The brand-asset proxy route defined `normalizeTrustedBrandAssetUrl()` and its trusted-host allowlist inline, so the https + allow-listed-CDN guard could not be unit-tested without the handler. This moves both into `apps/web/src/lib/brand-asset-url-lib.ts` and imports the guard back.

### Changes

- Add `apps/web/src/lib/brand-asset-url-lib.ts` — `TRUSTED_BRAND_ASSET_HOSTS` and `normalizeTrustedBrandAssetUrl(value)`.
- `apps/web/src/routes/api/brand-assets/$kind/$domain.ts` — import the guard; drop the local copy and the now-unused host set.
- Add `tests/brand-asset-url-lib.test.ts` — covers trusted https hosts (incl. host casing), non-https rejection, untrusted host rejection, and unparseable input. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/brand-asset-url-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the proxy accepts/rejects identical URLs.
