### PR TITLE
refactor(web): extract platform ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/platform-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/platform-itemlist-jsonld-lib.ts
@@ -1,0 +1,34 @@
+// Pure builder for a platform ("for/<platform>") page's schema.org ItemList
+// JSON-LD, split out of the route head() so the label/count/slice-cap behavior
+// can be unit-tested. The absolute-URL resolver is injected.
+
+type PlatformEntryLike = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/**
+ * schema.org ItemList JSON-LD for a platform's resources. numberOfItems reflects
+ * the full set; itemListElement is capped at the first 30 entries.
+ */
+export function platformItemListJsonLd(
+  label: string,
+  description: string,
+  entries: PlatformEntryLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Claude resources for ${label}`,
+    description,
+    numberOfItems: entries.length,
+    itemListElement: entries.slice(0, 30).map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -11,6 +11,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { platformItemListJsonLd } from "@/lib/platform-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
@@ -32,19 +33,7 @@ export const Route = createFileRoute("/for/$platform")({
     const title = `Claude resources for ${label} — HeyClaude`;
     const description = `${entries.length} source-backed Claude resources that work with ${label}: MCP servers, agents, skills, hooks, commands, and rules, curated in HeyClaude.`;
     const ogImage = ogImageUrl({ title: `Claude for ${label}`, eyebrow: "Platform", description });
-    const itemList = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: `Claude resources for ${label}`,
-      description,
-      numberOfItems: entries.length,
-      itemListElement: entries.slice(0, 30).map((e, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: e.title,
-        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
-      })),
-    };
+    const itemList = platformItemListJsonLd(label, description, entries, absoluteUrl);
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/platform-itemlist-jsonld-lib.test.ts
+++ b/tests/platform-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { platformItemListJsonLd } from "../apps/web/src/lib/platform-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const makeEntries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    title: `Entry ${i + 1}`,
+    category: "agents",
+    slug: `e${i + 1}`,
+  }));
+
+describe("platformItemListJsonLd", () => {
+  it("names the list for the platform and includes the description", () => {
+    const ld = platformItemListJsonLd("Cursor", "Some desc", [], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("Claude resources for Cursor");
+    expect(ld.description).toBe("Some desc");
+    expect(ld.numberOfItems).toBe(0);
+  });
+
+  it("maps entries to positioned ListItems with entry urls", () => {
+    const ld = platformItemListJsonLd("Cursor", "d", makeEntries(2), abs);
+    expect(ld.itemListElement[0]).toEqual({
+      "@type": "ListItem",
+      position: 1,
+      name: "Entry 1",
+      url: "https://heyclau.de/entry/agents/e1",
+    });
+    expect(ld.itemListElement[1].position).toBe(2);
+  });
+
+  it("reports the full count but caps list items at 30", () => {
+    const ld = platformItemListJsonLd("Cursor", "d", makeEntries(31), abs);
+    expect(ld.numberOfItems).toBe(31);
+    expect(ld.itemListElement).toHaveLength(30);
+  });
+});


### PR DESCRIPTION
### What & why

The per-platform route built its schema.org ItemList JSON-LD inline in `head()`, so the label/count and the first-30 slice cap could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/platform-itemlist-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/platform-itemlist-jsonld-lib.ts` — `platformItemListJsonLd(label, description, entries, absoluteUrl)`.
- `apps/web/src/routes/for.$platform.tsx` — build the ItemList via the helper.
- Add `tests/platform-itemlist-jsonld-lib.test.ts` — covers the platform-labelled name + description, positioned ListItems with entry urls, and that `numberOfItems` reflects the full set while the list is capped at 30.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/platform-itemlist-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
