### PR TITLE
refactor(web): extract contributor Person JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/contributor-person-jsonld-lib.ts
+++ b/apps/web/src/lib/contributor-person-jsonld-lib.ts
@@ -1,0 +1,23 @@
+// Pure builder for a contributor page's schema.org Person JSON-LD, split out of
+// the route head() so the conditional alternateName/description/sameAs fields
+// can be unit-tested without rendering the route.
+
+type ContributorLike = {
+  handle?: string | null;
+  bio?: string | null;
+  github?: string | null;
+};
+
+/** schema.org Person JSON-LD for a contributor at the given url + display name. */
+export function contributorPersonJsonLd(contributor: ContributorLike, url: string, name: string) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "@id": `${url}#person`,
+    name,
+    url,
+    ...(contributor.handle ? { alternateName: `@${contributor.handle}` } : {}),
+    ...(contributor.bio ? { description: contributor.bio } : {}),
+    ...(contributor.github ? { sameAs: [contributor.github] } : {}),
+  };
+}

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -22,6 +22,7 @@ import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
 import { submitterAttribution } from "@/lib/contributor-profile-summary";
 import type { Category, Contributor, Entry } from "@/types/registry";
@@ -41,16 +42,7 @@ export const Route = createFileRoute("/contributors/$slug")({
     const description =
       c.bio ?? `Resources contributed to the HeyClaude registry by ${name} (@${c.handle}).`;
     const ogImage = ogImageUrl({ title: name, eyebrow: "Contributor", description });
-    const person = {
-      "@context": "https://schema.org",
-      "@type": "Person",
-      "@id": `${url}#person`,
-      name,
-      url,
-      ...(c.handle ? { alternateName: `@${c.handle}` } : {}),
-      ...(c.bio ? { description: c.bio } : {}),
-      ...(c.github ? { sameAs: [c.github] } : {}),
-    };
+    const person = contributorPersonJsonLd(c, url, name);
     const profilePage = {
       "@context": "https://schema.org",
       "@type": "ProfilePage",

--- a/tests/contributor-person-jsonld-lib.test.ts
+++ b/tests/contributor-person-jsonld-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { contributorPersonJsonLd } from "../apps/web/src/lib/contributor-person-jsonld-lib";
+
+const URL = "https://heyclau.de/contributors/ada";
+
+describe("contributorPersonJsonLd", () => {
+  it("maps the core Person fields with an anchored @id", () => {
+    const ld = contributorPersonJsonLd({}, URL, "Ada") as Record<
+      string,
+      unknown
+    >;
+    expect(ld["@type"]).toBe("Person");
+    expect(ld["@id"]).toBe(`${URL}#person`);
+    expect(ld.name).toBe("Ada");
+    expect(ld.url).toBe(URL);
+  });
+
+  it("omits optional fields when absent", () => {
+    const ld = contributorPersonJsonLd({}, URL, "Ada");
+    expect("alternateName" in ld).toBe(false);
+    expect("description" in ld).toBe(false);
+    expect("sameAs" in ld).toBe(false);
+  });
+
+  it("includes alternateName, description, and sameAs when present", () => {
+    const ld = contributorPersonJsonLd(
+      { handle: "ada", bio: "Builds tools", github: "https://github.com/ada" },
+      URL,
+      "Ada",
+    );
+    expect(ld).toMatchObject({
+      alternateName: "@ada",
+      description: "Builds tools",
+      sameAs: ["https://github.com/ada"],
+    });
+  });
+});


### PR DESCRIPTION
### What & why

The contributor detail route built its schema.org Person JSON-LD inline in `head()`, so the conditional `alternateName`/`description`/`sameAs` fields could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/contributor-person-jsonld-lib.ts` and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/contributor-person-jsonld-lib.ts` — `contributorPersonJsonLd(contributor, url, name)`.
- `apps/web/src/routes/contributors.$slug.tsx` — build the Person `ld` via the helper.
- Add `tests/contributor-person-jsonld-lib.test.ts` — covers the core fields + anchored `@id`, omission of optional fields, and their inclusion when present. Branch coverage 100% (6/6).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/contributor-person-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted Person JSON-LD is unchanged.
