### PR TITLE
refactor(web): extract OG entry card field resolution into a lib

### DIFF
--- a/apps/web/src/lib/og-entry-card-lib.ts
+++ b/apps/web/src/lib/og-entry-card-lib.ts
@@ -1,0 +1,36 @@
+// Pure resolution of the OG card fields for an entry image, split out of the
+// per-entry OG route so the fallback precedence can be unit-tested without
+// rendering a PNG.
+
+type OgEntryLike = {
+  title?: string | null;
+  cardDescription?: string | null;
+  description?: string | null;
+  author?: string | null;
+  category?: string | null;
+};
+
+export type OgEntryCardFields = {
+  title: string;
+  description: string;
+  author: string;
+  category: string;
+};
+
+/**
+ * Resolve the OG card fields for an entry, falling back to the request's slug /
+ * category (and default copy) when the entry or its fields are missing.
+ */
+export function ogEntryCardFields(
+  entry: OgEntryLike | null | undefined,
+  fallbackSlug: string,
+  fallbackCategory: string,
+): OgEntryCardFields {
+  return {
+    title: entry?.title ?? fallbackSlug,
+    description:
+      entry?.cardDescription ?? entry?.description ?? "Curated in the HeyClaude registry.",
+    author: entry?.author ?? "HeyClaude",
+    category: entry?.category ?? fallbackCategory,
+  };
+}

--- a/apps/web/src/routes/og.$category.$slug.ts
+++ b/apps/web/src/routes/og.$category.$slug.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { getEntry } from "@/data/search";
 import { categoryAccent } from "@/lib/og-image";
+import { ogEntryCardFields } from "@/lib/og-entry-card-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 
 /**
@@ -13,11 +14,11 @@ export const Route = createFileRoute("/og/$category/$slug")({
     handlers: {
       GET: async ({ params }) => {
         const entry = getEntry(params.category, params.slug);
-        const title = entry?.title ?? params.slug;
-        const description =
-          entry?.cardDescription ?? entry?.description ?? "Curated in the HeyClaude registry.";
-        const author = entry?.author ?? "HeyClaude";
-        const category = entry?.category ?? params.category;
+        const { title, description, author, category } = ogEntryCardFields(
+          entry,
+          params.slug,
+          params.category,
+        );
 
         const image = await renderOgPng({
           // The category is the highlighted eyebrow; its accent color-codes the swash + rail.

--- a/tests/og-entry-card-lib.test.ts
+++ b/tests/og-entry-card-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { ogEntryCardFields } from "../apps/web/src/lib/og-entry-card-lib";
+
+describe("ogEntryCardFields", () => {
+  it("uses the entry's fields when present", () => {
+    expect(
+      ogEntryCardFields(
+        {
+          title: "My Agent",
+          cardDescription: "Card copy",
+          description: "Long copy",
+          author: "Ada",
+          category: "agents",
+        },
+        "slug",
+        "cat",
+      ),
+    ).toEqual({
+      title: "My Agent",
+      description: "Card copy",
+      author: "Ada",
+      category: "agents",
+    });
+  });
+
+  it("prefers description when cardDescription is missing", () => {
+    expect(
+      ogEntryCardFields({ description: "Long copy" }, "slug", "cat")
+        .description,
+    ).toBe("Long copy");
+  });
+
+  it("falls back to slug/category and default copy when the entry is absent", () => {
+    expect(ogEntryCardFields(undefined, "my-slug", "agents")).toEqual({
+      title: "my-slug",
+      description: "Curated in the HeyClaude registry.",
+      author: "HeyClaude",
+      category: "agents",
+    });
+  });
+});


### PR DESCRIPTION
### What & why

The per-entry OG image route resolved its card fields (title, description, author, category) with fallbacks inline, so the precedence could not be unit-tested without rendering a PNG. This moves it into `apps/web/src/lib/og-entry-card-lib.ts` and calls it from the handler.

### Changes

- Add `apps/web/src/lib/og-entry-card-lib.ts` — `ogEntryCardFields(entry, fallbackSlug, fallbackCategory)` with the title / cardDescription / description / author / category fallbacks.
- `apps/web/src/routes/og.$category.$slug.ts` — resolve the card fields via the helper.
- Add `tests/og-entry-card-lib.test.ts` — covers entry-present fields, cardDescription-vs-description precedence, and the entry-absent fallbacks. Branch coverage 100% (9/9).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/og-entry-card-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the OG card resolves identical fields.
