### PR TITLE
refactor(web): hoist duplicated og image url in three more routes

### DIFF
--- a/apps/web/src/routes/contributors.index.tsx
+++ b/apps/web/src/routes/contributors.index.tsx
@@ -9,6 +9,9 @@ import { breadcrumbScript, itemListScript } from "@/lib/seo-jsonld";
 import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "Contributors", eyebrow: "HeyClaude" });
+
 export const Route = createFileRoute("/contributors/")({
   head: () => ({
     meta: [
@@ -19,14 +22,14 @@ export const Route = createFileRoute("/contributors/")({
       { property: "og:url", content: absoluteUrl("/contributors") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "Contributors", eyebrow: "HeyClaude" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "Contributors", eyebrow: "HeyClaude" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/contributors") }],

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -117,6 +117,9 @@ const POPULAR_SEARCHES = [
   "react rules",
 ];
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "The directory for Claude workflows", eyebrow: "HeyClaude" });
+
 export const Route = createFileRoute("/")({
   head: () => ({
     meta: [
@@ -135,14 +138,14 @@ export const Route = createFileRoute("/")({
       { property: "og:url", content: absoluteUrl("/") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "The directory for Claude workflows", eyebrow: "HeyClaude" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "The directory for Claude workflows", eyebrow: "HeyClaude" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/") }],

--- a/apps/web/src/routes/trending.tsx
+++ b/apps/web/src/routes/trending.tsx
@@ -50,6 +50,9 @@ const REASON_LABELS: Record<string, string> = {
   source_backed_fallback: "source-backed fallback ranking",
 };
 
+// Same card for og:image and twitter:image; the inputs are static.
+const OG_IMAGE = ogImageUrl({ title: "Trending Claude workflows", eyebrow: "Trending" });
+
 export const Route = createFileRoute("/trending")({
   validateSearch: trendingSchema,
   search: {
@@ -66,14 +69,14 @@ export const Route = createFileRoute("/trending")({
       { property: "og:url", content: absoluteUrl("/trending") },
       {
         property: "og:image",
-        content: ogImageUrl({ title: "Trending Claude workflows", eyebrow: "Trending" }),
+        content: OG_IMAGE,
       },
       { property: "og:image:type", content: "image/png" },
       { property: "og:image:width", content: "1200" },
       { property: "og:image:height", content: "630" },
       {
         name: "twitter:image",
-        content: ogImageUrl({ title: "Trending Claude workflows", eyebrow: "Trending" }),
+        content: OG_IMAGE,
       },
     ],
     links: [{ rel: "canonical", href: absoluteUrl("/trending") }],


### PR DESCRIPTION
### What & why

The home, trending and contributors-index routes each called `ogImageUrl()` **twice with identical arguments** - once for `og:image` and once for `twitter:image` - so the card url was computed twice and the literal `title`/`eyebrow` had to be kept in sync by hand.

This hoists the call to a module-scope `OG_IMAGE` const (the inputs are static literals, so it evaluates once) and references it from both meta tags, matching the same cleanup already applied to the tools, platforms and integrations-index routes.

### Changes

- `apps/web/src/routes/index.tsx`, `apps/web/src/routes/trending.tsx`, `apps/web/src/routes/contributors.index.tsx` - hoist the duplicated `ogImageUrl(...)` call into a single `OG_IMAGE` const.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec prettier --check` on the touched files - clean
- each route now has exactly one `ogImageUrl(...)` call feeding both tags

### Notes

No matching open issue - maintainer-lane internal cleanup. No user-facing or behavior change; each route emits the same `og:image` and `twitter:image` url as before.

Like the other hub routes, these emit no `twitter:card` tag, so they are intentionally not migrated to the shared `ogImageMetaTags` helper (that would add a meta tag rather than being a pure dedup).
