### PR TITLE
test(scripts): extract indexnow ref parser and cover it

### DIFF
--- a/scripts/indexnow-changed-urls.mjs
+++ b/scripts/indexnow-changed-urls.mjs
@@ -5,6 +5,7 @@ import {
   normalizeSiteUrl,
 } from "./lib/indexnow.mjs";
 import { entryHubUrls } from "./lib/indexnow-hubs.mjs";
+import { parseRefs } from "./lib/indexnow-refs.mjs";
 
 // Expand changed entry refs ("category/slug", passed as CLI args) into the set
 // of URLs to notify IndexNow about: each entry plus the generated hubs whose
@@ -13,21 +14,6 @@ import { entryHubUrls } from "./lib/indexnow-hubs.mjs";
 // build or extra dependency is needed; tag hubs are simply skipped when that
 // JSON has not propagated yet (the daily cron re-catches them). The workflow
 // validates every emitted URL (HTTP 200) before submitting.
-
-function parseRefs(argv) {
-  const refs = [];
-  for (const raw of argv) {
-    const ref = String(raw).trim();
-    if (!ref) continue;
-    const slash = ref.indexOf("/");
-    if (slash < 0) continue;
-    const category = ref.slice(0, slash);
-    const slug = ref.slice(slash + 1);
-    if (!category || !slug || slug.includes("/")) continue;
-    refs.push({ category, slug });
-  }
-  return refs;
-}
 
 async function fetchTags(base, ref) {
   try {

--- a/scripts/lib/indexnow-refs.mjs
+++ b/scripts/lib/indexnow-refs.mjs
@@ -1,0 +1,24 @@
+// Pure CLI-argument parsing behind scripts/indexnow-changed-urls.mjs: turning the
+// changed-entry ref strings ("category/slug") passed as CLI args into structured
+// { category, slug } refs. Split out so the parsing can be unit-tested without the
+// network/fetch layer the script uses to expand each ref into hub URLs.
+
+/**
+ * Parse "category/slug" ref strings into { category, slug } objects. Blank refs,
+ * refs without a slash, and refs with an empty category/slug or a nested slug
+ * ("a/b/c") are skipped.
+ */
+export function parseRefs(argv) {
+  const refs = [];
+  for (const raw of argv) {
+    const ref = String(raw).trim();
+    if (!ref) continue;
+    const slash = ref.indexOf("/");
+    if (slash < 0) continue;
+    const category = ref.slice(0, slash);
+    const slug = ref.slice(slash + 1);
+    if (!category || !slug || slug.includes("/")) continue;
+    refs.push({ category, slug });
+  }
+  return refs;
+}

--- a/tests/indexnow-refs.test.ts
+++ b/tests/indexnow-refs.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRefs } from "../scripts/lib/indexnow-refs.mjs";
+
+describe("parseRefs", () => {
+  it("parses category/slug refs and trims surrounding whitespace", () => {
+    expect(parseRefs(["agents/example", "  mcp/foo-bar  "])).toEqual([
+      { category: "agents", slug: "example" },
+      { category: "mcp", slug: "foo-bar" },
+    ]);
+  });
+
+  it("skips blank refs and refs without a slash", () => {
+    expect(parseRefs(["", "   ", "nolash"])).toEqual([]);
+  });
+
+  it("skips refs with an empty category or slug", () => {
+    expect(parseRefs(["/slug", "category/"])).toEqual([]);
+  });
+
+  it("skips refs whose slug contains a nested slash", () => {
+    expect(parseRefs(["category/a/b"])).toEqual([]);
+  });
+
+  it("keeps valid refs mixed in with invalid ones", () => {
+    expect(parseRefs(["bad", "hooks/pre-commit", "/x", "skills/deep"])).toEqual(
+      [
+        { category: "hooks", slug: "pre-commit" },
+        { category: "skills", slug: "deep" },
+      ],
+    );
+  });
+
+  it("returns an empty array for no args", () => {
+    expect(parseRefs([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/indexnow-changed-urls.mjs` parsed its `category/slug` CLI ref args inline, next to the fetch layer that expands each ref into hub URLs, so the ref parsing was untestable without the network. This moves the pure parser into `scripts/lib/indexnow-refs.mjs` - joining the existing `lib/indexnow*` helpers the script already imports - and imports it back.

### Changes

- Add `scripts/lib/indexnow-refs.mjs` - `parseRefs`.
- `scripts/indexnow-changed-urls.mjs` - import `parseRefs`; drop the local copy.
- Add `tests/indexnow-refs.test.ts` - covers valid `category/slug` parsing with trimming, and the skips for blank refs, refs with no slash, empty category/slug, and nested-slug slugs, plus a mixed valid/invalid batch. Branch coverage 100% (9/9).

### Validation

- `pnpm exec vitest run tests/indexnow-refs.test.ts` - 6 passed
- `node --check scripts/indexnow-changed-urls.mjs` - clean; `parseRefs` is still used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the emitted URL set is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
