### PR TITLE
feat(web): track detail dossier TOC section analytics

### DIFF
--- a/apps/web/src/components/dossier-toc.tsx
+++ b/apps/web/src/components/dossier-toc.tsx
@@ -1,4 +1,10 @@
 import { useScrollSpy } from "@/hooks/use-scroll-spy";
+import { trackEvent } from "@/lib/analytics";
+import {
+  DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+  dossierTocSectionAnalyticsData,
+  dossierTocSectionAnalyticsEvent,
+} from "@/lib/dossier-toc-cta-events";
 import { cn } from "@/lib/utils";
 
 export interface TocItem {
@@ -10,7 +16,15 @@ export interface TocItem {
  * Right-rail table of contents with scroll-spy. Sections referenced by id
  * should set `scroll-mt-24` so the sticky header doesn't clip the heading.
  */
-export function DossierTOC({ items, className }: { items: TocItem[]; className?: string }) {
+export function DossierTOC({
+  entry,
+  items,
+  className,
+}: {
+  entry: { category: string; slug: string };
+  items: TocItem[];
+  className?: string;
+}) {
   const ids = items.map((i) => i.id);
   const active = useScrollSpy(ids);
 
@@ -27,6 +41,17 @@ export function DossierTOC({ items, className }: { items: TocItem[]; className?:
               <a
                 href={`#${item.id}`}
                 aria-current={isActive ? "true" : undefined}
+                onClick={() => {
+                  trackEvent(
+                    dossierTocSectionAnalyticsEvent(),
+                    dossierTocSectionAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      item.id,
+                      DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+                    ),
+                  );
+                }}
                 className={cn(
                   "group flex items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60",
                   isActive

--- a/apps/web/src/components/entry-detail-rail.tsx
+++ b/apps/web/src/components/entry-detail-rail.tsx
@@ -40,7 +40,7 @@ export function EntryDetailRail({
         </div>
       ) : null}
       <div className="hidden lg:block lg:sticky lg:top-20">
-        <DossierTOC items={tocItems} />
+        <DossierTOC entry={entry} items={tocItems} />
       </div>
       <ProvenanceBlock entry={entry} />
       <div className="rounded-xl border border-border bg-surface p-4 text-xs text-ink-muted">

--- a/apps/web/src/lib/dossier-toc-cta-events-lib.ts
+++ b/apps/web/src/lib/dossier-toc-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure dossier TOC CTA analytics helpers.
+ *
+ * Maps detail-rail section navigation clicks to privacy-light event names
+ * without embedding section labels or other free-text fields.
+ */
+
+export const DOSSIER_TOC_DETAIL_RAIL_SURFACE = "detail-dossier-toc";
+
+export function dossierTocEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function dossierTocSectionAnalyticsEvent(): string {
+  return "detail_toc_section_click";
+}
+
+export function dossierTocSectionAnalyticsData(
+  category: string,
+  slug: string,
+  sectionId: string,
+  surface: string = DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+) {
+  return {
+    entry: dossierTocEntryKey(category, slug),
+    surface,
+    section: sectionId,
+  };
+}

--- a/apps/web/src/lib/dossier-toc-cta-events.ts
+++ b/apps/web/src/lib/dossier-toc-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Dossier TOC CTA event surface.
+ */
+export {
+  DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+  dossierTocEntryKey,
+  dossierTocSectionAnalyticsData,
+  dossierTocSectionAnalyticsEvent,
+} from "@/lib/dossier-toc-cta-events-lib";

--- a/tests/dossier-toc-cta-events-lib.test.ts
+++ b/tests/dossier-toc-cta-events-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+  dossierTocSectionAnalyticsData,
+  dossierTocSectionAnalyticsEvent,
+} from "@/lib/dossier-toc-cta-events-lib";
+
+describe("dossier toc cta events lib", () => {
+  it("builds privacy-light dossier TOC section analytics", () => {
+    expect(dossierTocSectionAnalyticsEvent()).toBe("detail_toc_section_click");
+    expect(
+      dossierTocSectionAnalyticsData(
+        "mcp",
+        "browser",
+        "citations",
+        DOSSIER_TOC_DETAIL_RAIL_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-dossier-toc",
+      section: "citations",
+    });
+    expect(dossierTocSectionAnalyticsData("skills", "demo", "signals")).toEqual(
+      {
+        entry: "skills/demo",
+        surface: "detail-dossier-toc",
+        section: "signals",
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add dossier TOC CTA helpers emitting detail_toc_section_click with section id.
- Wire On this page section navigation clicks in the detail rail.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/dossier-toc-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)