### PR TITLE
refactor(web): extract feed link/last-built helpers into feed-items-lib

### DIFF
--- a/apps/web/src/lib/feed-items-lib.ts
+++ b/apps/web/src/lib/feed-items-lib.ts
@@ -1,0 +1,15 @@
+// Pure helpers for the RSS/Atom feed routes: absolutize item links against the
+// request origin and derive the feed's last-built timestamp. Split out so the
+// link handling and empty-feed fallback can be unit-tested without the route.
+
+/** Prefix each relative item link with the base origin; absolute links pass through. */
+export function absolutizeFeedLinks<T extends { link: string }>(items: T[], base: string): T[] {
+  return items.map((item) =>
+    item.link.startsWith("http") ? item : { ...item, link: `${base}${item.link}` },
+  );
+}
+
+/** The newest item's pubDate, or the epoch ISO string for an empty feed. */
+export function feedLastBuilt(items: Array<{ pubDate: string }>): string {
+  return items.length ? items[0].pubDate : new Date(0).toISOString();
+}

--- a/apps/web/src/routes/feed[.]xml.ts
+++ b/apps/web/src/routes/feed[.]xml.ts
@@ -1,16 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { buildRss, origin, respondFeed, SITE_NAME, SITE_TAGLINE, siteWideItems } from "@/lib/feeds";
+import { absolutizeFeedLinks, feedLastBuilt } from "@/lib/feed-items-lib";
 
 export const Route = createFileRoute("/feed.xml")({
   server: {
     handlers: {
       GET: async ({ request }) => {
         const base = origin(request);
-        const items = siteWideItems().map((i) => ({
-          ...i,
-          link: i.link.startsWith("http") ? i.link : `${base}${i.link}`,
-        }));
-        const lastBuilt = items.length ? items[0].pubDate : new Date(0).toISOString();
+        const items = absolutizeFeedLinks(siteWideItems(), base);
+        const lastBuilt = feedLastBuilt(items);
         const xml = buildRss({
           title: `${SITE_NAME} — registry changelog`,
           description: SITE_TAGLINE,

--- a/tests/feed-items-lib.test.ts
+++ b/tests/feed-items-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  absolutizeFeedLinks,
+  feedLastBuilt,
+} from "../apps/web/src/lib/feed-items-lib";
+
+describe("absolutizeFeedLinks", () => {
+  it("prefixes relative links with the base and preserves other fields", () => {
+    const out = absolutizeFeedLinks(
+      [{ link: "/changelog", title: "Note", pubDate: "2026-01-01" }],
+      "https://heyclau.de",
+    );
+    expect(out[0]).toEqual({
+      link: "https://heyclau.de/changelog",
+      title: "Note",
+      pubDate: "2026-01-01",
+    });
+  });
+
+  it("leaves absolute (http) links unchanged", () => {
+    const out = absolutizeFeedLinks(
+      [{ link: "https://elsewhere.example/x", pubDate: "2026-01-01" }],
+      "https://heyclau.de",
+    );
+    expect(out[0].link).toBe("https://elsewhere.example/x");
+  });
+});
+
+describe("feedLastBuilt", () => {
+  it("returns the newest item's pubDate", () => {
+    expect(
+      feedLastBuilt([{ pubDate: "2026-02-02" }, { pubDate: "2026-01-01" }]),
+    ).toBe("2026-02-02");
+  });
+
+  it("falls back to the epoch ISO string for an empty feed", () => {
+    expect(feedLastBuilt([])).toBe(new Date(0).toISOString());
+  });
+});


### PR DESCRIPTION
### What & why

The RSS feed route absolutized item links against the request origin and derived the last-built timestamp inline, so the link handling and empty-feed fallback could not be unit-tested without the handler. This moves them into `apps/web/src/lib/feed-items-lib.ts` and calls them from the route.

### Changes

- Add `apps/web/src/lib/feed-items-lib.ts` — `absolutizeFeedLinks(items, base)` and `feedLastBuilt(items)`.
- `apps/web/src/routes/feed[.]xml.ts` — absolutize and timestamp via the helpers.
- Add `tests/feed-items-lib.test.ts` — covers relative-link prefixing (preserving other fields), absolute-link passthrough, newest-pubDate selection, and the empty-feed epoch fallback. Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/feed-items-lib.test.ts` — 4 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the feed emits identical links and timestamp. The same helpers can later back the Atom route too.
