### PR TITLE
feat(web): add decision playbook compare CTAs

### DIFF
--- a/apps/web/src/components/entry-detail-decision-playbook.tsx
+++ b/apps/web/src/components/entry-detail-decision-playbook.tsx
@@ -1,9 +1,12 @@
 import { AlertTriangle, CheckCircle2, Circle, GitCompare, ShieldAlert } from "lucide-react";
+import { Link } from "@tanstack/react-router";
 import type {
   DecisionChecklistItem,
   DecisionChecklistTone,
+  DecisionPlaybookAction,
   EntryDetailDecisionPlaybookState,
 } from "@/lib/entry-detail-decision-playbook";
+import { entryDetailDecisionPlaybookActions } from "@/lib/entry-detail-decision-playbook";
 import { compareScoreLabel } from "@/lib/compare-score-label-lib";
 import { cn } from "@/lib/utils";
 
@@ -83,13 +86,95 @@ function SectionCard({
   );
 }
 
+function PlaybookActionButton({
+  action,
+  onToggleCompare,
+  onOpenCompareTray,
+  onAction,
+}: {
+  action: DecisionPlaybookAction;
+  onToggleCompare: () => void;
+  onOpenCompareTray: () => void;
+  onAction: (actionId: string) => void;
+}) {
+  const className = cn(
+    "inline-flex h-8 items-center rounded-md px-3 text-xs font-medium",
+    action.primary
+      ? "bg-ink text-background hover:bg-ink/90"
+      : "border border-border bg-background text-ink hover:bg-surface-2",
+    action.disabled && "cursor-not-allowed opacity-60",
+  );
+
+  if (action.kind === "open-full-compare" && action.compareIds) {
+    return (
+      <Link
+        to="/compare"
+        search={{ ids: action.compareIds }}
+        onClick={() => onAction(action.id)}
+        className={className}
+      >
+        {action.label}
+      </Link>
+    );
+  }
+
+  if (action.kind === "scroll" && action.scrollTargetId) {
+    return (
+      <button
+        type="button"
+        className={className}
+        onClick={() => {
+          onAction(action.id);
+          document.getElementById(action.scrollTargetId ?? "")?.scrollIntoView({
+            behavior: "smooth",
+            block: "start",
+          });
+        }}
+      >
+        {action.label}
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={className}
+      disabled={action.disabled}
+      title={action.hint ?? undefined}
+      onClick={() => {
+        if (action.disabled) return;
+        if (action.kind === "compare-toggle") onToggleCompare();
+        if (action.kind === "open-compare-tray") onOpenCompareTray();
+        onAction(action.id);
+      }}
+    >
+      {action.label}
+    </button>
+  );
+}
+
 export function EntryDetailDecisionPlaybook({
   state,
+  compareIds,
+  onToggleCompare,
+  onOpenCompareTray,
+  onAction,
   className,
 }: {
   state: EntryDetailDecisionPlaybookState;
+  compareIds: string;
+  onToggleCompare: () => void;
+  onOpenCompareTray: () => void;
+  onAction: (actionId: string) => void;
   className?: string;
 }) {
+  const actions = entryDetailDecisionPlaybookActions(
+    state.compare,
+    compareIds,
+    state.showEscalationCallout,
+  );
+
   return (
     <section
       id="decision-playbook"
@@ -144,6 +229,17 @@ export function EntryDetailDecisionPlaybook({
             No major trust-signal divergence detected in the current selection.
           </p>
         )}
+        <div className="mt-3 flex flex-wrap gap-2">
+          {actions.map((action) => (
+            <PlaybookActionButton
+              key={action.id}
+              action={action}
+              onToggleCompare={onToggleCompare}
+              onOpenCompareTray={onOpenCompareTray}
+              onAction={onAction}
+            />
+          ))}
+        </div>
       </div>
 
       <div className="mt-4 grid gap-3 lg:grid-cols-2">

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -11,6 +11,7 @@ import type { Entry } from "@/types/registry";
 
 export const ENTRY_DETAIL_COMMAND_CENTER_SURFACE = "detail-command-center";
 export const ENTRY_DETAIL_COMPARE_SURFACE = "detail-compare";
+export const ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE = "detail-decision-playbook";
 export const ENTRY_DETAIL_MOBILE_SURFACE = "detail-mobile";
 export const BROWSE_COMPARE_SURFACE = "browse-compare";
 export const COMPARE_TRAY_SURFACE = "compare-tray";
@@ -124,5 +125,23 @@ export function entryDetailMobileLlmsAnalyticsData(category: string, slug: strin
     entry: entryDetailEntryKey(category, slug),
     link: "llms",
     surface: ENTRY_DETAIL_MOBILE_SURFACE,
+  };
+}
+
+export function entryDetailPlaybookActionAnalyticsEvent(actionId: string): string {
+  return `detail_playbook_${actionId.replace(/-/g, "_")}`;
+}
+
+export function entryDetailPlaybookActionAnalyticsData(
+  category: string,
+  slug: string,
+  actionId: string,
+  compareCount: number,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    action: actionId,
+    surface: ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+    compareCount,
   };
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -6,6 +6,7 @@ export {
   COMPARE_TRAY_SURFACE,
   ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
   ENTRY_DETAIL_COMPARE_SURFACE,
+  ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   ENTRY_DETAIL_MOBILE_SURFACE,
   browseCompareOpenAnalyticsData,
   comparisonTrayFullCompareAnalyticsData,
@@ -25,4 +26,6 @@ export {
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
   entryDetailMobileLlmsAnalyticsData,
+  entryDetailPlaybookActionAnalyticsData,
+  entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-decision-playbook-lib.ts
+++ b/apps/web/src/lib/entry-detail-decision-playbook-lib.ts
@@ -7,6 +7,8 @@
 
 import type { Entry, TrustLevel } from "@/types/registry";
 import { sameEntry } from "@/lib/entry-identity";
+import { ENTRY_COMMAND_CENTER_ID } from "@/lib/entry-detail-command-center-lib";
+import { entryDetailCompareCtaState } from "@/lib/entry-detail-compare-ui-lib";
 
 export type DecisionChecklistTone = "complete" | "warning" | "critical";
 
@@ -43,6 +45,23 @@ export type EntryDetailDecisionPlaybookState = {
   sections: DecisionPlaybookSection[];
   showEscalationCallout: boolean;
   escalationText: string | null;
+};
+
+export type DecisionPlaybookActionKind =
+  | "compare-toggle"
+  | "open-compare-tray"
+  | "open-full-compare"
+  | "scroll";
+
+export type DecisionPlaybookAction = {
+  id: string;
+  label: string;
+  kind: DecisionPlaybookActionKind;
+  disabled?: boolean;
+  hint?: string | null;
+  primary?: boolean;
+  scrollTargetId?: string;
+  compareIds?: string;
 };
 
 const TRUST_RANK: Record<TrustLevel, number> = {
@@ -361,4 +380,70 @@ export function entryDetailDecisionPlaybookState(
     showEscalationCallout: Boolean(escalation),
     escalationText: escalation,
   };
+}
+
+export function entryDetailDecisionPlaybookActions(
+  compare: DecisionCompareContext,
+  compareIds: string,
+  showEscalationCallout: boolean,
+): DecisionPlaybookAction[] {
+  const cta = entryDetailCompareCtaState(compare.inCompareTray, compare.selectedCount);
+  const actions: DecisionPlaybookAction[] = [];
+  const hasMultiCompare = compare.selectedCount >= 2;
+  const hasDivergence = compare.divergingSignals.length > 0;
+
+  if (showEscalationCallout) {
+    actions.push({
+      id: "review-install-trust",
+      label: "Review install & trust",
+      kind: "scroll",
+      scrollTargetId: ENTRY_COMMAND_CENTER_ID,
+      primary: true,
+    });
+  } else if (hasMultiCompare && hasDivergence) {
+    actions.push({
+      id: "open-full-compare",
+      label: "Open full compare",
+      kind: "open-full-compare",
+      compareIds,
+      primary: true,
+    });
+  } else if (!compare.inCompareTray && !cta.disabled) {
+    actions.push({
+      id: "compare-toggle",
+      label: cta.label,
+      kind: "compare-toggle",
+      primary: true,
+    });
+  }
+
+  if (hasMultiCompare) {
+    actions.push({
+      id: "open-compare-tray",
+      label: "Open compare tray",
+      kind: "open-compare-tray",
+      primary: !showEscalationCallout && !(hasMultiCompare && hasDivergence),
+    });
+    if (!actions.some((action) => action.id === "open-full-compare")) {
+      actions.push({
+        id: "open-full-compare",
+        label: "Open full compare",
+        kind: "open-full-compare",
+        compareIds,
+      });
+    }
+  }
+
+  if (!actions.some((action) => action.id === "compare-toggle")) {
+    actions.push({
+      id: "compare-toggle",
+      label: cta.label,
+      kind: "compare-toggle",
+      disabled: cta.disabled,
+      hint: cta.hint,
+      primary: compare.inCompareTray && !hasMultiCompare && !showEscalationCallout,
+    });
+  }
+
+  return actions;
 }

--- a/apps/web/src/lib/entry-detail-decision-playbook.ts
+++ b/apps/web/src/lib/entry-detail-decision-playbook.ts
@@ -6,11 +6,14 @@ export type {
   DecisionChecklistItem,
   DecisionChecklistTone,
   DecisionCompareContext,
+  DecisionPlaybookAction,
+  DecisionPlaybookActionKind,
   DecisionPlaybookSection,
   EntryDetailDecisionPlaybookState,
 } from "@/lib/entry-detail-decision-playbook-lib";
 export {
   entryDecisionCompareContext,
   entryDecisionTrustScore,
+  entryDetailDecisionPlaybookActions,
   entryDetailDecisionPlaybookState,
 } from "@/lib/entry-detail-decision-playbook-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -74,12 +74,15 @@ import { useEffect, useMemo, useState, useCallback } from "react";
 import { toast } from "sonner";
 import { useRecents } from "@/lib/recents";
 import { useCompare, useIsCompared } from "@/lib/compare";
+import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent } from "@/lib/analytics";
 import {
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
+  entryDetailPlaybookActionAnalyticsData,
+  entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
@@ -357,6 +360,42 @@ function Dossier() {
     });
   }, [compare, entry.category, entry.slug]);
 
+  const compareIds = useMemo(() => serializeCompareItems(compare.items), [compare.items]);
+  const onPlaybookAction = useCallback(
+    (actionId: string) => {
+      trackEvent(entryDetailPlaybookActionAnalyticsEvent(actionId), {
+        ...entryDetailPlaybookActionAnalyticsData(
+          entry.category,
+          entry.slug,
+          actionId,
+          compare.items.length,
+        ),
+      });
+    },
+    [compare.items.length, entry.category, entry.slug],
+  );
+  const onPlaybookToggleCompare = useCallback(() => {
+    const wasIn = inCompare;
+    const changed = compare.toggle(entry);
+    if (!changed) {
+      toast.error(resourceCardCompareFullMessage());
+      return;
+    }
+    if (wasIn) {
+      toast(`Removed “${entry.title}” from compare`);
+    } else {
+      toast.success("Added to compare", {
+        action: {
+          label: "View",
+          onClick: () => compare.setOpen(true),
+        },
+      });
+    }
+  }, [compare, entry, inCompare]);
+  const onPlaybookOpenCompareTray = useCallback(() => {
+    compare.setOpen(true);
+  }, [compare]);
+
   const risk = installRiskLevel(entry);
   const hasSchema = hasSchemaDetails(entry);
 
@@ -555,7 +594,13 @@ function Dossier() {
             </p>
             <CitationFacts entry={entry} />
           </DossierSection>
-          <EntryDetailDecisionPlaybook state={decisionPlaybook} />
+          <EntryDetailDecisionPlaybook
+            state={decisionPlaybook}
+            compareIds={compareIds}
+            onToggleCompare={onPlaybookToggleCompare}
+            onOpenCompareTray={onPlaybookOpenCompareTray}
+            onAction={onPlaybookAction}
+          />
           <EntryAdoptionPlanPanel
             state={adoptionPlan}
             selectedPreset={adoptionPreset}

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -17,6 +17,8 @@ import {
   entryDetailMobileCopyIntentType,
   entryDetailMobileLinkIntentType,
   entryDetailMobileLlmsAnalyticsData,
+  entryDetailPlaybookActionAnalyticsData,
+  entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events-lib";
 
 describe("entry detail cta events lib", () => {
@@ -105,6 +107,25 @@ describe("entry detail cta events lib", () => {
       entry: "skills/demo",
       link: "llms",
       surface: "detail-mobile",
+    });
+  });
+
+  it("builds decision playbook action analytics on a dedicated surface", () => {
+    expect(entryDetailPlaybookActionAnalyticsEvent("open-full-compare")).toBe(
+      "detail_playbook_open_full_compare",
+    );
+    expect(
+      entryDetailPlaybookActionAnalyticsData(
+        "skills",
+        "demo",
+        "compare-toggle",
+        2,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      action: "compare-toggle",
+      surface: "detail-decision-playbook",
+      compareCount: 2,
     });
   });
 });

--- a/tests/entry-detail-decision-playbook-lib.test.ts
+++ b/tests/entry-detail-decision-playbook-lib.test.ts
@@ -3,8 +3,10 @@ import type { Entry } from "@/types/registry";
 import {
   entryDecisionCompareContext,
   entryDecisionTrustScore,
+  entryDetailDecisionPlaybookActions,
   entryDetailDecisionPlaybookState,
 } from "@/lib/entry-detail-decision-playbook-lib";
+import { ENTRY_DETAIL_COMPARE_MAX } from "@/lib/entry-detail-compare-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -210,5 +212,92 @@ describe("entry detail decision playbook lib", () => {
       [],
     );
     expect(state.heading).toContain("Ready to evaluate");
+  });
+
+  it("returns add-to-compare as primary when tray is empty", () => {
+    const actions = entryDetailDecisionPlaybookActions(
+      entryDecisionCompareContext(entry(), []),
+      "",
+      false,
+    );
+    expect(actions[0]).toMatchObject({
+      id: "compare-toggle",
+      label: "Add to compare",
+      primary: true,
+    });
+  });
+
+  it("blocks add-to-compare when the tray is full", () => {
+    const fullTray = Array.from(
+      { length: ENTRY_DETAIL_COMPARE_MAX },
+      (_, index) => entry({ slug: `peer-${index}` }),
+    );
+    const actions = entryDetailDecisionPlaybookActions(
+      entryDecisionCompareContext(entry(), fullTray),
+      "tools/peer-0,tools/peer-1,tools/peer-2,tools/peer-3",
+      false,
+    );
+    expect(
+      actions.find((action) => action.id === "compare-toggle"),
+    ).toMatchObject({
+      disabled: true,
+      hint: expect.stringContaining("Compare is full"),
+    });
+  });
+
+  it("surfaces tray and full compare actions when multiple entries are selected", () => {
+    const current = entry();
+    const peer = entry({ slug: "peer", title: "Peer" });
+    const compare = entryDecisionCompareContext(current, [current, peer]);
+    const actions = entryDetailDecisionPlaybookActions(
+      compare,
+      "tools/fixture,tools/peer",
+      false,
+    );
+    expect(actions.map((action) => action.id)).toEqual([
+      "open-compare-tray",
+      "open-full-compare",
+      "compare-toggle",
+    ]);
+    expect(actions[0]).toMatchObject({ primary: true });
+  });
+
+  it("prioritizes full compare when trust signals diverge", () => {
+    const current = entry({ source: "unverified" });
+    const peer = entry({
+      slug: "peer",
+      title: "Peer",
+      trust: "trusted",
+      reviewed: true,
+      source: "source-backed",
+      safetyNotes: "yes",
+      privacyNotes: "yes",
+      packageVerified: true,
+      claimed: true,
+    });
+    const compare = entryDecisionCompareContext(current, [current, peer]);
+    const actions = entryDetailDecisionPlaybookActions(
+      compare,
+      "tools/fixture,tools/peer",
+      false,
+    );
+    expect(actions[0]).toMatchObject({
+      id: "open-full-compare",
+      primary: true,
+    });
+  });
+
+  it("surfaces install review scroll action when escalation is required", () => {
+    const blocked = entry({ trust: "blocked", source: "unverified" });
+    const actions = entryDetailDecisionPlaybookActions(
+      entryDecisionCompareContext(blocked, []),
+      "",
+      true,
+    );
+    expect(actions[0]).toMatchObject({
+      id: "review-install-trust",
+      kind: "scroll",
+      primary: true,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds contextual next-step actions to the entry detail decision playbook compare block.
- Supports add/remove compare, open compare tray, open full compare, and scroll-to-command-center on escalation.
- Introduces playbook-specific analytics on the detail-decision-playbook surface.

Closes #556

## Validation
- `pnpm test tests/entry-detail-decision-playbook-lib.test.ts tests/entry-detail-cta-events-lib.test.ts` — 26 passed
- `pnpm type-check` — pass
- `pnpm build` — pass
- `npx prettier --write` on touched files

Made with [Cursor](https://cursor.com)