### PR TITLE
refactor(web): adopt shared og meta builder in four more routes

### DIFF
--- a/apps/web/src/routes/$category.tsx
+++ b/apps/web/src/routes/$category.tsx
@@ -22,6 +22,7 @@ import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { categoryItemListJsonLd } from "@/lib/category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl, categoryAccent } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 
 const categoryIds = new Set(CATEGORIES.map((c) => c.id));
 
@@ -66,13 +67,7 @@ export const Route = createFileRoute("/$category")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { property: "og:type", content: "website" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage, "website"),
       ],
       links: [
         { rel: "canonical", href: url },

--- a/apps/web/src/routes/contributors.$slug.tsx
+++ b/apps/web/src/routes/contributors.$slug.tsx
@@ -25,6 +25,7 @@ import { stringifyJsonLd } from "@/lib/json-ld";
 import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { contributorPersonJsonLd } from "@/lib/contributor-person-jsonld-lib";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { submitterAttribution } from "@/lib/contributor-profile-summary";
 import type { Category, Contributor, Entry } from "@/types/registry";
 import { categoryBreakdown } from "@/lib/contributor-category-breakdown-lib";
@@ -61,13 +62,7 @@ export const Route = createFileRoute("/contributors/$slug")({
         { property: "og:title", content: `${name} — HeyClaude` },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { property: "og:type", content: "profile" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage, "profile"),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [

--- a/apps/web/src/routes/for.$platform.$category.tsx
+++ b/apps/web/src/routes/for.$platform.$category.tsx
@@ -15,6 +15,7 @@ import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { platformCategoryItemListJsonLd } from "@/lib/platform-category-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 
 const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
 const CATEGORY_IDS = new Set(CATEGORIES.map((c) => c.id));
@@ -66,12 +67,7 @@ export const Route = createFileRoute("/for/$platform/$category")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage),
         // Single-entry intersections render (linked from the platform hub) but stay out of the
         // index to avoid thin pages — matches the sitemap policy below.
         ...(entries.length < 2 ? [{ name: "robots", content: "noindex, follow" }] : []),

--- a/apps/web/src/routes/for.$platform.tsx
+++ b/apps/web/src/routes/for.$platform.tsx
@@ -15,6 +15,7 @@ import { breadcrumbListJsonLd } from "@/lib/breadcrumb-jsonld-lib";
 import { platformItemListJsonLd } from "@/lib/platform-itemlist-jsonld-lib";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
+import { ogImageMetaTags } from "@/lib/og-meta-lib";
 
 const PLATFORM_IDS = new Set(Object.keys(PLATFORM_LABEL));
 
@@ -47,12 +48,7 @@ export const Route = createFileRoute("/for/$platform")({
         { property: "og:title", content: title },
         { property: "og:description", content: description },
         { property: "og:url", content: url },
-        { property: "og:image", content: ogImage },
-        { property: "og:image:type", content: "image/png" },
-        { property: "og:image:width", content: "1200" },
-        { property: "og:image:height", content: "630" },
-        { name: "twitter:card", content: "summary_large_image" },
-        { name: "twitter:image", content: ogImage },
+        ...ogImageMetaTags(ogImage),
       ],
       links: [{ rel: "canonical", href: url }],
       scripts: [


### PR DESCRIPTION
### What & why

Continue migrating routes off the hand-rolled og:image + twitter card meta block onto the shared `ogImageMetaTags` builder, so the card dimensions, image type and twitter card kind stay defined in one tested place.

### Changes

- `apps/web/src/routes/$category.tsx` (`"website"`) and `apps/web/src/routes/contributors.$slug.tsx` (`"profile"`) pass their `og:type` through the helper.
- `apps/web/src/routes/for.$platform.tsx` and `apps/web/src/routes/for.$platform.$category.tsx` declare no `og:type` and use the plain form.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/og-meta-lib.test.ts` - 4 passed
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal dedup. Each route emits the same meta tags in the same order as before; no user-facing or behavior change. Covered by the existing `og-meta-lib` tests. The remaining routes use a different tag arrangement and can migrate separately.
