### PR TITLE
refactor(web): extract pure twitterHandleFrom into twitter-handle-lib

### DIFF
--- a/apps/web/src/lib/twitter-handle-lib.ts
+++ b/apps/web/src/lib/twitter-handle-lib.ts
@@ -1,0 +1,16 @@
+// Pure derivation of an @handle from a profile URL, split out of __root.tsx so
+// the parsing and failure cases can be unit-tested without the route.
+
+/**
+ * The `@handle` for a Twitter/X profile URL: the first non-empty path segment,
+ * prefixed with a single `@` (an existing leading `@` is not doubled). Returns
+ * `undefined` when the URL is unparseable or carries no path segment.
+ */
+export function twitterHandleFrom(profileUrl: string): string | undefined {
+  try {
+    const handle = new URL(profileUrl).pathname.split("/").filter(Boolean)[0];
+    return handle ? `@${handle.replace(/^@/, "")}` : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -28,16 +28,10 @@ import { UmamiTracker } from "@/components/umami-tracker";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { twitterHandleFrom } from "@/lib/twitter-handle-lib";
 import { buildOrganizationJsonLd, buildWebsiteJsonLd } from "@heyclaude/registry/seo";
 
-const twitterHandle = (() => {
-  try {
-    const handle = new URL(siteConfig.twitterUrl).pathname.split("/").filter(Boolean)[0];
-    return handle ? `@${handle.replace(/^@/, "")}` : undefined;
-  } catch {
-    return undefined;
-  }
-})();
+const twitterHandle = twitterHandleFrom(siteConfig.twitterUrl);
 
 // Sitewide default OG/Twitter card. Routes that render a page-specific card override og:image.
 const defaultOgImage = absoluteUrl("/og-image.png");

--- a/tests/twitter-handle-lib.test.ts
+++ b/tests/twitter-handle-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { twitterHandleFrom } from "../apps/web/src/lib/twitter-handle-lib";
+
+describe("twitterHandleFrom", () => {
+  it("derives an @handle from the first path segment", () => {
+    expect(twitterHandleFrom("https://x.com/jsonbored")).toBe("@jsonbored");
+  });
+
+  it("does not double an existing @ in the path", () => {
+    expect(twitterHandleFrom("https://x.com/@jsonbored")).toBe("@jsonbored");
+  });
+
+  it("ignores trailing slashes and extra path segments", () => {
+    expect(twitterHandleFrom("https://twitter.com/jsonbored/status/1")).toBe(
+      "@jsonbored",
+    );
+    expect(twitterHandleFrom("https://x.com/jsonbored/")).toBe("@jsonbored");
+  });
+
+  it("returns undefined when the URL has no path segment", () => {
+    expect(twitterHandleFrom("https://x.com")).toBeUndefined();
+    expect(twitterHandleFrom("https://x.com/")).toBeUndefined();
+  });
+
+  it("returns undefined for an unparseable URL", () => {
+    expect(twitterHandleFrom("not a url")).toBeUndefined();
+    expect(twitterHandleFrom("")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Replaces the module-scope IIFE in `__root.tsx` with a pure helper in `apps/web/src/lib/twitter-handle-lib.ts`:

- `twitterHandleFrom(profileUrl)` — takes the first non-empty path segment of a Twitter/X profile URL and prefixes a single `@` (an existing leading `@` is not doubled). Returns `undefined` when the URL is unparseable or carries no path segment.

The route now derives the handle in one line. **No behavior change** — this makes the parsing and its failure cases unit-testable without the route, matching the existing `*-lib.ts` pattern across `apps/web/src/lib/`.

## Tests

`tests/twitter-handle-lib.test.ts`: handle from the first path segment, no `@` doubling, trailing slashes and extra path segments ignored, `undefined` for a URL with no path segment, and `undefined` for an unparseable/empty URL (5 cases).

```
pnpm exec vitest run tests/twitter-handle-lib.test.ts   # 5 passed
pnpm exec prettier --check <changed files>              # clean
```

Refs #556