### PR TITLE
feat(web): formalize submit flow analytics helpers

### DIFF
--- a/apps/web/src/lib/submit-cta-events-lib.ts
+++ b/apps/web/src/lib/submit-cta-events-lib.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure submit flow analytics helpers.
+ *
+ * Maps submission start and success events to privacy-light payloads without
+ * embedding entry titles, slugs, or form field content.
+ */
+
+export const SUBMIT_SURFACE = "submit";
+
+export type SubmitSuccessPath = "manual" | "gate";
+
+export function submitStartAnalyticsEvent(): string {
+  return "submit_start";
+}
+
+export function submitStartAnalyticsData(category: string, hasGate: boolean) {
+  return {
+    surface: SUBMIT_SURFACE,
+    category,
+    hasGate,
+  };
+}
+
+export function submitSuccessAnalyticsEvent(): string {
+  return "submit_success";
+}
+
+export function submitSuccessAnalyticsData(category: string, path: SubmitSuccessPath) {
+  return {
+    surface: SUBMIT_SURFACE,
+    category,
+    path,
+  };
+}

--- a/apps/web/src/lib/submit-cta-events.ts
+++ b/apps/web/src/lib/submit-cta-events.ts
@@ -1,0 +1,11 @@
+/**
+ * Submit flow CTA event surface.
+ */
+export {
+  SUBMIT_SURFACE,
+  submitStartAnalyticsData,
+  submitStartAnalyticsEvent,
+  submitSuccessAnalyticsData,
+  submitSuccessAnalyticsEvent,
+  type SubmitSuccessPath,
+} from "@/lib/submit-cta-events-lib";

--- a/apps/web/src/routes/submit.tsx
+++ b/apps/web/src/routes/submit.tsx
@@ -26,6 +26,12 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { cn } from "@/lib/utils";
 import { absoluteUrl } from "@/lib/seo";
 import { trackEvent } from "@/lib/analytics";
+import {
+  submitStartAnalyticsData,
+  submitStartAnalyticsEvent,
+  submitSuccessAnalyticsData,
+  submitSuccessAnalyticsEvent,
+} from "@/lib/submit-cta-events";
 
 export const Route = createFileRoute("/submit")({
   head: () => ({
@@ -153,10 +159,13 @@ function SubmitPage() {
     if (!category || submitBusy) return;
     setSubmitBusy(true);
     setSubmitError("");
-    trackEvent("submit-start", { category });
+    trackEvent(
+      submitStartAnalyticsEvent(),
+      submitStartAnalyticsData(category, Boolean(siteConfig.submissionGateUrl)),
+    );
     try {
       if (!siteConfig.submissionGateUrl) {
-        trackEvent("submit-success", { category, path: "manual" });
+        trackEvent(submitSuccessAnalyticsEvent(), submitSuccessAnalyticsData(category, "manual"));
         setDone({
           manualPr: {
             targetPath: prTarget,
@@ -187,7 +196,7 @@ function SubmitPage() {
       if (!response.ok || !payload?.ok) {
         throw new Error(payload?.error || "The private submission gate rejected the draft.");
       }
-      trackEvent("submit-success", { category, path: "gate" });
+      trackEvent(submitSuccessAnalyticsEvent(), submitSuccessAnalyticsData(category, "gate"));
       const authUrl = payload.authUrl ? safeGitHubAuthUrl(payload.authUrl) : "";
       if (payload.authUrl && !authUrl) {
         throw new Error("The submission gate returned an invalid GitHub auth URL.");

--- a/tests/submit-cta-events-lib.test.ts
+++ b/tests/submit-cta-events-lib.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBMIT_SURFACE,
+  submitStartAnalyticsData,
+  submitStartAnalyticsEvent,
+  submitSuccessAnalyticsData,
+  submitSuccessAnalyticsEvent,
+} from "@/lib/submit-cta-events-lib";
+
+describe("submit cta events lib", () => {
+  it("builds privacy-light submit flow analytics payloads", () => {
+    expect(submitStartAnalyticsEvent()).toBe("submit_start");
+    expect(submitStartAnalyticsData("mcp", true)).toEqual({
+      surface: SUBMIT_SURFACE,
+      category: "mcp",
+      hasGate: true,
+    });
+    expect(submitSuccessAnalyticsEvent()).toBe("submit_success");
+    expect(submitSuccessAnalyticsData("skills", "gate")).toEqual({
+      surface: SUBMIT_SURFACE,
+      category: "skills",
+      path: "gate",
+    });
+    expect(submitSuccessAnalyticsData("hooks", "manual")).toEqual({
+      surface: SUBMIT_SURFACE,
+      category: "hooks",
+      path: "manual",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Formalize submit flow start and success tracking through typed analytics helpers.
- Privacy-light payloads: category, path, and hasGate only.

## Events
- `submit_start` — `{ surface: "submit", category, hasGate }`
- `submit_success` — `{ surface: "submit", category, path: "manual" | "gate" }`

Refs #550

## Test plan
- [x] vitest for `submit-cta-events-lib`
- [x] type-check and build pass locally