### PR TITLE
test(scripts): extract impact-card SVG builders and cover them

### DIFF
--- a/scripts/gittensor-impact-card.mjs
+++ b/scripts/gittensor-impact-card.mjs
@@ -18,6 +18,7 @@ import {
   escapeXml,
   WEEKS,
 } from "./lib/impact-card-core.mjs";
+import { meter, sparkline } from "./lib/impact-card-svg.mjs";
 
 const THEME = {
   cardBg: "#121212",
@@ -39,36 +40,6 @@ async function fetchJson(url) {
   });
   if (!res.ok) throw new Error(`fetch failed: ${url} (${res.status})`);
   return res.json();
-}
-
-function sparkline(x, y, w, h, values, mutedColor, accentColor, cardBg) {
-  const max = Math.max(...values, 1);
-  const min = Math.min(...values, 0);
-  const range = max - min || 1;
-  const n = values.length;
-  const stepX = w / (n - 1);
-  const pts = values.map((v, i) => [
-    x + i * stepX,
-    y + h - ((v - min) / range) * h,
-  ]);
-  const svgPath = pts
-    .map(
-      ([px, py], i) =>
-        `${i === 0 ? "M" : "L"}${px.toFixed(1)},${py.toFixed(1)}`,
-    )
-    .join(" ");
-  const [lastX, lastY] = pts[pts.length - 1];
-  return `
-<path d="${svgPath}" fill="none" stroke="${mutedColor}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
-<circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="6" fill="${cardBg}"/>
-<circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="4" fill="${accentColor}"/>`;
-}
-
-function meter(x, y, w, h, value, max, accentColor, trackColor) {
-  const fillW = Math.max(h, Math.min(value / max, 1) * w);
-  return `
-<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${h / 2}" fill="${trackColor}"/>
-<rect x="${x}" y="${y}" width="${fillW.toFixed(1)}" height="${h}" rx="${h / 2}" fill="${accentColor}"/>`;
 }
 
 function render({ repo, impact, buckets, gtLogoB64, repoIconB64 }) {

--- a/scripts/lib/impact-card-svg.mjs
+++ b/scripts/lib/impact-card-svg.mjs
@@ -1,0 +1,43 @@
+// Pure SVG-geometry builders behind scripts/gittensor-impact-card.mjs: the
+// sparkline path/marker and the meter track/fill rectangles. Split out from the
+// fetch/render script so the coordinate math and emitted markup can be
+// unit-tested deterministically.
+
+/**
+ * Build an SVG sparkline (a polyline plus an end-point marker) for `values`
+ * within the box at (x, y) of size w x h. Values are min/max normalized with a
+ * floor of max>=1 / min<=0 so a flat or empty-ish series still renders.
+ */
+export function sparkline(x, y, w, h, values, mutedColor, accentColor, cardBg) {
+  const max = Math.max(...values, 1);
+  const min = Math.min(...values, 0);
+  const range = max - min || 1;
+  const n = values.length;
+  const stepX = w / (n - 1);
+  const pts = values.map((v, i) => [
+    x + i * stepX,
+    y + h - ((v - min) / range) * h,
+  ]);
+  const svgPath = pts
+    .map(
+      ([px, py], i) =>
+        `${i === 0 ? "M" : "L"}${px.toFixed(1)},${py.toFixed(1)}`,
+    )
+    .join(" ");
+  const [lastX, lastY] = pts[pts.length - 1];
+  return `
+<path d="${svgPath}" fill="none" stroke="${mutedColor}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+<circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="6" fill="${cardBg}"/>
+<circle cx="${lastX.toFixed(1)}" cy="${lastY.toFixed(1)}" r="4" fill="${accentColor}"/>`;
+}
+
+/**
+ * Build an SVG horizontal meter: a full-width track plus a fill whose width is
+ * value/max of w, clamped to [h, w] so the rounded cap never collapses.
+ */
+export function meter(x, y, w, h, value, max, accentColor, trackColor) {
+  const fillW = Math.max(h, Math.min(value / max, 1) * w);
+  return `
+<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="${h / 2}" fill="${trackColor}"/>
+<rect x="${x}" y="${y}" width="${fillW.toFixed(1)}" height="${h}" rx="${h / 2}" fill="${accentColor}"/>`;
+}

--- a/tests/impact-card-svg.test.ts
+++ b/tests/impact-card-svg.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { meter, sparkline } from "../scripts/lib/impact-card-svg.mjs";
+
+describe("sparkline", () => {
+  it("builds a normalized polyline with an end marker", () => {
+    const svg = sparkline(0, 0, 10, 10, [0, 5, 10], "#mut", "#acc", "#bg");
+    // 3 points across w=10 => stepX 5; min 0, max 10, range 10
+    expect(svg).toContain('d="M0.0,10.0 L5.0,5.0 L10.0,0.0"');
+    expect(svg).toContain('stroke="#mut"');
+    // end marker sits on the last point (10, 0)
+    expect(svg).toContain('<circle cx="10.0" cy="0.0" r="6" fill="#bg"/>');
+    expect(svg).toContain('<circle cx="10.0" cy="0.0" r="4" fill="#acc"/>');
+    // first command is a move, the rest are lines
+    expect(svg).toMatch(/d="M[^"]*"/);
+    expect(svg).toContain("L5.0,5.0");
+  });
+
+  it("applies the max>=1 / min<=0 flooring so small/negative series still render", () => {
+    // all values below 1 -> max floors to 1; a negative value -> min stays real
+    const svg = sparkline(0, 0, 4, 10, [-3, 0.5], "#mut", "#acc", "#bg");
+    // min -3, max 1, range 4; n=2, stepX 4
+    // p0: y = 10 - ((-3 - -3)/4)*10 = 10 ; p1: y = 10 - ((0.5 - -3)/4)*10 = 1.25 -> "1.3"
+    expect(svg).toContain('d="M0.0,10.0 L4.0,1.3"');
+  });
+});
+
+describe("meter", () => {
+  it("fills value/max of the width", () => {
+    const svg = meter(0, 0, 100, 10, 5, 10, "#acc", "#trk");
+    expect(svg).toContain(
+      '<rect x="0" y="0" width="100" height="10" rx="5" fill="#trk"/>',
+    );
+    expect(svg).toContain(
+      '<rect x="0" y="0" width="50.0" height="10" rx="5" fill="#acc"/>',
+    );
+  });
+
+  it("clamps the fill to the full width when value exceeds max", () => {
+    const svg = meter(0, 0, 100, 10, 25, 10, "#acc", "#trk");
+    expect(svg).toContain('width="100.0" height="10" rx="5" fill="#acc"');
+  });
+
+  it("floors the fill width to the bar height so the cap never collapses", () => {
+    const svg = meter(0, 0, 100, 10, 0, 10, "#acc", "#trk");
+    // value 0 -> fraction 0 -> Math.max(10, 0) = 10
+    expect(svg).toContain('width="10.0" height="10" rx="5" fill="#acc"');
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/gittensor-impact-card.mjs` built its sparkline and meter SVG fragments inline, next to the fetch/render pipeline, so the coordinate math and emitted markup were untestable. This moves the pure builders into `scripts/lib/impact-card-svg.mjs` - alongside the existing `lib/impact-card-core` helpers - and imports them back.

### Changes

- Add `scripts/lib/impact-card-svg.mjs` - `sparkline` and `meter`.
- `scripts/gittensor-impact-card.mjs` - import the builders; drop the local copies.
- Add `tests/impact-card-svg.test.ts` - covers the sparkline polyline/marker output including the M-vs-L command and the `max>=1` / `min<=0` flooring, and the meter track/fill including the value/max fill, the `>max` clamp, and the height floor.

### Validation

- `pnpm exec vitest run tests/impact-card-svg.test.ts` - 5 passed
- `node --check scripts/gittensor-impact-card.mjs` - clean; both builders still used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the rendered card markup is identical. Line coverage is 100%; the single uncovered branch is sparkline's `range = max - min || 1` fallback, which is unreachable given the `min<=0` / `max>=1` floors (range is always >= 1) - kept verbatim rather than dropping the defensive guard. Build scripts are inside the coverage scope, so this adds real covered lines.
