### PR TITLE
feat(web): add compare action to entry detail mobile bar

### DIFF
--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from "react";
 import { toast } from "sonner";
-import { Copy, ExternalLink, Package, FileText, Terminal } from "lucide-react";
+import { Copy, ExternalLink, Package, FileText, Terminal, GitCompare } from "lucide-react";
 import type { Entry } from "@/types/registry";
 import {
   ENTRY_COMMAND_CENTER_ID,
   resolveDetailMobileActions,
 } from "@/lib/entry-detail-command-center";
+import { entryDetailMobileCompareAction } from "@/lib/entry-detail-compare-ui";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
 import { trackEvent } from "@/lib/analytics";
@@ -21,11 +22,17 @@ import { cn } from "@/lib/utils";
 type EntryDetailMobileActionBarProps = {
   entry: Entry;
   copyPayload?: string;
+  compareCta: {
+    inCompare: boolean;
+    compareCount: number;
+    onToggle: () => void;
+  };
 };
 
 export function EntryDetailMobileActionBar({
   entry,
   copyPayload,
+  compareCta,
 }: EntryDetailMobileActionBarProps) {
   const entryPageUrl = absoluteUrl(`/entry/${entry.category}/${entry.slug}`);
   const actions = resolveDetailMobileActions(
@@ -34,6 +41,18 @@ export function EntryDetailMobileActionBar({
     entryPageUrl,
     siteConfig.githubUrl,
   );
+  const compareAction = entryDetailMobileCompareAction(
+    compareCta.inCompare,
+    compareCta.compareCount,
+  );
+
+  const onCompare = useCallback(() => {
+    if (compareAction.disabled) {
+      if (compareAction.hint) toast.error(compareAction.hint);
+      return;
+    }
+    compareCta.onToggle();
+  }, [compareAction.disabled, compareAction.hint, compareCta]);
 
   const onAction = useCallback(
     async (actionId: string) => {
@@ -82,6 +101,25 @@ export function EntryDetailMobileActionBar({
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40 border-t border-border bg-background/95 px-3 py-2 backdrop-blur lg:hidden">
       <div className="pointer-events-auto mx-auto flex max-w-[1200px] gap-2">
+        <button
+          type="button"
+          onClick={onCompare}
+          disabled={compareAction.disabled}
+          aria-label={compareAction.label}
+          className={cn(
+            "inline-flex h-10 min-w-0 flex-1 items-center justify-center gap-1.5 rounded-md px-2 text-xs font-medium",
+            compareAction.inCompare
+              ? "border border-accent/40 bg-accent/10 text-ink"
+              : "border border-border bg-surface text-ink hover:bg-surface-2",
+            compareAction.disabled && "cursor-not-allowed opacity-60",
+          )}
+        >
+          <GitCompare className="h-3.5 w-3.5" />
+          <span className="truncate">{compareAction.label}</span>
+          <span className="rounded bg-ink/10 px-1 font-mono text-[10px] text-ink-muted">
+            {compareAction.compareCount}/{compareAction.maxCount}
+          </span>
+        </button>
         {actions.map((action) => {
           const icon =
             action.id === "install" ? (

--- a/apps/web/src/lib/entry-detail-compare-ui-lib.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui-lib.ts
@@ -14,8 +14,22 @@ export type EntryDetailCompareCtaState = {
   showOpenCompare: boolean;
 };
 
+export type EntryDetailMobileCompareAction = {
+  id: "compare";
+  label: string;
+  disabled: boolean;
+  hint: string | null;
+  inCompare: boolean;
+  compareCount: number;
+  maxCount: number;
+};
+
 export function entryDetailCompareToggleLabel(inCompare: boolean): string {
   return inCompare ? "Remove from compare" : "Add to compare";
+}
+
+export function entryDetailMobileCompareLabel(inCompare: boolean): string {
+  return inCompare ? "In compare" : "Compare";
 }
 
 export function entryDetailCompareDisabledReason(
@@ -43,5 +57,23 @@ export function entryDetailCompareCtaState(
     disabled: Boolean(disabledReason),
     hint: disabledReason,
     showOpenCompare: entryDetailCompareDrawerEnabled(compareCount),
+  };
+}
+
+export function entryDetailMobileCompareAction(
+  inCompare: boolean,
+  compareCount: number,
+  maxCount = ENTRY_DETAIL_COMPARE_MAX,
+): EntryDetailMobileCompareAction {
+  const disabledReason = entryDetailCompareDisabledReason(inCompare, compareCount, maxCount);
+
+  return {
+    id: "compare",
+    label: entryDetailMobileCompareLabel(inCompare),
+    disabled: Boolean(disabledReason),
+    hint: disabledReason,
+    inCompare,
+    compareCount,
+    maxCount,
   };
 }

--- a/apps/web/src/lib/entry-detail-compare-ui.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui.ts
@@ -1,11 +1,16 @@
 /**
  * Entry detail compare CTA surface.
  */
-export type { EntryDetailCompareCtaState } from "@/lib/entry-detail-compare-ui-lib";
+export type {
+  EntryDetailCompareCtaState,
+  EntryDetailMobileCompareAction,
+} from "@/lib/entry-detail-compare-ui-lib";
 export {
   ENTRY_DETAIL_COMPARE_MAX,
   entryDetailCompareCtaState,
   entryDetailCompareDisabledReason,
   entryDetailCompareDrawerEnabled,
   entryDetailCompareToggleLabel,
+  entryDetailMobileCompareAction,
+  entryDetailMobileCompareLabel,
 } from "@/lib/entry-detail-compare-ui-lib";

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -45,6 +45,22 @@ export function entryDetailCompareAnalyticsData(category: string, slug: string) 
   };
 }
 
+export function entryDetailMobileCompareAnalyticsEvent(adding: boolean): string {
+  return adding ? "detail_mobile_compare_add" : "detail_mobile_compare_remove";
+}
+
+export function entryDetailMobileCompareAnalyticsData(
+  category: string,
+  slug: string,
+  compareCount: number,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_MOBILE_SURFACE,
+    compareCount,
+  };
+}
+
 export function browseCompareOpenAnalyticsData(selectedCount: number) {
   return {
     count: selectedCount,

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -12,6 +12,8 @@ export {
   comparisonTrayQuickCompareAnalyticsData,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailMobileCompareAnalyticsData,
+  entryDetailMobileCompareAnalyticsEvent,
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -78,6 +78,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailMobileCompareAnalyticsData,
+  entryDetailMobileCompareAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
@@ -310,6 +312,31 @@ function Dossier() {
     trackEvent(entryDetailCompareAnalyticsEvent(!wasIn), {
       ...entryDetailCompareAnalyticsData(entry.category, entry.slug),
       compareCount: wasIn ? Math.max(0, compare.items.length - 1) : compare.items.length + 1,
+    });
+    if (wasIn) {
+      toast(`Removed “${entry.title}” from compare`);
+    } else {
+      toast.success("Added to compare", {
+        action: {
+          label: "View",
+          onClick: () => compare.setOpen(true),
+        },
+      });
+    }
+  }, [compare, entry, inCompare]);
+  const onMobileToggleCompare = useCallback(() => {
+    const wasIn = inCompare;
+    const changed = compare.toggle(entry);
+    if (!changed) {
+      toast.error(resourceCardCompareFullMessage());
+      return;
+    }
+    trackEvent(entryDetailMobileCompareAnalyticsEvent(!wasIn), {
+      ...entryDetailMobileCompareAnalyticsData(
+        entry.category,
+        entry.slug,
+        wasIn ? Math.max(0, compare.items.length - 1) : compare.items.length + 1,
+      ),
     });
     if (wasIn) {
       toast(`Removed “${entry.title}” from compare`);
@@ -819,7 +846,15 @@ function Dossier() {
           readinessRows={readinessRows}
         />
       </div>
-      <EntryDetailMobileActionBar entry={entry} copyPayload={tabPayload} />
+      <EntryDetailMobileActionBar
+        entry={entry}
+        copyPayload={tabPayload}
+        compareCta={{
+          inCompare,
+          compareCount: compare.items.length,
+          onToggle: onMobileToggleCompare,
+        }}
+      />
       <div className="h-14 lg:hidden" aria-hidden />
     </div>
   );

--- a/tests/entry-detail-compare-ui-lib.test.ts
+++ b/tests/entry-detail-compare-ui-lib.test.ts
@@ -5,12 +5,16 @@ import {
   entryDetailCompareDisabledReason,
   entryDetailCompareDrawerEnabled,
   entryDetailCompareToggleLabel,
+  entryDetailMobileCompareAction,
+  entryDetailMobileCompareLabel,
 } from "@/lib/entry-detail-compare-ui-lib";
 
 describe("entry detail compare ui lib", () => {
   it("labels compare toggle actions", () => {
     expect(entryDetailCompareToggleLabel(false)).toBe("Add to compare");
     expect(entryDetailCompareToggleLabel(true)).toBe("Remove from compare");
+    expect(entryDetailMobileCompareLabel(false)).toBe("Compare");
+    expect(entryDetailMobileCompareLabel(true)).toBe("In compare");
   });
 
   it("blocks add-to-compare when the tray is full", () => {
@@ -47,6 +51,29 @@ describe("entry detail compare ui lib", () => {
       label: "Add to compare",
       disabled: true,
       showOpenCompare: true,
+    });
+  });
+
+  it("builds compact mobile compare action metadata", () => {
+    expect(entryDetailMobileCompareAction(false, 1)).toEqual({
+      id: "compare",
+      label: "Compare",
+      disabled: false,
+      hint: null,
+      inCompare: false,
+      compareCount: 1,
+      maxCount: ENTRY_DETAIL_COMPARE_MAX,
+    });
+    expect(entryDetailMobileCompareAction(true, 3)).toMatchObject({
+      label: "In compare",
+      inCompare: true,
+      compareCount: 3,
+    });
+    expect(
+      entryDetailMobileCompareAction(false, ENTRY_DETAIL_COMPARE_MAX),
+    ).toMatchObject({
+      disabled: true,
+      hint: expect.stringContaining("Compare is full"),
     });
   });
 });

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   comparisonTrayQuickCompareAnalyticsData,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailMobileCompareAnalyticsData,
+  entryDetailMobileCompareAnalyticsEvent,
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
@@ -39,6 +41,17 @@ describe("entry detail cta events lib", () => {
     expect(entryDetailCompareAnalyticsData("skills", "demo")).toEqual({
       entry: "skills/demo",
       surface: "detail-compare",
+    });
+    expect(entryDetailMobileCompareAnalyticsEvent(true)).toBe(
+      "detail_mobile_compare_add",
+    );
+    expect(entryDetailMobileCompareAnalyticsEvent(false)).toBe(
+      "detail_mobile_compare_remove",
+    );
+    expect(entryDetailMobileCompareAnalyticsData("skills", "demo", 2)).toEqual({
+      entry: "skills/demo",
+      surface: "detail-mobile",
+      compareCount: 2,
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds a Compare button to the entry detail mobile action bar with tray count and disabled-when-full state.
- Introduces mobile-specific compare analytics events on the detail-mobile surface.
- Keeps desktop command center compare behavior unchanged.

Closes #556

## Validation
- `pnpm test tests/entry-detail-compare-ui-lib.test.ts tests/entry-detail-cta-events-lib.test.ts` — 10 passed
- `pnpm type-check` — pass
- `pnpm build` — pass
- `npx prettier --write` on touched files

Made with [Cursor](https://cursor.com)