### PR TITLE
refactor(web): extract integration SoftwareApplication JSON-LD into a lib

### DIFF
--- a/apps/web/src/lib/integration-app-jsonld-lib.ts
+++ b/apps/web/src/lib/integration-app-jsonld-lib.ts
@@ -1,0 +1,27 @@
+// Pure builder for an integration page's schema.org SoftwareApplication JSON-LD,
+// split out of the route head() so the optional softwareVersion and publisher
+// fields can be unit-tested. The absolute-URL resolver is injected.
+
+type IntegrationAppFields = {
+  name: string;
+  description: string;
+  version?: string | null;
+};
+
+/** schema.org SoftwareApplication JSON-LD for an integration at the given url. */
+export function integrationAppJsonLd(
+  integration: IntegrationAppFields,
+  url: string,
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: integration.name,
+    description: integration.description,
+    url,
+    applicationCategory: "DeveloperApplication",
+    ...(integration.version ? { softwareVersion: integration.version } : {}),
+    publisher: { "@type": "Organization", name: "HeyClaude", url: absoluteUrl("/") },
+  };
+}

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -7,6 +7,7 @@ import { LiveVersionBadge } from "@/components/live-version-badge";
 import { CopyButton } from "@/components/copy-button";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { integrationAppJsonLd } from "@/lib/integration-app-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
 
 export const Route = createFileRoute("/integrations/$slug")({
@@ -21,16 +22,11 @@ export const Route = createFileRoute("/integrations/$slug")({
     const url = absoluteUrl(`/integrations/${params.slug}`);
     const description = it.tagline;
     const ogImage = ogImageUrl({ title: it.name, eyebrow: "Integration", description });
-    const app = {
-      "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      name: it.name,
-      description,
+    const app = integrationAppJsonLd(
+      { name: it.name, description, version: it.version },
       url,
-      applicationCategory: "DeveloperApplication",
-      ...(it.version ? { softwareVersion: it.version } : {}),
-      publisher: { "@type": "Organization", name: "HeyClaude", url: absoluteUrl("/") },
-    };
+      absoluteUrl,
+    );
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/integration-app-jsonld-lib.test.ts
+++ b/tests/integration-app-jsonld-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { integrationAppJsonLd } from "../apps/web/src/lib/integration-app-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+const URL = "https://heyclau.de/integrations/cursor";
+
+describe("integrationAppJsonLd", () => {
+  it("maps the core SoftwareApplication fields", () => {
+    const ld = integrationAppJsonLd(
+      { name: "Cursor", description: "AI editor" },
+      URL,
+      abs,
+    ) as Record<string, unknown>;
+    expect(ld["@type"]).toBe("SoftwareApplication");
+    expect(ld.name).toBe("Cursor");
+    expect(ld.description).toBe("AI editor");
+    expect(ld.url).toBe(URL);
+    expect(ld.applicationCategory).toBe("DeveloperApplication");
+    expect(ld.publisher).toEqual({
+      "@type": "Organization",
+      name: "HeyClaude",
+      url: "https://heyclau.de/",
+    });
+  });
+
+  it("includes softwareVersion only when a version is present", () => {
+    expect(
+      "softwareVersion" in
+        integrationAppJsonLd({ name: "X", description: "d" }, URL, abs),
+    ).toBe(false);
+    expect(
+      integrationAppJsonLd(
+        { name: "X", description: "d", version: "1.2.0" },
+        URL,
+        abs,
+      ),
+    ).toMatchObject({ softwareVersion: "1.2.0" });
+  });
+});


### PR DESCRIPTION
### What & why

The integration detail route built its schema.org SoftwareApplication JSON-LD inline in `head()`, so the optional `softwareVersion` and the publisher block could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/integration-app-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/integration-app-jsonld-lib.ts` — `integrationAppJsonLd(integration, url, absoluteUrl)`.
- `apps/web/src/routes/integrations.$slug.tsx` — build the SoftwareApplication `ld` via the helper.
- Add `tests/integration-app-jsonld-lib.test.ts` — covers the core fields + publisher, and conditional `softwareVersion`. Branch coverage 100% (2/2).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/integration-app-jsonld-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted JSON-LD is unchanged.
