### PR TITLE
refactor(web): add shared entry ItemList builder, use in tag builder

### DIFF
--- a/apps/web/src/lib/entry-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/entry-itemlist-jsonld-lib.ts
@@ -1,0 +1,40 @@
+// Shared builder for the schema.org ItemList JSON-LD that hub pages (tag,
+// category, platform, comparison, ...) emit over a list of registry entries.
+// Each page supplies its own list name/description; the ListItem mapping,
+// 1-based positions, numberOfItems and the item cap live here so they are
+// defined and tested once. The absolute-URL resolver is injected.
+
+export type ItemListEntryRef = {
+  title: string;
+  category: string;
+  slug: string;
+};
+
+/** Default number of ListItems emitted; numberOfItems still reflects the full set. */
+export const DEFAULT_ITEM_LIST_CAP = 30;
+
+/**
+ * schema.org ItemList JSON-LD over registry entries. `numberOfItems` reflects the
+ * full set; `itemListElement` is capped at `cap` entries (pass Infinity for all).
+ */
+export function entryItemListJsonLd(
+  name: string,
+  description: string,
+  entries: ItemListEntryRef[],
+  absoluteUrl: (path: string) => string,
+  cap: number = DEFAULT_ITEM_LIST_CAP,
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name,
+    description,
+    numberOfItems: entries.length,
+    itemListElement: entries.slice(0, cap).map((entry, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      name: entry.title,
+      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
+    })),
+  };
+}

--- a/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/tag-itemlist-jsonld-lib.ts
@@ -1,12 +1,8 @@
 // Pure builder for a tag page's schema.org ItemList JSON-LD, split out of the
 // route head() so the name/count and the first-30 slice cap can be unit-tested.
-// The absolute-URL resolver is injected.
+// The ListItem mapping is delegated to the shared entry ItemList builder.
 
-type TagEntryLike = {
-  title: string;
-  category: string;
-  slug: string;
-};
+import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
  * schema.org ItemList JSON-LD for a tag's resources. numberOfItems reflects the
@@ -15,20 +11,13 @@ type TagEntryLike = {
 export function tagItemListJsonLd(
   tagName: string,
   description: string,
-  entries: TagEntryLike[],
+  entries: ItemListEntryRef[],
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: `Claude resources tagged ${tagName}`,
+  return entryItemListJsonLd(
+    `Claude resources tagged ${tagName}`,
     description,
-    numberOfItems: entries.length,
-    itemListElement: entries.slice(0, 30).map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.title,
-      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
-    })),
-  };
+    entries,
+    absoluteUrl,
+  );
 }

--- a/tests/entry-itemlist-jsonld-lib.test.ts
+++ b/tests/entry-itemlist-jsonld-lib.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ITEM_LIST_CAP,
+  entryItemListJsonLd,
+} from "../apps/web/src/lib/entry-itemlist-jsonld-lib";
+
+const abs = (path: string) => `https://heyclau.de${path}`;
+
+const makeEntries = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    title: `Entry ${i + 1}`,
+    category: "agents",
+    slug: `e${i + 1}`,
+  }));
+
+describe("entryItemListJsonLd", () => {
+  it("builds a named ItemList with the given description", () => {
+    const ld = entryItemListJsonLd("My List", "Desc", [], abs);
+    expect(ld["@type"]).toBe("ItemList");
+    expect(ld.name).toBe("My List");
+    expect(ld.description).toBe("Desc");
+    expect(ld.numberOfItems).toBe(0);
+    expect(ld.itemListElement).toEqual([]);
+  });
+
+  it("maps entries to 1-based positioned ListItems with entry urls", () => {
+    const ld = entryItemListJsonLd("L", "d", makeEntries(2), abs);
+    expect(ld.itemListElement).toEqual([
+      {
+        "@type": "ListItem",
+        position: 1,
+        name: "Entry 1",
+        url: "https://heyclau.de/entry/agents/e1",
+      },
+      {
+        "@type": "ListItem",
+        position: 2,
+        name: "Entry 2",
+        url: "https://heyclau.de/entry/agents/e2",
+      },
+    ]);
+  });
+
+  it("reports the full count but caps list items at the default cap", () => {
+    const ld = entryItemListJsonLd(
+      "L",
+      "d",
+      makeEntries(DEFAULT_ITEM_LIST_CAP + 1),
+      abs,
+    );
+    expect(ld.numberOfItems).toBe(DEFAULT_ITEM_LIST_CAP + 1);
+    expect(ld.itemListElement).toHaveLength(DEFAULT_ITEM_LIST_CAP);
+  });
+
+  it("honors an explicit cap (Infinity emits every entry)", () => {
+    expect(
+      entryItemListJsonLd("L", "d", makeEntries(5), abs, 2).itemListElement,
+    ).toHaveLength(2);
+    expect(
+      entryItemListJsonLd("L", "d", makeEntries(35), abs, Infinity)
+        .itemListElement,
+    ).toHaveLength(35);
+  });
+});


### PR DESCRIPTION
### What & why

The hub pages (tag, category, platform, platform+category, comparison) each open-code the same schema.org ItemList mapping over registry entries: 1-based ListItem positions, entry urls, `numberOfItems` over the full set, and a 30-item cap. This adds a shared `entryItemListJsonLd` builder and adopts it in the tag builder so the mapping is defined and tested once; the remaining hub builders can migrate incrementally.

### Changes

- Add `apps/web/src/lib/entry-itemlist-jsonld-lib.ts` — `entryItemListJsonLd(name, description, entries, absoluteUrl, cap = DEFAULT_ITEM_LIST_CAP)` plus the `ItemListEntryRef` type. Pass `Infinity` to emit every entry.
- `apps/web/src/lib/tag-itemlist-jsonld-lib.ts` — delegate to the shared builder.
- Add `tests/entry-itemlist-jsonld-lib.test.ts` — covers the named list, 1-based positioned ListItems with entry urls, the default cap with full `numberOfItems`, and an explicit/`Infinity` cap.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/entry-itemlist-jsonld-lib.test.ts tests/tag-itemlist-jsonld-lib.test.ts` — 7 passed (existing tag tests untouched)
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor + dedup. No user-facing or behavior change; the emitted ItemList JSON-LD is unchanged. Mirrors the existing shared `breadcrumbListJsonLd` consolidation.
