### PR TITLE
refactor(web): extract entry WebPage JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/entry-webpage-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-webpage-jsonld-lib.ts
@@ -1,0 +1,21 @@
+// Pure builder for an entry detail page's schema.org WebPage JSON-LD, split out
+// of the route head() so the field mapping (dateModified fallback, optional
+// isBasedOn) can be unit-tested without rendering the route.
+
+import type { Entry } from "@/types/registry";
+
+/** schema.org WebPage JSON-LD for an entry at the given absolute url. */
+export function entryWebPageJsonLd(entry: Entry, url: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: entry.title,
+    description: entry.description,
+    url,
+    datePublished: entry.dateAdded,
+    dateModified: entry.reviewedAt ?? entry.dateAdded,
+    about: entry.category,
+    author: { "@type": "Person", name: entry.author },
+    ...(entry.sourceUrl ? { isBasedOn: entry.sourceUrl } : {}),
+  };
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -38,6 +38,7 @@ import { ComparisonTable } from "@/components/comparison-table";
 import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { entryWebPageJsonLd } from "@/lib/entry-webpage-jsonld-lib";
 import { hasSchemaDetails } from "@/lib/entry-schema-details-lib";
 import { booleanLabel } from "@/lib/boolean-label-lib";
 import { absoluteUrl, clampDescription } from "@/lib/seo";
@@ -162,18 +163,7 @@ export const Route = createFileRoute("/entry/$category/$slug")({
     const e = loaderData.entry;
     const path = `/entry/${params.category}/${params.slug}`;
     const url = absoluteUrl(path);
-    const ld = {
-      "@context": "https://schema.org",
-      "@type": "WebPage",
-      name: e.title,
-      description: e.description,
-      url,
-      datePublished: e.dateAdded,
-      dateModified: e.reviewedAt ?? e.dateAdded,
-      about: e.category,
-      author: { "@type": "Person", name: e.author },
-      ...(e.sourceUrl ? { isBasedOn: e.sourceUrl } : {}),
-    };
+    const ld = entryWebPageJsonLd(e, url);
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/entry-webpage-jsonld-lib.test.ts
+++ b/tests/entry-webpage-jsonld-lib.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { entryWebPageJsonLd } from "../apps/web/src/lib/entry-webpage-jsonld-lib";
+
+const entry = (over: Record<string, unknown> = {}): Entry =>
+  ({
+    title: "My Agent",
+    description: "Does things",
+    category: "agents",
+    author: "Ada",
+    dateAdded: "2026-01-01",
+    ...over,
+  }) as Entry;
+
+const URL = "https://heyclau.de/entry/agents/my-agent";
+
+describe("entryWebPageJsonLd", () => {
+  it("maps the core WebPage fields", () => {
+    const ld = entryWebPageJsonLd(entry(), URL) as Record<string, unknown>;
+    expect(ld["@type"]).toBe("WebPage");
+    expect(ld.name).toBe("My Agent");
+    expect(ld.url).toBe(URL);
+    expect(ld.about).toBe("agents");
+    expect(ld.author).toEqual({ "@type": "Person", name: "Ada" });
+  });
+
+  it("falls back dateModified to dateAdded, or uses reviewedAt when present", () => {
+    expect(entryWebPageJsonLd(entry(), URL).dateModified).toBe("2026-01-01");
+    expect(
+      entryWebPageJsonLd(entry({ reviewedAt: "2026-02-02" }), URL).dateModified,
+    ).toBe("2026-02-02");
+  });
+
+  it("includes isBasedOn only when sourceUrl is present", () => {
+    expect("isBasedOn" in entryWebPageJsonLd(entry(), URL)).toBe(false);
+    expect(
+      entryWebPageJsonLd(entry({ sourceUrl: "https://github.com/o/r" }), URL),
+    ).toMatchObject({ isBasedOn: "https://github.com/o/r" });
+  });
+});


### PR DESCRIPTION
### What & why

The entry detail route built its schema.org WebPage JSON-LD inline in `head()`, so the field mapping (dateModified fallback, optional `isBasedOn`) could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/entry-webpage-jsonld-lib.ts` and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/entry-webpage-jsonld-lib.ts` — `entryWebPageJsonLd(entry, url)`.
- `apps/web/src/routes/entry.$category.$slug.tsx` — build the WebPage `ld` via the helper.
- Add `tests/entry-webpage-jsonld-lib.test.ts` — covers the core fields, `dateModified` fallback vs `reviewedAt`, and the conditional `isBasedOn`. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/entry-webpage-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted JSON-LD is unchanged.
