### PR TITLE
feat(web): track command center copy tab analytics

### DIFF
--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -63,6 +63,23 @@ export function entryDetailStickyCopyVariantSelectAnalyticsData(
   };
 }
 
+export function entryDetailCopyTabSelectAnalyticsEvent(): string {
+  return "detail_copy_tab_select";
+}
+
+export function entryDetailCopyTabSelectAnalyticsData(
+  category: string,
+  slug: string,
+  variant: CopyVariant,
+  surface: string = ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface,
+    variant,
+  };
+}
+
 export function entryDetailCompareAnalyticsEvent(adding: boolean): string {
   return adding ? "detail_compare_add" : "detail_compare_remove";
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -38,6 +38,8 @@ export {
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailCopyTabSelectAnalyticsData,
+  entryDetailCopyTabSelectAnalyticsEvent,
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
   entryDetailEntryKey,

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -90,6 +90,8 @@ import {
   entryDetailCompareOpenTrayAnalyticsEvent,
   entryDetailCompareToastOpenAnalyticsData,
   entryDetailCompareToastOpenAnalyticsEvent,
+  entryDetailCopyTabSelectAnalyticsData,
+  entryDetailCopyTabSelectAnalyticsEvent,
   entryDetailMobileCompareAnalyticsData,
   entryDetailMobileCompareAnalyticsEvent,
   entryDetailMobileCompareToastOpenAnalyticsData,
@@ -301,7 +303,17 @@ function Dossier() {
   const [pref, setPref] = useCopyPref();
   const variantHas = (v: CopyVariant) => !!liveVariants.find((x) => x.id === v)?.value;
   const tab: CopyVariant = pref && variantHas(pref) ? pref : firstAvailable;
-  const setTab = (v: CopyVariant) => setPref(v);
+  const onTabChange = useCallback(
+    (v: CopyVariant) => {
+      if (v === tab) return;
+      trackEvent(
+        entryDetailCopyTabSelectAnalyticsEvent(),
+        entryDetailCopyTabSelectAnalyticsData(entry.category, entry.slug, v),
+      );
+      setPref(v);
+    },
+    [entry.category, entry.slug, setPref, tab],
+  );
 
   const tabPayload = liveVariants.find((v) => v.id === tab)?.value;
 
@@ -670,7 +682,7 @@ function Dossier() {
           onHarnessChange={(h) => setHarness(h)}
           liveVariants={liveVariants}
           tab={tab}
-          onTabChange={setTab}
+          onTabChange={onTabChange}
           tabPayload={tabPayload}
           relatedCount={rel.length}
           guideCount={guides.length}

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -28,6 +28,8 @@ import {
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailCopyTabSelectAnalyticsData,
+  entryDetailCopyTabSelectAnalyticsEvent,
   ENTRY_DETAIL_STICKY_META_SURFACE,
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
@@ -94,6 +96,28 @@ describe("entry detail cta events lib", () => {
       entry: "skills/demo",
       variant: "config",
       surface: "detail-sticky-meta",
+    });
+    expect(entryDetailCopyTabSelectAnalyticsEvent()).toBe(
+      "detail_copy_tab_select",
+    );
+    expect(
+      entryDetailCopyTabSelectAnalyticsData("mcp", "browser", "install"),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-command-center",
+      variant: "install",
+    });
+    expect(
+      entryDetailCopyTabSelectAnalyticsData(
+        "mcp",
+        "browser",
+        "full",
+        "detail-sticky-meta",
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-sticky-meta",
+      variant: "full",
     });
     expect(entryDetailCompareAnalyticsEvent(true)).toBe("detail_compare_add");
     expect(entryDetailCompareAnalyticsEvent(false)).toBe(


### PR DESCRIPTION
## Summary
- Track copy tab switches (install/config/full) in the entry detail command center.
- Skip re-select when clicking the active tab.

## Events
- `detail_copy_tab_select` — `{ entry, surface, variant }`
  - surface: `detail-command-center` (default)

Refs #550

## Test plan
- [x] vitest for `entry-detail-cta-events-lib` copy tab helpers
- [x] type-check and build pass locally