### PR TITLE
refactor(web): extract escapeXml into xml-escape-lib

### DIFF
--- a/apps/web/src/lib/xml-escape-lib.ts
+++ b/apps/web/src/lib/xml-escape-lib.ts
@@ -1,0 +1,12 @@
+// Pure XML text/attribute escaping, split out of the sitemap route so the
+// entity replacement can be unit-tested and reused.
+
+/** Escape the five predefined XML entities: & < > " '. */
+export function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -11,15 +11,7 @@ import { getIndexableTagGroups } from "@/lib/tags";
 import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
 import { REPORT_PATHS } from "@/lib/data-reports";
-
-function escapeXml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;");
-}
+import { escapeXml } from "@/lib/xml-escape-lib";
 
 function urlItem(pathname: string, priority: string, changefreq = "weekly", lastmodInput?: string) {
   const lastmod = String(lastmodInput || atlasRegistry.generatedAt || "").slice(0, 10);

--- a/tests/xml-escape-lib.test.ts
+++ b/tests/xml-escape-lib.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeXml } from "../apps/web/src/lib/xml-escape-lib";
+
+describe("escapeXml", () => {
+  it("escapes all five predefined XML entities", () => {
+    expect(escapeXml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&apos;");
+  });
+
+  it("escapes ampersands before other entities (no double-escaping)", () => {
+    expect(escapeXml("a & b < c")).toBe("a &amp; b &lt; c");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(escapeXml("https://heyclau.de/browse")).toBe(
+      "https://heyclau.de/browse",
+    );
+  });
+});


### PR DESCRIPTION
### What & why

The sitemap route defined `escapeXml()` inline, so the XML entity escaping could not be unit-tested without rendering the sitemap. This moves it into `apps/web/src/lib/xml-escape-lib.ts` and imports it back; `urlItem()` continues to use it.

### Changes

- Add `apps/web/src/lib/xml-escape-lib.ts` — `escapeXml(value)` (escapes `&` `<` `>` `"` `'`).
- `apps/web/src/routes/sitemap[.]xml.ts` — import `escapeXml`; drop the local copy.
- Add `tests/xml-escape-lib.test.ts` — covers all five entities, ampersand-first ordering, and passthrough.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/xml-escape-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the sitemap escapes identically.
