### PR TITLE
refactor(web): extract best-list ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/best-list-jsonld-lib.ts
+++ b/apps/web/src/lib/best-list-jsonld-lib.ts
@@ -1,0 +1,30 @@
+// Pure builder for a "best list" page's schema.org ItemList JSON-LD, split out
+// of the route head() so the pick mapping can be unit-tested. The absolute-URL
+// resolver and the ref->title lookup are injected to keep the builder pure.
+
+type BestListLike = {
+  title: string;
+  subtitle: string;
+  picks: Array<{ ref: string }>;
+};
+
+/** schema.org ItemList JSON-LD for a best list's ordered picks. */
+export function bestListItemListJsonLd(
+  list: BestListLike,
+  absoluteUrl: (path: string) => string,
+  resolveTitle: (ref: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: list.title,
+    description: list.subtitle,
+    numberOfItems: list.picks.length,
+    itemListElement: list.picks.map((pick, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: resolveTitle(pick.ref),
+      url: absoluteUrl(`/entry/${pick.ref}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -10,6 +10,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { getBestListEditorial } from "@/data/best-list-editorial";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { bestListItemListJsonLd } from "@/lib/best-list-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
@@ -26,22 +27,11 @@ export const Route = createFileRoute("/best/$slug")({
     const l = loaderData.list;
     const url = absoluteUrl(`/best/${params.slug}`);
     const ogImage = ogImageUrl({ title: l.title, eyebrow: "Best", description: l.seoDescription });
-    const ld = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: l.title,
-      description: l.subtitle,
-      numberOfItems: l.picks.length,
-      itemListElement: l.picks.map((p, i) => {
-        const entry = ENTRIES.find((e) => `${e.category}/${e.slug}` === p.ref);
-        return {
-          "@type": "ListItem",
-          position: i + 1,
-          name: entry?.title ?? p.ref,
-          url: absoluteUrl(`/entry/${p.ref}`),
-        };
-      }),
-    };
+    const ld = bestListItemListJsonLd(
+      l,
+      absoluteUrl,
+      (ref) => ENTRIES.find((e) => `${e.category}/${e.slug}` === ref)?.title ?? ref,
+    );
     return {
       meta: [
         { title: `${l.seoTitle} — HeyClaude` },

--- a/tests/best-list-jsonld-lib.test.ts
+++ b/tests/best-list-jsonld-lib.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { bestListItemListJsonLd } from "../apps/web/src/lib/best-list-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const list = {
+  title: "Best Agents",
+  subtitle: "Our top picks",
+  picks: [{ ref: "agents/a" }, { ref: "agents/b" }],
+};
+
+describe("bestListItemListJsonLd", () => {
+  it("builds an ItemList with name/description/count", () => {
+    const ld = bestListItemListJsonLd(list, abs, () => "");
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("Best Agents");
+    expect(ld.description).toBe("Our top picks");
+    expect(ld.numberOfItems).toBe(2);
+  });
+
+  it("maps picks to positioned ListItems with resolved titles and entry urls", () => {
+    const titles: Record<string, string> = { "agents/a": "Agent A" };
+    const ld = bestListItemListJsonLd(list, abs, (ref) => titles[ref] ?? ref);
+    expect(ld.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Agent A",
+        url: "https://heyclau.de/entry/agents/a",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "agents/b",
+        url: "https://heyclau.de/entry/agents/b",
+      },
+    ]);
+  });
+
+  it("handles an empty pick list", () => {
+    const ld = bestListItemListJsonLd({ ...list, picks: [] }, abs, () => "");
+    expect(ld.numberOfItems).toBe(0);
+    expect(ld.itemListElement).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

The best-list detail route built its schema.org ItemList JSON-LD inline in `head()`, so the pick-to-ListItem mapping could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/best-list-jsonld-lib.ts` (the `absoluteUrl` resolver and the ref->title lookup are injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/best-list-jsonld-lib.ts` — `bestListItemListJsonLd(list, absoluteUrl, resolveTitle)`.
- `apps/web/src/routes/best.$slug.tsx` — build the ItemList via the helper, passing an ENTRIES-backed title resolver.
- Add `tests/best-list-jsonld-lib.test.ts` — covers the list metadata, positioned ListItems with resolved titles + entry urls, and the empty-pick case.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/best-list-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
