### PR TITLE
feat(web): compose drawer signals interactive labels through delegate

### DIFF
--- a/apps/web/src/lib/compare-drawer-signals-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-signals-interactive-ui-lib.ts
@@ -1,14 +1,20 @@
 import type { Entry } from "@/types/registry";
-import { compareDrawerDivergingDecisionLabels } from "@/lib/compare-drawer-signals-ui-lib";
+import { compareDrawerPresentationDivergingDecisionLabels } from "@/lib/compare-drawer-presentation-ui-lib";
 
 export type CompareDrawerSignalsInteractiveUiState = {
   divergingDecisionLabels: Set<string>;
 };
 
+export function compareDrawerSignalsInteractiveDivergingDecisionLabels(
+  entries: Entry[],
+): Set<string> {
+  return compareDrawerPresentationDivergingDecisionLabels(entries);
+}
+
 export function compareDrawerSignalsInteractiveUiState(
   entries: Entry[],
 ): CompareDrawerSignalsInteractiveUiState {
   return {
-    divergingDecisionLabels: new Set(compareDrawerDivergingDecisionLabels(entries)),
+    divergingDecisionLabels: compareDrawerSignalsInteractiveDivergingDecisionLabels(entries),
   };
 }

--- a/tests/compare-drawer-signals-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-signals-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDrawerSignalsInteractiveUiState } from "@/lib/compare-drawer-signals-interactive-ui-lib";
+import {
+  compareDrawerSignalsInteractiveDivergingDecisionLabels,
+  compareDrawerSignalsInteractiveUiState,
+} from "@/lib/compare-drawer-signals-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -35,14 +38,17 @@ describe("compare drawer signals interactive ui lib", () => {
   });
 
   it("highlights diverging review status decision rows", () => {
-    expect(
-      compareDrawerSignalsInteractiveUiState([
-        entry(),
-        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
-      ]),
-    ).toEqual({
+    const entries = [
+      entry(),
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+    ];
+    const state = compareDrawerSignalsInteractiveUiState(entries);
+    expect(state).toEqual({
       divergingDecisionLabels: new Set(["Review status"]),
     });
+    expect(state.divergingDecisionLabels).toEqual(
+      compareDrawerSignalsInteractiveDivergingDecisionLabels(entries),
+    );
   });
 
   it("returns an empty label set when no entries are compared", () => {


### PR DESCRIPTION
## Summary
- Route `compareDrawerSignalsInteractiveUiState` `divergingDecisionLabels` through `compareDrawerSignalsInteractiveDivergingDecisionLabels` delegate aligned with drawer presentation helpers
- Assert bundled interactive label set matches delegate output in tests

## Test plan
- [x] `npx vitest run tests/compare-drawer-signals-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-drawer-signals-interactive-ui-lib.ts'` (100% lib coverage)
- [x] Related drawer interactive tests pass
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PR #4780


Made with [Cursor](https://cursor.com)