### PR TITLE
test(scripts): extract impact card core helpers and cover them

### DIFF
--- a/scripts/gittensor-impact-card.mjs
+++ b/scripts/gittensor-impact-card.mjs
@@ -12,7 +12,13 @@ import { readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-const WEEKS = 12;
+import {
+  bucketWeekly,
+  compact,
+  escapeXml,
+  WEEKS,
+} from "./lib/impact-card-core.mjs";
+
 const THEME = {
   cardBg: "#121212",
   fg: "#f3f2ee",
@@ -27,54 +33,12 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const repoIconPath = path.join(repoRoot, "apps/web/public/favicon.svg");
 
-function compact(n) {
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
-  if (n >= 1000) return (n / 1000).toFixed(0) + "k";
-  return String(n);
-}
-
-// api.gittensor.io values (and the repo name) end up as SVG <text> content,
-// so escape XML special chars rather than trust they're clean numbers/strings.
-function escapeXml(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#x27;");
-}
-
 async function fetchJson(url) {
   const res = await fetch(url, {
     headers: { "User-Agent": "gittensor-impact-card/1.0" },
   });
   if (!res.ok) throw new Error(`fetch failed: ${url} (${res.status})`);
   return res.json();
-}
-
-function bucketWeekly(prs, now) {
-  const weekMs = 7 * 24 * 60 * 60 * 1000;
-  const bucketStart = new Date(now.getTime() - WEEKS * weekMs);
-  const prBuckets = Array(WEEKS).fill(0);
-  const locBuckets = Array(WEEKS).fill(0);
-  const seenByBucket = Array.from({ length: WEEKS }, () => new Set());
-  const contributorBuckets = Array(WEEKS).fill(0);
-
-  for (const pr of prs) {
-    const t = new Date(pr.mergedAt);
-    if (Number.isNaN(t.getTime()) || t < bucketStart || t > now) continue;
-    const idx = Math.min(WEEKS - 1, Math.floor((t - bucketStart) / weekMs));
-    prBuckets[idx] += 1;
-    locBuckets[idx] += (pr.additions || 0) + (pr.deletions || 0);
-    seenByBucket[idx].add(pr.author);
-  }
-
-  const seenSoFar = new Set();
-  for (let i = 0; i < WEEKS; i++) {
-    for (const a of seenByBucket[i]) seenSoFar.add(a);
-    contributorBuckets[i] = seenSoFar.size;
-  }
-  return { prBuckets, locBuckets, contributorBuckets };
 }
 
 function sparkline(x, y, w, h, values, mutedColor, accentColor, cardBg) {

--- a/scripts/lib/impact-card-core.mjs
+++ b/scripts/lib/impact-card-core.mjs
@@ -1,0 +1,60 @@
+// Pure helpers behind the Gittensor impact card: number formatting, XML escaping
+// for SVG text, and the weekly bucketing of merged PRs. Split out of
+// scripts/gittensor-impact-card.mjs so they can be unit-tested without network
+// access or SVG rendering. Deterministic: bucketWeekly takes `now` as an input.
+
+/** Number of weekly buckets the card's sparklines cover. */
+export const WEEKS = 12;
+
+/** Compact number formatting for the card's stat values (1.2M / 34k / 900). */
+export function compact(n) {
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1000) return (n / 1000).toFixed(0) + "k";
+  return String(n);
+}
+
+/**
+ * Escape XML special chars. api.gittensor.io values (and the repo name) end up
+ * as SVG <text> content, so escape rather than trust they're clean.
+ */
+export function escapeXml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+/**
+ * Bucket merged PRs into the WEEKS weeks ending at `now`.
+ *
+ * Returns per-bucket PR counts, lines-changed totals, and the *cumulative*
+ * distinct-contributor count (a contributor seen in an earlier week still
+ * counts in later weeks). PRs outside the window, or with an unparseable
+ * mergedAt, are ignored.
+ */
+export function bucketWeekly(prs, now) {
+  const weekMs = 7 * 24 * 60 * 60 * 1000;
+  const bucketStart = new Date(now.getTime() - WEEKS * weekMs);
+  const prBuckets = Array(WEEKS).fill(0);
+  const locBuckets = Array(WEEKS).fill(0);
+  const seenByBucket = Array.from({ length: WEEKS }, () => new Set());
+  const contributorBuckets = Array(WEEKS).fill(0);
+
+  for (const pr of prs) {
+    const t = new Date(pr.mergedAt);
+    if (Number.isNaN(t.getTime()) || t < bucketStart || t > now) continue;
+    const idx = Math.min(WEEKS - 1, Math.floor((t - bucketStart) / weekMs));
+    prBuckets[idx] += 1;
+    locBuckets[idx] += (pr.additions || 0) + (pr.deletions || 0);
+    seenByBucket[idx].add(pr.author);
+  }
+
+  const seenSoFar = new Set();
+  for (let i = 0; i < WEEKS; i++) {
+    for (const a of seenByBucket[i]) seenSoFar.add(a);
+    contributorBuckets[i] = seenSoFar.size;
+  }
+  return { prBuckets, locBuckets, contributorBuckets };
+}

--- a/tests/impact-card-core.test.ts
+++ b/tests/impact-card-core.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bucketWeekly,
+  compact,
+  escapeXml,
+  WEEKS,
+} from "../scripts/lib/impact-card-core.mjs";
+
+const NOW = new Date("2026-04-01T00:00:00Z");
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+/** Start of the oldest bucket for the given `now`. */
+const windowStart = new Date(NOW.getTime() - WEEKS * WEEK_MS);
+/** A date `weeksAgo` weeks before `now`, nudged inside the bucket. */
+const at = (weeksAgo: number) =>
+  new Date(NOW.getTime() - weeksAgo * WEEK_MS + 60_000).toISOString();
+
+const pr = (over: Record<string, unknown> = {}) => ({
+  mergedAt: at(1),
+  author: "ada",
+  additions: 0,
+  deletions: 0,
+  ...over,
+});
+
+describe("compact", () => {
+  it("formats millions, thousands and small numbers", () => {
+    expect(compact(2_500_000)).toBe("2.5M");
+    expect(compact(1_000_000)).toBe("1.0M");
+    expect(compact(34_400)).toBe("34k");
+    expect(compact(1000)).toBe("1k");
+    expect(compact(999)).toBe("999");
+    expect(compact(0)).toBe("0");
+  });
+});
+
+describe("escapeXml", () => {
+  it("escapes the five XML entities", () => {
+    expect(escapeXml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#x27;");
+  });
+
+  it("escapes ampersands first and stringifies non-strings", () => {
+    expect(escapeXml("a & b")).toBe("a &amp; b");
+    expect(escapeXml(42)).toBe("42");
+  });
+});
+
+describe("bucketWeekly", () => {
+  it("returns WEEKS buckets, all zero for no PRs", () => {
+    const { prBuckets, locBuckets, contributorBuckets } = bucketWeekly([], NOW);
+    expect(prBuckets).toHaveLength(WEEKS);
+    expect(prBuckets.every((n: number) => n === 0)).toBe(true);
+    expect(locBuckets.every((n: number) => n === 0)).toBe(true);
+    expect(contributorBuckets.every((n: number) => n === 0)).toBe(true);
+  });
+
+  it("counts a PR and its lines changed in the right bucket", () => {
+    const { prBuckets, locBuckets } = bucketWeekly(
+      [pr({ mergedAt: at(1), additions: 10, deletions: 5 })],
+      NOW,
+    );
+    // one week ago falls in the last bucket
+    expect(prBuckets[WEEKS - 1]).toBe(1);
+    expect(locBuckets[WEEKS - 1]).toBe(15);
+    expect(prBuckets.reduce((a: number, b: number) => a + b, 0)).toBe(1);
+  });
+
+  it("ignores PRs outside the window or with an unparseable date", () => {
+    const tooOld = new Date(windowStart.getTime() - WEEK_MS).toISOString();
+    const future = new Date(NOW.getTime() + WEEK_MS).toISOString();
+    const { prBuckets } = bucketWeekly(
+      [
+        pr({ mergedAt: tooOld }),
+        pr({ mergedAt: future }),
+        pr({ mergedAt: "nope" }),
+      ],
+      NOW,
+    );
+    expect(prBuckets.reduce((a: number, b: number) => a + b, 0)).toBe(0);
+  });
+
+  it("counts contributors cumulatively across buckets", () => {
+    const { contributorBuckets } = bucketWeekly(
+      [
+        pr({ mergedAt: at(6), author: "ada" }),
+        pr({ mergedAt: at(1), author: "bob" }),
+      ],
+      NOW,
+    );
+    // ada is still counted in later buckets; bob joins at the end
+    expect(contributorBuckets[WEEKS - 1]).toBe(2);
+    expect(contributorBuckets[0]).toBe(0);
+    // monotonically non-decreasing
+    for (let i = 1; i < WEEKS; i++) {
+      expect(contributorBuckets[i]).toBeGreaterThanOrEqual(
+        contributorBuckets[i - 1],
+      );
+    }
+  });
+
+  it("does not double-count the same author within a bucket", () => {
+    const { contributorBuckets } = bucketWeekly(
+      [
+        pr({ mergedAt: at(1), author: "ada" }),
+        pr({ mergedAt: at(1), author: "ada" }),
+      ],
+      NOW,
+    );
+    expect(contributorBuckets[WEEKS - 1]).toBe(1);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/gittensor-impact-card.mjs` mixed pure logic with network fetches and SVG rendering, so its number formatting, XML escaping and weekly PR bucketing were untestable. This moves them into `scripts/lib/impact-card-core.mjs` - matching the existing `scripts/lib` convention used by `coverage-gaps.mjs`, `comparison-candidates.mjs`, etc. - and imports them back.

### Changes

- Add `scripts/lib/impact-card-core.mjs` - `WEEKS`, `compact(n)`, `escapeXml(value)` and `bucketWeekly(prs, now)`. `bucketWeekly` already took `now` as a parameter, so the helpers are fully deterministic.
- `scripts/gittensor-impact-card.mjs` - import the helpers; drop the local copies.
- Add `tests/impact-card-core.test.ts` - covers `compact`'s M/k/plain thresholds, `escapeXml`'s five entities plus ampersand-first ordering and non-string input, and `bucketWeekly`'s empty case, bucket placement, lines-changed totals, out-of-window / unparseable dates, the cumulative (monotonic) contributor count, and same-author de-duplication within a bucket. Branch coverage 100% (13/13).

### Validation

- `pnpm exec vitest run tests/impact-card-core.test.ts` - 8 passed
- `node --check scripts/gittensor-impact-card.mjs` - clean; the new module's exports resolve
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the rendered card is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
