### PR TITLE
feat(web): compose drawer presentation state through delegates

### DIFF
--- a/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
@@ -1,5 +1,5 @@
 import type { Entry } from "@/types/registry";
-import { compareDrawerActionsDiverge } from "@/lib/compare-drawer-actions";
+import { compareDrawerUiActionsDiverge } from "@/lib/compare-drawer-ui-lib";
 import { compareDrawerDivergingDecisionLabels } from "@/lib/compare-drawer-signals-ui-lib";
 
 export type CompareDrawerPresentationState = {
@@ -7,9 +7,19 @@ export type CompareDrawerPresentationState = {
   actionRowDiverges: boolean;
 };
 
+export function compareDrawerPresentationDivergingDecisionLabels(
+  items: Entry[],
+): Set<string> {
+  return new Set(compareDrawerDivergingDecisionLabels(items));
+}
+
+export function compareDrawerPresentationActionRowDiverges(items: Entry[]): boolean {
+  return compareDrawerUiActionsDiverge(items);
+}
+
 export function compareDrawerPresentationState(items: Entry[]): CompareDrawerPresentationState {
   return {
-    divergingDecisionLabels: new Set(compareDrawerDivergingDecisionLabels(items)),
-    actionRowDiverges: compareDrawerActionsDiverge(items),
+    divergingDecisionLabels: compareDrawerPresentationDivergingDecisionLabels(items),
+    actionRowDiverges: compareDrawerPresentationActionRowDiverges(items),
   };
 }

--- a/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-presentation-ui-lib.ts
@@ -7,9 +7,7 @@ export type CompareDrawerPresentationState = {
   actionRowDiverges: boolean;
 };
 
-export function compareDrawerPresentationDivergingDecisionLabels(
-  items: Entry[],
-): Set<string> {
+export function compareDrawerPresentationDivergingDecisionLabels(items: Entry[]): Set<string> {
   return new Set(compareDrawerDivergingDecisionLabels(items));
 }
 

--- a/tests/compare-drawer-presentation-ui-lib.test.ts
+++ b/tests/compare-drawer-presentation-ui-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDrawerPresentationState } from "@/lib/compare-drawer-presentation-ui-lib";
+import {
+  compareDrawerPresentationActionRowDiverges,
+  compareDrawerPresentationDivergingDecisionLabels,
+  compareDrawerPresentationState,
+} from "@/lib/compare-drawer-presentation-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -41,11 +45,18 @@ describe("compare drawer presentation ui lib", () => {
   });
 
   it("highlights diverging decision rows and next actions", () => {
-    const state = compareDrawerPresentationState([
+    const items = [
       entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
       entry({ slug: "other", installCommand: "npm i fixture" }),
-    ]);
+    ];
+    const state = compareDrawerPresentationState(items);
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.actionRowDiverges).toBe(true);
+    expect(state.divergingDecisionLabels).toEqual(
+      compareDrawerPresentationDivergingDecisionLabels(items),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareDrawerPresentationActionRowDiverges(items),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Route `compareDrawerPresentationState` `divergingDecisionLabels` and `actionRowDiverges` through `compareDrawerPresentationDivergingDecisionLabels` / `compareDrawerPresentationActionRowDiverges` delegates
- Assert bundled presentation fields match delegate outputs in tests

## Test plan
- [x] `npx vitest run tests/compare-drawer-presentation-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-drawer-presentation-ui-lib.ts'` (100% lib coverage)
- [x] Related drawer interactive tests pass
- [x] Verified clean merge-tree against open PR #4778


Made with [Cursor](https://cursor.com)