### PR TITLE
refactor(web): extract registry trending entry helpers into a lib

### DIFF
--- a/apps/web/src/lib/registry-feed-aliases-lib.ts
+++ b/apps/web/src/lib/registry-feed-aliases-lib.ts
@@ -1,0 +1,25 @@
+// Pure builders for the registry feed route's category/platform alias maps,
+// split out so the path construction can be unit-tested without the handler.
+
+import { platformFeedSlug } from "@heyclaude/registry/artifacts";
+
+/** Map each category id to its category feed JSON path. */
+export function categoryFeedAliases(
+  categories: Array<{ category: string }>,
+): Record<string, string> {
+  return Object.fromEntries(
+    categories.map(({ category }) => [category, `/data/feeds/categories/${category}.json`]),
+  );
+}
+
+/** Map each platform page slug to its platform feed JSON path. */
+export function platformFeedAliases(
+  definitions: Array<{ platform: string; slug: string }>,
+): Record<string, string> {
+  return Object.fromEntries(
+    definitions.map(({ platform, slug }) => [
+      slug,
+      `/data/feeds/platforms/${platformFeedSlug(platform)}.json`,
+    ]),
+  );
+}

--- a/apps/web/src/lib/registry-trending-entry-lib.ts
+++ b/apps/web/src/lib/registry-trending-entry-lib.ts
@@ -1,0 +1,32 @@
+// Pure per-entry derivations for the registry trending API route: canonical URL,
+// source status, and first-party package flag. Split out of the route so the
+// embedded-legacy-field fallbacks can be unit-tested without the handler.
+
+import type { Entry } from "@/types/registry";
+
+type LegacyGeneratedFields = {
+  canonicalUrl?: unknown;
+  downloadTrust?: unknown;
+  trustSignals?: { sourceStatus?: unknown };
+};
+
+/** Embedded canonical URL when present, else the derived entry detail URL. */
+export function entryCanonicalUrl(entry: Entry): string {
+  const embedded = (entry as LegacyGeneratedFields).canonicalUrl;
+  return typeof embedded === "string" && embedded.trim()
+    ? embedded
+    : `https://heyclau.de/entry/${entry.category}/${entry.slug}`;
+}
+
+/** Embedded source status when present, else derived from the source field. */
+export function entrySourceStatus(entry: Entry): string {
+  const embedded = (entry as LegacyGeneratedFields).trustSignals?.sourceStatus;
+  if (typeof embedded === "string" && embedded.trim()) return embedded;
+  return entry.source === "unverified" ? "missing" : "available";
+}
+
+/** True for a first-party download or a verified package with a download URL. */
+export function isFirstPartyPackage(entry: Entry): boolean {
+  const legacyTrust = (entry as LegacyGeneratedFields).downloadTrust;
+  return legacyTrust === "first-party" || Boolean(entry.downloadUrl && entry.packageVerified);
+}

--- a/apps/web/src/routes/api/registry/feed.ts
+++ b/apps/web/src/routes/api/registry/feed.ts
@@ -1,11 +1,10 @@
 import { createApiFileRoute } from "@/lib/api/file-route";
 
-import { platformFeedSlug } from "@heyclaude/registry/artifacts";
-
 import { createApiHandler } from "@/lib/api/router";
 import { getCategorySummaries, getRegistryManifest } from "@/lib/content.server";
 import { cachedJsonResponse } from "@/lib/http-cache";
 import { getPlatformPageDefinitions } from "@/lib/platform-pages";
+import { categoryFeedAliases, platformFeedAliases } from "@/lib/registry-feed-aliases-lib";
 import { siteConfig } from "@/lib/site";
 
 const JOBS_API_PATH = "/api/jobs?limit=100";
@@ -13,25 +12,10 @@ const QUALITY_METHODOLOGY_PATH = "/quality#methodology";
 const CATEGORY_FEED_PATH = "/data/feeds/categories/{category}.json";
 const PLATFORM_FEED_PATH = "/data/feeds/platforms/{platform}.json";
 
-function categoryFeedAliases(categories: Array<{ category: string }>) {
-  return Object.fromEntries(
-    categories.map(({ category }) => [category, `/data/feeds/categories/${category}.json`]),
-  );
-}
-
-function platformFeedAliases() {
-  return Object.fromEntries(
-    getPlatformPageDefinitions().map(({ platform, slug }) => [
-      slug,
-      `/data/feeds/platforms/${platformFeedSlug(platform)}.json`,
-    ]),
-  );
-}
-
 export const GET = createApiHandler("registry.feed", async ({ request }) => {
   const [manifest, categories] = await Promise.all([getRegistryManifest(), getCategorySummaries()]);
   const categoryFeeds = categoryFeedAliases(categories);
-  const platformFeeds = platformFeedAliases();
+  const platformFeeds = platformFeedAliases(getPlatformPageDefinitions());
 
   return cachedJsonResponse(request, {
     schemaVersion: 1,

--- a/apps/web/src/routes/api/registry/trending.ts
+++ b/apps/web/src/routes/api/registry/trending.ts
@@ -7,14 +7,14 @@ import { entryCommunityTarget, safeCommunitySignalCounts } from "@/lib/community
 import { communityDiscoveryScore } from "@/lib/growth-ranking";
 import { cachedJsonResponse } from "@/lib/http-cache";
 import { safeIntentEventCounts } from "@/lib/intent-events";
+import {
+  entryCanonicalUrl,
+  entrySourceStatus,
+  isFirstPartyPackage,
+} from "@/lib/registry-trending-entry-lib";
 import { safeVoteCounts } from "@/lib/votes";
 
 type Entry = (typeof ENTRIES)[number];
-type LegacyGeneratedFields = {
-  canonicalUrl?: unknown;
-  downloadTrust?: unknown;
-  trustSignals?: { sourceStatus?: unknown };
-};
 
 const entryKey = (entry: Entry) => `${entry.category}:${entry.slug}`;
 const communityTarget = (entry: Entry) => entryCommunityTarget(entry.category, entry.slug);
@@ -45,24 +45,6 @@ const reasonCodes = (input: ReturnType<typeof trendInput>) =>
     input.firstPartyPackage ? "first_party_package" : "",
     input.productionVerified ? "production_verified" : "",
   ].filter(Boolean);
-
-function entryCanonicalUrl(entry: Entry) {
-  const embedded = (entry as LegacyGeneratedFields).canonicalUrl;
-  return typeof embedded === "string" && embedded.trim()
-    ? embedded
-    : `https://heyclau.de/entry/${entry.category}/${entry.slug}`;
-}
-
-function entrySourceStatus(entry: Entry) {
-  const embedded = (entry as LegacyGeneratedFields).trustSignals?.sourceStatus;
-  if (typeof embedded === "string" && embedded.trim()) return embedded;
-  return entry.source === "unverified" ? "missing" : "available";
-}
-
-function isFirstPartyPackage(entry: Entry) {
-  const legacyTrust = (entry as LegacyGeneratedFields).downloadTrust;
-  return legacyTrust === "first-party" || Boolean(entry.downloadUrl && entry.packageVerified);
-}
 
 function trendInput(entry: Entry, states: Awaited<ReturnType<typeof readStates>>) {
   return {

--- a/tests/registry-feed-aliases-lib.test.ts
+++ b/tests/registry-feed-aliases-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  categoryFeedAliases,
+  platformFeedAliases,
+} from "../apps/web/src/lib/registry-feed-aliases-lib";
+
+describe("categoryFeedAliases", () => {
+  it("maps each category to its feed path", () => {
+    expect(
+      categoryFeedAliases([{ category: "agents" }, { category: "mcp" }]),
+    ).toEqual({
+      agents: "/data/feeds/categories/agents.json",
+      mcp: "/data/feeds/categories/mcp.json",
+    });
+  });
+
+  it("returns an empty map for no categories", () => {
+    expect(categoryFeedAliases([])).toEqual({});
+  });
+});
+
+describe("platformFeedAliases", () => {
+  it("maps each definition's slug to its platform feed path", () => {
+    const aliases = platformFeedAliases([
+      { platform: "claude-code", slug: "claude-code" },
+    ]);
+    expect(Object.keys(aliases)).toEqual(["claude-code"]);
+    expect(aliases["claude-code"]).toMatch(
+      /^\/data\/feeds\/platforms\/.+\.json$/,
+    );
+  });
+
+  it("returns an empty map for no definitions", () => {
+    expect(platformFeedAliases([])).toEqual({});
+  });
+});

--- a/tests/registry-trending-entry-lib.test.ts
+++ b/tests/registry-trending-entry-lib.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import {
+  entryCanonicalUrl,
+  entrySourceStatus,
+  isFirstPartyPackage,
+} from "../apps/web/src/lib/registry-trending-entry-lib";
+
+const entry = (over: Record<string, unknown> = {}): Entry =>
+  ({
+    category: "agents",
+    slug: "my-agent",
+    source: "unverified",
+    ...over,
+  }) as Entry;
+
+describe("entryCanonicalUrl", () => {
+  it("prefers a non-empty embedded canonicalUrl", () => {
+    expect(entryCanonicalUrl(entry({ canonicalUrl: "https://x.dev/a" }))).toBe(
+      "https://x.dev/a",
+    );
+  });
+
+  it("derives the detail URL when embedded is missing or blank", () => {
+    expect(entryCanonicalUrl(entry())).toBe(
+      "https://heyclau.de/entry/agents/my-agent",
+    );
+    expect(entryCanonicalUrl(entry({ canonicalUrl: "   " }))).toBe(
+      "https://heyclau.de/entry/agents/my-agent",
+    );
+  });
+});
+
+describe("entrySourceStatus", () => {
+  it("prefers a non-empty embedded sourceStatus", () => {
+    expect(
+      entrySourceStatus(entry({ trustSignals: { sourceStatus: "verified" } })),
+    ).toBe("verified");
+  });
+
+  it("derives missing/available from the source field", () => {
+    expect(entrySourceStatus(entry({ source: "unverified" }))).toBe("missing");
+    expect(entrySourceStatus(entry({ source: "source-backed" }))).toBe(
+      "available",
+    );
+  });
+});
+
+describe("isFirstPartyPackage", () => {
+  it("is true for a first-party downloadTrust", () => {
+    expect(isFirstPartyPackage(entry({ downloadTrust: "first-party" }))).toBe(
+      true,
+    );
+  });
+
+  it("is true for a verified package with a download URL", () => {
+    expect(
+      isFirstPartyPackage(
+        entry({ downloadUrl: "https://x.dev/p.zip", packageVerified: true }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false otherwise", () => {
+    expect(isFirstPartyPackage(entry())).toBe(false);
+    expect(
+      isFirstPartyPackage(entry({ downloadUrl: "https://x.dev/p.zip" })),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

The registry trending route derived each entry's canonical URL, source status, and first-party package flag inline (reading embedded legacy fields), so those fallbacks could not be unit-tested without the handler. This moves them into `apps/web/src/lib/registry-trending-entry-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/registry-trending-entry-lib.ts` — `entryCanonicalUrl`, `entrySourceStatus`, `isFirstPartyPackage` (with the `LegacyGeneratedFields` shape).
- `apps/web/src/routes/api/registry/trending.ts` — import the helpers; drop the local copies and the now-unused `LegacyGeneratedFields` type.
- Add `tests/registry-trending-entry-lib.test.ts` — covers embedded-vs-derived canonical URL and source status, and each first-party-package path. Branch coverage 100% (14/14).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/registry-trending-entry-lib.test.ts` — 7 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the trending payload is unchanged.
