### PR TITLE
test(scripts): extract artifact output-path guard and cover it

### DIFF
--- a/scripts/build-content-index.mjs
+++ b/scripts/build-content-index.mjs
@@ -17,6 +17,7 @@ import {
 } from "@heyclaude/registry/content-builder";
 
 import { pickAtlasEntry } from "./lib/atlas-entry.mjs";
+import { artifactOutputPath } from "./lib/artifact-output-path.mjs";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(scriptDir, "..");
@@ -169,20 +170,6 @@ function writeFileIfChanged(filePath, content) {
   fs.writeFileSync(tempFile, content);
   fs.renameSync(tempFile, filePath);
   return true;
-}
-
-function artifactOutputPath(artifactPath) {
-  const dataRoot = path.resolve(publicDataDir);
-  const outputPath = path.resolve(dataRoot, artifactPath);
-  const dataRootPrefix = `${dataRoot}${path.sep}`;
-
-  if (outputPath !== dataRoot && !outputPath.startsWith(dataRootPrefix)) {
-    throw new Error(
-      `Refusing to write artifact outside public data dir: ${artifactPath}`,
-    );
-  }
-
-  return outputPath;
 }
 
 function writeJsonFile(filePath, value) {
@@ -440,7 +427,7 @@ async function main() {
       "The Claude directory for agents, MCP servers, skills, commands, hooks, rules, guides, collections, and statuslines.",
   });
   const artifactResults = artifactFiles.map((file) => {
-    const outputPath = artifactOutputPath(file.path);
+    const outputPath = artifactOutputPath(file.path, publicDataDir);
     const wrote =
       file.type === "json"
         ? writeJsonFile(outputPath, file.value)

--- a/scripts/lib/artifact-output-path.mjs
+++ b/scripts/lib/artifact-output-path.mjs
@@ -1,0 +1,25 @@
+// Pure path-safety guard behind scripts/build-content-index.mjs: resolving a
+// generated artifact's output path and refusing any path that escapes the public
+// data directory. Split out - with the data directory injected - so the
+// traversal guard can be unit-tested without the build pipeline.
+
+import path from "node:path";
+
+/**
+ * Resolve `artifactPath` under `dataDir` and return the absolute path, throwing
+ * if it would land outside `dataDir` (path traversal). The data dir itself is a
+ * valid target; anything above or beside it is rejected.
+ */
+export function artifactOutputPath(artifactPath, dataDir) {
+  const dataRoot = path.resolve(dataDir);
+  const outputPath = path.resolve(dataRoot, artifactPath);
+  const dataRootPrefix = `${dataRoot}${path.sep}`;
+
+  if (outputPath !== dataRoot && !outputPath.startsWith(dataRootPrefix)) {
+    throw new Error(
+      `Refusing to write artifact outside public data dir: ${artifactPath}`,
+    );
+  }
+
+  return outputPath;
+}

--- a/tests/artifact-output-path.test.ts
+++ b/tests/artifact-output-path.test.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { artifactOutputPath } from "../scripts/lib/artifact-output-path.mjs";
+
+const dataDir = path.resolve("some", "public", "data");
+
+describe("artifactOutputPath", () => {
+  it("resolves a relative artifact path under the data dir", () => {
+    expect(artifactOutputPath("entries/agents/x.json", dataDir)).toBe(
+      path.join(dataDir, "entries", "agents", "x.json"),
+    );
+  });
+
+  it("normalizes '.'-style segments that stay inside the dir", () => {
+    expect(artifactOutputPath("./feeds/index.json", dataDir)).toBe(
+      path.join(dataDir, "feeds", "index.json"),
+    );
+  });
+
+  it("allows the data dir itself as a target", () => {
+    expect(artifactOutputPath(".", dataDir)).toBe(dataDir);
+  });
+
+  it("rejects a path that escapes the data dir via traversal", () => {
+    expect(() => artifactOutputPath("../evil.json", dataDir)).toThrow(
+      /outside public data dir/,
+    );
+  });
+
+  it("rejects an absolute path outside the data dir", () => {
+    const outside = path.resolve("some", "other", "place.json");
+    expect(() => artifactOutputPath(outside, dataDir)).toThrow(
+      /outside public data dir/,
+    );
+  });
+
+  it("accepts an absolute path that lands inside the data dir", () => {
+    const inside = path.join(dataDir, "search-index.json");
+    expect(artifactOutputPath(inside, dataDir)).toBe(inside);
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/build-content-index.mjs` resolved each generated artifact's output path and enforced its "must stay inside `public/data`" traversal guard inline against a module-scoped dir, so this security-relevant check was untestable. This moves the pure guard into `scripts/lib/artifact-output-path.mjs` - matching the existing `scripts/lib` convention - with the data directory injected, and imports it back.

### Changes

- Add `scripts/lib/artifact-output-path.mjs` - `artifactOutputPath(artifactPath, dataDir)`.
- `scripts/build-content-index.mjs` - import the guard and pass `publicDataDir` at the call site; drop the local copy.
- Add `tests/artifact-output-path.test.ts` - covers relative resolution under the data dir, `.`-style normalization, the data dir itself as a valid target, and rejection of traversal / outside absolute paths, plus acceptance of an inside absolute path. Branch coverage 100% (4/4).

### Validation

- `pnpm exec vitest run tests/artifact-output-path.test.ts` - 6 passed
- `node --check scripts/build-content-index.mjs` - clean; the guard is still used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; path resolution and the guard are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
