### PR TITLE
feat(web): formalize AI referral analytics helpers

### DIFF
--- a/apps/web/src/components/ai-referral.tsx
+++ b/apps/web/src/components/ai-referral.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import { trackEvent } from "@/lib/analytics";
+import { aiReferralAnalyticsData, aiReferralAnalyticsEvent } from "@/lib/ai-referral-cta-events";
 import { matchAiReferrer } from "@/lib/ai-sources";
 
 const SESSION_FLAG = "ai-referral-tracked";
@@ -11,7 +12,7 @@ export function emitAiReferralEvent(source: string, landing: string): boolean {
   if (typeof umami?.track !== "function") return false;
 
   try {
-    trackEvent("ai-referral", { source, landing });
+    trackEvent(aiReferralAnalyticsEvent(), aiReferralAnalyticsData(source, landing));
   } catch {
     return false;
   }

--- a/apps/web/src/lib/ai-referral-cta-events-lib.ts
+++ b/apps/web/src/lib/ai-referral-cta-events-lib.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure AI referral analytics helpers.
+ *
+ * Maps one-per-session AI assistant referral attribution to privacy-light event
+ * names without embedding full landing paths or entry slugs.
+ */
+
+export const AI_REFERRAL_SURFACE = "ai-referral";
+
+export function aiReferralAnalyticsEvent(): string {
+  return "ai-referral";
+}
+
+export function aiReferralLandingSegment(pathname: string): string {
+  const normalized = pathname.trim() || "/";
+  if (normalized === "/") return "home";
+  const segment = normalized.split("/").filter(Boolean)[0];
+  return segment ?? "home";
+}
+
+export function aiReferralAnalyticsData(source: string, pathname: string) {
+  return {
+    surface: AI_REFERRAL_SURFACE,
+    source,
+    landingSegment: aiReferralLandingSegment(pathname),
+  };
+}

--- a/apps/web/src/lib/ai-referral-cta-events.ts
+++ b/apps/web/src/lib/ai-referral-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * AI referral CTA event surface.
+ */
+export {
+  AI_REFERRAL_SURFACE,
+  aiReferralAnalyticsData,
+  aiReferralAnalyticsEvent,
+  aiReferralLandingSegment,
+} from "@/lib/ai-referral-cta-events-lib";

--- a/tests/ai-referral-cta-events-lib.test.ts
+++ b/tests/ai-referral-cta-events-lib.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  AI_REFERRAL_SURFACE,
+  aiReferralAnalyticsData,
+  aiReferralAnalyticsEvent,
+  aiReferralLandingSegment,
+} from "@/lib/ai-referral-cta-events-lib";
+
+describe("ai referral cta events lib", () => {
+  it("builds privacy-light ai referral analytics payloads", () => {
+    expect(aiReferralAnalyticsEvent()).toBe("ai-referral");
+    expect(aiReferralLandingSegment("/")).toBe("home");
+    expect(aiReferralLandingSegment("/agents")).toBe("agents");
+    expect(aiReferralLandingSegment("/entry/mcp/browser")).toBe("entry");
+    expect(aiReferralAnalyticsData("claude", "/agents")).toEqual({
+      surface: AI_REFERRAL_SURFACE,
+      source: "claude",
+      landingSegment: "agents",
+    });
+  });
+});

--- a/tests/ai-referral.test.ts
+++ b/tests/ai-referral.test.ts
@@ -39,7 +39,8 @@ describe("emitAiReferralEvent", () => {
     expect(emitAiReferralEvent("claude", "/agents")).toBe(true);
     expect(track).toHaveBeenCalledWith("ai-referral", {
       source: "claude",
-      landing: "/agents",
+      surface: "ai-referral",
+      landingSegment: "agents",
     });
     expect(sessionStorage.setItem).toHaveBeenCalledWith(
       "ai-referral-tracked",


### PR DESCRIPTION
## Summary
- Formalize one-per-session AI referral tracking through typed analytics helpers.
- Replace full landing pathname with top-level landingSegment for privacy.

## Events
- `ai-referral` — `{ surface, source, landingSegment }`
  - landingSegment: first path segment (e.g. `agents`, `entry`, `home`)

Refs #550

## Test plan
- [x] vitest for `ai-referral-cta-events-lib` and `ai-referral.test.ts`
- [x] type-check and build pass locally