### PR TITLE
feat(web): browse decision panel entry egress analytics

### DIFF
--- a/apps/web/src/components/browse-adoption-queue-panel.tsx
+++ b/apps/web/src/components/browse-adoption-queue-panel.tsx
@@ -1,5 +1,12 @@
+import { Link } from "@tanstack/react-router";
 import type { BrowseAdoptionPresetId, BrowseAdoptionQueueState } from "@/lib/browse-adoption-queue";
 import { browseAdoptionTierClass } from "@/lib/browse-adoption-queue";
+import {
+  browseAdoptionQueueEntryAnalyticsData,
+  browseAdoptionQueueEntryAnalyticsEvent,
+  parseBrowseDecisionPanelEntryRef,
+} from "@/lib/browse-decision-panel-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: BrowseAdoptionPresetId; label: string }[] = [
@@ -64,46 +71,75 @@ export function BrowseAdoptionQueuePanel({
       </div>
 
       <div className="mt-3 grid gap-2">
-        {state.rows.map((row) => (
-          <article key={row.entryRef} className="rounded-lg border border-border bg-background p-3">
-            <div className="flex flex-wrap items-start justify-between gap-2">
-              <div className="min-w-0">
-                <h4 className="text-sm font-semibold text-ink">{row.title}</h4>
-                <p className="mt-0.5 text-[11px] text-ink-muted">
-                  {row.blockers.length > 0
-                    ? `${row.blockers.length} blockers: ${row.blockers.slice(0, 2).join(", ")}`
-                    : "No required blockers for this preset."}
-                </p>
-              </div>
-              <div className="text-right">
-                <span
-                  className={cn(
-                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                    browseAdoptionTierClass(row.tier),
+        {state.rows.map((row) => {
+          const parsed = parseBrowseDecisionPanelEntryRef(row.entryRef);
+          const title = <h4 className="text-sm font-semibold text-ink">{row.title}</h4>;
+          return (
+            <article
+              key={row.entryRef}
+              className="rounded-lg border border-border bg-background p-3"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          browseAdoptionQueueEntryAnalyticsEvent(),
+                          browseAdoptionQueueEntryAnalyticsData(
+                            row.entryRef,
+                            selectedPreset,
+                            row.tier,
+                            row.readinessScore,
+                            row.blockers.length,
+                          ),
+                        )
+                      }
+                      className="underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    title
                   )}
-                >
-                  {row.tier}
-                </span>
-                <p className="mt-1 font-mono text-xs text-ink">{row.readinessScore}/100</p>
+                  <p className="mt-0.5 text-[11px] text-ink-muted">
+                    {row.blockers.length > 0
+                      ? `${row.blockers.length} blockers: ${row.blockers.slice(0, 2).join(", ")}`
+                      : "No required blockers for this preset."}
+                  </p>
+                </div>
+                <div className="text-right">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                      browseAdoptionTierClass(row.tier),
+                    )}
+                  >
+                    {row.tier}
+                  </span>
+                  <p className="mt-1 font-mono text-xs text-ink">{row.readinessScore}/100</p>
+                </div>
               </div>
-            </div>
 
-            <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
-              {row.nextSteps.map((step) => (
-                <p
-                  key={`${row.entryRef}-${step}`}
-                  className="rounded border border-border px-2 py-1 text-[11px] text-ink-muted"
-                >
-                  {step}
-                </p>
-              ))}
-            </div>
+              <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+                {row.nextSteps.map((step) => (
+                  <p
+                    key={`${row.entryRef}-${step}`}
+                    className="rounded border border-border px-2 py-1 text-[11px] text-ink-muted"
+                  >
+                    {step}
+                  </p>
+                ))}
+              </div>
 
-            <p className="mt-2 text-[11px] text-ink-subtle">
-              {row.entryRef} · trust {row.trust} · confidence {row.confidence}%
-            </p>
-          </article>
-        ))}
+              <p className="mt-2 text-[11px] text-ink-subtle">
+                {row.entryRef} · trust {row.trust} · confidence {row.confidence}%
+              </p>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/components/browse-decision-confidence-panel.tsx
+++ b/apps/web/src/components/browse-decision-confidence-panel.tsx
@@ -1,8 +1,15 @@
+import { Link } from "@tanstack/react-router";
 import type {
   BrowseConfidencePresetId,
   BrowseDecisionConfidenceState,
 } from "@/lib/browse-decision-confidence";
 import { browseConfidenceBandClass } from "@/lib/browse-decision-confidence";
+import {
+  browseDecisionConfidenceEntryAnalyticsData,
+  browseDecisionConfidenceEntryAnalyticsEvent,
+  parseBrowseDecisionPanelEntryRef,
+} from "@/lib/browse-decision-panel-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: BrowseConfidencePresetId; label: string }[] = [
@@ -67,51 +74,77 @@ export function BrowseDecisionConfidencePanel({
       </div>
 
       <div className="mt-3 grid gap-2">
-        {state.entries.map((entry) => (
-          <article
-            key={entry.entryRef}
-            className="rounded-lg border border-border bg-background p-3"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-2">
-              <div className="min-w-0">
-                <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>
-                <p className="mt-0.5 text-[11px] text-ink-muted">{entry.recommendation}</p>
-              </div>
-              <div className="text-right">
-                <span
-                  className={cn(
-                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                    browseConfidenceBandClass(entry.band),
+        {state.entries.map((entry) => {
+          const parsed = parseBrowseDecisionPanelEntryRef(entry.entryRef);
+          const title = <h4 className="text-sm font-semibold text-ink">{entry.title}</h4>;
+          return (
+            <article
+              key={entry.entryRef}
+              className="rounded-lg border border-border bg-background p-3"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          browseDecisionConfidenceEntryAnalyticsEvent(),
+                          browseDecisionConfidenceEntryAnalyticsData(
+                            entry.entryRef,
+                            selectedPreset,
+                            entry.band,
+                            entry.confidenceScore,
+                            entry.missingSignals.length,
+                          ),
+                        )
+                      }
+                      className="underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    title
                   )}
-                >
-                  {entry.band}
-                </span>
-                <p className="mt-1 font-mono text-xs text-ink">{entry.confidenceScore}/100</p>
-              </div>
-            </div>
-
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {entry.missingSignals.length > 0 ? (
-                entry.missingSignals.slice(0, 3).map((signal) => (
+                  <p className="mt-0.5 text-[11px] text-ink-muted">{entry.recommendation}</p>
+                </div>
+                <div className="text-right">
                   <span
-                    key={`${entry.entryRef}-${signal}`}
-                    className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                    className={cn(
+                      "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                      browseConfidenceBandClass(entry.band),
+                    )}
                   >
-                    Missing: {signal}
+                    {entry.band}
                   </span>
-                ))
-              ) : (
-                <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
-                  All key signals present
-                </span>
-              )}
-            </div>
+                  <p className="mt-1 font-mono text-xs text-ink">{entry.confidenceScore}/100</p>
+                </div>
+              </div>
 
-            <p className="mt-2 text-[11px] text-ink-subtle">
-              {entry.entryRef} · trust {entry.trust}
-            </p>
-          </article>
-        ))}
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {entry.missingSignals.length > 0 ? (
+                  entry.missingSignals.slice(0, 3).map((signal) => (
+                    <span
+                      key={`${entry.entryRef}-${signal}`}
+                      className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                    >
+                      Missing: {signal}
+                    </span>
+                  ))
+                ) : (
+                  <span className="rounded border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted">
+                    All key signals present
+                  </span>
+                )}
+              </div>
+
+              <p className="mt-2 text-[11px] text-ink-subtle">
+                {entry.entryRef} · trust {entry.trust}
+              </p>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/lib/browse-decision-panel-cta-events-lib.ts
+++ b/apps/web/src/lib/browse-decision-panel-cta-events-lib.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure browse decision panel entry egress analytics helpers.
+ *
+ * Maps adoption-queue and decision-confidence entry navigation to privacy-light
+ * event names without embedding entry titles, blockers, or signal labels.
+ */
+
+import type { BrowseAdoptionPresetId, BrowseAdoptionTier } from "@/lib/browse-adoption-queue-lib";
+import type {
+  BrowseConfidenceBand,
+  BrowseConfidencePresetId,
+} from "@/lib/browse-decision-confidence-lib";
+
+export const BROWSE_ADOPTION_QUEUE_SURFACE = "browse-adoption-queue";
+export const BROWSE_DECISION_CONFIDENCE_SURFACE = "browse-decision-confidence";
+
+export function browseAdoptionQueueEntryAnalyticsEvent(): string {
+  return "browse_adoption_queue_entry_click";
+}
+
+export function browseAdoptionQueueEntryAnalyticsData(
+  entryRef: string,
+  preset: BrowseAdoptionPresetId,
+  tier: BrowseAdoptionTier,
+  readinessScore: number,
+  blockerCount: number,
+) {
+  return {
+    surface: BROWSE_ADOPTION_QUEUE_SURFACE,
+    entry: entryRef,
+    preset,
+    tier,
+    readinessScore,
+    blockerCount,
+  };
+}
+
+export function browseDecisionConfidenceEntryAnalyticsEvent(): string {
+  return "browse_decision_confidence_entry_click";
+}
+
+export function browseDecisionConfidenceEntryAnalyticsData(
+  entryRef: string,
+  preset: BrowseConfidencePresetId,
+  band: BrowseConfidenceBand,
+  confidenceScore: number,
+  missingSignalCount: number,
+) {
+  return {
+    surface: BROWSE_DECISION_CONFIDENCE_SURFACE,
+    entry: entryRef,
+    preset,
+    band,
+    confidenceScore,
+    missingSignalCount,
+  };
+}
+
+export function parseBrowseDecisionPanelEntryRef(
+  entryRef: string,
+): { category: string; slug: string } | null {
+  const slash = entryRef.indexOf("/");
+  if (slash <= 0 || slash >= entryRef.length - 1) {
+    return null;
+  }
+  return {
+    category: entryRef.slice(0, slash),
+    slug: entryRef.slice(slash + 1),
+  };
+}

--- a/apps/web/src/lib/browse-decision-panel-cta-events.ts
+++ b/apps/web/src/lib/browse-decision-panel-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Browse decision panel CTA event surface.
+ */
+export {
+  BROWSE_ADOPTION_QUEUE_SURFACE,
+  BROWSE_DECISION_CONFIDENCE_SURFACE,
+  browseAdoptionQueueEntryAnalyticsData,
+  browseAdoptionQueueEntryAnalyticsEvent,
+  browseDecisionConfidenceEntryAnalyticsData,
+  browseDecisionConfidenceEntryAnalyticsEvent,
+  parseBrowseDecisionPanelEntryRef,
+} from "@/lib/browse-decision-panel-cta-events-lib";

--- a/tests/browse-decision-panel-cta-events-lib.test.ts
+++ b/tests/browse-decision-panel-cta-events-lib.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  BROWSE_ADOPTION_QUEUE_SURFACE,
+  BROWSE_DECISION_CONFIDENCE_SURFACE,
+  browseAdoptionQueueEntryAnalyticsData,
+  browseAdoptionQueueEntryAnalyticsEvent,
+  browseDecisionConfidenceEntryAnalyticsData,
+  browseDecisionConfidenceEntryAnalyticsEvent,
+  parseBrowseDecisionPanelEntryRef,
+} from "@/lib/browse-decision-panel-cta-events-lib";
+
+describe("browse decision panel cta events lib", () => {
+  it("builds privacy-light browse decision panel analytics payloads", () => {
+    expect(browseAdoptionQueueEntryAnalyticsEvent()).toBe(
+      "browse_adoption_queue_entry_click",
+    );
+    expect(
+      browseAdoptionQueueEntryAnalyticsData(
+        "mcp/browser",
+        "security-first",
+        "caution",
+        72,
+        2,
+      ),
+    ).toEqual({
+      surface: BROWSE_ADOPTION_QUEUE_SURFACE,
+      entry: "mcp/browser",
+      preset: "security-first",
+      tier: "caution",
+      readinessScore: 72,
+      blockerCount: 2,
+    });
+    expect(browseDecisionConfidenceEntryAnalyticsEvent()).toBe(
+      "browse_decision_confidence_entry_click",
+    );
+    expect(
+      browseDecisionConfidenceEntryAnalyticsData(
+        "agents/foo",
+        "strict",
+        "low",
+        41,
+        3,
+      ),
+    ).toEqual({
+      surface: BROWSE_DECISION_CONFIDENCE_SURFACE,
+      entry: "agents/foo",
+      preset: "strict",
+      band: "low",
+      confidenceScore: 41,
+      missingSignalCount: 3,
+    });
+    expect(parseBrowseDecisionPanelEntryRef("mcp/browser")).toEqual({
+      category: "mcp",
+      slug: "browser",
+    });
+    expect(parseBrowseDecisionPanelEntryRef("invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Link adoption queue and decision confidence entry titles to detail pages.
- Track entry egress with typed analytics helpers (no titles or blocker text).

## Events
- `browse_adoption_queue_entry_click` — `{ surface, entry, preset, tier, readinessScore, blockerCount }`
- `browse_decision_confidence_entry_click` — `{ surface, entry, preset, band, confidenceScore, missingSignalCount }`

Refs #550

## Test plan
- [x] vitest for `browse-decision-panel-cta-events-lib`
- [x] type-check and build pass locally