### PR TITLE
feat(web): track detail provenance outbound link analytics

### DIFF
--- a/apps/web/src/components/provenance-block.tsx
+++ b/apps/web/src/components/provenance-block.tsx
@@ -5,9 +5,25 @@ import {
 } from "@/components/contributor-attribution";
 import { CLAIM_LABEL } from "@/types/registry";
 import { Github, ExternalLink } from "lucide-react";
+import { trackEvent, outboundHost } from "@/lib/analytics";
+import {
+  provenanceLinkAnalyticsData,
+  provenanceLinkAnalyticsEvent,
+  type ProvenanceLinkKind,
+} from "@/lib/provenance-block-cta-events";
 
 export function ProvenanceBlock({ entry }: { entry: Entry }) {
   const claim = entry.claimStatus ?? (entry.claimed ? "verified" : "unclaimed");
+  const submissionUrl = entry.sourceSubmissionUrl;
+  const importPrUrl = entry.importPrUrl;
+
+  const onProvenanceOpen = (href: string, kind: ProvenanceLinkKind) => {
+    trackEvent(
+      provenanceLinkAnalyticsEvent(),
+      provenanceLinkAnalyticsData(entry.category, entry.slug, kind, outboundHost(href)),
+    );
+  };
+
   return (
     <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">
       <div className="eyebrow mb-3">Provenance</div>
@@ -33,21 +49,23 @@ export function ProvenanceBlock({ entry }: { entry: Entry }) {
         <Row label="Claim" value={CLAIM_LABEL[claim]} />
       </dl>
       <div className="mt-3 flex flex-wrap gap-2 border-t border-border pt-3 text-xs">
-        {entry.sourceSubmissionUrl && (
+        {submissionUrl && (
           <a
-            href={entry.sourceSubmissionUrl}
+            href={submissionUrl}
             target="_blank"
             rel="noreferrer"
+            onClick={() => onProvenanceOpen(submissionUrl, "submission")}
             className="inline-flex items-center gap-1 text-ink-muted hover:text-ink"
           >
             Original submission <ExternalLink className="h-3 w-3" />
           </a>
         )}
-        {entry.importPrUrl && (
+        {importPrUrl && (
           <a
-            href={entry.importPrUrl}
+            href={importPrUrl}
             target="_blank"
             rel="noreferrer"
+            onClick={() => onProvenanceOpen(importPrUrl, "import-pr")}
             className="inline-flex items-center gap-1 text-ink-muted hover:text-ink"
           >
             Import PR <ExternalLink className="h-3 w-3" />

--- a/apps/web/src/lib/provenance-block-cta-events-lib.ts
+++ b/apps/web/src/lib/provenance-block-cta-events-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure provenance block CTA analytics helpers.
+ *
+ * Maps detail-rail provenance outbound links to privacy-light event names
+ * without embedding full URLs or other sensitive fields.
+ */
+
+export const PROVENANCE_DETAIL_RAIL_SURFACE = "detail-provenance";
+
+export type ProvenanceLinkKind = "submission" | "import-pr";
+
+export function provenanceLinkEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function provenanceLinkAnalyticsEvent(): string {
+  return "detail_provenance_open";
+}
+
+export function provenanceLinkAnalyticsData(
+  category: string,
+  slug: string,
+  kind: ProvenanceLinkKind,
+  host: string,
+  surface: string = PROVENANCE_DETAIL_RAIL_SURFACE,
+) {
+  return {
+    entry: provenanceLinkEntryKey(category, slug),
+    surface,
+    link: kind,
+    host,
+  };
+}

--- a/apps/web/src/lib/provenance-block-cta-events.ts
+++ b/apps/web/src/lib/provenance-block-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Provenance block CTA event surface.
+ */
+export {
+  PROVENANCE_DETAIL_RAIL_SURFACE,
+  provenanceLinkAnalyticsData,
+  provenanceLinkAnalyticsEvent,
+  provenanceLinkEntryKey,
+  type ProvenanceLinkKind,
+} from "@/lib/provenance-block-cta-events-lib";

--- a/tests/provenance-block-cta-events-lib.test.ts
+++ b/tests/provenance-block-cta-events-lib.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROVENANCE_DETAIL_RAIL_SURFACE,
+  provenanceLinkAnalyticsData,
+  provenanceLinkAnalyticsEvent,
+} from "@/lib/provenance-block-cta-events-lib";
+
+describe("provenance block cta events lib", () => {
+  it("builds privacy-light provenance link analytics", () => {
+    expect(provenanceLinkAnalyticsEvent()).toBe("detail_provenance_open");
+    expect(
+      provenanceLinkAnalyticsData(
+        "mcp",
+        "browser",
+        "submission",
+        "github.com",
+        PROVENANCE_DETAIL_RAIL_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-provenance",
+      link: "submission",
+      host: "github.com",
+    });
+    expect(
+      provenanceLinkAnalyticsData("skills", "demo", "import-pr", "github.com"),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-provenance",
+      link: "import-pr",
+      host: "github.com",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add provenance block CTA helpers emitting detail_provenance_open with link kind and host.
- Wire Original submission and Import PR outbound clicks in the detail rail provenance panel.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/provenance-block-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)