### PR TITLE
feat(web): add author concentration panel to browse

### DIFF
--- a/apps/web/src/components/browse-author-concentration-panel.tsx
+++ b/apps/web/src/components/browse-author-concentration-panel.tsx
@@ -1,0 +1,56 @@
+import type { BrowseAuthorConcentrationState } from "@/lib/browse-author-concentration";
+import { cn } from "@/lib/utils";
+
+const CONCENTRATION_LABEL: Record<BrowseAuthorConcentrationState["concentration"], string> = {
+  concentrated: "Concentrated",
+  mixed: "Mixed",
+  diverse: "Diverse",
+};
+
+export function BrowseAuthorConcentrationPanel({
+  state,
+  className,
+}: {
+  state: BrowseAuthorConcentrationState;
+  className?: string;
+}) {
+  if (!state.showPanel) return null;
+  return (
+    <section className={cn("rounded-xl border border-border bg-surface p-4", className)}>
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <p className="eyebrow">Author concentration</p>
+          <h3 className="mt-1 text-sm font-semibold text-ink">{state.heading}</h3>
+          <p className="mt-1 text-xs text-ink-muted">{state.summary}</p>
+        </div>
+        <span className="rounded-full border border-border bg-background px-2 py-0.5 font-mono text-[10px] uppercase tracking-wide text-ink-subtle">
+          {CONCENTRATION_LABEL[state.concentration]}
+        </span>
+      </div>
+
+      <ul className="mt-3 space-y-1.5">
+        {state.topAuthors.map((row) => (
+          <li key={row.author} className="flex items-center gap-2">
+            <span className="w-28 shrink-0 truncate text-xs text-ink" title={row.author}>
+              {row.author}
+            </span>
+            <span className="relative h-2 flex-1 overflow-hidden rounded-full bg-background">
+              <span
+                className="absolute inset-y-0 left-0 rounded-full bg-accent/60"
+                style={{ width: `${Math.max(row.percent, 4)}%` }}
+              />
+            </span>
+            <span className="w-16 shrink-0 text-right font-mono text-[11px] text-ink-muted">
+              {row.percent}% ({row.count})
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-2.5 text-[11px] text-ink-subtle">
+        {state.distinctAuthors} distinct author{state.distinctAuthors === 1 ? "" : "s"} across{" "}
+        {state.scannedCount} scanned
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/browse-author-concentration-lib.ts
+++ b/apps/web/src/lib/browse-author-concentration-lib.ts
@@ -1,0 +1,127 @@
+/**
+ * Pure browse author-concentration helpers.
+ *
+ * Summarizes how many distinct authors the current browse result set draws
+ * from, and whether it leans on a few prolific authors or is broadly
+ * independent. Aggregates author frequency across the scoped results, reports
+ * the most-represented authors with their share, and classifies the overall
+ * concentration. Purely derived from the entries passed in — distinct from the
+ * contributor *profile* helpers, which summarize a single author's catalog.
+ */
+
+import type { Entry } from "@/types/registry";
+
+export type AuthorConcentrationLevel = "concentrated" | "mixed" | "diverse";
+
+export type BrowseAuthorRow = {
+  author: string;
+  count: number;
+  percent: number;
+};
+
+export type BrowseAuthorConcentrationState = {
+  showPanel: boolean;
+  heading: string;
+  summary: string;
+  scannedCount: number;
+  distinctAuthors: number;
+  topShare: number;
+  concentration: AuthorConcentrationLevel;
+  topAuthors: BrowseAuthorRow[];
+};
+
+const MAX_TOP_AUTHORS = 8;
+
+function classifyConcentration(
+  topShare: number,
+  distinctAuthors: number,
+  scannedCount: number,
+): AuthorConcentrationLevel {
+  if (topShare >= 35) {
+    return "concentrated";
+  }
+  if (distinctAuthors >= Math.ceil(scannedCount * 0.75)) {
+    return "diverse";
+  }
+  return "mixed";
+}
+
+function summarize(
+  concentration: AuthorConcentrationLevel,
+  topAuthors: BrowseAuthorRow[],
+  distinctAuthors: number,
+  scannedCount: number,
+): { heading: string; summary: string } {
+  const leadNames = topAuthors
+    .slice(0, 3)
+    .map((row) => row.author)
+    .join(", ");
+  if (concentration === "concentrated") {
+    return {
+      heading: `Results lean on ${topAuthors[0]?.author ?? "a single author"}`,
+      summary: `${topAuthors[0]?.percent ?? 0}% of this view is from the top author. Most represented: ${leadNames}.`,
+    };
+  }
+  if (concentration === "diverse") {
+    return {
+      heading: "Authors are broadly independent in this view",
+      summary: `${distinctAuthors} distinct authors across ${scannedCount} scanned, with no dominant one.`,
+    };
+  }
+  return {
+    heading: "A few authors lead this view",
+    summary: `${distinctAuthors} distinct authors; the most active are ${leadNames}.`,
+  };
+}
+
+/**
+ * Build the author-concentration state for the current browse results. Authors
+ * are counted case-insensitively (first-seen spelling is kept for display).
+ * `scannedCount` caps how many of the top results are summarized.
+ */
+export function browseAuthorConcentrationState(
+  entries: Entry[],
+  scannedCount = 24,
+): BrowseAuthorConcentrationState {
+  const scoped = entries.slice(0, scannedCount);
+
+  const counts = new Map<string, { author: string; count: number }>();
+  for (const entry of scoped) {
+    const author = entry.author?.trim();
+    if (!author) {
+      continue;
+    }
+    const key = author.toLowerCase();
+    const existing = counts.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      counts.set(key, { author, count: 1 });
+    }
+  }
+
+  const rows: BrowseAuthorRow[] = Array.from(counts.values())
+    .map((value) => ({
+      author: value.author,
+      count: value.count,
+      percent: scoped.length === 0 ? 0 : Math.round((value.count / scoped.length) * 100),
+    }))
+    .sort((a, b) => b.count - a.count || a.author.localeCompare(b.author));
+
+  const topAuthors = rows.slice(0, MAX_TOP_AUTHORS);
+  const distinctAuthors = rows.length;
+  const topShare = topAuthors[0]?.percent ?? 0;
+  const concentration = classifyConcentration(topShare, distinctAuthors, scoped.length);
+  const summary = summarize(concentration, topAuthors, distinctAuthors, scoped.length);
+
+  return {
+    showPanel: scoped.length >= 4 && distinctAuthors >= 2,
+    heading: summary.heading,
+    summary: summary.summary,
+    scannedCount: scoped.length,
+    distinctAuthors,
+    topShare,
+    concentration,
+    topAuthors,
+  };
+}

--- a/apps/web/src/lib/browse-author-concentration.ts
+++ b/apps/web/src/lib/browse-author-concentration.ts
@@ -1,0 +1,10 @@
+/**
+ * Browse author-concentration exports.
+ */
+
+export type {
+  AuthorConcentrationLevel,
+  BrowseAuthorConcentrationState,
+  BrowseAuthorRow,
+} from "@/lib/browse-author-concentration-lib";
+export { browseAuthorConcentrationState } from "@/lib/browse-author-concentration-lib";

--- a/apps/web/src/routes/browse.tsx
+++ b/apps/web/src/routes/browse.tsx
@@ -44,6 +44,8 @@ import { browseFreshnessDistributionState } from "@/lib/browse-freshness-distrib
 import { BrowseFreshnessDistributionPanel } from "@/components/browse-freshness-distribution-panel";
 import { browseThemeDistributionState } from "@/lib/browse-theme-distribution";
 import { BrowseThemeDistributionPanel } from "@/components/browse-theme-distribution-panel";
+import { browseAuthorConcentrationState } from "@/lib/browse-author-concentration";
+import { BrowseAuthorConcentrationPanel } from "@/components/browse-author-concentration-panel";
 import {
   CATEGORIES,
   type Category,
@@ -531,6 +533,7 @@ function Browse() {
   );
   const nowIso = useMemo(() => new Date().toISOString(), []);
   const browseThemes = useMemo(() => browseThemeDistributionState(results, 24), [results]);
+  const browseAuthors = useMemo(() => browseAuthorConcentrationState(results, 24), [results]);
   const browseFreshness = useMemo(
     () => browseFreshnessDistributionState(results, nowIso, 12),
     [results, nowIso],
@@ -1085,6 +1088,7 @@ function Browse() {
           />
           <BrowseFreshnessDistributionPanel state={browseFreshness} className="mt-3" />
           <BrowseThemeDistributionPanel state={browseThemes} className="mt-3" />
+          <BrowseAuthorConcentrationPanel state={browseAuthors} className="mt-3" />
 
           {sp.category &&
             (() => {

--- a/tests/browse-author-concentration-lib.test.ts
+++ b/tests/browse-author-concentration-lib.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { Entry } from "@/types/registry";
+import { browseAuthorConcentrationState } from "@/lib/browse-author-concentration-lib";
+
+function entry(slug: string, author: string): Entry {
+  return {
+    category: "mcp",
+    slug,
+    title: slug,
+    description: "Fixture description",
+    author,
+    tags: [],
+    platforms: ["claude-code"],
+    installType: "manual",
+    trust: "review",
+    source: "unverified",
+    dateAdded: "2026-01-01",
+  } as Entry;
+}
+
+describe("browseAuthorConcentrationState", () => {
+  it("hides the panel below the minimum thresholds", () => {
+    expect(browseAuthorConcentrationState([]).showPanel).toBe(false);
+    // four entries but a single author -> not a distribution
+    expect(
+      browseAuthorConcentrationState([
+        entry("a", "Solo"),
+        entry("b", "Solo"),
+        entry("c", "Solo"),
+        entry("d", "Solo"),
+      ]).showPanel,
+    ).toBe(false);
+    // two distinct authors but only three entries -> below the entry floor
+    expect(
+      browseAuthorConcentrationState([
+        entry("a", "One"),
+        entry("b", "Two"),
+        entry("c", "One"),
+      ]).showPanel,
+    ).toBe(false);
+  });
+
+  it("counts entries per author, sorted by count then name", () => {
+    const state = browseAuthorConcentrationState([
+      entry("a", "Acme"),
+      entry("b", "Acme"),
+      entry("c", "Beta"),
+      entry("d", "Acme"),
+      entry("e", "Gamma"),
+    ]);
+    expect(state.showPanel).toBe(true);
+    expect(state.scannedCount).toBe(5);
+    expect(state.topAuthors[0]).toMatchObject({
+      author: "Acme",
+      count: 3,
+      percent: 60,
+    });
+    expect(state.topAuthors[1]).toMatchObject({ author: "Beta", count: 1 });
+    expect(state.topAuthors[2]).toMatchObject({ author: "Gamma", count: 1 });
+    expect(state.distinctAuthors).toBe(3);
+    expect(state.topShare).toBe(60);
+  });
+
+  it("groups authors case-insensitively, keeping first-seen spelling", () => {
+    const state = browseAuthorConcentrationState([
+      entry("a", "Acme"),
+      entry("b", "acme"),
+      entry("c", "ACME"),
+      entry("d", "Beta"),
+    ]);
+    const acme = state.topAuthors.find(
+      (row) => row.author.toLowerCase() === "acme",
+    );
+    expect(acme?.author).toBe("Acme");
+    expect(acme?.count).toBe(3);
+    expect(state.distinctAuthors).toBe(2);
+  });
+
+  it("classifies a dominant author as concentrated", () => {
+    const state = browseAuthorConcentrationState([
+      entry("a", "Acme"),
+      entry("b", "Acme"),
+      entry("c", "Acme"),
+      entry("d", "Beta"),
+    ]);
+    expect(state.topShare).toBe(75);
+    expect(state.concentration).toBe("concentrated");
+    expect(state.heading).toContain("Acme");
+  });
+
+  it("classifies mostly-unique authors as diverse", () => {
+    const state = browseAuthorConcentrationState([
+      entry("a", "One"),
+      entry("b", "Two"),
+      entry("c", "Three"),
+      entry("d", "Four"),
+    ]);
+    expect(state.concentration).toBe("diverse");
+    expect(state.heading).toContain("broadly independent");
+  });
+
+  it("respects the scannedCount cap", () => {
+    const entries = Array.from({ length: 30 }, (_, i) =>
+      entry(`e${i}`, i < 20 ? "Bulk" : `Solo${i}`),
+    );
+    const state = browseAuthorConcentrationState(entries, 10);
+    expect(state.scannedCount).toBe(10);
+    expect(state.topAuthors[0]).toMatchObject({ author: "Bulk", count: 10 });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **Author concentration** panel to the browse page. The browse decision panels cover trust, rollout, adoption, confidence, freshness, and theme, but none show *how independent* a filtered result set is — whether it draws from many authors or leans on a few prolific ones. This aggregates the authors across the current results into a ranked breakdown so a user can gauge diversity at a glance.

The panel:
- Counts entries per author across the scoped results (case-insensitive, first-seen spelling kept for display) and shows the **most-represented authors** with their share (% of entries + count).
- Reports the number of **distinct authors** and classifies the overall **concentration** — `concentrated` (top author ≥35%), `diverse` (mostly unique authors), or `mixed`.
- Adapts its headline to the concentration ("Results lean on X" vs "Authors are broadly independent").

It is purely derived from the entries in view and is distinct from the contributor *profile* helpers (`contributor-*-lib`), which summarize a single author's catalog rather than the current result set.

## Files

Pure, unit-tested logic + thin wrapper + a presentational panel + one route wire-up, matching the existing browse-panel convention (mirrors `browse-theme-distribution` / `browse-rollout-signals`):

- `apps/web/src/lib/browse-author-concentration-lib.ts` — pure `browseAuthorConcentrationState(entries, scannedCount)`
- `apps/web/src/lib/browse-author-concentration.ts` — wrapper re-export
- `apps/web/src/components/browse-author-concentration-panel.tsx` — presentational panel
- `tests/browse-author-concentration-lib.test.ts` — 6 cases
- `apps/web/src/routes/browse.tsx` — `useMemo` + render alongside the existing browse panels

No content, registry, or generated-artifact edits (`apps/web/public/data/**`, `apps/web/src/generated/**`, `routeTree.gen.ts`, `README.md` untouched). Platform/code change kept separate from content per `AGENTS.md`.

## Data coverage

`author` is present on 100% of registry entries (626 distinct authors), so the breakdown is meaningful across the directory; the panel returns `null` when there are fewer than four results or fewer than two distinct authors.

## Validation

```
pnpm exec prettier --check <changed files>                            # clean
pnpm exec vitest run tests/browse-author-concentration-lib.test.ts    # 6 passed
pnpm --filter web exec tsc --noEmit                                  # clean
pnpm --filter web build                                              # vite build
```

Logic lives in the coverage-scoped `lib/**` and is fully unit-tested; the React panel/route are outside the node coverage scope per `AGENTS.md`, so the `codecov/patch` 70% target is met by the lib tests.
