### PR TITLE
feat(web): entry compare benchmark peer egress analytics

### DIFF
--- a/apps/web/src/components/entry-compare-benchmark-panel.tsx
+++ b/apps/web/src/components/entry-compare-benchmark-panel.tsx
@@ -1,8 +1,15 @@
+import { Link } from "@tanstack/react-router";
 import type {
   CompareBenchmarkPresetId,
   EntryCompareBenchmarkState,
 } from "@/lib/entry-compare-benchmark";
 import { compareBenchmarkVerdictClass } from "@/lib/entry-compare-benchmark";
+import {
+  detailCompareBenchmarkEntryAnalyticsData,
+  detailCompareBenchmarkEntryAnalyticsEvent,
+  parseDetailEntryRef,
+} from "@/lib/entry-detail-decision-preset-cta-events";
+import { trackEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 const PRESETS: { id: CompareBenchmarkPresetId; label: string }[] = [
@@ -13,11 +20,15 @@ const PRESETS: { id: CompareBenchmarkPresetId; label: string }[] = [
 
 export function EntryCompareBenchmarkPanel({
   state,
+  category,
+  slug,
   selectedPreset,
   onSelectPreset,
   className,
 }: {
   state: EntryCompareBenchmarkState;
+  category: string;
+  slug: string;
   selectedPreset: CompareBenchmarkPresetId;
   onSelectPreset: (preset: CompareBenchmarkPresetId) => void;
   className?: string;
@@ -65,46 +76,78 @@ export function EntryCompareBenchmarkPanel({
       ) : null}
 
       <div className="mt-3 grid gap-2">
-        {state.rows.map((row) => (
-          <article key={row.entryRef} className="rounded-lg border border-border bg-background p-3">
-            <div className="flex flex-wrap items-start justify-between gap-2">
-              <div className="min-w-0">
-                <h4 className="text-sm font-semibold text-ink">{row.title}</h4>
-                <p className="mt-0.5 text-[11px] text-ink-muted">{row.summary}</p>
-              </div>
-              <div className="text-right">
-                <span
-                  className={cn(
-                    "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
-                    compareBenchmarkVerdictClass(row.verdict),
+        {state.rows.map((row) => {
+          const parsed = parseDetailEntryRef(row.entryRef);
+          const title = <h4 className="text-sm font-semibold text-ink">{row.title}</h4>;
+          return (
+            <article
+              key={row.entryRef}
+              className="rounded-lg border border-border bg-background p-3"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                  {parsed ? (
+                    <Link
+                      to="/entry/$category/$slug"
+                      params={{ category: parsed.category, slug: parsed.slug }}
+                      onClick={() =>
+                        trackEvent(
+                          detailCompareBenchmarkEntryAnalyticsEvent(),
+                          detailCompareBenchmarkEntryAnalyticsData(
+                            category,
+                            slug,
+                            row.entryRef,
+                            selectedPreset,
+                            row.verdict,
+                            row.totalScore,
+                            row.delta,
+                            state.rows.length,
+                          ),
+                        )
+                      }
+                      className="underline-offset-2 hover:text-accent hover:underline"
+                    >
+                      {title}
+                    </Link>
+                  ) : (
+                    title
                   )}
-                >
-                  {row.verdict}
-                </span>
-                <p className="mt-1 font-mono text-xs text-ink">
-                  {row.totalScore}/100 ({row.delta >= 0 ? "+" : ""}
-                  {row.delta})
-                </p>
-              </div>
-            </div>
-
-            <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
-              {row.dimensions.map((dimension) => (
-                <div
-                  key={`${row.entryRef}-${dimension.id}`}
-                  className="rounded border border-border px-2 py-1"
-                >
-                  <p className="text-[10px] uppercase tracking-wide text-ink-subtle">
-                    {dimension.label}
-                  </p>
-                  <p className="text-[11px] text-ink-muted">
-                    {dimension.score}/100 · {dimension.detail}
+                  <p className="mt-0.5 text-[11px] text-ink-muted">{row.summary}</p>
+                </div>
+                <div className="text-right">
+                  <span
+                    className={cn(
+                      "inline-flex rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wide",
+                      compareBenchmarkVerdictClass(row.verdict),
+                    )}
+                  >
+                    {row.verdict}
+                  </span>
+                  <p className="mt-1 font-mono text-xs text-ink">
+                    {row.totalScore}/100 ({row.delta >= 0 ? "+" : ""}
+                    {row.delta})
                   </p>
                 </div>
-              ))}
-            </div>
-          </article>
-        ))}
+              </div>
+
+              <div className="mt-2 grid gap-1.5 sm:grid-cols-2">
+                {row.dimensions.map((dimension) => (
+                  <div
+                    key={`${row.entryRef}-${dimension.id}`}
+                    className="rounded border border-border px-2 py-1"
+                  >
+                    <p className="text-[10px] uppercase tracking-wide text-ink-subtle">
+                      {dimension.label}
+                    </p>
+                    <p className="text-[11px] text-ink-muted">
+                      {dimension.score}/100 · {dimension.detail}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </article>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events-lib.ts
@@ -5,6 +5,9 @@
  * privacy-light event names without embedding panel copy.
  */
 
+import type { CompareBenchmarkPresetId } from "@/lib/entry-compare-benchmark-lib";
+import type { CompareBenchmarkVerdict } from "@/lib/entry-compare-benchmark-lib";
+
 export type DetailDecisionPanelId =
   | "adoption-plan"
   | "evidence-matrix"
@@ -34,5 +37,42 @@ export function detailDecisionPresetAnalyticsData(
     surface: detailDecisionPresetSurface(panel),
     panel,
     preset,
+  };
+}
+
+export function detailCompareBenchmarkEntryAnalyticsEvent(): string {
+  return "detail_compare_benchmark_entry_click";
+}
+
+export function detailCompareBenchmarkEntryAnalyticsData(
+  fromCategory: string,
+  fromSlug: string,
+  peerEntryRef: string,
+  preset: CompareBenchmarkPresetId,
+  verdict: CompareBenchmarkVerdict,
+  totalScore: number,
+  delta: number,
+  peerCount: number,
+) {
+  return {
+    entry: detailDecisionPresetEntryKey(fromCategory, fromSlug),
+    surface: detailDecisionPresetSurface("compare-benchmark"),
+    peer: peerEntryRef,
+    preset,
+    verdict,
+    totalScore,
+    delta,
+    peerCount,
+  };
+}
+
+export function parseDetailEntryRef(entryRef: string): { category: string; slug: string } | null {
+  const slash = entryRef.indexOf("/");
+  if (slash <= 0 || slash >= entryRef.length - 1) {
+    return null;
+  }
+  return {
+    category: entryRef.slice(0, slash),
+    slug: entryRef.slice(slash + 1),
   };
 }

--- a/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
+++ b/apps/web/src/lib/entry-detail-decision-preset-cta-events.ts
@@ -2,9 +2,12 @@
  * Entry detail decision preset CTA event surface.
  */
 export {
+  detailCompareBenchmarkEntryAnalyticsData,
+  detailCompareBenchmarkEntryAnalyticsEvent,
   detailDecisionPresetAnalyticsData,
   detailDecisionPresetAnalyticsEvent,
   detailDecisionPresetEntryKey,
   detailDecisionPresetSurface,
+  parseDetailEntryRef,
   type DetailDecisionPanelId,
 } from "@/lib/entry-detail-decision-preset-cta-events-lib";

--- a/apps/web/src/routes/entry.$category.$slug.tsx
+++ b/apps/web/src/routes/entry.$category.$slug.tsx
@@ -767,6 +767,8 @@ function Dossier() {
           />
           <EntryCompareBenchmarkPanel
             state={compareBenchmark}
+            category={entry.category}
+            slug={entry.slug}
             selectedPreset={benchmarkPreset}
             onSelectPreset={onBenchmarkPresetSelect}
           />

--- a/tests/entry-detail-decision-preset-cta-events-lib.test.ts
+++ b/tests/entry-detail-decision-preset-cta-events-lib.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
+  detailCompareBenchmarkEntryAnalyticsData,
+  detailCompareBenchmarkEntryAnalyticsEvent,
   detailDecisionPresetAnalyticsData,
   detailDecisionPresetAnalyticsEvent,
   detailDecisionPresetSurface,
+  parseDetailEntryRef,
 } from "@/lib/entry-detail-decision-preset-cta-events-lib";
 
 describe("entry detail decision preset cta events lib", () => {
@@ -39,5 +42,34 @@ describe("entry detail decision preset cta events lib", () => {
       panel: "compare-benchmark",
       preset: "strict",
     });
+    expect(detailCompareBenchmarkEntryAnalyticsEvent()).toBe(
+      "detail_compare_benchmark_entry_click",
+    );
+    expect(
+      detailCompareBenchmarkEntryAnalyticsData(
+        "mcp",
+        "browser",
+        "agents/foo",
+        "security",
+        "stronger",
+        84,
+        12,
+        3,
+      ),
+    ).toEqual({
+      entry: "mcp/browser",
+      surface: "detail-compare-benchmark",
+      peer: "agents/foo",
+      preset: "security",
+      verdict: "stronger",
+      totalScore: 84,
+      delta: 12,
+      peerCount: 3,
+    });
+    expect(parseDetailEntryRef("mcp/browser")).toEqual({
+      category: "mcp",
+      slug: "browser",
+    });
+    expect(parseDetailEntryRef("invalid")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- Link compare benchmark peer entry titles to detail pages on the entry dossier.
- Track peer egress with typed analytics helpers (no titles or dimension copy).

## Events
- `detail_compare_benchmark_entry_click` — `{ entry, surface, peer, preset, verdict, totalScore, delta, peerCount }`

Refs #550

## Test plan
- [x] vitest for `entry-detail-decision-preset-cta-events-lib`
- [x] type-check and build pass locally