### PR TITLE
feat(web): normalize compare claim CTA analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -23,6 +23,7 @@ import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-inter
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { brandIdentityLabel } from "@/lib/brand-icons";
@@ -261,12 +262,10 @@ function DrawerActionButton({ entry, action }: { entry: Entry; action: CompareAc
         <Link
           to="/claim"
           onClick={() => {
-            if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, {
-                entry: eventKey,
-                surface: COMPARE_DRAWER_SURFACE,
-              });
-            }
+            trackEvent(
+              claimCtaAnalyticsEvent(),
+              claimCtaAnalyticsData("compare-drawer", entry.category, entry.slug),
+            );
           }}
           className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
         >

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -22,6 +22,7 @@ import { compareTableActionsForEntry } from "@/lib/compare-table-actions-interac
 import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { cn } from "@/lib/utils";
 import type { Entry } from "@/types/registry";
 import { EntryBrandMark } from "./entry-brand-mark";
@@ -112,12 +113,10 @@ function TableActionButton({ entry, action }: { entry: Entry; action: CompareAct
         <Link
           to="/claim"
           onClick={() => {
-            if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, {
-                entry: eventKey,
-                surface: COMPARE_TABLE_SURFACE,
-              });
-            }
+            trackEvent(
+              claimCtaAnalyticsEvent(),
+              claimCtaAnalyticsData("compare-table", entry.category, entry.slug),
+            );
           }}
           className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
         >

--- a/apps/web/src/lib/compare-entry-actions-lib.ts
+++ b/apps/web/src/lib/compare-entry-actions-lib.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Entry } from "@/types/registry";
+import { claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events-lib";
 
 export type CompareActionKind = "link" | "copy";
 
@@ -139,7 +140,7 @@ export function resolveCompareEntryActions(
       id: "claim",
       label: "Claim listing",
       kind: "link",
-      analyticsEvent: "compare_claim_cta",
+      analyticsEvent: claimCtaAnalyticsEvent(),
     });
   }
 

--- a/apps/web/src/lib/conversion-cta-events-lib.ts
+++ b/apps/web/src/lib/conversion-cta-events-lib.ts
@@ -10,7 +10,8 @@ export type ClaimCtaSurface =
   | "detail-command-center"
   | "detail-mobile"
   | "compare-table"
-  | "compare-drawer";
+  | "compare-drawer"
+  | "compare-page";
 
 export function claimCtaAnalyticsEvent(): string {
   return "claim_cta_click";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -38,6 +38,7 @@ import {
   type MitigationPriorityPresetId,
 } from "@/lib/compare-mitigation-priority";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
 import { cn } from "@/lib/utils";
@@ -502,9 +503,10 @@ function CompareActionButton({ entry, action }: { entry: Entry; action: CompareA
         <Link
           to="/claim"
           onClick={() => {
-            if (action.analyticsEvent) {
-              trackEvent(action.analyticsEvent, { entry: eventKey, surface: COMPARE_PAGE_SURFACE });
-            }
+            trackEvent(
+              claimCtaAnalyticsEvent(),
+              claimCtaAnalyticsData("compare-page", entry.category, entry.slug),
+            );
           }}
           className="inline-flex h-7 items-center rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:bg-surface-2"
         >

--- a/tests/compare-entry-actions-lib.test.ts
+++ b/tests/compare-entry-actions-lib.test.ts
@@ -257,7 +257,8 @@ describe("action metadata", () => {
     expect(
       actions.every((action) => {
         if (!action.analyticsEvent) return false;
-        if (action.id === "claim") return action.analyticsEvent === claimCtaAnalyticsEvent();
+        if (action.id === "claim")
+          return action.analyticsEvent === claimCtaAnalyticsEvent();
         return action.analyticsEvent.startsWith("compare_");
       }),
     ).toBe(true);

--- a/tests/compare-entry-actions-lib.test.ts
+++ b/tests/compare-entry-actions-lib.test.ts
@@ -7,6 +7,7 @@ import {
   resolveCompareEntryActions,
   type CompareAction,
 } from "../apps/web/src/lib/compare-entry-actions-lib";
+import { claimCtaAnalyticsEvent } from "../apps/web/src/lib/conversion-cta-events-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -254,7 +255,11 @@ describe("action metadata", () => {
       }),
     );
     expect(
-      actions.every((action) => action.analyticsEvent?.startsWith("compare_")),
+      actions.every((action) => {
+        if (!action.analyticsEvent) return false;
+        if (action.id === "claim") return action.analyticsEvent === claimCtaAnalyticsEvent();
+        return action.analyticsEvent.startsWith("compare_");
+      }),
     ).toBe(true);
   });
 });
@@ -445,7 +450,7 @@ describe("claim CTA", () => {
       id: "claim",
       label: "Claim listing",
       kind: "link",
-      analyticsEvent: "compare_claim_cta",
+      analyticsEvent: claimCtaAnalyticsEvent(),
     });
   });
 
@@ -683,7 +688,7 @@ describe("analytics event coverage", () => {
     ["install", "compare_copy_install"],
     ["config", "compare_copy_config"],
     ["source", "compare_open_source"],
-    ["claim", "compare_claim_cta"],
+    ["claim", claimCtaAnalyticsEvent()],
   ] as const)("maps %s to %s", (id, analyticsEvent) => {
     const action = resolveCompareEntryActions(
       entry({

--- a/tests/conversion-cta-events-lib.test.ts
+++ b/tests/conversion-cta-events-lib.test.ts
@@ -19,6 +19,10 @@ describe("conversion cta events lib", () => {
     expect(claimCtaAnalyticsData("compare-table")).toEqual({
       surface: "compare-table",
     });
+    expect(claimCtaAnalyticsData("compare-page", "mcp", "browser")).toEqual({
+      surface: "compare-page",
+      entry: "mcp/browser",
+    });
   });
 
   it("builds newsletter subscribe analytics without email or PII", () => {


### PR DESCRIPTION
## Summary
- Route compare drawer, table, and index claim clicks through `claim_cta_click` with typed surfaces.
- Align compare-entry-actions claim metadata with conversion CTA helpers used on entry detail.

Closes #556

## Test plan
- [x] pnpm test tests/compare-entry-actions-lib.test.ts tests/conversion-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)