### PR TITLE
fix(web): keep the D1 db module out of the intent-event client graph

### DIFF
--- a/apps/web/src/lib/intent-events-lib.ts
+++ b/apps/web/src/lib/intent-events-lib.ts
@@ -1,4 +1,8 @@
-import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
+﻿// `D1DatabaseLike` is imported as a type only: `queryIntentEventCounts` receives
+// its database as an argument, so this module must not pull `@/lib/db` (and
+// through it `cloudflare-env.server`) into the browser bundle. The client
+// reaches this file via `intent-event-client.ts` for `normalizeIntentEntryKey`.
+import type { D1DatabaseLike } from "@/lib/db";
 import { chunk, inPlaceholders } from "@/lib/d1-batch";
 
 export const INTENT_EVENT_TYPES = ["copy", "open", "install", "download", "vote"] as const;

--- a/tests/intent-events-client-graph.test.ts
+++ b/tests/intent-events-client-graph.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * `intent-event-client.ts` runs in the browser and imports
+ * `intent-events-lib.ts` for `normalizeIntentEntryKey`. That lib must therefore
+ * never pull `@/lib/db` in at runtime, because `@/lib/db` imports
+ * `cloudflare-env.server`. It only needs the `D1DatabaseLike` *type*, since
+ * `queryIntentEventCounts` receives its database as an argument.
+ */
+describe("intent-event client module graph", () => {
+  const repoRoot = new URL("..", import.meta.url);
+  const read = (relativePath: string) =>
+    fs.readFileSync(new URL(relativePath, repoRoot), "utf8");
+
+  const lib = read("apps/web/src/lib/intent-events-lib.ts");
+
+  it("imports D1DatabaseLike from @/lib/db as a type-only import", () => {
+    expect(lib).toContain('import type { D1DatabaseLike } from "@/lib/db"');
+  });
+
+  it("never imports a runtime binding from @/lib/db", () => {
+    // A value import (e.g. `import { getSiteDb }`) would drag
+    // cloudflare-env.server into the browser bundle.
+    expect(lib).not.toMatch(/^import\s*\{[^}]*\}\s*from\s*"@\/lib\/db"/m);
+    expect(lib).not.toContain("getSiteDb");
+  });
+
+  it("still lets the client reach the entry-key normalizer", () => {
+    const client = read("apps/web/src/lib/intent-event-client.ts");
+    expect(client).toContain(
+      'import { normalizeIntentEntryKey } from "@/lib/intent-events-lib"',
+    );
+  });
+
+  it("keeps the server-side surface free to use getSiteDb", () => {
+    // safeIntentEventCounts lives in the surface module, which is server-only.
+    expect(read("apps/web/src/lib/intent-events.ts")).toContain(
+      'import { getSiteDb } from "@/lib/db"',
+    );
+  });
+});


### PR DESCRIPTION
Follows up #4746 on the same #556 surface — this one is about the *client* side of intent events.

## The bug

`intent-events-lib.ts` imported `getSiteDb` from `@/lib/db` as a **runtime binding but never called it**:

```ts
import { getSiteDb, type D1DatabaseLike } from "@/lib/db";   // getSiteDb: unused
```

`queryIntentEventCounts(db: D1DatabaseLike, …)` receives its database as an argument, so only the *type* was ever needed.

That matters because `intent-event-client.ts` runs in the **browser** and imports this lib for `normalizeIntentEntryKey`. The dead import therefore placed `@/lib/db` — and through it `cloudflare-env.server` — on the client module graph:

```
intent-event-client.ts  (browser)
  └─ intent-events-lib.ts
       └─ @/lib/db                    ← only for an unused binding
            └─ cloudflare-env.server
```

## The fix

Import `D1DatabaseLike` as a type-only import, so the edge is erased at build time. Nothing else changes:

- the server-side surface `intent-events.ts` still imports `getSiteDb` for `safeIntentEventCounts`;
- `routes/api/intent-events.ts` still imports it from `@/lib/db` directly.

**No behavior change.**

## Tests

Adds `tests/intent-events-client-graph.test.ts` (4 cases) pinning the boundary in the same source-assertion idiom the repo already uses in `codeql-regressions.test.ts`: the lib must use a type-only import, must contain no runtime binding from `@/lib/db`, the client must still reach `normalizeIntentEntryKey`, and the server surface must remain free to use `getSiteDb`.

I verified the guard actually guards — temporarily restoring the old import makes 2 of its 4 assertions fail, and reverting the restore makes them pass again.

```
pnpm exec vitest run tests/intent-events-client-graph.test.ts tests/intent-events-*.test.ts \
  tests/intent-event-client.test.ts tests/dynamic-api-routes.test.ts tests/codeql-regressions.test.ts   # 280 passed
pnpm test    # 63 failed / 37910 passed — identical 38 failing files to main's baseline (63 failed / 37906 passed);
             # those suites need generated artifacts. +4 passed = exactly this PR's guard tests, zero new failures.
pnpm exec prettier --check <changed files>   # clean
```

Refs #556