### PR TITLE
feat(web): compose compare shell interactive UI through delegates

### DIFF
--- a/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-browse-interactive-ui-lib.ts
@@ -8,16 +8,23 @@ export type BrowseCompareInteractiveUiState = NonNullable<
   showHint: boolean;
 };
 
+export function browseCompareInteractiveUiShowsHint(items: Entry[]): boolean {
+  return shouldShowBrowseCompareHint(items);
+}
+
+export function browseCompareInteractiveBundledState(
+  items: Entry[],
+): ReturnType<typeof browseCompareUiState> {
+  return browseCompareUiState(items);
+}
+
 export function browseCompareInteractiveUiState(
   items: Entry[],
 ): BrowseCompareInteractiveUiState | null {
-  if (!shouldShowBrowseCompareHint(items)) return null;
+  const bundled = browseCompareInteractiveBundledState(items);
+  if (!bundled) return null;
   return {
-    ...browseCompareUiState(items)!,
+    ...bundled,
     showHint: browseCompareInteractiveUiShowsHint(items),
   };
-}
-
-export function browseCompareInteractiveUiShowsHint(items: Entry[]): boolean {
-  return shouldShowBrowseCompareHint(items);
 }

--- a/apps/web/src/lib/compare-context-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-context-interactive-ui-lib.ts
@@ -6,25 +6,25 @@ export type CompareContextInteractiveUiState = {
   shareUrl: string;
 };
 
+export function compareContextInteractiveSelectionParam(items: Entry[]): string {
+  return compareContextSelectionParam(items);
+}
+
+export function compareContextInteractiveShareUrl(items: Entry[]): string {
+  return compareContextShareUrl(items);
+}
+
 export function compareContextInteractiveUiState(items: Entry[]): CompareContextInteractiveUiState {
   return {
-    selectionParam: compareContextSelectionParam(items),
-    shareUrl: compareContextShareUrl(items),
+    selectionParam: compareContextInteractiveSelectionParam(items),
+    shareUrl: compareContextInteractiveShareUrl(items),
   };
 }
 
 /** True when hydrated selection differs from the live compare tray selection. */
 export function compareContextSelectionChanged(next: Entry[], current: Entry[]): boolean {
   return (
-    compareContextInteractiveUiState(next).selectionParam !==
-    compareContextInteractiveUiState(current).selectionParam
+    compareContextInteractiveSelectionParam(next) !==
+    compareContextInteractiveSelectionParam(current)
   );
-}
-
-export function compareContextInteractiveSelectionParam(items: Entry[]): string {
-  return compareContextInteractiveUiState(items).selectionParam;
-}
-
-export function compareContextInteractiveShareUrl(items: Entry[]): string {
-  return compareContextInteractiveUiState(items).shareUrl;
 }

--- a/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-curated-interactive-ui-lib.ts
@@ -1,7 +1,10 @@
 import type { EntryIdentity } from "@/lib/entry-identity";
 import {
   compareCuratedHasRenderableEntries,
-  compareCuratedUiState,
+  compareCuratedHeaderBannerTexts,
+  compareCuratedInteractiveLinkLabel,
+  compareCuratedInteractiveSearch,
+  compareCuratedResolvedEntries,
   type CompareCuratedUiState,
 } from "@/lib/compare-curated-ui-lib";
 
@@ -9,19 +12,23 @@ export type CompareCuratedInteractiveUiState = CompareCuratedUiState & {
   renderable: boolean;
 };
 
-export function compareCuratedInteractiveUiState(
-  refs: string[],
-  catalog: EntryIdentity[],
-): CompareCuratedInteractiveUiState {
-  return {
-    ...compareCuratedUiState(refs, catalog),
-    renderable: compareCuratedInteractivePageRenderable(refs, catalog),
-  };
-}
-
 export function compareCuratedInteractivePageRenderable(
   refs: string[],
   catalog: EntryIdentity[],
 ): boolean {
   return compareCuratedHasRenderableEntries(refs, catalog);
+}
+
+export function compareCuratedInteractiveUiState(
+  refs: string[],
+  catalog: EntryIdentity[],
+): CompareCuratedInteractiveUiState {
+  const entries = compareCuratedResolvedEntries(refs, catalog);
+  return {
+    entries,
+    bannerTexts: compareCuratedHeaderBannerTexts(entries),
+    interactiveSearch: compareCuratedInteractiveSearch(entries),
+    interactiveLinkLabel: compareCuratedInteractiveLinkLabel(entries.length),
+    renderable: compareCuratedInteractivePageRenderable(refs, catalog),
+  };
 }

--- a/apps/web/src/lib/compare-drawer-empty-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-empty-interactive-ui-lib.ts
@@ -6,11 +6,19 @@ export type CompareDrawerEmptyInteractiveUiState = {
   shareUrl: string;
 };
 
+export function compareDrawerEmptyInteractiveEmptyHint(): string {
+  return compareDrawerEmptyStateHint();
+}
+
+export function compareDrawerEmptyInteractiveShareUrl(items: Entry[]): string {
+  return compareDrawerShareUrl(items);
+}
+
 export function compareDrawerEmptyInteractiveUiState(
   items: Entry[],
 ): CompareDrawerEmptyInteractiveUiState {
   return {
-    emptyHint: compareDrawerEmptyStateHint(),
-    shareUrl: compareDrawerShareUrl(items),
+    emptyHint: compareDrawerEmptyInteractiveEmptyHint(),
+    shareUrl: compareDrawerEmptyInteractiveShareUrl(items),
   };
 }

--- a/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-interactive-ui-lib.ts
@@ -1,9 +1,16 @@
 import type { Entry } from "@/types/registry";
 import type { CompareDrawerActionCell } from "@/lib/compare-drawer-actions-ui-lib";
-import { compareDrawerActionsInteractiveUiState } from "@/lib/compare-drawer-actions-interactive-ui-lib";
-import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
+import {
+  compareDrawerActionsInteractiveActionCells,
+  compareDrawerActionsInteractiveActionRowDiverges,
+} from "@/lib/compare-drawer-actions-interactive-ui-lib";
+import {
+  compareDrawerEmptyInteractiveEmptyHint,
+  compareDrawerEmptyInteractiveShareUrl,
+} from "@/lib/compare-drawer-empty-interactive-ui-lib";
 import { compareSingleItemHintText } from "@/lib/compare-empty-guidance-lib";
 import {
+  compareDrawerUiInteractiveDivergingDecisionLabels,
   compareDrawerUiInteractiveUiState,
   type CompareDrawerUiState,
 } from "@/lib/compare-drawer-ui-interactive-ui-lib";
@@ -18,17 +25,27 @@ export type CompareDrawerInteractiveUiState = {
   actionCells: CompareDrawerActionCell[];
 };
 
+export function compareDrawerInteractiveEmptyHint(items: Entry[]): string {
+  return compareDrawerEmptyInteractiveEmptyHint();
+}
+
+export function compareDrawerInteractiveShareUrl(items: Entry[]): string {
+  return compareDrawerEmptyInteractiveShareUrl(items);
+}
+
+export function compareDrawerInteractiveSingleItemHint(itemCount: number): string | null {
+  return compareSingleItemHintText(itemCount);
+}
+
 export function compareDrawerInteractiveUiState(items: Entry[]): CompareDrawerInteractiveUiState {
-  const emptyUi = compareDrawerEmptyInteractiveUiState(items);
   const { divergingDecisionLabels, ...drawerUi } = compareDrawerUiInteractiveUiState(items);
-  const actions = compareDrawerActionsInteractiveUiState(items);
   return {
     drawerUi,
-    emptyHint: emptyUi.emptyHint,
-    singleItemHint: compareSingleItemHintText(items.length),
-    shareUrl: emptyUi.shareUrl,
-    divergingDecisionLabels,
-    actionRowDiverges: drawerUi.actionRowDiverges,
-    actionCells: actions.actionCells,
+    emptyHint: compareDrawerInteractiveEmptyHint(items),
+    singleItemHint: compareDrawerInteractiveSingleItemHint(items.length),
+    shareUrl: compareDrawerInteractiveShareUrl(items),
+    divergingDecisionLabels: compareDrawerUiInteractiveDivergingDecisionLabels(items),
+    actionRowDiverges: compareDrawerActionsInteractiveActionRowDiverges(items),
+    actionCells: compareDrawerActionsInteractiveActionCells(items),
   };
 }

--- a/apps/web/src/lib/compare-drawer-presentation-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-presentation-ui-interactive-ui-lib.ts
@@ -7,8 +7,14 @@ import {
 export type { CompareDrawerPresentationState };
 export type CompareDrawerPresentationUiInteractiveUiState = CompareDrawerPresentationState;
 
-export function compareDrawerPresentationUiInteractiveUiState(
+export function compareDrawerPresentationUiInteractivePresentationState(
   items: Entry[],
 ): CompareDrawerPresentationUiInteractiveUiState {
   return compareDrawerPresentationState(items);
+}
+
+export function compareDrawerPresentationUiInteractiveUiState(
+  items: Entry[],
+): CompareDrawerPresentationUiInteractiveUiState {
+  return compareDrawerPresentationUiInteractivePresentationState(items);
 }

--- a/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-drawer-ui-interactive-ui-lib.ts
@@ -1,5 +1,8 @@
 import type { Entry } from "@/types/registry";
-import { compareDrawerPresentationState } from "@/lib/compare-drawer-presentation-ui-lib";
+import {
+  compareDrawerPresentationActionRowDiverges,
+  compareDrawerPresentationDivergingDecisionLabels,
+} from "@/lib/compare-drawer-presentation-ui-lib";
 import { compareDrawerUiState, type CompareDrawerUiState } from "@/lib/compare-drawer-ui-lib";
 
 export type { CompareDrawerUiState };
@@ -7,14 +10,21 @@ export type CompareDrawerUiInteractiveUiState = CompareDrawerUiState & {
   divergingDecisionLabels: Set<string>;
 };
 
+export function compareDrawerUiInteractiveDivergingDecisionLabels(items: Entry[]): Set<string> {
+  return compareDrawerPresentationDivergingDecisionLabels(items);
+}
+
+export function compareDrawerUiInteractiveActionRowDiverges(items: Entry[]): boolean {
+  return compareDrawerPresentationActionRowDiverges(items);
+}
+
 export function compareDrawerUiInteractiveUiState(
   items: Entry[],
 ): CompareDrawerUiInteractiveUiState {
   const drawerUi = compareDrawerUiState(items);
-  const presentation = compareDrawerPresentationState(items);
   return {
     ...drawerUi,
-    actionRowDiverges: presentation.actionRowDiverges,
-    divergingDecisionLabels: presentation.divergingDecisionLabels,
+    actionRowDiverges: compareDrawerUiInteractiveActionRowDiverges(items),
+    divergingDecisionLabels: compareDrawerUiInteractiveDivergingDecisionLabels(items),
   };
 }

--- a/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-entry-interactive-ui-lib.ts
@@ -19,6 +19,21 @@ export type CompareEntryInteractiveUiState = {
   showDossierCompareSection: boolean;
 };
 
+export function compareEntryInteractiveDossierUi(
+  entry: Entry,
+  alternatives: Entry[],
+): CompareDossierInteractiveUiState {
+  return compareDossierInteractiveUiState(entry, alternatives);
+}
+
+export function compareEntryInteractiveFeaturedUi(
+  comparisons: ReadonlyArray<{ slug: string; refs: string[] }>,
+  lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
+  catalog: EntryIdentity[],
+): CompareEntryFeaturedInteractiveUiState {
+  return compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog);
+}
+
 export function compareEntryInteractiveUiState(
   entry: Entry,
   alternatives: Entry[],
@@ -26,17 +41,14 @@ export function compareEntryInteractiveUiState(
   lists: ReadonlyArray<{ slug: string; picks: BestListPickRef[] }>,
   catalog: EntryIdentity[],
 ): CompareEntryInteractiveUiState {
-  const dossierUi = compareDossierInteractiveUiState(entry, alternatives);
-  const featuredUi = compareEntryFeaturedInteractiveUiState(comparisons, lists, catalog);
   return {
-    dossierUi,
-    featuredUi,
-    hasFeaturedLinks: compareEntryFeaturedInteractiveShowsFeaturedLinks(
-      comparisons,
-      lists,
-      catalog,
+    dossierUi: compareEntryInteractiveDossierUi(entry, alternatives),
+    featuredUi: compareEntryInteractiveFeaturedUi(comparisons, lists, catalog),
+    hasFeaturedLinks: compareEntryInteractiveShowsFeaturedLinks(comparisons, lists, catalog),
+    showDossierCompareSection: compareEntryInteractiveShowsDossierCompareSection(
+      entry,
+      alternatives,
     ),
-    showDossierCompareSection: compareDossierInteractiveShowCompareSection(entry, alternatives),
   };
 }
 

--- a/apps/web/src/lib/compare-page-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-interactive-ui-lib.ts
@@ -1,11 +1,12 @@
 import type { Entry } from "@/types/registry";
 import type { EntryIdentity } from "@/lib/entry-identity";
 import type { ComparePageActionCell } from "@/lib/compare-page-actions-ui-lib";
-import { comparePageActionsInteractiveUiState } from "@/lib/compare-page-actions-interactive-ui-lib";
+import { comparePageActionCells } from "@/lib/compare-page-actions-ui-lib";
 import {
   comparePageEmptyInteractiveUiState,
   type ComparePageEmptyUiState,
 } from "@/lib/compare-page-empty-interactive-ui-lib";
+import { comparePagePresentationActionRowDiverges } from "@/lib/compare-page-presentation-ui-lib";
 import {
   comparePageUiInteractiveUiState,
   type ComparePageUiState,
@@ -18,18 +19,36 @@ export type ComparePageInteractiveUiState = {
   actionCells: ComparePageActionCell[];
 };
 
+export function comparePageInteractivePageUi(items: Entry[]): ComparePageUiState {
+  return comparePageUiInteractiveUiState(items);
+}
+
+export function comparePageInteractiveEmptyUi(
+  ids: string,
+  comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
+  catalog: EntryIdentity[],
+): ComparePageEmptyUiState {
+  return comparePageEmptyInteractiveUiState(ids, comparisons, catalog);
+}
+
+export function comparePageInteractiveActionRowDiverges(items: Entry[]): boolean {
+  return comparePagePresentationActionRowDiverges(items);
+}
+
+export function comparePageInteractiveActionCells(items: Entry[]): ComparePageActionCell[] {
+  return comparePageActionCells(items);
+}
+
 export function comparePageInteractiveUiState(
   items: Entry[],
   ids: string,
   comparisons: ReadonlyArray<{ slug: string; heading: string; refs: string[] }>,
   catalog: EntryIdentity[],
 ): ComparePageInteractiveUiState {
-  const pageUi = comparePageUiInteractiveUiState(items);
-  const actions = comparePageActionsInteractiveUiState(items);
   return {
-    pageUi,
-    emptyUi: comparePageEmptyInteractiveUiState(ids, comparisons, catalog),
-    actionRowDiverges: pageUi.actionRowDiverges,
-    actionCells: actions.actionCells,
+    pageUi: comparePageInteractivePageUi(items),
+    emptyUi: comparePageInteractiveEmptyUi(ids, comparisons, catalog),
+    actionRowDiverges: comparePageInteractiveActionRowDiverges(items),
+    actionCells: comparePageInteractiveActionCells(items),
   };
 }

--- a/apps/web/src/lib/compare-page-presentation-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-presentation-ui-interactive-ui-lib.ts
@@ -7,8 +7,14 @@ import {
 export type { ComparePagePresentationState };
 export type ComparePagePresentationUiInteractiveUiState = ComparePagePresentationState;
 
-export function comparePagePresentationUiInteractiveUiState(
+export function comparePagePresentationUiInteractivePresentationState(
   items: Entry[],
 ): ComparePagePresentationUiInteractiveUiState {
   return comparePagePresentationState(items);
+}
+
+export function comparePagePresentationUiInteractiveUiState(
+  items: Entry[],
+): ComparePagePresentationUiInteractiveUiState {
+  return comparePagePresentationUiInteractivePresentationState(items);
 }

--- a/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-page-ui-interactive-ui-lib.ts
@@ -1,15 +1,18 @@
 import type { Entry } from "@/types/registry";
-import { comparePagePresentationState } from "@/lib/compare-page-presentation-ui-lib";
+import { comparePagePresentationActionRowDiverges } from "@/lib/compare-page-presentation-ui-lib";
 import { comparePageUiState, type ComparePageUiState } from "@/lib/compare-page-ui-lib";
 
 export type { ComparePageUiState };
 export type ComparePageUiInteractiveUiState = ComparePageUiState;
 
+export function comparePageUiInteractiveActionRowDiverges(items: Entry[]): boolean {
+  return comparePagePresentationActionRowDiverges(items);
+}
+
 export function comparePageUiInteractiveUiState(items: Entry[]): ComparePageUiInteractiveUiState {
   const pageUi = comparePageUiState(items);
-  const presentation = comparePagePresentationState(items);
   return {
     ...pageUi,
-    actionRowDiverges: presentation.actionRowDiverges,
+    actionRowDiverges: comparePageUiInteractiveActionRowDiverges(items),
   };
 }

--- a/apps/web/src/lib/compare-table-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-interactive-ui-lib.ts
@@ -1,7 +1,7 @@
 import type { Entry } from "@/types/registry";
 import type { CompareTableActionCell } from "@/lib/compare-table-actions-ui-lib";
 import { compareTableActionsInteractiveUiState } from "@/lib/compare-table-actions-interactive-ui-lib";
-import { compareTableUiInteractiveUiState } from "@/lib/compare-table-ui-interactive-ui-lib";
+import { compareTableUiInteractivePresentationState } from "@/lib/compare-table-ui-interactive-ui-lib";
 
 export type CompareTableInteractiveUiState = {
   divergingDecisionLabels: Set<string>;
@@ -10,14 +10,46 @@ export type CompareTableInteractiveUiState = {
   actionCells: CompareTableActionCell[];
 };
 
+export function compareTableInteractiveDivergingDecisionLabels(
+  entries: Entry[],
+  showNextActions: boolean,
+): Set<string> {
+  return compareTableUiInteractivePresentationState(entries, showNextActions)
+    .divergingDecisionLabels;
+}
+
+export function compareTableInteractiveRenderNextActions(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return compareTableActionsInteractiveUiState(entries, showNextActions).renderNextActions;
+}
+
+export function compareTableInteractiveActionRowDiverges(
+  entries: Entry[],
+  showNextActions: boolean,
+): boolean {
+  return compareTableActionsInteractiveUiState(entries, showNextActions).actionRowDiverges;
+}
+
+export function compareTableInteractiveActionCells(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTableActionCell[] {
+  return compareTableActionsInteractiveUiState(entries, showNextActions).actionCells;
+}
+
 export function compareTableInteractiveUiState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableInteractiveUiState {
-  const tableUi = compareTableUiInteractiveUiState(entries, showNextActions);
-  const actions = compareTableActionsInteractiveUiState(entries, showNextActions);
   return {
-    ...tableUi,
-    actionCells: actions.actionCells,
+    divergingDecisionLabels: compareTableInteractiveDivergingDecisionLabels(
+      entries,
+      showNextActions,
+    ),
+    renderNextActions: compareTableInteractiveRenderNextActions(entries, showNextActions),
+    actionRowDiverges: compareTableInteractiveActionRowDiverges(entries, showNextActions),
+    actionCells: compareTableActionsInteractiveUiState(entries, showNextActions).actionCells,
   };
 }

--- a/apps/web/src/lib/compare-table-ui-interactive-ui-lib.ts
+++ b/apps/web/src/lib/compare-table-ui-interactive-ui-lib.ts
@@ -7,9 +7,16 @@ import {
 export type { CompareTablePresentationState };
 export type CompareTableUiInteractiveUiState = CompareTablePresentationState;
 
-export function compareTableUiInteractiveUiState(
+export function compareTableUiInteractivePresentationState(
   entries: Entry[],
   showNextActions: boolean,
 ): CompareTableUiInteractiveUiState {
   return compareTablePresentationState(entries, showNextActions);
+}
+
+export function compareTableUiInteractiveUiState(
+  entries: Entry[],
+  showNextActions: boolean,
+): CompareTableUiInteractiveUiState {
+  return compareTableUiInteractivePresentationState(entries, showNextActions);
 }

--- a/tests/compare-browse-interactive-ui-lib.test.ts
+++ b/tests/compare-browse-interactive-ui-lib.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  browseCompareInteractiveBundledState,
   browseCompareInteractiveUiShowsHint,
   browseCompareInteractiveUiState,
 } from "@/lib/compare-browse-interactive-ui-lib";
@@ -52,6 +53,10 @@ describe("compare browse interactive ui lib", () => {
     expect(browseCompareInteractiveUiShowsHint(five)).toBe(true);
     const bundled = browseCompareInteractiveUiState(five);
     expect(bundled?.showHint).toBe(browseCompareInteractiveUiShowsHint(five));
+    expect(bundled).toEqual({
+      ...browseCompareInteractiveBundledState(five)!,
+      showHint: true,
+    });
   });
 
   it("surfaces divergence hints in browse compare CTA state", () => {

--- a/tests/compare-curated-interactive-ui-lib.test.ts
+++ b/tests/compare-curated-interactive-ui-lib.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareCuratedHeaderBannerTexts,
+  compareCuratedInteractiveLinkLabel,
+  compareCuratedInteractiveSearch,
+  compareCuratedResolvedEntries,
+} from "@/lib/compare-curated-ui-lib";
+import {
   compareCuratedInteractivePageRenderable,
   compareCuratedInteractiveUiState,
 } from "@/lib/compare-curated-interactive-ui-lib";
@@ -99,5 +105,15 @@ describe("compare curated interactive ui lib", () => {
     ).toEqual([
       "1 trust signal differ across this comparison (Review status).",
     ]);
+    const entries = compareCuratedResolvedEntries(refs, extendedCatalog);
+    expect(compareCuratedHeaderBannerTexts(entries)).toEqual([
+      "1 trust signal differ across this comparison (Review status).",
+    ]);
+    expect(compareCuratedInteractiveSearch(entries)).toEqual({
+      ids: refs.join(","),
+    });
+    expect(compareCuratedInteractiveLinkLabel(entries.length)).toBe(
+      "Open in the interactive comparison tool",
+    );
   });
 });

--- a/tests/compare-drawer-empty-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-empty-interactive-ui-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDrawerEmptyInteractiveUiState } from "@/lib/compare-drawer-empty-interactive-ui-lib";
+import {
+  compareDrawerEmptyInteractiveEmptyHint,
+  compareDrawerEmptyInteractiveShareUrl,
+  compareDrawerEmptyInteractiveUiState,
+} from "@/lib/compare-drawer-empty-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -28,15 +32,17 @@ describe("compare drawer empty interactive ui lib", () => {
   });
 
   it("builds browse share URLs for multi-item drawer selections", () => {
-    expect(
-      compareDrawerEmptyInteractiveUiState([
-        entry({ category: "skills", slug: "alpha" }),
-        entry({ category: "hooks", slug: "beta" }),
-      ]),
-    ).toEqual({
+    const items = [
+      entry({ category: "skills", slug: "alpha" }),
+      entry({ category: "hooks", slug: "beta" }),
+    ];
+    const state = compareDrawerEmptyInteractiveUiState(items);
+    expect(state).toEqual({
       emptyHint: expect.stringContaining("Compare"),
       shareUrl: "/browse?compare=skills%2Falpha%2Chooks%2Fbeta",
     });
+    expect(state.emptyHint).toBe(compareDrawerEmptyInteractiveEmptyHint());
+    expect(state.shareUrl).toBe(compareDrawerEmptyInteractiveShareUrl(items));
   });
 
   it("preserves single-entry drawer share URLs", () => {

--- a/tests/compare-drawer-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-interactive-ui-lib.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
+import {
+  compareDrawerActionsInteractiveActionCells,
+  compareDrawerActionsInteractiveActionRowDiverges,
+} from "@/lib/compare-drawer-actions-interactive-ui-lib";
+import { compareDrawerUiInteractiveDivergingDecisionLabels } from "@/lib/compare-drawer-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -73,5 +78,18 @@ describe("compare drawer interactive ui lib", () => {
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    const items = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
+    expect(state.divergingDecisionLabels).toEqual(
+      compareDrawerUiInteractiveDivergingDecisionLabels(items),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareDrawerActionsInteractiveActionRowDiverges(items),
+    );
+    expect(state.actionCells).toEqual(
+      compareDrawerActionsInteractiveActionCells(items),
+    );
   });
 });

--- a/tests/compare-drawer-presentation-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-presentation-ui-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDrawerPresentationUiInteractiveUiState } from "@/lib/compare-drawer-presentation-ui-interactive-ui-lib";
+import {
+  compareDrawerPresentationUiInteractivePresentationState,
+  compareDrawerPresentationUiInteractiveUiState,
+} from "@/lib/compare-drawer-presentation-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -34,5 +37,12 @@ describe("compare drawer presentation ui interactive ui lib", () => {
     ]);
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.actionRowDiverges).toBe(true);
+    const items = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
+    expect(state).toEqual(
+      compareDrawerPresentationUiInteractivePresentationState(items),
+    );
   });
 });

--- a/tests/compare-drawer-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-drawer-ui-interactive-ui-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareDrawerUiInteractiveUiState } from "@/lib/compare-drawer-ui-interactive-ui-lib";
+import {
+  compareDrawerUiInteractiveActionRowDiverges,
+  compareDrawerUiInteractiveDivergingDecisionLabels,
+  compareDrawerUiInteractiveUiState,
+} from "@/lib/compare-drawer-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -50,5 +54,17 @@ describe("compare drawer ui interactive ui lib", () => {
     ]);
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.actionRowDiverges).toBe(true);
+    expect(state.divergingDecisionLabels).toEqual(
+      compareDrawerUiInteractiveDivergingDecisionLabels([
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ]),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareDrawerUiInteractiveActionRowDiverges([
+        entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+        entry({ slug: "other", installCommand: "npm i fixture" }),
+      ]),
+    );
   });
 });

--- a/tests/compare-entry-interactive-ui-lib.test.ts
+++ b/tests/compare-entry-interactive-ui-lib.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
 import {
+  compareEntryInteractiveDossierUi,
+  compareEntryInteractiveFeaturedUi,
   compareEntryInteractiveShowsDossierCompareSection,
   compareEntryInteractiveShowsFeaturedLinks,
   compareEntryInteractiveUiState,
@@ -117,6 +119,23 @@ describe("compare entry interactive ui lib", () => {
       compareEntryInteractiveShowsDossierCompareSection(primary, [
         entry({ category: "hooks", slug: "alt" }),
       ]),
+    );
+    expect(bundled.dossierUi).toEqual(
+      compareEntryInteractiveDossierUi(primary, [
+        entry({ category: "hooks", slug: "alt" }),
+      ]),
+    );
+    expect(bundled.featuredUi).toEqual(
+      compareEntryInteractiveFeaturedUi(
+        [{ slug: "pair", refs: ["skills/alpha", "hooks/beta"] }],
+        [
+          {
+            slug: "top-picks",
+            picks: [{ ref: "skills/alpha" }, { ref: "hooks/beta" }],
+          },
+        ],
+        catalog,
+      ),
     );
   });
 

--- a/tests/compare-page-interactive-ui-lib.test.ts
+++ b/tests/compare-page-interactive-ui-lib.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { comparePageInteractiveUiState } from "@/lib/compare-page-interactive-ui-lib";
+import {
+  comparePageInteractiveActionCells,
+  comparePageInteractiveActionRowDiverges,
+  comparePageInteractiveUiState,
+} from "@/lib/compare-page-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -89,6 +93,14 @@ describe("compare page interactive ui lib", () => {
     );
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    const items = [
+      entry({ installCommand: "npm i fixture" }),
+      entry({ slug: "other" }),
+    ];
+    expect(state.actionRowDiverges).toBe(
+      comparePageInteractiveActionRowDiverges(items),
+    );
+    expect(state.actionCells).toEqual(comparePageInteractiveActionCells(items));
     expect(state.actionCells[0]).toEqual(
       expect.objectContaining({ entryKey: "mcp:fixture" }),
     );

--- a/tests/compare-page-presentation-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-page-presentation-ui-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { comparePagePresentationUiInteractiveUiState } from "@/lib/compare-page-presentation-ui-interactive-ui-lib";
+import {
+  comparePagePresentationUiInteractivePresentationState,
+  comparePagePresentationUiInteractiveUiState,
+} from "@/lib/compare-page-presentation-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -27,11 +30,11 @@ describe("compare page presentation ui interactive ui lib", () => {
   });
 
   it("highlights diverging next-action rows for mixed compare columns", () => {
-    expect(
-      comparePagePresentationUiInteractiveUiState([
-        entry({ installCommand: "npm i fixture" }),
-        entry(),
-      ]).actionRowDiverges,
-    ).toBe(true);
+    const items = [entry({ installCommand: "npm i fixture" }), entry()];
+    const state = comparePagePresentationUiInteractiveUiState(items);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state).toEqual(
+      comparePagePresentationUiInteractivePresentationState(items),
+    );
   });
 });

--- a/tests/compare-page-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-page-ui-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { comparePageUiInteractiveUiState } from "@/lib/compare-page-ui-interactive-ui-lib";
+import {
+  comparePageUiInteractiveActionRowDiverges,
+  comparePageUiInteractiveUiState,
+} from "@/lib/compare-page-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -41,11 +44,14 @@ describe("compare page ui interactive ui lib", () => {
   });
 
   it("highlights diverging next actions in bundled page presentation state", () => {
-    expect(
-      comparePageUiInteractiveUiState([
-        entry({ installCommand: "npm i fixture" }),
-        entry({ slug: "other" }),
-      ]).actionRowDiverges,
-    ).toBe(true);
+    const items = [
+      entry({ installCommand: "npm i fixture" }),
+      entry({ slug: "other" }),
+    ];
+    const state = comparePageUiInteractiveUiState(items);
+    expect(state.actionRowDiverges).toBe(true);
+    expect(state.actionRowDiverges).toBe(
+      comparePageUiInteractiveActionRowDiverges(items),
+    );
   });
 });

--- a/tests/compare-table-interactive-ui-lib.test.ts
+++ b/tests/compare-table-interactive-ui-lib.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareTableInteractiveUiState } from "@/lib/compare-table-interactive-ui-lib";
+import {
+  compareTableInteractiveActionCells,
+  compareTableInteractiveActionRowDiverges,
+  compareTableInteractiveDivergingDecisionLabels,
+  compareTableInteractiveRenderNextActions,
+  compareTableInteractiveUiState,
+} from "@/lib/compare-table-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -67,5 +73,21 @@ describe("compare table interactive ui lib", () => {
     expect(state.renderNextActions).toBe(true);
     expect(state.actionRowDiverges).toBe(true);
     expect(state.actionCells).toHaveLength(2);
+    const entries = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
+    expect(state.divergingDecisionLabels).toEqual(
+      compareTableInteractiveDivergingDecisionLabels(entries, true),
+    );
+    expect(state.renderNextActions).toBe(
+      compareTableInteractiveRenderNextActions(entries, true),
+    );
+    expect(state.actionRowDiverges).toBe(
+      compareTableInteractiveActionRowDiverges(entries, true),
+    );
+    expect(state.actionCells).toEqual(
+      compareTableInteractiveActionCells(entries, true),
+    );
   });
 });

--- a/tests/compare-table-ui-interactive-ui-lib.test.ts
+++ b/tests/compare-table-ui-interactive-ui-lib.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Entry } from "@/types/registry";
-import { compareTableUiInteractiveUiState } from "@/lib/compare-table-ui-interactive-ui-lib";
+import {
+  compareTableUiInteractivePresentationState,
+  compareTableUiInteractiveUiState,
+} from "@/lib/compare-table-ui-interactive-ui-lib";
 
 function entry(overrides: Partial<Entry> = {}): Entry {
   return {
@@ -53,5 +56,12 @@ describe("compare table ui interactive ui lib", () => {
     expect(state.divergingDecisionLabels).toEqual(new Set(["Review status"]));
     expect(state.renderNextActions).toBe(true);
     expect(state.actionRowDiverges).toBe(true);
+    const entries = [
+      entry({ reviewedBy: "maintainer", reviewedAt: "2026-01-02" }),
+      entry({ slug: "other", installCommand: "npm i fixture" }),
+    ];
+    expect(state).toEqual(
+      compareTableUiInteractivePresentationState(entries, true),
+    );
   });
 });


### PR DESCRIPTION
## Summary
Bundle compare shell interactive delegate composition across 13 libs:

- **Drawer shell**: `compare-drawer-ui-interactive`, `compare-drawer-empty-interactive`, `compare-drawer-interactive`, `compare-drawer-presentation-ui-interactive`
- **Page shell**: `compare-page-ui-interactive`, `compare-page-interactive`, `compare-page-presentation-ui-interactive`
- **Table shell**: `compare-table-ui-interactive`, `compare-table-interactive`
- **Context / curated / browse / entry**: interactive shell helpers wired through named delegates

Does not overlap with #4832 (page/table/best/dossier/featured leaf interactive libs).

## Test plan
- [x] 42 related vitest cases pass across 13 test files
- [x] 100% coverage on all 13 changed libs (49 statements)
- [x] Prettier applied to changed files
- [x] Verified clean merge-tree against open PRs #4833, #4832, #4831, #4829


Made with [Cursor](https://cursor.com)