### PR TITLE
feat(web): track detail decision panel preset analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure entry detail decision panel preset analytics helpers.
+ *
+ * Maps adoption/evidence/timeline/benchmark preset chip clicks to
+ * privacy-light event names without embedding panel copy.
+ */
+
+export type DetailDecisionPanelId =
+  | "adoption-plan"
+  | "evidence-matrix"
+  | "decision-timeline"
+  | "compare-benchmark";
+
+export function detailDecisionPresetEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function detailDecisionPresetSurface(panel: DetailDecisionPanelId): string {
+  return `detail-${panel}`;
+}
+
+export function detailDecisionPresetAnalyticsEvent(): string {
+  return "detail_decision_preset_select";
+}
+
+export function detailDecisionPresetAnalyticsData(
+  category: string,
+  slug: string,
+  panel: DetailDecisionPanelId,
+  preset: string,
+) {
+  return {
+    entry: detailDecisionPresetEntryKey(category, slug),
+    surface: detailDecisionPresetSurface(panel),
+    panel,
+    preset,
+  };
+}

--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Entry detail decision preset CTA event surface.
+ */
+export {
+  detailDecisionPresetAnalyticsData,
+  detailDecisionPresetAnalyticsEvent,
+  detailDecisionPresetEntryKey,
+  detailDecisionPresetSurface,
+  type DetailDecisionPanelId,
+} from "@/lib/entry-detail-decision-preset-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -95,6 +95,10 @@ import {
   entryDetailPlaybookActionAnalyticsData,
   entryDetailPlaybookActionAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  detailDecisionPresetAnalyticsData,
+  detailDecisionPresetAnalyticsEvent,
+} from "@/lib/entry-detail-decision-preset-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
@@ -414,6 +418,50 @@ function Dossier() {
   const onPlaybookOpenCompareTray = useCallback(() => {
     compare.setOpen(true);
   }, [compare]);
+  const onAdoptionPresetSelect = useCallback(
+    (preset: AdoptionPlanPresetId) => {
+      if (preset === adoptionPreset) return;
+      trackEvent(
+        detailDecisionPresetAnalyticsEvent(),
+        detailDecisionPresetAnalyticsData(entry.category, entry.slug, "adoption-plan", preset),
+      );
+      setAdoptionPreset(preset);
+    },
+    [adoptionPreset, entry.category, entry.slug],
+  );
+  const onEvidencePresetSelect = useCallback(
+    (preset: EvidenceMatrixPresetId) => {
+      if (preset === evidencePreset) return;
+      trackEvent(
+        detailDecisionPresetAnalyticsEvent(),
+        detailDecisionPresetAnalyticsData(entry.category, entry.slug, "evidence-matrix", preset),
+      );
+      setEvidencePreset(preset);
+    },
+    [entry.category, entry.slug, evidencePreset],
+  );
+  const onTimelinePresetSelect = useCallback(
+    (preset: DecisionTimelinePresetId) => {
+      if (preset === timelinePreset) return;
+      trackEvent(
+        detailDecisionPresetAnalyticsEvent(),
+        detailDecisionPresetAnalyticsData(entry.category, entry.slug, "decision-timeline", preset),
+      );
+      setTimelinePreset(preset);
+    },
+    [entry.category, entry.slug, timelinePreset],
+  );
+  const onBenchmarkPresetSelect = useCallback(
+    (preset: CompareBenchmarkPresetId) => {
+      if (preset === benchmarkPreset) return;
+      trackEvent(
+        detailDecisionPresetAnalyticsEvent(),
+        detailDecisionPresetAnalyticsData(entry.category, entry.slug, "compare-benchmark", preset),
+      );
+      setBenchmarkPreset(preset);
+    },
+    [benchmarkPreset, entry.category, entry.slug],
+  );
 
   const risk = installRiskLevel(entry);
   const hasSchema = hasSchemaDetails(entry);
@@ -626,22 +674,22 @@ function Dossier() {
           <EntryAdoptionPlanPanel
             state={adoptionPlan}
             selectedPreset={adoptionPreset}
-            onSelectPreset={setAdoptionPreset}
+            onSelectPreset={onAdoptionPresetSelect}
           />
           <EntryEvidenceReadinessMatrix
             state={evidenceMatrix}
             selectedPreset={evidencePreset}
-            onSelectPreset={setEvidencePreset}
+            onSelectPreset={onEvidencePresetSelect}
           />
           <EntryDecisionTimelinePanel
             state={decisionTimeline}
             selectedPreset={timelinePreset}
-            onSelectPreset={setTimelinePreset}
+            onSelectPreset={onTimelinePresetSelect}
           />
           <EntryCompareBenchmarkPanel
             state={compareBenchmark}
             selectedPreset={benchmarkPreset}
-            onSelectPreset={setBenchmarkPreset}
+            onSelectPreset={onBenchmarkPresetSelect}
           />
           <EntryPrerequisiteReadinessPanel
             state={prerequisiteReadiness}

--- a/tests/entry-detail-decision-preset-cta-events-lib.test.ts
+++ b/tests/entry-detail-decision-preset-cta-events-lib.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  detailDecisionPresetAnalyticsData,
+  detailDecisionPresetAnalyticsEvent,
+  detailDecisionPresetSurface,
+} from "@/lib/entry-detail-decision-preset-cta-events-lib";
+
+describe("entry detail decision preset cta events lib", () => {
+  it("builds privacy-light decision preset analytics", () => {
+    expect(detailDecisionPresetAnalyticsEvent()).toBe(
+      "detail_decision_preset_select",
+    );
+    expect(detailDecisionPresetSurface("adoption-plan")).toBe(
+      "detail-adoption-plan",
+    );
+    expect(
+      detailDecisionPresetAnalyticsData(
+        "mcp",
+        "browser",
+        "adoption-plan",
+        "balanced-rollout",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-adoption-plan",
+      panel: "adoption-plan",
+      preset: "balanced-rollout",
+    });
+    expect(
+      detailDecisionPresetAnalyticsData(
+        "skills",
+        "demo",
+        "compare-benchmark",
+        "strict",
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-compare-benchmark",
+      panel: "compare-benchmark",
+      preset: "strict",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add decision preset CTA helpers emitting detail_decision_preset_select with panel and preset ids.
- Track adoption, evidence, timeline, and compare benchmark preset chip changes on detail pages.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/entry-detail-decision-preset-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)