### PR TITLE
feat(web): track command bar palette analytics

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -23,6 +23,14 @@ import { useShortcuts } from "./shortcuts-dialog";
 import { cn } from "@/lib/utils";
 import { filterCommandActions } from "@/lib/command-bar-actions-lib";
 import { trackEvent } from "@/lib/analytics";
+import {
+  commandBarActionSelectAnalyticsData,
+  commandBarActionSelectAnalyticsEvent,
+  commandBarResultSelectAnalyticsData,
+  commandBarResultSelectAnalyticsEvent,
+  commandBarScopeSelectAnalyticsData,
+  commandBarScopeSelectAnalyticsEvent,
+} from "@/lib/command-bar-cta-events";
 
 const EXAMPLES = [
   "postgres MCP",
@@ -194,6 +202,25 @@ export function CommandBar({
     navigate({ to: "/browse", search: { q } });
   };
 
+  const queryLength = q.trim().length;
+
+  const trackResultSelect = React.useCallback(
+    (category: string, slug: string, resultIndex: number) => {
+      trackEvent(
+        commandBarResultSelectAnalyticsEvent(),
+        commandBarResultSelectAnalyticsData(
+          category,
+          slug,
+          resultIndex,
+          results.length,
+          quickCat,
+          queryLength,
+        ),
+      );
+    },
+    [queryLength, quickCat, results.length],
+  );
+
   const handleBlur = (e: React.FocusEvent<HTMLDivElement>) => {
     const next = e.relatedTarget as Node | null;
     if (next && wrapperRef.current?.contains(next)) return;
@@ -204,11 +231,16 @@ export function CommandBar({
     const opt = options[i];
     if (!opt) return submit();
     if (opt.kind === "result") {
+      trackResultSelect(opt.r.category, opt.r.slug, i);
       navigate({
         to: "/entry/$category/$slug",
         params: { category: opt.r.category, slug: opt.r.slug },
       });
     } else {
+      trackEvent(
+        commandBarActionSelectAnalyticsEvent(),
+        commandBarActionSelectAnalyticsData(opt.a.id, queryLength, results.length),
+      );
       opt.a.run();
     }
     setOpen(false);
@@ -315,6 +347,12 @@ export function CommandBar({
                 type="button"
                 onMouseDown={(e) => {
                   e.preventDefault();
+                  if (quickCat !== c.id) {
+                    trackEvent(
+                      commandBarScopeSelectAnalyticsEvent(),
+                      commandBarScopeSelectAnalyticsData(c.id, queryLength),
+                    );
+                  }
                   setQuickCat(c.id);
                 }}
                 className={cn(
@@ -359,6 +397,7 @@ export function CommandBar({
                     to="/entry/$category/$slug"
                     params={{ category: r.category, slug: r.slug }}
                     onMouseEnter={() => setActive(i)}
+                    onClick={() => trackResultSelect(r.category, r.slug, i)}
                     className={cn(
                       "flex flex-col gap-1 px-4 py-2 text-sm focus-visible:outline-none",
                       active === i && "bg-surface-2",

--- a/apps/web/src/lib/command-bar-cta-events-lib.ts
+++ b/apps/web/src/lib/command-bar-cta-events-lib.ts
@@ -1,0 +1,59 @@
+/**
+ * Pure command bar analytics helpers.
+ *
+ * Maps palette result, action, and scope selections to privacy-light event
+ * names without embedding search queries, titles, or descriptions.
+ */
+
+export const COMMAND_BAR_SURFACE = "command-bar";
+
+export function commandBarScopeSelectAnalyticsEvent(): string {
+  return "command_bar_scope_select";
+}
+
+export function commandBarScopeSelectAnalyticsData(scopeCategory: string, queryLength: number) {
+  return {
+    surface: COMMAND_BAR_SURFACE,
+    scopeCategory: scopeCategory || "all",
+    queryLength,
+  };
+}
+
+export function commandBarResultSelectAnalyticsEvent(): string {
+  return "command_bar_result_select";
+}
+
+export function commandBarResultSelectAnalyticsData(
+  category: string,
+  slug: string,
+  resultIndex: number,
+  resultCount: number,
+  scopeCategory: string,
+  queryLength: number,
+) {
+  return {
+    surface: COMMAND_BAR_SURFACE,
+    entry: `${category}/${slug}`,
+    resultIndex,
+    resultCount,
+    scopeCategory: scopeCategory || "all",
+    queryLength,
+  };
+}
+
+export function commandBarActionSelectAnalyticsEvent(): string {
+  return "command_bar_action_select";
+}
+
+export function commandBarActionSelectAnalyticsData(
+  actionId: string,
+  queryLength: number,
+  resultCount: number,
+) {
+  return {
+    surface: COMMAND_BAR_SURFACE,
+    actionId,
+    queryLength,
+    resultCount,
+  };
+}

--- a/apps/web/src/lib/command-bar-cta-events.ts
+++ b/apps/web/src/lib/command-bar-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Command bar CTA event surface.
+ */
+export {
+  COMMAND_BAR_SURFACE,
+  commandBarActionSelectAnalyticsData,
+  commandBarActionSelectAnalyticsEvent,
+  commandBarResultSelectAnalyticsData,
+  commandBarResultSelectAnalyticsEvent,
+  commandBarScopeSelectAnalyticsData,
+  commandBarScopeSelectAnalyticsEvent,
+} from "@/lib/command-bar-cta-events-lib";

--- a/tests/command-bar-cta-events-lib.test.ts
+++ b/tests/command-bar-cta-events-lib.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  COMMAND_BAR_SURFACE,
+  commandBarActionSelectAnalyticsData,
+  commandBarActionSelectAnalyticsEvent,
+  commandBarResultSelectAnalyticsData,
+  commandBarResultSelectAnalyticsEvent,
+  commandBarScopeSelectAnalyticsData,
+  commandBarScopeSelectAnalyticsEvent,
+} from "@/lib/command-bar-cta-events-lib";
+
+describe("command bar cta events lib", () => {
+  it("builds privacy-light command bar analytics payloads", () => {
+    expect(commandBarScopeSelectAnalyticsEvent()).toBe(
+      "command_bar_scope_select",
+    );
+    expect(commandBarScopeSelectAnalyticsData("mcp", 12)).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      scopeCategory: "mcp",
+      queryLength: 12,
+    });
+    expect(commandBarScopeSelectAnalyticsData("", 0)).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      scopeCategory: "all",
+      queryLength: 0,
+    });
+    expect(commandBarResultSelectAnalyticsEvent()).toBe(
+      "command_bar_result_select",
+    );
+    expect(
+      commandBarResultSelectAnalyticsData("skills", "demo", 1, 6, "skills", 8),
+    ).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      entry: "skills/demo",
+      resultIndex: 1,
+      resultCount: 6,
+      scopeCategory: "skills",
+      queryLength: 8,
+    });
+    expect(commandBarActionSelectAnalyticsEvent()).toBe(
+      "command_bar_action_select",
+    );
+    expect(commandBarActionSelectAnalyticsData("go-browse", 0, 0)).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      actionId: "go-browse",
+      queryLength: 0,
+      resultCount: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track command palette scope chips, search result picks, and quick actions.
- Privacy-light payloads: entry keys, action ids, counts, and query length only.

## Events
- `command_bar_scope_select` — `{ surface, scopeCategory, queryLength }`
- `command_bar_result_select` — `{ surface, entry, resultIndex, resultCount, scopeCategory, queryLength }`
- `command_bar_action_select` — `{ surface, actionId, queryLength, resultCount }`

Refs #550

## Test plan
- [x] vitest for `command-bar-cta-events-lib`
- [x] type-check and build pass locally