### PR TITLE
refactor(web): add shared og:image meta tags builder, use in tag route

### DIFF
--- a/apps/web/src/lib/og-meta-lib.ts
+++ b/apps/web/src/lib/og-meta-lib.ts
@@ -1,0 +1,19 @@
+// Shared og:image + twitter card meta tags for the 1200x630 PNG social card that
+// every hub/detail route emits. Defined once so the dimensions, type, and
+// twitter card kind stay consistent (and are unit-tested) across routes.
+
+export type OgImageMetaTag =
+  | { property: string; content: string }
+  | { name: string; content: string };
+
+/** The standard og:image + twitter card meta tags for a 1200x630 PNG card. */
+export function ogImageMetaTags(ogImage: string): OgImageMetaTag[] {
+  return [
+    { property: "og:image", content: ogImage },
+    { property: "og:image:type", content: "image/png" },
+    { property: "og:image:width", content: "1200" },
+    { property: "og:image:height", content: "630" },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:image", content: ogImage },
+  ];
+}

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -13,6 +13,7 @@ import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { tagItemListJsonLd } from "@/lib/tag-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { getTagGroup, relatedTags } from "@/lib/tags";
 
 // The categories a tag's entries actually span — used to vary intro copy per tag so no
@@ -43,12 +44,7 @@ export const Route = createFileRoute("/tags/$tag")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage),
         // Single-entry tag pages are thin and excluded from the sitemap; keep them usable for
         // in-page tag links but out of the index to match the sitemap policy.
         ...(group.entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),

--- a/tests/og-meta-lib.test.ts
+++ b/tests/og-meta-lib.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { ogImageMetaTags } from "../apps/web/src/lib/og-meta-lib";
+
+describe("ogImageMetaTags", () => {
+  it("emits the og:image tags and the twitter card, in order", () => {
+    expect(ogImageMetaTags("https://heyclau.de/og/agents/a")).toEqual([
+      { property: "og:image", content: "https://heyclau.de/og/agents/a" },
+      { property: "og:image:type", content: "image/png" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
+      { name: "twitter:card", content: "summary_large_image" },
+      { name: "twitter:image", content: "https://heyclau.de/og/agents/a" },
+    ]);
+  });
+
+  it("uses the same image url for og:image and twitter:image", () => {
+    const tags = ogImageMetaTags("https://x.dev/card.png");
+    const urls = tags
+      .filter((t) => "content" in t && t.content.startsWith("https://x.dev"))
+      .map((t) => t.content);
+    expect(urls).toEqual(["https://x.dev/card.png", "https://x.dev/card.png"]);
+  });
+});


### PR DESCRIPTION
### What & why

Twenty-two routes repeat the identical og:image + twitter card meta block for the 1200x630 PNG social card. This adds a shared `ogImageMetaTags` builder and adopts it in the tag route so the dimensions, image type, and twitter card kind are defined and tested once; the remaining routes can migrate incrementally.

### Changes

- Add `apps/web/src/lib/og-meta-lib.ts` — `ogImageMetaTags(ogImage)` returning the `og:image`, `og:image:type`, `og:image:width`/`height`, `twitter:card` and `twitter:image` tags.
- `apps/web/src/routes/tags.$tag.tsx` — spread the shared tags into `head().meta`.
- Add `tests/og-meta-lib.test.ts` — covers the emitted tags and their order, and that the same image url backs both `og:image` and `twitter:image`.

### Validation

- `pnpm --filter web exec tsc --noEmit` — clean
- `pnpm exec vitest run tests/og-meta-lib.test.ts` — 2 passed
- `pnpm exec prettier --check` on the touched files — clean

### Notes

No matching open issue — maintainer-lane internal refactor + dedup. No user-facing or behavior change; the emitted meta tags are identical (same tags, same order). Mirrors the existing shared `breadcrumbListJsonLd` consolidation.
