### PR TITLE
feat(web): track browse recents panel link analytics

### DIFF
--- a/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events-lib.ts
@@ -8,6 +8,7 @@
 import type { SavedSearch } from "@/lib/recents-types-lib";
 
 export const BROWSE_SAVED_SEARCH_SURFACE = "browse-saved-search";
+export const BROWSE_RECENTS_PANEL_SURFACE = "browse-recents-panel";
 export const BROWSE_RESULTS_SURFACE = "browse-results";
 
 export function savedSearchFilterCount(
@@ -71,5 +72,44 @@ export function browseEmptySuggestionApplyAnalyticsData(matchCount: number) {
   return {
     surface: BROWSE_RESULTS_SURFACE,
     matchCount,
+  };
+}
+
+export function browseSavedSearchLinkClickAnalyticsEvent(): string {
+  return "browse_saved_search_link_click";
+}
+
+export function browseSavedSearchLinkClickAnalyticsData(
+  search: Pick<SavedSearch, "q" | "category" | "trust" | "source" | "signal" | "platform"> & {
+    alerts?: SavedSearch["alerts"];
+  },
+) {
+  return {
+    surface: BROWSE_RECENTS_PANEL_SURFACE,
+    filterCount: savedSearchFilterCount(search),
+    hasAlerts: Boolean(search.alerts?.enabled),
+  };
+}
+
+export function browseSavedSearchRemoveAnalyticsEvent(): string {
+  return "browse_saved_search_remove";
+}
+
+export function browseSavedSearchRemoveAnalyticsData(savedCount: number) {
+  return {
+    surface: BROWSE_RECENTS_PANEL_SURFACE,
+    savedCount,
+  };
+}
+
+export function browseRecentEntryClickAnalyticsEvent(): string {
+  return "browse_recent_entry_click";
+}
+
+export function browseRecentEntryClickAnalyticsData(position: number, recentCount: number) {
+  return {
+    surface: BROWSE_RECENTS_PANEL_SURFACE,
+    position,
+    recentCount,
   };
 }

--- a/apps/web/src/lib/browse-saved-search-cta-events.ts
+++ b/apps/web/src/lib/browse-saved-search-cta-events.ts
@@ -2,14 +2,21 @@
  * Browse saved-search CTA event surface.
  */
 export {
+  BROWSE_RECENTS_PANEL_SURFACE,
   BROWSE_RESULTS_SURFACE,
   BROWSE_SAVED_SEARCH_SURFACE,
   browseEmptySuggestionApplyAnalyticsData,
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
   browseLoadMoreAnalyticsEvent,
+  browseRecentEntryClickAnalyticsData,
+  browseRecentEntryClickAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
+  browseSavedSearchLinkClickAnalyticsData,
+  browseSavedSearchLinkClickAnalyticsEvent,
+  browseSavedSearchRemoveAnalyticsData,
+  browseSavedSearchRemoveAnalyticsEvent,
   browseSavedSearchSaveAnalyticsData,
   browseSavedSearchSaveAnalyticsEvent,
   savedSearchFilterCount,

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -87,8 +87,14 @@ import {
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
   browseLoadMoreAnalyticsEvent,
+  browseRecentEntryClickAnalyticsData,
+  browseRecentEntryClickAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
+  browseSavedSearchLinkClickAnalyticsData,
+  browseSavedSearchLinkClickAnalyticsEvent,
+  browseSavedSearchRemoveAnalyticsData,
+  browseSavedSearchRemoveAnalyticsEvent,
   browseSavedSearchSaveAnalyticsData,
   browseSavedSearchSaveAnalyticsEvent,
 } from "@/lib/browse-saved-search-cta-events";
@@ -1177,12 +1183,22 @@ function Browse() {
                               compare: sp.compare,
                             }}
                             className="text-ink hover:underline"
+                            onClick={() =>
+                              trackEvent(
+                                browseSavedSearchLinkClickAnalyticsEvent(),
+                                browseSavedSearchLinkClickAnalyticsData(s),
+                              )
+                            }
                           >
                             {s.label}
                           </Link>
                           <button
                             type="button"
                             onClick={() => {
+                              trackEvent(
+                                browseSavedSearchRemoveAnalyticsEvent(),
+                                browseSavedSearchRemoveAnalyticsData(recents.saved.length),
+                              );
                               recents.removeSaved(s.id);
                               toast(`Removed “${s.label}”`);
                             }}
@@ -1200,12 +1216,18 @@ function Browse() {
                   <div className="flex items-start gap-2">
                     <Clock className="mt-1 h-3.5 w-3.5 shrink-0 text-ink-subtle" aria-hidden />
                     <div className="flex flex-wrap gap-1.5">
-                      {recentEntries.map((e) => (
+                      {recentEntries.map((e, index) => (
                         <Link
                           key={`${e.category}/${e.slug}`}
                           to="/entry/$category/$slug"
                           params={{ category: e.category, slug: e.slug }}
                           className="inline-flex items-center rounded-md border border-border bg-background px-2 py-0.5 text-xs text-ink-muted hover:text-ink"
+                          onClick={() =>
+                            trackEvent(
+                              browseRecentEntryClickAnalyticsEvent(),
+                              browseRecentEntryClickAnalyticsData(index, recentEntries.length),
+                            )
+                          }
                         >
                           {e.title}
                         </Link>

--- a/tests/browse-saved-search-cta-events-lib.test.ts
+++ b/tests/browse-saved-search-cta-events-lib.test.ts
@@ -1,13 +1,20 @@
 import { describe, expect, it } from "vitest";
 import {
+  BROWSE_RECENTS_PANEL_SURFACE,
   BROWSE_RESULTS_SURFACE,
   BROWSE_SAVED_SEARCH_SURFACE,
   browseEmptySuggestionApplyAnalyticsData,
   browseEmptySuggestionApplyAnalyticsEvent,
   browseLoadMoreAnalyticsData,
   browseLoadMoreAnalyticsEvent,
+  browseRecentEntryClickAnalyticsData,
+  browseRecentEntryClickAnalyticsEvent,
   browseSavedSearchApplyAnalyticsData,
   browseSavedSearchApplyAnalyticsEvent,
+  browseSavedSearchLinkClickAnalyticsData,
+  browseSavedSearchLinkClickAnalyticsEvent,
+  browseSavedSearchRemoveAnalyticsData,
+  browseSavedSearchRemoveAnalyticsEvent,
   browseSavedSearchSaveAnalyticsData,
   browseSavedSearchSaveAnalyticsEvent,
   savedSearchFilterCount,
@@ -24,6 +31,15 @@ describe("browse saved search cta events lib", () => {
     expect(browseLoadMoreAnalyticsEvent()).toBe("browse_load_more");
     expect(browseEmptySuggestionApplyAnalyticsEvent()).toBe(
       "browse_empty_suggestion_apply",
+    );
+    expect(browseSavedSearchLinkClickAnalyticsEvent()).toBe(
+      "browse_saved_search_link_click",
+    );
+    expect(browseSavedSearchRemoveAnalyticsEvent()).toBe(
+      "browse_saved_search_remove",
+    );
+    expect(browseRecentEntryClickAnalyticsEvent()).toBe(
+      "browse_recent_entry_click",
     );
     expect(
       savedSearchFilterCount({
@@ -73,6 +89,30 @@ describe("browse saved search cta events lib", () => {
     expect(browseEmptySuggestionApplyAnalyticsData(8)).toEqual({
       surface: BROWSE_RESULTS_SURFACE,
       matchCount: 8,
+    });
+    expect(
+      browseSavedSearchLinkClickAnalyticsData({
+        q: "hooks",
+        category: "",
+        trust: "",
+        source: "",
+        signal: "",
+        platform: "",
+        alerts: { enabled: false, channels: ["inapp"], cadence: "weekly" },
+      }),
+    ).toEqual({
+      surface: BROWSE_RECENTS_PANEL_SURFACE,
+      filterCount: 1,
+      hasAlerts: false,
+    });
+    expect(browseSavedSearchRemoveAnalyticsData(3)).toEqual({
+      surface: BROWSE_RECENTS_PANEL_SURFACE,
+      savedCount: 3,
+    });
+    expect(browseRecentEntryClickAnalyticsData(1, 6)).toEqual({
+      surface: BROWSE_RECENTS_PANEL_SURFACE,
+      position: 1,
+      recentCount: 6,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Track saved-search link clicks, removes, and recent entry clicks in the collapsed recents panel.
- Uses `browse-recents-panel` surface to distinguish from chip-row `browse-saved-search` apply events.

## Events
- `browse_saved_search_link_click` — `{ surface, filterCount, hasAlerts }`
- `browse_saved_search_remove` — `{ surface, savedCount }`
- `browse_recent_entry_click` — `{ surface, position, recentCount }`

Refs #550

## Test plan
- [x] vitest for extended `browse-saved-search-cta-events-lib`
- [x] type-check and build pass locally