### PR TITLE
feat(web): track compare drawer preset analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -31,6 +31,10 @@ import {
   compareDrawerSourceAnalyticsData,
   compareDrawerSourceAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events";
+import {
+  compareDrawerDecisionPresetAnalyticsData,
+  compareDrawerDecisionPresetAnalyticsEvent,
+} from "@/lib/compare-drawer-decision-preset-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -392,6 +396,51 @@ export function CompareDrawer() {
   const mitigationPriority = compareMitigationPriorityState(items, mitigationPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
+  const onRolloutPresetSelect = React.useCallback(
+    (preset: RolloutPresetId) => {
+      if (preset === rolloutPreset) return;
+      trackEvent(
+        compareDrawerDecisionPresetAnalyticsEvent(),
+        compareDrawerDecisionPresetAnalyticsData("rollout-readiness", preset, items.length),
+      );
+      setRolloutPreset(preset);
+    },
+    [items.length, rolloutPreset],
+  );
+  const onFitPresetSelect = React.useCallback(
+    (preset: OperationalFitPresetId) => {
+      if (preset === fitPreset) return;
+      trackEvent(
+        compareDrawerDecisionPresetAnalyticsEvent(),
+        compareDrawerDecisionPresetAnalyticsData("operational-fit", preset, items.length),
+      );
+      setFitPreset(preset);
+    },
+    [fitPreset, items.length],
+  );
+  const onRiskPresetSelect = React.useCallback(
+    (preset: DeploymentRiskPresetId) => {
+      if (preset === riskPreset) return;
+      trackEvent(
+        compareDrawerDecisionPresetAnalyticsEvent(),
+        compareDrawerDecisionPresetAnalyticsData("deployment-risk", preset, items.length),
+      );
+      setRiskPreset(preset);
+    },
+    [items.length, riskPreset],
+  );
+  const onMitigationPresetSelect = React.useCallback(
+    (preset: MitigationPriorityPresetId) => {
+      if (preset === mitigationPreset) return;
+      trackEvent(
+        compareDrawerDecisionPresetAnalyticsEvent(),
+        compareDrawerDecisionPresetAnalyticsData("mitigation-priority", preset, items.length),
+      );
+      setMitigationPreset(preset);
+    },
+    [items.length, mitigationPreset],
+  );
+
   const onClear = () => {
     const snapshot = items.map((e) => `${e.category}/${e.slug}`).join(",");
     if (!snapshot) return clear();
@@ -510,28 +559,28 @@ export function CompareDrawer() {
             <CompareRolloutReadinessPanel
               state={rolloutReadiness}
               selectedPreset={rolloutPreset}
-              onSelectPreset={setRolloutPreset}
+              onSelectPreset={onRolloutPresetSelect}
               compact
               className="m-3 mt-0"
             />
             <CompareOperationalFitHeatmapPanel
               state={operationalFitHeatmap}
               selectedPreset={fitPreset}
-              onSelectPreset={setFitPreset}
+              onSelectPreset={onFitPresetSelect}
               compact
               className="m-3 mt-0"
             />
             <CompareDeploymentRiskMapPanel
               state={deploymentRiskMap}
               selectedPreset={riskPreset}
-              onSelectPreset={setRiskPreset}
+              onSelectPreset={onRiskPresetSelect}
               compact
               className="m-3 mt-0"
             />
             <CompareMitigationPriorityPanel
               state={mitigationPriority}
               selectedPreset={mitigationPreset}
-              onSelectPreset={setMitigationPreset}
+              onSelectPreset={onMitigationPresetSelect}
               compact
               className="m-3 mt-0"
             />

--- a/apps/web/src/lib/compare-drawer-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-decision-preset-cta-events-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure compare drawer decision panel preset analytics helpers.
+ *
+ * Maps rollout, fit, risk, and mitigation preset chip clicks to
+ * privacy-light event names without embedding panel copy.
+ */
+
+export type CompareDrawerDecisionPanelId =
+  | "rollout-readiness"
+  | "operational-fit"
+  | "deployment-risk"
+  | "mitigation-priority";
+
+export function compareDrawerDecisionPresetSurface(panel: CompareDrawerDecisionPanelId): string {
+  return `compare-drawer-${panel}`;
+}
+
+export function compareDrawerDecisionPresetAnalyticsEvent(): string {
+  return "compare_drawer_preset_select";
+}
+
+export function compareDrawerDecisionPresetAnalyticsData(
+  panel: CompareDrawerDecisionPanelId,
+  preset: string,
+  compareCount: number,
+) {
+  return {
+    surface: compareDrawerDecisionPresetSurface(panel),
+    panel,
+    preset,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-decision-preset-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Compare drawer decision preset CTA event surface.
+ */
+export {
+  compareDrawerDecisionPresetAnalyticsData,
+  compareDrawerDecisionPresetAnalyticsEvent,
+  compareDrawerDecisionPresetSurface,
+  type CompareDrawerDecisionPanelId,
+} from "@/lib/compare-drawer-decision-preset-cta-events-lib";

--- a/tests/compare-drawer-decision-preset-cta-events-lib.test.ts
+++ b/tests/compare-drawer-decision-preset-cta-events-lib.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDrawerDecisionPresetAnalyticsData,
+  compareDrawerDecisionPresetAnalyticsEvent,
+  compareDrawerDecisionPresetSurface,
+} from "@/lib/compare-drawer-decision-preset-cta-events-lib";
+
+describe("compare drawer decision preset cta events lib", () => {
+  it("builds privacy-light compare drawer preset analytics", () => {
+    expect(compareDrawerDecisionPresetAnalyticsEvent()).toBe(
+      "compare_drawer_preset_select",
+    );
+    expect(compareDrawerDecisionPresetSurface("rollout-readiness")).toBe(
+      "compare-drawer-rollout-readiness",
+    );
+    expect(
+      compareDrawerDecisionPresetAnalyticsData("rollout-readiness", "team", 3),
+    ).toEqual({
+      surface: "compare-drawer-rollout-readiness",
+      panel: "rollout-readiness",
+      preset: "team",
+      compareCount: 3,
+    });
+    expect(
+      compareDrawerDecisionPresetAnalyticsData(
+        "mitigation-priority",
+        "strict",
+        2,
+      ),
+    ).toEqual({
+      surface: "compare-drawer-mitigation-priority",
+      panel: "mitigation-priority",
+      preset: "strict",
+      compareCount: 2,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add compare drawer preset CTA helpers emitting compare_drawer_preset_select.
- Track rollout, operational fit, deployment risk, and mitigation preset chips.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/compare-drawer-decision-preset-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)