### PR TITLE
refactor(web): dedupe category route breadcrumbs via shared builder

### DIFF
--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -18,6 +18,7 @@ import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { CategoryRankingTable } from "@/components/category-ranking-table";
 import { hubHighlights, hubStats } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { categoryItemListJsonLd } from "@/lib/category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, categoryAccent } from "@/lib/og-image";
@@ -53,14 +54,10 @@ export const Route = createFileRoute("/$category")({
     });
 
     const itemList = categoryItemListJsonLd(label, description, entries, absoluteUrl);
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-        { "@type": "ListItem", position: 2, name: label, item: url },
-      ],
-    };
+    const breadcrumbs = breadcrumbListJsonLd([
+      { name: "Directory", item: absoluteUrl("/browse") },
+      { name: label, item: url },
+    ]);
 
     return {
       meta: [


### PR DESCRIPTION
### What & why

The category route open-coded its schema.org BreadcrumbList with manual ListItem positions. This reuses the shared `breadcrumbListJsonLd` helper so the crumb-to-ListItem mapping lives in one tested place.

### Changes

- `apps/web/src/routes/$category.tsx` — build the breadcrumbs via `breadcrumbListJsonLd([...])`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged (`Directory > <label>`). Covered by the existing `breadcrumb-jsonld-lib` tests.
