### PR TITLE
feat(web): track browse decision preset analytics

### DIFF
--- a/apps/web/src/lib/browse-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-decision-preset-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure browse decision panel preset analytics helpers.
+ *
+ * Maps adoption queue and decision confidence preset chip clicks to
+ * privacy-light event names without embedding panel copy.
+ */
+
+export type BrowseDecisionPanelId = "adoption-queue" | "decision-confidence";
+
+export function browseDecisionPresetSurface(panel: BrowseDecisionPanelId): string {
+  return `browse-${panel}`;
+}
+
+export function browseDecisionPresetAnalyticsEvent(): string {
+  return "browse_decision_preset_select";
+}
+
+export function browseDecisionPresetAnalyticsData(
+  panel: BrowseDecisionPanelId,
+  preset: string,
+  resultCount: number,
+) {
+  return {
+    surface: browseDecisionPresetSurface(panel),
+    panel,
+    preset,
+    resultCount,
+  };
+}

--- a/apps/web/src/lib/browse-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/browse-decision-preset-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Browse decision preset CTA event surface.
+ */
+export {
+  browseDecisionPresetAnalyticsData,
+  browseDecisionPresetAnalyticsEvent,
+  browseDecisionPresetSurface,
+  type BrowseDecisionPanelId,
+} from "@/lib/browse-decision-preset-cta-events-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -7,7 +7,7 @@ import {
   useNavigate,
 } from "@tanstack/react-router";
 import { z } from "zod";
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import { toast } from "sonner";
 import { ResourceCard } from "@/components/resource-card";
 import { FilterChip, FilterChipGroup } from "@/components/filter-chip";
@@ -62,6 +62,10 @@ import {
   browseCompareOpenAnalyticsData,
   browseCompareOpenAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
+import {
+  browseDecisionPresetAnalyticsData,
+  browseDecisionPresetAnalyticsEvent,
+} from "@/lib/browse-decision-preset-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
@@ -372,6 +376,28 @@ function Browse() {
   const browseDecisionConfidence = useMemo(
     () => browseDecisionConfidenceState(results, confidencePreset, 8),
     [results, confidencePreset],
+  );
+  const onAdoptionPresetSelect = useCallback(
+    (preset: BrowseAdoptionPresetId) => {
+      if (preset === adoptionPreset) return;
+      trackEvent(
+        browseDecisionPresetAnalyticsEvent(),
+        browseDecisionPresetAnalyticsData("adoption-queue", preset, results.length),
+      );
+      setAdoptionPreset(preset);
+    },
+    [adoptionPreset, results.length],
+  );
+  const onConfidencePresetSelect = useCallback(
+    (preset: BrowseConfidencePresetId) => {
+      if (preset === confidencePreset) return;
+      trackEvent(
+        browseDecisionPresetAnalyticsEvent(),
+        browseDecisionPresetAnalyticsData("decision-confidence", preset, results.length),
+      );
+      setConfidencePreset(preset);
+    },
+    [confidencePreset, results.length],
   );
   const nowIso = useMemo(() => new Date().toISOString(), []);
   const browseFreshness = useMemo(
@@ -859,13 +885,13 @@ function Browse() {
           <BrowseAdoptionQueuePanel
             state={browseAdoptionQueue}
             selectedPreset={adoptionPreset}
-            onSelectPreset={setAdoptionPreset}
+            onSelectPreset={onAdoptionPresetSelect}
             className="mt-3"
           />
           <BrowseDecisionConfidencePanel
             state={browseDecisionConfidence}
             selectedPreset={confidencePreset}
-            onSelectPreset={setConfidencePreset}
+            onSelectPreset={onConfidencePresetSelect}
             className="mt-3"
           />
           <BrowseFreshnessDistributionPanel state={browseFreshness} className="mt-3" />

--- a/tests/browse-decision-preset-cta-events-lib.test.ts
+++ b/tests/browse-decision-preset-cta-events-lib.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  browseDecisionPresetAnalyticsData,
+  browseDecisionPresetAnalyticsEvent,
+  browseDecisionPresetSurface,
+} from "@/lib/browse-decision-preset-cta-events-lib";
+
+describe("browse decision preset cta events lib", () => {
+  it("builds privacy-light browse preset analytics", () => {
+    expect(browseDecisionPresetAnalyticsEvent()).toBe(
+      "browse_decision_preset_select",
+    );
+    expect(browseDecisionPresetSurface("adoption-queue")).toBe(
+      "browse-adoption-queue",
+    );
+    expect(
+      browseDecisionPresetAnalyticsData("adoption-queue", "security-first", 42),
+    ).toEqual({
+      surface: "browse-adoption-queue",
+      panel: "adoption-queue",
+      preset: "security-first",
+      resultCount: 42,
+    });
+    expect(
+      browseDecisionPresetAnalyticsData("decision-confidence", "strict", 8),
+    ).toEqual({
+      surface: "browse-decision-confidence",
+      panel: "decision-confidence",
+      preset: "strict",
+      resultCount: 8,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add browse decision preset CTA helpers emitting browse_decision_preset_select.
- Track adoption queue and decision confidence preset chip changes on browse.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/browse-decision-preset-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)