### PR TITLE
refactor(web): support og:type in shared og meta builder, adopt in 3 routes

### DIFF
--- a/apps/web/src/lib/og-meta-lib.ts
+++ b/apps/web/src/lib/og-meta-lib.ts
@@ -6,13 +6,19 @@ export type OgImageMetaTag =
   | { property: string; content: string }
   | { name: string; content: string };
 
-/** The standard og:image + twitter card meta tags for a 1200x630 PNG card. */
-export function ogImageMetaTags(ogImage: string): OgImageMetaTag[] {
+/**
+ * The standard og:image + twitter card meta tags for a 1200x630 PNG card.
+ * When `ogType` is given ("website" / "article"), an `og:type` tag is emitted
+ * between the image tags and the twitter card tags, matching the routes that
+ * declare one.
+ */
+export function ogImageMetaTags(ogImage: string, ogType?: string): OgImageMetaTag[] {
   return [
     { property: "og:image", content: ogImage },
     { property: "og:image:type", content: "image/png" },
     { property: "og:image:width", content: "1200" },
     { property: "og:image:height", content: "630" },
+    ...(ogType ? [{ property: "og:type", content: ogType }] : []),
     { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:image", content: ogImage },
   ];

--- a/apps/web/src/routes/best.$slug.tsx
+++ b/apps/web/src/routes/best.$slug.tsx
@@ -13,6 +13,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { bestListItemListJsonLd } from "@/lib/best-list-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { breadcrumbScript } from "@/lib/seo-jsonld";
 import { useMemo } from "react";
 
@@ -39,13 +40,7 @@ export const Route = createFileRoute("/best/$slug")({
         { property: "og:title", content: l.title },
         { property: "og:description", content: l.seoDescription },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { property: "og:type", content: "article" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage, "article"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -9,6 +9,7 @@ import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { comparisonItemListJsonLd } from "@/lib/comparison-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { getComparison } from "@/data/comparisons";
 import {
   compareCuratedInteractivePageRenderable,
@@ -47,13 +48,7 @@ export const Route = createFileRoute("/compare/$slug")({
         { property: "og:title", content: comparison.title },
         { property: "og:description", content: comparison.seoDescription },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { property: "og:type", content: "article" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage, "article"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/integrations.$slug.tsx
+++ b/apps/web/src/routes/integrations.$slug.tsx
@@ -10,6 +10,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { integrationAppJsonLd } from "@/lib/integration-app-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 
 export const Route = createFileRoute("/integrations/$slug")({
   loader: ({ params }) => {
@@ -39,13 +40,7 @@ export const Route = createFileRoute("/integrations/$slug")({
         { property: "og:title", content: `${it.name} — HeyClaude` },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { property: "og:type", content: "website" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage, "website"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/tests/og-meta-lib.test.ts
+++ b/tests/og-meta-lib.test.ts
@@ -14,6 +14,24 @@ describe("ogImageMetaTags", () => {
     ]);
   });
 
+  it("inserts og:type between the image tags and the twitter card when given", () => {
+    const tags = ogImageMetaTags("https://x.dev/card.png", "article");
+    expect(tags).toHaveLength(7);
+    expect(tags[4]).toEqual({ property: "og:type", content: "article" });
+    expect(tags[5]).toEqual({
+      name: "twitter:card",
+      content: "summary_large_image",
+    });
+  });
+
+  it("omits og:type when not given", () => {
+    const tags = ogImageMetaTags("https://x.dev/card.png");
+    expect(tags).toHaveLength(6);
+    expect(tags.some((t) => "property" in t && t.property === "og:type")).toBe(
+      false,
+    );
+  });
+
   it("uses the same image url for og:image and twitter:image", () => {
     const tags = ogImageMetaTags("https://x.dev/card.png");
     const urls = tags


### PR DESCRIPTION
### What & why

Most routes that emit the shared og:image + twitter card block also declare an `og:type` **between** the image tags and the twitter card. This teaches `ogImageMetaTags` to emit `og:type` in exactly that position, then adopts the shared builder in three more routes.

### Changes

- `apps/web/src/lib/og-meta-lib.ts` - `ogImageMetaTags(ogImage, ogType?)` emits `og:type` between the image tags and the twitter card tags when a type is given.
- `apps/web/src/routes/integrations.$slug.tsx` (`"website"`), `apps/web/src/routes/best.$slug.tsx` (`"article"`), `apps/web/src/routes/compare.$slug.tsx` (`"article"`) - spread the shared tags into `head().meta`.
- `tests/og-meta-lib.test.ts` - cover `og:type` placement and its omission when absent.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/og-meta-lib.test.ts` - 4 passed. Branch coverage 100% (2/2).
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal dedup. No user-facing or behavior change; each route emits the same meta tags in the same order as before. Remaining routes can migrate incrementally.
