### PR TITLE
refactor(web): hoist duplicated og image url in three hub routes

### DIFF
--- a/apps/web/src/routes/integrations.index.tsx
+++ b/apps/web/src/routes/integrations.index.tsx
@@ -7,6 +7,9 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "HeyClaude integrations", eyebrow: "Integrations" });
+
 export const Route = createFileRoute("/integrations/")({
   head: () => ({
     meta: [
@@ -24,14 +27,14 @@ export const Route = createFileRoute("/integrations/")({
       { property: "og:url", content: absoluteUrl("/integrations") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "HeyClaude integrations", eyebrow: "Integrations" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "HeyClaude integrations", eyebrow: "Integrations" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/integrations") }],

--- a/apps/web/src/routes/platforms.tsx
+++ b/apps/web/src/routes/platforms.tsx
@@ -7,6 +7,9 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" });
+
 export const Route = createFileRoute("/platforms")({
   head: () => ({
     meta: [
@@ -24,14 +27,14 @@ export const Route = createFileRoute("/platforms")({
       { property: "og:url", content: absoluteUrl("/platforms") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "Platform compatibility", eyebrow: "Platforms" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/platforms") }],

--- a/apps/web/src/routes/tools.tsx
+++ b/apps/web/src/routes/tools.tsx
@@ -7,6 +7,9 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" });
+
 export const Route = createFileRoute("/tools")({
   head: () => ({
     meta: [
@@ -24,14 +27,14 @@ export const Route = createFileRoute("/tools")({
       { property: "og:url", content: absoluteUrl("/tools") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "Tools that pair well with Claude", eyebrow: "Tools" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/tools") }],


### PR DESCRIPTION
### What & why

The tools, platforms and integrations-index routes each called `ogImageUrl()` **twice with identical arguments** - once for `og:image` and once for `twitter:image` - so the card url was computed twice and the literal `title`/`eyebrow` had to be kept in sync by hand.

This hoists the call to a module-scope `OG_IMAGE` const (the inputs are static literals, so it evaluates once) and references it from both meta tags.

### Changes

- `apps/web/src/routes/tools.tsx`, `apps/web/src/routes/platforms.tsx`, `apps/web/src/routes/integrations.index.tsx` - hoist the duplicated `ogImageUrl(...)` call into a single `OG_IMAGE` const.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec prettier --check` on the touched files - clean
- each route now has exactly one `ogImageUrl(...)` call feeding both tags

### Notes

No matching open issue - maintainer-lane internal cleanup. No user-facing or behavior change; each route emits the same `og:image` and `twitter:image` url as before.

These three routes are deliberately **not** migrated to the shared `ogImageMetaTags` helper: unlike the routes already migrated, they emit no `twitter:card` tag, so adopting the helper would add a meta tag rather than being a pure dedup.
