### PR TITLE
refactor(web): extract entry breadcrumb JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts
@@ -1,0 +1,27 @@
+// Pure builder for an entry detail page's schema.org BreadcrumbList JSON-LD,
+// split out of the route head() so the Directory > category > entry trail can be
+// unit-tested. The absolute-URL resolver is injected to keep the builder pure.
+
+import type { Entry } from "@/types/registry";
+
+/** schema.org BreadcrumbList JSON-LD: Directory > category > entry. */
+export function entryBreadcrumbJsonLd(
+  entry: Entry,
+  url: string,
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: entry.category,
+        item: absoluteUrl(`/${entry.category}`),
+      },
+      { "@type": "ListItem", position: 3, name: entry.title, item: url },
+    ],
+  };
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -38,6 +38,7 @@ import { ComparisonTable } from "@/components/comparison-table";
 import { compareEntryInteractiveUiState } from "@/lib/compare-entry-interactive-ui-lib";
 import { buildEntryJsonLd } from "@heyclaude/registry";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { entryBreadcrumbJsonLd } from "@/lib/entry-breadcrumb-jsonld-lib";
 import { entryWebPageJsonLd } from "@/lib/entry-webpage-jsonld-lib";
 import { hasSchemaDetails } from "@/lib/entry-schema-details-lib";
 import { booleanLabel } from "@/lib/boolean-label-lib";
@@ -164,20 +165,7 @@ export const Route = createFileRoute("/entry/$category/$slug")({
     const path = `/entry/${params.category}/${params.slug}`;
     const url = absoluteUrl(path);
     const ld = entryWebPageJsonLd(e, url);
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-        {
-          "@type": "ListItem",
-          position: 2,
-          name: e.category,
-          item: absoluteUrl(`/${e.category}`),
-        },
-        { "@type": "ListItem", position: 3, name: e.title, item: url },
-      ],
-    };
+    const breadcrumbs = entryBreadcrumbJsonLd(e, url, absoluteUrl);
     const ogUrl = absoluteUrl(`/og/${params.category}/${params.slug}`);
     const ogTitle = `${e.title} — HeyClaude`;
     const metaDescription = clampDescription(e.seoDescription ?? e.description);

--- a/tests/entry-breadcrumb-jsonld-lib.test.ts
+++ b/tests/entry-breadcrumb-jsonld-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import type { Entry } from "../apps/web/src/types/registry";
+import { entryBreadcrumbJsonLd } from "../apps/web/src/lib/entry-breadcrumb-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+const entry = (over: Record<string, unknown> = {}): Entry =>
+  ({ title: "My Agent", category: "agents", ...over }) as Entry;
+
+const URL = "https://heyclau.de/entry/agents/my-agent";
+
+describe("entryBreadcrumbJsonLd", () => {
+  it("builds a three-item Directory > category > entry trail", () => {
+    const ld = entryBreadcrumbJsonLd(entry(), URL, abs);
+    expect(ld["@type"]).toBe("BreadcrumbList");
+    const items = ld.itemListElement;
+    expect(items.map((i) => i.position)).toEqual([1, 2, 3]);
+    expect(items.map((i) => i.name)).toEqual([
+      "Directory",
+      "agents",
+      "My Agent",
+    ]);
+  });
+
+  it("resolves list item urls via the injected absoluteUrl (entry uses the given url)", () => {
+    const ld = entryBreadcrumbJsonLd(entry(), URL, abs);
+    expect(ld.itemListElement[0].item).toBe("https://heyclau.de/browse");
+    expect(ld.itemListElement[1].item).toBe("https://heyclau.de/agents");
+    expect(ld.itemListElement[2].item).toBe(URL);
+  });
+});


### PR DESCRIPTION
### What & why

The entry detail route built its schema.org BreadcrumbList JSON-LD inline in `head()`, so the Directory > category > entry trail could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts` (the `absoluteUrl` resolver is injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts` — `entryBreadcrumbJsonLd(entry, url, absoluteUrl)`.
- `apps/web/src/routes/entry.$category.$slug.tsx` — build the breadcrumbs via the helper.
- Add `tests/entry-breadcrumb-jsonld-lib.test.ts` — covers the three-item trail (positions/names) and injected-URL resolution.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/entry-breadcrumb-jsonld-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted breadcrumb JSON-LD is unchanged.
