### PR TITLE
fix(web): cap blocked browse confidence

### DIFF
--- a/apps/web/src/lib/browse-decision-confidence-lib.ts
+++ b/apps/web/src/lib/browse-decision-confidence-lib.ts
@@ -115,7 +115,8 @@ function trustPenalty(entry: Entry): number {
   return 0;
 }
 
-function confidenceBand(score: number): BrowseConfidenceBand {
+function confidenceBand(score: number, entry: Entry): BrowseConfidenceBand {
+  if (entry.trust === "blocked") return "low";
   if (score >= 74) return "high";
   if (score >= 46) return "medium";
   return "low";
@@ -144,7 +145,8 @@ function scoreEntry(
   return Math.max(0, Math.min(100, points - trustPenalty(entry)));
 }
 
-function recommendationFor(score: number, missing: string[]): string {
+function recommendationFor(score: number, missing: string[], entry: Entry): string {
+  if (entry.trust === "blocked") return "Hold adoption until registry trust is restored.";
   if (score >= 74) return "Confident candidate for staged adoption.";
   if (score >= 46) {
     return missing.length > 0
@@ -184,7 +186,7 @@ export function browseDecisionConfidenceState(
         .filter((key) => !signalState[key])
         .map((key) => SIGNAL_LABELS[key]);
       const confidenceScore = scoreEntry(entry, preset, signalState);
-      const band = confidenceBand(confidenceScore);
+      const band = confidenceBand(confidenceScore, entry);
       return {
         entryRef: entryRef(entry),
         title: entry.title,
@@ -192,7 +194,7 @@ export function browseDecisionConfidenceState(
         confidenceScore,
         band,
         missingSignals,
-        recommendation: recommendationFor(confidenceScore, missingSignals),
+        recommendation: recommendationFor(confidenceScore, missingSignals, entry),
       } satisfies BrowseConfidenceEntry;
     })
     .sort((a, b) => b.confidenceScore - a.confidenceScore || a.title.localeCompare(b.title))

--- a/tests/browse-decision-confidence-lib.test.ts
+++ b/tests/browse-decision-confidence-lib.test.ts
@@ -87,6 +87,30 @@ describe("browse decision confidence lib", () => {
     ).toBe("low");
   });
 
+  it("prevents blocked entries from receiving high-confidence recommendations", () => {
+    const blocked = entry({
+      slug: "blocked",
+      title: "Blocked",
+      trust: "blocked",
+      source: "source-backed",
+      sourceUrl: "https://github.com/acme/blocked",
+      reviewed: true,
+      safetyNotes: "present",
+      privacyNotes: "present",
+      packageVerified: true,
+      downloadSha256: "abc",
+      installCommand: "npm i blocked",
+    });
+
+    const state = browseDecisionConfidenceState([blocked], "strict");
+
+    expect(state.entries[0].confidenceScore).toBe(76);
+    expect(state.entries[0].band).toBe("low");
+    expect(state.entries[0].recommendation).toContain("Hold adoption");
+    expect(state.highCount).toBe(0);
+    expect(state.lowRefs).toContain("tools/blocked");
+  });
+
   it("tracks band counters", () => {
     const state = browseDecisionConfidenceState([strong, weak], "balanced");
     expect(state.highCount).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
### Motivation
- The browse decision confidence logic could classify `trust: "blocked"` entries as high-confidence because trust was only applied as a small numeric penalty, which could mislead users about unsafe registry resources.
- Blocked entries must never be promoted as high-confidence or receive adoption-positive recommendations regardless of other signal weights.

### Description
- Cap blocked entries to the `low` band by passing the `entry` into `confidenceBand` and returning `low` when `entry.trust === "blocked"` in `apps/web/src/lib/browse-decision-confidence-lib.ts`.
- Override recommendations for blocked entries by passing `entry` into `recommendationFor` and returning an explicit hold message for blocked trust cases.
- Wire the `entry` context through row generation so band and recommendation derive from both numeric score and trust state.
- Add a regression test in `tests/browse-decision-confidence-lib.test.ts` that demonstrates a fully-signaled blocked entry still scores `76` under the `strict` preset but is rendered as `low` with a hold recommendation and does not increment `highCount`.

### Testing
- Ran Prettier formatting check with `pnpm exec prettier --check apps/web/src/lib/browse-decision-confidence-lib.ts tests/browse-decision-confidence-lib.test.ts` which passed. 
- Ran unit tests with `pnpm exec vitest run tests/browse-decision-confidence-lib.test.ts` and all tests passed. 
- Verified `git diff --check` reporting no whitespace issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f23d56cb0832c8b2e9135a8025460)