### PR TITLE
fix(web): restrict vote client ids to opaque tokens

### DIFF
--- a/apps/web/src/lib/votes-lib.ts
+++ b/apps/web/src/lib/votes-lib.ts
@@ -1,5 +1,19 @@
-export function isValidEntryKey(key: string) {
+﻿export function isValidEntryKey(key: string) {
   return /^[a-z0-9-]+:[a-z0-9-]+$/.test(key);
+}
+
+/**
+ * Vote client ids are opaque, browser-generated correlation tokens (`hc-<uuid>`)
+ * and the votes table stores them verbatim, so only the URL-safe base64
+ * alphabet is accepted â€” the same guard `normalizeCommunityClientId` already
+ * applies to community signals. This keeps free text (an email, a URL carrying
+ * a token, a JWT) out of `votes.client_id`. The existing 8..128 length bound is
+ * unchanged, so every id a current client generates keeps working.
+ */
+const VOTE_CLIENT_ID_PATTERN = /^[A-Za-z0-9_-]{8,128}$/;
+
+export function isValidVoteClientId(clientId: string) {
+  return VOTE_CLIENT_ID_PATTERN.test(clientId);
 }
 
 export function getFallbackVoteCounts(keys: string[]) {

--- a/apps/web/src/lib/votes.ts
+++ b/apps/web/src/lib/votes.ts
@@ -1,8 +1,13 @@
 import { getSiteDb, type D1DatabaseLike } from "@/lib/db";
 import { chunk, inPlaceholders } from "@/lib/d1-batch";
-import { getFallbackClientVotes, getFallbackVoteCounts, isValidEntryKey } from "@/lib/votes-lib";
+import {
+  getFallbackClientVotes,
+  getFallbackVoteCounts,
+  isValidEntryKey,
+  isValidVoteClientId,
+} from "@/lib/votes-lib";
 
-export { getFallbackClientVotes, getFallbackVoteCounts, isValidEntryKey };
+export { getFallbackClientVotes, getFallbackVoteCounts, isValidEntryKey, isValidVoteClientId };
 
 export function getVotesDb(): D1DatabaseLike | null {
   return getSiteDb();

--- a/apps/web/src/routes/api/votes/toggle.ts
+++ b/apps/web/src/routes/api/votes/toggle.ts
@@ -3,7 +3,7 @@ import { createApiFileRoute } from "@/lib/api/file-route";
 import { votesToggleBodySchema } from "@/lib/api/contracts";
 import { apiError, apiJson, createApiHandler, type InferApiBody } from "@/lib/api/router";
 import { logApiError, logApiInfo, logApiWarn, sample } from "@/lib/api-logs";
-import { getVotesDb, isValidEntryKey, toggleVote } from "@/lib/votes";
+import { getVotesDb, isValidEntryKey, isValidVoteClientId, toggleVote } from "@/lib/votes";
 
 export const POST = createApiHandler("votes.toggle", async ({ request, body, requestId }) => {
   const payload = body as InferApiBody<typeof votesToggleBodySchema>;
@@ -16,7 +16,7 @@ export const POST = createApiHandler("votes.toggle", async ({ request, body, req
     return apiError("invalid_payload", 400, { requestId });
   }
 
-  if (clientId.length < 8 || clientId.length > 128) {
+  if (!isValidVoteClientId(clientId)) {
     logApiWarn(request, "votes.toggle.invalid_client_id", {
       clientIdLength: clientId.length,
     });

--- a/tests/votes-lib.test.ts
+++ b/tests/votes-lib.test.ts
@@ -2,9 +2,40 @@ import { describe, expect, it } from "vitest";
 
 import {
   isValidEntryKey,
+  isValidVoteClientId,
   getFallbackVoteCounts,
   getFallbackClientVotes,
 } from "../apps/web/src/lib/votes-lib";
+
+describe("votes-lib isValidVoteClientId", () => {
+  it("accepts the opaque ids the browser client actually generates", () => {
+    // `hc-${crypto.randomUUID()}` and the time+random fallback.
+    expect(isValidVoteClientId("hc-123e4567-e89b-12d3-a456-426614174000")).toBe(
+      true,
+    );
+    expect(isValidVoteClientId("hc-lz4k9x-a1b2c3d4e5f6g7h8")).toBe(true);
+    expect(isValidVoteClientId("A_b-9xxxxxxxxxxx")).toBe(true);
+  });
+
+  it("keeps personal data and credentials out of votes.client_id", () => {
+    // The votes table stores the id verbatim, so free text must not reach it.
+    expect(isValidVoteClientId("user@example.com")).toBe(false);
+    expect(isValidVoteClientId("Ada Lovelace")).toBe(false);
+    expect(isValidVoteClientId("https://heyclau.de/u/1?token=abc")).toBe(false);
+    expect(isValidVoteClientId("eyJhbGci.eyJzdWIi.SflKxwRJ")).toBe(false);
+  });
+
+  it("keeps the pre-existing 8..128 length bound", () => {
+    expect(isValidVoteClientId("a".repeat(7))).toBe(false);
+    expect(isValidVoteClientId("a".repeat(8))).toBe(true);
+    expect(isValidVoteClientId("a".repeat(128))).toBe(true);
+    expect(isValidVoteClientId("a".repeat(129))).toBe(false);
+  });
+
+  it("rejects an empty id", () => {
+    expect(isValidVoteClientId("")).toBe(false);
+  });
+});
 
 describe("votes-lib isValidEntryKey", () => {
   it("accepts category:slug keys with lowercase alphanumeric hyphen segments", () => {


### PR DESCRIPTION
Same bug class as #4746, on the votes surface. Found while auditing #556's *"Keep sensitive payloads out of intent events"* requirement across the other caller-supplied-id endpoints.

## The gap

`/api/votes/toggle` validated `clientId` by **length only**:

```ts
if (clientId.length < 8 || clientId.length > 128) { ... return apiError("invalid_client_id", 400) }
```

and `toggleVote` binds it verbatim:

```ts
.bind(entryKey, clientId)
```

So `user@example.com` (16 chars) passed validation and was persisted into `votes.client_id`, as would a URL carrying a `?token=`, a JWT, or a spaced name.

**The sibling surface already gets this right.** Community signals run their id through `normalizeCommunityClientId`:

```ts
return /^[a-zA-Z0-9_-]{16,96}$/.test(normalized) ? normalized : null;
```

Votes had no charset check at all — the inconsistency is the bug.

## The fix

A pure `isValidVoteClientId` guard in `votes-lib.ts` using the same URL-safe alphabet, and the route's length check swapped for it. Malformed ids keep returning the existing `400 invalid_client_id` with the same `votes.toggle.invalid_client_id` warn log — only the acceptance criterion changed.

**I deliberately kept the existing `8..128` length bound** rather than tightening to community signals' `16..96`. Voting dedupes on `client_id`, so narrowing the length would silently stop existing voters from toggling. Both shapes the browser actually generates pass:

| id | passes |
|---|---|
| `hc-${crypto.randomUUID()}` | ✅ |
| `hc-<base36>-<random>` fallback | ✅ |
| `user@example.com` | ❌ |
| `https://heyclau.de/u/1?token=abc` | ❌ |
| `eyJhbGci.eyJzdWIi.SflKxwRJ` | ❌ |

**No behavior change for legitimate clients.**

## Tests

Extends `tests/votes-lib.test.ts` (+4 cases): the ids the browser really generates are accepted; emails / spaced names / token-bearing URLs / JWTs are rejected; the pre-existing `8..128` bound is pinned at all four edges (7, 8, 128, 129); an empty id is rejected.

The guard is load-bearing — weakening the pattern back to a length-only `/^.{8,128}$/` makes exactly the *"keeps personal data and credentials out of votes.client_id"* case fail, and restoring it turns it green (verified).

```
pnpm exec vitest run tests/votes-lib.test.ts                                  # 622 passed
pnpm exec vitest run tests/api-contracts.test.ts tests/codeql-regressions.test.ts   # passed
pnpm test    # 63 failed / 38 failing files — identical to main's baseline. The one votes-adjacent
             # failure, d1-vote-sync.test.ts, is a pre-existing 30s-timeout flake: clean main fails it
             # with 2 failures, this branch with 1. Zero new failures.
pnpm exec prettier --check <changed files>   # clean
```

Refs #556