### PR TITLE
refactor(web): extract saved-search query params into a lib

### DIFF
--- a/apps/web/src/lib/saved-search-query-lib.ts
+++ b/apps/web/src/lib/saved-search-query-lib.ts
@@ -1,0 +1,16 @@
+// Pure extraction of a saved-search query from URL params, split out of the
+// per-slug feed route so the param mapping can be unit-tested without the
+// handler. The type-only import keeps this decoupled from the feed runtime.
+
+import type { SavedSearchQuery } from "@/lib/feeds";
+
+/** Build a SavedSearchQuery from feed URL params (absent params -> undefined). */
+export function savedSearchQueryFromParams(params: URLSearchParams): SavedSearchQuery {
+  return {
+    q: params.get("q") ?? undefined,
+    category: params.get("category") ?? undefined,
+    trust: params.get("trust") ?? undefined,
+    source: params.get("source") ?? undefined,
+    platform: params.get("platform") ?? undefined,
+  };
+}

--- a/apps/web/src/routes/feeds.$slug.ts
+++ b/apps/web/src/routes/feeds.$slug.ts
@@ -9,9 +9,9 @@ import {
   respondFeed,
   SITE_NAME,
   trendingItems,
-  type SavedSearchQuery,
 } from "@/lib/feeds";
 import { absolutizeFeedLinks, feedLastBuilt } from "@/lib/feed-items-lib";
+import { savedSearchQueryFromParams } from "@/lib/saved-search-query-lib";
 import type { Category } from "@/types/registry";
 
 const CHANGELOG_STREAMS = ["release", "policy", "security"] as const;
@@ -42,13 +42,7 @@ export const Route = createFileRoute("/feeds/$slug")({
           title = `${SITE_NAME} — ${stream} notes`;
           description = `${stream} notes on ${SITE_NAME}.`;
         } else if (slug === "saved") {
-          const q: SavedSearchQuery = {
-            q: url.searchParams.get("q") ?? undefined,
-            category: url.searchParams.get("category") ?? undefined,
-            trust: url.searchParams.get("trust") ?? undefined,
-            source: url.searchParams.get("source") ?? undefined,
-            platform: url.searchParams.get("platform") ?? undefined,
-          };
+          const q = savedSearchQueryFromParams(url.searchParams);
           const label = url.searchParams.get("label") ?? "Saved search";
           items = applySavedSearch(q);
           title = `${SITE_NAME} — ${label}`;

--- a/tests/saved-search-query-lib.test.ts
+++ b/tests/saved-search-query-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { savedSearchQueryFromParams } from "../apps/web/src/lib/saved-search-query-lib";
+
+describe("savedSearchQueryFromParams", () => {
+  it("maps each recognized param", () => {
+    const q = savedSearchQueryFromParams(
+      new URLSearchParams({
+        q: "mcp",
+        category: "mcp",
+        trust: "verified",
+        source: "github",
+        platform: "cursor",
+      }),
+    );
+    expect(q).toEqual({
+      q: "mcp",
+      category: "mcp",
+      trust: "verified",
+      source: "github",
+      platform: "cursor",
+    });
+  });
+
+  it("leaves absent params undefined and ignores unknown ones", () => {
+    const q = savedSearchQueryFromParams(
+      new URLSearchParams({ q: "agents", extra: "x" }),
+    );
+    expect(q).toEqual({
+      q: "agents",
+      category: undefined,
+      trust: undefined,
+      source: undefined,
+      platform: undefined,
+    });
+  });
+});


### PR DESCRIPTION
### What & why

The per-slug feed route built the "saved" feed's `SavedSearchQuery` from URL params inline, so the param mapping could not be unit-tested without the handler. This moves it into `apps/web/src/lib/saved-search-query-lib.ts` (a type-only import keeps it decoupled from the feed runtime) and calls it from the route.

### Changes

- Add `apps/web/src/lib/saved-search-query-lib.ts` — `savedSearchQueryFromParams(params)`.
- `apps/web/src/routes/feeds.$slug.ts` — build the query via the helper; drop the now-unused `SavedSearchQuery` type import.
- Add `tests/saved-search-query-lib.test.ts` — covers all recognized params and the absent/unknown-param handling.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/saved-search-query-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the saved feed resolves the same query.
