### PR TITLE
feat(web): track compare empty browse directory egress

### DIFF
--- a/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-page-empty-egress-cta-events-lib.ts
@@ -7,7 +7,7 @@
 
 export const COMPARE_PAGE_EMPTY_SURFACE = "compare-page-empty";
 
-export type ComparePageEmptyEgressLinkKind = "curated-page" | "interactive";
+export type ComparePageEmptyEgressLinkKind = "curated-page" | "interactive" | "browse-directory";
 
 export function comparePageEmptyEgressAnalyticsEvent(): string {
   return "compare_page_empty_egress_click";
@@ -15,12 +15,18 @@ export function comparePageEmptyEgressAnalyticsEvent(): string {
 
 export function comparePageEmptyEgressAnalyticsData(
   linkKind: ComparePageEmptyEgressLinkKind,
-  refCount: number,
-  hasInteractive: boolean,
+  refCount = 0,
+  hasInteractive = false,
 ) {
-  return {
+  const base = {
     surface: COMPARE_PAGE_EMPTY_SURFACE,
     linkKind,
+  };
+  if (linkKind === "browse-directory") {
+    return base;
+  }
+  return {
+    ...base,
     refCount,
     hasInteractive,
   };

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -282,6 +282,12 @@ function ComparePage() {
             <Link
               to="/browse"
               className="inline-flex h-9 items-center rounded-md bg-ink px-4 text-sm font-medium text-background hover:bg-ink/90"
+              onClick={() =>
+                trackEvent(
+                  comparePageEmptyEgressAnalyticsEvent(),
+                  comparePageEmptyEgressAnalyticsData("browse-directory"),
+                )
+              }
             >
               Browse the directory
             </Link>

--- a/tests/compare-page-empty-egress-cta-events-lib.test.ts
+++ b/tests/compare-page-empty-egress-cta-events-lib.test.ts
@@ -26,5 +26,9 @@ describe("compare page empty egress cta events lib", () => {
         hasInteractive: true,
       },
     );
+    expect(comparePageEmptyEgressAnalyticsData("browse-directory")).toEqual({
+      surface: COMPARE_PAGE_EMPTY_SURFACE,
+      linkKind: "browse-directory",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Track the primary `Browse the directory` CTA on the empty /compare page.
- Extends existing empty-state egress event with a `browse-directory` linkKind.

## Events
- `compare_page_empty_egress_click` — `{ surface: "compare-page-empty", linkKind: "browse-directory" }`

Refs #550

## Test plan
- [x] vitest for `compare-page-empty-egress-cta-events-lib` browse-directory helper
- [x] type-check and build pass locally