### PR TITLE
test(scripts): extract brand-domain candidate selection and cover it

### DIFF
--- a/scripts/enrich-brand-assets.mjs
+++ b/scripts/enrich-brand-assets.mjs
@@ -3,13 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 
 import matter from "gray-matter";
-import {
-  domainFromUrl,
-  isHostingOrRegistryDomain,
-  normalizeBrandDomain,
-} from "@heyclaude/registry/brand-assets";
+import { normalizeBrandDomain } from "@heyclaude/registry/brand-assets";
 import { orderFrontmatter } from "@heyclaude/registry/content-schema";
 import { parseSafeFrontmatter } from "@heyclaude/registry/frontmatter";
+
+import { candidateDomain } from "./lib/brand-domain-candidate.mjs";
 
 const repoRoot = process.cwd();
 const contentRoot = path.join(repoRoot, "content");
@@ -26,23 +24,6 @@ function walkMdx(directory) {
 
 function clean(value) {
   return String(value || "").trim();
-}
-
-function candidateDomain(data) {
-  const explicit = normalizeBrandDomain(data.brandDomain);
-  if (explicit) return { domain: explicit, source: "explicit" };
-
-  const websiteDomain = domainFromUrl(data.websiteUrl);
-  if (websiteDomain && !isHostingOrRegistryDomain(websiteDomain)) {
-    return { domain: websiteDomain, source: "websiteUrl" };
-  }
-
-  const docsDomain = domainFromUrl(data.documentationUrl);
-  if (docsDomain && !isHostingOrRegistryDomain(docsDomain)) {
-    return { domain: docsDomain, source: "documentationUrl-review-only" };
-  }
-
-  return { domain: "", source: "missing" };
 }
 
 const rows = [];

--- a/scripts/lib/brand-domain-candidate.mjs
+++ b/scripts/lib/brand-domain-candidate.mjs
@@ -1,0 +1,34 @@
+// Pure brand-domain selection behind scripts/enrich-brand-assets.mjs: picking the
+// best candidate brand domain for a content entry from its explicit brandDomain,
+// then its websiteUrl, then (review-only) its documentationUrl - skipping hosting
+// and registry domains. Split out so the selection can be unit-tested without the
+// mdx walk / file writes the script performs.
+
+import {
+  domainFromUrl,
+  isHostingOrRegistryDomain,
+  normalizeBrandDomain,
+} from "@heyclaude/registry/brand-assets";
+
+/**
+ * Choose a brand domain for an entry, returning { domain, source }. Prefers an
+ * explicit brandDomain, then a non-hosting websiteUrl domain, then a non-hosting
+ * documentationUrl domain (flagged review-only); otherwise { domain: "",
+ * source: "missing" }.
+ */
+export function candidateDomain(data) {
+  const explicit = normalizeBrandDomain(data.brandDomain);
+  if (explicit) return { domain: explicit, source: "explicit" };
+
+  const websiteDomain = domainFromUrl(data.websiteUrl);
+  if (websiteDomain && !isHostingOrRegistryDomain(websiteDomain)) {
+    return { domain: websiteDomain, source: "websiteUrl" };
+  }
+
+  const docsDomain = domainFromUrl(data.documentationUrl);
+  if (docsDomain && !isHostingOrRegistryDomain(docsDomain)) {
+    return { domain: docsDomain, source: "documentationUrl-review-only" };
+  }
+
+  return { domain: "", source: "missing" };
+}

--- a/tests/brand-domain-candidate.test.ts
+++ b/tests/brand-domain-candidate.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { candidateDomain } from "../scripts/lib/brand-domain-candidate.mjs";
+
+describe("candidateDomain", () => {
+  it("prefers an explicit brandDomain", () => {
+    expect(
+      candidateDomain({
+        brandDomain: "acme.com",
+        websiteUrl: "https://other.com",
+      }),
+    ).toEqual({ domain: "acme.com", source: "explicit" });
+  });
+
+  it("uses a non-hosting websiteUrl domain when there is no brandDomain", () => {
+    expect(candidateDomain({ websiteUrl: "https://acme.com/product" })).toEqual(
+      {
+        domain: "acme.com",
+        source: "websiteUrl",
+      },
+    );
+  });
+
+  it("skips a hosting websiteUrl and falls back to a documentationUrl domain", () => {
+    expect(
+      candidateDomain({
+        websiteUrl: "https://github.com/acme/tool",
+        documentationUrl: "https://docs.acme.io/start",
+      }),
+    ).toEqual({
+      domain: "docs.acme.io",
+      source: "documentationUrl-review-only",
+    });
+  });
+
+  it("returns the missing sentinel when nothing usable is present", () => {
+    expect(candidateDomain({})).toEqual({ domain: "", source: "missing" });
+    expect(
+      candidateDomain({
+        websiteUrl: "https://github.com/x",
+        documentationUrl: "https://npmjs.com/package/y",
+      }),
+    ).toEqual({ domain: "", source: "missing" });
+  });
+});


### PR DESCRIPTION
### What & why

`scripts/enrich-brand-assets.mjs` chose each entry's candidate brand domain inline, so the `brandDomain` -> `websiteUrl` -> `documentationUrl` precedence (with hosting / registry domains skipped) was untestable without the mdx walk and file writes. This moves the pure selector into `scripts/lib/brand-domain-candidate.mjs` - matching the existing `scripts/lib` convention - and imports it back.

### Changes

- Add `scripts/lib/brand-domain-candidate.mjs` - `candidateDomain`, re-using the registry brand-assets helpers.
- `scripts/enrich-brand-assets.mjs` - import `candidateDomain`; drop the local copy and the now-unused `domainFromUrl` / `isHostingOrRegistryDomain` imports (`normalizeBrandDomain` is still used for the existing-domain read).
- Add `tests/brand-domain-candidate.test.ts` - covers the explicit `brandDomain`, the non-hosting `websiteUrl` domain, the hosting-website -> `documentationUrl` fallback, and the missing sentinel when everything is absent or hosting. Branch coverage 100% (10/10).

### Validation

- `pnpm exec vitest run tests/brand-domain-candidate.test.ts` - 4 passed
- `node --check scripts/enrich-brand-assets.mjs` - clean; `candidateDomain` is imported and used
- `pnpm exec prettier --check` on the touched files - clean

### Notes

No matching open issue - maintainer-lane internal refactor (pure-logic extraction + tests). No behavior change; candidate selection is identical. Build scripts are inside the coverage scope, so this adds real covered lines.
