### PR TITLE
refactor(web): extract tag ItemList JSON-LD builder into a lib

### DIFF
--- a/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
@@ -1,0 +1,34 @@
+// Pure builder for a tag page's schema.org ItemList JSON-LD, split out of the
+// route head() so the name/count and the first-30 slice cap can be unit-tested.
+// The absolute-URL resolver is injected.
+
+type TagEntryLike = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/**
+ * schema.org ItemList JSON-LD for a tag's resources. numberOfItems reflects the
+ * full set; itemListElement is capped at the first 30 entries.
+ */
+export function tagItemListJsonLd(
+  tagName: string,
+  description: string,
+  entries: TagEntryLike[],
+  absoluteUrl: (path: string) => string,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `Claude resources tagged ${tagName}`,
+    description,
+    numberOfItems: entries.length,
+    itemListElement: entries.slice(0, 30).map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -10,6 +10,7 @@ import { categorySpread } from "@/lib/category-spread-lib";
 import { joinList } from "@/lib/join-list-lib";
 import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
+import { tagItemListJsonLd } from "@/lib/tag-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { getTagGroup, relatedTags } from "@/lib/tags";
@@ -29,19 +30,7 @@ export const Route = createFileRoute("/tags/$tag")({
     const title = `Claude ${group.name} resources — HeyClaude`;
     const description = `${group.entries.length} Claude Code resources tagged "${group.name}" — MCP servers, agents, skills, hooks, commands, rules, and more, curated in HeyClaude.`;
     const ogImage = ogImageUrl({ title: `Tagged "${group.name}"`, eyebrow: "Tag", description });
-    const itemList = {
-      "@context": "https://schema.org",
-      "@type": "ItemList",
-      name: `Claude resources tagged ${group.name}`,
-      description,
-      numberOfItems: group.entries.length,
-      itemListElement: group.entries.slice(0, 30).map((e, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: e.title,
-        url: absoluteUrl(`/entry/${e.category}/${e.slug}`),
-      })),
-    };
+    const itemList = tagItemListJsonLd(group.name, description, group.entries, absoluteUrl);
     const breadcrumbs = breadcrumbListJsonLd([
       { name: "Directory", item: absoluteUrl("/browse") },
       { name: "Tags", item: absoluteUrl("/tags") },

--- a/tests/tag-itemlist-jsonld-lib.test.ts
+++ b/tests/tag-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { tagItemListJsonLd } from "../apps/web/src/lib/tag-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const makeEntries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    title: `Entry ${i + 1}`,
+    category: "agents",
+    slug: `e${i + 1}`,
+  }));
+
+describe("tagItemListJsonLd", () => {
+  it("names the list for the tag and includes the description", () => {
+    const ld = tagItemListJsonLd("cli", "Tagged cli", [], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("Claude resources tagged cli");
+    expect(ld.description).toBe("Tagged cli");
+    expect(ld.numberOfItems).toBe(0);
+  });
+
+  it("maps entries to positioned ListItems with entry urls", () => {
+    const ld = tagItemListJsonLd("cli", "d", makeEntries(2), abs);
+    expect(ld.itemListElement[0]).toEqual({
+      "@type": "ListItem",
+      position: 1,
+      name: "Entry 1",
+      url: "https://heyclau.de/entry/agents/e1",
+    });
+    expect(ld.itemListElement[1].position).toBe(2);
+  });
+
+  it("reports the full count but caps list items at 30", () => {
+    const ld = tagItemListJsonLd("cli", "d", makeEntries(31), abs);
+    expect(ld.numberOfItems).toBe(31);
+    expect(ld.itemListElement).toHaveLength(30);
+  });
+});


### PR DESCRIPTION
### What & why

The tag detail route built its schema.org ItemList JSON-LD inline in `head()`, so the name/count and the first-30 slice cap could not be unit-tested without rendering the route. This moves it into `apps/web/src/lib/tag-itemlist-jsonld-lib.ts` (`absoluteUrl` injected) and calls it from `head()`.

### Changes

- Add `apps/web/src/lib/tag-itemlist-jsonld-lib.ts` — `tagItemListJsonLd(tagName, description, entries, absoluteUrl)`.
- `apps/web/src/routes/tags.$tag.tsx` — build the ItemList via the helper.
- Add `tests/tag-itemlist-jsonld-lib.test.ts` — covers the tag-named list + description, positioned ListItems with entry urls, and full-count-with-30-item-cap.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/tag-itemlist-jsonld-lib.test.ts` — 3 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged.
