### PR TITLE
feat(web): browse distribution panel egress analytics

### DIFF
--- a/apps/web/src/components/browse-freshness-distribution-panel.tsx
+++ b/apps/web/src/components/browse-freshness-distribution-panel.tsx
@@ -1,5 +1,12 @@
+import { Link } from "@tanstack/react-router";
 import { toneClass } from "@/lib/browse-rollout-tone-lib";
 import type { BrowseFreshnessDistributionState } from "@/lib/browse-freshness-distribution";
+import {
+  browseFreshnessStaleEntryAnalyticsData,
+  browseFreshnessStaleEntryAnalyticsEvent,
+  parseBrowseFreshnessEntryRef,
+} from "@/lib/browse-distribution-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 export function BrowseFreshnessDistributionPanel({
@@ -51,20 +58,46 @@ export function BrowseFreshnessDistributionPanel({
         <div className="mt-3 rounded-md border border-border bg-background p-2.5">
           <p className="text-[11px] font-medium text-ink">Oldest entries in this view</p>
           <ul className="mt-1.5 space-y-1.5">
-            {state.staleEntries.map((entry) => (
-              <li
-                key={entry.entryRef}
-                className="flex items-start justify-between gap-2 text-[11px]"
-              >
+            {state.staleEntries.map((entry) => {
+              const parsed = parseBrowseFreshnessEntryRef(entry.entryRef);
+              const title = (
                 <div className="min-w-0">
                   <p className="truncate text-ink">{entry.title}</p>
                   <p className="truncate text-ink-subtle">
                     {entry.verified ? "Verified previously" : "Not yet verified"}
                   </p>
                 </div>
-                <span className="shrink-0 font-mono text-ink-muted">{entry.ageDays}d</span>
-              </li>
-            ))}
+              );
+              return (
+                <li
+                  key={entry.entryRef}
+                  className="flex items-start justify-between gap-2 text-[11px]"
+                >
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          browseFreshnessStaleEntryAnalyticsEvent(),
+                          browseFreshnessStaleEntryAnalyticsData(
+                            entry.entryRef,
+                            entry.ageDays,
+                            entry.verified,
+                          ),
+                        )
+                      }
+                      className="min-w-0 flex-1 underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    title
+                  )}
+                  <span className="shrink-0 font-mono text-ink-muted">{entry.ageDays}d</span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/apps/web/src/components/browse-theme-distribution-panel.tsx
+++ b/apps/web/src/components/browse-theme-distribution-panel.tsx
@@ -1,4 +1,10 @@
+import { Link } from "@tanstack/react-router";
 import type { BrowseThemeDistributionState } from "@/lib/browse-theme-distribution";
+import {
+  browseThemeDistributionSelectAnalyticsData,
+  browseThemeDistributionSelectAnalyticsEvent,
+} from "@/lib/browse-distribution-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const CONCENTRATION_LABEL: Record<BrowseThemeDistributionState["concentration"], string> = {
@@ -29,11 +35,28 @@ export function BrowseThemeDistributionPanel({
       </div>
 
       <ul className="mt-3 space-y-1.5">
-        {state.topThemes.map((theme) => (
+        {state.topThemes.map((theme, index) => (
           <li key={theme.slug} className="flex items-center gap-2">
-            <span className="w-28 shrink-0 truncate text-xs text-ink" title={theme.tag}>
+            <Link
+              to="/tags/$tag"
+              params={{ tag: theme.slug }}
+              onClick={() =>
+                trackEvent(
+                  browseThemeDistributionSelectAnalyticsEvent(),
+                  browseThemeDistributionSelectAnalyticsData(
+                    theme.slug,
+                    theme.percent,
+                    index + 1,
+                    state.concentration,
+                    state.scannedCount,
+                  ),
+                )
+              }
+              className="w-28 shrink-0 truncate text-xs text-ink underline-offset-2 hover:text-accent hover:underline"
+              title={`Browse ${theme.tag} tag hub`}
+            >
               {theme.tag}
-            </span>
+            </Link>
             <span className="relative h-2 flex-1 overflow-hidden rounded-full bg-background">
               <span
                 className="absolute inset-y-0 left-0 rounded-full bg-accent/60"

--- a/apps/web/src/lib/browse-distribution-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-distribution-cta-events-lib.ts
@@ -1,0 +1,62 @@
+/**
+ * Pure browse distribution panel analytics helpers.
+ *
+ * Maps theme-distribution tag egress and freshness stale-entry navigation to
+ * privacy-light event names without embedding tag display names or entry titles.
+ */
+
+import type { BrowseThemeConcentration } from "@/lib/browse-theme-distribution-lib";
+
+export const BROWSE_THEME_DISTRIBUTION_SURFACE = "browse-theme-distribution";
+export const BROWSE_FRESHNESS_DISTRIBUTION_SURFACE = "browse-freshness-distribution";
+
+export function browseThemeDistributionSelectAnalyticsEvent(): string {
+  return "browse_theme_distribution_select";
+}
+
+export function browseThemeDistributionSelectAnalyticsData(
+  tagSlug: string,
+  percent: number,
+  rank: number,
+  concentration: BrowseThemeConcentration,
+  scannedCount: number,
+) {
+  return {
+    surface: BROWSE_THEME_DISTRIBUTION_SURFACE,
+    tagSlug,
+    percent,
+    rank,
+    concentration,
+    scannedCount,
+  };
+}
+
+export function browseFreshnessStaleEntryAnalyticsEvent(): string {
+  return "browse_freshness_stale_entry_click";
+}
+
+export function browseFreshnessStaleEntryAnalyticsData(
+  entryRef: string,
+  ageDays: number,
+  verified: boolean,
+) {
+  return {
+    surface: BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+    entry: entryRef,
+    ageDays,
+    verified,
+  };
+}
+
+export function parseBrowseFreshnessEntryRef(
+  entryRef: string,
+): { category: string; slug: string } | null {
+  const slash = entryRef.indexOf("/");
+  if (slash <= 0 || slash >= entryRef.length - 1) {
+    return null;
+  }
+  return {
+    category: entryRef.slice(0, slash),
+    slug: entryRef.slice(slash + 1),
+  };
+}

--- a/apps/web/src/lib/browse-distribution-cta-events.ts
+++ b/apps/web/src/lib/browse-distribution-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Browse distribution CTA event surface.
+ */
+export {
+  BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+  BROWSE_THEME_DISTRIBUTION_SURFACE,
+  browseFreshnessStaleEntryAnalyticsData,
+  browseFreshnessStaleEntryAnalyticsEvent,
+  browseThemeDistributionSelectAnalyticsData,
+  browseThemeDistributionSelectAnalyticsEvent,
+  parseBrowseFreshnessEntryRef,
+} from "@/lib/browse-distribution-cta-events-lib";

--- a/tests/browse-distribution-cta-events-lib.test.ts
+++ b/tests/browse-distribution-cta-events-lib.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+  BROWSE_THEME_DISTRIBUTION_SURFACE,
+  browseFreshnessStaleEntryAnalyticsData,
+  browseFreshnessStaleEntryAnalyticsEvent,
+  browseThemeDistributionSelectAnalyticsData,
+  browseThemeDistributionSelectAnalyticsEvent,
+  parseBrowseFreshnessEntryRef,
+} from "@/lib/browse-distribution-cta-events-lib";
+
+describe("browse distribution cta events lib", () => {
+  it("builds privacy-light browse distribution analytics payloads", () => {
+    expect(browseThemeDistributionSelectAnalyticsEvent()).toBe(
+      "browse_theme_distribution_select",
+    );
+    expect(
+      browseThemeDistributionSelectAnalyticsData(
+        "memory",
+        42,
+        1,
+        "focused",
+        24,
+      ),
+    ).toEqual({
+      surface: BROWSE_THEME_DISTRIBUTION_SURFACE,
+      tagSlug: "memory",
+      percent: 42,
+      rank: 1,
+      concentration: "focused",
+      scannedCount: 24,
+    });
+    expect(browseFreshnessStaleEntryAnalyticsEvent()).toBe(
+      "browse_freshness_stale_entry_click",
+    );
+    expect(
+      browseFreshnessStaleEntryAnalyticsData("mcp/browser", 210, false),
+    ).toEqual({
+      surface: BROWSE_FRESHNESS_DISTRIBUTION_SURFACE,
+      entry: "mcp/browser",
+      ageDays: 210,
+      verified: false,
+    });
+    expect(parseBrowseFreshnessEntryRef("mcp/browser")).toEqual({
+      category: "mcp",
+      slug: "browser",
+    });
+    expect(parseBrowseFreshnessEntryRef("invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Make browse theme-distribution rows link to tag hubs with typed analytics.
- Make freshness stale-entry rows link to entry detail pages with typed analytics.

## Events
- `browse_theme_distribution_select` — `{ surface, tagSlug, percent, rank, concentration, scannedCount }`
- `browse_freshness_stale_entry_click` — `{ surface, entry, ageDays, verified }`

Refs #550

## Test plan
- [x] vitest for `browse-distribution-cta-events-lib`
- [x] type-check and build pass locally