### PR TITLE
refactor(web): og meta builder declares the card's real dimensions

### DIFF
--- a/apps/web/src/lib/og-meta-lib.ts
+++ b/apps/web/src/lib/og-meta-lib.ts
@@ -1,13 +1,17 @@
-// Shared og:image + twitter card meta tags for the 1200x630 PNG social card that
-// every hub/detail route emits. Defined once so the dimensions, type, and
-// twitter card kind stay consistent (and are unit-tested) across routes.
+// Shared og:image + twitter card meta tags for the PNG social card that every
+// hub/detail route emits. Defined once so the dimensions, type, and twitter card
+// kind stay consistent (and are unit-tested) across routes. The dimensions come
+// from the canonical OG_WIDTH/OG_HEIGHT used to render the card, so the declared
+// size can never drift from the image actually produced.
+
+import { OG_HEIGHT, OG_WIDTH } from "@/lib/og-image";
 
 export type OgImageMetaTag =
   | { property: string; content: string }
   | { name: string; content: string };
 
 /**
- * The standard og:image + twitter card meta tags for a 1200x630 PNG card.
+ * The standard og:image + twitter card meta tags for the social card.
  * When `ogType` is given ("website" / "article"), an `og:type` tag is emitted
  * between the image tags and the twitter card tags, matching the routes that
  * declare one.
@@ -16,8 +20,8 @@ export function ogImageMetaTags(ogImage: string, ogType?: string): OgImageMetaTa
   return [
     { property: "og:image", content: ogImage },
     { property: "og:image:type", content: "image/png" },
-    { property: "og:image:width", content: "1200" },
-    { property: "og:image:height", content: "630" },
+    { property: "og:image:width", content: String(OG_WIDTH) },
+    { property: "og:image:height", content: String(OG_HEIGHT) },
     ...(ogType ? [{ property: "og:type", content: ogType }] : []),
     { name: "twitter:card", content: "summary_large_image" },
     { name: "twitter:image", content: ogImage },

--- a/tests/og-meta-lib.test.ts
+++ b/tests/og-meta-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { OG_HEIGHT, OG_WIDTH } from "../apps/web/src/lib/og-image";
 import { ogImageMetaTags } from "../apps/web/src/lib/og-meta-lib";
 
 describe("ogImageMetaTags", () => {
@@ -7,11 +8,25 @@ describe("ogImageMetaTags", () => {
     expect(ogImageMetaTags("https://heyclau.de/og/agents/a")).toEqual([
       { property: "og:image", content: "https://heyclau.de/og/agents/a" },
       { property: "og:image:type", content: "image/png" },
-      { property: "og:image:width", content: "1200" },
-      { property: "og:image:height", content: "630" },
+      { property: "og:image:width", content: String(OG_WIDTH) },
+      { property: "og:image:height", content: String(OG_HEIGHT) },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:image", content: "https://heyclau.de/og/agents/a" },
     ]);
+  });
+
+  it("declares the same dimensions the card is rendered at", () => {
+    const tags = ogImageMetaTags("https://x.dev/card.png");
+    expect(tags[2]).toEqual({
+      property: "og:image:width",
+      content: String(OG_WIDTH),
+    });
+    expect(tags[3]).toEqual({
+      property: "og:image:height",
+      content: String(OG_HEIGHT),
+    });
+    expect(OG_WIDTH).toBe(1200);
+    expect(OG_HEIGHT).toBe(630);
   });
 
   it("inserts og:type between the image tags and the twitter card when given", () => {


### PR DESCRIPTION
### What & why

`ogImageMetaTags` hardcoded `"1200"` and `"630"` for `og:image:width`/`height`, while the card itself is rendered from the `OG_WIDTH` / `OG_HEIGHT` constants in `og-image-lib` (as the `state-of-*` routes already do). If the card size ever changed, the declared dimensions would silently drift from the image actually produced.

This derives the tag values from `OG_WIDTH` / `OG_HEIGHT` so there is one source of truth.

### Changes

- `apps/web/src/lib/og-meta-lib.ts` - use `String(OG_WIDTH)` / `String(OG_HEIGHT)`.
- `tests/og-meta-lib.test.ts` - assert the tags against the constants (and pin their current values), so the test stays honest if the card size changes.

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/og-meta-lib.test.ts` - 5 passed
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal cleanup. No user-facing or behavior change; the constants are 1200x630 today, so the emitted tags are identical.
