### PR TITLE
feat(web): compose page presentation actionRowDiverges through delegate

### DIFF
--- a/apps/web/src/lib/compare-page-presentation-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-presentation-ui-lib.ts
@@ -1,12 +1,16 @@
 import type { Entry } from "@/types/registry";
-import { comparePageActionsDiverge } from "@/lib/compare-page-actions-ui-lib";
+import { comparePageActionsDiverge } from "@/lib/compare-page-ui-lib";
 
 export type ComparePagePresentationState = {
   actionRowDiverges: boolean;
 };
 
+export function comparePagePresentationActionRowDiverges(items: Entry[]): boolean {
+  return comparePageActionsDiverge(items);
+}
+
 export function comparePagePresentationState(items: Entry[]): ComparePagePresentationState {
   return {
-    actionRowDiverges: comparePageActionsDiverge(items),
+    actionRowDiverges: comparePagePresentationActionRowDiverges(items),
   };
 }

--- a/tests/compare-page-presentation-ui-lib.test.ts
+++ b/tests/compare-page-presentation-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { comparePagePresentationState } from "@/lib/compare-page-presentation-ui-lib";
+import {
+  comparePagePresentationActionRowDiverges,
+  comparePagePresentationState,
+} from "@/lib/compare-page-presentation-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -38,11 +41,11 @@ describe("compare page presentation ui lib", () => {
   });
 
   it("highlights diverging next-action rows for mixed compare columns", () => {
-    expect(
-      comparePagePresentationState([
-        entry({ installCommand: "npm i fixture" }),
-        entry(),
-      ]).actionRowDiverges,
-    ).toBe(true);
+    const items = [entry({ installCommand: "npm i fixture" }), entry()];
+    const state = comparePagePresentationState(items);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionRowDiverges).toBe(
+      comparePagePresentationActionRowDiverges(items),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Route `comparePagePresentationState` `actionRowDiverges` through `comparePagePresentationActionRowDiverges` delegate aligned with `comparePageActionsDiverge`
- Assert bundled presentation field matches delegate output in tests

## Test plan
- [x] `npx vitest run tests/compare-page-presentation-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-page-presentation-ui-lib.ts'` (100% lib coverage)
- [x] Related page presentation interactive tests pass
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PR #4780


Made with [Cursor](https://cursor.com)