### PR TITLE
feat(web): normalize source repository link analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -22,12 +22,14 @@ import { COMPARE_DRAWER_SURFACE, type CompareAction } from "@/lib/compare-drawer
 import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
 import { recordCompareIntentEvent } from "@/lib/compare-entry-actions";
-import { trackEvent, entryEventKey } from "@/lib/analytics";
+import { trackEvent, entryEventKey, outboundHost } from "@/lib/analytics";
 import {
   compareDrawerClearAnalyticsData,
   compareDrawerClearAnalyticsEvent,
   compareDrawerUndoRestoreAnalyticsData,
   compareDrawerUndoRestoreAnalyticsEvent,
+  compareDrawerSourceAnalyticsData,
+  compareDrawerSourceAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
@@ -71,6 +73,34 @@ import {
 interface RowDef {
   label: string;
   render: (e: Entry) => React.ReactNode;
+}
+
+function CompareDrawerSourceCell({ entry }: { entry: Entry }) {
+  if (!entry.sourceUrl) {
+    return <span className="text-xs text-ink-subtle">—</span>;
+  }
+
+  return (
+    <a
+      href={entry.sourceUrl}
+      target="_blank"
+      rel="noreferrer"
+      onClick={() => {
+        trackEvent(
+          compareDrawerSourceAnalyticsEvent(),
+          compareDrawerSourceAnalyticsData(
+            entry.category,
+            entry.slug,
+            outboundHost(entry.sourceUrl!),
+          ),
+        );
+        void recordCompareIntentEvent("open", entry);
+      }}
+      className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
+    >
+      Repository <ExternalLink className="h-3 w-3" />
+    </a>
+  );
 }
 
 const ROWS: RowDef[] = [
@@ -173,19 +203,7 @@ const ROWS: RowDef[] = [
   },
   {
     label: "Source",
-    render: (e) =>
-      e.sourceUrl ? (
-        <a
-          href={e.sourceUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
-        >
-          Repository <ExternalLink className="h-3 w-3" />
-        </a>
-      ) : (
-        <span className="text-xs text-ink-subtle">—</span>
-      ),
+    render: (e) => <CompareDrawerSourceCell entry={e} />,
   },
   {
     label: "Claim",

--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -38,6 +38,8 @@ import {
   entryDetailCopyIntentType,
   entryDetailIntegrationAnalyticsData,
   entryDetailIntegrationAnalyticsEvent,
+  entryDetailSourceAnalyticsData,
+  entryDetailSourceAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
 import {
   detailIntegrationLinkIcon,
@@ -45,7 +47,7 @@ import {
   type DetailIntegrationLinkIcon,
 } from "@/lib/entry-detail-integration-links";
 import { recordIntentEvent } from "@/lib/intent-event-client";
-import { trackEvent } from "@/lib/analytics";
+import { trackEvent, outboundHost } from "@/lib/analytics";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { INSTALL_RISK_LABEL } from "@/lib/trust";
 import type { InstallRisk } from "@/lib/trust-lib";
@@ -151,6 +153,17 @@ export function EntryDetailCommandCenter({
               href={entry.sourceUrl}
               target="_blank"
               rel="noreferrer"
+              onClick={() => {
+                trackEvent(
+                  entryDetailSourceAnalyticsEvent(),
+                  entryDetailSourceAnalyticsData(
+                    entry.category,
+                    entry.slug,
+                    outboundHost(entry.sourceUrl!),
+                  ),
+                );
+                void recordIntentEvent("open", entry);
+              }}
               className="inline-flex items-center gap-1 text-xs text-ink-muted hover:text-ink"
             >
               Source <ArrowUpRight className="h-3 w-3" />

--- a/apps/web/src/components/resource-card.tsx
+++ b/apps/web/src/components/resource-card.tsx
@@ -24,6 +24,8 @@ import {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardSourceAnalyticsData,
+  resourceCardSourceAnalyticsEvent,
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
@@ -352,11 +354,14 @@ function ResourceCardInner({
                 target="_blank"
                 rel="noreferrer"
                 onClick={() =>
-                  trackEvent("source-click", {
-                    entry: resourceCardInstallAnalyticsData(entry.category, entry.slug).entry,
-                    host: outboundHost(entry.sourceUrl!),
-                    surface: installAnalyticsData.surface,
-                  })
+                  trackEvent(
+                    resourceCardSourceAnalyticsEvent(),
+                    resourceCardSourceAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      outboundHost(entry.sourceUrl!),
+                    ),
+                  )
                 }
                 className="inline-flex h-7 w-full items-center justify-center gap-1 rounded-md border border-border bg-surface px-2 text-xs font-medium text-ink hover:border-border-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
               >

--- a/apps/web/src/lib/compare-drawer-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events-lib.ts
@@ -30,3 +30,15 @@ export function compareDrawerUndoRestoreAnalyticsData(count: number) {
     surface: COMPARE_DRAWER_SURFACE,
   };
 }
+
+export function compareDrawerSourceAnalyticsEvent(): string {
+  return "compare_drawer_source_open";
+}
+
+export function compareDrawerSourceAnalyticsData(category: string, slug: string, host: string) {
+  return {
+    entry: `${category}/${slug}`,
+    surface: COMPARE_DRAWER_SURFACE,
+    host,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events.ts
@@ -7,4 +7,6 @@ export {
   compareDrawerClearAnalyticsEvent,
   compareDrawerUndoRestoreAnalyticsData,
   compareDrawerUndoRestoreAnalyticsEvent,
+  compareDrawerSourceAnalyticsData,
+  compareDrawerSourceAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events-lib";

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -240,6 +240,18 @@ export function entryDetailIntegrationAnalyticsData(
   };
 }
 
+export function entryDetailSourceAnalyticsEvent(): string {
+  return "detail_source_open";
+}
+
+export function entryDetailSourceAnalyticsData(category: string, slug: string, host: string) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+    host,
+  };
+}
+
 export function entryDetailMobileLlmsAnalyticsData(category: string, slug: string) {
   return {
     entry: entryDetailEntryKey(category, slug),

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -39,6 +39,8 @@ export {
   entryDetailEntryKey,
   entryDetailIntegrationAnalyticsData,
   entryDetailIntegrationAnalyticsEvent,
+  entryDetailSourceAnalyticsData,
+  entryDetailSourceAnalyticsEvent,
   entryDetailMobileActionAnalyticsData,
   entryDetailMobileActionAnalyticsEvent,
   entryDetailMobileCopyIntentType,

--- a/apps/web/src/lib/resource-card-cta-events-lib.ts
+++ b/apps/web/src/lib/resource-card-cta-events-lib.ts
@@ -57,3 +57,15 @@ export function resourceCardCompareToastOpenAnalyticsData(
     compareCount,
   };
 }
+
+export function resourceCardSourceAnalyticsEvent(): string {
+  return "browse_card_source_open";
+}
+
+export function resourceCardSourceAnalyticsData(category: string, slug: string, host: string) {
+  return {
+    entry: resourceCardEntryKey(category, slug),
+    surface: RESOURCE_CARD_SURFACE,
+    host,
+  };
+}

--- a/apps/web/src/lib/resource-card-cta-events.ts
+++ b/apps/web/src/lib/resource-card-cta-events.ts
@@ -7,6 +7,8 @@ export {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardSourceAnalyticsData,
+  resourceCardSourceAnalyticsEvent,
   resourceCardEntryKey,
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,

--- a/tests/compare-drawer-cta-events-lib.test.ts
+++ b/tests/compare-drawer-cta-events-lib.test.ts
@@ -4,6 +4,8 @@ import {
   compareDrawerClearAnalyticsEvent,
   compareDrawerUndoRestoreAnalyticsData,
   compareDrawerUndoRestoreAnalyticsEvent,
+  compareDrawerSourceAnalyticsData,
+  compareDrawerSourceAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events-lib";
 
 describe("compare drawer cta events lib", () => {
@@ -19,6 +21,16 @@ describe("compare drawer cta events lib", () => {
     expect(compareDrawerUndoRestoreAnalyticsData(2)).toEqual({
       count: 2,
       surface: "compare-drawer",
+    });
+    expect(compareDrawerSourceAnalyticsEvent()).toBe(
+      "compare_drawer_source_open",
+    );
+    expect(
+      compareDrawerSourceAnalyticsData("mcp", "browser", "github.com"),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "compare-drawer",
+      host: "github.com",
     });
   });
 });

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -29,6 +29,8 @@ import {
   entryDetailCopyIntentType,
   entryDetailIntegrationAnalyticsData,
   entryDetailIntegrationAnalyticsEvent,
+  entryDetailSourceAnalyticsData,
+  entryDetailSourceAnalyticsEvent,
   entryDetailMobileActionAnalyticsData,
   entryDetailMobileActionAnalyticsEvent,
   entryDetailMobileCopyIntentType,
@@ -196,6 +198,14 @@ describe("entry detail cta events lib", () => {
       entry: "mcp/browser",
       link: "llms",
       surface: "detail-command-center",
+    });
+    expect(entryDetailSourceAnalyticsEvent()).toBe("detail_source_open");
+    expect(
+      entryDetailSourceAnalyticsData("mcp", "browser", "github.com"),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-command-center",
+      host: "github.com",
     });
     expect(entryDetailMobileLlmsAnalyticsData("skills", "demo")).toEqual({
       entry: "skills/demo",

--- a/tests/resource-card-cta-events-lib.test.ts
+++ b/tests/resource-card-cta-events-lib.test.ts
@@ -4,6 +4,8 @@ import {
   resourceCardCompareAnalyticsEvent,
   resourceCardCompareToastOpenAnalyticsData,
   resourceCardCompareToastOpenAnalyticsEvent,
+  resourceCardSourceAnalyticsData,
+  resourceCardSourceAnalyticsEvent,
   resourceCardInstallAnalyticsData,
   resourceCardInstallAnalyticsEvent,
   resourceCardInstallIntentType,
@@ -44,6 +46,14 @@ describe("resource card cta events lib", () => {
       entry: "skills/demo",
       surface: "browse-card",
       compareCount: 2,
+    });
+    expect(resourceCardSourceAnalyticsEvent()).toBe("browse_card_source_open");
+    expect(
+      resourceCardSourceAnalyticsData("skills", "demo", "github.com"),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "browse-card",
+      host: "github.com",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add typed source-open analytics helpers for browse cards, entry detail command center, and compare drawer repository links.
- Replace inline `source-click` tracking on browse cards and wire previously untracked detail/drawer source CTAs.

Closes #556

## Test plan
- [x] `pnpm test tests/resource-card-cta-events-lib.test.ts tests/entry-detail-cta-events-lib.test.ts tests/compare-drawer-cta-events-lib.test.ts`
- [x] `pnpm type-check`
- [x] `pnpm build`