### PR TITLE
feat(web): add safety and privacy surface panel to entry detail

### DIFF
--- a/apps/web/src/components/entry-safety-surface-panel.tsx
+++ b/apps/web/src/components/entry-safety-surface-panel.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import type { EntrySafetySurfaceState } from "@/lib/entry-safety-surface";
+import { cn } from "@/lib/utils";
+
+export function EntrySafetySurfacePanel({
+  state,
+  className,
+}: {
+  state: EntrySafetySurfaceState;
+  className?: string;
+}) {
+  if (!state.showPanel) {
+    return null;
+  }
+  return (
+    <section
+      id="safety-surface"
+      aria-label="Safety and privacy surface"
+      className={cn("rounded-xl border border-border bg-surface p-4 sm:p-5", className)}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="eyebrow">Safety &amp; privacy surface</p>
+          <h3 className="mt-1 text-base font-semibold text-ink sm:text-lg">{state.heading}</h3>
+          <p className="mt-1.5 text-sm text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="inline-flex shrink-0 rounded-full border border-border bg-background px-2.5 py-0.5 font-mono text-[11px] uppercase tracking-wide text-ink-muted">
+          {state.coverageCount} area{state.coverageCount === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {state.kinds.map((kind) => {
+          const sensitive = state.sensitiveKinds.includes(kind.kind);
+          return (
+            <span
+              key={kind.kind}
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px]",
+                sensitive
+                  ? "border-amber-500/40 bg-amber-500/5 text-amber-900"
+                  : "border-border bg-background text-ink-muted",
+              )}
+            >
+              {kind.kindLabel}
+              <span className="font-mono text-ink">{kind.count}</span>
+            </span>
+          );
+        })}
+      </div>
+
+      <ul className="mt-4 space-y-2">
+        {state.items.map((item) => (
+          <li
+            key={item.id}
+            className="flex items-start gap-2.5 rounded-lg border border-border bg-background px-3 py-2.5"
+          >
+            {item.source === "safety" ? (
+              <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-trust-trusted" aria-hidden />
+            ) : (
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-ink-muted" aria-hidden />
+            )}
+            <span className="min-w-0">
+              <span className="flex flex-wrap items-center gap-1.5">
+                <span className="rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                  {item.source === "safety" ? "Safety" : "Privacy"}
+                </span>
+                <span className="rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                  {item.kindLabel}
+                </span>
+              </span>
+              <span className="mt-1 block text-sm text-ink">{item.text}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {state.disclosure ? (
+        <p className="mt-3 rounded-md border border-border bg-background px-3 py-2 text-xs text-ink-muted">
+          Disclosure: {state.disclosure}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/lib/entry-safety-surface-lib.ts
+++ b/apps/web/src/lib/entry-safety-surface-lib.ts
@@ -1,0 +1,283 @@
+/**
+ * Pure entry safety & privacy surface helpers.
+ *
+ * Turns an entry's declared `safetyNotes` / `privacyNotes` (today rendered as
+ * flat note lists) into a categorized risk surface so a reader can see, at a
+ * glance, what kinds of behavior the resource discloses — execution, network,
+ * filesystem, credentials, permissions, data retention, telemetry, or
+ * third-party handling — and how broadly those areas are covered. Purely
+ * descriptive of the entry's own declared notes; no scoring of the resource.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export type SafetySurfaceSource = "safety" | "privacy";
+
+export type SafetyRiskKind =
+  | "execution"
+  | "network"
+  | "filesystem"
+  | "credentials"
+  | "permissions"
+  | "retention"
+  | "telemetry"
+  | "third-party"
+  | "general";
+
+export type SafetySurfaceItem = {
+  id: string;
+  text: string;
+  source: SafetySurfaceSource;
+  kind: SafetyRiskKind;
+  kindLabel: string;
+};
+
+export type SafetyKindSummary = {
+  kind: SafetyRiskKind;
+  kindLabel: string;
+  count: number;
+};
+
+export type EntrySafetySurfaceState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  items: SafetySurfaceItem[];
+  kinds: SafetyKindSummary[];
+  safetyCount: number;
+  privacyCount: number;
+  coverageCount: number;
+  sensitiveKinds: SafetyRiskKind[];
+  disclosure: string | null;
+};
+
+export const SAFETY_RISK_KIND_LABEL: Record<SafetyRiskKind, string> = {
+  execution: "Execution & processes",
+  network: "Network access",
+  filesystem: "Local files",
+  credentials: "Credentials & tokens",
+  permissions: "Permissions & scopes",
+  retention: "Data retention",
+  telemetry: "Telemetry",
+  "third-party": "Third-party handling",
+  general: "General",
+};
+
+/** Kinds a reader should pay closer attention to when present. */
+const SENSITIVE_KINDS: SafetyRiskKind[] = ["credentials", "permissions", "network", "third-party"];
+
+const KIND_DISPLAY_ORDER: SafetyRiskKind[] = [
+  "execution",
+  "network",
+  "filesystem",
+  "credentials",
+  "permissions",
+  "retention",
+  "telemetry",
+  "third-party",
+  "general",
+];
+
+/**
+ * Classification precedence — first matching group wins. Ordered so the more
+ * specific / higher-attention categories are matched before broad ones.
+ */
+const KIND_MATCHERS: Array<[SafetyRiskKind, string[]]> = [
+  [
+    "credentials",
+    [
+      "credential",
+      "api key",
+      "api-key",
+      "apikey",
+      "token",
+      "secret",
+      "password",
+      "oauth",
+      "access key",
+      "private key",
+      "session",
+    ],
+  ],
+  [
+    "permissions",
+    [
+      "permission",
+      "scope",
+      "grant",
+      "role",
+      "authoriz",
+      "access control",
+      "elevated",
+      "sudo",
+      "admin",
+    ],
+  ],
+  [
+    "network",
+    [
+      "network",
+      "http",
+      "request",
+      "endpoint",
+      "remote",
+      "outbound",
+      "connect to",
+      "api call",
+      "webhook",
+      "download",
+      "upload",
+    ],
+  ],
+  [
+    "third-party",
+    [
+      "third-party",
+      "third party",
+      "external service",
+      "vendor",
+      "shares data",
+      "sends data",
+      "sent to",
+      "provider",
+    ],
+  ],
+  [
+    "filesystem",
+    [
+      "file",
+      "filesystem",
+      "disk",
+      "directory",
+      "folder",
+      "write to",
+      "read from",
+      "local storage",
+      "path",
+    ],
+  ],
+  [
+    "execution",
+    [
+      "execute",
+      "run",
+      "shell",
+      "command",
+      "script",
+      "process",
+      "background worker",
+      "spawn",
+      "install",
+      "destructive",
+    ],
+  ],
+  [
+    "retention",
+    ["retention", "retain", "stored", "store", "logged", "log", "history", "cache", "persist"],
+  ],
+  ["telemetry", ["telemetry", "analytics", "tracking", "usage data", "metrics", "report usage"]],
+];
+
+/** Classify a single note line into a risk kind. Deterministic, first-match-wins. */
+export function classifySafetyNote(text: string): SafetyRiskKind {
+  const value = text.toLowerCase();
+  for (const [kind, needles] of KIND_MATCHERS) {
+    if (needles.some((needle) => value.includes(needle))) {
+      return kind;
+    }
+  }
+  return "general";
+}
+
+function notesFor(single: string | undefined, list: string[] | undefined): string[] {
+  const source = list && list.length > 0 ? list : single ? [single] : [];
+  return source.map((line) => line.trim()).filter((line) => line.length > 0);
+}
+
+function buildSummary(
+  safetyCount: number,
+  privacyCount: number,
+  coverageCount: number,
+  sensitiveKinds: SafetyRiskKind[],
+): string {
+  const total = safetyCount + privacyCount;
+  if (total === 0) {
+    return "No safety or privacy behavior is declared for this resource.";
+  }
+  const parts: string[] = [];
+  if (safetyCount > 0) {
+    parts.push(`${safetyCount} safety`);
+  }
+  if (privacyCount > 0) {
+    parts.push(`${privacyCount} privacy`);
+  }
+  let summary = `${parts.join(" and ")} note${total === 1 ? "" : "s"} across ${coverageCount} risk area${coverageCount === 1 ? "" : "s"}.`;
+  if (sensitiveKinds.length > 0) {
+    const labels = sensitiveKinds.map((kind) => SAFETY_RISK_KIND_LABEL[kind].toLowerCase());
+    summary += ` Review closely: ${labels.join(", ")}.`;
+  }
+  return summary;
+}
+
+/**
+ * Build the safety & privacy surface state for the detail page from an entry's
+ * declared notes. Safety notes are listed before privacy notes; item ids are
+ * stable within each source (`safety-1`, `privacy-1`, …).
+ */
+export function entrySafetySurfaceState(entry: Entry): EntrySafetySurfaceState {
+  const safetyNotes = notesFor(entry.safetyNotes, entry.safetyNotesList);
+  const privacyNotes = notesFor(entry.privacyNotes, entry.privacyNotesList);
+
+  const items: SafetySurfaceItem[] = [
+    ...safetyNotes.map((text, index) => {
+      const kind = classifySafetyNote(text);
+      return {
+        id: `safety-${index + 1}`,
+        text,
+        source: "safety" as const,
+        kind,
+        kindLabel: SAFETY_RISK_KIND_LABEL[kind],
+      };
+    }),
+    ...privacyNotes.map((text, index) => {
+      const kind = classifySafetyNote(text);
+      return {
+        id: `privacy-${index + 1}`,
+        text,
+        source: "privacy" as const,
+        kind,
+        kindLabel: SAFETY_RISK_KIND_LABEL[kind],
+      };
+    }),
+  ];
+
+  const counts = new Map<SafetyRiskKind, number>();
+  for (const item of items) {
+    counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
+  }
+
+  const kinds: SafetyKindSummary[] = KIND_DISPLAY_ORDER.filter((kind) => counts.has(kind)).map(
+    (kind) => ({
+      kind,
+      kindLabel: SAFETY_RISK_KIND_LABEL[kind],
+      count: counts.get(kind) ?? 0,
+    }),
+  );
+
+  const sensitiveKinds = SENSITIVE_KINDS.filter((kind) => counts.has(kind));
+  const coverageCount = kinds.length;
+  const trimmedDisclosure = entry.disclosure?.trim();
+
+  return {
+    showPanel: items.length > 0,
+    heading: "Safety & privacy surface",
+    summary: buildSummary(safetyNotes.length, privacyNotes.length, coverageCount, sensitiveKinds),
+    items,
+    kinds,
+    safetyCount: safetyNotes.length,
+    privacyCount: privacyNotes.length,
+    coverageCount,
+    sensitiveKinds,
+    disclosure: trimmedDisclosure ? trimmedDisclosure : null,
+  };
+}

--- a/apps/web/src/lib/entry-safety-surface.ts
+++ b/apps/web/src/lib/entry-safety-surface.ts
@@ -1,0 +1,16 @@
+/**
+ * Entry safety & privacy surface exports.
+ */
+
+export type {
+  EntrySafetySurfaceState,
+  SafetyKindSummary,
+  SafetyRiskKind,
+  SafetySurfaceItem,
+  SafetySurfaceSource,
+} from "@/lib/entry-safety-surface-lib";
+export {
+  SAFETY_RISK_KIND_LABEL,
+  classifySafetyNote,
+  entrySafetySurfaceState,
+} from "@/lib/entry-safety-surface-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -66,6 +66,7 @@ import { EntryAdoptionPlanPanel } from "@/components/entry-adoption-plan-panel";
 import { EntryEvidenceReadinessMatrix } from "@/components/entry-evidence-readiness-matrix";
 import { EntryCompareBenchmarkPanel } from "@/components/entry-compare-benchmark-panel";
 import { EntryPrerequisiteReadinessPanel } from "@/components/entry-prerequisite-readiness-panel";
+import { EntrySafetySurfacePanel } from "@/components/entry-safety-surface-panel";
 import { EntrySetupSnapshotPanel } from "@/components/entry-setup-snapshot-panel";
 import { PLATFORM_SUPPORT_LABEL, type Entry } from "@/types/registry";
 import {
@@ -122,6 +123,7 @@ import type { Harness } from "@/types/registry";
 import { cn } from "@/lib/utils";
 import { entryAdoptionPlanState, type AdoptionPlanPresetId } from "@/lib/entry-adoption-plan";
 import { entryPrerequisiteReadinessState } from "@/lib/entry-prerequisite-readiness";
+import { entrySafetySurfaceState } from "@/lib/entry-safety-surface";
 import { entryDetailDecisionPlaybookState } from "@/lib/entry-detail-decision-playbook";
 import {
   entryEvidenceReadinessMatrixState,
@@ -565,6 +567,7 @@ function Dossier() {
   const quickLinks = useMemo(() => entryQuickLinks(entry), [entry]);
   const readinessRows = useMemo(() => entryReadinessRows(entry), [entry]);
   const prerequisiteReadiness = useMemo(() => entryPrerequisiteReadinessState(entry), [entry]);
+  const safetySurface = useMemo(() => entrySafetySurfaceState(entry), [entry]);
   const adoptionPlan = useMemo(
     () => entryAdoptionPlanState(entry, adoptionPreset, compare.items),
     [entry, adoptionPreset, compare.items],
@@ -772,6 +775,7 @@ function Dossier() {
             category={entry.category}
             slug={entry.slug}
           />
+          <EntrySafetySurfacePanel state={safetySurface} />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">
               <NoteList value={entry.safetyNotesList ?? [entry.safetyNotes]} />

--- a/tests/entry-safety-surface-lib.test.ts
+++ b/tests/entry-safety-surface-lib.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import {
+  SAFETY_RISK_KIND_LABEL,
+  classifySafetyNote,
+  entrySafetySurfaceState,
+} from "@/lib/entry-safety-surface-lib";
+
+function entry(overrides: Partial<Entry> = {}): Entry {
+  return {
+    category: "mcp",
+    slug: "fixture",
+    title: "Fixture",
+    description: "Fixture description",
+    author: "Author",
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+    ...overrides,
+  } as Entry;
+}
+
+describe("classifySafetyNote", () => {
+  it("routes credential and permission phrasing first", () => {
+    expect(classifySafetyNote("Requires an API token to authenticate")).toBe(
+      "credentials",
+    );
+    expect(classifySafetyNote("Needs elevated permission scopes")).toBe(
+      "permissions",
+    );
+  });
+
+  it("classifies network, filesystem, execution, retention, telemetry", () => {
+    expect(
+      classifySafetyNote("Makes outbound network requests to an endpoint"),
+    ).toBe("network");
+    expect(classifySafetyNote("Writes files to a local directory")).toBe(
+      "filesystem",
+    );
+    expect(classifySafetyNote("Runs a shell command in the background")).toBe(
+      "execution",
+    );
+    expect(classifySafetyNote("Data is retained and stored in a cache")).toBe(
+      "retention",
+    );
+    expect(classifySafetyNote("Collects anonymous usage analytics")).toBe(
+      "telemetry",
+    );
+  });
+
+  it("classifies third-party handling", () => {
+    expect(
+      classifySafetyNote("Sends data to an external service provider"),
+    ).toBe("third-party");
+  });
+
+  it("falls back to general and is case-insensitive", () => {
+    expect(classifySafetyNote("General informational note")).toBe("general");
+    expect(classifySafetyNote("MAKES NETWORK REQUESTS")).toBe("network");
+  });
+
+  it("exposes a label for every kind", () => {
+    for (const kind of [
+      "execution",
+      "network",
+      "filesystem",
+      "credentials",
+      "permissions",
+      "retention",
+      "telemetry",
+      "third-party",
+      "general",
+    ] as const) {
+      expect(SAFETY_RISK_KIND_LABEL[kind]).toBeTruthy();
+    }
+  });
+});
+
+describe("entrySafetySurfaceState", () => {
+  it("hides the panel when no notes are declared", () => {
+    const state = entrySafetySurfaceState(entry());
+    expect(state.showPanel).toBe(false);
+    expect(state.summary).toContain("No safety or privacy");
+  });
+
+  it("prefers list fields, trims, and drops blanks with stable ids", () => {
+    const state = entrySafetySurfaceState(
+      entry({
+        safetyNotesList: ["  Runs a shell command  ", "   "],
+        privacyNotesList: ["Stores logs locally"],
+      }),
+    );
+    expect(state.safetyCount).toBe(1);
+    expect(state.privacyCount).toBe(1);
+    expect(state.items.map((item) => item.id)).toEqual([
+      "safety-1",
+      "privacy-1",
+    ]);
+    expect(state.items[0]?.text).toBe("Runs a shell command");
+  });
+
+  it("falls back to the single-string note fields", () => {
+    const state = entrySafetySurfaceState(
+      entry({ safetyNotes: "Makes network requests" }),
+    );
+    expect(state.safetyCount).toBe(1);
+    expect(state.items[0]?.source).toBe("safety");
+    expect(state.items[0]?.kind).toBe("network");
+  });
+
+  it("summarizes counts, coverage, and flags sensitive kinds", () => {
+    const state = entrySafetySurfaceState(
+      entry({
+        safetyNotesList: [
+          "Runs a shell command",
+          "Requires an API token",
+          "Makes network requests",
+        ],
+        privacyNotesList: ["Sends data to an external provider"],
+        disclosure: "Editorial listing",
+      }),
+    );
+    expect(state.showPanel).toBe(true);
+    expect(state.safetyCount).toBe(3);
+    expect(state.privacyCount).toBe(1);
+    expect(state.coverageCount).toBe(4);
+    expect(state.kinds.map((k) => k.kind)).toEqual([
+      "execution",
+      "network",
+      "credentials",
+      "third-party",
+    ]);
+    expect(state.sensitiveKinds).toEqual([
+      "credentials",
+      "network",
+      "third-party",
+    ]);
+    expect(state.summary).toContain("3 safety and 1 privacy");
+    expect(state.summary).toContain("Review closely");
+    expect(state.disclosure).toBe("Editorial listing");
+  });
+
+  it("returns null disclosure when absent or blank", () => {
+    const state = entrySafetySurfaceState(
+      entry({ safetyNotes: "Runs a command", disclosure: "   " }),
+    );
+    expect(state.disclosure).toBeNull();
+  });
+
+  it("collapses duplicate kinds into one summary entry with a count", () => {
+    const state = entrySafetySurfaceState(
+      entry({ safetyNotesList: ["Writes a file", "Reads from a file"] }),
+    );
+    expect(state.kinds).toHaveLength(1);
+    expect(state.kinds[0]).toMatchObject({ kind: "filesystem", count: 2 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Safety & privacy surface** panel to the entry detail page. Today an entry's `safetyNotes` and `privacyNotes` render as two flat note lists; this derives a categorized risk surface from them so a reader can see, at a glance, what kinds of behavior a resource discloses and which areas warrant a closer look before adopting.

The panel:
- Classifies each declared safety/privacy note into a risk kind — **execution / network / filesystem / credentials / permissions / retention / telemetry / third-party** (deterministic, case-insensitive keyword classification, `general` fallback).
- Shows per-kind coverage counts and a headline summarizing how many safety vs. privacy notes span how many risk areas.
- Highlights **sensitive areas** (credentials, permissions, network, third-party) when present, and echoes the entry's `disclosure`.

It is purely descriptive of the entry's own declared notes — no scoring of the resource — so it complements (does not replace) the existing note lists and is distinct from the adoption-plan and prerequisite-readiness panels.

## Files

Pure, unit-tested logic + thin wrapper + a presentational panel + one route wire-up, matching the established browse/entry panel convention:

- `apps/web/src/lib/entry-safety-surface-lib.ts` — pure `entrySafetySurfaceState(entry)` + `classifySafetyNote()`
- `apps/web/src/lib/entry-safety-surface.ts` — wrapper re-export
- `apps/web/src/components/entry-safety-surface-panel.tsx` — presentational panel
- `tests/entry-safety-surface-lib.test.ts` — 11 cases
- `apps/web/src/routes/entry.$category.$slug.tsx` — `useMemo` + render alongside the existing detail panels

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Platform/code change kept separate from content per `AGENTS.md`.

## Data coverage

`safetyNotes` is present on ~92% of registry entries and `privacyNotes` is widely populated, so the panel renders meaningfully across the directory; it returns `null` when an entry declares neither.

## Validation

```
pnpm exec prettier --check <changed files>                       # clean
pnpm exec vitest run tests/entry-safety-surface-lib.test.ts      # 11 passed
pnpm --filter web exec tsc --noEmit                              # clean
pnpm --filter web build                                          # vite build
```

Logic lives in the coverage-scoped `lib/**` and is fully unit-tested; the React panel/route are outside the node coverage scope per `AGENTS.md`, so the `codecov/patch` 70% target is met by the lib tests.
