### PR TITLE
feat(web): compose dossier compare UI through page delegates

### DIFF
--- a/apps/web/src/lib/compare-dossier-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-ui-lib.ts
@@ -35,8 +35,8 @@ export function compareDossierUiState(entry: Entry, alternatives: Entry[]): Comp
   const comparedCount = alternatives.length + 1;
   return {
     showCompareSection: compareDossierShowCompareSection(alternatives),
-    bannerTexts: compareDossierBannerTexts(entry, alternatives),
-    interactiveSearch: compareDossierInteractiveSearch(entry, alternatives),
-    interactiveLinkLabel: compareInteractiveLinkLabel(comparedCount),
+    bannerTexts: compareDossierHeaderBannerTexts(entry, alternatives),
+    interactiveSearch: compareDossierInteractiveCompareSearch(entry, alternatives),
+    interactiveLinkLabel: compareDossierInteractiveLinkLabel(comparedCount),
   };
 }

--- a/tests/compare-dossier-ui-lib.test.ts
+++ b/tests/compare-dossier-ui-lib.test.ts
@@ -98,6 +98,15 @@ describe("compare dossier ui lib", () => {
     expect(bundled.showCompareSection).toBe(
       compareDossierShowCompareSection(alternatives),
     );
+    expect(bundled.bannerTexts).toEqual(
+      compareDossierHeaderBannerTexts(primary, alternatives),
+    );
+    expect(bundled.interactiveSearch).toEqual(
+      compareDossierInteractiveCompareSearch(primary, alternatives),
+    );
+    expect(bundled.interactiveLinkLabel).toBe(
+      compareDossierInteractiveLinkLabel(alternatives.length + 1),
+    );
     expect(
       compareDossierUiState(primary, [
         entry({


### PR DESCRIPTION
## Summary
- Route `compareDossierUiState` `bannerTexts`, `interactiveSearch`, and `interactiveLinkLabel` through existing dossier delegate helpers
- Assert bundled dossier fields match delegate outputs in tests

## Test plan
- [x] `npx vitest run tests/compare-dossier-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-dossier-ui-lib.ts'` (100% lib coverage)
- [x] Related dossier interactive tests pass
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PR #4780


Made with [Cursor](https://cursor.com)