### PR TITLE
refactor(web): add shared breadcrumb JSON-LD builder, use in contributor route

### DIFF
--- a/apps/web/src/lib/breadcrumb-jsonld-lib.ts
+++ b/apps/web/src/lib/breadcrumb-jsonld-lib.ts
@@ -1,0 +1,22 @@
+// Pure builder for schema.org BreadcrumbList JSON-LD from an ordered list of
+// { name, item } crumbs, split out so route head() functions can share one
+// tested implementation instead of open-coding the ListItem positions.
+
+export type BreadcrumbCrumb = {
+  name: string;
+  item: string;
+};
+
+/** schema.org BreadcrumbList JSON-LD; positions are 1-based in list order. */
+export function breadcrumbListJsonLd(crumbs: BreadcrumbCrumb[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: crumbs.map((crumb, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: crumb.name,
+      item: crumb.item,
+    })),
+  };
+}

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -22,6 +22,7 @@ import { CategoryPill, SourceBadge, TrustBadge } from "@/components/badges";
 import { Monogram } from "@/components/monogram";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
 import { submitterAttribution } from "@/lib/contributor-profile-summary";
@@ -49,19 +50,10 @@ export const Route = createFileRoute("/contributors/$slug")({
       url,
       mainEntity: { "@id": `${url}#person` },
     };
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        {
-          "@type": "ListItem",
-          position: 1,
-          name: "Contributors",
-          item: absoluteUrl("/contributors"),
-        },
-        { "@type": "ListItem", position: 2, name, item: url },
-      ],
-    };
+    const breadcrumbs = breadcrumbListJsonLd([
+      { name: "Contributors", item: absoluteUrl("/contributors") },
+      { name, item: url },
+    ]);
     return {
       meta: [
         { title: `${name} — HeyClaude contributor` },

--- a/tests/breadcrumb-jsonld-lib.test.ts
+++ b/tests/breadcrumb-jsonld-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { breadcrumbListJsonLd } from "../apps/web/src/lib/breadcrumb-jsonld-lib";
+
+describe("breadcrumbListJsonLd", () => {
+  it("builds a BreadcrumbList with 1-based positions in order", () => {
+    const ld = breadcrumbListJsonLd([
+      { name: "Contributors", item: "https://heyclau.de/contributors" },
+      { name: "Ada", item: "https://heyclau.de/contributors/ada" },
+    ]);
+    expect(ld["@type"]).toBe("BreadcrumbList");
+    expect(ld.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Contributors",
+        item: "https://heyclau.de/contributors",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Ada",
+        item: "https://heyclau.de/contributors/ada",
+      },
+    ]);
+  });
+
+  it("returns an empty itemListElement for no crumbs", () => {
+    expect(breadcrumbListJsonLd([]).itemListElement).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

Route `head()` functions open-code their schema.org BreadcrumbList JSON-LD with manual ListItem positions. This adds a shared `breadcrumbListJsonLd(crumbs)` builder and adopts it in the contributor detail route so the position/order logic is defined and tested once (other routes can migrate incrementally).

### Changes

- Add `apps/web/src/lib/breadcrumb-jsonld-lib.ts` — `breadcrumbListJsonLd(crumbs)` mapping `{ name, item }` crumbs to positioned ListItems.
- `apps/web/src/routes/contributors.$slug.tsx` — build the breadcrumbs via the helper.
- Add `tests/breadcrumb-jsonld-lib.test.ts` — covers 1-based positions in order and the empty-crumbs case.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/breadcrumb-jsonld-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged. Adopting the shared helper in the remaining routes can follow incrementally.
