### PR TITLE
refactor(web): move submit route URL guards into submit-url-safety-lib

### DIFF
--- a/apps/web/src/lib/submit-url-safety-lib.ts
+++ b/apps/web/src/lib/submit-url-safety-lib.ts
@@ -1,6 +1,7 @@
 // Pure same-origin URL guards for the submit flow, split out of the route so the
-// origin allowlisting can be unit-tested. Both never throw and collapse unsafe
-// or cross-origin input to "".
+// origin allowlisting can be unit-tested. None of these throw, and they collapse
+// unsafe or cross-origin input to "" (or, for a nextAction, to `undefined`).
+// The siteConfig-backed URLs are default parameters so tests can inject them.
 
 import { siteConfig } from "@/lib/site";
 
@@ -40,4 +41,47 @@ export function safeUrlForOrigins(
   } catch {
     return "";
   }
+}
+
+/**
+ * A submission-gate status URL, accepted only when it lives on the gate's own
+ * origin. Anything else — missing, cross-origin, or an unset/unparseable gate
+ * URL (which allows no origins at all) — becomes "".
+ */
+export function safeGateStatusUrl(
+  value: string | undefined,
+  gateUrl = siteConfig.submissionGateUrl,
+): string {
+  const gateOrigin = originFor(gateUrl);
+  return safeUrlForOrigins(value, new Set(gateOrigin ? [gateOrigin] : []));
+}
+
+/** The part of a preflight response whose `nextAction` URL must stay same-origin. */
+export type WithNextAction = {
+  nextAction?: {
+    label: string;
+    url?: string;
+  };
+};
+
+/**
+ * Clamp a preflight response's `nextAction.url` to `siteUrl`'s own origin. The
+ * payload is returned untouched when it carries no `nextAction.url` (or the
+ * site origin is unparseable); otherwise a cross-origin or unsafe URL is
+ * dropped to `undefined` and a same-origin one is normalized.
+ */
+export function sanitizeNextActionUrl<T extends WithNextAction>(
+  payload: T,
+  siteUrl = siteConfig.url,
+): T {
+  const siteOrigin = originFor(siteUrl);
+  if (!payload.nextAction?.url || !siteOrigin) return payload;
+  const safeNextUrl = safeUrlForOrigins(payload.nextAction.url, new Set([siteOrigin]), siteUrl);
+  return {
+    ...payload,
+    nextAction: {
+      ...payload.nextAction,
+      ...(safeNextUrl ? { url: safeNextUrl } : { url: undefined }),
+    },
+  };
 }

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -20,7 +20,7 @@ import {
 import { logClientError } from "@/lib/client-logs";
 import { safeGitHubAuthUrl } from "@/lib/github-auth-url-lib";
 import { siteConfig } from "@/lib/site";
-import { originFor, safeUrlForOrigins } from "@/lib/submit-url-safety-lib";
+import { safeGateStatusUrl, sanitizeNextActionUrl } from "@/lib/submit-url-safety-lib";
 import { CopyButton } from "@/components/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
@@ -76,28 +76,6 @@ type PreflightResponse = {
     url?: string;
   };
 };
-
-function safeGateStatusUrl(value: string | undefined) {
-  const gateOrigin = originFor(siteConfig.submissionGateUrl);
-  return safeUrlForOrigins(value, new Set(gateOrigin ? [gateOrigin] : []));
-}
-
-function sanitizePreflightResponse(payload: PreflightResponse) {
-  const siteOrigin = originFor(siteConfig.url);
-  if (!payload.nextAction?.url || !siteOrigin) return payload;
-  const safeNextUrl = safeUrlForOrigins(
-    payload.nextAction.url,
-    new Set([siteOrigin]),
-    siteConfig.url,
-  );
-  return {
-    ...payload,
-    nextAction: {
-      ...payload.nextAction,
-      ...(safeNextUrl ? { url: safeNextUrl } : { url: undefined }),
-    },
-  };
-}
 
 type SubmitResult = {
   statusUrl?: string;
@@ -156,7 +134,7 @@ function SubmitPage() {
       if (!response.ok || !payload?.ok) {
         throw new Error("Server preflight failed. Retry before continuing to GitHub.");
       }
-      const safePayload = sanitizePreflightResponse(payload);
+      const safePayload = sanitizeNextActionUrl(payload);
       setPreflightResult(safePayload);
       return safePayload;
     } catch (error) {

--- a/tests/submit-url-safety-lib.test.ts
+++ b/tests/submit-url-safety-lib.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   originFor,
+  safeGateStatusUrl,
   safeUrlForOrigins,
+  sanitizeNextActionUrl,
 } from "../apps/web/src/lib/submit-url-safety-lib";
 
 const BASE = "https://base.example";
+const GATE = "https://gate.example";
 
 describe("originFor", () => {
   it("returns the origin of a valid URL", () => {
@@ -60,5 +63,71 @@ describe("safeUrlForOrigins", () => {
 
   it("returns '' when the URL cannot be parsed (invalid base)", () => {
     expect(safeUrlForOrigins("x", new Set([BASE]), "")).toBe("");
+  });
+});
+
+describe("safeGateStatusUrl", () => {
+  it("accepts a status URL on the gate's own origin", () => {
+    expect(safeGateStatusUrl(`${GATE}/status/abc`, GATE)).toBe(
+      `${GATE}/status/abc`,
+    );
+  });
+
+  it("rejects a status URL on any other origin", () => {
+    expect(safeGateStatusUrl("https://evil.example/status/abc", GATE)).toBe("");
+  });
+
+  it("rejects everything when the gate URL is unset", () => {
+    expect(safeGateStatusUrl(`${GATE}/status/abc`, "")).toBe("");
+  });
+
+  it("returns '' for a missing status URL", () => {
+    expect(safeGateStatusUrl(undefined, GATE)).toBe("");
+  });
+});
+
+describe("sanitizeNextActionUrl", () => {
+  it("returns the payload untouched when there is no nextAction", () => {
+    const payload = { ok: true as const };
+    expect(sanitizeNextActionUrl(payload, BASE)).toBe(payload);
+  });
+
+  it("returns the payload untouched when nextAction has no url", () => {
+    const payload = { nextAction: { label: "Open" } };
+    expect(sanitizeNextActionUrl(payload, BASE)).toBe(payload);
+  });
+
+  it("keeps a same-origin nextAction url, normalized", () => {
+    const result = sanitizeNextActionUrl(
+      { nextAction: { label: "Open", url: "/pr/1" } },
+      BASE,
+    );
+    expect(result.nextAction).toEqual({ label: "Open", url: "/pr/1" });
+  });
+
+  it("drops a cross-origin nextAction url to undefined", () => {
+    const result = sanitizeNextActionUrl(
+      { nextAction: { label: "Open", url: "https://evil.example/x" } },
+      BASE,
+    );
+    expect(result.nextAction).toEqual({ label: "Open", url: undefined });
+  });
+
+  it("preserves the rest of the payload", () => {
+    const result = sanitizeNextActionUrl(
+      {
+        valid: true,
+        nextAction: { label: "Open", url: "https://evil.example/x" },
+      },
+      BASE,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns the payload untouched when the site origin is unparseable", () => {
+    const payload = {
+      nextAction: { label: "Open", url: "https://evil.example/x" },
+    };
+    expect(sanitizeNextActionUrl(payload, "")).toBe(payload);
   });
 });


### PR DESCRIPTION
## What

Moves the two remaining URL guards out of `routes/submit.tsx` into the existing pure module `apps/web/src/lib/submit-url-safety-lib.ts` — which already holds their `originFor` / `safeUrlForOrigins` primitives, so this puts the whole submit URL-safety surface in one testable place (same shape as #4628 moving `missingNoteWarnings` into `submission-preflight-lib`).

- `safeGateStatusUrl(value, gateUrl?)` — accepts a status URL only on the submission gate's own origin; missing, cross-origin, or an unset/unparseable gate URL (which allows no origins at all) yields `""`.
- `sanitizeNextActionUrl(payload, siteUrl?)` — clamps a preflight response's `nextAction.url` to the site's own origin, dropping a cross-origin/unsafe URL to `undefined` and normalizing a same-origin one. Generic over a minimal `{ nextAction?: { label, url? } }` shape, so the lib stays decoupled from the route's `PreflightResponse` type.

The `siteConfig`-backed URLs are now **default parameters** (mirroring the module's existing `baseUrl = siteConfig.url` style). Call sites in the route are unchanged, but both guards become unit-testable without depending on the env-derived gate URL — previously untestable, since `submissionGateUrl` is empty outside a configured env. **No behavior change.**

## Tests

Extends `tests/submit-url-safety-lib.test.ts` from 6 to 18 cases. New coverage: gate-origin accept/reject, unset gate URL rejecting everything, missing value; and for `sanitizeNextActionUrl` — no `nextAction`, no `url`, same-origin kept, cross-origin dropped to `undefined`, rest-of-payload preserved, and an unparseable site origin returning the payload untouched.

```
pnpm exec vitest run tests/submit-url-safety-lib.test.ts   # 18 passed
pnpm exec prettier --check <changed files>                 # clean
```

Refs #556