### PR TITLE
refactor(web): extract listing-leads CSV helpers into a lib

### DIFF
--- a/apps/web/src/lib/listing-leads-csv-lib.ts
+++ b/apps/web/src/lib/listing-leads-csv-lib.ts
@@ -1,0 +1,39 @@
+// Pure helpers for the admin listing-leads route: normalize the kind filter to
+// an allowlist and render lead rows to CSV. Split out of the route so both can
+// be unit-tested without the handler.
+
+import { csvEscape } from "@/lib/csv";
+
+const ALLOWED_KINDS = new Set(["job", "tool", "claim"]);
+
+const CSV_COLUMNS = [
+  "id",
+  "kind",
+  "status",
+  "tier_interest",
+  "contact_name",
+  "contact_email",
+  "company_name",
+  "listing_title",
+  "website_url",
+  "apply_url",
+  "message",
+  "created_at",
+  "updated_at",
+] as const;
+
+/** Normalize a lead-kind filter to an allow-listed value, or "" when unknown. */
+export function normalizeKind(value: string | null): string {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  return ALLOWED_KINDS.has(normalized) ? normalized : "";
+}
+
+/** Render listing-lead rows to CSV using the fixed column order. */
+export function leadsToCsv(rows: Record<string, unknown>[]): string {
+  return [
+    CSV_COLUMNS.join(","),
+    ...rows.map((row) => CSV_COLUMNS.map((column) => csvEscape(row[column])).join(",")),
+  ].join("\n");
+}

--- a/apps/web/src/routes/api/admin/listing-leads.ts
+++ b/apps/web/src/routes/api/admin/listing-leads.ts
@@ -15,40 +15,10 @@ import {
 } from "@/lib/api/router";
 import { isLeadsAdminAuthorized } from "@/lib/admin-auth";
 import { logApiError, logApiInfo, logApiWarn } from "@/lib/api-logs";
-import { csvEscape } from "@/lib/csv";
+import { leadsToCsv, normalizeKind } from "@/lib/listing-leads-csv-lib";
 import { getSiteDb } from "@/lib/db";
 
-const ALLOWED_KINDS = new Set(["job", "tool", "claim"]);
 const MAX_LIMIT = 100;
-const CSV_COLUMNS = [
-  "id",
-  "kind",
-  "status",
-  "tier_interest",
-  "contact_name",
-  "contact_email",
-  "company_name",
-  "listing_title",
-  "website_url",
-  "apply_url",
-  "message",
-  "created_at",
-  "updated_at",
-] as const;
-
-function normalizeKind(value: string | null) {
-  const normalized = String(value ?? "")
-    .trim()
-    .toLowerCase();
-  return ALLOWED_KINDS.has(normalized) ? normalized : "";
-}
-
-function leadsToCsv(rows: Record<string, unknown>[]) {
-  return [
-    CSV_COLUMNS.join(","),
-    ...rows.map((row) => CSV_COLUMNS.map((column) => csvEscape(row[column])).join(",")),
-  ].join("\n");
-}
 
 export const GET = createApiHandler(
   "adminListingLeads.list",

--- a/tests/listing-leads-csv-lib.test.ts
+++ b/tests/listing-leads-csv-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { leadsToCsv, normalizeKind } from "@/lib/listing-leads-csv-lib";
+
+describe("normalizeKind", () => {
+  it("accepts allow-listed kinds, case/space-insensitively", () => {
+    expect(normalizeKind("job")).toBe("job");
+    expect(normalizeKind("  Tool ")).toBe("tool");
+    expect(normalizeKind("CLAIM")).toBe("claim");
+  });
+
+  it("returns '' for unknown or missing kinds", () => {
+    expect(normalizeKind("sponsor")).toBe("");
+    expect(normalizeKind(null)).toBe("");
+  });
+});
+
+describe("leadsToCsv", () => {
+  it("emits the header row followed by column-ordered values", () => {
+    const csv = leadsToCsv([
+      { id: "1", kind: "job", contact_email: "a@b.com", message: "hi" },
+    ]);
+    const [header, row] = csv.split("\n");
+    expect(header.split(",")[0]).toBe("id");
+    expect(header).toContain("contact_email");
+    const cols = row.split(",");
+    expect(cols[0]).toBe("1");
+    expect(cols[1]).toBe("job");
+  });
+
+  it("escapes values containing commas and quotes", () => {
+    const csv = leadsToCsv([{ message: 'a,b "c"' }]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain('"a,b ""c"""');
+  });
+
+  it("renders only the header for no rows", () => {
+    const csv = leadsToCsv([]);
+    expect(csv.split("\n")).toHaveLength(1);
+    expect(csv.startsWith("id,kind,status")).toBe(true);
+  });
+});


### PR DESCRIPTION
### What & why

The admin listing-leads route defined `normalizeKind()` and `leadsToCsv()` (with their allowlist and column constants) inline, so the kind normalization and CSV rendering could not be unit-tested without the handler. This moves them into `apps/web/src/lib/listing-leads-csv-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/listing-leads-csv-lib.ts` — `normalizeKind` and `leadsToCsv` (with the private `ALLOWED_KINDS` and `CSV_COLUMNS` constants).
- `apps/web/src/routes/api/admin/listing-leads.ts` — import the helpers; drop the local copies and the now-unused `csvEscape` import.
- Add `tests/listing-leads-csv-lib.test.ts` — covers the kind allowlist (casing / spacing / unknown / null), CSV header + column ordering, quote/comma escaping, and header-only output for no rows. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/listing-leads-csv-lib.test.ts` — 5 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the route filters and exports identically.
