### PR TITLE
refactor(web): extract trending platform matching into a lib

### DIFF
--- a/apps/web/src/lib/registry-trending-platform-lib.ts
+++ b/apps/web/src/lib/registry-trending-platform-lib.ts
@@ -1,0 +1,36 @@
+// Pure platform-matching helpers for the registry trending API route: normalize
+// platform strings, expand query aliases, collect an entry's platforms, and test
+// membership. Split out of the route so they can be unit-tested without the handler.
+
+import type { Entry } from "@/types/registry";
+
+/** Lowercase + trim a platform string. */
+export function normalizePlatform(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+/** Expand a platform query value to the set of ids it should match. */
+export function platformAliases(value: string): string[] {
+  const platform = normalizePlatform(value);
+  if (!platform) return [];
+  if (platform === "claude") return ["claude", "claude-code", "claude-desktop"];
+  if (platform === "vs code") return ["vscode"];
+  return [platform];
+}
+
+/** Normalized set of platforms an entry supports (platforms + compatibility). */
+export function entryPlatforms(entry: Entry): string[] {
+  const values = new Set<string>();
+  for (const platform of entry.platforms ?? []) values.add(normalizePlatform(platform));
+  for (const item of entry.platformCompatibility ?? [])
+    values.add(normalizePlatform(item.platform));
+  return [...values];
+}
+
+/** True when the entry supports the queried platform (empty query matches all). */
+export function matchesPlatform(entry: Entry, value: string): boolean {
+  const platforms = platformAliases(value);
+  if (!platforms.length) return true;
+  const supported = entryPlatforms(entry);
+  return platforms.some((platform) => supported.includes(platform));
+}

--- a/apps/web/src/routes/api/registry/trending.ts
+++ b/apps/web/src/routes/api/registry/trending.ts
@@ -12,33 +12,13 @@ import {
   entrySourceStatus,
   isFirstPartyPackage,
 } from "@/lib/registry-trending-entry-lib";
+import { entryPlatforms, matchesPlatform } from "@/lib/registry-trending-platform-lib";
 import { safeVoteCounts } from "@/lib/votes";
 
 type Entry = (typeof ENTRIES)[number];
 
 const entryKey = (entry: Entry) => `${entry.category}:${entry.slug}`;
 const communityTarget = (entry: Entry) => entryCommunityTarget(entry.category, entry.slug);
-const normalizePlatform = (value: string) => value.trim().toLowerCase();
-const platformAliases = (value: string) => {
-  const platform = normalizePlatform(value);
-  if (!platform) return [];
-  if (platform === "claude") return ["claude", "claude-code", "claude-desktop"];
-  if (platform === "vs code") return ["vscode"];
-  return [platform];
-};
-const entryPlatforms = (entry: Entry) => {
-  const values = new Set<string>();
-  for (const platform of entry.platforms ?? []) values.add(normalizePlatform(platform));
-  for (const item of entry.platformCompatibility ?? [])
-    values.add(normalizePlatform(item.platform));
-  return [...values];
-};
-const matchesPlatform = (entry: Entry, value: string) => {
-  const platforms = platformAliases(value);
-  if (!platforms.length) return true;
-  const supported = entryPlatforms(entry);
-  return platforms.some((platform) => supported.includes(platform));
-};
 
 const reasonCodes = (input: ReturnType<typeof trendInput>) =>
   [

--- a/tests/registry-trending-platform-lib.test.ts
+++ b/tests/registry-trending-platform-lib.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import {
+  entryPlatforms,
+  matchesPlatform,
+  normalizePlatform,
+  platformAliases,
+} from "../apps/web/src/lib/registry-trending-platform-lib";
+
+const entry = (over: Record<string, unknown> = {}): Entry =>
+  ({ category: "agents", slug: "a", ...over }) as Entry;
+
+describe("normalizePlatform", () => {
+  it("trims and lowercases", () => {
+    expect(normalizePlatform("  Claude-Code ")).toBe("claude-code");
+  });
+});
+
+describe("platformAliases", () => {
+  it("expands claude and vs code, passes others through, empty for blank", () => {
+    expect(platformAliases("claude")).toEqual([
+      "claude",
+      "claude-code",
+      "claude-desktop",
+    ]);
+    expect(platformAliases("VS Code")).toEqual(["vscode"]);
+    expect(platformAliases("cursor")).toEqual(["cursor"]);
+    expect(platformAliases("   ")).toEqual([]);
+  });
+});
+
+describe("entryPlatforms", () => {
+  it("normalizes and dedupes platforms + compatibility", () => {
+    const result = entryPlatforms(
+      entry({
+        platforms: ["Claude-Code", "cursor"],
+        platformCompatibility: [{ platform: "CURSOR" }, { platform: "zed" }],
+      }),
+    );
+    expect(result.sort()).toEqual(["claude-code", "cursor", "zed"]);
+  });
+
+  it("is empty when no platforms are present", () => {
+    expect(entryPlatforms(entry())).toEqual([]);
+  });
+});
+
+describe("matchesPlatform", () => {
+  const e = entry({ platforms: ["claude-code"] });
+
+  it("matches everything for a blank query", () => {
+    expect(matchesPlatform(e, "")).toBe(true);
+  });
+
+  it("matches via alias expansion", () => {
+    expect(matchesPlatform(e, "claude")).toBe(true);
+  });
+
+  it("is false when unsupported", () => {
+    expect(matchesPlatform(e, "cursor")).toBe(false);
+  });
+});


### PR DESCRIPTION
### What & why

The registry trending route defined the platform-matching cluster (`normalizePlatform`, `platformAliases`, `entryPlatforms`, `matchesPlatform`) inline, so the alias expansion and membership test could not be unit-tested without the handler. This moves them into `apps/web/src/lib/registry-trending-platform-lib.ts` and imports them back.

### Changes

- Add `apps/web/src/lib/registry-trending-platform-lib.ts` — `normalizePlatform`, `platformAliases`, `entryPlatforms`, `matchesPlatform`.
- `apps/web/src/routes/api/registry/trending.ts` — import `entryPlatforms` and `matchesPlatform`; drop the local copies.
- Add `tests/registry-trending-platform-lib.test.ts` — covers normalization, claude/vs-code alias expansion + passthrough, platform+compatibility dedupe, and blank/alias/unsupported matching. Branch coverage 100% (12/12).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/registry-trending-platform-lib.test.ts` — 7 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; platform filtering is unchanged.
