### PR TITLE
refactor(web): extract comparison ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/comparison-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/comparison-itemlist-jsonld-lib.ts
@@ -1,0 +1,35 @@
+// Pure builder for a comparison page's schema.org ItemList JSON-LD, split out of
+// the route head() so the entry mapping can be unit-tested. The absolute-URL
+// resolver is injected to keep the builder pure.
+
+type ComparisonLike = {
+  heading: string;
+  seoDescription: string;
+};
+
+type ComparisonEntryLike = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/** schema.org ItemList JSON-LD for a comparison's resolved entries. */
+export function comparisonItemListJsonLd(
+  comparison: ComparisonLike,
+  entries: ComparisonEntryLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: comparison.heading,
+    description: comparison.seoDescription,
+    numberOfItems: entries.length,
+    itemListElement: entries.map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -5,6 +5,7 @@ import { ComparisonTable } from "@/components/comparison-table";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { comparisonItemListJsonLd } from "@/lib/comparison-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getComparison } from "@/data/comparisons";
@@ -32,19 +33,7 @@ export const Route = createFileRoute("/compare/$slug")({
       eyebrow: "Compare",
       description: comparison.seoDescription,
     });
-    const itemList = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: comparison.heading,
-      description: comparison.seoDescription,
-      numberOfItems: entries.length,
-      itemListElement: entries.map((e, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: e.title,
-        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
-      })),
-    };
+    const itemList = comparisonItemListJsonLd(comparison, entries, absoluteUrl);
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/comparison-itemlist-jsonld-lib.test.ts
+++ b/tests/comparison-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { comparisonItemListJsonLd } from "../apps/web/src/lib/comparison-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+const comparison = { heading: "A vs B", seoDescription: "Compare A and B" };
+
+describe("comparisonItemListJsonLd", () => {
+  it("builds an ItemList with heading/description/count", () => {
+    const ld = comparisonItemListJsonLd(comparison, [], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("A vs B");
+    expect(ld.description).toBe("Compare A and B");
+    expect(ld.numberOfItems).toBe(0);
+    expect(ld.itemListElement).toEqual([]);
+  });
+
+  it("maps entries to positioned ListItems with entry urls", () => {
+    const ld = comparisonItemListJsonLd(
+      comparison,
+      [
+        { title: "Agent A", category: "agents", slug: "a" },
+        { title: "Agent B", category: "agents", slug: "b" },
+      ],
+      abs,
+    );
+    expect(ld.numberOfItems).toBe(2);
+    expect(ld.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Agent A",
+        url: "https://heyclau.de/entry/agents/a",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Agent B",
+        url: "https://heyclau.de/entry/agents/b",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### What & why

The comparison detail route built its schema.org ItemList JSON-LD inline in `head()`, so the entry-to-ListItem mapping could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/comparison-itemlist-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/comparison-itemlist-jsonld-lib.ts` — `comparisonItemListJsonLd(comparison, entries, absoluteUrl)`.
- `apps/web/src/routes/compare.$slug.tsx` — build the ItemList via the helper.
- Add `tests/comparison-itemlist-jsonld-lib.test.ts` — covers the list metadata + empty case, and positioned ListItems with entry urls.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/comparison-itemlist-jsonld-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
