### PR TITLE
feat(web): compare panel entry egress analytics

### DIFF
--- a/apps/web/src/components/compare-decision-brief-panel.tsx
+++ b/apps/web/src/components/compare-decision-brief-panel.tsx
@@ -1,5 +1,12 @@
+import { Link } from "@tanstack/react-router";
 import { AlertTriangle, CheckCircle2, Circle, Scale, ShieldAlert } from "lucide-react";
 import type { CompareDecisionBriefState, CompareBriefTone } from "@/lib/compare-decision-brief";
+import {
+  compareDecisionBriefEntryAnalyticsData,
+  compareDecisionBriefEntryAnalyticsEvent,
+  parseComparePanelEntryRef,
+} from "@/lib/compare-panel-entry-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const TONE_BADGE: Record<CompareBriefTone, string> = {
@@ -26,10 +33,12 @@ function ChecklistMark({ done }: { done: boolean }) {
 
 export function CompareDecisionBriefPanel({
   state,
+  surface,
   className,
   compact = false,
 }: {
   state: CompareDecisionBriefState;
+  surface: string;
   className?: string;
   compact?: boolean;
 }) {
@@ -79,83 +88,110 @@ export function CompareDecisionBriefPanel({
       <div
         className={cn("mt-4 grid gap-3", compact ? "grid-cols-1" : "grid-cols-1 xl:grid-cols-2")}
       >
-        {state.entryBriefs.map((brief) => (
-          <article
-            key={brief.entryRef}
-            className={cn(
-              "rounded-lg border border-border bg-background p-3",
-              brief.rank === 1 && "ring-1 ring-trust-trusted/30",
-            )}
-          >
-            <div className="flex flex-wrap items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
-                    #{brief.rank}
-                  </span>
-                  <h4 className="truncate text-sm font-semibold text-ink">{brief.title}</h4>
+        {state.entryBriefs.map((brief) => {
+          const parsed = parseComparePanelEntryRef(brief.entryRef);
+          const title = <h4 className="truncate text-sm font-semibold text-ink">{brief.title}</h4>;
+          return (
+            <article
+              key={brief.entryRef}
+              className={cn(
+                "rounded-lg border border-border bg-background p-3",
+                brief.rank === 1 && "ring-1 ring-trust-trusted/30",
+              )}
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
+                      #{brief.rank}
+                    </span>
+                    {parsed ? (
+                      <Link
+                        to="/entry/$category/$slug"
+                        params={{ category: parsed.category, slug: parsed.slug }}
+                        onClick={() =>
+                          trackEvent(
+                            compareDecisionBriefEntryAnalyticsEvent(),
+                            compareDecisionBriefEntryAnalyticsData(
+                              surface,
+                              brief.entryRef,
+                              brief.rank,
+                              brief.tone,
+                              brief.score,
+                              state.comparedCount,
+                            ),
+                          )
+                        }
+                        className="min-w-0 underline-offset-2 hover:text-accent hover:underline"
+                      >
+                        {title}
+                      </Link>
+                    ) : (
+                      title
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-ink-muted">{brief.headline}</p>
                 </div>
-                <p className="mt-1 text-xs text-ink-muted">{brief.headline}</p>
-              </div>
-              <div className="text-right">
-                <span
-                  className={cn(
-                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
-                    TONE_BADGE[brief.tone],
-                  )}
-                >
-                  {TONE_LABEL[brief.tone]}
-                </span>
-                <p className="mt-1 font-mono text-xs text-ink">Score {brief.score}</p>
-              </div>
-            </div>
-
-            <p className="mt-2 text-xs text-ink">{brief.recommendation}</p>
-            <p className="mt-1 text-[11px] text-ink-subtle">{brief.compareDeltaSummary}</p>
-
-            <ul className="mt-2 flex flex-wrap gap-1.5">
-              {brief.reasons.map((reason) => (
-                <li
-                  key={reason}
-                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
-                >
-                  {reason}
-                </li>
-              ))}
-            </ul>
-
-            {!compact && (
-              <ul className="mt-3 space-y-1.5">
-                {brief.checklist.map((item) => (
-                  <li
-                    key={item.id}
-                    className="flex items-start justify-between gap-2 rounded-md border border-border/70 px-2 py-1.5"
+                <div className="text-right">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
+                      TONE_BADGE[brief.tone],
+                    )}
                   >
-                    <div className="min-w-0">
-                      <p className="text-[11px] font-medium text-ink">
-                        {item.label}
-                        {item.required ? (
-                          <span className="ml-1 rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
-                            Required
-                          </span>
-                        ) : null}
-                      </p>
-                      <p className="mt-0.5 text-[10px] text-ink-subtle">{item.detail}</p>
-                    </div>
-                    <ChecklistMark done={item.done} />
+                    {TONE_LABEL[brief.tone]}
+                  </span>
+                  <p className="mt-1 font-mono text-xs text-ink">Score {brief.score}</p>
+                </div>
+              </div>
+
+              <p className="mt-2 text-xs text-ink">{brief.recommendation}</p>
+              <p className="mt-1 text-[11px] text-ink-subtle">{brief.compareDeltaSummary}</p>
+
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {brief.reasons.map((reason) => (
+                  <li
+                    key={reason}
+                    className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                  >
+                    {reason}
                   </li>
                 ))}
               </ul>
-            )}
 
-            {compact && brief.checklist.some((item) => item.required && !item.done) ? (
-              <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-900">
-                <AlertTriangle className="h-3 w-3" aria-hidden />
-                Required checks still pending
-              </div>
-            ) : null}
-          </article>
-        ))}
+              {!compact && (
+                <ul className="mt-3 space-y-1.5">
+                  {brief.checklist.map((item) => (
+                    <li
+                      key={item.id}
+                      className="flex items-start justify-between gap-2 rounded-md border border-border/70 px-2 py-1.5"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-[11px] font-medium text-ink">
+                          {item.label}
+                          {item.required ? (
+                            <span className="ml-1 rounded bg-ink/10 px-1 py-0.5 text-[9px] uppercase tracking-wide text-ink-muted">
+                              Required
+                            </span>
+                          ) : null}
+                        </p>
+                        <p className="mt-0.5 text-[10px] text-ink-subtle">{item.detail}</p>
+                      </div>
+                      <ChecklistMark done={item.done} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {compact && brief.checklist.some((item) => item.required && !item.done) ? (
+                <div className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-900">
+                  <AlertTriangle className="h-3 w-3" aria-hidden />
+                  Required checks still pending
+                </div>
+              ) : null}
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/components/compare-drawer.tsx
+++ b/apps/web/src/components/compare-drawer.tsx
@@ -46,7 +46,9 @@ import {
 import {
   compareDrawerScenarioAnalyticsData,
   compareDrawerScenarioAnalyticsEvent,
+  compareDrawerScenarioSurface,
 } from "@/lib/compare-drawer-scenario-cta-events";
+import { compareDrawerDecisionBriefSurface } from "@/lib/compare-panel-entry-cta-events";
 import {
   compareDrawerSnippetCopyAnalyticsData,
   compareDrawerSnippetCopyAnalyticsEvent,
@@ -631,9 +633,15 @@ export function CompareDrawer() {
           </div>
         ) : (
           <div className="h-[calc(88vh-57px)] overflow-auto">
-            <CompareDecisionBriefPanel state={decisionBrief} compact className="m-3" />
+            <CompareDecisionBriefPanel
+              state={decisionBrief}
+              surface={compareDrawerDecisionBriefSurface()}
+              compact
+              className="m-3"
+            />
             <CompareScenarioRankingPanel
               state={scenarioRanking}
+              surface={compareDrawerScenarioSurface()}
               selectedScenario={scenario}
               onSelectScenario={onScenarioSelect}
               compact

--- a/apps/web/src/components/compare-scenario-ranking-panel.tsx
+++ b/apps/web/src/components/compare-scenario-ranking-panel.tsx
@@ -1,19 +1,28 @@
+import { Link } from "@tanstack/react-router";
 import type {
   CompareScenarioId,
   CompareScenarioRankingState,
 } from "@/lib/compare-scenario-ranking";
 import { COMPARE_SCENARIO_PRESETS } from "@/lib/compare-scenario-ranking";
+import {
+  compareScenarioRankingEntryAnalyticsData,
+  compareScenarioRankingEntryAnalyticsEvent,
+  parseComparePanelEntryRef,
+} from "@/lib/compare-panel-entry-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { scoreDeltaText } from "@/lib/scenario-score-delta-lib";
 import { cn } from "@/lib/utils";
 
 export function CompareScenarioRankingPanel({
   state,
+  surface,
   selectedScenario,
   onSelectScenario,
   compact = false,
   className,
 }: {
   state: CompareScenarioRankingState;
+  surface: string;
   selectedScenario: CompareScenarioId;
   onSelectScenario: (scenario: CompareScenarioId) => void;
   compact?: boolean;
@@ -59,41 +68,68 @@ export function CompareScenarioRankingPanel({
       <div
         className={cn("mt-3 grid gap-2", compact ? "grid-cols-1" : "grid-cols-1 xl:grid-cols-2")}
       >
-        {state.ranked.map((item) => (
-          <article
-            key={item.entryRef}
-            className={cn(
-              "rounded-lg border border-border bg-background p-3",
-              item.rank === 1 && "ring-1 ring-accent/40",
-            )}
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div className="min-w-0">
-                <div className="flex items-center gap-2">
-                  <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
-                    #{item.rank}
-                  </span>
-                  <h4 className="truncate text-sm font-semibold text-ink">{item.title}</h4>
+        {state.ranked.map((item) => {
+          const parsed = parseComparePanelEntryRef(item.entryRef);
+          const title = <h4 className="truncate text-sm font-semibold text-ink">{item.title}</h4>;
+          return (
+            <article
+              key={item.entryRef}
+              className={cn(
+                "rounded-lg border border-border bg-background p-3",
+                item.rank === 1 && "ring-1 ring-accent/40",
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="rounded bg-surface-2 px-1.5 py-0.5 font-mono text-[10px] text-ink-subtle">
+                      #{item.rank}
+                    </span>
+                    {parsed ? (
+                      <Link
+                        to="/entry/$category/$slug"
+                        params={{ category: parsed.category, slug: parsed.slug }}
+                        onClick={() =>
+                          trackEvent(
+                            compareScenarioRankingEntryAnalyticsEvent(),
+                            compareScenarioRankingEntryAnalyticsData(
+                              surface,
+                              item.entryRef,
+                              item.rank,
+                              item.score,
+                              selectedScenario,
+                              state.ranked.length,
+                            ),
+                          )
+                        }
+                        className="min-w-0 underline-offset-2 hover:text-accent hover:underline"
+                      >
+                        {title}
+                      </Link>
+                    ) : (
+                      title
+                    )}
+                  </div>
+                  <p className="mt-1 text-[11px] text-ink-muted">{item.rationale[0]}</p>
                 </div>
-                <p className="mt-1 text-[11px] text-ink-muted">{item.rationale[0]}</p>
+                <div className="text-right">
+                  <p className="font-mono text-xs text-ink">Score {item.score}</p>
+                  <p className="text-[10px] text-ink-subtle">{scoreDeltaText(item.deltaFromTop)}</p>
+                </div>
               </div>
-              <div className="text-right">
-                <p className="font-mono text-xs text-ink">Score {item.score}</p>
-                <p className="text-[10px] text-ink-subtle">{scoreDeltaText(item.deltaFromTop)}</p>
-              </div>
-            </div>
-            <ul className="mt-2 flex flex-wrap gap-1.5">
-              {item.rationale.slice(1).map((reason) => (
-                <li
-                  key={reason}
-                  className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
-                >
-                  {reason}
-                </li>
-              ))}
-            </ul>
-          </article>
-        ))}
+              <ul className="mt-2 flex flex-wrap gap-1.5">
+                {item.rationale.slice(1).map((reason) => (
+                  <li
+                    key={reason}
+                    className="rounded-full border border-border bg-surface px-2 py-0.5 text-[10px] text-ink-muted"
+                  >
+                    {reason}
+                  </li>
+                ))}
+              </ul>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/lib/compare-panel-entry-cta-events-lib.ts
+++ b/apps/web/src/lib/compare-panel-entry-cta-events-lib.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure compare decision brief and scenario ranking entry egress analytics helpers.
+ *
+ * Maps compare panel entry navigation to privacy-light event names without
+ * embedding entry titles, recommendations, or rationale copy.
+ */
+
+import type { CompareBriefTone } from "@/lib/compare-decision-brief-lib";
+import type { CompareScenarioId } from "@/lib/compare-scenario-ranking-lib";
+
+export function comparePageDecisionBriefSurface(): string {
+  return "compare-page-decision-brief";
+}
+
+export function compareDrawerDecisionBriefSurface(): string {
+  return "compare-drawer-decision-brief";
+}
+
+export function compareDecisionBriefEntryAnalyticsEvent(): string {
+  return "compare_decision_brief_entry_click";
+}
+
+export function compareDecisionBriefEntryAnalyticsData(
+  surface: string,
+  entryRef: string,
+  rank: number,
+  tone: CompareBriefTone,
+  score: number,
+  comparedCount: number,
+) {
+  return {
+    surface,
+    entry: entryRef,
+    rank,
+    tone,
+    score,
+    comparedCount,
+  };
+}
+
+export function compareScenarioRankingEntryAnalyticsEvent(): string {
+  return "compare_scenario_ranking_entry_click";
+}
+
+export function compareScenarioRankingEntryAnalyticsData(
+  surface: string,
+  entryRef: string,
+  rank: number,
+  score: number,
+  scenario: CompareScenarioId,
+  comparedCount: number,
+) {
+  return {
+    surface,
+    entry: entryRef,
+    rank,
+    score,
+    scenario,
+    comparedCount,
+  };
+}
+
+export function parseComparePanelEntryRef(
+  entryRef: string,
+): { category: string; slug: string } | null {
+  const slash = entryRef.indexOf("/");
+  if (slash <= 0 || slash >= entryRef.length - 1) {
+    return null;
+  }
+  return {
+    category: entryRef.slice(0, slash),
+    slug: entryRef.slice(slash + 1),
+  };
+}

--- a/apps/web/src/lib/compare-panel-entry-cta-events.ts
+++ b/apps/web/src/lib/compare-panel-entry-cta-events.ts
@@ -1,0 +1,12 @@
+/**
+ * Compare panel entry CTA event surface.
+ */
+export {
+  compareDecisionBriefEntryAnalyticsData,
+  compareDecisionBriefEntryAnalyticsEvent,
+  compareDrawerDecisionBriefSurface,
+  comparePageDecisionBriefSurface,
+  compareScenarioRankingEntryAnalyticsData,
+  compareScenarioRankingEntryAnalyticsEvent,
+  parseComparePanelEntryRef,
+} from "@/lib/compare-panel-entry-cta-events-lib";

--- a/apps/web/src/routes/compare.index.tsx
+++ b/apps/web/src/routes/compare.index.tsx
@@ -45,7 +45,9 @@ import {
 import {
   comparePageScenarioAnalyticsData,
   comparePageScenarioAnalyticsEvent,
+  comparePageScenarioSurface,
 } from "@/lib/compare-page-scenario-cta-events";
+import { comparePageDecisionBriefSurface } from "@/lib/compare-panel-entry-cta-events";
 import {
   comparePageShareLinkCopyAnalyticsData,
   comparePageShareLinkCopyAnalyticsEvent,
@@ -385,9 +387,14 @@ function ComparePage() {
       </div>
 
       <div className="mt-4 overflow-auto rounded-xl border border-border">
-        <CompareDecisionBriefPanel state={decisionBrief} className="m-3 mb-0" />
+        <CompareDecisionBriefPanel
+          state={decisionBrief}
+          surface={comparePageDecisionBriefSurface()}
+          className="m-3 mb-0"
+        />
         <CompareScenarioRankingPanel
           state={scenarioRanking}
+          surface={comparePageScenarioSurface()}
           selectedScenario={scenario}
           onSelectScenario={onScenarioSelect}
           className="m-3"

--- a/tests/compare-panel-entry-cta-events-lib.test.ts
+++ b/tests/compare-panel-entry-cta-events-lib.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareDecisionBriefEntryAnalyticsData,
+  compareDecisionBriefEntryAnalyticsEvent,
+  compareDrawerDecisionBriefSurface,
+  comparePageDecisionBriefSurface,
+  compareScenarioRankingEntryAnalyticsData,
+  compareScenarioRankingEntryAnalyticsEvent,
+  parseComparePanelEntryRef,
+} from "@/lib/compare-panel-entry-cta-events-lib";
+
+describe("compare panel entry cta events lib", () => {
+  it("builds privacy-light compare panel entry analytics payloads", () => {
+    expect(comparePageDecisionBriefSurface()).toBe(
+      "compare-page-decision-brief",
+    );
+    expect(compareDrawerDecisionBriefSurface()).toBe(
+      "compare-drawer-decision-brief",
+    );
+    expect(compareDecisionBriefEntryAnalyticsEvent()).toBe(
+      "compare_decision_brief_entry_click",
+    );
+    expect(
+      compareDecisionBriefEntryAnalyticsData(
+        comparePageDecisionBriefSurface(),
+        "mcp/browser",
+        1,
+        "ready",
+        88,
+        3,
+      ),
+    ).toEqual({
+      surface: "compare-page-decision-brief",
+      entry: "mcp/browser",
+      rank: 1,
+      tone: "ready",
+      score: 88,
+      comparedCount: 3,
+    });
+    expect(compareScenarioRankingEntryAnalyticsEvent()).toBe(
+      "compare_scenario_ranking_entry_click",
+    );
+    expect(
+      compareScenarioRankingEntryAnalyticsData(
+        "compare-drawer-scenario-ranking",
+        "agents/foo",
+        2,
+        71,
+        "safety-first",
+        4,
+      ),
+    ).toEqual({
+      surface: "compare-drawer-scenario-ranking",
+      entry: "agents/foo",
+      rank: 2,
+      score: 71,
+      scenario: "safety-first",
+      comparedCount: 4,
+    });
+    expect(parseComparePanelEntryRef("mcp/browser")).toEqual({
+      category: "mcp",
+      slug: "browser",
+    });
+    expect(parseComparePanelEntryRef("invalid")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Link decision brief and scenario ranking entry titles to detail pages.
- Track egress on compare page and drawer with typed analytics helpers.

## Events
- `compare_decision_brief_entry_click` — `{ surface, entry, rank, tone, score, comparedCount }`
- `compare_scenario_ranking_entry_click` — `{ surface, entry, rank, score, scenario, comparedCount }`

Refs #550

## Test plan
- [x] vitest for `compare-panel-entry-cta-events-lib`
- [x] type-check and build pass locally