### PR TITLE
refactor(web): extract pure sitemapUrlItem into sitemap-url-item-lib

### DIFF
--- a/apps/web/src/lib/sitemap-url-item-lib.ts
+++ b/apps/web/src/lib/sitemap-url-item-lib.ts
@@ -1,0 +1,37 @@
+// Pure <url> entry rendering for the XML sitemap, split out of sitemap[.]xml.ts
+// so the escaping, lastmod normalization, and field order can be unit-tested
+// without the generated registry or the route.
+
+import { escapeXml } from "@/lib/xml-escape-lib";
+
+/**
+ * Render one `<url>` block for the XML sitemap. `loc` is `siteUrl + pathname`,
+ * XML-escaped. `lastmod` is truncated to its leading `YYYY-MM-DD` and the line
+ * is omitted entirely when it resolves to an empty string. Fields are emitted
+ * in sitemap order: loc, lastmod, changefreq, priority.
+ */
+export function sitemapUrlItem({
+  siteUrl,
+  pathname,
+  priority,
+  changefreq = "weekly",
+  lastmod,
+}: {
+  siteUrl: string;
+  pathname: string;
+  priority: string;
+  changefreq?: string;
+  lastmod?: string;
+}): string {
+  const day = String(lastmod || "").slice(0, 10);
+  return [
+    "  <url>",
+    `    <loc>${escapeXml(`${siteUrl}${pathname}`)}</loc>`,
+    day ? `    <lastmod>${escapeXml(day)}</lastmod>` : "",
+    `    <changefreq>${changefreq}</changefreq>`,
+    `    <priority>${priority}</priority>`,
+    "  </url>",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}

--- a/apps/web/src/routes/sitemap[.]xml.ts
+++ b/apps/web/src/routes/sitemap[.]xml.ts
@@ -11,20 +11,16 @@ import { getIndexableTagGroups } from "@/lib/tags";
 import { isSitemapIndexableEntry } from "@/lib/sitemap-policy";
 import { COMPARISONS } from "@/data/comparisons";
 import { REPORT_PATHS } from "@/lib/data-reports";
-import { escapeXml } from "@/lib/xml-escape-lib";
+import { sitemapUrlItem } from "@/lib/sitemap-url-item-lib";
 
 function urlItem(pathname: string, priority: string, changefreq = "weekly", lastmodInput?: string) {
-  const lastmod = String(lastmodInput || atlasRegistry.generatedAt || "").slice(0, 10);
-  return [
-    "  <url>",
-    `    <loc>${escapeXml(`${siteConfig.url}${pathname}`)}</loc>`,
-    lastmod ? `    <lastmod>${escapeXml(lastmod)}</lastmod>` : "",
-    `    <changefreq>${changefreq}</changefreq>`,
-    `    <priority>${priority}</priority>`,
-    "  </url>",
-  ]
-    .filter(Boolean)
-    .join("\n");
+  return sitemapUrlItem({
+    siteUrl: siteConfig.url,
+    pathname,
+    priority,
+    changefreq,
+    lastmod: lastmodInput || atlasRegistry.generatedAt,
+  });
 }
 
 async function renderSitemap() {

--- a/tests/sitemap-url-item-lib.test.ts
+++ b/tests/sitemap-url-item-lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { sitemapUrlItem } from "../apps/web/src/lib/sitemap-url-item-lib";
+
+const SITE = "https://heyclau.de";
+
+describe("sitemapUrlItem", () => {
+  it("renders loc, lastmod, changefreq and priority in sitemap order", () => {
+    expect(
+      sitemapUrlItem({
+        siteUrl: SITE,
+        pathname: "/browse",
+        priority: "0.8",
+        changefreq: "daily",
+        lastmod: "2026-07-08",
+      }),
+    ).toBe(
+      [
+        "  <url>",
+        "    <loc>https://heyclau.de/browse</loc>",
+        "    <lastmod>2026-07-08</lastmod>",
+        "    <changefreq>daily</changefreq>",
+        "    <priority>0.8</priority>",
+        "  </url>",
+      ].join("\n"),
+    );
+  });
+
+  it("defaults changefreq to weekly", () => {
+    const xml = sitemapUrlItem({
+      siteUrl: SITE,
+      pathname: "/",
+      priority: "1.0",
+    });
+    expect(xml).toContain("<changefreq>weekly</changefreq>");
+  });
+
+  it("truncates an ISO timestamp lastmod to YYYY-MM-DD", () => {
+    const xml = sitemapUrlItem({
+      siteUrl: SITE,
+      pathname: "/x",
+      priority: "0.5",
+      lastmod: "2026-07-08T12:34:56.000Z",
+    });
+    expect(xml).toContain("<lastmod>2026-07-08</lastmod>");
+  });
+
+  it("omits the lastmod line entirely when lastmod is absent or empty", () => {
+    expect(
+      sitemapUrlItem({ siteUrl: SITE, pathname: "/x", priority: "0.5" }),
+    ).not.toContain("<lastmod>");
+    expect(
+      sitemapUrlItem({
+        siteUrl: SITE,
+        pathname: "/x",
+        priority: "0.5",
+        lastmod: "",
+      }),
+    ).not.toContain("<lastmod>");
+  });
+
+  it("XML-escapes the loc", () => {
+    const xml = sitemapUrlItem({
+      siteUrl: SITE,
+      pathname: "/tags/a&b",
+      priority: "0.5",
+    });
+    expect(xml).toContain("<loc>https://heyclau.de/tags/a&amp;b</loc>");
+  });
+});


### PR DESCRIPTION
## What

Moves the sitemap `<url>` block rendering out of `sitemap[.]xml.ts` into a pure module `apps/web/src/lib/sitemap-url-item-lib.ts`:

- `sitemapUrlItem({ siteUrl, pathname, priority, changefreq?, lastmod? })` — XML-escapes the `loc`, truncates `lastmod` to its leading `YYYY-MM-DD` (omitting the line entirely when it resolves to empty), defaults `changefreq` to `weekly`, and emits fields in sitemap order: loc, lastmod, changefreq, priority.

`siteUrl` and `lastmod` become explicit inputs. The route keeps a thin adapter binding `siteConfig.url` and the `atlasRegistry.generatedAt` fallback, so the escaping and lastmod normalization are now testable **without the generated registry** — previously the helper couldn't be exercised at all outside a built app, because it read `@/generated/atlas-registry.json` at module scope. **No behavior change.**

## Tests

`tests/sitemap-url-item-lib.test.ts`: full block in sitemap field order, `changefreq` defaulting to `weekly`, ISO-timestamp `lastmod` truncated to `YYYY-MM-DD`, the `<lastmod>` line omitted for absent/empty input, and XML-escaping of the `loc` (5 cases).

```
pnpm exec vitest run tests/sitemap-url-item-lib.test.ts   # 5 passed
pnpm exec prettier --check <changed files>                # clean
```

Refs #556