### PR TITLE
fix(web): heal directory-index cache after a transient load failure

### DIFF
--- a/apps/web/src/lib/content-query-lib.ts
+++ b/apps/web/src/lib/content-query-lib.ts
@@ -2,6 +2,29 @@ import type { CategorySummary, DirectoryEntry } from "@heyclaude/registry";
 
 export const MAX_ENTRY_DETAIL_CACHE_SIZE = 512;
 
+/**
+ * Single-flight memoization for an async loader that heals after failure.
+ *
+ * The returned function caches the in-flight/resolved promise so concurrent
+ * callers share one load, but drops the cached promise if it rejects so the
+ * next caller retries a fresh load. Without this, a plain `promise ??= load()`
+ * singleton keeps returning the same *rejected* promise forever (a rejected
+ * promise is non-nullish, so `??=` never reassigns it), turning a single
+ * transient load failure into a permanent outage for the process lifetime.
+ * Mirrors the self-healing, delete-on-reject behavior of the per-key
+ * entry-detail cache in `content.server.ts`.
+ */
+export function createResettablePromiseCache<T>(load: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | null = null;
+  return () => {
+    promise ??= load().catch((error: unknown) => {
+      promise = null;
+      throw error;
+    });
+    return promise;
+  };
+}
+
 export function entryDetailCacheKey(category: string, slug: string) {
   return `${category}:${slug}`;
 }

--- a/apps/web/src/lib/content.server.ts
+++ b/apps/web/src/lib/content.server.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/content-artifact-lib";
 import {
   buildCategorySummaries,
+  createResettablePromiseCache,
   entryDetailCacheKey,
   MAX_ENTRY_DETAIL_CACHE_SIZE,
   pruneEntryDetailCache,
@@ -47,7 +48,6 @@ export {
   normalizeRegistryEntries,
 } from "@/lib/content-artifact-lib";
 
-let directoryIndexPromise: Promise<DirectoryEntry[]> | null = null;
 const entryDetailPromises = new Map<string, Promise<ContentEntry | null>>();
 
 type EntryDetailPayload = {
@@ -108,13 +108,19 @@ export async function loadTextDataFile(fileName: string): Promise<string> {
   }
 }
 
-const loadDirectoryIndex = cache(async (): Promise<DirectoryEntry[]> => {
-  directoryIndexPromise ??=
+// Persist the directory index across requests in a single-flight cache that
+// heals after a transient load failure (see createResettablePromiseCache); a
+// plain `??=` singleton would pin the first rejected promise forever and take
+// down every directory-backed surface for the isolate's lifetime. `cache()`
+// layers per-request deduplication on top.
+const loadDirectoryIndexOnce = createResettablePromiseCache(
+  (): Promise<DirectoryEntry[]> =>
     loadJsonDataFile<import("@heyclaude/registry").RegistryEnvelope<DirectoryEntry>>(
       "directory-index.json",
-    ).then(normalizeRegistryEntries);
-  return directoryIndexPromise;
-});
+    ).then(normalizeRegistryEntries),
+);
+
+const loadDirectoryIndex = cache(loadDirectoryIndexOnce);
 
 const loadSearchIndex = cache(async () => {
   return loadJsonDataFile<import("@heyclaude/registry").RegistryEnvelope<SearchDocument>>(

--- a/tests/content-query-lib.test.ts
+++ b/tests/content-query-lib.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   MAX_ENTRY_DETAIL_CACHE_SIZE,
   buildCategorySummaries,
+  createResettablePromiseCache,
   entryDetailCacheKey,
   pruneEntryDetailCache,
   sortRecentDirectoryEntries,
@@ -3234,5 +3235,57 @@ describe("content-query-lib sortRecentDirectoryEntries", () => {
     }));
     const sorted = sortRecentDirectoryEntries(entries, 8);
     expect(sorted.length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("content-query-lib createResettablePromiseCache", () => {
+  it("shares a single in-flight load across concurrent callers", async () => {
+    let calls = 0;
+    const load = createResettablePromiseCache(async () => {
+      calls += 1;
+      return calls;
+    });
+    const [a, b] = await Promise.all([load(), load()]);
+    expect(calls).toBe(1);
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+  });
+
+  it("memoizes the resolved value on subsequent calls", async () => {
+    let calls = 0;
+    const load = createResettablePromiseCache(async () => {
+      calls += 1;
+      return calls;
+    });
+    expect(await load()).toBe(1);
+    expect(await load()).toBe(1);
+    expect(calls).toBe(1);
+  });
+
+  it("retries after a rejection instead of pinning the rejected promise", async () => {
+    let calls = 0;
+    const load = createResettablePromiseCache(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("transient failure");
+      return "recovered";
+    });
+
+    await expect(load()).rejects.toThrow("transient failure");
+    // Without reset-on-reject the second call would resurface the same
+    // rejected promise; with it, the loader re-runs and heals.
+    expect(await load()).toBe("recovered");
+    expect(calls).toBe(2);
+  });
+
+  it("propagates the rejection to every concurrent caller of a failed load", async () => {
+    let calls = 0;
+    const load = createResettablePromiseCache(async () => {
+      calls += 1;
+      throw new Error("boom");
+    });
+    const results = await Promise.allSettled([load(), load()]);
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+    // One shared in-flight attempt for the two concurrent callers.
+    expect(calls).toBe(1);
   });
 });


### PR DESCRIPTION
## Problem

The directory index — the backbone of the home page, browse/category pages, the sitemap, and `GET /api/registry/feed` — is memoized in a module-level singleton in `apps/web/src/lib/content.server.ts`:

```ts
let directoryIndexPromise: Promise<DirectoryEntry[]> | null = null;

const loadDirectoryIndex = cache(async (): Promise<DirectoryEntry[]> => {
  directoryIndexPromise ??=
    loadJsonDataFile<...>("directory-index.json").then(normalizeRegistryEntries);
  return directoryIndexPromise;
});
```

The singleton is **never reset when the promise rejects**. Because a rejected promise is a non-nullish value, `??=` will not reassign it — so once `directoryIndexPromise` holds a rejected promise, *every* subsequent call returns that same rejected promise.

### Root cause / impact

`loadJsonDataFile` falls back to `ASSETS.fetch(...)` in the Cloudflare runtime. A single transient failure — a momentary ASSETS 5xx during a deploy rollover, a cold asset, or a briefly-malformed envelope that makes `normalizeRegistryEntries` throw — permanently poisons the cache. Unlike a normal per-request retry that would recover on the next request, the isolate keeps serving the rejected promise for its **entire lifetime**, taking down all directory-backed surfaces even after the asset is healthy again.

The sibling per-key entry-detail cache in the same file already does the right thing — it deletes the cache entry inside `.catch(...)` so a failed load can be retried. The directory index just missed that treatment.

## Fix

Extract a small, reusable `createResettablePromiseCache` helper (into the already-unit-tested `content-query-lib.ts`) that memoizes a single-flight load but **drops the cached promise on rejection**, so the next caller retries a fresh load:

```ts
export function createResettablePromiseCache<T>(load: () => Promise<T>): () => Promise<T> {
  let promise: Promise<T> | null = null;
  return () => {
    promise ??= load().catch((error: unknown) => {
      promise = null;
      throw error;
    });
    return promise;
  };
}
```

`content.server.ts` uses it for the directory index; per-request deduplication via React `cache()` is preserved by layering it on top. This mirrors the existing self-healing pattern rather than inventing a new one.

## Risk / tradeoffs

- Behaviorally identical on the happy path: one shared in-flight load, memoized result across requests.
- The only change is that a *rejected* load no longer sticks — exactly the desired healing behavior.
- No API, schema, or dependency changes. Backward compatible.

## Tests & validation

- Adds focused unit tests in `tests/content-query-lib.test.ts`: single-flight sharing, memoization, retry-after-rejection, and shared-rejection propagation.
- `pnpm exec vitest run tests/content-query-lib.test.ts` → all pass (incl. the 4 new cases).
- `pnpm type-check` → clean.
- `pnpm build` → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)