### PR TITLE
test(scripts): extract readme-refresh github formatters and cover them

### DIFF
--- a/scripts/build-readme-refresh-body.mjs
+++ b/scripts/build-readme-refresh-body.mjs
@@ -6,6 +6,12 @@ import { pathToFileURL } from "node:url";
 import categorySpec from "@heyclaude/registry/category-spec";
 import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
 
+import {
+  escapeMarkdownText,
+  formatGithubProfileLink,
+  formatPullRequestLink,
+} from "./lib/readme-refresh-format.mjs";
+
 const categoryOrder = categorySpec.categoryOrder;
 const categoryRank = new Map(
   categoryOrder.map((category, index) => [category, index]),
@@ -14,75 +20,6 @@ const readmeLinePrefix = "- **[";
 const readmeUrlPrefix = "https://heyclau.de/";
 const readmeEntryRoutePrefix = "entry/";
 const readmeUrlSuffix = ")** - ";
-const githubUrlPrefix = "https://github.com/";
-const githubLoginPattern =
-  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/;
-const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
-
-function escapeMarkdownText(value) {
-  return String(value || "")
-    .replace(/@/g, "&#64;")
-    .replace(/(^|\s)#(?=\d)/g, "$1&#35;")
-    .replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function cleanGithubHandle(value) {
-  const raw = String(value || "").trim();
-  if (!raw) return "";
-
-  let handle = raw.replace(/^@/, "");
-  try {
-    const parsed = new URL(raw);
-    if (parsed.hostname.toLowerCase() === "github.com") {
-      handle = parsed.pathname.split("/").filter(Boolean)[0] ?? "";
-    }
-  } catch {
-    // Treat non-URL values as GitHub logins.
-  }
-
-  return githubLoginPattern.test(handle) ? `@${handle}` : "";
-}
-
-function cleanGithubLogin(value) {
-  return cleanGithubHandle(value).replace(/^@/, "");
-}
-
-function cleanRepository(value) {
-  const repository = String(value || "").trim();
-  return repositoryPattern.test(repository) ? repository : "";
-}
-
-function formatGithubProfileLink(login) {
-  const cleanLogin = cleanGithubLogin(login);
-  if (!cleanLogin) return "";
-  return `[@${cleanLogin}](${githubUrlPrefix}${cleanLogin})`;
-}
-
-function formatPullRequestLink({ number, repository, htmlUrl }) {
-  if (!number) return "";
-
-  const numericNumber = Number(number);
-  const label = Number.isFinite(numericNumber) ? `#${numericNumber}` : "";
-  if (!label) return "";
-
-  if (htmlUrl) {
-    try {
-      const parsed = new URL(htmlUrl);
-      if (parsed.hostname.toLowerCase() === "github.com") {
-        return `[${label}](${parsed.href})`;
-      }
-    } catch {
-      // Fall back to repository-based links below.
-    }
-  }
-
-  const cleanRepo = cleanRepository(repository);
-  return cleanRepo
-    ? `[${label}](${githubUrlPrefix}${cleanRepo}/pull/${numericNumber})`
-    : label;
-}
 
 function formatReadmeEntryLink(change, frontmatter = {}) {
   const title = escapeMarkdownText(frontmatter.title || change.title);

--- a/scripts/lib/readme-refresh-format.mjs
+++ b/scripts/lib/readme-refresh-format.mjs
@@ -1,0 +1,83 @@
+// Pure markdown/GitHub formatting helpers behind scripts/build-readme-refresh-body.mjs:
+// escaping README text and normalizing/linking GitHub handles, repos and PRs.
+// Split out so they can be unit-tested without git or filesystem access.
+
+const githubUrlPrefix = "https://github.com/";
+const githubLoginPattern =
+  /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?(?:\[bot\])?$/;
+const repositoryPattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/** Escape a value for inline README markdown (and neutralize @/# mentions). */
+export function escapeMarkdownText(value) {
+  return String(value || "")
+    .replace(/@/g, "&#64;")
+    .replace(/(^|\s)#(?=\d)/g, "$1&#35;")
+    .replace(/([\\`*_{}\[\]()#+\-.!|>])/g, "\\$1")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Normalize a GitHub handle/profile-URL to "@login", or "" if not a valid login. */
+export function cleanGithubHandle(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+
+  let handle = raw.replace(/^@/, "");
+  try {
+    const parsed = new URL(raw);
+    if (parsed.hostname.toLowerCase() === "github.com") {
+      handle = parsed.pathname.split("/").filter(Boolean)[0] ?? "";
+    }
+  } catch {
+    // Treat non-URL values as GitHub logins.
+  }
+
+  return githubLoginPattern.test(handle) ? `@${handle}` : "";
+}
+
+/** Like cleanGithubHandle but without the leading "@". */
+export function cleanGithubLogin(value) {
+  return cleanGithubHandle(value).replace(/^@/, "");
+}
+
+/** Return an "owner/repo" string when it matches the repo shape, else "". */
+export function cleanRepository(value) {
+  const repository = String(value || "").trim();
+  return repositoryPattern.test(repository) ? repository : "";
+}
+
+/** Markdown link to a GitHub profile ("[@login](url)"), or "" for an invalid login. */
+export function formatGithubProfileLink(login) {
+  const cleanLogin = cleanGithubLogin(login);
+  if (!cleanLogin) return "";
+  return `[@${cleanLogin}](${githubUrlPrefix}${cleanLogin})`;
+}
+
+/**
+ * Markdown link to a pull request. Prefers a trusted github.com htmlUrl; else
+ * derives the URL from a valid repository; else falls back to the bare "#<n>"
+ * label. Returns "" when there is no usable PR number.
+ */
+export function formatPullRequestLink({ number, repository, htmlUrl }) {
+  if (!number) return "";
+
+  const numericNumber = Number(number);
+  const label = Number.isFinite(numericNumber) ? `#${numericNumber}` : "";
+  if (!label) return "";
+
+  if (htmlUrl) {
+    try {
+      const parsed = new URL(htmlUrl);
+      if (parsed.hostname.toLowerCase() === "github.com") {
+        return `[${label}](${parsed.href})`;
+      }
+    } catch {
+      // Fall back to repository-based links below.
+    }
+  }
+
+  const cleanRepo = cleanRepository(repository);
+  return cleanRepo
+    ? `[${label}](${githubUrlPrefix}${cleanRepo}/pull/${numericNumber})`
+    : label;
+}

--- a/tests/readme-github-format.test.ts
+++ b/tests/readme-github-format.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  cleanGithubHandle,
+  cleanGithubLogin,
+  cleanRepository,
+  escapeMarkdownText,
+  formatGithubProfileLink,
+  formatPullRequestLink,
+} from "../scripts/lib/readme-refresh-format.mjs";
+
+describe("escapeMarkdownText", () => {
+  it("stringifies null/undefined to '' and trims", () => {
+    expect(escapeMarkdownText(null)).toBe("");
+    expect(escapeMarkdownText(undefined)).toBe("");
+    expect(escapeMarkdownText("  hi  ")).toBe("hi");
+  });
+
+  it("neutralizes @ mentions and #-number references", () => {
+    // the @/# entities are emitted first, then the generic escape pass
+    // backslash-escapes the "#" inside those entities as well
+    expect(escapeMarkdownText("@octocat")).toBe("&\\#64;octocat");
+    expect(escapeMarkdownText("see #42")).toBe("see &\\#35;42");
+    // a hash not followed by a digit is escaped as a normal special char
+    expect(escapeMarkdownText("#tag")).toBe("\\#tag");
+  });
+
+  it("backslash-escapes markdown special characters", () => {
+    expect(escapeMarkdownText("a*b_c")).toBe("a\\*b\\_c");
+    expect(escapeMarkdownText("[x](y)")).toBe("\\[x\\]\\(y\\)");
+  });
+
+  it("collapses internal whitespace to single spaces", () => {
+    expect(escapeMarkdownText("a\n\t  b   c")).toBe("a b c");
+  });
+});
+
+describe("cleanGithubHandle", () => {
+  it("returns '' for empty/blank input", () => {
+    expect(cleanGithubHandle("")).toBe("");
+    expect(cleanGithubHandle("   ")).toBe("");
+    expect(cleanGithubHandle(null)).toBe("");
+  });
+
+  it("normalizes a bare or @-prefixed login", () => {
+    expect(cleanGithubHandle("octocat")).toBe("@octocat");
+    expect(cleanGithubHandle("@octocat")).toBe("@octocat");
+  });
+
+  it("accepts bot logins", () => {
+    expect(cleanGithubHandle("dependabot[bot]")).toBe("@dependabot[bot]");
+  });
+
+  it("extracts the login from a github.com profile URL", () => {
+    expect(cleanGithubHandle("https://github.com/octocat")).toBe("@octocat");
+    expect(cleanGithubHandle("https://GitHub.com/octocat/foo")).toBe(
+      "@octocat",
+    );
+  });
+
+  it("returns '' for a github.com URL with no login segment", () => {
+    expect(cleanGithubHandle("https://github.com/")).toBe("");
+  });
+
+  it("treats a non-github URL as a literal login and rejects it", () => {
+    // "https://example.com/octocat" is not a valid login shape
+    expect(cleanGithubHandle("https://example.com/octocat")).toBe("");
+  });
+
+  it("returns '' for invalid login characters", () => {
+    expect(cleanGithubHandle("not a login")).toBe("");
+    expect(cleanGithubHandle("-leadinghyphen")).toBe("");
+  });
+});
+
+describe("cleanGithubLogin", () => {
+  it("drops the leading @", () => {
+    expect(cleanGithubLogin("octocat")).toBe("octocat");
+    expect(cleanGithubLogin("@octocat")).toBe("octocat");
+    expect(cleanGithubLogin("bad login")).toBe("");
+  });
+});
+
+describe("cleanRepository", () => {
+  it("passes through a valid owner/repo", () => {
+    expect(cleanRepository("JSONbored/awesome-claude")).toBe(
+      "JSONbored/awesome-claude",
+    );
+    expect(cleanRepository("  a/b  ")).toBe("a/b");
+  });
+
+  it("returns '' for a non-matching value", () => {
+    expect(cleanRepository("no-slash")).toBe("");
+    expect(cleanRepository("a/b/c")).toBe("");
+    expect(cleanRepository("")).toBe("");
+  });
+});
+
+describe("formatGithubProfileLink", () => {
+  it("links a valid login", () => {
+    expect(formatGithubProfileLink("octocat")).toBe(
+      "[@octocat](https://github.com/octocat)",
+    );
+  });
+
+  it("returns '' for an invalid login", () => {
+    expect(formatGithubProfileLink("bad login")).toBe("");
+    expect(formatGithubProfileLink("")).toBe("");
+  });
+});
+
+describe("formatPullRequestLink", () => {
+  it("returns '' without a number", () => {
+    expect(formatPullRequestLink({})).toBe("");
+    expect(formatPullRequestLink({ number: 0 })).toBe("");
+  });
+
+  it("returns '' when the number is not finite", () => {
+    expect(formatPullRequestLink({ number: "abc" })).toBe("");
+  });
+
+  it("prefers a trusted github.com htmlUrl", () => {
+    expect(
+      formatPullRequestLink({
+        number: 42,
+        htmlUrl: "https://github.com/JSONbored/awesome-claude/pull/42",
+      }),
+    ).toBe("[#42](https://github.com/JSONbored/awesome-claude/pull/42)");
+  });
+
+  it("ignores a non-github htmlUrl and falls back to the repository", () => {
+    expect(
+      formatPullRequestLink({
+        number: 42,
+        repository: "JSONbored/awesome-claude",
+        htmlUrl: "https://evil.example/JSONbored/awesome-claude/pull/42",
+      }),
+    ).toBe("[#42](https://github.com/JSONbored/awesome-claude/pull/42)");
+  });
+
+  it("ignores a malformed htmlUrl and falls back to the repository", () => {
+    expect(
+      formatPullRequestLink({
+        number: 42,
+        repository: "JSONbored/awesome-claude",
+        htmlUrl: "not a url",
+      }),
+    ).toBe("[#42](https://github.com/JSONbored/awesome-claude/pull/42)");
+  });
+
+  it("returns the bare label when there is no usable repository", () => {
+    expect(formatPullRequestLink({ number: 42 })).toBe("#42");
+    expect(formatPullRequestLink({ number: 42, repository: "bogus" })).toBe(
+      "#42",
+    );
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/build-readme-refresh-body.mjs` interleaved its pure markdown/GitHub formatting helpers with git and filesystem work, so the README text escaping and the handle/repo/PR link builders behind the refreshed contributor lines were untestable. This moves the pure helpers into `scripts/lib/readme-refresh-format.mjs` - matching the existing `scripts/lib` convention - and imports them back. The git/filesystem logic stays in the script.

### Changes

- Add `scripts/lib/readme-refresh-format.mjs` - `escapeMarkdownText`, `cleanGithubHandle`, `cleanGithubLogin`, `cleanRepository`, `formatGithubProfileLink`, `formatPullRequestLink`, plus their login/repository patterns and the GitHub URL prefix.
- `scripts/build-readme-refresh-body.mjs` - import the three helpers it uses; drop the local copies and the now-unused module-scope constants.
- Add `tests/readme-github-format.test.ts` - covers markdown escaping (@/# neutralization, special-char escaping, whitespace collapse), handle normalization (bare/@/bot logins, github.com URL extraction, empty-segment and non-github URL fallbacks, invalid logins), repository validation, profile links, and PR links (trusted `htmlUrl`, non-github and malformed `htmlUrl` fallbacks, repository-derived and bare-label paths). Branch coverage 100% (30/30).

### Validation

- `pnpm exec vitest run tests/readme-github-format.test.ts` - 22 passed
- `node --check scripts/build-readme-refresh-body.mjs` - clean; the imported helpers are all still used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the generated README body is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
