### PR TITLE
feat(web): add setup at a glance snapshot to entry detail

### DIFF
--- a/apps/web/src/components/entry-setup-snapshot-panel.tsx
+++ b/apps/web/src/components/entry-setup-snapshot-panel.tsx
@@ -1,0 +1,153 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  ClipboardCopy,
+  Clock,
+  FileCog,
+  Gauge,
+  ListChecks,
+  MonitorSmartphone,
+  Package,
+  Terminal,
+} from "lucide-react";
+import type { Entry, InstallType } from "@/types/registry";
+import { cn } from "@/lib/utils";
+
+const INSTALL_TYPE_LABEL: Record<InstallType, string> = {
+  cli: "CLI install",
+  config: "Config edit",
+  copy: "Copy & paste",
+  package: "Package install",
+  manual: "Manual setup",
+};
+
+type StatTone = "good" | "watch" | "risk" | "muted";
+
+function toneText(tone: StatTone): string {
+  if (tone === "good") return "text-trust-trusted";
+  if (tone === "watch") return "text-amber-900";
+  if (tone === "risk") return "text-trust-blocked";
+  return "text-ink-muted";
+}
+
+function StatTile({
+  icon: Icon,
+  label,
+  value,
+  tone,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  tone: StatTone;
+}) {
+  return (
+    <article className="rounded-lg border border-border bg-background p-3">
+      <div className="flex items-center gap-2">
+        <Icon className={cn("h-4 w-4 shrink-0", toneText(tone))} aria-hidden />
+        <p className="text-xs font-medium text-ink-muted">{label}</p>
+      </div>
+      <p className={cn("mt-1.5 text-sm font-semibold", toneText(tone))}>{value}</p>
+    </article>
+  );
+}
+
+export function EntrySetupSnapshotPanel({
+  entry,
+  className,
+}: {
+  entry: Entry;
+  className?: string;
+}) {
+  const hasCommand = Boolean(entry.installCommand);
+  const hasConfig = Boolean(entry.configSnippet);
+  const hasCopy = Boolean(entry.copySnippet || entry.fullCopy);
+  const setupTime = entry.estimatedSetupTime?.trim();
+  const prereqCount = entry.prerequisites?.length ?? 0;
+  const platformCount = entry.platforms?.length ?? 0;
+  const difficulty =
+    typeof entry.difficultyScore === "number" ? Math.round(entry.difficultyScore) : null;
+
+  if (!hasCommand && !hasConfig && !hasCopy && !setupTime && prereqCount === 0) {
+    return null;
+  }
+
+  const readiness = hasCopy
+    ? "Copy-ready — paste the snippet to get started."
+    : entry.installType === "cli" || hasCommand
+      ? "Run the install command to set up."
+      : entry.installType === "config" || hasConfig
+        ? "Add the configuration to enable it."
+        : "Follow the manual setup steps.";
+
+  return (
+    <section
+      id="setup-snapshot"
+      aria-label="Setup at a glance"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Setup at a glance</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">
+            {INSTALL_TYPE_LABEL[entry.installType]}
+          </h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{readiness}</p>
+        </div>
+        {setupTime ? (
+          <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-background px-2.5 py-0.5 font-mono text-[11px] text-ink-muted">
+            <Clock className="h-3 w-3" aria-hidden />
+            {setupTime}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        <StatTile
+          icon={Terminal}
+          label="Install command"
+          value={hasCommand ? "Provided" : "Not provided"}
+          tone={hasCommand ? "good" : "muted"}
+        />
+        <StatTile
+          icon={FileCog}
+          label="Config snippet"
+          value={hasConfig ? "Provided" : "Not provided"}
+          tone={hasConfig ? "good" : "muted"}
+        />
+        <StatTile
+          icon={ClipboardCopy}
+          label="Copy snippet"
+          value={hasCopy ? "Provided" : "Not provided"}
+          tone={hasCopy ? "good" : "muted"}
+        />
+        <StatTile
+          icon={ListChecks}
+          label="Prerequisites"
+          value={prereqCount > 0 ? `${prereqCount} to clear` : "None"}
+          tone={prereqCount > 0 ? "watch" : "good"}
+        />
+        <StatTile
+          icon={MonitorSmartphone}
+          label="Platforms"
+          value={platformCount > 0 ? `${platformCount} listed` : "Not listed"}
+          tone="muted"
+        />
+        {difficulty !== null ? (
+          <StatTile
+            icon={Gauge}
+            label="Difficulty"
+            value={`${difficulty}/100`}
+            tone={difficulty >= 66 ? "risk" : difficulty >= 33 ? "watch" : "good"}
+          />
+        ) : (
+          <StatTile
+            icon={Package}
+            label="Install type"
+            value={INSTALL_TYPE_LABEL[entry.installType]}
+            tone="muted"
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -66,6 +66,7 @@ import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
 import { EntryCompareBenchmarkPanel } from "@/components/entry-compare-benchmark-panel";
 import { EntryPrerequisiteReadinessPanel } from "@/components/entry-prerequisite-readiness-panel";
+import { EntrySetupSnapshotPanel } from "@/components/entry-setup-snapshot-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
   buildEntryTocItems,
@@ -675,6 +676,7 @@ function Dossier() {
             onOpenCompareTray={onPlaybookOpenCompareTray}
             onAction={onPlaybookAction}
           />
+          <EntrySetupSnapshotPanel entry={entry} />
           <EntryAdoptionPlanPanel
             state={adoptionPlan}
             selectedPreset={adoptionPreset}


### PR DESCRIPTION
## Summary

Adds a compact **Setup at a glance** card to the entry detail page — a scannable snapshot of a resource's practical setup facts, so a reader can size up what adopting it takes without scrolling the full dossier.

The card surfaces, from the entry's own metadata:
- The **install type** (CLI / config / copy / package / manual) with a one-line readiness hint.
- Whether an **install command**, **config snippet**, and **copy snippet** are provided.
- **Estimated setup time**, **prerequisite count**, **platform count**, and **difficulty** (when present).

It renders as a tidy badge grid and returns nothing when an entry has no concrete setup signals, so it never shows an empty shell.

## Files

Presentational only — one new component, wired into the entry route alongside the existing decision panels:

- `apps/web/src/components/entry-setup-snapshot-panel.tsx` — the `EntrySetupSnapshotPanel` component
- `apps/web/src/routes/entry.$category.$slug.tsx` — render it above the adoption-plan panel

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Purely additive display, distinct from the command center's interactive copy tabs — this is a read-only metadata summary.

## Validation

```
pnpm exec prettier --check <changed files>   # clean
pnpm --filter web exec tsc --noEmit          # clean
pnpm --filter web build                       # vite build
```

Presentational component + route wiring only, so there is no new coverage-scoped logic (React components/routes are outside the node coverage scope per `AGENTS.md`); `validate-web`, `validate-ci`, and the build are the relevant gates.
