### PR TITLE
feat(web): normalize browse compare open analytics

### DIFF
--- a/apps/web/src/components/browse-compare-selection-banner.tsx
+++ b/apps/web/src/components/browse-compare-selection-banner.tsx
@@ -2,7 +2,10 @@ import { Link } from "@tanstack/react-router";
 import { GitCompare } from "lucide-react";
 import type { BrowseCompareSelectionContextState } from "@/lib/resource-card-trust-decision";
 import { browseCompareSelectionDivergingLine } from "@/lib/resource-card-trust-decision";
-import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import {
+  browseCompareOpenAnalyticsData,
+  browseCompareOpenAnalyticsEvent,
+} from "@/lib/entry-detail-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
@@ -38,10 +41,13 @@ export function BrowseCompareSelectionBanner({
           to="/compare"
           search={compareSearch}
           onClick={() => {
-            trackEvent("browse_compare_open", {
-              ...browseCompareOpenAnalyticsData(state.selectedCount),
-              surface: "browse-compare-selection-banner",
-            });
+            trackEvent(
+              browseCompareOpenAnalyticsEvent(),
+              browseCompareOpenAnalyticsData(
+                state.selectedCount,
+                "browse-compare-selection-banner",
+              ),
+            );
           }}
           className="inline-flex shrink-0 items-center gap-1.5 self-start rounded-full border border-accent bg-background px-3 py-1.5 text-xs font-medium text-ink hover:bg-surface"
         >

--- a/apps/web/src/components/browse-results-trust-panel.tsx
+++ b/apps/web/src/components/browse-results-trust-panel.tsx
@@ -1,7 +1,10 @@
 import { Link } from "@tanstack/react-router";
 import { GitCompare, Shield, Lock, BadgeCheck, GitBranch, UserCheck } from "lucide-react";
 import type { BrowseResultsTrustDecisionUiState } from "@/lib/browse-results-trust-decision";
-import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import {
+  browseCompareOpenAnalyticsData,
+  browseCompareOpenAnalyticsEvent,
+} from "@/lib/entry-detail-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
@@ -61,10 +64,10 @@ export function BrowseResultsTrustPanel({
             to="/compare"
             search={compareLink.search}
             onClick={() => {
-              trackEvent("browse_compare_open", {
-                ...browseCompareOpenAnalyticsData(compareLink.selectedCount),
-                surface: "browse-trust-panel",
-              });
+              trackEvent(
+                browseCompareOpenAnalyticsEvent(),
+                browseCompareOpenAnalyticsData(compareLink.selectedCount, "browse-trust-panel"),
+              );
             }}
             className="inline-flex shrink-0 items-center gap-1.5 self-start rounded-full border border-accent bg-accent/10 px-3 py-1.5 text-xs font-medium text-ink hover:bg-accent/15"
           >

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -16,6 +16,11 @@ export const ENTRY_DETAIL_MOBILE_SURFACE = "detail-mobile";
 export const BROWSE_COMPARE_SURFACE = "browse-compare";
 export const COMPARE_TRAY_SURFACE = "compare-tray";
 
+export type BrowseCompareOpenSurface =
+  | "browse-toolbar"
+  | "browse-compare-selection-banner"
+  | "browse-trust-panel";
+
 export function entryDetailEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;
 }
@@ -78,10 +83,17 @@ export function entryDetailMobileCompareAnalyticsData(
   };
 }
 
-export function browseCompareOpenAnalyticsData(selectedCount: number) {
+export function browseCompareOpenAnalyticsEvent(): string {
+  return "browse_compare_open";
+}
+
+export function browseCompareOpenAnalyticsData(
+  selectedCount: number,
+  surface: BrowseCompareOpenSurface,
+) {
   return {
     count: selectedCount,
-    surface: BROWSE_COMPARE_SURFACE,
+    surface,
   };
 }
 

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -9,6 +9,8 @@ export {
   ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   ENTRY_DETAIL_MOBILE_SURFACE,
   browseCompareOpenAnalyticsData,
+  browseCompareOpenAnalyticsEvent,
+  type BrowseCompareOpenSurface,
   comparisonTrayFullCompareAnalyticsData,
   comparisonTrayQuickCompareAnalyticsData,
   comparisonTrayRemoveAnalyticsData,

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -55,7 +55,10 @@ import {
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
 import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
-import { browseCompareOpenAnalyticsData } from "@/lib/entry-detail-cta-events";
+import {
+  browseCompareOpenAnalyticsData,
+  browseCompareOpenAnalyticsEvent,
+} from "@/lib/entry-detail-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
@@ -706,9 +709,13 @@ function Browse() {
                       to="/compare"
                       search={browseCompareUi.search}
                       onClick={() => {
-                        trackEvent("browse_compare_open", {
-                          ...browseCompareOpenAnalyticsData(browseCompareUi.selectedCount),
-                        });
+                        trackEvent(
+                          browseCompareOpenAnalyticsEvent(),
+                          browseCompareOpenAnalyticsData(
+                            browseCompareUi.selectedCount,
+                            "browse-toolbar",
+                          ),
+                        );
                       }}
                       className="inline-flex items-center gap-1.5 rounded-full border border-accent bg-accent/10 px-2.5 py-1 text-[11px] font-medium text-ink hover:bg-accent/15"
                     >

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   browseCompareOpenAnalyticsData,
+  browseCompareOpenAnalyticsEvent,
   comparisonTrayClearAnalyticsData,
   comparisonTrayClearAnalyticsEvent,
   comparisonTrayFullCompareAnalyticsData,
@@ -72,9 +73,20 @@ describe("entry detail cta events lib", () => {
   });
 
   it("builds browse and compare tray analytics data without entry payloads", () => {
-    expect(browseCompareOpenAnalyticsData(3)).toEqual({
+    expect(browseCompareOpenAnalyticsEvent()).toBe("browse_compare_open");
+    expect(browseCompareOpenAnalyticsData(3, "browse-toolbar")).toEqual({
       count: 3,
-      surface: "browse-compare",
+      surface: "browse-toolbar",
+    });
+    expect(
+      browseCompareOpenAnalyticsData(2, "browse-compare-selection-banner"),
+    ).toEqual({
+      count: 2,
+      surface: "browse-compare-selection-banner",
+    });
+    expect(browseCompareOpenAnalyticsData(4, "browse-trust-panel")).toEqual({
+      count: 4,
+      surface: "browse-trust-panel",
     });
     expect(comparisonTrayQuickCompareAnalyticsData(2)).toEqual({
       count: 2,


### PR DESCRIPTION
## Summary
- Add `browseCompareOpenAnalyticsEvent` with typed browse surfaces.
- Wire toolbar, selection banner, and trust panel compare CTAs through shared helpers.

Closes #556

## Test plan
- [x] pnpm test tests/entry-detail-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)