### PR TITLE
feat(web): normalize detail compare tray-open analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -51,6 +51,22 @@ export function entryDetailCompareAnalyticsData(category: string, slug: string) 
   };
 }
 
+export function entryDetailCompareOpenTrayAnalyticsEvent(): string {
+  return "detail_compare_open_tray";
+}
+
+export function entryDetailCompareOpenTrayAnalyticsData(
+  category: string,
+  slug: string,
+  compareCount: number,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+    compareCount,
+  };
+}
+
 export function entryDetailCompareFullAnalyticsEvent(): string {
   return "detail_compare_open_full";
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -23,6 +23,8 @@ export {
   comparisonTrayClearAnalyticsEvent,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  entryDetailCompareOpenTrayAnalyticsData,
+  entryDetailCompareOpenTrayAnalyticsEvent,
   entryDetailCompareFullAnalyticsData,
   entryDetailCompareFullAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -84,6 +84,8 @@ import {
   entryDetailCompareAnalyticsEvent,
   entryDetailCompareFullAnalyticsData,
   entryDetailCompareFullAnalyticsEvent,
+  entryDetailCompareOpenTrayAnalyticsData,
+  entryDetailCompareOpenTrayAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailPlaybookActionAnalyticsData,
@@ -336,10 +338,10 @@ function Dossier() {
   }, [compare, entry, inCompare]);
   const onOpenCompare = useCallback(() => {
     compare.setOpen(true);
-    trackEvent("detail_compare_open_tray", {
-      ...entryDetailCompareAnalyticsData(entry.category, entry.slug),
-      compareCount: compare.items.length,
-    });
+    trackEvent(
+      entryDetailCompareOpenTrayAnalyticsEvent(),
+      entryDetailCompareOpenTrayAnalyticsData(entry.category, entry.slug, compare.items.length),
+    );
   }, [compare, entry.category, entry.slug]);
 
   const onOpenFullCompare = useCallback(() => {

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -16,6 +16,8 @@ import {
   entryDetailCompareAnalyticsEvent,
   entryDetailCompareFullAnalyticsData,
   entryDetailCompareFullAnalyticsEvent,
+  entryDetailCompareOpenTrayAnalyticsData,
+  entryDetailCompareOpenTrayAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailCopyAnalyticsData,
@@ -54,6 +56,16 @@ describe("entry detail cta events lib", () => {
     expect(entryDetailCompareAnalyticsData("skills", "demo")).toEqual({
       entry: "skills/demo",
       surface: "detail-compare",
+    });
+    expect(entryDetailCompareOpenTrayAnalyticsEvent()).toBe(
+      "detail_compare_open_tray",
+    );
+    expect(
+      entryDetailCompareOpenTrayAnalyticsData("skills", "demo", 2),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-compare",
+      compareCount: 2,
     });
     expect(entryDetailCompareFullAnalyticsEvent()).toBe(
       "detail_compare_open_full",


### PR DESCRIPTION
## Summary
- Add shared helpers for detail compare tray-open analytics.
- Wire detail route tray-open CTA to the shared helper instead of inline event data.

Closes #556

## Test plan
- [x] pnpm test tests/entry-detail-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)