### PR TITLE
feat(web): track detail share menu action analytics

### DIFF
--- a/apps/web/src/components/share-menu.tsx
+++ b/apps/web/src/components/share-menu.tsx
@@ -9,6 +9,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { trackEvent } from "@/lib/analytics";
+import {
+  entryDetailShareAnalyticsData,
+  entryDetailShareAnalyticsEvent,
+  type EntryDetailShareAction,
+} from "@/lib/entry-detail-share-cta-events";
 import { absoluteShareUrl } from "@/lib/share-url-lib";
 
 export interface ShareMenuProps {
@@ -22,6 +28,8 @@ export interface ShareMenuProps {
   ogUrl?: string;
   /** Optional raycast deeplink (e.g. raycast://extensions/...). */
   raycastUrl?: string;
+  /** When set, emits detail share analytics for dropdown actions. */
+  analyticsEntry?: { category: string; slug: string };
 }
 
 async function copy(value: string, label: string) {
@@ -33,7 +41,15 @@ async function copy(value: string, label: string) {
   }
 }
 
-export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl }: ShareMenuProps) {
+export function ShareMenu({
+  url,
+  title,
+  description,
+  llmsUrl,
+  ogUrl,
+  raycastUrl,
+  analyticsEntry,
+}: ShareMenuProps) {
   const absolute = absoluteShareUrl(
     url,
     typeof window === "undefined" ? "" : window.location.origin,
@@ -42,7 +58,19 @@ export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl 
     ? `[${title}](${absolute}) — ${description}`
     : `[${title}](${absolute})`;
 
+  const trackShare = React.useCallback(
+    (action: EntryDetailShareAction) => {
+      if (!analyticsEntry) return;
+      trackEvent(
+        entryDetailShareAnalyticsEvent(),
+        entryDetailShareAnalyticsData(analyticsEntry.category, analyticsEntry.slug, action),
+      );
+    },
+    [analyticsEntry],
+  );
+
   const onNativeShare = async () => {
+    trackShare("system-share");
     if (typeof navigator !== "undefined" && navigator.share) {
       try {
         await navigator.share({ title, text: description, url: absolute });
@@ -69,17 +97,32 @@ export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl 
       <DropdownMenuContent align="end" className="w-60">
         <DropdownMenuLabel className="text-xs">Share this resource</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => copy(absolute, "Link copied")}>
+        <DropdownMenuItem
+          onSelect={() => {
+            trackShare("copy-link");
+            void copy(absolute, "Link copied");
+          }}
+        >
           <Link2 className="mr-2 h-3.5 w-3.5" />
           Copy link
         </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => copy(citation, "Markdown citation copied")}>
+        <DropdownMenuItem
+          onSelect={() => {
+            trackShare("copy-markdown");
+            void copy(citation, "Markdown citation copied");
+          }}
+        >
           <FileText className="mr-2 h-3.5 w-3.5" />
           Copy as markdown
         </DropdownMenuItem>
         {llmsUrl && (
           <DropdownMenuItem asChild>
-            <a href={llmsUrl} target="_blank" rel="noreferrer">
+            <a
+              href={llmsUrl}
+              target="_blank"
+              rel="noreferrer"
+              onClick={() => trackShare("open-llms")}
+            >
               <Code2 className="mr-2 h-3.5 w-3.5" />
               Open llms.txt
             </a>
@@ -87,7 +130,7 @@ export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl 
         )}
         {ogUrl && (
           <DropdownMenuItem asChild>
-            <a href={ogUrl} target="_blank" rel="noreferrer">
+            <a href={ogUrl} target="_blank" rel="noreferrer" onClick={() => trackShare("view-og")}>
               <ImageIcon className="mr-2 h-3.5 w-3.5" />
               View share image
             </a>
@@ -95,7 +138,7 @@ export function ShareMenu({ url, title, description, llmsUrl, ogUrl, raycastUrl 
         )}
         {raycastUrl && (
           <DropdownMenuItem asChild>
-            <a href={raycastUrl}>
+            <a href={raycastUrl} onClick={() => trackShare("open-raycast")}>
               <Share2 className="mr-2 h-3.5 w-3.5" />
               Open in Raycast
             </a>

--- a/apps/web/src/lib/entry-detail-share-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-share-cta-events-lib.ts
@@ -1,0 +1,37 @@
+/**
+ * Pure entry detail share menu CTA analytics helpers.
+ *
+ * Maps share dropdown actions to privacy-light event names without
+ * embedding URLs, citations, or other sensitive payloads.
+ */
+
+export const ENTRY_DETAIL_SHARE_SURFACE = "detail-share";
+
+export type EntryDetailShareAction =
+  | "copy-link"
+  | "copy-markdown"
+  | "open-llms"
+  | "view-og"
+  | "open-raycast"
+  | "system-share";
+
+export function entryDetailShareEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailShareAnalyticsEvent(): string {
+  return "detail_share_action";
+}
+
+export function entryDetailShareAnalyticsData(
+  category: string,
+  slug: string,
+  action: EntryDetailShareAction,
+  surface: string = ENTRY_DETAIL_SHARE_SURFACE,
+) {
+  return {
+    entry: entryDetailShareEntryKey(category, slug),
+    surface,
+    action,
+  };
+}

--- a/apps/web/src/lib/entry-detail-share-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-share-cta-events.ts
@@ -1,0 +1,10 @@
+/**
+ * Entry detail share menu CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_SHARE_SURFACE,
+  entryDetailShareAnalyticsData,
+  entryDetailShareAnalyticsEvent,
+  entryDetailShareEntryKey,
+  type EntryDetailShareAction,
+} from "@/lib/entry-detail-share-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -563,6 +563,7 @@ function Dossier() {
               description={entry.description}
               ogUrl={`/og/${entry.category}/${entry.slug}`}
               llmsUrl={`/api/registry/entries/${entry.category}/${entry.slug}/llms`}
+              analyticsEntry={{ category: entry.category, slug: entry.slug }}
             />
           </div>
 

--- a/tests/entry-detail-share-cta-events-lib.test.ts
+++ b/tests/entry-detail-share-cta-events-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_SHARE_SURFACE,
+  entryDetailShareAnalyticsData,
+  entryDetailShareAnalyticsEvent,
+} from "@/lib/entry-detail-share-cta-events-lib";
+
+describe("entry detail share cta events lib", () => {
+  it("builds privacy-light share menu analytics", () => {
+    expect(entryDetailShareAnalyticsEvent()).toBe("detail_share_action");
+    expect(
+      entryDetailShareAnalyticsData(
+        "mcp",
+        "browser",
+        "copy-markdown",
+        ENTRY_DETAIL_SHARE_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-share",
+      action: "copy-markdown",
+    });
+    expect(
+      entryDetailShareAnalyticsData("skills", "demo", "open-llms"),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-share",
+      action: "open-llms",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add share menu CTA helpers emitting detail_share_action with action id.
- Wire ShareMenu dropdown actions on detail pages via optional analyticsEntry prop.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/entry-detail-share-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)