### PR TITLE
refactor(web): extract trending reason codes into a lib

### DIFF
--- a/apps/web/src/lib/trending-reason-codes-lib.ts
+++ b/apps/web/src/lib/trending-reason-codes-lib.ts
@@ -1,0 +1,13 @@
+// Pure mapping of an entry's trend signals to its reason codes, split out of
+// the registry trending route so the code selection can be unit-tested.
+
+/** Reason codes for the trend signals present on an entry (order preserved). */
+export function trendingReasonCodes(signals: {
+  firstPartyPackage: boolean;
+  productionVerified: boolean;
+}): string[] {
+  return [
+    signals.firstPartyPackage ? "first_party_package" : "",
+    signals.productionVerified ? "production_verified" : "",
+  ].filter(Boolean);
+}

--- a/apps/web/src/routes/api/registry/trending.ts
+++ b/apps/web/src/routes/api/registry/trending.ts
@@ -13,18 +13,13 @@ import {
   isFirstPartyPackage,
 } from "@/lib/registry-trending-entry-lib";
 import { entryPlatforms, matchesPlatform } from "@/lib/registry-trending-platform-lib";
+import { trendingReasonCodes } from "@/lib/trending-reason-codes-lib";
 import { safeVoteCounts } from "@/lib/votes";
 
 type Entry = (typeof ENTRIES)[number];
 
 const entryKey = (entry: Entry) => `${entry.category}:${entry.slug}`;
 const communityTarget = (entry: Entry) => entryCommunityTarget(entry.category, entry.slug);
-
-const reasonCodes = (input: ReturnType<typeof trendInput>) =>
-  [
-    input.firstPartyPackage ? "first_party_package" : "",
-    input.productionVerified ? "production_verified" : "",
-  ].filter(Boolean);
 
 function trendInput(entry: Entry, states: Awaited<ReturnType<typeof readStates>>) {
   return {
@@ -58,7 +53,7 @@ export const GET = createApiHandler("registry.trending", async ({ request, query
   const ranked = scopedEntries
     .map((entry) => {
       const input = trendInput(entry, states);
-      return { entry, score: communityDiscoveryScore(input), reasons: reasonCodes(input) };
+      return { entry, score: communityDiscoveryScore(input), reasons: trendingReasonCodes(input) };
     })
     .filter((item) => item.score > 0)
     .sort(

--- a/tests/trending-reason-codes-lib.test.ts
+++ b/tests/trending-reason-codes-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { trendingReasonCodes } from "../apps/web/src/lib/trending-reason-codes-lib";
+
+describe("trendingReasonCodes", () => {
+  it("returns both codes when both signals are set", () => {
+    expect(
+      trendingReasonCodes({
+        firstPartyPackage: true,
+        productionVerified: true,
+      }),
+    ).toEqual(["first_party_package", "production_verified"]);
+  });
+
+  it("returns only the set signal's code", () => {
+    expect(
+      trendingReasonCodes({
+        firstPartyPackage: true,
+        productionVerified: false,
+      }),
+    ).toEqual(["first_party_package"]);
+    expect(
+      trendingReasonCodes({
+        firstPartyPackage: false,
+        productionVerified: true,
+      }),
+    ).toEqual(["production_verified"]);
+  });
+
+  it("returns an empty list when neither signal is set", () => {
+    expect(
+      trendingReasonCodes({
+        firstPartyPackage: false,
+        productionVerified: false,
+      }),
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

The registry trending route mapped an entry's trend signals to reason codes inline, so the code selection could not be unit-tested without the handler. This moves it into `apps/web/src/lib/trending-reason-codes-lib.ts` and imports it back.

### Changes

- Add `apps/web/src/lib/trending-reason-codes-lib.ts` — `trendingReasonCodes(signals)`.
- `apps/web/src/routes/api/registry/trending.ts` — import and use it; drop the local `reasonCodes`.
- Add `tests/trending-reason-codes-lib.test.ts` — covers both signals set, each alone, and neither. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/trending-reason-codes-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the trending payload's reason codes are unchanged.
