### PR TITLE
test(scripts): extract wrangler d1 row parser and cover it

### DIFF
--- a/scripts/lib/wrangler-rows.mjs
+++ b/scripts/lib/wrangler-rows.mjs
@@ -1,0 +1,17 @@
+// Pure parser behind scripts/verify-d1-votes.mjs: extracting the result rows from
+// the text `pnpm wrangler d1 execute` prints. Split out from the execFileSync
+// caller so the output parsing can be unit-tested without invoking wrangler.
+
+/**
+ * Parse the trailing JSON array of a wrangler d1 execute run and return its
+ * first statement's `results` (or [] when absent). Throws with the run label
+ * when no JSON array can be found in the output.
+ */
+export function parseWranglerRows(output, label) {
+  const jsonMatch = String(output).match(/(\[\s*\{[\s\S]*\])\s*$/);
+  if (!jsonMatch) {
+    throw new Error(`Could not parse wrangler output for ${label}`);
+  }
+  const payload = JSON.parse(jsonMatch[1]);
+  return payload?.[0]?.results ?? [];
+}

--- a/scripts/verify-d1-votes.mjs
+++ b/scripts/verify-d1-votes.mjs
@@ -4,6 +4,7 @@ import {
   enumerateContentVoteKeys,
   findOrphanVoteKeys,
 } from "./lib/enumerate-content-vote-keys.mjs";
+import { parseWranglerRows } from "./lib/wrangler-rows.mjs";
 
 const repoRoot = process.cwd();
 const d1Binding = process.env.SITE_D1_BINDING || "SITE_DB";
@@ -35,12 +36,7 @@ function getRows(runMode, query) {
     cwd: repoRoot,
     encoding: "utf8",
   });
-  const jsonMatch = output.match(/(\[\s*\{[\s\S]*\])\s*$/);
-  if (!jsonMatch) {
-    throw new Error(`Could not parse wrangler output for ${runMode}`);
-  }
-  const payload = JSON.parse(jsonMatch[1]);
-  return payload?.[0]?.results ?? [];
+  return parseWranglerRows(output, runMode);
 }
 
 function verifyRunMode(runMode) {

--- a/tests/wrangler-rows.test.ts
+++ b/tests/wrangler-rows.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { parseWranglerRows } from "../scripts/lib/wrangler-rows.mjs";
+
+describe("parseWranglerRows", () => {
+  it("returns the first statement's results from wrangler output", () => {
+    const output = [
+      "🌀 Executing on local database SITE_DB",
+      '[ { "results": [ { "entry_key": "agents/x", "upvote_count": 3 } ], "success": true } ]',
+    ].join("\n");
+    expect(parseWranglerRows(output, "local")).toEqual([
+      { entry_key: "agents/x", upvote_count: 3 },
+    ]);
+  });
+
+  it("defaults to [] when the first statement has no results", () => {
+    expect(parseWranglerRows('[ { "success": true } ]', "remote")).toEqual([]);
+  });
+
+  it("throws with the run label when no JSON array is present", () => {
+    expect(() => parseWranglerRows("no json here", "remote")).toThrow(
+      /Could not parse wrangler output for remote/,
+    );
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/verify-d1-votes.mjs` parsed the JSON rows out of `pnpm wrangler d1 execute` output inline inside its `execFileSync` caller, so that parsing was untestable without invoking wrangler. This moves the pure parser into `scripts/lib/wrangler-rows.mjs` - matching the existing `scripts/lib` convention - and has `getRows` delegate to it.

### Changes

- Add `scripts/lib/wrangler-rows.mjs` - `parseWranglerRows(output, label)`.
- `scripts/verify-d1-votes.mjs` - `getRows` now execs and delegates the parse; drop the inline regex/JSON handling.
- Add `tests/wrangler-rows.test.ts` - covers extracting the first statement's results, the no-results -> `[]` fallback, and the throw (with run label) when no JSON array is present. Branch coverage 100% (4/4).

### Validation

- `pnpm exec vitest run tests/wrangler-rows.test.ts` - 3 passed
- `node --check scripts/verify-d1-votes.mjs` - clean; the parser is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; the parsed rows are identical. Build scripts are inside the coverage scope, so this adds real covered lines.
