### PR TITLE
refactor(web): extract pure classifyRegistryPath into registry-event-classify-lib

### DIFF
--- a/apps/web/src/lib/registry-event-classify-lib.ts
+++ b/apps/web/src/lib/registry-event-classify-lib.ts
@@ -1,0 +1,58 @@
+// Pure classification of a changed repo path into a registry feed event, split
+// out of the GitHub webhook route so the path matching can be unit-tested
+// without a request, a signature, or the edge cache.
+
+/** A registry feed event derived from one changed path in a push. */
+export interface RegistryEvent {
+  id: string;
+  kind: "entry" | "changelog" | "validator" | "unknown";
+  category?: string;
+  slug?: string;
+  action: "added" | "updated" | "removed";
+  commit: string;
+  date: string;
+  title?: string;
+}
+
+/** How a path changed in the push that produced the event. */
+export type RegistryEventAction = RegistryEvent["action"];
+
+/**
+ * Classify a changed repo path into a {@link RegistryEvent}, or `null` when the
+ * path is not part of the registry surface. Rules are applied in order:
+ *
+ * 1. `content/<category>/<slug>.{md,mdx,json}` → an `entry` carrying the
+ *    category and slug. This runs first, so a two-segment changelog path such
+ *    as `content/changelog/x.mdx` classifies as an `entry` (category
+ *    `changelog`), not as a `changelog`.
+ * 2. A `content/changelog…` path that did not match rule 1, or any path ending
+ *    in `registry-changelog.json` → `changelog`.
+ * 3. Any remaining path containing `validators` → `validator`.
+ */
+export function classifyRegistryPath(
+  path: string,
+  action: RegistryEventAction,
+  commit: string,
+  date: string,
+): RegistryEvent | null {
+  // content/<category>/<slug>.mdx
+  const m = path.match(/^content\/([^/]+)\/([^/]+)\.(?:mdx?|json)$/);
+  if (m) {
+    return {
+      id: `${commit}:${path}`,
+      kind: "entry",
+      category: m[1],
+      slug: m[2],
+      action,
+      commit,
+      date,
+    };
+  }
+  if (/^content\/changelog/.test(path) || /registry-changelog\.json$/.test(path)) {
+    return { id: `${commit}:${path}`, kind: "changelog", action, commit, date };
+  }
+  if (/validators/.test(path)) {
+    return { id: `${commit}:${path}`, kind: "validator", action, commit, date };
+  }
+  return null;
+}

--- a/apps/web/src/routes/api/public/github/webhook.ts
+++ b/apps/web/src/routes/api/public/github/webhook.ts
@@ -14,6 +14,7 @@ import { createApiFileRoute } from "@/lib/api/file-route";
 
 import { BodyTooLargeError, readRequestTextWithinLimit } from "@/lib/api-security";
 import { getEnvString } from "@/lib/cloudflare-env.server";
+import { classifyRegistryPath, type RegistryEvent } from "@/lib/registry-event-classify-lib";
 import { timingSafeStringEqual, toHex } from "@/lib/webhook-signature-lib";
 
 const ALLOWED_REPO = "jsonbored/awesome-claude";
@@ -21,16 +22,7 @@ const ALLOWED_BRANCH = "main";
 const CACHE_KEY = "https://heyclau.de/internal/alerts-cache";
 export const GITHUB_WEBHOOK_BODY_LIMIT_BYTES = 1024 * 1024;
 
-export interface RegistryEvent {
-  id: string;
-  kind: "entry" | "changelog" | "validator" | "unknown";
-  category?: string;
-  slug?: string;
-  action: "added" | "updated" | "removed";
-  commit: string;
-  date: string;
-  title?: string;
-}
+export type { RegistryEvent };
 
 interface PushFile {
   added?: string[];
@@ -53,34 +45,6 @@ async function verify(secret: string, signature: string | null, body: string): P
   const digest = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body));
   const expected = `sha256=${toHex(digest)}`;
   return timingSafeStringEqual(signature, expected);
-}
-
-function classify(
-  path: string,
-  action: "added" | "updated" | "removed",
-  commit: string,
-  date: string,
-): RegistryEvent | null {
-  // content/<category>/<slug>.mdx
-  const m = path.match(/^content\/([^/]+)\/([^/]+)\.(?:mdx?|json)$/);
-  if (m) {
-    return {
-      id: `${commit}:${path}`,
-      kind: "entry",
-      category: m[1],
-      slug: m[2],
-      action,
-      commit,
-      date,
-    };
-  }
-  if (/^content\/changelog/.test(path) || /registry-changelog\.json$/.test(path)) {
-    return { id: `${commit}:${path}`, kind: "changelog", action, commit, date };
-  }
-  if (/validators/.test(path)) {
-    return { id: `${commit}:${path}`, kind: "validator", action, commit, date };
-  }
-  return null;
 }
 
 async function appendEvents(events: RegistryEvent[]): Promise<void> {
@@ -160,15 +124,15 @@ export async function handleGithubWebhookPost(request: Request) {
       const commit = c.id ?? "unknown";
       const date = c.timestamp ?? new Date().toISOString();
       for (const p of c.added ?? []) {
-        const ev = classify(p, "added", commit, date);
+        const ev = classifyRegistryPath(p, "added", commit, date);
         if (ev) events.push(ev);
       }
       for (const p of c.modified ?? []) {
-        const ev = classify(p, "updated", commit, date);
+        const ev = classifyRegistryPath(p, "updated", commit, date);
         if (ev) events.push(ev);
       }
       for (const p of c.removed ?? []) {
-        const ev = classify(p, "removed", commit, date);
+        const ev = classifyRegistryPath(p, "removed", commit, date);
         if (ev) events.push(ev);
       }
     }

--- a/tests/registry-event-classify-lib.test.ts
+++ b/tests/registry-event-classify-lib.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyRegistryPath } from "../apps/web/src/lib/registry-event-classify-lib";
+
+const COMMIT = "abc123";
+const DATE = "2026-07-08T12:00:00.000Z";
+
+const classify = (path: string) =>
+  classifyRegistryPath(path, "added", COMMIT, DATE);
+
+describe("classifyRegistryPath", () => {
+  it("classifies a content entry, carrying category and slug", () => {
+    expect(classify("content/mcp/opensearch.mdx")).toEqual({
+      id: `${COMMIT}:content/mcp/opensearch.mdx`,
+      kind: "entry",
+      category: "mcp",
+      slug: "opensearch",
+      action: "added",
+      commit: COMMIT,
+      date: DATE,
+    });
+  });
+
+  it("accepts .md and .json entry extensions", () => {
+    expect(classify("content/agents/x.md")?.kind).toBe("entry");
+    expect(classify("content/agents/x.json")?.kind).toBe("entry");
+  });
+
+  it("rejects an unsupported entry extension", () => {
+    expect(classify("content/agents/x.txt")).toBeNull();
+  });
+
+  it("rejects a nested entry path (slug may not contain a slash)", () => {
+    expect(classify("content/agents/nested/x.mdx")).toBeNull();
+  });
+
+  it("treats a two-segment changelog path as an entry, since the entry rule runs first", () => {
+    const ev = classify("content/changelog/x.mdx");
+    expect(ev?.kind).toBe("entry");
+    expect(ev?.category).toBe("changelog");
+  });
+
+  it("classifies a changelog path that does not match the entry rule", () => {
+    expect(classify("content/changelog/2026/notes.txt")?.kind).toBe(
+      "changelog",
+    );
+  });
+
+  it("classifies any registry-changelog.json path as changelog", () => {
+    const ev = classify("apps/web/public/data/registry-changelog.json");
+    expect(ev?.kind).toBe("changelog");
+    expect(ev?.category).toBeUndefined();
+  });
+
+  it("classifies a validators path as validator", () => {
+    expect(classify("apps/web/src/routes/validators.tsx")?.kind).toBe(
+      "validator",
+    );
+  });
+
+  it("returns null for an unrelated path", () => {
+    expect(classify("README.md")).toBeNull();
+    expect(classify("apps/web/src/lib/utils.ts")).toBeNull();
+  });
+
+  it("threads the action, commit and date through", () => {
+    const ev = classifyRegistryPath(
+      "content/mcp/x.mdx",
+      "removed",
+      "deadbeef",
+      DATE,
+    );
+    expect(ev).toMatchObject({
+      action: "removed",
+      commit: "deadbeef",
+      date: DATE,
+    });
+    expect(ev?.id).toBe("deadbeef:content/mcp/x.mdx");
+  });
+});


### PR DESCRIPTION
## What

Moves the changed-path classifier and the `RegistryEvent` interface out of the GitHub webhook route into a pure module `apps/web/src/lib/registry-event-classify-lib.ts`:

- `classifyRegistryPath(path, action, commit, date)` — maps a changed repo path to a `RegistryEvent`, or `null` when the path isn't part of the registry surface.

Previously this logic could only be reached through a signed webhook request, so it was untested. The route now imports the helper, re-exports `RegistryEvent` to keep its existing export surface, and uses `classifyRegistryPath` at its three call sites. **No behavior change** — `tests/github-webhook-route.test.ts` still passes untouched.

## A subtlety worth recording

The doc comment now states the precedence the regexes already implied: the entry rule runs **first**, so a two-segment path like `content/changelog/x.mdx` classifies as an **entry** with category `changelog` — not as a `changelog`. The `changelog` rule only catches paths that miss the entry pattern (a deeper path, a non-`md/mdx/json` extension) or any `registry-changelog.json`. This is existing behavior, now pinned by a test rather than left implicit.

## Tests

`tests/registry-event-classify-lib.test.ts` (10 cases): entry with category/slug, `.md`/`.json` extensions accepted, unsupported extension and nested slug rejected, the changelog-vs-entry precedence above, deeper changelog paths, any `registry-changelog.json`, `validators` paths, unrelated paths returning `null`, and action/commit/date threading into the event `id`.

```
pnpm exec vitest run tests/registry-event-classify-lib.test.ts   # 10 passed
pnpm exec vitest run tests/github-webhook-route.test.ts          # 7 passed (unchanged)
pnpm exec prettier --check <changed files>                       # clean
```

Refs #556