### PR TITLE
feat(web): track source citation outbound link analytics

### DIFF
--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -274,7 +274,7 @@ export const COMPARISON_ROWS: RowDef[] = [
     label: "Citations",
     render: (e) => (
       <div className="text-xs">
-        <SourceCitations entry={e} />
+        <SourceCitations entry={e} surface={COMPARE_TABLE_SURFACE} />
       </div>
     ),
   },

--- a/apps/web/src/components/lazy-linked-attribution.tsx
+++ b/apps/web/src/components/lazy-linked-attribution.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import type { Entry } from "@/types/registry";
 import { EntryAttributionLabel } from "./entry-attribution-label";
+import { PEEK_PANEL_SURFACE } from "@/lib/peek-panel-cta-events";
 
 const LinkedAttribution = React.lazy(async () => {
   const module = await import("./contributor-attribution");
@@ -17,6 +18,7 @@ const LinkedSourceCitations = React.lazy(async () => {
       return (
         <SourceCitations
           entry={entry}
+          surface={PEEK_PANEL_SURFACE}
           resolveContributorSlug={(name, profileUrl) =>
             findContributorForIdentity(name, profileUrl)?.slug
           }

--- a/apps/web/src/components/source-citations.tsx
+++ b/apps/web/src/components/source-citations.tsx
@@ -10,7 +10,14 @@ import {
 } from "lucide-react";
 import { Link } from "@tanstack/react-router";
 import type { Entry } from "@/types/registry";
+import { trackEvent, outboundHost } from "@/lib/analytics";
 import { hostOf } from "@/lib/source-citations-lib";
+import {
+  SOURCE_CITATIONS_DETAIL_SURFACE,
+  sourceCitationAnalyticsData,
+  sourceCitationAnalyticsEvent,
+  type SourceCitationKind,
+} from "@/lib/source-citations-cta-events";
 
 type Citation = {
   label: string;
@@ -19,14 +26,17 @@ type Citation = {
   Icon: React.ElementType;
   verifiedAt?: string;
   contributorSlug?: string;
+  kind?: SourceCitationKind;
 };
 
 export function SourceCitations({
   entry,
   resolveContributorSlug,
+  surface = SOURCE_CITATIONS_DETAIL_SURFACE,
 }: {
   entry: Entry;
   resolveContributorSlug?: (name: string, profileUrl?: string) => string | undefined;
+  surface?: string;
 }) {
   const cites: Citation[] = [];
   if (entry.sourceUrl) {
@@ -36,6 +46,7 @@ export function SourceCitations({
       hint: hostOf(entry.sourceUrl),
       Icon: GitBranch,
       verifiedAt: entry.brandVerifiedAt ?? entry.reviewedAt,
+      kind: "source-repo",
     });
   } else if (entry.repoUrl) {
     cites.push({
@@ -43,6 +54,7 @@ export function SourceCitations({
       href: entry.repoUrl,
       hint: hostOf(entry.repoUrl),
       Icon: GitBranch,
+      kind: "repo",
     });
   }
   if (entry.docsUrl) {
@@ -51,6 +63,7 @@ export function SourceCitations({
       href: entry.docsUrl,
       hint: hostOf(entry.docsUrl),
       Icon: BookOpen,
+      kind: "docs",
     });
   }
   if (
@@ -63,6 +76,7 @@ export function SourceCitations({
       href: entry.websiteUrl,
       hint: hostOf(entry.websiteUrl),
       Icon: ExternalLink,
+      kind: "website",
     });
   }
   if (entry.downloadUrl) {
@@ -71,6 +85,7 @@ export function SourceCitations({
       href: entry.downloadUrl,
       hint: hostOf(entry.downloadUrl),
       Icon: Package,
+      kind: "package",
     });
   }
   if (entry.reviewedBy) {
@@ -90,6 +105,23 @@ export function SourceCitations({
       contributorSlug,
     });
   }
+
+  const onCitationOpen = React.useCallback(
+    (citation: Citation) => {
+      if (!citation.kind || !citation.href) return;
+      trackEvent(
+        sourceCitationAnalyticsEvent(),
+        sourceCitationAnalyticsData(
+          entry.category,
+          entry.slug,
+          citation.kind,
+          citation.hint ?? outboundHost(citation.href),
+          surface,
+        ),
+      );
+    },
+    [entry.category, entry.slug, surface],
+  );
 
   if (cites.length === 0) {
     return (
@@ -134,6 +166,7 @@ export function SourceCitations({
                   href={c.href}
                   target="_blank"
                   rel="noreferrer"
+                  onClick={() => onCitationOpen(c)}
                   className="block rounded-md px-2 transition-colors duration-200 hover:bg-surface-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60"
                 >
                   {body}

--- a/apps/web/src/lib/source-citations-cta-events-lib.ts
+++ b/apps/web/src/lib/source-citations-cta-events-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure source citations CTA analytics helpers.
+ *
+ * Maps citation panel outbound links to privacy-light event names without
+ * embedding full URLs or other sensitive fields.
+ */
+
+export const SOURCE_CITATIONS_DETAIL_SURFACE = "detail-source-citations";
+
+export type SourceCitationKind = "source-repo" | "repo" | "docs" | "website" | "package";
+
+export function sourceCitationEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function sourceCitationAnalyticsEvent(): string {
+  return "detail_citation_open";
+}
+
+export function sourceCitationAnalyticsData(
+  category: string,
+  slug: string,
+  kind: SourceCitationKind,
+  host: string,
+  surface: string,
+) {
+  return {
+    entry: sourceCitationEntryKey(category, slug),
+    surface,
+    citation: kind,
+    host,
+  };
+}

--- a/apps/web/src/lib/source-citations-cta-events.ts
+++ b/apps/web/src/lib/source-citations-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Source citations CTA event surface.
+ */
+export {
+  SOURCE_CITATIONS_DETAIL_SURFACE,
+  sourceCitationAnalyticsData,
+  sourceCitationAnalyticsEvent,
+  sourceCitationEntryKey,
+  type SourceCitationKind,
+} from "@/lib/source-citations-cta-events-lib";

--- a/tests/source-citations-cta-events-lib.test.ts
+++ b/tests/source-citations-cta-events-lib.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  SOURCE_CITATIONS_DETAIL_SURFACE,
+  sourceCitationAnalyticsData,
+  sourceCitationAnalyticsEvent,
+} from "@/lib/source-citations-cta-events-lib";
+
+describe("source citations cta events lib", () => {
+  it("builds privacy-light citation analytics", () => {
+    expect(sourceCitationAnalyticsEvent()).toBe("detail_citation_open");
+    expect(
+      sourceCitationAnalyticsData(
+        "mcp",
+        "browser",
+        "docs",
+        "docs.example.com",
+        SOURCE_CITATIONS_DETAIL_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-source-citations",
+      citation: "docs",
+      host: "docs.example.com",
+    });
+    expect(
+      sourceCitationAnalyticsData(
+        "skills",
+        "demo",
+        "package",
+        "cdn.example.com",
+        "compare-table",
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "compare-table",
+      citation: "package",
+      host: "cdn.example.com",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add source-citations CTA analytics helpers emitting detail_citation_open with citation kind and host.
- Wire SourceCitations outbound clicks on detail, compare table, and peek panel surfaces.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/source-citations-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)