### PR TITLE
refactor(web): entry breadcrumb builder delegates to shared breadcrumb lib

### DIFF
--- a/apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts
@@ -1,8 +1,10 @@
 // Pure builder for an entry detail page's schema.org BreadcrumbList JSON-LD,
 // split out of the route head() so the Directory > category > entry trail can be
 // unit-tested. The absolute-URL resolver is injected to keep the builder pure.
+// The ListItem/position mapping is delegated to the shared breadcrumb builder.
 
 import type { Entry } from "@/types/registry";
+import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 
 /** schema.org BreadcrumbList JSON-LD: Directory > category > entry. */
 export function entryBreadcrumbJsonLd(
@@ -10,18 +12,9 @@ export function entryBreadcrumbJsonLd(
   url: string,
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Directory", item: absoluteUrl("/browse") },
-      {
-        "@type": "ListItem",
-        position: 2,
-        name: entry.category,
-        item: absoluteUrl(`/${entry.category}`),
-      },
-      { "@type": "ListItem", position: 3, name: entry.title, item: url },
-    ],
-  };
+  return breadcrumbListJsonLd([
+    { name: "Directory", item: absoluteUrl("/browse") },
+    { name: entry.category, item: absoluteUrl(`/${entry.category}`) },
+    { name: entry.title, item: url },
+  ]);
 }


### PR DESCRIPTION
### What & why

`entryBreadcrumbJsonLd` open-coded the ListItem/position mapping that the shared `breadcrumbListJsonLd` builder already provides. This delegates to it so the mapping lives in exactly one place.

### Changes

- `apps/web/src/lib/entry-breadcrumb-jsonld-lib.ts` — build the trail via `breadcrumbListJsonLd`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/entry-breadcrumb-jsonld-lib.test.ts tests/breadcrumb-jsonld-lib.test.ts` — 4 passed (existing tests untouched)
- `pnpm exec prettier --check` on the touched file — clean

### Notes

No matching open issue — maintainer-lane internal dedup. No user-facing or behavior change; the emitted BreadcrumbList JSON-LD is unchanged (`Directory > category > entry`).
