### PR TITLE
feat(web): track compare page preset analytics

### DIFF
--- a/apps/web/src/lib/compare-page-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-decision-preset-cta-events-lib.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure compare page decision panel preset analytics helpers.
+ *
+ * Maps rollout, fit, risk, and mitigation preset chip clicks to
+ * privacy-light event names without embedding panel copy.
+ */
+
+export type ComparePageDecisionPanelId =
+  | "rollout-readiness"
+  | "operational-fit"
+  | "deployment-risk"
+  | "mitigation-priority";
+
+export function comparePageDecisionPresetSurface(panel: ComparePageDecisionPanelId): string {
+  return `compare-page-${panel}`;
+}
+
+export function comparePageDecisionPresetAnalyticsEvent(): string {
+  return "compare_page_preset_select";
+}
+
+export function comparePageDecisionPresetAnalyticsData(
+  panel: ComparePageDecisionPanelId,
+  preset: string,
+  compareCount: number,
+) {
+  return {
+    surface: comparePageDecisionPresetSurface(panel),
+    panel,
+    preset,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-page-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/compare-page-decision-preset-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Compare page decision preset CTA event surface.
+ */
+export {
+  comparePageDecisionPresetAnalyticsData,
+  comparePageDecisionPresetAnalyticsEvent,
+  comparePageDecisionPresetSurface,
+  type ComparePageDecisionPanelId,
+} from "@/lib/compare-page-decision-preset-cta-events-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -38,6 +38,10 @@ import {
   type MitigationPriorityPresetId,
 } from "@/lib/compare-mitigation-priority";
 import { trackEvent, entryEventKey } from "@/lib/analytics";
+import {
+  comparePageDecisionPresetAnalyticsData,
+  comparePageDecisionPresetAnalyticsEvent,
+} from "@/lib/compare-page-decision-preset-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -127,6 +131,51 @@ function ComparePage() {
   const mitigationPriority = React.useMemo(
     () => compareMitigationPriorityState(items, mitigationPreset),
     [items, mitigationPreset],
+  );
+
+  const onRolloutPresetSelect = React.useCallback(
+    (preset: RolloutPresetId) => {
+      if (preset === rolloutPreset) return;
+      trackEvent(
+        comparePageDecisionPresetAnalyticsEvent(),
+        comparePageDecisionPresetAnalyticsData("rollout-readiness", preset, items.length),
+      );
+      setRolloutPreset(preset);
+    },
+    [items.length, rolloutPreset],
+  );
+  const onFitPresetSelect = React.useCallback(
+    (preset: OperationalFitPresetId) => {
+      if (preset === fitPreset) return;
+      trackEvent(
+        comparePageDecisionPresetAnalyticsEvent(),
+        comparePageDecisionPresetAnalyticsData("operational-fit", preset, items.length),
+      );
+      setFitPreset(preset);
+    },
+    [fitPreset, items.length],
+  );
+  const onRiskPresetSelect = React.useCallback(
+    (preset: DeploymentRiskPresetId) => {
+      if (preset === riskPreset) return;
+      trackEvent(
+        comparePageDecisionPresetAnalyticsEvent(),
+        comparePageDecisionPresetAnalyticsData("deployment-risk", preset, items.length),
+      );
+      setRiskPreset(preset);
+    },
+    [items.length, riskPreset],
+  );
+  const onMitigationPresetSelect = React.useCallback(
+    (preset: MitigationPriorityPresetId) => {
+      if (preset === mitigationPreset) return;
+      trackEvent(
+        comparePageDecisionPresetAnalyticsEvent(),
+        comparePageDecisionPresetAnalyticsData("mitigation-priority", preset, items.length),
+      );
+      setMitigationPreset(preset);
+    },
+    [items.length, mitigationPreset],
   );
 
   const pushIds = (next: Entry[]) => {
@@ -255,25 +304,25 @@ function ComparePage() {
         <CompareRolloutReadinessPanel
           state={rolloutReadiness}
           selectedPreset={rolloutPreset}
-          onSelectPreset={setRolloutPreset}
+          onSelectPreset={onRolloutPresetSelect}
           className="m-3 mt-0"
         />
         <CompareOperationalFitHeatmapPanel
           state={operationalFitHeatmap}
           selectedPreset={fitPreset}
-          onSelectPreset={setFitPreset}
+          onSelectPreset={onFitPresetSelect}
           className="m-3 mt-0"
         />
         <CompareDeploymentRiskMapPanel
           state={deploymentRiskMap}
           selectedPreset={riskPreset}
-          onSelectPreset={setRiskPreset}
+          onSelectPreset={onRiskPresetSelect}
           className="m-3 mt-0"
         />
         <CompareMitigationPriorityPanel
           state={mitigationPriority}
           selectedPreset={mitigationPreset}
-          onSelectPreset={setMitigationPreset}
+          onSelectPreset={onMitigationPresetSelect}
           className="m-3 mt-0"
         />
       </div>

--- a/tests/compare-page-decision-preset-cta-events-lib.test.ts
+++ b/tests/compare-page-decision-preset-cta-events-lib.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  comparePageDecisionPresetAnalyticsData,
+  comparePageDecisionPresetAnalyticsEvent,
+  comparePageDecisionPresetSurface,
+} from "@/lib/compare-page-decision-preset-cta-events-lib";
+
+describe("compare page decision preset cta events lib", () => {
+  it("builds privacy-light compare page preset analytics", () => {
+    expect(comparePageDecisionPresetAnalyticsEvent()).toBe(
+      "compare_page_preset_select",
+    );
+    expect(comparePageDecisionPresetSurface("operational-fit")).toBe(
+      "compare-page-operational-fit",
+    );
+    expect(
+      comparePageDecisionPresetAnalyticsData("deployment-risk", "balanced", 4),
+    ).toEqual({
+      surface: "compare-page-deployment-risk",
+      panel: "deployment-risk",
+      preset: "balanced",
+      compareCount: 4,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add compare page preset CTA helpers emitting compare_page_preset_select.
- Track rollout, operational fit, deployment risk, and mitigation preset chips on /compare.

Closes #556

## Test plan
- [x] pnpm exec vitest run tests/compare-page-decision-preset-cta-events-lib.test.ts
- [x] pnpm type-check
- [x] pnpm build

Made with [Cursor](https://cursor.com)