### PR TITLE
refactor(web): dedupe integration route breadcrumbs via shared builder

### DIFF
--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -7,6 +7,7 @@ import { LiveVersionBadge } from "@/components/live-version-badge";
 import { CopyButton } from "@/components/copy-button";
 import { absoluteUrl } from "@/lib/seo";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { integrationAppJsonLd } from "@/lib/integration-app-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
 
@@ -27,19 +28,10 @@ export const Route = createFileRoute("/integrations/$slug")({
       url,
       absoluteUrl,
     );
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        {
-          "@type": "ListItem",
-          position: 1,
-          name: "Integrations",
-          item: absoluteUrl("/integrations"),
-        },
-        { "@type": "ListItem", position: 2, name: it.name, item: url },
-      ],
-    };
+    const breadcrumbs = breadcrumbListJsonLd([
+      { name: "Integrations", item: absoluteUrl("/integrations") },
+      { name: it.name, item: url },
+    ]);
     return {
       meta: [
         { title: `${it.name} — HeyClaude integration` },


### PR DESCRIPTION
### What & why

The integration detail route open-coded its schema.org BreadcrumbList with manual ListItem positions. This reuses the shared `breadcrumbListJsonLd` helper (added earlier) so the crumb-to-ListItem mapping lives in one tested place.

### Changes

- `apps/web/src/routes/integrations.$slug.tsx` — build the breadcrumbs via `breadcrumbListJsonLd([{ name: "Integrations", item: ... }, { name: it.name, item: url }])`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged (`Integrations > <name>`). Covered by the existing `breadcrumb-jsonld-lib` tests.
