### PR TITLE
refactor(scripts): dedupe release-watch CLI arg parsing and cover it

### DIFF
--- a/scripts/check-mcp-release-due.mjs
+++ b/scripts/check-mcp-release-due.mjs
@@ -10,13 +10,14 @@ import {
   isTrustedReleaseWatchIssue,
   latestSemverTag,
   MCP_RELEASE_DUE_MARKER,
+  parseReleaseWatchArgs,
 } from "./lib/release-watch-core.mjs";
 
 const PACKAGE_JSON_PATH = "packages/mcp/package.json";
 const PACKAGE_NAME = "@heyclaude/mcp";
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseReleaseWatchArgs(process.argv.slice(2));
   const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
   const latestTag = latestSemverTag(readTags("mcp-v*"), "mcp-v");
   const commits = readCommits(latestTag ? `${latestTag.tag}..HEAD` : "HEAD");
@@ -44,23 +45,6 @@ async function main() {
         : "No MCP release due.\n",
     );
   }
-}
-
-function parseArgs(argv) {
-  const args = { json: false, output: null, upsertIssue: false };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--json") {
-      args.json = true;
-    } else if (arg === "--output") {
-      args.output = argv[++index];
-    } else if (arg === "--upsert-issue") {
-      args.upsertIssue = true;
-    } else {
-      throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-  return args;
 }
 
 function readTags(pattern) {

--- a/scripts/check-raycast-release-due.mjs
+++ b/scripts/check-raycast-release-due.mjs
@@ -9,13 +9,14 @@ import {
   buildRaycastReleaseReport,
   isTrustedReleaseWatchIssue,
   latestSemverTag,
+  parseReleaseWatchArgs,
   RAYCAST_RELEASE_DUE_MARKER,
 } from "./lib/release-watch-core.mjs";
 
 const PACKAGE_JSON_PATH = "integrations/raycast/package.json";
 
 async function main() {
-  const args = parseArgs(process.argv.slice(2));
+  const args = parseReleaseWatchArgs(process.argv.slice(2));
   const packageJson = JSON.parse(readFileSync(PACKAGE_JSON_PATH, "utf8"));
   const latestTag = latestSemverTag(readTags("raycast-v*"), "raycast-v");
   const commits = readCommits(latestTag ? `${latestTag.tag}..HEAD` : "HEAD");
@@ -42,23 +43,6 @@ async function main() {
         : "No Raycast upstream update due.\n",
     );
   }
-}
-
-function parseArgs(argv) {
-  const args = { json: false, output: null, upsertIssue: false };
-  for (let index = 0; index < argv.length; index += 1) {
-    const arg = argv[index];
-    if (arg === "--json") {
-      args.json = true;
-    } else if (arg === "--output") {
-      args.output = argv[++index];
-    } else if (arg === "--upsert-issue") {
-      args.upsertIssue = true;
-    } else {
-      throw new Error(`Unknown option: ${arg}`);
-    }
-  }
-  return args;
 }
 
 function readTags(pattern) {

--- a/scripts/lib/release-watch-core.mjs
+++ b/scripts/lib/release-watch-core.mjs
@@ -6,6 +6,27 @@ export const RAYCAST_RELEASE_DUE_MARKER =
   "<!-- heyclaude:raycast-release-due -->";
 const RELEASE_WATCH_CONFIG_PATH = ".github/release-watch.json";
 
+/**
+ * Parse the shared release-watch CLI flags (--json, --output <path>,
+ * --upsert-issue) into an options object. Throws on any unknown option.
+ */
+export function parseReleaseWatchArgs(argv) {
+  const args = { json: false, output: null, upsertIssue: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--json") {
+      args.json = true;
+    } else if (arg === "--output") {
+      args.output = argv[++index];
+    } else if (arg === "--upsert-issue") {
+      args.upsertIssue = true;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+  return args;
+}
+
 export function readReleaseWatchConfig({ repoRoot = process.cwd() } = {}) {
   const configPath = resolve(repoRoot, RELEASE_WATCH_CONFIG_PATH);
   let parsed;

--- a/tests/release-watch-args.test.ts
+++ b/tests/release-watch-args.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { parseReleaseWatchArgs } from "../scripts/lib/release-watch-core.mjs";
+
+describe("parseReleaseWatchArgs", () => {
+  it("defaults every flag off for no args", () => {
+    expect(parseReleaseWatchArgs([])).toEqual({
+      json: false,
+      output: null,
+      upsertIssue: false,
+    });
+  });
+
+  it("sets --json and --upsert-issue booleans", () => {
+    expect(parseReleaseWatchArgs(["--json", "--upsert-issue"])).toEqual({
+      json: true,
+      output: null,
+      upsertIssue: true,
+    });
+  });
+
+  it("consumes the value after --output", () => {
+    expect(parseReleaseWatchArgs(["--output", "report.json"])).toEqual({
+      json: false,
+      output: "report.json",
+      upsertIssue: false,
+    });
+  });
+
+  it("parses a full combination in order", () => {
+    expect(
+      parseReleaseWatchArgs([
+        "--json",
+        "--output",
+        "out.json",
+        "--upsert-issue",
+      ]),
+    ).toEqual({ json: true, output: "out.json", upsertIssue: true });
+  });
+
+  it("throws on an unknown option", () => {
+    expect(() => parseReleaseWatchArgs(["--nope"])).toThrow(
+      /Unknown option: --nope/,
+    );
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/check-mcp-release-due.mjs` and `scripts/check-raycast-release-due.mjs` each carried a byte-identical local `parseArgs` for the shared `--json`/`--output`/`--upsert-issue` flags, and neither copy was tested. This hoists a single `parseReleaseWatchArgs` into the existing `scripts/lib/release-watch-core.mjs` (which both scripts already import) and uses it from both.

### Changes

- `scripts/lib/release-watch-core.mjs` - add `parseReleaseWatchArgs`.
- `scripts/check-mcp-release-due.mjs`, `scripts/check-raycast-release-due.mjs` - import the shared parser; drop the duplicated local copies.
- Add `tests/release-watch-args.test.ts` - covers the flag defaults, the boolean flags, the `--output` value consumption, a full in-order combination, and the unknown-option throw. The new function's lines/branches are fully covered.

### Validation

- `pnpm exec vitest run tests/release-watch-args.test.ts tests/release-watch.test.ts` - 15 passed
- `node --check` on both scripts and the lib - clean; both now call `parseReleaseWatchArgs`
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (dedupe + pure-logic extraction + tests). No behavior change; both scripts parse their arguments identically. Build scripts are inside the coverage scope, so this adds real covered lines.
