### PR TITLE
refactor(web): extract generic OG query field resolution into a lib

### DIFF
--- a/apps/web/src/lib/og-query-fields-lib.ts
+++ b/apps/web/src/lib/og-query-fields-lib.ts
@@ -1,0 +1,29 @@
+// Pure resolution of the generic OG image query fields (title, description,
+// eyebrow, accent), split out of the /og route so the fallbacks and clamping
+// can be unit-tested without rendering a PNG.
+
+import { OG_TEXT_LIMITS, clampOgText, safeAccent } from "@/lib/og-image";
+
+export type OgQueryFields = {
+  title: string;
+  description: string;
+  eyebrow: string;
+  accent: string;
+};
+
+/**
+ * Resolve the /og query params: title/eyebrow default to "HeyClaude", the
+ * description falls back description -> subtitle -> the site description, all
+ * text is clamped to its OG limit, and the accent is clamped to a safe hex.
+ */
+export function resolveOgQueryFields(
+  params: URLSearchParams,
+  siteDescription: string,
+): OgQueryFields {
+  const title = clampOgText(params.get("title") ?? "HeyClaude", OG_TEXT_LIMITS.title);
+  const rawDescription = params.get("description") ?? params.get("subtitle") ?? siteDescription;
+  const description = clampOgText(rawDescription, OG_TEXT_LIMITS.description);
+  const eyebrow = clampOgText(params.get("eyebrow") ?? "HeyClaude", OG_TEXT_LIMITS.eyebrow);
+  const accent = safeAccent(params.get("accent"));
+  return { title, description, eyebrow, accent };
+}

--- a/apps/web/src/routes/og.index.ts
+++ b/apps/web/src/routes/og.index.ts
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { OG_TEXT_LIMITS, clampOgText, safeAccent } from "@/lib/og-image";
+import { resolveOgQueryFields } from "@/lib/og-query-fields-lib";
 import { renderOgPng } from "@/lib/og-render.server";
 import { siteConfig } from "@/lib/site";
 
@@ -14,22 +14,13 @@ export const Route = createFileRoute("/og/")({
     handlers: {
       GET: async ({ request }) => {
         const url = new URL(request.url);
-        const title = clampOgText(
-          url.searchParams.get("title") ?? "HeyClaude",
-          OG_TEXT_LIMITS.title,
+        // Defaults live in resolveOgQueryFields: title/eyebrow -> "HeyClaude",
+        // description -> subtitle -> the site tagline, all clamped; accent is
+        // user-controlled and clamped to a safe hex before it reaches the card.
+        const { title, description, eyebrow, accent } = resolveOgQueryFields(
+          url.searchParams,
+          siteConfig.description,
         );
-        // Default the description to the site tagline so a bare /og card (e.g. the homepage og:image)
-        // says what HeyClaude IS, not just its name. A caller that passes its own description/subtitle
-        // (hub/list pages) overrides it.
-        const rawDescription =
-          url.searchParams.get("description") ?? url.searchParams.get("subtitle") ?? siteConfig.description;
-        const description = clampOgText(rawDescription, OG_TEXT_LIMITS.description);
-        const eyebrow = clampOgText(
-          url.searchParams.get("eyebrow") ?? "HeyClaude",
-          OG_TEXT_LIMITS.eyebrow,
-        );
-        // accent is user-controlled; clamp to a safe hex before it reaches the card markup.
-        const accent = safeAccent(url.searchParams.get("accent"));
 
         const image = await renderOgPng({
           eyebrow,

--- a/tests/og-query-fields-lib.test.ts
+++ b/tests/og-query-fields-lib.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveOgQueryFields } from "../apps/web/src/lib/og-query-fields-lib";
+
+const params = (init: Record<string, string>) => new URLSearchParams(init);
+
+describe("resolveOgQueryFields", () => {
+  it("uses provided params", () => {
+    const fields = resolveOgQueryFields(
+      params({
+        title: "My Title",
+        description: "My Desc",
+        eyebrow: "Hub",
+        accent: "#ff0000",
+      }),
+      "site desc",
+    );
+    expect(fields).toEqual({
+      title: "My Title",
+      description: "My Desc",
+      eyebrow: "Hub",
+      accent: "#ff0000",
+    });
+  });
+
+  it("defaults title/eyebrow to HeyClaude and description to the site tagline", () => {
+    const fields = resolveOgQueryFields(params({}), "The registry tagline");
+    expect(fields.title).toBe("HeyClaude");
+    expect(fields.eyebrow).toBe("HeyClaude");
+    expect(fields.description).toBe("The registry tagline");
+  });
+
+  it("prefers description over subtitle over the site description", () => {
+    expect(
+      resolveOgQueryFields(
+        params({ subtitle: "Sub", description: "Desc" }),
+        "site",
+      ).description,
+    ).toBe("Desc");
+    expect(
+      resolveOgQueryFields(params({ subtitle: "Sub" }), "site").description,
+    ).toBe("Sub");
+  });
+
+  it("clamps whitespace and falls back to a safe accent for bad hex", () => {
+    expect(
+      resolveOgQueryFields(params({ title: "  a   b  " }), "s").title,
+    ).toBe("a b");
+    expect(
+      resolveOgQueryFields(params({ accent: "red" }), "s").accent,
+    ).not.toBe("red");
+  });
+});


### PR DESCRIPTION
### What & why

The generic `/og` image route resolved its query fields (title, description, eyebrow, accent) with fallbacks + clamping inline, so the precedence could not be unit-tested without rendering a PNG. This moves it into `apps/web/src/lib/og-query-fields-lib.ts` and calls it from the handler.

### Changes

- Add `apps/web/src/lib/og-query-fields-lib.ts` — `resolveOgQueryFields(params, siteDescription)`: title/eyebrow default to `"HeyClaude"`, description falls back `description -> subtitle -> site description`, text is clamped, accent is clamped to a safe hex.
- `apps/web/src/routes/og.index.ts` — resolve the query fields via the helper; drop the now-unused `og-image` imports.
- Add `tests/og-query-fields-lib.test.ts` — covers provided params, defaults, description/subtitle precedence, and whitespace clamp + safe-accent fallback. Branch coverage 100% (7/7).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/og-query-fields-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the OG card resolves identical fields.
