### PR TITLE
feat(web): track compare drawer snippet analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -17,7 +17,7 @@ import { TrustDrilldown } from "./trust-drilldown";
 import { CopyButton } from "./copy-button";
 import { CopySegmented, variantsForEntry } from "./copy-segmented";
 import { EntryBrandMark } from "./entry-brand-mark";
-import { useCopyPref, useHarnessPref } from "@/lib/dossier-prefs";
+import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { COMPARE_DRAWER_SURFACE, type CompareAction } from "@/lib/compare-drawer-actions-ui-lib";
 import { compareDrawerActionsForEntry } from "@/lib/compare-drawer-actions-interactive-ui-lib";
 import { compareDrawerInteractiveUiState } from "@/lib/compare-drawer-interactive-ui-lib";
@@ -47,6 +47,12 @@ import {
   compareDrawerScenarioAnalyticsData,
   compareDrawerScenarioAnalyticsEvent,
 } from "@/lib/compare-drawer-scenario-cta-events";
+import {
+  compareDrawerSnippetCopyAnalyticsData,
+  compareDrawerSnippetCopyAnalyticsEvent,
+  compareDrawerSnippetVariantAnalyticsData,
+  compareDrawerSnippetVariantAnalyticsEvent,
+} from "@/lib/compare-drawer-snippet-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -374,6 +380,12 @@ function SnippetCell({ entry }: { entry: Entry }) {
             value={payload}
             label={`Copy ${active}`}
             toastLabel={`Copied ${active} — ${entry.title}`}
+            event={compareDrawerSnippetCopyAnalyticsEvent(active as CopyVariant)}
+            eventData={compareDrawerSnippetCopyAnalyticsData(
+              entry.category,
+              entry.slug,
+              active as CopyVariant,
+            )}
           />
         </>
       ) : (
@@ -463,6 +475,16 @@ export function CompareDrawer() {
       setMitigationPreset(preset);
     },
     [items.length, mitigationPreset],
+  );
+
+  const onSnippetVariantSelect = React.useCallback(
+    (variant: CopyVariant) => {
+      trackEvent(
+        compareDrawerSnippetVariantAnalyticsEvent(),
+        compareDrawerSnippetVariantAnalyticsData(variant, items.length),
+      );
+    },
+    [items.length],
   );
 
   const onClear = () => {
@@ -556,6 +578,7 @@ export function CompareDrawer() {
                       { id: "full", label: "Full", value: items.find((e) => e.fullCopy)?.fullCopy },
                     ]}
                     hideCopy
+                    onVariantSelect={onSnippetVariantSelect}
                   />
                 </div>
               )}

--- a/apps/web/src/components/copy-segmented.tsx
+++ b/apps/web/src/components/copy-segmented.tsx
@@ -20,6 +20,8 @@ interface Props {
   labelId?: string;
   /** Optional hook after a successful clipboard write. */
   onCopied?: (variant: CopyVariant) => void;
+  /** Optional hook when the active snippet variant changes. */
+  onVariantSelect?: (variant: CopyVariant) => void;
 }
 
 /**
@@ -35,6 +37,7 @@ export function CopySegmented({
   hideCopy = false,
   labelId,
   onCopied,
+  onVariantSelect,
 }: Props) {
   const [pref, setPref] = useCopyPref();
   const available = variants.filter((v) => !!v.value);
@@ -62,11 +65,20 @@ export function CopySegmented({
     }
   }, [payload, active, entryTitle, onCopied]);
 
+  const selectVariant = React.useCallback(
+    (variant: CopyVariant) => {
+      if (variant === active) return;
+      setPref(variant);
+      onVariantSelect?.(variant);
+    },
+    [active, onVariantSelect, setPref],
+  );
+
   const moveBy = (delta: number) => {
     const idx = available.findIndex((v) => v.id === active);
     if (idx === -1) return;
     const next = available[(idx + delta + available.length) % available.length];
-    if (next) setPref(next.id);
+    if (next) selectVariant(next.id);
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -78,11 +90,11 @@ export function CopySegmented({
       moveBy(-1);
     } else if (e.key === "Home") {
       e.preventDefault();
-      if (available[0]) setPref(available[0].id);
+      if (available[0]) selectVariant(available[0].id);
     } else if (e.key === "End") {
       e.preventDefault();
       const last = available[available.length - 1];
-      if (last) setPref(last.id);
+      if (last) selectVariant(last.id);
     } else if (e.key.toLowerCase() === "c" && !e.metaKey && !e.ctrlKey) {
       e.preventDefault();
       void copy();
@@ -114,7 +126,7 @@ export function CopySegmented({
               aria-disabled={disabled || undefined}
               tabIndex={isActive ? 0 : -1}
               disabled={disabled}
-              onClick={() => !disabled && setPref(v.id)}
+              onClick={() => !disabled && selectVariant(v.id)}
               title={
                 disabled
                   ? `No ${v.label.toLowerCase()} payload`

--- a/apps/web/src/lib/compare-drawer-snippet-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-drawer-snippet-cta-events-lib.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure compare drawer snippet analytics helpers.
+ *
+ * Maps header variant picks and per-entry snippet copies to privacy-light
+ * event names without embedding snippet payloads.
+ */
+
+import type { CopyVariant } from "@/lib/dossier-prefs";
+import { COMPARE_DRAWER_SURFACE } from "@/lib/compare-drawer-actions-lib";
+
+export function compareDrawerSnippetVariantAnalyticsEvent(): string {
+  return "compare_drawer_snippet_variant_select";
+}
+
+export function compareDrawerSnippetVariantAnalyticsData(
+  variant: CopyVariant,
+  compareCount: number,
+) {
+  return {
+    surface: COMPARE_DRAWER_SURFACE,
+    variant,
+    compareCount,
+  };
+}
+
+export function compareDrawerSnippetCopyAnalyticsEvent(variant: CopyVariant): string {
+  if (variant === "install") return "compare_copy_install";
+  if (variant === "config") return "compare_copy_config";
+  return "compare_drawer_snippet_copy";
+}
+
+export function compareDrawerSnippetCopyAnalyticsData(
+  category: string,
+  slug: string,
+  variant: CopyVariant,
+) {
+  return {
+    entry: `${category}/${slug}`,
+    surface: COMPARE_DRAWER_SURFACE,
+    variant,
+  };
+}

--- a/apps/web/src/lib/compare-drawer-snippet-cta-events.ts
+++ b/apps/web/src/lib/compare-drawer-snippet-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Compare drawer snippet CTA event surface.
+ */
+export {
+  compareDrawerSnippetCopyAnalyticsData,
+  compareDrawerSnippetCopyAnalyticsEvent,
+  compareDrawerSnippetVariantAnalyticsData,
+  compareDrawerSnippetVariantAnalyticsEvent,
+} from "@/lib/compare-drawer-snippet-cta-events-lib";

--- a/tests/compare-drawer-snippet-cta-events-lib.test.ts
+++ b/tests/compare-drawer-snippet-cta-events-lib.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDrawerSnippetCopyAnalyticsData,
+  compareDrawerSnippetCopyAnalyticsEvent,
+  compareDrawerSnippetVariantAnalyticsData,
+  compareDrawerSnippetVariantAnalyticsEvent,
+} from "@/lib/compare-drawer-snippet-cta-events-lib";
+
+describe("compare drawer snippet cta events lib", () => {
+  it("builds privacy-light compare drawer snippet analytics", () => {
+    expect(compareDrawerSnippetVariantAnalyticsEvent()).toBe(
+      "compare_drawer_snippet_variant_select",
+    );
+    expect(compareDrawerSnippetVariantAnalyticsData("install", 3)).toEqual({
+      surface: "compare-drawer",
+      variant: "install",
+      compareCount: 3,
+    });
+    expect(compareDrawerSnippetCopyAnalyticsEvent("install")).toBe(
+      "compare_copy_install",
+    );
+    expect(compareDrawerSnippetCopyAnalyticsEvent("config")).toBe(
+      "compare_copy_config",
+    );
+    expect(compareDrawerSnippetCopyAnalyticsEvent("full")).toBe(
+      "compare_drawer_snippet_copy",
+    );
+    expect(
+      compareDrawerSnippetCopyAnalyticsData("mcp", "browser", "config"),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "compare-drawer",
+      variant: "config",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add compare_drawer_snippet_variant_select for header CopySegmented variant picks
- Wire compare_copy_install/config and compare_drawer_snippet_copy on SnippetCell CopyButtons
- Add optional onVariantSelect hook to CopySegmented (skip re-select)

Refs #550

## Test plan
- [x] prettier, vitest, type-check, build
- [ ] CI green

Made with [Cursor](https://cursor.com)