### PR TITLE
refactor(web): dedupe atom feed link/last-built via feed-items-lib

### DIFF
--- a/apps/web/src/routes/atom[.]xml.ts
+++ b/apps/web/src/routes/atom[.]xml.ts
@@ -7,17 +7,15 @@ import {
   SITE_TAGLINE,
   siteWideItems,
 } from "@/lib/feeds";
+import { absolutizeFeedLinks, feedLastBuilt } from "@/lib/feed-items-lib";
 
 export const Route = createFileRoute("/atom.xml")({
   server: {
     handlers: {
       GET: async ({ request }) => {
         const base = origin(request);
-        const items = siteWideItems().map((i) => ({
-          ...i,
-          link: i.link.startsWith("http") ? i.link : `${base}${i.link}`,
-        }));
-        const lastBuilt = items.length ? items[0].pubDate : new Date(0).toISOString();
+        const items = absolutizeFeedLinks(siteWideItems(), base);
+        const lastBuilt = feedLastBuilt(items);
         const xml = buildAtom({
           title: `${SITE_NAME} — registry changelog`,
           description: SITE_TAGLINE,


### PR DESCRIPTION
### What & why

The Atom feed route open-coded the same item-link absolutization and last-built timestamp derivation as the RSS route. This reuses the shared `feed-items-lib` helpers so the logic lives in one tested place.

### Changes

- `apps/web/src/routes/atom[.]xml.ts` — absolutize links via `absolutizeFeedLinks` and derive the timestamp via `feedLastBuilt`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the Atom feed emits identical links and timestamp. Covered by the existing `feed-items-lib` tests.
