### PR TITLE
refactor(web): extract platform+category ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
@@ -1,0 +1,36 @@
+// Pure builder for a platform+category ("for/<platform>/<category>") page's
+// schema.org ItemList JSON-LD, split out of the route head() so the name/count
+// and the first-30 slice cap can be unit-tested. The absolute-URL resolver is
+// injected.
+
+type PlatformCategoryEntryLike = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/**
+ * schema.org ItemList JSON-LD for a platform+category's resources.
+ * numberOfItems reflects the full set; itemListElement is capped at 30 entries.
+ */
+export function platformCategoryItemListJsonLd(
+  platformLabel: string,
+  categoryLabel: string,
+  description: string,
+  entries: PlatformCategoryEntryLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Claude ${categoryLabel} for ${platformLabel}`,
+    description,
+    numberOfItems: entries.length,
+    itemListElement: entries.slice(0, 30).map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -11,6 +11,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { platformCategoryItemListJsonLd } from "@/lib/platform-category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
@@ -44,19 +45,13 @@ export const Route = createFileRoute("/for/$platform/$category")({
     const title = `Claude ${cLabel} for ${pLabel} — HeyClaude`;
     const description = `${entries.length} source-backed Claude ${cLabel} that work with ${pLabel}, curated and metadata-reviewed in HeyClaude.`;
     const ogImage = ogImageUrl({ title: `${cLabel} for ${pLabel}`, eyebrow: pLabel, description });
-    const itemList = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: `Claude ${cLabel} for ${pLabel}`,
+    const itemList = platformCategoryItemListJsonLd(
+      pLabel,
+      cLabel,
       description,
-      numberOfItems: entries.length,
-      itemListElement: entries.slice(0, 30).map((e, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: e.title,
-        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
-      })),
-    };
+      entries,
+      absoluteUrl,
+    );
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/platform-category-itemlist-jsonld-lib.test.ts
+++ b/tests/platform-category-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { platformCategoryItemListJsonLd } from "../apps/web/src/lib/platform-category-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const makeEntries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    title: `Entry ${i + 1}`,
+    category: "mcp",
+    slug: `e${i + 1}`,
+  }));
+
+describe("platformCategoryItemListJsonLd", () => {
+  it("names the list from both labels and includes the description", () => {
+    const ld = platformCategoryItemListJsonLd(
+      "Cursor",
+      "MCP servers",
+      "d",
+      [],
+      abs,
+    );
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("Claude MCP servers for Cursor");
+    expect(ld.description).toBe("d");
+    expect(ld.numberOfItems).toBe(0);
+  });
+
+  it("maps entries to positioned ListItems with entry urls", () => {
+    const ld = platformCategoryItemListJsonLd(
+      "Cursor",
+      "MCP",
+      "d",
+      makeEntries(2),
+      abs,
+    );
+    expect(ld.itemListElement[0]).toEqual({
+      "@type": "ListItem",
+      position: 1,
+      name: "Entry 1",
+      url: "https://heyclau.de/entry/mcp/e1",
+    });
+    expect(ld.itemListElement[1].position).toBe(2);
+  });
+
+  it("reports the full count but caps list items at 30", () => {
+    const ld = platformCategoryItemListJsonLd(
+      "Cursor",
+      "MCP",
+      "d",
+      makeEntries(31),
+      abs,
+    );
+    expect(ld.numberOfItems).toBe(31);
+    expect(ld.itemListElement).toHaveLength(30);
+  });
+});


### PR DESCRIPTION
### What & why

The platform+category route built its schema.org ItemList JSON-LD inline in `head()`, so the two-label name and the first-30 slice cap could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts` — `platformCategoryItemListJsonLd(platformLabel, categoryLabel, description, entries, absoluteUrl)`.
- `apps/web/src/routes/for.$platform.$category.tsx` — build the ItemList via the helper.
- Add `tests/platform-category-itemlist-jsonld-lib.test.ts` — covers the two-label name + description, positioned ListItems with entry urls, and full-count-with-30-item-cap.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/platform-category-itemlist-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
