### PR TITLE
refactor(web): extract watch alert mapping into a lib

### DIFF
--- a/apps/web/src/lib/watch-alert-lib.ts
+++ b/apps/web/src/lib/watch-alert-lib.ts
@@ -1,0 +1,31 @@
+// Pure conversion of a registry feed event into a watch Alert, split out of the
+// watch provider so the target matching, action mapping and severity/copy
+// selection can be unit-tested without React.
+
+import type { Alert, WatchTarget } from "@/lib/watch-types-lib";
+import { eventTargetId, type RegistryEvent } from "@/lib/watch-events-lib";
+
+/**
+ * Build the Alert a watched target should show for a registry event, or null
+ * when the event does not belong to that target (or carries no date).
+ */
+export function eventToAlert(event: RegistryEvent, target: WatchTarget): Alert | null {
+  const targetId = eventTargetId(event);
+  if (!targetId || targetId !== target.id || !event.date) return null;
+  const action =
+    event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
+  const label = event.title || target.label;
+  return {
+    id: event.id || `${target.id}:${event.date}:${action}`,
+    targetId: target.id,
+    kind: target.kind,
+    title: `${label} ${action}`,
+    body:
+      action === "removed"
+        ? "This watched registry entry was removed from the source content."
+        : "This watched registry entry changed in the source content.",
+    severity: action === "removed" ? "warning" : "info",
+    href: target.href,
+    date: event.date,
+  };
+}

--- a/apps/web/src/lib/watch-types-lib.ts
+++ b/apps/web/src/lib/watch-types-lib.ts
@@ -1,0 +1,26 @@
+// Shared watch/alert types, split out of the watch provider so pure helpers can
+// depend on them without importing the React module (and creating a cycle).
+// `@/lib/watch` re-exports these, so existing importers stay unchanged.
+
+export type WatchKind = "entry" | "validator" | "changelog-stream" | "integration" | "saved-search";
+
+export interface WatchTarget {
+  id: string;
+  kind: WatchKind;
+  label: string;
+  href?: string;
+  addedAt: string;
+}
+
+export type AlertSeverity = "info" | "warning" | "blocker";
+
+export interface Alert {
+  id: string;
+  targetId: string;
+  kind: WatchKind;
+  title: string;
+  body: string;
+  severity: AlertSeverity;
+  href?: string;
+  date: string;
+}

--- a/apps/web/src/lib/watch.tsx
+++ b/apps/web/src/lib/watch.tsx
@@ -6,32 +6,13 @@ import {
   savedSearchAlertTargetId,
 } from "@/lib/saved-search-alerts";
 import { savedSearchSignature } from "@/lib/saved-search-signature-lib";
+import { eventToAlert } from "@/lib/watch-alert-lib";
 import { entryDetailUrl, eventTargetId, type RegistryEvent } from "@/lib/watch-events-lib";
+import type { Alert, AlertSeverity, WatchKind, WatchTarget } from "@/lib/watch-types-lib";
 import type { RegistryEntry } from "@/data/entry-normalize";
 import type { Entry } from "@/types/registry";
 
-export type WatchKind = "entry" | "validator" | "changelog-stream" | "integration" | "saved-search";
-
-export interface WatchTarget {
-  id: string;
-  kind: WatchKind;
-  label: string;
-  href?: string;
-  addedAt: string;
-}
-
-export type AlertSeverity = "info" | "warning" | "blocker";
-
-export interface Alert {
-  id: string;
-  targetId: string;
-  kind: WatchKind;
-  title: string;
-  body: string;
-  severity: AlertSeverity;
-  href?: string;
-  date: string;
-}
+export type { Alert, AlertSeverity, WatchKind, WatchTarget };
 
 interface WatchCtx {
   targets: WatchTarget[];
@@ -74,27 +55,6 @@ function saveState(state: StoredState) {
   } catch {
     /* noop */
   }
-}
-
-function eventToAlert(event: RegistryEvent, target: WatchTarget): Alert | null {
-  const targetId = eventTargetId(event);
-  if (!targetId || targetId !== target.id || !event.date) return null;
-  const action =
-    event.action === "removed" ? "removed" : event.action === "added" ? "added" : "updated";
-  const label = event.title || target.label;
-  return {
-    id: event.id || `${target.id}:${event.date}:${action}`,
-    targetId: target.id,
-    kind: target.kind,
-    title: `${label} ${action}`,
-    body:
-      action === "removed"
-        ? "This watched registry entry was removed from the source content."
-        : "This watched registry entry changed in the source content.",
-    severity: action === "removed" ? "warning" : "info",
-    href: target.href,
-    date: event.date,
-  };
 }
 
 async function loadEventEntries(events: RegistryEvent[]) {

--- a/tests/watch-alert-lib.test.ts
+++ b/tests/watch-alert-lib.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { eventToAlert } from "../apps/web/src/lib/watch-alert-lib";
+import type { RegistryEvent } from "../apps/web/src/lib/watch-events-lib";
+import type { WatchTarget } from "../apps/web/src/lib/watch-types-lib";
+
+const target: WatchTarget = {
+  id: "entry:agents/my-agent",
+  kind: "entry",
+  label: "My Agent",
+  href: "/entry/agents/my-agent",
+  addedAt: "2026-01-01",
+};
+
+const event = (over: Partial<RegistryEvent> = {}): RegistryEvent => ({
+  kind: "entry",
+  category: "agents",
+  slug: "my-agent",
+  date: "2026-02-02",
+  ...over,
+});
+
+describe("eventToAlert", () => {
+  it("returns null when the event is not for this target", () => {
+    expect(eventToAlert(event({ slug: "other" }), target)).toBeNull();
+    expect(eventToAlert(event({ kind: "changelog" }), target)).toBeNull();
+  });
+
+  it("returns null when the event has no date", () => {
+    expect(eventToAlert(event({ date: undefined }), target)).toBeNull();
+  });
+
+  it("maps removed events to a warning with removal copy", () => {
+    const alert = eventToAlert(event({ action: "removed" }), target);
+    expect(alert?.severity).toBe("warning");
+    expect(alert?.title).toBe("My Agent removed");
+    expect(alert?.body).toContain("removed from the source content");
+  });
+
+  it("maps added and unknown actions to info alerts", () => {
+    expect(eventToAlert(event({ action: "added" }), target)?.title).toBe(
+      "My Agent added",
+    );
+    expect(eventToAlert(event({ action: "wat" }), target)?.title).toBe(
+      "My Agent updated",
+    );
+    expect(eventToAlert(event(), target)?.severity).toBe("info");
+  });
+
+  it("prefers the event title over the target label", () => {
+    expect(eventToAlert(event({ title: "Renamed" }), target)?.title).toBe(
+      "Renamed updated",
+    );
+  });
+
+  it("uses the event id when present, else a derived id", () => {
+    expect(eventToAlert(event({ id: "evt-1" }), target)?.id).toBe("evt-1");
+    expect(eventToAlert(event(), target)?.id).toBe(
+      "entry:agents/my-agent:2026-02-02:updated",
+    );
+  });
+
+  it("carries the target's kind/href and the event date through", () => {
+    const alert = eventToAlert(event(), target);
+    expect(alert?.kind).toBe("entry");
+    expect(alert?.href).toBe("/entry/agents/my-agent");
+    expect(alert?.targetId).toBe(target.id);
+    expect(alert?.date).toBe("2026-02-02");
+  });
+});


### PR DESCRIPTION
### What & why

The watch provider built each `Alert` from a registry feed event inline, so the target matching, action mapping, severity/copy selection and id fallback could not be unit-tested without React.

This splits the watch/alert types into `watch-types-lib.ts` (so pure helpers can depend on them without importing the React module and creating a cycle), moves `eventToAlert` into `watch-alert-lib.ts`, and imports both back. `watch.tsx` re-exports the types, so existing `@/lib/watch` importers are unchanged.

### Changes

- Add `apps/web/src/lib/watch-types-lib.ts` - `WatchKind`, `WatchTarget`, `AlertSeverity`, `Alert`.
- Add `apps/web/src/lib/watch-alert-lib.ts` - `eventToAlert(event, target)`.
- `apps/web/src/lib/watch.tsx` - import the helper/types and re-export the types; drop the local copies.
- Add `tests/watch-alert-lib.test.ts` - covers non-matching target/kind, missing date, `removed` -> warning copy, `added`/unknown -> info, event-title override, event-id vs derived id, and the kind/href/date passthrough. Branch coverage 100% (17/17).

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/watch-alert-lib.test.ts` - 7 passed
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the provider builds the same alerts. The type re-export keeps `watch-button.tsx` (`WatchKind`) and the other `@/lib/watch` consumers working unchanged.
