### PR TITLE
fix(web): report hooks that disclose BOTH safety and privacy, not the min

### DIFF
--- a/apps/web/src/lib/hooks-stats-lib.ts
+++ b/apps/web/src/lib/hooks-stats-lib.ts
@@ -148,8 +148,11 @@ export function buildHooksReport(entries: ReadonlyArray<Entry>, asOf: string): R
   const total = hooks.length;
 
   const events = hookEventDistribution(hooks);
-  const withSafety = hooks.filter((h) => hasNotes(h.safetyNotesList ?? h.safetyNotes)).length;
-  const withPrivacy = hooks.filter((h) => hasNotes(h.privacyNotesList ?? h.privacyNotes)).length;
+  const withBoth = hooks.filter(
+    (h) =>
+      hasNotes(h.safetyNotesList ?? h.safetyNotes) &&
+      hasNotes(h.privacyNotesList ?? h.privacyNotes),
+  ).length;
   const simple = hooks.filter(
     (h) => typeof h.difficultyScore === "number" && h.difficultyScore <= 2,
   ).length;
@@ -238,7 +241,7 @@ export function buildHooksReport(entries: ReadonlyArray<Entry>, asOf: string): R
       {
         key: "safety-privacy",
         label: "Disclose safety & privacy",
-        value: Math.min(pctOf(withSafety, total), pctOf(withPrivacy, total)),
+        value: pctOf(withBoth, total),
         hint: "%",
       },
       {

--- a/tests/hooks-stats-lib.test.ts
+++ b/tests/hooks-stats-lib.test.ts
@@ -131,6 +131,33 @@ describe("hooks-stats-lib buildHooksReport (deterministic)", () => {
     expect(a.stats.find((s) => s.key === "total")?.value).toBe(4);
   });
 
+  it("counts hooks disclosing BOTH safety and privacy, not the min of each", () => {
+    // Disjoint coverage: 2 disclose safety only, 2 privacy only, 0 disclose both.
+    // The old Math.min(pct(safety), pct(privacy)) reported 50%; the truth is 0%.
+    const disjoint = [
+      hook({ trigger: "PostToolUse", safetyNotes: "runs shell" }),
+      hook({ trigger: "Stop", safetyNotes: "writes files" }),
+      hook({ trigger: "PreToolUse", privacyNotes: "reads env" }),
+      hook({ trigger: "Notification", privacyNotes: "sends telemetry" }),
+    ];
+    const disjointModel = buildHooksReport(disjoint, "2026-06-20");
+    expect(
+      disjointModel.stats.find((s) => s.key === "safety-privacy")?.value,
+    ).toBe(0);
+
+    // Overlapping coverage: exactly 1 of 4 discloses both -> 25%.
+    const mixed = [
+      hook({ trigger: "PostToolUse", safetyNotes: "s", privacyNotes: "p" }),
+      hook({ trigger: "Stop", safetyNotes: "s" }),
+      hook({ trigger: "PreToolUse", privacyNotes: "p" }),
+      hook({ trigger: "Notification" }),
+    ];
+    const mixedModel = buildHooksReport(mixed, "2026-06-20");
+    expect(
+      mixedModel.stats.find((s) => s.key === "safety-privacy")?.value,
+    ).toBe(25);
+  });
+
   it("drops degenerate single-bucket dimensions", () => {
     const uniform = [
       hook({ trigger: "PostToolUse" }),


### PR DESCRIPTION
## Problem

The **"Disclose safety & privacy"** headline stat in the public *State of Claude Code Hooks* report is computed wrong in `apps/web/src/lib/hooks-stats-lib.ts`:

```ts
const withSafety = hooks.filter((h) => hasNotes(h.safetyNotesList ?? h.safetyNotes)).length;
const withPrivacy = hooks.filter((h) => hasNotes(h.privacyNotesList ?? h.privacyNotes)).length;
...
value: Math.min(pctOf(withSafety, total), pctOf(withPrivacy, total)),   // ← wrong
```

The stat is meant to report the share of hooks that disclose **both** safety and privacy behavior. `Math.min(pct(safety), pct(privacy))` is an **upper bound** on that intersection, not the intersection. When safety notes and privacy notes sit on *different* entries, it overstates the number.

### Concrete failing case

4 hooks — 2 with safety notes only, 2 with privacy notes only, none with both:

- `total = 4`, `withSafety = 2`, `withPrivacy = 2`, actual `both = 0`
- **Buggy output:** `Math.min(50, 50) = 50` → the published report reads **"50% disclose safety & privacy"**
- **Correct output:** `pctOf(0, 4) = 0` → **0%**

Zero hooks disclose both, yet the report claims half do — an objectively wrong number on a public data report.

## Fix

Compute the real intersection and report it — exactly how the sibling agents report (`agents-stats-lib.ts`) already does it (`both = filter(hasSafety && hasPrivacy)`):

```ts
const withBoth = hooks.filter(
  (h) =>
    hasNotes(h.safetyNotesList ?? h.safetyNotes) &&
    hasNotes(h.privacyNotesList ?? h.privacyNotes),
).length;
...
value: pctOf(withBoth, total),
```

## Risk / tradeoffs

- Pure function `buildHooksReport`; no signature or API change. Backward compatible.
- The corrected value is always ≤ the old value (the old one was an overstatement), so this only ever lowers a previously-inflated headline toward the truth.

## Tests

- Adds a regression test: disjoint coverage expects **0%** (old code gave 50%), overlapping coverage expects **25%**. The prior sample masked the bug by putting both note kinds on the same single hook.
- `pnpm exec vitest run tests/hooks-stats-lib.test.ts` → 16/16 pass.
- `pnpm type-check` clean; `pnpm build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)