### PR TITLE
refactor(web): extract pure confirmResultHtml into newsletter-confirm-page-lib

### DIFF
--- a/apps/web/src/lib/newsletter-confirm-page-lib.ts
+++ b/apps/web/src/lib/newsletter-confirm-page-lib.ts
@@ -1,0 +1,52 @@
+// Pure rendering for the newsletter confirmation landing page, split out of the
+// confirm route so the markup and status selection can be unit-tested without
+// constructing a Response.
+
+import { escapeHtml } from "@/lib/newsletter-emails-lib";
+import { siteConfig } from "@/lib/site";
+
+export interface ConfirmResultOptions {
+  ok: boolean;
+  heading: string;
+  body: string;
+  /** When present, renders a confirm form that re-posts this token. */
+  token?: string;
+  /** Explicit HTTP status; otherwise derived from `ok`. */
+  status?: number;
+}
+
+/** The confirmation page's status: an explicit `status`, else 200 when ok and 400 when not. */
+export function confirmResultStatus(ok: boolean, status?: number): number {
+  return status ?? (ok ? 200 : 400);
+}
+
+/**
+ * Render the minimal, on-brand confirmation landing page. A `token` renders the
+ * re-post confirm form (with the token HTML-escaped); without one the page
+ * links back to `siteUrl`'s browse page. The accent glyph and colour follow
+ * `ok`.
+ */
+export function confirmResultHtml(
+  opts: Pick<ConfirmResultOptions, "ok" | "heading" | "body" | "token">,
+  siteUrl = siteConfig.url,
+): string {
+  const accent = opts.ok ? "#2f8f5b" : "#b4541f";
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <title>${opts.heading} — HeyClaude</title>
+  </head>
+  <body style="margin:0;background:#f7f5ef;font:400 16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#171614;">
+    <main style="max-width:480px;margin:0 auto;padding:80px 20px;text-align:center;">
+      <div style="font:600 13px/1.4 sans-serif;letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude</div>
+      <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
+      <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
+      <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
+      ${opts.token ? `<form method="post" action="/api/public/newsletter/confirm" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteUrl}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
+    </main>
+  </body>
+</html>`;
+}

--- a/apps/web/src/routes/api/public/newsletter/confirm.ts
+++ b/apps/web/src/routes/api/public/newsletter/confirm.ts
@@ -6,39 +6,19 @@ import { BodyTooLargeError, readRequestTextWithinLimit } from "@/lib/api-securit
 import { getEnvString } from "@/lib/cloudflare-env.server";
 import { verifyConfirmToken } from "@/lib/newsletter-token.server";
 import { addNewsletterContact } from "@/routes/api/newsletter/subscribe";
-import { buildWelcomeEmail, escapeHtml } from "@/lib/newsletter-emails";
+import { buildWelcomeEmail } from "@/lib/newsletter-emails";
+import {
+  type ConfirmResultOptions,
+  confirmResultHtml,
+  confirmResultStatus,
+} from "@/lib/newsletter-confirm-page-lib";
 import { sendResendEmail } from "@/lib/newsletter-send.server";
 import { siteConfig } from "@/lib/site";
 
 // Minimal, on-brand confirmation landing page (light theme, matches the site).
-function resultPage(opts: {
-  ok: boolean;
-  heading: string;
-  body: string;
-  token?: string;
-  status?: number;
-}): Response {
-  const accent = opts.ok ? "#2f8f5b" : "#b4541f";
-  const html = `<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="robots" content="noindex" />
-    <title>${opts.heading} — HeyClaude</title>
-  </head>
-  <body style="margin:0;background:#f7f5ef;font:400 16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;color:#171614;">
-    <main style="max-width:480px;margin:0 auto;padding:80px 20px;text-align:center;">
-      <div style="font:600 13px/1.4 sans-serif;letter-spacing:1.5px;text-transform:uppercase;color:#6b6a64;">HeyClaude</div>
-      <div style="margin-top:20px;font-size:40px;color:${accent};">${opts.ok ? "✓" : "—"}</div>
-      <h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">${opts.heading}</h1>
-      <p style="margin:14px 0 0;color:#4d4c47;">${opts.body}</p>
-      ${opts.token ? `<form method="post" action="/api/public/newsletter/confirm" style="margin:28px 0 0;"><input type="hidden" name="token" value="${escapeHtml(opts.token)}" /><button type="submit" style="border:0;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;cursor:pointer;">Confirm subscription</button></form>` : `<a href="${siteConfig.url}/browse" style="display:inline-block;margin-top:28px;background:#171614;color:#fff;text-decoration:none;font-weight:600;padding:12px 20px;border-radius:10px;">Browse the directory</a>`}
-    </main>
-  </body>
-</html>`;
-  return new Response(html, {
-    status: opts.status ?? (opts.ok ? 200 : 400),
+function resultPage(opts: ConfirmResultOptions): Response {
+  return new Response(confirmResultHtml(opts), {
+    status: confirmResultStatus(opts.ok, opts.status),
     headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
   });
 }

--- a/tests/newsletter-confirm-page-lib.test.ts
+++ b/tests/newsletter-confirm-page-lib.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  confirmResultHtml,
+  confirmResultStatus,
+} from "../apps/web/src/lib/newsletter-confirm-page-lib";
+
+const SITE = "https://heyclau.de";
+
+describe("confirmResultStatus", () => {
+  it("defaults to 200 when ok and 400 when not", () => {
+    expect(confirmResultStatus(true)).toBe(200);
+    expect(confirmResultStatus(false)).toBe(400);
+  });
+
+  it("prefers an explicit status", () => {
+    expect(confirmResultStatus(true, 202)).toBe(202);
+    expect(confirmResultStatus(false, 410)).toBe(410);
+  });
+});
+
+describe("confirmResultHtml", () => {
+  const base = { ok: true, heading: "Subscribed", body: "You're in." };
+
+  it("renders the heading in the title and the body copy", () => {
+    const html = confirmResultHtml(base, SITE);
+    expect(html).toContain("<title>Subscribed — HeyClaude</title>");
+    expect(html).toContain(
+      '<h1 style="margin:12px 0 0;font-size:26px;font-weight:700;">Subscribed</h1>',
+    );
+    expect(html).toContain("You're in.");
+  });
+
+  it("uses the success glyph and accent when ok", () => {
+    const html = confirmResultHtml(base, SITE);
+    expect(html).toContain("#2f8f5b");
+    expect(html).toContain("✓");
+  });
+
+  it("uses the failure glyph and accent when not ok", () => {
+    const html = confirmResultHtml({ ...base, ok: false }, SITE);
+    expect(html).toContain("#b4541f");
+    expect(html).toContain("—");
+  });
+
+  it("renders a confirm form carrying the token when one is given", () => {
+    const html = confirmResultHtml({ ...base, token: "tok123" }, SITE);
+    expect(html).toContain('action="/api/public/newsletter/confirm"');
+    expect(html).toContain('name="token" value="tok123"');
+    expect(html).not.toContain("Browse the directory");
+  });
+
+  it("HTML-escapes the token", () => {
+    const html = confirmResultHtml({ ...base, token: '"><script>' }, SITE);
+    expect(html).not.toContain('value=""><script>');
+    expect(html).toContain("&lt;script&gt;");
+  });
+
+  it("links back to the site's browse page when there is no token", () => {
+    const html = confirmResultHtml(base, SITE);
+    expect(html).toContain(`href="${SITE}/browse"`);
+    expect(html).toContain("Browse the directory");
+    expect(html).not.toContain("<form");
+  });
+
+  it("marks the page noindex", () => {
+    expect(confirmResultHtml(base, SITE)).toContain(
+      'name="robots" content="noindex"',
+    );
+  });
+});


### PR DESCRIPTION
## What

Moves the newsletter confirmation landing page out of the confirm route into a pure module `apps/web/src/lib/newsletter-confirm-page-lib.ts`:

- `confirmResultHtml(opts, siteUrl?)` — renders the page. With a `token` it emits the re-post confirm form (token HTML-escaped); without one it links back to `siteUrl`'s browse page. Glyph and accent colour follow `ok`.
- `confirmResultStatus(ok, status?)` — an explicit `status`, else `200` when ok and `400` when not.

`resultPage` in the route is now just the `Response` shell, and its **ten call sites are unchanged**. `siteUrl` is a default parameter, so the markup is testable without `siteConfig`. **No behavior change.**

## Tests

`tests/newsletter-confirm-page-lib.test.ts` (9 cases): status defaulting and explicit override; heading in `<title>` and `<h1>`; success vs failure glyph/accent; the confirm form rendered only with a token; **token HTML-escaping** (a `"><script>` token cannot break out of the `value` attribute); the browse link rendered only without a token; and the `noindex` robots tag.

Note the `heading`/`body` copy is interpolated raw, exactly as before — every call site passes an internal literal. I kept that as-is rather than change behavior in a refactor.

```
pnpm exec vitest run tests/newsletter-confirm-page-lib.test.ts   # 9 passed
pnpm exec vitest run tests/newsletter-*-lib.test.ts              # 79 passed
pnpm exec prettier --check <changed files>                       # clean
```

Refs #556