### PR TITLE
refactor(web): extract registry feed alias builders into a lib

### DIFF
--- a/apps/web/src/lib/registry-feed-aliases-lib.ts
+++ b/apps/web/src/lib/registry-feed-aliases-lib.ts
@@ -1,0 +1,25 @@
+// Pure builders for the registry feed route's category/platform alias maps,
+// split out so the path construction can be unit-tested without the handler.
+
+import { platformFeedSlug } from "@heyclaude/registry/artifacts";
+
+/** Map each category id to its category feed JSON path. */
+export function categoryFeedAliases(
+  categories: Array<{ category: string }>,
+): Record<string, string> {
+  return Object.fromEntries(
+    categories.map(({ category }) => [category, `/data/feeds/categories/${category}.json`]),
+  );
+}
+
+/** Map each platform page slug to its platform feed JSON path. */
+export function platformFeedAliases(
+  definitions: Array<{ platform: string; slug: string }>,
+): Record<string, string> {
+  return Object.fromEntries(
+    definitions.map(({ platform, slug }) => [
+      slug,
+      `/data/feeds/platforms/${platformFeedSlug(platform)}.json`,
+    ]),
+  );
+}

--- a/apps/web/src/routes/api/registry/feed.ts
+++ b/apps/web/src/routes/api/registry/feed.ts
@@ -1,11 +1,10 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
-import { platformFeedSlug } from "@heyclaude/registry/artifacts";
-
 import { createApiHandler } from "@/lib/api/router";
 import { getCategorySummaries, getRegistryManifest } from "@/lib/content.server";
 import { cachedJsonResponse } from "@/lib/http-cache";
 import { getPlatformPageDefinitions } from "@/lib/platform-pages";
+import { categoryFeedAliases, platformFeedAliases } from "@/lib/registry-feed-aliases-lib";
 import { siteConfig } from "@/lib/site";
 
 const JOBS_API_PATH = "/api/jobs?limit=100";
@@ -13,25 +12,10 @@ const QUALITY_METHODOLOGY_PATH = "/quality#methodology";
 const CATEGORY_FEED_PATH = "/data/feeds/categories/{category}.json";
 const PLATFORM_FEED_PATH = "/data/feeds/platforms/{platform}.json";
 
-function categoryFeedAliases(categories: Array<{ category: string }>) {
-  return Object.fromEntries(
-    categories.map(({ category }) => [category, `/data/feeds/categories/${category}.json`]),
-  );
-}
-
-function platformFeedAliases() {
-  return Object.fromEntries(
-    getPlatformPageDefinitions().map(({ platform, slug }) => [
-      slug,
-      `/data/feeds/platforms/${platformFeedSlug(platform)}.json`,
-    ]),
-  );
-}
-
 export const GET = createApiHandler("registry.feed", async ({ request }) => {
   const [manifest, categories] = await Promise.all([getRegistryManifest(), getCategorySummaries()]);
   const categoryFeeds = categoryFeedAliases(categories);
-  const platformFeeds = platformFeedAliases();
+  const platformFeeds = platformFeedAliases(getPlatformPageDefinitions());
 
   return cachedJsonResponse(request, {
     schemaVersion: 1,

--- a/tests/registry-feed-aliases-lib.test.ts
+++ b/tests/registry-feed-aliases-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  categoryFeedAliases,
+  platformFeedAliases,
+} from "../apps/web/src/lib/registry-feed-aliases-lib";
+
+describe("categoryFeedAliases", () => {
+  it("maps each category to its feed path", () => {
+    expect(
+      categoryFeedAliases([{ category: "agents" }, { category: "mcp" }]),
+    ).toEqual({
+      agents: "/data/feeds/categories/agents.json",
+      mcp: "/data/feeds/categories/mcp.json",
+    });
+  });
+
+  it("returns an empty map for no categories", () => {
+    expect(categoryFeedAliases([])).toEqual({});
+  });
+});
+
+describe("platformFeedAliases", () => {
+  it("maps each definition's slug to its platform feed path", () => {
+    const aliases = platformFeedAliases([
+      { platform: "claude-code", slug: "claude-code" },
+    ]);
+    expect(Object.keys(aliases)).toEqual(["claude-code"]);
+    expect(aliases["claude-code"]).toMatch(
+      /^\/data\/feeds\/platforms\/.+\.json$/,
+    );
+  });
+
+  it("returns an empty map for no definitions", () => {
+    expect(platformFeedAliases([])).toEqual({});
+  });
+});


### PR DESCRIPTION
### What & why

The registry feed route built the category/platform feed alias maps inline, so the path construction could not be unit-tested without the handler. This moves `categoryFeedAliases()` and `platformFeedAliases()` into `apps/web/src/lib/registry-feed-aliases-lib.ts` (the platform definitions are now passed in) and imports them back.

### Changes

- Add `apps/web/src/lib/registry-feed-aliases-lib.ts` — `categoryFeedAliases(categories)` and `platformFeedAliases(definitions)`.
- `apps/web/src/routes/api/registry/feed.ts` — import the builders; pass `getPlatformPageDefinitions()` into `platformFeedAliases`; drop the local copies and the now-unused `platformFeedSlug` import.
- Add `tests/registry-feed-aliases-lib.test.ts` — covers the category and platform alias maps plus the empty cases.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/registry-feed-aliases-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the feed exposes identical alias paths.
