### PR TITLE
feat(web): compose best compare interactive fields through delegates

### DIFF
--- a/apps/web/src/lib/compare-best-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-ui-lib.ts
@@ -32,7 +32,7 @@ export function compareBestUiState(entries: Entry[]): CompareBestUiState {
   return {
     showCompareSection: compareBestShowCompareSection(entries),
     bannerTexts: compareBestHeaderBannerTexts(entries),
-    interactiveSearch: compareInteractiveSearch(entries),
-    interactiveLinkLabel: compareInteractiveLinkLabel(entries.length),
+    interactiveSearch: compareBestInteractiveSearch(entries),
+    interactiveLinkLabel: compareBestInteractiveLinkLabel(entries.length),
   };
 }

--- a/tests/compare-best-ui-lib.test.ts
+++ b/tests/compare-best-ui-lib.test.ts
@@ -103,6 +103,12 @@ describe("compare best ui lib", () => {
       compareBestShowCompareSection(entries),
     );
     expect(bundled.bannerTexts).toEqual(compareBestHeaderBannerTexts(entries));
+    expect(bundled.interactiveSearch).toEqual(
+      compareBestInteractiveSearch(entries),
+    );
+    expect(bundled.interactiveLinkLabel).toBe(
+      compareBestInteractiveLinkLabel(entries.length),
+    );
     expect(
       compareBestUiState([
         entry(),


### PR DESCRIPTION
## Summary
- Route `compareBestUiState` `interactiveSearch` and `interactiveLinkLabel` through existing `compareBestInteractiveSearch` / `compareBestInteractiveLinkLabel` delegates
- Assert bundled interactive fields match delegate outputs in tests

## Test plan
- [x] `npx vitest run tests/compare-best-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-best-ui-lib.ts'` (100% lib coverage)
- [x] Full test suite passes
- [x] Verified clean merge-tree against open PRs #4773, #4772, #4762, #4745


Made with [Cursor](https://cursor.com)