### PR TITLE
feat(web): track compare curated page interactive egress analytics

### DIFF
--- a/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events-lib.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure compare curated page egress analytics helpers.
+ *
+ * Maps curated comparison page links to privacy-light event names without
+ * embedding comparison slugs or search payloads.
+ */
+
+export const COMPARE_CURATED_PAGE_SURFACE = "compare-curated-page";
+
+export type CompareCuratedEgressLinkKind = "interactive";
+
+export function compareCuratedEgressAnalyticsEvent(): string {
+  return "compare_curated_egress_click";
+}
+
+export function compareCuratedEgressAnalyticsData(
+  linkKind: CompareCuratedEgressLinkKind,
+  refCount: number,
+  hasInteractive: boolean,
+) {
+  return {
+    surface: COMPARE_CURATED_PAGE_SURFACE,
+    linkKind,
+    refCount,
+    hasInteractive,
+  };
+}

--- a/apps/web/src/lib/compare-curated-egress-cta-events.ts
+++ b/apps/web/src/lib/compare-curated-egress-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Compare curated page egress CTA event surface.
+ */
+export {
+  COMPARE_CURATED_PAGE_SURFACE,
+  compareCuratedEgressAnalyticsData,
+  compareCuratedEgressAnalyticsEvent,
+  type CompareCuratedEgressLinkKind,
+} from "@/lib/compare-curated-egress-cta-events-lib";

--- a/apps/web/src/routes/compare.$slug.tsx
+++ b/apps/web/src/routes/compare.$slug.tsx
@@ -16,6 +16,11 @@ import {
   compareCuratedInteractiveUiState,
 } from "@/lib/compare-curated-interactive-ui-lib";
 import { compareCuratedResolvedEntries } from "@/lib/compare-curated-ui-lib";
+import { trackEvent } from "@/lib/analytics";
+import {
+  compareCuratedEgressAnalyticsData,
+  compareCuratedEgressAnalyticsEvent,
+} from "@/lib/compare-curated-egress-cta-events";
 
 export const Route = createFileRoute("/compare/$slug")({
   loader: ({ params }) => {
@@ -104,6 +109,12 @@ function ComparisonPage() {
             to="/compare"
             search={interactiveSearch}
             className="mt-4 inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-ink"
+            onClick={() =>
+              trackEvent(
+                compareCuratedEgressAnalyticsEvent(),
+                compareCuratedEgressAnalyticsData("interactive", entries.length, true),
+              )
+            }
           >
             <ArrowLeft className="h-4 w-4" /> {interactiveLinkLabel}
           </Link>

--- a/tests/compare-curated-egress-cta-events-lib.test.ts
+++ b/tests/compare-curated-egress-cta-events-lib.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARE_CURATED_PAGE_SURFACE,
+  compareCuratedEgressAnalyticsData,
+  compareCuratedEgressAnalyticsEvent,
+} from "@/lib/compare-curated-egress-cta-events-lib";
+
+describe("compare curated egress cta events lib", () => {
+  it("builds privacy-light compare curated egress analytics", () => {
+    expect(compareCuratedEgressAnalyticsEvent()).toBe(
+      "compare_curated_egress_click",
+    );
+    expect(compareCuratedEgressAnalyticsData("interactive", 4, true)).toEqual({
+      surface: COMPARE_CURATED_PAGE_SURFACE,
+      linkKind: "interactive",
+      refCount: 4,
+      hasInteractive: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track the open-interactively egress link on curated comparison pages (`/compare/\`).
- Privacy-light payload: surface, linkKind, refCount, hasInteractive — no slugs or search params.

## Events
- `compare_curated_egress_click` — `{ surface: compare-curated-page, linkKind: interactive, refCount, hasInteractive }`

Refs #550

## Test plan
- [x] vitest for `compare-curated-egress-cta-events-lib`
- [x] type-check and build pass locally