### PR TITLE
refactor(web): extract pure filterCommandActions into command-bar-actions-lib

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -21,6 +21,7 @@ import { CategoryPill, Kbd, TrustBadge } from "./badges";
 import { useTheme } from "@/lib/theme";
 import { useShortcuts } from "./shortcuts-dialog";
 import { cn } from "@/lib/utils";
+import { filterCommandActions } from "@/lib/command-bar-actions-lib";
 import { trackEvent } from "@/lib/analytics";
 
 const EXAMPLES = [
@@ -66,9 +67,9 @@ export function CommandBar({
 
   // Lazy-load the in-memory search index (and the registry dataset it pulls in) only when the
   // bar is opened or typed into, so the ~1 MB dataset stays out of the universal client bundle.
-  const [searchFn, setSearchFn] = React.useState<
-    (typeof import("@/data/search"))["search"] | null
-  >(null);
+  const [searchFn, setSearchFn] = React.useState<(typeof import("@/data/search"))["search"] | null>(
+    null,
+  );
   React.useEffect(() => {
     if ((!open && !q) || searchFn) return;
     let cancelled = false;
@@ -169,9 +170,7 @@ export function CommandBar({
         run: () => shortcuts?.open(),
       },
     ];
-    if (!q.trim()) return all;
-    const needle = q.toLowerCase();
-    return all.filter((a) => a.label.toLowerCase().includes(needle)).slice(0, 4);
+    return filterCommandActions(all, q);
   }, [q, navigate, toggleTheme, shortcuts]);
 
   // Build a flat option list (results first, then actions) for keyboard nav.

--- a/apps/web/src/lib/command-bar-actions-lib.ts
+++ b/apps/web/src/lib/command-bar-actions-lib.ts
@@ -1,0 +1,17 @@
+// Pure query-filtering for the command bar's action list, split out of
+// command-bar.tsx so the match and cap rules can be unit-tested without React.
+
+/** How many matching actions the command bar shows for a non-empty query. */
+export const MAX_MATCHED_ACTIONS = 4;
+
+/**
+ * Filter the command bar's actions for a query. A blank (or whitespace-only)
+ * query returns every action unchanged; otherwise actions are matched by
+ * case-insensitive substring on their `label` and capped at
+ * {@link MAX_MATCHED_ACTIONS}.
+ */
+export function filterCommandActions<T extends { label: string }>(all: T[], q: string): T[] {
+  if (!q.trim()) return all;
+  const needle = q.toLowerCase();
+  return all.filter((a) => a.label.toLowerCase().includes(needle)).slice(0, MAX_MATCHED_ACTIONS);
+}

--- a/tests/command-bar-actions-lib.test.ts
+++ b/tests/command-bar-actions-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_MATCHED_ACTIONS,
+  filterCommandActions,
+} from "../apps/web/src/lib/command-bar-actions-lib";
+
+const actions = [
+  { id: "a", label: "Browse all resources" },
+  { id: "b", label: "Trending this week" },
+  { id: "c", label: "Ecosystem & integrations" },
+  { id: "d", label: "Registry quality" },
+  { id: "e", label: "Best of HeyClaude" },
+  { id: "f", label: "Submit a resource" },
+];
+
+describe("filterCommandActions", () => {
+  it("returns every action unchanged for a blank query", () => {
+    expect(filterCommandActions(actions, "")).toBe(actions);
+  });
+
+  it("treats a whitespace-only query as blank", () => {
+    expect(filterCommandActions(actions, "   ")).toBe(actions);
+  });
+
+  it("matches labels case-insensitively", () => {
+    expect(filterCommandActions(actions, "TRENDING").map((a) => a.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("matches on substrings, not just prefixes", () => {
+    expect(filterCommandActions(actions, "quality").map((a) => a.id)).toEqual([
+      "d",
+    ]);
+  });
+
+  it("caps matches at MAX_MATCHED_ACTIONS", () => {
+    // "e" appears in every label above, so every action matches.
+    const matched = filterCommandActions(actions, "e");
+    expect(matched).toHaveLength(MAX_MATCHED_ACTIONS);
+    expect(matched.map((a) => a.id)).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(filterCommandActions(actions, "zzzz")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Moves the command bar's action query-filtering out of `command-bar.tsx` into a pure module `apps/web/src/lib/command-bar-actions-lib.ts`:

- `filterCommandActions(all, q)` — a blank (or whitespace-only) query returns every action unchanged; otherwise actions are matched by case-insensitive substring on their `label` and capped at `MAX_MATCHED_ACTIONS` (4).

The helper is generic over `{ label: string }`, so the lib stays decoupled from the component's local `ActionItem` type. **No behavior change** — this makes the match and cap rules unit-testable without React, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/command-bar-actions-lib.test.ts`: blank and whitespace-only queries return the input array, case-insensitive matching, substring (not prefix) matching, the 4-item cap, and the no-match empty case (6 cases).

```
pnpm exec vitest run tests/command-bar-actions-lib.test.ts   # 6 passed
pnpm exec prettier --check <changed files>                   # clean
```

Refs #556