### PR TITLE
feat(web): track compare scenario selection analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -35,6 +35,10 @@ import {
   compareDrawerDecisionPresetAnalyticsData,
   compareDrawerDecisionPresetAnalyticsEvent,
 } from "@/lib/compare-drawer-decision-preset-cta-events";
+import {
+  compareDrawerScenarioAnalyticsData,
+  compareDrawerScenarioAnalyticsEvent,
+} from "@/lib/compare-drawer-scenario-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -396,6 +400,17 @@ export function CompareDrawer() {
   const mitigationPriority = compareMitigationPriorityState(items, mitigationPreset);
   const { bannerTexts, fullViewSearch } = drawerUi;
 
+  const onScenarioSelect = React.useCallback(
+    (next: CompareScenarioId) => {
+      if (next === scenario) return;
+      trackEvent(
+        compareDrawerScenarioAnalyticsEvent(),
+        compareDrawerScenarioAnalyticsData(next, items.length),
+      );
+      setScenario(next);
+    },
+    [items.length, scenario],
+  );
   const onRolloutPresetSelect = React.useCallback(
     (preset: RolloutPresetId) => {
       if (preset === rolloutPreset) return;
@@ -551,7 +566,7 @@ export function CompareDrawer() {
             <CompareScenarioRankingPanel
               state={scenarioRanking}
               selectedScenario={scenario}
-              onSelectScenario={setScenario}
+              onSelectScenario={onScenarioSelect}
               compact
               className="mx-3"
             />

--- a/apps/web/src/lib/compare-drawer-scenario-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-scenario-cta-events-lib.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure compare drawer scenario ranking analytics helpers.
+ *
+ * Maps scenario preset chip clicks to privacy-light event names without
+ * embedding ranking copy or entry titles.
+ */
+
+import type { CompareScenarioId } from "@/lib/compare-scenario-ranking-lib";
+
+export function compareDrawerScenarioSurface(): string {
+  return "compare-drawer-scenario-ranking";
+}
+
+export function compareDrawerScenarioAnalyticsEvent(): string {
+  return "compare_drawer_scenario_select";
+}
+
+export function compareDrawerScenarioAnalyticsData(
+  scenario: CompareScenarioId,
+  compareCount: number,
+) {
+  return {
+    surface: compareDrawerScenarioSurface(),
+    scenario,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-scenario-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-scenario-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Compare drawer scenario CTA event surface.
+ */
+export {
+  compareDrawerScenarioAnalyticsData,
+  compareDrawerScenarioAnalyticsEvent,
+  compareDrawerScenarioSurface,
+} from "@/lib/compare-drawer-scenario-cta-events-lib";

--- a/apps/web/src/lib/compare-page-scenario-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-scenario-cta-events-lib.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure compare page scenario ranking analytics helpers.
+ *
+ * Maps scenario preset chip clicks to privacy-light event names without
+ * embedding ranking copy or entry titles.
+ */
+
+import type { CompareScenarioId } from "@/lib/compare-scenario-ranking-lib";
+
+export function comparePageScenarioSurface(): string {
+  return "compare-page-scenario-ranking";
+}
+
+export function comparePageScenarioAnalyticsEvent(): string {
+  return "compare_page_scenario_select";
+}
+
+export function comparePageScenarioAnalyticsData(
+  scenario: CompareScenarioId,
+  compareCount: number,
+) {
+  return {
+    surface: comparePageScenarioSurface(),
+    scenario,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-page-scenario-cta-events.ts
+++ b/apps/web/src/lib/compare-page-scenario-cta-events.ts
@@ -1,0 +1,8 @@
+/**
+ * Compare page scenario CTA event surface.
+ */
+export {
+  comparePageScenarioAnalyticsData,
+  comparePageScenarioAnalyticsEvent,
+  comparePageScenarioSurface,
+} from "@/lib/compare-page-scenario-cta-events-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -42,6 +42,10 @@ import {
   comparePageDecisionPresetAnalyticsData,
   comparePageDecisionPresetAnalyticsEvent,
 } from "@/lib/compare-page-decision-preset-cta-events";
+import {
+  comparePageScenarioAnalyticsData,
+  comparePageScenarioAnalyticsEvent,
+} from "@/lib/compare-page-scenario-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -133,6 +137,17 @@ function ComparePage() {
     [items, mitigationPreset],
   );
 
+  const onScenarioSelect = React.useCallback(
+    (next: CompareScenarioId) => {
+      if (next === scenario) return;
+      trackEvent(
+        comparePageScenarioAnalyticsEvent(),
+        comparePageScenarioAnalyticsData(next, items.length),
+      );
+      setScenario(next);
+    },
+    [items.length, scenario],
+  );
   const onRolloutPresetSelect = React.useCallback(
     (preset: RolloutPresetId) => {
       if (preset === rolloutPreset) return;
@@ -297,7 +312,7 @@ function ComparePage() {
         <CompareScenarioRankingPanel
           state={scenarioRanking}
           selectedScenario={scenario}
-          onSelectScenario={setScenario}
+          onSelectScenario={onScenarioSelect}
           className="m-3"
         />
         <CompareEvidenceGapsPanel state={evidenceGaps} className="m-3 mt-0" />

--- a/tests/compare-drawer-scenario-cta-events-lib.test.ts
+++ b/tests/compare-drawer-scenario-cta-events-lib.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDrawerScenarioAnalyticsData,
+  compareDrawerScenarioAnalyticsEvent,
+  compareDrawerScenarioSurface,
+} from "@/lib/compare-drawer-scenario-cta-events-lib";
+
+describe("compare drawer scenario cta events lib", () => {
+  it("builds privacy-light compare drawer scenario analytics", () => {
+    expect(compareDrawerScenarioAnalyticsEvent()).toBe(
+      "compare_drawer_scenario_select",
+    );
+    expect(compareDrawerScenarioSurface()).toBe(
+      "compare-drawer-scenario-ranking",
+    );
+    expect(compareDrawerScenarioAnalyticsData("speed-first", 2)).toEqual({
+      surface: "compare-drawer-scenario-ranking",
+      scenario: "speed-first",
+      compareCount: 2,
+    });
+  });
+});

--- a/tests/compare-page-scenario-cta-events-lib.test.ts
+++ b/tests/compare-page-scenario-cta-events-lib.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  comparePageScenarioAnalyticsData,
+  comparePageScenarioAnalyticsEvent,
+  comparePageScenarioSurface,
+} from "@/lib/compare-page-scenario-cta-events-lib";
+
+describe("compare page scenario cta events lib", () => {
+  it("builds privacy-light compare page scenario analytics", () => {
+    expect(comparePageScenarioAnalyticsEvent()).toBe(
+      "compare_page_scenario_select",
+    );
+    expect(comparePageScenarioSurface()).toBe("compare-page-scenario-ranking");
+    expect(comparePageScenarioAnalyticsData("safety-first", 3)).toEqual({
+      surface: "compare-page-scenario-ranking",
+      scenario: "safety-first",
+      compareCount: 3,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add compare_page_scenario_select and compare_drawer_scenario_select events
- Wire scenario chip callbacks on /compare and compare drawer (skip re-select)

Closes #556

## Test plan
- [x] prettier, vitest, type-check, build
- [ ] CI green

Made with [Cursor](https://cursor.com)