### PR TITLE
refactor(web): remaining ItemList builders delegate to the shared builder

### DIFF
--- a/apps/web/src/lib/category-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/category-itemlist-jsonld-lib.ts
@@ -1,12 +1,8 @@
 // Pure builder for a category ("/<category>") page's schema.org ItemList
-// JSON-LD, split out of the route head() so the name/count and the first-30
-// slice cap can be unit-tested. The absolute-URL resolver is injected.
+// JSON-LD, split out of the route head(). The ListItem mapping and the item cap
+// are delegated to the shared entry ItemList builder.
 
-type CategoryEntryLike = {
-  title: string;
-  category: string;
-  slug: string;
-};
+import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
  * schema.org ItemList JSON-LD for a category's resources. numberOfItems reflects
@@ -15,20 +11,8 @@ type CategoryEntryLike = {
 export function categoryItemListJsonLd(
   label: string,
   description: string,
-  entries: CategoryEntryLike[],
+  entries: ItemListEntryRef[],
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: `Claude ${label}`,
-    description,
-    numberOfItems: entries.length,
-    itemListElement: entries.slice(0, 30).map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.title,
-      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
-    })),
-  };
+  return entryItemListJsonLd(`Claude ${label}`, description, entries, absoluteUrl);
 }

--- a/apps/web/src/lib/comparison-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/comparison-itemlist-jsonld-lib.ts
@@ -1,35 +1,25 @@
 // Pure builder for a comparison page's schema.org ItemList JSON-LD, split out of
-// the route head() so the entry mapping can be unit-tested. The absolute-URL
-// resolver is injected to keep the builder pure.
+// the route head(). The ListItem mapping is delegated to the shared entry
+// ItemList builder; a comparison lists every entry, so no cap is applied.
+
+import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 type ComparisonLike = {
   heading: string;
   seoDescription: string;
 };
 
-type ComparisonEntryLike = {
-  title: string;
-  category: string;
-  slug: string;
-};
-
-/** schema.org ItemList JSON-LD for a comparison's resolved entries. */
+/** schema.org ItemList JSON-LD for a comparison's resolved entries (uncapped). */
 export function comparisonItemListJsonLd(
   comparison: ComparisonLike,
-  entries: ComparisonEntryLike[],
+  entries: ItemListEntryRef[],
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: comparison.heading,
-    description: comparison.seoDescription,
-    numberOfItems: entries.length,
-    itemListElement: entries.map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.title,
-      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
-    })),
-  };
+  return entryItemListJsonLd(
+    comparison.heading,
+    comparison.seoDescription,
+    entries,
+    absoluteUrl,
+    Infinity,
+  );
 }

--- a/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/platform-category-itemlist-jsonld-lib.ts
@@ -1,13 +1,8 @@
 // Pure builder for a platform+category ("for/<platform>/<category>") page's
-// schema.org ItemList JSON-LD, split out of the route head() so the name/count
-// and the first-30 slice cap can be unit-tested. The absolute-URL resolver is
-// injected.
+// schema.org ItemList JSON-LD, split out of the route head(). The ListItem
+// mapping and the item cap are delegated to the shared entry ItemList builder.
 
-type PlatformCategoryEntryLike = {
-  title: string;
-  category: string;
-  slug: string;
-};
+import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
  * schema.org ItemList JSON-LD for a platform+category's resources.
@@ -17,20 +12,13 @@ export function platformCategoryItemListJsonLd(
   platformLabel: string,
   categoryLabel: string,
   description: string,
-  entries: PlatformCategoryEntryLike[],
+  entries: ItemListEntryRef[],
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: `Claude ${categoryLabel} for ${platformLabel}`,
+  return entryItemListJsonLd(
+    `Claude ${categoryLabel} for ${platformLabel}`,
     description,
-    numberOfItems: entries.length,
-    itemListElement: entries.slice(0, 30).map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.title,
-      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
-    })),
-  };
+    entries,
+    absoluteUrl,
+  );
 }

--- a/apps/web/src/lib/platform-itemlist-jsonld-lib.ts
+++ b/apps/web/src/lib/platform-itemlist-jsonld-lib.ts
@@ -1,12 +1,8 @@
 // Pure builder for a platform ("for/<platform>") page's schema.org ItemList
-// JSON-LD, split out of the route head() so the label/count/slice-cap behavior
-// can be unit-tested. The absolute-URL resolver is injected.
+// JSON-LD, split out of the route head(). The ListItem mapping and the item cap
+// are delegated to the shared entry ItemList builder.
 
-type PlatformEntryLike = {
-  title: string;
-  category: string;
-  slug: string;
-};
+import { entryItemListJsonLd, type ItemListEntryRef } from "@/lib/entry-itemlist-jsonld-lib";
 
 /**
  * schema.org ItemList JSON-LD for a platform's resources. numberOfItems reflects
@@ -15,20 +11,8 @@ type PlatformEntryLike = {
 export function platformItemListJsonLd(
   label: string,
   description: string,
-  entries: PlatformEntryLike[],
+  entries: ItemListEntryRef[],
   absoluteUrl: (path: string) => string,
 ) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "ItemList",
-    name: `Claude resources for ${label}`,
-    description,
-    numberOfItems: entries.length,
-    itemListElement: entries.slice(0, 30).map((entry, index) => ({
-      "@type": "ListItem",
-      position: index + 1,
-      name: entry.title,
-      url: absoluteUrl(`/entry/${entry.category}/${entry.slug}`),
-    })),
-  };
+  return entryItemListJsonLd(`Claude resources for ${label}`, description, entries, absoluteUrl);
 }


### PR DESCRIPTION
### What & why

The category, platform, platform+category and comparison ItemList builders each open-coded the same schema.org mapping (1-based ListItem positions, entry urls, `numberOfItems` over the full set, item cap) that the shared `entryItemListJsonLd` builder now provides. This delegates to it so the mapping lives in exactly one place.

### Changes

- `category-itemlist-jsonld-lib.ts`, `platform-itemlist-jsonld-lib.ts`, `platform-category-itemlist-jsonld-lib.ts` - delegate, keeping their own list name and the default 30-item cap.
- `comparison-itemlist-jsonld-lib.ts` - delegates with an `Infinity` cap, since a comparison lists every resolved entry.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run` over all six ItemList test files - 18 passed (existing per-builder tests untouched)
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal dedup. No user-facing or behavior change; each builder emits the same ItemList JSON-LD as before. Completes the consolidation started by the shared `entryItemListJsonLd` builder, mirroring the shared `breadcrumbListJsonLd` one.
