### PR TITLE
test(web): pin intent-event route degradation and payload hygiene

### DIFF
--- a/tests/intent-events-route.test.ts
+++ b/tests/intent-events-route.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSiteDbMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/db", () => ({
+  getSiteDb: getSiteDbMock,
+}));
+
+function jsonRequest(body: Record<string, unknown>) {
+  return new Request("https://heyclau.de/api/intent-events", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: "https://heyclau.de",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** A fake D1 that records the values bound to the INSERT. */
+function recordingDb(boundCalls: unknown[][]) {
+  return {
+    prepare: () => ({
+      bind: (...values: unknown[]) => {
+        boundCalls.push(values);
+        return { run: async () => ({ success: true }) };
+      },
+    }),
+  };
+}
+
+/** A fake D1 whose write always fails, standing in for a D1 outage. */
+function failingDb() {
+  return {
+    prepare: () => ({
+      bind: () => ({
+        run: async () => {
+          throw new Error("D1_ERROR: network failure");
+        },
+      }),
+    }),
+  };
+}
+
+const post = async (body: Record<string, unknown>) => {
+  const { POST } = await import("@/routes/api/intent-events");
+  return POST(jsonRequest(body));
+};
+
+describe("POST /api/intent-events degradation", () => {
+  beforeEach(() => {
+    getSiteDbMock.mockReset();
+  });
+
+  it("still answers 200 when the D1 write throws, so a CTA never surfaces an error", async () => {
+    getSiteDbMock.mockReturnValue(failingDb());
+
+    const response = await post({
+      type: "copy",
+      entryKey: "skills:example-skill",
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      ok: false,
+      stored: false,
+      reason: "insert_failed",
+    });
+  });
+
+  it("reports the event as stored on a successful write", async () => {
+    getSiteDbMock.mockReturnValue(recordingDb([]));
+
+    const response = await post({ type: "install", entryKey: "mcp:example" });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true, stored: true });
+  });
+});
+
+describe("POST /api/intent-events payload hygiene", () => {
+  let bound: unknown[][];
+
+  beforeEach(() => {
+    bound = [];
+    getSiteDbMock.mockReset();
+    getSiteDbMock.mockReturnValue(recordingDb(bound));
+  });
+
+  // bind order: (event_type, entry_key, session_id)
+  const sessionIdOf = (calls: unknown[][]) => calls[0][2];
+
+  it("persists an opaque session id verbatim", async () => {
+    await post({ type: "copy", entryKey: "skills:a", sessionId: "hc-9aF_x-1" });
+    expect(sessionIdOf(bound)).toBe("hc-9aF_x-1");
+  });
+
+  it("never persists an email as a session id", async () => {
+    await post({
+      type: "copy",
+      entryKey: "skills:a",
+      sessionId: "user@example.com",
+    });
+    expect(sessionIdOf(bound)).toBeNull();
+  });
+
+  it("never persists a credential or URL as a session id", async () => {
+    await post({
+      type: "open",
+      entryKey: "skills:a",
+      sessionId: "https://heyclau.de/u/1?token=abc",
+    });
+    expect(sessionIdOf(bound)).toBeNull();
+  });
+
+  it("still records the event when the session id is dropped", async () => {
+    const response = await post({
+      type: "copy",
+      entryKey: "skills:a",
+      sessionId: "Ada Lovelace",
+    });
+
+    await expect(response.json()).resolves.toEqual({ ok: true, stored: true });
+    expect(bound).toHaveLength(1);
+    expect(bound[0][0]).toBe("copy");
+    expect(bound[0][1]).toBe("skills:a");
+    expect(sessionIdOf(bound)).toBeNull();
+  });
+
+  it("binds NULL rather than an empty string for a missing entry key", async () => {
+    await post({ type: "copy" });
+    expect(bound[0][1]).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes the last untested corner of #556's two non-visual acceptance criteria, following #4746 and #4752.

## The gap

`/api/intent-events` has a `catch` branch that keeps a CTA working through a D1 outage:

```ts
} catch {
  logApiWarn(request, "intent_events.insert_failed", { eventType });
  return apiJson({ ok: false, stored: false, reason: "insert_failed" }, { status: 200, ... });
}
```

Nothing exercised it. `dynamic-api-routes.test.ts` covers only the *"SITE_DB is missing"* path — a database that is present but **failing mid-write** was unpinned, as was the successful-write path.

## What this adds

`tests/intent-events-route.test.ts` drives the real exported `POST` handler against a fake D1 and pins both criteria:

**Degradation** — *"CTA events degrade safely when D1/analytics is unavailable"*
- a write that throws still answers `200 {ok:false, stored:false, reason:"insert_failed"}`, so a copy/install CTA never surfaces an error;
- a successful write reports `stored:true`.

**Payload hygiene** — *"Keep sensitive payloads out of intent events"*

The fake D1 records the values bound to the `INSERT`, so the assertions are about what actually reaches the table rather than about the normalizer in isolation:
- an opaque session id (`hc-9aF_x-1`) is persisted verbatim;
- an email, and a URL carrying a `?token=`, are bound as **NULL**;
- a spaced name is dropped **and the event is still recorded** (`stored:true`) — degradation and hygiene holding together;
- a missing `entryKey` binds `NULL` rather than `""`.

## These tests guard, they don't just restate

I reverted #4746's session-id guard locally: **3 of the 7 fail**. Restored: all 7 pass. The `insert_failed` case is confirmed to reach the `catch` branch by the `intent_events.insert_failed` warn line the run emits.

```
pnpm exec vitest run tests/intent-events-route.test.ts   # 7 passed
pnpm exec vitest run tests/intent-events-route.test.ts tests/dynamic-api-routes.test.ts \
  tests/intent-events-normalizers.test.ts tests/codeql-regressions.test.ts   # 30 passed
pnpm test    # 63 failed / 38 failing files — identical to main's baseline; no intent failures. Those
             # suites need generated artifacts. Zero new failures.
pnpm exec prettier --check tests/intent-events-route.test.ts   # clean
```

Test-only change; no source files touched.

Refs #556