### PR TITLE
feat(web): add single-item hint to compare drawer

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -351,8 +351,15 @@ export function CompareDrawer() {
   const [riskPreset, setRiskPreset] = React.useState<DeploymentRiskPresetId>("balanced");
   const [mitigationPreset, setMitigationPreset] =
     React.useState<MitigationPriorityPresetId>("balanced");
-  const { drawerUi, emptyHint, shareUrl, divergingDecisionLabels, actionRowDiverges, actionCells } =
-    compareDrawerInteractiveUiState(items);
+  const {
+    drawerUi,
+    emptyHint,
+    singleItemHint,
+    shareUrl,
+    divergingDecisionLabels,
+    actionRowDiverges,
+    actionCells,
+  } = compareDrawerInteractiveUiState(items);
   const decisionBrief = compareDecisionBriefState(items);
   const scenarioRanking = compareScenarioRankingState(items, scenario);
   const evidenceGaps = compareEvidenceGapsState(items);
@@ -402,6 +409,9 @@ export function CompareDrawer() {
                   </p>
                 ))}
               </div>
+            ) : null}
+            {singleItemHint ? (
+              <p className="w-full text-xs text-ink-muted">{singleItemHint}</p>
             ) : null}
             <div className="flex flex-wrap items-center gap-2">
               {items.length > 0 && (

--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -2,6 +2,7 @@ import type { Entry } from "@/types/registry";
 import type { CompareDrawerActionCell } from "@/lib/compare-drawer-actions-ui-lib";
 import { compareDrawerActionsInteractiveUiState } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
+import { compareSingleItemHintText } from "@/lib/compare-empty-guidance-lib";
 import {
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
@@ -10,6 +11,7 @@ import {
 export type CompareDrawerInteractiveUiState = {
   drawerUi: CompareDrawerUiState;
   emptyHint: string;
+  singleItemHint: string | null;
   shareUrl: string;
   divergingDecisionLabels: Set<string>;
   actionRowDiverges: boolean;
@@ -23,6 +25,7 @@ export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerIn
   return {
     drawerUi,
     emptyHint: emptyUi.emptyHint,
+    singleItemHint: compareSingleItemHintText(items.length),
     shareUrl: emptyUi.shareUrl,
     divergingDecisionLabels,
     actionRowDiverges: drawerUi.actionRowDiverges,

--- a/tests/compare-drawer-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-interactive-ui-lib.test.ts
@@ -28,11 +28,24 @@ describe("compare drawer interactive ui lib", () => {
         fullViewSearch: null,
       },
       emptyHint: expect.stringContaining("Compare"),
+      singleItemHint: null,
       shareUrl: "/browse",
       divergingDecisionLabels: new Set(),
       actionRowDiverges: false,
       actionCells: [],
     });
+  });
+
+  it("surfaces single-item guidance when only one resource is selected", () => {
+    expect(compareDrawerInteractiveUiState([entry()]).singleItemHint).toBe(
+      "Add one more resource to unlock trust and next-step comparisons across the full table.",
+    );
+    expect(
+      compareDrawerInteractiveUiState([
+        entry(),
+        entry({ slug: "other", category: "skills" }),
+      ]).singleItemHint,
+    ).toBeNull();
   });
 
   it("surfaces full-view search and share URLs for multi-item selections", () => {


### PR DESCRIPTION
## Summary
- Surfaces the existing single-item compare guidance in the quick compare drawer header.
- Reuses compareSingleItemHintText for parity with the interactive /compare page.
- Helps users understand they need one more entry before trust and next-step rows unlock.

Closes #556

## Validation
- `pnpm test tests/compare-drawer-interactive-ui-lib.test.ts` — 4 passed
- `pnpm type-check` — pass
- `pnpm build` — pass
- `npx prettier --write` on touched files

Made with [Cursor](https://cursor.com)