### PR TITLE
feat(web): track compare share link copy analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -30,6 +30,8 @@ import {
   compareDrawerUndoRestoreAnalyticsEvent,
   compareDrawerSourceAnalyticsData,
   compareDrawerSourceAnalyticsEvent,
+  compareDrawerShareLinkCopyAnalyticsData,
+  compareDrawerShareLinkCopyAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events";
 import {
   compareDrawerDecisionPresetAnalyticsData,
@@ -544,6 +546,8 @@ export function CompareDrawer() {
                 value={shareUrl}
                 label="Copy compare link"
                 disabled={items.length === 0}
+                event={compareDrawerShareLinkCopyAnalyticsEvent()}
+                eventData={compareDrawerShareLinkCopyAnalyticsData(items.length)}
               />
               <button
                 type="button"

--- a/apps/web/src/lib/compare-drawer-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events-lib.ts
@@ -42,3 +42,14 @@ export function compareDrawerSourceAnalyticsData(category: string, slug: string,
     host,
   };
 }
+
+export function compareDrawerShareLinkCopyAnalyticsEvent(): string {
+  return "compare_drawer_share_link_copy";
+}
+
+export function compareDrawerShareLinkCopyAnalyticsData(compareCount: number) {
+  return {
+    surface: COMPARE_DRAWER_SURFACE,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-cta-events.ts
@@ -9,4 +9,6 @@ export {
   compareDrawerUndoRestoreAnalyticsEvent,
   compareDrawerSourceAnalyticsData,
   compareDrawerSourceAnalyticsEvent,
+  compareDrawerShareLinkCopyAnalyticsData,
+  compareDrawerShareLinkCopyAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events-lib";

--- a/apps/web/src/lib/compare-page-share-link-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-share-link-cta-events-lib.ts
@@ -1,0 +1,19 @@
+/**
+ * Pure compare page share link copy analytics helpers.
+ *
+ * Maps share-link copy clicks to privacy-light event names without
+ * embedding compare URLs or entry identifiers.
+ */
+
+import { COMPARE_PAGE_SURFACE } from "@/lib/compare-page-summary-lib";
+
+export function comparePageShareLinkCopyAnalyticsEvent(): string {
+  return "compare_page_share_link_copy";
+}
+
+export function comparePageShareLinkCopyAnalyticsData(compareCount: number) {
+  return {
+    surface: COMPARE_PAGE_SURFACE,
+    compareCount,
+  };
+}

--- a/apps/web/src/lib/compare-page-share-link-cta-events.ts
+++ b/apps/web/src/lib/compare-page-share-link-cta-events.ts
@@ -1,0 +1,7 @@
+/**
+ * Compare page share link CTA event surface.
+ */
+export {
+  comparePageShareLinkCopyAnalyticsData,
+  comparePageShareLinkCopyAnalyticsEvent,
+} from "@/lib/compare-page-share-link-cta-events-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -46,6 +46,10 @@ import {
   comparePageScenarioAnalyticsData,
   comparePageScenarioAnalyticsEvent,
 } from "@/lib/compare-page-scenario-cta-events";
+import {
+  comparePageShareLinkCopyAnalyticsData,
+  comparePageShareLinkCopyAnalyticsEvent,
+} from "@/lib/compare-page-share-link-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import { sameEntry } from "@/lib/entry-identity";
 import { search } from "@/data/search";
@@ -293,7 +297,12 @@ function ComparePage() {
           ) : null}
         </div>
         <div className="flex items-center gap-2">
-          <CopyButton value={copyShare()} label="Copy share link" />
+          <CopyButton
+            value={copyShare()}
+            label="Copy share link"
+            event={comparePageShareLinkCopyAnalyticsEvent()}
+            eventData={comparePageShareLinkCopyAnalyticsData(items.length)}
+          />
           <button
             type="button"
             onClick={() => {

--- a/tests/compare-drawer-cta-events-lib.test.ts
+++ b/tests/compare-drawer-cta-events-lib.test.ts
@@ -6,6 +6,8 @@ import {
   compareDrawerUndoRestoreAnalyticsEvent,
   compareDrawerSourceAnalyticsData,
   compareDrawerSourceAnalyticsEvent,
+  compareDrawerShareLinkCopyAnalyticsData,
+  compareDrawerShareLinkCopyAnalyticsEvent,
 } from "@/lib/compare-drawer-cta-events-lib";
 
 describe("compare drawer cta events lib", () => {
@@ -31,6 +33,13 @@ describe("compare drawer cta events lib", () => {
       entry: "mcp/browser",
       surface: "compare-drawer",
       host: "github.com",
+    });
+    expect(compareDrawerShareLinkCopyAnalyticsEvent()).toBe(
+      "compare_drawer_share_link_copy",
+    );
+    expect(compareDrawerShareLinkCopyAnalyticsData(3)).toEqual({
+      surface: "compare-drawer",
+      compareCount: 3,
     });
   });
 });

--- a/tests/compare-page-share-link-cta-events-lib.test.ts
+++ b/tests/compare-page-share-link-cta-events-lib.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import {
+  comparePageShareLinkCopyAnalyticsData,
+  comparePageShareLinkCopyAnalyticsEvent,
+} from "@/lib/compare-page-share-link-cta-events-lib";
+
+describe("compare page share link cta events lib", () => {
+  it("builds privacy-light compare page share link copy analytics", () => {
+    expect(comparePageShareLinkCopyAnalyticsEvent()).toBe(
+      "compare_page_share_link_copy",
+    );
+    expect(comparePageShareLinkCopyAnalyticsData(4)).toEqual({
+      surface: "compare-page",
+      compareCount: 4,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add compare_page_share_link_copy and compare_drawer_share_link_copy events
- Wire CopyButton on /compare header and compare drawer (privacy-light: surface + compareCount)

Closes #556

## Test plan
- [x] prettier, vitest, type-check, build
- [ ] CI green

Made with [Cursor](https://cursor.com)