### PR TITLE
feat(web): add theme distribution panel to browse

### DIFF
--- a/apps/web/src/components/browse-theme-distribution-panel.tsx
+++ b/apps/web/src/components/browse-theme-distribution-panel.tsx
@@ -1,0 +1,56 @@
+import type { BrowseThemeDistributionState } from "@/lib/browse-theme-distribution";
+import { cn } from "@/lib/utils";
+
+const CONCENTRATION_LABEL: Record<BrowseThemeDistributionState["concentration"], string> = {
+  focused: "Focused",
+  mixed: "Mixed",
+  diverse: "Diverse",
+};
+
+export function BrowseThemeDistributionPanel({
+  state,
+  className,
+}: {
+  state: BrowseThemeDistributionState;
+  className?: string;
+}) {
+  if (!state.showPanel) return null;
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="eyebrow">Theme distribution</p>
+          <h3 className="mt-1 text-sm font-semibold text-ink">{state.heading}</h3>
+          <p className="mt-1 text-xs text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-subtle">
+          {CONCENTRATION_LABEL[state.concentration]}
+        </span>
+      </div>
+
+      <ul className="mt-3 space-y-1.5">
+        {state.topThemes.map((theme) => (
+          <li key={theme.slug} className="flex items-center gap-2">
+            <span className="w-28 shrink-0 truncate text-xs text-ink" title={theme.tag}>
+              {theme.tag}
+            </span>
+            <span className="relative h-2 flex-1 overflow-hidden rounded-full bg-background">
+              <span
+                className="absolute inset-y-0 left-0 rounded-full bg-accent/60"
+                style={{ width: `${Math.max(theme.percent, 4)}%` }}
+              />
+            </span>
+            <span className="w-16 shrink-0 text-right font-mono text-[11px] text-ink-muted">
+              {theme.percent}% ({theme.count})
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-2.5 text-[11px] text-ink-subtle">
+        {state.distinctThemes} distinct theme{state.distinctThemes === 1 ? "" : "s"} across{" "}
+        {state.scannedCount} scanned
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-theme-distribution-lib.ts
+++ b/apps/web/src/lib/browse-theme-distribution-lib.ts
@@ -1,0 +1,145 @@
+/**
+ * Pure browse theme-distribution helpers.
+ *
+ * Summarizes which themes (tags) dominate the current browse result set so a
+ * user can tell, at a glance, whether a filtered view is focused on a few
+ * topics or spread broadly across many. Aggregates tag frequency across the
+ * scoped results, reports the top themes with their coverage, and classifies
+ * the overall concentration. Purely derived from the entries passed in.
+ */
+
+import type { Entry } from "@/types/registry";
+import { tagSlug } from "@/lib/tags-lib";
+
+export type BrowseThemeConcentration = "focused" | "mixed" | "diverse";
+
+export type BrowseThemeRow = {
+  tag: string;
+  slug: string;
+  count: number;
+  percent: number;
+};
+
+export type BrowseThemeDistributionState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  distinctThemes: number;
+  focusPercent: number;
+  concentration: BrowseThemeConcentration;
+  topThemes: BrowseThemeRow[];
+};
+
+const MAX_TOP_THEMES = 8;
+
+function normalizeTags(entry: Entry): string[] {
+  const seen = new Set<string>();
+  const tags: string[] = [];
+  for (const raw of entry.tags ?? []) {
+    const tag = raw.trim();
+    if (tag.length === 0) {
+      continue;
+    }
+    const key = tag.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    tags.push(tag);
+  }
+  return tags;
+}
+
+function classifyConcentration(
+  focusPercent: number,
+  distinctThemes: number,
+  scannedCount: number,
+): BrowseThemeConcentration {
+  if (focusPercent >= 50) {
+    return "focused";
+  }
+  if (distinctThemes >= scannedCount * 2) {
+    return "diverse";
+  }
+  return "mixed";
+}
+
+function summarize(
+  concentration: BrowseThemeConcentration,
+  topThemes: BrowseThemeRow[],
+  distinctThemes: number,
+): { heading: string; summary: string } {
+  const leadNames = topThemes
+    .slice(0, 3)
+    .map((row) => row.tag)
+    .join(", ");
+  if (concentration === "focused") {
+    return {
+      heading: `Results center on ${topThemes[0]?.tag ?? "a single theme"}`,
+      summary: `${topThemes[0]?.percent ?? 0}% of this view shares the top theme. Leading themes: ${leadNames}.`,
+    };
+  }
+  if (concentration === "diverse") {
+    return {
+      heading: "Themes are broadly spread across this view",
+      summary: `${distinctThemes} distinct themes with no dominant one. Most common: ${leadNames}.`,
+    };
+  }
+  return {
+    heading: "A few themes lead this view",
+    summary: `${distinctThemes} distinct themes; the most common are ${leadNames}.`,
+  };
+}
+
+/**
+ * Build the theme-distribution state for the current browse results. Tag
+ * frequency is counted as the number of scoped entries carrying each tag
+ * (case-insensitive, de-duplicated within an entry). `scannedCount` caps how
+ * many of the top results are summarized.
+ */
+export function browseThemeDistributionState(
+  entries: Entry[],
+  scannedCount = 24,
+): BrowseThemeDistributionState {
+  const scoped = entries.slice(0, scannedCount);
+
+  const counts = new Map<string, { tag: string; count: number }>();
+  for (const entry of scoped) {
+    for (const tag of normalizeTags(entry)) {
+      const slug = tagSlug(tag);
+      const existing = counts.get(slug);
+      if (existing) {
+        existing.count += 1;
+      } else {
+        counts.set(slug, { tag, count: 1 });
+      }
+    }
+  }
+
+  const rows: BrowseThemeRow[] = Array.from(counts.entries())
+    .map(([slug, value]) => ({
+      tag: value.tag,
+      slug,
+      count: value.count,
+      percent: scoped.length === 0 ? 0 : Math.round((value.count / scoped.length) * 100),
+    }))
+    .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+
+  const topThemes = rows.slice(0, MAX_TOP_THEMES);
+  const distinctThemes = rows.length;
+  const focusPercent = topThemes[0]?.percent ?? 0;
+  const concentration = classifyConcentration(focusPercent, distinctThemes, scoped.length);
+  const summary = summarize(concentration, topThemes, distinctThemes);
+
+  return {
+    showPanel: scoped.length >= 3 && topThemes.length >= 2,
+    heading: summary.heading,
+    summary: summary.summary,
+    scannedCount: scoped.length,
+    distinctThemes,
+    focusPercent,
+    concentration,
+    topThemes,
+  };
+}

--- a/apps/web/src/lib/browse-theme-distribution.ts
+++ b/apps/web/src/lib/browse-theme-distribution.ts
@@ -1,0 +1,10 @@
+/**
+ * Browse theme-distribution exports.
+ */
+
+export type {
+  BrowseThemeConcentration,
+  BrowseThemeDistributionState,
+  BrowseThemeRow,
+} from "@/lib/browse-theme-distribution-lib";
+export { browseThemeDistributionState } from "@/lib/browse-theme-distribution-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -42,6 +42,8 @@ import {
 import { BrowseDecisionConfidencePanel } from "@/components/browse-decision-confidence-panel";
 import { browseFreshnessDistributionState } from "@/lib/browse-freshness-distribution";
 import { BrowseFreshnessDistributionPanel } from "@/components/browse-freshness-distribution-panel";
+import { browseThemeDistributionState } from "@/lib/browse-theme-distribution";
+import { BrowseThemeDistributionPanel } from "@/components/browse-theme-distribution-panel";
 import {
   CATEGORIES,
   type Category,
@@ -528,6 +530,7 @@ function Browse() {
     [confidencePreset, results.length],
   );
   const nowIso = useMemo(() => new Date().toISOString(), []);
+  const browseThemes = useMemo(() => browseThemeDistributionState(results, 24), [results]);
   const browseFreshness = useMemo(
     () => browseFreshnessDistributionState(results, nowIso, 12),
     [results, nowIso],
@@ -1081,6 +1084,7 @@ function Browse() {
             className="mt-3"
           />
           <BrowseFreshnessDistributionPanel state={browseFreshness} className="mt-3" />
+          <BrowseThemeDistributionPanel state={browseThemes} className="mt-3" />
 
           {sp.category &&
             (() => {

--- a/tests/browse-theme-distribution-lib.test.ts
+++ b/tests/browse-theme-distribution-lib.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { browseThemeDistributionState } from "@/lib/browse-theme-distribution-lib";
+
+function entry(slug: string, tags: string[]): Entry {
+  return {
+    category: "mcp",
+    slug,
+    title: slug,
+    description: "Fixture description",
+    author: "Author",
+    tags,
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+  } as Entry;
+}
+
+describe("browseThemeDistributionState", () => {
+  it("hides the panel below the minimum entry/theme threshold", () => {
+    expect(browseThemeDistributionState([]).showPanel).toBe(false);
+    expect(
+      browseThemeDistributionState([entry("a", ["x"]), entry("b", ["x"])])
+        .showPanel,
+    ).toBe(false);
+    // three entries but only one distinct theme -> not a distribution
+    expect(
+      browseThemeDistributionState([
+        entry("a", ["x"]),
+        entry("b", ["x"]),
+        entry("c", ["x"]),
+      ]).showPanel,
+    ).toBe(false);
+  });
+
+  it("counts tag frequency across entries and sorts by count then name", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["memory", "rag"]),
+      entry("b", ["memory", "search"]),
+      entry("c", ["memory", "rag"]),
+    ]);
+    expect(state.showPanel).toBe(true);
+    expect(state.scannedCount).toBe(3);
+    expect(state.topThemes[0]).toMatchObject({
+      tag: "memory",
+      count: 3,
+      percent: 100,
+    });
+    expect(state.topThemes[1]).toMatchObject({ tag: "rag", count: 2 });
+    expect(state.topThemes[2]).toMatchObject({ tag: "search", count: 1 });
+    expect(state.distinctThemes).toBe(3);
+  });
+
+  it("de-duplicates repeated tags within one entry and is case-insensitive", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["Memory", "memory", "MEMORY"]),
+      entry("b", ["memory"]),
+      entry("c", ["rag"]),
+    ]);
+    const memory = state.topThemes.find((t) => t.slug === "memory");
+    expect(memory?.count).toBe(2);
+  });
+
+  it("classifies a dominant theme as focused", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["memory", "rag"]),
+      entry("b", ["memory", "search"]),
+      entry("c", ["memory", "graph"]),
+      entry("d", ["memory"]),
+    ]);
+    expect(state.focusPercent).toBe(100);
+    expect(state.concentration).toBe("focused");
+    expect(state.heading).toContain("memory");
+  });
+
+  it("classifies many unique tags as diverse", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["t1", "t2", "t3"]),
+      entry("b", ["t4", "t5", "t6"]),
+      entry("c", ["t7", "t8", "t9"]),
+    ]);
+    // 9 distinct themes over 3 entries (>= 3*2) with no dominant tag
+    expect(state.concentration).toBe("diverse");
+    expect(state.heading).toContain("broadly spread");
+  });
+
+  it("respects the scannedCount cap", () => {
+    const entries = Array.from({ length: 40 }, (_, i) =>
+      entry(`e${i}`, ["shared", `t${i}`]),
+    );
+    const state = browseThemeDistributionState(entries, 10);
+    expect(state.scannedCount).toBe(10);
+    expect(state.topThemes[0]).toMatchObject({ tag: "shared", count: 10 });
+  });
+
+  it("ignores blank tags", () => {
+    const state = browseThemeDistributionState([
+      entry("a", ["memory", "  ", ""]),
+      entry("b", ["memory", "rag"]),
+      entry("c", ["rag", "search"]),
+    ]);
+    const tags = state.topThemes.map((t) => t.tag);
+    expect(tags).not.toContain("");
+    expect(tags).toContain("memory");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Theme distribution** panel to the browse page. The browse decision panels cover trust, rollout, adoption, confidence, and freshness, but none summarize *what a filtered result set is actually about*. This aggregates the tags across the current results into a ranked theme breakdown, so a user can tell at a glance whether a view is focused on a few topics or spread broadly.

The panel:
- Counts tag frequency across the scoped results (case-insensitive, de-duplicated within an entry) and shows the **top themes** with per-theme coverage (share of entries + count).
- Reports the number of **distinct themes** and classifies the overall **concentration** — `focused` (a dominant theme ≥50%), `diverse` (many unique tags, no dominant one), or `mixed`.
- Adapts its headline to the concentration ("Results center on X" vs "Themes are broadly spread").

It is purely derived from the entries in view and reuses the existing `tagSlug` helper for consistent slugs; it complements (does not duplicate) the tag *page* helpers, which group the whole catalog rather than the current result set.

## Files

Pure, unit-tested logic + thin wrapper + a presentational panel + one route wire-up, matching the existing browse-panel convention (mirrors `browse-freshness-distribution` / `browse-rollout-signals`):

- `apps/web/src/lib/browse-theme-distribution-lib.ts` — pure `browseThemeDistributionState(entries, scannedCount)`
- `apps/web/src/lib/browse-theme-distribution.ts` — wrapper re-export
- `apps/web/src/components/browse-theme-distribution-panel.tsx` — presentational panel
- `tests/browse-theme-distribution-lib.test.ts` — 7 cases
- `apps/web/src/routes/browse.tsx` — `useMemo` + render alongside the existing browse panels

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Platform/code change kept separate from content per `AGENTS.md`.

## Data coverage

`tags` is present on ~99% of registry entries (avg ~5 tags/entry, 2200+ distinct), so the distribution is meaningful across the directory; the panel returns `null` when there are fewer than three results or fewer than two distinct themes.

## Validation

```
pnpm exec prettier --check <changed files>                        # clean
pnpm exec vitest run tests/browse-theme-distribution-lib.test.ts  # 7 passed
pnpm --filter web exec tsc --noEmit                              # clean
pnpm --filter web build                                          # vite build
```

Logic lives in the coverage-scoped `lib/**` and is fully unit-tested; the React panel/route are outside the node coverage scope per `AGENTS.md`, so the `codecov/patch` 70% target is met by the lib tests.
