### PR TITLE
feat(web): entry safety surface kind filter analytics

### DIFF
--- a/apps/web/src/components/entry-safety-surface-panel.tsx
+++ b/apps/web/src/components/entry-safety-surface-panel.tsx
@@ -1,14 +1,57 @@
+import { useCallback, useMemo, useState } from "react";
 import { AlertTriangle, ShieldCheck } from "lucide-react";
 import type { EntrySafetySurfaceState } from "@/lib/entry-safety-surface";
+import type { SafetyRiskKind } from "@/lib/entry-safety-surface-lib";
+import {
+  entrySafetySurfaceKindSelectAnalyticsData,
+  entrySafetySurfaceKindSelectAnalyticsEvent,
+} from "@/lib/entry-safety-surface-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 export function EntrySafetySurfacePanel({
   state,
+  category,
+  slug,
   className,
 }: {
   state: EntrySafetySurfaceState;
+  category: string;
+  slug: string;
   className?: string;
 }) {
+  const [selectedKind, setSelectedKind] = useState<SafetyRiskKind | null>(null);
+
+  const visibleItems = useMemo(() => {
+    if (!selectedKind) {
+      return state.items;
+    }
+    return state.items.filter((item) => item.kind === selectedKind);
+  }, [selectedKind, state.items]);
+
+  const onKindSelect = useCallback(
+    (kind: SafetyRiskKind, itemCount: number, sensitive: boolean) => {
+      const next = selectedKind === kind ? null : kind;
+      if (next === selectedKind) {
+        return;
+      }
+      setSelectedKind(next);
+      trackEvent(
+        entrySafetySurfaceKindSelectAnalyticsEvent(),
+        entrySafetySurfaceKindSelectAnalyticsData(
+          category,
+          slug,
+          kind,
+          next === kind,
+          itemCount,
+          state.coverageCount,
+          sensitive,
+        ),
+      );
+    },
+    [category, slug, selectedKind, state.coverageCount],
+  );
+
   if (!state.showPanel) {
     return null;
   }
@@ -32,25 +75,38 @@ export function EntrySafetySurfacePanel({
       <div className="mt-3 flex flex-wrap items-center gap-2">
         {state.kinds.map((kind) => {
           const sensitive = state.sensitiveKinds.includes(kind.kind);
+          const active = selectedKind === kind.kind;
           return (
-            <span
+            <button
               key={kind.kind}
+              type="button"
+              aria-pressed={active}
+              onClick={() => onKindSelect(kind.kind, kind.count, sensitive)}
               className={cn(
-                "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px]",
-                sensitive
-                  ? "border-amber-500/40 bg-amber-500/5 text-amber-900"
-                  : "border-border bg-background text-ink-muted",
+                "inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] transition-colors",
+                active
+                  ? "border-accent bg-accent/10 text-ink"
+                  : sensitive
+                    ? "border-amber-500/40 bg-amber-500/5 text-amber-900 hover:border-amber-500/60"
+                    : "border-border bg-background text-ink-muted hover:text-ink",
               )}
             >
               {kind.kindLabel}
               <span className="font-mono text-ink">{kind.count}</span>
-            </span>
+            </button>
           );
         })}
       </div>
 
+      {selectedKind ? (
+        <p className="mt-2 text-xs text-ink-muted" role="status">
+          Showing {visibleItems.length} note{visibleItems.length === 1 ? "" : "s"} for this risk
+          area.
+        </p>
+      ) : null}
+
       <ul className="mt-4 space-y-2">
-        {state.items.map((item) => (
+        {visibleItems.map((item) => (
           <li
             key={item.id}
             className="flex items-start gap-2.5 rounded-lg border border-border bg-background px-3 py-2.5"

--- a/apps/web/src/lib/entry-safety-surface-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-safety-surface-cta-events-lib.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure entry safety-surface panel analytics helpers.
+ *
+ * Maps kind-chip filter interactions to privacy-light event names without
+ * embedding note text or other free-form safety/privacy copy.
+ */
+
+import type { SafetyRiskKind } from "@/lib/entry-safety-surface-lib";
+
+export const ENTRY_SAFETY_SURFACE_PANEL_SURFACE = "detail-safety-surface";
+
+export function entrySafetySurfaceEntryKey(category: string, slug: string): string {
+  return `${category}/${slug}`;
+}
+
+export function entrySafetySurfaceKindSelectAnalyticsEvent(): string {
+  return "detail_safety_surface_kind_select";
+}
+
+export function entrySafetySurfaceKindSelectAnalyticsData(
+  category: string,
+  slug: string,
+  kind: SafetyRiskKind,
+  active: boolean,
+  itemCount: number,
+  coverageCount: number,
+  sensitive: boolean,
+) {
+  return {
+    entry: entrySafetySurfaceEntryKey(category, slug),
+    surface: ENTRY_SAFETY_SURFACE_PANEL_SURFACE,
+    kind,
+    active,
+    itemCount,
+    coverageCount,
+    sensitive,
+  };
+}

--- a/apps/web/src/lib/entry-safety-surface-cta-events.ts
+++ b/apps/web/src/lib/entry-safety-surface-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Entry safety-surface CTA event surface.
+ */
+export {
+  ENTRY_SAFETY_SURFACE_PANEL_SURFACE,
+  entrySafetySurfaceEntryKey,
+  entrySafetySurfaceKindSelectAnalyticsData,
+  entrySafetySurfaceKindSelectAnalyticsEvent,
+} from "@/lib/entry-safety-surface-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -775,7 +775,11 @@ function Dossier() {
             category={entry.category}
             slug={entry.slug}
           />
-          <EntrySafetySurfacePanel state={safetySurface} />
+          <EntrySafetySurfacePanel
+            state={safetySurface}
+            category={entry.category}
+            slug={entry.slug}
+          />
           {entry.safetyNotes && (
             <DossierSection id="safety" icon={ShieldCheck} title="Safety notes" tone="trust">
               <NoteList value={entry.safetyNotesList ?? [entry.safetyNotes]} />

--- a/tests/entry-safety-surface-cta-events-lib.test.ts
+++ b/tests/entry-safety-surface-cta-events-lib.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  ENTRY_SAFETY_SURFACE_PANEL_SURFACE,
+  entrySafetySurfaceEntryKey,
+  entrySafetySurfaceKindSelectAnalyticsData,
+  entrySafetySurfaceKindSelectAnalyticsEvent,
+} from "@/lib/entry-safety-surface-cta-events-lib";
+
+describe("entry safety surface cta events lib", () => {
+  it("builds privacy-light safety surface analytics payloads", () => {
+    expect(entrySafetySurfaceEntryKey("mcp", "browser")).toBe("mcp/browser");
+    expect(entrySafetySurfaceKindSelectAnalyticsEvent()).toBe(
+      "detail_safety_surface_kind_select",
+    );
+    expect(
+      entrySafetySurfaceKindSelectAnalyticsData(
+        "mcp",
+        "browser",
+        "credentials",
+        true,
+        2,
+        4,
+        true,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_SAFETY_SURFACE_PANEL_SURFACE,
+      kind: "credentials",
+      active: true,
+      itemCount: 2,
+      coverageCount: 4,
+      sensitive: true,
+    });
+    expect(
+      entrySafetySurfaceKindSelectAnalyticsData(
+        "mcp",
+        "browser",
+        "network",
+        false,
+        5,
+        4,
+        true,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: ENTRY_SAFETY_SURFACE_PANEL_SURFACE,
+      kind: "network",
+      active: false,
+      itemCount: 5,
+      coverageCount: 4,
+      sensitive: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add kind-chip filtering on the entry safety & privacy surface panel.
- Track filter toggles with typed analytics helpers (no note text in payloads).

## Events
- `detail_safety_surface_kind_select` — `{ entry, surface, kind, active, itemCount, coverageCount, sensitive }`

Refs #550

## Test plan
- [x] vitest for `entry-safety-surface-cta-events-lib`
- [x] type-check and build pass locally