### PR TITLE
feat(web): track global back-to-top analytics

### DIFF
--- a/apps/web/src/components/back-to-top.tsx
+++ b/apps/web/src/components/back-to-top.tsx
@@ -1,6 +1,12 @@
 import * as React from "react";
 import { ArrowUp } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { trackEvent } from "@/lib/analytics";
+import {
+  appShellBackToTopAnalyticsData,
+  appShellBackToTopAnalyticsEvent,
+  appShellBackToTopScrollProgress,
+} from "@/lib/app-shell-back-to-top-cta-events";
 
 /**
  * Floating "back to top" button. Appears after the user scrolls past
@@ -17,11 +23,21 @@ export function BackToTop({ threshold = 800 }: { threshold?: number }) {
     return () => window.removeEventListener("scroll", onScroll);
   }, [threshold]);
 
+  const onBackToTop = React.useCallback(() => {
+    const scrollProgress = appShellBackToTopScrollProgress(
+      window.scrollY,
+      document.documentElement.scrollHeight,
+      window.innerHeight,
+    );
+    trackEvent(appShellBackToTopAnalyticsEvent(), appShellBackToTopAnalyticsData(scrollProgress));
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, []);
+
   return (
     <button
       type="button"
       aria-label="Back to top"
-      onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+      onClick={onBackToTop}
       className={cn(
         "fixed bottom-5 right-5 z-40 inline-flex h-10 w-10 items-center justify-center rounded-full border border-border bg-surface text-ink shadow-sm transition-[opacity,transform,background-color,border-color] duration-200 ease-out hover:bg-surface-2",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-background",

--- a/apps/web/src/lib/app-shell-back-to-top-cta-events-lib.ts
+++ b/apps/web/src/lib/app-shell-back-to-top-cta-events-lib.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure app shell back-to-top analytics helpers.
+ *
+ * Maps the global floating back-to-top control to privacy-light event names
+ * without embedding route paths, titles, or other page content.
+ */
+
+export const APP_SHELL_BACK_TO_TOP_SURFACE = "app-shell-back-to-top";
+
+export function appShellBackToTopScrollProgress(
+  scrollY: number,
+  scrollHeight: number,
+  innerHeight: number,
+): number {
+  const max = scrollHeight - innerHeight;
+  if (max <= 0) return 0;
+  return Math.round(Math.min(100, Math.max(0, (scrollY / max) * 100)));
+}
+
+export function appShellBackToTopAnalyticsEvent(): string {
+  return "app_shell_back_to_top_click";
+}
+
+export function appShellBackToTopAnalyticsData(scrollProgress: number) {
+  return {
+    surface: APP_SHELL_BACK_TO_TOP_SURFACE,
+    scrollProgress: Math.round(scrollProgress),
+  };
+}

--- a/apps/web/src/lib/app-shell-back-to-top-cta-events.ts
+++ b/apps/web/src/lib/app-shell-back-to-top-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * App shell back-to-top CTA event surface.
+ */
+export {
+  APP_SHELL_BACK_TO_TOP_SURFACE,
+  appShellBackToTopAnalyticsData,
+  appShellBackToTopAnalyticsEvent,
+  appShellBackToTopScrollProgress,
+} from "@/lib/app-shell-back-to-top-cta-events-lib";

--- a/tests/app-shell-back-to-top-cta-events-lib.test.ts
+++ b/tests/app-shell-back-to-top-cta-events-lib.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  APP_SHELL_BACK_TO_TOP_SURFACE,
+  appShellBackToTopAnalyticsData,
+  appShellBackToTopAnalyticsEvent,
+  appShellBackToTopScrollProgress,
+} from "@/lib/app-shell-back-to-top-cta-events-lib";
+
+describe("app shell back to top cta events lib", () => {
+  it("builds privacy-light app shell back-to-top analytics", () => {
+    expect(appShellBackToTopAnalyticsEvent()).toBe(
+      "app_shell_back_to_top_click",
+    );
+    expect(appShellBackToTopAnalyticsData(64.6)).toEqual({
+      surface: APP_SHELL_BACK_TO_TOP_SURFACE,
+      scrollProgress: 65,
+    });
+  });
+
+  it("computes scroll progress from viewport metrics", () => {
+    expect(appShellBackToTopScrollProgress(400, 2000, 800)).toBe(29);
+    expect(appShellBackToTopScrollProgress(1200, 2000, 800)).toBe(100);
+    expect(appShellBackToTopScrollProgress(0, 800, 800)).toBe(0);
+  });
+});

--- a/tests/app-shell-back-to-top-cta-events-lib.test.ts
+++ b/tests/app-shell-back-to-top-cta-events-lib.test.ts
@@ -18,7 +18,7 @@ describe("app shell back to top cta events lib", () => {
   });
 
   it("computes scroll progress from viewport metrics", () => {
-    expect(appShellBackToTopScrollProgress(400, 2000, 800)).toBe(29);
+    expect(appShellBackToTopScrollProgress(400, 2000, 800)).toBe(33);
     expect(appShellBackToTopScrollProgress(1200, 2000, 800)).toBe(100);
     expect(appShellBackToTopScrollProgress(0, 800, 800)).toBe(0);
   });


### PR DESCRIPTION
## Summary
- Track clicks on the global floating back-to-top control in the app shell.
- Privacy-light payload: surface and scroll progress only.

## Events
- `app_shell_back_to_top_click` — `{ surface: "app-shell-back-to-top", scrollProgress }`

Refs #550

## Test plan
- [x] vitest for `app-shell-back-to-top-cta-events-lib`
- [x] type-check and build pass locally