### PR TITLE
feat(web): browse rollout flagged entry egress analytics

### DIFF
--- a/apps/web/src/components/browse-rollout-signals-panel.tsx
+++ b/apps/web/src/components/browse-rollout-signals-panel.tsx
@@ -1,5 +1,12 @@
+import { Link } from "@tanstack/react-router";
 import { toneClass } from "@/lib/browse-rollout-tone-lib";
 import type { BrowseRolloutSignalsState } from "@/lib/browse-rollout-signals";
+import {
+  browseRolloutFlaggedEntryAnalyticsData,
+  browseRolloutFlaggedEntryAnalyticsEvent,
+  parseBrowseRolloutEntryRef,
+} from "@/lib/browse-rollout-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 export function BrowseRolloutSignalsPanel({
@@ -51,11 +58,9 @@ export function BrowseRolloutSignalsPanel({
         <div className="mt-3 rounded-md border border-border bg-background p-2.5">
           <p className="text-[11px] font-medium text-ink">Most at-risk entries in this view</p>
           <ul className="mt-1.5 space-y-1.5">
-            {state.flaggedEntries.map((entry) => (
-              <li
-                key={entry.entryRef}
-                className="flex items-start justify-between gap-2 text-[11px]"
-              >
+            {state.flaggedEntries.map((entry) => {
+              const parsed = parseBrowseRolloutEntryRef(entry.entryRef);
+              const title = (
                 <div className="min-w-0">
                   <p className="truncate text-ink">{entry.title}</p>
                   <p className="truncate text-ink-subtle">
@@ -64,11 +69,39 @@ export function BrowseRolloutSignalsPanel({
                       : "No required rollout gaps"}
                   </p>
                 </div>
-                <span className="shrink-0 font-mono text-ink-muted">
-                  {entry.signalCoveragePercent}%
-                </span>
-              </li>
-            ))}
+              );
+              return (
+                <li
+                  key={entry.entryRef}
+                  className="flex items-start justify-between gap-2 text-[11px]"
+                >
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          browseRolloutFlaggedEntryAnalyticsEvent(),
+                          browseRolloutFlaggedEntryAnalyticsData(
+                            entry.entryRef,
+                            entry.missingRequired.length,
+                            entry.signalCoveragePercent,
+                          ),
+                        )
+                      }
+                      className="min-w-0 flex-1 underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    title
+                  )}
+                  <span className="shrink-0 font-mono text-ink-muted">
+                    {entry.signalCoveragePercent}%
+                  </span>
+                </li>
+              );
+            })}
           </ul>
         </div>
       ) : null}

--- a/apps/web/src/lib/browse-rollout-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-rollout-cta-events-lib.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure browse rollout signals panel analytics helpers.
+ *
+ * Maps flagged-entry navigation from the rollout signal scan to privacy-light
+ * event names without embedding entry titles or missing-signal labels.
+ */
+
+export const BROWSE_ROLLOUT_SIGNALS_SURFACE = "browse-rollout-signals";
+
+export function browseRolloutFlaggedEntryAnalyticsEvent(): string {
+  return "browse_rollout_flagged_entry_click";
+}
+
+export function browseRolloutFlaggedEntryAnalyticsData(
+  entryRef: string,
+  missingRequiredCount: number,
+  signalCoveragePercent: number,
+) {
+  return {
+    surface: BROWSE_ROLLOUT_SIGNALS_SURFACE,
+    entry: entryRef,
+    missingRequiredCount,
+    signalCoveragePercent,
+  };
+}
+
+export function parseBrowseRolloutEntryRef(
+  entryRef: string,
+): { category: string; slug: string } | null {
+  const slash = entryRef.indexOf("/");
+  if (slash <= 0 || slash >= entryRef.length - 1) {
+    return null;
+  }
+  return {
+    category: entryRef.slice(0, slash),
+    slug: entryRef.slice(slash + 1),
+  };
+}

--- a/apps/web/src/lib/browse-rollout-cta-events.ts
+++ b/apps/web/src/lib/browse-rollout-cta-events.ts
@@ -1,0 +1,9 @@
+/**
+ * Browse rollout CTA event surface.
+ */
+export {
+  BROWSE_ROLLOUT_SIGNALS_SURFACE,
+  browseRolloutFlaggedEntryAnalyticsData,
+  browseRolloutFlaggedEntryAnalyticsEvent,
+  parseBrowseRolloutEntryRef,
+} from "@/lib/browse-rollout-cta-events-lib";

--- a/tests/browse-rollout-cta-events-lib.test.ts
+++ b/tests/browse-rollout-cta-events-lib.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSE_ROLLOUT_SIGNALS_SURFACE,
+  browseRolloutFlaggedEntryAnalyticsData,
+  browseRolloutFlaggedEntryAnalyticsEvent,
+  parseBrowseRolloutEntryRef,
+} from "@/lib/browse-rollout-cta-events-lib";
+
+describe("browse rollout cta events lib", () => {
+  it("builds privacy-light browse rollout analytics payloads", () => {
+    expect(browseRolloutFlaggedEntryAnalyticsEvent()).toBe(
+      "browse_rollout_flagged_entry_click",
+    );
+    expect(
+      browseRolloutFlaggedEntryAnalyticsData("mcp/browser", 2, 33),
+    ).toEqual({
+      surface: BROWSE_ROLLOUT_SIGNALS_SURFACE,
+      entry: "mcp/browser",
+      missingRequiredCount: 2,
+      signalCoveragePercent: 33,
+    });
+    expect(parseBrowseRolloutEntryRef("mcp/browser")).toEqual({
+      category: "mcp",
+      slug: "browser",
+    });
+    expect(parseBrowseRolloutEntryRef("invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Link rollout signal scan flagged entries to entry detail pages.
- Track flagged-entry clicks with typed analytics helpers.

## Events
- `browse_rollout_flagged_entry_click` — `{ surface, entry, missingRequiredCount, signalCoveragePercent }`

Refs #550

## Test plan
- [x] vitest for `browse-rollout-cta-events-lib`
- [x] type-check and build pass locally