### PR TITLE
feat(web): compose best compare bannerTexts through page delegate

### DIFF
--- a/apps/web/src/lib/compare-best-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-ui-lib.ts
@@ -31,7 +31,7 @@ export type CompareBestUiState = {
 export function compareBestUiState(entries: Entry[]): CompareBestUiState {
   return {
     showCompareSection: compareBestShowCompareSection(entries),
-    bannerTexts: compareBestBannerTexts(entries),
+    bannerTexts: compareBestHeaderBannerTexts(entries),
     interactiveSearch: compareInteractiveSearch(entries),
     interactiveLinkLabel: compareInteractiveLinkLabel(entries.length),
   };

--- a/tests/compare-best-ui-lib.test.ts
+++ b/tests/compare-best-ui-lib.test.ts
@@ -102,6 +102,7 @@ describe("compare best ui lib", () => {
     expect(bundled.showCompareSection).toBe(
       compareBestShowCompareSection(entries),
     );
+    expect(bundled.bannerTexts).toEqual(compareBestHeaderBannerTexts(entries));
     expect(
       compareBestUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Compose `bannerTexts` in `compareBestUiState` via `compareBestHeaderBannerTexts` instead of calling `compareBestBannerTexts` directly
- Assert bundled `bannerTexts` matches the delegate in tests (100% lib coverage)

## Conflict safety
- Touches only `compare-best-ui-lib.ts` and its test file
- Verified clean merge with open PRs #4700–#4707 via `git merge-tree`

## Test plan
- [x] `pnpm exec vitest run tests/compare-best-ui-lib.test.ts`
- [x] 100% coverage on `compare-best-ui-lib.ts`

Part of #556 compare surface bundling.

Made with [Cursor](https://cursor.com)