### PR TITLE
feat(web): normalize mobile claim CTA analytics

### DIFF
--- a/apps/web/src/components/entry-detail-mobile-action-bar.tsx
+++ b/apps/web/src/components/entry-detail-mobile-action-bar.tsx
@@ -10,6 +10,7 @@ import { entryDetailMobileCompareAction } from "@/lib/entry-detail-compare-ui";
 import { siteConfig } from "@/lib/site";
 import { absoluteUrl } from "@/lib/seo";
 import { trackEvent } from "@/lib/analytics";
+import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import {
   entryDetailMobileActionAnalyticsData,
   entryDetailMobileActionAnalyticsEvent,
@@ -85,7 +86,14 @@ export function EntryDetailMobileActionBar({
       }
 
       if (action.kind === "link" && action.href) {
-        trackEvent(entryDetailMobileActionAnalyticsEvent(actionId), analyticsData);
+        if (actionId === "claim") {
+          trackEvent(
+            claimCtaAnalyticsEvent(),
+            claimCtaAnalyticsData("detail-mobile", entry.category, entry.slug),
+          );
+        } else {
+          trackEvent(entryDetailMobileActionAnalyticsEvent(actionId), analyticsData);
+        }
         const intentType = entryDetailMobileLinkIntentType(actionId);
         if (intentType) void recordIntentEvent(intentType, entry);
         if (action.external) {

--- a/tests/conversion-cta-events-lib.test.ts
+++ b/tests/conversion-cta-events-lib.test.ts
@@ -16,6 +16,10 @@ describe("conversion cta events lib", () => {
       surface: "detail-command-center",
       entry: "mcp/browser",
     });
+    expect(claimCtaAnalyticsData("detail-mobile", "skills", "demo")).toEqual({
+      surface: "detail-mobile",
+      entry: "skills/demo",
+    });
     expect(claimCtaAnalyticsData("compare-table")).toEqual({
       surface: "compare-table",
     });


### PR DESCRIPTION
## Summary
- Route entry detail mobile claim clicks through `claim_cta_click` with `detail-mobile` surface.
- Completes claim CTA normalization across detail and compare conversion surfaces.

Closes #556

## Test plan
- [x] pnpm test tests/conversion-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)