### PR TITLE
refactor(web): extract umami upstream origin allowlisting into a lib

### DIFF
--- a/apps/web/src/lib/upstream-origin-lib.ts
+++ b/apps/web/src/lib/upstream-origin-lib.ts
@@ -1,0 +1,26 @@
+// Pure helpers for the umami collector proxy's upstream-origin allowlisting,
+// split out of the route so the CSV parsing and origin validation can be
+// unit-tested without the handler (the env/default origins are injected).
+
+/** Parse a comma-separated allowlist, falling back to the defaults when empty. */
+export function parseAllowedUpstreamOrigins(
+  configured: string | undefined,
+  defaults: readonly string[],
+): string[] {
+  return configured
+    ? configured
+        .split(",")
+        .map((origin) => origin.trim())
+        .filter(Boolean)
+    : [...defaults];
+}
+
+/** Return the upstream's origin when it is allow-listed, else "" (incl. bad URL). */
+export function validateUpstreamOrigin(upstream: string, allowedOrigins: string[]): string {
+  try {
+    const origin = new URL(upstream).origin;
+    return allowedOrigins.includes(origin) ? origin : "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/web/src/routes/u.api.send.ts
+++ b/apps/web/src/routes/u.api.send.ts
@@ -11,6 +11,7 @@ import {
 import { logApiWarn } from "@/lib/api-logs";
 import { joinAnalyticsUpstreamUrl, scrubSensitiveAnalyticsBody } from "@/lib/analytics-proxy";
 import { getEnvString } from "@/lib/cloudflare-env.server";
+import { parseAllowedUpstreamOrigins, validateUpstreamOrigin } from "@/lib/upstream-origin-lib";
 
 const BODY_LIMIT_BYTES = 16 * 1024;
 const RATE_LIMIT = {
@@ -27,22 +28,14 @@ function getRequestId(request: Request) {
 }
 
 function allowedUpstreamOrigins() {
-  const configured = getEnvString("UMAMI_ALLOWED_UPSTREAM_ORIGINS");
-  return configured
-    ? configured
-        .split(",")
-        .map((origin) => origin.trim())
-        .filter(Boolean)
-    : [...DEFAULT_ALLOWED_UPSTREAM_ORIGINS];
+  return parseAllowedUpstreamOrigins(
+    getEnvString("UMAMI_ALLOWED_UPSTREAM_ORIGINS"),
+    DEFAULT_ALLOWED_UPSTREAM_ORIGINS,
+  );
 }
 
 function validatedUpstreamOrigin(upstream: string) {
-  try {
-    const origin = new URL(upstream).origin;
-    return allowedUpstreamOrigins().includes(origin) ? origin : "";
-  } catch {
-    return "";
-  }
+  return validateUpstreamOrigin(upstream, allowedUpstreamOrigins());
 }
 
 /**

--- a/tests/upstream-origin-lib.test.ts
+++ b/tests/upstream-origin-lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseAllowedUpstreamOrigins,
+  validateUpstreamOrigin,
+} from "../apps/web/src/lib/upstream-origin-lib";
+
+const DEFAULTS = ["https://tasty.aethereal.dev"] as const;
+
+describe("parseAllowedUpstreamOrigins", () => {
+  it("splits, trims, and drops empties from a configured list", () => {
+    expect(
+      parseAllowedUpstreamOrigins("https://a.dev , https://b.dev ,", DEFAULTS),
+    ).toEqual(["https://a.dev", "https://b.dev"]);
+  });
+
+  it("falls back to the defaults when unset or empty", () => {
+    expect(parseAllowedUpstreamOrigins(undefined, DEFAULTS)).toEqual([
+      "https://tasty.aethereal.dev",
+    ]);
+    expect(parseAllowedUpstreamOrigins("", DEFAULTS)).toEqual([
+      "https://tasty.aethereal.dev",
+    ]);
+  });
+});
+
+describe("validateUpstreamOrigin", () => {
+  const allowed = ["https://tasty.aethereal.dev"];
+
+  it("returns the origin when allow-listed", () => {
+    expect(
+      validateUpstreamOrigin("https://tasty.aethereal.dev/collect", allowed),
+    ).toBe("https://tasty.aethereal.dev");
+  });
+
+  it("returns '' for a non-allow-listed origin", () => {
+    expect(validateUpstreamOrigin("https://evil.example/x", allowed)).toBe("");
+  });
+
+  it("returns '' for an unparseable upstream", () => {
+    expect(validateUpstreamOrigin("not a url", allowed)).toBe("");
+  });
+});


### PR DESCRIPTION
### What & why

The umami collector proxy resolved its allowed upstream origins and validated the configured upstream inline, so the CSV parsing and origin allowlist check could not be unit-tested without the handler. This moves the pure cores into `apps/web/src/lib/upstream-origin-lib.ts` (env/defaults injected) and delegates from the route.

### Changes

- Add `apps/web/src/lib/upstream-origin-lib.ts` — `parseAllowedUpstreamOrigins(configured, defaults)` and `validateUpstreamOrigin(upstream, allowedOrigins)`.
- `apps/web/src/routes/u.api.send.ts` — `allowedUpstreamOrigins` / `validatedUpstreamOrigin` now delegate to the helpers (the env read stays in the route).
- Add `tests/upstream-origin-lib.test.ts` — covers CSV split/trim/empty + default fallback, and allow-listed / rejected / unparseable origin validation. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/upstream-origin-lib.test.ts` — 5 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the proxy allowlists identically.
