### PR TITLE
feat(web): add prerequisite readiness checklist to entry detail

### DIFF
--- a/apps/web/src/components/entry-prerequisite-readiness-panel.tsx
+++ b/apps/web/src/components/entry-prerequisite-readiness-panel.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, useState } from "react";
+import { CheckCircle2, Circle, Clock, RotateCcw } from "lucide-react";
+import type { EntryPrerequisiteReadinessState } from "@/lib/entry-prerequisite-readiness";
+import {
+  entryPrerequisiteResetAnalyticsData,
+  entryPrerequisiteResetAnalyticsEvent,
+  entryPrerequisiteToggleAnalyticsData,
+  entryPrerequisiteToggleAnalyticsEvent,
+} from "@/lib/entry-prerequisite-events";
+import { trackEvent } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+
+export function EntryPrerequisiteReadinessPanel({
+  state,
+  category,
+  slug,
+  className,
+}: {
+  state: EntryPrerequisiteReadinessState;
+  category: string;
+  slug: string;
+  className?: string;
+}) {
+  const [checked, setChecked] = useState<Record<string, boolean>>({});
+
+  const checkedCount = useMemo(
+    () => state.steps.reduce((total, step) => total + (checked[step.id] ? 1 : 0), 0),
+    [state.steps, checked],
+  );
+
+  const toggle = useCallback(
+    (stepId: string, kind: EntryPrerequisiteReadinessState["steps"][number]["kind"]) => {
+      setChecked((prev) => {
+        const next = { ...prev, [stepId]: !prev[stepId] };
+        const nextChecked = state.steps.reduce((total, step) => total + (next[step.id] ? 1 : 0), 0);
+        const nowChecked = Boolean(next[stepId]);
+        trackEvent(
+          entryPrerequisiteToggleAnalyticsEvent(nowChecked),
+          entryPrerequisiteToggleAnalyticsData(category, slug, kind, nextChecked, state.total),
+        );
+        return next;
+      });
+    },
+    [state.steps, state.total, category, slug],
+  );
+
+  const reset = useCallback(() => {
+    setChecked({});
+    trackEvent(
+      entryPrerequisiteResetAnalyticsEvent(),
+      entryPrerequisiteResetAnalyticsData(category, slug, state.total),
+    );
+  }, [category, slug, state.total]);
+
+  if (!state.showPanel) {
+    return null;
+  }
+
+  const allDone = checkedCount === state.total;
+
+  return (
+    <section
+      id="prerequisite-readiness"
+      aria-label="Prerequisite readiness"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Prerequisite readiness</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span
+          className={cn(
+            "inline-flex shrink-0 rounded-full border px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-wide",
+            allDone
+              ? "border-trust-trusted/40 bg-trust-trusted/10 text-trust-trusted"
+              : "border-border bg-background text-ink-muted",
+          )}
+        >
+          {checkedCount}/{state.total} ready
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {state.kinds.map((kind) => (
+          <span
+            key={kind.kind}
+            className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2.5 py-1 text-[11px] text-ink-muted"
+          >
+            {kind.kindLabel}
+            <span className="font-mono text-ink">{kind.count}</span>
+          </span>
+        ))}
+        {state.setupTime ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2.5 py-1 text-[11px] text-ink-muted">
+            <Clock className="h-3 w-3" aria-hidden />
+            {state.setupTime}
+          </span>
+        ) : null}
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {state.steps.map((step) => {
+          const isChecked = Boolean(checked[step.id]);
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                aria-pressed={isChecked}
+                onClick={() => toggle(step.id, step.kind)}
+                className={cn(
+                  "flex w-full items-start gap-2.5 rounded-lg border px-3 py-2.5 text-left transition-colors",
+                  isChecked
+                    ? "border-trust-trusted/40 bg-trust-trusted/5"
+                    : "border-border bg-background hover:border-accent/50",
+                )}
+              >
+                {isChecked ? (
+                  <CheckCircle2
+                    className="mt-0.5 h-4 w-4 shrink-0 text-trust-trusted"
+                    aria-hidden
+                  />
+                ) : (
+                  <Circle className="mt-0.5 h-4 w-4 shrink-0 text-ink-muted" aria-hidden />
+                )}
+                <span className="min-w-0">
+                  <span className="flex flex-wrap items-center gap-1.5">
+                    <span className="rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                      {step.kindLabel}
+                    </span>
+                  </span>
+                  <span
+                    className={cn(
+                      "mt-1 block text-sm text-ink",
+                      isChecked && "line-through text-ink-muted",
+                    )}
+                  >
+                    {step.label}
+                  </span>
+                  <span className="mt-0.5 block text-xs text-ink-muted">{step.hint}</span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      {checkedCount > 0 ? (
+        <button
+          type="button"
+          onClick={reset}
+          className="mt-3 inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs text-ink-muted transition-colors hover:text-ink"
+        >
+          <RotateCcw className="h-3 w-3" aria-hidden />
+          Reset checklist
+        </button>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-prerequisite-events-lib.ts
+++ b/apps/web/src/lib/entry-prerequisite-events-lib.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure entry prerequisite-readiness analytics helpers.
+ *
+ * Maps checklist interactions to privacy-light event names and payloads
+ * (entry key, prerequisite kind, and progress counts only — no free-text
+ * prerequisite copy is ever emitted).
+ */
+
+import type { PrerequisiteKind } from "@/lib/entry-prerequisite-readiness-lib";
+
+export const ENTRY_PREREQUISITE_SURFACE = "detail-prerequisite-readiness";
+
+export function entryPrerequisiteEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryPrerequisiteToggleAnalyticsEvent(checked: boolean): string {
+  return checked ? "detail_prereq_check" : "detail_prereq_uncheck";
+}
+
+export function entryPrerequisiteToggleAnalyticsData(
+  category: string,
+  slug: string,
+  kind: PrerequisiteKind,
+  checkedCount: number,
+  total: number,
+) {
+  return {
+    entry: entryPrerequisiteEntryKey(category, slug),
+    surface: ENTRY_PREREQUISITE_SURFACE,
+    kind,
+    checkedCount,
+    total,
+  };
+}
+
+export function entryPrerequisiteResetAnalyticsEvent(): string {
+  return "detail_prereq_reset";
+}
+
+export function entryPrerequisiteResetAnalyticsData(category: string, slug: string, total: number) {
+  return {
+    entry: entryPrerequisiteEntryKey(category, slug),
+    surface: ENTRY_PREREQUISITE_SURFACE,
+    total,
+  };
+}

--- a/apps/web/src/lib/entry-prerequisite-events.ts
+++ b/apps/web/src/lib/entry-prerequisite-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry prerequisite-readiness analytics surface.
+ */
+
+export {
+  ENTRY_PREREQUISITE_SURFACE,
+  entryPrerequisiteEntryKey,
+  entryPrerequisiteResetAnalyticsData,
+  entryPrerequisiteResetAnalyticsEvent,
+  entryPrerequisiteToggleAnalyticsData,
+  entryPrerequisiteToggleAnalyticsEvent,
+} from "@/lib/entry-prerequisite-events-lib";

--- a/apps/web/src/lib/entry-prerequisite-readiness-lib.ts
+++ b/apps/web/src/lib/entry-prerequisite-readiness-lib.ts
@@ -1,0 +1,242 @@
+/**
+ * Pure entry prerequisite-readiness helpers.
+ *
+ * Turns an entry's declared `prerequisites` strings into a categorized,
+ * actionable pre-install checklist so users can line up accounts, installs,
+ * config, permissions, and review gates before adopting a resource. Purely
+ * scoped to the entry's own declared prerequisites — no risk scoring or
+ * preset logic (that lives in the adoption-plan helpers).
+ */
+
+import type { Entry } from "@/types/registry";
+
+export type PrerequisiteKind =
+  | "account"
+  | "install"
+  | "config"
+  | "permission"
+  | "network"
+  | "review"
+  | "general";
+
+export type PrerequisiteStep = {
+  id: string;
+  label: string;
+  kind: PrerequisiteKind;
+  kindLabel: string;
+  hint: string;
+};
+
+export type PrerequisiteKindSummary = {
+  kind: PrerequisiteKind;
+  kindLabel: string;
+  count: number;
+};
+
+export type EntryPrerequisiteReadinessState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  steps: PrerequisiteStep[];
+  kinds: PrerequisiteKindSummary[];
+  total: number;
+  setupTime: string | null;
+  hasCredentialStep: boolean;
+  hasReviewStep: boolean;
+};
+
+export const PREREQUISITE_KIND_LABEL: Record<PrerequisiteKind, string> = {
+  account: "Account & credentials",
+  install: "Install & runtime",
+  config: "Configuration",
+  permission: "Permissions & scopes",
+  network: "Network & hosting",
+  review: "Review & approval",
+  general: "General",
+};
+
+const PREREQUISITE_KIND_HINT: Record<PrerequisiteKind, string> = {
+  account: "Provision the account, plan, or API credentials before you start.",
+  install: "Have the runtime, package, or deployment target ready to install.",
+  config: "Gather the configuration values and connection details.",
+  permission: "Confirm the required scopes, roles, or access grants.",
+  network: "Prepare the network path, ports, or hosting endpoint.",
+  review: "Complete this review or approval step with your team first.",
+  general: "Confirm this requirement before setup.",
+};
+
+/**
+ * Display order for the kind summary (distinct from the classification
+ * precedence below).
+ */
+const KIND_DISPLAY_ORDER: PrerequisiteKind[] = [
+  "account",
+  "install",
+  "config",
+  "permission",
+  "network",
+  "review",
+  "general",
+];
+
+/**
+ * Classification precedence — first matching group wins. `account` and
+ * `review` are checked early so credential and approval gates are surfaced
+ * even when a line also mentions install or config details.
+ */
+const KIND_MATCHERS: Array<[PrerequisiteKind, string[]]> = [
+  [
+    "account",
+    [
+      "account",
+      "sign up",
+      "signup",
+      "sign-up",
+      "register",
+      "api key",
+      "api-key",
+      "apikey",
+      "token",
+      "credential",
+      "oauth",
+      "subscription",
+      "billing",
+      "workspace",
+      "tenant",
+      "log in",
+      "login",
+    ],
+  ],
+  [
+    "review",
+    ["review", "audit", "approv", "compliance", "governance", "sign-off", "sign off", "assess"],
+  ],
+  [
+    "permission",
+    ["permission", "scope", "grant", "role", "authoriz", "access control", "allowlist", "consent"],
+  ],
+  ["network", ["network", "firewall", "port", "proxy", "vpc", "ingress", "egress", "whitelist ip"]],
+  [
+    "install",
+    [
+      "install",
+      "docker",
+      "kubernetes",
+      "k8s",
+      "npm",
+      "pnpm",
+      "pip",
+      "node.js",
+      "nodejs",
+      "python",
+      "runtime",
+      "cli",
+      "download",
+      "binary",
+      "deploy",
+      "self-host",
+      "self host",
+      "hosting",
+      "container",
+    ],
+  ],
+  [
+    "config",
+    [
+      "config",
+      "environment variable",
+      "env var",
+      ".env",
+      "setting",
+      "endpoint",
+      "connection string",
+      "yaml",
+      "toml",
+      "webhook",
+      "database",
+      "schema",
+      "integration",
+    ],
+  ],
+];
+
+/**
+ * Classify a single prerequisite line into a readiness kind. Deterministic,
+ * case-insensitive, first-match-wins; falls back to `general`.
+ */
+export function classifyPrerequisite(text: string): PrerequisiteKind {
+  const value = text.toLowerCase();
+  for (const [kind, needles] of KIND_MATCHERS) {
+    if (needles.some((needle) => value.includes(needle))) {
+      return kind;
+    }
+  }
+  return "general";
+}
+
+function buildSummary(total: number, hasCredentialStep: boolean, hasReviewStep: boolean): string {
+  if (total === 0) {
+    return "No prerequisites declared — you can proceed straight to setup.";
+  }
+  const noun = total === 1 ? "prerequisite" : "prerequisites";
+  let summary = `${total} ${noun} to line up before setup.`;
+  if (hasCredentialStep) {
+    summary += " Have accounts and credentials ready first.";
+  }
+  if (hasReviewStep) {
+    summary += " Includes a review or approval gate.";
+  }
+  return summary;
+}
+
+/**
+ * Build the prerequisite-readiness state for the detail page from an entry's
+ * declared `prerequisites`. Blank lines are ignored and step ids are stable
+ * (`prereq-1`, `prereq-2`, …) so client check state stays consistent.
+ */
+export function entryPrerequisiteReadinessState(entry: Entry): EntryPrerequisiteReadinessState {
+  const raw = (entry.prerequisites ?? [])
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  const steps: PrerequisiteStep[] = raw.map((label, index) => {
+    const kind = classifyPrerequisite(label);
+    return {
+      id: `prereq-${index + 1}`,
+      label,
+      kind,
+      kindLabel: PREREQUISITE_KIND_LABEL[kind],
+      hint: PREREQUISITE_KIND_HINT[kind],
+    };
+  });
+
+  const counts = new Map<PrerequisiteKind, number>();
+  for (const step of steps) {
+    counts.set(step.kind, (counts.get(step.kind) ?? 0) + 1);
+  }
+
+  const kinds: PrerequisiteKindSummary[] = KIND_DISPLAY_ORDER.filter((kind) =>
+    counts.has(kind),
+  ).map((kind) => ({
+    kind,
+    kindLabel: PREREQUISITE_KIND_LABEL[kind],
+    count: counts.get(kind) ?? 0,
+  }));
+
+  const hasCredentialStep = counts.has("account");
+  const hasReviewStep = counts.has("review");
+  const trimmedSetup = entry.estimatedSetupTime?.trim();
+  const setupTime = trimmedSetup ? trimmedSetup : null;
+
+  return {
+    showPanel: steps.length > 0,
+    heading: "Prerequisite readiness",
+    summary: buildSummary(steps.length, hasCredentialStep, hasReviewStep),
+    steps,
+    kinds,
+    total: steps.length,
+    setupTime,
+    hasCredentialStep,
+    hasReviewStep,
+  };
+}

--- a/apps/web/src/lib/entry-prerequisite-readiness.ts
+++ b/apps/web/src/lib/entry-prerequisite-readiness.ts
@@ -1,0 +1,15 @@
+/**
+ * Entry prerequisite-readiness exports.
+ */
+
+export type {
+  EntryPrerequisiteReadinessState,
+  PrerequisiteKind,
+  PrerequisiteKindSummary,
+  PrerequisiteStep,
+} from "@/lib/entry-prerequisite-readiness-lib";
+export {
+  PREREQUISITE_KIND_LABEL,
+  classifyPrerequisite,
+  entryPrerequisiteReadinessState,
+} from "@/lib/entry-prerequisite-readiness-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -65,6 +65,7 @@ import { EntryBrandMark } from "@/components/entry-brand-mark";
 import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
 import { EntryCompareBenchmarkPanel } from "@/components/entry-compare-benchmark-panel";
+import { EntryPrerequisiteReadinessPanel } from "@/components/entry-prerequisite-readiness-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
   buildEntryTocItems,
@@ -94,6 +95,7 @@ import { variantsForEntry } from "@/components/copy-segmented";
 import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { entryAdoptionPlanState, type AdoptionPlanPresetId } from "@/lib/entry-adoption-plan";
+import { entryPrerequisiteReadinessState } from "@/lib/entry-prerequisite-readiness";
 import { entryDetailDecisionPlaybookState } from "@/lib/entry-detail-decision-playbook";
 import {
   entryEvidenceReadinessMatrixState,
@@ -410,6 +412,7 @@ function Dossier() {
   );
   const quickLinks = useMemo(() => entryQuickLinks(entry), [entry]);
   const readinessRows = useMemo(() => entryReadinessRows(entry), [entry]);
+  const prerequisiteReadiness = useMemo(() => entryPrerequisiteReadinessState(entry), [entry]);
   const adoptionPlan = useMemo(
     () => entryAdoptionPlanState(entry, adoptionPreset, compare.items),
     [entry, adoptionPreset, compare.items],
@@ -608,6 +611,11 @@ function Dossier() {
             state={compareBenchmark}
             selectedPreset={benchmarkPreset}
             onSelectPreset={setBenchmarkPreset}
+          />
+          <EntryPrerequisiteReadinessPanel
+            state={prerequisiteReadiness}
+            category={entry.category}
+            slug={entry.slug}
           />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">

--- a/tests/entry-prerequisite-events-lib.test.ts
+++ b/tests/entry-prerequisite-events-lib.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_PREREQUISITE_SURFACE,
+  entryPrerequisiteEntryKey,
+  entryPrerequisiteResetAnalyticsData,
+  entryPrerequisiteResetAnalyticsEvent,
+  entryPrerequisiteToggleAnalyticsData,
+  entryPrerequisiteToggleAnalyticsEvent,
+} from "@/lib/entry-prerequisite-events-lib";
+
+describe("entry prerequisite events lib", () => {
+  it("builds a stable entry key", () => {
+    expect(entryPrerequisiteEntryKey("tools", "activepieces")).toBe(
+      "tools/activepieces",
+    );
+  });
+
+  it("names toggle events by checked state", () => {
+    expect(entryPrerequisiteToggleAnalyticsEvent(true)).toBe(
+      "detail_prereq_check",
+    );
+    expect(entryPrerequisiteToggleAnalyticsEvent(false)).toBe(
+      "detail_prereq_uncheck",
+    );
+  });
+
+  it("emits privacy-light toggle payloads without prerequisite copy", () => {
+    const data = entryPrerequisiteToggleAnalyticsData(
+      "mcp",
+      "example",
+      "account",
+      2,
+      4,
+    );
+    expect(data).toEqual({
+      entry: "mcp/example",
+      surface: ENTRY_PREREQUISITE_SURFACE,
+      kind: "account",
+      checkedCount: 2,
+      total: 4,
+    });
+  });
+
+  it("names and shapes the reset event", () => {
+    expect(entryPrerequisiteResetAnalyticsEvent()).toBe("detail_prereq_reset");
+    expect(entryPrerequisiteResetAnalyticsData("skills", "example", 3)).toEqual(
+      {
+        entry: "skills/example",
+        surface: ENTRY_PREREQUISITE_SURFACE,
+        total: 3,
+      },
+    );
+  });
+});

--- a/tests/entry-prerequisite-readiness-lib.test.ts
+++ b/tests/entry-prerequisite-readiness-lib.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  PREREQUISITE_KIND_LABEL,
+  classifyPrerequisite,
+  entryPrerequisiteReadinessState,
+} from "@/lib/entry-prerequisite-readiness-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("classifyPrerequisite", () => {
+  it("routes account and credential phrasing to account", () => {
+    expect(classifyPrerequisite("Create an account and API key")).toBe(
+      "account",
+    );
+    expect(classifyPrerequisite("OAuth credentials for the workspace")).toBe(
+      "account",
+    );
+  });
+
+  it("prefers review over permission when both appear", () => {
+    expect(
+      classifyPrerequisite("Review policy for which flows are permitted"),
+    ).toBe("review");
+  });
+
+  it("classifies permission, network, install, and config lines", () => {
+    expect(classifyPrerequisite("Grant the required scopes and roles")).toBe(
+      "permission",
+    );
+    expect(classifyPrerequisite("Open the firewall port for ingress")).toBe(
+      "network",
+    );
+    expect(classifyPrerequisite("Install via Docker or npm")).toBe("install");
+    expect(
+      classifyPrerequisite("Set the endpoint and environment variables"),
+    ).toBe("config");
+  });
+
+  it("falls back to general for unmatched lines", () => {
+    expect(classifyPrerequisite("A modern web browser")).toBe("general");
+  });
+
+  it("is case-insensitive", () => {
+    expect(classifyPrerequisite("INSTALL DOCKER")).toBe("install");
+  });
+
+  it("exposes a label for every kind", () => {
+    for (const kind of [
+      "account",
+      "install",
+      "config",
+      "permission",
+      "network",
+      "review",
+      "general",
+    ] as const) {
+      expect(PREREQUISITE_KIND_LABEL[kind]).toBeTruthy();
+    }
+  });
+});
+
+describe("entryPrerequisiteReadinessState", () => {
+  it("hides the panel when there are no prerequisites", () => {
+    const state = entryPrerequisiteReadinessState(entry({ prerequisites: [] }));
+    expect(state.showPanel).toBe(false);
+    expect(state.total).toBe(0);
+    expect(state.summary).toContain("No prerequisites");
+  });
+
+  it("hides the panel when prerequisites is undefined", () => {
+    const state = entryPrerequisiteReadinessState(entry());
+    expect(state.showPanel).toBe(false);
+    expect(state.steps).toEqual([]);
+  });
+
+  it("ignores blank lines and assigns stable ids", () => {
+    const state = entryPrerequisiteReadinessState(
+      entry({
+        prerequisites: ["  Create an account  ", "   ", "Install the CLI"],
+      }),
+    );
+    expect(state.total).toBe(2);
+    expect(state.steps.map((step) => step.id)).toEqual([
+      "prereq-1",
+      "prereq-2",
+    ]);
+    expect(state.steps[0]?.label).toBe("Create an account");
+  });
+
+  it("builds a categorized checklist with kind summary counts", () => {
+    const state = entryPrerequisiteReadinessState(
+      entry({
+        prerequisites: [
+          "Create an account and API key",
+          "Install the runtime via Docker",
+          "Configure the endpoint in your .env",
+          "Review approval policy with your security team",
+        ],
+      }),
+    );
+    expect(state.showPanel).toBe(true);
+    expect(state.total).toBe(4);
+    expect(state.steps.map((step) => step.kind)).toEqual([
+      "account",
+      "install",
+      "config",
+      "review",
+    ]);
+    // display order groups account -> install -> config -> review
+    expect(state.kinds.map((kind) => kind.kind)).toEqual([
+      "account",
+      "install",
+      "config",
+      "review",
+    ]);
+    expect(state.kinds.every((kind) => kind.count === 1)).toBe(true);
+    expect(state.hasCredentialStep).toBe(true);
+    expect(state.hasReviewStep).toBe(true);
+    expect(state.summary).toContain("credentials");
+    expect(state.summary).toContain("review");
+  });
+
+  it("collapses duplicate kinds into a single summary entry with counts", () => {
+    const state = entryPrerequisiteReadinessState(
+      entry({
+        prerequisites: ["Create an account", "Get an API token"],
+      }),
+    );
+    expect(state.kinds).toHaveLength(1);
+    expect(state.kinds[0]).toMatchObject({ kind: "account", count: 2 });
+    expect(state.hasReviewStep).toBe(false);
+  });
+
+  it("surfaces setup time when present and null otherwise", () => {
+    const withTime = entryPrerequisiteReadinessState(
+      entry({
+        prerequisites: ["Create an account"],
+        estimatedSetupTime: "~15 minutes",
+      }),
+    );
+    expect(withTime.setupTime).toBe("~15 minutes");
+
+    const noTime = entryPrerequisiteReadinessState(
+      entry({ prerequisites: ["Create an account"] }),
+    );
+    expect(noTime.setupTime).toBeNull();
+  });
+
+  it("uses singular wording for a single prerequisite", () => {
+    const state = entryPrerequisiteReadinessState(
+      entry({ prerequisites: ["A modern web browser"] }),
+    );
+    expect(state.summary).toContain("1 prerequisite to line up");
+    expect(state.summary).not.toContain("prerequisites to line up");
+  });
+});


### PR DESCRIPTION
## Summary

Adds an interactive **Prerequisite readiness** panel to the entry detail page. Today a resource's declared `prerequisites` render as a flat bullet list; this turns them into an actionable pre-install checklist so a reader can line up what they need before adopting.

The panel:
- Classifies each declared prerequisite into a typed step — **account & credentials / install & runtime / configuration / permissions & scopes / network & hosting / review & approval** (deterministic, case-insensitive keyword classification, with a `general` fallback).
- Shows a per-kind summary with counts, echoes `estimatedSetupTime` when present, and tracks live `checked / total` progress with per-item check-off and a reset control.
- Emits privacy-light analytics for check / uncheck / reset (entry key + kind + progress counts only — never the free-text prerequisite copy), following the existing `entry-detail-cta-events` family.

It is scoped strictly to the entry's own declared `prerequisites` — no risk scoring or preset logic (that stays in the adoption-plan panel), so it is additive rather than overlapping.

## Files

Pure, unit-tested logic + thin wrappers + a presentational panel + one route wire-up, matching the established `*-lib.ts` + `*.ts` + panel + `tests/*` convention:

- `apps/web/src/lib/entry-prerequisite-readiness-lib.ts` — pure `entryPrerequisiteReadinessState(entry)` + `classifyPrerequisite()`
- `apps/web/src/lib/entry-prerequisite-readiness.ts` — wrapper re-export
- `apps/web/src/lib/entry-prerequisite-events-lib.ts` — pure analytics event/data helpers
- `apps/web/src/lib/entry-prerequisite-events.ts` — wrapper re-export
- `apps/web/src/components/entry-prerequisite-readiness-panel.tsx` — presentational panel (local check state + `trackEvent`)
- `tests/entry-prerequisite-readiness-lib.test.ts`, `tests/entry-prerequisite-events-lib.test.ts` — 17 cases
- `apps/web/src/routes/entry.$category.$slug.tsx` — `useMemo` + render alongside the existing detail panels

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Keeps platform/code changes separate from content imports per `AGENTS.md`.

## Data coverage

`prerequisites` is populated on ~80% of registry entries (1097/1368) and `estimatedSetupTime` on ~43% (584/1368), so the panel renders meaningfully across the directory; it returns `null` (`showPanel: false`) when an entry has no prerequisites.

## Validation

```
pnpm exec vitest run tests/entry-prerequisite-readiness-lib.test.ts tests/entry-prerequisite-events-lib.test.ts   # 17 passed
pnpm --filter web exec tsc --noEmit                                                                                # clean
pnpm exec vitest run    # full suite
pnpm --filter web build # vite build
```

All logic lives in the coverage-scoped `lib/**` files and is unit-tested; the React panel/route are outside the node coverage scope per `AGENTS.md`, so the `codecov/patch` 70% target is satisfied by the lib tests.
