### PR TITLE
refactor(web): extract webhook signature helpers into a lib

### DIFF
--- a/apps/web/src/lib/webhook-signature-lib.ts
+++ b/apps/web/src/lib/webhook-signature-lib.ts
@@ -1,0 +1,22 @@
+// Pure encoding/compare helpers for HMAC webhook signature verification, split
+// out of the github webhook route so hex encoding and the constant-time string
+// compare can be unit-tested.
+
+/** Lowercase hex encoding of a byte buffer. */
+export function toHex(buffer: ArrayBuffer): string {
+  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Length-checked, constant-time string equality. Returns false immediately for
+ * differing lengths; otherwise compares every character with no early exit so
+ * timing does not leak how many leading characters matched.
+ */
+export function timingSafeStringEqual(left: string, right: string): boolean {
+  if (left.length !== right.length) return false;
+  let diff = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
+  }
+  return diff === 0;
+}

--- a/apps/web/src/routes/api/public/github/webhook.ts
+++ b/apps/web/src/routes/api/public/github/webhook.ts
@@ -14,6 +14,7 @@ import { createApiFileRoute } from "@/lib/api/file-route";
 
 import { BodyTooLargeError, readRequestTextWithinLimit } from "@/lib/api-security";
 import { getEnvString } from "@/lib/cloudflare-env.server";
+import { timingSafeStringEqual, toHex } from "@/lib/webhook-signature-lib";
 
 const ALLOWED_REPO = "jsonbored/awesome-claude";
 const ALLOWED_BRANCH = "main";
@@ -38,19 +39,6 @@ interface PushFile {
   id?: string;
   timestamp?: string;
   message?: string;
-}
-
-function toHex(buffer: ArrayBuffer) {
-  return [...new Uint8Array(buffer)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-}
-
-function timingSafeStringEqual(left: string, right: string) {
-  if (left.length !== right.length) return false;
-  let diff = 0;
-  for (let index = 0; index < left.length; index += 1) {
-    diff |= left.charCodeAt(index) ^ right.charCodeAt(index);
-  }
-  return diff === 0;
 }
 
 async function verify(secret: string, signature: string | null, body: string): Promise<boolean> {

--- a/tests/webhook-signature-lib.test.ts
+++ b/tests/webhook-signature-lib.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { timingSafeStringEqual, toHex } from "@/lib/webhook-signature-lib";
+
+describe("toHex", () => {
+  it("lowercase-hex encodes a byte buffer with zero padding", () => {
+    const bytes = new Uint8Array([0, 15, 16, 255]);
+    expect(toHex(bytes.buffer)).toBe("000f10ff");
+  });
+
+  it("returns an empty string for an empty buffer", () => {
+    expect(toHex(new Uint8Array([]).buffer)).toBe("");
+  });
+});
+
+describe("timingSafeStringEqual", () => {
+  it("is true for equal strings", () => {
+    expect(timingSafeStringEqual("sha256=abc", "sha256=abc")).toBe(true);
+    expect(timingSafeStringEqual("", "")).toBe(true);
+  });
+
+  it("is false for differing lengths", () => {
+    expect(timingSafeStringEqual("abc", "abcd")).toBe(false);
+  });
+
+  it("is false for same-length but differing content", () => {
+    expect(timingSafeStringEqual("abc", "abd")).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

The github webhook route defined `toHex()` and `timingSafeStringEqual()` inline, so the hex encoding and constant-time comparison used for HMAC signature verification could not be unit-tested without the handler. This moves them into `apps/web/src/lib/webhook-signature-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/webhook-signature-lib.ts` — `toHex(buffer)` and `timingSafeStringEqual(a, b)`.
- `apps/web/src/routes/api/public/github/webhook.ts` — import the helpers; drop the local copies. `verify()` uses the imported versions.
- Add `tests/webhook-signature-lib.test.ts` — covers hex zero-padding and the empty buffer, and equal / length-mismatch / same-length-different comparisons. Branch coverage 100% (2/2).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/webhook-signature-lib.test.ts` — 5 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; signature verification is unchanged. The constant-time compare is preserved verbatim (length check first, then no-early-exit XOR accumulation).
