### PR TITLE
fix(web): restrict intent-event session ids to opaque tokens

### DIFF
--- a/apps/web/src/lib/intent-events-lib.ts
+++ b/apps/web/src/lib/intent-events-lib.ts
@@ -36,9 +36,23 @@ export function normalizeIntentEntryKey(value: unknown) {
   return /^[a-z0-9-]+:[a-z0-9-]+$/.test(normalized) ? normalized : "";
 }
 
+/**
+ * Session ids are opaque correlation tokens, so only the URL-safe base64
+ * alphabet is persisted — the same alphabet the entry-signals client id uses.
+ * This keeps free text out of `intent_events.session_id`: emails, URLs, JWTs
+ * (dot-separated), JSON, and whitespace all fail the pattern.
+ */
+const INTENT_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/**
+ * Normalize a caller-supplied session id. Returns the trimmed id when it is an
+ * opaque token of at most 128 characters, otherwise "" — which the intent-event
+ * route stores as NULL, so an event with an unusable session id is still
+ * recorded rather than rejected.
+ */
 export function normalizeIntentSessionId(value: unknown) {
   const normalized = String(value ?? "").trim();
-  return normalized.length <= 128 ? normalized : "";
+  return INTENT_SESSION_ID_PATTERN.test(normalized) ? normalized : "";
 }
 
 export function getFallbackIntentEventCounts(keys: string[]) {

--- a/tests/intent-events-normalizers.test.ts
+++ b/tests/intent-events-normalizers.test.ts
@@ -46,6 +46,33 @@ describe("normalizeIntentSessionId", () => {
     // Oversized ids are dropped rather than stored unbounded.
     expect(normalizeIntentSessionId("x".repeat(129))).toBe("");
   });
+
+  it("accepts the opaque URL-safe token alphabet", () => {
+    expect(normalizeIntentSessionId("hc-9aF_x-1")).toBe("hc-9aF_x-1");
+    expect(normalizeIntentSessionId("session-0")).toBe("session-0");
+  });
+
+  it("keeps personal data out of session_id", () => {
+    // An email, a name with spaces, or non-ASCII free text is not an opaque token.
+    expect(normalizeIntentSessionId("user@example.com")).toBe("");
+    expect(normalizeIntentSessionId("Ada Lovelace")).toBe("");
+    expect(normalizeIntentSessionId("józef")).toBe("");
+  });
+
+  it("rejects credentials and URLs that would otherwise be persisted verbatim", () => {
+    // A JWT is dot-separated, so the dot alone disqualifies it.
+    expect(normalizeIntentSessionId("eyJhbGci.eyJzdWIi.SflKxwRJ")).toBe("");
+    expect(normalizeIntentSessionId("https://heyclau.de/u/1?token=abc")).toBe(
+      "",
+    );
+    expect(normalizeIntentSessionId('{"email":"a@b.c"}')).toBe("");
+  });
+
+  it("returns the empty sentinel for nullish input", () => {
+    expect(normalizeIntentSessionId(null)).toBe("");
+    expect(normalizeIntentSessionId(undefined)).toBe("");
+    expect(normalizeIntentSessionId("")).toBe("");
+  });
 });
 
 describe("getFallbackIntentEventCounts", () => {


### PR DESCRIPTION
Addresses one of #556's explicit requirements: **"Keep sensitive payloads out of intent events."**

## The gap

`normalizeIntentSessionId` accepted **any** caller-supplied string up to 128 characters and the route persisted it verbatim into `intent_events.session_id`:

```ts
const normalized = String(value ?? "").trim();
return normalized.length <= 128 ? normalized : "";   // no charset restriction
```

`/api/intent-events` is a public POST endpoint and its request schema is just `z.string().trim().max(128)`, so an email, a JWT, a URL with a token query param, or arbitrary free text would land in the analytics table. The first-party client is deliberately privacy-light and **never sends a `sessionId` at all** (`buildIntentEventRequestBody` only emits `{ type, entryKey }`), so nothing legitimate relies on the permissive shape.

## The fix

Session ids are opaque correlation tokens, so only the URL-safe base64 alphabet is persisted — the same alphabet the entry-signals client id already requires (`/^[a-zA-Z0-9_-]{16,96}$/`):

```ts
const INTENT_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
```

Anything else normalizes to `""`, which the route already binds as `NULL`. Emails, names with spaces, non-ASCII text, JWTs (dot-separated), URLs, and JSON all fail the pattern.

## Why not reject the request

The event is still **recorded** with a `NULL` session id rather than 400'd. This mirrors how an invalid `entryKey` is already dropped to `NULL`, and keeps #556's other criterion intact — *"CTA events degrade safely"*. The zod schema is intentionally left permissive so no existing caller starts getting errors; the value is dropped server-side instead.

I kept the existing `1..128` length bound rather than adopting the client id's `16..96` floor, so no currently-accepted opaque id changes behavior.

## Tests

Extends `tests/intent-events-normalizers.test.ts` (+4 cases): the opaque alphabet is accepted; emails / spaced names / non-ASCII are dropped; JWTs, URLs and JSON are dropped; nullish input still returns the `""` sentinel. Every pre-existing assertion (`"abc123"`, `"session-0"`, `"a".repeat(128)`, the 129-char rejection) passes unchanged — the guard is a charset restriction, not a new length floor.

```
pnpm exec vitest run tests/intent-events-normalizers.test.ts tests/intent-events-lib.test.ts tests/codeql-regressions.test.ts   # 267 passed
pnpm test    # 63 failed / 37910 passed — identical 38 failing files to main's baseline (63 failed / 37906 passed);
             # those suites need generated artifacts. +4 passed = exactly this PR's new tests, zero new failures.
pnpm exec prettier --check <changed files>   # clean
```

Refs #556