### PR TITLE
refactor(web): extract ecosystem integrations JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/ecosystem-jsonld-lib.ts
+++ b/apps/web/src/lib/ecosystem-jsonld-lib.ts
@@ -1,0 +1,26 @@
+// Pure builder for the ecosystem page's schema.org ItemList of integrations,
+// split out of the route head() so the mapping can be unit-tested. The
+// absolute-URL resolver is injected to keep the builder pure.
+
+type IntegrationRefLike = {
+  name: string;
+  slug: string;
+};
+
+/** schema.org ItemList JSON-LD linking each integration's detail page. */
+export function ecosystemIntegrationsJsonLd(
+  integrations: IntegrationRefLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "HeyClaude integrations",
+    itemListElement: integrations.map((integration, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: integration.name,
+      url: absoluteUrl(`/integrations/${integration.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/ecosystem.tsx
+++ b/apps/web/src/routes/ecosystem.tsx
@@ -19,6 +19,7 @@ import { CopyButton } from "@/components/copy-button";
 import { CountUp } from "@/components/count-up";
 import { cn } from "@/lib/utils";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { ecosystemIntegrationsJsonLd } from "@/lib/ecosystem-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 
 const CLIENTS = [
@@ -189,17 +190,7 @@ const SUB_NAV = [
 
 export const Route = createFileRoute("/ecosystem")({
   head: () => {
-    const ld = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: "HeyClaude integrations",
-      itemListElement: INTEGRATIONS.map((it, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: it.name,
-        url: absoluteUrl(`/integrations/${it.slug}`),
-      })),
-    };
+    const ld = ecosystemIntegrationsJsonLd(INTEGRATIONS, absoluteUrl);
     return {
       meta: [
         { title: "Ecosystem — HeyClaude" },

--- a/tests/ecosystem-jsonld-lib.test.ts
+++ b/tests/ecosystem-jsonld-lib.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { ecosystemIntegrationsJsonLd } from "../apps/web/src/lib/ecosystem-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+describe("ecosystemIntegrationsJsonLd", () => {
+  it("builds a named ItemList (empty when there are no integrations)", () => {
+    const ld = ecosystemIntegrationsJsonLd([], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("HeyClaude integrations");
+    expect(ld.itemListElement).toEqual([]);
+  });
+
+  it("maps integrations to positioned ListItems with detail urls", () => {
+    const ld = ecosystemIntegrationsJsonLd(
+      [
+        { name: "Cursor", slug: "cursor" },
+        { name: "Zed", slug: "zed" },
+      ],
+      abs,
+    );
+    expect(ld.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Cursor",
+        url: "https://heyclau.de/integrations/cursor",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Zed",
+        url: "https://heyclau.de/integrations/zed",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
### What & why

The ecosystem route built its schema.org ItemList of integrations inline in `head()`, so the mapping could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/ecosystem-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/ecosystem-jsonld-lib.ts` — `ecosystemIntegrationsJsonLd(integrations, absoluteUrl)`.
- `apps/web/src/routes/ecosystem.tsx` — build the ItemList via the helper over `INTEGRATIONS`.
- Add `tests/ecosystem-jsonld-lib.test.ts` — covers the named empty list and positioned ListItems with detail urls.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/ecosystem-jsonld-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
