### PR TITLE
refactor(web): dedupe per-slug feed link/last-built via feed-items-lib

### DIFF
--- a/apps/web/src/routes/feeds.$slug.ts
+++ b/apps/web/src/routes/feeds.$slug.ts
@@ -11,6 +11,7 @@ import {
   trendingItems,
   type SavedSearchQuery,
 } from "@/lib/feeds";
+import { absolutizeFeedLinks, feedLastBuilt } from "@/lib/feed-items-lib";
 import type { Category } from "@/types/registry";
 
 const CHANGELOG_STREAMS = ["release", "policy", "security"] as const;
@@ -60,11 +61,8 @@ export const Route = createFileRoute("/feeds/$slug")({
           throw notFound();
         }
 
-        const linked = items.map((i) => ({
-          ...i,
-          link: i.link.startsWith("http") ? i.link : `${base}${i.link}`,
-        }));
-        const lastBuilt = linked.length ? linked[0].pubDate : new Date(0).toISOString();
+        const linked = absolutizeFeedLinks(items, base);
+        const lastBuilt = feedLastBuilt(linked);
         const xml = buildRss({
           title,
           description,


### PR DESCRIPTION
### What & why

The per-slug feed route open-coded the same item-link absolutization and last-built timestamp derivation as the RSS/Atom routes. This reuses the shared `feed-items-lib` helpers so the logic lives in one tested place.

### Changes

- `apps/web/src/routes/feeds.$slug.ts` — absolutize links via `absolutizeFeedLinks` and derive the timestamp via `feedLastBuilt`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the feed emits identical links and timestamp. Covered by the existing `feed-items-lib` tests.
