### PR TITLE
feat(web): refine playbook compare toggle analytics

### DIFF
--- a/apps/web/src/components/entry-detail-decision-playbook.tsx
+++ b/apps/web/src/components/entry-detail-decision-playbook.tsx
@@ -93,9 +93,9 @@ function PlaybookActionButton({
   onAction,
 }: {
   action: DecisionPlaybookAction;
-  onToggleCompare: () => void;
+  onToggleCompare: () => boolean | undefined;
   onOpenCompareTray: () => void;
-  onAction: (actionId: string) => void;
+  onAction: (actionId: string, meta?: { adding?: boolean }) => void;
 }) {
   const className = cn(
     "inline-flex h-8 items-center rounded-md px-3 text-xs font-medium",
@@ -144,7 +144,12 @@ function PlaybookActionButton({
       title={action.hint ?? undefined}
       onClick={() => {
         if (action.disabled) return;
-        if (action.kind === "compare-toggle") onToggleCompare();
+        if (action.kind === "compare-toggle") {
+          const adding = onToggleCompare();
+          if (typeof adding !== "boolean") return;
+          onAction(action.id, { adding });
+          return;
+        }
         if (action.kind === "open-compare-tray") onOpenCompareTray();
         onAction(action.id);
       }}
@@ -164,9 +169,9 @@ export function EntryDetailDecisionPlaybook({
 }: {
   state: EntryDetailDecisionPlaybookState;
   compareIds: string;
-  onToggleCompare: () => void;
+  onToggleCompare: () => boolean | undefined;
   onOpenCompareTray: () => void;
-  onAction: (actionId: string) => void;
+  onAction: (actionId: string, meta?: { adding?: boolean }) => void;
   className?: string;
 }) {
   const actions = entryDetailDecisionPlaybookActions(

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -46,10 +46,14 @@ export function entryDetailCompareAnalyticsEvent(adding: boolean): string {
   return adding ? "detail_compare_add" : "detail_compare_remove";
 }
 
-export function entryDetailCompareAnalyticsData(category: string, slug: string) {
+export function entryDetailCompareAnalyticsData(
+  category: string,
+  slug: string,
+  surface: string = ENTRY_DETAIL_COMPARE_SURFACE,
+) {
   return {
     entry: entryDetailEntryKey(category, slug),
-    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+    surface,
   };
 }
 
@@ -61,10 +65,11 @@ export function entryDetailCompareOpenTrayAnalyticsData(
   category: string,
   slug: string,
   compareCount: number,
+  surface: string = ENTRY_DETAIL_COMPARE_SURFACE,
 ) {
   return {
     entry: entryDetailEntryKey(category, slug),
-    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+    surface,
     compareCount,
   };
 }
@@ -77,10 +82,11 @@ export function entryDetailCompareToastOpenAnalyticsData(
   category: string,
   slug: string,
   compareCount: number,
+  surface: string = ENTRY_DETAIL_COMPARE_SURFACE,
 ) {
   return {
     entry: entryDetailEntryKey(category, slug),
-    surface: ENTRY_DETAIL_COMPARE_SURFACE,
+    surface,
     compareCount,
   };
 }
@@ -366,11 +372,13 @@ export function entryDetailPlaybookActionAnalyticsData(
   slug: string,
   actionId: string,
   compareCount: number,
+  adding?: boolean,
 ) {
   return {
     entry: entryDetailEntryKey(category, slug),
     action: actionId,
     surface: ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
     compareCount,
+    ...(typeof adding === "boolean" ? { adding } : {}),
   };
 }

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -81,6 +81,7 @@ import { useCompare, useIsCompared } from "@/lib/compare";
 import { serializeCompareItems } from "@/lib/compare-selection";
 import { trackEvent } from "@/lib/analytics";
 import {
+  ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
   entryDetailCompareFullAnalyticsData,
@@ -413,29 +414,39 @@ function Dossier() {
 
   const compareIds = useMemo(() => serializeCompareItems(compare.items), [compare.items]);
   const onPlaybookAction = useCallback(
-    (actionId: string) => {
+    (actionId: string, meta?: { adding?: boolean }) => {
       trackEvent(entryDetailPlaybookActionAnalyticsEvent(actionId), {
         ...entryDetailPlaybookActionAnalyticsData(
           entry.category,
           entry.slug,
           actionId,
           compare.items.length,
+          meta?.adding,
         ),
       });
     },
     [compare.items.length, entry.category, entry.slug],
   );
-  const onPlaybookToggleCompare = useCallback(() => {
+  const onPlaybookToggleCompare = useCallback((): boolean | undefined => {
     const wasIn = inCompare;
     const changed = compare.toggle(entry);
     if (!changed) {
       toast.error(resourceCardCompareFullMessage());
-      return;
+      return undefined;
     }
+    const adding = !wasIn;
+    const compareCount = wasIn ? Math.max(0, compare.items.length - 1) : compare.items.length + 1;
+    trackEvent(entryDetailCompareAnalyticsEvent(adding), {
+      ...entryDetailCompareAnalyticsData(
+        entry.category,
+        entry.slug,
+        ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+      ),
+      compareCount,
+    });
     if (wasIn) {
       toast(`Removed “${entry.title}” from compare`);
     } else {
-      const compareCount = compare.items.length + 1;
       toast.success("Added to compare", {
         action: {
           label: "View",
@@ -443,16 +454,31 @@ function Dossier() {
             compare.setOpen(true);
             trackEvent(
               entryDetailCompareToastOpenAnalyticsEvent(),
-              entryDetailCompareToastOpenAnalyticsData(entry.category, entry.slug, compareCount),
+              entryDetailCompareToastOpenAnalyticsData(
+                entry.category,
+                entry.slug,
+                compareCount,
+                ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+              ),
             );
           },
         },
       });
     }
+    return adding;
   }, [compare, entry, inCompare]);
   const onPlaybookOpenCompareTray = useCallback(() => {
     compare.setOpen(true);
-  }, [compare]);
+    trackEvent(
+      entryDetailCompareOpenTrayAnalyticsEvent(),
+      entryDetailCompareOpenTrayAnalyticsData(
+        entry.category,
+        entry.slug,
+        compare.items.length,
+        ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+      ),
+    );
+  }, [compare, entry.category, entry.slug]);
   const onAdoptionPresetSelect = useCallback(
     (preset: AdoptionPlanPresetId) => {
       if (preset === adoptionPreset) return;

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -14,6 +14,7 @@ import {
   comparisonTrayViewSelectionAnalyticsEvent,
   entryDetailCompareAnalyticsData,
   entryDetailCompareAnalyticsEvent,
+  ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
   entryDetailCompareFullAnalyticsData,
   entryDetailCompareFullAnalyticsEvent,
   entryDetailCompareOpenTrayAnalyticsData,
@@ -75,6 +76,16 @@ describe("entry detail cta events lib", () => {
       entry: "skills/demo",
       surface: "detail-compare",
     });
+    expect(
+      entryDetailCompareAnalyticsData(
+        "skills",
+        "demo",
+        ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-decision-playbook",
+    });
     expect(entryDetailCompareOpenTrayAnalyticsEvent()).toBe(
       "detail_compare_open_tray",
     );
@@ -85,6 +96,18 @@ describe("entry detail cta events lib", () => {
       surface: "detail-compare",
       compareCount: 2,
     });
+    expect(
+      entryDetailCompareOpenTrayAnalyticsData(
+        "skills",
+        "demo",
+        2,
+        ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-decision-playbook",
+      compareCount: 2,
+    });
     expect(entryDetailCompareToastOpenAnalyticsEvent()).toBe(
       "detail_compare_toast_open",
     );
@@ -93,6 +116,18 @@ describe("entry detail cta events lib", () => {
     ).toEqual({
       entry: "skills/demo",
       surface: "detail-compare",
+      compareCount: 3,
+    });
+    expect(
+      entryDetailCompareToastOpenAnalyticsData(
+        "skills",
+        "demo",
+        3,
+        ENTRY_DETAIL_DECISION_PLAYBOOK_SURFACE,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      surface: "detail-decision-playbook",
       compareCount: 3,
     });
     expect(entryDetailCompareFullAnalyticsEvent()).toBe(
@@ -305,6 +340,21 @@ describe("entry detail cta events lib", () => {
       action: "compare-toggle",
       surface: "detail-decision-playbook",
       compareCount: 2,
+    });
+    expect(
+      entryDetailPlaybookActionAnalyticsData(
+        "skills",
+        "demo",
+        "compare-toggle",
+        3,
+        true,
+      ),
+    ).toEqual({
+      entry: "skills/demo",
+      action: "compare-toggle",
+      surface: "detail-decision-playbook",
+      compareCount: 3,
+      adding: true,
     });
   });
 });


### PR DESCRIPTION
## Summary
- Mirror compare add/remove and open-tray events on the decision playbook surface.
- Add `adding` direction to `detail_playbook_compare_toggle` payloads.
- Skip playbook action tracking when compare toggle fails (tray full).

## Events (surface: `detail-decision-playbook`)
- `detail_compare_add` / `detail_compare_remove` — playbook compare toggle
- `detail_compare_open_tray` — playbook open-tray action
- `detail_compare_toast_open` — toast View after playbook add
- `detail_playbook_compare_toggle` — now includes `adding: boolean`

Refs #550

## Test plan
- [x] vitest for extended `entry-detail-cta-events-lib`
- [x] type-check and build pass locally