### PR TITLE
test(scripts): extract coverage-gaps arg parser and cover it

### DIFF
--- a/scripts/audit-coverage-gaps.mjs
+++ b/scripts/audit-coverage-gaps.mjs
@@ -13,7 +13,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { findCoverageGaps } from "./lib/coverage-gaps.mjs";
+import {
+  findCoverageGaps,
+  parseCoverageGapsArgs,
+} from "./lib/coverage-gaps.mjs";
 
 const repoRoot = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -30,20 +33,8 @@ function loadEntries() {
   return atlas.entries ?? [];
 }
 
-function parseArgs(argv) {
-  const args = { json: false, minDemand: 12, perCategory: 12 };
-  for (let i = 0; i < argv.length; i += 1) {
-    if (argv[i] === "--json") args.json = true;
-    else if (argv[i] === "--min-demand")
-      args.minDemand = Number(argv[++i]) || 12;
-    else if (argv[i] === "--per-category")
-      args.perCategory = Number(argv[++i]) || 12;
-  }
-  return args;
-}
-
 function main(argv = process.argv.slice(2)) {
-  const args = parseArgs(argv);
+  const args = parseCoverageGapsArgs(argv);
   const groups = findCoverageGaps(loadEntries(), {
     minDemand: args.minDemand,
     maxInCategory: 1,

--- a/scripts/lib/coverage-gaps.mjs
+++ b/scripts/lib/coverage-gaps.mjs
@@ -60,6 +60,23 @@ function tally(entries, exclude) {
 }
 
 /**
+ * Parse the audit-coverage-gaps CLI flags (--json, --min-demand <n>,
+ * --per-category <n>) into an options object. Non-numeric or zero numeric
+ * values fall back to the default of 12.
+ */
+export function parseCoverageGapsArgs(argv) {
+  const args = { json: false, minDemand: 12, perCategory: 12 };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === "--json") args.json = true;
+    else if (argv[i] === "--min-demand")
+      args.minDemand = Number(argv[++i]) || 12;
+    else if (argv[i] === "--per-category")
+      args.perCategory = Number(argv[++i]) || 12;
+  }
+  return args;
+}
+
+/**
  * Priority groups of under-covered intents.
  * @param opts.minDemand global tag count to be considered a real intent (default 8)
  * @param opts.maxInCategory at-or-below this count in a category = under-covered (default 1)

--- a/tests/coverage-gaps.test.ts
+++ b/tests/coverage-gaps.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   findCoverageGaps,
   NON_INTENT_TAGS,
+  parseCoverageGapsArgs,
 } from "../scripts/lib/coverage-gaps.mjs";
 
 function e(category: string, tags: string[]) {
@@ -60,5 +61,40 @@ describe("findCoverageGaps", () => {
     expect(a.map((g) => g.category)).toEqual(
       [...a.map((g) => g.category)].sort(),
     );
+  });
+});
+
+describe("parseCoverageGapsArgs", () => {
+  it("defaults to json off and demand/per-category of 12", () => {
+    expect(parseCoverageGapsArgs([])).toEqual({
+      json: false,
+      minDemand: 12,
+      perCategory: 12,
+    });
+  });
+
+  it("sets --json and reads the numeric flags", () => {
+    expect(
+      parseCoverageGapsArgs([
+        "--json",
+        "--min-demand",
+        "16",
+        "--per-category",
+        "5",
+      ]),
+    ).toEqual({ json: true, minDemand: 16, perCategory: 5 });
+  });
+
+  it("falls back to 12 for non-numeric or zero numeric values", () => {
+    expect(parseCoverageGapsArgs(["--min-demand", "abc"]).minDemand).toBe(12);
+    expect(parseCoverageGapsArgs(["--per-category", "0"]).perCategory).toBe(12);
+  });
+
+  it("ignores unrecognized tokens", () => {
+    expect(parseCoverageGapsArgs(["--nope", "stray"])).toEqual({
+      json: false,
+      minDemand: 12,
+      perCategory: 12,
+    });
   });
 });


### PR DESCRIPTION
### What & why

`scripts/audit-coverage-gaps.mjs` parsed its `--json`/`--min-demand`/`--per-category` flags with a local `parseArgs` that had no tests. This hoists it into the existing `scripts/lib/coverage-gaps.mjs` (which the script already imports for `findCoverageGaps`) as `parseCoverageGapsArgs` and uses it from the script.

### Changes

- `scripts/lib/coverage-gaps.mjs` - add `parseCoverageGapsArgs`.
- `scripts/audit-coverage-gaps.mjs` - import the shared parser; drop the local copy.
- `tests/coverage-gaps.test.ts` - add cases for the flag defaults, `--json` plus the numeric flags, the non-numeric / zero fallback to 12, and ignored tokens. The new function's lines and branches are fully covered.

### Validation

- `pnpm exec vitest run tests/coverage-gaps.test.ts` - 8 passed
- `node --check scripts/audit-coverage-gaps.mjs` - clean; the parser is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the CLI arguments parse identically. Build scripts are inside the coverage scope, so this adds real covered lines.
