### PR TITLE
refactor(web): extract registry diff query helpers into registry-diff-lib

### DIFF
--- a/apps/web/src/lib/registry-diff-lib.ts
+++ b/apps/web/src/lib/registry-diff-lib.ts
@@ -1,0 +1,14 @@
+// Pure query-parameter helpers for the registry diff API route, split out so the
+// since-date parsing and hash-shape guard can be unit-tested without the handler.
+
+/** Parse a `since` value to epoch ms, or null when absent/unparseable. */
+export function parseSinceDate(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** True when the value looks like a 32–128 char hex signature/hash. */
+export function looksLikeHash(value: string | null): boolean {
+  return Boolean(value && /^[a-f0-9]{32,128}$/i.test(value));
+}

--- a/apps/web/src/routes/api/registry/diff.ts
+++ b/apps/web/src/routes/api/registry/diff.ts
@@ -4,18 +4,9 @@ import { registryDiffQuerySchema } from "@/lib/api/contracts";
 import { createApiHandler, type InferApiQuery } from "@/lib/api/router";
 import { getRegistryChangelog } from "@/lib/content.server";
 import { cachedJsonResponse } from "@/lib/http-cache";
+import { looksLikeHash, parseSinceDate } from "@/lib/registry-diff-lib";
 
 type ChangelogEntry = Awaited<ReturnType<typeof getRegistryChangelog>>["entries"][number];
-
-function parseSinceDate(value: string | null) {
-  if (!value) return null;
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function looksLikeHash(value: string | null) {
-  return Boolean(value && /^[a-f0-9]{32,128}$/i.test(value));
-}
 
 export const GET = createApiHandler("registry.diff", async ({ request, query: parsedQuery }) => {
   const { since, limit } = parsedQuery as InferApiQuery<typeof registryDiffQuerySchema>;

--- a/tests/registry-diff-lib.test.ts
+++ b/tests/registry-diff-lib.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  looksLikeHash,
+  parseSinceDate,
+} from "../apps/web/src/lib/registry-diff-lib";
+
+describe("parseSinceDate", () => {
+  it("parses an ISO date to epoch ms", () => {
+    expect(parseSinceDate("2026-01-02T00:00:00Z")).toBe(
+      Date.parse("2026-01-02T00:00:00Z"),
+    );
+  });
+
+  it("returns null for absent or unparseable values", () => {
+    expect(parseSinceDate(null)).toBeNull();
+    expect(parseSinceDate("")).toBeNull();
+    expect(parseSinceDate("not-a-date")).toBeNull();
+  });
+});
+
+describe("looksLikeHash", () => {
+  it("accepts 32–128 char hex, case-insensitively", () => {
+    expect(looksLikeHash("a".repeat(32))).toBe(true);
+    expect(looksLikeHash("ABCDEF0123".padEnd(64, "0"))).toBe(true);
+  });
+
+  it("rejects too-short, too-long, non-hex, or empty values", () => {
+    expect(looksLikeHash("a".repeat(31))).toBe(false);
+    expect(looksLikeHash("a".repeat(129))).toBe(false);
+    expect(looksLikeHash("z".repeat(40))).toBe(false);
+    expect(looksLikeHash(null)).toBe(false);
+    expect(looksLikeHash("")).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

The registry diff route defined `parseSinceDate()` and `looksLikeHash()` inline, so the since-date parsing and hash-shape guard could not be unit-tested without the handler. This moves them into `apps/web/src/lib/registry-diff-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/registry-diff-lib.ts` — `parseSinceDate(value)` and `looksLikeHash(value)`.
- `apps/web/src/routes/api/registry/diff.ts` — import the helpers; drop the local copies.
- Add `tests/registry-diff-lib.test.ts` — covers ISO parsing, absent/unparseable dates, and hex length/charset boundaries. Branch coverage 100% (6/6).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/registry-diff-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the route parses and validates identically.
