### PR TITLE
feat(web): track compare page empty-state egress analytics

### DIFF
--- a/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure compare page empty-state egress analytics helpers.
+ *
+ * Maps popular comparison links on the empty /compare page to privacy-light
+ * event names without embedding comparison slugs or search payloads.
+ */
+
+export const COMPARE_PAGE_EMPTY_SURFACE = "compare-page-empty";
+
+export type ComparePageEmptyEgressLinkKind = "curated-page" | "interactive";
+
+export function comparePageEmptyEgressAnalyticsEvent(): string {
+  return "compare_page_empty_egress_click";
+}
+
+export function comparePageEmptyEgressAnalyticsData(
+  linkKind: ComparePageEmptyEgressLinkKind,
+  refCount: number,
+  hasInteractive: boolean,
+) {
+  return {
+    surface: COMPARE_PAGE_EMPTY_SURFACE,
+    linkKind,
+    refCount,
+    hasInteractive,
+  };
+}

--- a/apps/web/src/lib/compare-page-empty-egress-cta-events.ts
+++ b/apps/web/src/lib/compare-page-empty-egress-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Compare page empty-state egress CTA event surface.
+ */
+export {
+  COMPARE_PAGE_EMPTY_SURFACE,
+  comparePageEmptyEgressAnalyticsData,
+  comparePageEmptyEgressAnalyticsEvent,
+  type ComparePageEmptyEgressLinkKind,
+} from "@/lib/compare-page-empty-egress-cta-events-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -51,6 +51,10 @@ import {
   comparePageShareLinkCopyAnalyticsEvent,
 } from "@/lib/compare-page-share-link-cta-events";
 import {
+  comparePageEmptyEgressAnalyticsData,
+  comparePageEmptyEgressAnalyticsEvent,
+} from "@/lib/compare-page-empty-egress-cta-events";
+import {
   comparePageAddOpenAnalyticsData,
   comparePageAddOpenAnalyticsEvent,
   comparePageAddSelectAnalyticsData,
@@ -285,29 +289,49 @@ function ComparePage() {
           <div className="mt-6">
             <div className="eyebrow mb-2">Popular comparisons</div>
             <div className="flex flex-wrap justify-center gap-2">
-              {emptyUi.popularComparisonLinks.map((comparison) => (
-                <div
-                  key={comparison.slug}
-                  className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
-                >
-                  <Link
-                    to="/compare/$slug"
-                    params={{ slug: comparison.slug }}
-                    className="text-xs text-ink-muted hover:text-ink"
+              {emptyUi.popularComparisonLinks.map((comparison) => {
+                const refCount =
+                  COMPARISONS.find((item) => item.slug === comparison.slug)?.refs.length ?? 0;
+                return (
+                  <div
+                    key={comparison.slug}
+                    className="inline-flex flex-wrap items-center justify-center gap-1.5 rounded-full border border-border bg-background px-3 py-1.5"
                   >
-                    {comparison.heading}
-                  </Link>
-                  {comparison.interactiveSearch ? (
                     <Link
-                      to="/compare"
-                      search={comparison.interactiveSearch}
-                      className="text-[10px] text-ink-subtle hover:text-ink"
+                      to="/compare/$slug"
+                      params={{ slug: comparison.slug }}
+                      className="text-xs text-ink-muted hover:text-ink"
+                      onClick={() =>
+                        trackEvent(
+                          comparePageEmptyEgressAnalyticsEvent(),
+                          comparePageEmptyEgressAnalyticsData(
+                            "curated-page",
+                            refCount,
+                            Boolean(comparison.interactiveSearch),
+                          ),
+                        )
+                      }
                     >
-                      {comparison.interactiveLabel}
+                      {comparison.heading}
                     </Link>
-                  ) : null}
-                </div>
-              ))}
+                    {comparison.interactiveSearch ? (
+                      <Link
+                        to="/compare"
+                        search={comparison.interactiveSearch}
+                        className="text-[10px] text-ink-subtle hover:text-ink"
+                        onClick={() =>
+                          trackEvent(
+                            comparePageEmptyEgressAnalyticsEvent(),
+                            comparePageEmptyEgressAnalyticsData("interactive", refCount, true),
+                          )
+                        }
+                      >
+                        {comparison.interactiveLabel}
+                      </Link>
+                    ) : null}
+                  </div>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/tests/compare-page-empty-egress-cta-events-lib.test.ts
+++ b/tests/compare-page-empty-egress-cta-events-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMPARE_PAGE_EMPTY_SURFACE,
+  comparePageEmptyEgressAnalyticsData,
+  comparePageEmptyEgressAnalyticsEvent,
+} from "@/lib/compare-page-empty-egress-cta-events-lib";
+
+describe("compare page empty egress cta events lib", () => {
+  it("builds privacy-light compare page empty egress analytics", () => {
+    expect(comparePageEmptyEgressAnalyticsEvent()).toBe(
+      "compare_page_empty_egress_click",
+    );
+    expect(
+      comparePageEmptyEgressAnalyticsData("curated-page", 3, true),
+    ).toEqual({
+      surface: COMPARE_PAGE_EMPTY_SURFACE,
+      linkKind: "curated-page",
+      refCount: 3,
+      hasInteractive: true,
+    });
+    expect(comparePageEmptyEgressAnalyticsData("interactive", 3, true)).toEqual(
+      {
+        surface: COMPARE_PAGE_EMPTY_SURFACE,
+        linkKind: "interactive",
+        refCount: 3,
+        hasInteractive: true,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Track popular comparison egress links on the empty /compare page.
- Privacy-light payloads: surface, linkKind, refCount, hasInteractive — no slugs or search params.

## Events
- `compare_page_empty_egress_click` — `{ surface: compare-page-empty, linkKind, refCount, hasInteractive }`
  - linkKind: `curated-page` (heading link) or `interactive` (open interactively link)

Refs #550

## Test plan
- [x] vitest for `compare-page-empty-egress-cta-events-lib`
- [x] type-check and build pass locally