### PR TITLE
feat(web): track tags detail related and notfound analytics

### DIFF
--- a/apps/web/src/lib/tags-detail-cta-events-lib.ts
+++ b/apps/web/src/lib/tags-detail-cta-events-lib.ts
@@ -1,0 +1,36 @@
+/**
+ * Pure tags detail CTA analytics helpers.
+ *
+ * Maps tag hub related-topic navigation and not-found egress to privacy-light
+ * event names without embedding tag display names or entry titles.
+ */
+
+export const TAGS_DETAIL_SURFACE = "tags-detail";
+export const TAGS_DETAIL_NOTFOUND_SURFACE = "tags-detail-notfound";
+
+export function tagsDetailRelatedSelectAnalyticsEvent(): string {
+  return "tags_detail_related_select";
+}
+
+export function tagsDetailRelatedSelectAnalyticsData(
+  fromTagSlug: string,
+  tagSlug: string,
+  entryCount: number,
+) {
+  return {
+    surface: TAGS_DETAIL_SURFACE,
+    fromTagSlug,
+    tagSlug,
+    entryCount,
+  };
+}
+
+export function tagsDetailNotFoundEgressAnalyticsEvent(): string {
+  return "tags_detail_notfound_egress_click";
+}
+
+export function tagsDetailNotFoundEgressAnalyticsData() {
+  return {
+    surface: TAGS_DETAIL_NOTFOUND_SURFACE,
+  };
+}

--- a/apps/web/src/lib/tags-detail-cta-events.ts
+++ b/apps/web/src/lib/tags-detail-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Tags detail CTA event surface.
+ */
+export {
+  TAGS_DETAIL_NOTFOUND_SURFACE,
+  TAGS_DETAIL_SURFACE,
+  tagsDetailNotFoundEgressAnalyticsData,
+  tagsDetailNotFoundEgressAnalyticsEvent,
+  tagsDetailRelatedSelectAnalyticsData,
+  tagsDetailRelatedSelectAnalyticsEvent,
+} from "@/lib/tags-detail-cta-events-lib";

--- a/apps/web/src/routes/tags.$tag.tsx
+++ b/apps/web/src/routes/tags.$tag.tsx
@@ -15,6 +15,13 @@ import { absoluteUrl } from "@/lib/seo";
 import { ogImageUrl } from "@/lib/og-image";
 import { ogImageMetaTags } from "@/lib/og-meta-lib";
 import { getTagGroup, relatedTags } from "@/lib/tags";
+import { trackEvent } from "@/lib/analytics";
+import {
+  tagsDetailNotFoundEgressAnalyticsData,
+  tagsDetailNotFoundEgressAnalyticsEvent,
+  tagsDetailRelatedSelectAnalyticsData,
+  tagsDetailRelatedSelectAnalyticsEvent,
+} from "@/lib/tags-detail-cta-events";
 
 // The categories a tag's entries actually span — used to vary intro copy per tag so no
 // two indexable tag pages emit the same boilerplate sentence.
@@ -64,6 +71,12 @@ export const Route = createFileRoute("/tags/$tag")({
       <Link
         to="/tags"
         className="mt-6 inline-flex h-9 items-center gap-1.5 rounded-md bg-ink px-4 font-medium text-background hover:opacity-90"
+        onClick={() =>
+          trackEvent(
+            tagsDetailNotFoundEgressAnalyticsEvent(),
+            tagsDetailNotFoundEgressAnalyticsData(),
+          )
+        }
       >
         Browse all tags <ArrowRight className="h-4 w-4" />
       </Link>
@@ -121,6 +134,12 @@ function TagHub() {
               key={g.slug}
               to="/tags/$tag"
               params={{ tag: g.slug }}
+              onClick={() =>
+                trackEvent(
+                  tagsDetailRelatedSelectAnalyticsEvent(),
+                  tagsDetailRelatedSelectAnalyticsData(tag, g.slug, g.entries.length),
+                )
+              }
               className="rounded-md border border-border bg-surface px-2 py-0.5 text-xs text-ink-muted transition-colors hover:border-ink/20 hover:text-ink"
             >
               {g.name}

--- a/tests/tags-detail-cta-events-lib.test.ts
+++ b/tests/tags-detail-cta-events-lib.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  TAGS_DETAIL_NOTFOUND_SURFACE,
+  TAGS_DETAIL_SURFACE,
+  tagsDetailNotFoundEgressAnalyticsData,
+  tagsDetailNotFoundEgressAnalyticsEvent,
+  tagsDetailRelatedSelectAnalyticsData,
+  tagsDetailRelatedSelectAnalyticsEvent,
+} from "@/lib/tags-detail-cta-events-lib";
+
+describe("tags detail cta events lib", () => {
+  it("builds privacy-light tags detail analytics payloads", () => {
+    expect(tagsDetailRelatedSelectAnalyticsEvent()).toBe(
+      "tags_detail_related_select",
+    );
+    expect(
+      tagsDetailRelatedSelectAnalyticsData("postgres", "database", 18),
+    ).toEqual({
+      surface: TAGS_DETAIL_SURFACE,
+      fromTagSlug: "postgres",
+      tagSlug: "database",
+      entryCount: 18,
+    });
+    expect(tagsDetailNotFoundEgressAnalyticsEvent()).toBe(
+      "tags_detail_notfound_egress_click",
+    );
+    expect(tagsDetailNotFoundEgressAnalyticsData()).toEqual({
+      surface: TAGS_DETAIL_NOTFOUND_SURFACE,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track related-topic clicks on tag hub pages (/tags/\).
- Track not-found egress back to the tags index.

## Events
- `tags_detail_related_select` — `{ surface, fromTagSlug, tagSlug, entryCount }`
- `tags_detail_notfound_egress_click` — `{ surface: "tags-detail-notfound" }`

Refs #550

## Test plan
- [x] vitest for `tags-detail-cta-events-lib`
- [x] type-check and build pass locally