### PR TITLE
refactor(web): dedupe platform+category route breadcrumbs via shared builder

### DIFF
--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -11,6 +11,7 @@ import { NewsletterInline } from "@/components/newsletter-inline";
 import { HubHighlights, HubSignalStats } from "@/components/hub-highlights";
 import { hubHighlights, hubStats, trustPosture } from "@/lib/hub-highlights";
 import { stringifyJsonLd } from "@/lib/json-ld";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { platformCategoryItemListJsonLd } from "@/lib/platform-category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
@@ -52,21 +53,12 @@ export const Route = createFileRoute("/for/$platform/$category")({
       entries,
       absoluteUrl,
     );
-    const breadcrumbs = {
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: [
-        { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-        { "@type": "ListItem", position: 2, name: "Platforms", item: absoluteUrl("/for") },
-        {
-          "@type": "ListItem",
-          position: 3,
-          name: pLabel,
-          item: absoluteUrl(`/for/${params.platform}`),
-        },
-        { "@type": "ListItem", position: 4, name: cLabel, item: url },
-      ],
-    };
+    const breadcrumbs = breadcrumbListJsonLd([
+      { name: "Directory", item: absoluteUrl("/browse") },
+      { name: "Platforms", item: absoluteUrl("/for") },
+      { name: pLabel, item: absoluteUrl(`/for/${params.platform}`) },
+      { name: cLabel, item: url },
+    ]);
     return {
       meta: [
         { title },


### PR DESCRIPTION
### What & why

The platform+category route open-coded its schema.org BreadcrumbList with manual ListItem positions. This reuses the shared `breadcrumbListJsonLd` helper so the crumb-to-ListItem mapping lives in one tested place.

### Changes

- `apps/web/src/routes/for.$platform.$category.tsx` — build the breadcrumbs via `breadcrumbListJsonLd([...])`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged (`Directory > Platforms > <platform> > <category>`). Covered by the existing `breadcrumb-jsonld-lib` tests.
