### PR TITLE
feat(web): track alerts dropdown open and interaction analytics

### DIFF
--- a/apps/web/src/components/alerts-dropdown.tsx
+++ b/apps/web/src/components/alerts-dropdown.tsx
@@ -5,6 +5,15 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useWatch } from "@/lib/watch";
 import { groupAlertsByBucket } from "@/lib/alerts-group-lib";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  alertsDropdownItemClickAnalyticsData,
+  alertsDropdownItemClickAnalyticsEvent,
+  alertsDropdownMarkAllReadAnalyticsData,
+  alertsDropdownMarkAllReadAnalyticsEvent,
+  alertsDropdownOpenAnalyticsData,
+  alertsDropdownOpenAnalyticsEvent,
+} from "@/lib/alerts-dropdown-cta-events";
 
 const SEV_ICON = {
   info: { Icon: Info, cls: "text-ink-muted" },
@@ -19,9 +28,39 @@ export function AlertsDropdown() {
     () => groupAlertsByBucket(alerts, Date.now()),
     [alerts, lastSeenAt],
   );
+  const [open, setOpen] = React.useState(false);
+  const openRef = React.useRef(open);
+  openRef.current = open;
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (next && !openRef.current) {
+        trackEvent(
+          alertsDropdownOpenAnalyticsEvent(),
+          alertsDropdownOpenAnalyticsData(
+            unreadCount,
+            alerts.length,
+            targets.length,
+            savedSearchAlertCount,
+          ),
+        );
+      }
+      setOpen(next);
+    },
+    [alerts.length, savedSearchAlertCount, targets.length, unreadCount],
+  );
+
+  const onMarkAllRead = React.useCallback(() => {
+    if (unreadCount === 0) return;
+    trackEvent(
+      alertsDropdownMarkAllReadAnalyticsEvent(),
+      alertsDropdownMarkAllReadAnalyticsData(unreadCount),
+    );
+    markAllRead();
+  }, [markAllRead, unreadCount]);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -49,7 +88,7 @@ export function AlertsDropdown() {
           </div>
           <button
             type="button"
-            onClick={markAllRead}
+            onClick={onMarkAllRead}
             disabled={unreadCount === 0}
             className="inline-flex items-center gap-1 text-[11px] font-medium text-ink-muted hover:text-ink disabled:opacity-40"
           >
@@ -97,7 +136,21 @@ export function AlertsDropdown() {
                           className="border-b border-border last:border-0 hover:bg-surface-2"
                         >
                           {a.href ? (
-                            <Link to={a.href} className="block">
+                            <Link
+                              to={a.href}
+                              className="block"
+                              onClick={() =>
+                                trackEvent(
+                                  alertsDropdownItemClickAnalyticsEvent(),
+                                  alertsDropdownItemClickAnalyticsData(
+                                    a.severity,
+                                    k,
+                                    a.kind,
+                                    unread,
+                                  ),
+                                )
+                              }
+                            >
                               {body}
                             </Link>
                           ) : (

--- a/apps/web/src/lib/alerts-dropdown-cta-events-lib.ts
+++ b/apps/web/src/lib/alerts-dropdown-cta-events-lib.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure alerts dropdown analytics helpers.
+ *
+ * Maps alerts popover interactions to privacy-light event names without
+ * embedding alert titles, bodies, or destination URLs.
+ */
+
+import type { AlertBucket } from "@/lib/alerts-bucket-lib";
+import type { AlertSeverity, WatchKind } from "@/lib/watch-types-lib";
+
+export const ALERTS_DROPDOWN_SURFACE = "alerts-dropdown";
+
+export function alertsDropdownOpenAnalyticsEvent(): string {
+  return "alerts_dropdown_open";
+}
+
+export function alertsDropdownOpenAnalyticsData(
+  unreadCount: number,
+  alertCount: number,
+  watchCount: number,
+  savedSearchAlertCount: number,
+) {
+  return {
+    surface: ALERTS_DROPDOWN_SURFACE,
+    unreadCount,
+    alertCount,
+    watchCount,
+    savedSearchAlertCount,
+  };
+}
+
+export function alertsDropdownMarkAllReadAnalyticsEvent(): string {
+  return "alerts_dropdown_mark_all_read";
+}
+
+export function alertsDropdownMarkAllReadAnalyticsData(unreadCount: number) {
+  return {
+    surface: ALERTS_DROPDOWN_SURFACE,
+    unreadCount,
+  };
+}
+
+export function alertsDropdownItemClickAnalyticsEvent(): string {
+  return "alerts_dropdown_item_click";
+}
+
+export function alertsDropdownItemClickAnalyticsData(
+  severity: AlertSeverity,
+  bucket: AlertBucket,
+  kind: WatchKind,
+  unread: boolean,
+) {
+  return {
+    surface: ALERTS_DROPDOWN_SURFACE,
+    severity,
+    bucket,
+    kind,
+    unread,
+  };
+}

--- a/apps/web/src/lib/alerts-dropdown-cta-events.ts
+++ b/apps/web/src/lib/alerts-dropdown-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Alerts dropdown CTA event surface.
+ */
+export {
+  ALERTS_DROPDOWN_SURFACE,
+  alertsDropdownItemClickAnalyticsData,
+  alertsDropdownItemClickAnalyticsEvent,
+  alertsDropdownMarkAllReadAnalyticsData,
+  alertsDropdownMarkAllReadAnalyticsEvent,
+  alertsDropdownOpenAnalyticsData,
+  alertsDropdownOpenAnalyticsEvent,
+} from "@/lib/alerts-dropdown-cta-events-lib";

--- a/tests/alerts-dropdown-cta-events-lib.test.ts
+++ b/tests/alerts-dropdown-cta-events-lib.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  ALERTS_DROPDOWN_SURFACE,
+  alertsDropdownItemClickAnalyticsData,
+  alertsDropdownItemClickAnalyticsEvent,
+  alertsDropdownMarkAllReadAnalyticsData,
+  alertsDropdownMarkAllReadAnalyticsEvent,
+  alertsDropdownOpenAnalyticsData,
+  alertsDropdownOpenAnalyticsEvent,
+} from "@/lib/alerts-dropdown-cta-events-lib";
+
+describe("alerts dropdown cta events lib", () => {
+  it("builds privacy-light alerts dropdown analytics", () => {
+    expect(alertsDropdownOpenAnalyticsEvent()).toBe("alerts_dropdown_open");
+    expect(alertsDropdownOpenAnalyticsData(3, 12, 5, 2)).toEqual({
+      surface: ALERTS_DROPDOWN_SURFACE,
+      unreadCount: 3,
+      alertCount: 12,
+      watchCount: 5,
+      savedSearchAlertCount: 2,
+    });
+    expect(alertsDropdownMarkAllReadAnalyticsEvent()).toBe(
+      "alerts_dropdown_mark_all_read",
+    );
+    expect(alertsDropdownMarkAllReadAnalyticsData(4)).toEqual({
+      surface: ALERTS_DROPDOWN_SURFACE,
+      unreadCount: 4,
+    });
+    expect(alertsDropdownItemClickAnalyticsEvent()).toBe(
+      "alerts_dropdown_item_click",
+    );
+    expect(
+      alertsDropdownItemClickAnalyticsData("warning", "Today", "entry", true),
+    ).toEqual({
+      surface: ALERTS_DROPDOWN_SURFACE,
+      severity: "warning",
+      bucket: "Today",
+      kind: "entry",
+      unread: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track alerts popover open, mark-all-read, and linked alert item clicks.
- Privacy-light payloads: counts, severity, bucket, kind, unread — no titles or URLs.

## Events
- `alerts_dropdown_open` — `{ surface, unreadCount, alertCount, watchCount, savedSearchAlertCount }`
- `alerts_dropdown_mark_all_read` — `{ surface, unreadCount }`
- `alerts_dropdown_item_click` — `{ surface, severity, bucket, kind, unread }`

Refs #550

## Test plan
- [x] vitest for `alerts-dropdown-cta-events-lib`
- [x] type-check and build pass locally