### PR TITLE
feat(web): track browse saved-search and pagination analytics

### DIFF
--- a/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure browse saved-search and pagination analytics helpers.
+ *
+ * Maps saved-search and load-more interactions to privacy-light event
+ * names without embedding search labels or query strings.
+ */
+
+import type { SavedSearch } from "@/lib/recents-types-lib";
+
+export const BROWSE_SAVED_SEARCH_SURFACE = "browse-saved-search";
+export const BROWSE_RESULTS_SURFACE = "browse-results";
+
+export function savedSearchFilterCount(
+  search: Pick<SavedSearch, "q" | "category" | "trust" | "source" | "signal" | "platform">,
+): number {
+  return (
+    Number(!!search.q) +
+    Number(!!search.category) +
+    Number(!!search.trust) +
+    Number(!!search.source) +
+    Number(!!search.signal) +
+    Number(!!search.platform)
+  );
+}
+
+export function browseSavedSearchApplyAnalyticsEvent(): string {
+  return "browse_saved_search_apply";
+}
+
+export function browseSavedSearchApplyAnalyticsData(
+  search: Pick<SavedSearch, "q" | "category" | "trust" | "source" | "signal" | "platform"> & {
+    alerts?: SavedSearch["alerts"];
+  },
+) {
+  return {
+    surface: BROWSE_SAVED_SEARCH_SURFACE,
+    filterCount: savedSearchFilterCount(search),
+    hasAlerts: Boolean(search.alerts?.enabled),
+  };
+}
+
+export function browseSavedSearchSaveAnalyticsEvent(): string {
+  return "browse_saved_search_save";
+}
+
+export function browseSavedSearchSaveAnalyticsData(activeCount: number) {
+  return {
+    surface: BROWSE_SAVED_SEARCH_SURFACE,
+    activeCount,
+  };
+}
+
+export function browseLoadMoreAnalyticsEvent(): string {
+  return "browse_load_more";
+}
+
+export function browseLoadMoreAnalyticsData(shown: number, total: number, loadCount: number) {
+  return {
+    surface: BROWSE_RESULTS_SURFACE,
+    shown,
+    total,
+    loadCount,
+  };
+}
+
+export function browseEmptySuggestionApplyAnalyticsEvent(): string {
+  return "browse_empty_suggestion_apply";
+}
+
+export function browseEmptySuggestionApplyAnalyticsData(matchCount: number) {
+  return {
+    surface: BROWSE_RESULTS_SURFACE,
+    matchCount,
+  };
+}

--- a/apps/web/src/lib/browse-saved-search-cta-events.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events.ts
@@ -1,0 +1,16 @@
+/**
+ * Browse saved-search CTA event surface.
+ */
+export {
+  BROWSE_RESULTS_SURFACE,
+  BROWSE_SAVED_SEARCH_SURFACE,
+  browseEmptySuggestionApplyAnalyticsData,
+  browseEmptySuggestionApplyAnalyticsEvent,
+  browseLoadMoreAnalyticsData,
+  browseLoadMoreAnalyticsEvent,
+  browseSavedSearchApplyAnalyticsData,
+  browseSavedSearchApplyAnalyticsEvent,
+  browseSavedSearchSaveAnalyticsData,
+  browseSavedSearchSaveAnalyticsEvent,
+  savedSearchFilterCount,
+} from "@/lib/browse-saved-search-cta-events-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -82,6 +82,16 @@ import {
   browseViewSelectAnalyticsEvent,
   type BrowseFilterAxis,
 } from "@/lib/browse-filter-cta-events";
+import {
+  browseEmptySuggestionApplyAnalyticsData,
+  browseEmptySuggestionApplyAnalyticsEvent,
+  browseLoadMoreAnalyticsData,
+  browseLoadMoreAnalyticsEvent,
+  browseSavedSearchApplyAnalyticsData,
+  browseSavedSearchApplyAnalyticsEvent,
+  browseSavedSearchSaveAnalyticsData,
+  browseSavedSearchSaveAnalyticsEvent,
+} from "@/lib/browse-saved-search-cta-events";
 import { trackEvent } from "@/lib/analytics";
 import { useRecents, type SavedSearch } from "@/lib/recents";
 import { entryByRef } from "@/data/entries";
@@ -95,30 +105,15 @@ function SavedSearchChipRow({
   currentLabel,
   canSave,
   onSave,
+  onApplySaved,
 }: {
   currentLabel: string;
   canSave: boolean;
   onSave: () => void;
+  onApplySaved: (search: SavedSearch) => void;
 }) {
   const recents = useRecents();
-  const navigate = useNavigate();
   const [managerOpen, setManagerOpen] = React.useState(false);
-
-  const apply = (s: SavedSearch) =>
-    navigate({
-      to: "/browse",
-      search: {
-        q: s.q ?? "",
-        category: s.category ?? "",
-        trust: s.trust ?? "",
-        source: s.source ?? "",
-        signal: s.signal ?? "",
-        platform: s.platform ?? "",
-        sort: (s.sort as "popular" | "newest" | "title") ?? "popular",
-        view: "row" as const,
-        compare: "",
-      },
-    });
 
   if (recents.saved.length === 0 && !canSave) return null;
 
@@ -131,7 +126,7 @@ function SavedSearchChipRow({
           <button
             key={s.id}
             type="button"
-            onClick={() => apply(s)}
+            onClick={() => onApplySaved(s)}
             className="inline-flex h-6 items-center gap-1 rounded-full border border-border bg-surface px-2 text-[11px] text-ink hover:bg-surface-2"
             title={`Open: ${s.label}`}
           >
@@ -575,8 +570,36 @@ function Browse() {
     clearAll();
   }, [activeCount, countForSlice, sp]);
 
+  const applySavedSearch = useCallback(
+    (search: SavedSearch) => {
+      trackEvent(
+        browseSavedSearchApplyAnalyticsEvent(),
+        browseSavedSearchApplyAnalyticsData(search),
+      );
+      navigate({
+        to: "/browse",
+        search: {
+          q: search.q ?? "",
+          category: search.category ?? "",
+          trust: search.trust ?? "",
+          source: search.source ?? "",
+          signal: search.signal ?? "",
+          platform: search.platform ?? "",
+          sort: (search.sort as "popular" | "newest" | "title") ?? "popular",
+          view: "row" as const,
+          compare: "",
+        },
+      });
+    },
+    [navigate],
+  );
+
   const saveCurrent = () => {
     if (activeCount === 0) return;
+    trackEvent(
+      browseSavedSearchSaveAnalyticsEvent(),
+      browseSavedSearchSaveAnalyticsData(activeCount),
+    );
     const label = sp.q
       ? `“${sp.q}”${sp.category ? ` · ${sp.category}` : ""}`
       : `${sp.category || sp.trust || sp.source || browseTrustSignalLabel(sp.signal) || sp.platform || "Filter"}`;
@@ -599,6 +622,15 @@ function Browse() {
   React.useEffect(() => {
     setShown(PAGE);
   }, [sp.q, sp.category, sp.trust, sp.source, sp.signal, sp.platform, sp.sort]);
+
+  const onLoadMore = useCallback(() => {
+    const loadCount = Math.min(PAGE, results.length - shown);
+    trackEvent(
+      browseLoadMoreAnalyticsEvent(),
+      browseLoadMoreAnalyticsData(shown, results.length, loadCount),
+    );
+    setShown((n) => n + PAGE);
+  }, [results.length, shown]);
 
   // Per-axis facet counts: how many results if this value were the only filter
   // in its axis. Memoized on the search params and counted without sorting so
@@ -977,6 +1009,7 @@ function Browse() {
               }
               canSave={activeCount > 0}
               onSave={saveCurrent}
+              onApplySaved={applySavedSearch}
             />
             <FilterChipGroup label="Trust signal quick filters" multi={false}>
               {BROWSE_TRUST_SIGNAL_OPTIONS.map((option) => (
@@ -1206,7 +1239,13 @@ function Browse() {
                     <li key={s.label}>
                       <button
                         type="button"
-                        onClick={s.apply}
+                        onClick={() => {
+                          trackEvent(
+                            browseEmptySuggestionApplyAnalyticsEvent(),
+                            browseEmptySuggestionApplyAnalyticsData(s.count),
+                          );
+                          s.apply();
+                        }}
                         className="inline-flex w-full items-center justify-between gap-3 rounded-md border border-border bg-surface px-3 py-1.5 text-ink transition-colors duration-200 ease-out hover:bg-surface-2 motion-safe:active:scale-[0.99]"
                       >
                         <span>{s.label}</span>
@@ -1295,7 +1334,7 @@ function Browse() {
                 <div className="mt-4 flex justify-center">
                   <button
                     type="button"
-                    onClick={() => setShown((n) => n + PAGE)}
+                    onClick={onLoadMore}
                     className="inline-flex h-9 items-center gap-1.5 rounded-md border border-border bg-surface px-4 text-sm font-medium text-ink transition-colors duration-200 ease-out hover:bg-surface-2 motion-safe:active:scale-[0.98]"
                   >
                     Load {Math.min(PAGE, results.length - shown)} more · {results.length - shown}{" "}

--- a/tests/browse-saved-search-cta-events-lib.test.ts
+++ b/tests/browse-saved-search-cta-events-lib.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSE_RESULTS_SURFACE,
+  BROWSE_SAVED_SEARCH_SURFACE,
+  browseEmptySuggestionApplyAnalyticsData,
+  browseLoadMoreAnalyticsData,
+  browseSavedSearchApplyAnalyticsData,
+  browseSavedSearchSaveAnalyticsData,
+  savedSearchFilterCount,
+} from "@/lib/browse-saved-search-cta-events-lib";
+
+describe("browse saved search cta events lib", () => {
+  it("builds privacy-light browse saved search analytics", () => {
+    expect(
+      savedSearchFilterCount({
+        q: "mcp",
+        category: "mcp",
+        trust: "",
+        source: "",
+        signal: "",
+        platform: "",
+      }),
+    ).toBe(2);
+    expect(
+      browseSavedSearchApplyAnalyticsData({
+        q: "",
+        category: "skills",
+        trust: "verified",
+        source: "",
+        signal: "",
+        platform: "",
+        alerts: { enabled: true, channels: ["inapp"], cadence: "weekly" },
+      }),
+    ).toEqual({
+      surface: BROWSE_SAVED_SEARCH_SURFACE,
+      filterCount: 2,
+      hasAlerts: true,
+    });
+    expect(browseSavedSearchSaveAnalyticsData(4)).toEqual({
+      surface: BROWSE_SAVED_SEARCH_SURFACE,
+      activeCount: 4,
+    });
+    expect(browseLoadMoreAnalyticsData(30, 120, 30)).toEqual({
+      surface: BROWSE_RESULTS_SURFACE,
+      shown: 30,
+      total: 120,
+      loadCount: 30,
+    });
+    expect(browseEmptySuggestionApplyAnalyticsData(8)).toEqual({
+      surface: BROWSE_RESULTS_SURFACE,
+      matchCount: 8,
+    });
+  });
+});

--- a/tests/browse-saved-search-cta-events-lib.test.ts
+++ b/tests/browse-saved-search-cta-events-lib.test.ts
@@ -3,14 +3,28 @@ import {
   BROWSE_RESULTS_SURFACE,
   BROWSE_SAVED_SEARCH_SURFACE,
   browseEmptySuggestionApplyAnalyticsData,
+  browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
+  browseLoadMoreAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
+  browseSavedSearchApplyAnalyticsEvent,
   browseSavedSearchSaveAnalyticsData,
+  browseSavedSearchSaveAnalyticsEvent,
   savedSearchFilterCount,
 } from "@/lib/browse-saved-search-cta-events-lib";
 
 describe("browse saved search cta events lib", () => {
   it("builds privacy-light browse saved search analytics", () => {
+    expect(browseSavedSearchApplyAnalyticsEvent()).toBe(
+      "browse_saved_search_apply",
+    );
+    expect(browseSavedSearchSaveAnalyticsEvent()).toBe(
+      "browse_saved_search_save",
+    );
+    expect(browseLoadMoreAnalyticsEvent()).toBe("browse_load_more");
+    expect(browseEmptySuggestionApplyAnalyticsEvent()).toBe(
+      "browse_empty_suggestion_apply",
+    );
     expect(
       savedSearchFilterCount({
         q: "mcp",
@@ -21,6 +35,16 @@ describe("browse saved search cta events lib", () => {
         platform: "",
       }),
     ).toBe(2);
+    expect(
+      savedSearchFilterCount({
+        q: "",
+        category: "",
+        trust: "verified",
+        source: "community",
+        signal: "trending",
+        platform: "claude-code",
+      }),
+    ).toBe(4);
     expect(
       browseSavedSearchApplyAnalyticsData({
         q: "",


### PR DESCRIPTION
## Summary
- Add browse saved-search analytics: apply and save events with filter counts (no query text).
- Track load-more pagination and empty-state suggestion applies on the browse results surface.

## Events
- `browse_saved_search_apply` — `{ surface, filterCount, hasAlerts }`
- `browse_saved_search_save` — `{ surface, activeCount }`
- `browse_load_more` — `{ surface, shown, total, loadCount }`
- `browse_empty_suggestion_apply` — `{ surface, matchCount }`

Refs #550

## Test plan
- [x] vitest for `browse-saved-search-cta-events-lib`
- [x] type-check and build pass locally