### PR TITLE
feat(web): track harness variant picker analytics

### DIFF
--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -53,6 +53,10 @@ import {
   compareDrawerSnippetVariantAnalyticsData,
   compareDrawerSnippetVariantAnalyticsEvent,
 } from "@/lib/compare-drawer-snippet-cta-events";
+import {
+  harnessVariantSelectAnalyticsData,
+  harnessVariantSelectAnalyticsEvent,
+} from "@/lib/harness-variant-cta-events";
 import { claimCtaAnalyticsData, claimCtaAnalyticsEvent } from "@/lib/conversion-cta-events";
 import type { Entry, Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
@@ -369,6 +373,17 @@ function SnippetCell({ entry }: { entry: Entry }) {
           available={harnessAvailable}
           value={harness as Harness | null}
           onChange={setHarness}
+          onVariantSelect={(nextHarness) =>
+            trackEvent(
+              harnessVariantSelectAnalyticsEvent(),
+              harnessVariantSelectAnalyticsData(
+                entry.category,
+                entry.slug,
+                COMPARE_DRAWER_SURFACE,
+                nextHarness,
+              ),
+            )
+          }
         />
       )}
       {payload ? (

--- a/apps/web/src/components/entry-detail-command-center.tsx
+++ b/apps/web/src/components/entry-detail-command-center.tsx
@@ -50,7 +50,12 @@ import {
   entryDetailCommunityAnchorAnalyticsEvent,
   entryDetailTrustSectionAnalyticsData,
   entryDetailTrustSectionAnalyticsEvent,
+  ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
 } from "@/lib/entry-detail-cta-events";
+import {
+  harnessVariantSelectAnalyticsData,
+  harnessVariantSelectAnalyticsEvent,
+} from "@/lib/harness-variant-cta-events";
 import {
   detailIntegrationLinkIcon,
   resolveDetailIntegrationLinks,
@@ -255,6 +260,17 @@ export function EntryDetailCommandCenter({
                 available={harnessAvailable}
                 value={harness}
                 onChange={onHarnessChange}
+                onVariantSelect={(nextHarness) =>
+                  trackEvent(
+                    harnessVariantSelectAnalyticsEvent(),
+                    harnessVariantSelectAnalyticsData(
+                      entry.category,
+                      entry.slug,
+                      ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+                      nextHarness,
+                    ),
+                  )
+                }
               />
             </div>
           )}

--- a/apps/web/src/components/harness-variant-picker.tsx
+++ b/apps/web/src/components/harness-variant-picker.tsx
@@ -6,6 +6,7 @@ interface Props {
   available: Harness[];
   value: Harness | null;
   onChange: (h: Harness) => void;
+  onVariantSelect?: (h: Harness) => void;
   className?: string;
   labelId?: string;
 }
@@ -14,9 +15,21 @@ interface Props {
  * Small radiogroup that scopes install/config/full payloads to a specific
  * harness. Renders nothing when fewer than 2 variants exist.
  */
-export function HarnessVariantPicker({ available, value, onChange, className, labelId }: Props) {
+export function HarnessVariantPicker({
+  available,
+  value,
+  onChange,
+  onVariantSelect,
+  className,
+  labelId,
+}: Props) {
   if (!available || available.length < 2) return null;
   const ordered = HARNESSES.map((h) => h.id).filter((id) => available.includes(id));
+  const selectHarness = (id: Harness) => {
+    if (id === value) return;
+    onChange(id);
+    onVariantSelect?.(id);
+  };
   return (
     <div
       role="radiogroup"
@@ -33,16 +46,16 @@ export function HarnessVariantPicker({ available, value, onChange, className, la
             role="radio"
             aria-checked={active}
             tabIndex={active ? 0 : -1}
-            onClick={() => onChange(id)}
+            onClick={() => selectHarness(id)}
             onKeyDown={(e) => {
               if (e.key === "ArrowRight" || e.key === "ArrowDown") {
                 e.preventDefault();
                 const idx = ordered.indexOf(value ?? ordered[0]!);
-                onChange(ordered[(idx + 1) % ordered.length]!);
+                selectHarness(ordered[(idx + 1) % ordered.length]!);
               } else if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
                 e.preventDefault();
                 const idx = ordered.indexOf(value ?? ordered[0]!);
-                onChange(ordered[(idx - 1 + ordered.length) % ordered.length]!);
+                selectHarness(ordered[(idx - 1 + ordered.length) % ordered.length]!);
               }
             }}
             className={cn(

--- a/apps/web/src/components/peek-button.tsx
+++ b/apps/web/src/components/peek-button.tsx
@@ -39,7 +39,12 @@ import {
   peekPanelOpenAnalyticsEvent,
   peekSnippetVariantSelectAnalyticsData,
   peekSnippetVariantSelectAnalyticsEvent,
+  PEEK_PANEL_SURFACE,
 } from "@/lib/peek-panel-cta-events";
+import {
+  harnessVariantSelectAnalyticsData,
+  harnessVariantSelectAnalyticsEvent,
+} from "@/lib/harness-variant-cta-events";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 
 export interface PeekHandle {
@@ -216,6 +221,17 @@ function PeekBody({ entry, peekId }: { entry: Entry; peekId: string }) {
             value={harness as Harness | null}
             onChange={setHarness}
             labelId={`peek-harness-${peekId}`}
+            onVariantSelect={(nextHarness) =>
+              trackEvent(
+                harnessVariantSelectAnalyticsEvent(),
+                harnessVariantSelectAnalyticsData(
+                  entry.category,
+                  entry.slug,
+                  PEEK_PANEL_SURFACE,
+                  nextHarness,
+                ),
+              )
+            }
           />
         </div>
       )}

--- a/apps/web/src/lib/harness-variant-cta-events-lib.ts
+++ b/apps/web/src/lib/harness-variant-cta-events-lib.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure harness variant selection analytics helpers.
+ *
+ * Maps harness picker interactions to privacy-light event names without
+ * embedding snippet payloads.
+ */
+
+import type { Harness } from "@/types/registry";
+
+export function harnessVariantSelectAnalyticsEvent(): string {
+  return "harness_variant_select";
+}
+
+export function harnessVariantSelectAnalyticsData(
+  category: string,
+  slug: string,
+  surface: string,
+  harness: Harness,
+) {
+  return {
+    entry: `${category}/${slug}`,
+    surface,
+    harness,
+  };
+}

--- a/apps/web/src/lib/harness-variant-cta-events.ts
+++ b/apps/web/src/lib/harness-variant-cta-events.ts
@@ -1,0 +1,7 @@
+/**
+ * Harness variant CTA event surface.
+ */
+export {
+  harnessVariantSelectAnalyticsData,
+  harnessVariantSelectAnalyticsEvent,
+} from "@/lib/harness-variant-cta-events-lib";

--- a/tests/harness-variant-cta-events-lib.test.ts
+++ b/tests/harness-variant-cta-events-lib.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  harnessVariantSelectAnalyticsData,
+  harnessVariantSelectAnalyticsEvent,
+} from "@/lib/harness-variant-cta-events-lib";
+
+describe("harness variant cta events lib", () => {
+  it("builds privacy-light harness variant analytics", () => {
+    expect(harnessVariantSelectAnalyticsEvent()).toBe("harness_variant_select");
+    expect(
+      harnessVariantSelectAnalyticsData(
+        "skills",
+        "code-review",
+        "detail-command-center",
+        "claude-code",
+      ),
+    ).toEqual({
+      entry: "skills/code-review",
+      surface: "detail-command-center",
+      harness: "claude-code",
+    });
+    expect(
+      harnessVariantSelectAnalyticsData(
+        "mcp",
+        "browser",
+        "compare-drawer",
+        "cursor",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "compare-drawer",
+      harness: "cursor",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track harness variant selection in command center, peek panel, and compare drawer.
- Skip re-select; keyboard navigation uses the same analytics path.

## Events
- `harness_variant_select` — `{ entry, surface, harness }`
  - surfaces: `detail-command-center`, `peek-panel`, `compare-drawer`

Refs #550

## Test plan
- [x] vitest for `harness-variant-cta-events-lib`
- [x] type-check and build pass locally