### PR TITLE
feat(web): track detail badge markdown copy analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-badge-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-badge-cta-events-lib.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure entry detail badge CTA analytics helpers.
+ *
+ * Maps README badge markdown copy actions to privacy-light event names
+ * without embedding the copied markdown payload.
+ */
+
+export const ENTRY_DETAIL_BADGE_SURFACE = "detail-badge";
+
+export function entryDetailBadgeEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailBadgeCopyAnalyticsEvent(): string {
+  return "detail_badge_markdown_copy";
+}
+
+export function entryDetailBadgeCopyAnalyticsData(category: string, slug: string) {
+  return {
+    entry: entryDetailBadgeEntryKey(category, slug),
+    surface: ENTRY_DETAIL_BADGE_SURFACE,
+  };
+}

--- a/apps/web/src/lib/entry-detail-badge-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-badge-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry detail badge CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_BADGE_SURFACE,
+  entryDetailBadgeCopyAnalyticsData,
+  entryDetailBadgeCopyAnalyticsEvent,
+  entryDetailBadgeEntryKey,
+} from "@/lib/entry-detail-badge-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -99,6 +99,10 @@ import {
   detailDecisionPresetAnalyticsData,
   detailDecisionPresetAnalyticsEvent,
 } from "@/lib/entry-detail-decision-preset-cta-events";
+import {
+  entryDetailBadgeCopyAnalyticsData,
+  entryDetailBadgeCopyAnalyticsEvent,
+} from "@/lib/entry-detail-badge-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
@@ -1013,6 +1017,8 @@ function BadgeSection({
           iconOnly
           size="md"
           toastLabel="Badge Markdown copied"
+          event={entryDetailBadgeCopyAnalyticsEvent()}
+          eventData={entryDetailBadgeCopyAnalyticsData(category, slug)}
         />
       </div>
     </DossierSection>

--- a/tests/entry-detail-badge-cta-events-lib.test.ts
+++ b/tests/entry-detail-badge-cta-events-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_BADGE_SURFACE,
+  entryDetailBadgeCopyAnalyticsData,
+  entryDetailBadgeCopyAnalyticsEvent,
+} from "@/lib/entry-detail-badge-cta-events-lib";
+
+describe("entry detail badge cta events lib", () => {
+  it("builds privacy-light badge markdown copy analytics", () => {
+    expect(entryDetailBadgeCopyAnalyticsEvent()).toBe(
+      "detail_badge_markdown_copy",
+    );
+    expect(entryDetailBadgeCopyAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_DETAIL_BADGE_SURFACE,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add badge CTA helpers emitting detail_badge_markdown_copy with entry and surface.
- Wire README badge CopyButton on detail pages.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/entry-detail-badge-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)