### PR TITLE
refactor(web): extract pure groupAlertsByBucket into alerts-group-lib

### DIFF
--- a/apps/web/src/components/alerts-dropdown.tsx
+++ b/apps/web/src/components/alerts-dropdown.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 import { Bell, CheckCheck, AlertTriangle, Info, OctagonX } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useWatch, type Alert } from "@/lib/watch";
-import { alertBucket } from "@/lib/alerts-bucket-lib";
+import { useWatch } from "@/lib/watch";
+import { groupAlertsByBucket } from "@/lib/alerts-group-lib";
 import { cn } from "@/lib/utils";
 
 const SEV_ICON = {
@@ -15,12 +15,10 @@ const SEV_ICON = {
 export function AlertsDropdown() {
   const { alerts, unreadCount, lastSeenAt, markAllRead, targets, savedSearchAlertCount } =
     useWatch();
-  const grouped = React.useMemo(() => {
-    const out: Record<string, Alert[]> = { Today: [], "This week": [], Earlier: [] };
-    const now = Date.now();
-    for (const a of alerts) out[alertBucket(a.date, now)].push(a);
-    return out;
-  }, [alerts, lastSeenAt]);
+  const grouped = React.useMemo(
+    () => groupAlertsByBucket(alerts, Date.now()),
+    [alerts, lastSeenAt],
+  );
 
   return (
     <Popover>

--- a/apps/web/src/lib/alerts-group-lib.ts
+++ b/apps/web/src/lib/alerts-group-lib.ts
@@ -1,0 +1,23 @@
+// Pure recency-grouping for the alerts dropdown, split out of
+// alerts-dropdown.tsx so the bucketing can be unit-tested with an injected
+// `now` (no reliance on the real clock).
+
+import { type AlertBucket, alertBucket } from "@/lib/alerts-bucket-lib";
+
+/** Alerts keyed by recency bucket, in display order. */
+export type GroupedAlerts<T> = Record<AlertBucket, T[]>;
+
+/**
+ * Group alerts into "Today" / "This week" / "Earlier" by their ISO `date`
+ * relative to `now` (epoch ms), using {@link alertBucket}. Every bucket is
+ * always present — empty when it has no alerts — and the input order is
+ * preserved within each bucket.
+ */
+export function groupAlertsByBucket<T extends { date: string }>(
+  alerts: readonly T[],
+  now: number,
+): GroupedAlerts<T> {
+  const out: GroupedAlerts<T> = { Today: [], "This week": [], Earlier: [] };
+  for (const a of alerts) out[alertBucket(a.date, now)].push(a);
+  return out;
+}

--- a/tests/alerts-group-lib.test.ts
+++ b/tests/alerts-group-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { groupAlertsByBucket } from "../apps/web/src/lib/alerts-group-lib";
+
+const DAY_MS = 86_400_000;
+const NOW = Date.parse("2026-07-08T12:00:00.000Z");
+
+const at = (id: string, msAgo: number) => ({
+  id,
+  date: new Date(NOW - msAgo).toISOString(),
+});
+
+describe("groupAlertsByBucket", () => {
+  it("always returns all three buckets, empty for no alerts", () => {
+    expect(groupAlertsByBucket([], NOW)).toEqual({
+      Today: [],
+      "This week": [],
+      Earlier: [],
+    });
+  });
+
+  it("routes alerts into Today, This week, and Earlier by age", () => {
+    const grouped = groupAlertsByBucket(
+      [at("today", 1000), at("week", 3 * DAY_MS), at("old", 30 * DAY_MS)],
+      NOW,
+    );
+    expect(grouped.Today.map((a) => a.id)).toEqual(["today"]);
+    expect(grouped["This week"].map((a) => a.id)).toEqual(["week"]);
+    expect(grouped.Earlier.map((a) => a.id)).toEqual(["old"]);
+  });
+
+  it("preserves input order within a bucket", () => {
+    const grouped = groupAlertsByBucket(
+      [at("a", 1000), at("b", 2000), at("c", 3000)],
+      NOW,
+    );
+    expect(grouped.Today.map((a) => a.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("puts unparseable dates in Earlier", () => {
+    const grouped = groupAlertsByBucket(
+      [{ id: "bad", date: "not-a-date" }],
+      NOW,
+    );
+    expect(grouped.Earlier.map((a) => a.id)).toEqual(["bad"]);
+    expect(grouped.Today).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Moves the alerts dropdown's recency grouping out of `alerts-dropdown.tsx` into a pure module `apps/web/src/lib/alerts-group-lib.ts`:

- `groupAlertsByBucket(alerts, now)` — buckets alerts into `Today` / `This week` / `Earlier` by their ISO `date`, reusing the existing `alertBucket` helper with an injected `now`. Every bucket is always present (empty when it has no alerts) and input order is preserved within each bucket.

The helper is generic over `{ date: string }`, so the lib stays decoupled from the `Alert` type in `lib/watch`. **No behavior change** — the component now calls `groupAlertsByBucket(alerts, Date.now())`, and the returned `Record<AlertBucket, T[]>` types the existing `Object.keys(grouped)` iteration more precisely than the previous `Record<string, Alert[]>`.

## Tests

`tests/alerts-group-lib.test.ts`: all three buckets always present (empty input), age-based routing across Today/This week/Earlier, input-order preservation within a bucket, and unparseable dates falling into `Earlier` (4 cases). `now` is injected, so no reliance on the real clock.

```
pnpm exec vitest run tests/alerts-group-lib.test.ts   # 4 passed
pnpm exec prettier --check <changed files>            # clean
```

Refs #556