### PR TITLE
feat(web): compose drawer actions interactive state through delegates

### DIFF
--- a/apps/web/src/lib/compare-drawer-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-actions-interactive-ui-lib.ts
@@ -1,21 +1,31 @@
 import type { Entry } from "@/types/registry";
 import {
   compareDrawerActionCells,
-  compareDrawerActionsDiverge,
   type CompareDrawerActionCell,
 } from "@/lib/compare-drawer-actions-ui-lib";
+import { compareDrawerPresentationActionRowDiverges } from "@/lib/compare-drawer-presentation-ui-lib";
 
 export type CompareDrawerActionsInteractiveUiState = {
   actionRowDiverges: boolean;
   actionCells: CompareDrawerActionCell[];
 };
 
+export function compareDrawerActionsInteractiveActionRowDiverges(entries: Entry[]): boolean {
+  return compareDrawerPresentationActionRowDiverges(entries);
+}
+
+export function compareDrawerActionsInteractiveActionCells(
+  entries: Entry[],
+): CompareDrawerActionCell[] {
+  return compareDrawerActionCells(entries);
+}
+
 export function compareDrawerActionsInteractiveUiState(
   entries: Entry[],
 ): CompareDrawerActionsInteractiveUiState {
   return {
-    actionRowDiverges: compareDrawerActionsDiverge(entries),
-    actionCells: compareDrawerActionCells(entries),
+    actionRowDiverges: compareDrawerActionsInteractiveActionRowDiverges(entries),
+    actionCells: compareDrawerActionsInteractiveActionCells(entries),
   };
 }
 

--- a/tests/compare-drawer-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-actions-interactive-ui-lib.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
   compareDrawerActionsForEntry,
+  compareDrawerActionsInteractiveActionCells,
+  compareDrawerActionsInteractiveActionRowDiverges,
   compareDrawerActionsInteractiveUiState,
 } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 
@@ -62,12 +64,16 @@ describe("compare drawer actions interactive ui lib", () => {
   });
 
   it("highlights diverging next-action rows for mixed compare columns", () => {
-    const state = compareDrawerActionsInteractiveUiState([
-      entry({ installCommand: "npm i fixture" }),
-      entry(),
-    ]);
+    const entries = [entry({ installCommand: "npm i fixture" }), entry()];
+    const state = compareDrawerActionsInteractiveUiState(entries);
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    expect(state.actionRowDiverges).toBe(
+      compareDrawerActionsInteractiveActionRowDiverges(entries),
+    );
+    expect(state.actionCells).toEqual(
+      compareDrawerActionsInteractiveActionCells(entries),
+    );
     expect(compareDrawerActionsForEntry(entry(), state.actionCells)).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: "dossier" })]),
     );


### PR DESCRIPTION
## Summary
- Route `compareDrawerActionsInteractiveUiState` `actionRowDiverges` and `actionCells` through named delegate helpers
- `actionRowDiverges` aligns with drawer presentation helpers; `actionCells` wraps drawer actions UI lib
- Assert bundled interactive action fields match delegate outputs in tests

## Test plan
- [x] `npx vitest run tests/compare-drawer-actions-interactive-ui-lib.test.ts --coverage --coverage.include='apps/web/src/lib/compare-drawer-actions-interactive-ui-lib.ts'` (100% lib coverage)
- [x] Related drawer interactive tests pass
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PR #4784


Made with [Cursor](https://cursor.com)