### PR TITLE
refactor(web): extract MCP response header decoration into a lib

### DIFF
--- a/apps/web/src/lib/mcp-headers-lib.ts
+++ b/apps/web/src/lib/mcp-headers-lib.ts
@@ -1,0 +1,29 @@
+// Pure response-decoration for the MCP streamable route: apply the MCP CORS
+// allowlist, the shared security headers, and no-store caching. Split out of the
+// route so the header application can be unit-tested without the handler.
+
+import { applySecurityHeaders } from "@/lib/security-headers";
+
+const mcpCorsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": "POST, DELETE, OPTIONS",
+  "access-control-allow-headers":
+    "content-type, accept, mcp-session-id, mcp-protocol-version, mcp-method, mcp-name, last-event-id",
+  "access-control-expose-headers": "mcp-session-id, mcp-protocol-version",
+};
+
+/**
+ * Return a copy of the response with the MCP CORS headers, the shared security
+ * headers, and `cache-control: no-store` applied. Status, status text, and body
+ * are preserved.
+ */
+export function applyMcpHeaders(response: Response): Response {
+  const headers = applySecurityHeaders(new Headers(response.headers));
+  for (const [key, value] of Object.entries(mcpCorsHeaders)) headers.set(key, value);
+  headers.set("cache-control", "no-store");
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/apps/web/src/routes/api/mcp.ts
+++ b/apps/web/src/routes/api/mcp.ts
@@ -10,33 +10,14 @@ import {
 } from "@/lib/api-security";
 import { logApiError, logApiWarn } from "@/lib/api-logs";
 import { getCloudflareBinding } from "@/lib/cloudflare-env.server";
+import { applyMcpHeaders } from "@/lib/mcp-headers-lib";
 import { createMcpArtifactReaders } from "@/lib/mcp-artifact-readers-lib";
-import { applySecurityHeaders } from "@/lib/security-headers";
 
 const route = getApiRouteDefinition("mcp.streamable");
 
 type StaticAssetsBinding = {
   fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 };
-
-const mcpCorsHeaders = {
-  "access-control-allow-origin": "*",
-  "access-control-allow-methods": "POST, DELETE, OPTIONS",
-  "access-control-allow-headers":
-    "content-type, accept, mcp-session-id, mcp-protocol-version, mcp-method, mcp-name, last-event-id",
-  "access-control-expose-headers": "mcp-session-id, mcp-protocol-version",
-};
-
-function applyMcpHeaders(response: Response) {
-  const headers = applySecurityHeaders(new Headers(response.headers));
-  for (const [key, value] of Object.entries(mcpCorsHeaders)) headers.set(key, value);
-  headers.set("cache-control", "no-store");
-  return new Response(response.body, {
-    status: response.status,
-    statusText: response.statusText,
-    headers,
-  });
-}
 
 function mcpError(
   request: Request,

--- a/tests/mcp-headers-lib.test.ts
+++ b/tests/mcp-headers-lib.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { applyMcpHeaders } from "../apps/web/src/lib/mcp-headers-lib";
+
+describe("applyMcpHeaders", () => {
+  it("applies the MCP CORS headers and no-store caching", () => {
+    const res = applyMcpHeaders(new Response("hi", { status: 200 }));
+    expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    expect(res.headers.get("access-control-allow-methods")).toBe(
+      "POST, DELETE, OPTIONS",
+    );
+    expect(res.headers.get("access-control-expose-headers")).toContain(
+      "mcp-session-id",
+    );
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("preserves status, status text, and body", async () => {
+    const res = applyMcpHeaders(
+      new Response("payload", { status: 202, statusText: "Accepted" }),
+    );
+    expect(res.status).toBe(202);
+    expect(res.statusText).toBe("Accepted");
+    expect(await res.text()).toBe("payload");
+  });
+
+  it("carries incoming headers through", () => {
+    const res = applyMcpHeaders(
+      new Response(null, { status: 204, headers: { "x-keep": "1" } }),
+    );
+    expect(res.headers.get("x-keep")).toBe("1");
+  });
+});


### PR DESCRIPTION
### What & why

The MCP streamable route defined `applyMcpHeaders()` (and its CORS header map) inline, so the CORS + security + no-store header application could not be unit-tested without the handler. This moves them into `apps/web/src/lib/mcp-headers-lib.ts` and imports the helper back.

### Changes

- Add `apps/web/src/lib/mcp-headers-lib.ts` — `applyMcpHeaders(response)` with the private `mcpCorsHeaders` map.
- `apps/web/src/routes/api/mcp.ts` — import `applyMcpHeaders`; drop the local copy, the CORS map, and the now-unused `applySecurityHeaders` import.
- Add `tests/mcp-headers-lib.test.ts` — covers CORS/no-store application, status / statusText / body preservation, and incoming header carry-through.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/mcp-headers-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; MCP responses carry identical headers.
