### PR TITLE
refactor(web): dedupe confirm route escapeHtml to reuse newsletter-emails

### DIFF
--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -6,7 +6,7 @@ import { BodyTooLargeError, readRequestTextWithinLimit } from "@/lib/api-securit
 import { getEnvString } from "@/lib/cloudflare-env.server";
 import { verifyConfirmToken } from "@/lib/newsletter-token.server";
 import { addNewsletterContact } from "@/routes/api/newsletter/subscribe";
-import { buildWelcomeEmail } from "@/lib/newsletter-emails";
+import { buildWelcomeEmail, escapeHtml } from "@/lib/newsletter-emails";
 import { sendResendEmail } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
@@ -41,14 +41,6 @@ function resultPage(opts: {
     status: opts.status ?? (opts.ok ? 200 : 400),
     headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
   });
-}
-
-function escapeHtml(value: string): string {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
 }
 
 const consumedConfirmTokens = new Map<string, number>();


### PR DESCRIPTION
### What & why

The newsletter confirm route defined a private `escapeHtml()` that is identical in behavior to the one already exported from `@/lib/newsletter-emails` (the route already imports that module for `buildWelcomeEmail`). This reuses the shared helper and drops the duplicate.

### Changes

- `apps/web/src/routes/api/public/newsletter/confirm.ts` — import `escapeHtml` from `@/lib/newsletter-emails`; remove the duplicate local function.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the shared helper escapes the same `&`, `<`, `>`, and `"` entities (it uses `replace(/…/g, …)` where the local copy used `replaceAll(…)` — equivalent output).
