### PR TITLE
fix(content): bind LocalAI quickstart to loopback

### DIFF
--- a/content/tools/localai.mdx
+++ b/content/tools/localai.mdx
@@ -79,11 +79,12 @@ This is distinct from the agent frameworks, memory, search, and training tools i
 
 ## Getting started
 
-LocalAI is open source and self-hosted. The quickest path is a container: run `docker run -ti --name
-local-ai -p 8080:8080 localai/localai:latest`, which serves the API on local port 8080; native
-binaries and a desktop app are also available. Pull a model from the gallery or provide your own,
-then point an OpenAI-, Anthropic-, or ElevenLabs-compatible client at your LocalAI endpoint. Backends
-are pulled on demand, so you only install what your models need.
+LocalAI is open source and self-hosted. The quickest path is a container for local-only use: run
+`docker run -ti --name local-ai -p 127.0.0.1:8080:8080 localai/localai:latest`, which binds
+the API to loopback on port 8080; native binaries and a desktop app are also available. Pull a model
+from the gallery or provide your own, then point an OpenAI-, Anthropic-, or ElevenLabs-compatible
+client at your LocalAI endpoint. Configure API-key authentication before binding LocalAI to a LAN or
+public interface. Backends are pulled on demand, so you only install what your models need.
 
 ## Source notes
 


### PR DESCRIPTION
### Motivation
- The LocalAI quickstart recommended `-p 8080:8080`, which publishes the unauthenticated API on all host interfaces by default and could expose it to LAN or internet access; the guidance should default to a safer, loopback-only binding and call out auth configuration.

### Description
- Updated `content/tools/localai.mdx` to replace the Docker quickstart `-p 8080:8080` with `-p 127.0.0.1:8080:8080` and added an explicit note to configure API-key authentication before exposing LocalAI to a LAN or public interface.

### Testing
- Ran `pnpm -s validate:content -- content/tools/localai.mdx` and `git diff --check`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bb21456c832c93dd53df328975f0)