### PR TITLE
refactor(web): dedupe comparison route breadcrumbs via shared builder

### DIFF
--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -5,6 +5,7 @@ import { ComparisonTable } from "@/components/comparison-table";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { NewsletterInline } from "@/components/newsletter-inline";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { comparisonItemListJsonLd } from "@/lib/comparison-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -34,15 +35,11 @@ export const Route = createFileRoute("/compare/$slug")({
       description: comparison.seoDescription,
     });
     const itemList = comparisonItemListJsonLd(comparison, entries, absoluteUrl);
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-        { "@type": "ListItem", position: 2, name: "Compare", item: absoluteUrl("/compare") },
-        { "@type": "ListItem", position: 3, name: comparison.heading, item: url },
-      ],
-    };
+    const breadcrumbs = breadcrumbListJsonLd([
+      { name: "Directory", item: absoluteUrl("/browse") },
+      { name: "Compare", item: absoluteUrl("/compare") },
+      { name: comparison.heading, item: url },
+    ]);
     return {
       meta: [
         { title: `${comparison.title} — HeyClaude` },


### PR DESCRIPTION
### What & why

The comparison detail route open-coded its schema.org BreadcrumbList with manual ListItem positions. This reuses the shared `breadcrumbListJsonLd` helper so the crumb-to-ListItem mapping lives in one tested place.

### Changes

- `apps/web/src/routes/compare.$slug.tsx` — build the breadcrumbs via `breadcrumbListJsonLd([...])`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged (`Directory > Compare > <heading>`). Covered by the existing `breadcrumb-jsonld-lib` tests.
