### PR TITLE
feat(web): track sticky meta bar nav and back-to-top analytics

### DIFF
--- a/apps/web/src/components/sticky-meta-bar.tsx
+++ b/apps/web/src/components/sticky-meta-bar.tsx
@@ -17,9 +17,13 @@ import { trackEvent } from "@/lib/analytics";
 import { recordIntentEvent } from "@/lib/intent-event-client";
 import {
   ENTRY_DETAIL_STICKY_META_SURFACE,
+  entryDetailBrowseCategoryAnalyticsData,
+  entryDetailBrowseCategoryAnalyticsEvent,
   entryDetailCopyAnalyticsData,
   entryDetailCopyAnalyticsEvent,
   entryDetailCopyIntentType,
+  entryDetailStickyBackToTopAnalyticsData,
+  entryDetailStickyBackToTopAnalyticsEvent,
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
 } from "@/lib/entry-detail-cta-events";
@@ -67,6 +71,23 @@ export function StickyMetaBar({
     },
     [entry.category, entry.slug],
   );
+  const onStickyBrowseCategory = useCallback(() => {
+    trackEvent(
+      entryDetailBrowseCategoryAnalyticsEvent(),
+      entryDetailBrowseCategoryAnalyticsData(
+        entry.category,
+        entry.slug,
+        ENTRY_DETAIL_STICKY_META_SURFACE,
+      ),
+    );
+  }, [entry.category, entry.slug]);
+  const onStickyBackToTop = useCallback(() => {
+    trackEvent(
+      entryDetailStickyBackToTopAnalyticsEvent(),
+      entryDetailStickyBackToTopAnalyticsData(entry.category, entry.slug, progress),
+    );
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [entry.category, entry.slug, progress]);
 
   // Visibility observer on the header sentinel.
   useEffect(() => {
@@ -139,6 +160,7 @@ export function StickyMetaBar({
               search={{ category: entry.category }}
               className="shrink-0"
               aria-label={`Back to ${entry.category}`}
+              onClick={onStickyBrowseCategory}
             >
               <CategoryPill>{entry.category}</CategoryPill>
             </Link>
@@ -171,7 +193,7 @@ export function StickyMetaBar({
             </span>
             <button
               type="button"
-              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+              onClick={onStickyBackToTop}
               className="hidden h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-2 text-[11px] text-ink-muted hover:border-border-strong hover:text-ink sm:inline-flex"
               aria-label="Back to top"
             >
@@ -200,7 +222,7 @@ export function StickyMetaBar({
               {/* Mobile: only a single copy button, no segmented control */}
               <button
                 type="button"
-                onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+                onClick={onStickyBackToTop}
                 className="inline-flex h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-surface px-2 text-[11px] text-ink-muted hover:border-border-strong hover:text-ink sm:hidden"
                 aria-label="Back to top"
               >

--- a/apps/web/src/lib/entry-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-cta-events-lib.ts
@@ -63,6 +63,22 @@ export function entryDetailStickyCopyVariantSelectAnalyticsData(
   };
 }
 
+export function entryDetailStickyBackToTopAnalyticsEvent(): string {
+  return "detail_sticky_back_to_top_click";
+}
+
+export function entryDetailStickyBackToTopAnalyticsData(
+  category: string,
+  slug: string,
+  scrollProgress: number,
+) {
+  return {
+    entry: entryDetailEntryKey(category, slug),
+    surface: ENTRY_DETAIL_STICKY_META_SURFACE,
+    scrollProgress: Math.round(scrollProgress),
+  };
+}
+
 export function entryDetailCopyTabSelectAnalyticsEvent(): string {
   return "detail_copy_tab_select";
 }
@@ -349,10 +365,14 @@ export function entryDetailBrowseCategoryAnalyticsEvent(): string {
   return "detail_browse_category_open";
 }
 
-export function entryDetailBrowseCategoryAnalyticsData(category: string, slug: string) {
+export function entryDetailBrowseCategoryAnalyticsData(
+  category: string,
+  slug: string,
+  surface: string = ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+) {
   return {
     entry: entryDetailEntryKey(category, slug),
-    surface: ENTRY_DETAIL_COMMAND_CENTER_SURFACE,
+    surface,
     category,
   };
 }

--- a/apps/web/src/lib/entry-detail-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-cta-events.ts
@@ -42,6 +42,8 @@ export {
   entryDetailCopyTabSelectAnalyticsEvent,
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
+  entryDetailStickyBackToTopAnalyticsData,
+  entryDetailStickyBackToTopAnalyticsEvent,
   entryDetailEntryKey,
   entryDetailIntegrationAnalyticsData,
   entryDetailIntegrationAnalyticsEvent,

--- a/tests/entry-detail-cta-events-lib.test.ts
+++ b/tests/entry-detail-cta-events-lib.test.ts
@@ -33,6 +33,8 @@ import {
   ENTRY_DETAIL_STICKY_META_SURFACE,
   entryDetailStickyCopyVariantSelectAnalyticsData,
   entryDetailStickyCopyVariantSelectAnalyticsEvent,
+  entryDetailStickyBackToTopAnalyticsData,
+  entryDetailStickyBackToTopAnalyticsEvent,
   entryDetailIntegrationAnalyticsData,
   entryDetailIntegrationAnalyticsEvent,
   entryDetailSourceAnalyticsData,
@@ -96,6 +98,16 @@ describe("entry detail cta events lib", () => {
       entry: "skills/demo",
       variant: "config",
       surface: "detail-sticky-meta",
+    });
+    expect(entryDetailStickyBackToTopAnalyticsEvent()).toBe(
+      "detail_sticky_back_to_top_click",
+    );
+    expect(
+      entryDetailStickyBackToTopAnalyticsData("mcp", "browser", 72.4),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-sticky-meta",
+      scrollProgress: 72,
     });
     expect(entryDetailCopyTabSelectAnalyticsEvent()).toBe(
       "detail_copy_tab_select",
@@ -345,6 +357,17 @@ describe("entry detail cta events lib", () => {
     expect(entryDetailBrowseCategoryAnalyticsData("mcp", "browser")).toEqual({
       entry: "mcp/browser",
       surface: "detail-command-center",
+      category: "mcp",
+    });
+    expect(
+      entryDetailBrowseCategoryAnalyticsData(
+        "mcp",
+        "browser",
+        ENTRY_DETAIL_STICKY_META_SURFACE,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-sticky-meta",
       category: "mcp",
     });
     expect(entryDetailCommunityAnchorAnalyticsEvent()).toBe(


### PR DESCRIPTION
## Summary
- Track category pill and back-to-top interactions in the entry detail sticky meta bar.
- Reuses browse-category event with sticky surface; adds dedicated back-to-top event.

## Events
- `detail_browse_category_open` — `{ entry, surface: "detail-sticky-meta", category }`
- `detail_sticky_back_to_top_click` — `{ entry, surface: "detail-sticky-meta", scrollProgress }`

Refs #550

## Test plan
- [x] vitest for sticky back-to-top and browse-category surface override
- [x] type-check and build pass locally