### PR TITLE
feat(web): track peek panel snippet variant select analytics

### DIFF
--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -37,6 +37,8 @@ import {
   peekPanelActionAnalyticsEvent,
   peekPanelOpenAnalyticsData,
   peekPanelOpenAnalyticsEvent,
+  peekSnippetVariantSelectAnalyticsData,
+  peekSnippetVariantSelectAnalyticsEvent,
 } from "@/lib/peek-panel-cta-events";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 
@@ -139,6 +141,16 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
     [entry],
   );
 
+  const onPeekVariantSelect = React.useCallback(
+    (variant: CopyVariant) => {
+      trackEvent(
+        peekSnippetVariantSelectAnalyticsEvent(),
+        peekSnippetVariantSelectAnalyticsData(entry.category, entry.slug, variant),
+      );
+    },
+    [entry.category, entry.slug],
+  );
+
   const onPeekAction = React.useCallback(
     (action: "dossier" | "source" | "docs") => {
       trackEvent(
@@ -218,6 +230,7 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
             entryTitle={entry.title}
             labelId={`peek-snippet-${peekId}`}
             onCopied={onPeekCopy}
+            onVariantSelect={onPeekVariantSelect}
           />
         </div>
         {variants.find((v) => v.id === variants.find((x) => x.value)?.id)?.value && (

--- a/apps/web/src/lib/peek-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/peek-panel-cta-events-lib.ts
@@ -29,6 +29,22 @@ export function peekCopyAnalyticsData(category: string, slug: string, variant: C
   };
 }
 
+export function peekSnippetVariantSelectAnalyticsEvent(): string {
+  return "peek_snippet_variant_select";
+}
+
+export function peekSnippetVariantSelectAnalyticsData(
+  category: string,
+  slug: string,
+  variant: CopyVariant,
+) {
+  return {
+    entry: peekPanelEntryKey(category, slug),
+    variant,
+    surface: PEEK_PANEL_SURFACE,
+  };
+}
+
 export function peekPanelActionAnalyticsEvent(action: PeekPanelAction): string {
   return `peek_${action}`;
 }

--- a/apps/web/src/lib/peek-panel-cta-events.ts
+++ b/apps/web/src/lib/peek-panel-cta-events.ts
@@ -7,6 +7,8 @@ export {
   peekCopyAnalyticsData,
   peekCopyAnalyticsEvent,
   peekCopyIntentType,
+  peekSnippetVariantSelectAnalyticsData,
+  peekSnippetVariantSelectAnalyticsEvent,
   peekPanelActionAnalyticsData,
   peekPanelActionAnalyticsEvent,
   peekPanelEntryKey,

--- a/tests/peek-panel-cta-events-lib.test.ts
+++ b/tests/peek-panel-cta-events-lib.test.ts
@@ -7,6 +7,8 @@ import {
   peekPanelActionAnalyticsEvent,
   peekPanelOpenAnalyticsData,
   peekPanelOpenAnalyticsEvent,
+  peekSnippetVariantSelectAnalyticsData,
+  peekSnippetVariantSelectAnalyticsEvent,
 } from "@/lib/peek-panel-cta-events-lib";
 
 describe("peek panel cta events lib", () => {
@@ -31,6 +33,16 @@ describe("peek panel cta events lib", () => {
     expect(peekPanelOpenAnalyticsEvent()).toBe("peek_open");
     expect(peekPanelOpenAnalyticsData("mcp", "browser")).toEqual({
       entry: "mcp/browser",
+      surface: "peek-panel",
+    });
+    expect(peekSnippetVariantSelectAnalyticsEvent()).toBe(
+      "peek_snippet_variant_select",
+    );
+    expect(
+      peekSnippetVariantSelectAnalyticsData("skills", "demo", "config"),
+    ).toEqual({
+      entry: "skills/demo",
+      variant: "config",
       surface: "peek-panel",
     });
   });


### PR DESCRIPTION
## Summary
- Track snippet variant selection in the peek panel CopySegmented control.
- Copy events were already tracked; variant pill clicks were silent.

## Events
- `peek_snippet_variant_select` — `{ entry, variant, surface: peek-panel }`

Refs #550

## Test plan
- [x] vitest for extended `peek-panel-cta-events-lib`
- [x] type-check and build pass locally