### PR TITLE
feat(web): track detail compare egress link analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-compare-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-compare-egress-cta-events-lib.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure entry detail compare egress analytics helpers.
+ *
+ * Maps featured-in and dossier compare links to privacy-light event names
+ * without embedding destination titles, slugs, or search payloads.
+ */
+
+export const ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED = "detail-featured-in";
+export const ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE = "detail-compare-section";
+
+export type EntryDetailCompareEgressSurface =
+  | typeof ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED
+  | typeof ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE;
+
+export type EntryDetailCompareEgressLinkKind =
+  | "best-list"
+  | "best-list-interactive"
+  | "comparison-page"
+  | "comparison-interactive"
+  | "dossier-interactive";
+
+export function entryDetailCompareEgressEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entryDetailCompareEgressAnalyticsEvent(): string {
+  return "detail_compare_egress_click";
+}
+
+export function entryDetailCompareEgressAnalyticsData(
+  category: string,
+  slug: string,
+  surface: EntryDetailCompareEgressSurface,
+  linkKind: EntryDetailCompareEgressLinkKind,
+  refCount: number,
+  hasInteractive: boolean,
+) {
+  return {
+    entry: entryDetailCompareEgressEntryKey(category, slug),
+    surface,
+    linkKind,
+    refCount,
+    hasInteractive,
+  };
+}

--- a/apps/web/src/lib/entry-detail-compare-egress-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-compare-egress-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Entry detail compare egress CTA event surface.
+ */
+export {
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+  entryDetailCompareEgressAnalyticsData,
+  entryDetailCompareEgressAnalyticsEvent,
+  entryDetailCompareEgressEntryKey,
+  type EntryDetailCompareEgressLinkKind,
+  type EntryDetailCompareEgressSurface,
+} from "@/lib/entry-detail-compare-egress-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -104,6 +104,14 @@ import {
   entryDetailBadgeCopyAnalyticsData,
   entryDetailBadgeCopyAnalyticsEvent,
 } from "@/lib/entry-detail-badge-cta-events";
+import {
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+  entryDetailCompareEgressAnalyticsData,
+  entryDetailCompareEgressAnalyticsEvent,
+  type EntryDetailCompareEgressLinkKind,
+  type EntryDetailCompareEgressSurface,
+} from "@/lib/entry-detail-compare-egress-cta-events";
 import { resourceCardCompareFullMessage } from "@/lib/resource-card-compare-ui";
 import { useCopyPref, useHarnessPref, type CopyVariant } from "@/lib/dossier-prefs";
 import { variantsForEntry } from "@/components/copy-segmented";
@@ -380,6 +388,28 @@ function Dossier() {
       ...entryDetailCompareFullAnalyticsData(entry.category, entry.slug, compare.items.length),
     });
   }, [compare.items.length, entry.category, entry.slug]);
+
+  const trackCompareEgress = useCallback(
+    (
+      surface: EntryDetailCompareEgressSurface,
+      linkKind: EntryDetailCompareEgressLinkKind,
+      refCount: number,
+      hasInteractive: boolean,
+    ) => {
+      trackEvent(
+        entryDetailCompareEgressAnalyticsEvent(),
+        entryDetailCompareEgressAnalyticsData(
+          entry.category,
+          entry.slug,
+          surface,
+          linkKind,
+          refCount,
+          hasInteractive,
+        ),
+      );
+    },
+    [entry.category, entry.slug],
+  );
 
   const compareIds = useMemo(() => serializeCompareItems(compare.items), [compare.items]);
   const onPlaybookAction = useCallback(
@@ -837,6 +867,14 @@ function Dossier() {
                   to="/compare"
                   search={dossierCompareUi.interactiveSearch}
                   className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+                  onClick={() =>
+                    trackCompareEgress(
+                      ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+                      "dossier-interactive",
+                      alternatives.length + 1,
+                      true,
+                    )
+                  }
                 >
                   <ArrowLeft className="h-4 w-4" />
                   {dossierCompareUi.interactiveLinkLabel}
@@ -908,6 +946,14 @@ function Dossier() {
                         to="/best/$slug"
                         params={{ slug: l.slug }}
                         className="story-link text-ink"
+                        onClick={() =>
+                          trackCompareEgress(
+                            ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+                            "best-list",
+                            l.picks.length,
+                            Boolean(bestListLink?.search),
+                          )
+                        }
                       >
                         Best list: {l.title}
                       </Link>
@@ -916,6 +962,14 @@ function Dossier() {
                           to="/compare"
                           search={bestListLink.search}
                           className="text-xs text-ink-muted hover:text-ink"
+                          onClick={() =>
+                            trackCompareEgress(
+                              ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+                              "best-list-interactive",
+                              l.picks.length,
+                              true,
+                            )
+                          }
                         >
                           {bestListLink.label}
                         </Link>
@@ -936,6 +990,14 @@ function Dossier() {
                         to="/compare/$slug"
                         params={{ slug: c.slug }}
                         className="story-link text-ink"
+                        onClick={() =>
+                          trackCompareEgress(
+                            ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+                            "comparison-page",
+                            c.refs.length,
+                            Boolean(featuredLink?.search),
+                          )
+                        }
                       >
                         Comparison: {c.title}
                       </Link>
@@ -944,6 +1006,14 @@ function Dossier() {
                           to="/compare"
                           search={featuredLink.search}
                           className="text-xs text-ink-muted hover:text-ink"
+                          onClick={() =>
+                            trackCompareEgress(
+                              ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+                              "comparison-interactive",
+                              c.refs.length,
+                              true,
+                            )
+                          }
                         >
                           {featuredLink.label}
                         </Link>

--- a/tests/entry-detail-compare-egress-cta-events-lib.test.ts
+++ b/tests/entry-detail-compare-egress-cta-events-lib.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+  ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+  entryDetailCompareEgressAnalyticsData,
+  entryDetailCompareEgressAnalyticsEvent,
+  entryDetailCompareEgressEntryKey,
+} from "@/lib/entry-detail-compare-egress-cta-events-lib";
+
+describe("entry detail compare egress cta events lib", () => {
+  it("builds privacy-light detail compare egress analytics", () => {
+    expect(entryDetailCompareEgressAnalyticsEvent()).toBe(
+      "detail_compare_egress_click",
+    );
+    expect(entryDetailCompareEgressEntryKey("mcp", "browser")).toBe(
+      "mcp/browser",
+    );
+    expect(
+      entryDetailCompareEgressAnalyticsData(
+        "skills",
+        "code-review",
+        ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+        "best-list",
+        5,
+        true,
+      ),
+    ).toEqual({
+      entry: "skills/code-review",
+      surface: ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+      linkKind: "best-list",
+      refCount: 5,
+      hasInteractive: true,
+    });
+    expect(
+      entryDetailCompareEgressAnalyticsData(
+        "mcp",
+        "filesystem",
+        ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+        "comparison-interactive",
+        3,
+        true,
+      ),
+    ).toEqual({
+      entry: "mcp/filesystem",
+      surface: ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_FEATURED,
+      linkKind: "comparison-interactive",
+      refCount: 3,
+      hasInteractive: true,
+    });
+    expect(
+      entryDetailCompareEgressAnalyticsData(
+        "agents",
+        "planner",
+        ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+        "dossier-interactive",
+        4,
+        true,
+      ),
+    ).toEqual({
+      entry: "agents/planner",
+      surface: ENTRY_DETAIL_COMPARE_EGRESS_SURFACE_COMPARE,
+      linkKind: "dossier-interactive",
+      refCount: 4,
+      hasInteractive: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track detail compare egress clicks from featured-in and the dossier compare section.
- Privacy-light payloads: entry key, surface, linkKind, refCount, hasInteractive — no titles or search params.

## Events
- `detail_compare_egress_click` — `{ entry, surface, linkKind, refCount, hasInteractive }`
  - linkKind: `best-list`, `best-list-interactive`, `comparison-page`, `comparison-interactive`, `dossier-interactive`
  - surface: `detail-featured-in`, `detail-compare-section`

Refs #550

## Test plan
- [x] vitest for `entry-detail-compare-egress-cta-events-lib`
- [x] type-check and build pass locally