### PR TITLE
feat(web): add full compare link to entry command center

### DIFF
--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -68,8 +68,10 @@ type EntryDetailCommandCenterProps = {
   compareCta: {
     inCompare: boolean;
     compareCount: number;
+    compareIds: string;
     onToggle: () => void;
     onOpenCompare: () => void;
+    onOpenFullCompare: () => void;
   };
 };
 
@@ -123,7 +125,11 @@ export function EntryDetailCommandCenter({
   const quickLinks = resolveDetailQuickLinks(entry);
   const integrationLinks = resolveDetailIntegrationLinks(entry);
   const communityAnchors = resolveDetailCommunityAnchors(relatedCount, guideCount, true);
-  const compareState = entryDetailCompareCtaState(compareCta.inCompare, compareCta.compareCount);
+  const compareState = entryDetailCompareCtaState(
+    compareCta.inCompare,
+    compareCta.compareCount,
+    compareCta.compareIds,
+  );
   const safetyGate = detailSafetyGateMessage(risk, entry);
   const elevateSafety = shouldElevateDetailSafetyGate(risk, entry);
   const suggestUrl = entryDetailSuggestChangeUrl(
@@ -322,6 +328,16 @@ export function EntryDetailCommandCenter({
               >
                 Open compare tray
               </button>
+            ) : null}
+            {compareState.showOpenFullCompare && compareState.compareSearch ? (
+              <Link
+                to="/compare"
+                search={compareState.compareSearch}
+                onClick={compareCta.onOpenFullCompare}
+                className="inline-flex items-center gap-1.5 text-ink-muted hover:text-ink"
+              >
+                Open full compare
+              </Link>
             ) : null}
           </div>
         </div>

--- a/apps/web/src/lib/entry-detail-compare-ui-lib.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui-lib.ts
@@ -12,6 +12,8 @@ export type EntryDetailCompareCtaState = {
   disabled: boolean;
   hint: string | null;
   showOpenCompare: boolean;
+  showOpenFullCompare: boolean;
+  compareSearch: { ids: string } | null;
 };
 
 export type EntryDetailMobileCompareAction = {
@@ -45,18 +47,29 @@ export function entryDetailCompareDrawerEnabled(compareCount: number): boolean {
   return compareCount >= 2;
 }
 
+export function entryDetailCompareFullSearch(compareIds: string): { ids: string } | null {
+  const count = compareIds.split(",").filter((id) => id.trim()).length;
+  if (count < 2) return null;
+  return { ids: compareIds };
+}
+
 export function entryDetailCompareCtaState(
   inCompare: boolean,
   compareCount: number,
+  compareIds = "",
   maxCount = ENTRY_DETAIL_COMPARE_MAX,
 ): EntryDetailCompareCtaState {
   const disabledReason = entryDetailCompareDisabledReason(inCompare, compareCount, maxCount);
+  const showOpenCompare = entryDetailCompareDrawerEnabled(compareCount);
+  const compareSearch = showOpenCompare ? entryDetailCompareFullSearch(compareIds) : null;
 
   return {
     label: entryDetailCompareToggleLabel(inCompare),
     disabled: Boolean(disabledReason),
     hint: disabledReason,
-    showOpenCompare: entryDetailCompareDrawerEnabled(compareCount),
+    showOpenCompare,
+    showOpenFullCompare: Boolean(compareSearch),
+    compareSearch,
   };
 }
 

--- a/apps/web/src/lib/entry-detail-compare-ui.ts
+++ b/apps/web/src/lib/entry-detail-compare-ui.ts
@@ -10,6 +10,7 @@ export {
   entryDetailCompareCtaState,
   entryDetailCompareDisabledReason,
   entryDetailCompareDrawerEnabled,
+  entryDetailCompareFullSearch,
   entryDetailCompareToggleLabel,
   entryDetailMobileCompareAction,
   entryDetailMobileCompareLabel,

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -46,6 +46,22 @@ export function entryDetailCompareAnalyticsData(category: string, slug: string) 
   };
 }
 
+export function entryDetailCompareFullAnalyticsEvent(): string {
+  return "detail_compare_open_full";
+}
+
+export function entryDetailCompareFullAnalyticsData(
+  category: string,
+  slug: string,
+  compareCount: number,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+    compareCount,
+  };
+}
+
 export function entryDetailMobileCompareAnalyticsEvent(adding: boolean): string {
   return adding ? "detail_mobile_compare_add" : "detail_mobile_compare_remove";
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -13,6 +13,8 @@ export {
   comparisonTrayQuickCompareAnalyticsData,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailCompareFullAnalyticsData,
+  entryDetailCompareFullAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailCopyAnalyticsData,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -81,6 +81,8 @@ import { trackEvent } from "@/lib/analytics";
 import {
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailCompareFullAnalyticsData,
+  entryDetailCompareFullAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailPlaybookActionAnalyticsData,
@@ -338,6 +340,12 @@ function Dossier() {
     });
   }, [compare, entry.category, entry.slug]);
 
+  const onOpenFullCompare = useCallback(() => {
+    trackEvent(entryDetailCompareFullAnalyticsEvent(), {
+      ...entryDetailCompareFullAnalyticsData(entry.category, entry.slug, compare.items.length),
+    });
+  }, [compare.items.length, entry.category, entry.slug]);
+
   const compareIds = useMemo(() => serializeCompareItems(compare.items), [compare.items]);
   const onPlaybookAction = useCallback(
     (actionId: string) => {
@@ -524,8 +532,10 @@ function Dossier() {
           compareCta={{
             inCompare,
             compareCount: compare.items.length,
+            compareIds,
             onToggle: onToggleCompare,
             onOpenCompare,
+            onOpenFullCompare,
           }}
         />
       </header>

--- a/tests/entry-detail-compare-ui-lib.test.ts
+++ b/tests/entry-detail-compare-ui-lib.test.ts
@@ -4,6 +4,7 @@ import {
   entryDetailCompareCtaState,
   entryDetailCompareDisabledReason,
   entryDetailCompareDrawerEnabled,
+  entryDetailCompareFullSearch,
   entryDetailCompareToggleLabel,
   entryDetailMobileCompareAction,
   entryDetailMobileCompareLabel,
@@ -40,17 +41,30 @@ describe("entry detail compare ui lib", () => {
       disabled: false,
       hint: null,
       showOpenCompare: false,
+      showOpenFullCompare: false,
+      compareSearch: null,
     });
-    expect(entryDetailCompareCtaState(true, 3)).toEqual({
+    expect(entryDetailCompareCtaState(true, 3, "mcp/a,mcp/b")).toEqual({
       label: "Remove from compare",
       disabled: false,
       hint: null,
       showOpenCompare: true,
+      showOpenFullCompare: true,
+      compareSearch: { ids: "mcp/a,mcp/b" },
     });
     expect(entryDetailCompareCtaState(false, 4)).toMatchObject({
       label: "Add to compare",
       disabled: true,
       showOpenCompare: true,
+      showOpenFullCompare: false,
+      compareSearch: null,
+    });
+  });
+
+  it("builds full compare search only when two or more ids are present", () => {
+    expect(entryDetailCompareFullSearch("mcp/a")).toBeNull();
+    expect(entryDetailCompareFullSearch("mcp/a,mcp/b")).toEqual({
+      ids: "mcp/a,mcp/b",
     });
   });
 

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -5,6 +5,8 @@ import {
   comparisonTrayQuickCompareAnalyticsData,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailCompareFullAnalyticsData,
+  entryDetailCompareFullAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailCopyAnalyticsData,
@@ -43,6 +45,14 @@ describe("entry detail cta events lib", () => {
     expect(entryDetailCompareAnalyticsData("skills", "demo")).toEqual({
       entry: "skills/demo",
       surface: "detail-compare",
+    });
+    expect(entryDetailCompareFullAnalyticsEvent()).toBe(
+      "detail_compare_open_full",
+    );
+    expect(entryDetailCompareFullAnalyticsData("skills", "demo", 3)).toEqual({
+      entry: "skills/demo",
+      surface: "detail-compare",
+      compareCount: 3,
     });
     expect(entryDetailMobileCompareAnalyticsEvent(true)).toBe(
       "detail_mobile_compare_add",


### PR DESCRIPTION
## Summary
- Adds Open full compare to the entry detail command center when 2+ entries are selected.
- Builds compare search from serialized tray ids via entry-detail-compare-ui-lib.
- Tracks detail_compare_open_full analytics on the detail-compare surface.

Closes #556

## Validation
- `pnpm test tests/entry-detail-compare-ui-lib.test.ts tests/entry-detail-cta-events-lib.test.ts` — 12 passed
- `pnpm type-check` — pass
- `pnpm build` — pass
- `npx prettier --write` on touched files

Made with [Cursor](https://cursor.com)