### PR TITLE
feat(web): track browse URL compare opens and drawer undo restore

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -23,6 +23,12 @@ import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-inter
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import {
+  compareDrawerClearAnalyticsData,
+  compareDrawerClearAnalyticsEvent,
+  compareDrawerUndoRestoreAnalyticsData,
+  compareDrawerUndoRestoreAnalyticsEvent,
+} from "@/lib/compare-drawer-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -371,14 +377,20 @@ export function CompareDrawer() {
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
     if (!snapshot) return clear();
+    const clearedCount = items.length;
+    trackEvent(compareDrawerClearAnalyticsEvent(), compareDrawerClearAnalyticsData(clearedCount));
     clear();
     toast("Compare cleared", {
-      description: `${items.length} item${items.length === 1 ? "" : "s"} removed`,
+      description: `${clearedCount} item${clearedCount === 1 ? "" : "s"} removed`,
       action: {
         label: "Undo",
         onClick: () => {
           hydrate(snapshot);
           setOpen(true);
+          trackEvent(
+            compareDrawerUndoRestoreAnalyticsEvent(),
+            compareDrawerUndoRestoreAnalyticsData(clearedCount),
+          );
         },
       },
     });

--- a/apps/web/src/lib/compare-browse-share-link-lib.ts
+++ b/apps/web/src/lib/compare-browse-share-link-lib.ts
@@ -18,3 +18,9 @@ export function compareBrowseShareUrlFromEntries(entries: EntryIdentity[], origi
 export function compareBrowseShareUrlForWindow(entries: EntryIdentity[]): string {
   return compareBrowseShareUrlFromEntries(entries, compareShareOrigin());
 }
+
+export function browseCompareUrlSelectedCount(compareParam: string | undefined | null): number {
+  const raw = String(compareParam ?? "").trim();
+  if (!raw) return 0;
+  return raw.split(",").filter((part) => part.trim().length > 0).length;
+}

--- a/apps/web/src/lib/compare-drawer-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events-lib.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure compare drawer CTA analytics helpers.
+ *
+ * Maps drawer-level actions to privacy-light event names without embedding
+ * entry payloads or other sensitive fields.
+ */
+
+import { COMPARE_DRAWER_SURFACE } from "@/lib/compare-drawer-actions-lib";
+
+export { COMPARE_DRAWER_SURFACE };
+
+export function compareDrawerClearAnalyticsEvent(): string {
+  return "compare_drawer_clear";
+}
+
+export function compareDrawerClearAnalyticsData(count: number) {
+  return {
+    count,
+    surface: COMPARE_DRAWER_SURFACE,
+  };
+}
+
+export function compareDrawerUndoRestoreAnalyticsEvent(): string {
+  return "compare_drawer_undo_restore";
+}
+
+export function compareDrawerUndoRestoreAnalyticsData(count: number) {
+  return {
+    count,
+    surface: COMPARE_DRAWER_SURFACE,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Compare drawer CTA event surface.
+ */
+export {
+  COMPARE_DRAWER_SURFACE,
+  compareDrawerClearAnalyticsData,
+  compareDrawerClearAnalyticsEvent,
+  compareDrawerUndoRestoreAnalyticsData,
+  compareDrawerUndoRestoreAnalyticsEvent,
+} from "@/lib/compare-drawer-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -19,7 +19,8 @@ export const COMPARE_TRAY_SURFACE = "compare-tray";
 export type BrowseCompareOpenSurface =
   | "browse-toolbar"
   | "browse-compare-selection-banner"
-  | "browse-trust-panel";
+  | "browse-trust-panel"
+  | "browse-compare-url";
 
 export function entryDetailEntryKey(category: string, slug: string): string {
   return `${category}/${slug}`;

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -57,6 +57,7 @@ import {
 } from "lucide-react";
 import { useCompare } from "@/lib/compare";
 import { browseCompareInteractiveUiState } from "@/lib/compare-browse-interactive-ui-lib";
+import { browseCompareUrlSelectedCount } from "@/lib/compare-browse-share-link";
 import {
   browseCompareOpenAnalyticsData,
   browseCompareOpenAnalyticsEvent,
@@ -305,7 +306,16 @@ function Browse() {
   // Hydrate from URL on mount + whenever the param changes externally
   React.useEffect(() => {
     compare.hydrate(compareParam);
-    if (compareParam) compare.setOpen(true);
+    if (compareParam) {
+      compare.setOpen(true);
+      const selectedCount = browseCompareUrlSelectedCount(compareParam);
+      if (selectedCount > 0) {
+        trackEvent(
+          browseCompareOpenAnalyticsEvent(),
+          browseCompareOpenAnalyticsData(selectedCount, "browse-compare-url"),
+        );
+      }
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [compareParam]);
   // Push selection changes back into the URL (debounced via effect)

--- a/tests/compare-browse-share-link-lib.test.ts
+++ b/tests/compare-browse-share-link-lib.test.ts
@@ -2,11 +2,20 @@ import { describe, expect, it } from "vitest";
 import {
   compareBrowseSharePath,
   compareBrowseShareUrl,
+  browseCompareUrlSelectedCount,
 } from "../apps/web/src/lib/compare-browse-share-link-lib";
 
 describe("compare-browse-share-link-lib", () => {
   it("builds browse share path", () => {
     expect(compareBrowseSharePath("mcp:a")).toContain("/browse?compare=");
+  });
+  it("counts selected entries in browse compare url params", () => {
+    expect(browseCompareUrlSelectedCount("")).toBe(0);
+    expect(browseCompareUrlSelectedCount("mcp/browser")).toBe(1);
+    expect(browseCompareUrlSelectedCount("mcp/browser,skills/demo")).toBe(2);
+    expect(browseCompareUrlSelectedCount(" mcp/browser , ,skills/demo ")).toBe(
+      2,
+    );
   });
   it("compareBrowseShareUrl matrix 0", () => {
     expect(compareBrowseShareUrl("mcp:slug-0", "https://heyclau.de")).toContain(

--- a/tests/compare-drawer-cta-events-lib.test.ts
+++ b/tests/compare-drawer-cta-events-lib.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDrawerClearAnalyticsData,
+  compareDrawerClearAnalyticsEvent,
+  compareDrawerUndoRestoreAnalyticsData,
+  compareDrawerUndoRestoreAnalyticsEvent,
+} from "@/lib/compare-drawer-cta-events-lib";
+
+describe("compare drawer cta events lib", () => {
+  it("builds privacy-light clear and undo restore analytics", () => {
+    expect(compareDrawerClearAnalyticsEvent()).toBe("compare_drawer_clear");
+    expect(compareDrawerClearAnalyticsData(3)).toEqual({
+      count: 3,
+      surface: "compare-drawer",
+    });
+    expect(compareDrawerUndoRestoreAnalyticsEvent()).toBe(
+      "compare_drawer_undo_restore",
+    );
+    expect(compareDrawerUndoRestoreAnalyticsData(2)).toEqual({
+      count: 2,
+      surface: "compare-drawer",
+    });
+  });
+});

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -128,6 +128,10 @@ describe("entry detail cta events lib", () => {
       count: 4,
       surface: "browse-trust-panel",
     });
+    expect(browseCompareOpenAnalyticsData(2, "browse-compare-url")).toEqual({
+      count: 2,
+      surface: "browse-compare-url",
+    });
     expect(comparisonTrayQuickCompareAnalyticsEvent()).toBe(
       "compare_tray_quick_compare",
     );


### PR DESCRIPTION
## Summary
- Track `browse_compare_open` when browse hydrates compare selection from a shared `?compare=` URL (`browse-compare-url` surface).
- Add compare drawer clear/undo restore analytics helpers and wire the drawer clear toast Undo action.

Closes #556

## Test plan
- [x] `pnpm test tests/compare-drawer-cta-events-lib.test.ts tests/compare-browse-share-link-lib.test.ts tests/entry-detail-cta-events-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`