### PR TITLE
refactor(web): extract changelog ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/changelog-jsonld-lib.ts
+++ b/apps/web/src/lib/changelog-jsonld-lib.ts
@@ -1,0 +1,31 @@
+// Pure builder for the changelog page's schema.org ItemList of NewsArticles,
+// split out of the route head() so the note mapping and stream->section labels
+// can be unit-tested without rendering the route.
+
+type ReleaseNoteLike = {
+  title: string;
+  date: string;
+  body: string;
+  stream: string;
+};
+
+/** schema.org ItemList JSON-LD of NewsArticles for the changelog release notes. */
+export function changelogItemListJsonLd(notes: ReleaseNoteLike[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "HeyClaude registry changelog",
+    itemListElement: notes.map((note, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "NewsArticle",
+        headline: note.title,
+        datePublished: note.date,
+        articleSection:
+          note.stream === "release" ? "Releases" : note.stream === "policy" ? "Policy" : "Security",
+        description: note.body,
+      },
+    })),
+  };
+}

--- a/apps/web/src/routes/changelog.tsx
+++ b/apps/web/src/routes/changelog.tsx
@@ -6,6 +6,7 @@ import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
 import { PageContainer } from "@/components/page-container";
 import { cn } from "@/lib/utils";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { changelogItemListJsonLd } from "@/lib/changelog-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 
 export const Route = createFileRoute("/changelog")({
@@ -43,23 +44,7 @@ export const Route = createFileRoute("/changelog")({
     scripts: [
       {
         type: "application/ld+json",
-        children: stringifyJsonLd({
-          "@context": "https://schema.org",
-          "@type": "ItemList",
-          name: "HeyClaude registry changelog",
-          itemListElement: RELEASE_NOTES.map((n, i) => ({
-            "@type": "ListItem",
-            position: i + 1,
-            item: {
-              "@type": "NewsArticle",
-              headline: n.title,
-              datePublished: n.date,
-              articleSection:
-                n.stream === "release" ? "Releases" : n.stream === "policy" ? "Policy" : "Security",
-              description: n.body,
-            },
-          })),
-        }),
+        children: stringifyJsonLd(changelogItemListJsonLd(RELEASE_NOTES)),
       },
     ],
   }),

--- a/tests/changelog-jsonld-lib.test.ts
+++ b/tests/changelog-jsonld-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { changelogItemListJsonLd } from "../apps/web/src/lib/changelog-jsonld-lib";
+
+const note = (stream: string, over: Record<string, unknown> = {}) => ({
+  title: `${stream} note`,
+  date: "2026-01-01",
+  body: "details",
+  stream,
+  ...over,
+});
+
+describe("changelogItemListJsonLd", () => {
+  it("builds an ItemList named for the changelog", () => {
+    const ld = changelogItemListJsonLd([]);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("HeyClaude registry changelog");
+    expect(ld.itemListElement).toEqual([]);
+  });
+
+  it("maps notes to positioned NewsArticles", () => {
+    const ld = changelogItemListJsonLd([note("release"), note("policy")]);
+    expect(ld.itemListElement.map((i) => i.position)).toEqual([1, 2]);
+    expect(ld.itemListElement[0].item).toMatchObject({
+      "@type": "NewsArticle",
+      headline: "release note",
+      datePublished: "2026-01-01",
+      description: "details",
+    });
+  });
+
+  it("labels articleSection from the stream", () => {
+    const sections = changelogItemListJsonLd([
+      note("release"),
+      note("policy"),
+      note("security"),
+    ]).itemListElement.map((i) => i.item.articleSection);
+    expect(sections).toEqual(["Releases", "Policy", "Security"]);
+  });
+});


### PR DESCRIPTION
### What & why

The changelog route built its schema.org ItemList of NewsArticles inline in `head()`, so the note mapping and the stream->articleSection labels could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/changelog-jsonld-lib.ts` and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/changelog-jsonld-lib.ts` — `changelogItemListJsonLd(notes)`.
- `apps/web/src/routes/changelog.tsx` — build the ItemList via the helper over `RELEASE_NOTES`.
- Add `tests/changelog-jsonld-lib.test.ts` — covers the empty list, positioned NewsArticles, and the release/policy/security section labels. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/changelog-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
