### PR TITLE
feat(web): track command bar search submit analytics

### DIFF
--- a/apps/web/src/components/command-bar.tsx
+++ b/apps/web/src/components/command-bar.tsx
@@ -30,6 +30,8 @@ import {
   commandBarResultSelectAnalyticsEvent,
   commandBarScopeSelectAnalyticsData,
   commandBarScopeSelectAnalyticsEvent,
+  commandBarSearchSubmitAnalyticsData,
+  commandBarSearchSubmitAnalyticsEvent,
 } from "@/lib/command-bar-cta-events";
 
 const EXAMPLES = [
@@ -198,7 +200,10 @@ export function CommandBar({
   const submit = () => {
     const query = q.trim();
     if (!query) return;
-    trackEvent("search", { q: query.slice(0, 64) });
+    trackEvent(
+      commandBarSearchSubmitAnalyticsEvent(),
+      commandBarSearchSubmitAnalyticsData(query.length, results.length, quickCat),
+    );
     navigate({ to: "/browse", search: { q } });
   };
 

--- a/apps/web/src/lib/command-bar-cta-events-lib.ts
+++ b/apps/web/src/lib/command-bar-cta-events-lib.ts
@@ -57,3 +57,20 @@ export function commandBarActionSelectAnalyticsData(
     resultCount,
   };
 }
+
+export function commandBarSearchSubmitAnalyticsEvent(): string {
+  return "command_bar_search_submit";
+}
+
+export function commandBarSearchSubmitAnalyticsData(
+  queryLength: number,
+  resultCount: number,
+  scopeCategory: string,
+) {
+  return {
+    surface: COMMAND_BAR_SURFACE,
+    queryLength,
+    resultCount,
+    scopeCategory: scopeCategory || "all",
+  };
+}

--- a/apps/web/src/lib/command-bar-cta-events.ts
+++ b/apps/web/src/lib/command-bar-cta-events.ts
@@ -9,4 +9,6 @@ export {
   commandBarResultSelectAnalyticsEvent,
   commandBarScopeSelectAnalyticsData,
   commandBarScopeSelectAnalyticsEvent,
+  commandBarSearchSubmitAnalyticsData,
+  commandBarSearchSubmitAnalyticsEvent,
 } from "@/lib/command-bar-cta-events-lib";

--- a/tests/command-bar-cta-events-lib.test.ts
+++ b/tests/command-bar-cta-events-lib.test.ts
@@ -7,6 +7,8 @@ import {
   commandBarResultSelectAnalyticsEvent,
   commandBarScopeSelectAnalyticsData,
   commandBarScopeSelectAnalyticsEvent,
+  commandBarSearchSubmitAnalyticsData,
+  commandBarSearchSubmitAnalyticsEvent,
 } from "@/lib/command-bar-cta-events-lib";
 
 describe("command bar cta events lib", () => {
@@ -45,6 +47,15 @@ describe("command bar cta events lib", () => {
       actionId: "go-browse",
       queryLength: 0,
       resultCount: 0,
+    });
+    expect(commandBarSearchSubmitAnalyticsEvent()).toBe(
+      "command_bar_search_submit",
+    );
+    expect(commandBarSearchSubmitAnalyticsData(11, 4, "mcp")).toEqual({
+      surface: COMMAND_BAR_SURFACE,
+      queryLength: 11,
+      resultCount: 4,
+      scopeCategory: "mcp",
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace legacy command bar `search` event with typed search submit analytics.
- Privacy-light payload: query length, result count, and scope category only.

## Events
- `command_bar_search_submit` — `{ surface, queryLength, resultCount, scopeCategory }`

Refs #550

## Test plan
- [x] vitest for `command-bar-cta-events-lib` search submit helper
- [x] type-check and build pass locally