### PR TITLE
refactor(web): extract saved-search signature into a lib

### DIFF
--- a/apps/web/src/lib/saved-search-signature-lib.ts
+++ b/apps/web/src/lib/saved-search-signature-lib.ts
@@ -1,0 +1,28 @@
+// Pure serialization of a saved-search list into a stable signature string,
+// split out of the watch provider so the change-detection key can be unit-tested
+// without React. The type-only import keeps this decoupled at runtime.
+
+import type { SavedSearchAlertSearch } from "@/lib/saved-search-alerts";
+
+/**
+ * Stable, tab/newline-delimited signature of the alert-relevant fields of each
+ * saved search. Used as a memo/effect key so the watch provider only refetches
+ * when a search's alert configuration actually changes.
+ */
+export function savedSearchSignature(searches: SavedSearchAlertSearch[]): string {
+  return searches
+    .map((search) =>
+      [
+        search.id,
+        search.label,
+        search.q,
+        search.category,
+        search.trust,
+        search.source,
+        search.platform,
+        search.alerts?.enabled ? "1" : "0",
+        search.alerts?.channels?.join(",") ?? "",
+      ].join("\t"),
+    )
+    .join("\n");
+}

--- a/apps/web/src/lib/watch.tsx
+++ b/apps/web/src/lib/watch.tsx
@@ -4,8 +4,8 @@ import {
   activeInAppSavedSearches,
   buildSavedSearchAlerts,
   savedSearchAlertTargetId,
-  type SavedSearchAlertSearch,
 } from "@/lib/saved-search-alerts";
+import { savedSearchSignature } from "@/lib/saved-search-signature-lib";
 import { entryDetailUrl, eventTargetId, type RegistryEvent } from "@/lib/watch-events-lib";
 import type { RegistryEntry } from "@/data/entry-normalize";
 import type { Entry } from "@/types/registry";
@@ -95,24 +95,6 @@ function eventToAlert(event: RegistryEvent, target: WatchTarget): Alert | null {
     href: target.href,
     date: event.date,
   };
-}
-
-function savedSearchSignature(searches: SavedSearchAlertSearch[]) {
-  return searches
-    .map((search) =>
-      [
-        search.id,
-        search.label,
-        search.q,
-        search.category,
-        search.trust,
-        search.source,
-        search.platform,
-        search.alerts?.enabled ? "1" : "0",
-        search.alerts?.channels?.join(",") ?? "",
-      ].join("\t"),
-    )
-    .join("\n");
 }
 
 async function loadEventEntries(events: RegistryEvent[]) {

--- a/tests/saved-search-signature-lib.test.ts
+++ b/tests/saved-search-signature-lib.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import type { SavedSearchAlertSearch } from "../apps/web/src/lib/saved-search-alerts";
+import { savedSearchSignature } from "../apps/web/src/lib/saved-search-signature-lib";
+
+const search = (over: Record<string, unknown> = {}): SavedSearchAlertSearch =>
+  ({ id: "s1", label: "Mine", q: "mcp", ...over }) as SavedSearchAlertSearch;
+
+describe("savedSearchSignature", () => {
+  it("is empty for no searches", () => {
+    expect(savedSearchSignature([])).toBe("");
+  });
+
+  it("joins fields with tabs and searches with newlines", () => {
+    const sig = savedSearchSignature([
+      search({ id: "a" }),
+      search({ id: "b" }),
+    ]);
+    const lines = sig.split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0].split("\t")[0]).toBe("a");
+    expect(lines[1].split("\t")[0]).toBe("b");
+  });
+
+  it("changes when the alert configuration changes", () => {
+    const off = savedSearchSignature([search({ alerts: { enabled: false } })]);
+    const on = savedSearchSignature([search({ alerts: { enabled: true } })]);
+    expect(on).not.toBe(off);
+  });
+
+  it("changes when alert channels change, and tolerates missing alerts", () => {
+    const none = savedSearchSignature([search()]);
+    const chans = savedSearchSignature([
+      search({ alerts: { enabled: true, channels: ["email"] } }),
+    ]);
+    const more = savedSearchSignature([
+      search({ alerts: { enabled: true, channels: ["email", "web"] } }),
+    ]);
+    expect(none).not.toBe(chans);
+    expect(chans).not.toBe(more);
+  });
+
+  it("is stable for identical input", () => {
+    expect(savedSearchSignature([search()])).toBe(
+      savedSearchSignature([search()]),
+    );
+  });
+});


### PR DESCRIPTION
### What & why

The watch provider built the saved-search change-detection key inline, so the signature (which decides when the alerts effect refetches) could not be unit-tested without React. This moves it into `apps/web/src/lib/saved-search-signature-lib.ts` and imports it back; the type-only import keeps the lib decoupled at runtime.

### Changes

- Add `apps/web/src/lib/saved-search-signature-lib.ts` - `savedSearchSignature(searches)`.
- `apps/web/src/lib/watch.tsx` - import the helper; drop the local copy and the now-unused `SavedSearchAlertSearch` type import.
- Add `tests/saved-search-signature-lib.test.ts` - covers the empty list, tab/newline delimiting, and that the signature changes when alerts are toggled or channels change (and is stable otherwise). Branch coverage 100% (4/4).

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/saved-search-signature-lib.test.ts` - 5 passed
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the provider computes the same key.
