### PR TITLE
refactor(web): extract category ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/category-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/category-itemlist-jsonld-lib.ts
@@ -1,0 +1,34 @@
+// Pure builder for a category ("/<category>") page's schema.org ItemList
+// JSON-LD, split out of the route head() so the name/count and the first-30
+// slice cap can be unit-tested. The absolute-URL resolver is injected.
+
+type CategoryEntryLike = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/**
+ * schema.org ItemList JSON-LD for a category's resources. numberOfItems reflects
+ * the full set; itemListElement is capped at the first 30 entries.
+ */
+export function categoryItemListJsonLd(
+  label: string,
+  description: string,
+  entries: CategoryEntryLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Claude ${label}`,
+    description,
+    numberOfItems: entries.length,
+    itemListElement: entries.slice(0, 30).map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -18,6 +18,7 @@ import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { CategoryRankingTable } from "@/components/category-ranking-table";
 import { hubHighlights, hubStats } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { categoryItemListJsonLd } from "@/lib/category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, categoryAccent } from "@/lib/og-image";
 
@@ -51,19 +52,7 @@ export const Route = createFileRoute("/$category")({
       accent: categoryAccent(id),
     });
 
-    const itemList = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: `Claude ${label}`,
-      description,
-      numberOfItems: entries.length,
-      itemListElement: entries.slice(0, 30).map((e, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: e.title,
-        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
-      })),
-    };
+    const itemList = categoryItemListJsonLd(label, description, entries, absoluteUrl);
     const breadcrumbs = {
       "@context": "https://schema.org",
       "@type": "BreadcrumbList",

--- a/tests/category-itemlist-jsonld-lib.test.ts
+++ b/tests/category-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { categoryItemListJsonLd } from "../apps/web/src/lib/category-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const makeEntries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    title: `Entry ${i + 1}`,
+    category: "agents",
+    slug: `e${i + 1}`,
+  }));
+
+describe("categoryItemListJsonLd", () => {
+  it("names the list for the category and includes the description", () => {
+    const ld = categoryItemListJsonLd("agents", "All agents", [], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("Claude agents");
+    expect(ld.description).toBe("All agents");
+    expect(ld.numberOfItems).toBe(0);
+  });
+
+  it("maps entries to positioned ListItems with entry urls", () => {
+    const ld = categoryItemListJsonLd("agents", "d", makeEntries(2), abs);
+    expect(ld.itemListElement[0]).toEqual({
+      "@type": "ListItem",
+      position: 1,
+      name: "Entry 1",
+      url: "https://heyclau.de/entry/agents/e1",
+    });
+    expect(ld.itemListElement[1].position).toBe(2);
+  });
+
+  it("reports the full count but caps list items at 30", () => {
+    const ld = categoryItemListJsonLd("agents", "d", makeEntries(31), abs);
+    expect(ld.numberOfItems).toBe(31);
+    expect(ld.itemListElement).toHaveLength(30);
+  });
+});


### PR DESCRIPTION
### What & why

The category route built its schema.org ItemList JSON-LD inline in `head()`, so the name/count and the first-30 slice cap could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/category-itemlist-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/category-itemlist-jsonld-lib.ts` — `categoryItemListJsonLd(label, description, entries, absoluteUrl)`.
- `apps/web/src/routes/$category.tsx` — build the ItemList via the helper.
- Add `tests/category-itemlist-jsonld-lib.test.ts` — covers the category-labelled name + description, positioned ListItems with entry urls, and full-count-with-30-item-cap.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/category-itemlist-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
