### PR TITLE
feat(web): compose compare interactive UI state through delegates

### DIFF
--- a/apps/web/src/lib/compare-best-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-best-interactive-ui-lib.ts
@@ -1,8 +1,15 @@
 import type { Entry } from "@/types/registry";
-import { shouldShowBestCompareSection } from "@/lib/compare-best-summary";
-import { compareBestUiState, type CompareBestUiState } from "@/lib/compare-best-ui-lib";
+import {
+  compareBestShowCompareSection,
+  compareBestUiState,
+  type CompareBestUiState,
+} from "@/lib/compare-best-ui-lib";
 
 export type CompareBestInteractiveUiState = CompareBestUiState;
+
+export function compareBestInteractiveShowCompareSection(entries: Entry[]): boolean {
+  return compareBestShowCompareSection(entries);
+}
 
 export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInteractiveUiState {
   const ui = compareBestUiState(entries);
@@ -10,8 +17,4 @@ export function compareBestInteractiveUiState(entries: Entry[]): CompareBestInte
     ...ui,
     showCompareSection: compareBestInteractiveShowCompareSection(entries),
   };
-}
-
-export function compareBestInteractiveShowCompareSection(entries: Entry[]): boolean {
-  return shouldShowBestCompareSection(entries);
 }

--- a/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-dossier-interactive-ui-lib.ts
@@ -1,26 +1,29 @@
 import type { Entry } from "@/types/registry";
 import {
+  compareDossierHeaderBannerTexts,
+  compareDossierInteractiveCompareSearch,
+  compareDossierInteractiveLinkLabel,
   compareDossierShowCompareSection,
-  compareDossierUiState,
   type CompareDossierUiState,
 } from "@/lib/compare-dossier-ui-lib";
 
 export type CompareDossierInteractiveUiState = CompareDossierUiState;
-
-export function compareDossierInteractiveUiState(
-  entry: Entry,
-  alternatives: Entry[],
-): CompareDossierInteractiveUiState {
-  const ui = compareDossierUiState(entry, alternatives);
-  return {
-    ...ui,
-    showCompareSection: compareDossierInteractiveShowCompareSection(entry, alternatives),
-  };
-}
 
 export function compareDossierInteractiveShowCompareSection(
   _entry: Entry,
   alternatives: Entry[],
 ): boolean {
   return compareDossierShowCompareSection(alternatives);
+}
+
+export function compareDossierInteractiveUiState(
+  entry: Entry,
+  alternatives: Entry[],
+): CompareDossierInteractiveUiState {
+  return {
+    showCompareSection: compareDossierInteractiveShowCompareSection(entry, alternatives),
+    bannerTexts: compareDossierHeaderBannerTexts(entry, alternatives),
+    interactiveSearch: compareDossierInteractiveCompareSearch(entry, alternatives),
+    interactiveLinkLabel: compareDossierInteractiveLinkLabel(alternatives.length + 1),
+  };
 }

--- a/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-featured-interactive-ui-lib.ts
@@ -1,13 +1,20 @@
 import type { BestListPickRef } from "@/lib/compare-best-summary";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import {
-  compareEntryFeaturedBestListLinks,
-  compareEntryFeaturedComparisonLinks,
+  compareEntryFeaturedShowsFeaturedLinks,
   compareEntryFeaturedUiState,
   type CompareEntryFeaturedUiState,
 } from "@/lib/compare-entry-featured-ui-lib";
 
 export type CompareEntryFeaturedInteractiveUiState = CompareEntryFeaturedUiState;
+
+export function compareEntryFeaturedInteractiveShowsFeaturedLinks(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): boolean {
+  return compareEntryFeaturedShowsFeaturedLinks(comparisons, lists, catalog);
+}
 
 export function compareEntryFeaturedInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
@@ -23,15 +30,4 @@ export function compareEntryFeaturedInteractiveUiState(
       catalog,
     ),
   };
-}
-
-export function compareEntryFeaturedInteractiveShowsFeaturedLinks(
-  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
-  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
-  catalog: EntryIdentity[],
-): boolean {
-  return (
-    compareEntryFeaturedComparisonLinks(comparisons, catalog).length > 0 ||
-    compareEntryFeaturedBestListLinks(lists, catalog).length > 0
-  );
 }

--- a/apps/web/src/lib/compare-page-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-actions-interactive-ui-lib.ts
@@ -1,21 +1,31 @@
 import type { Entry } from "@/types/registry";
 import {
   comparePageActionCells,
-  comparePageActionsDiverge,
   type ComparePageActionCell,
 } from "@/lib/compare-page-actions-ui-lib";
+import { comparePagePresentationActionRowDiverges } from "@/lib/compare-page-presentation-ui-lib";
 
 export type ComparePageActionsInteractiveUiState = {
   actionRowDiverges: boolean;
   actionCells: ComparePageActionCell[];
 };
 
+export function comparePageActionsInteractiveActionRowDiverges(entries: Entry[]): boolean {
+  return comparePagePresentationActionRowDiverges(entries);
+}
+
+export function comparePageActionsInteractiveActionCells(
+  entries: Entry[],
+): ComparePageActionCell[] {
+  return comparePageActionCells(entries);
+}
+
 export function comparePageActionsInteractiveUiState(
   entries: Entry[],
 ): ComparePageActionsInteractiveUiState {
   return {
-    actionRowDiverges: comparePageActionsDiverge(entries),
-    actionCells: comparePageActionCells(entries),
+    actionRowDiverges: comparePageActionsInteractiveActionRowDiverges(entries),
+    actionCells: comparePageActionsInteractiveActionCells(entries),
   };
 }
 

--- a/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-interactive-ui-lib.ts
@@ -1,5 +1,6 @@
 import type { EntryIdentity } from "@/lib/entry-identity";
-import { comparePageFeaturedInteractiveUiState } from "@/lib/compare-page-featured-interactive-ui-lib";
+import type { ComparePagePopularComparisonLink } from "@/lib/compare-page-featured-ui-lib";
+import { comparePageFeaturedInteractivePopularComparisonLinks } from "@/lib/compare-page-featured-interactive-ui-lib";
 import type { ComparePageEmptyUiState } from "@/lib/compare-page-empty-ui-lib";
 import {
   comparePageEmptyStateDescription,
@@ -9,14 +10,29 @@ import {
 export type { ComparePageEmptyUiState };
 export type ComparePageEmptyInteractiveUiState = ComparePageEmptyUiState;
 
+export function comparePageEmptyInteractiveDescription(): string {
+  return comparePageEmptyStateDescription();
+}
+
+export function comparePageEmptyInteractiveInvalidUrlHint(ids: string): string | null {
+  return comparePageInvalidUrlHint(ids, 0);
+}
+
+export function comparePageEmptyInteractivePopularComparisonLinks(
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePagePopularComparisonLink[] {
+  return comparePageFeaturedInteractivePopularComparisonLinks(comparisons, catalog);
+}
+
 export function comparePageEmptyInteractiveUiState(
   ids: string,
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageEmptyInteractiveUiState {
   return {
-    description: comparePageEmptyStateDescription(),
-    invalidUrlHint: comparePageInvalidUrlHint(ids, 0),
-    popularComparisonLinks: comparePageFeaturedInteractiveUiState(comparisons, catalog),
+    description: comparePageEmptyInteractiveDescription(),
+    invalidUrlHint: comparePageEmptyInteractiveInvalidUrlHint(ids),
+    popularComparisonLinks: comparePageEmptyInteractivePopularComparisonLinks(comparisons, catalog),
   };
 }

--- a/apps/web/src/lib/compare-page-featured-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-featured-interactive-ui-lib.ts
@@ -6,9 +6,16 @@ import {
 
 export type ComparePageFeaturedInteractiveUiState = ComparePagePopularComparisonLink[];
 
+export function comparePageFeaturedInteractivePopularComparisonLinks(
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePagePopularComparisonLink[] {
+  return comparePagePopularComparisonLinks(comparisons, catalog);
+}
+
 export function comparePageFeaturedInteractiveUiState(
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageFeaturedInteractiveUiState {
-  return comparePagePopularComparisonLinks(comparisons, catalog);
+  return comparePageFeaturedInteractivePopularComparisonLinks(comparisons, catalog);
 }

--- a/apps/web/src/lib/compare-table-actions-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-actions-interactive-ui-lib.ts
@@ -1,10 +1,12 @@
 import type { Entry } from "@/types/registry";
 import {
   compareTableActionCells,
-  compareTableActionsDiverge,
-  shouldRenderCompareTableActions,
   type CompareTableActionCell,
 } from "@/lib/compare-table-actions-ui-lib";
+import {
+  compareTablePresentationActionRowDiverges,
+  compareTablePresentationRenderNextActions,
+} from "@/lib/compare-table-ui-lib";
 
 export type CompareTableActionsInteractiveUiState = {
   renderNextActions: boolean;
@@ -12,15 +14,34 @@ export type CompareTableActionsInteractiveUiState = {
   actionCells: CompareTableActionCell[];
 };
 
+export function compareTableActionsInteractiveRenderNextActions(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return compareTablePresentationRenderNextActions(entries, showNextActions);
+}
+
+export function compareTableActionsInteractiveActionRowDiverges(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return compareTablePresentationActionRowDiverges(entries, showNextActions);
+}
+
+export function compareTableActionsInteractiveActionCells(
+  entries: Entry[],
+): CompareTableActionCell[] {
+  return compareTableActionCells(entries);
+}
+
 export function compareTableActionsInteractiveUiState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableActionsInteractiveUiState {
-  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
   return {
-    renderNextActions,
-    actionRowDiverges: renderNextActions && compareTableActionsDiverge(entries),
-    actionCells: compareTableActionCells(entries),
+    renderNextActions: compareTableActionsInteractiveRenderNextActions(entries, showNextActions),
+    actionRowDiverges: compareTableActionsInteractiveActionRowDiverges(entries, showNextActions),
+    actionCells: compareTableActionsInteractiveActionCells(entries),
   };
 }
 

--- a/apps/web/src/lib/compare-table-signals-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-signals-interactive-ui-lib.ts
@@ -1,14 +1,20 @@
 import type { Entry } from "@/types/registry";
-import { compareTableDivergingDecisionLabels } from "@/lib/compare-table-signals-ui-lib";
+import { compareTablePresentationDivergingDecisionLabels } from "@/lib/compare-table-ui-lib";
 
 export type CompareTableSignalsInteractiveUiState = {
   divergingDecisionLabels: Set<string>;
 };
 
+export function compareTableSignalsInteractiveDivergingDecisionLabels(
+  entries: Entry[],
+): Set<string> {
+  return compareTablePresentationDivergingDecisionLabels(entries);
+}
+
 export function compareTableSignalsInteractiveUiState(
   entries: Entry[],
 ): CompareTableSignalsInteractiveUiState {
   return {
-    divergingDecisionLabels: new Set(compareTableDivergingDecisionLabels(entries)),
+    divergingDecisionLabels: compareTableSignalsInteractiveDivergingDecisionLabels(entries),
   };
 }

--- a/apps/web/src/lib/compare-table-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-ui-lib.ts
@@ -11,14 +11,34 @@ export type CompareTablePresentationState = {
   actionRowDiverges: boolean;
 };
 
+export function compareTablePresentationDivergingDecisionLabels(entries: Entry[]): Set<string> {
+  return new Set(divergingDecisionRowLabels(entries));
+}
+
+export function compareTablePresentationRenderNextActions(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return shouldRenderCompareTableActions(entries, showNextActions);
+}
+
+export function compareTablePresentationActionRowDiverges(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return (
+    compareTablePresentationRenderNextActions(entries, showNextActions) &&
+    compareTableActionsDiverge(entries)
+  );
+}
+
 export function compareTablePresentationState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTablePresentationState {
-  const renderNextActions = shouldRenderCompareTableActions(entries, showNextActions);
   return {
-    divergingDecisionLabels: new Set(divergingDecisionRowLabels(entries)),
-    renderNextActions,
-    actionRowDiverges: renderNextActions && compareTableActionsDiverge(entries),
+    divergingDecisionLabels: compareTablePresentationDivergingDecisionLabels(entries),
+    renderNextActions: compareTablePresentationRenderNextActions(entries, showNextActions),
+    actionRowDiverges: compareTablePresentationActionRowDiverges(entries, showNextActions),
   };
 }

--- a/tests/compare-best-interactive-ui-lib.test.ts
+++ b/tests/compare-best-interactive-ui-lib.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareBestHeaderBannerTexts,
+  compareBestInteractiveLinkLabel,
+  compareBestInteractiveSearch,
+  compareBestShowCompareSection,
+} from "@/lib/compare-best-ui-lib";
+import {
   compareBestInteractiveShowCompareSection,
   compareBestInteractiveUiState,
 } from "@/lib/compare-best-interactive-ui-lib";
@@ -58,6 +64,16 @@ describe("compare best interactive ui lib", () => {
     const bundled = compareBestInteractiveUiState(entries);
     expect(bundled.showCompareSection).toBe(
       compareBestInteractiveShowCompareSection(entries),
+    );
+    expect(bundled.showCompareSection).toBe(
+      compareBestShowCompareSection(entries),
+    );
+    expect(bundled.bannerTexts).toEqual(compareBestHeaderBannerTexts(entries));
+    expect(bundled.interactiveSearch).toEqual(
+      compareBestInteractiveSearch(entries),
+    );
+    expect(bundled.interactiveLinkLabel).toBe(
+      compareBestInteractiveLinkLabel(entries.length),
     );
   });
 

--- a/tests/compare-dossier-interactive-ui-lib.test.ts
+++ b/tests/compare-dossier-interactive-ui-lib.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareDossierHeaderBannerTexts,
+  compareDossierInteractiveCompareSearch,
+  compareDossierInteractiveLinkLabel,
+} from "@/lib/compare-dossier-ui-lib";
+import {
   compareDossierInteractiveShowCompareSection,
   compareDossierInteractiveUiState,
 } from "@/lib/compare-dossier-interactive-ui-lib";
@@ -51,6 +56,15 @@ describe("compare dossier interactive ui lib", () => {
     const bundled = compareDossierInteractiveUiState(primary, alternatives);
     expect(bundled.showCompareSection).toBe(
       compareDossierInteractiveShowCompareSection(primary, alternatives),
+    );
+    expect(bundled.bannerTexts).toEqual(
+      compareDossierHeaderBannerTexts(primary, alternatives),
+    );
+    expect(bundled.interactiveSearch).toEqual(
+      compareDossierInteractiveCompareSearch(primary, alternatives),
+    );
+    expect(bundled.interactiveLinkLabel).toBe(
+      compareDossierInteractiveLinkLabel(alternatives.length + 1),
     );
   });
 

--- a/tests/compare-entry-featured-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-featured-interactive-ui-lib.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
+import { compareEntryFeaturedShowsFeaturedLinks } from "@/lib/compare-entry-featured-ui-lib";
 import {
   compareEntryFeaturedInteractiveShowsFeaturedLinks,
   compareEntryFeaturedInteractiveUiState,
@@ -81,6 +82,40 @@ describe("compare entry featured interactive ui lib", () => {
         catalog,
       ),
     ).toBe(true);
+    const bundled = compareEntryFeaturedInteractiveUiState(
+      [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+      [
+        {
+          slug: "top-picks",
+          picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+        },
+      ],
+      catalog,
+    );
+    expect(bundled.hasFeaturedLinks).toBe(
+      compareEntryFeaturedInteractiveShowsFeaturedLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    );
+    expect(bundled.hasFeaturedLinks).toBe(
+      compareEntryFeaturedShowsFeaturedLinks(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
+    );
   });
 
   it("formats overflow labels for wide featured best lists", () => {

--- a/tests/compare-page-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-page-actions-interactive-ui-lib.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
   comparePageActionsForEntry,
+  comparePageActionsInteractiveActionCells,
+  comparePageActionsInteractiveActionRowDiverges,
   comparePageActionsInteractiveUiState,
 } from "@/lib/compare-page-actions-interactive-ui-lib";
 
@@ -62,12 +64,16 @@ describe("compare page actions interactive ui lib", () => {
   });
 
   it("highlights diverging next-action rows for mixed compare columns", () => {
-    const state = comparePageActionsInteractiveUiState([
-      entry({ installCommand: "npm i fixture" }),
-      entry(),
-    ]);
+    const entries = [entry({ installCommand: "npm i fixture" }), entry()];
+    const state = comparePageActionsInteractiveUiState(entries);
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    expect(state.actionRowDiverges).toBe(
+      comparePageActionsInteractiveActionRowDiverges(entries),
+    );
+    expect(state.actionCells).toEqual(
+      comparePageActionsInteractiveActionCells(entries),
+    );
     expect(comparePageActionsForEntry(entry(), state.actionCells)).toEqual(
       expect.arrayContaining([expect.objectContaining({ id: "dossier" })]),
     );

--- a/tests/compare-page-empty-interactive-ui-lib.test.ts
+++ b/tests/compare-page-empty-interactive-ui-lib.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { comparePageEmptyInteractiveUiState } from "@/lib/compare-page-empty-interactive-ui-lib";
+import {
+  comparePageEmptyInteractiveDescription,
+  comparePageEmptyInteractiveInvalidUrlHint,
+  comparePageEmptyInteractivePopularComparisonLinks,
+  comparePageEmptyInteractiveUiState,
+} from "@/lib/compare-page-empty-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -26,19 +31,15 @@ const catalog = [
 
 describe("compare page empty interactive ui lib", () => {
   it("bundles empty-state copy, invalid URL hints, and popular comparison links", () => {
-    expect(
-      comparePageEmptyInteractiveUiState(
-        "",
-        [
-          {
-            slug: "pair",
-            heading: "Alpha vs Beta",
-            refs: ["skills/alpha", "hooks/beta"],
-          },
-        ],
-        catalog,
-      ),
-    ).toEqual({
+    const comparisons = [
+      {
+        slug: "pair",
+        heading: "Alpha vs Beta",
+        refs: ["skills/alpha", "hooks/beta"],
+      },
+    ];
+    const state = comparePageEmptyInteractiveUiState("", comparisons, catalog);
+    expect(state).toEqual({
       description: expect.stringContaining("directory"),
       invalidUrlHint: null,
       popularComparisonLinks: [
@@ -50,6 +51,13 @@ describe("compare page empty interactive ui lib", () => {
         },
       ],
     });
+    expect(state.description).toBe(comparePageEmptyInteractiveDescription());
+    expect(state.invalidUrlHint).toBe(
+      comparePageEmptyInteractiveInvalidUrlHint(""),
+    );
+    expect(state.popularComparisonLinks).toEqual(
+      comparePageEmptyInteractivePopularComparisonLinks(comparisons, catalog),
+    );
   });
 
   it("surfaces invalid URL hints when ids cannot be resolved", () => {

--- a/tests/compare-table-actions-interactive-ui-lib.test.ts
+++ b/tests/compare-table-actions-interactive-ui-lib.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
   compareTableActionsForEntry,
+  compareTableActionsInteractiveActionCells,
+  compareTableActionsInteractiveActionRowDiverges,
+  compareTableActionsInteractiveRenderNextActions,
   compareTableActionsInteractiveUiState,
 } from "@/lib/compare-table-actions-interactive-ui-lib";
 
@@ -59,12 +62,22 @@ describe("compare table actions interactive ui lib", () => {
   });
 
   it("highlights diverging next-action rows when enabled for mixed columns", () => {
-    const state = compareTableActionsInteractiveUiState(
-      [entry({ installCommand: "npm i fixture" }), entry({ slug: "other" })],
-      true,
-    );
+    const entries = [
+      entry({ installCommand: "npm i fixture" }),
+      entry({ slug: "other" }),
+    ];
+    const state = compareTableActionsInteractiveUiState(entries, true);
     expect(state.renderNextActions).toBe(true);
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    expect(state.renderNextActions).toBe(
+      compareTableActionsInteractiveRenderNextActions(entries, true),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareTableActionsInteractiveActionRowDiverges(entries, true),
+    );
+    expect(state.actionCells).toEqual(
+      compareTableActionsInteractiveActionCells(entries),
+    );
   });
 });

--- a/tests/compare-table-signals-interactive-ui-lib.test.ts
+++ b/tests/compare-table-signals-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareTableSignalsInteractiveUiState } from "@/lib/compare-table-signals-interactive-ui-lib";
+import {
+  compareTableSignalsInteractiveDivergingDecisionLabels,
+  compareTableSignalsInteractiveUiState,
+} from "@/lib/compare-table-signals-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -35,14 +38,17 @@ describe("compare table signals interactive ui lib", () => {
   });
 
   it("highlights diverging review status decision rows", () => {
-    expect(
-      compareTableSignalsInteractiveUiState([
-        entry(),
-        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
-      ]),
-    ).toEqual({
+    const entries = [
+      entry(),
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+    ];
+    const state = compareTableSignalsInteractiveUiState(entries);
+    expect(state).toEqual({
       divergingDecisionLabels: new Set(["Review status"]),
     });
+    expect(state.divergingDecisionLabels).toEqual(
+      compareTableSignalsInteractiveDivergingDecisionLabels(entries),
+    );
   });
 
   it("returns an empty label set when no entries are compared", () => {

--- a/tests/compare-table-ui-lib.test.ts
+++ b/tests/compare-table-ui-lib.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareTablePresentationState } from "@/lib/compare-table-ui-lib";
+import {
+  compareTablePresentationActionRowDiverges,
+  compareTablePresentationDivergingDecisionLabels,
+  compareTablePresentationRenderNextActions,
+  compareTablePresentationState,
+} from "@/lib/compare-table-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -49,15 +54,22 @@ describe("compare table ui lib", () => {
   });
 
   it("highlights diverging decision rows and next actions", () => {
-    const state = compareTablePresentationState(
-      [
-        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
-        entry({ slug: "other", installCommand: "npm i fixture" }),
-      ],
-      true,
-    );
+    const entries = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
+    const state = compareTablePresentationState(entries, true);
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.renderNextActions).toBe(true);
     expect(state.actionRowDiverges).toBe(true);
+    expect(state.divergingDecisionLabels).toEqual(
+      compareTablePresentationDivergingDecisionLabels(entries),
+    );
+    expect(state.renderNextActions).toBe(
+      compareTablePresentationRenderNextActions(entries, true),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareTablePresentationActionRowDiverges(entries, true),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Bundle compare interactive delegate composition across table, page, dossier, best-list, featured, and empty UI libs:

- **Table presentation** (`compare-table-ui-lib`): delegate `divergingDecisionLabels`, `renderNextActions`, `actionRowDiverges`
- **Table/page actions interactive**: route bundled fields through presentation-aligned delegates
- **Table signals interactive**: route label sets through table presentation delegates
- **Dossier/best/featured/empty interactive**: route bundled fields through page-level delegate helpers
- **Page featured interactive**: add named delegate for popular comparison links

## Test plan
- [x] 40 related vitest cases pass across 12 test files
- [x] 100% coverage on all 9 changed libs (33 statements)
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PRs #4831, #4829


Made with [Cursor](https://cursor.com)