### PR TITLE
feat(web): add freshness distribution panel to browse

### DIFF
--- a/apps/web/src/components/browse-freshness-distribution-panel.tsx
+++ b/apps/web/src/components/browse-freshness-distribution-panel.tsx
@@ -1,0 +1,73 @@
+import { toneClass } from "@/lib/browse-rollout-tone-lib";
+import type { BrowseFreshnessDistributionState } from "@/lib/browse-freshness-distribution";
+import { cn } from "@/lib/utils";
+
+export function BrowseFreshnessDistributionPanel({
+  state,
+  className,
+}: {
+  state: BrowseFreshnessDistributionState;
+  className?: string;
+}) {
+  if (!state.showPanel) return null;
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="eyebrow">Freshness distribution</p>
+          <h3 className="mt-1 text-sm font-semibold text-ink">{state.heading}</h3>
+          <p className="mt-1 text-xs text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] text-ink-subtle">
+          median {state.medianAgeDays}d
+        </span>
+      </div>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        {state.buckets.map((bucket) => (
+          <article key={bucket.id} className="rounded-md border border-border bg-background p-2.5">
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <p className="text-xs font-medium text-ink">{bucket.label}</p>
+                <p className="mt-0.5 text-[11px] text-ink-muted">{bucket.rangeLabel}</p>
+              </div>
+              <span
+                className={cn(
+                  "inline-flex rounded-full border px-1.5 py-0.5 text-[10px] uppercase tracking-wide",
+                  toneClass(bucket.tone),
+                )}
+              >
+                {bucket.percent}%
+              </span>
+            </div>
+            <p className="mt-1.5 font-mono text-[11px] text-ink">
+              {bucket.count} {bucket.count === 1 ? "entry" : "entries"}
+            </p>
+          </article>
+        ))}
+      </div>
+
+      {state.staleEntries.length > 0 ? (
+        <div className="mt-3 rounded-md border border-border bg-background p-2.5">
+          <p className="text-[11px] font-medium text-ink">Oldest entries in this view</p>
+          <ul className="mt-1.5 space-y-1.5">
+            {state.staleEntries.map((entry) => (
+              <li
+                key={entry.entryRef}
+                className="flex items-start justify-between gap-2 text-[11px]"
+              >
+                <div className="min-w-0">
+                  <p className="truncate text-ink">{entry.title}</p>
+                  <p className="truncate text-ink-subtle">
+                    {entry.verified ? "Verified previously" : "Not yet verified"}
+                  </p>
+                </div>
+                <span className="shrink-0 font-mono text-ink-muted">{entry.ageDays}d</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-freshness-distribution-lib.ts
+++ b/apps/web/src/lib/browse-freshness-distribution-lib.ts
@@ -1,0 +1,192 @@
+/**
+ * Pure browse freshness-distribution helpers.
+ *
+ * Summarizes how recently the current browse result set was added so users can
+ * gauge staleness at a glance: entries are bucketed by age (from `dateAdded`)
+ * into fresh / recent / aging / stale, with per-bucket share, a median age, and
+ * the oldest entries flagged for re-verification. Time is injected (`nowIso`) so
+ * the function stays fully deterministic and unit-testable.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export type FreshnessBucketId = "fresh" | "recent" | "aging" | "stale";
+
+export type FreshnessTone = "good" | "watch" | "risk";
+
+export type FreshnessBucket = {
+  id: FreshnessBucketId;
+  label: string;
+  rangeLabel: string;
+  count: number;
+  percent: number;
+  tone: FreshnessTone;
+};
+
+export type FreshnessStaleFlag = {
+  entryRef: string;
+  title: string;
+  ageDays: number;
+  verified: boolean;
+};
+
+export type BrowseFreshnessDistributionState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  freshCount: number;
+  staleCount: number;
+  medianAgeDays: number;
+  buckets: FreshnessBucket[];
+  staleEntries: FreshnessStaleFlag[];
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const BUCKET_META: Record<
+  FreshnessBucketId,
+  { label: string; rangeLabel: string; tone: FreshnessTone }
+> = {
+  fresh: { label: "Fresh", rangeLabel: "≤ 30 days", tone: "good" },
+  recent: { label: "Recent", rangeLabel: "31–90 days", tone: "good" },
+  aging: { label: "Aging", rangeLabel: "91–180 days", tone: "watch" },
+  stale: { label: "Stale", rangeLabel: "> 180 days", tone: "risk" },
+};
+
+const BUCKET_ORDER: FreshnessBucketId[] = ["fresh", "recent", "aging", "stale"];
+
+/** Whole days between `dateAdded` and `nowIso`; 0 for future or unparseable dates. */
+export function entryAgeDays(dateAdded: string, nowIso: string): number {
+  const added = Date.parse(dateAdded);
+  const now = Date.parse(nowIso);
+  if (Number.isNaN(added) || Number.isNaN(now)) {
+    return 0;
+  }
+  const diff = Math.floor((now - added) / DAY_MS);
+  return diff < 0 ? 0 : diff;
+}
+
+/** Map an age in days to a freshness bucket. */
+export function freshnessBucketId(ageDays: number): FreshnessBucketId {
+  if (ageDays <= 30) return "fresh";
+  if (ageDays <= 90) return "recent";
+  if (ageDays <= 180) return "aging";
+  return "stale";
+}
+
+function medianOf(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  }
+  return sorted[mid]!;
+}
+
+function entryRef(entry: Entry): string {
+  return `${entry.category}/${entry.slug}`;
+}
+
+function summarize(
+  scannedCount: number,
+  freshCount: number,
+  staleAgingCount: number,
+  medianAgeDays: number,
+): { heading: string; summary: string } {
+  if (scannedCount === 0) {
+    return {
+      heading: "Add filters to inspect freshness",
+      summary: "Freshness distribution appears once browse results are available.",
+    };
+  }
+  const staleShare = Math.round((staleAgingCount / scannedCount) * 100);
+  if (staleAgingCount === 0) {
+    return {
+      heading: "Current results are broadly fresh",
+      summary: `Median age ${medianAgeDays} days; all ${scannedCount} scanned entries are within 90 days.`,
+    };
+  }
+  if (staleShare >= 40) {
+    return {
+      heading: `${staleShare}% of this view is aging or stale`,
+      summary: `Median age ${medianAgeDays} days; ${freshCount} fresh of ${scannedCount} scanned. Re-verify the oldest entries.`,
+    };
+  }
+  return {
+    heading: "Mostly fresh with a few aging entries",
+    summary: `Median age ${medianAgeDays} days; ${freshCount} fresh, ${staleAgingCount} aging or stale of ${scannedCount} scanned.`,
+  };
+}
+
+/**
+ * Build the freshness-distribution state for the current browse results.
+ * `nowIso` is the reference "now" (ISO string); `scannedCount` caps how many of
+ * the top results are summarized.
+ */
+export function browseFreshnessDistributionState(
+  entries: Entry[],
+  nowIso: string,
+  scannedCount = 12,
+): BrowseFreshnessDistributionState {
+  const scoped = entries.slice(0, scannedCount).map((entry) => {
+    const ageDays = entryAgeDays(entry.dateAdded, nowIso);
+    return { entry, ageDays, bucket: freshnessBucketId(ageDays) };
+  });
+
+  const counts: Record<FreshnessBucketId, number> = {
+    fresh: 0,
+    recent: 0,
+    aging: 0,
+    stale: 0,
+  };
+  for (const item of scoped) {
+    counts[item.bucket] += 1;
+  }
+
+  const buckets: FreshnessBucket[] = BUCKET_ORDER.map((id) => {
+    const count = counts[id];
+    const percent = scoped.length === 0 ? 0 : Math.round((count / scoped.length) * 100);
+    return {
+      id,
+      label: BUCKET_META[id].label,
+      rangeLabel: BUCKET_META[id].rangeLabel,
+      count,
+      percent,
+      tone: BUCKET_META[id].tone,
+    };
+  });
+
+  const freshCount = counts.fresh + counts.recent;
+  const staleCount = counts.stale;
+  const staleAgingCount = counts.aging + counts.stale;
+  const medianAgeDays = medianOf(scoped.map((item) => item.ageDays));
+
+  const staleEntries: FreshnessStaleFlag[] = scoped
+    .filter((item) => item.bucket === "aging" || item.bucket === "stale")
+    .sort((a, b) => b.ageDays - a.ageDays)
+    .slice(0, 5)
+    .map((item) => ({
+      entryRef: entryRef(item.entry),
+      title: item.entry.title,
+      ageDays: item.ageDays,
+      verified: Boolean(item.entry.verifiedAt),
+    }));
+
+  const summary = summarize(scoped.length, freshCount, staleAgingCount, medianAgeDays);
+
+  return {
+    showPanel: scoped.length >= 2,
+    heading: summary.heading,
+    summary: summary.summary,
+    scannedCount: scoped.length,
+    freshCount,
+    staleCount,
+    medianAgeDays,
+    buckets,
+    staleEntries,
+  };
+}

--- a/apps/web/src/lib/browse-freshness-distribution.ts
+++ b/apps/web/src/lib/browse-freshness-distribution.ts
@@ -1,0 +1,16 @@
+/**
+ * Browse freshness-distribution exports.
+ */
+
+export type {
+  BrowseFreshnessDistributionState,
+  FreshnessBucket,
+  FreshnessBucketId,
+  FreshnessStaleFlag,
+  FreshnessTone,
+} from "@/lib/browse-freshness-distribution-lib";
+export {
+  browseFreshnessDistributionState,
+  entryAgeDays,
+  freshnessBucketId,
+} from "@/lib/browse-freshness-distribution-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -35,6 +35,8 @@ import {
   type BrowseConfidencePresetId,
 } from "@/lib/browse-decision-confidence";
 import { BrowseDecisionConfidencePanel } from "@/components/browse-decision-confidence-panel";
+import { browseFreshnessDistributionState } from "@/lib/browse-freshness-distribution";
+import { BrowseFreshnessDistributionPanel } from "@/components/browse-freshness-distribution-panel";
 import {
   CATEGORIES,
   type Category,
@@ -360,6 +362,11 @@ function Browse() {
   const browseDecisionConfidence = useMemo(
     () => browseDecisionConfidenceState(results, confidencePreset, 8),
     [results, confidencePreset],
+  );
+  const nowIso = useMemo(() => new Date().toISOString(), []);
+  const browseFreshness = useMemo(
+    () => browseFreshnessDistributionState(results, nowIso, 12),
+    [results, nowIso],
   );
 
   const activeCount =
@@ -851,6 +858,7 @@ function Browse() {
             onSelectPreset={setConfidencePreset}
             className="mt-3"
           />
+          <BrowseFreshnessDistributionPanel state={browseFreshness} className="mt-3" />
 
           {sp.category &&
             (() => {

--- a/tests/browse-freshness-distribution-lib.test.ts
+++ b/tests/browse-freshness-distribution-lib.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  browseFreshnessDistributionState,
+  entryAgeDays,
+  freshnessBucketId,
+} from "@/lib/browse-freshness-distribution-lib";
+
+const NOW = "2026-07-10T00:00:00.000Z";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "tools",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-07-01",
+    ...overrides,
+  } as Entry;
+}
+
+/** Build an entry whose dateAdded is `days` before NOW. */
+function agedEntry(
+  slug: string,
+  days: number,
+  overrides: Partial<Entry> = {},
+): Entry {
+  const added = new Date(Date.parse(NOW) - days * 24 * 60 * 60 * 1000);
+  return entry({
+    slug,
+    dateAdded: added.toISOString().slice(0, 10),
+    ...overrides,
+  });
+}
+
+describe("entryAgeDays", () => {
+  it("computes whole days between dateAdded and now", () => {
+    expect(entryAgeDays("2026-07-01T00:00:00.000Z", NOW)).toBe(9);
+  });
+
+  it("clamps future dates to zero", () => {
+    expect(entryAgeDays("2026-08-01T00:00:00.000Z", NOW)).toBe(0);
+  });
+
+  it("returns zero for unparseable dates", () => {
+    expect(entryAgeDays("not-a-date", NOW)).toBe(0);
+    expect(entryAgeDays("2026-07-01", "not-a-date")).toBe(0);
+  });
+});
+
+describe("freshnessBucketId", () => {
+  it("maps ages to buckets at the boundaries", () => {
+    expect(freshnessBucketId(0)).toBe("fresh");
+    expect(freshnessBucketId(30)).toBe("fresh");
+    expect(freshnessBucketId(31)).toBe("recent");
+    expect(freshnessBucketId(90)).toBe("recent");
+    expect(freshnessBucketId(91)).toBe("aging");
+    expect(freshnessBucketId(180)).toBe("aging");
+    expect(freshnessBucketId(181)).toBe("stale");
+  });
+});
+
+describe("browseFreshnessDistributionState", () => {
+  it("hides the panel for fewer than two entries", () => {
+    expect(browseFreshnessDistributionState([], NOW).showPanel).toBe(false);
+    expect(
+      browseFreshnessDistributionState([agedEntry("a", 5)], NOW).showPanel,
+    ).toBe(false);
+  });
+
+  it("buckets entries by age with percentages summing to 100", () => {
+    const entries = [
+      agedEntry("fresh", 10),
+      agedEntry("recent", 60),
+      agedEntry("aging", 120),
+      agedEntry("stale", 400),
+    ];
+    const state = browseFreshnessDistributionState(entries, NOW);
+    expect(state.showPanel).toBe(true);
+    expect(state.scannedCount).toBe(4);
+    const byId = Object.fromEntries(state.buckets.map((b) => [b.id, b]));
+    expect(byId.fresh?.count).toBe(1);
+    expect(byId.recent?.count).toBe(1);
+    expect(byId.aging?.count).toBe(1);
+    expect(byId.stale?.count).toBe(1);
+    expect(state.buckets.reduce((sum, b) => sum + b.percent, 0)).toBe(100);
+    expect(state.buckets.map((b) => b.id)).toEqual([
+      "fresh",
+      "recent",
+      "aging",
+      "stale",
+    ]);
+  });
+
+  it("keeps fresh + recent in freshCount and only >180d in staleCount", () => {
+    const entries = [
+      agedEntry("a", 5),
+      agedEntry("b", 45),
+      agedEntry("c", 200),
+      agedEntry("d", 300),
+    ];
+    const state = browseFreshnessDistributionState(entries, NOW);
+    expect(state.freshCount).toBe(2);
+    expect(state.staleCount).toBe(2);
+  });
+
+  it("computes a median age", () => {
+    const entries = [
+      agedEntry("a", 10),
+      agedEntry("b", 20),
+      agedEntry("c", 60),
+    ];
+    expect(browseFreshnessDistributionState(entries, NOW).medianAgeDays).toBe(
+      20,
+    );
+  });
+
+  it("flags the oldest aging/stale entries with verification status, newest excluded", () => {
+    const entries = [
+      agedEntry("fresh", 5),
+      agedEntry("old-verified", 300, { verifiedAt: "2026-01-01" }),
+      agedEntry("older", 500),
+    ];
+    const state = browseFreshnessDistributionState(entries, NOW);
+    expect(state.staleEntries.map((flag) => flag.entryRef)).toEqual([
+      "tools/older",
+      "tools/old-verified",
+    ]);
+    expect(state.staleEntries[0]?.ageDays).toBe(500);
+    expect(state.staleEntries[1]?.verified).toBe(true);
+    expect(state.staleEntries[0]?.verified).toBe(false);
+  });
+
+  it("reports a broadly-fresh headline when nothing is aging or stale", () => {
+    const entries = [agedEntry("a", 5), agedEntry("b", 40)];
+    const state = browseFreshnessDistributionState(entries, NOW);
+    expect(state.heading).toContain("broadly fresh");
+    expect(state.staleEntries).toEqual([]);
+  });
+
+  it("headlines the aging/stale share when it dominates", () => {
+    const entries = [
+      agedEntry("a", 200),
+      agedEntry("b", 300),
+      agedEntry("c", 5),
+    ];
+    const state = browseFreshnessDistributionState(entries, NOW);
+    expect(state.heading).toContain("%");
+    expect(state.summary).toContain("Re-verify");
+  });
+
+  it("respects the scannedCount cap", () => {
+    const entries = Array.from({ length: 20 }, (_, i) => agedEntry(`e${i}`, i));
+    const state = browseFreshnessDistributionState(entries, NOW, 5);
+    expect(state.scannedCount).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Freshness distribution** panel to the browse page. The browse decision panels today cover trust, rollout, adoption, and confidence, but nothing summarizes how *recent* the current result set is — useful in a directory where staleness matters. This buckets the scoped results by age and surfaces the oldest entries for re-verification.

The panel:
- Buckets the top results by age (from `dateAdded`) into **fresh (≤30d) / recent (31–90d) / aging (91–180d) / stale (>180d)** with per-bucket counts and share.
- Shows the **median age** and a headline that adapts to how much of the view is aging/stale.
- Lists the **oldest entries** in the current view with their age and whether they've been verified before — an actionable curation signal.

Time is injected into the pure helper (`nowIso`), so the logic is fully deterministic and unit-tested; the panel returns `null` when there are fewer than two results.

## Files

Pure, unit-tested logic + thin wrapper + a presentational panel + one route wire-up, matching the existing browse-panel convention (mirrors `browse-rollout-signals`):

- `apps/web/src/lib/browse-freshness-distribution-lib.ts` — pure `browseFreshnessDistributionState(entries, nowIso, scannedCount)` + `entryAgeDays()` + `freshnessBucketId()`
- `apps/web/src/lib/browse-freshness-distribution.ts` — wrapper re-export
- `apps/web/src/components/browse-freshness-distribution-panel.tsx` — presentational panel (reuses the shared `toneClass`)
- `tests/browse-freshness-distribution-lib.test.ts` — 12 cases
- `apps/web/src/routes/browse.tsx` — `useMemo` + render alongside the existing browse panels

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Platform/code change kept separate from content per `AGENTS.md`.

## Data coverage

`dateAdded` is present on 100% of registry entries (1368/1368) with a real spread (2025-09 → 2026-07), so the buckets are meaningful across the directory; `verifiedAt` (~13%) is used only as a secondary "verified previously" flag.

## Validation

```
pnpm exec prettier --check <changed files>                              # clean
pnpm exec vitest run tests/browse-freshness-distribution-lib.test.ts    # 12 passed
pnpm --filter web exec tsc --noEmit                                     # clean
pnpm --filter web build                                                 # vite build
```

Logic lives in the coverage-scoped `lib/**` and is fully unit-tested; the React panel/route are outside the node coverage scope per `AGENTS.md`, so the `codecov/patch` 70% target is met by the lib tests.
