### PR TITLE
feat(web): track detail watch button analytics

### DIFF
--- a/apps/web/src/components/watch-button.tsx
+++ b/apps/web/src/components/watch-button.tsx
@@ -2,6 +2,11 @@ import * as React from "react";
 import { Bell, BellOff } from "lucide-react";
 import { toast } from "sonner";
 import { useWatch, type WatchKind } from "@/lib/watch";
+import { trackEvent } from "@/lib/analytics";
+import {
+  entryDetailWatchAnalyticsData,
+  entryDetailWatchAnalyticsEvent,
+} from "@/lib/entry-detail-watch-cta-events";
 import { cn } from "@/lib/utils";
 
 export function WatchButton({
@@ -12,6 +17,7 @@ export function WatchButton({
   size = "md",
   variant = "outline",
   fullLabel,
+  analyticsEntry,
 }: {
   id: string;
   kind: WatchKind;
@@ -21,6 +27,8 @@ export function WatchButton({
   variant?: "outline" | "ghost";
   /** Optional label override displayed in the watching/unwatched states. */
   fullLabel?: { on?: string; off?: string };
+  /** When set, emits detail watch analytics for toggle actions. */
+  analyticsEntry?: { category: string; slug: string };
 }) {
   const watch = useWatch();
   const active = watch.isWatching(id);
@@ -29,7 +37,14 @@ export function WatchButton({
     <button
       type="button"
       onClick={() => {
+        const watching = !active;
         watch.toggle({ id, kind, label, href });
+        if (analyticsEntry) {
+          trackEvent(
+            entryDetailWatchAnalyticsEvent(watching),
+            entryDetailWatchAnalyticsData(analyticsEntry.category, analyticsEntry.slug, kind),
+          );
+        }
         if (active) toast(`Stopped watching ${label}`);
         else
           toast.success(`Watching ${label}`, {

--- a/apps/web/src/lib/entry-detail-watch-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-watch-cta-events-lib.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure entry detail watch button analytics helpers.
+ *
+ * Maps watch/unwatch toggles to privacy-light event names without
+ * embedding entry titles or other sensitive payloads.
+ */
+
+import type { WatchKind } from "@/lib/watch-types-lib";
+
+export const ENTRY_DETAIL_WATCH_SURFACE = "detail-watch";
+
+export function entryDetailWatchEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailWatchAnalyticsEvent(watching: boolean): string {
+  return watching ? "detail_watch_add" : "detail_watch_remove";
+}
+
+export function entryDetailWatchAnalyticsData(
+  category: string,
+  slug: string,
+  kind: WatchKind = "entry",
+) {
+  return {
+    entry: entryDetailWatchEntryKey(category, slug),
+    surface: ENTRY_DETAIL_WATCH_SURFACE,
+    kind,
+  };
+}

--- a/apps/web/src/lib/entry-detail-watch-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-watch-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry detail watch CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_WATCH_SURFACE,
+  entryDetailWatchAnalyticsData,
+  entryDetailWatchAnalyticsEvent,
+  entryDetailWatchEntryKey,
+} from "@/lib/entry-detail-watch-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -556,6 +556,7 @@ function Dossier() {
               label={entry.title}
               href={`/entry/${entry.category}/${entry.slug}`}
               size="sm"
+              analyticsEntry={{ category: entry.category, slug: entry.slug }}
             />
             <ShareMenu
               url={entryUrl}

--- a/tests/entry-detail-watch-cta-events-lib.test.ts
+++ b/tests/entry-detail-watch-cta-events-lib.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_WATCH_SURFACE,
+  entryDetailWatchAnalyticsData,
+  entryDetailWatchAnalyticsEvent,
+} from "@/lib/entry-detail-watch-cta-events-lib";
+
+describe("entry detail watch cta events lib", () => {
+  it("builds privacy-light watch toggle analytics", () => {
+    expect(entryDetailWatchAnalyticsEvent(true)).toBe("detail_watch_add");
+    expect(entryDetailWatchAnalyticsEvent(false)).toBe("detail_watch_remove");
+    expect(entryDetailWatchAnalyticsData("mcp", "browser")).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_DETAIL_WATCH_SURFACE,
+      kind: "entry",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add detail_watch_add and detail_watch_remove events
- Wire optional analyticsEntry on WatchButton from entry detail header

Closes #556

## Test plan
- [x] prettier, vitest, type-check, build
- [ ] CI green

Made with [Cursor](https://cursor.com)