### PR TITLE
refactor(web): extract recents state parsing into a lib

### DIFF
--- a/apps/web/src/lib/recents-storage-lib.ts
+++ b/apps/web/src/lib/recents-storage-lib.ts
@@ -1,0 +1,29 @@
+// Pure parsing/normalization of the persisted recents payload, split out of the
+// recents provider so the shape guards can be unit-tested. The storage access
+// itself stays in the provider, inside its try/catch.
+
+import type { RecentsState } from "@/lib/recents-types-lib";
+
+/** A fresh, empty recents state. */
+export function emptyRecentsState(): RecentsState {
+  return { entries: [], saved: [], follows: [], segments: [] };
+}
+
+/**
+ * Parse a persisted recents payload, tolerating a missing value, malformed JSON,
+ * and non-array fields. Always returns a fully-populated state.
+ */
+export function parseRecentsState(raw: string | null | undefined): RecentsState {
+  if (!raw) return emptyRecentsState();
+  try {
+    const parsed = JSON.parse(raw) as Partial<RecentsState>;
+    return {
+      entries: Array.isArray(parsed.entries) ? parsed.entries : [],
+      saved: Array.isArray(parsed.saved) ? parsed.saved : [],
+      follows: Array.isArray(parsed.follows) ? parsed.follows : [],
+      segments: Array.isArray(parsed.segments) ? parsed.segments : [],
+    };
+  } catch {
+    return emptyRecentsState();
+  }
+}

--- a/apps/web/src/lib/recents-types-lib.ts
+++ b/apps/web/src/lib/recents-types-lib.ts
@@ -1,0 +1,60 @@
+// Shared recents/saved-search/follow types, split out of the recents provider so
+// pure helpers can depend on them without importing the React module.
+// `@/lib/recents` re-exports these, so existing importers stay unchanged.
+
+export interface RecentEntry {
+  category: string;
+  slug: string;
+  title: string;
+  visitedAt: string;
+}
+
+export type AlertChannel = "inapp" | "email" | "rss";
+export type AlertCadence = "instant" | "daily" | "weekly";
+
+export interface AlertSchedule {
+  enabled: boolean;
+  channels: AlertChannel[];
+  cadence: AlertCadence;
+  email?: string;
+  lastNotifiedAt?: string;
+}
+
+export interface SavedSearch {
+  id: string;
+  label: string;
+  q: string;
+  category?: string;
+  trust?: string;
+  source?: string;
+  signal?: string;
+  platform?: string;
+  sort?: string;
+  savedAt: string;
+  alerts?: AlertSchedule;
+}
+
+export interface Follow {
+  id: string; // local id
+  label: string; // display label (rename-able)
+  followId: string; // e.g. "category:mcp"
+  source?: string;
+  email?: string;
+  segmentId?: string; // resolved Resend segment id (optional)
+  createdAt: string;
+}
+
+export interface Segment {
+  id: string; // Resend segment id or follow id
+  label: string;
+  email: string;
+  subscribedAt: string;
+}
+
+/** The whole persisted recents payload. */
+export interface RecentsState {
+  entries: RecentEntry[];
+  saved: SavedSearch[];
+  follows: Follow[];
+  segments: Segment[];
+}

--- a/apps/web/src/lib/recents.tsx
+++ b/apps/web/src/lib/recents.tsx
@@ -1,63 +1,32 @@
 import * as React from "react";
 
+import { emptyRecentsState, parseRecentsState } from "@/lib/recents-storage-lib";
+import type {
+  AlertCadence,
+  AlertChannel,
+  AlertSchedule,
+  Follow,
+  RecentEntry,
+  RecentsState,
+  SavedSearch,
+  Segment,
+} from "@/lib/recents-types-lib";
+
+export type {
+  AlertCadence,
+  AlertChannel,
+  AlertSchedule,
+  Follow,
+  RecentEntry,
+  RecentsState,
+  SavedSearch,
+  Segment,
+};
+
 const STORAGE_KEY = "hc.recents.v1";
 const MAX_RECENT = 8;
 
-export interface RecentEntry {
-  category: string;
-  slug: string;
-  title: string;
-  visitedAt: string;
-}
-
-export type AlertChannel = "inapp" | "email" | "rss";
-export type AlertCadence = "instant" | "daily" | "weekly";
-
-export interface AlertSchedule {
-  enabled: boolean;
-  channels: AlertChannel[];
-  cadence: AlertCadence;
-  email?: string;
-  lastNotifiedAt?: string;
-}
-
-export interface SavedSearch {
-  id: string;
-  label: string;
-  q: string;
-  category?: string;
-  trust?: string;
-  source?: string;
-  signal?: string;
-  platform?: string;
-  sort?: string;
-  savedAt: string;
-  alerts?: AlertSchedule;
-}
-
-export interface Follow {
-  id: string; // local id
-  label: string; // display label (rename-able)
-  followId: string; // e.g. "category:mcp"
-  source?: string;
-  email?: string;
-  segmentId?: string; // resolved Resend segment id (optional)
-  createdAt: string;
-}
-
-export interface Segment {
-  id: string; // Resend segment id or follow id
-  label: string;
-  email: string;
-  subscribedAt: string;
-}
-
-interface State {
-  entries: RecentEntry[];
-  saved: SavedSearch[];
-  follows: Follow[];
-  segments: Segment[];
-}
+type State = RecentsState;
 
 interface RecentsCtx extends State {
   pushEntry: (e: Omit<RecentEntry, "visitedAt">) => void;
@@ -77,20 +46,13 @@ interface RecentsCtx extends State {
 const Ctx = React.createContext<RecentsCtx | null>(null);
 
 function load(): State {
-  const empty: State = { entries: [], saved: [], follows: [], segments: [] };
-  if (typeof window === "undefined") return empty;
+  if (typeof window === "undefined") return emptyRecentsState();
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) return empty;
-    const p = JSON.parse(raw) as Partial<State>;
-    return {
-      entries: Array.isArray(p.entries) ? p.entries : [],
-      saved: Array.isArray(p.saved) ? p.saved : [],
-      follows: Array.isArray(p.follows) ? p.follows : [],
-      segments: Array.isArray(p.segments) ? p.segments : [],
-    };
+    // The storage read stays inside the try/catch: the getter itself can throw
+    // (SecurityError) in sandboxed / storage-blocked contexts.
+    return parseRecentsState(window.localStorage.getItem(STORAGE_KEY));
   } catch {
-    return empty;
+    return emptyRecentsState();
   }
 }
 

--- a/tests/recents-storage-lib.test.ts
+++ b/tests/recents-storage-lib.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  emptyRecentsState,
+  parseRecentsState,
+} from "../apps/web/src/lib/recents-storage-lib";
+
+describe("emptyRecentsState", () => {
+  it("has every list empty", () => {
+    expect(emptyRecentsState()).toEqual({
+      entries: [],
+      saved: [],
+      follows: [],
+      segments: [],
+    });
+  });
+
+  it("returns a fresh object each call", () => {
+    const a = emptyRecentsState();
+    a.entries.push({
+      category: "agents",
+      slug: "x",
+      title: "X",
+      visitedAt: "",
+    });
+    expect(emptyRecentsState().entries).toEqual([]);
+  });
+});
+
+describe("parseRecentsState", () => {
+  it("returns the empty state for a missing value", () => {
+    expect(parseRecentsState(null)).toEqual(emptyRecentsState());
+    expect(parseRecentsState(undefined)).toEqual(emptyRecentsState());
+    expect(parseRecentsState("")).toEqual(emptyRecentsState());
+  });
+
+  it("returns the empty state for malformed JSON", () => {
+    expect(parseRecentsState("{not json")).toEqual(emptyRecentsState());
+  });
+
+  it("round-trips a well-formed payload", () => {
+    const state = {
+      entries: [
+        { category: "agents", slug: "a", title: "A", visitedAt: "2026-01-01" },
+      ],
+      saved: [],
+      follows: [],
+      segments: [],
+    };
+    expect(parseRecentsState(JSON.stringify(state))).toEqual(state);
+  });
+
+  it("replaces non-array fields with empty lists", () => {
+    expect(
+      parseRecentsState(
+        JSON.stringify({ entries: "nope", saved: 5, follows: null }),
+      ),
+    ).toEqual(emptyRecentsState());
+  });
+
+  it("fills in fields missing from the payload", () => {
+    const parsed = parseRecentsState(JSON.stringify({ saved: [{ id: "s1" }] }));
+    expect(parsed.saved).toHaveLength(1);
+    expect(parsed.entries).toEqual([]);
+    expect(parsed.follows).toEqual([]);
+    expect(parsed.segments).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

The recents provider parsed and normalized its persisted payload inline, so the shape guards (missing value, malformed JSON, non-array fields) could not be unit-tested without React and `localStorage`.

This splits the recents types into `recents-types-lib.ts` (so pure helpers can depend on them without importing the React module) and moves the parse/normalize into `recents-storage-lib.ts`. `recents.tsx` re-exports the types, so the existing `@/lib/recents` importers - including `saved-search-alerts-lib`, `saved-search-hash-lib` and `browse.tsx` - are unchanged.

### Changes

- Add `apps/web/src/lib/recents-types-lib.ts` - `RecentEntry`, `AlertChannel`, `AlertCadence`, `AlertSchedule`, `SavedSearch`, `Follow`, `Segment`, plus the `RecentsState` payload type.
- Add `apps/web/src/lib/recents-storage-lib.ts` - `emptyRecentsState()` and `parseRecentsState(raw)`.
- `apps/web/src/lib/recents.tsx` - `load()` delegates to the helpers. The `localStorage` read stays inside its `try/catch`, since the getter itself can throw (`SecurityError`) in sandboxed / storage-blocked contexts.
- Add `tests/recents-storage-lib.test.ts` - covers missing value, malformed JSON, a well-formed round trip, non-array fields, and fields absent from the payload. Branch coverage 100% (10/10).

### Validation

- `pnpm --filter web exec tsc --noEmit` - clean
- `pnpm exec vitest run tests/recents-storage-lib.test.ts` - 7 passed
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No user-facing or behavior change; the provider loads the same state. Only the pure parse moved: the storage access is deliberately left in the provider's `try/catch`.
