### PR TITLE
fix(web): floor timeAgo units so sub-boundary timestamps keep the right label

### DIFF
--- a/apps/web/src/lib/format-lib.ts
+++ b/apps/web/src/lib/format-lib.ts
@@ -31,14 +31,17 @@ export function timeAgo(iso: string | undefined | null): string {
   if (Number.isNaN(d)) return "—";
   const diff = Date.now() - d;
   if (diff < 0) return "—";
-  const min = Math.round(diff / 60_000);
+  // Floor (not round) each unit: rounding pushes a value that is short of the next boundary up
+  // into the higher unit, defeating the `< 60`/`< 24`/`< 30` guard below it — e.g. 23h30m would
+  // render "1d ago" and 45s would render "1m ago" instead of "just now".
+  const min = Math.floor(diff / 60_000);
   if (min < 1) return "just now";
   if (min < 60) return `${min}m ago`;
-  const h = Math.round(min / 60);
+  const h = Math.floor(min / 60);
   if (h < 24) return `${h}h ago`;
-  const day = Math.round(h / 24);
+  const day = Math.floor(h / 24);
   if (day < 30) return `${day}d ago`;
-  const mo = Math.round(day / 30);
+  const mo = Math.floor(day / 30);
   if (mo < 12) return `${mo}mo ago`;
-  return `${Math.round(mo / 12)}y ago`;
+  return `${Math.floor(mo / 12)}y ago`;
 }

--- a/tests/format-lib.test.ts
+++ b/tests/format-lib.test.ts
@@ -103,4 +103,15 @@ describe("timeAgo", () => {
     expect(timeAgo(ago(400 * DAY))).toBe("1y ago");
     expect(timeAgo(ago(800 * DAY))).toBe("2y ago");
   });
+
+  it("floors each unit at sub-boundary values instead of rounding up", () => {
+    // Regression: these all sit just short of the next unit's boundary. With Math.round they
+    // rounded up into the wrong bucket ("just now"->"1m", "1h"->"2h", "23h"->"1d", "29d"->"1mo").
+    expect(timeAgo(ago(45 * SECOND))).toBe("just now");
+    expect(timeAgo(ago(59 * MINUTE + 59 * SECOND))).toBe("59m ago");
+    expect(timeAgo(ago(90 * MINUTE))).toBe("1h ago");
+    expect(timeAgo(ago(23 * HOUR + 30 * MINUTE))).toBe("23h ago");
+    expect(timeAgo(ago(29 * DAY + 12 * HOUR))).toBe("29d ago");
+    expect(timeAgo(ago(345 * DAY))).toBe("11mo ago");
+  });
 });


### PR DESCRIPTION
## Problem

`timeAgo` in `apps/web/src/lib/format-lib.ts` computed each time unit with `Math.round`. Because rounding pushes a value that is *just short* of the next boundary **up** into the higher unit, the value crosses into the next bucket before its own `< 60` / `< 24` / `< 30` guard runs — so recent timestamps get the wrong label:

| Actual age | Rendered (buggy) | Correct |
|---|---|---|
| 45 seconds | `1m ago` | `just now` |
| 90 minutes | `2h ago` | `1h ago` |
| 23h 30m | `1d ago` | `23h ago` |
| 29d 12h | `1mo ago` | `29d ago` |
| 59m 59s | `1h ago` | `59m ago` |

Trace for 23h30m: `min = round(1410) = 1410` → `h = round(1410/60) = round(23.5) = 24` → `h < 24` is now **false** → `day = round(24/24) = 1` → `"1d ago"`. An item under a day old is labeled "1d ago".

This is user-visible wherever `timeAgo` renders: resource cards ("Added …"), the live-version badge, and the feed-health panel.

## Fix

Switch the five unit computations from `Math.round` to `Math.floor`, so a bucket only advances once its threshold is actually crossed. This matches the sibling `relativePosted` helper in `jobs-utils-lib.ts`, which already floors for exactly this bucketing.

```diff
-  const min = Math.round(diff / 60_000);
+  const min = Math.floor(diff / 60_000);
   ...
-  const h = Math.round(min / 60);
+  const h = Math.floor(min / 60);
   ...
-  const day = Math.round(h / 24);
+  const day = Math.floor(h / 24);
   ...
-  const mo = Math.round(day / 30);
+  const mo = Math.floor(day / 30);
   ...
-  return `${Math.round(mo / 12)}y ago`;
+  return `${Math.floor(mo / 12)}y ago`;
```

## Risk / tradeoffs

- Pure function, no API/signature change. Backward compatible.
- The existing mid-bucket tests (5m, 59m, 2h, 23h, 2d, 29d, 60d, 330d, 400d, 800d) are all unaffected by the change — only the previously-mislabeled boundary values change, and they change to the correct label.
- No `"0h ago"`/`"0d ago"` edge is introduced: each higher unit is only reached after the lower unit's `<` guard fails, which guarantees the floored value is ≥ 1.

## Tests & validation

- Adds a boundary regression test in `tests/format-lib.test.ts` covering 45s, 59m59s, 90m, 23h30m, 29d12h, and 345d.
- `pnpm exec vitest run tests/format-lib.test.ts` → 16/16 pass.
- `pnpm type-check` → clean. `pnpm build` → succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)