### PR TITLE
fix(registry): detect mid-body Prerequisites sections + correct 24 skills entries

### DIFF
--- a/content/skills/audio-transcription-summarization.mdx
+++ b/content/skills/audio-transcription-summarization.mdx
@@ -63,7 +63,7 @@ readingTime: 3
 packageVerified: true
 difficultyScore: 71
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/bun-runtime-modern-javascript.mdx
+++ b/content/skills/bun-runtime-modern-javascript.mdx
@@ -80,7 +80,7 @@ readingTime: 4
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/cli-data-viz-quickstart.mdx
+++ b/content/skills/cli-data-viz-quickstart.mdx
@@ -63,7 +63,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 96
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/cloudflare-workers-ai-edge.mdx
+++ b/content/skills/cloudflare-workers-ai-edge.mdx
@@ -87,7 +87,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/csv-excel-data-wrangler.mdx
+++ b/content/skills/csv-excel-data-wrangler.mdx
@@ -69,7 +69,7 @@ readingTime: 4
 packageVerified: true
 difficultyScore: 94
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/cursor-windsurf-ai-ide-setup.mdx
+++ b/content/skills/cursor-windsurf-ai-ide-setup.mdx
@@ -103,7 +103,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/docx-report-generator.mdx
+++ b/content/skills/docx-report-generator.mdx
@@ -60,7 +60,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/fastapi-python-backend.mdx
+++ b/content/skills/fastapi-python-backend.mdx
@@ -110,7 +110,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/github-actions-ai-cicd.mdx
+++ b/content/skills/github-actions-ai-cicd.mdx
@@ -225,7 +225,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/image-ocr-table-extraction.mdx
+++ b/content/skills/image-ocr-table-extraction.mdx
@@ -69,7 +69,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 96
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/json-schema-validation-transformation.mdx
+++ b/content/skills/json-schema-validation-transformation.mdx
@@ -68,7 +68,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/log-parsing-incident-timeline.mdx
+++ b/content/skills/log-parsing-incident-timeline.mdx
@@ -58,7 +58,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/markdown-knowledge-base-composer.mdx
+++ b/content/skills/markdown-knowledge-base-composer.mdx
@@ -77,7 +77,7 @@ readingTime: 5
 packageVerified: true
 difficultyScore: 96
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/playwright-e2e-testing.mdx
+++ b/content/skills/playwright-e2e-testing.mdx
@@ -76,7 +76,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/postgresql-query-optimization.mdx
+++ b/content/skills/postgresql-query-optimization.mdx
@@ -70,7 +70,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/rest-api-client-harness.mdx
+++ b/content/skills/rest-api-client-harness.mdx
@@ -73,7 +73,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/supabase-realtime-database.mdx
+++ b/content/skills/supabase-realtime-database.mdx
@@ -75,7 +75,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/svelte-sveltekit-fullstack.mdx
+++ b/content/skills/svelte-sveltekit-fullstack.mdx
@@ -72,7 +72,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/trpc-type-safe-api.mdx
+++ b/content/skills/trpc-type-safe-api.mdx
@@ -113,7 +113,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/v0-rapid-prototyping.mdx
+++ b/content/skills/v0-rapid-prototyping.mdx
@@ -122,7 +122,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/vite-build-optimization.mdx
+++ b/content/skills/vite-build-optimization.mdx
@@ -96,7 +96,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/webassembly-module-development.mdx
+++ b/content/skills/webassembly-module-development.mdx
@@ -99,7 +99,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/website-crawler-summarizer.mdx
+++ b/content/skills/website-crawler-summarizer.mdx
@@ -67,7 +67,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/content/skills/windsurf-collaborative-development.mdx
+++ b/content/skills/windsurf-collaborative-development.mdx
@@ -86,7 +86,7 @@ readingTime: 6
 packageVerified: true
 difficultyScore: 100
 hasTroubleshooting: true
-hasPrerequisites: false
+hasPrerequisites: true
 hasBreakingChanges: false
 robotsIndex: true
 robotsFollow: true

--- a/packages/registry/src/content-schema-lib.js
+++ b/packages/registry/src/content-schema-lib.js
@@ -431,7 +431,7 @@ export function inferSectionBooleans(body = "") {
 
   return {
     hasPrerequisites:
-      /^##\s+Prerequisites\b|^##\s+Prerequisites\s+&|^##\s+Prerequisites\s+and\b/i.test(
+      /^##\s+Prerequisites\b|^##\s+Prerequisites\s+&|^##\s+Prerequisites\s+and\b/im.test(
         normalized,
       ),
     hasTroubleshooting:

--- a/tests/content-schema-lib.test.ts
+++ b/tests/content-schema-lib.test.ts
@@ -675,6 +675,12 @@ describe("inferSectionBooleans", () => {
       "## Prerequisites\n\nA\n\n## Troubleshooting Guide\n\nB",
       { hasPrerequisites: true, hasTroubleshooting: true },
     ],
+    // A Prerequisites heading anywhere in the body must be detected, not only at
+    // offset 0 — real entry bodies open with a title/intro before their sections.
+    [
+      "# Title\n\nIntro.\n\n## Prerequisites\n\nNeed tool",
+      { hasPrerequisites: true, hasTroubleshooting: false },
+    ],
     [
       "### Not prerequisites",
       { hasPrerequisites: false, hasTroubleshooting: false },
@@ -691,7 +697,7 @@ describe("inferSectionBooleans", () => {
     ],
     [
       "## Troubleshooting\n\n## Prerequisites",
-      { hasPrerequisites: false, hasTroubleshooting: true },
+      { hasPrerequisites: true, hasTroubleshooting: true },
     ],
   ])("detects guide sections in %j", (body, expected) => {
     expect(inferSectionBooleans(body)).toEqual(expected);


### PR DESCRIPTION
## Problem

`inferSectionBooleans` in `packages/registry/src/content-schema-lib.js` computes `hasPrerequisites` with a case-insensitive but **not multiline** regex, while its structurally-identical sibling `hasTroubleshooting` uses `im`:

```js
hasPrerequisites:
  /^##\s+Prerequisites\b|.../i.test(normalized),      // ← missing `m`
hasTroubleshooting:
  /^##\s+Troubleshooting\b|.../im.test(normalized),   // ← has `m`
```

Every alternative is `^`-anchored, so without the `m` flag `^` only matches the **start of the whole body string**. A `## Prerequisites` heading that appears after the opening title/intro — i.e. how every real entry is written — is never detected.

```js
inferSectionBooleans("# Title\n\nIntro.\n\n## Prerequisites\n\n...")
// before: { hasPrerequisites: false, ... }   ← wrong
// after:  { hasPrerequisites: true,  ... }
```

### Impact

- `buildContentEntry` (`content-builder-lib.js`) publishes this straight into the generated registry artifact when frontmatter omits `hasPrerequisites`, so entries get `hasPrerequisites: false` baked in despite having the section.
- `validate-content` / `audit-content` use the flag for their consistency check ("`hasPrerequisites=false` but Prerequisites section exists"). Because the flag was wrongly `false`, that check **silently under-fired** — the exact mismatch it exists to catch.

The masked mismatch had already accumulated in content: **24 skills entries** declare `hasPrerequisites: false` while shipping a real `## Prerequisites` section **and** a populated `prerequisites:` array (verified on every one). Fixing the regex alone would make `validate:content:strict` correctly flag all 24, so the data must be corrected in the same change.

## Fix

1. Add the `m` flag to the `hasPrerequisites` regex so it matches a heading anywhere in the body — matching the `hasTroubleshooting` sibling.
2. Flip `hasPrerequisites: false` → `true` on the 24 skills entries that genuinely have prerequisites, so metadata matches reality and strict validation passes. One line changed per entry; nothing else touched.
3. Tests: add a regression case for a mid-body Prerequisites heading, and correct the one existing case (`"## Troubleshooting\n\n## Prerequisites"`) that had encoded the buggy offset-0-only behavior.

## Risk / tradeoffs

- The regex change only makes detection **more** correct; the sibling proves the intended behavior.
- The 24 content edits are a single mechanical `false`→`true` per file, each with a matching `## Prerequisites` section + `prerequisites:` array, so they're unambiguously correct.
- It's a larger PR than a pure one-liner because the code fix and the data it exposes are coupled — they can't land separately without breaking strict validation.

## Validation

- `pnpm validate:content:strict -- --category skills` → **passed** (176 files).
- `pnpm audit:content -- --category skills` → 0 issues.
- `pnpm exec vitest run tests/content-schema-lib.test.ts tests/content-schema.test.ts tests/non-ui-branch-matrix.test.ts` → all pass.
- `pnpm type-check` clean; `pnpm build` succeeds; `registry-artifacts` regenerates cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)