### PR TITLE
refactor(web): extract newsletter webhook helpers into a lib

### DIFF
--- a/apps/web/src/lib/newsletter-webhook-lib.ts
+++ b/apps/web/src/lib/newsletter-webhook-lib.ts
@@ -1,0 +1,44 @@
+// Pure helpers for the newsletter (Resend) webhook route: decide whether an
+// event is notify-worthy and render its Discord message. Split out of the route
+// so the event-type routing can be unit-tested without the handler.
+
+export type ResendEvent = {
+  type?: string;
+  data?: Record<string, unknown>;
+};
+
+/** Best-effort subscriber email from a Resend event payload. */
+export function getEventEmail(data?: Record<string, unknown>): string {
+  const value = data?.email;
+  return typeof value === "string" ? value : "unknown";
+}
+
+/** True for contact.* events and delivered/bounced email events. */
+export function shouldNotify(event: ResendEvent): boolean {
+  const type = String(event.type ?? "");
+  return type.startsWith("contact.") || type === "email.delivered" || type === "email.bounced";
+}
+
+/** Human-readable Discord message for a Resend event. */
+export function toDiscordContent(event: ResendEvent): string {
+  const type = String(event.type ?? "unknown");
+  const email = getEventEmail(event.data);
+
+  if (type === "contact.created") {
+    return `Newsletter subscriber added: \`${email}\``;
+  }
+  if (type === "contact.updated") {
+    const unsubscribed = Boolean(event.data?.unsubscribed);
+    return unsubscribed
+      ? `Newsletter unsubscribe: \`${email}\``
+      : `Newsletter subscriber updated: \`${email}\``;
+  }
+  if (type === "email.bounced") {
+    return `Newsletter delivery bounced: \`${email}\``;
+  }
+  if (type === "email.delivered") {
+    return `Newsletter delivered: \`${email}\``;
+  }
+
+  return `Resend event: \`${type}\` (\`${email}\`)`;
+}

--- a/apps/web/src/routes/api/newsletter/webhook.ts
+++ b/apps/web/src/routes/api/newsletter/webhook.ts
@@ -5,44 +5,12 @@ import { Webhook } from "svix";
 import { apiError, apiJson, createApiHandler } from "@/lib/api/router";
 import { logApiError, logApiInfo, logApiWarn, redactEmail } from "@/lib/api-logs";
 import { getEnvString } from "@/lib/cloudflare-env.server";
-
-type ResendEvent = {
-  type?: string;
-  data?: Record<string, unknown>;
-};
-
-function getEventEmail(data?: Record<string, unknown>) {
-  const value = data?.email;
-  return typeof value === "string" ? value : "unknown";
-}
-
-function shouldNotify(event: ResendEvent) {
-  const type = String(event.type ?? "");
-  return type.startsWith("contact.") || type === "email.delivered" || type === "email.bounced";
-}
-
-function toDiscordContent(event: ResendEvent) {
-  const type = String(event.type ?? "unknown");
-  const email = getEventEmail(event.data);
-
-  if (type === "contact.created") {
-    return `Newsletter subscriber added: \`${email}\``;
-  }
-  if (type === "contact.updated") {
-    const unsubscribed = Boolean(event.data?.unsubscribed);
-    return unsubscribed
-      ? `Newsletter unsubscribe: \`${email}\``
-      : `Newsletter subscriber updated: \`${email}\``;
-  }
-  if (type === "email.bounced") {
-    return `Newsletter delivery bounced: \`${email}\``;
-  }
-  if (type === "email.delivered") {
-    return `Newsletter delivered: \`${email}\``;
-  }
-
-  return `Resend event: \`${type}\` (\`${email}\`)`;
-}
+import {
+  getEventEmail,
+  shouldNotify,
+  toDiscordContent,
+  type ResendEvent,
+} from "@/lib/newsletter-webhook-lib";
 
 function verifyWebhookSignature(params: { rawBody: string; request: Request; secret: string }) {
   const { rawBody, request, secret } = params;

--- a/tests/newsletter-webhook-lib.test.ts
+++ b/tests/newsletter-webhook-lib.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getEventEmail,
+  shouldNotify,
+  toDiscordContent,
+} from "@/lib/newsletter-webhook-lib";
+
+describe("getEventEmail", () => {
+  it("returns the string email or 'unknown'", () => {
+    expect(getEventEmail({ email: "a@b.com" })).toBe("a@b.com");
+    expect(getEventEmail({ email: 123 })).toBe("unknown");
+    expect(getEventEmail(undefined)).toBe("unknown");
+  });
+});
+
+describe("shouldNotify", () => {
+  it("notifies for contact.* and delivered/bounced", () => {
+    expect(shouldNotify({ type: "contact.created" })).toBe(true);
+    expect(shouldNotify({ type: "email.delivered" })).toBe(true);
+    expect(shouldNotify({ type: "email.bounced" })).toBe(true);
+  });
+
+  it("ignores other event types", () => {
+    expect(shouldNotify({ type: "email.opened" })).toBe(false);
+    expect(shouldNotify({})).toBe(false);
+  });
+});
+
+describe("toDiscordContent", () => {
+  it("renders contact.created", () => {
+    expect(
+      toDiscordContent({ type: "contact.created", data: { email: "a@b.com" } }),
+    ).toContain("subscriber added: `a@b.com`");
+  });
+
+  it("distinguishes updated vs unsubscribed for contact.updated", () => {
+    expect(
+      toDiscordContent({ type: "contact.updated", data: { email: "a@b.com" } }),
+    ).toContain("subscriber updated");
+    expect(
+      toDiscordContent({
+        type: "contact.updated",
+        data: { email: "a@b.com", unsubscribed: true },
+      }),
+    ).toContain("unsubscribe");
+  });
+
+  it("renders bounced and delivered", () => {
+    expect(toDiscordContent({ type: "email.bounced" })).toContain("bounced");
+    expect(toDiscordContent({ type: "email.delivered" })).toContain(
+      "delivered",
+    );
+  });
+
+  it("falls back for unknown types", () => {
+    expect(toDiscordContent({ type: "email.opened" })).toContain(
+      "Resend event: `email.opened`",
+    );
+    expect(toDiscordContent({})).toContain("`unknown`");
+  });
+});


### PR DESCRIPTION
### What & why

The newsletter (Resend) webhook route defined `getEventEmail()`, `shouldNotify()`, and `toDiscordContent()` inline, so the event-type routing and Discord message rendering could not be unit-tested without the handler. This moves them plus the `ResendEvent` type into `apps/web/src/lib/newsletter-webhook-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/newsletter-webhook-lib.ts` — `ResendEvent`, `getEventEmail`, `shouldNotify`, `toDiscordContent`.
- `apps/web/src/routes/api/newsletter/webhook.ts` — import the helpers/type; drop the local copies.
- Add `tests/newsletter-webhook-lib.test.ts` — covers email extraction, the notify allowlist, and every `toDiscordContent` branch (created / updated / unsubscribed / bounced / delivered / fallback). Branch coverage 100% (19/19).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/newsletter-webhook-lib.test.ts` — 7 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the webhook notifies and renders identically.
